### PR TITLE
Prevent the CPU benchmark from attempting to continue into the game

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5286,15 +5286,19 @@ function StressCPU(waitTime)
 
         BenchTime = scoreSkew2 * BenchTime + scoreSkew1
 
+        -- The bench might have yeilded to a launcher, so we verify the lobbyComm is available when
+        -- we need it in a moment here (as well as aborting if we're wasting our time more than usual)
+        if not lobbyComm then
+            return
+        end
+
         --If this benchmark was better than our best so far...
         if BenchTime < currentBestBenchmark then
             --Make this our best benchmark
             currentBestBenchmark = BenchTime
 
             --Send it to the other players
-            if lobbyComm then
-                lobbyComm:BroadcastData( { Type = 'CPUBenchmark', PlayerName = localPlayerName, Result = currentBestBenchmark} )
-            end
+            lobbyComm:BroadcastData( { Type = 'CPUBenchmark', PlayerName = localPlayerName, Result = currentBestBenchmark} )
 
             --Add the benchmark to the local benchmark table
             CPU_Benchmarks[localPlayerName] = currentBestBenchmark


### PR DESCRIPTION
There was a race condition where the end of CPUBenchmark() could yeild to the coroutine starting the game, causing us to "miss" that the game had started and try to update the UI anyway, causing an error. It was probably harmless, but oh well.

Fixes #292.