### PR TITLE
Chat rework

### DIFF
--- a/SCHOOK/lua/UserSync.lua
+++ b/SCHOOK/lua/UserSync.lua
@@ -1,6 +1,19 @@
 # Here's an opportunity for user side script to examine the Sync table for the new tick
 local baseOnSync = OnSync
 OnSync = function()
+
+
+    if not table.empty(Sync.Chat) then
+        if SessionIsReplay() then
+            for id, data in Sync.Chat do
+                data.Msg.Chat = true
+                import('/lua/ui/game/chat.lua').ReceiveChatFromSim(data.Sender, data.Msg)
+            end
+        else
+            Sync.Chat = {}
+        end
+    end
+
     baseOnSync()
     import('/lua/UserCamera.lua').ProcessCameraRequests(Sync.CameraRequests)
 

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -28,6 +28,8 @@ local SUtils = import('/lua/ai/sorianutilities.lua')
 
 Callbacks.BreakAlliance = SimUtils.BreakAlliance
 
+Callbacks.SaveChatToReplay = SimUtils.SaveChatToReplay
+
 Callbacks.GiveUnitsToPlayer = SimUtils.GiveUnitsToPlayer
 
 Callbacks.GiveResourcesToPlayer = SimUtils.GiveResourcesToPlayer

