### PR TITLE
fix: cartographic view all black if map file doesn't contain cartographi...

### DIFF
--- a/effects/cartographic.fx
+++ b/effects/cartographic.fx
@@ -151,6 +151,21 @@ float4 TerrainPS0( TerrainPixel pixel) : COLOR0
 	float3 hypsometric = tex1D(hypsometricSampler,h.x).rgb;
 	float1 topographic = tex1D(topographicSampler,h.x).a;
 	
+	// if the map doesnt contain color info for contour map already, lets magic some info up
+	if (hypsometric[0] == 0 && hypsometric[1] == 0 && hypsometric[2] == 0)
+	{
+		float chunkiness = 10;
+		float3 dark = float3(0.45, 0.38, 0.41);
+		float3 light = float3(0.80, 0.80, 0.68);
+
+		// background color is halfway between dark and light
+		hypsometric = lerp(dark, light, h.x);
+
+		// the "alpha" we return will be between 0 and 1, and used to determine if we should draw a contour line or not
+		// we could just return hyposometric but its too detailed. this logic chunks it up, which ends up drawing nicer lines
+		topographic = int((h.x * 100) / chunkiness) * chunkiness / 100;
+	}
+
 	return float4(hypsometric,topographic);
 }
 

--- a/units/XSA0202/XSA0202_unit.bp
+++ b/units/XSA0202/XSA0202_unit.bp
@@ -107,6 +107,7 @@ UnitBlueprint {
         'RECLAIMABLE',
         'OVERLAYANTIAIR',
         'OVERLAYRADAR',
+        'BOMBER',
     },
     Defense = {
         AirThreatLevel = 6,


### PR DESCRIPTION
lots of maps incorrectly have all black settings for the cartographic view, resulting in the view being all black.
this occurs when someone saves a map using the current buggy map editor.
this fix detects if there is no colour data and makes some colours up at runtime instead