### PR TITLE
Use a shorter format for observer metadata

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -4006,37 +4006,31 @@ function CreateUI(maxPlayers)
                     end
                 end
                 for slot, observer in gameInfo.Observers do
+                    -- Create a label for this observer of the form:
+                    -- PlayerName (R:xxx, P:xxx, C:xxx)
+                    -- Such conciseness is necessary as the field in the UI is rather narrow...
+                    local observer_label = observer.PlayerName .. " (R:" .. observer.PL
+
+                    -- Add the ping only if this entry refers to a different client.
                     if observer and (observer.OwnerID ~= localPlayerID) and observer.ObserverListIndex then
                         local peer = lobbyComm:GetPeer(observer.OwnerID)
-                        --Lobby "bug" fix.  This should fix the problem where the lobby pings get bugged.
-                        -- -Duck42
+
                         local ping = 0
                         if peer.ping ~= nil then
                             ping = math.floor(peer.ping)
                         end
-                        -- CPU benchmark modified code
-                        local score_CPU =  FindBenchmarkForName(observer.PlayerName)
-                        local cputext = ""
-                        if score_CPU then
-                            cputext = ", CPU = "..tostring(score_CPU.Result)
-                        end
-                        pingtext = LOC("<LOC lobui_0240> (Ping = ")..tostring(ping)
-                        ratingtext = ", Rating = " .. tostring(observer.PL)
-                        --PlayerName (Ping = xxx, Rating = xxx, CPU = xxx)
-                        GUI.observerList:ModifyItem(observer.ObserverListIndex, observer.PlayerName .. pingtext ..
-                        ratingtext .. cputext .. ")")
-                    elseif observer.OwnerID == localPlayerID then
-                        local score_CPU =  FindBenchmarkForName(observer.PlayerName)
-                        local cputext = ""
-                        if score_CPU then
-                            cputext = ", CPU = "..tostring(score_CPU.Result)
-                        end
-                        pingtext = ""
-                        ratingtext = " (Rating = "..tostring(observer.PL)
-                        --PlayerName (Rating = xxx, CPU = xxx)
-                        GUI.observerList:ModifyItem(observer.ObserverListIndex, observer.PlayerName..ratingtext .. cputext..")")
-                        -- End CPU benchmark modified code
+
+                        observer_label = observer_label .. ", P:" .. ping
                     end
+
+                    -- Add the CPU score if one is available.
+                    local score_CPU = FindBenchmarkForName(observer.PlayerName)
+                    if score_CPU then
+                        observer_label = observer_label .. ", C:" .. score_CPU.Result
+                    end
+                    observer_label = observer_label .. ")"
+
+                    GUI.observerList:ModifyItem(observer.ObserverListIndex, observer_label)
                 end
                 WaitSeconds(1)
             end


### PR DESCRIPTION
Currently the rating/ping/cpu values shown in brakets to the right of an observer's name are generally not visible, in part because the box is too narrow.
This pull request does some trivial code cleanup (stop using globals everywhere!), factorises the obsever-message-building code, and has it employ a more concise format.

There exists an unrelated problem I hope to solve which casues rating values for observers to routinely show as "nil". Is this in the issue tracker? I'm as yet to come up with clear STR: testing is slightly awkward at the moment.
