### PR TITLE
Rename "randomfaction" skin to "random"

### DIFF
--- a/lua/skins/skins.lua
+++ b/lua/skins/skins.lua
@@ -77,7 +77,7 @@ skins = {
         tooltipBorderColor = "FFeee274",
         tooltipTitleColor = "FF725b1a",
     },
-    randomfaction = {
+    random = {
         default = "default",
         texturesPath = "/textures/ui/random",
         imagerMesh = "/meshes/game/map-border_squ_uef_mesh",

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -262,8 +262,8 @@ function RotateSkin(direction)
         dir = -1
     end
 
-    -- Find the next skin from our current skin, skipping default, as it's not really a skin!
-    -- note that if the skin table is updated while running, the order of the table might change
+    -- Find the next skin from our current skin, skipping default/randomfaction: they're not really
+    -- skins note that if the skin table is updated while running, the order of the table might change
     -- so your cycle may be different. No big deal, just be aware it's a side effect.
     local numSkins = table.getn(skinNames)
     for index, skinName in skinNames do
@@ -271,7 +271,7 @@ function RotateSkin(direction)
             local nextSkinIndex = index + dir
             if nextSkinIndex > numSkins then nextSkinIndex = 1 end
             if nextSkinIndex < 1 then nextSkinIndex = numSkins end
-            if skinNames[nextSkinIndex] == 'default' then   -- skip default entry as it's not really a skin
+            if skinNames[nextSkinIndex] == 'default' or skinNames[nextSkinIndex] == 'random'  then   -- skip default entry as it's not really a skin
                 nextSkinIndex = nextSkinIndex + dir
                 if nextSkinIndex > numSkins then nextSkinIndex = 1 end
                 if nextSkinIndex < 1 then nextSkinIndex = numSkins end


### PR DESCRIPTION
This allows the skin to actually be loaded.

Additionally, the skin is excluded from the in-game skin switcher, as it isn't really a full skin (doesn't have a complete suite of assets)