--- a/lua/SimSync.lua
+++ b/lua/SimSync.lua
@@ -10,6 +10,7 @@ function ResetSyncTable()
     Sync = {
         # A list of camera control operations that we'd like the user layer to perform.
         CameraRequests = {},
+        Chat = {},
         Sounds = {},
         Voice = {},
 		AIChat = {},

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -1,16 +1,17 @@
-# Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#
-# General Sim scripts
+-- Copyright Â© 2005 Gas Powered Games, Inc.  All rights reserved.
+--
+-- General Sim scripts
 
-#==============================================================================
-# Diplomacy
-#==============================================================================
+--==============================================================================
+-- Diplomacy
+--==============================================================================
 
 local sharedUnits = {}
+local chatID = 1
 
 function BreakAlliance( data )
 
-    # You cannot change alliances in a team game
+    -- You cannot change alliances in a team game
     if ScenarioInfo.TeamGame then
         return
     end
@@ -27,7 +28,7 @@ function BreakAlliance( data )
 end
 
 function OnAllianceResult( resultData )
-    # You cannot change alliances in a team game
+    -- You cannot change alliances in a team game
     if ScenarioInfo.TeamGame then
         return
     end
@@ -46,14 +47,14 @@ end
 import('/lua/SimPlayerQuery.lua').AddResultListener( "OfferAlliance", OnAllianceResult )
 
 function KillSharedUnits(owner)
-	if sharedUnits[owner] and table.getn(sharedUnits[owner]) > 0 then
-		for index,unit in sharedUnits[owner] do
-			if not unit:IsDead() and unit.oldowner then
-				unit:Kill()
-			end
-		end
-		sharedUnits[owner] = {}
-	end
+    if sharedUnits[owner] and table.getn(sharedUnits[owner]) > 0 then
+        for index,unit in sharedUnits[owner] do
+            if not unit:IsDead() and unit.oldowner then
+                unit:Kill()
+            end
+        end
+        sharedUnits[owner] = {}
+    end
 end
 
 function TransferUnitsOwnership(units, ToArmyIndex)
@@ -61,16 +62,16 @@ function TransferUnitsOwnership(units, ToArmyIndex)
     if not toBrain or toBrain:IsDefeated() or not units or table.getn(units) < 1 then
         return
     end
-    local newUnits = {}	
+    local newUnits = {} 
     for k,v in units do
-        local owner = v:GetArmy()		
+        local owner = v:GetArmy()       
         if owner == ToArmyIndex or GetArmyBrain(owner):IsDefeated() then
             continue
-            # removed " not IsAlly(owner,ToArmyIndex) or " because else it doesnt work when unit captured
+            -- removed " not IsAlly(owner,ToArmyIndex) or " because else it doesnt work when unit captured
         end
-        # Only allow units not attached to be given. This is because units will give all of it's children over
-        # aswell, so we only want the top level units to be given. Also, don't allow commanders to be given.
-        if v:GetParent() != v or (v.Parent and v.Parent != v) then
+        -- Only allow units not attached to be given. This is because units will give all of it's children over
+        -- aswell, so we only want the top level units to be given. Also, don't allow commanders to be given.
+        if v:GetParent() ~= v or (v.Parent and v.Parent ~= v) then
             continue
         end
 
@@ -78,24 +79,24 @@ function TransferUnitsOwnership(units, ToArmyIndex)
         local bp = unit:GetBlueprint()
         local unitId = unit:GetUnitId()
 
-        # B E F O R E
-        local numNukes = unit:GetNukeSiloAmmoCount()  #looks like one of these 2 works for SMDs also
+        -- B E F O R E
+        local numNukes = unit:GetNukeSiloAmmoCount()  --looks like one of these 2 works for SMDs also
         local numTacMsl = unit:GetTacticalSiloAmmoCount()
-        local unitKills = unit:GetStat('KILLS', 0).Value   #also takes care of the veteran level
+        local unitKills = unit:GetStat('KILLS', 0).Value   --also takes care of the veteran level
         local unitHealth = unit:GetHealth()
         local shieldIsOn = false
         local ShieldHealth = 0
         local hasFuel = false
         local fuelRatio = 0
-        local enh = {} # enhancements
+        local enh = {} -- enhancements
 
         if unit.MyShield then
             shieldIsOn = unit:ShieldIsOn()
             ShieldHealth = unit.MyShield:GetHealth()
         end
-        if bp.Physics.FuelUseTime and bp.Physics.FuelUseTime > 0 then   # going through the BP to check for fuel
-            fuelRatio = unit:GetFuelRatio()                             # usage is more reliable then unit.HasFuel
-            hasFuel = true                                              # cause some buildings say they use fuel
+        if bp.Physics.FuelUseTime and bp.Physics.FuelUseTime > 0 then   -- going through the BP to check for fuel
+            fuelRatio = unit:GetFuelRatio()                             -- usage is more reliable then unit.HasFuel
+            hasFuel = true                                              -- cause some buildings say they use fuel
         end
         local posblEnh = bp.Enhancements
         if posblEnh then
@@ -105,18 +106,19 @@ function TransferUnitsOwnership(units, ToArmyIndex)
                 end
             end
         end
-	
-		local oldOwner = nil
-		if unit.oldowner then
-			oldOwner = unit.oldowner
-		end
+    
+        local oldOwner = nil
+        if unit.oldowner then
+            oldOwner = unit.oldowner
+        end
 
-        # changing owner
+        -- changing owner
         unit:OnBeforeTransferingOwnership(ToArmyIndex)
         unit = ChangeUnitArmy(unit,ToArmyIndex)
         if not unit then
             continue
         end
+
         table.insert(newUnits, unit)	
 		
 		if IsAlly(owner,ToArmyIndex) then
@@ -135,8 +137,8 @@ function TransferUnitsOwnership(units, ToArmyIndex)
 			end
 		end
 		
-        # A F T E R
-        if unitKills and unitKills > 0 then # set veterancy first
+        -- A F T E R
+        if unitKills and unitKills > 0 then -- set veterancy first
             unit:AddKills( unitKills )
         end
         if enh and table.getn(enh) > 0 then
@@ -165,7 +167,7 @@ function TransferUnitsOwnership(units, ToArmyIndex)
                 unit:DisableShield()
             end
         end
-        unit:OnAfterTransferingOwnership(owner) # owner var contains the now ex-owner
+        unit:OnAfterTransferingOwnership(owner) -- owner var contains the now ex-owner
     end
     return newUnits
 end
@@ -173,7 +175,7 @@ end
 function GiveUnitsToPlayer( data, units )
     if units then
         local owner = units[1]:GetArmy()
-        if OkayToMessWithArmy(owner) and IsAlly(owner,data.To) then			
+        if OkayToMessWithArmy(owner) and IsAlly(owner,data.To) then         
             TransferUnitsOwnership( units, data.To )
         end
     end
@@ -186,7 +188,7 @@ function SetResourceSharing( data )
 end
 
 function RequestAlliedVictory( data )
-    # You cannot change this in a team game
+    -- You cannot change this in a team game
 
     if ScenarioInfo.TeamGame then
         return
@@ -206,11 +208,11 @@ function SetOfferDraw(data)
 end
 
 
-#==============================================================================
-# UNIT CAP
-#==============================================================================
+--==============================================================================
+-- UNIT CAP
+--==============================================================================
 function UpdateUnitCap(deadArmy)
-    # If we are asked to share out unit cap for the defeated army, do the following...
+    -- If we are asked to share out unit cap for the defeated army, do the following...
     local mode = ScenarioInfo.Options.ShareUnitCap
     
     if(not mode or mode == 'none') then
@@ -252,29 +254,31 @@ function UpdateUnitCap(deadArmy)
     end
 end
 
-function SendChatToReplay(data)
-	if data.Sender and data.Msg then
-		if not Sync.UnitData.Chat then
-			Sync.UnitData.Chat = {}
-		end
-		table.insert(Sync.UnitData.Chat, {sender=data.Sender, msg=data.Msg})
-	end
+function SaveChatToReplay(data)
+    if data.Sender and data.Msg then
+        if not Sync.Chat then
+            chatID = 1
+            Sync.Chat = {}
+        end
+        chatID = chatID + 1
+        Sync.Chat[chatID] = {Sender=data.Sender, Msg=data.Msg}
+        --table.insert(Sync.Chat, {Sender=data.Sender, Msg=data.Msg})
+    end
 end
 
 function GiveResourcesToPlayer(data)
-	SendChatToReplay(data)
-	if data.From != -1 then
-		if not OkayToMessWithArmy(data.From) then
-			return
-		end
-		local fromBrain = GetArmyBrain(data.From)
-		local toBrain = GetArmyBrain(data.To)
-		if fromBrain:IsDefeated() or toBrain:IsDefeated() then
-			return
-		end
-		local massTaken = fromBrain:TakeResource('Mass',data.Mass * fromBrain:GetEconomyStored('Mass'))
-		local energyTaken = fromBrain:TakeResource('Energy',data.Energy * fromBrain:GetEconomyStored('Energy'))
-		toBrain:GiveResource('Mass',massTaken)
-		toBrain:GiveResource('Energy',energyTaken)
-	end
+    if data.From ~= -1 then
+        if not OkayToMessWithArmy(data.From) then
+            return
+        end
+        local fromBrain = GetArmyBrain(data.From)
+        local toBrain = GetArmyBrain(data.To)
+        if fromBrain:IsDefeated() or toBrain:IsDefeated() then
+            return
+        end
+        local massTaken = fromBrain:TakeResource('Mass',data.Mass * fromBrain:GetEconomyStored('Mass'))
+        local energyTaken = fromBrain:TakeResource('Energy',data.Energy * fromBrain:GetEconomyStored('Energy'))
+        toBrain:GiveResource('Mass',massTaken)
+        toBrain:GiveResource('Energy',energyTaken)
+    end
 end

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -1,24 +1,24 @@
-# The global sync table is copied from the sim layer every time the main and sim threads are
-# synchronized on the sim beat (which is like a tick but happens even when the game is paused)
+-- The global sync table is copied from the sim layer every time the main and sim threads are
+-- synchronized on the sim beat (which is like a tick but happens even when the game is paused)
 Sync = {}
 
-# The PreviousSync table holds just what you'd expect it to, the sync table from the previous
-# beat.
+-- The PreviousSync table holds just what you'd expect it to, the sync table from the previous
+-- beat.
 PreviousSync = {}
 
-# Unit specific data that's been sync'd. Data changes are accumulated by merging
-# the Sync.UnitData table into this table each sync (if there's new data)
+-- Unit specific data that's been sync'd. Data changes are accumulated by merging
+-- the Sync.UnitData table into this table each sync (if there's new data)
 UnitData = {}
 
-# Here's an opportunity for user side script to examine the Sync table for the new tick
+-- Here's an opportunity for user side script to examine the Sync table for the new tick
 function OnSync()
 	
     if Sync.RequestingExit then
-        #LOG("Got it")
+        --LOG("Got it")
         ExitGame()
     end
 
-    #Play Sounds
+    --Play Sounds
     for k, v in Sync.Sounds do
         PlaySound(Sound{ Bank=v.Bank, Cue=v.Cue })
     end
@@ -58,4 +58,5 @@ function OnSync()
     if Sync.NukeLaunchData then
 		import('/modules/nukelaunchping.lua').DoNukePing(Sync.NukeLaunchData)
 	end
+
 end

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -28,15 +28,17 @@ local chatHistory = {}
 local commandHistory = {}
 
 local ChatTo = import('/lua/lazyvar.lua').Create()
-  
-local defOptions = { all_color = 1, 
-        allies_color = 2,
-        priv_color = 3,
-        link_color = 4,
-        font_size = 14,
-        fade_time = 15,
-        win_alpha = 1}
-        
+
+local defOptions = {
+    all_color = 1,
+    allies_color = 2,
+    priv_color = 3,
+    link_color = 4,
+    font_size = 14,
+    fade_time = 15,
+    win_alpha = 1
+}
+
 local ChatOptions = Prefs.GetFromCurrentProfile("chatoptions") or defOptions
 
 GUI = {
@@ -53,7 +55,7 @@ for k, FactionData in Factions do
 end
 table.insert( FactionsIcon, '/widgets/faction-icons-alpha_bmp/observer_ico.dds' )
 
-	
+
 local chatColors = {'ffffffff', 'ffff4242', 'ffefff42','ff4fff42', 'ff42fff8', 'ff424fff', 'ffff42eb'}
 
 local ToStrings = {
@@ -68,18 +70,20 @@ function SetLayout()
 end
 
 function CreateChatBackground()
-    local location = {Top = function() return GetFrame(0).Bottom() - 393 end,
+    local location = {
+        Top = function() return GetFrame(0).Bottom() - 393 end,
         Left = function() return GetFrame(0).Left() + 8 end,
         Right = function() return GetFrame(0).Left() + 430 end,
-        Bottom = function() return GetFrame(0).Bottom() - 238 end}
+        Bottom = function() return GetFrame(0).Bottom() - 238 end
+    }
     local bg = Window(GetFrame(0), '', nil, true, true, nil, nil, 'chat_window', location)
     bg.Depth:Set(200)
-    
+
     bg.DragTL = Bitmap(bg, UIUtil.UIFile('/game/drag-handle/drag-handle-ul_btn_up.dds'))
     bg.DragTR = Bitmap(bg, UIUtil.UIFile('/game/drag-handle/drag-handle-ur_btn_up.dds'))
     bg.DragBL = Bitmap(bg, UIUtil.UIFile('/game/drag-handle/drag-handle-ll_btn_up.dds'))
     bg.DragBR = Bitmap(bg, UIUtil.UIFile('/game/drag-handle/drag-handle-lr_btn_up.dds'))
-    
+
     local controlMap = {
         tl = {bg.DragTL},
         tr = {bg.DragTR},
@@ -90,7 +94,7 @@ function CreateChatBackground()
         tm = {bg.DragTL,bg.DragTR},
         bm = {bg.DragBL,bg.DragBR},
     }
-    
+
     bg.RolloverHandler = function(control, event, xControl, yControl, cursor, controlID)
         if bg._lockSize then return end
         local styles = import('/lua/maui/window.lua').styles
@@ -120,39 +124,39 @@ function CreateChatBackground()
             end
         end
     end
-    
+
     bg.OnResizeSet = function(control)
         bg.DragTL:SetTexture(bg.DragTL.textures.up)
         bg.DragTR:SetTexture(bg.DragTR.textures.up)
         bg.DragBL:SetTexture(bg.DragBL.textures.up)
         bg.DragBR:SetTexture(bg.DragBR.textures.up)
     end
-    
+
     bg.DragTL.Left:Set(function() return bg.Left() - 26 end)
     bg.DragTL.Top:Set(function() return bg.Top() - 6 end)
     bg.DragTL.Depth:Set(220)
     bg.DragTL:DisableHitTest()
-    
+
     bg.DragTR.Right:Set(function() return bg.Right() + 22 end)
     bg.DragTR.Top:Set(function() return bg.Top() - 8 end)
     bg.DragTR.Depth:Set(bg.DragTL.Depth)
     bg.DragTR:DisableHitTest()
-    
+
     bg.DragBL.Left:Set(function() return bg.Left() - 26 end)
     bg.DragBL.Bottom:Set(function() return bg.Bottom() + 8 end)
     bg.DragBL.Depth:Set(bg.DragTL.Depth)
     bg.DragBL:DisableHitTest()
-    
+
     bg.DragBR.Right:Set(function() return bg.Right() + 22 end)
     bg.DragBR.Bottom:Set(function() return bg.Bottom() + 8 end)
     bg.DragBR.Depth:Set(bg.DragTL.Depth)
     bg.DragBR:DisableHitTest()
-    
+
     bg.ResetPositionBtn = Button(bg,
-        UIUtil.SkinnableFile('/game/menu-btns/default_btn_up.dds'),
-        UIUtil.SkinnableFile('/game/menu-btns/default_btn_down.dds'),
-        UIUtil.SkinnableFile('/game/menu-btns/default_btn_over.dds'),
-        UIUtil.SkinnableFile('/game/menu-btns/default_btn_dis.dds'))
+    UIUtil.SkinnableFile('/game/menu-btns/default_btn_up.dds'),
+    UIUtil.SkinnableFile('/game/menu-btns/default_btn_down.dds'),
+    UIUtil.SkinnableFile('/game/menu-btns/default_btn_over.dds'),
+    UIUtil.SkinnableFile('/game/menu-btns/default_btn_dis.dds'))
     LayoutHelpers.LeftOf(bg.ResetPositionBtn, bg._configBtn)
     bg.ResetPositionBtn.Depth:Set(function() return bg.Depth() + 10 end)
     bg.ResetPositionBtn.OnClick = function(self, modifiers) 
@@ -164,9 +168,9 @@ function CreateChatBackground()
         CreateChatLines()
         bg:SaveWindowLocation()
     end
-    
+
     Tooltip.AddButtonTooltip(bg.ResetPositionBtn, 'chat_reset')    
-    
+
     bg:SetMinimumResize(400, 160)
     return bg
 end
@@ -174,46 +178,46 @@ end
 function CreateChatLines()
     local function CreateChatLine()
         local line = Group(GUI.chatContainer)
-        
+
         line.teamColor = Bitmap(line)
         line.teamColor:SetSolidColor('00000000')
         line.teamColor.Height:Set(line.Height)
         line.teamColor.Width:Set(line.Height)
         line.teamColor.Left:Set(line.Left)
         line.teamColor.Top:Set(line.Top)
-        
+
         line.topBG = Bitmap(line)
         line.topBG:SetSolidColor('00000000')
         line.topBG.Height:Set(2)
         line.topBG.Left:Set(line.Left)
         line.topBG.Right:Set(line.Right)
         line.topBG.Bottom:Set(line.Top)
-        
+
         line.leftBG = Bitmap(line)
         line.leftBG:SetSolidColor('00000000')
         line.leftBG.Width:Set(1)
         line.leftBG.Right:Set(line.Left)
         line.leftBG.Top:Set(line.topBG.Top)
         line.leftBG.Bottom:Set(line.Bottom)
-        
+
         line.rightBG = Bitmap(line)
         line.rightBG:SetSolidColor('00000000')
         line.rightBG.Width:Set(1)
         line.rightBG.Left:Set(line.Right)
         line.rightBG.Top:Set(line.topBG.Top)
         line.rightBG.Bottom:Set(line.Bottom)
-                
+
         line.factionIcon = Bitmap(line.teamColor)
         line.factionIcon:SetSolidColor('00000000')
         LayoutHelpers.FillParent(line.factionIcon, line.teamColor)
-        
+
         line.name = UIUtil.CreateText(line, '', ChatOptions.font_size, "Arial Bold")
         line.name.Left:Set(function() return line.teamColor.Right() + 4 end)
         LayoutHelpers.AtVerticalCenterIn(line.name, line.teamColor)
         line.name.Depth:Set(function() return line.Depth() + 10 end)
         line.name:SetColor('ffffffff')
         line.name:DisableHitTest()
-        
+
         line.nameBG = Bitmap(line.name)
         line.nameBG:SetSolidColor('00000000')
         line.nameBG.Depth:Set(function() return line.name.Depth() - 1 end)
@@ -239,7 +243,7 @@ function CreateChatLines()
                 end
             end
         end
-        
+
         line.text = UIUtil.CreateText(line, '', ChatOptions.font_size, "Arial")
         line.text.Depth:Set(function() return line.Depth() + 10 end)
         line.text.Left:Set(function() return line.nameBG.Right() + 2 end)
@@ -248,7 +252,7 @@ function CreateChatLines()
         line.text:DisableHitTest()
         line.text:SetColor('ffc2f6ff')
         LayoutHelpers.AtVerticalCenterIn(line.text, line.teamColor)
-        
+
         line.textBG = Bitmap(line)
         line.textBG.Depth:Set(function() return line.text.Depth() - 1 end)
         line.textBG.Left:Set(line.nameBG.Right)
@@ -281,9 +285,10 @@ function CreateChatLines()
                 end
             end
         end
-        
+
         return line
     end
+
     if GUI.chatContainer then
         local curEntries = table.getsize(GUI.chatLines)
         local neededEntries = math.floor(GUI.chatContainer.Height() / (GUI.chatLines[1].Height() + 2))
@@ -312,9 +317,9 @@ function CreateChatLines()
         GUI.chatContainer.Top:Set(function() return clientArea.Top() + 2 end)
         GUI.chatContainer.Right:Set(function() return clientArea.Right() - 38 end)
         GUI.chatContainer.Bottom:Set(function() return GUI.chatEdit.Top() - 10 end)
-        
+
         SetupChatScroll()
-        
+
         if not GUI.chatLines[1] then
             GUI.chatLines[1] = CreateChatLine()
             LayoutHelpers.AtLeftTopIn(GUI.chatLines[1], GUI.chatContainer, 0, 0)
@@ -333,834 +338,839 @@ function CreateChatLines()
         end
     end
 end
+
 function OnNISBegin()
     CloseChat()
 end
-	function SetupChatScroll()
-		GUI.chatContainer.top = 1
-		GUI.chatContainer.scroll = UIUtil.CreateVertScrollbarFor(GUI.chatContainer)
-		
-		local numLines = function() return table.getsize(GUI.chatLines) end
-		GUI.chatContainer.prevtabsize = 0
-		GUI.chatContainer.prevsize = 0
-		
-		local function IsValidEntry(entryData)
-			local result = true
-			if entryData.camera then
-				result = ChatOptions.links
-			else
-				result = ChatOptions[entryData.armyID]
-			end
-			return result
-		end
-		
-		local function DataSize()
-			if GUI.chatContainer.prevtabsize != table.getn(chatHistory) then
-				local size = 0
-				for i, v in chatHistory do
-					if IsValidEntry(v) then
-						size = size + table.getn(v.wrappedtext)
-					end
-				end
-				GUI.chatContainer.prevtabsize = table.getn(chatHistory)
-				GUI.chatContainer.prevsize = size
-			end
-			return GUI.chatContainer.prevsize
-		end
-		
-		-- called when the scrollbar for the control requires data to size itself
-		-- GetScrollValues must return 4 values in this order:
-		-- rangeMin, rangeMax, visibleMin, visibleMax
-		-- aixs can be "Vert" or "Horz"
-		GUI.chatContainer.GetScrollValues = function(self, axis)
-			local size = DataSize()
-			--LOG(size, ":", self.top, ":", math.min(self.top + numLines(), size))
-			return 1, size, self.top, math.min(self.top + numLines(), size)
-		end
-	
-		-- called when the scrollbar wants to scroll a specific number of lines (negative indicates scroll up)
-		GUI.chatContainer.ScrollLines = function(self, axis, delta)
-			self:ScrollSetTop(axis, self.top + math.floor(delta))
-		end
-	
-		-- called when the scrollbar wants to scroll a specific number of pages (negative indicates scroll up)
-		GUI.chatContainer.ScrollPages = function(self, axis, delta)
-			self:ScrollSetTop(axis, self.top + math.floor(delta) * numLines())
-		end
-	
-		-- called when the scrollbar wants to set a new visible top line
-		GUI.chatContainer.ScrollSetTop = function(self, axis, top)
-			top = math.floor(top)
-			if top == self.top then return end
-			local size = DataSize()
-			self.top = math.max(math.min(size - numLines()+1, top), 1)
-			self:CalcVisible()
-		end
-	
-		-- called to determine if the control is scrollable on a particular access. Must return true or false.
-		GUI.chatContainer.IsScrollable = function(self, axis)
-			return true
-		end
-		
-		GUI.chatContainer.ScrollToBottom = function(self)
-			--LOG(DataSize())
-			GUI.chatContainer:ScrollSetTop(nil, DataSize())
-		end
-		
-		-- determines what controls should be visible or not
-		GUI.chatContainer.CalcVisible = function(self)
-			GUI.bg.curTime = 0
-			local index = 1
-			local tempTop = self.top
-			local curEntry = 1
-			local curTop = 1
-			local tempsize = 0
-			for i, v in chatHistory do
-				if IsValidEntry(v) then
-					if tempsize + table.getsize(v.wrappedtext) < tempTop then
-						tempsize = tempsize + table.getsize(v.wrappedtext)
-					else
-						curEntry = i
-						for h, x in v.wrappedtext do
-							if h + tempsize == tempTop then
-								curTop = h
-								break
-							end
-						end
-						break
-					end
-				end
-			end
-			while GUI.chatLines[index] do
-				if not chatHistory[curEntry].wrappedtext[curTop] then
-					if chatHistory[curEntry].new then chatHistory[curEntry].new = nil end
-					curTop = 1
-					curEntry = curEntry + 1
-					while chatHistory[curEntry] and not IsValidEntry(chatHistory[curEntry]) do
-						curEntry = curEntry + 1
-					end
-				end
-				if chatHistory[curEntry] then
-					local Index = index
-					if curTop == 1 then
-						GUI.chatLines[index].name:SetText(chatHistory[curEntry].name)
-						if chatHistory[curEntry].armyID == GetFocusArmy() then
-							GUI.chatLines[index].nameBG:Disable()
-						else
-							GUI.chatLines[index].nameBG:Enable()
-						end
-						GUI.chatLines[index].text:SetText(chatHistory[curEntry].wrappedtext[curTop] or "")
-						GUI.chatLines[index].teamColor:SetSolidColor(chatHistory[curEntry].color)
-						GUI.chatLines[index].factionIcon:SetTexture(UIUtil.UIFile(FactionsIcon[chatHistory[curEntry].faction]))
-						GUI.chatLines[index].topBG.Right:Set(GUI.chatLines[index].Right)
-						GUI.chatLines[index].IsTop = true
-						GUI.chatLines[index].chatID = chatHistory[curEntry].armyID
-						if chatHistory[curEntry].camera and not GUI.chatLines[index].camIcon then
-							GUI.chatLines[index].camIcon = Bitmap(GUI.chatLines[index].textBG, UIUtil.UIFile('/game/camera-btn/pinned_btn_up.dds'))
-							GUI.chatLines[index].camIcon.Height:Set(16)
-							GUI.chatLines[index].camIcon.Width:Set(20)
-							LayoutHelpers.AtVerticalCenterIn(GUI.chatLines[index].camIcon, GUI.chatLines[index].teamColor)
-							GUI.chatLines[index].camIcon.Left:Set(function() return GUI.chatLines[Index].name.Right() + 4 end)
-							GUI.chatLines[index].text.Left:Set(function() return GUI.chatLines[Index].camIcon.Right() + 4 end)
-						elseif not chatHistory[curEntry].camera and GUI.chatLines[index].camIcon then
-							GUI.chatLines[index].camIcon:Destroy()
-							GUI.chatLines[index].camIcon = false
-							GUI.chatLines[index].text.Left:Set(function() return GUI.chatLines[Index].nameBG.Right() + 2 end)
-						end
-					else
-						GUI.chatLines[index].topBG.Right:Set(GUI.chatLines[index].teamColor.Right)
-						GUI.chatLines[index].nameBG:Disable()
-						GUI.chatLines[index].name:SetText('')
-						GUI.chatLines[index].text:SetText(chatHistory[curEntry].wrappedtext[curTop] or "")
-						GUI.chatLines[index].teamColor:SetSolidColor('00000000')
-						GUI.chatLines[index].factionIcon:SetSolidColor('00000000')
-						GUI.chatLines[index].IsTop = false
-						if GUI.chatLines[index].camIcon then
-							GUI.chatLines[index].camIcon:Destroy()
-							GUI.chatLines[index].camIcon = false
-							GUI.chatLines[index].text.Left:Set(function() return GUI.chatLines[Index].nameBG.Right() + 2 end)
-						end
-					end
-					if chatHistory[curEntry].camera then
-						GUI.chatLines[index].cameraData = chatHistory[curEntry].camera
-						GUI.chatLines[index].textBG:Enable()
-						GUI.chatLines[index].text:SetColor(chatColors[ChatOptions.link_color])
-					else
-						GUI.chatLines[index].textBG:Disable()
-						GUI.chatLines[index].text:SetColor('ffc2f6ff')
-						GUI.chatLines[index].text:SetColor(chatColors[ChatOptions[chatHistory[curEntry].tokey]])
-					end
-					if not GUI.bg:IsHidden() then
-						GUI.chatLines[index].rightBG:Show()
-						GUI.chatLines[index].leftBG:Show()
-					end
-					GUI.chatLines[index].textBG:SetSolidColor('00000000')
-					GUI.chatLines[index].nameBG:SetSolidColor('00000000')
-					GUI.chatLines[index].EntryID = curEntry
-					if chatHistory[curEntry].new and GUI.bg:IsHidden() then 
-						GUI.chatLines[index]:Show()
-						GUI.chatLines[index].topBG:Hide()
-						GUI.chatLines[index].rightBG:Hide()
-						GUI.chatLines[index].leftBG:Hide()
-						if GUI.chatLines[index].name:GetText() == '' then
-							GUI.chatLines[index].teamColor:Hide()
-						end
-						GUI.chatLines[index].time = 0
-						GUI.chatLines[index].OnFrame = function(self, delta)
-							self.time = self.time + delta
-							if self.time > ChatOptions.fade_time then
-								if GUI.bg:IsHidden() then
-									self:Hide()
-								end
-								self:SetNeedsFrameUpdate(false)
-							end
-						end
-						GUI.chatLines[index]:SetNeedsFrameUpdate(true)
-					end
-				else
-					GUI.chatLines[index].nameBG:Disable()
-					GUI.chatLines[index].name:SetText('')
-					GUI.chatLines[index].text:SetText('')
-					GUI.chatLines[index].teamColor:SetSolidColor('00000000')
-					GUI.chatLines[index].textBG:SetSolidColor('00000000')
-					GUI.chatLines[index].nameBG:SetSolidColor('00000000')
-					GUI.chatLines[index].topBG:SetSolidColor('00000000')
-					GUI.chatLines[index].leftBG:SetSolidColor('00000000')
-					GUI.chatLines[index].rightBG:SetSolidColor('00000000')
-				end
-				GUI.chatLines[index]:SetAlpha(ChatOptions.win_alpha, true)
-				curTop = curTop + 1
-				index = index + 1
-			end
-		end
-	end
-	
-	function FindClients(id)
-		local t = GetArmiesTable()
-		local focus = t.focusArmy
-		local result = {}
-		if focus == -1 then
-			for index,client in GetSessionClients() do
-				if not client.connected then
-					continue
-				end
-				local playerIsObserver = true
-				for id, player in GetArmiesTable().armiesTable do
-					if player.outOfGame and player.human and player.nickname == client.name then						
-						table.insert(result, index)
-						playerIsObserver = false
-						break
-					elseif player.nickname == client.name then
-						playerIsObserver = false
-						break
-					end
-				end
-				if playerIsObserver then
-					table.insert(result, index)
-				end
-			end
-		else
-			local srcs = {}
-			for army,info in t.armiesTable do
-				if id then
-					if army == id then
-						for k,cmdsrc in info.authorizedCommandSources do
-							srcs[cmdsrc] = true
-						end
-						break
-					end
-				else
-					if IsAlly(focus, army) then
-						for k,cmdsrc in info.authorizedCommandSources do
-							srcs[cmdsrc] = true
-						end
-					end
-				end
-			end
-			for index,client in GetSessionClients() do
-				for k,cmdsrc in client.authorizedCommandSources do
-					if srcs[cmdsrc] then
-						table.insert(result, index)
-						break
-					end
-				end
-			end
-		end
-		return result
-	end
 
-	function CreateChatEdit()
-		local parent = GUI.bg:GetClientGroup()
-		local group = Group(parent)
-		
-		group.Bottom:Set(parent.Bottom)
-		group.Right:Set(parent.Right)
-		group.Left:Set(parent.Left)
-		group.Top:Set(function() return group.Bottom() - group.Height() end)
-		
-		local toText = UIUtil.CreateText(group, '', 14, 'Arial')
-		toText.Bottom:Set(function() return group.Bottom() - 1 end)
-		toText.Left:Set(function() return group.Left() + 35 end)
-		
-		ChatTo.OnDirty = function(self)
-			if ToStrings[self()] then
-				toText:SetText(LOC(ToStrings[self()].caps))
-			else
-				toText:SetText(LOCF('%s %s:', ToStrings['to'].caps, GetArmyData(self()).nickname))
-			end
-		end
-		
-		group.edit = Edit(group)
-		group.edit.Left:Set(function() return toText.Right() + 5 end)
-		group.edit.Right:Set(function() return group.Right() - 38 end)
-		group.edit.Depth:Set(function() return GUI.bg:GetClientGroup().Depth() + 200 end)
-		group.edit.Bottom:Set(function() return group.Bottom() - 1 end)
-		group.edit.Height:Set(function() return group.edit:GetFontHeight() end)
-		UIUtil.SetupEditStd(group.edit, "ff00ff00", nil, "ffffffff", UIUtil.highlightColor, UIUtil.bodyFont, 14, 200)
-		group.edit:SetDropShadow(true)
-		group.edit:ShowBackground(false)
-		
-		group.edit:SetText('')
-		
-		group.Height:Set(function() return group.edit.Height() end)
-		
-		local function CreateTestBtn(text)
-			local btn = UIUtil.CreateCheckboxStd(group, '/dialogs/toggle_btn/toggle')
-			btn.Depth:Set(function() return group.Depth() + 10 end)
-			btn.OnClick = function(self, modifiers)
-				if self._checkState == "unchecked" then
-					self:ToggleCheck()
-				end
-			end
-			btn.txt = UIUtil.CreateText(btn, text, 12, UIUtil.bodyFont)
-			LayoutHelpers.AtCenterIn(btn.txt, btn)
-			btn.txt:SetColor('ffffffff')
-			btn.txt:DisableHitTest()
-			return btn
-		end
-		
-		group.camData = UIUtil.CreateCheckbox(group,
-			UIUtil.SkinnableFile('/game/camera-btn/pinned_btn_up.dds'),
-			UIUtil.SkinnableFile('/game/camera-btn/pinned_btn_down.dds'),
-			UIUtil.SkinnableFile('/game/camera-btn/pinned_btn_over.dds'),
-			UIUtil.SkinnableFile('/game/camera-btn/pinned_btn_over.dds'),
-			UIUtil.SkinnableFile('/game/camera-btn/pinned_btn_dis.dds'),
-			UIUtil.SkinnableFile('/game/camera-btn/pinned_btn_dis.dds'))
-		
-		LayoutHelpers.AtRightIn(group.camData, group, 5)
-		LayoutHelpers.AtVerticalCenterIn(group.camData, group.edit, -1)
-		
-		group.chatBubble = Button(group,
-			UIUtil.UIFile('/game/chat-box_btn/radio_btn_up.dds'),
-			UIUtil.UIFile('/game/chat-box_btn/radio_btn_down.dds'),
-			UIUtil.UIFile('/game/chat-box_btn/radio_btn_over.dds'),
-			UIUtil.UIFile('/game/chat-box_btn/radio_btn_dis.dds'))
-		group.chatBubble.OnClick = function(self, modifiers)
-			if not self.list then
-				self.list = CreateChatList(self)
-				LayoutHelpers.Above(self.list, self, 15)
-				LayoutHelpers.AtLeftIn(self.list, self, 15)
-			else
-				self.list:Destroy()
-				self.list = nil
-			end
-		end
-		
-		toText.HandleEvent = function(self, event)
-			if event.Type == 'ButtonPress' then
-				group.chatBubble:OnClick(event.Modifiers)
-			end
-		end
-		
-		LayoutHelpers.AtLeftIn(group.chatBubble, group, 3)
-		LayoutHelpers.AtVerticalCenterIn(group.chatBubble, group.edit)
-		
-		group.edit.OnNonTextKeyPressed = function(self, charcode, event)
-			GUI.bg.curTime = 0
-			local function RecallCommand(entryNumber)
-				self:SetText(commandHistory[self.recallEntry].text)
-				if commandHistory[self.recallEntry].camera then
-					self.tempCam = commandHistory[self.recallEntry].camera
-					group.camData:Disable()
-					group.camData:SetCheck(true)
-				else
-					self.tempCam = nil
-					group.camData:Enable()
-					group.camData:SetCheck(false)
-				end
-			end
-			if charcode == UIUtil.VK_NEXT then
-				local mod = 10
-				if event.Modifiers.Shift then
-					mod = 1
-				end
-				ChatPageDown(mod)
-				return true
-			elseif charcode == UIUtil.VK_PRIOR then
-				local mod = 10
-				if event.Modifiers.Shift then
-					mod = 1
-				end
-				ChatPageUp(mod)
-				return true
-			elseif charcode == UIUtil.VK_UP then
-				if table.getsize(commandHistory) > 0 then
-					if self.recallEntry then
-						self.recallEntry = math.max(self.recallEntry-1, 1)
-					else
-						self.recallEntry = table.getsize(commandHistory)
-					end
-					RecallCommand(self.recallEntry)
-				end
-			elseif charcode == UIUtil.VK_DOWN then
-				if table.getsize(commandHistory) > 0 then
-					if self.recallEntry then
-						self.recallEntry = math.min(self.recallEntry+1, table.getsize(commandHistory))
-						RecallCommand(self.recallEntry)
-						if self.recallEntry == table.getsize(commandHistory) then
-							self.recallEntry = nil
-						end
-					else
-						self:SetText('')
-					end
-				end
-			else
-				return true
-			end
-		end
-		
-		group.edit.OnCharPressed = function(self, charcode)
-			local charLim = self:GetMaxChars()
-			if charcode == 9 then
-				return true
-			end
-			GUI.bg.curTime = 0
-			if STR_Utf8Len(self:GetText()) >= charLim then
-				local sound = Sound({Cue = 'UI_Menu_Error_01', Bank = 'Interface',})
-				PlaySound(sound)
-			end
-		end
-		
-		group.edit.OnEnterPressed = function(self, text)
-			GUI.bg.curTime = 0
-			if group.camData:IsDisabled() then
-				group.camData:Enable()
-			end
-			if text == "" then
-				ToggleChat()
-			else
-				local gnBegin, gnEnd = string.find(text, "%s+")
-				if gnBegin and (gnBegin == 1 and gnEnd == string.len(text)) then
-					return
-				end
-				if import('/lua/ui/game/taunt.lua').CheckForAndHandleTaunt(text) then
-					return
-				end
-	
-				msg = { to = ChatTo(), Chat = true }
-				if self.tempCam then
-					msg.camera = self.tempCam
-				elseif group.camData:IsChecked() then
-					msg.camera = GetCamera('WorldCamera'):SaveSettings()
-				end
-				msg.text = text
-				if ChatTo() == 'allies' then
-					if GetFocusArmy() != -1 then
-						SessionSendChatMessage(FindClients(), msg)
-					else
-						msg.Observer = true
-						SessionSendChatMessage(FindClients(), msg)
-					end
-				elseif type(ChatTo()) == 'number' then
-					if GetFocusArmy() != -1 then
-						SessionSendChatMessage(FindClients(ChatTo()), msg)
-						msg.echo = true
-						msg.from = GetArmyData(GetFocusArmy()).nickname
-						ReceiveChat(GetArmyData(ChatTo()).nickname, msg)
-					end
-				else
-					if GetFocusArmy() == -1 then
-						msg.Observer = true
-						SessionSendChatMessage(FindClients(), msg)
-					else
-						SessionSendChatMessage(msg)
-					end
-				end
-				table.insert(commandHistory, msg)
-				self.recallEntry = nil
-				self.tempCam = nil
-			end
-		end
-		
-		ChatTo:Set('all')
-		group.edit:AcquireFocus()
-		
-		return group
-	end
-		
-	function ReceiveChat(sender, msg)
-		if not msg.ConsoleOutput then
-			SimCallback({Func="GiveResourcesToPlayer", Args={ From=GetFocusArmy(), To=GetFocusArmy(), Mass=0, Energy=0, Sender=sender, Msg=msg},} , true)
-		end
-		if not SessionIsReplay() then
-			ReceiveChatFromSim(sender, msg)
-		end
+function SetupChatScroll()
+    GUI.chatContainer.top = 1
+    GUI.chatContainer.scroll = UIUtil.CreateVertScrollbarFor(GUI.chatContainer)
 
-	end
+    local numLines = function() return table.getsize(GUI.chatLines) end
+    GUI.chatContainer.prevtabsize = 0
+    GUI.chatContainer.prevsize = 0
 
-	function ReceiveChatFromSim(sender, msg)		
-		sender = sender or "nil sender"
-		if msg.ConsoleOutput then
-			print(LOCF("%s %s", sender, msg.ConsoleOutput))
-			return
-		end
-		if not msg.Chat then			
-			return
-		end
-		if type(msg) == 'string' then
-			msg = { text = msg }
-		elseif type(msg) != 'table' then
-			msg = { text = repr(msg) }
-		end
-		local armyData = GetArmyData(sender)
-		if not armyData and GetFocusArmy() != -1 and not SessionIsReplay() then
-			return
-		end
-		local towho = LOC(ToStrings[msg.to].text) or LOC(ToStrings['private'].text)		
-		local tokey = ToStrings[msg.to].colorkey or ToStrings['private'].colorkey
-		if msg.Observer then
-			towho = LOC("<LOC lobui_0592>to observes:")
-			tokey = "link_color"			
-		end
-		if msg.Observer and armyData.faction then
-			armyData.faction = table.getn(FactionsIcon) - 1
-		end
-		if type(msg.to) == 'number' and SessionIsReplay() then
-			towho = string.format("%s %s:", LOC(ToStrings.to.text), GetArmyData(msg.to).nickname)
-		end
-		local name = sender .. ' ' .. towho
-		if msg.echo then			
-			if msg.from and SessionIsReplay() then
-				name = string.format("%s %s:", LOC(ToStrings.to.text), sender)
-				name = msg.from.." "..name
-			else
-				name = string.format("%s %s:", LOC(ToStrings.to.caps), sender)
-			end
-		end		
-		local tempText = WrapText({text = msg.text, name = name})
-		-- if text wrap produces no lines (ie text is all white space) then add a blank line
-		if table.getn(tempText) == 0 then
-			tempText = {""}
-		end
-		local entry = {name = name,
-			tokey = tokey,
-			color = (armyData.color or "ffffffff"),
-			armyID = (armyData.ArmyID or 1),
-			faction = (armyData.faction or (table.getn(FactionsIcon)-1))+1,
-			text = msg.text,
-			wrappedtext = tempText,
-			new = true}
-		if msg.camera then
-			entry.camera = msg.camera
-		end
-		table.insert(chatHistory, entry)
-		if ChatOptions[entry.armyID] then
-			if table.getsize(chatHistory) == 1 then
-				GUI.chatContainer:CalcVisible()
-			else
-				GUI.chatContainer:ScrollToBottom()
-			end
-		end
-		if SessionIsReplay() then
-			PlaySound(Sound({Bank = 'Interface', Cue = 'UI_Diplomacy_Close'}))
-		end
-	end
-	
-	function ToggleChat()
-		if GUI.bg:IsHidden() then			
-			GUI.bg:Show()
-			GUI.chatEdit.edit:AcquireFocus()
-			if not GUI.bg.pinned then
-				GUI.bg:SetNeedsFrameUpdate(true)
-				GUI.bg.curTime = 0
-			end
-			for i, v in GUI.chatLines do
-				v:SetNeedsFrameUpdate(false)
-				v:Show()
-				v.OnFrame = nil
-			end			
-		else
-			GUI.bg:Hide()
-			GUI.chatEdit.edit:AbandonFocus()
-			GUI.bg:SetNeedsFrameUpdate(false)
-		end
-	end
-	
-	function ActivateChat(modifiers)		
-		if type(ChatTo()) != 'number' then
-			if modifiers.Shift then
-				ChatTo:Set('allies')
-			else
-				ChatTo:Set('all')
-			end
-		end
-		ToggleChat()		
-	end
+    local function IsValidEntry(entryData)
+        local result = true
+        if entryData.camera then
+            result = ChatOptions.links
+        else
+            result = ChatOptions[entryData.armyID]
+        end
 
-	#############
-	#Added for sorian ai
-	#############
-	
-	function CreateChatList(parent)
-		local armies = GetArmiesTable()
-		local container = Group(GUI.chatEdit)
-		container:DisableHitTest()
-		container.Depth:Set(GetFrame(0):GetTopmostDepth() + 1)
-		container.entries = {}
-		local function CreatePlayerEntry(data)
-			if not data.human and not data.civilian then
-				data.nickname = UiUtilsS.trim(string.gsub(data.nickname,'%b()', '' ))
-			end
-			local text = UIUtil.CreateText(container, data.nickname, 12, "Arial")
-			text:SetColor('ffffffff')
-			text:DisableHitTest()
-        
-			text.BG = Bitmap(text)
-			text.BG:SetSolidColor('ff000000')
-			text.BG.Depth:Set(function() return text.Depth() - 1 end)
-			text.BG.Left:Set(function() return text.Left() - 6 end)
-			text.BG.Top:Set(function() return text.Top() - 1 end)
-			text.BG.Width:Set(function() return container.Width() + 8 end)
-			text.BG.Bottom:Set(function() return text.Bottom() + 1 end)
-        
-			text.BG.HandleEvent = function(self, event)
-				if event.Type == 'MouseEnter' then
-					self:SetSolidColor('ff666666')
-				elseif event.Type == 'MouseExit' then
-					self:SetSolidColor('ff000000')
-				elseif event.Type == 'ButtonPress' then
-					ChatTo:Set(data.armyID)
-					container:Destroy()
-					parent.list = nil
-					GUI.chatEdit.edit:Enable()
-					GUI.chatEdit.edit:AcquireFocus()
-				end
-				GUI.bg.curTime = 0
-			end
-			return text
-		end
-    
-		local entries = {
-			{nickname = ToStrings.all.caps, armyID = 'all'},
-			{nickname = ToStrings.allies.caps, armyID = 'allies'},
-		}
-    
-		for armyID, armyData in armies.armiesTable do
-			if armyID != armies.focusArmy and not armyData.civilian then
-				table.insert(entries, {nickname = armyData.nickname, armyID = armyID})
-			end
-		end
-    
-		local maxWidth = 0
-		local height = 0
-		for index, data in entries do
-			local i = index
-			table.insert(container.entries, CreatePlayerEntry(data))
-			if container.entries[i].Width() > maxWidth then
-				maxWidth = container.entries[i].Width() + 8
-			end
-			height = height + container.entries[i].Height()
-			if i > 1 then
-				LayoutHelpers.Above(container.entries[i], container.entries[i-1])
-			else
-				LayoutHelpers.AtLeftIn(container.entries[i], container)
-				LayoutHelpers.AtBottomIn(container.entries[i], container)
-			end
-		end
-		container.Width:Set(maxWidth)
-		container.Height:Set(height)
-    
-		container.LTBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_ul.dds'))
-		container.LTBG:DisableHitTest()
-		container.LTBG.Right:Set(container.Left)
-		container.LTBG.Bottom:Set(container.Top)
-    
-		container.RTBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_ur.dds'))
-		container.RTBG:DisableHitTest()
-		container.RTBG.Left:Set(container.Right)
-		container.RTBG.Bottom:Set(container.Top)
-		
-		container.RBBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_lr.dds'))
-		container.RBBG:DisableHitTest()
-		container.RBBG.Left:Set(container.Right)
-		container.RBBG.Top:Set(container.Bottom)
-		
-		container.RLBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_ll.dds'))
-		container.RLBG:DisableHitTest()
-		container.RLBG.Right:Set(container.Left)
-		container.RLBG.Top:Set(container.Bottom)
-		
-		container.LBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_vert_l.dds'))
-		container.LBG:DisableHitTest()
-		container.LBG.Right:Set(container.Left)
-		container.LBG.Top:Set(container.Top)
-		container.LBG.Bottom:Set(container.Bottom)
-		
-		container.RBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_vert_r.dds'))
-		container.RBG:DisableHitTest()
-		container.RBG.Left:Set(container.Right)
-		container.RBG.Top:Set(container.Top)
-		container.RBG.Bottom:Set(container.Bottom)
-		
-		container.TBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_horz_um.dds'))
-		container.TBG:DisableHitTest()
-		container.TBG.Left:Set(container.Left)
-		container.TBG.Right:Set(container.Right)
-		container.TBG.Bottom:Set(container.Top)
-		
-		container.BBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_lm.dds'))
-		container.BBG:DisableHitTest()
-		container.BBG.Left:Set(container.Left)
-		container.BBG.Right:Set(container.Right)
-		container.BBG.Top:Set(container.Bottom)
-		
-		function DestroySelf()
-			parent:OnClick()
-		end
-		
-		UIMain.AddOnMouseClickedFunc(DestroySelf)
-		
-		container.OnDestroy = function(self)
-			UIMain.RemoveOnMouseClickedFunc(DestroySelf)
-		end
-		
-		return container
-	end
-	
+        return result
+    end
+
+    local function DataSize()
+        if GUI.chatContainer.prevtabsize ~= table.getn(chatHistory) then
+            local size = 0
+            for i, v in chatHistory do
+                if IsValidEntry(v) then
+                    size = size + table.getn(v.wrappedtext)
+                end
+            end
+            GUI.chatContainer.prevtabsize = table.getn(chatHistory)
+            GUI.chatContainer.prevsize = size
+        end
+        return GUI.chatContainer.prevsize
+    end
+
+    -- called when the scrollbar for the control requires data to size itself
+    -- GetScrollValues must return 4 values in this order:
+    -- rangeMin, rangeMax, visibleMin, visibleMax
+    -- aixs can be "Vert" or "Horz"
+    GUI.chatContainer.GetScrollValues = function(self, axis)
+        local size = DataSize()
+        --LOG(size, ":", self.top, ":", math.min(self.top + numLines(), size))
+        return 1, size, self.top, math.min(self.top + numLines(), size)
+    end
+
+    -- called when the scrollbar wants to scroll a specific number of lines (negative indicates scroll up)
+    GUI.chatContainer.ScrollLines = function(self, axis, delta)
+        self:ScrollSetTop(axis, self.top + math.floor(delta))
+    end
+
+    -- called when the scrollbar wants to scroll a specific number of pages (negative indicates scroll up)
+    GUI.chatContainer.ScrollPages = function(self, axis, delta)
+        self:ScrollSetTop(axis, self.top + math.floor(delta) * numLines())
+    end
+
+    -- called when the scrollbar wants to set a new visible top line
+    GUI.chatContainer.ScrollSetTop = function(self, axis, top)
+        top = math.floor(top)
+        if top == self.top then return end
+        local size = DataSize()
+        self.top = math.max(math.min(size - numLines()+1, top), 1)
+        self:CalcVisible()
+    end
+
+    -- called to determine if the control is scrollable on a particular access. Must return true or false.
+    GUI.chatContainer.IsScrollable = function(self, axis)
+        return true
+    end
+
+    GUI.chatContainer.ScrollToBottom = function(self)
+        --LOG(DataSize())
+        GUI.chatContainer:ScrollSetTop(nil, DataSize())
+    end
+
+    -- determines what controls should be visible or not
+    GUI.chatContainer.CalcVisible = function(self)
+        GUI.bg.curTime = 0
+        local index = 1
+        local tempTop = self.top
+        local curEntry = 1
+        local curTop = 1
+        local tempsize = 0
+        for i, v in chatHistory do
+            if IsValidEntry(v) then
+                if tempsize + table.getsize(v.wrappedtext) < tempTop then
+                    tempsize = tempsize + table.getsize(v.wrappedtext)
+                else
+                    curEntry = i
+                    for h, x in v.wrappedtext do
+                        if h + tempsize == tempTop then
+                            curTop = h
+                            break
+                        end
+                    end
+                    break
+                end
+            end
+        end
+        while GUI.chatLines[index] do
+            if not chatHistory[curEntry].wrappedtext[curTop] then
+                if chatHistory[curEntry].new then chatHistory[curEntry].new = nil end
+                curTop = 1
+                curEntry = curEntry + 1
+                while chatHistory[curEntry] and not IsValidEntry(chatHistory[curEntry]) do
+                    curEntry = curEntry + 1
+                end
+            end
+            if chatHistory[curEntry] then
+                local Index = index
+                if curTop == 1 then
+                    GUI.chatLines[index].name:SetText(chatHistory[curEntry].name)
+                    if chatHistory[curEntry].armyID == GetFocusArmy() then
+                        GUI.chatLines[index].nameBG:Disable()
+                    else
+                        GUI.chatLines[index].nameBG:Enable()
+                    end
+                    GUI.chatLines[index].text:SetText(chatHistory[curEntry].wrappedtext[curTop] or "")
+                    GUI.chatLines[index].teamColor:SetSolidColor(chatHistory[curEntry].color)
+                    GUI.chatLines[index].factionIcon:SetTexture(UIUtil.UIFile(FactionsIcon[chatHistory[curEntry].faction]))
+                    GUI.chatLines[index].topBG.Right:Set(GUI.chatLines[index].Right)
+                    GUI.chatLines[index].IsTop = true
+                    GUI.chatLines[index].chatID = chatHistory[curEntry].armyID
+                    if chatHistory[curEntry].camera and not GUI.chatLines[index].camIcon then
+                        GUI.chatLines[index].camIcon = Bitmap(GUI.chatLines[index].textBG, UIUtil.UIFile('/game/camera-btn/pinned_btn_up.dds'))
+                        GUI.chatLines[index].camIcon.Height:Set(16)
+                        GUI.chatLines[index].camIcon.Width:Set(20)
+                        LayoutHelpers.AtVerticalCenterIn(GUI.chatLines[index].camIcon, GUI.chatLines[index].teamColor)
+                        GUI.chatLines[index].camIcon.Left:Set(function() return GUI.chatLines[Index].name.Right() + 4 end)
+                        GUI.chatLines[index].text.Left:Set(function() return GUI.chatLines[Index].camIcon.Right() + 4 end)
+                    elseif not chatHistory[curEntry].camera and GUI.chatLines[index].camIcon then
+                        GUI.chatLines[index].camIcon:Destroy()
+                        GUI.chatLines[index].camIcon = false
+                        GUI.chatLines[index].text.Left:Set(function() return GUI.chatLines[Index].nameBG.Right() + 2 end)
+                    end
+                else
+                    GUI.chatLines[index].topBG.Right:Set(GUI.chatLines[index].teamColor.Right)
+                    GUI.chatLines[index].nameBG:Disable()
+                    GUI.chatLines[index].name:SetText('')
+                    GUI.chatLines[index].text:SetText(chatHistory[curEntry].wrappedtext[curTop] or "")
+                    GUI.chatLines[index].teamColor:SetSolidColor('00000000')
+                    GUI.chatLines[index].factionIcon:SetSolidColor('00000000')
+                    GUI.chatLines[index].IsTop = false
+                    if GUI.chatLines[index].camIcon then
+                        GUI.chatLines[index].camIcon:Destroy()
+                        GUI.chatLines[index].camIcon = false
+                        GUI.chatLines[index].text.Left:Set(function() return GUI.chatLines[Index].nameBG.Right() + 2 end)
+                    end
+                end
+                if chatHistory[curEntry].camera then
+                    GUI.chatLines[index].cameraData = chatHistory[curEntry].camera
+                    GUI.chatLines[index].textBG:Enable()
+                    GUI.chatLines[index].text:SetColor(chatColors[ChatOptions.link_color])
+                else
+                    GUI.chatLines[index].textBG:Disable()
+                    GUI.chatLines[index].text:SetColor('ffc2f6ff')
+                    GUI.chatLines[index].text:SetColor(chatColors[ChatOptions[chatHistory[curEntry].tokey]])
+                end
+                if not GUI.bg:IsHidden() then
+                    GUI.chatLines[index].rightBG:Show()
+                    GUI.chatLines[index].leftBG:Show()
+                end
+                GUI.chatLines[index].textBG:SetSolidColor('00000000')
+                GUI.chatLines[index].nameBG:SetSolidColor('00000000')
+                GUI.chatLines[index].EntryID = curEntry
+                if chatHistory[curEntry].new and GUI.bg:IsHidden() then 
+                    GUI.chatLines[index]:Show()
+                    GUI.chatLines[index].topBG:Hide()
+                    GUI.chatLines[index].rightBG:Hide()
+                    GUI.chatLines[index].leftBG:Hide()
+                    if GUI.chatLines[index].name:GetText() == '' then
+                        GUI.chatLines[index].teamColor:Hide()
+                    end
+                    GUI.chatLines[index].time = 0
+                    GUI.chatLines[index].OnFrame = function(self, delta)
+                        self.time = self.time + delta
+                        if self.time > ChatOptions.fade_time then
+                            if GUI.bg:IsHidden() then
+                                self:Hide()
+                            end
+                            self:SetNeedsFrameUpdate(false)
+                        end
+                    end
+                    GUI.chatLines[index]:SetNeedsFrameUpdate(true)
+                end
+            else
+                GUI.chatLines[index].nameBG:Disable()
+                GUI.chatLines[index].name:SetText('')
+                GUI.chatLines[index].text:SetText('')
+                GUI.chatLines[index].teamColor:SetSolidColor('00000000')
+                GUI.chatLines[index].textBG:SetSolidColor('00000000')
+                GUI.chatLines[index].nameBG:SetSolidColor('00000000')
+                GUI.chatLines[index].topBG:SetSolidColor('00000000')
+                GUI.chatLines[index].leftBG:SetSolidColor('00000000')
+                GUI.chatLines[index].rightBG:SetSolidColor('00000000')
+            end
+            GUI.chatLines[index]:SetAlpha(ChatOptions.win_alpha, true)
+            curTop = curTop + 1
+            index = index + 1
+        end
+    end
+end
+
+function FindClients(id)
+    local t = GetArmiesTable()
+    local focus = t.focusArmy
+    local result = {}
+    if focus == -1 then
+        for index,client in GetSessionClients() do
+            if not client.connected then
+                continue
+            end
+            local playerIsObserver = true
+            for id, player in GetArmiesTable().armiesTable do
+                if player.outOfGame and player.human and player.nickname == client.name then                        
+                    table.insert(result, index)
+                    playerIsObserver = false
+                    break
+                elseif player.nickname == client.name then
+                    playerIsObserver = false
+                    break
+                end
+            end
+            if playerIsObserver then
+                table.insert(result, index)
+            end
+        end
+    else
+        local srcs = {}
+        for army,info in t.armiesTable do
+            if id then
+                if army == id then
+                    for k,cmdsrc in info.authorizedCommandSources do
+                        srcs[cmdsrc] = true
+                    end
+                    break
+                end
+            else
+                if IsAlly(focus, army) then
+                    for k,cmdsrc in info.authorizedCommandSources do
+                        srcs[cmdsrc] = true
+                    end
+                end
+            end
+        end
+        for index,client in GetSessionClients() do
+            for k,cmdsrc in client.authorizedCommandSources do
+                if srcs[cmdsrc] then
+                    table.insert(result, index)
+                    break
+                end
+            end
+        end
+    end
+    return result
+end
+
+function CreateChatEdit()
+    local parent = GUI.bg:GetClientGroup()
+    local group = Group(parent)
+
+    group.Bottom:Set(parent.Bottom)
+    group.Right:Set(parent.Right)
+    group.Left:Set(parent.Left)
+    group.Top:Set(function() return group.Bottom() - group.Height() end)
+
+    local toText = UIUtil.CreateText(group, '', 14, 'Arial')
+    toText.Bottom:Set(function() return group.Bottom() - 1 end)
+    toText.Left:Set(function() return group.Left() + 35 end)
+
+    ChatTo.OnDirty = function(self)
+        if ToStrings[self()] then
+            toText:SetText(LOC(ToStrings[self()].caps))
+        else
+            toText:SetText(LOCF('%s %s:', ToStrings['to'].caps, GetArmyData(self()).nickname))
+        end
+    end
+
+    group.edit = Edit(group)
+    group.edit.Left:Set(function() return toText.Right() + 5 end)
+    group.edit.Right:Set(function() return group.Right() - 38 end)
+    group.edit.Depth:Set(function() return GUI.bg:GetClientGroup().Depth() + 200 end)
+    group.edit.Bottom:Set(function() return group.Bottom() - 1 end)
+    group.edit.Height:Set(function() return group.edit:GetFontHeight() end)
+    UIUtil.SetupEditStd(group.edit, "ff00ff00", nil, "ffffffff", UIUtil.highlightColor, UIUtil.bodyFont, 14, 200)
+    group.edit:SetDropShadow(true)
+    group.edit:ShowBackground(false)
+
+    group.edit:SetText('')
+
+    group.Height:Set(function() return group.edit.Height() end)
+
+    local function CreateTestBtn(text)
+        local btn = UIUtil.CreateCheckboxStd(group, '/dialogs/toggle_btn/toggle')
+        btn.Depth:Set(function() return group.Depth() + 10 end)
+        btn.OnClick = function(self, modifiers)
+            if self._checkState == "unchecked" then
+                self:ToggleCheck()
+            end
+        end
+        btn.txt = UIUtil.CreateText(btn, text, 12, UIUtil.bodyFont)
+        LayoutHelpers.AtCenterIn(btn.txt, btn)
+        btn.txt:SetColor('ffffffff')
+        btn.txt:DisableHitTest()
+        return btn
+    end
+
+    group.camData = UIUtil.CreateCheckbox(group,
+    UIUtil.SkinnableFile('/game/camera-btn/pinned_btn_up.dds'),
+    UIUtil.SkinnableFile('/game/camera-btn/pinned_btn_down.dds'),
+    UIUtil.SkinnableFile('/game/camera-btn/pinned_btn_over.dds'),
+    UIUtil.SkinnableFile('/game/camera-btn/pinned_btn_over.dds'),
+    UIUtil.SkinnableFile('/game/camera-btn/pinned_btn_dis.dds'),
+    UIUtil.SkinnableFile('/game/camera-btn/pinned_btn_dis.dds'))
+
+    LayoutHelpers.AtRightIn(group.camData, group, 5)
+    LayoutHelpers.AtVerticalCenterIn(group.camData, group.edit, -1)
+
+    group.chatBubble = Button(group,
+    UIUtil.UIFile('/game/chat-box_btn/radio_btn_up.dds'),
+    UIUtil.UIFile('/game/chat-box_btn/radio_btn_down.dds'),
+    UIUtil.UIFile('/game/chat-box_btn/radio_btn_over.dds'),
+    UIUtil.UIFile('/game/chat-box_btn/radio_btn_dis.dds'))
+    group.chatBubble.OnClick = function(self, modifiers)
+        if not self.list then
+            self.list = CreateChatList(self)
+            LayoutHelpers.Above(self.list, self, 15)
+            LayoutHelpers.AtLeftIn(self.list, self, 15)
+        else
+            self.list:Destroy()
+            self.list = nil
+        end
+    end
+
+    toText.HandleEvent = function(self, event)
+        if event.Type == 'ButtonPress' then
+            group.chatBubble:OnClick(event.Modifiers)
+        end
+    end
+
+    LayoutHelpers.AtLeftIn(group.chatBubble, group, 3)
+    LayoutHelpers.AtVerticalCenterIn(group.chatBubble, group.edit)
+
+    group.edit.OnNonTextKeyPressed = function(self, charcode, event)
+        GUI.bg.curTime = 0
+        local function RecallCommand(entryNumber)
+            self:SetText(commandHistory[self.recallEntry].text)
+            if commandHistory[self.recallEntry].camera then
+                self.tempCam = commandHistory[self.recallEntry].camera
+                group.camData:Disable()
+                group.camData:SetCheck(true)
+            else
+                self.tempCam = nil
+                group.camData:Enable()
+                group.camData:SetCheck(false)
+            end
+        end
+        if charcode == UIUtil.VK_NEXT then
+            local mod = 10
+            if event.Modifiers.Shift then
+                mod = 1
+            end
+            ChatPageDown(mod)
+            return true
+        elseif charcode == UIUtil.VK_PRIOR then
+            local mod = 10
+            if event.Modifiers.Shift then
+                mod = 1
+            end
+            ChatPageUp(mod)
+            return true
+        elseif charcode == UIUtil.VK_UP then
+            if table.getsize(commandHistory) > 0 then
+                if self.recallEntry then
+                    self.recallEntry = math.max(self.recallEntry-1, 1)
+                else
+                    self.recallEntry = table.getsize(commandHistory)
+                end
+                RecallCommand(self.recallEntry)
+            end
+        elseif charcode == UIUtil.VK_DOWN then
+            if table.getsize(commandHistory) > 0 then
+                if self.recallEntry then
+                    self.recallEntry = math.min(self.recallEntry+1, table.getsize(commandHistory))
+                    RecallCommand(self.recallEntry)
+                    if self.recallEntry == table.getsize(commandHistory) then
+                        self.recallEntry = nil
+                    end
+                else
+                    self:SetText('')
+                end
+            end
+        else
+            return true
+        end
+    end
+
+    group.edit.OnCharPressed = function(self, charcode)
+        local charLim = self:GetMaxChars()
+        if charcode == 9 then
+            return true
+        end
+        GUI.bg.curTime = 0
+        if STR_Utf8Len(self:GetText()) >= charLim then
+            local sound = Sound({Cue = 'UI_Menu_Error_01', Bank = 'Interface',})
+            PlaySound(sound)
+        end
+    end
+
+    group.edit.OnEnterPressed = function(self, text)
+        GUI.bg.curTime = 0
+        if group.camData:IsDisabled() then
+            group.camData:Enable()
+        end
+        if text == "" then
+            ToggleChat()
+        else
+            local gnBegin, gnEnd = string.find(text, "%s+")
+            if gnBegin and (gnBegin == 1 and gnEnd == string.len(text)) then
+                return
+            end
+            if import('/lua/ui/game/taunt.lua').CheckForAndHandleTaunt(text) then
+                return
+            end
+
+            msg = { to = ChatTo(), Chat = true }
+            if self.tempCam then
+                msg.camera = self.tempCam
+            elseif group.camData:IsChecked() then
+                msg.camera = GetCamera('WorldCamera'):SaveSettings()
+            end
+            msg.text = text
+            if ChatTo() == 'allies' then
+                if GetFocusArmy() ~= -1 then
+                    SessionSendChatMessage(FindClients(), msg)
+                else
+                    msg.Observer = true
+                    SessionSendChatMessage(FindClients(), msg)
+                end
+            elseif type(ChatTo()) == 'number' then
+                if GetFocusArmy() ~= -1 then
+                    SessionSendChatMessage(FindClients(ChatTo()), msg)
+                    msg.echo = true
+                    msg.from = GetArmyData(GetFocusArmy()).nickname
+                    ReceiveChat(GetArmyData(ChatTo()).nickname, msg)
+                end
+            else
+                if GetFocusArmy() == -1 then
+                    msg.Observer = true
+                    SessionSendChatMessage(FindClients(), msg)
+                else
+                    SessionSendChatMessage(msg)
+                end
+            end
+            table.insert(commandHistory, msg)
+            self.recallEntry = nil
+            self.tempCam = nil
+        end
+    end
+
+    ChatTo:Set('all')
+    group.edit:AcquireFocus()
+
+    return group
+end
+
+function ReceiveChat(sender, msg)
+    if not msg.ConsoleOutput then
+        SimCallback({Func="SaveChatToReplay", Args={Sender=sender, Msg=msg}} , true)
+    end
+    if not SessionIsReplay() then
+        ReceiveChatFromSim(sender, msg)
+    end
+end
+
+function ReceiveChatFromSim(sender, msg)        
+    sender = sender or "nil sender"
+    if msg.ConsoleOutput then
+        print(LOCF("%s %s", sender, msg.ConsoleOutput))
+        return
+    end
+    if not msg.Chat then            
+        return
+    end
+    if type(msg) == 'string' then
+        msg = { text = msg }
+    elseif type(msg) ~= 'table' then
+        msg = { text = repr(msg) }
+    end
+    local armyData = GetArmyData(sender)
+    if not armyData and GetFocusArmy() ~= -1 and not SessionIsReplay() then
+        return
+    end
+    local towho = LOC(ToStrings[msg.to].text) or LOC(ToStrings['private'].text)     
+    local tokey = ToStrings[msg.to].colorkey or ToStrings['private'].colorkey
+    if msg.Observer then
+        towho = LOC("<LOC lobui_0592>to observes:")
+        tokey = "link_color"            
+    end
+    if msg.Observer and armyData.faction then
+        armyData.faction = table.getn(FactionsIcon) - 1
+    end
+    if type(msg.to) == 'number' and SessionIsReplay() then
+        towho = string.format("%s %s:", LOC(ToStrings.to.text), GetArmyData(msg.to).nickname)
+    end
+    local name = sender .. ' ' .. towho
+
+    if msg.echo then            
+        if msg.from and SessionIsReplay() then
+            armyData = GetArmyData(msg.from)
+            name = string.format("%s %s %s:", msg.from, LOC(ToStrings.to.text), GetArmyData(msg.to).nickname)
+        else
+            name = string.format("%s %s:", LOC(ToStrings.to.caps), sender)
+        end
+    end     
+    local tempText = WrapText({text = msg.text, name = name})
+    -- if text wrap produces no lines (ie text is all white space) then add a blank line
+    if table.getn(tempText) == 0 then
+        tempText = {""} 
+    end
+    local entry = {
+        name = name,
+        tokey = tokey,
+        color = (armyData.color or "ffffffff"),
+        armyID = (armyData.ArmyID or 1),
+        faction = (armyData.faction or (table.getn(FactionsIcon)-1))+1,
+        text = msg.text,
+        wrappedtext = tempText,
+        new = true
+    }
+
+    if msg.camera then
+        entry.camera = msg.camera
+    end
+    table.insert(chatHistory, entry)
+    if ChatOptions[entry.armyID] then
+        if table.getsize(chatHistory) == 1 then
+            GUI.chatContainer:CalcVisible()
+        else
+            GUI.chatContainer:ScrollToBottom()
+        end
+    end
+    if SessionIsReplay() then
+        PlaySound(Sound({Bank = 'Interface', Cue = 'UI_Diplomacy_Close'}))
+    end
+end
+function ToggleChat()
+    if GUI.bg:IsHidden() then           
+        GUI.bg:Show()
+        GUI.chatEdit.edit:AcquireFocus()
+        if not GUI.bg.pinned then
+            GUI.bg:SetNeedsFrameUpdate(true)
+            GUI.bg.curTime = 0
+        end
+        for i, v in GUI.chatLines do
+            v:SetNeedsFrameUpdate(false)
+            v:Show()
+            v.OnFrame = nil
+        end         
+    else
+        GUI.bg:Hide()
+        GUI.chatEdit.edit:AbandonFocus()
+        GUI.bg:SetNeedsFrameUpdate(false)
+    end
+end
+
+function ActivateChat(modifiers)        
+    if type(ChatTo()) ~= 'number' then
+        if modifiers.Shift then
+            ChatTo:Set('allies')
+        else
+            ChatTo:Set('all')
+        end
+    end
+    ToggleChat()        
+end
+
+-------------------------
+-- Added for sorian ai --
+-------------------------
+
+function CreateChatList(parent)
+    local armies = GetArmiesTable()
+    local container = Group(GUI.chatEdit)
+    container:DisableHitTest()
+    container.Depth:Set(GetFrame(0):GetTopmostDepth() + 1)
+    container.entries = {}
+    local function CreatePlayerEntry(data)
+        if not data.human and not data.civilian then
+            data.nickname = UiUtilsS.trim(string.gsub(data.nickname,'%b()', '' ))
+        end
+        local text = UIUtil.CreateText(container, data.nickname, 12, "Arial")
+        text:SetColor('ffffffff')
+        text:DisableHitTest()
+
+        text.BG = Bitmap(text)
+        text.BG:SetSolidColor('ff000000')
+        text.BG.Depth:Set(function() return text.Depth() - 1 end)
+        text.BG.Left:Set(function() return text.Left() - 6 end)
+        text.BG.Top:Set(function() return text.Top() - 1 end)
+        text.BG.Width:Set(function() return container.Width() + 8 end)
+        text.BG.Bottom:Set(function() return text.Bottom() + 1 end)
+
+        text.BG.HandleEvent = function(self, event)
+            if event.Type == 'MouseEnter' then
+                self:SetSolidColor('ff666666')
+            elseif event.Type == 'MouseExit' then
+                self:SetSolidColor('ff000000')
+            elseif event.Type == 'ButtonPress' then
+                ChatTo:Set(data.armyID)
+                container:Destroy()
+                parent.list = nil
+                GUI.chatEdit.edit:Enable()
+                GUI.chatEdit.edit:AcquireFocus()
+            end
+            GUI.bg.curTime = 0
+        end
+        return text
+    end
+
+    local entries = {
+        {nickname = ToStrings.all.caps, armyID = 'all'},
+        {nickname = ToStrings.allies.caps, armyID = 'allies'},
+    }
+
+    for armyID, armyData in armies.armiesTable do
+        if armyID ~= armies.focusArmy and not armyData.civilian then
+            table.insert(entries, {nickname = armyData.nickname, armyID = armyID})
+        end
+    end
+
+    local maxWidth = 0
+    local height = 0
+    for index, data in entries do
+        local i = index
+        table.insert(container.entries, CreatePlayerEntry(data))
+        if container.entries[i].Width() > maxWidth then
+            maxWidth = container.entries[i].Width() + 8
+        end
+        height = height + container.entries[i].Height()
+        if i > 1 then
+            LayoutHelpers.Above(container.entries[i], container.entries[i-1])
+        else
+            LayoutHelpers.AtLeftIn(container.entries[i], container)
+            LayoutHelpers.AtBottomIn(container.entries[i], container)
+        end
+    end
+    container.Width:Set(maxWidth)
+    container.Height:Set(height)
+
+    container.LTBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_ul.dds'))
+    container.LTBG:DisableHitTest()
+    container.LTBG.Right:Set(container.Left)
+    container.LTBG.Bottom:Set(container.Top)
+
+    container.RTBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_ur.dds'))
+    container.RTBG:DisableHitTest()
+    container.RTBG.Left:Set(container.Right)
+    container.RTBG.Bottom:Set(container.Top)
+
+    container.RBBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_lr.dds'))
+    container.RBBG:DisableHitTest()
+    container.RBBG.Left:Set(container.Right)
+    container.RBBG.Top:Set(container.Bottom)
+
+    container.RLBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_ll.dds'))
+    container.RLBG:DisableHitTest()
+    container.RLBG.Right:Set(container.Left)
+    container.RLBG.Top:Set(container.Bottom)
+
+    container.LBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_vert_l.dds'))
+    container.LBG:DisableHitTest()
+    container.LBG.Right:Set(container.Left)
+    container.LBG.Top:Set(container.Top)
+    container.LBG.Bottom:Set(container.Bottom)
+
+    container.RBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_vert_r.dds'))
+    container.RBG:DisableHitTest()
+    container.RBG.Left:Set(container.Right)
+    container.RBG.Top:Set(container.Top)
+    container.RBG.Bottom:Set(container.Bottom)
+
+    container.TBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_horz_um.dds'))
+    container.TBG:DisableHitTest()
+    container.TBG.Left:Set(container.Left)
+    container.TBG.Right:Set(container.Right)
+    container.TBG.Bottom:Set(container.Top)
+
+    container.BBG = Bitmap(container, UIUtil.UIFile('/game/chat_brd/drop-box_brd_lm.dds'))
+    container.BBG:DisableHitTest()
+    container.BBG.Left:Set(container.Left)
+    container.BBG.Right:Set(container.Right)
+    container.BBG.Top:Set(container.Bottom)
+
+    function DestroySelf()
+        parent:OnClick()
+    end
+
+    UIMain.AddOnMouseClickedFunc(DestroySelf)
+
+    container.OnDestroy = function(self)
+        UIMain.RemoveOnMouseClickedFunc(DestroySelf)
+    end
+
+    return container
+end
+
 function SetupChatLayout(mapGroup)
     savedParent = mapGroup
     CreateChat()
     import('/lua/ui/game/gamemain.lua').RegisterChatFunc(ReceiveChat, 'Chat')
 end
-	
-	function CreateChat()
-		if GUI.bg then
-			GUI.bg.OnClose()
-		end
-		GUI.bg = CreateChatBackground()
-		GUI.chatEdit = CreateChatEdit()
-		GUI.bg.OnResize = function(self, x, y, firstFrame)
-			if firstFrame then
-				self:SetNeedsFrameUpdate(false)
-			end
-			CreateChatLines()
-			GUI.chatContainer:CalcVisible()
-		end
-		GUI.bg.OnResizeSet = function(self)
-			if not self:IsPinned() then
-				self:SetNeedsFrameUpdate(true)
-			end
-			RewrapLog()
-			CreateChatLines()
-			GUI.chatContainer:CalcVisible()
-			GUI.chatEdit.edit:AcquireFocus()
-		end
-		GUI.bg.OnMove = function(self, x, y, firstFrame)
-			if firstFrame then
-				self:SetNeedsFrameUpdate(false)
-			end
-		end
-		GUI.bg.OnMoveSet = function(self)
-			GUI.chatEdit.edit:AcquireFocus()
-			if not self:IsPinned() then
-				self:SetNeedsFrameUpdate(true)
-			end
-		end
-		GUI.bg.OnMouseWheel = function(self, rotation)
-			local newTop = GUI.chatContainer.top - math.floor(rotation / 100)
-			GUI.chatContainer:ScrollSetTop(nil, newTop)
-		end
-		GUI.bg.OnClose = function(self)
-			ToggleChat()
-		end
-		GUI.bg.OnOptionsSet = function(self)
-			GUI.chatContainer:Destroy()
-			GUI.chatContainer = false
-			for i, v in GUI.chatLines do
-				v:Destroy()
-			end
-			GUI.bg:SetAlpha(ChatOptions.win_alpha, true)
-			GUI.chatLines = {}
-			CreateChatLines()
-			RewrapLog()
-			GUI.chatContainer:CalcVisible()
-			GUI.chatEdit.edit:AcquireFocus()
-			if not GUI.bg.pinned then
-				GUI.bg.curTime = 0
-				GUI.bg:SetNeedsFrameUpdate(true)
-			end
-		end
-		GUI.bg.OnHideWindow = function(self, hidden)
-			if not hidden then
-				for i, v in GUI.chatLines do
-					v:SetNeedsFrameUpdate(false)
-				end
-			end
-		end
-		GUI.bg.curTime = 0
-		GUI.bg.pinned = false
-		GUI.bg.OnFrame = function(self, delta)
-			self.curTime = self.curTime + delta
-			if self.curTime > ChatOptions.fade_time then
-				ToggleChat()
-			end
-		end
-		GUI.bg.OnPinCheck = function(self, checked)
-			GUI.bg.pinned = checked
-			GUI.bg:SetNeedsFrameUpdate(not checked)
-			GUI.bg.curTime = 0
-			GUI.chatEdit.edit:AcquireFocus()
-			if checked then
-				Tooltip.AddCheckboxTooltip(GUI.bg._pinBtn, 'chat_pinned')
-			else
-				Tooltip.AddCheckboxTooltip(GUI.bg._pinBtn, 'chat_pin')
-			end
-		end
-		GUI.bg.OnConfigClick = function(self, checked)
-			if GUI.config then GUI.config:Destroy() GUI.config = false return end
-			CreateConfigWindow()
-			GUI.bg:SetNeedsFrameUpdate(false)
-			
-		end
-		for i, v in GetArmiesTable().armiesTable do
-			if not v.civilian then
-				ChatOptions[i] = true
-			end
-		end
-		GUI.bg:SetAlpha(ChatOptions.win_alpha, true)
-		Tooltip.AddButtonTooltip(GUI.bg._closeBtn, 'chat_close')
-		GUI.bg.OldHandleEvent = GUI.bg.HandleEvent
-		GUI.bg.HandleEvent = function(self, event)
-			if event.Type == "WheelRotation" and self:IsHidden() then
-				import('/lua/ui/game/worldview.lua').ForwardMouseWheelInput(event)
-				return true
-			else
-				return GUI.bg.OldHandleEvent(self, event)
-			end
-		end
-		
-		Tooltip.AddCheckboxTooltip(GUI.bg._pinBtn, 'chat_pin')
-		Tooltip.AddControlTooltip(GUI.bg._configBtn, 'chat_config')
-		Tooltip.AddControlTooltip(GUI.bg._closeBtn, 'chat_close')
-		Tooltip.AddCheckboxTooltip(GUI.chatEdit.camData, 'chat_camera')
-		
-		ChatOptions['links'] = ChatOptions.links or true
-		CreateChatLines()
-		RewrapLog()
-		GUI.chatContainer:CalcVisible()
-		ToggleChat()
-	end
-	
+
+function CreateChat()
+    if GUI.bg then
+        GUI.bg.OnClose()
+    end
+    GUI.bg = CreateChatBackground()
+    GUI.chatEdit = CreateChatEdit()
+    GUI.bg.OnResize = function(self, x, y, firstFrame)
+        if firstFrame then
+            self:SetNeedsFrameUpdate(false)
+        end
+        CreateChatLines()
+        GUI.chatContainer:CalcVisible()
+    end
+    GUI.bg.OnResizeSet = function(self)
+        if not self:IsPinned() then
+            self:SetNeedsFrameUpdate(true)
+        end
+        RewrapLog()
+        CreateChatLines()
+        GUI.chatContainer:CalcVisible()
+        GUI.chatEdit.edit:AcquireFocus()
+    end
+    GUI.bg.OnMove = function(self, x, y, firstFrame)
+        if firstFrame then
+            self:SetNeedsFrameUpdate(false)
+        end
+    end
+    GUI.bg.OnMoveSet = function(self)
+        GUI.chatEdit.edit:AcquireFocus()
+        if not self:IsPinned() then
+            self:SetNeedsFrameUpdate(true)
+        end
+    end
+    GUI.bg.OnMouseWheel = function(self, rotation)
+        local newTop = GUI.chatContainer.top - math.floor(rotation / 100)
+        GUI.chatContainer:ScrollSetTop(nil, newTop)
+    end
+    GUI.bg.OnClose = function(self)
+        ToggleChat()
+    end
+    GUI.bg.OnOptionsSet = function(self)
+        GUI.chatContainer:Destroy()
+        GUI.chatContainer = false
+        for i, v in GUI.chatLines do
+            v:Destroy()
+        end
+        GUI.bg:SetAlpha(ChatOptions.win_alpha, true)
+        GUI.chatLines = {}
+        CreateChatLines()
+        RewrapLog()
+        GUI.chatContainer:CalcVisible()
+        GUI.chatEdit.edit:AcquireFocus()
+        if not GUI.bg.pinned then
+            GUI.bg.curTime = 0
+            GUI.bg:SetNeedsFrameUpdate(true)
+        end
+    end
+    GUI.bg.OnHideWindow = function(self, hidden)
+        if not hidden then
+            for i, v in GUI.chatLines do
+                v:SetNeedsFrameUpdate(false)
+            end
+        end
+    end
+    GUI.bg.curTime = 0
+    GUI.bg.pinned = false
+    GUI.bg.OnFrame = function(self, delta)
+        self.curTime = self.curTime + delta
+        if self.curTime > ChatOptions.fade_time then
+            ToggleChat()
+        end
+    end
+    GUI.bg.OnPinCheck = function(self, checked)
+        GUI.bg.pinned = checked
+        GUI.bg:SetNeedsFrameUpdate(not checked)
+        GUI.bg.curTime = 0
+        GUI.chatEdit.edit:AcquireFocus()
+        if checked then
+            Tooltip.AddCheckboxTooltip(GUI.bg._pinBtn, 'chat_pinned')
+        else
+            Tooltip.AddCheckboxTooltip(GUI.bg._pinBtn, 'chat_pin')
+        end
+    end
+    GUI.bg.OnConfigClick = function(self, checked)
+        if GUI.config then GUI.config:Destroy() GUI.config = false return end
+        CreateConfigWindow()
+        GUI.bg:SetNeedsFrameUpdate(false)
+
+    end
+    for i, v in GetArmiesTable().armiesTable do
+        if not v.civilian then
+            ChatOptions[i] = true
+        end
+    end
+    GUI.bg:SetAlpha(ChatOptions.win_alpha, true)
+    Tooltip.AddButtonTooltip(GUI.bg._closeBtn, 'chat_close')
+    GUI.bg.OldHandleEvent = GUI.bg.HandleEvent
+    GUI.bg.HandleEvent = function(self, event)
+        if event.Type == "WheelRotation" and self:IsHidden() then
+            import('/lua/ui/game/worldview.lua').ForwardMouseWheelInput(event)
+            return true
+        else
+            return GUI.bg.OldHandleEvent(self, event)
+        end
+    end
+
+    Tooltip.AddCheckboxTooltip(GUI.bg._pinBtn, 'chat_pin')
+    Tooltip.AddControlTooltip(GUI.bg._configBtn, 'chat_config')
+    Tooltip.AddControlTooltip(GUI.bg._closeBtn, 'chat_close')
+    Tooltip.AddCheckboxTooltip(GUI.chatEdit.camData, 'chat_camera')
+
+    ChatOptions['links'] = ChatOptions.links or true
+    CreateChatLines()
+    RewrapLog()
+    GUI.chatContainer:CalcVisible()
+    ToggleChat()
+end
+
 function RewrapLog()
     local tempSize = 0
     for i, v in chatHistory do
@@ -1174,16 +1184,16 @@ end
 
 function WrapText(data)
     return import('/lua/maui/text.lua').WrapText(data.text, 
-            function(line)
-                if line == 1 then
-                    return GUI.chatLines[1].Right() - (GUI.chatLines[1].teamColor.Right() + GUI.chatLines[1].name:GetStringAdvance(data.name) + 4)
-                else
-                    return GUI.chatLines[1].Right() - GUI.chatLines[1].nameBG.Right()
-                end
-            end, 
-            function(text) 
-                return GUI.chatLines[1].text:GetStringAdvance(text) 
-            end)
+    function(line)
+        if line == 1 then
+            return GUI.chatLines[1].Right() - (GUI.chatLines[1].teamColor.Right() + GUI.chatLines[1].name:GetStringAdvance(data.name) + 4)
+        else
+            return GUI.chatLines[1].Right() - GUI.chatLines[1].nameBG.Right()
+        end
+    end, 
+    function(text) 
+        return GUI.chatLines[1].text:GetStringAdvance(text) 
+    end)
 end
 
 function GetArmyData(army)
@@ -1217,7 +1227,7 @@ end
 
 function ToggleChat()
     if GUI.bg:IsHidden() then
-        if GetFocusArmy() != -1 then
+        if GetFocusArmy() ~= -1 then
             GUI.bg:Show()
             GUI.chatEdit.edit:AcquireFocus()
             if not GUI.bg.pinned then
@@ -1238,8 +1248,8 @@ function ToggleChat()
 end
 
 function ActivateChat(modifiers)
-    if GetFocusArmy() != -1 then
-        if type(ChatTo()) != 'number' then
+    if GetFocusArmy() ~= -1 then
+        if type(ChatTo()) ~= 'number' then
             if modifiers.Shift then
                 ChatTo:Set('allies')
             else
@@ -1271,63 +1281,63 @@ function CreateConfigWindow()
     GUI.config.Width:Set(300)
     LayoutHelpers.AtHorizontalCenterIn(GUI.config, GetFrame(0))
     LayoutHelpers.ResetRight(GUI.config)
-    
+
     GUI.config.DragTL = Bitmap(GUI.config, UIUtil.SkinnableFile('/game/drag-handle/drag-handle-ul_btn_up.dds'))
     GUI.config.DragTR = Bitmap(GUI.config, UIUtil.SkinnableFile('/game/drag-handle/drag-handle-ur_btn_up.dds'))
     GUI.config.DragBL = Bitmap(GUI.config, UIUtil.SkinnableFile('/game/drag-handle/drag-handle-ll_btn_up.dds'))
     GUI.config.DragBR = Bitmap(GUI.config, UIUtil.SkinnableFile('/game/drag-handle/drag-handle-lr_btn_up.dds'))
-    
+
     LayoutHelpers.AtLeftTopIn(GUI.config.DragTL, GUI.config, -24, -8)
-    
+
     LayoutHelpers.AtRightTopIn(GUI.config.DragTR, GUI.config, -22, -8)
-    
+
     LayoutHelpers.AtLeftIn(GUI.config.DragBL, GUI.config, -24)
     LayoutHelpers.AtBottomIn(GUI.config.DragBL, GUI.config, -8)
-    
+
     LayoutHelpers.AtRightIn(GUI.config.DragBR, GUI.config, -22)
     LayoutHelpers.AtBottomIn(GUI.config.DragBR, GUI.config, -8)
-    
+
     GUI.config.DragTL.Depth:Set(function() return GUI.config.Depth() + 10 end)
     GUI.config.DragTR.Depth:Set(GUI.config.DragTL.Depth)
     GUI.config.DragBL.Depth:Set(GUI.config.DragTL.Depth)
     GUI.config.DragBR.Depth:Set(GUI.config.DragTL.Depth)
-    
+
     GUI.config.DragTL:DisableHitTest()
     GUI.config.DragTR:DisableHitTest()
     GUI.config.DragBL:DisableHitTest()
     GUI.config.DragBR:DisableHitTest()
-    
+
     GUI.config.OnClose = function(self)
         GUI.config:Destroy()
         GUI.config = false
     end
-    
+
     local options = {
         filters = {{type = 'filter', name = '<LOC _Links>Links', key = 'links', tooltip = 'chat_filter'}},
         winOptions = {
-                {type = 'color', name = '<LOC _All>', key = 'all_color', tooltip = 'chat_color'},
-                {type = 'color', name = '<LOC _Allies>', key = 'allies_color', tooltip = 'chat_color'},
-                {type = 'color', name = '<LOC _Private>', key = 'priv_color', tooltip = 'chat_color'},
-                {type = 'color', name = '<LOC _Links>', key = 'link_color', tooltip = 'chat_color'},
-                {type = 'splitter'},
-                {type = 'slider', name = '<LOC chat_0009>Chat Font Size', key = 'font_size', tooltip = 'chat_fontsize', min = 12, max = 18, inc = 2},
-                {type = 'slider', name = '<LOC chat_0010>Window Fade Time', key = 'fade_time', tooltip = 'chat_fadetime', min = 5, max = 30, inc = 1},
-                {type = 'slider', name = '<LOC chat_0011>Window Alpha', key = 'win_alpha', tooltip = 'chat_alpha', min = 20, max = 100, inc = 1},
+            {type = 'color', name = '<LOC _All>', key = 'all_color', tooltip = 'chat_color'},
+            {type = 'color', name = '<LOC _Allies>', key = 'allies_color', tooltip = 'chat_color'},
+            {type = 'color', name = '<LOC _Private>', key = 'priv_color', tooltip = 'chat_color'},
+            {type = 'color', name = '<LOC _Links>', key = 'link_color', tooltip = 'chat_color'},
+            {type = 'splitter'},
+            {type = 'slider', name = '<LOC chat_0009>Chat Font Size', key = 'font_size', tooltip = 'chat_fontsize', min = 12, max = 18, inc = 2},
+            {type = 'slider', name = '<LOC chat_0010>Window Fade Time', key = 'fade_time', tooltip = 'chat_fadetime', min = 5, max = 30, inc = 1},
+            {type = 'slider', name = '<LOC chat_0011>Window Alpha', key = 'win_alpha', tooltip = 'chat_alpha', min = 20, max = 100, inc = 1},
         },
     }
-        
+
     local optionGroup = Group(GUI.config:GetClientGroup())
     LayoutHelpers.FillParent(optionGroup, GUI.config:GetClientGroup())
     optionGroup.options = {}
     local tempOptions = {}
-    
+
     local function UpdateOption(key, value)
         if key == 'win_alpha' then
             value = value / 100
         end
         tempOptions[key] = value
     end
-    
+
     local function CreateSplitter()
         local splitter = Bitmap(optionGroup)
         splitter:SetSolidColor('ff000000')
@@ -1336,7 +1346,7 @@ function CreateConfigWindow()
         splitter.Height:Set(2)
         return splitter
     end
-    
+
     local function CreateEntry(data)
         local group = Group(optionGroup)
         if data.type == 'filter' then
@@ -1372,10 +1382,10 @@ function CreateConfigWindow()
             group.name = UIUtil.CreateText(group, data.name, 14, "Arial")
             LayoutHelpers.AtLeftTopIn(group.name, group)
             group.slider = IntegerSlider(group, false, 
-                data.min, data.max, 
-                data.inc, UIUtil.SkinnableFile('/slider02/slider_btn_up.dds'), 
-                UIUtil.SkinnableFile('/slider02/slider_btn_over.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_down.dds'), 
-                UIUtil.SkinnableFile('/dialogs/options-02/slider-back_bmp.dds'))
+            data.min, data.max, 
+            data.inc, UIUtil.SkinnableFile('/slider02/slider_btn_up.dds'), 
+            UIUtil.SkinnableFile('/slider02/slider_btn_over.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_down.dds'), 
+            UIUtil.SkinnableFile('/dialogs/options-02/slider-back_bmp.dds'))
             LayoutHelpers.Below(group.slider, group.name)
             group.slider.key = data.key
             group.Height:Set(function() return group.name.Height() + group.slider.Height() end)
@@ -1399,19 +1409,19 @@ function CreateConfigWindow()
             group.Width:Set(group.split.Width)
             group.Height:Set(group.split.Height)
         end
-        if data.type != 'splitter' then
+        if data.type ~= 'splitter' then
             Tooltip.AddControlTooltip(group, data.tooltip or 'chat_filter')
         end
         return group
     end
-    
+
     local armyData = GetArmiesTable()
     for i, v in armyData.armiesTable do
         if not v.civilian then
             table.insert(options.filters, {type = 'filter', name = v.nickname, key = i})
         end
     end
-    
+
     local filterTitle = UIUtil.CreateText(optionGroup, '<LOC chat_0012>Message Filters', 14, "Arial Bold")
     LayoutHelpers.AtLeftTopIn(filterTitle, optionGroup, 5, 5)
     Tooltip.AddControlTooltip(filterTitle, 'chat_filter')
@@ -1430,12 +1440,12 @@ function CreateConfigWindow()
     local splitIndex = index
     local splitter = CreateSplitter()
     splitter.Top:Set(function() return optionGroup.options[splitIndex-1].Bottom() + 5 end)
-    
+
     local WindowTitle = UIUtil.CreateText(optionGroup, '<LOC chat_0013>Message Colors', 14, "Arial Bold")
     LayoutHelpers.Below(WindowTitle, splitter, 5)
     WindowTitle.Left:Set(filterTitle.Left)
     Tooltip.AddControlTooltip(WindowTitle, 'chat_color')
-    
+
     local firstOption = true
     local optionIndex = 1
     for i, v in options.winOptions do
@@ -1459,7 +1469,7 @@ function CreateConfigWindow()
         optionIndex = optionIndex + 1
         index = index + 1
     end
-    
+
     local resetBtn = UIUtil.CreateButtonStd(optionGroup, '/widgets02/small', '<LOC _Reset>', 16)
     LayoutHelpers.Below(resetBtn, optionGroup.options[index-1], 4)
     LayoutHelpers.AtHorizontalCenterIn(resetBtn, optionGroup)
@@ -1481,7 +1491,7 @@ function CreateConfigWindow()
             end
         end
     end
-    
+
     local okBtn = UIUtil.CreateButtonStd(optionGroup, '/widgets02/small', '<LOC _Ok>', 16)
     LayoutHelpers.Below(okBtn, resetBtn, 4)
     LayoutHelpers.AtLeftIn(okBtn, optionGroup)
@@ -1492,7 +1502,7 @@ function CreateConfigWindow()
         GUI.config:Destroy()
         GUI.config = false
     end
-    
+
     local cancelBtn = UIUtil.CreateButtonStd(optionGroup, '/widgets02/small', '<LOC _Cancel>', 16)
     LayoutHelpers.Below(cancelBtn, resetBtn, 4)
     LayoutHelpers.AtRightIn(cancelBtn, optionGroup)
@@ -1501,8 +1511,8 @@ function CreateConfigWindow()
         GUI.config:Destroy()
         GUI.config = false
     end
-    
-    
+
+
     GUI.config.Bottom:Set(function() return okBtn.Bottom() + 5 end)
 end
 

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -31,11 +31,8 @@ local isReplay = false
 
 local waitingDialog = false
 
-###variables for FAF
-local sendChat = import('/lua/ui/game/chat.lua').ReceiveChatFromSim
 local oldData = {}
 local lastObserving
-##end faf variables
 
 -- Hotbuild stuff
 modifiersKeys = {}
@@ -43,7 +40,7 @@ modifiersKeys = {}
 local currentKeyMap = import('/lua/keymap/keymapper.lua').GetKeyMappings(true)
 for key, action in currentKeyMap do
     if action["category"] == "hotbuilding" then
-        if key != nil then
+        if key ~= nil then
             if not import('/lua/keymap/keymapper.lua').IsKeyInMap("Shift-" .. key, currentKeyMap) then
                 modifiersKeys["Shift-" .. key] = action
             else
@@ -134,7 +131,7 @@ function OnFirstUpdate()
                end
                )
 
