### PR TITLE
Disable collision on sinking air wrecks

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1220,8 +1220,9 @@ Unit = Class(moho.unit_methods) {
 
         if self.PlayDeathAnimation and not self:IsBeingBuilt() then
             self:ForkThread(self.PlayAnimationThread, 'AnimationDeath')
-	    self:SetCollisionShape('None')
         end
+
+        self:SetCollisionShape('None')
 
         self:DoUnitCallbacks( 'OnKilled' )
         self:OnKilledVO()

--- a/projectiles/Sinker/Sinker_proj.bp
+++ b/projectiles/Sinker/Sinker_proj.bp
@@ -28,6 +28,7 @@ ProjectileBlueprint {
         HelpText = 0,
     },
     Physics = {
+        CollideEntity = false,
         DestroyOnWater = false,
         InitialSpeed = 0,
         LeadTarget = false,
@@ -35,7 +36,6 @@ ProjectileBlueprint {
         UseGravity = false, -- not using gravity, units sink way to fast
         SinkSpeed = 0.05,
         VelocityAlign = false,
-
         RotationalVelocity = 1,
         RotationalVelocityRange = 6,
         DirectionX = 0,


### PR DESCRIPTION
Air wrecks were colliding with other units, sometimes causing them to get
stuck in naval units.

This resulted in scouts having intel so long as they didn't sink to
sea-bottom and get wrecked

Fixes #194
