### PR TITLE
Amusing hack to prevent quitting players from stopping games.

### DIFF
--- a/lua/ui/dialogs/eschandler.lua
+++ b/lua/ui/dialogs/eschandler.lua
@@ -1,0 +1,57 @@
+--*****************************************************************************
+--* File: lua/modules/ui/dialogs/eschandler.lua
+--* Author: Chris Blackwell
+--* Summary: Determines appropriate actions to take when the escape key is pressed in game
+--*
+--* Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--*****************************************************************************
+
+local UIUtil = import('/lua/ui/uiutil.lua')
+local Prefs = import('/lua/user/prefs.lua')
+local Utils = import('/lua/system/utils.lua')
+
+local quickDialog = false
+
+-- Ridiculous evil hack to perform graceful game exits.
+-- Instead of just killing the app (which leads everyone to have to wait for a timeout), we call
+-- the methods involved in terminating a game session. This will broadcast a message on the next
+-- tick that will have everyone else boot us: we just have to keep the app alive long enough for
+-- that to happen. A second *should* be sufficient, as more than that would've been lagging like a
+-- fish in play anyway...
+-- We use safeCall because none of these things will work sensibly if not in a game. It allows those
+-- useless calls to be skipped over and an exit to be achieved in the usual case.
+function SafeQuit()
+    ExitGame()
+    Utils.safecall("Don't panic.", SessionEndGame)
+    Utils.safecall("Don't panic.", WaitSeconds, 1)
+    ExitApplication()
+end
+
+-- If yesNoOnly is true, then the in game dialog will never be shown
+function HandleEsc(yesNoOnly)
+
+    local function CreateYesNoDialog()
+        if quickDialog then
+            return
+        end
+        GetCursor():Show()
+        quickDialog = UIUtil.QuickDialog(GetFrame(0), "<LOC EXITDLG_0000>Are you sure you'd like to quit?",
+            "<LOC _Yes>", function() SafeQuit() end,
+            "<LOC _No>", function() quickDialog:Destroy() quickDialog = false end,
+            nil, nil,
+            true,
+            {escapeButton = 2, enterButton = 1, worldCover = true})
+    end
+
+    if yesNoOnly then
+        if Prefs.GetOption('quick_exit') == 'true' then
+            SafeQuit()
+        else
+            CreateYesNoDialog()
+        end
+    elseif import('/lua/ui/game/commandmode.lua').GetCommandMode()[1] != false then
+    import('/lua/ui/game/commandmode.lua').EndCommandMode(true)
+    elseif GetSelectedUnits() then
+        SelectUnits(nil)
+    end
+end

--- a/lua/ui/game/tabs.lua
+++ b/lua/ui/game/tabs.lua
@@ -7,6 +7,7 @@ local Checkbox = import('/lua/maui/checkbox.lua').Checkbox
 local Button = import('/lua/maui/button.lua').Button
 local GameMain = import('/lua/ui/game/gamemain.lua')
 local Tooltip = import('/lua/ui/game/tooltip.lua')
+local EscapeHandler = import('/lua/ui/dialogs/eschandler.lua')
 
 local savedParent = false
 local animationLock = false
@@ -246,7 +247,7 @@ local actions = {
     ExitMPGame = function()
         UIUtil.QuickDialog(GetFrame(0), "<LOC EXITDLG_0003>Are you sure you'd like to exit?", 
             "<LOC _Yes>", function()
-                ExitApplication()
+                EscapeHandler.SafeQuit()
             end, 
             "<LOC _No>", nil,
             nil, nil,


### PR DESCRIPTION
People exiting with ALT+F4 cause games to hang for a minute or so until a timeout is reached and everyone boots them.

This is intensely annoying. The problem seems not to occur when a player gracefully quits from the menu. This patch is a ridiculous hack that causes the "graceful exit" code path to execute when a user simply ALT+F4s the game in rage.

I'd appreciate it if someone could test this properly: I'm yet to get a good solution to running multiple clients sorted out (someone got two computers handy or something equally ridiculous?)
