### PR TITLE
Repair null-statistic observers.

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3141,6 +3141,7 @@ function CreateUI(maxPlayers)
 
     -- Create skirmish mode's "load game" button.
     GUI.loadButton = UIUtil.CreateButtonWithDropshadow(GUI.optionsPanel, '/BUTTON/small/',"<LOC lobui_0176>Load")
+    UIUtil.setVisible(GUI.loadButton, singlePlayer)
     LayoutHelpers.LeftOf(GUI.loadButton, GUI.launchGameButton, 10)
     LayoutHelpers.AtVerticalCenterIn(GUI.loadButton, GUI.launchGameButton)
     GUI.loadButton.OnClick = function(self, modifiers)


### PR DESCRIPTION
Needs a spot more testing (really going to put in those VMs now), but this seems to fix a problem that was causing #196.

For some strange reason, the code for refreshing the observer list was in the ping refresh thread instead of the usual UI update place. (It was also rather comprehensively broken).
