### PR TITLE
Fix transport-related hard-crash

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -506,7 +506,7 @@ Shield = Class(moho.shield_methods,Entity) {
     },
 
     ProtectTransportedUnits = function(self)
-        if EntityCategoryContains(categories.TRANSPORTATION, self.Owner) then
+        if EntityCategoryContains(categories.TRANSPORTATION, self.Owner) and self.Owner:IsDead() != true then
             self.Owner:SetCanTakeDamage(false)        
             local Cargo = self.Owner:GetCargo()
             for _, v in Cargo do
@@ -517,7 +517,7 @@ Shield = Class(moho.shield_methods,Entity) {
     end,
     
     RevokeTransportProtection = function(self)
-        if EntityCategoryContains(categories.TRANSPORTATION, self.Owner) then    
+        if EntityCategoryContains(categories.TRANSPORTATION, self.Owner) and self.Owner:IsDead() != true then
             self.Owner:SetCanTakeDamage(true)        
             local Cargo = self.Owner:GetCargo()
             for _, v in Cargo do


### PR DESCRIPTION
This is a fix based entirely on guesswork from the following error:

warning: Error running lua script: Unit:GetCargo only valid for transport units
        stack traceback:
               [C]: in function `GetCargo'
               ...rogramdata\faforever\gamedata\lua.nx2\lua\shield.lua(522): in function `RevokeTransportProtection'
               ...rogramdata\faforever\gamedata\lua.nx2\lua\shield.lua(437): in function <...rogramdata\faforever\gamedata\lua.nx2\lua\shield.lua:411>

I honestly can't think of or find a single reason for a non-transport unit to make it to this call, so my only idea so far is that the unit had died when the call was made...

Any input appreciated!