### PR TITLE
Remove the "Extra" backgrounds option

### DIFF
--- a/LOC/ES/strings_db.lua
+++ b/LOC/ES/strings_db.lua
@@ -5122,7 +5122,6 @@ lobui_0407="Concept Art"
 lobui_0408="Screenshot"
 lobui_0409="Map"
 lobui_0410="None"
-lobui_0411="Extra"
 
 # Lobby changelog panel
 lobui_0412="What's new in Lobby?"

--- a/LOC/FR/strings_db.lua
+++ b/LOC/FR/strings_db.lua
@@ -5121,7 +5121,6 @@ lobui_0407="Concept Art"
 lobui_0408="Screenshot"
 lobui_0409="Map"
 lobui_0410="None"
-lobui_0411="Extra"
 
 # Lobby changelog panel
 lobui_0412="What's new in Lobby?"

--- a/LOC/IT/strings_db.lua
+++ b/LOC/IT/strings_db.lua
@@ -5122,7 +5122,6 @@ lobui_0407="Concept Art"
 lobui_0408="Screenshot"
 lobui_0409="Map"
 lobui_0410="None"
-lobui_0411="Extra"
 
 # Lobby changelog panel
 lobui_0412="What's new in Lobby?"

--- a/LOC/US/strings_db.lua
+++ b/LOC/US/strings_db.lua
@@ -4243,7 +4243,6 @@ lobui_0407="Concept Art"
 lobui_0408="Screenshot"
 lobui_0409="Map"
 lobui_0410="None"
-lobui_0411="Extra"
 
 # Lobby changelog panel
 lobui_0412="What's new in Lobby?"

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5915,35 +5915,6 @@ function ChangeBackgroundLobby(slot, faction)
             GUI.background2:Hide()
             GUI.background:SetTexture(UIUtil.UIFile("/BACKGROUND/background-paint_black_bmp.dds"))
             LASTLobbyBackground = 5
-
-        elseif LobbyBackground == 6 then -- Extra
-			LOGX('>> Background EXTRA', 'Background')
-            GUI.background:Show()
-            GUI.background2:Hide()
-            faction = faction or Prefs.GetFromCurrentProfile('LastFaction') or 1
-            if DiskGetFileInfo("/Mods/Lobby Background/mod_info.lua") then
-                settings = import("/Mods/Lobby Background/mod_info.lua")
-                if settings.BackgroundType == 1 then
-                    if faction == 1 and settings.uef > 0 then
-                        GUI.background:SetTexture("/Mods/Lobby Background/BACKGROUND/uef"..math.random(1, settings.uef)..".png")
-                    elseif faction == 2 and settings.aeon > 0 then
-                        GUI.background:SetTexture("/Mods/Lobby Background/BACKGROUND/aeo"..math.random(1, settings.aeon)..".png")
-                    elseif faction == 3 and settings.cybran > 0 then
-                        GUI.background:SetTexture("/Mods/Lobby Background/BACKGROUND/cyb"..math.random(1, settings.cybran)..".png")
-                    elseif faction == 4 and settings.seraphim > 0 then
-                        GUI.background:SetTexture("/Mods/Lobby Background/BACKGROUND/ser"..math.random(1, settings.seraphim)..".png")
-                    elseif faction == 5 and settings.random > 0 then
-                        GUI.background:SetTexture("/Mods/Lobby Background/BACKGROUND/ran"..math.random(1, settings.random)..".png")
-                    else
-                        GUI.background:SetTexture("/textures/ui/common/BACKGROUND/background-paint_black_bmp.dds")
-                    end
-                elseif settings.BackgroundType == 2 then
-                    GUI.background:SetTexture("/Mods/Lobby Background/BACKGROUND/"..math.random(1, settings.random)..".png")
-                end
-            else
-                GUI.background:SetTexture("/textures/ui/common/BACKGROUND/background-paint_black_bmp.dds")
-            end
-            LASTLobbyBackground = 6
         end
     end
 end
@@ -5972,7 +5943,6 @@ function CreateOptionLobbyDialog()
         LOC("<LOC lobui_0408>"), -- Screenshot
         LOC("<LOC lobui_0409>"), -- Map
         LOC("<LOC lobui_0410>"), -- None
-        LOC("<LOC lobui_0411>")  -- Extra
     }
     local selectedBackgroundState = backgroundStates[Prefs.GetFromCurrentProfile("LobbyBackground") or 1]
     local backgroundRadiobutton = UIUtil.CreateRadioButtonsStd(dialog2, '/CHECKBOX/radio', LOC("<LOC lobui_0405>"), backgroundStates, selectedBackgroundState)


### PR DESCRIPTION
This option relied on a mod that seems not to be bundled with this one.

This logic should be moved into the "Extra backgrounds" mod, or a pull request should be opened to merge that mod with this one. As-is, this code isn't contributing anything useful.
