### PR TITLE
Always generate cartographic view

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ Changelog for patch 3639
 *Exploit fixes*
 - Fixed a regression of the free ACU upgrade exploit
 
+*Game improvements*
+- Cartographic map previews are now being generated even for maps that do not contain colour information for them.
+
 *Bug fixes*
 - Fixed air wrecks floating mid air on certain maps
 - Fixed air wrecks sinking to bottom of water, then jumping back up to surface
@@ -43,8 +46,9 @@ Contributors:
  - ChrisKitching
  - Crotalus
  - IceDreamer
- - Sheeo
+ - Partytime
  - Santa Claus
+ - Sheeo
  - Xinnony
 
 Changelog for patch 3638

--- a/effects/cartographic.fx
+++ b/effects/cartographic.fx
@@ -151,6 +151,21 @@ float4 TerrainPS0( TerrainPixel pixel) : COLOR0
 	float3 hypsometric = tex1D(hypsometricSampler,h.x).rgb;
 	float1 topographic = tex1D(topographicSampler,h.x).a;
 	
+	// if the map doesnt contain color info for contour map already, lets magic some info up
+	if (hypsometric[0] == 0 && hypsometric[1] == 0 && hypsometric[2] == 0)
+	{
+		float chunkiness = 10;
+		float3 dark = float3(0.45, 0.38, 0.41);
+		float3 light = float3(0.80, 0.80, 0.68);
+
+		// background color is halfway between dark and light
+		hypsometric = lerp(dark, light, h.x);
+
+		// the "alpha" we return will be between 0 and 1, and used to determine if we should draw a contour line or not
+		// we could just return hyposometric but its too detailed. this logic chunks it up, which ends up drawing nicer lines
+		topographic = int((h.x * 100) / chunkiness) * chunkiness / 100;
+	}
+
 	return float4(hypsometric,topographic);
 }
 


### PR DESCRIPTION
Before this, if a map file doesn't contain cartographic colours, the preview
will not be generated.

Since the shaders are not being passed the water height level, the cartographic
preview cannot include the water level of the map, however.

There's a discussion thread on the forums about patching the engine for this
[here](http://forums.faforever.com/forums/viewtopic.php?f=45&t=9141).