### PR TITLE
Repair map preview closing

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2849,24 +2849,29 @@ function CreateUI(maxPlayers)
     else
         GUI.exitButton.label:SetText(LOC("<LOC _Back>"))
     end
-    import('/lua/ui/uimain.lua').SetEscapeHandler(function() GUI.exitButton.OnClick(GUI.exitButton) end)
-    LayoutHelpers.AtLeftIn(GUI.exitButton, GUI.chatPanel, 22)
-    LayoutHelpers.AtVerticalCenterIn(GUI.exitButton, GUI.launchGameButton)
-    GUI.exitButton.OnClick = function(self)
+
+    -- A function to show the "Exit game lobby?" dialog.
+    GUI.exitLobbyEscapeHandler = function()
         GUI.chatEdit:AbandonFocus()
         UIUtil.QuickDialog(GUI,
-                            "<LOC lobby_0000>Exit game lobby?",
-                            "<LOC _Yes>", function()
-                                ReturnToMenu(false)
-                            end,
-                            "<LOC _Cancel>", function()
-                                GUI.chatEdit:AcquireFocus()
-                            end,
-                            nil, nil,
-                            true,
-                            {worldCover = true, enterButton = 1, escapeButton = 2}
+            "<LOC lobby_0000>Exit game lobby?",
+            "<LOC _Yes>", function()
+                ReturnToMenu(false)
+            end,
+            "<LOC _Cancel>", function()
+                GUI.chatEdit:AcquireFocus()
+            end,
+            nil, nil,
+            true,
+            {worldCover = true, enterButton = 1, escapeButton = 2}
         )
     end
+    LayoutHelpers.AtLeftIn(GUI.exitButton, GUI.chatPanel, 22)
+    LayoutHelpers.AtVerticalCenterIn(GUI.exitButton, GUI.launchGameButton)
+    GUI.exitButton.OnClick = GUI.exitLobbyEscapeHandler
+    -- Behave as if the exit button was clicked when escape is pressed.
+    import('/lua/ui/uimain.lua').SetEscapeHandler(GUI.exitLobbyEscapeHandler)
+
 
     ---------------------------------------------------------------------------
     -- set up chat display
@@ -4942,6 +4947,11 @@ function CreateBigPreview(depth, parent)
         CloseBigPreview()
     end
 
+    -- Close the large map when the escape key is pressed.
+    import('/lua/ui/uimain.lua').SetEscapeHandler(function()
+        CloseBigPreview()
+    end)
+
     -- Keep the close button on top of the border (which is itself on top of the map preview)
     LayoutHelpers.DepthOverParent(closeBtn, border, 1)
 
@@ -5003,6 +5013,9 @@ end
 
 function CloseBigPreview()
     LrgMap:Hide()
+
+    -- Restore the default escape handler.
+    import('/lua/ui/uimain.lua').SetEscapeHandler(GUI.exitLobbyEscapeHandler)
 end
 
 local posGroup = false

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -4897,6 +4897,13 @@ end
 
 local LrgMap = false
 function CreateBigPreview(depth, parent)
+    -- We don't want to create more than one!
+    -- TODO: It might be nice to make clicking outside of the preview close it (or do nothing).
+    -- That might obviate this slight ugliness (recreating the control all the time)
+    if LrgMap then
+        LrgMap:Destroy()
+    end
+
     -- Size of the border image around the large map.
     local MAP_PREVIEW_BORDER_SIZE = 754
 


### PR DESCRIPTION
Fixes #277 (a regression from #260 - sorry!)

Here, I fix a bug that allows the map preview to be opened repeatedly in a way that stopped you from closing it. Good spot @aeoncleanse!
Additionally, I add support for pushing "Escape" to close the map preview. I've wanted this feature for a while, and it turned out not to be hard :D.