### PR TITLE
Don't check for always-nonexistent zero-element

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -6787,7 +6787,7 @@ end
 -- GUI --
 function GUI_PRESET()
     local profiles = GetPreference("UserPresetLobby")
-    if not profiles or profiles[0] == nil then
+    if not profiles or profiles[1] == nil then
         GUI_PRESET_INPUT(-1)
     end
 


### PR DESCRIPTION
Since Lua arrays are 1-based, doesn't an attempt to access element zero always return a nil?

... So this was an if(true). Whoops.