-    if Prefs.GetOption('skin_change_on_start') != 'no' then
+    if Prefs.GetOption('skin_change_on_start') ~= 'no' then
         local focusarmy = GetFocusArmy()
         local armyInfo = GetArmiesTable()
         if focusarmy >= 1 then
@@ -224,17 +221,15 @@ function CreateUI(isReplay)
     Prefetcher:Update(prefetchTable)
 
 
-    ##below added for FAF
-    import("/modules/displayrings.lua").Init()	##added for acu and engineer build radius ui mod
+    import("/modules/displayrings.lua").Init()	--#added for acu and engineer build radius ui mod
     if SessionIsReplay() then
-        ForkThread(SendChat)
         lastObserving = true
         import('/lua/ui/game/economy.lua').ToggleEconPanel(false)
         import('/lua/ui/game/avatars.lua').ToggleAvatars(false)
         AddBeatFunction(UiBeat)
     end
 
-    if options.gui_scu_manager != 0 then
+    if options.gui_scu_manager ~= 0 then
         import('/modules/scumanager.lua').Init()
     end
 
@@ -442,8 +437,8 @@ function OnQueueChanged(newQueue)
     end
 end
 
-# Called after the Sim has confirmed the game is indeed paused. This will happen
-# on everyone's machine in a network game.
+-- Called after the Sim has confirmed the game is indeed paused. This will happen
+-- on everyone's machine in a network game.
 function OnPause(pausedBy, timeoutsRemaining)
     local isOwner = false
     if pausedBy == SessionGetLocalCommandSource() then
