### PR TITLE
Switch in-game skin to the real factional skin on game start

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -4288,7 +4288,7 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
 
     lobbyComm.ConnectionFailed = function(self, reason)
         LOG("CONNECTION FAILED " .. reason)
-        GUI.connectionFailedDialog = UIUtil.ShowInfoDialog(GUI.panel, LOCF(Strings.ConnectionFailed, Strings[reason] or reason),
+        GUI.connectionFailedDialog = UIUtil.ShowInfoDialog(GUI.panel, LOCF(lobbyComm.Strings.ConnectionFailed, lobbyComm.Strings[reason] or reason),
                                                            "<LOC _OK>", ReturnToMenu)
 
         lobbyComm:Destroy()
@@ -4296,13 +4296,13 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
     end
 
     lobbyComm.LaunchFailed = function(self,reasonKey)
-        AddChatText(LOC(Strings[reasonKey] or reasonKey))
+        AddChatText(LOC(lobbyComm.Strings[reasonKey] or reasonKey))
     end
 
     lobbyComm.Ejected = function(self,reason)
         LOG("EJECTED " .. reason)
 
-        GUI.connectionFailedDialog = UIUtil.ShowInfoDialog(GUI, LOCF(Strings.Ejected, Strings[reason] or reason), "<LOC _OK>", ReturnToMenu)
+        GUI.connectionFailedDialog = UIUtil.ShowInfoDialog(GUI, LOCF(lobbyComm.Strings.Ejected, lobbyComm.Strings[reason] or reason), "<LOC _OK>", ReturnToMenu)
         lobbyComm:Destroy()
         lobbyComm = nil
     end
@@ -4674,7 +4674,7 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
                     if peer.quiet > LobbyComm.quietTimeout then
                         lobbyComm:EjectPeer(peer.id,'TimedOutToHost')
                         SendSystemMessage(LOCF("<LOC lobui_0226>%s timed out.", peer.name), "lobui_0205")
-                        --SendSystemMessage(LOCF(Strings.TimedOut,peer.name), "lobui_0205")
+                        --SendSystemMessage(LOCF(lobbyComm.Strings.TimedOut,peer.name), "lobui_0205")
                         --AddChatText('TIMEOUT !')
                         
                         -- Search and Remove the peer disconnected

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -4586,6 +4586,10 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
         for i, v in gameInfo.PlayerOptions do
             if v.Human and v.OwnerID == player then
                 Prefs.SetToCurrentProfile('LoadingFaction', v.Faction)
+
+                -- Set current skin to the actual faction you'll be playing as (the skin may not be
+                -- correct if the player chose "random").
+                UIUtil.SetCurrentSkin(FACTION_NAMES[v.faction])
                 break
             end
         end


### PR DESCRIPTION
This stops "random" being a skin after the game has started, causing you to get the proper factional UI for the faction you actually ended up being.

This also obviates the need to import a ton more resources to fix the whole default/uef skin problem.