### PR TITLE
Have the CPU benchmark abort if the user leaves the lobby.

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5366,6 +5366,11 @@ function CPUBenchmark()
     local l
     local m
     for h = 1, 48, 1 do
+        -- If the need for the benchmark no longer exists, abort it now.
+        if not lobbyComm then
+            return
+        end
+
         lastTime = GetSystemTimeSeconds()
         for i = 1.0, 25.0, 0.0008 do
             --This instruction set should cover most LUA operators
@@ -5444,18 +5449,24 @@ function CPU_AddControlTooltip(control, delay, slotNumber)
     end
 end
 
-function StressCPU(waitTime)
-    --This function instructs the PC to do a CPU score benchmark.
-    --It handles the necessary UI updates during the benchmark, sends
-    --the benchmark result to other players when finished, and it updates the local
-    --user's UI with their new result.
-    --    waitTime: The delay in seconds that this function should wait before starting the benchmark.
 
-    if waitTime == nil then waitTime = 10 end
+-- This function instructs the PC to do a CPU score benchmark.
+-- It handles the necessary UI updates during the benchmark, sends
+-- the benchmark result to other players when finished, and it updates the local
+-- user's UI with their new result.
+--    waitTime: The delay in seconds that this function should wait before starting the benchmark.
+function StressCPU(waitTime)
 
     for i = waitTime, 1, -1 do
-        if GUI.rerunBenchmark.label then GUI.rerunBenchmark.label:SetText(i..'s') end
+        GUI.rerunBenchmark.label:SetText(i..'s')
         WaitSeconds(1)
+
+        -- lobbyComm is destroyed when the lobby is exited. If the user left the lobby, we no longer
+        -- want to run the benchmark (it just introduces lag as the user is trying to do something
+        -- else.
+        if not lobbyComm then
+            return
+        end
     end
 
     --Get our last benchmark (if there was one)


### PR DESCRIPTION
An edgecase, but it's been annoying me: The CPU benchmark runs to completion even if the user returns to the main menu (which, admittedly, can only happen if you're in a LAN game).

While I'd dearly like to just exterminate this ridiculous benchmark entirely, this should go some way to making it less irritating.

More generally, we should perhaps consider replacing it with something that gives a more accurate picture of how well a machine will cope in-game. Testing the performance of Lua arithmetic operators isn't a sensible way to do this: this is not the nature of the majority of the game's load.
Realistically, the best way to produce a rating would be just to read system information (whatever windows' equivalent of `lspci`, `/proc/cpuinfo` and `/proc/meminfo` are) and make a decision based on that. As-is, the benchmark often spits out slightly stupid numbers that aren't really representative of how well a machine will perform in-game, and causes many seconds of UI unusability while it's thinking about it...
