### PR TITLE
Don't send table to function expecting string

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1397,7 +1397,7 @@ function SendSystemMessage(text, id)
         Id = id or '',
     }
     lobbyComm:BroadcastData(data)
-    AddChatText(data)
+    AddChatText(data.Text)
 end
 
 function PublicChat(text)


### PR DESCRIPTION
Fixes this error from #315 

warning: Error running DataReceived script in CScriptObject at 11024960: ...ged alliance\gamedata\mohodata.scd\lua\maui\text.lua(170): bad argument #1 to gfind' (string expected, got table) stack traceback: [C]: in functiongfind'
...ged alliance\gamedata\mohodata.scd\lua\maui\text.lua(170): in function WrapText' ...ta\faforever\gamedata\lua.nx2\lua\ui\lobby\lobby.lua(3999): in functionAddChatText'
...ta\faforever\gamedata\lua.nx2\lua\ui\lobby\lobby.lua(1400): in function SendSystemMessage' ...ta\faforever\gamedata\lua.nx2\lua\ui\lobby\lobby.lua(2259): in functionHostTryAddObserver'
...ta\faforever\gamedata\lua.nx2\lua\ui\lobby\lobby.lua(2124): in function `HostTryAddPlayer'
...ta\faforever\gamedata\lua.nx2\lua\ui\lobby\lobby.lua(4385): in function <...ta\faforever\gamedata\lua.nx2\lua\ui\lobby\lobby.lua:4344>