### PR TITLE
replaysync support

### DIFF
--- a/lua/multiplayer/gpgnet.lua
+++ b/lua/multiplayer/gpgnet.lua
@@ -2,8 +2,12 @@ local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 local Group = import('/lua/maui/group.lua').Group
 
 function CreateUI()
-    local mainFrame = GetFrame(0)
-    local mainGroup = Group(mainFrame, "gpgnetgroup")
-    LayoutHelpers.FillParentFixedBorder(mainGroup, mainFrame, 20)
+    if HasCommandLineArg("/syncreplay") and HasCommandLineArg("/gpgnet") then
+        import('/lua/ui/uiutil.lua').QuickDialog(GetFrame(0), "Connection failed to\n" .. GetCommandLineArg('/gpgnet',1)[1], "Exit", function() ExitApplication() end)
+    else
+		local mainFrame = GetFrame(0)
+		local mainGroup = Group(mainFrame, "gpgnetgroup")
+		LayoutHelpers.FillParentFixedBorder(mainGroup, mainFrame, 20)
+	end
 end
 

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -783,6 +783,9 @@ function UiBeat()
         lastObserving = observing
         import('/lua/ui/game/economy.lua').ToggleEconPanel(not observing)
     end
+    if HasCommandLineArg("/syncreplay") and HasCommandLineArg("/gpgnet") then	
+        GpgNetSend("BEAT",GameTick(),GetGameSpeed()) 
+    end
 end
 
 SendChat = function()


### PR DESCRIPTION
You need the replaysync tool to get it work. (http://dropcanvas.com/tgnyf)

If the game started with /syncreplay and /gpgnet parameters:
- it will send the players current ticknumber on every beat to the lobby program.
- adds option to pause the game from the lobby program
- adds option to change speed from the lobby program
- displays a helper dialog while downloading replay from the lobby program
