### PR TITLE
Better support for parallel orders

### DIFF
--- a/lua/spreadattack.lua
+++ b/lua/spreadattack.lua
@@ -181,8 +181,10 @@ function GiveOrders(Data)
 
     for id, orders in final do
         local unit = GetEntityById(id)
-        table.insert(all_units, unit)
-        IssueClearCommands({unit})
+        if(OkayToMessWithArmy(unit:GetArmy())) then
+          table.insert(all_units, unit)
+          IssueClearCommands({unit})
+        end
     end
 
     for id, orders in final do


### PR DESCRIPTION
You can now spread other orders than attacks, like move / overcharge /
build

For instance, you can select 10 engineers and then queue up building 10
mexes, when you spread the engineers will divide the orders between them

The orders are distributed according to the distance between a unit and
the destination

Fixes #27