@@ -456,7 +451,7 @@ function OnPause(pausedBy, timeoutsRemaining)
     import('/lua/ui/game/missiontext.lua').OnGamePause(true)
 end
 
-# Called after the Sim has confirmed that the game has resumed.
+-- Called after the Sim has confirmed that the game has resumed.
 function OnResume()
     PauseSound("World",false)
     PauseSound("Music",false)
@@ -465,9 +460,9 @@ function OnResume()
     import('/lua/ui/game/missiontext.lua').OnGamePause(false)
 end
 
-# Called immediately when the user hits the pause button. This only ever gets
-# called on the machine that initiated the pause (i.e. other network players
-                                                  # won't call this)
+-- Called immediately when the user hits the pause button. This only ever gets
+-- called on the machine that initiated the pause (i.e. other network players
+                                                  -- won't call this)
 function OnUserPause(pause)
     local Tabs = import('/lua/ui/game/tabs.lua')
     local focus = GetArmiesTable().focusArmy
@@ -566,10 +561,10 @@ function HideGameUI(state)
     end
 end
 
-# Given a userunit that is adjacent to a given blueprint, does it yield a
-# bonus? Used by the UI to draw extra info
+-- Given a userunit that is adjacent to a given blueprint, does it yield a
+-- bonus? Used by the UI to draw extra info
 function OnDetectAdjacencyBonus(userUnit, otherBp)
-    # fixme: todo
+    -- fixme: todo
     return true
 end
 
@@ -619,7 +614,7 @@ function NISMode(state)
             ConExecute(i..' false')
         end
         preNISSettings.gameSpeed = GetGameSpeed()
-        if preNISSettings.gameSpeed != 0 then
+        if preNISSettings.gameSpeed ~= 0 then
             SetGameSpeed(0)
         end
         preNISSettings.Units = GetSelectedUnits()
@@ -635,7 +630,7 @@ function NISMode(state)
         end
         worldView.viewLeft:EnableResourceRendering(preNISSettings.Resources)
         worldView.viewLeft:SetCartographic(preNISSettings.Cartographic)
-        # Todo: Restore settings of overlays, lifebars properly
+        -- Todo: Restore settings of overlays, lifebars properly
         ConExecute('UI_RenderUnitBars true')
         ConExecute('UI_NisRenderIcons true')
         ConExecute('ren_SelectBoxes true')
@@ -646,7 +641,7 @@ function NISMode(state)
                 ConExecute(i..' '..tostring(Prefs.GetFromCurrentProfile(i)))
             end
         end
-        if GetGameSpeed() != preNISSettings.gameSpeed then
+        if GetGameSpeed() ~= preNISSettings.gameSpeed then
             SetGameSpeed(preNISSettings.gameSpeed)
         end
         SelectUnits(preNISSettings.Units)
@@ -768,14 +763,12 @@ function SimChangeCameraZoom(newMult)
         defaultZoom = newMult
         local views = import('/lua/ui/game/worldview.lua').GetWorldViews()
         for _, viewControl in views do
-            if viewControl._cameraName != 'MiniMap' then
+            if viewControl._cameraName ~= 'MiniMap' then
                 GetCamera(viewControl._cameraName):SetMaxZoomMult(newMult)
             end
         end
     end
 end
-
-####below is FAF function
 
 function UiBeat()
     local observing = (GetFocusArmy() == -1)
@@ -785,35 +778,5 @@ function UiBeat()
     end
     if HasCommandLineArg("/syncreplay") and HasCommandLineArg("/gpgnet") then	
         GpgNetSend("BEAT",GameTick(),GetGameSpeed()) 
-    end
-end
-
-SendChat = function()
-    while true do
-        if UnitData.Chat then
-            if table.getn(UnitData.Chat) > 0 then
-                for index, chat in UnitData.Chat do
-                    local newChat = true
-                    if table.getn(oldData) > 0 then
-                        for index, old in oldData do
-                            if (old.oldTime + 3) < GetGameTimeSeconds() then
-                                oldData[index] = nil
-                            elseif old.msg.text == chat.msg.text and old.sender == chat.sender and chat.msg.to == old.msg.to then
-                                newChat = false
-                            elseif type(chat.msg.to) == 'number' and chat.msg.to == old.msg.to and old.msg.text == chat.msg.text then
-                                newChat = false
-                            end
-                        end
-                    end						
-                    if newChat then							
-                        chat.oldTime = GetGameTimeSeconds()
-                        table.insert(oldData, chat)
-                        sendChat(chat.sender, chat.msg)
-                    end
-                end
-                UnitData.Chat = {}
-            end
-        end
-        WaitSeconds(0.1)
     end
 end


### PR DESCRIPTION
- Saving chat to replay now uses own callback.
- Got rid of a thread watching sync every tick, instead check in UserSync
- Security check in UserSync so the game runs in replay-mode.
- Keep track of chat-id to remove identical messages

Fixes #125
