### PR TITLE
Push connectivity-related events through DisplaySystemMessage

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -798,9 +798,9 @@ function SetSlotInfo(slot, playerInfo)
             if not table.find(ConnectionEstablished, playerInfo.PlayerName) then
                 if playerInfo.Human and not isLocallyOwned then
                     if table.find(ConnectedWithProxy, playerInfo.OwnerID) then
-                        AddChatText(LOCF("<LOC Engine0004>Connection to %s established.", playerInfo.PlayerName)..' (FAF Proxy)', "Engine0004")
+                        DisplaySystemMessage(LOCF("<LOC Engine0004>Connection to %s established.", playerInfo.PlayerName)..' (FAF Proxy)', "Engine0004")
                     else
-                        AddChatText(LOCF("<LOC Engine0004>Connection to %s established.", playerInfo.PlayerName), "Engine0004")
+                        DisplaySystemMessage(LOCF("<LOC Engine0004>Connection to %s established.", playerInfo.PlayerName), "Engine0004")
                     end
                     table.insert(ConnectionEstablished, playerInfo.PlayerName)
                     for k, v in CurrentConnection do -- Remove PlayerName in this Table
@@ -1405,18 +1405,8 @@ end
 
 -- Display, if appropriate, a system message.
 function DisplaySystemMessage(data)
-    -- If the message is related to use connectivity and the user has turned off system messages,
-    -- don't display the message.'
-
-    --switch = Player switched with other Player
-    --lobui_0202 = Joined as a Observer
-    --lobui_0226 = Move Player to Observer
-    --lobui_0227 = Move Observer to Player
-    --lobui_0205 = Timed Out
-    if data.Id == 'lobui_0202' or data.Id == 'lobui_0226' or data.Id == 'lobui_0227' or data.Id == 'lobui_0205' or data.Id == 'switch' then
-        if not SystemMessagesEnabled() then
-            return
-        end
+    if not SystemMessagesEnabled() then
+        return
     end
 
     AddChatText(data.Text)
@@ -3987,9 +3977,9 @@ function CalcConnectionStatus(peer)
                 if not table.find(ConnectionEstablished, peer.name) then
                     if gameInfo.PlayerOptions[FindSlotForID(peer.id)].Human and not IsLocallyOwned(FindSlotForID(peer.id)) then
                         if table.find(ConnectedWithProxy, peer.id) then
-                            AddChatText(LOCF("<LOC Engine0004>Connection to %s established.", peer.name)..' (FAF Proxy)', "Engine0004")
+                            DisplaySystemMessage(LOCF("<LOC Engine0004>Connection to %s established.", peer.name)..' (FAF Proxy)', "Engine0004")
                         else
-                            AddChatText(LOCF("<LOC Engine0004>Connection to %s established.", peer.name), "Engine0004")
+                            DisplaySystemMessage(LOCF("<LOC Engine0004>Connection to %s established.", peer.name), "Engine0004")
                         end
                         table.insert(ConnectionEstablished, peer.name)
                         for k, v in CurrentConnection do -- Remove PlayerName in this Table
@@ -4511,7 +4501,7 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
                         gameInfo.Observers[data.Slot] = nil
                     end
                 end
-                AddChatText(LOCF("<LOC Engine0003>Lost connection to %s.", data.Options.PlayerName), "Engine0003")
+                DisplaySystemMessage(LOCF("<LOC Engine0003>Lost connection to %s.", data.Options.PlayerName), "Engine0003")
                 ClearSlotInfo(data.Slot)
                 UpdateGame()
             elseif data.Type == 'SlotAssigned' then


### PR DESCRIPTION
According to the "discussion" over in #276, these count as system messages, too. The likely cause of that bug is that those messages were just being printed with AddChatText instead of being subjected to something that checks SystemMessagesEnabled.
It seems that DisplaySystemMessage is the "Display a system message if it's enabled" function. Let's push the problematic messages through it so they'll be muffled if the tickbox is set.

There was also logic in DisplaySystemMessage that causes some messages to be displayed irrespective of the setting. Either the nomenclature, or this behaviour, needs to be changed. It's either a "system message" (in which case it should be shown only if those are enabled), or it's some other sort of message that we just display. It's very strange for a function called DisplaySystemMessage to in some cases show a message given that SystemMessagesEnabled() is false.

To sum up:

- The cause of #276 is that the problematic messages have never been printed in a way that checks SystemMessagesEnabled.
- We need to consider precisely what we mean by "system message" and decide what, if any, messages should be exempt from filtering. Do we even want this feature at all? It seems like you definitely want to hear about players being disconnected from your lobby...