### PR TITLE
Remove load/save list buttons from the mod manager.

### DIFF
--- a/lua/ui/lobby/ModsManager.lua
+++ b/lua/ui/lobby/ModsManager.lua
@@ -93,18 +93,6 @@ function NEW_MODS_GUI(parent, IsHost, modstatus, availableMods)
 	local SaveButton = UIUtil.CreateButtonWithDropshadow(dialog2, '/BUTTON/medium/', "Ok", -1)
         LayoutHelpers.AtLeftIn(SaveButton, dialog2, 0)
         LayoutHelpers.AtBottomIn(SaveButton, dialog2, 10)
-    -- SAVE LIST button --
-	local SaveListButton = UIUtil.CreateButtonWithDropshadow(dialog2, '/BUTTON/small/', "Save List", -1)
-        LayoutHelpers.AtRightIn(SaveListButton, dialog2, 0)
-        LayoutHelpers.AtTopIn(SaveListButton, dialog2, 10)
-		Tooltip.AddCheckboxTooltip(SaveListButton, {text='Save List', body='Save the currents selecteds Mods in a List'})
-		SaveListButton:Disable()
-	--------------------------
-    -- LOAD LIST button --
-	local LoadListButton = UIUtil.CreateButtonWithDropshadow(dialog2, '/BUTTON/small/', "Load List", -1)
-        LayoutHelpers.AtLeftTopIn(LoadListButton, dialog2, 0, 10)
-		Tooltip.AddCheckboxTooltip(LoadListButton, {text='Load List', body='Load a List of Mods'})
-		LoadListButton:Disable()
 	-------------------------------------
 	-- CHECKBOX UI MOD FILTER --
 	local cbox_UI = UIUtil.CreateCheckboxStd(dialog2, '/RADIOBOX/radio')

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2778,6 +2778,8 @@ function CreateUI(maxPlayers)
     -- Checkbox Show changed Options
     local cbox_ShowChangedOption = UIUtil.CreateCheckboxStd(GUI.optionsPanel, '/CHECKBOX/radio')
     LayoutHelpers.AtLeftTopIn(cbox_ShowChangedOption, GUI.optionsPanel, 3, 0)
+    -- TODO: Localise!
+
     Tooltip.AddCheckboxTooltip(cbox_ShowChangedOption, {text='Hide default Options', body='Show only changed Options and Advanced Map Options'})
     local cbox_ShowChangedOption_TEXT = UIUtil.CreateText(cbox_ShowChangedOption, 'Hide default Options', 11, 'Arial')
     cbox_ShowChangedOption_TEXT:SetColor('B9BFB9')


### PR DESCRIPTION
The feature these buttons provide doesn't exist (they have no click listeners, they're just two disabled buttons)

Move it to a feature branch and merge it when you've actually written it, @Xinnony.
