### PR TITLE
Coop Merge

### DIFF
--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -25,6 +25,15 @@ function ExitGame()
     Sync.RequestingExit = true
 end
 
+function fillCoop()    
+    local tblArmy = ListArmies()
+    for iArmy, strArmy in pairs(tblArmy) do
+        if iArmy >= ScenarioInfo.Coop1 then
+            table.insert(ScenarioInfo.HumanPlayers, iArmy)
+        end
+    end
+end
+
 # Call to end an operation
 #   bool _success - instructs UI which dialog to show
 #   bool _allPrimary - true if all primary objectives completed, otherwise, false
@@ -95,6 +104,18 @@ local timerThread = nil
 function CreateTimerTrigger( cb, seconds, displayBool)
     timerThread = TriggerFile.CreateTimerTrigger(cb, seconds, displayBool)
     return timerThread
+end
+
+function CreateTimerTriggerUnlockCoop(cb, faction, seconds, displayBool)
+    local tblArmy = ListArmies()
+    for iArmy, strArmy in pairs(tblArmy) do
+        if iArmy >= ScenarioInfo.Coop1 then
+            factionIdx = GetArmyBrain(strArmy):GetFactionIndex()
+            if(factionIdx == faction) then
+                CreateTimerTrigger(cb, seconds, displayBool)
+            end
+        end
+    end
 end
 
 function ResetUITimer()
@@ -959,6 +980,23 @@ function RemoveRestriction(army, categories, isSilent)
     RemoveBuildRestriction(army, categories)
 end
 
+function RemoveRestrictionCoop(faction, categories, isSilent)
+    --for coop players
+    local tblArmy = ListArmies()
+    for iArmy, strArmy in pairs(tblArmy) do
+        if iArmy >= ScenarioInfo.Coop1 then     
+            factionIdx = GetArmyBrain(strArmy):GetFactionIndex()
+            if(factionIdx == faction) then
+                SimUIVars.SaveTechAllowance(categories)
+                if not isSilent then
+                    if not Sync.NewTech then Sync.NewTech = {} end
+                    table.insert(Sync.NewTech, EntityCategoryGetUnitList(categories))
+                end
+                RemoveBuildRestriction(iArmy, categories)
+            end
+        end
+    end
+end
 
 #### returns lists of factories by category
 #### <point> and <radius> are optional

--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -841,7 +841,7 @@ function FakeTeleportUnit(unit,killUnit)
     IssueClearCommands({unit})
     unit:SetCanBeKilled( false )
 
-    unit:PlayTeleportChargeEffects()
+    unit:PlayTeleportChargeEffects(unit:GetPosition())
     unit:PlayUnitSound('GateCharge')
     WaitSeconds(2)
 

--- a/lua/ScenarioPlatoonAI.lua
+++ b/lua/ScenarioPlatoonAI.lua
@@ -1,0 +1,2564 @@
+#****************************************************************************
+#**
+#**  File     :  /lua/ai/ScenarioPlatoonAI.lua
+#**  Author(s):  Drew Staltman
+#**
+#**  Summary  :  Houses a number of AI threads that are used in operations
+#**
+#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+local Utilities = import('/lua/utilities.lua')
+local AIBuildStructures = import('/lua/ai/aibuildstructures.lua')
+local ScenarioFramework = import('/lua/ScenarioFramework.lua')
+local BuildingTemplates = import('/lua/BuildingTemplates.lua').BuildingTemplates
+local ScenarioUtils = import('/lua/sim/ScenarioUtilities.lua')
+
+####################################################################
+### PlatoonAttackClosestUnit
+###     - Attacks Closest Unit the AI Brain knows about
+### PlatoonData -
+####################################################################
+##############################################################################################################
+# function: PlatoonAttackClosestUnit = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function PlatoonAttackClosestUnit(platoon)
+    local aiBrain = platoon:GetBrain()
+    local target
+
+    while not target do
+        target = platoon:FindClosestUnit('Attack', 'Enemy', true, categories.ALLUNITS)
+        WaitSeconds(3)
+    end
+
+    platoon:Stop()
+
+    local cmd = platoon:AggressiveMoveToLocation( target:GetPosition() )
+    while aiBrain:PlatoonExists(platoon) do
+        if target ~= nil then
+            if target:IsDead() or not platoon:IsCommandsActive(cmd) then
+                target = platoon:FindClosestUnit('Attack', 'Enemy', true, categories.ALLUNITS-categories.WALL)
+                if target and not target:IsDead() then
+                    platoon:Stop()
+                    cmd = platoon:AggressiveMoveToLocation( target:GetPosition() )
+                end
+            end
+        else
+            target = platoon:FindClosestUnit('Attack', 'Enemy', true, categories.ALLUNITS)
+        end
+        WaitSeconds(17)
+    end
+end
+
+####################################################
+# function: BuildOnce = AddFunction     doc = ""
+#
+# parameter 0: string    platoon = "default_platoon"
+#
+####################################################
+function BuildOnce(platoon)
+    local aiBrain = platoon:GetBrain()
+    if aiBrain:PBMHasPlatoonList() then
+        aiBrain:PBMSetPriority(platoon, 0)
+    else
+        platoon.BuilderHandle:SetPriority(0)
+    end
+end
+
+##############################################################################################################
+# function: DefaultOSBasePatrol = AddFunction   doc = "Please work function docs."
+#
+# parameter 0: string   platoon     = "default_platoon"
+#
+##############################################################################################################
+function DefaultOSBasePatrol(platoon)
+    local aiBrain = platoon:GetBrain()
+    local master = string.sub(platoon.PlatoonData.BuilderName, 11)
+    local facIndex = aiBrain:GetFactionIndex()
+    local chain = false
+    if platoon.PlatoonData.LocationType and Scenario.Chains[aiBrain.Name .. '_' .. platoon.PlatoonData.LocationType .. '_BasePatrolChain'] then
+        chain = aiBrain.Name .. '_' .. platoon.PlatoonData.LocationType .. '_BasePatrolChain'
+    elseif Scenario.Chains[master .. '_BasePatrolChain'] then
+        chain = master .. '_BasePatrolChain'
+    elseif Scenario.Chains[aiBrain.Name .. '_BasePatrolChain'] then
+        chain = aiBrain.Name .. '_BasePatrolChain'
+    end
+    if chain then
+        platoon.PlatoonData.PatrolChain = chain
+        PatrolThread(platoon)
+    end
+end
+
+####################################################################
+### PlatoonAssignOrders
+###     - Assigns orders from the editor to a platoon
+### PlatoonData -
+###     OrderName - Name of the Order from the editor
+###     Target - Handle to Unit used in orders that require a target (OPTIONAL)
+####################################################################
+##############################################################################################################
+# function: PlatoonAssignOrders = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function PlatoonAssignOrders(platoon)
+    platoon:Stop()
+    local data = platoon.PlatoonData
+    if not data.OrderName then
+        error('*SCENARIO PLATOON AI ERROR: No OrderName given to PlatoonAssignOrders AI Function', 2)
+        return false
+    end
+    ScenarioUtils.AssignOrders( data.OrderName, platoon, data.Target)
+end
+
+####################################################################
+### PlatoonAttackHighestThreat
+###     - Attacks Location on the map with the highest threat
+### PlatoonData -
+####################################################################
+##############################################################################################################
+# function: PlatoonAttackHighestThreat = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function PlatoonAttackHighestThreat(platoon)
+    local patrol = false
+    local aiBrain = platoon:GetBrain()
+    local location,threat = aiBrain:GetHighestThreatPosition(1, true)
+    platoon:Stop()
+    local cmd = platoon:AggressiveMoveToLocation(location)
+    while aiBrain:PlatoonExists(platoon) do
+        if not platoon:IsCommandsActive(cmd) then
+            location,threat = aiBrain:GetHighestThreatPosition(1, true)
+            if threat > 0 then
+                platoon:Stop()
+                cmd = platoon:AggressiveMoveToLocation(location)
+            end
+        end
+        WaitSeconds(13)
+    end
+end
+
+####################################################################
+### PlatoonAttackLocation
+###     - Attack moves to a specific location on the map
+###     - After reaching location will attack highest threat
+### PlatoonData -
+###     Location - (REQUIRED) location on the map to attack move to
+####################################################################
+##############################################################################################################
+# function: PlatoonAttackLocation = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function PlatoonAttackLocation(platoon)
+    platoon:Stop()
+    local data = platoon.PlatoonData
+    if not data.Location then
+        error('*SCENARIO PLATOON AI ERROR: PlatoonAttackLocation requires a Location to operate', 2)
+    end
+    local location = data.Location
+    if type(location) == 'string' then
+        location = ScenarioUtils.MarkerToPosition(location)
+    end
+    local aiBrain = platoon:GetBrain()
+    local cmd = platoon:AggressiveMoveToLocation(location)
+    local threat = 0
+    while aiBrain:PlatoonExists(platoon) do
+        if not platoon:IsCommandsActive(cmd) then
+            location, threat = platoon:GetBrain():GetHighestThreatPosition(1, true)
+            platoon:Stop()
+            cmd = platoon:AggressiveMoveToLocation(location)
+        end
+        WaitSeconds(13)
+    end
+end
+
+####################################################################
+### PlatoonAttackLocationList
+###     - Attack moves to a location chosen from a list
+###     - Location can be the highest threat or the lowest non-negative threat
+###     - After reaching location will attack next location from the list
+### PlatoonData -
+###     LocationList - (REQUIRED) location on the map to attack move to
+###     LocationChain - (REQUIRED) Chain on the map to attack move to
+###     High - true will attack highest threats first, false lowest - defaults to false/lowest
+####################################################################
+##############################################################################################################
+# function: PlatoonAttackLocationList = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function PlatoonAttackLocationList(platoon)
+    platoon:Stop()
+    local location = nil
+    local aiBrain = platoon:GetBrain()
+    local data = platoon.PlatoonData
+    if not data.LocationList and not data.LocationChain then
+        error('*SCENARIO PLATOON AI ERROR: PlatoonAttackLocationList requires a LocationList or LocationChain in PlatoonData to operate', 2)
+    end
+    local positions = {}
+    if data.LocationChain then
+        positions = ScenarioUtils.ChainToPositions(data.LocationChain)
+    else
+        for k,v in data.LocationList do
+            if type(v) == 'string' then
+                table.insert(positions, ScenarioUtils.MarkerToPosition(v))
+            else
+                table.insert(positions, v)
+            end
+        end
+    end
+    if data.High then
+        location = PlatoonChooseHighest( platoon:GetBrain(), positions, 1)
+    else
+        location = PlatoonChooseLowestNonNegative( platoon:GetBrain(), positions, 1)
+    end
+    local cmd
+    if location then
+        cmd = platoon:AggressiveMoveToLocation(location)
+    end
+    while aiBrain:PlatoonExists(platoon) do
+        if not location or not platoon:IsCommandsActive(cmd) then
+            if data.High then
+                location = PlatoonChooseHighest( platoon:GetBrain(), positions, 1, location )
+            else
+                location = PlatoonChooseLowestNonNegative( platoon:GetBrain(), positions, 1, location )
+            end
+            if location then
+                platoon:Stop()
+                cmd = platoon:AggressiveMoveToLocation(location)
+            end
+        end
+        WaitSeconds(13)
+    end
+end
+
+####################################################################
+### TransportPool
+###     - Moves unit to location if specified
+###     - Assigns units in platoon to TransportPool platoon for other platoons to use
+### PlatoonData -
+###     TransportMoveLocation - Location to move transport to before assigning to transport pool
+####################################################################
+##############################################################################################################
+# function: TransportPool = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function TransportPool(platoon)
+    local aiBrain = platoon:GetBrain()
+    local tPool = aiBrain:GetPlatoonUniquelyNamed('TransportPool')
+    local location = false
+    local data = platoon.PlatoonData
+    if platoon.PlatoonData then
+        if data.TransportMoveLocation then
+            if type(data.TransportMoveLocation) == 'string' then
+                location = ScenarioUtils.MarkerToPosition(data.TransportMoveLocation)
+            else
+                location = data.TransportMoveLocation
+            end
+        end
+    end
+    if not tPool then
+        tPool = aiBrain:MakePlatoon( 'None', 'None' )
+        tPool:UniquelyNamePlatoon('TransportPool')
+    end
+    for k,unit in platoon:GetPlatoonUnits() do
+        aiBrain:AssignUnitsToPlatoon('TransportPool', {unit}, 'Scout', 'GrowthFormation' )
+        if location then
+            IssueMove( {unit}, location )
+        end
+    end
+end
+
+####################################################################
+### LandAssaultWithTransports
+###     - Grabs a specific number of transports from the TransportPool platoon
+###     - Loads units onto transports
+###     - Sets a ready variable if required
+###     - Waits while another variable has not been set if needed
+###     - Flys to lowest threat in a list of locations and unloads land units
+###     - Transports return to a location and are re-added to transport pool
+###     - Attacks a list of locations starting with highest threat from a list
+###
+### PlatoonData -
+###     ReadyVariable - ScenarioInfo.VarTable[ReadyVariable] Variable set when units are on transports
+###     WaitVariable - ScenarioInfo.VarTable[WaitVariable] Variable checked before transports leave
+###     LandingList - (REQUIRED or LandingChain) List of possible locations for transports to unload units
+###     LandingChain - (REQUIRED or LandingList) Chain of possible landing locations
+###     TransportReturn - Location for transports to return to (they will attack with land units if this isn't set)
+###     AttackPoints - (REQUIRED or AttackChain or PatrolChain) List of locations to attack.
+###                                              The platoon attacks the highest threat first
+###     AttackChain - (REQUIRED or AttackPoints or PatrolChain) Marker Chain of postitions to attack
+###     PatrolChain - (REQUIRED or AttackChain or AttackPoints) Chain of patrolling
+###     RandomPatrol - Bool if you want the patrol things to be random rather than in order
+####################################################################
+##############################################################################################################
+# function: LandAssaultWithTransports = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function LandAssaultWithTransports(platoon)
+    local aiBrain = platoon:GetBrain()
+    local data = platoon.PlatoonData
+
+    for varName, varData in data do
+        if not(varName == 'ReadyVariable' or varName == 'WaitVariable' or varName == 'LandingList' or
+               varName == 'LandingChain' or varName == 'TransportReturn' or varName == 'AttackPoints' or
+               varName == 'AttackChain' or varName == 'AMPlatoons' or varName == 'PlatoonName'
+               or varName == 'AMMasterPlatoon' or varName == 'UsePool' or varName == 'LocationType'
+               or varName == 'BuilderName' or varName == 'LockTimer' or varName == 'DiffLockTimerD1'
+               or varName == 'DiffLockTimerD2' or varName == 'DiffLockTimerD3' or varName == 'AssaultChains'
+               or varName == 'Ratio' or varName == 'LockTimer' or varName == 'MovePath' or varName == 'PatrolChain'
+               or varName == 'RandomPatrol' ) and varName ~= 'Categories' then
+            error('*SCENARIO PLATOON AI ERROR: LandAssaultWithTransports does not accept variable named-'..varName,2)
+        end
+    end
+
+    if not data.AttackPoints and not data.AttackChain and not data.AssaultChains then
+        error('*SCENARIO PLATOON AI ERROR: LandAssaultWithTransports requires AttackPoints in PlatoonData to operate', 2)
+    elseif not data.LandingList and not data.LandingChain and not data.AssaultChains then
+        error('*SCENARIO PLATOON AI ERROR: LandAssaultWithTransports requires LandingList in PlatoonData to operate', 2)
+    end
+
+    local assaultAttackChain, assaultLandingChain
+    if data.AssaultChains then
+        local tempChains = {}
+        local tempNum = 0
+        for landingChain, attackChain in data.AssaultChains do
+            for num, pos in ScenarioUtils.ChainToPositions( attackChain ) do
+                if aiBrain:GetThreatAtPosition( pos, 1, true ) > 0 then
+                    tempChains[landingChain] = attackChain
+                    tempNum = tempNum + 1
+                    break
+                end
+            end
+        end
+        local pickNum = Random(1,tempNum)
+        tempNum = 0
+        for landingChain, attackChain in tempChains do
+            tempNum = tempNum + 1
+            if tempNum == pickNum then
+                assaultAttackChain = attackChain
+                assaultLandingChain = landingChain
+                break
+            end
+        end
+    end
+
+    # Make attack positions out of chain, markers, or marker names
+    local attackPositions = {}
+    if data.AttackChain then
+        attackPositions = ScenarioUtils.ChainToPositions(data.AttackChain)
+    elseif assaultAttackChain then
+        attackPositions = ScenarioUtils.ChainToPositions(assaultAttackChain)
+    else
+        for k,v in data.AttackPoints do
+            if type(v) == 'string' then
+                table.insert(attackPositions, ScenarioUtils.MarkerToPosition(v))
+            else
+                table.insert(attackPositions, v)
+            end
+        end
+    end
+
+    # make landing positions out of chain, markers, or marker names
+    local landingPositions = {}
+    if data.LandingChain then
+        landingPositions = ScenarioUtils.ChainToPositions(data.LandingChain)
+    elseif assaultLandingChain then
+        landingPositions = ScenarioUtils.ChainToPositions(assaultLandingChain)
+    else
+        for k,v in data.LandingList do
+            if type(v) == 'string' then
+                table.insert(landingPositions, ScenarioUtils.MarkerToPosition(v))
+            else
+                table.insert(landingPositions, v)
+            end
+        end
+    end
+
+    platoon:Stop()
+
+    # Load transports
+    if not GetLoadTransports(platoon) then
+        return
+    end
+
+    if not ReadyWaitVariables(data) then
+        return
+    end
+
+    if data.MovePath and not MoveAlongRoute(platoon, ScenarioUtils.ChainToPositions(data.MovePath)) then
+        return
+    end
+
+    # Find landing location and unload units at right spot
+    local landingLocation
+    if ScenarioInfo.Options.Difficulty and ScenarioInfo.Options.Difficulty == 3 then
+        landingLocation = PlatoonChooseRandomNonNegative(aiBrain, landingPositions, 1)
+    else
+        landingLocation = PlatoonChooseRandomNonNegative(aiBrain, landingPositions, 1)
+    end
+    cmd = platoon:UnloadAllAtLocation(landingLocation)
+    local attached = true
+    while attached do
+        attached = false
+        WaitSeconds(3)
+        if not aiBrain:PlatoonExists(platoon) then
+            return
+        end
+        for num, unit in platoon:GetPlatoonUnits() do
+            if not unit:IsDead() and not EntityCategoryContains(categories.TRANSPORTATION, unit) and unit:IsUnitState('Attached') then
+                attached = true
+                break
+            end
+        end
+    end
+
+    if data.PatrolChain then
+        if data.RandomPatrol then
+            ScenarioFramework.PlatoonPatrolRoute( platoon, GetRandomPatrolRoute(ScenarioUtils.ChainToPositions(data.PatrolChain)))
+        else
+            ScenarioFramework.PlatoonPatrolChain( platoon, data.PatrolChain )
+        end
+    else
+        # Patrol attack route by creating attack route
+        local attackRoute = {}
+        attackRoute = PlatoonChooseHighestAttackRoute(aiBrain, attackPositions, 1)
+        # Send transports back to base if desired
+        if(platoon.PlatoonData.TransportReturn) then
+            ReturnTransportsToPool(platoon,data)
+        end
+
+        for k,v in attackRoute do
+            platoon:Patrol(v)
+        end
+    end
+
+    for num, unit in platoon:GetPlatoonUnits() do
+        if EntityCategoryContains(categories.ENGINEER, unit) then
+            platoon:CaptureAI()
+            break
+        end
+    end
+
+end
+
+
+####################################################################################################################
+### MoveToThread
+###     - Moves to a set of locations
+###
+### PlatoonData
+###     - MoveToRoute - List of locations to move to
+###     - MoveChain - Chain of locations to move
+###     - UseTransports - boolean, if true, use transports to move
+###
+####################################################################################################################
+##############################################################################################################
+# function: MoveToThread = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function MoveToThread(platoon)
+    local data = platoon.PlatoonData
+
+    if(data) then
+        if(data.MoveRoute or data.MoveChain) then
+            local movePositions = {}
+            if data.MoveChain then
+                movePositions = ScenarioUtils.ChainToPositions(data.MoveChain)
+            else
+                for k, v in data.MoveRoute do
+                    if type(v) == 'string' then
+                        table.insert(movePositions, ScenarioUtils.MarkerToPosition(v))
+                    else
+                        table.insert(movePositions, v)
+                    end
+                end
+            end
+            if(data.UseTransports) then
+                for k, v in movePositions do
+                    platoon:MoveToLocation(v, data.UseTransports)
+                end
+            else
+                for k, v in movePositions do
+                    platoon:MoveToLocation(v, false)
+                end
+            end
+        else
+            error('*SCENARIO PLATOON AI ERROR: MoveToRoute or MoveChain not defined', 2)
+        end
+    else
+        error('*SCENARIO PLATOON AI ERROR: PlatoonData not defined', 2)
+    end
+end
+
+
+####################################################################################################################
+### PatrolThread
+###     - Patrols a set of locations
+###
+### PlatoonData
+###     - PatrolRoute - List of locations to patrol
+###     - PatrolChain - Chain of locations to patrol
+###
+####################################################################################################################
+##############################################################################################################
+# function: PatrolThread = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function PatrolThread(platoon)
+    local data = platoon.PlatoonData
+    platoon:Stop()
+    if(data) then
+        if(data.PatrolRoute or data.PatrolChain) then
+            if data.PatrolChain then
+                ScenarioFramework.PlatoonPatrolRoute(platoon, ScenarioUtils.ChainToPositions(data.PatrolChain))
+            else
+                for k,v in data.PatrolRoute do
+                    if type(v) == 'string' then
+                        platoon:Patrol(ScenarioUtils.MarkerToPosition(v))
+                    else
+                        platoon:Patrol(v)
+                    end
+                end
+            end
+        else
+            error('*SCENARIO PLATOON AI ERROR: PatrolRoute or PatrolChain not defined', 2)
+        end
+    else
+        error('*SCENARIO PLATOON AI ERROR: PlatoonData not defined', 2)
+    end
+end
+
+
+####################################################################################################################
+### RandomPatrolThread
+###     - Gives a platoon a random patrol path from a set of locations
+###
+### PlatoonData
+###     - PatrolRoute - List of locations to patrol
+###     - PatrolChain - Chain of locations to patrol
+###
+####################################################################################################################
+##############################################################################################################
+# function: RandomPatrolThread = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function RandomPatrolThread(platoon)
+    local data = platoon.PlatoonData
+    platoon:Stop()
+    if(data) then
+        if(data.PatrolRoute or data.PatrolChain) then
+            if data.PatrolChain then
+                ScenarioFramework.PlatoonPatrolRoute(platoon,
+                                  GetRandomPatrolRoute(ScenarioUtils.ChainToPositions(data.PatrolChain)))
+            else
+                local route = {}
+                for k,v in data.PatrolRoute do
+                    if type(v) == 'string' then
+                        table.insert(route, ScenarioUtils.MarkerToPosition(v))
+                    else
+                        table.insert(route,v)
+                    end
+                end
+                ScenarioFramework.PlatoonPatrolRoute(platoon, GetRandomPatrolRoute(route))
+            end
+        else
+            error('*SCENARIO PLATOON AI ERROR: PatrolRoute or PatrolChain not defined', 2)
+        end
+    else
+        error('*SCENARIO PLATOON AI ERROR: PlatoonData not defined', 2)
+    end
+end
+
+
+####################################################################################################################
+### RandomDefensePatrolThread
+###     - Gives a platoon a random patrol path from a set of locations
+###
+### PlatoonData
+###     - PatrolChain - Chain of locations to patrol
+###
+####################################################################################################################
+##############################################################################################################
+# function: RandomDefensePatrolThread = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function RandomDefensePatrolThread(platoon)
+    local data = platoon.PlatoonData
+    platoon:Stop()
+    if(data) then
+        if(data.PatrolChain) then
+            for k, v in platoon:GetPlatoonUnits() do
+                ScenarioFramework.GroupPatrolRoute({v}, GetRandomPatrolRoute(ScenarioUtils.ChainToPositions(data.PatrolChain)))
+            end
+        else
+            error('*SCENARIO PLATOON AI ERROR: PatrolChain not defined', 2)
+        end
+    else
+        error('*SCENARIO PLATOON AI ERROR: PlatoonData not defined', 2)
+    end
+end
+
+####################################################################################################################
+### PatrolChainPickerThread
+###     - Gives a platoon a random patrol chain from a set of chains
+###
+### PlatoonData
+###     - PatrolChains - List of chains to choose from
+###
+####################################################################################################################
+##############################################################################################################
+# function: PatrolChainPickerThread = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function PatrolChainPickerThread(platoon)
+    local data = platoon.PlatoonData
+    platoon:Stop()
+    if(data) then
+        if(data.PatrolChains) then
+            local chain = Random(1, table.getn(data.PatrolChains))
+            ScenarioFramework.PlatoonPatrolRoute(platoon, ScenarioUtils.ChainToPositions(data.PatrolChains[chain]))
+            #LOG('Picked chain number ', chain)
+        else
+            error('*SCENARIO PLATOON AI ERROR: PatrolChains not defined', 2)
+        end
+    else
+        error('*SCENARIO PLATOON AI ERROR: PlatoonData not defined', 2)
+    end
+end
+
+##############################################################################################################
+# function: EngineersBuildPlatoon = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function EngineersBuildPlatoon(platoon)
+    local aiBrain = platoon:GetBrain()
+    local platoonUnits = platoon:GetPlatoonUnits()
+    local data = platoon.PlatoonData
+    local platoonName = data.PlatoonName
+    local eng = false
+    local engTable = {}
+    local buildingPlatoon = false
+    local buildingData
+    local unitBeingBuilt = false
+    local busy = false
+    local buildingTemplate = BuildingTemplates[aiBrain:GetFactionIndex()]
+
+    if not data.PlatoonsTable then
+        error('*SCENARIO PLATOON AI ERROR: EngineersBuildPlatoon requires PlatoonsTable', 2)
+    end
+
+    # Find all engineers in platoon
+    for k, v in platoonUnits do
+        if EntityCategoryContains(categories.CONSTRUCTION, v) then
+            if not eng then
+                eng = v
+            else
+                table.insert(engTable, v)
+            end
+        end
+    end
+    if not eng then
+        error('*SCENARIO PLATOON AI ERROR: No Engineers found in platoon using EngineersBuildPlatoon',2)
+    end
+    # Wait for eng to stop moving
+    while eng:IsUnitState('Moving') do
+        WaitSeconds(3)
+        if not aiBrain:PlatoonExists(platoon) then
+            return
+        end
+    end
+
+    #=== Have all engineers guard main engineer
+    if table.getn(engTable) > 0 then
+        if eng:IsDead() then # Must check if a death occured since platoon was forked
+            for num, unit in engTable do
+                if not unit:IsDead() then
+                    eng = table.remove(engTable, num)
+                    if table.getn(engTable) > 0 then
+                        IssueGuard(engTable, eng)
+                    end
+                    break
+                end
+            end
+        else
+            IssueGuard(engTable, eng)
+        end
+    end
+
+    if not aiBrain.EngBuiltPlatoonList then
+        aiBrain.EngBuiltPlatoonList = {}
+    end
+
+    while aiBrain:PlatoonExists(platoon) do
+        # Set new primary eng
+        if eng:IsDead() then
+            return
+        end
+        if not buildingPlatoon then
+            for k,v in data.PlatoonsTable do
+                if not aiBrain.EngBuiltPlatoonList[v.PlatoonName] then
+                    buildingPlatoon = v.PlatoonName
+                    buildingData = v
+                    break
+                else
+                    local plat = aiBrain.EngBuiltPlatoonList[v.PlatoonName]
+                    if not aiBrain:PlatoonExists(plat) then
+                        buildingPlatoon = v.PlatoonName
+                        buildingData = v
+                        break
+                    end
+                end
+            end
+        end
+        if not eng:IsUnitState('Patrolling') and
+            (eng:IsUnitState('Reclaiming') or eng:IsUnitState('Building') or eng:IsUnitState('Upgrading') or eng:IsUnitState('Repairing')) then
+            busy = true
+        end
+        if not busy and buildingPlatoon then
+            local newPlatoonUnits = {}
+            local unitGroup = ScenarioUtils.FlattenTreeGroup( aiBrain.Name, buildingPlatoon )
+            local plat
+            for strName, tblData in unitGroup do
+                if eng and aiBrain:CanBuildStructureAt( tblData.type, tblData.Position ) then
+                    IssueStop({eng})
+                    IssueClearCommands({eng})
+                    local result = aiBrain:BuildStructure(eng, tblData.type, {tblData.Position[1], tblData.Position[3], 0}, false)
+                    unitBeingBuilt = false
+
+                    repeat
+                        WaitSeconds(5)
+                        if eng:IsDead() then
+                            eng, engTable = AssistOtherEngineer(eng, engTable, unitBeingBuilt)
+                        else
+                            if not unitBeingBuilt then
+                                unitBeingBuilt = eng:GetUnitBeingBuilt()
+                                if unitBeingBuilt then
+                                    table.insert( newPlatoonUnits, unitBeingBuilt )
+                                end
+                            end
+                        end
+                    until not eng or eng:IsDead() or eng:IsIdleState() #not (eng:IsUnitState('Building') or eng:IsUnitState('Repairing') or eng:IsUnitState('Moving'))
+                    if not aiBrain.EngBuiltPlatoonList[buildingPlatoon] then
+                        plat = aiBrain:MakePlatoon('', '')
+                        aiBrain.EngBuiltPlatoonList[buildingPlatoon] = plat
+                        plat.EngBuildName = buildingPlatoon
+                        plat:AddDestroyCallback( function(aiBrain, plat)
+                                                     aiBrain.EngBuiltPlatoonList[plat.EngBuildName] = false
+                                                 end
+                        )
+                    end
+                    aiBrain:AssignUnitsToPlatoon( aiBrain.EngBuiltPlatoonList[buildingPlatoon], {unitBeingBuilt}, 'Attack', 'NoFormation')
+                end
+            end
+            buildingPlatoon = false
+            if table.getn( plat:GetPlatoonUnits() ) > 0 then
+                if buildingData.PlatoonData then
+                    plat.PlatoonData = buildingData.PlatoonData
+                end
+                if plat.PlatoonData.AMPlatoons then
+                    for k,v in plat.PlatoonData.AMPlatoons do
+                        plat:SetPartOfAttackForce()
+                        break
+                    end
+                end
+                if buildingData.ScenPlatoonAI then
+                    plat:ForkAIThread( import('/lua/ScenarioPlatoonAI.lua')[buildingData.ScenPlatoonAI] )
+                elseif buildingData.PlatoonAI then
+                    plat:ForkAIThread( import('/lua/platoon.lua')[buildingData.PlatoonAI] )
+                elseif buildingData.LocalFunction and buildingData.ScenName then
+                    plat:ForkAIThread( import('/maps/'..buildingData.ScenName..'/'..buildingData.ScenName..'_script.lua')[LocalFunction] )
+                end
+            end
+            newPlatoonUnits = {}
+
+            ### Disband if desired
+            if aiBrain:PlatoonExists(platoon) and data.DisbandAfterBuilding then
+                aiBrain:DisbandPlatoon(platoon)
+            end
+        end
+        if not eng:IsUnitState('Patrolling') and data.PatrolChain then
+            for k,v in ScenarioUtils.ChainToPositions( data.PatrolChain ) do
+                platoon:Patrol(v)
+            end
+        end
+        WaitSeconds(11)
+    end
+end
+
+
+####################################################################################################################
+### CategoryHunterPlatoonAI
+###    -- Sends out units to hunt and attack Experimental Air units (Soul Ripper, Czar, etc)
+###    -- It cheats to find the air units.  This should *NOT* ever be used in skirmish.
+###    -- This platoon only seeks out PLAYER experimentals.  It will never find any other army's
+###
+### PlatoonData -
+###    -- CategoryList : The categories we are going to find and attack
+##################################################################################################################
+##############################################################################################################
+# function: CategoryHunterPlatoonAI = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function CategoryHunterPlatoonAI(platoon)
+    local aiBrain = platoon:GetBrain()
+    local platoonUnits = platoon:GetPlatoonUnits()
+    local data = platoon.PlatoonData
+    local target = false
+    while aiBrain:PlatoonExists(platoon) do
+
+        -- Find nearest enemy category to this platoon
+        -- Cheat to find the focus army's units
+        local newTarget = false
+        local platPos = platoon:GetPlatoonPosition()
+        for catNum,category in platoon.PlatoonData.CategoryList do
+            -- interate over all armies
+            local tblArmy = ListArmies()
+            for iArmy, strArmy in pairs(tblArmy) do
+                if ScenarioInfo.ArmySetup[strArmy].Human then
+                    local brain = GetArmyBrain(strArmy)
+                    local unitList = brain:GetListOfUnits( category, false, false )
+                    if table.getn(unitList) > 0 then
+                        local distance = 100000
+                        for k,v in unitList do
+                            if not v:IsDead() then
+                                local currDist = VDist3( platPos, v:GetPosition() )
+                                if currDist < distance then
+                                    newTarget = v
+                                    distance = currDist
+                                end
+                            end
+                        end
+                        -- If the target has changed, attack new target
+                        if newTarget != target then
+                            platoon:Stop()
+                            platoon:AttackTarget( newTarget )
+                        end
+                    end
+                    if newTarget then
+                        break
+                    end
+                end
+            end
+        end
+
+        -- If there are no targets, seek out and fight nearest enemy the platoon can find; no cheeting here
+        if not newTarget then
+            target = platoon:FindClosestUnit('Attack', 'Enemy', true, categories.ALLUNITS-categories.WALL)
+            if target and not target:IsDead() then
+                platoon:Stop()
+                platoon:AggressiveMoveToLocation( target:GetPosition() )
+
+            -- If we still cant find a target, go to the highest threat position on the map
+            else
+                platoon:Stop()
+                platoon:AggressiveMoveToLocation( aiBrain:GetHighestThreatPosition(1, true) )
+            end
+        end
+        WaitSeconds(Random(73,181) * .1)
+    end
+end
+
+
+####################################################################################################################
+### StartBaseEngineerThread
+###     - Upgrades engineer to desired tech level
+###     - Moves an engineer to a location with either transports or using a transport beacon
+###     - Builds specific buildings found in PlatoonData.Construction
+###     - Can maintain a base found in PlatoonData
+###     - Can patrol a route either while maintaining a base or just prior to disbanding back into the PoolPlatoon
+###
+### PlatoonData -
+###     ReadyVariable - ScenarioInfo.VarTable[ReadyVariable] Variable set when units are on transports
+###     WaitVariable - ScenarioInfo.VarTable[WaitVariable] Variable checked before transports leave
+###     LandingLocation - Location for transports to drop engineers
+###     MoveBeacon - TransportBeacon to use to move engineer to location
+###     Construction - Table that holds data for a specific building order
+###                  - only the buildings specified in BuildStructures be built
+###         -> BuildingTemplate - building template found in BaseTemplates.lua
+###                               (only required if trying to build different factions buildings )
+###         -> BaseTemplate - Name of base template to use.  This template is generated from bases made in the editor
+###         -> BuildClose - Bool if you want to have unit pick closest of next building to build
+###         -> BuildStructures - List of buildings to build in order, ex:T1AirFactory, T2ShieldDefense, etc
+###
+###     BuildBaseTemplate - BaseTemplate of the base to build once
+###     MaintainBaseTemplate - BaseTemplate of base to build any non-existing buildings for.
+###     AssistFactories - Bool; will assist factories in a Location Type when set true; break off and rebuild if maintain
+###     LocationType - PBM Location Type to have the engineers assist build factories in
+###     BuildingTemplate - building template found in BaseTemplates.lua
+###                        (only required if trying to build different factions buildings )
+###     PatrolRoute - Route of locations to patrol while maintaining or after platoon disbanded
+###     PatrolChain - Chain of locations to patrol while maintaining or after platoon disbanded
+###     TransportRoute - List of locations for the transport to use to get to the location
+###     TransportChain - Chain of locations for the transport to use to get to landing location
+###     DisbandAfterPatrol - bool, if true, platoon will disband if its not maintaining a base and given a patrol order
+###     RandomPatrol - bool, if true, platoon will sort PatrolRoute randomly
+###     UseTransports - bool, if true, platoons will use transports to move
+###     NamedUnitBuild - table of unit names; platoon will build these specific units and only build them once
+###     GroupBuildOnce - name of a group to build each thing in the group only once
+###
+### Order of events:
+###     Grab transports, set ready variable, wait for wait variable, travel using transports,
+###         travel using beacon, build structures in Construction block, build base using BuildBaseTemplate,
+###         the platoon will assist factories if assigned to do so, they will break off and rebuild if Maintain is set,
+###         maintain a base using MaintainBaseTemplate (will patrol here if PatrolRoute given),
+###         patrol using PatrolRoute, platoon can disband if given a patrol and is not maintaining a base
+##################################################################################################################
+##############################################################################################################
+# function: StartBaseEngineerThread = AddFunction	doc = "Please work function docs."
+#
+# parameter 0: string	platoon         = "default_platoon"
+#
+##############################################################################################################
+function StartBaseEngineerThread(platoon)
+    local aiBrain = platoon:GetBrain()
+    local platoonUnits = platoon:GetPlatoonUnits()
+    local data = platoon.PlatoonData
+    local baseName
+    # Check for bad variables
+    for varName, varData in data do
+        if not(varName == 'ReadyVariable' or varName == 'WaitVariable' or varName == 'LandingLocation' or
+               varName == 'MoveBeacon' or varName == 'Construction' or varName == 'BuildBaseTemplate' or
+               varName == 'MaintainBaseTemplate' or varName == 'BuildingTemplate' or varName == 'PatrolRoute' or
+               varName == 'PatrolChain'  or varName == 'TransportRoute' or varName == 'TransportChain' or
+               varName == 'DisbandAfterPatrol' or varName == 'RandomPatrol' or varName == 'UseTransports' or
+               varName == 'LocationType' or varName == 'AssistFactories' or varName == 'Busy' or
+               varName == 'ReassignAssist' or varName == 'FactoryAssistList' or varName == 'BuilderName' or
+               varName == 'NamedUnitBuild' or varName == 'LocationType' or varName == 'MaintainDiffLevel'
+               or varName == 'LockTimer' or varName == 'DiffLockTimerD1' or varName == 'DiffLockTimerD2'
+               or varName == 'DiffLockTimerD3' or varName == 'GroupBuildOnce' or varName == 'NamedUnitFinishedCallback'
+               or varName == 'NamedUnitBuildReportCallback' ) then
+            error('*SCENARIO PLATOON AI ERROR: StartBaseEngineerThread does not accept variable named-'..varName,2)
+        end
+    end
+    # Check Construction table for bad variables
+    if data.Construction then
+        for varName, varData in data.Construction do
+            if not(varName == 'BuildingTemplate' or varName == 'BaseTemplate' or varName == 'BuildClose' or
+                   varName == 'BuildStructures' ) then
+                error('*SCENARIO PLATOON AI ERROR: StartBaseEngineerThread does not accept Construction Table variable named-'..varName,2)
+            end
+        end
+    end
+
+    # Set BaseTemplats in brain if not existing already
+    if data then
+        baseName = data.MaintainBaseTemplate
+        if baseName then
+            if not aiBrain.BaseTemplates[baseName] then
+                AIBuildStructures.CreateBuildingTemplate( aiBrain, aiBrain.Name, baseName)
+            end
+        end
+        if data.BuildBaseTemplate then
+            if not aiBrain.BaseTemplates[data.BuildBaseTemplate] then
+                AIBuildStructures.CreateBuildingTemplate( aiBrain, aiBrain.Name, data.BuildBaseTemplate)
+            end
+        end
+        if data.Construction then
+            if data.Construction.BaseTemplate then
+                if not aiBrain.BaseTemplates[data.Construction.BaseTemplate] then
+                    AIBuildStructures.CreateBuildingTemplate( aiBrain, aiBrain.Name, data.Construction.BaseTemplate )
+                end
+            end
+        end
+    end
+    local eng = false
+    local engTable = {}
+    local cmd
+    local unitBeingBuilt
+
+    # Find all engineers in platoon
+    for k, v in platoonUnits do
+        if EntityCategoryContains(categories.CONSTRUCTION, v) then
+            if not eng then
+                eng = v
+            else
+                table.insert(engTable, v)
+            end
+        end
+    end
+    if not eng then
+        error('*SCENARIO PLATOON AI ERROR: No Engineers found in platoon using StartBaseEngineer',2)
+    end
+    # Wait for eng to stop moving
+    while not eng:IsDead() and  eng:IsUnitState('Moving') do
+        WaitSeconds(3)
+        if not aiBrain:PlatoonExists(platoon) then
+            return
+        end
+    end
+    platoon:Stop()
+
+    # if platoon needs transports get em
+    if data.UseTransports then
+        if not GetLoadTransports(platoon) then
+            return
+        end
+    end
+
+    # Set Ready and hold for Wait variable
+    if not ReadyWaitVariables(data) then
+        return
+    end
+
+    # Move and unload units
+    if not StartBaseTransports(platoon, data, aiBrain) then
+        return
+    end
+
+    #=== Have all engineers guard main engineer
+    if table.getn(engTable) > 0 then
+        if eng:IsDead() then # Must check if a death occured since platoon was forked
+            for num, unit in engTable do
+                if not unit:IsDead() then
+                    eng = table.remove(engTable, num)
+                    if table.getn(engTable) > 0 then
+                        IssueGuard(engTable, eng)
+                    end
+                    break
+                end
+            end
+        else
+            IssueGuard(engTable, eng)
+        end
+    end
+
+    # Construction Block building
+    if not StartBaseConstruction(eng, engTable, data, aiBrain) then
+        return
+    end
+
+    # Build specific units
+    if not StartBaseBuildUnits(eng, engTable, data, aiBrain) then
+        return
+    end
+
+    # Build group unit once thing
+    if not StartBaseGroupOnceBuild( eng, engTable, data, aiBrain) then
+        return
+    end
+
+    # BuildBaseTemplate building
+    if not StartBaseBuildBase(eng, engTable, data, aiBrain) then
+        return
+    end
+
+    # Factory assisting
+    if data.LocationType and data.AssistFactories then
+        ForkThread(EngineersAssistFactories,platoon, data.LocationType)
+    end
+
+    # MaintainBaseTemplate
+    if ScenarioInfo.Options.Difficulty >= (data.MaintainDiffLevel or 2) then
+        if not StartBaseMaintainBase(platoon, eng, engTable, data, aiBrain) then
+            return
+        end
+    end
+
+    # Send engineers on patrol
+    if aiBrain:PlatoonExists(platoon) then
+        EngPatrol(eng, engTable, data)
+    end
+
+    ## Disband if desired
+    if aiBrain:PlatoonExists(platoon) and data.DisbandAfterPatrol then
+        aiBrain:DisbandPlatoon(platoon)
+    end
+end
+
+
+
+# -----------------
+# UTILITY FUNCTIONS
+# -----------------
+
+# ---------------------------------------------------------
+# Utility Function
+# Gets engineers using StartBaseEngineers to their location
+# ---------------------------------------------------------
+function StartBaseTransports(platoon, data, aiBrain)
+    ## Move the unit using transports
+    if data.UseTransports then
+        if data.TransportRoute then
+            for k, v in data.TransportRoute do
+                if type(v) == 'string' then
+                    platoon:MoveToLocation( ScenarioUtils.MarkerToPosition(v), false, 'Scout' )
+                else
+                    platoon:MoveToLocation( v, false, 'Scout' )
+                end
+            end
+        elseif data.TransportChain then
+            local transPositionChain = {}
+            transPositionChain = ScenarioUtils.ChainToPositions(data.TransportChain)
+            for k,v in transPositionChain do
+                platoon:MoveToLocation( v, false, 'Scout' )
+            end
+        end
+
+        # Unload transports
+        if type(data.LandingLocation) == 'string' then
+            cmd = platoon:UnloadAllAtLocation( ScenarioUtils.MarkerToPosition(data.LandingLocation))
+        else
+            cmd = platoon:UnloadAllAtLocation( data.LandingLocation)
+        end
+        # Wait for unload to end
+        while platoon:IsCommandsActive(cmd) do
+            WaitSeconds(3)
+            if not aiBrain:PlatoonExists(platoon) then
+                return false
+            end
+        end
+        if data.TransportReturn then
+            ReturnTransportsToPool(platoon, data)
+        end
+    end
+
+    #### Move unit if needed - USING FERRYS
+    if data.MoveBeacon then
+        while not ScenarioInfo.VarTable[data.MoveBeacon] do
+            WaitSeconds(3)
+            if not aiBrain:PlatoonExists(platoon) then
+                return false
+            end
+        end
+        cmd = platoon:UseFerryBeacon(categories.ALLUNITS, ScenarioInfo.VarTable[data.MoveBeacon])
+        while platoon:IsCommandsActive(cmd) do
+            WaitSeconds(3)
+            if not aiBrain:PlatoonExists(platoon) then
+                return false
+            end
+        end
+    end
+    return true
+end
+
+
+# ------------------------------------------------------------------------------------
+# Utility Function
+# Takes transports in platoon, returns them to pool, flys them back to return location
+# ------------------------------------------------------------------------------------
+function ReturnTransportsToPool(platoon, data)
+    # Put transports back in TPool
+    local aiBrain = platoon:GetBrain()
+    for k,unit in platoon:GetPlatoonUnits() do
+        if EntityCategoryContains( categories.TRANSPORTATION, unit ) then
+            # If a route was given, reverse the route on return
+            if data.TransportRoute then
+                aiBrain:AssignUnitsToPlatoon( 'TransportPool', {unit}, 'Scout', 'None' )
+                for i=table.getn(data.TransportRoute),1,-1 do
+                    if type(data.TransportRoute[1]) == 'string' then
+                        IssueMove( {unit}, ScenarioUtils.MarkerToPosition(data.TransportRoute[i]) )
+                    else
+                        IssueMove( {unit}, data.TransportRoute[i])
+                    end
+                end
+                if data.TransportReturn then
+                    if type(data.TransportReturn) == 'string' then
+                        IssueMove( {unit}, ScenarioUtils.MarkerToPosition(data.TransportReturn) )
+                    else
+                        IssueMove( {unit}, data.TransportReturn)
+                    end
+                end
+                # If a route chain was given, reverse the route on return
+            elseif data.TransportChain then
+                local transPositionChain = {}
+                transPositionChain = ScenarioUtils.ChainToPositions(data.TransportChain)
+                aiBrain:AssignUnitsToPlatoon( 'TransportPool', {unit}, 'Scout', 'None' )
+                for i=table.getn(transPositionChain),1,-1 do
+                    IssueMove( {unit}, transPositionChain[i] )
+                end
+                if data.TransportReturn then
+                    if type(data.TransportReturn) == 'string' then
+                        IssueMove( {unit}, ScenarioUtils.MarkerToPosition(data.TransportReturn) )
+                    else
+                        IssueMove( {unit}, data.TransportReturn)
+                    end
+                end
+                # return to Transport Return if no route
+            else
+                if data.TransportReturn then
+                    aiBrain:AssignUnitsToPlatoon( 'TransportPool', {unit}, 'Scout', 'None' )
+                    if type(data.TransportReturn) == 'string' then
+                        IssueMove( {unit}, ScenarioUtils.MarkerToPosition(data.TransportReturn) )
+                    else
+                        IssueMove( {unit}, data.TransportReturn)
+                    end
+                end
+            end
+        end
+    end
+end
+
+# -------------------------------------------------------------------------------
+# Utility Function
+# Uses UnitBuild block to build specific units on the map using StartBaseEngineer
+# -------------------------------------------------------------------------------
+function StartBaseBuildUnits(eng, engTable, data, aiBrain)
+    local unitBeingBuilt
+    local unitTable = data.NamedUnitBuild
+    if unitTable then
+        for num, unitName in unitTable do
+            local unit = ScenarioUtils.FindUnit(unitName, Scenario.Armies[aiBrain.Name].Units)
+            if unit then
+                if aiBrain:CanBuildStructureAt(unit.type, unit.Position) then
+                    IssueStop({eng})
+                    IssueClearCommands({eng})
+                    local result = aiBrain:BuildStructure(eng, unit.type, {unit.Position[1], unit.Position[3], 0}, false)
+                    if result then
+                        unitBeingBuilt = eng:GetUnitBeingBuilt()
+                    end
+                    repeat
+                        WaitSeconds(5)
+                        if eng:IsDead() then
+                            eng, engTable = AssistOtherEngineer(eng, engTable, unitBeingBuilt)
+                            if not eng then
+                                return false
+                            end
+                        else
+                            if not unitBeingBuilt then
+                                unitBeingBuilt = eng:GetUnitBeingBuilt()
+                            end
+                            if unitBeingBuilt and data.NamedUnitBuildReportCallback then
+                                data.NamedUnitBuildReportCallback(unitBeingBuilt, eng)
+                            end
+                        end
+                    until not (eng:IsUnitState('Building') or eng:IsUnitState('Repairing') or eng:IsUnitState('Moving' or eng:IsUnitState('Reclaiming')))
+                    data.NamedUnitFinishedCallback(unitBeingBuilt)
+                end
+            end
+        end
+    end
+    return true
+end
+
+# --------------------------------------------------------------------------
+# Utility Function
+# Uses GroupBuildOnce and builds each thing in said group once and only once
+# --------------------------------------------------------------------------
+function StartBaseGroupOnceBuild( eng, engTable, data, aiBrain)
+    local unitBeingBuilt
+    if data.GroupBuildOnce then
+        local buildGroup = ScenarioUtils.FlattenTreeGroup( aiBrain.Name, data.GroupBuildOnce )
+        if not buildGroup then
+            return true
+        end
+        for k,v in buildGroup do
+            if aiBrain:CanBuildStructureAt( v.type, v.Position ) then
+                IssueStop({eng})
+                IssueClearCommands({eng})
+                local result = aiBrain:BuildStructure( eng, v.type, { v.Position[1], v.Position[3], 0}, false)
+                if result then
+                    unitBeingBuilt = eng:GetUnitBeingBuilt()
+                end
+                repeat
+                    WaitSeconds(5)
+                    if eng:IsDead() then
+                        eng, engTable = AssistOtherEngineer(eng, engTable, unitBeingBuilt)
+                        if not eng then
+                            return false
+                        end
+                    else
+                        unitBeingBuilt = eng:GetUnitBeingBuilt()
+                    end
+                until eng:IsIdleState()
+            end
+        end
+    end
+    return true
+end
+
+
+# -------------------------------------------------------------
+# Utility Function
+# Uses Construction blocks in engineers using StartBaseEngineer
+# -------------------------------------------------------------
+function StartBaseConstruction(eng, engTable, data, aiBrain)
+    local cons = data.Construction
+    local buildingTmpl
+    if cons and cons.BuildingTemplate then
+        buildingTmpl = cons.BuildingTemplate
+    end
+    local unitBeingBuilt
+    if cons and cons.BuildStructures then
+        local baseTmpl = aiBrain.BaseTemplates[cons.BaseTemplate].Template
+        local closeToBuilder = nil
+        if cons.BuildClose then
+            closeToBuilder = eng
+        end
+        for k, v in cons.BuildStructures do
+            if(string.find(v, 'T2Air') or string.find(v, 'T3Air')
+                or string.find(v, 'T2Land') or string.find(v, 'T3Land')
+                or string.find(v, 'T2Naval') or string.find(v, 'T3Naval')) then
+                v = string.gsub(v, '2', '1')
+                v = string.gsub(v, '3', '1')
+            end
+            #platoon:Stop()
+            EngineerBuildStructure(aiBrain, eng, v, baseTmpl, buildingTmpl )
+            if eng:GetUnitBeingBuilt() then
+                unitBeingBuilt = eng:GetUnitBeingBuilt()
+            end
+            repeat
+                WaitSeconds(7)
+                if eng:IsDead() then
+                    eng, engTable = AssistOtherEngineer(eng, engTable, unitBeingBuilt)
+                    if not eng then
+                        return false
+                    end
+                else
+                    unitBeingBuilt = eng:GetUnitBeingBuilt()
+                end
+            until not ( eng:IsUnitState('Building') or eng:IsUnitState('Repairing') or eng:IsUnitState('Moving') or eng:IsUnitState('Reclaiming') )
+        end
+    end
+    return true
+end
+
+
+# ---------------------------------------------------------------------------
+# Utility Function
+# Builds a base using BuildBaseTemplate for engineers using StartBaseEngineer
+# ---------------------------------------------------------------------------
+function StartBaseBuildBase(eng, engTable, data, aiBrain)
+    local unitBeingBuilt
+    if data.BuildBaseTemplate then
+        if not aiBrain.BaseTemplates[data.BuildBaseTemplate] then
+            error('*SCENARIO PLATOON AI ERROR: Invalid BaseTemplate - ' .. data.BuildBaseTemplate, 2)
+        else
+            local allBuilt = false
+            while not allBuilt do
+                local busy = false
+                if not eng:IsDead() then
+                    if eng:IsUnitState('Building') or eng:IsUnitState('Repairing')
+                        or eng:IsUnitState('Reclaiming') or eng:IsUnitState('Moving') then
+                            busy = true
+                    end
+                    if not busy then
+                        if AIBuildStructures.AIMaintainBuildList(eng:GetAIBrain(), eng, data.BuildingTemplate,
+                                                                 aiBrain.BaseTemplates[data.BuildBaseTemplate]) then
+                            if eng:GetUnitBeingBuilt() then
+                                unitBeingBuilt = eng:GetUnitBeingBuilt()
+                            end
+                            busy = true
+                        else
+                            allBuilt = true
+                        end
+                    end
+                end
+                WaitSeconds(5)
+                if eng:IsDead() then
+                    eng, engTable = AssistOtherEngineer(eng, engTable, unitBeingBuilt)
+                    if not eng then
+                        return false
+                    end
+                else
+                    unitBeingBuilt = eng:GetUnitBeingBuilt()
+                end
+            end
+        end
+    end
+    return true
+end
+
+
+# -------------------------------------------------
+# Utility Function
+# Maintains a base for engs using StartBaseEngineer
+# -------------------------------------------------
+function StartBaseMaintainBase(platoon, eng, engTable, data, aiBrain)
+    local unitBeingBuilt
+    if data.MaintainBaseTemplate then
+        if not aiBrain.BaseTemplates[data.MaintainBaseTemplate] then
+            error('*SCENARIO PLATOON AI ERROR: Invalid basename - ' .. data.MaintainBaseTemplate, 2)
+        end
+    end
+    if not eng and aiBrain:PlatoonExists(platoon) then
+        eng, engTable = AssistOtherEngineer(eng, engTable, unitBeingBuilt)
+        if not eng then
+            return false
+        end
+    end
+    while data.MaintainBaseTemplate do
+        local busy = false
+        if eng and not eng:IsDead() then
+            if eng:IsUnitState('Building') or eng:IsUnitState('Reclaiming') or eng:IsUnitState('Repairing') or
+                              (eng:IsUnitState('Moving') and not eng:IsUnitState('Patrolling')) then
+                busy = true
+            elseif data.Busy then
+                data.Busy = false
+                data.ReassignAssist = true
+            end
+            if not busy then
+                if AIBuildStructures.AIMaintainBuildList(eng:GetAIBrain(), eng, data.BuildingTemplate,
+                                                         aiBrain.BaseTemplates[data.MaintainBaseTemplate] )then
+                    busy = true
+                    data.Busy = true
+                    BreakOffFactoryAssist(platoon, data)
+                    IssueClearCommands(engTable)
+                    IssueGuard(engTable, eng)
+                    unitBeingBuilt = eng:GetUnitBeingBuilt()
+                end
+            end
+        end
+        if (data.PatrolRoute or data.PatrolChain) and not busy and not (eng:IsUnitState('Moving')
+                             or eng:IsUnitState('Building')or eng:IsUnitState('Repairing')
+                             or eng:IsUnitState('Patrolling') or eng:IsUnitState('Reclaiming')) then
+            local patrolPositions = {}
+            if data.PatrolChain then
+                patrolPositions = ScenarioUtils.ChainToPositions(data.PatrolChain)
+            else
+                for k,v in data.PatrolRoute do
+                    if type(v) == 'string' then
+                        table.insert(patrolPositions, ScenarioUtils.MarkerToPosition(v))
+                    else
+                        table.insert(patrolPositions, v)
+                    end
+                end
+            end
+            if(data.RandomPatrol) then
+                for num, pos in GetRandomPatrolRoute(patrolPositions) do
+                    IssuePatrol({eng}, pos)
+                end
+            else
+                for num, pos in patrolPositions do
+                    IssuePatrol({eng}, pos)
+                end
+            end
+        end
+        WaitSeconds(5)
+        if not aiBrain:PlatoonExists(platoon) then
+            return false
+        end
+        if eng and eng:IsDead()  then
+            eng, engTable = AssistOtherEngineer(eng, engTable, unitBeingBuilt)
+            if not eng then
+                return false
+            end
+        elseif eng then
+            unitBeingBuilt = eng:GetUnitBeingBuilt()
+        end
+    end
+    return true
+end
+
+
+# -----------------------------------------------
+# Utility Function
+# Sends engineers on patrol for StartBaseEngineer
+# -----------------------------------------------
+function EngPatrol(eng, engTable, data)
+    table.insert(engTable, eng)
+    ## Patrol an area if nothing else to do
+    if data.PatrolRoute or data.PatrolChain then
+        local patrolPositions = {}
+        if data.PatrolChain then
+            patrolPositions = ScenarioUtils.ChainToPositions(data.PatrolChain)
+        else
+            for k,v in data.PatrolRoute do
+                if type(v) == 'string' then
+                    table.insert(patrolPositions, ScenarioUtils.MarkerToPosition(v))
+                else
+                    table.insert(patrolPositions, v)
+                end
+            end
+        end
+        if(data.RandomPatrol) then
+            for num, pos in GetRandomPatrolRoute(patrolPositions) do
+                IssuePatrol(engTable, pos)
+            end
+        else
+            for num, pos in patrolPositions do
+                IssuePatrol(engTable, pos)
+            end
+        end
+    end
+    return true
+end
+
+# -------------------------------------------------------
+# Utility Function
+# Resets main engineer and engTablef or StartBaseEngineer
+# -------------------------------------------------------
+function AssistOtherEngineer(eng, engTable, unitBeingBuilt)
+    if engTable and table.getn(engTable) > 0 then
+        for num, unit in engTable do
+            if not unit:IsDead() then
+                eng = table.remove(engTable, num)
+                if table.getn(engTable) > 0 then
+                    IssueGuard(engTable, eng)
+                end
+                if unitBeingBuilt and not unitBeingBuilt:IsDead() then
+                    IssueRepair({eng}, unitBeingBuilt)
+                end
+                break
+            end
+        end
+        if eng:IsDead() then
+            return false
+        end
+    end
+    return eng, engTable
+end
+
+
+# -----------------------------------------------------------------------
+# Utility Function
+# Has an engineer build a certain type of structure using a base template
+# -----------------------------------------------------------------------
+function EngineerBuildStructure(aiBrain, builder, building, brainBaseTemplate, buildingTemplate)
+    local structureCategory
+    if not buildingTemplate then
+        buildingTemplate = BuildingTemplates[aiBrain:GetFactionIndex()]
+    end
+    for k,v in buildingTemplate do
+        if building == v[1] then
+            structureCategory = v[2]
+            break
+        end
+    end
+    if building == 'Resource' or building == 'T1HydroCarbon' then
+        for l,type in brainBaseTemplate.Template do
+            if type[1][1] == building.StructureType then
+                for m,location in type do
+                    if m > 1 then
+                        if aiBrain:CanBuildStructureAt(structureCategory, {location[1], 0, location[2]}) then
+                            IssueStop({builder})
+                            IssueClearCommands({builder})
+                            local result = aiBrain:BuildStructure(builder, structureCategory, location, false)
+                            if result then
+                                return true
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    else
+        if aiBrain:FindPlaceToBuild( building, structureCategory, brainBaseTemplate, false, nil ) then
+            IssueStop({builder})
+            IssueClearCommands({builder})
+            if AIBuildStructures.AIExecuteBuildStructure(aiBrain, builder, building, builder, false,
+                                                         buildingTemplate, brainBaseTemplate) then
+                return true
+            end
+        end
+    end
+    return false
+end
+
+# -----------------------------------------------------------------
+# Utility Function
+# Stops factory assisting when an eng platoon is maintaining a base
+# -----------------------------------------------------------------
+function BreakOffFactoryAssist(platoon, data)
+    local aiBrain = platoon:GetBrain()
+    if platoon.PlatoonData.FactoryAssistList then
+        for listFacNum, listFac in platoon.PlatoonData.FactoryAssistList do
+            local num = 1
+            while num <= table.getn(listFac.Engineers) do
+                table.remove(listFac.Engineers, num)
+                listFac.NumEngs = listFac.NumEngs - 1
+                for brainFacNum, brainFacData in aiBrain.FactoryAssistList do
+                    if brainFacData.Factory == listFac.Factory then
+                        brainFacData.NumEngs = brainFacData.NumEngs - 1
+                    end
+                end
+            end
+        end
+    end
+end
+
+
+# ----------------------------------------------------
+# Utility Function
+# Tell engineers to assist factories in a locationType
+# ----------------------------------------------------
+function EngineersAssistFactories(platoon, locationType)
+    locationType = locationType or platoon.PlatoonData.LocationType
+    local aiBrain = platoon:GetBrain()
+    local location, radius
+    local needReorganize = true
+    local reassignEngs = false
+    local firstAssign = true
+    local reassignEngPool = {}
+    platoon.PlatoonData.FactoryAssistList = {}
+
+    # Find location out of brain
+    for num,locData in aiBrain.PBM.Locations do
+        if locationType == locData.LocationType then
+            location = locData.Location
+            radius = locData.Radius
+        end
+    end
+    if not location then
+        error('*SCENARIO PLATOON AI ERROR: No LocationType found for StartBaseEngineerThread, location named- '..repr(locationType),2)
+    end
+
+    # Find engineers
+    local engTable = {}
+    for num,unit in platoon:GetPlatoonUnits() do
+        if EntityCategoryContains(categories.CONSTRUCTION, unit) then
+            table.insert(engTable, unit)
+            table.insert(reassignEngPool,unit)
+        end
+    end
+
+    #### Main loop for assisting below
+
+    local newFactory = false
+    while aiBrain:PlatoonExists(platoon) do
+        if not platoon.PlatoonData.Busy then
+            # check for dead factories
+            local num = 1
+            while num <= table.getn(platoon.PlatoonData.FactoryAssistList) do
+                if platoon.PlatoonData.FactoryAssistList[num].Factory:IsDead() then
+                    reassignEngs = true
+                    for engNum, eng in platoon.PlatoonData.FactoryAssistList[num].Engineers do
+                        table.insert(reassignEngPool, eng)
+                    end
+                    table.remove(platoon.PlatoonData.FactoryAssistList, num)
+                else
+                    num = num + 1
+                end
+            end
+
+            # Find factories in the area belonging to proper brain
+            local tempFactories = aiBrain:GetUnitsAroundPoint(categories.FACTORY, location, radius, 'Ally')
+            for num, factory in tempFactories do
+                if factory:GetAIBrain() == aiBrain then
+                    local found = false
+                    for listFacNum, listFac in platoon.PlatoonData.FactoryAssistList do
+                        if listFac.Factory == factory then
+                            found = true
+                            break
+                        end
+                    end
+                    if not found then
+                        table.insert(platoon.PlatoonData.FactoryAssistList, {Factory = factory, Engineers = {}, NumEngs = 0 })
+                        needReorganize = true
+                    end
+                end
+            end
+            # Add factory data to brain assist list if needed, update number of engs per factory
+            for num, pltnFacData in platoon.PlatoonData.FactoryAssistList do
+                local found = false
+                local brainFacData
+                for listFacNum, listFac in aiBrain.FactoryAssistList do
+                    if listFac.Factory == pltnFacData.Factory then
+                        brainFacData = listFac
+                        found = true
+                        break
+                    end
+                end
+                if not found then
+                    table.insert(aiBrain.FactoryAssistList, { Factory = pltnFacData.Factory, NumEngs = 0, })
+                    pltnFacData.NumEngs = 0
+                else
+                    pltnFacData.NumEngs = brainFacData.NumEngs
+                end
+            end
+
+            # check for dead engineers
+            local engNum = 1
+            while engNum < table.getn(engTable) do
+                local eng = engTable[engNum]
+                if eng:IsDead() then
+                    table.remove(engTable, engNum)
+                    # Remove from platoon factory assist list
+                    for facNum, facData in platoon.PlatoonData.FactoryAssistList do
+                        for facEngNum, facEngData in facData.Engineers do
+                            if eng == facEngData then
+                                facData.NumEngs = facData.NumEngs - 1
+                                table.remove(facData.Engineers, facEngNum)
+                                # reduce number in global fac list
+                                for brainFacNum, brainFacData in aiBrain.FactoryAssistList do
+                                    if brainFacData.Factory == facData.Factory then
+                                        brainFacData.NumEngs = brainFacData.NumEngs - 1
+                                        break
+                                    end
+                                end
+                            end
+                        end
+                    end
+                else
+                    engNum = engNum + 1
+                end
+            end
+
+            # if maintain base finished, reassign all engs
+            if platoon.PlatoonData.ReassignAssist then
+                for num,unit in platoon:GetPlatoonUnits() do
+                    if not unit:IsDead() and EntityCategoryContains(categories.CONSTRUCTION, unit) then
+                        table.insert(reassignEngPool,unit)
+                    end
+                end
+            end
+
+            # Reassign engs if needed then reevaluate balance
+            if reassignEngs or platoon.PlatoonData.ReassignAssist then
+                EngAssist(platoon, reassignEngPool)
+            end
+
+            # Check if engs needs to be reorganized on factories
+            if not needReorganize then
+                needReorganize = CheckFactoryAssistBalance(platoon.PlatoonData.FactoryAssistList)
+            end
+
+            # reassign engs if factory lost; assign all engs if needed
+            if firstAssign then
+                EngAssist(platoon, reassignEngPool)
+            elseif needReorganize then
+                ReorganizeEngineers(platoon, engTable)
+            end
+            # any leftovers?
+            if table.getn(reassignEngPool) > 0 then
+                EngAssist(platoon, reassignEngPool)
+            end
+
+            # reset locals
+            needReorganize = false
+            firstAssign = false
+            reassignEngs = false
+            platoon.PlatoonData.ReassignAssist = false
+            reassignEngPool = {}
+        end
+        WaitSeconds(7)
+    end
+end
+
+
+# -------------------------------------------------------
+# Utility Function
+# Reorganizes engineer assisting if there is an imbalance
+# -------------------------------------------------------
+function ReorganizeEngineers(platoon, engTable)
+    local unbalanced = true
+    local aiBrain = platoon:GetBrain()
+    local loopCounter = 0
+    while unbalanced and loopCounter < 20 do
+        loopCounter = loopCounter + 1
+        unbalanced = false
+        local facLowNum = -1
+        local facLowData
+        local facHighNum = 0
+        local facHighData
+        # Finds the high and low of engs assisting a factory
+        for facNum, facData in platoon.PlatoonData.FactoryAssistList do
+            if facLowNum == -1 or facData.NumEngs < facLowNum then
+                facLowNum = facData.NumEngs
+                facLowData = facData
+            end
+            if facData.NumEngs > facHighNum then
+                facHighNum = facData.NumEngs
+                facHighData = facData
+            end
+        end
+        # If difference is greater than 1 across factories: reorganize
+        if (facHighNum - facLowNum) > 1 and facHighData ~= facLowData and table.getn(facHighData.Engineers) > 0 then
+            unbalanced = true
+            if table.getn(facHighData.Engineers) > 0 then
+                for engNum, engData in facHighData.Engineers do
+                    if not engData:IsDead() then
+                        local moveEng = table.remove(facHighData.Engineers, engNum)
+                        facHighData.NumEngs = facHighData.NumEngs - 1
+                        # decrease number in global fac list
+                        for brainFacNum, brainFacData in aiBrain.FactoryAssistList do
+                            if brainFacData.Factory == facHighData.Factory then
+                                brainFacData.NumEngs = brainFacData.NumEngs - 1
+                                break
+                            end
+                        end
+                        facLowData.NumEngs = facLowData.NumEngs + 1
+                        # increment number in global fac list
+                        for brainFacNum, brainFacData in aiBrain.FactoryAssistList do
+                            if brainFacData.Factory == facLowData.Factory then
+                                brainFacData.NumEngs = brainFacData.NumEngs + 1
+                            end
+                        end
+                        IssueClearCommands({moveEng})
+                        IssueGuard({moveEng}, facLowData.Factory)
+                        break
+                    end
+                end
+            end
+        end
+    end
+end
+
+
+# ---------------------------------------
+# Utility Function
+# Assign engineers to factories to assist
+# ---------------------------------------
+function EngAssist(platoon, engTable)
+    local aiBrain = platoon:GetBrain()
+    # Have engineers assist the factories
+    local engNum = 1
+    while engNum <= table.getn(engTable) do
+        eng = engTable[engNum]
+        if not eng:IsDead() and not platoon.PlatoonData.Rebuilding then
+            local lowNum = -1
+            local lowFac = false
+            for facNum, fac in platoon.PlatoonData.FactoryAssistList do
+                if lowNum == -1 or fac.NumEngs < lowNum then
+                    lowFac = fac
+                    lowNum = fac.NumEngs
+                end
+            end
+            # Store eng with correct factory, update number, have engs assist
+            if lowFac then
+                table.insert(lowFac.Engineers, eng)
+                lowFac.NumEngs = lowFac.NumEngs + 1
+                for brainNumFac, brainFacData in aiBrain.FactoryAssistList do
+                    if lowFac.Factory == brainFacData.Factory then
+                        brainFacData.NumEngs = brainFacData.NumEngs + 1
+                        break
+                    end
+                end
+                IssueClearCommands({eng})
+                IssueGuard({eng}, lowFac.Factory)
+                table.remove(engTable, engNum)
+            else
+                engNum = engNum + 1
+            end
+        else
+            engNum = engNum + 1
+        end
+    end
+end
+
+
+# ---------------------------------------------------------------
+# Utility Function
+# Check all factories in given table to see if there is imbalance
+# ---------------------------------------------------------------
+function CheckFactoryAssistBalance(factoryTable)
+    local facLowNum = -1
+    local facHighNum = 0
+    for facNum, facData in factoryTable do
+        if facLowNum == -1 or facData.NumEngs < facLowNum then
+            facLowNum = facData.NumEngs
+        end
+        if facData.NumEngs > facHighNum then
+            facHighNum = facData.NumEngs
+        end
+    end
+    if (facHighNum - facLowNum) > 1 then
+        return true
+    end
+    return false
+end
+
+
+# ------------------------------------------------------
+# Utility Function
+# Set Ready Variable and wait for Wait Variable if given
+# ------------------------------------------------------
+function ReadyWaitVariables(data)
+    ## Set ready and check wait variable after upgraded and/or loaded on transport
+    ## Just prior to moving the unit
+    if data.ReadyVariable then
+        ScenarioInfo.VarTable[data.ReadyVariable] = true
+    end
+
+    if data.WaitVariable then
+        while not ScenarioInfo.VarTable[data.WaitVariable] do
+            WaitSeconds(5)
+            if not aiBrain:PlatoonExists(platoon) then
+                return false
+            end
+        end
+    end
+    return true
+end
+
+# ------------------------------------------
+# Utility Function
+# Get and load transports with platoon units
+# ------------------------------------------
+function GetLoadTransports(platoon)
+    local numTransports = GetTransportsThread(platoon)
+    if not numTransports then
+        return false
+    end
+
+    platoon:Stop()
+    local aiBrain = platoon:GetBrain()
+
+
+        # Load transports
+    local transportTable = {}
+    local transSlotTable = {}
+
+    local scoutUnits = platoon:GetSquadUnits('scout') or {}
+
+    for num,unit in scoutUnits do
+        local id = unit:GetUnitId()
+        if not transSlotTable[id] then
+            transSlotTable[id] = GetNumTransportSlots(unit)
+        end
+        table.insert( transportTable,
+            {
+                Transport = unit,
+                LargeSlots = transSlotTable[id].Large,
+                MediumSlots = transSlotTable[id].Medium,
+                SmallSlots = transSlotTable[id].Small,
+                Units = {}
+            }
+        )
+    end
+    local shields = {}
+    local remainingSize3 = {}
+    local remainingSize2 = {}
+    local remainingSize1 = {}
+    for num, unit in platoon:GetPlatoonUnits() do
+        if EntityCategoryContains( categories.url0306 + categories.DEFENSE, unit ) then
+            table.insert( shields, unit )
+        elseif unit:GetBlueprint().Transport.TransportClass == 3 then
+            table.insert( remainingSize3, unit )
+        elseif unit:GetBlueprint().Transport.TransportClass == 2 then
+            table.insert( remainingSize2, unit )
+        elseif unit:GetBlueprint().Transport.TransportClass == 1 then
+            table.insert( remainingSize1, unit )
+        else
+            table.insert( remainingSize1, unit )
+        end
+    end
+#    LOG( '*AI DEBUG: NUM SHIELDS= ', table.getn( shields ) )
+#    LOG( '*AI DEBUG: NUM LARGE = ', table.getn( remainingSize3 ) )
+#    LOG( '*AI DEBUG: NUM MEDIUM = ', table.getn( remainingSize2 ) )
+#    LOG( '*AI DEBUG: NUM SMALL = ', table.getn( remainingSize1 ) )
+    local needed = GetNumTransports(platoon)
+    local largeHave = 0
+    for num, data in transportTable do
+        largeHave = largeHave + data.LargeSlots
+    end
+    local leftoverUnits = {}
+    local currLeftovers = {}
+    local leftoverShields = {}
+    transportTable, leftoverShields = SortUnitsOnTransports( transportTable, shields, largeHave - needed.Large )
+#    LOG('*AI DEBUG: NUM LEFTOVER SHIELDS = ', table.getn( leftoverShields ) )
+    transportTable, leftoverUnits = SortUnitsOnTransports( transportTable, remainingSize3, -1 )
+#    LOG('*AI DEBUG: NUM LEFTOVER LARGE = ', table.getn( leftoverUnits ) )
+    transportTable, currLeftovers = SortUnitsOnTransports( transportTable, leftoverShields, -1 )
+#    LOG('*AI DEBUG: NUM LEFTOVER SHIELDS SHIELDS = ', table.getn( currLeftovers ) )
+    for k,v in currLeftovers do table.insert(leftoverUnits, v) end
+    transportTable, currLeftovers = SortUnitsOnTransports( transportTable, remainingSize2, -1 )
+#    LOG('*AI DEBUG: NUM LEFTOVER MEDIUM = ', table.getn( currLeftovers ) )
+    for k,v in currLeftovers do table.insert(leftoverUnits, v) end
+    transportTable, currLeftovers = SortUnitsOnTransports( transportTable, remainingSize1, -1 )
+#    LOG('*AI DEBUG: NUM LEFTOVER SMALL = ', table.getn( currLeftovers ) )
+    for k,v in currLeftovers do table.insert(leftoverUnits, v) end
+    transportTable, currLeftovers = SortUnitsOnTransports( transportTable, currLeftovers, -1 )
+#    LOG('*AI DEBUG: NUM LEFTOVER FINAL = ', table.getn( currLeftovers ) )
+
+
+        # Old load transports
+    local monitorUnits = {}
+    for num, data in transportTable do
+        if table.getn( data.Units ) > 0 then
+            IssueClearCommands( data.Units )
+            IssueTransportLoad( data.Units, data.Transport )
+            for k,v in data.Units do table.insert( monitorUnits, v) end
+        end
+    end
+#    LOG('*AI DEBUG: NUM LEFTOVER UNITS = ', table.getn(leftoverUnits) )
+#    LOG('*AI DEBUG: NUM UNITS MONITORED = ', table.getn(monitorUnits) + table.getn(transportTable) )
+#    LOG('*AI DEBUG: NUM UNITS OMGZ = ', table.getn(platoon:GetPlatoonUnits()) )
+#    cmd = platoon:LoadUnits(categories.ALLUNITS)
+    local attached = true
+    repeat
+        WaitSeconds(2)
+        if not aiBrain:PlatoonExists(platoon) then
+            return false
+        end
+        attached = true
+        for k,v in monitorUnits do
+            if not v:IsDead() and not v:IsIdleState() then
+                attached = false
+                break
+            end
+        end
+    until attached
+    # Any units that aren't transports and aren't attached send back to pool
+    local pool
+    if platoon.PlatoonData.BuilderName and platoon.PlatoonData.LocationType then
+        pool = aiBrain:GetPlatoonUniquelyNamed(platoon.PlatoonData.LocationType..'_LeftoverUnits')
+        if not pool then
+            pool = aiBrain:MakePlatoon('', '')
+            pool:UniquelyNamePlatoon(platoon.PlatoonData.LocationType..'_LeftoverUnits')
+            if platoon.PlatoonData.AMPlatoons then
+                pool.PlatoonData.AMPlatoons = { platoon.PlatoonData.LocationType..'_LeftoverUnits' }
+                pool:SetPartOfAttackForce()
+            end
+        end
+    else
+        pool = aiBrain:GetPlatoonUniquelyNamed('ArmyPool')
+    end
+    for k,unit in platoon:GetPlatoonUnits() do
+        if not EntityCategoryContains( categories.TRANSPORTATION, unit ) then
+            if not unit:IsUnitState('Attached') then
+                aiBrain:AssignUnitsToPlatoon( pool, {unit}, 'Unassigned', 'None' )
+                #LOG('*DEBUG: ADDING UNIT TO LEFTOVER POOL')
+            end
+        end
+    end
+    return true
+end
+
+
+# ------------------------------------------------
+# Utility function
+# Sorts units onto transports distributing equally
+# ------------------------------------------------
+function SortUnitsOnTransports( transportTable, unitTable, numSlots )
+    local leftoverUnits = {}
+    numSlots = numSlots or -1
+    for num, unit in unitTable do
+        if numSlots == -1 or num <= numSlots then
+            local transSlotNum = 0
+            local remainingLarge = 0
+            local remainingMed = 0
+            local remainingSml = 0
+            for tNum, tData in transportTable do
+                if tData.LargeSlots > remainingLarge then
+                    transSlotNum = tNum
+                    remainingLarge = tData.LargeSlots
+                    remainingMed = tData.MediumSlots
+                    remainingSml = tData.SmallSlots
+                elseif tData.LargeSlots == remainingLarge and tData.MediumSlots > remainingMed then
+                    transSlotNum = tNum
+                    remainingLarge = tData.LargeSlots
+                    remainingMed = tData.MediumSlots
+                    remainingSml = tData.SmallSlots
+                elseif tData.LargeSlots == remainingLarge and tData.MediumSlots == remainingMed and tData.SmallSlots > remainingSml then
+                    transSlotNum = tNum
+                    remainingLarge = tData.LargeSlots
+                    remainingMed = tData.MediumSlots
+                    remainingSml = tData.SmallSlots
+                end
+            end
+            if transSlotNum > 0 then
+                table.insert( transportTable[transSlotNum].Units, unit )
+                if unit:GetBlueprint().Transport.TransportClass == 3 and remainingLarge >= 1 then
+                    transportTable[transSlotNum].LargeSlots = transportTable[transSlotNum].LargeSlots - 1
+                    transportTable[transSlotNum].MediumSlots = transportTable[transSlotNum].MediumSlots - 2
+                    transportTable[transSlotNum].SmallSlots = transportTable[transSlotNum].SmallSlots - 4
+                elseif unit:GetBlueprint().Transport.TransportClass == 2 and remainingMed > 0 then
+                    if transportTable[transSlotNum].LargeSlots > 0 then
+                        transportTable[transSlotNum].LargeSlots = transportTable[transSlotNum].LargeSlots - .5
+                    end
+                    transportTable[transSlotNum].MediumSlots = transportTable[transSlotNum].MediumSlots - 1
+                    transportTable[transSlotNum].SmallSlots = transportTable[transSlotNum].SmallSlots - 2
+                elseif unit:GetBlueprint().Transport.TransportClass == 1 and remainingSml > 0 then
+                    transportTable[transSlotNum].SmallSlots = transportTable[transSlotNum].SmallSlots - 1
+                elseif remainingSml > 0 then
+                    transportTable[transSlotNum].SmallSlots = transportTable[transSlotNum].SmallSlots - 1
+                else
+                    #LOG('*AI DEBUG: FOUND TRANSPORT NOT ENOUGH SLOTS')
+                    table.insert(leftoverUnits, unit)
+                end
+            else
+                #LOG('*AI DEBUG: NO TRANSPORT FOUND')
+                table.insert(leftoverUnits, unit)
+            end
+        end
+    end
+    return transportTable, leftoverUnits
+end
+
+
+# ------------------------------------------------------
+# Utility function
+# Generates a random patrol route for RandomPatrolThread
+# ------------------------------------------------------
+function GetRandomPatrolRoute(patrol)
+    local randPatrol = {}
+    local tempPatrol = {}
+    for k, v in patrol do
+        table.insert(tempPatrol, v)
+    end
+
+    local num = table.getn(tempPatrol)
+    local rand
+    for i = 1, num do
+        rand = Random(1, num + 1 - i)
+        table.insert(randPatrol, tempPatrol[rand])
+        table.remove(tempPatrol, rand)
+    end
+
+    return randPatrol
+end
+
+
+# ------------------------------------------------
+# Utility Function
+# Returns location with lowest non-negative threat
+# ------------------------------------------------
+function PlatoonChooseLowestNonNegative( aiBrain, locationList, ringSize, location )
+    local bestLocation = {}
+    local bestThreat = 0
+    local currThreat = 0
+    local locationSet = false
+
+    for k, v in locationList do
+        currThreat = aiBrain:GetThreatAtPosition( v, ringSize, true )
+		WaitSeconds(0.1)
+        if not location or location ~= v then
+            if (currThreat < bestThreat and currThreat > 0) or not locationSet then
+                locationSet = true
+                bestThreat = currThreat
+                bestLocation = v
+            end
+        end
+    end
+    if not locationSet then
+        bestLocation = locationList[1]
+    end
+
+    return bestLocation
+end
+
+# --------------------------------------------------------
+# Utility Function
+# Returns location with lowest threat (including negative)
+# --------------------------------------------------------
+function PlatoonChooseLowest(aiBrain, locationList, ringSize, location)
+    local bestLocation = {}
+    local locationSet = false
+    local bestThreat = 0
+    local currThreat = 0
+
+    for k, v in locationList do
+        currThreat = aiBrain:GetThreatAtPosition(v, ringSize, true)
+		WaitSeconds(0.1)
+        if not location or location ~= v then
+            if (currThreat < bestThreat ) or not locationSet then
+                locationSet = true
+                bestThreat = currThreat
+                bestLocation = v
+            end
+        end
+    end
+    if not locationSet then
+        bestLocation = locationList[1]
+    end
+
+    return bestLocation
+end
+
+# ----------------------------------------
+# Utility Function
+# Returns location with the highest threat
+# ----------------------------------------
+function PlatoonChooseHighest( aiBrain, locationList, ringSize, location )
+    local bestLocation = locationList[1]
+    local highestThreat = 0
+    local currThreat = 0
+
+    for k, v in locationList do
+        currThreat = aiBrain:GetThreatAtPosition( v, ringSize, true )
+		WaitSeconds(0.1)
+        if(currThreat > highestThreat) and (not location or location ~= v) then
+            highestThreat = currThreat
+            bestLocation = v
+        end
+    end
+
+    return bestLocation
+end
+
+# -----------------------------------------
+# Utility Function
+# Returns location randomly with threat > 0
+# -----------------------------------------
+function PlatoonChooseRandomNonNegative( aiBrain, locationList, ringSize )
+    local landingList = {}
+    for k, v in locationList do
+        if aiBrain:GetThreatAtPosition( v, ringSize, true ) > 0 then
+			WaitSeconds(0.1)
+            table.insert(landingList, v)
+        end
+    end
+    local loc = landingList[Random(1,table.getn(landingList))]
+    if not loc then
+        loc = locationList[Random(1,table.getn(locationList))]
+    end
+    return loc
+end
+
+# -------------------------------------------------------
+# Utility Function
+# Arranges a route from highest to lowest based on threat
+# -------------------------------------------------------
+function PlatoonChooseHighestAttackRoute(aiBrain, locationList, ringSize)
+    local attackRoute = {}
+    local tempRoute = {}
+
+    for k, v in locationList do
+        table.insert(tempRoute, v)
+    end
+
+    local num = table.getn(tempRoute)
+    for i = 1, num do
+        table.insert(attackRoute, PlatoonChooseHighest(aiBrain, tempRoute, ringSize))
+        for k, v in tempRoute do
+            if(attackRoute[i] == v) then
+                table.remove(tempRoute, k)
+                break
+            end
+        end
+    end
+
+    return attackRoute
+end
+
+# -------------------------------------------------
+# Utility Function
+# Arranges a route from lowest to highest on threat
+# -------------------------------------------------
+function PlatoonChooseLowestAttackRoute(aiBrain, locationList, ringSize)
+    local attackRoute = {}
+    local tempRoute = {}
+
+    for k, v in locationList do
+        table.insert(tempRoute, v)
+    end
+
+    local num = table.getn(tempRoute)
+    for i = 1, num do
+        table.insert(attackRoute, PlatoonChooseLowestNonNegative(aiBrain, tempRoute, ringSize))
+        for k, v in tempRoute do
+            if(attackRoute[i] == v) then
+                table.remove(tempRoute, k)
+                break
+            end
+        end
+    end
+
+    return attackRoute
+end
+
+
+# -----------------------------------------------------------------
+# Utility Function
+# Function that gets the correct number of transports for a platoon
+# -----------------------------------------------------------------
+function GetTransportsThread(platoon)
+    local data = platoon.PlatoonData
+    local aiBrain = platoon:GetBrain()
+
+    local neededTable = GetNumTransports(platoon)
+    local numTransports = 0
+    local transportsNeeded = false
+    if neededTable.Small > 0 or neededTable.Medium > 0 or neededTable.Large > 0 then
+        transportsNeeded = true
+    end
+    local transSlotTable = {}
+
+    if transportsNeeded then
+        local pool = aiBrain:GetPlatoonUniquelyNamed( 'TransportPool' )
+        if not pool then
+            pool = aiBrain:MakePlatoon('None', 'None')
+            pool:UniquelyNamePlatoon('TransportPool')
+        end
+        while transportsNeeded do
+            neededTable = GetNumTransports(platoon)
+            # make sure more are needed
+            local tempNeeded = {}
+            tempNeeded.Small = neededTable.Small
+            tempNeeded.Medium = neededTable.Medium
+            tempNeeded.Large = neededTable.Large
+            # Find out how many units are needed currently
+            for k,v in platoon:GetPlatoonUnits() do
+                if not v:IsDead() then
+                    if EntityCategoryContains( categories.TRANSPORTATION, v ) then
+                        local id = v:GetUnitId()
+                        if not transSlotTable[id] then
+                            transSlotTable[id] = GetNumTransportSlots(v)
+                        end
+                        local tempSlots = {}
+                        tempSlots.Small = transSlotTable[id].Small
+                        tempSlots.Medium = transSlotTable[id].Medium
+                        tempSlots.Large = transSlotTable[id].Large
+                        while tempNeeded.Large > 0 and tempSlots.Large > 0 do
+                            tempNeeded.Large = tempNeeded.Large - 1
+                            tempSlots.Large = tempSlots.Large - 1
+                            tempSlots.Medium = tempSlots.Medium - 2
+                            tempSlots.Small = tempSlots.Small - 4
+                        end
+                        while tempNeeded.Medium > 0 and tempSlots.Medium > 0 do
+                            tempNeeded.Medium = tempNeeded.Medium - 1
+                            tempSlots.Medium = tempSlots.Medium - 1
+                            tempSlots.Small = tempSlots.Small - 2
+                        end
+                        while tempNeeded.Small > 0 and tempSlots.Small > 0 do
+                            tempNeeded.Small = tempNeeded.Small - 1
+                            tempSlots.Small = tempSlots.Small - 1
+                        end
+                        if tempNeeded.Small <= 0 and tempNeeded.Medium <= 0 and tempNeeded.Large <= 0 then
+                            transportsNeeded = false
+                        end
+                    end
+                end
+            end
+            if transportsNeeded then
+                local location = platoon:GetPlatoonPosition()
+                local transports = {}
+                # Determine distance of transports from platoon
+                for k,unit in pool:GetPlatoonUnits() do
+                    if EntityCategoryContains( categories.TRANSPORTATION, unit ) and not unit:IsUnitState('Busy') then
+                        local unitPos = unit:GetPosition()
+                        local curr = { Unit=unit, Distance=VDist2( unitPos[1], unitPos[3], location[1], location[3] ),
+                                       Id = unit:GetUnitId() }
+                        table.insert( transports, curr )
+                    end
+                end
+                if table.getn(transports) > 0 then
+                    local sortedList = {}
+                    # Sort distances
+                    for k = 1,table.getn(transports) do
+                        local lowest = -1
+                        local key, value
+                        for j,u in transports do
+                            if lowest == -1 or u.Distance < lowest then
+                                lowest = u.Distance
+                                value = u
+                                key = j
+                            end
+                        end
+                        sortedList[k] = value
+                        # remove from unsorted table
+                        table.remove( transports, key )
+                    end
+                    # Take transports as needed
+                    for i=1,table.getn(sortedList) do
+                        if transportsNeeded then
+                            local id = sortedList[i].Id
+                            aiBrain:AssignUnitsToPlatoon(platoon, {sortedList[i].Unit}, 'Scout', 'GrowthFormation')
+                            numTransports = numTransports + 1
+                            #IssueMove( {sortedList[i].Unit}, platoon:GetPlatoonPosition() )
+                            if not transSlotTable[id] then
+                                transSlotTable[id] = GetNumTransportSlots(sortedList[i].Unit)
+                            end
+                            local tempSlots = {}
+                            tempSlots.Small = transSlotTable[id].Small
+                            tempSlots.Medium = transSlotTable[id].Medium
+                            tempSlots.Large = transSlotTable[id].Large
+                            # update number of slots needed
+                            while tempNeeded.Large > 0 and tempSlots.Large > 0 do
+                                tempNeeded.Large = tempNeeded.Large - 1
+                                tempSlots.Large = tempSlots.Large - 1
+                                tempSlots.Medium = tempSlots.Medium - 2
+                                tempSlots.Small = tempSlots.Small - 4
+                            end
+                            while tempNeeded.Medium > 0 and tempSlots.Medium > 0 do
+                                tempNeeded.Medium = tempNeeded.Medium - 1
+                                tempSlots.Medium = tempSlots.Medium - 1
+                                tempSlots.Small = tempSlots.Small - 2
+                            end
+                            while tempNeeded.Small > 0 and tempSlots.Small > 0 do
+                                tempNeeded.Small = tempNeeded.Small - 1
+                                tempSlots.Small = tempSlots.Small - 1
+                            end
+                            if tempNeeded.Small <= 0 and tempNeeded.Medium <= 0 and tempNeeded.Large <= 0 then
+                                transportsNeeded = false
+                            end
+                        end
+                    end
+                end
+            end
+            if transportsNeeded then
+                WaitSeconds(7)
+                if not aiBrain:PlatoonExists(platoon) then
+                    return false
+                end
+                local unitFound = false
+                for k,unit in platoon:GetPlatoonUnits() do
+                    if not EntityCategoryContains( categories.TRANSPORTATION, unit ) then
+                        unitFound = true
+                        break
+                    end
+                end
+                if not unitFound then
+                    ReturnTransportsToPool(platoon, data)
+                    return false
+                end
+            end
+        end
+    end
+    return numTransports
+end
+
+# -------------------------------------------------------------
+# Utility Function
+# Returns the number of transports required to move the platoon
+# -------------------------------------------------------------
+function GetNumTransports(platoon)
+    local transportNeeded = {
+        Small = 0,
+        Medium = 0,
+        Large = 0,
+    }
+    local transportClass
+    for k, v in platoon:GetPlatoonUnits() do
+        transportClass = v:GetBlueprint().Transport.TransportClass
+        if(transportClass == 1) then
+            transportNeeded.Small = transportNeeded.Small + 1
+        elseif(transportClass == 2) then
+            transportNeeded.Medium = transportNeeded.Medium + 1
+        elseif(transportClass == 3) then
+            transportNeeded.Large = transportNeeded.Large + 1
+        else
+            transportNeeded.Small = transportNeeded.Small + 1
+        end
+    end
+
+    return transportNeeded
+end
+
+# -------------------------------------------------------
+# Utility Function
+# Returns the number of slots the transport has available
+# -------------------------------------------------------
+function GetNumTransportSlots(unit)
+    local bones = {
+        Large = 0,
+        Medium = 0,
+        Small = 0,
+    }
+    for i=1,unit:GetBoneCount() do
+        if unit:GetBoneName(i) ~= nil then
+            if string.find(unit:GetBoneName(i), 'Attachpoint_Lrg') then
+                bones.Large = bones.Large + 1
+            elseif string.find(unit:GetBoneName(i), 'Attachpoint_Med') then
+                bones.Medium = bones.Medium + 1
+            elseif string.find(unit:GetBoneName(i), 'Attachpoint') then
+                bones.Small = bones.Small + 1
+            end
+        end
+    end
+    return bones
+end
+
+# ---------------------------------------
+# Utility Function
+# NOT USED - Creates a route to something
+# ---------------------------------------
+function GetRouteToVector(platoon, squad)
+    local aiBrain = platoon:GetBrain()
+    local data = platoon.PlatoonData
+
+    # All vectors in the table
+    aiBrain:SetUpAttackVectorsToArmy()
+    local vectorTable = aiBrain:GetAttackVectors()
+    local lowX = 10000
+    local lowZ = 10000
+    local highX = -1
+    local highZ = -1
+    for k, vec in vectorTable do
+        if vec[1] < lowX then
+            lowX = vec[1]
+        end
+        if vec[1] > highX then
+            highX = vec[1]
+        end
+        if vec[3] < lowZ then
+            lowZ = vec[3]
+        end
+        if vec[3] > highZ then
+            highZ = vec[3]
+        end
+    end
+
+    # Check if route needs to be generated
+    local atkVector = aiBrain:PickBestAttackVector(platoon, squad, 'Enemy', data.CompareCategory, data.CompareType)
+    local pltPosition = platoon:GetSquadPosition(squad)
+    local moveEW, moveNS
+    if lowX > pltPosition[1] and lowX < atkVector[1] then
+        moveEW = true
+    elseif highX < pltPosition[1] and highX > atkVector[1] then
+        moveEW = true
+    end
+    if lowZ > pltPosition[3] and lowZ < pltPosition[3] then
+        moveNS = true
+    elseif highZ < pltPosition[3] and highZ > pltPosition[3] then
+        moveNS = true
+    end
+
+    #### Move vector out
+    if moveEW or moveNS then
+        if atkVector[4] < 0 then
+            moveEW = 'west'
+        elseif atkVector[4] > 0 then
+            moveEW = 'east'
+        end
+        if atkVector[6] < 0 then
+            moveNS = 'north'
+        elseif atkVector[6] > 0 then
+            moveNS = 'south'
+        end
+        local route = {}
+        route[1] = { atkVector[1], atkVector[2], atkVector[3] }
+        local firstPoint = false
+        while not firstPoint do
+            route[1][1] = route[1][1] - atkVector[4]
+            route[1][3] = route[1][3] - atkVector[6]
+            if route[1][1] < lowX or route[1][1] > highX then
+                firstPoint = true
+            elseif route[1][3] < lowZ or route[1][3] > highZ then
+                firstPoint = true
+            end
+        end
+    end
+end
+
+# ------------------------------------------------------------------
+# Utility Function
+# Moves a platoon along a route holding up the thread until finished
+# ------------------------------------------------------------------
+function MoveAlongRoute(platoon, route)
+    local cmd = false
+    local aiBrain = platoon:GetBrain()
+
+    # move platoon along route
+    for k,v in route do
+        cmd = platoon:MoveToLocation(v, false)
+    end
+
+    # make sure we have a command then check if commands are finished every second
+    if cmd then
+        while platoon:IsCommandsActive(cmd) do
+            WaitSeconds(1)
+            if not aiBrain:PlatoonExists(platoon) then
+                return false
+            end
+        end
+    end
+    return true
+end

--- a/lua/ScenarioPlatoonAI.lua
+++ b/lua/ScenarioPlatoonAI.lua
@@ -1,29 +1,29 @@
-#****************************************************************************
-#**
-#**  File     :  /lua/ai/ScenarioPlatoonAI.lua
-#**  Author(s):  Drew Staltman
-#**
-#**  Summary  :  Houses a number of AI threads that are used in operations
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /lua/ai/ScenarioPlatoonAI.lua
+--**  Author(s):  Drew Staltman
+--**
+--**  Summary  :  Houses a number of AI threads that are used in operations
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 local Utilities = import('/lua/utilities.lua')
 local AIBuildStructures = import('/lua/ai/aibuildstructures.lua')
 local ScenarioFramework = import('/lua/ScenarioFramework.lua')
 local BuildingTemplates = import('/lua/BuildingTemplates.lua').BuildingTemplates
 local ScenarioUtils = import('/lua/sim/ScenarioUtilities.lua')
 
-####################################################################
-### PlatoonAttackClosestUnit
-###     - Attacks Closest Unit the AI Brain knows about
-### PlatoonData -
-####################################################################
-##############################################################################################################
-# function: PlatoonAttackClosestUnit = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------
+------ PlatoonAttackClosestUnit
+------     - Attacks Closest Unit the AI Brain knows about
+------ PlatoonData -
+----------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: PlatoonAttackClosestUnit = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function PlatoonAttackClosestUnit(platoon)
     local aiBrain = platoon:GetBrain()
     local target
@@ -52,12 +52,12 @@ function PlatoonAttackClosestUnit(platoon)
     end
 end
 
-####################################################
-# function: BuildOnce = AddFunction     doc = ""
-#
-# parameter 0: string    platoon = "default_platoon"
-#
-####################################################
+--------------------------------------------------------------------------------------------------------
+-- function: BuildOnce = AddFunction     doc = ""
+--
+-- parameter 0: string    platoon = "default_platoon"
+--
+--------------------------------------------------------------------------------------------------------
 function BuildOnce(platoon)
     local aiBrain = platoon:GetBrain()
     if aiBrain:PBMHasPlatoonList() then
@@ -67,12 +67,12 @@ function BuildOnce(platoon)
     end
 end
 
-##############################################################################################################
-# function: DefaultOSBasePatrol = AddFunction   doc = "Please work function docs."
-#
-# parameter 0: string   platoon     = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: DefaultOSBasePatrol = AddFunction   doc = "Please work function docs."
+--
+-- parameter 0: string   platoon     = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function DefaultOSBasePatrol(platoon)
     local aiBrain = platoon:GetBrain()
     local master = string.sub(platoon.PlatoonData.BuilderName, 11)
@@ -91,19 +91,19 @@ function DefaultOSBasePatrol(platoon)
     end
 end
 
-####################################################################
-### PlatoonAssignOrders
-###     - Assigns orders from the editor to a platoon
-### PlatoonData -
-###     OrderName - Name of the Order from the editor
-###     Target - Handle to Unit used in orders that require a target (OPTIONAL)
-####################################################################
-##############################################################################################################
-# function: PlatoonAssignOrders = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------
+------ PlatoonAssignOrders
+------     - Assigns orders from the editor to a platoon
+------ PlatoonData -
+------     OrderName - Name of the Order from the editor
+------     Target - Handle to Unit used in orders that require a target (OPTIONAL)
+----------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: PlatoonAssignOrders = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function PlatoonAssignOrders(platoon)
     platoon:Stop()
     local data = platoon.PlatoonData
@@ -114,17 +114,17 @@ function PlatoonAssignOrders(platoon)
     ScenarioUtils.AssignOrders( data.OrderName, platoon, data.Target)
 end
 
-####################################################################
-### PlatoonAttackHighestThreat
-###     - Attacks Location on the map with the highest threat
-### PlatoonData -
-####################################################################
-##############################################################################################################
-# function: PlatoonAttackHighestThreat = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------
+------ PlatoonAttackHighestThreat
+------     - Attacks Location on the map with the highest threat
+------ PlatoonData -
+----------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: PlatoonAttackHighestThreat = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function PlatoonAttackHighestThreat(platoon)
     local patrol = false
     local aiBrain = platoon:GetBrain()
@@ -143,19 +143,19 @@ function PlatoonAttackHighestThreat(platoon)
     end
 end
 
-####################################################################
-### PlatoonAttackLocation
-###     - Attack moves to a specific location on the map
-###     - After reaching location will attack highest threat
-### PlatoonData -
-###     Location - (REQUIRED) location on the map to attack move to
-####################################################################
-##############################################################################################################
-# function: PlatoonAttackLocation = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------
+------ PlatoonAttackLocation
+------     - Attack moves to a specific location on the map
+------     - After reaching location will attack highest threat
+------ PlatoonData -
+------     Location - (REQUIRED) location on the map to attack move to
+----------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: PlatoonAttackLocation = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function PlatoonAttackLocation(platoon)
     platoon:Stop()
     local data = platoon.PlatoonData
@@ -179,22 +179,22 @@ function PlatoonAttackLocation(platoon)
     end
 end
 
-####################################################################
-### PlatoonAttackLocationList
-###     - Attack moves to a location chosen from a list
-###     - Location can be the highest threat or the lowest non-negative threat
-###     - After reaching location will attack next location from the list
-### PlatoonData -
-###     LocationList - (REQUIRED) location on the map to attack move to
-###     LocationChain - (REQUIRED) Chain on the map to attack move to
-###     High - true will attack highest threats first, false lowest - defaults to false/lowest
-####################################################################
-##############################################################################################################
-# function: PlatoonAttackLocationList = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------
+------ PlatoonAttackLocationList
+------     - Attack moves to a location chosen from a list
+------     - Location can be the highest threat or the lowest non-negative threat
+------     - After reaching location will attack next location from the list
+------ PlatoonData -
+------     LocationList - (REQUIRED) location on the map to attack move to
+------     LocationChain - (REQUIRED) Chain on the map to attack move to
+------     High - true will attack highest threats first, false lowest - defaults to false/lowest
+----------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: PlatoonAttackLocationList = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function PlatoonAttackLocationList(platoon)
     platoon:Stop()
     local location = nil
@@ -240,19 +240,19 @@ function PlatoonAttackLocationList(platoon)
     end
 end
 
-####################################################################
-### TransportPool
-###     - Moves unit to location if specified
-###     - Assigns units in platoon to TransportPool platoon for other platoons to use
-### PlatoonData -
-###     TransportMoveLocation - Location to move transport to before assigning to transport pool
-####################################################################
-##############################################################################################################
-# function: TransportPool = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------
+------ TransportPool
+------     - Moves unit to location if specified
+------     - Assigns units in platoon to TransportPool platoon for other platoons to use
+------ PlatoonData -
+------     TransportMoveLocation - Location to move transport to before assigning to transport pool
+----------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: TransportPool = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function TransportPool(platoon)
     local aiBrain = platoon:GetBrain()
     local tPool = aiBrain:GetPlatoonUniquelyNamed('TransportPool')
@@ -279,34 +279,34 @@ function TransportPool(platoon)
     end
 end
 
-####################################################################
-### LandAssaultWithTransports
-###     - Grabs a specific number of transports from the TransportPool platoon
-###     - Loads units onto transports
-###     - Sets a ready variable if required
-###     - Waits while another variable has not been set if needed
-###     - Flys to lowest threat in a list of locations and unloads land units
-###     - Transports return to a location and are re-added to transport pool
-###     - Attacks a list of locations starting with highest threat from a list
-###
-### PlatoonData -
-###     ReadyVariable - ScenarioInfo.VarTable[ReadyVariable] Variable set when units are on transports
-###     WaitVariable - ScenarioInfo.VarTable[WaitVariable] Variable checked before transports leave
-###     LandingList - (REQUIRED or LandingChain) List of possible locations for transports to unload units
-###     LandingChain - (REQUIRED or LandingList) Chain of possible landing locations
-###     TransportReturn - Location for transports to return to (they will attack with land units if this isn't set)
-###     AttackPoints - (REQUIRED or AttackChain or PatrolChain) List of locations to attack.
-###                                              The platoon attacks the highest threat first
-###     AttackChain - (REQUIRED or AttackPoints or PatrolChain) Marker Chain of postitions to attack
-###     PatrolChain - (REQUIRED or AttackChain or AttackPoints) Chain of patrolling
-###     RandomPatrol - Bool if you want the patrol things to be random rather than in order
-####################################################################
-##############################################################################################################
-# function: LandAssaultWithTransports = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------
+------ LandAssaultWithTransports
+------     - Grabs a specific number of transports from the TransportPool platoon
+------     - Loads units onto transports
+------     - Sets a ready variable if required
+------     - Waits while another variable has not been set if needed
+------     - Flys to lowest threat in a list of locations and unloads land units
+------     - Transports return to a location and are re-added to transport pool
+------     - Attacks a list of locations starting with highest threat from a list
+------
+------ PlatoonData -
+------     ReadyVariable - ScenarioInfo.VarTable[ReadyVariable] Variable set when units are on transports
+------     WaitVariable - ScenarioInfo.VarTable[WaitVariable] Variable checked before transports leave
+------     LandingList - (REQUIRED or LandingChain) List of possible locations for transports to unload units
+------     LandingChain - (REQUIRED or LandingList) Chain of possible landing locations
+------     TransportReturn - Location for transports to return to (they will attack with land units if this isn't set)
+------     AttackPoints - (REQUIRED or AttackChain or PatrolChain) List of locations to attack.
+------                                              The platoon attacks the highest threat first
+------     AttackChain - (REQUIRED or AttackPoints or PatrolChain) Marker Chain of postitions to attack
+------     PatrolChain - (REQUIRED or AttackChain or AttackPoints) Chain of patrolling
+------     RandomPatrol - Bool if you want the patrol things to be random rather than in order
+----------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: LandAssaultWithTransports = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function LandAssaultWithTransports(platoon)
     local aiBrain = platoon:GetBrain()
     local data = platoon.PlatoonData
@@ -355,7 +355,7 @@ function LandAssaultWithTransports(platoon)
         end
     end
 
-    # Make attack positions out of chain, markers, or marker names
+    -- Make attack positions out of chain, markers, or marker names
     local attackPositions = {}
     if data.AttackChain then
         attackPositions = ScenarioUtils.ChainToPositions(data.AttackChain)
@@ -371,7 +371,7 @@ function LandAssaultWithTransports(platoon)
         end
     end
 
-    # make landing positions out of chain, markers, or marker names
+    -- make landing positions out of chain, markers, or marker names
     local landingPositions = {}
     if data.LandingChain then
         landingPositions = ScenarioUtils.ChainToPositions(data.LandingChain)
@@ -389,7 +389,7 @@ function LandAssaultWithTransports(platoon)
 
     platoon:Stop()
 
-    # Load transports
+    -- Load transports
     if not GetLoadTransports(platoon) then
         return
     end
@@ -402,7 +402,7 @@ function LandAssaultWithTransports(platoon)
         return
     end
 
-    # Find landing location and unload units at right spot
+    -- Find landing location and unload units at right spot
     local landingLocation
     if ScenarioInfo.Options.Difficulty and ScenarioInfo.Options.Difficulty == 3 then
         landingLocation = PlatoonChooseRandomNonNegative(aiBrain, landingPositions, 1)
@@ -432,10 +432,10 @@ function LandAssaultWithTransports(platoon)
             ScenarioFramework.PlatoonPatrolChain( platoon, data.PatrolChain )
         end
     else
-        # Patrol attack route by creating attack route
+        -- Patrol attack route by creating attack route
         local attackRoute = {}
         attackRoute = PlatoonChooseHighestAttackRoute(aiBrain, attackPositions, 1)
-        # Send transports back to base if desired
+        -- Send transports back to base if desired
         if(platoon.PlatoonData.TransportReturn) then
             ReturnTransportsToPool(platoon,data)
         end
@@ -455,22 +455,22 @@ function LandAssaultWithTransports(platoon)
 end
 
 
-####################################################################################################################
-### MoveToThread
-###     - Moves to a set of locations
-###
-### PlatoonData
-###     - MoveToRoute - List of locations to move to
-###     - MoveChain - Chain of locations to move
-###     - UseTransports - boolean, if true, use transports to move
-###
-####################################################################################################################
-##############################################################################################################
-# function: MoveToThread = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+------ MoveToThread
+------     - Moves to a set of locations
+------
+------ PlatoonData
+------     - MoveToRoute - List of locations to move to
+------     - MoveChain - Chain of locations to move
+------     - UseTransports - boolean, if true, use transports to move
+------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: MoveToThread = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function MoveToThread(platoon)
     local data = platoon.PlatoonData
 
@@ -506,21 +506,21 @@ function MoveToThread(platoon)
 end
 
 
-####################################################################################################################
-### PatrolThread
-###     - Patrols a set of locations
-###
-### PlatoonData
-###     - PatrolRoute - List of locations to patrol
-###     - PatrolChain - Chain of locations to patrol
-###
-####################################################################################################################
-##############################################################################################################
-# function: PatrolThread = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+------ PatrolThread
+------     - Patrols a set of locations
+------
+------ PlatoonData
+------     - PatrolRoute - List of locations to patrol
+------     - PatrolChain - Chain of locations to patrol
+------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: PatrolThread = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function PatrolThread(platoon)
     local data = platoon.PlatoonData
     platoon:Stop()
@@ -546,21 +546,21 @@ function PatrolThread(platoon)
 end
 
 
-####################################################################################################################
-### RandomPatrolThread
-###     - Gives a platoon a random patrol path from a set of locations
-###
-### PlatoonData
-###     - PatrolRoute - List of locations to patrol
-###     - PatrolChain - Chain of locations to patrol
-###
-####################################################################################################################
-##############################################################################################################
-# function: RandomPatrolThread = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+------ RandomPatrolThread
+------     - Gives a platoon a random patrol path from a set of locations
+------
+------ PlatoonData
+------     - PatrolRoute - List of locations to patrol
+------     - PatrolChain - Chain of locations to patrol
+------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: RandomPatrolThread = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function RandomPatrolThread(platoon)
     local data = platoon.PlatoonData
     platoon:Stop()
@@ -589,20 +589,20 @@ function RandomPatrolThread(platoon)
 end
 
 
-####################################################################################################################
-### RandomDefensePatrolThread
-###     - Gives a platoon a random patrol path from a set of locations
-###
-### PlatoonData
-###     - PatrolChain - Chain of locations to patrol
-###
-####################################################################################################################
-##############################################################################################################
-# function: RandomDefensePatrolThread = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+------ RandomDefensePatrolThread
+------     - Gives a platoon a random patrol path from a set of locations
+------
+------ PlatoonData
+------     - PatrolChain - Chain of locations to patrol
+------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: RandomDefensePatrolThread = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function RandomDefensePatrolThread(platoon)
     local data = platoon.PlatoonData
     platoon:Stop()
@@ -619,20 +619,20 @@ function RandomDefensePatrolThread(platoon)
     end
 end
 
-####################################################################################################################
-### PatrolChainPickerThread
-###     - Gives a platoon a random patrol chain from a set of chains
-###
-### PlatoonData
-###     - PatrolChains - List of chains to choose from
-###
-####################################################################################################################
-##############################################################################################################
-# function: PatrolChainPickerThread = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+------ PatrolChainPickerThread
+------     - Gives a platoon a random patrol chain from a set of chains
+------
+------ PlatoonData
+------     - PatrolChains - List of chains to choose from
+------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: PatrolChainPickerThread = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function PatrolChainPickerThread(platoon)
     local data = platoon.PlatoonData
     platoon:Stop()
@@ -640,7 +640,7 @@ function PatrolChainPickerThread(platoon)
         if(data.PatrolChains) then
             local chain = Random(1, table.getn(data.PatrolChains))
             ScenarioFramework.PlatoonPatrolRoute(platoon, ScenarioUtils.ChainToPositions(data.PatrolChains[chain]))
-            #LOG('Picked chain number ', chain)
+            --LOG('Picked chain number ', chain)
         else
             error('*SCENARIO PLATOON AI ERROR: PatrolChains not defined', 2)
         end
@@ -649,12 +649,12 @@ function PatrolChainPickerThread(platoon)
     end
 end
 
-##############################################################################################################
-# function: EngineersBuildPlatoon = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: EngineersBuildPlatoon = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function EngineersBuildPlatoon(platoon)
     local aiBrain = platoon:GetBrain()
     local platoonUnits = platoon:GetPlatoonUnits()
@@ -672,7 +672,7 @@ function EngineersBuildPlatoon(platoon)
         error('*SCENARIO PLATOON AI ERROR: EngineersBuildPlatoon requires PlatoonsTable', 2)
     end
 
-    # Find all engineers in platoon
+    -- Find all engineers in platoon
     for k, v in platoonUnits do
         if EntityCategoryContains(categories.CONSTRUCTION, v) then
             if not eng then
@@ -685,7 +685,7 @@ function EngineersBuildPlatoon(platoon)
     if not eng then
         error('*SCENARIO PLATOON AI ERROR: No Engineers found in platoon using EngineersBuildPlatoon',2)
     end
-    # Wait for eng to stop moving
+    -- Wait for eng to stop moving
     while eng:IsUnitState('Moving') do
         WaitSeconds(3)
         if not aiBrain:PlatoonExists(platoon) then
@@ -693,9 +693,9 @@ function EngineersBuildPlatoon(platoon)
         end
     end
 
-    #=== Have all engineers guard main engineer
+    --=== Have all engineers guard main engineer
     if table.getn(engTable) > 0 then
-        if eng:IsDead() then # Must check if a death occured since platoon was forked
+        if eng:IsDead() then -- Must check if a death occured since platoon was forked
             for num, unit in engTable do
                 if not unit:IsDead() then
                     eng = table.remove(engTable, num)
@@ -715,7 +715,7 @@ function EngineersBuildPlatoon(platoon)
     end
 
     while aiBrain:PlatoonExists(platoon) do
-        # Set new primary eng
+        -- Set new primary eng
         if eng:IsDead() then
             return
         end
@@ -762,7 +762,7 @@ function EngineersBuildPlatoon(platoon)
                                 end
                             end
                         end
-                    until not eng or eng:IsDead() or eng:IsIdleState() #not (eng:IsUnitState('Building') or eng:IsUnitState('Repairing') or eng:IsUnitState('Moving'))
+                    until not eng or eng:IsDead() or eng:IsIdleState() --not (eng:IsUnitState('Building') or eng:IsUnitState('Repairing') or eng:IsUnitState('Moving'))
                     if not aiBrain.EngBuiltPlatoonList[buildingPlatoon] then
                         plat = aiBrain:MakePlatoon('', '')
                         aiBrain.EngBuiltPlatoonList[buildingPlatoon] = plat
@@ -796,7 +796,7 @@ function EngineersBuildPlatoon(platoon)
             end
             newPlatoonUnits = {}
 
-            ### Disband if desired
+            ------ Disband if desired
             if aiBrain:PlatoonExists(platoon) and data.DisbandAfterBuilding then
                 aiBrain:DisbandPlatoon(platoon)
             end
@@ -811,21 +811,21 @@ function EngineersBuildPlatoon(platoon)
 end
 
 
-####################################################################################################################
-### CategoryHunterPlatoonAI
-###    -- Sends out units to hunt and attack Experimental Air units (Soul Ripper, Czar, etc)
-###    -- It cheats to find the air units.  This should *NOT* ever be used in skirmish.
-###    -- This platoon only seeks out PLAYER experimentals.  It will never find any other army's
-###
-### PlatoonData -
-###    -- CategoryList : The categories we are going to find and attack
-##################################################################################################################
-##############################################################################################################
-# function: CategoryHunterPlatoonAI = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+------ CategoryHunterPlatoonAI
+------    -- Sends out units to hunt and attack Experimental Air units (Soul Ripper, Czar, etc)
+------    -- It cheats to find the air units.  This should *NOT* ever be used in skirmish.
+------    -- This platoon only seeks out PLAYER experimentals.  It will never find any other army's
+------
+------ PlatoonData -
+------    -- CategoryList : The categories we are going to find and attack
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: CategoryHunterPlatoonAI = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function CategoryHunterPlatoonAI(platoon)
     local aiBrain = platoon:GetBrain()
     local platoonUnits = platoon:GetPlatoonUnits()
@@ -886,62 +886,62 @@ function CategoryHunterPlatoonAI(platoon)
 end
 
 
-####################################################################################################################
-### StartBaseEngineerThread
-###     - Upgrades engineer to desired tech level
-###     - Moves an engineer to a location with either transports or using a transport beacon
-###     - Builds specific buildings found in PlatoonData.Construction
-###     - Can maintain a base found in PlatoonData
-###     - Can patrol a route either while maintaining a base or just prior to disbanding back into the PoolPlatoon
-###
-### PlatoonData -
-###     ReadyVariable - ScenarioInfo.VarTable[ReadyVariable] Variable set when units are on transports
-###     WaitVariable - ScenarioInfo.VarTable[WaitVariable] Variable checked before transports leave
-###     LandingLocation - Location for transports to drop engineers
-###     MoveBeacon - TransportBeacon to use to move engineer to location
-###     Construction - Table that holds data for a specific building order
-###                  - only the buildings specified in BuildStructures be built
-###         -> BuildingTemplate - building template found in BaseTemplates.lua
-###                               (only required if trying to build different factions buildings )
-###         -> BaseTemplate - Name of base template to use.  This template is generated from bases made in the editor
-###         -> BuildClose - Bool if you want to have unit pick closest of next building to build
-###         -> BuildStructures - List of buildings to build in order, ex:T1AirFactory, T2ShieldDefense, etc
-###
-###     BuildBaseTemplate - BaseTemplate of the base to build once
-###     MaintainBaseTemplate - BaseTemplate of base to build any non-existing buildings for.
-###     AssistFactories - Bool; will assist factories in a Location Type when set true; break off and rebuild if maintain
-###     LocationType - PBM Location Type to have the engineers assist build factories in
-###     BuildingTemplate - building template found in BaseTemplates.lua
-###                        (only required if trying to build different factions buildings )
-###     PatrolRoute - Route of locations to patrol while maintaining or after platoon disbanded
-###     PatrolChain - Chain of locations to patrol while maintaining or after platoon disbanded
-###     TransportRoute - List of locations for the transport to use to get to the location
-###     TransportChain - Chain of locations for the transport to use to get to landing location
-###     DisbandAfterPatrol - bool, if true, platoon will disband if its not maintaining a base and given a patrol order
-###     RandomPatrol - bool, if true, platoon will sort PatrolRoute randomly
-###     UseTransports - bool, if true, platoons will use transports to move
-###     NamedUnitBuild - table of unit names; platoon will build these specific units and only build them once
-###     GroupBuildOnce - name of a group to build each thing in the group only once
-###
-### Order of events:
-###     Grab transports, set ready variable, wait for wait variable, travel using transports,
-###         travel using beacon, build structures in Construction block, build base using BuildBaseTemplate,
-###         the platoon will assist factories if assigned to do so, they will break off and rebuild if Maintain is set,
-###         maintain a base using MaintainBaseTemplate (will patrol here if PatrolRoute given),
-###         patrol using PatrolRoute, platoon can disband if given a patrol and is not maintaining a base
-##################################################################################################################
-##############################################################################################################
-# function: StartBaseEngineerThread = AddFunction	doc = "Please work function docs."
-#
-# parameter 0: string	platoon         = "default_platoon"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+------ StartBaseEngineerThread
+------     - Upgrades engineer to desired tech level
+------     - Moves an engineer to a location with either transports or using a transport beacon
+------     - Builds specific buildings found in PlatoonData.Construction
+------     - Can maintain a base found in PlatoonData
+------     - Can patrol a route either while maintaining a base or just prior to disbanding back into the PoolPlatoon
+------
+------ PlatoonData -
+------     ReadyVariable - ScenarioInfo.VarTable[ReadyVariable] Variable set when units are on transports
+------     WaitVariable - ScenarioInfo.VarTable[WaitVariable] Variable checked before transports leave
+------     LandingLocation - Location for transports to drop engineers
+------     MoveBeacon - TransportBeacon to use to move engineer to location
+------     Construction - Table that holds data for a specific building order
+------                  - only the buildings specified in BuildStructures be built
+------         -> BuildingTemplate - building template found in BaseTemplates.lua
+------                               (only required if trying to build different factions buildings )
+------         -> BaseTemplate - Name of base template to use.  This template is generated from bases made in the editor
+------         -> BuildClose - Bool if you want to have unit pick closest of next building to build
+------         -> BuildStructures - List of buildings to build in order, ex:T1AirFactory, T2ShieldDefense, etc
+------
+------     BuildBaseTemplate - BaseTemplate of the base to build once
+------     MaintainBaseTemplate - BaseTemplate of base to build any non-existing buildings for.
+------     AssistFactories - Bool; will assist factories in a Location Type when set true; break off and rebuild if maintain
+------     LocationType - PBM Location Type to have the engineers assist build factories in
+------     BuildingTemplate - building template found in BaseTemplates.lua
+------                        (only required if trying to build different factions buildings )
+------     PatrolRoute - Route of locations to patrol while maintaining or after platoon disbanded
+------     PatrolChain - Chain of locations to patrol while maintaining or after platoon disbanded
+------     TransportRoute - List of locations for the transport to use to get to the location
+------     TransportChain - Chain of locations for the transport to use to get to landing location
+------     DisbandAfterPatrol - bool, if true, platoon will disband if its not maintaining a base and given a patrol order
+------     RandomPatrol - bool, if true, platoon will sort PatrolRoute randomly
+------     UseTransports - bool, if true, platoons will use transports to move
+------     NamedUnitBuild - table of unit names; platoon will build these specific units and only build them once
+------     GroupBuildOnce - name of a group to build each thing in the group only once
+------
+------ Order of events:
+------     Grab transports, set ready variable, wait for wait variable, travel using transports,
+------         travel using beacon, build structures in Construction block, build base using BuildBaseTemplate,
+------         the platoon will assist factories if assigned to do so, they will break off and rebuild if Maintain is set,
+------         maintain a base using MaintainBaseTemplate (will patrol here if PatrolRoute given),
+------         patrol using PatrolRoute, platoon can disband if given a patrol and is not maintaining a base
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: StartBaseEngineerThread = AddFunction    doc = "Please work function docs."
+--
+-- parameter 0: string    platoon         = "default_platoon"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function StartBaseEngineerThread(platoon)
     local aiBrain = platoon:GetBrain()
     local platoonUnits = platoon:GetPlatoonUnits()
     local data = platoon.PlatoonData
     local baseName
-    # Check for bad variables
+    -- Check for bad variables
     for varName, varData in data do
         if not(varName == 'ReadyVariable' or varName == 'WaitVariable' or varName == 'LandingLocation' or
                varName == 'MoveBeacon' or varName == 'Construction' or varName == 'BuildBaseTemplate' or
@@ -957,7 +957,7 @@ function StartBaseEngineerThread(platoon)
             error('*SCENARIO PLATOON AI ERROR: StartBaseEngineerThread does not accept variable named-'..varName,2)
         end
     end
-    # Check Construction table for bad variables
+    -- Check Construction table for bad variables
     if data.Construction then
         for varName, varData in data.Construction do
             if not(varName == 'BuildingTemplate' or varName == 'BaseTemplate' or varName == 'BuildClose' or
@@ -967,7 +967,7 @@ function StartBaseEngineerThread(platoon)
         end
     end
 
-    # Set BaseTemplats in brain if not existing already
+    -- Set BaseTemplats in brain if not existing already
     if data then
         baseName = data.MaintainBaseTemplate
         if baseName then
@@ -993,7 +993,7 @@ function StartBaseEngineerThread(platoon)
     local cmd
     local unitBeingBuilt
 
-    # Find all engineers in platoon
+    -- Find all engineers in platoon
     for k, v in platoonUnits do
         if EntityCategoryContains(categories.CONSTRUCTION, v) then
             if not eng then
@@ -1006,7 +1006,7 @@ function StartBaseEngineerThread(platoon)
     if not eng then
         error('*SCENARIO PLATOON AI ERROR: No Engineers found in platoon using StartBaseEngineer',2)
     end
-    # Wait for eng to stop moving
+    -- Wait for eng to stop moving
     while not eng:IsDead() and  eng:IsUnitState('Moving') do
         WaitSeconds(3)
         if not aiBrain:PlatoonExists(platoon) then
@@ -1015,26 +1015,26 @@ function StartBaseEngineerThread(platoon)
     end
     platoon:Stop()
 
-    # if platoon needs transports get em
+    -- if platoon needs transports get em
     if data.UseTransports then
         if not GetLoadTransports(platoon) then
             return
         end
     end
 
-    # Set Ready and hold for Wait variable
+    -- Set Ready and hold for Wait variable
     if not ReadyWaitVariables(data) then
         return
     end
 
-    # Move and unload units
+    -- Move and unload units
     if not StartBaseTransports(platoon, data, aiBrain) then
         return
     end
 
-    #=== Have all engineers guard main engineer
+    --=== Have all engineers guard main engineer
     if table.getn(engTable) > 0 then
-        if eng:IsDead() then # Must check if a death occured since platoon was forked
+        if eng:IsDead() then -- Must check if a death occured since platoon was forked
             for num, unit in engTable do
                 if not unit:IsDead() then
                     eng = table.remove(engTable, num)
@@ -1049,44 +1049,44 @@ function StartBaseEngineerThread(platoon)
         end
     end
 
-    # Construction Block building
+    -- Construction Block building
     if not StartBaseConstruction(eng, engTable, data, aiBrain) then
         return
     end
 
-    # Build specific units
+    -- Build specific units
     if not StartBaseBuildUnits(eng, engTable, data, aiBrain) then
         return
     end
 
-    # Build group unit once thing
+    -- Build group unit once thing
     if not StartBaseGroupOnceBuild( eng, engTable, data, aiBrain) then
         return
     end
 
-    # BuildBaseTemplate building
+    -- BuildBaseTemplate building
     if not StartBaseBuildBase(eng, engTable, data, aiBrain) then
         return
     end
 
-    # Factory assisting
+    -- Factory assisting
     if data.LocationType and data.AssistFactories then
         ForkThread(EngineersAssistFactories,platoon, data.LocationType)
     end
 
-    # MaintainBaseTemplate
+    -- MaintainBaseTemplate
     if ScenarioInfo.Options.Difficulty >= (data.MaintainDiffLevel or 2) then
         if not StartBaseMaintainBase(platoon, eng, engTable, data, aiBrain) then
             return
         end
     end
 
-    # Send engineers on patrol
+    -- Send engineers on patrol
     if aiBrain:PlatoonExists(platoon) then
         EngPatrol(eng, engTable, data)
     end
 
-    ## Disband if desired
+    ---- Disband if desired
     if aiBrain:PlatoonExists(platoon) and data.DisbandAfterPatrol then
         aiBrain:DisbandPlatoon(platoon)
     end
@@ -1094,16 +1094,16 @@ end
 
 
 
-# -----------------
-# UTILITY FUNCTIONS
-# -----------------
+-- -----------------
+-- UTILITY FUNCTIONS
+-- -----------------
 
-# ---------------------------------------------------------
-# Utility Function
-# Gets engineers using StartBaseEngineers to their location
-# ---------------------------------------------------------
+-- ---------------------------------------------------------
+-- Utility Function
+-- Gets engineers using StartBaseEngineers to their location
+-- ---------------------------------------------------------
 function StartBaseTransports(platoon, data, aiBrain)
-    ## Move the unit using transports
+    ---- Move the unit using transports
     if data.UseTransports then
         if data.TransportRoute then
             for k, v in data.TransportRoute do
@@ -1121,13 +1121,13 @@ function StartBaseTransports(platoon, data, aiBrain)
             end
         end
 
-        # Unload transports
+        -- Unload transports
         if type(data.LandingLocation) == 'string' then
             cmd = platoon:UnloadAllAtLocation( ScenarioUtils.MarkerToPosition(data.LandingLocation))
         else
             cmd = platoon:UnloadAllAtLocation( data.LandingLocation)
         end
-        # Wait for unload to end
+        -- Wait for unload to end
         while platoon:IsCommandsActive(cmd) do
             WaitSeconds(3)
             if not aiBrain:PlatoonExists(platoon) then
@@ -1139,7 +1139,7 @@ function StartBaseTransports(platoon, data, aiBrain)
         end
     end
 
-    #### Move unit if needed - USING FERRYS
+    -------- Move unit if needed - USING FERRYS
     if data.MoveBeacon then
         while not ScenarioInfo.VarTable[data.MoveBeacon] do
             WaitSeconds(3)
@@ -1159,16 +1159,16 @@ function StartBaseTransports(platoon, data, aiBrain)
 end
 
 
-# ------------------------------------------------------------------------------------
-# Utility Function
-# Takes transports in platoon, returns them to pool, flys them back to return location
-# ------------------------------------------------------------------------------------
+-- ------------------------------------------------------------------------------------
+-- Utility Function
+-- Takes transports in platoon, returns them to pool, flys them back to return location
+-- ------------------------------------------------------------------------------------
 function ReturnTransportsToPool(platoon, data)
-    # Put transports back in TPool
+    -- Put transports back in TPool
     local aiBrain = platoon:GetBrain()
     for k,unit in platoon:GetPlatoonUnits() do
         if EntityCategoryContains( categories.TRANSPORTATION, unit ) then
-            # If a route was given, reverse the route on return
+            -- If a route was given, reverse the route on return
             if data.TransportRoute then
                 aiBrain:AssignUnitsToPlatoon( 'TransportPool', {unit}, 'Scout', 'None' )
                 for i=table.getn(data.TransportRoute),1,-1 do
@@ -1185,7 +1185,7 @@ function ReturnTransportsToPool(platoon, data)
                         IssueMove( {unit}, data.TransportReturn)
                     end
                 end
-                # If a route chain was given, reverse the route on return
+                -- If a route chain was given, reverse the route on return
             elseif data.TransportChain then
                 local transPositionChain = {}
                 transPositionChain = ScenarioUtils.ChainToPositions(data.TransportChain)
@@ -1200,7 +1200,7 @@ function ReturnTransportsToPool(platoon, data)
                         IssueMove( {unit}, data.TransportReturn)
                     end
                 end
-                # return to Transport Return if no route
+                -- return to Transport Return if no route
             else
                 if data.TransportReturn then
                     aiBrain:AssignUnitsToPlatoon( 'TransportPool', {unit}, 'Scout', 'None' )
@@ -1215,10 +1215,10 @@ function ReturnTransportsToPool(platoon, data)
     end
 end
 
-# -------------------------------------------------------------------------------
-# Utility Function
-# Uses UnitBuild block to build specific units on the map using StartBaseEngineer
-# -------------------------------------------------------------------------------
+-- -------------------------------------------------------------------------------
+-- Utility Function
+-- Uses UnitBuild block to build specific units on the map using StartBaseEngineer
+-- -------------------------------------------------------------------------------
 function StartBaseBuildUnits(eng, engTable, data, aiBrain)
     local unitBeingBuilt
     local unitTable = data.NamedUnitBuild
@@ -1257,10 +1257,10 @@ function StartBaseBuildUnits(eng, engTable, data, aiBrain)
     return true
 end
 
-# --------------------------------------------------------------------------
-# Utility Function
-# Uses GroupBuildOnce and builds each thing in said group once and only once
-# --------------------------------------------------------------------------
+-- --------------------------------------------------------------------------
+-- Utility Function
+-- Uses GroupBuildOnce and builds each thing in said group once and only once
+-- --------------------------------------------------------------------------
 function StartBaseGroupOnceBuild( eng, engTable, data, aiBrain)
     local unitBeingBuilt
     if data.GroupBuildOnce then
@@ -1294,10 +1294,10 @@ function StartBaseGroupOnceBuild( eng, engTable, data, aiBrain)
 end
 
 
-# -------------------------------------------------------------
-# Utility Function
-# Uses Construction blocks in engineers using StartBaseEngineer
-# -------------------------------------------------------------
+-- -------------------------------------------------------------
+-- Utility Function
+-- Uses Construction blocks in engineers using StartBaseEngineer
+-- -------------------------------------------------------------
 function StartBaseConstruction(eng, engTable, data, aiBrain)
     local cons = data.Construction
     local buildingTmpl
@@ -1318,7 +1318,7 @@ function StartBaseConstruction(eng, engTable, data, aiBrain)
                 v = string.gsub(v, '2', '1')
                 v = string.gsub(v, '3', '1')
             end
-            #platoon:Stop()
+            --platoon:Stop()
             EngineerBuildStructure(aiBrain, eng, v, baseTmpl, buildingTmpl )
             if eng:GetUnitBeingBuilt() then
                 unitBeingBuilt = eng:GetUnitBeingBuilt()
@@ -1340,10 +1340,10 @@ function StartBaseConstruction(eng, engTable, data, aiBrain)
 end
 
 
-# ---------------------------------------------------------------------------
-# Utility Function
-# Builds a base using BuildBaseTemplate for engineers using StartBaseEngineer
-# ---------------------------------------------------------------------------
+-- ---------------------------------------------------------------------------
+-- Utility Function
+-- Builds a base using BuildBaseTemplate for engineers using StartBaseEngineer
+-- ---------------------------------------------------------------------------
 function StartBaseBuildBase(eng, engTable, data, aiBrain)
     local unitBeingBuilt
     if data.BuildBaseTemplate then
@@ -1386,10 +1386,10 @@ function StartBaseBuildBase(eng, engTable, data, aiBrain)
 end
 
 
-# -------------------------------------------------
-# Utility Function
-# Maintains a base for engs using StartBaseEngineer
-# -------------------------------------------------
+-- -------------------------------------------------
+-- Utility Function
+-- Maintains a base for engs using StartBaseEngineer
+-- -------------------------------------------------
 function StartBaseMaintainBase(platoon, eng, engTable, data, aiBrain)
     local unitBeingBuilt
     if data.MaintainBaseTemplate then
@@ -1467,13 +1467,13 @@ function StartBaseMaintainBase(platoon, eng, engTable, data, aiBrain)
 end
 
 
-# -----------------------------------------------
-# Utility Function
-# Sends engineers on patrol for StartBaseEngineer
-# -----------------------------------------------
+-- -----------------------------------------------
+-- Utility Function
+-- Sends engineers on patrol for StartBaseEngineer
+-- -----------------------------------------------
 function EngPatrol(eng, engTable, data)
     table.insert(engTable, eng)
-    ## Patrol an area if nothing else to do
+    ---- Patrol an area if nothing else to do
     if data.PatrolRoute or data.PatrolChain then
         local patrolPositions = {}
         if data.PatrolChain then
@@ -1500,10 +1500,10 @@ function EngPatrol(eng, engTable, data)
     return true
 end
 
-# -------------------------------------------------------
-# Utility Function
-# Resets main engineer and engTablef or StartBaseEngineer
-# -------------------------------------------------------
+-- -------------------------------------------------------
+-- Utility Function
+-- Resets main engineer and engTablef or StartBaseEngineer
+-- -------------------------------------------------------
 function AssistOtherEngineer(eng, engTable, unitBeingBuilt)
     if engTable and table.getn(engTable) > 0 then
         for num, unit in engTable do
@@ -1526,10 +1526,10 @@ function AssistOtherEngineer(eng, engTable, unitBeingBuilt)
 end
 
 
-# -----------------------------------------------------------------------
-# Utility Function
-# Has an engineer build a certain type of structure using a base template
-# -----------------------------------------------------------------------
+-- -----------------------------------------------------------------------
+-- Utility Function
+-- Has an engineer build a certain type of structure using a base template
+-- -----------------------------------------------------------------------
 function EngineerBuildStructure(aiBrain, builder, building, brainBaseTemplate, buildingTemplate)
     local structureCategory
     if not buildingTemplate then
@@ -1571,10 +1571,10 @@ function EngineerBuildStructure(aiBrain, builder, building, brainBaseTemplate, b
     return false
 end
 
-# -----------------------------------------------------------------
-# Utility Function
-# Stops factory assisting when an eng platoon is maintaining a base
-# -----------------------------------------------------------------
+-- -----------------------------------------------------------------
+-- Utility Function
+-- Stops factory assisting when an eng platoon is maintaining a base
+-- -----------------------------------------------------------------
 function BreakOffFactoryAssist(platoon, data)
     local aiBrain = platoon:GetBrain()
     if platoon.PlatoonData.FactoryAssistList then
@@ -1594,10 +1594,10 @@ function BreakOffFactoryAssist(platoon, data)
 end
 
 
-# ----------------------------------------------------
-# Utility Function
-# Tell engineers to assist factories in a locationType
-# ----------------------------------------------------
+-- ----------------------------------------------------
+-- Utility Function
+-- Tell engineers to assist factories in a locationType
+-- ----------------------------------------------------
 function EngineersAssistFactories(platoon, locationType)
     locationType = locationType or platoon.PlatoonData.LocationType
     local aiBrain = platoon:GetBrain()
@@ -1608,7 +1608,7 @@ function EngineersAssistFactories(platoon, locationType)
     local reassignEngPool = {}
     platoon.PlatoonData.FactoryAssistList = {}
 
-    # Find location out of brain
+    -- Find location out of brain
     for num,locData in aiBrain.PBM.Locations do
         if locationType == locData.LocationType then
             location = locData.Location
@@ -1619,7 +1619,7 @@ function EngineersAssistFactories(platoon, locationType)
         error('*SCENARIO PLATOON AI ERROR: No LocationType found for StartBaseEngineerThread, location named- '..repr(locationType),2)
     end
 
-    # Find engineers
+    -- Find engineers
     local engTable = {}
     for num,unit in platoon:GetPlatoonUnits() do
         if EntityCategoryContains(categories.CONSTRUCTION, unit) then
@@ -1628,12 +1628,12 @@ function EngineersAssistFactories(platoon, locationType)
         end
     end
 
-    #### Main loop for assisting below
+    -------- Main loop for assisting below
 
     local newFactory = false
     while aiBrain:PlatoonExists(platoon) do
         if not platoon.PlatoonData.Busy then
-            # check for dead factories
+            -- check for dead factories
             local num = 1
             while num <= table.getn(platoon.PlatoonData.FactoryAssistList) do
                 if platoon.PlatoonData.FactoryAssistList[num].Factory:IsDead() then
@@ -1647,7 +1647,7 @@ function EngineersAssistFactories(platoon, locationType)
                 end
             end
 
-            # Find factories in the area belonging to proper brain
+            -- Find factories in the area belonging to proper brain
             local tempFactories = aiBrain:GetUnitsAroundPoint(categories.FACTORY, location, radius, 'Ally')
             for num, factory in tempFactories do
                 if factory:GetAIBrain() == aiBrain then
@@ -1664,7 +1664,7 @@ function EngineersAssistFactories(platoon, locationType)
                     end
                 end
             end
-            # Add factory data to brain assist list if needed, update number of engs per factory
+            -- Add factory data to brain assist list if needed, update number of engs per factory
             for num, pltnFacData in platoon.PlatoonData.FactoryAssistList do
                 local found = false
                 local brainFacData
@@ -1683,19 +1683,19 @@ function EngineersAssistFactories(platoon, locationType)
                 end
             end
 
-            # check for dead engineers
+            -- check for dead engineers
             local engNum = 1
             while engNum < table.getn(engTable) do
                 local eng = engTable[engNum]
                 if eng:IsDead() then
                     table.remove(engTable, engNum)
-                    # Remove from platoon factory assist list
+                    -- Remove from platoon factory assist list
                     for facNum, facData in platoon.PlatoonData.FactoryAssistList do
                         for facEngNum, facEngData in facData.Engineers do
                             if eng == facEngData then
                                 facData.NumEngs = facData.NumEngs - 1
                                 table.remove(facData.Engineers, facEngNum)
-                                # reduce number in global fac list
+                                -- reduce number in global fac list
                                 for brainFacNum, brainFacData in aiBrain.FactoryAssistList do
                                     if brainFacData.Factory == facData.Factory then
                                         brainFacData.NumEngs = brainFacData.NumEngs - 1
@@ -1710,7 +1710,7 @@ function EngineersAssistFactories(platoon, locationType)
                 end
             end
 
-            # if maintain base finished, reassign all engs
+            -- if maintain base finished, reassign all engs
             if platoon.PlatoonData.ReassignAssist then
                 for num,unit in platoon:GetPlatoonUnits() do
                     if not unit:IsDead() and EntityCategoryContains(categories.CONSTRUCTION, unit) then
@@ -1719,28 +1719,28 @@ function EngineersAssistFactories(platoon, locationType)
                 end
             end
 
-            # Reassign engs if needed then reevaluate balance
+            -- Reassign engs if needed then reevaluate balance
             if reassignEngs or platoon.PlatoonData.ReassignAssist then
                 EngAssist(platoon, reassignEngPool)
             end
 
-            # Check if engs needs to be reorganized on factories
+            -- Check if engs needs to be reorganized on factories
             if not needReorganize then
                 needReorganize = CheckFactoryAssistBalance(platoon.PlatoonData.FactoryAssistList)
             end
 
-            # reassign engs if factory lost; assign all engs if needed
+            -- reassign engs if factory lost; assign all engs if needed
             if firstAssign then
                 EngAssist(platoon, reassignEngPool)
             elseif needReorganize then
                 ReorganizeEngineers(platoon, engTable)
             end
-            # any leftovers?
+            -- any leftovers?
             if table.getn(reassignEngPool) > 0 then
                 EngAssist(platoon, reassignEngPool)
             end
 
-            # reset locals
+            -- reset locals
             needReorganize = false
             firstAssign = false
             reassignEngs = false
@@ -1752,10 +1752,10 @@ function EngineersAssistFactories(platoon, locationType)
 end
 
 
-# -------------------------------------------------------
-# Utility Function
-# Reorganizes engineer assisting if there is an imbalance
-# -------------------------------------------------------
+-- -------------------------------------------------------
+-- Utility Function
+-- Reorganizes engineer assisting if there is an imbalance
+-- -------------------------------------------------------
 function ReorganizeEngineers(platoon, engTable)
     local unbalanced = true
     local aiBrain = platoon:GetBrain()
@@ -1767,7 +1767,7 @@ function ReorganizeEngineers(platoon, engTable)
         local facLowData
         local facHighNum = 0
         local facHighData
-        # Finds the high and low of engs assisting a factory
+        -- Finds the high and low of engs assisting a factory
         for facNum, facData in platoon.PlatoonData.FactoryAssistList do
             if facLowNum == -1 or facData.NumEngs < facLowNum then
                 facLowNum = facData.NumEngs
@@ -1778,7 +1778,7 @@ function ReorganizeEngineers(platoon, engTable)
                 facHighData = facData
             end
         end
-        # If difference is greater than 1 across factories: reorganize
+        -- If difference is greater than 1 across factories: reorganize
         if (facHighNum - facLowNum) > 1 and facHighData ~= facLowData and table.getn(facHighData.Engineers) > 0 then
             unbalanced = true
             if table.getn(facHighData.Engineers) > 0 then
@@ -1786,7 +1786,7 @@ function ReorganizeEngineers(platoon, engTable)
                     if not engData:IsDead() then
                         local moveEng = table.remove(facHighData.Engineers, engNum)
                         facHighData.NumEngs = facHighData.NumEngs - 1
-                        # decrease number in global fac list
+                        -- decrease number in global fac list
                         for brainFacNum, brainFacData in aiBrain.FactoryAssistList do
                             if brainFacData.Factory == facHighData.Factory then
                                 brainFacData.NumEngs = brainFacData.NumEngs - 1
@@ -1794,7 +1794,7 @@ function ReorganizeEngineers(platoon, engTable)
                             end
                         end
                         facLowData.NumEngs = facLowData.NumEngs + 1
-                        # increment number in global fac list
+                        -- increment number in global fac list
                         for brainFacNum, brainFacData in aiBrain.FactoryAssistList do
                             if brainFacData.Factory == facLowData.Factory then
                                 brainFacData.NumEngs = brainFacData.NumEngs + 1
@@ -1811,13 +1811,13 @@ function ReorganizeEngineers(platoon, engTable)
 end
 
 
-# ---------------------------------------
-# Utility Function
-# Assign engineers to factories to assist
-# ---------------------------------------
+-- ---------------------------------------
+-- Utility Function
+-- Assign engineers to factories to assist
+-- ---------------------------------------
 function EngAssist(platoon, engTable)
     local aiBrain = platoon:GetBrain()
-    # Have engineers assist the factories
+    -- Have engineers assist the factories
     local engNum = 1
     while engNum <= table.getn(engTable) do
         eng = engTable[engNum]
@@ -1830,7 +1830,7 @@ function EngAssist(platoon, engTable)
                     lowNum = fac.NumEngs
                 end
             end
-            # Store eng with correct factory, update number, have engs assist
+            -- Store eng with correct factory, update number, have engs assist
             if lowFac then
                 table.insert(lowFac.Engineers, eng)
                 lowFac.NumEngs = lowFac.NumEngs + 1
@@ -1853,10 +1853,10 @@ function EngAssist(platoon, engTable)
 end
 
 
-# ---------------------------------------------------------------
-# Utility Function
-# Check all factories in given table to see if there is imbalance
-# ---------------------------------------------------------------
+-- ---------------------------------------------------------------
+-- Utility Function
+-- Check all factories in given table to see if there is imbalance
+-- ---------------------------------------------------------------
 function CheckFactoryAssistBalance(factoryTable)
     local facLowNum = -1
     local facHighNum = 0
@@ -1875,13 +1875,13 @@ function CheckFactoryAssistBalance(factoryTable)
 end
 
 
-# ------------------------------------------------------
-# Utility Function
-# Set Ready Variable and wait for Wait Variable if given
-# ------------------------------------------------------
+-- ------------------------------------------------------
+-- Utility Function
+-- Set Ready Variable and wait for Wait Variable if given
+-- ------------------------------------------------------
 function ReadyWaitVariables(data)
-    ## Set ready and check wait variable after upgraded and/or loaded on transport
-    ## Just prior to moving the unit
+    ---- Set ready and check wait variable after upgraded and/or loaded on transport
+    ---- Just prior to moving the unit
     if data.ReadyVariable then
         ScenarioInfo.VarTable[data.ReadyVariable] = true
     end
@@ -1897,10 +1897,10 @@ function ReadyWaitVariables(data)
     return true
 end
 
-# ------------------------------------------
-# Utility Function
-# Get and load transports with platoon units
-# ------------------------------------------
+-- ------------------------------------------
+-- Utility Function
+-- Get and load transports with platoon units
+-- ------------------------------------------
 function GetLoadTransports(platoon)
     local numTransports = GetTransportsThread(platoon)
     if not numTransports then
@@ -1911,7 +1911,7 @@ function GetLoadTransports(platoon)
     local aiBrain = platoon:GetBrain()
 
 
-        # Load transports
+        -- Load transports
     local transportTable = {}
     local transSlotTable = {}
 
@@ -1949,10 +1949,10 @@ function GetLoadTransports(platoon)
             table.insert( remainingSize1, unit )
         end
     end
-#    LOG( '*AI DEBUG: NUM SHIELDS= ', table.getn( shields ) )
-#    LOG( '*AI DEBUG: NUM LARGE = ', table.getn( remainingSize3 ) )
-#    LOG( '*AI DEBUG: NUM MEDIUM = ', table.getn( remainingSize2 ) )
-#    LOG( '*AI DEBUG: NUM SMALL = ', table.getn( remainingSize1 ) )
+--    LOG( '*AI DEBUG: NUM SHIELDS= ', table.getn( shields ) )
+--    LOG( '*AI DEBUG: NUM LARGE = ', table.getn( remainingSize3 ) )
+--    LOG( '*AI DEBUG: NUM MEDIUM = ', table.getn( remainingSize2 ) )
+--    LOG( '*AI DEBUG: NUM SMALL = ', table.getn( remainingSize1 ) )
     local needed = GetNumTransports(platoon)
     local largeHave = 0
     for num, data in transportTable do
@@ -1962,23 +1962,23 @@ function GetLoadTransports(platoon)
     local currLeftovers = {}
     local leftoverShields = {}
     transportTable, leftoverShields = SortUnitsOnTransports( transportTable, shields, largeHave - needed.Large )
-#    LOG('*AI DEBUG: NUM LEFTOVER SHIELDS = ', table.getn( leftoverShields ) )
+--    LOG('*AI DEBUG: NUM LEFTOVER SHIELDS = ', table.getn( leftoverShields ) )
     transportTable, leftoverUnits = SortUnitsOnTransports( transportTable, remainingSize3, -1 )
-#    LOG('*AI DEBUG: NUM LEFTOVER LARGE = ', table.getn( leftoverUnits ) )
+--    LOG('*AI DEBUG: NUM LEFTOVER LARGE = ', table.getn( leftoverUnits ) )
     transportTable, currLeftovers = SortUnitsOnTransports( transportTable, leftoverShields, -1 )
-#    LOG('*AI DEBUG: NUM LEFTOVER SHIELDS SHIELDS = ', table.getn( currLeftovers ) )
+--    LOG('*AI DEBUG: NUM LEFTOVER SHIELDS SHIELDS = ', table.getn( currLeftovers ) )
     for k,v in currLeftovers do table.insert(leftoverUnits, v) end
     transportTable, currLeftovers = SortUnitsOnTransports( transportTable, remainingSize2, -1 )
-#    LOG('*AI DEBUG: NUM LEFTOVER MEDIUM = ', table.getn( currLeftovers ) )
+--    LOG('*AI DEBUG: NUM LEFTOVER MEDIUM = ', table.getn( currLeftovers ) )
     for k,v in currLeftovers do table.insert(leftoverUnits, v) end
     transportTable, currLeftovers = SortUnitsOnTransports( transportTable, remainingSize1, -1 )
-#    LOG('*AI DEBUG: NUM LEFTOVER SMALL = ', table.getn( currLeftovers ) )
+--    LOG('*AI DEBUG: NUM LEFTOVER SMALL = ', table.getn( currLeftovers ) )
     for k,v in currLeftovers do table.insert(leftoverUnits, v) end
     transportTable, currLeftovers = SortUnitsOnTransports( transportTable, currLeftovers, -1 )
-#    LOG('*AI DEBUG: NUM LEFTOVER FINAL = ', table.getn( currLeftovers ) )
+--    LOG('*AI DEBUG: NUM LEFTOVER FINAL = ', table.getn( currLeftovers ) )
 
 
-        # Old load transports
+        -- Old load transports
     local monitorUnits = {}
     for num, data in transportTable do
         if table.getn( data.Units ) > 0 then
@@ -1987,10 +1987,10 @@ function GetLoadTransports(platoon)
             for k,v in data.Units do table.insert( monitorUnits, v) end
         end
     end
-#    LOG('*AI DEBUG: NUM LEFTOVER UNITS = ', table.getn(leftoverUnits) )
-#    LOG('*AI DEBUG: NUM UNITS MONITORED = ', table.getn(monitorUnits) + table.getn(transportTable) )
-#    LOG('*AI DEBUG: NUM UNITS OMGZ = ', table.getn(platoon:GetPlatoonUnits()) )
-#    cmd = platoon:LoadUnits(categories.ALLUNITS)
+--    LOG('*AI DEBUG: NUM LEFTOVER UNITS = ', table.getn(leftoverUnits) )
+--    LOG('*AI DEBUG: NUM UNITS MONITORED = ', table.getn(monitorUnits) + table.getn(transportTable) )
+--    LOG('*AI DEBUG: NUM UNITS OMGZ = ', table.getn(platoon:GetPlatoonUnits()) )
+--    cmd = platoon:LoadUnits(categories.ALLUNITS)
     local attached = true
     repeat
         WaitSeconds(2)
@@ -2005,7 +2005,7 @@ function GetLoadTransports(platoon)
             end
         end
     until attached
-    # Any units that aren't transports and aren't attached send back to pool
+    -- Any units that aren't transports and aren't attached send back to pool
     local pool
     if platoon.PlatoonData.BuilderName and platoon.PlatoonData.LocationType then
         pool = aiBrain:GetPlatoonUniquelyNamed(platoon.PlatoonData.LocationType..'_LeftoverUnits')
@@ -2024,7 +2024,7 @@ function GetLoadTransports(platoon)
         if not EntityCategoryContains( categories.TRANSPORTATION, unit ) then
             if not unit:IsUnitState('Attached') then
                 aiBrain:AssignUnitsToPlatoon( pool, {unit}, 'Unassigned', 'None' )
-                #LOG('*DEBUG: ADDING UNIT TO LEFTOVER POOL')
+                --LOG('*DEBUG: ADDING UNIT TO LEFTOVER POOL')
             end
         end
     end
@@ -2032,10 +2032,10 @@ function GetLoadTransports(platoon)
 end
 
 
-# ------------------------------------------------
-# Utility function
-# Sorts units onto transports distributing equally
-# ------------------------------------------------
+-- ------------------------------------------------
+-- Utility function
+-- Sorts units onto transports distributing equally
+-- ------------------------------------------------
 function SortUnitsOnTransports( transportTable, unitTable, numSlots )
     local leftoverUnits = {}
     numSlots = numSlots or -1
@@ -2080,11 +2080,11 @@ function SortUnitsOnTransports( transportTable, unitTable, numSlots )
                 elseif remainingSml > 0 then
                     transportTable[transSlotNum].SmallSlots = transportTable[transSlotNum].SmallSlots - 1
                 else
-                    #LOG('*AI DEBUG: FOUND TRANSPORT NOT ENOUGH SLOTS')
+                    --LOG('*AI DEBUG: FOUND TRANSPORT NOT ENOUGH SLOTS')
                     table.insert(leftoverUnits, unit)
                 end
             else
-                #LOG('*AI DEBUG: NO TRANSPORT FOUND')
+                --LOG('*AI DEBUG: NO TRANSPORT FOUND')
                 table.insert(leftoverUnits, unit)
             end
         end
@@ -2093,10 +2093,10 @@ function SortUnitsOnTransports( transportTable, unitTable, numSlots )
 end
 
 
-# ------------------------------------------------------
-# Utility function
-# Generates a random patrol route for RandomPatrolThread
-# ------------------------------------------------------
+-- ------------------------------------------------------
+-- Utility function
+-- Generates a random patrol route for RandomPatrolThread
+-- ------------------------------------------------------
 function GetRandomPatrolRoute(patrol)
     local randPatrol = {}
     local tempPatrol = {}
@@ -2116,10 +2116,10 @@ function GetRandomPatrolRoute(patrol)
 end
 
 
-# ------------------------------------------------
-# Utility Function
-# Returns location with lowest non-negative threat
-# ------------------------------------------------
+-- ------------------------------------------------
+-- Utility Function
+-- Returns location with lowest non-negative threat
+-- ------------------------------------------------
 function PlatoonChooseLowestNonNegative( aiBrain, locationList, ringSize, location )
     local bestLocation = {}
     local bestThreat = 0
@@ -2128,7 +2128,7 @@ function PlatoonChooseLowestNonNegative( aiBrain, locationList, ringSize, locati
 
     for k, v in locationList do
         currThreat = aiBrain:GetThreatAtPosition( v, ringSize, true )
-		WaitSeconds(0.1)
+        WaitSeconds(0.1)
         if not location or location ~= v then
             if (currThreat < bestThreat and currThreat > 0) or not locationSet then
                 locationSet = true
@@ -2144,10 +2144,10 @@ function PlatoonChooseLowestNonNegative( aiBrain, locationList, ringSize, locati
     return bestLocation
 end
 
-# --------------------------------------------------------
-# Utility Function
-# Returns location with lowest threat (including negative)
-# --------------------------------------------------------
+-- --------------------------------------------------------
+-- Utility Function
+-- Returns location with lowest threat (including negative)
+-- --------------------------------------------------------
 function PlatoonChooseLowest(aiBrain, locationList, ringSize, location)
     local bestLocation = {}
     local locationSet = false
@@ -2156,7 +2156,7 @@ function PlatoonChooseLowest(aiBrain, locationList, ringSize, location)
 
     for k, v in locationList do
         currThreat = aiBrain:GetThreatAtPosition(v, ringSize, true)
-		WaitSeconds(0.1)
+        WaitSeconds(0.1)
         if not location or location ~= v then
             if (currThreat < bestThreat ) or not locationSet then
                 locationSet = true
@@ -2172,10 +2172,10 @@ function PlatoonChooseLowest(aiBrain, locationList, ringSize, location)
     return bestLocation
 end
 
-# ----------------------------------------
-# Utility Function
-# Returns location with the highest threat
-# ----------------------------------------
+-- ----------------------------------------
+-- Utility Function
+-- Returns location with the highest threat
+-- ----------------------------------------
 function PlatoonChooseHighest( aiBrain, locationList, ringSize, location )
     local bestLocation = locationList[1]
     local highestThreat = 0
@@ -2183,7 +2183,7 @@ function PlatoonChooseHighest( aiBrain, locationList, ringSize, location )
 
     for k, v in locationList do
         currThreat = aiBrain:GetThreatAtPosition( v, ringSize, true )
-		WaitSeconds(0.1)
+        WaitSeconds(0.1)
         if(currThreat > highestThreat) and (not location or location ~= v) then
             highestThreat = currThreat
             bestLocation = v
@@ -2193,15 +2193,15 @@ function PlatoonChooseHighest( aiBrain, locationList, ringSize, location )
     return bestLocation
 end
 
-# -----------------------------------------
-# Utility Function
-# Returns location randomly with threat > 0
-# -----------------------------------------
+-- -----------------------------------------
+-- Utility Function
+-- Returns location randomly with threat > 0
+-- -----------------------------------------
 function PlatoonChooseRandomNonNegative( aiBrain, locationList, ringSize )
     local landingList = {}
     for k, v in locationList do
         if aiBrain:GetThreatAtPosition( v, ringSize, true ) > 0 then
-			WaitSeconds(0.1)
+            WaitSeconds(0.1)
             table.insert(landingList, v)
         end
     end
@@ -2212,10 +2212,10 @@ function PlatoonChooseRandomNonNegative( aiBrain, locationList, ringSize )
     return loc
 end
 
-# -------------------------------------------------------
-# Utility Function
-# Arranges a route from highest to lowest based on threat
-# -------------------------------------------------------
+-- -------------------------------------------------------
+-- Utility Function
+-- Arranges a route from highest to lowest based on threat
+-- -------------------------------------------------------
 function PlatoonChooseHighestAttackRoute(aiBrain, locationList, ringSize)
     local attackRoute = {}
     local tempRoute = {}
@@ -2238,10 +2238,10 @@ function PlatoonChooseHighestAttackRoute(aiBrain, locationList, ringSize)
     return attackRoute
 end
 
-# -------------------------------------------------
-# Utility Function
-# Arranges a route from lowest to highest on threat
-# -------------------------------------------------
+-- -------------------------------------------------
+-- Utility Function
+-- Arranges a route from lowest to highest on threat
+-- -------------------------------------------------
 function PlatoonChooseLowestAttackRoute(aiBrain, locationList, ringSize)
     local attackRoute = {}
     local tempRoute = {}
@@ -2265,10 +2265,10 @@ function PlatoonChooseLowestAttackRoute(aiBrain, locationList, ringSize)
 end
 
 
-# -----------------------------------------------------------------
-# Utility Function
-# Function that gets the correct number of transports for a platoon
-# -----------------------------------------------------------------
+-- -----------------------------------------------------------------
+-- Utility Function
+-- Function that gets the correct number of transports for a platoon
+-- -----------------------------------------------------------------
 function GetTransportsThread(platoon)
     local data = platoon.PlatoonData
     local aiBrain = platoon:GetBrain()
@@ -2289,12 +2289,12 @@ function GetTransportsThread(platoon)
         end
         while transportsNeeded do
             neededTable = GetNumTransports(platoon)
-            # make sure more are needed
+            -- make sure more are needed
             local tempNeeded = {}
             tempNeeded.Small = neededTable.Small
             tempNeeded.Medium = neededTable.Medium
             tempNeeded.Large = neededTable.Large
-            # Find out how many units are needed currently
+            -- Find out how many units are needed currently
             for k,v in platoon:GetPlatoonUnits() do
                 if not v:IsDead() then
                     if EntityCategoryContains( categories.TRANSPORTATION, v ) then
@@ -2330,7 +2330,7 @@ function GetTransportsThread(platoon)
             if transportsNeeded then
                 local location = platoon:GetPlatoonPosition()
                 local transports = {}
-                # Determine distance of transports from platoon
+                -- Determine distance of transports from platoon
                 for k,unit in pool:GetPlatoonUnits() do
                     if EntityCategoryContains( categories.TRANSPORTATION, unit ) and not unit:IsUnitState('Busy') then
                         local unitPos = unit:GetPosition()
@@ -2341,7 +2341,7 @@ function GetTransportsThread(platoon)
                 end
                 if table.getn(transports) > 0 then
                     local sortedList = {}
-                    # Sort distances
+                    -- Sort distances
                     for k = 1,table.getn(transports) do
                         local lowest = -1
                         local key, value
@@ -2353,16 +2353,16 @@ function GetTransportsThread(platoon)
                             end
                         end
                         sortedList[k] = value
-                        # remove from unsorted table
+                        -- remove from unsorted table
                         table.remove( transports, key )
                     end
-                    # Take transports as needed
+                    -- Take transports as needed
                     for i=1,table.getn(sortedList) do
                         if transportsNeeded then
                             local id = sortedList[i].Id
                             aiBrain:AssignUnitsToPlatoon(platoon, {sortedList[i].Unit}, 'Scout', 'GrowthFormation')
                             numTransports = numTransports + 1
-                            #IssueMove( {sortedList[i].Unit}, platoon:GetPlatoonPosition() )
+                            --IssueMove( {sortedList[i].Unit}, platoon:GetPlatoonPosition() )
                             if not transSlotTable[id] then
                                 transSlotTable[id] = GetNumTransportSlots(sortedList[i].Unit)
                             end
@@ -2370,7 +2370,7 @@ function GetTransportsThread(platoon)
                             tempSlots.Small = transSlotTable[id].Small
                             tempSlots.Medium = transSlotTable[id].Medium
                             tempSlots.Large = transSlotTable[id].Large
-                            # update number of slots needed
+                            -- update number of slots needed
                             while tempNeeded.Large > 0 and tempSlots.Large > 0 do
                                 tempNeeded.Large = tempNeeded.Large - 1
                                 tempSlots.Large = tempSlots.Large - 1
@@ -2415,10 +2415,10 @@ function GetTransportsThread(platoon)
     return numTransports
 end
 
-# -------------------------------------------------------------
-# Utility Function
-# Returns the number of transports required to move the platoon
-# -------------------------------------------------------------
+-- -------------------------------------------------------------
+-- Utility Function
+-- Returns the number of transports required to move the platoon
+-- -------------------------------------------------------------
 function GetNumTransports(platoon)
     local transportNeeded = {
         Small = 0,
@@ -2442,10 +2442,10 @@ function GetNumTransports(platoon)
     return transportNeeded
 end
 
-# -------------------------------------------------------
-# Utility Function
-# Returns the number of slots the transport has available
-# -------------------------------------------------------
+-- -------------------------------------------------------
+-- Utility Function
+-- Returns the number of slots the transport has available
+-- -------------------------------------------------------
 function GetNumTransportSlots(unit)
     local bones = {
         Large = 0,
@@ -2466,15 +2466,15 @@ function GetNumTransportSlots(unit)
     return bones
 end
 
-# ---------------------------------------
-# Utility Function
-# NOT USED - Creates a route to something
-# ---------------------------------------
+-- ---------------------------------------
+-- Utility Function
+-- NOT USED - Creates a route to something
+-- ---------------------------------------
 function GetRouteToVector(platoon, squad)
     local aiBrain = platoon:GetBrain()
     local data = platoon.PlatoonData
 
-    # All vectors in the table
+    -- All vectors in the table
     aiBrain:SetUpAttackVectorsToArmy()
     local vectorTable = aiBrain:GetAttackVectors()
     local lowX = 10000
@@ -2496,7 +2496,7 @@ function GetRouteToVector(platoon, squad)
         end
     end
 
-    # Check if route needs to be generated
+    -- Check if route needs to be generated
     local atkVector = aiBrain:PickBestAttackVector(platoon, squad, 'Enemy', data.CompareCategory, data.CompareType)
     local pltPosition = platoon:GetSquadPosition(squad)
     local moveEW, moveNS
@@ -2511,7 +2511,7 @@ function GetRouteToVector(platoon, squad)
         moveNS = true
     end
 
-    #### Move vector out
+    -------- Move vector out
     if moveEW or moveNS then
         if atkVector[4] < 0 then
             moveEW = 'west'
@@ -2538,20 +2538,20 @@ function GetRouteToVector(platoon, squad)
     end
 end
 
-# ------------------------------------------------------------------
-# Utility Function
-# Moves a platoon along a route holding up the thread until finished
-# ------------------------------------------------------------------
+-- ------------------------------------------------------------------
+-- Utility Function
+-- Moves a platoon along a route holding up the thread until finished
+-- ------------------------------------------------------------------
 function MoveAlongRoute(platoon, route)
     local cmd = false
     local aiBrain = platoon:GetBrain()
 
-    # move platoon along route
+    -- move platoon along route
     for k,v in route do
         cmd = platoon:MoveToLocation(v, false)
     end
 
-    # make sure we have a command then check if commands are finished every second
+    -- make sure we have a command then check if commands are finished every second
     if cmd then
         while platoon:IsCommandsActive(cmd) do
             WaitSeconds(1)

--- a/lua/SimObjectives.lua
+++ b/lua/SimObjectives.lua
@@ -1,0 +1,1812 @@
+#****************************************************************************
+#**
+#**  File     :  /lua/SimObjectives.lua
+#**
+#**  Summary  : Sim side objectives
+#**
+#**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+##
+## SUPPORTED OBJECTIVE TYPES:
+##      Kill
+##      Capture
+##      KillOrCapture
+##      Reclaim
+##      Locate
+##      SpecificUnitsInArea
+##      CategoriesInArea
+##      ArmyStatCompare
+##      UnitStatCompare
+##      CategoryStatCompare
+##      Protect
+##      Timer
+##      Unknown
+##
+##      Camera
+local ScenarioUtils = import('/lua/sim/ScenarioUtilities.lua')
+local Triggers = import('/lua/scenariotriggers.lua')
+local VizMarker = import('/lua/sim/VizMarker.lua').VizMarker
+local objNum = 0 # Used to create unique tags for objectives
+local DecalLOD = 4000
+
+local objectiveDecal = '/env/utility/decals/objective_debug_albedo.dds'
+local SavedList = {}
+
+#
+# Camera objective by roates
+# Creates markers that satisfy the objective when they are all inside of the camera viewport
+#
+# Camera( objectiveType, completeState, title, description, positionTable)
+#
+# objectiveType = 'primary' or 'bonus' etc...
+# completeState = 'complete' or 'incomplete'
+# title = title string table from map's string file
+# description = description string table from map's string file
+# positionTable = table of position tables where markers will be created. { {x1, y1, z1}, {x2, y2, z2} } format
+#
+function Camera(objectiveType, completeState, title, description, positionTable)
+    local numMarkers = 0
+    local curMarkers = 0
+
+    local objective = AddObjective(objectiveType, completeState, title, description, nil, positionTable)
+
+    local RemoveMarker = function(mark)
+        mark:Destroy()
+        curMarkers = curMarkers + 1
+
+        UpdateObjective( title, 'Progress', '('..curMarkers..'/'..numMarkers..')', objective.Tag )
+        objective:OnProgress(curMarkers, numMarkers)
+
+        if curMarkers == numMarkers then
+            --Win an Internet
+            objective.Active = false
+            UpdateObjective( title, 'complete', 'complete', objective.Tag )
+            objective:OnResult(true)
+        end
+    end
+
+    for i,v in positionTable do
+        numMarkers = numMarkers + 1
+
+        local newMark = import('/lua/simcameramarkers.lua').AddCameraMarker(v)
+        newMark:AddCallback(RemoveMarker)
+    end
+
+    objective:OnProgress(curMarkers, numMarkers)
+    UpdateObjective( title, 'Progress', '('..curMarkers..'/'..numMarkers..')', objective.Tag )
+
+    return objective
+end
+
+
+#
+# ControlGroup
+#   Complete when specified units matching the target blueprint types are in
+# a control group. We don't care exactly which units they are (pre-built or
+# newly constructed), as long as the requirements are ment. We just check
+# the area for what units are in control groups and look at the blueprints (and optionally
+# match the army, use -1 for don't care).
+#
+# Target = {
+#   Requirements = {
+#       {  Category=<cat1>, CompareOp=<op>, Value=<x>, [ArmyIndex=<index>]},
+#       {  Category=<cat2>, CompareOp=<op>, Value=<y>, [ArmyIndex=<index>] },
+#       ...
+#       {  Category=<cat3>, CompareOp=<op>, Value=<z>, [ArmyIndex=<index>] },
+#   }
+# }
+#
+# -- op is one of: '<=', '>=', '<', '>', or '=='
+#
+function ControlGroup(Type,Complete,Title,Description,Target)
+
+    local image = GetActionIcon('group')
+    local objective = AddObjective(Type, Complete, Title, Description, image, Target)
+    local lastReqsMet = -1
+
+    # call ManualResult
+    objective.ManualResult = function(self, result)
+        self.Active = false
+        self:OnResult(result)
+        local resultStr
+        if result then
+            resultStr = 'complete'
+        else
+            resultStr = 'failed'
+        end
+        UpdateObjective( Title, 'complete', resultStr, self.Tag )
+    end
+
+    local function WatchGroups(requirements)
+        local totalReqs = table.getn(requirements)
+        while objective.Active do
+            local reqsMet = 0
+
+            for i,requirement in requirements do
+                local units = ScenarioInfo.ControlGroupUnits
+                local cnt = 0
+                if units then
+                    for k,unit in units do
+                        if not requirement.ArmyIndex or (requirement.ArmyIndex == unit:GetArmy()) then
+                            if EntityCategoryContains(requirement.Category, unit) then
+                                if not unit.Marked and objective.MarkUnits then
+                                    unit.Marked = true
+                                    local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
+                                    local arrow = ObjectiveArrow { AttachTo = unit }
+                                    objective:AddUnitTarget(unit)
+                                end
+                                cnt = cnt+1
+                            end
+                        end
+                    end
+                    #LOG('debug: ControlGroup: reqsmet '..reqsMet..'count '.. cnt )
+                end
+                if not requirement.CompareFunc then
+                    requirement.CompareFunc = GetCompareFunc(requirement.CompareOp)
+                end
+                if requirement.CompareFunc(cnt,requirement.Value) then
+                    reqsMet = reqsMet +1
+                end
+            end
+
+            if lastReqsMet != reqsMet then
+                local progress = string.format('(%s/%s)', reqsMet, totalReqs)
+                UpdateObjective( Title, 'Progress', progress, objective.Tag )
+                objective:OnProgress(reqsMet,totalReqs)
+                lastReqsMet = reqsMet
+            end
+
+            if reqsMet == totalReqs then
+                objective.Active = false
+                objective:OnResult(true)
+                UpdateObjective( Title, 'complete', 'complete', objective.Tag)
+                return
+            end
+            WaitTicks(10)
+        end
+    end
+
+    UpdateObjective( Title, 'Progress', '(0/0)', objective.Tag )
+    ForkThread( WatchGroups, Target.Requirements )
+
+    return objective
+end
+
+
+
+
+#
+# CreateGroup
+#
+#   Takes list of objective tables which are produced by the objective creation
+# functions such as Kill, Protect, Capture, etc.
+#
+#   UserCallback is executed when all objectives in the list are complete
+#
+function CreateGroup( name, userCallback, numRequired )
+    LOG('Creating objective group ',name)
+    local objectiveGroup =  {
+        Name = name,
+        Active = true,
+        Objectives = {},
+        NumRequired = numRequired,
+        NumCompleted = 0,
+        AddObjective = function(self,objective) end, # defined later
+        RemoveObjective = function(self,objective) end, # defined later
+        OnComplete = userCallback,
+    }
+
+    local function OnResult(result)
+        if not objectiveGroup.Active then
+            LOG('ObjectiveGroup ',objectiveGroup.Name,' is not active.')
+            return
+        end
+
+        if result then
+            objectiveGroup.NumCompleted = objectiveGroup.NumCompleted + 1
+        end
+
+        if objectiveGroup.NumRequired then
+            LOG('ObjectiveGroup ',objectiveGroup.Name,' Progress ',objectiveGroup.NumRequired, '/',objectiveGroup.NumCompleted)
+            if objectiveGroup.NumCompleted < objectiveGroup.NumRequired then
+                return
+            end
+        else
+            if objectiveGroup.Objectives then
+                for k,v in objectiveGroup.Objectives do
+                    if v.Active then
+                        return
+                    end
+                end
+            end
+        end
+
+        # Complete!
+        objectiveGroup.Active = false
+        objectiveGroup.OnComplete()
+    end
+
+    objectiveGroup.AddObjective = function(self,objective)
+        table.insert(self.Objectives,objective)
+        objective:AddResultCallback(OnResult)
+    end
+
+    objectiveGroup.RemoveObjective = function(self,objective)
+        table.removeByValue(self.Objectives,objective)
+    end
+
+    return objectiveGroup
+end
+
+#
+# Kill
+#   Kill units
+function Kill(Type,Complete,Title,Description,Target)
+    Target.killed = 0
+    Target.total = table.getn(Target.Units)
+
+    local image = GetActionIcon('kill')
+    local objective = AddObjective(Type,Complete,Title,Description,image,Target)
+
+    # call ManualResult
+    objective.ManualResult = function(self, result)
+        objective.Active = false
+        objective:OnResult(result)
+        local resultStr
+        if result then
+            resultStr = 'complete'
+        else
+            resultStr = 'failed'
+        end
+        UpdateObjective( Title, 'complete', resultStr, objective.Tag)
+    end
+
+    local function OnUnitKilled(unit)
+        Target.killed = Target.killed + 1
+
+        local progress = string.format('(%s/%s)', Target.killed, Target.total)
+        UpdateObjective( Title, 'Progress', progress, objective.Tag )
+        objective:OnProgress(Target.killed,Target.total)
+
+        if Target.killed == Target.total then
+            UpdateObjective( Title, 'complete', "complete", objective.Tag )
+            objective.Active = false
+            objective:OnResult(true, unit)
+        end
+    end
+
+    for k,unit in Target.Units do
+        if not unit:IsDead() then
+            # Mark the units unless MarkUnits == false
+            if ( Target.MarkUnits == nil ) or Target.MarkUnits then
+                local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
+                local arrow = ObjectiveArrow { AttachTo = unit }
+            end
+            if Target.FlashVisible then
+                FlashViz( unit )
+            end
+            Triggers.CreateUnitDeathTrigger(OnUnitKilled, unit)
+            Triggers.CreateUnitReclaimedTrigger(OnUnitKilled, unit) #same as killing for our purposes
+        else
+            OnUnitKilled(unit)
+        end
+    end
+
+    local progress = string.format('(%s/%s)', Target.killed, Target.total)
+    UpdateObjective( Title, 'Progress', progress, objective.Tag )
+
+    return objective
+end
+
+#
+# Capture
+#   Capture units
+#
+# Target = {
+#       Units = <units>,
+#       NumRequired = <x>,
+# }
+#
+function Capture(Type,Complete,Title,Description,Target)
+    Target.captured = 0
+    Target.total = table.getn(Target.Units)
+    local required = Target.NumRequired or Target.total
+    local returnUnits = {}
+
+    local image = GetActionIcon('capture')
+    local objective = AddObjective(Type,Complete,Title,Description,image,Target)
+
+    objective.ManualResult = function(self, result)
+        self.Active = false
+        self:OnResult(result)
+        local resultStr
+        if result then
+            resultStr = 'complete'
+        else
+            resultStr = 'failed'
+        end
+        UpdateObjective( Title, 'complete', resultStr, self.Tag )
+    end
+
+    local function OnUnitCaptured(unit, captor)
+        table.insert(returnUnits, unit)
+        if not objective.Active then
+            return
+        end
+
+        Target.captured = Target.captured + 1
+        local progress = string.format('(%s/%s)', Target.captured, required)
+        objective:OnProgress(Target.captured,required)
+        UpdateObjective( Title, 'Progress', progress, objective.Tag )
+        if Target.captured >= required then
+            objective.Active = false
+            objective:OnResult(true, returnUnits)
+            UpdateObjective( Title, 'complete', "complete", objective.Tag )
+        end
+    end
+
+    local function OnUnitKilled(unit)
+        if not objective.Active then
+            return
+        end
+        Target.total = Target.total - 1
+        if Target.total < required then
+            objective.Active = false
+            objective:OnResult(false)
+            UpdateObjective( Title, 'complete', 'failed', objective.Tag )
+        end
+    end
+
+    for k,unit in Target.Units do
+        if not unit:IsDead() then
+            # Mark the units unless MarkUnits == false
+            if ( Target.MarkUnits == nil ) or Target.MarkUnits then
+                local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
+                local arrow = ObjectiveArrow { AttachTo = unit }
+            end
+
+            Triggers.CreateUnitCapturedTrigger(nil,OnUnitCaptured,unit)
+            Triggers.CreateUnitDeathTrigger(OnUnitKilled, unit)
+            Triggers.CreateUnitReclaimedTrigger(OnUnitKilled, unit) #same functionality as killed
+
+            if Target.FlashVisible then
+                FlashViz( unit )
+            end
+        else
+            #treat as killed Matt 8.30.06
+            OnUnitKilled(unit)
+        end
+    end
+
+    local progress = string.format('(%s/%s)', Target.captured, required)
+    UpdateObjective( Title, 'Progress', progress, objective.Tag )
+
+    return objective
+end
+
+#
+# Kill or Capture
+#   Kill or Capture units
+function KillOrCapture(Type,Complete,Title,Description,Target)
+    Target.killed_or_captured = 0
+    Target.total = table.getn(Target.Units)
+
+    local image = GetActionIcon('KillOrCapture')
+    local objective = AddObjective(Type,Complete,Title,Description,image,Target)
+
+    objective.ManualResult = function(self, result)
+        self.Active = false
+        self:OnResult(result)
+        local resultStr
+        if result then
+            resultStr = 'complete'
+        else
+            resultStr = 'failed'
+        end
+        UpdateObjective( Title, 'complete', resultStr, self.Tag )
+    end
+
+    # keep track of captured units so subsequent kills don't get counted
+    local captured = {}
+
+    local function OnUnitKilled(unit)
+        for k,v in captured do
+            if v == unit then
+                # ignore units already captured
+                return
+            end
+        end
+
+
+        Target.killed_or_captured = Target.killed_or_captured + 1
+        local progress = string.format('(%s/%s)', Target.killed_or_captured, Target.total)
+        objective:OnProgress(Target.killed_or_captured,Target.total)
+        UpdateObjective( Title, 'Progress', progress, objective.Tag )
+        if Target.killed_or_captured == Target.total then
+            objective.Active = false
+            objective:OnResult(true, unit)
+            UpdateObjective( Title, 'complete', "complete", objective.Tag )
+        end
+    end
+
+    local function OnUnitCaptured(unit)
+        table.insert(captured,unit)
+        Target.killed_or_captured = Target.killed_or_captured + 1
+        local progress = string.format('(%s/%s)', Target.killed_or_captured, Target.total)
+        objective:OnProgress(Target.killed_or_captured,Target.total)
+        UpdateObjective( Title, 'Progress', progress, objective.Tag )
+        if Target.killed_or_captured == Target.total then
+            objective.Active = false
+            objective:OnResult(true, unit)
+            UpdateObjective( Title, 'complete', "complete", objective.Tag )
+        end
+    end
+
+
+    local function OnUnitReclaimed(unit)
+        if not objective.Active then
+            return
+        end
+
+        Target.killed_or_captured = Target.killed_or_captured + 1
+        local progress = string.format('(%s/%s)', Target.killed_or_captured, Target.total)
+        objective:OnProgress(Target.killed_or_captured,Target.total)
+        UpdateObjective( Title, 'Progress', progress, objective.Tag )
+        if Target.killed_or_captured == Target.total then
+            objective.Active = false
+            objective:OnResult(true, unit)
+            UpdateObjective( Title, 'complete', "complete", objective.Tag )
+        end
+    end
+
+    for k,unit in Target.Units do
+        if not unit:IsDead() then
+            # Mark the units unless MarkUnits == false
+            if ( Target.MarkUnits == nil ) or Target.MarkUnits then
+                local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
+                local arrow = ObjectiveArrow { AttachTo = unit }
+            end
+
+            if Target.FlashVisible then
+                FlashViz( unit )
+            end
+
+            # note: you won't get an OnKilled after an OnCaptured because once
+            # captured it's actually a new unit with no callback.
+            Triggers.CreateUnitCapturedTrigger(nil,OnUnitCaptured,unit)
+            Triggers.CreateUnitDeathTrigger(OnUnitKilled, unit)
+            Triggers.CreateUnitReclaimedTrigger(OnUnitReclaimed, unit)
+        else
+            OnUnitKilled(unit)
+        end
+    end
+
+    local progress = string.format('(%s/%s)', Target.killed_or_captured, Target.total)
+    UpdateObjective( Title, 'Progress', progress, objective.Tag )
+
+    return objective
+end
+
+#
+# Reclaim
+#   Reclaim units
+function Reclaim(Type,Complete,Title,Description,Target)
+    Target.reclaimed = 0
+    Target.total = table.getn(Target.Units)
+
+    local image = GetActionIcon("reclaim")
+    local objective = AddObjective(Type,Complete,Title,Description,image,Target)
+
+    # call ManualResult
+    objective.ManualResult = function(self, result)
+        self.Active = false
+        self:OnResult(result)
+        local resultStr
+        if result then
+            resultStr = 'complete'
+        else
+            resultStr = 'failed'
+        end
+        UpdateObjective( Title, 'complete', resultStr, self.Tag )
+    end
+
+    local function OnUnitReclaimed(unit)
+        if not objective.Active then
+            return
+        end
+
+        Target.reclaimed = Target.reclaimed + 1
+        local progress = string.format('(%s/%s)', Target.reclaimed, Target.total)
+        objective:OnProgress(Target.reclaimed,Target.total)
+        UpdateObjective( Title, 'Progress', progress, objective.Tag )
+        if Target.reclaimed == Target.total then
+            objective.Active = false
+            objective:OnResult(true)
+            UpdateObjective( Title, 'complete', "complete", objective.Tag )
+        end
+    end
+
+    local function OnUnitKilled(unit)
+        objective.Active = false
+        objective:OnResult(false)
+        UpdateObjective( Title, 'complete', 'failed', objective.Tag )
+    end
+
+    # If the unit is captured it can still be reclaimed to complete the
+    # objective, so track the new unit created on a capture.
+    local function OnUnitCaptured(newUnit,captor)
+        Triggers.CreateUnitCapturedTrigger(nil,OnUnitCaptured,newUnit)
+        Triggers.CreateUnitDeathTrigger(OnUnitKilled, newUnit)
+        Triggers.CreateUnitReclaimedTrigger(OnUnitReclaimed, newUnit)
+        local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
+        local arrow = ObjectiveArrow { AttachTo = newUnit }
+    end
+
+    for k,unit in Target.Units do
+        local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
+        local arrow = ObjectiveArrow { AttachTo = unit }
+        Triggers.CreateUnitCapturedTrigger(nil,OnUnitCaptured,unit )
+        Triggers.CreateUnitDeathTrigger(OnUnitKilled, unit )
+        Triggers.CreateUnitReclaimedTrigger(OnUnitReclaimed, unit )
+    end
+
+    local progress = string.format('(%s/%s)', Target.reclaimed, Target.total)
+    UpdateObjective( Title, 'Progress', progress, objective.Tag )
+
+    return objective
+end
+
+#
+# Locate
+#   Locate units
+function Locate(Type,Complete,Title,Description,Target)
+    Target.located = 0
+    Target.total = table.getn(Target.Units)
+
+    local image = GetActionIcon("locate")
+    local objective = AddObjective(Type,Complete,Title,Description,image,Target)
+
+    local function OnUnitLocated(unit)
+        Target.located = Target.located + 1
+        local progress = string.format('(%s/%s)', Target.located, Target.total)
+        UpdateObjective( Title, 'Progress', progress, objective.Tag )
+        objective:OnProgress(Target.located,Target.total)
+        if Target.located == Target.total then
+            objective.Active = false
+            objective:OnResult(true)
+            UpdateObjective( Title, 'complete', "complete", objective.Tag )
+        end
+    end
+
+    for k,unit in Target.Units do
+        local IntelTrigger = import('/lua/ScenarioTriggers.lua').CreateArmyIntelTrigger
+        IntelTrigger(OnUnitLocated,
+                    GetArmyBrain(1),
+                    'LOSNow',
+                    unit,
+                    true,
+                    categories.ALLUNITS,
+                    true,
+                    unit:GetAIBrain() )
+    end
+
+    local progress = string.format('(%s/%s)', Target.located, Target.total)
+    UpdateObjective( Title, 'Progress', progress, objective.Tag )
+
+    return objective
+end
+
+#
+# SpecificUnitsInArea
+#   Complete when specified units are in the target area. We don't care how
+# they got there (cheat teleport, etc), we just check if they're in there
+# ShowProgress, optional:
+function SpecificUnitsInArea(Type,Complete,Title,Description,Target)
+    local image = GetActionIcon('Move')
+    local objective = AddObjective(Type,Complete,Title,Description,image,Target)
+    local total = table.getn(Target.Units)
+    local numRequired = Target.NumRequired or total
+    Target.Count = 0
+
+    # call ManualResult
+    objective.ManualResult = function(self, result)
+        self.Active = false
+        self:OnResult(result)
+        local resultStr
+        if result then
+            resultStr = 'complete'
+        else
+            resultStr = 'failed'
+        end
+        UpdateObjective( Title, 'complete', resultStr, self.Tag )
+    end
+
+    local function WatchArea(units,rect)
+        while objective.Active do
+            local cnt = 0
+            for k,unit in units do
+                if not unit:IsDead() then
+                    if ScenarioUtils.InRect( unit:GetPosition(), rect ) then
+                        cnt = cnt + 1
+                    end
+                end
+            end
+
+            if cnt != Target.Count then
+                Target.Count = cnt
+                local progress = string.format('(%s/%s)', Target.Count, numRequired)
+                objective:OnProgress(Target.Count,numRequired)
+                if (Target.ShowProgress) then
+                    UpdateObjective( Title, 'Progress', progress, objective.Tag)
+                end
+            end
+
+            if cnt >= numRequired then
+                objective.Active = false
+                objective:OnResult(true)
+                UpdateObjective( Title, 'complete', 'complete', objective.Tag)
+                return
+            end
+            WaitTicks(5)
+        end
+    end
+
+    local rect = ScenarioUtils.AreaToRect( Target.Area )
+
+    local w = rect.x1 - rect.x0
+    local h = rect.y1 - rect.y0
+    local x = rect.x0 + ( w / 2.0 )
+    local z = rect.y0 + ( h / 2.0 )
+
+    if Target.MarkArea then
+        objective.Decals[Target.Area] = CreateObjectiveDecal(x, z, w, h)
+    end
+
+    local watchThread = ForkThread( WatchArea, Target.Units, rect )
+
+    local function OnUnitKilled(unit)
+        total = total - 1
+        if objective.Active and total < numRequired then
+            objective.Active = false
+            objective:OnResult(false)
+            UpdateObjective( Title, 'complete', 'failed', objective.Tag)
+            KillThread(watchThread)
+        end
+    end
+
+    for k,v in Target.Units do
+        Triggers.CreateUnitDeathTrigger(OnUnitKilled, v )
+        Triggers.CreateUnitReclaimedTrigger(OnUnitKilled, v )
+    end
+
+    if (Target.ShowProgress) then
+        local progress = string.format('(%s/%s)', Target.Count, numRequired)
+        UpdateObjective( Title, 'Progress', progress, objective.Tag)
+    end
+
+    return objective
+end
+
+#
+# CategoriesInArea
+#   Complete when specified units matching the target blueprint types are in
+# the target area. We don't care exactly which units they are (pre-built or
+# newly constructed) or how they got there (cheat teleport, etc). We just check
+# the area for what units are inside and look at the blueprints (and optionally
+# match the army, use -1 for don't care).
+#
+# Target = {
+#   Requirements = {
+#       { Area = <areaName>, Category=<cat1>, CompareOp=<op>, Value=<x>, [ArmyIndex=<index>]},
+#       { Area = <areaName>, Category=<cat2>, CompareOp=<op>, Value=<y>, [ArmyIndex=<index>] },
+#       ...
+#       { Area = <areaName>, Category=<cat3>, CompareOp=<op>, Value=<z>, [ArmyIndex=<index>] },
+#   }
+# }
+#
+# -- op is one of: '<=', '>=', '<', '>', or '=='
+#
+function CategoriesInArea(Type,Complete,Title,Description,Action,Target)
+
+    local image = GetActionIcon(Action)
+    local objective = AddObjective(Type,Complete,Title,Description,image,Target)
+    local lastReqsMet = 0
+
+    # call ManualResult
+    objective.ManualResult = function(self, result)
+        self.Active = false
+        self:OnResult(result)
+        local resultStr
+        if result then
+            resultStr = 'complete'
+        else
+            resultStr = 'failed'
+        end
+        UpdateObjective( Title, 'complete', resultStr, self.Tag )
+    end
+
+    local function WatchArea(requirements)
+        local totalReqs = table.getn(requirements)
+        while objective.Active do
+            local reqsMet = 0
+
+            for i,requirement in requirements do
+                local units = GetUnitsInRect(requirement.Rect)
+                local cnt = 0
+                if units then
+                    for k,unit in units do
+                        if not unit:IsDead() and not unit:IsBeingBuilt() then
+                            if not requirement.ArmyIndex or (requirement.ArmyIndex == unit:GetArmy()) then
+                                if EntityCategoryContains(requirement.Category, unit) then
+                                    if not unit.Marked and objective.MarkUnits then
+                                        unit.Marked = true
+                                        local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
+                                        local arrow = ObjectiveArrow { AttachTo = unit }
+                                        objective:AddUnitTarget(unit)
+                                    end
+                                    cnt = cnt+1
+                                end
+                            end
+                        end
+                    end
+                    #LOG('debug: CategoriesInArea: reqsmet '..reqsMet..'count '.. cnt )
+                end
+                if requirement.CompareFunc(cnt,requirement.Value) then
+                    reqsMet = reqsMet +1
+                end
+            end
+
+            if lastReqsMet != reqsMet then
+                local progress = string.format('(%s/%s)', reqsMet, totalReqs)
+                UpdateObjective( Title, 'Progress', progress, objective.Tag )
+                objective:OnProgress(reqsMet,totalReqs)
+                lastReqsMet = reqsMet
+            end
+
+            if reqsMet == totalReqs then
+                objective.Active = false
+                objective:OnResult(true)
+                UpdateObjective( Title, 'complete', 'complete', objective.Tag)
+                return
+            end
+            WaitTicks(10)
+        end
+    end
+
+    for k,requirement in Target.Requirements do
+        local rect = ScenarioUtils.AreaToRect( requirement.Area )
+
+        local w = rect.x1 - rect.x0
+        local h = rect.y1 - rect.y0
+        local x = rect.x0 + ( w / 2.0 )
+        local z = rect.y0 + ( h / 2.0 )
+
+        if Target.MarkArea and not objective.Decals[requirement.Area] then
+            local decal = CreateObjectiveDecal(x, z, w, h)
+            objective.Decals[requirement.Area] = decal
+        elseif Target.FlashVisible then
+            FlashViz( requirement.Area )
+        end
+
+        if Target.MarkUnits then
+            objective.MarkUnits = true
+        end
+
+        local reqRef = requirement
+        reqRef.Rect = rect
+        reqRef.CompareFunc = GetCompareFunc(requirement.CompareOp)
+    end
+
+    UpdateObjective( Title, 'Progress', string.format('(0/%d)', table.getsize(Target.Requirements)), objective.Tag )
+    ForkThread( WatchArea, Target.Requirements )
+
+    return objective
+end
+
+#
+# ArmyStatCompare
+#   Army stat is compared <=, >=, >, <, or == to some value.
+#
+# Target = {
+#       Army=<index>,
+#       StatName=<name>,
+#       CompareOp=<op>,   -- op is one of: '<=', '>=', '<', '>', or '=='
+#       Value=<value>,
+#       [Category=<category>], -- optional to compare to a blueprint stat
+#       ShowProgress, optional: shows #/#. may not make sense for all compare types
+# }
+#
+# Note: Be careful when using '==' as the stat is only checked every 5 ticks.
+#
+function ArmyStatCompare(Type,Complete,Title,Description,Action,Target)
+    local image = GetActionIcon(Action)
+    local objective = AddObjective(Type,Complete,Title,Description,image,Target)
+
+    local function WatchStat(statName,brain,compareFunc,value,category)
+        local oldVal
+
+        while objective.Active do
+            local result = false
+            local testVal = 0
+
+            if category then
+                testVal = brain:GetBlueprintStat(statName,category)
+
+            else
+                testVal = brain:GetArmyStat(statName,value).Value
+            end
+
+            if (Target.ShowProgress) then
+                if (testVal ~= oldVal) then
+                    #LOG('*** progress! ', testVal, ' ', oldVal)
+                    local progress = string.format('(%s/%s)', testVal, value)
+                    UpdateObjective( Title, 'Progress', progress, objective.Tag )
+                    oldVal = testVal
+                end
+            end
+
+            result = compareFunc(testVal,value)
+
+            if result then
+                objective.Active = false
+                objective:OnResult(true)
+                UpdateObjective( Title, 'complete', 'complete', objective.Tag )
+                return
+            end
+            WaitTicks(5)
+        end
+    end
+
+    local op = GetCompareFunc(Target.CompareOp)
+    if op then
+        ForkThread( WatchStat, Target.StatName, GetArmyBrain(Target.Army), op, Target.Value, Target.Category )
+    end
+
+    objective.ManualResult = function(self, result)
+        self.Active = false
+        self:OnResult(result)
+        local resultStr
+        if result then
+            resultStr = 'complete'
+        else
+            resultStr = 'failed'
+        end
+        UpdateObjective( Title, 'complete', resultStr, self.Tag )
+    end
+
+    return objective
+end
+
+#
+# UnitStatCompare
+#   A specified unit's stat is <=, >=, >, <, or == to some value.
+#
+# Target = {
+#       Unit=<unit>,
+#       StatName=<name>,
+#       CompareOp=<op>,   -- op is one of: '<=', '>=', '<', '>', or '=='
+#       Value=<value>,
+# }
+#
+# Note: Be careful when using '==' as the stat is only checked every 5 ticks.
+#
+function UnitStatCompare(Type,Complete,Title,Description,Action,Target)
+    local image = GetActionIcon(Action)
+    local objective = AddObjective(Type,Complete,Title,Description,image,Target)
+
+    local function WatchStat(statName,unit,compareFunc,value)
+        while objective.Active do
+            if compareFunc(unit:GetStat(statName,value).Value,value) then
+                objective.Active = false
+                objective:OnResult(true)
+                UpdateObjective( Title, 'complete', 'complete', objective.Tag )
+                return
+            end
+            WaitTicks(5)
+        end
+    end
+
+    local op = GetCompareFunc(Target.CompareOp)
+    if op then
+        ForkThread( WatchStat, Target.StatName, Target.Unit, op, Target.Value )
+    end
+
+    return objective
+end
+
+#
+# CategoryStatCompare
+#   Some unit belonging to specified category has a stat <=, >=, >, <, or ==
+# to some value.
+#
+# Target = {
+#       Army=<index>,
+#       Category=<unit>,
+#       StatName=<name>,
+#       CompareOp=<op>,   -- op is one of: '<=', '>=', '<', '>', or '=='
+#       Value=<value>,
+# }
+#
+# Note: Be careful when using '==' as the stat is only checked every 5 ticks.
+#
+function CategoryStatCompare(Type,Complete,Title,Description,Action,Target)
+    local image = GetActionIcon(Action)
+    local objective = AddObjective(Type,Complete,Title,Description,image,Target)
+
+    local function WatchStat(statName,brain,category,compareFunc,value)
+        while objective.Active do
+            local unitsInCategory = brain:GetListOfUnits(category,false)
+            if unitsInCategory then
+                for k,unit in unitsInCategory do
+                    if compareFunc(unit:GetStat(statName,value).Value,value) then
+                        objective.Active = false
+                        objective:OnResult(true)
+                        UpdateObjective( Title, 'complete', 'complete', objective.Tag )
+                        return
+                    end
+                end
+            end
+            WaitTicks(5)
+        end
+    end
+
+    local op = GetCompareFunc(Target.CompareOp)
+    if op then
+        ForkThread( WatchStat, Target.StatName, GetArmyBrain(Target.Army), Target.Category, op, Target.Value )
+    end
+
+    return objective
+end
+
+#
+# Protect
+#   Fails if # of units in list falls below NumRequired before the timer expires
+# or, in the case of no timer, the objective is manually update to complete.
+#
+# Target = {
+#       Units = {},
+#       Timer = <seconds> or nil,   -- if nil, requires manual completion
+#       NumRequired = <#>,          -- how many must survive
+# }
+function Protect(Type,Complete,Title,Description,Target)
+
+    local image = GetActionIcon("protect")
+    local objective = AddObjective(Type,Complete,Title,Description,image,Target)
+    local total = table.getn(Target.Units)
+    local max = total
+    local numRequired = Target.NumRequired or total
+    local timer = nil
+
+    local function OnUnitKilled(unit)
+        if not objective.Active then
+            return
+        end
+
+        total = total - 1
+        objective:OnProgress( total, numRequired )
+
+        if (Target.ShowProgress) then
+            local progress = string.format('(%s/%s)', total, numRequired)
+            UpdateObjective( Title, 'Progress', progress, objective.Tag )
+        elseif (Target.PercentProgress) then
+            #local progress = LOCF('<LOC A02_M01_OBJ_010_113>(%s%%/%s%%)',math.ceil( total / max * 100),math.ceil( numRequired / max * 100))
+            local progress = string.format('(%s%%)',math.ceil( total / max * 100))
+            UpdateObjective( Title, 'Progress', progress, objective.Tag )
+        end
+
+        if objective.Active and total < numRequired then
+            objective.Active = false
+            objective:OnResult(false,unit)
+            UpdateObjective( Title, 'complete', 'failed', objective.Tag)
+            Sync.ObjectiveTimer = 0
+            if timer then
+                KillThread(timer)
+            end
+        end
+    end
+
+    local function OnExpired()
+        if objective.Active then
+            objective.Active = false
+            objective:OnResult(true)
+            UpdateObjective( Title, 'complete', 'complete', objective.Tag)
+        end
+        Sync.ObjectiveTimer = 0
+    end
+
+    objective.ManualResult = function(self, result)
+        self.Active = false
+        self:OnResult(result)
+        local resultStr
+        if result then
+            resultStr = 'complete'
+        else
+            resultStr = 'failed'
+        end
+        UpdateObjective( Title, 'complete', resultStr, self.Tag )
+    end
+
+    if Target.Timer then
+        timer = import('/lua/ScenarioTriggers.lua').CreateTimerTrigger(
+            OnExpired,
+            Target.Timer,
+            true
+        )
+    end
+
+    for k,v in Target.Units do
+        Triggers.CreateUnitDeathTrigger(OnUnitKilled, v )
+        Triggers.CreateUnitReclaimedTrigger(OnUnitKilled, v )
+    end
+
+    if (Target.ShowProgress) then
+        local progress = string.format('(%s/%s)', total, numRequired)
+        UpdateObjective( Title, 'Progress', progress, objective.Tag )
+    elseif (Target.PercentProgress) then
+        #local progress = LOCF('<LOC A02_M01_OBJ_010_113>(%s%%/%s%%)',math.ceil( total / max * 100),math.ceil( numRequired / max * 100))
+        local progress = string.format('(%s%%)',math.ceil( total / max * 100))
+        UpdateObjective( Title, 'Progress', progress, objective.Tag )
+    end
+
+    return objective
+end
+
+#
+# Timer
+#   OnResult() is called when the timer expires. The result depends on whether
+# ExpireResult is set to complete or failed.
+#
+# Target = {
+#       Timer = <seconds>
+#       ExpireResult = 'complete' or 'failed'
+# }
+function Timer(Type,Complete,Title,Description,Target)
+
+    local image = GetActionIcon("timer")
+    local objective = AddObjective(Type,Complete,Title,Description,image,Target)
+
+    # call ManualResult
+    objective.ManualResult = function(self, result)
+        self.Active = false
+        self:OnResult(result)
+        local resultStr
+        if result then
+            resultStr = 'complete'
+        else
+            resultStr = 'failed'
+        end
+        UpdateObjective( Title, 'complete', resultStr, self.Tag )
+    end
+
+    local function onTick(newTime)
+        UpdateObjective( Title, 'timer', {Time = newTime}, objective.Tag)
+    end
+
+    local function OnExpired()
+        objective.Active = false
+        if Target.ExpireResult == 'complete' then
+            objective:OnResult(true)
+            UpdateObjective( Title, 'complete', 'complete', objective.Tag)
+        else
+            objective:OnResult(false)
+            UpdateObjective( Title, 'complete', 'failed', objective.Tag)
+        end
+        Sync.ObjectiveTimer = 0
+    end
+
+    import('/lua/ScenarioTriggers.lua').CreateTimerTrigger(
+        OnExpired,
+        Target.Timer,
+        false,
+        true,
+        onTick
+    )
+
+    return objective
+end
+
+function Unknown(Type,Complete,Title,Description)
+    local objective = AddObjective(Type,Complete,Title,Description)
+
+    # call ManualResult
+    objective.ManualResult = function(self, result)
+        self.Active = false
+        self:OnResult(result)
+        local resultStr
+        if result then
+            resultStr = 'complete'
+        else
+            resultStr = 'failed'
+        end
+        UpdateObjective( Title, 'complete', resultStr, self.Tag )
+    end
+
+    return objective
+end
+
+function Basic(Type,Complete,Title,Description,Image,Target)
+    local objective = AddObjective(Type,Complete,Title,Description,Image,Target)
+
+    # call ManualResult
+    objective.ManualResult = function(self, result)
+        objective.Active = false
+        objective:OnResult(result)
+        local resultStr
+        if result then
+            resultStr = 'complete'
+        else
+            resultStr = 'failed'
+        end
+        UpdateObjective( Title, 'complete', resultStr, objective.Tag)
+    end
+
+    objective.AddBasicUnitTarget = function(self, unit)
+        objective:AddUnitTarget( unit )
+        local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
+        local arrow = ObjectiveArrow { AttachTo = unit }
+        table.insert( objective.UnitMarkers, arrow )
+    end
+
+    objective.AddTarget = function(self, target)
+        if (target.Area) then
+            local rect = ScenarioUtils.AreaToRect( target.Area )
+
+            local w = rect.x1 - rect.x0
+            local h = rect.y1 - rect.y0
+            local x = rect.x0 + ( w / 2.0 )
+            local z = rect.y0 + ( h / 2.0 )
+
+            if target.MarkArea then
+                objective.Decals[target.Area] = CreateObjectiveDecal(x, z, w, h)
+            end
+            if Target.FlashVisible then
+                FlashViz( target.Area )
+            end
+        end
+        if target.Areas and target.MarkArea then
+            for k,v in target.Areas do
+                local rect = ScenarioUtils.AreaToRect( v )
+
+                local w = rect.x1 - rect.x0
+                local h = rect.y1 - rect.y0
+                local x = rect.x0 + ( w / 2.0 )
+                local z = rect.y0 + ( h / 2.0 )
+
+                objective.Decals[v] = CreateObjectiveDecal(x, z, w, h)
+                if Target.FlashVisible then
+                    FlashViz( v )
+                end
+            end
+        end
+        if (target.Units) then
+            if (target.MarkUnits) then
+                for k,unit in target.Units do
+                    if not unit:IsDead() then
+                        local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
+                        local arrow = ObjectiveArrow { AttachTo = unit }
+                        table.insert( objective.UnitMarkers, arrow )
+                        if target.AlwaysVisible then
+                            SetupVizMarker(self, unit)
+                        end
+                        if Target.FlashVisible then
+                            FlashViz( unit )
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    if Target then
+        objective:AddTarget(Target)
+    end
+
+    return objective
+end
+
+
+### Adds objective for the objectives screen
+function AddObjective(Type,         # 'primary', 'bonus', etc
+                      Complete,     # 'complete', 'incomplete'
+                      Title,        # e.g. "Destroy Radar Stations"
+                      Description,  # e.g. "A reason why you need to destroy the radar stations"
+                      ActionImage,        # '/textures/ui/common/missions/mission1.dds'
+                      Target,       # Can be one of:
+                                    #   Units = { unit1, unit2, ... }
+                                    #   Areas = { 'areaName1', 'areaName2', ... }
+                      IsLoading,    # Are we loading a saved game?
+                      loadedTag     # If IsLoading is specified, what's the tag?
+                      )
+
+    if Type == 'bonus' then
+        return {Tag = 'Invalid'} # bonus objectives cut
+    end
+
+    if(not Sync.ObjectivesTable) then
+        Sync.ObjectivesTable = {}
+    end
+
+    local tag
+
+    if IsLoading then
+        tag = loadedTag
+    else
+        tag = 'Objective' .. objNum
+        objNum = objNum + 1
+        table.insert( SavedList, {AddArgs = {Type,Complete,Title,Description,ActionImage,Target,true,tag,n=8},Tag=tag} )
+    end
+
+    #LOG("Debug: AddObjective: ", Title,":", Description, " (Tag=",tag,")")
+
+    # Set up objective table to return.
+    local objective = {
+        # Used to synchronize sim objectives with user side objectives
+        Tag = tag,
+
+        # Whether the objective is in progress or not and does not indicate
+        # success or failure.
+        Active = true,
+
+        # success or failure.
+        Complete = false,
+
+        # Decal table, key'd by area names
+        Decals = {},
+
+        # Unit arrow table
+        UnitMarkers = {},
+
+        # Visibility markers that we manage
+        VizMarkers = {},
+
+        # Single decal
+        Decal = false,
+
+        # Strategic icon overrides
+        IconOverrides = {},
+
+        # For tracking targets
+        NextTargetTag = 0,
+        PositionUpdateThreads = {},
+
+        Title = Title,
+        Description = Description,
+
+        SimStartTime = GetGameTimeSeconds(),
+
+        # Called on success or failure
+        ResultCallbacks = {},
+        AddResultCallback = function(self,cb)
+            table.insert(self.ResultCallbacks,cb)
+        end,
+
+        # Some objective types can provide progress updates (not success/fail)
+        ProgressCallbacks = {},
+        AddProgressCallback = function(self,cb)
+            table.insert(self.ProgressCallbacks,cb)
+        end,
+
+        # Don't override these if you want notification. Call Add???Callback
+        # intead
+        OnResult = function(self,success,data)
+
+            self.Complete = success
+
+            for k,v in self.ResultCallbacks do v(success,data) end
+
+            # Destroy decals
+            for k,v in self.Decals do v:Destroy() end
+
+            # Destroy unit marker things
+            for k,v in self.UnitMarkers do
+                v:Destroy()
+            end
+
+            # Revert strategic icons
+            for k,v in self.IconOverrides do
+                if not v:BeenDestroyed() then
+                    v:SetStrategicUnderlay("")
+                end
+            end
+
+            # Destroy visibility markers
+            for k,v in self.VizMarkers do
+                v:Destroy()
+            end
+
+            if self.PositionUpdateThreads then
+                for k,v in self.PositionUpdateThreads do
+                    if v then
+                        KillThread(self.PositionUpdateThreads[k])
+                        self.PositionUpdateThreads[k] = false
+                    end
+                end
+            end
+        end,
+
+        OnProgress = function(self,current,total)
+            for k,v in self.ProgressCallbacks do v(current,total) end
+        end,
+
+        # Call this to manually fail the objective
+        Fail = function(self)
+            self.Active = false
+            self:OnResult(false)
+            UpdateObjective(self.Title,'complete','failed',self.Tag)
+        end,
+
+        AddUnitTarget = function(self,unit) end, # defined below
+        AddAreaTarget = function(self,area) end, # defined below
+    }
+
+    # Takes a unit that is an objective target and uses its recon detect
+    # event to notify the objectives that we have a blip for the unit.
+    local function SetupNotify(obj,unit,targetTag)
+		if GetFocusArmy() == -1 then
+			return
+		end
+        # Add a detectedBy callback to notify the user layer when our recon
+        # on the target comes in and out.
+        local detectedByCB = function(cbunit,armyindex)
+            			
+            if armyindex != 1 then
+                return
+            end
+            
+            if not obj.Active then
+                return
+            end
+            LOG('detected by ',armyindex, ' focus = ',GetFocusArmy())
+            # now if we've been detected by the focus army ...
+            if armyindex == GetFocusArmy() then
+                # get the blip that is associated with the unit
+                local blip = cbunit:GetBlip(armyindex)
+
+                # Only provide the target position to the user layer if
+                # the blip IsSeenEver() (i.e. has been identified).
+                obj.PositionUpdateThreads[targetTag] = ForkThread(
+                    function()
+                        while obj.Active do
+                            WaitTicks(10)
+                            if blip:BeenDestroyed() then
+                                return
+                            end
+
+                            if blip:IsSeenEver(armyindex) then
+                                UpdateObjective(Title,
+                                                'Target',
+                                                {
+                                                    Type = 'Position',
+                                                    Value = blip:GetPosition(),
+                                                    BlueprintId = blip:GetBlueprint().BlueprintId,
+                                                    TargetTag=targetTag
+                                                },
+                                                obj.Tag )
+
+                                # If it's not mobile we can exit the thread since
+                                # the blip won't move.
+                                if not unit:IsDead() and not unit:BeenDestroyed() and not EntityCategoryContains( categories.MOBILE, unit ) then
+                                    return
+                                end
+                            end
+                        end
+                    end
+                )
+
+                local destroyCB = function(cbblip)
+                    if not obj.Active then
+                        return
+                    end
+
+                    if obj.PositionUpdateThreads[targetTag] then
+                        #LOG('killing thread')
+                        KillThread( obj.PositionUpdateThreads[targetTag] )
+                        obj.PositionUpdateThreads[targetTag] = false
+                    end
+
+                    # when the blip is destroyed, tell objectives we dont
+                    # have a blip anymore. This doesn't necessarily mean the
+                    # unit is killed, we simply lost the blip.
+                    UpdateObjective(Title,
+                                    'Target',
+                                    {
+                                        Type = 'Position',
+                                        Value = nil,
+                                        BlueprintId = nil,
+                                        TargetTag=targetTag,
+                                    },
+                                    obj.Tag )
+                end
+
+                # When the blip is destroyed, have it call this callback
+                # function (defined above)
+                blip:AddDestroyHook(destroyCB)
+            end
+        end
+
+        # When the unit is detected by an army, have it call this callback
+        # function (defined above)
+        unit:AddDetectedByHook(detectedByCB)
+
+        # See if we can detect the unit right now
+        local blip = unit:GetBlip(GetFocusArmy())
+        if blip then
+            detectedByCB(unit,GetFocusArmy())
+        end
+    end
+
+    # Take an objective target unit that is owned by the focus army
+    # Info passed to user layer to handle zoom to button and chiclet image
+    function SetupFocusNotify(obj, unit, targetTag)
+        obj.PositionUpdateThreads[targetTag] = ForkThread(
+            function()
+                while obj.Active do
+                    if unit:BeenDestroyed() then
+                        return
+                    end
+
+                    UpdateObjective(Title,
+                                    'Target',
+                                    {
+                                        Type = 'Position',
+                                        Value = unit:GetPosition(),
+                                        BlueprintId = unit:GetBlueprint().BlueprintId,
+                                        TargetTag=targetTag
+                                    },
+                                    obj.Tag )
+
+                    # If it's not mobile we can exit the thread since
+                    # the unit won't move.
+                    if not unit:IsDead() and not unit:BeenDestroyed() and not EntityCategoryContains( categories.MOBILE, unit ) then
+                        return
+                    end
+                    WaitTicks(10)
+                end
+            end
+        )
+
+        local destroyCB = function()
+            if not obj.Active then
+                return
+            end
+
+            if obj.PositionUpdateThreads[targetTag] then
+                #LOG('killing thread')
+                KillThread( obj.PositionUpdateThreads[targetTag] )
+                obj.PositionUpdateThreads[targetTag] = false
+            end
+
+            # when the blip is destroyed, tell objectives we dont
+            # have a blip anymore. This doesn't necessarily mean the
+            # unit is killed, we simply lost the blip.
+            UpdateObjective(Title,
+                            'Target',
+                            {
+                                Type = 'Position',
+                                Value = nil,
+                                BlueprintId = nil,
+                                TargetTag=targetTag,
+                            },
+                            obj.Tag )
+        end
+
+        # When the unit is destroyed have it call this callback
+        # function (defined above)
+        Triggers.CreateUnitDeathTrigger(destroyCB, unit )
+    end
+
+    function SetupVizMarker(objective, object)
+        if IsEntity(object) then
+            local pos = object:GetPosition()
+            local spec = {
+                X = pos[1],
+                Z = pos[2],
+                Radius = 8,
+                LifeTime = -1,
+                Omni = false,
+                Vision = true,
+                Army = 1,
+            }
+            local vizmarker = VizMarker(spec)
+            object.Trash:Add(vizmarker)
+            vizmarker:AttachBoneTo(-1,object,-1)
+        else
+            local rect = ScenarioUtils.AreaToRect(Target.Area)
+            local width = rect.x1 - rect.x0
+            local height = rect.y1 - rect.y0
+            local spec = {
+                X = rect.x0 + width/2,
+                Z = rect.y0 + height/2,
+                Radius = math.max( width, height ),
+                LifeTime = -1,
+                Omni = false,
+                Vision = true,
+                Army = 1,
+            }
+            local vizmarker = VizMarker(spec)
+            table.insert(objective.VizMarkers,vizmarker);
+        end
+    end
+
+    function FlashViz (object)
+        if IsEntity(object) then
+
+            local pos = object:GetPosition()
+            local spec = {
+                X = pos[1],
+                Z = pos[2],
+                Radius = 2,
+                LifeTime = 1.00,
+                Omni = false,
+                Vision = true,
+                Radar = false,
+                Army = 1,
+            }
+            local vizmarker = VizMarker(spec)
+            object.Trash:Add(vizmarker)
+            vizmarker:AttachBoneTo(-1,object,-1)
+        else
+            local rect = ScenarioUtils.AreaToRect(object)
+            local width = rect.x1 - rect.x0
+            local height = rect.y1 - rect.y0
+            local spec = {
+                X = rect.x0 + width/2,
+                Z = rect.y0 + height/2,
+                Radius = math.max( width, height ),
+                LifeTime = 0.01,
+                Omni = false,
+                Vision = true,
+                Radar = false,
+                Army = 1,
+            }
+            local vizmarker = VizMarker(spec)
+        end
+    end
+
+    local userTargets = {}
+    if Target.ShowFaction then
+        if Target.ShowFaction == 'Cybran' then
+            Target.Image = '/textures/ui/common/faction_icon-lg/cybran_ico.dds'
+        elseif Target.ShowFaction == 'Aeon' then
+            Target.Image = '/textures/ui/common/faction_icon-lg/aeon_ico.dds'
+        elseif Target.ShowFaction == 'UEF' then
+            Target.Image = '/textures/ui/common/faction_icon-lg/uef_ico.dds'
+        end
+    end
+
+    if Target and Target.Requirements then
+        for k,req in Target.Requirements do
+            if req.Area then
+                table.insert(userTargets, { Type = 'Area', Value = ScenarioUtils.AreaToRect(req.Area) })
+            end
+        end
+    elseif Target and Target.Timer then
+        userTargets = {Type = 'Timer', Time = Target.Timer}
+    end
+
+    if Target.Category then
+        local bps = EntityCategoryGetUnitList(Target.Category)
+        if table.getn(bps) > 0 then
+            table.insert(userTargets, { Type = 'Blueprint', BlueprintId = bps[1] })
+        end
+    end
+
+    local userObjectiveData = {
+        tag = tag,
+        type = Type,
+        complete = Complete,
+        title = Title,
+        description = Description,
+        actionImage = ActionImage,
+        targetImage = Target.Image,
+        progress = "",
+        targets = userTargets,
+        loading = IsLoading,
+        StartTime = objective.SimStartTime,
+    }
+
+    Sync.ObjectivesTable[tag] = userObjectiveData
+
+    objective.AddUnitTarget = function(self,unit)
+        self.NextTargetTag = self.NextTargetTag + 1
+        if unit:GetArmy() == GetFocusArmy() then
+            --it's our unit
+            if GetFocusArmy() == 1 then
+                SetupFocusNotify(self,unit,self.NextTargetTag)
+            end
+        else
+            --it's someone else unit
+            SetupNotify(self,unit,self.NextTargetTag)
+        end
+        if Target.AlwaysVisible then
+            SetupVizMarker(self,unit)
+        end
+
+        table.insert(self.IconOverrides,unit)
+
+        # Mark the units unless MarkUnits == false
+        if ( Target.MarkUnits == nil ) or Target.MarkUnits then
+            if Type == 'primary' then
+                unit:SetStrategicUnderlay('icon_objective_primary')
+            elseif Type == 'secondary' then
+                unit:SetStrategicUnderlay('icon_objective_secondary')
+            end
+        end
+    end
+
+    objective.AddAreaTarget = function(self,area)
+        self.NextTargetTag = self.NextTargetTag + 1
+        UpdateObjective(Title,
+                        'Target',
+                        {
+                            Type = 'Area',
+                            Value = ScenarioUtils.AreaToRect(area),
+                            TargetTag=self.NextTargetTag
+                        },
+                        self.Tag )
+
+        if Target.AlwaysVisible then
+            SetupVizMarker(self,area)
+        end
+    end
+
+    if Target then
+        if Target.Units then
+            for k,v in Target.Units do
+                if v and v.IsDead and not v:IsDead() then
+                    objective:AddUnitTarget(v)
+                end
+            end
+        end
+
+        if Target.Unit then
+            if Target.Unit.IsDead and not Target.Unit:IsDead() then
+                objective:AddUnitTarget(Target.Unit)
+            end
+        end
+
+        if Target.Areas then
+            for k,v in Target.Areas do
+                objective:AddAreaTarget(v)
+            end
+        end
+
+        if Target.Area then
+            objective:AddAreaTarget(Target.Area)
+        end
+    end
+
+    return objective
+end
+
+function DeleteObjective(Objective, IsLoading)
+    local userObjectiveUpdate = {
+        tag = Objective.Tag,
+        updateField = 'delete',
+    }
+    if not IsLoading then
+        table.insert( SavedList, {DeleteArgs = userObjectiveUpdate} )
+    end
+    table.insert(Sync.ObjectivesUpdateTable, userObjectiveUpdate)
+end
+
+### Update legacy style objective using correct syntax
+function UpdateBasicObjective(Objective, UpdateField, NewData)
+    UpdateObjective(Objective.Title, UpdateField, NewData, Objective.Tag)
+end
+### Updates an objective, referencing it by objective title
+function UpdateObjective(Title, UpdateField, NewData, objTag, IsLoading, InTime)
+
+    if objTag == 'Invalid' then
+        return
+    end
+
+    if(not Sync.ObjectivesUpdateTable) then
+        Sync.ObjectivesUpdateTable = {}
+    end
+
+    if type(objTag) ~= 'string' then
+        error('SimObjectives error: Invalid type for objTag in UpdateObjective.  String expected but got '
+        .. type(objTag), 2)
+    end
+    if type(UpdateField) ~= 'string' then
+        error('SimObjectives error: Invalid type for UpdateField in UpdateObjective. String expected but got ' .. type(UpdateField), 2)
+    end
+    #if type(Title) ~= 'string' then
+    #    error('SimObjectives error: Invalid type for Title in UpdateObjective. String expected but got ' .. type(Title), 2)
+    #end
+
+    if not IsLoading then
+        table.insert( SavedList, {UpdateArgs = {Title,UpdateField,NewData,objTag,true, GetGameTimeSeconds(),n=6},Tag=objTag} )
+    end
+
+    # All fields are stored with lowercase names
+    UpdateField = string.lower(UpdateField)
+    if not (
+        (UpdateField == 'type') or
+        (UpdateField == 'complete') or
+        (UpdateField == 'title') or
+        (UpdateField == 'description') or
+        (UpdateField == 'image') or
+        (UpdateField == 'progress') or
+        (UpdateField == 'target') or
+        (UpdateField == 'timer') or
+        (UpdateField == 'delete')
+        )
+      then
+        error( 'Unknown UpdateField: ' .. UpdateField .. '.  Cannot process UpdateObjective request.', 2 )
+    else
+        local userObjectiveUpdate = {
+            title = Title,
+            updateField = UpdateField,
+            updateData = NewData,
+            tag = objTag,
+            loading = IsLoading,
+        }
+        if UpdateField == 'complete' then
+            userObjectiveUpdate['time'] = InTime or GetGameTimeSeconds()
+        end
+        table.insert(Sync.ObjectivesUpdateTable, userObjectiveUpdate)
+    end
+end
+
+function GetCompareFunc( op )
+    function gt(a,b) return a > b end
+    function lt(a,b) return a < b end
+    function gte(a,b) return a >= b end
+    function lte(a,b) return a <= b end
+    function eq(a,b) return a == b end
+
+    if op == '<=' then return lte end
+    if op == '>=' then return gte end
+    if op == '<' then return lt end
+    if op == '>' then return gt end
+    if op == '==' then return eq end
+
+    WARN("Unsupported CompareOp '",op,"'")
+end
+
+function GetActionIcon(actionString)
+    local action = string.lower(actionString)
+    if action == "kill"     then return "/game/orders/attack_btn_up.dds"        end
+    if action == "capture"  then return "/game/orders/convert_btn_up.dds"       end
+    if action == "build"    then return "/game/orders/production_btn_up.dds"    end
+    if action == "protect"  then return "/game/orders/guard_btn_up.dds"         end
+    if action == "timer"    then return "/game/orders/guard_btn_up.dds"         end
+    if action == "move"     then return "/game/orders/move_btn_up.dds"          end
+    if action == "reclaim"  then return "/game/orders/reclaim_btn_up.dds"       end
+    if action == "repair"   then return "/game/orders/repair_btn_up.dds"        end
+    if action == "locate"   then return "/game/orders/omni_btn_up.dds"          end
+    if action == "group"    then return "/game/orders/move_btn_up.dds"          end
+
+     # todo: make 'kill or capture' icon?
+    if action == "killorcapture" then return "/game/orders/attack_btn_up.dds" end
+
+    return ""
+end
+
+function IsComplete(obj)
+    if obj then
+        if obj.Complete then
+            return true
+        end
+    end
+
+    return false
+end
+
+function OnPostLoad()
+    for k,v in SavedList do
+        if v.AddArgs then
+            AddObjective(unpack(v.AddArgs))
+        elseif v.UpdateArgs then
+            UpdateObjective(unpack(v.UpdateArgs))
+        elseif v.DeleteArgs then
+            DeleteObjective(v.DeleteArgs, true)
+        end
+    end
+end
+
+function CreateObjectiveDecal(x, z, w, h)
+    return CreateDecal(Vector(x,0,z), 0, objectiveDecal, '', 'Water Albedo', w, h, DecalLOD, 0, 1, 0)
+end

--- a/lua/SimObjectives.lua
+++ b/lua/SimObjectives.lua
@@ -1,49 +1,49 @@
-#****************************************************************************
-#**
-#**  File     :  /lua/SimObjectives.lua
-#**
-#**  Summary  : Sim side objectives
-#**
-#**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
-##
-## SUPPORTED OBJECTIVE TYPES:
-##      Kill
-##      Capture
-##      KillOrCapture
-##      Reclaim
-##      Locate
-##      SpecificUnitsInArea
-##      CategoriesInArea
-##      ArmyStatCompare
-##      UnitStatCompare
-##      CategoryStatCompare
-##      Protect
-##      Timer
-##      Unknown
-##
-##      Camera
+--****************************************************************************
+--**
+--**  File     :  /lua/SimObjectives.lua
+--**
+--**  Summary  : Sim side objectives
+--**
+--**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
+----
+---- SUPPORTED OBJECTIVE TYPES:
+----      Kill
+----      Capture
+----      KillOrCapture
+----      Reclaim
+----      Locate
+----      SpecificUnitsInArea
+----      CategoriesInArea
+----      ArmyStatCompare
+----      UnitStatCompare
+----      CategoryStatCompare
+----      Protect
+----      Timer
+----      Unknown
+----
+----      Camera
 local ScenarioUtils = import('/lua/sim/ScenarioUtilities.lua')
 local Triggers = import('/lua/scenariotriggers.lua')
 local VizMarker = import('/lua/sim/VizMarker.lua').VizMarker
-local objNum = 0 # Used to create unique tags for objectives
+local objNum = 0 -- Used to create unique tags for objectives
 local DecalLOD = 4000
 
 local objectiveDecal = '/env/utility/decals/objective_debug_albedo.dds'
 local SavedList = {}
 
-#
-# Camera objective by roates
-# Creates markers that satisfy the objective when they are all inside of the camera viewport
-#
-# Camera( objectiveType, completeState, title, description, positionTable)
-#
-# objectiveType = 'primary' or 'bonus' etc...
-# completeState = 'complete' or 'incomplete'
-# title = title string table from map's string file
-# description = description string table from map's string file
-# positionTable = table of position tables where markers will be created. { {x1, y1, z1}, {x2, y2, z2} } format
-#
+--
+-- Camera objective by roates
+-- Creates markers that satisfy the objective when they are all inside of the camera viewport
+--
+-- Camera( objectiveType, completeState, title, description, positionTable)
+--
+-- objectiveType = 'primary' or 'bonus' etc...
+-- completeState = 'complete' or 'incomplete'
+-- title = title string table from map's string file
+-- description = description string table from map's string file
+-- positionTable = table of position tables where markers will be created. { {x1, y1, z1}, {x2, y2, z2} } format
+--
 function Camera(objectiveType, completeState, title, description, positionTable)
     local numMarkers = 0
     local curMarkers = 0
@@ -79,32 +79,32 @@ function Camera(objectiveType, completeState, title, description, positionTable)
 end
 
 
-#
-# ControlGroup
-#   Complete when specified units matching the target blueprint types are in
-# a control group. We don't care exactly which units they are (pre-built or
-# newly constructed), as long as the requirements are ment. We just check
-# the area for what units are in control groups and look at the blueprints (and optionally
-# match the army, use -1 for don't care).
-#
-# Target = {
-#   Requirements = {
-#       {  Category=<cat1>, CompareOp=<op>, Value=<x>, [ArmyIndex=<index>]},
-#       {  Category=<cat2>, CompareOp=<op>, Value=<y>, [ArmyIndex=<index>] },
-#       ...
-#       {  Category=<cat3>, CompareOp=<op>, Value=<z>, [ArmyIndex=<index>] },
-#   }
-# }
-#
-# -- op is one of: '<=', '>=', '<', '>', or '=='
-#
+--
+-- ControlGroup
+--   Complete when specified units matching the target blueprint types are in
+-- a control group. We don't care exactly which units they are (pre-built or
+-- newly constructed), as long as the requirements are ment. We just check
+-- the area for what units are in control groups and look at the blueprints (and optionally
+-- match the army, use -1 for don't care).
+--
+-- Target = {
+--   Requirements = {
+--       {  Category=<cat1>, CompareOp=<op>, Value=<x>, [ArmyIndex=<index>]},
+--       {  Category=<cat2>, CompareOp=<op>, Value=<y>, [ArmyIndex=<index>] },
+--       ...
+--       {  Category=<cat3>, CompareOp=<op>, Value=<z>, [ArmyIndex=<index>] },
+--   }
+-- }
+--
+-- -- op is one of: '<=', '>=', '<', '>', or '=='
+--
 function ControlGroup(Type,Complete,Title,Description,Target)
 
     local image = GetActionIcon('group')
     local objective = AddObjective(Type, Complete, Title, Description, image, Target)
     local lastReqsMet = -1
 
-    # call ManualResult
+    -- call ManualResult
     objective.ManualResult = function(self, result)
         self.Active = false
         self:OnResult(result)
@@ -139,7 +139,7 @@ function ControlGroup(Type,Complete,Title,Description,Target)
                             end
                         end
                     end
-                    #LOG('debug: ControlGroup: reqsmet '..reqsMet..'count '.. cnt )
+                    --LOG('debug: ControlGroup: reqsmet '..reqsMet..'count '.. cnt )
                 end
                 if not requirement.CompareFunc then
                     requirement.CompareFunc = GetCompareFunc(requirement.CompareOp)
@@ -175,14 +175,14 @@ end
 
 
 
-#
-# CreateGroup
-#
-#   Takes list of objective tables which are produced by the objective creation
-# functions such as Kill, Protect, Capture, etc.
-#
-#   UserCallback is executed when all objectives in the list are complete
-#
+--
+-- CreateGroup
+--
+--   Takes list of objective tables which are produced by the objective creation
+-- functions such as Kill, Protect, Capture, etc.
+--
+--   UserCallback is executed when all objectives in the list are complete
+--
 function CreateGroup( name, userCallback, numRequired )
     LOG('Creating objective group ',name)
     local objectiveGroup =  {
@@ -191,8 +191,8 @@ function CreateGroup( name, userCallback, numRequired )
         Objectives = {},
         NumRequired = numRequired,
         NumCompleted = 0,
-        AddObjective = function(self,objective) end, # defined later
-        RemoveObjective = function(self,objective) end, # defined later
+        AddObjective = function(self,objective) end, -- defined later
+        RemoveObjective = function(self,objective) end, -- defined later
         OnComplete = userCallback,
     }
 
@@ -221,7 +221,7 @@ function CreateGroup( name, userCallback, numRequired )
             end
         end
 
-        # Complete!
+        -- Complete!
         objectiveGroup.Active = false
         objectiveGroup.OnComplete()
     end
@@ -238,9 +238,9 @@ function CreateGroup( name, userCallback, numRequired )
     return objectiveGroup
 end
 
-#
-# Kill
-#   Kill units
+--
+-- Kill
+--   Kill units
 function Kill(Type,Complete,Title,Description,Target)
     Target.killed = 0
     Target.total = table.getn(Target.Units)
@@ -248,7 +248,7 @@ function Kill(Type,Complete,Title,Description,Target)
     local image = GetActionIcon('kill')
     local objective = AddObjective(Type,Complete,Title,Description,image,Target)
 
-    # call ManualResult
+    -- call ManualResult
     objective.ManualResult = function(self, result)
         objective.Active = false
         objective:OnResult(result)
@@ -277,7 +277,7 @@ function Kill(Type,Complete,Title,Description,Target)
 
     for k,unit in Target.Units do
         if not unit:IsDead() then
-            # Mark the units unless MarkUnits == false
+            -- Mark the units unless MarkUnits == false
             if ( Target.MarkUnits == nil ) or Target.MarkUnits then
                 local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
                 local arrow = ObjectiveArrow { AttachTo = unit }
@@ -286,7 +286,7 @@ function Kill(Type,Complete,Title,Description,Target)
                 FlashViz( unit )
             end
             Triggers.CreateUnitDeathTrigger(OnUnitKilled, unit)
-            Triggers.CreateUnitReclaimedTrigger(OnUnitKilled, unit) #same as killing for our purposes
+            Triggers.CreateUnitReclaimedTrigger(OnUnitKilled, unit) --same as killing for our purposes
         else
             OnUnitKilled(unit)
         end
@@ -298,15 +298,15 @@ function Kill(Type,Complete,Title,Description,Target)
     return objective
 end
 
-#
-# Capture
-#   Capture units
-#
-# Target = {
-#       Units = <units>,
-#       NumRequired = <x>,
-# }
-#
+--
+-- Capture
+--   Capture units
+--
+-- Target = {
+--       Units = <units>,
+--       NumRequired = <x>,
+-- }
+--
 function Capture(Type,Complete,Title,Description,Target)
     Target.captured = 0
     Target.total = table.getn(Target.Units)
@@ -359,7 +359,7 @@ function Capture(Type,Complete,Title,Description,Target)
 
     for k,unit in Target.Units do
         if not unit:IsDead() then
-            # Mark the units unless MarkUnits == false
+            -- Mark the units unless MarkUnits == false
             if ( Target.MarkUnits == nil ) or Target.MarkUnits then
                 local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
                 local arrow = ObjectiveArrow { AttachTo = unit }
@@ -367,13 +367,13 @@ function Capture(Type,Complete,Title,Description,Target)
 
             Triggers.CreateUnitCapturedTrigger(nil,OnUnitCaptured,unit)
             Triggers.CreateUnitDeathTrigger(OnUnitKilled, unit)
-            Triggers.CreateUnitReclaimedTrigger(OnUnitKilled, unit) #same functionality as killed
+            Triggers.CreateUnitReclaimedTrigger(OnUnitKilled, unit) --same functionality as killed
 
             if Target.FlashVisible then
                 FlashViz( unit )
             end
         else
-            #treat as killed Matt 8.30.06
+            --treat as killed Matt 8.30.06
             OnUnitKilled(unit)
         end
     end
@@ -384,9 +384,9 @@ function Capture(Type,Complete,Title,Description,Target)
     return objective
 end
 
-#
-# Kill or Capture
-#   Kill or Capture units
+--
+-- Kill or Capture
+--   Kill or Capture units
 function KillOrCapture(Type,Complete,Title,Description,Target)
     Target.killed_or_captured = 0
     Target.total = table.getn(Target.Units)
@@ -406,13 +406,13 @@ function KillOrCapture(Type,Complete,Title,Description,Target)
         UpdateObjective( Title, 'complete', resultStr, self.Tag )
     end
 
-    # keep track of captured units so subsequent kills don't get counted
+    -- keep track of captured units so subsequent kills don't get counted
     local captured = {}
 
     local function OnUnitKilled(unit)
         for k,v in captured do
             if v == unit then
-                # ignore units already captured
+                -- ignore units already captured
                 return
             end
         end
@@ -461,7 +461,7 @@ function KillOrCapture(Type,Complete,Title,Description,Target)
 
     for k,unit in Target.Units do
         if not unit:IsDead() then
-            # Mark the units unless MarkUnits == false
+            -- Mark the units unless MarkUnits == false
             if ( Target.MarkUnits == nil ) or Target.MarkUnits then
                 local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
                 local arrow = ObjectiveArrow { AttachTo = unit }
@@ -471,8 +471,8 @@ function KillOrCapture(Type,Complete,Title,Description,Target)
                 FlashViz( unit )
             end
 
-            # note: you won't get an OnKilled after an OnCaptured because once
-            # captured it's actually a new unit with no callback.
+            -- note: you won't get an OnKilled after an OnCaptured because once
+            -- captured it's actually a new unit with no callback.
             Triggers.CreateUnitCapturedTrigger(nil,OnUnitCaptured,unit)
             Triggers.CreateUnitDeathTrigger(OnUnitKilled, unit)
             Triggers.CreateUnitReclaimedTrigger(OnUnitReclaimed, unit)
@@ -487,9 +487,9 @@ function KillOrCapture(Type,Complete,Title,Description,Target)
     return objective
 end
 
-#
-# Reclaim
-#   Reclaim units
+--
+-- Reclaim
+--   Reclaim units
 function Reclaim(Type,Complete,Title,Description,Target)
     Target.reclaimed = 0
     Target.total = table.getn(Target.Units)
@@ -497,7 +497,7 @@ function Reclaim(Type,Complete,Title,Description,Target)
     local image = GetActionIcon("reclaim")
     local objective = AddObjective(Type,Complete,Title,Description,image,Target)
 
-    # call ManualResult
+    -- call ManualResult
     objective.ManualResult = function(self, result)
         self.Active = false
         self:OnResult(result)
@@ -532,8 +532,8 @@ function Reclaim(Type,Complete,Title,Description,Target)
         UpdateObjective( Title, 'complete', 'failed', objective.Tag )
     end
 
-    # If the unit is captured it can still be reclaimed to complete the
-    # objective, so track the new unit created on a capture.
+    -- If the unit is captured it can still be reclaimed to complete the
+    -- objective, so track the new unit created on a capture.
     local function OnUnitCaptured(newUnit,captor)
         Triggers.CreateUnitCapturedTrigger(nil,OnUnitCaptured,newUnit)
         Triggers.CreateUnitDeathTrigger(OnUnitKilled, newUnit)
@@ -556,9 +556,9 @@ function Reclaim(Type,Complete,Title,Description,Target)
     return objective
 end
 
-#
-# Locate
-#   Locate units
+--
+-- Locate
+--   Locate units
 function Locate(Type,Complete,Title,Description,Target)
     Target.located = 0
     Target.total = table.getn(Target.Units)
@@ -596,11 +596,11 @@ function Locate(Type,Complete,Title,Description,Target)
     return objective
 end
 
-#
-# SpecificUnitsInArea
-#   Complete when specified units are in the target area. We don't care how
-# they got there (cheat teleport, etc), we just check if they're in there
-# ShowProgress, optional:
+--
+-- SpecificUnitsInArea
+--   Complete when specified units are in the target area. We don't care how
+-- they got there (cheat teleport, etc), we just check if they're in there
+-- ShowProgress, optional:
 function SpecificUnitsInArea(Type,Complete,Title,Description,Target)
     local image = GetActionIcon('Move')
     local objective = AddObjective(Type,Complete,Title,Description,image,Target)
@@ -608,7 +608,7 @@ function SpecificUnitsInArea(Type,Complete,Title,Description,Target)
     local numRequired = Target.NumRequired or total
     Target.Count = 0
 
-    # call ManualResult
+    -- call ManualResult
     objective.ManualResult = function(self, result)
         self.Active = false
         self:OnResult(result)
@@ -687,32 +687,32 @@ function SpecificUnitsInArea(Type,Complete,Title,Description,Target)
     return objective
 end
 
-#
-# CategoriesInArea
-#   Complete when specified units matching the target blueprint types are in
-# the target area. We don't care exactly which units they are (pre-built or
-# newly constructed) or how they got there (cheat teleport, etc). We just check
-# the area for what units are inside and look at the blueprints (and optionally
-# match the army, use -1 for don't care).
-#
-# Target = {
-#   Requirements = {
-#       { Area = <areaName>, Category=<cat1>, CompareOp=<op>, Value=<x>, [ArmyIndex=<index>]},
-#       { Area = <areaName>, Category=<cat2>, CompareOp=<op>, Value=<y>, [ArmyIndex=<index>] },
-#       ...
-#       { Area = <areaName>, Category=<cat3>, CompareOp=<op>, Value=<z>, [ArmyIndex=<index>] },
-#   }
-# }
-#
-# -- op is one of: '<=', '>=', '<', '>', or '=='
-#
+--
+-- CategoriesInArea
+--   Complete when specified units matching the target blueprint types are in
+-- the target area. We don't care exactly which units they are (pre-built or
+-- newly constructed) or how they got there (cheat teleport, etc). We just check
+-- the area for what units are inside and look at the blueprints (and optionally
+-- match the army, use -1 for don't care).
+--
+-- Target = {
+--   Requirements = {
+--       { Area = <areaName>, Category=<cat1>, CompareOp=<op>, Value=<x>, [ArmyIndex=<index>]},
+--       { Area = <areaName>, Category=<cat2>, CompareOp=<op>, Value=<y>, [ArmyIndex=<index>] },
+--       ...
+--       { Area = <areaName>, Category=<cat3>, CompareOp=<op>, Value=<z>, [ArmyIndex=<index>] },
+--   }
+-- }
+--
+-- -- op is one of: '<=', '>=', '<', '>', or '=='
+--
 function CategoriesInArea(Type,Complete,Title,Description,Action,Target)
 
     local image = GetActionIcon(Action)
     local objective = AddObjective(Type,Complete,Title,Description,image,Target)
     local lastReqsMet = 0
 
-    # call ManualResult
+    -- call ManualResult
     objective.ManualResult = function(self, result)
         self.Active = false
         self:OnResult(result)
@@ -749,7 +749,7 @@ function CategoriesInArea(Type,Complete,Title,Description,Action,Target)
                             end
                         end
                     end
-                    #LOG('debug: CategoriesInArea: reqsmet '..reqsMet..'count '.. cnt )
+                    --LOG('debug: CategoriesInArea: reqsmet '..reqsMet..'count '.. cnt )
                 end
                 if requirement.CompareFunc(cnt,requirement.Value) then
                     reqsMet = reqsMet +1
@@ -803,21 +803,21 @@ function CategoriesInArea(Type,Complete,Title,Description,Action,Target)
     return objective
 end
 
-#
-# ArmyStatCompare
-#   Army stat is compared <=, >=, >, <, or == to some value.
-#
-# Target = {
-#       Army=<index>,
-#       StatName=<name>,
-#       CompareOp=<op>,   -- op is one of: '<=', '>=', '<', '>', or '=='
-#       Value=<value>,
-#       [Category=<category>], -- optional to compare to a blueprint stat
-#       ShowProgress, optional: shows #/#. may not make sense for all compare types
-# }
-#
-# Note: Be careful when using '==' as the stat is only checked every 5 ticks.
-#
+--
+-- ArmyStatCompare
+--   Army stat is compared <=, >=, >, <, or == to some value.
+--
+-- Target = {
+--       Army=<index>,
+--       StatName=<name>,
+--       CompareOp=<op>,   -- op is one of: '<=', '>=', '<', '>', or '=='
+--       Value=<value>,
+--       [Category=<category>], -- optional to compare to a blueprint stat
+--       ShowProgress, optional: shows --/--. may not make sense for all compare types
+-- }
+--
+-- Note: Be careful when using '==' as the stat is only checked every 5 ticks.
+--
 function ArmyStatCompare(Type,Complete,Title,Description,Action,Target)
     local image = GetActionIcon(Action)
     local objective = AddObjective(Type,Complete,Title,Description,image,Target)
@@ -838,7 +838,7 @@ function ArmyStatCompare(Type,Complete,Title,Description,Action,Target)
 
             if (Target.ShowProgress) then
                 if (testVal ~= oldVal) then
-                    #LOG('*** progress! ', testVal, ' ', oldVal)
+                    --LOG('*** progress! ', testVal, ' ', oldVal)
                     local progress = string.format('(%s/%s)', testVal, value)
                     UpdateObjective( Title, 'Progress', progress, objective.Tag )
                     oldVal = testVal
@@ -877,19 +877,19 @@ function ArmyStatCompare(Type,Complete,Title,Description,Action,Target)
     return objective
 end
 
-#
-# UnitStatCompare
-#   A specified unit's stat is <=, >=, >, <, or == to some value.
-#
-# Target = {
-#       Unit=<unit>,
-#       StatName=<name>,
-#       CompareOp=<op>,   -- op is one of: '<=', '>=', '<', '>', or '=='
-#       Value=<value>,
-# }
-#
-# Note: Be careful when using '==' as the stat is only checked every 5 ticks.
-#
+--
+-- UnitStatCompare
+--   A specified unit's stat is <=, >=, >, <, or == to some value.
+--
+-- Target = {
+--       Unit=<unit>,
+--       StatName=<name>,
+--       CompareOp=<op>,   -- op is one of: '<=', '>=', '<', '>', or '=='
+--       Value=<value>,
+-- }
+--
+-- Note: Be careful when using '==' as the stat is only checked every 5 ticks.
+--
 function UnitStatCompare(Type,Complete,Title,Description,Action,Target)
     local image = GetActionIcon(Action)
     local objective = AddObjective(Type,Complete,Title,Description,image,Target)
@@ -914,21 +914,21 @@ function UnitStatCompare(Type,Complete,Title,Description,Action,Target)
     return objective
 end
 
-#
-# CategoryStatCompare
-#   Some unit belonging to specified category has a stat <=, >=, >, <, or ==
-# to some value.
-#
-# Target = {
-#       Army=<index>,
-#       Category=<unit>,
-#       StatName=<name>,
-#       CompareOp=<op>,   -- op is one of: '<=', '>=', '<', '>', or '=='
-#       Value=<value>,
-# }
-#
-# Note: Be careful when using '==' as the stat is only checked every 5 ticks.
-#
+--
+-- CategoryStatCompare
+--   Some unit belonging to specified category has a stat <=, >=, >, <, or ==
+-- to some value.
+--
+-- Target = {
+--       Army=<index>,
+--       Category=<unit>,
+--       StatName=<name>,
+--       CompareOp=<op>,   -- op is one of: '<=', '>=', '<', '>', or '=='
+--       Value=<value>,
+-- }
+--
+-- Note: Be careful when using '==' as the stat is only checked every 5 ticks.
+--
 function CategoryStatCompare(Type,Complete,Title,Description,Action,Target)
     local image = GetActionIcon(Action)
     local objective = AddObjective(Type,Complete,Title,Description,image,Target)
@@ -958,16 +958,16 @@ function CategoryStatCompare(Type,Complete,Title,Description,Action,Target)
     return objective
 end
 
-#
-# Protect
-#   Fails if # of units in list falls below NumRequired before the timer expires
-# or, in the case of no timer, the objective is manually update to complete.
-#
-# Target = {
-#       Units = {},
-#       Timer = <seconds> or nil,   -- if nil, requires manual completion
-#       NumRequired = <#>,          -- how many must survive
-# }
+--
+-- Protect
+--   Fails if -- of units in list falls below NumRequired before the timer expires
+-- or, in the case of no timer, the objective is manually update to complete.
+--
+-- Target = {
+--       Units = {},
+--       Timer = <seconds> or nil,   -- if nil, requires manual completion
+--       NumRequired = <-->,          -- how many must survive
+-- }
 function Protect(Type,Complete,Title,Description,Target)
 
     local image = GetActionIcon("protect")
@@ -989,7 +989,7 @@ function Protect(Type,Complete,Title,Description,Target)
             local progress = string.format('(%s/%s)', total, numRequired)
             UpdateObjective( Title, 'Progress', progress, objective.Tag )
         elseif (Target.PercentProgress) then
-            #local progress = LOCF('<LOC A02_M01_OBJ_010_113>(%s%%/%s%%)',math.ceil( total / max * 100),math.ceil( numRequired / max * 100))
+            --local progress = LOCF('<LOC A02_M01_OBJ_010_113>(%s%%/%s%%)',math.ceil( total / max * 100),math.ceil( numRequired / max * 100))
             local progress = string.format('(%s%%)',math.ceil( total / max * 100))
             UpdateObjective( Title, 'Progress', progress, objective.Tag )
         end
@@ -1043,7 +1043,7 @@ function Protect(Type,Complete,Title,Description,Target)
         local progress = string.format('(%s/%s)', total, numRequired)
         UpdateObjective( Title, 'Progress', progress, objective.Tag )
     elseif (Target.PercentProgress) then
-        #local progress = LOCF('<LOC A02_M01_OBJ_010_113>(%s%%/%s%%)',math.ceil( total / max * 100),math.ceil( numRequired / max * 100))
+        --local progress = LOCF('<LOC A02_M01_OBJ_010_113>(%s%%/%s%%)',math.ceil( total / max * 100),math.ceil( numRequired / max * 100))
         local progress = string.format('(%s%%)',math.ceil( total / max * 100))
         UpdateObjective( Title, 'Progress', progress, objective.Tag )
     end
@@ -1051,21 +1051,21 @@ function Protect(Type,Complete,Title,Description,Target)
     return objective
 end
 
-#
-# Timer
-#   OnResult() is called when the timer expires. The result depends on whether
-# ExpireResult is set to complete or failed.
-#
-# Target = {
-#       Timer = <seconds>
-#       ExpireResult = 'complete' or 'failed'
-# }
+--
+-- Timer
+--   OnResult() is called when the timer expires. The result depends on whether
+-- ExpireResult is set to complete or failed.
+--
+-- Target = {
+--       Timer = <seconds>
+--       ExpireResult = 'complete' or 'failed'
+-- }
 function Timer(Type,Complete,Title,Description,Target)
 
     local image = GetActionIcon("timer")
     local objective = AddObjective(Type,Complete,Title,Description,image,Target)
 
-    # call ManualResult
+    -- call ManualResult
     objective.ManualResult = function(self, result)
         self.Active = false
         self:OnResult(result)
@@ -1108,7 +1108,7 @@ end
 function Unknown(Type,Complete,Title,Description)
     local objective = AddObjective(Type,Complete,Title,Description)
 
-    # call ManualResult
+    -- call ManualResult
     objective.ManualResult = function(self, result)
         self.Active = false
         self:OnResult(result)
@@ -1127,7 +1127,7 @@ end
 function Basic(Type,Complete,Title,Description,Image,Target)
     local objective = AddObjective(Type,Complete,Title,Description,Image,Target)
 
-    # call ManualResult
+    -- call ManualResult
     objective.ManualResult = function(self, result)
         objective.Active = false
         objective:OnResult(result)
@@ -1205,21 +1205,21 @@ function Basic(Type,Complete,Title,Description,Image,Target)
 end
 
 
-### Adds objective for the objectives screen
-function AddObjective(Type,         # 'primary', 'bonus', etc
-                      Complete,     # 'complete', 'incomplete'
-                      Title,        # e.g. "Destroy Radar Stations"
-                      Description,  # e.g. "A reason why you need to destroy the radar stations"
-                      ActionImage,        # '/textures/ui/common/missions/mission1.dds'
-                      Target,       # Can be one of:
-                                    #   Units = { unit1, unit2, ... }
-                                    #   Areas = { 'areaName1', 'areaName2', ... }
-                      IsLoading,    # Are we loading a saved game?
-                      loadedTag     # If IsLoading is specified, what's the tag?
+------ Adds objective for the objectives screen
+function AddObjective(Type,         -- 'primary', 'bonus', etc
+                      Complete,     -- 'complete', 'incomplete'
+                      Title,        -- e.g. "Destroy Radar Stations"
+                      Description,  -- e.g. "A reason why you need to destroy the radar stations"
+                      ActionImage,        -- '/textures/ui/common/missions/mission1.dds'
+                      Target,       -- Can be one of:
+                                    --   Units = { unit1, unit2, ... }
+                                    --   Areas = { 'areaName1', 'areaName2', ... }
+                      IsLoading,    -- Are we loading a saved game?
+                      loadedTag     -- If IsLoading is specified, what's the tag?
                       )
 
     if Type == 'bonus' then
-        return {Tag = 'Invalid'} # bonus objectives cut
+        return {Tag = 'Invalid'} -- bonus objectives cut
     end
 
     if(not Sync.ObjectivesTable) then
@@ -1236,36 +1236,36 @@ function AddObjective(Type,         # 'primary', 'bonus', etc
         table.insert( SavedList, {AddArgs = {Type,Complete,Title,Description,ActionImage,Target,true,tag,n=8},Tag=tag} )
     end
 
-    #LOG("Debug: AddObjective: ", Title,":", Description, " (Tag=",tag,")")
+    --LOG("Debug: AddObjective: ", Title,":", Description, " (Tag=",tag,")")
 
-    # Set up objective table to return.
+    -- Set up objective table to return.
     local objective = {
-        # Used to synchronize sim objectives with user side objectives
+        -- Used to synchronize sim objectives with user side objectives
         Tag = tag,
 
-        # Whether the objective is in progress or not and does not indicate
-        # success or failure.
+        -- Whether the objective is in progress or not and does not indicate
+        -- success or failure.
         Active = true,
 
-        # success or failure.
+        -- success or failure.
         Complete = false,
 
-        # Decal table, key'd by area names
+        -- Decal table, key'd by area names
         Decals = {},
 
-        # Unit arrow table
+        -- Unit arrow table
         UnitMarkers = {},
 
-        # Visibility markers that we manage
+        -- Visibility markers that we manage
         VizMarkers = {},
 
-        # Single decal
+        -- Single decal
         Decal = false,
 
-        # Strategic icon overrides
+        -- Strategic icon overrides
         IconOverrides = {},
 
-        # For tracking targets
+        -- For tracking targets
         NextTargetTag = 0,
         PositionUpdateThreads = {},
 
@@ -1274,42 +1274,42 @@ function AddObjective(Type,         # 'primary', 'bonus', etc
 
         SimStartTime = GetGameTimeSeconds(),
 
-        # Called on success or failure
+        -- Called on success or failure
         ResultCallbacks = {},
         AddResultCallback = function(self,cb)
             table.insert(self.ResultCallbacks,cb)
         end,
 
-        # Some objective types can provide progress updates (not success/fail)
+        -- Some objective types can provide progress updates (not success/fail)
         ProgressCallbacks = {},
         AddProgressCallback = function(self,cb)
             table.insert(self.ProgressCallbacks,cb)
         end,
 
-        # Don't override these if you want notification. Call Add???Callback
-        # intead
+        -- Don't override these if you want notification. Call Add???Callback
+        -- intead
         OnResult = function(self,success,data)
 
             self.Complete = success
 
             for k,v in self.ResultCallbacks do v(success,data) end
 
-            # Destroy decals
+            -- Destroy decals
             for k,v in self.Decals do v:Destroy() end
 
-            # Destroy unit marker things
+            -- Destroy unit marker things
             for k,v in self.UnitMarkers do
                 v:Destroy()
             end
 
-            # Revert strategic icons
+            -- Revert strategic icons
             for k,v in self.IconOverrides do
                 if not v:BeenDestroyed() then
                     v:SetStrategicUnderlay("")
                 end
             end
 
-            # Destroy visibility markers
+            -- Destroy visibility markers
             for k,v in self.VizMarkers do
                 v:Destroy()
             end
@@ -1328,27 +1328,27 @@ function AddObjective(Type,         # 'primary', 'bonus', etc
             for k,v in self.ProgressCallbacks do v(current,total) end
         end,
 
-        # Call this to manually fail the objective
+        -- Call this to manually fail the objective
         Fail = function(self)
             self.Active = false
             self:OnResult(false)
             UpdateObjective(self.Title,'complete','failed',self.Tag)
         end,
 
-        AddUnitTarget = function(self,unit) end, # defined below
-        AddAreaTarget = function(self,area) end, # defined below
+        AddUnitTarget = function(self,unit) end, -- defined below
+        AddAreaTarget = function(self,area) end, -- defined below
     }
 
-    # Takes a unit that is an objective target and uses its recon detect
-    # event to notify the objectives that we have a blip for the unit.
+    -- Takes a unit that is an objective target and uses its recon detect
+    -- event to notify the objectives that we have a blip for the unit.
     local function SetupNotify(obj,unit,targetTag)
-		if GetFocusArmy() == -1 then
-			return
-		end
-        # Add a detectedBy callback to notify the user layer when our recon
-        # on the target comes in and out.
+        if GetFocusArmy() == -1 then
+            return
+        end
+        -- Add a detectedBy callback to notify the user layer when our recon
+        -- on the target comes in and out.
         local detectedByCB = function(cbunit,armyindex)
-            			
+                        
             if armyindex != 1 then
                 return
             end
@@ -1356,13 +1356,13 @@ function AddObjective(Type,         # 'primary', 'bonus', etc
             if not obj.Active then
                 return
             end
-            # now if we've been detected by the focus army ...
+            -- now if we've been detected by the focus army ...
             if armyindex == GetFocusArmy() then
-                # get the blip that is associated with the unit
+                -- get the blip that is associated with the unit
                 local blip = cbunit:GetBlip(armyindex)
 
-                # Only provide the target position to the user layer if
-                # the blip IsSeenEver() (i.e. has been identified).
+                -- Only provide the target position to the user layer if
+                -- the blip IsSeenEver() (i.e. has been identified).
                 obj.PositionUpdateThreads[targetTag] = ForkThread(
                     function()
                         while obj.Active do
@@ -1382,8 +1382,8 @@ function AddObjective(Type,         # 'primary', 'bonus', etc
                                                 },
                                                 obj.Tag )
 
-                                # If it's not mobile we can exit the thread since
-                                # the blip won't move.
+                                -- If it's not mobile we can exit the thread since
+                                -- the blip won't move.
                                 if not unit:IsDead() and not unit:BeenDestroyed() and not EntityCategoryContains( categories.MOBILE, unit ) then
                                     return
                                 end
@@ -1398,14 +1398,14 @@ function AddObjective(Type,         # 'primary', 'bonus', etc
                     end
 
                     if obj.PositionUpdateThreads[targetTag] then
-                        #LOG('killing thread')
+                        --LOG('killing thread')
                         KillThread( obj.PositionUpdateThreads[targetTag] )
                         obj.PositionUpdateThreads[targetTag] = false
                     end
 
-                    # when the blip is destroyed, tell objectives we dont
-                    # have a blip anymore. This doesn't necessarily mean the
-                    # unit is killed, we simply lost the blip.
+                    -- when the blip is destroyed, tell objectives we dont
+                    -- have a blip anymore. This doesn't necessarily mean the
+                    -- unit is killed, we simply lost the blip.
                     UpdateObjective(Title,
                                     'Target',
                                     {
@@ -1417,25 +1417,25 @@ function AddObjective(Type,         # 'primary', 'bonus', etc
                                     obj.Tag )
                 end
 
-                # When the blip is destroyed, have it call this callback
-                # function (defined above)
+                -- When the blip is destroyed, have it call this callback
+                -- function (defined above)
                 blip:AddDestroyHook(destroyCB)
             end
         end
 
-        # When the unit is detected by an army, have it call this callback
-        # function (defined above)
+        -- When the unit is detected by an army, have it call this callback
+        -- function (defined above)
         unit:AddDetectedByHook(detectedByCB)
 
-        # See if we can detect the unit right now
+        -- See if we can detect the unit right now
         local blip = unit:GetBlip(GetFocusArmy())
         if blip then
             detectedByCB(unit,GetFocusArmy())
         end
     end
 
-    # Take an objective target unit that is owned by the focus army
-    # Info passed to user layer to handle zoom to button and chiclet image
+    -- Take an objective target unit that is owned by the focus army
+    -- Info passed to user layer to handle zoom to button and chiclet image
     function SetupFocusNotify(obj, unit, targetTag)
         obj.PositionUpdateThreads[targetTag] = ForkThread(
             function()
@@ -1454,8 +1454,8 @@ function AddObjective(Type,         # 'primary', 'bonus', etc
                                     },
                                     obj.Tag )
 
-                    # If it's not mobile we can exit the thread since
-                    # the unit won't move.
+                    -- If it's not mobile we can exit the thread since
+                    -- the unit won't move.
                     if not unit:IsDead() and not unit:BeenDestroyed() and not EntityCategoryContains( categories.MOBILE, unit ) then
                         return
                     end
@@ -1470,14 +1470,14 @@ function AddObjective(Type,         # 'primary', 'bonus', etc
             end
 
             if obj.PositionUpdateThreads[targetTag] then
-                #LOG('killing thread')
+                --LOG('killing thread')
                 KillThread( obj.PositionUpdateThreads[targetTag] )
                 obj.PositionUpdateThreads[targetTag] = false
             end
 
-            # when the blip is destroyed, tell objectives we dont
-            # have a blip anymore. This doesn't necessarily mean the
-            # unit is killed, we simply lost the blip.
+            -- when the blip is destroyed, tell objectives we dont
+            -- have a blip anymore. This doesn't necessarily mean the
+            -- unit is killed, we simply lost the blip.
             UpdateObjective(Title,
                             'Target',
                             {
@@ -1489,8 +1489,8 @@ function AddObjective(Type,         # 'primary', 'bonus', etc
                             obj.Tag )
         end
 
-        # When the unit is destroyed have it call this callback
-        # function (defined above)
+        -- When the unit is destroyed have it call this callback
+        -- function (defined above)
         Triggers.CreateUnitDeathTrigger(destroyCB, unit )
     end
 
@@ -1623,7 +1623,7 @@ function AddObjective(Type,         # 'primary', 'bonus', etc
 
         table.insert(self.IconOverrides,unit)
 
-        # Mark the units unless MarkUnits == false
+        -- Mark the units unless MarkUnits == false
         if ( Target.MarkUnits == nil ) or Target.MarkUnits then
             if Type == 'primary' then
                 unit:SetStrategicUnderlay('icon_objective_primary')
@@ -1689,11 +1689,11 @@ function DeleteObjective(Objective, IsLoading)
     table.insert(Sync.ObjectivesUpdateTable, userObjectiveUpdate)
 end
 
-### Update legacy style objective using correct syntax
+------ Update legacy style objective using correct syntax
 function UpdateBasicObjective(Objective, UpdateField, NewData)
     UpdateObjective(Objective.Title, UpdateField, NewData, Objective.Tag)
 end
-### Updates an objective, referencing it by objective title
+------ Updates an objective, referencing it by objective title
 function UpdateObjective(Title, UpdateField, NewData, objTag, IsLoading, InTime)
 
     if objTag == 'Invalid' then
@@ -1711,15 +1711,15 @@ function UpdateObjective(Title, UpdateField, NewData, objTag, IsLoading, InTime)
     if type(UpdateField) ~= 'string' then
         error('SimObjectives error: Invalid type for UpdateField in UpdateObjective. String expected but got ' .. type(UpdateField), 2)
     end
-    #if type(Title) ~= 'string' then
-    #    error('SimObjectives error: Invalid type for Title in UpdateObjective. String expected but got ' .. type(Title), 2)
-    #end
+    --if type(Title) ~= 'string' then
+    --    error('SimObjectives error: Invalid type for Title in UpdateObjective. String expected but got ' .. type(Title), 2)
+    --end
 
     if not IsLoading then
         table.insert( SavedList, {UpdateArgs = {Title,UpdateField,NewData,objTag,true, GetGameTimeSeconds(),n=6},Tag=objTag} )
     end
 
-    # All fields are stored with lowercase names
+    -- All fields are stored with lowercase names
     UpdateField = string.lower(UpdateField)
     if not (
         (UpdateField == 'type') or
@@ -1778,7 +1778,7 @@ function GetActionIcon(actionString)
     if action == "locate"   then return "/game/orders/omni_btn_up.dds"          end
     if action == "group"    then return "/game/orders/move_btn_up.dds"          end
 
-     # todo: make 'kill or capture' icon?
+     -- todo: make 'kill or capture' icon?
     if action == "killorcapture" then return "/game/orders/attack_btn_up.dds" end
 
     return ""

--- a/lua/SimObjectives.lua
+++ b/lua/SimObjectives.lua
@@ -1356,7 +1356,6 @@ function AddObjective(Type,         # 'primary', 'bonus', etc
             if not obj.Active then
                 return
             end
-            LOG('detected by ',armyindex, ' focus = ',GetFocusArmy())
             # now if we've been detected by the focus army ...
             if armyindex == GetFocusArmy() then
                 # get the blip that is associated with the unit

--- a/lua/cinematics.lua
+++ b/lua/cinematics.lua
@@ -1,0 +1,208 @@
+#****************************************************************************
+#**
+#**  File     :  /lua/cinematics.lua
+#**  Author(s):  David Tomandl
+#**
+#**  Summary  :  Helper functions for cinematics
+#**
+#**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+#
+# One cautionary note: don't change the playable area during an in-game cinematic.
+# If you do, and you move the camera to a marker in the new area, the engine
+# may not handle it well.
+#
+
+SimCamera = import('/lua/simcamera.lua').SimCamera
+local ScenarioUtils = import('/lua/sim/ScenarioUtilities.lua')
+local ScenarioFramework = import('/lua/ScenarioFramework.lua')
+
+function IsOpEnded()
+    if ScenarioInfo.OpEnded then
+        return true
+    else
+        return false
+    end
+end
+
+# To be used when starting a cinematic / NIS
+function EnterNISMode()
+    ScenarioInfo.Camera = SimCamera('WorldCamera')
+    LockInput()
+    ScenarioInfo.Camera:UseGameClock()
+    Sync.NISMode = 'on'
+    ScenarioInfo.OpEnded = true
+    #Take Away UI
+    #Set Game Speed to normal
+end
+
+# Used at the end of a cinematic / NIS
+function ExitNISMode()
+    #Set Game Speed to user value
+    #Restore UI
+    ScenarioInfo.OpEnded = false
+    CameraRevertRotation()
+    Sync.NISMode = 'off'
+    ScenarioInfo.Camera:UseSystemClock()
+    SetInvincible( nil, true )
+    UnlockInput()
+    ScenarioInfo.Camera = nil
+end
+
+function SetInvincible( area, invinBool )
+    if not invinBool then
+        local checkAreas = {}
+        if area and type(area) == 'table' then
+            for k,v in area do
+                table.insert( checkAreas, ScenarioUtils.AreaToRect(v) )
+            end
+        elseif area then
+            table.insert( checkAreas, ScenarioUtils.AreaToRect(area) )
+        end
+        local unitTable = {}
+        for k,v in checkAreas do
+            for uNum,unit in GetUnitsInRect( v ) do
+                table.insert( unitTable, unit )
+            end
+        end
+        ScenarioFramework.FlagUnkillableSelect( 1, unitTable )
+    else
+        ScenarioFramework.UnflagUnkillable( 1 )
+    end
+end
+
+# This will move the camera to the position of a marker
+function CameraMoveToMarker( marker, seconds )
+
+    # Adding this in case we just want to start the camera
+    # somewhere at the beginning of an operation without
+    # playing a full NIS
+    if not ScenarioInfo.Camera then
+        ScenarioInfo.Camera = SimCamera('WorldCamera')
+    end
+
+    if type(marker) == 'string' then
+        marker = ScenarioUtils.GetMarker(marker)
+    end
+
+    # Move the camera
+    ScenarioInfo.Camera:MoveToMarker( marker, seconds )
+
+    if ( seconds ) and ( seconds != 0 ) then
+        # Wait for it to be done
+        WaitForCamera()
+    end
+end
+
+# This will move the camera to a rectangle
+function CameraMoveToRectangle( rectangle, seconds )
+
+    # Adding this in case we just want to start the camera
+    # somewhere at the beginning of an operation without
+    # playing a full NIS
+    if not ScenarioInfo.Camera then
+        ScenarioInfo.Camera = SimCamera('WorldCamera')
+    end
+
+    # Move the camera
+    ScenarioInfo.Camera:MoveTo( rectangle, seconds )
+
+    if ( seconds ) and ( seconds != 0 ) then
+        # Wait for it to be done
+        WaitForCamera()
+    end
+end
+
+# See track entities
+function CameraTrackEntity( entity, zoom, seconds )
+    CameraTrackEntities({entity}, zoom, seconds)
+end
+
+# This will make the camera track a group of entities.
+# The "seconds" field is how long it will take to get in place.
+# After that the camera will follow that unit until told to do something else.
+# Zoom is measured in LOD units.  It's the value of the width of the view frustum
+# at the focus point
+function CameraTrackEntities( units, zoom, seconds )
+    local army = GetFocusArmy()
+    if army == -1 then
+        army = 1
+    end
+    for i,v in units do
+        if army ~= v:GetArmy() then
+            units[i] = v:GetBlip(army)
+        end
+    end
+
+    # Watch the entities
+    ScenarioInfo.Camera:TrackEntities( units, zoom, seconds )
+
+    # Keep it from pitching up all the way
+    ScenarioInfo.Camera:HoldRotation()
+
+    if ( seconds ) and ( seconds != 0 ) then
+        # Wait for it to be done
+        WaitForCamera()
+    end
+end
+
+# Similar to CameraTrackEntity, but this gives more control with the
+# pitchAdjust parameter.
+function CameraThirdPerson( entity, pitchAdjust, zoom, seconds )
+    ScenarioInfo.Camera:NoseCam( entity, pitchAdjust, zoom, seconds )
+
+    if ( seconds ) and ( seconds != 0 ) then
+        # Wait for it to be done
+        WaitForCamera()
+    end
+end
+
+# This will modify the current zoom of the camera without
+# adjusting its position.
+function CameraSetZoom( zoom, seconds )
+    # Move the camera
+    ScenarioInfo.Camera:SetZoom( zoom, seconds )
+
+    if ( seconds ) and ( seconds != 0 ) then
+        # Wait for it to be done
+        WaitForCamera()
+    end
+end
+
+# This will spin/zoom the camera for the specified
+# number of seconds, then stop the camera again.
+# Using it with 0 seconds will keep the camera
+# spinning/zooming until the next command.
+function CameraSpinAndZoom( spin, zoom, seconds )
+    # Move the camera
+    ScenarioInfo.Camera:Spin( spin, zoom )
+
+    if ( seconds ) and ( seconds != 0 ) then
+        # Wait for it to be done
+        WaitForCamera()
+        # Stop the camera
+        ScenarioInfo.Camera:Spin( 0, 0 )
+    end
+end
+
+# This will bring the camera to the highest zoomed-out level.
+function CameraReset()
+    ScenarioInfo.Camera:Reset()
+end
+
+# This will reset the azimuth back to default and change
+# the rotation back to default as well
+function CameraRevertRotation()
+    ScenarioInfo.Camera:RevertRotation()
+end
+
+# Used by other functions to make sure that they don't return
+# before the camera is done moving.
+function WaitForCamera()
+    # Wait for it to be done
+    ScenarioInfo.Camera:WaitFor()
+
+    # Reset the event tracker, so that the next
+    # camera action can be waited for
+    ScenarioInfo.Camera:EventReset()
+end

--- a/lua/cinematics.lua
+++ b/lua/cinematics.lua
@@ -1,17 +1,17 @@
-#****************************************************************************
-#**
-#**  File     :  /lua/cinematics.lua
-#**  Author(s):  David Tomandl
-#**
-#**  Summary  :  Helper functions for cinematics
-#**
-#**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
-#
-# One cautionary note: don't change the playable area during an in-game cinematic.
-# If you do, and you move the camera to a marker in the new area, the engine
-# may not handle it well.
-#
+--****************************************************************************
+--**
+--**  File     :  /lua/cinematics.lua
+--**  Author(s):  David Tomandl
+--**
+--**  Summary  :  Helper functions for cinematics
+--**
+--**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
+--
+-- One cautionary note: don't change the playable area during an in-game cinematic.
+-- If you do, and you move the camera to a marker in the new area, the engine
+-- may not handle it well.
+--
 
 SimCamera = import('/lua/simcamera.lua').SimCamera
 local ScenarioUtils = import('/lua/sim/ScenarioUtilities.lua')
@@ -25,21 +25,21 @@ function IsOpEnded()
     end
 end
 
-# To be used when starting a cinematic / NIS
+-- To be used when starting a cinematic / NIS
 function EnterNISMode()
     ScenarioInfo.Camera = SimCamera('WorldCamera')
     LockInput()
     ScenarioInfo.Camera:UseGameClock()
     Sync.NISMode = 'on'
     ScenarioInfo.OpEnded = true
-    #Take Away UI
-    #Set Game Speed to normal
+    --Take Away UI
+    --Set Game Speed to normal
 end
 
-# Used at the end of a cinematic / NIS
+-- Used at the end of a cinematic / NIS
 function ExitNISMode()
-    #Set Game Speed to user value
-    #Restore UI
+    --Set Game Speed to user value
+    --Restore UI
     ScenarioInfo.OpEnded = false
     CameraRevertRotation()
     Sync.NISMode = 'off'
@@ -71,12 +71,12 @@ function SetInvincible( area, invinBool )
     end
 end
 
-# This will move the camera to the position of a marker
+-- This will move the camera to the position of a marker
 function CameraMoveToMarker( marker, seconds )
 
-    # Adding this in case we just want to start the camera
-    # somewhere at the beginning of an operation without
-    # playing a full NIS
+    -- Adding this in case we just want to start the camera
+    -- somewhere at the beginning of an operation without
+    -- playing a full NIS
     if not ScenarioInfo.Camera then
         ScenarioInfo.Camera = SimCamera('WorldCamera')
     end
@@ -85,44 +85,44 @@ function CameraMoveToMarker( marker, seconds )
         marker = ScenarioUtils.GetMarker(marker)
     end
 
-    # Move the camera
+    -- Move the camera
     ScenarioInfo.Camera:MoveToMarker( marker, seconds )
 
     if ( seconds ) and ( seconds != 0 ) then
-        # Wait for it to be done
+        -- Wait for it to be done
         WaitForCamera()
     end
 end
 
-# This will move the camera to a rectangle
+-- This will move the camera to a rectangle
 function CameraMoveToRectangle( rectangle, seconds )
 
-    # Adding this in case we just want to start the camera
-    # somewhere at the beginning of an operation without
-    # playing a full NIS
+    -- Adding this in case we just want to start the camera
+    -- somewhere at the beginning of an operation without
+    -- playing a full NIS
     if not ScenarioInfo.Camera then
         ScenarioInfo.Camera = SimCamera('WorldCamera')
     end
 
-    # Move the camera
+    -- Move the camera
     ScenarioInfo.Camera:MoveTo( rectangle, seconds )
 
     if ( seconds ) and ( seconds != 0 ) then
-        # Wait for it to be done
+        -- Wait for it to be done
         WaitForCamera()
     end
 end
 
-# See track entities
+-- See track entities
 function CameraTrackEntity( entity, zoom, seconds )
     CameraTrackEntities({entity}, zoom, seconds)
 end
 
-# This will make the camera track a group of entities.
-# The "seconds" field is how long it will take to get in place.
-# After that the camera will follow that unit until told to do something else.
-# Zoom is measured in LOD units.  It's the value of the width of the view frustum
-# at the focus point
+-- This will make the camera track a group of entities.
+-- The "seconds" field is how long it will take to get in place.
+-- After that the camera will follow that unit until told to do something else.
+-- Zoom is measured in LOD units.  It's the value of the width of the view frustum
+-- at the focus point
 function CameraTrackEntities( units, zoom, seconds )
     local army = GetFocusArmy()
     if army == -1 then
@@ -134,75 +134,75 @@ function CameraTrackEntities( units, zoom, seconds )
         end
     end
 
-    # Watch the entities
+    -- Watch the entities
     ScenarioInfo.Camera:TrackEntities( units, zoom, seconds )
 
-    # Keep it from pitching up all the way
+    -- Keep it from pitching up all the way
     ScenarioInfo.Camera:HoldRotation()
 
     if ( seconds ) and ( seconds != 0 ) then
-        # Wait for it to be done
+        -- Wait for it to be done
         WaitForCamera()
     end
 end
 
-# Similar to CameraTrackEntity, but this gives more control with the
-# pitchAdjust parameter.
+-- Similar to CameraTrackEntity, but this gives more control with the
+-- pitchAdjust parameter.
 function CameraThirdPerson( entity, pitchAdjust, zoom, seconds )
     ScenarioInfo.Camera:NoseCam( entity, pitchAdjust, zoom, seconds )
 
     if ( seconds ) and ( seconds != 0 ) then
-        # Wait for it to be done
+        -- Wait for it to be done
         WaitForCamera()
     end
 end
 
-# This will modify the current zoom of the camera without
-# adjusting its position.
+-- This will modify the current zoom of the camera without
+-- adjusting its position.
 function CameraSetZoom( zoom, seconds )
-    # Move the camera
+    -- Move the camera
     ScenarioInfo.Camera:SetZoom( zoom, seconds )
 
     if ( seconds ) and ( seconds != 0 ) then
-        # Wait for it to be done
+        -- Wait for it to be done
         WaitForCamera()
     end
 end
 
-# This will spin/zoom the camera for the specified
-# number of seconds, then stop the camera again.
-# Using it with 0 seconds will keep the camera
-# spinning/zooming until the next command.
+-- This will spin/zoom the camera for the specified
+-- number of seconds, then stop the camera again.
+-- Using it with 0 seconds will keep the camera
+-- spinning/zooming until the next command.
 function CameraSpinAndZoom( spin, zoom, seconds )
-    # Move the camera
+    -- Move the camera
     ScenarioInfo.Camera:Spin( spin, zoom )
 
     if ( seconds ) and ( seconds != 0 ) then
-        # Wait for it to be done
+        -- Wait for it to be done
         WaitForCamera()
-        # Stop the camera
+        -- Stop the camera
         ScenarioInfo.Camera:Spin( 0, 0 )
     end
 end
 
-# This will bring the camera to the highest zoomed-out level.
+-- This will bring the camera to the highest zoomed-out level.
 function CameraReset()
     ScenarioInfo.Camera:Reset()
 end
 
-# This will reset the azimuth back to default and change
-# the rotation back to default as well
+-- This will reset the azimuth back to default and change
+-- the rotation back to default as well
 function CameraRevertRotation()
     ScenarioInfo.Camera:RevertRotation()
 end
 
-# Used by other functions to make sure that they don't return
-# before the camera is done moving.
+-- Used by other functions to make sure that they don't return
+-- before the camera is done moving.
 function WaitForCamera()
-    # Wait for it to be done
+    -- Wait for it to be done
     ScenarioInfo.Camera:WaitFor()
 
-    # Reset the event tracker, so that the next
-    # camera action can be waited for
+    -- Reset the event tracker, so that the next
+    -- camera action can be waited for
     ScenarioInfo.Camera:EventReset()
 end

--- a/lua/editor/OtherArmyUnitCountBuildConditions.lua
+++ b/lua/editor/OtherArmyUnitCountBuildConditions.lua
@@ -1,0 +1,216 @@
+#****************************************************************************
+#**
+#**  File     :  /lua/editor/OtherArmyUnitCountBuildConditions.lua
+#**  Author(s): Dru Staltman
+#**
+#**  Summary  : Generic AI Platoon Build Conditions
+#**             Build conditions always return true or false
+#**
+#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+local AIUtils = import('/lua/ai/aiutilities.lua')
+local ScenarioFramework = import('/lua/scenarioframework.lua')
+local ScenarioUtils = import('/lua/sim/ScenarioUtilities.lua')
+
+##############################################################################################################
+# function: BrainGreaterThanNumCategory = BuildCondition	doc = "Please work function docs."
+#
+# parameter 0: string	aiBrain		= "default_brain"
+# parameter 1: string	targetBrain	= "ArmyName"
+# parameter 2: int	numReq		= 0			doc = "docs for param1"
+# parameter 3: expr	category	= categories.ALLUNITS			doc = "param2 docs"
+#
+##############################################################################################################
+function BrainGreaterThanNumCategory( aiBrain, targetBrain, numReq, category )
+    local testBrain = ArmyBrains[1]
+    for k,v in ArmyBrains do
+        if v.Name == targetBrain then
+            testBrain = v
+            break
+        end
+    end
+    local numUnits = 0   
+	
+    if testBrain.Name == 'Player' then
+        local tblArmy = ListArmies()
+        for iArmy, strArmy in pairs(tblArmy) do
+            if ScenarioInfo.ArmySetup[strArmy].Human then
+                testBrain = GetArmyBrain(strArmy)
+                numUnits = numUnits + testBrain:GetCurrentUnits(category)
+            end
+        end    
+    else
+        numUnits = testBrain:GetCurrentUnits(category)
+    end
+    if numUnits > numReq then
+        return true
+    else
+        return false
+    end
+end
+
+
+##############################################################################################################
+# function: BrainLessThanNumCategory = BuildCondition	doc = "Please work function docs."
+#
+# parameter 0: string	aiBrain		= "default_brain"
+# parameter 1: string	targetBrain	= "ArmyName"
+# parameter 2: int	numReq		= 0			doc = "docs for param1"
+# parameter 3: expr	category	= categories.ALLUNITS			doc = "param2 docs"
+#
+##############################################################################################################
+function BrainLessThanNumCategory( aiBrain, targetBrain, numReq, category )
+    local testBrain = ArmyBrains[1]
+    for k,v in ArmyBrains do
+        if v.Name == targetBrain then
+            testBrain = v
+            break
+        end
+    end
+    
+    local numUnits = 0    
+    if testBrain.Name == 'Player' then
+        local tblArmy = ListArmies()
+        for iArmy, strArmy in pairs(tblArmy) do
+            if ScenarioInfo.ArmySetup[strArmy].Human then
+                testBrain = GetArmyBrain(strArmy)
+                numUnits = numUnits + testBrain:GetCurrentUnits(category)
+            end
+        end    
+    else
+        numUnits = testBrain:GetCurrentUnits(category)
+    end
+    
+    if numUnits < numReq then
+        return true
+    else
+        return false
+    end
+end
+
+
+##############################################################################################################
+# function: BrainGreaterThanOrEqualNumCategory = BuildCondition	doc = "Please work function docs."
+#
+# parameter 0: string	aiBrain		= "default_brain"
+# parameter 1: string	targetBrain	= "ArmyName"
+# parameter 2: int	numReq		= 0			doc = "docs for param1"
+# parameter 3: expr	category	= categories.ALLUNITS			doc = "param2 docs"
+#
+##############################################################################################################
+function BrainGreaterThanOrEqualNumCategory( aiBrain, targetBrain, numReq, category )
+    local testBrain = ArmyBrains[1]
+    for k,v in ArmyBrains do
+        if v.Name == targetBrain then
+            testBrain = v
+            break
+        end
+    end
+    
+    local numUnits = 0    
+    if testBrain.Name == 'Player' then
+        local tblArmy = ListArmies()
+        for iArmy, strArmy in pairs(tblArmy) do
+            if ScenarioInfo.ArmySetup[strArmy].Human then
+                testBrain = GetArmyBrain(strArmy)
+                numUnits = numUnits + testBrain:GetCurrentUnits(category)
+            end
+        end    
+    else
+        numUnits = testBrain:GetCurrentUnits(category)
+    end
+    
+    
+    if numUnits >= numReq then
+        return true
+    else
+        return false
+    end
+end
+
+
+##############################################################################################################
+# function: BrainLessThanOrEqualNumCategory = BuildCondition	doc = "Please work function docs."
+#
+# parameter 0: string	aiBrain		= "default_brain"
+# parameter 1: string	targetBrain	= "ArmyName"
+# parameter 2: int	numReq		= 0			doc = "docs for param1"
+# parameter 3: expr	category	= categories.ALLUNITS			doc = "param2 docs"
+#
+##############################################################################################################
+function BrainLessThanOrEqualNumCategory( aiBrain, targetBrain, numReq, category )
+    local testBrain = ArmyBrains[1]
+    for k,v in ArmyBrains do
+        if v.Name == targetBrain then
+            testBrain = v
+            break
+        end
+    end
+    
+    local numUnits = 0    
+    if testBrain.Name == 'Player' then
+        local tblArmy = ListArmies()
+        for iArmy, strArmy in pairs(tblArmy) do
+            if ScenarioInfo.ArmySetup[strArmy].Human then
+                testBrain = GetArmyBrain(strArmy)
+                numUnits = numUnits + testBrain:GetCurrentUnits(category)
+            end
+        end    
+    else
+        numUnits = testBrain:GetCurrentUnits(category)
+    end    
+
+    if numUnits <= numReq then
+        return true
+    else
+        return false
+    end
+end
+
+##############################################################################################################
+# function: FocusBrainBeingBuiltOrActiveCategoryCompare = BuildCondition	doc = "Please work function docs."
+#
+# parameter 0: string	aiBrain		= "default_brain"
+# parameter 1: int	numReq		= 0			doc = "docs for param1"
+# parameter 2: expr	categories	= categories.ALLUNITS			doc = "param2 docs"
+# parameter 3: string compareType = ">="
+#
+##############################################################################################################
+function FocusBrainBeingBuiltOrActiveCategoryCompare( aiBrain, numReq, categories, compareType )
+
+    local num = 0
+
+    local tblArmy = ListArmies()
+    for iArmy, strArmy in pairs(tblArmy) do
+        if ScenarioInfo.ArmySetup[strArmy].Human then
+            local testBrain = GetArmyBrain(strArmy)
+                for k,v in categories do
+                    num = num + testBrain:GetBlueprintStat('Units_BeingBuilt', v)
+                    num = num + testBrain:GetBlueprintStat('Units_Active', v)
+                end            
+        end
+    end
+
+    if not compareType or compareType == '>=' then
+        if num >= numReq then
+            return true
+        end
+    elseif compareType == '==' then
+        if num == numReq then
+            return true
+        end
+    elseif compareType == '<=' then
+        if num <= numReq then
+            return true
+        end
+    elseif compareType == '>' then
+        if num > numReq then
+            return true
+        end
+    elseif compareType == '<' then
+        if num < numReq then
+            return true
+        end
+    end
+    return false
+end

--- a/lua/editor/OtherArmyUnitCountBuildConditions.lua
+++ b/lua/editor/OtherArmyUnitCountBuildConditions.lua
@@ -1,26 +1,26 @@
-#****************************************************************************
-#**
-#**  File     :  /lua/editor/OtherArmyUnitCountBuildConditions.lua
-#**  Author(s): Dru Staltman
-#**
-#**  Summary  : Generic AI Platoon Build Conditions
-#**             Build conditions always return true or false
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /lua/editor/OtherArmyUnitCountBuildConditions.lua
+--**  Author(s): Dru Staltman
+--**
+--**  Summary  : Generic AI Platoon Build Conditions
+--**             Build conditions always return true or false
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 local AIUtils = import('/lua/ai/aiutilities.lua')
 local ScenarioFramework = import('/lua/scenarioframework.lua')
 local ScenarioUtils = import('/lua/sim/ScenarioUtilities.lua')
 
-##############################################################################################################
-# function: BrainGreaterThanNumCategory = BuildCondition	doc = "Please work function docs."
-#
-# parameter 0: string	aiBrain		= "default_brain"
-# parameter 1: string	targetBrain	= "ArmyName"
-# parameter 2: int	numReq		= 0			doc = "docs for param1"
-# parameter 3: expr	category	= categories.ALLUNITS			doc = "param2 docs"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: BrainGreaterThanNumCategory = BuildCondition    doc = "Please work function docs."
+--
+-- parameter 0: string    aiBrain        = "default_brain"
+-- parameter 1: string    targetBrain    = "ArmyName"
+-- parameter 2: int    numReq        = 0            doc = "docs for param1"
+-- parameter 3: expr    category    = categories.ALLUNITS            doc = "param2 docs"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function BrainGreaterThanNumCategory( aiBrain, targetBrain, numReq, category )
     local testBrain = ArmyBrains[1]
     for k,v in ArmyBrains do
@@ -30,7 +30,7 @@ function BrainGreaterThanNumCategory( aiBrain, targetBrain, numReq, category )
         end
     end
     local numUnits = 0   
-	
+    
     if testBrain.Name == 'Player' then
         local tblArmy = ListArmies()
         for iArmy, strArmy in pairs(tblArmy) do
@@ -50,15 +50,15 @@ function BrainGreaterThanNumCategory( aiBrain, targetBrain, numReq, category )
 end
 
 
-##############################################################################################################
-# function: BrainLessThanNumCategory = BuildCondition	doc = "Please work function docs."
-#
-# parameter 0: string	aiBrain		= "default_brain"
-# parameter 1: string	targetBrain	= "ArmyName"
-# parameter 2: int	numReq		= 0			doc = "docs for param1"
-# parameter 3: expr	category	= categories.ALLUNITS			doc = "param2 docs"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: BrainLessThanNumCategory = BuildCondition    doc = "Please work function docs."
+--
+-- parameter 0: string    aiBrain        = "default_brain"
+-- parameter 1: string    targetBrain    = "ArmyName"
+-- parameter 2: int    numReq        = 0            doc = "docs for param1"
+-- parameter 3: expr    category    = categories.ALLUNITS            doc = "param2 docs"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function BrainLessThanNumCategory( aiBrain, targetBrain, numReq, category )
     local testBrain = ArmyBrains[1]
     for k,v in ArmyBrains do
@@ -89,15 +89,15 @@ function BrainLessThanNumCategory( aiBrain, targetBrain, numReq, category )
 end
 
 
-##############################################################################################################
-# function: BrainGreaterThanOrEqualNumCategory = BuildCondition	doc = "Please work function docs."
-#
-# parameter 0: string	aiBrain		= "default_brain"
-# parameter 1: string	targetBrain	= "ArmyName"
-# parameter 2: int	numReq		= 0			doc = "docs for param1"
-# parameter 3: expr	category	= categories.ALLUNITS			doc = "param2 docs"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: BrainGreaterThanOrEqualNumCategory = BuildCondition    doc = "Please work function docs."
+--
+-- parameter 0: string    aiBrain        = "default_brain"
+-- parameter 1: string    targetBrain    = "ArmyName"
+-- parameter 2: int    numReq        = 0            doc = "docs for param1"
+-- parameter 3: expr    category    = categories.ALLUNITS            doc = "param2 docs"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function BrainGreaterThanOrEqualNumCategory( aiBrain, targetBrain, numReq, category )
     local testBrain = ArmyBrains[1]
     for k,v in ArmyBrains do
@@ -129,15 +129,15 @@ function BrainGreaterThanOrEqualNumCategory( aiBrain, targetBrain, numReq, categ
 end
 
 
-##############################################################################################################
-# function: BrainLessThanOrEqualNumCategory = BuildCondition	doc = "Please work function docs."
-#
-# parameter 0: string	aiBrain		= "default_brain"
-# parameter 1: string	targetBrain	= "ArmyName"
-# parameter 2: int	numReq		= 0			doc = "docs for param1"
-# parameter 3: expr	category	= categories.ALLUNITS			doc = "param2 docs"
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: BrainLessThanOrEqualNumCategory = BuildCondition    doc = "Please work function docs."
+--
+-- parameter 0: string    aiBrain        = "default_brain"
+-- parameter 1: string    targetBrain    = "ArmyName"
+-- parameter 2: int    numReq        = 0            doc = "docs for param1"
+-- parameter 3: expr    category    = categories.ALLUNITS            doc = "param2 docs"
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function BrainLessThanOrEqualNumCategory( aiBrain, targetBrain, numReq, category )
     local testBrain = ArmyBrains[1]
     for k,v in ArmyBrains do
@@ -167,15 +167,15 @@ function BrainLessThanOrEqualNumCategory( aiBrain, targetBrain, numReq, category
     end
 end
 
-##############################################################################################################
-# function: FocusBrainBeingBuiltOrActiveCategoryCompare = BuildCondition	doc = "Please work function docs."
-#
-# parameter 0: string	aiBrain		= "default_brain"
-# parameter 1: int	numReq		= 0			doc = "docs for param1"
-# parameter 2: expr	categories	= categories.ALLUNITS			doc = "param2 docs"
-# parameter 3: string compareType = ">="
-#
-##############################################################################################################
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-- function: FocusBrainBeingBuiltOrActiveCategoryCompare = BuildCondition    doc = "Please work function docs."
+--
+-- parameter 0: string    aiBrain        = "default_brain"
+-- parameter 1: int    numReq        = 0            doc = "docs for param1"
+-- parameter 2: expr    categories    = categories.ALLUNITS            doc = "param2 docs"
+-- parameter 3: string compareType = ">="
+--
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 function FocusBrainBeingBuiltOrActiveCategoryCompare( aiBrain, numReq, categories, compareType )
 
     local num = 0

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -1,0 +1,1615 @@
+#--[                                                                             ]--
+#--[  File     : ScenarioUtilities.lua                                           ]--
+#--[  Author(s): Ivan Rumsey                                                     ]--
+#--[                                                                             ]--
+#--[  Summary  : Utility functions for use with scenario save file.              ]--
+#--[             Created from examples provided by Jeff Petkau.                  ]--
+#--[                                                                             ]--
+#--[  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.             ]--
+local Entity = import('/lua/sim/Entity.lua').Entity
+local ScenarioFramework = import('/lua/ScenarioFramework.lua')
+
+function EnableLoadBalance(enabled, unitThreshold) --distributeTime)
+    if not ScenarioInfo.LoadBalance then 
+        ScenarioInfo.LoadBalance = 
+        {
+            Accumulator = 0,
+            Enabled = false,
+            SpawnGroups = {},
+            PlatoonGroups = {},
+        }
+    end
+    
+    if enabled == ScenarioInfo.LoadBalance.Enabled then return end
+    
+    ScenarioInfo.LoadBalance.Enabled = enabled 
+    
+    if enabled then
+        ScenarioInfo.LoadBalance.UnitThreshold = unitThreshold or 50
+    else
+        ForkThread(function()       
+            --local timePerGroup = ScenarioInfo.DistributeTime/table.getn(ScenarioInfo.LoadBalance.SpawnGroups)
+            
+            --Get time
+            local time = GetSystemTimeSecondsOnlyForProfileUse()
+            
+            --Spawn bases
+            while table.getn(ScenarioInfo.LoadBalance.SpawnGroups) > 0 do
+                local base, name, uncapturable = unpack(table.remove( ScenarioInfo.LoadBalance.SpawnGroups, 1))
+                base:SpawnGroup( name, uncapturable, true )
+            end
+            
+            --Spawn units
+            while table.getn(ScenarioInfo.LoadBalance.PlatoonGroups) > 0 do
+                local strArmy, strGroup, formation, callback = unpack(table.remove( ScenarioInfo.LoadBalance.PlatoonGroups, 1)) 
+                CreateArmyGroupAsPlatoonBalanced(strArmy, strGroup, formation, callback)
+            end
+            
+            --Report time taken
+            LOG("Time to spawn: " .. (GetSystemTimeSecondsOnlyForProfileUse() - time))
+        end)
+    end
+end
+
+function GetMarkers()
+    return Scenario.MasterChain._MASTERCHAIN_.Markers
+end
+
+function GetMarker(name)
+    return Scenario.MasterChain._MASTERCHAIN_.Markers[name]
+end
+
+function ChainToPositions(chainName)
+    local chain = Scenario.Chains[chainName]
+    if not chain then
+        error('ERROR: Invalid Chain Named- ' .. chainName, 2)
+    end
+    local positionTable = {}
+    for num, marker in chain.Markers do
+        table.insert(positionTable, Scenario.MasterChain._MASTERCHAIN_.Markers[marker]['position'])
+    end
+    return positionTable
+end
+
+#--[  FindParentChain                                                ]--
+#--[                                                                      ]--
+#--[  Gets the parent chain that the supplied marker belongs to           ]--
+function FindParentChain(markerName)
+    for cName,chain in Scenario.Chains do
+        for mNum,marker in chain.Markers do
+            if marker == markerName then
+                return chain
+            end
+        end
+    end
+    return nil
+end
+
+
+
+function GetMarkerChain(name)
+    local chain = Scenario.Chains[name]
+    if not chain then
+        error('ERROR: Invalid Chain Named- ' .. name, 2)
+    end
+    return chain
+end
+
+#--[  MarkerToPosition                                                           ]--
+#--[                                                                             ]--
+#--[  Converts a marker as specified in *_save.lua file to a position.           ]--
+function MarkerToPosition(strMarker)
+    local marker = GetMarker(strMarker)
+        if not marker then
+            error('ERROR: Invalid marker name- '..strMarker)
+        end
+    return marker.position
+end
+
+#--[  AreaToRect                                                                 ]--
+#--[                                                                             ]--
+#--[  Converts an area as specified in *_save.lua file to a rectangle.           ]--
+function AreaToRect(strArea)
+    local area = Scenario.Areas[strArea]
+    if not area then
+        error('ERROR: Invalid area name')
+    end
+    local rectangle = area.rectangle
+    return Rect(rectangle[1],rectangle[2],rectangle[3],rectangle[4])
+end
+
+function InRect( vectorPos, rect )
+    return vectorPos[1] > rect.x0 and vectorPos[1] < rect.x1 and
+           vectorPos[3] > rect.y0 and vectorPos[3] < rect.y1
+end
+
+#--[  AssembleUnitGroup                                                          ]--
+#--[                                                                             ]--
+#--[  Returns all units (leaf nodes) under the specified group.                  ]--
+function AssembleUnitGroup(tblNode,tblResult)
+    tblResult = tblResult or {}
+
+    if nil == tblNode then
+        return tblResult
+    end
+
+    for strName, tblData in pairs(tblNode.Units) do
+        if 'GROUP' == tblData.type then
+            tblResult = AssembleUnitGroup(tblData,tblResult)
+        else
+            tblResult[strName] = tblData
+        end
+    end
+
+    return tblResult
+end
+
+#--[  AssemblePlatoons                                                           ]--
+#--[                                                                             ]--
+#--[  Returns all platoon template names specified under group.                  ]--
+function AssemblePlatoons(tblNode,tblResult)
+    tblResult = tblResult or {}
+
+    if nil == tblNode then
+        return tblResult
+    end
+
+    if nil != tblNode.platoon and '' != tblNode.platoon then
+        table.insert(tblResult,tblNode.platoon)
+    end
+
+    if 'GROUP' == tblNode.type then
+        for strName, tblData in pairs(tblNode.Units) do
+            tblResult = AssemblePlatoons(tblData,tblResult)
+        end
+    end
+
+    return tblResult
+end
+
+#--[  FindUnit                                                                   ]--
+#--[                                                                             ]--
+#--[  Finds the unit with the specified name.                                    ]--
+function FindUnit(strUnit,tblNode)
+    if nil == tblNode then
+        return nil
+    end
+
+    local tblResult = nil
+
+    for strName, tblData in pairs(tblNode.Units) do
+        if 'GROUP' == tblData.type then
+            tblResult = FindUnit(strUnit,tblData)
+        elseif strName == strUnit then
+            tblResult = tblData
+        end
+
+        if nil != tblResult then
+            break
+        end
+    end
+
+    return tblResult
+end
+
+#--[  CreateArmyUnit                                                             ]--
+#--[                                                                             ]--
+#--[  Creates a named unit in an army.                                           ]--
+function CreateArmyUnit(strArmy,strUnit)
+    local tblUnit = FindUnit(strUnit,Scenario.Armies[strArmy].Units)
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    if nil != tblUnit then
+        local unit = CreateUnitHPR(
+            tblUnit.type,
+            strArmy,
+            tblUnit.Position[1], tblUnit.Position[2], tblUnit.Position[3],
+            tblUnit.Orientation[1], tblUnit.Orientation[2], tblUnit.Orientation[3]
+        )
+        if unit:GetBlueprint().Physics.FlattenSkirt then
+            unit:CreateTarmac(true, true, true, false, false)
+        end             
+        local platoon
+        local brain = GetArmyBrain(strArmy)
+        if tblUnit.platoon ~= nil and tblUnit.platoon ~= '' then
+            local i = 3
+            while i <= table.getn(Scenario.Platoons[tblUnit.platoon]) do
+                if tblUnit.Type == currTemplate[i][1] then
+                    platoon = brain:MakePlatoon('None', 'None')
+                    brain:AssignUnitsToPlatoon(platoon, {unit}, currTemplate[i][4], currTemplate[i][5])
+                    break
+                end
+                i = i + 1
+            end
+        end
+        local armyIndex = brain:GetArmyIndex()
+        if ScenarioInfo.UnitNames[armyIndex] then
+            ScenarioInfo.UnitNames[armyIndex][strUnit] = unit
+        end
+        unit.UnitName = strUnit
+        if not brain.IgnoreArmyCaps then
+            SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+        end
+        return unit, platoon, tblUnit.platoon
+    end
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    return nil
+end
+
+#--[  FindUnitGroup                                                              ]--
+#--[                                                                             ]--
+#--[  Finds the unit group with the specified name.                              ]--
+function FindUnitGroup(strGroup,tblNode)
+    if nil == tblNode then
+        return nil
+    end
+
+    local tblResult = nil
+    for strName, tblData in pairs(tblNode.Units) do
+        if 'GROUP' == tblData.type then
+            if strName == strGroup then
+                tblResult = tblData
+            else
+                tblResult = FindUnitGroup(strGroup,tblData)
+            end
+        end
+
+        if nil != tblResult then
+            break
+        end
+    end
+
+    return tblResult
+end
+
+#--[  AssembleArmyGroup                                                          ]--
+#--[                                                                             ]--
+#--[  Returns a table of units in the group owned by the specified army.         ]--
+function AssembleArmyGroup(strArmy,strGroup)
+    return AssembleUnitGroup(FindUnitGroup(strGroup,Scenario.Armies[strArmy].Units))
+end
+
+#--[  CreateArmySubGroup                                                                      ]--
+#--[                                                                                          ]--
+#--[  Creates Army groups from a number of groups specified in order from the Units Hierarchy ]--
+function CreateArmySubGroup(strArmy,strGroup,...)
+    local tblNode = Scenario.Armies[strArmy].Units
+    local tblResult = {}
+    local treeResult = {}
+    local platoonList = {}
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    for strName, tblData in pairs(tblNode.Units) do
+        if 'GROUP' == tblData.type then
+            if strName == strGroup then
+                if arg['n'] >= 1 then
+                    platoonList, tblResult, treeResult = CreateSubGroup(tblNode.Units[strName], strArmy, unpack(arg))
+                else
+                    platoonList, tblResult, treeResult = CreatePlatoons( strArmy, tblNode.Units[strName] )
+                end
+            end
+        end
+    end
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    if tblResult == nil then
+        error('SCENARIO UTILITIES WARNING: No units found for for Army- ' .. strArmy .. ' Group- ' .. strGroup, 2)
+    end
+    return tblResult, treeResult, platoonList
+end
+
+#--[  CreateSubGroup                                                                      ]--
+#--[                                                                                      ]--
+#--[  Used by CreateArmySubGroup                                                          ]--
+function CreateSubGroup(tblNode, strArmy, strGroup, ...)
+    local tblResult = {}
+    local treeResult = {}
+    local platoonList = {}
+    for strName, tblData in pairs(tblNode.Units) do
+        if 'GROUP' == tblData.type then
+            if strName == strGroup then
+                if arg['n'] >= 1 then
+                    platoonList, tblResult, treeResult = CreateSubGroup(tblNode.Units[strName], strArmy, unpack(arg))
+                else
+                    platoonList, tblResult, treeResult = CreatePlatoons( strArmy, tblNode.Units[strName] )
+                end
+            end
+        end
+    end
+    return platoonList, tblResult, treeResult
+end
+
+
+#--[  CreateInitialArmyGroup                                                     ]--
+#--[                                                                             ]--
+function CreateInitialArmyGroup(strArmy, createCommander)
+    local tblGroup = CreateArmyGroup( strArmy, 'INITIAL')
+    local cdrUnit = false
+
+    if createCommander and ( tblGroup == nil or 0 == table.getn(tblGroup) ) then
+        local factionIndex = GetArmyBrain(strArmy):GetFactionIndex()
+        local initialUnitName = import('/lua/factions.lua').Factions[factionIndex].InitialUnit
+        cdrUnit = CreateInitialArmyUnit(strArmy, initialUnitName)
+        if EntityCategoryContains(categories.COMMAND, cdrUnit) then
+            if ScenarioInfo.Options['PrebuiltUnits'] == 'Off' then
+                cdrUnit:HideBone(0, true)
+                ForkThread(CommanderWarpDelay, cdrUnit, 3)
+            end
+        end
+    end
+
+    return tblGroup, cdrUnit
+end
+
+function CommanderWarpDelay(cdrUnit, delay)
+    WaitSeconds(delay)
+    cdrUnit:PlayCommanderWarpInEffect()
+end
+
+#--[  CreateProps                                                                ]--
+#--[                                                                             ]--
+#--[                                                                             ]--
+function CreateProps()
+    for i, tblData in pairs(Scenario['Props']) do
+        CreatePropHPR(
+            tblData.prop,
+            tblData.Position[1], tblData.Position[2], tblData.Position[3],
+            tblData.Orientation[1], tblData.Orientation[2], tblData.Orientation[3]
+        )
+    end
+end
+
+#--[  CreateResources                                                            ]--
+#--[                                                                             ]--
+#--[                                                                             ]--
+function CreateResources()
+    local markers = GetMarkers()
+    for i, tblData in pairs(markers) do
+        if tblData.resource then
+            CreateResourceDeposit(
+                tblData.type,
+                tblData.position[1], tblData.position[2], tblData.position[3],
+                tblData.size
+            )
+
+            # fixme: texture names should come from editor
+            local albedo, sx, sz, lod
+            if tblData.type == "Mass" then
+                albedo = "/env/common/splats/mass_marker.dds"
+                sx = 2
+                sz = 2
+                lod = 100
+                CreatePropHPR(
+                    '/env/common/props/massDeposit01_prop.bp',
+                    tblData.position[1], tblData.position[2], tblData.position[3],
+                    Random(0,360), 0, 0
+                )
+            else
+                albedo = "/env/common/splats/hydrocarbon_marker.dds"
+                sx = 6
+                sz = 6
+                lod = 200
+                CreatePropHPR(
+                    '/env/common/props/hydrocarbonDeposit01_prop.bp',
+                    tblData.position[1], tblData.position[2], tblData.position[3],
+                    Random(0,360), 0, 0
+                )
+            end
+            # Decal - (position, heading, textureName1, textureName2, type, sizeX, sizeZ, lodParam, duration, army)
+            # Splat - (position, heading, textureName1, textureName2, type, sizeX, sizeZ, lodParam, duration, army)
+#            if not ScenarioInfo.MapData.Decals then
+#                ScenarioInfo.MapData.Decals = {}
+#            end
+#            table.insert( ScenarioInfo.MapData.Decals, CreateDecal(
+#                tblData.position, # position
+#                0, # heading
+#                albedo, "", # TEX1, TEX2
+#                "Albedo", # TYPE
+#                sx, sz, # SIZE
+#                lod, # LOD
+#                0, # DURACTION
+#                -1 # ARMY
+#            ) )
+            CreateSplat(
+                tblData.position,           # Position
+                0,                          # Heading (rotation)
+                albedo,                     # Texture name for albedo
+                sx, sz,                     # SizeX/Z
+                lod,                        # LOD
+                0,                          # Duration (0 == does not expire)
+                -1 ,                         # army (-1 == not owned by any single army)
+                0
+            )
+        end
+    end
+end
+
+#--[  InitializeArmies                                                           ]--
+#--[                                                                             ]--
+#--[                                                                             ]--
+function InitializeArmies()
+    local tblGroups = {}
+    local tblArmy = ListArmies()
+
+    local civOpt = ScenarioInfo.Options.CivilianAlliance
+
+    local bCreateInitial = ShouldCreateInitialArmyUnits()
+
+    for iArmy, strArmy in pairs(tblArmy) do
+        local tblData = Scenario.Armies[strArmy]
+
+        tblGroups[ strArmy ] = {}
+
+        if tblData then
+
+            #--[ If an actual starting position is defined, overwrite the        ]--
+            #--[ randomly generated one.                                         ]--
+
+            #LOG('*DEBUG: InitializeArmies, army = ', strArmy)
+
+            SetArmyEconomy( strArmy, tblData.Economy.mass, tblData.Economy.energy)
+            
+            #GetArmyBrain(strArmy):InitializePlatoonBuildManager()
+            #LoadArmyPBMBuilders(strArmy)
+            if GetArmyBrain(strArmy).SkirmishSystems then
+                GetArmyBrain(strArmy):InitializeSkirmishSystems()
+            end
+
+            local armyIsCiv = ScenarioInfo.ArmySetup[strArmy].Civilian
+
+            if (not armyIsCiv and bCreateInitial) or (armyIsCiv and civOpt != 'removed') then
+                local commander = (not ScenarioInfo.ArmySetup[strArmy].Civilian)
+                local cdrUnit
+                tblGroups[strArmy], cdrUnit = CreateInitialArmyGroup( strArmy, commander)
+                if commander and cdrUnit and ArmyBrains[iArmy].Nickname then
+                    cdrUnit:SetCustomName( ArmyBrains[iArmy].Nickname )
+                end
+            end
+
+            local wreckageGroup = FindUnitGroup('WRECKAGE', Scenario.Armies[strArmy].Units)
+            if wreckageGroup then
+                local platoonList, tblResult, treeResult = CreatePlatoons(strArmy, wreckageGroup )
+                for num,unit in tblResult do
+                    unit:CreateWreckageProp(0)
+                    unit:Destroy()
+                end
+            end
+
+
+
+            #--[ irumsey                                                         ]--
+            #--[ Temporary defaults.  Make sure some fighting will break out.    ]--
+            for iEnemy, strEnemy in pairs(tblArmy) do
+                local enemyIsCiv = ScenarioInfo.ArmySetup[strEnemy].Civilian
+
+                if iArmy != iEnemy and strArmy != 'NEUTRAL_CIVILIAN' and strEnemy != 'NEUTRAL_CIVILIAN' then
+                    if (armyIsCiv or enemyIsCiv) and civOpt == 'neutral' then
+                        SetAlliance( iArmy, iEnemy, 'Neutral')
+                    else
+                        SetAlliance( iArmy, iEnemy, 'Enemy')
+                    end
+                elseif strArmy == 'NEUTRAL_CIVILIAN' or strEnemy == 'NEUTRAL_CIVILIAN' then
+                    SetAlliance( iArmy, iEnemy, 'Neutral')
+                end
+            end
+
+
+        end
+
+    end
+
+    return tblGroups
+end
+
+
+#--[  InitializeScenarioArmies                                                   ]--
+#--[                                                                             ]--
+#--[                                                                             ]--
+function InitializeScenarioArmies()
+    local tblGroups = {}
+    local tblArmy = ListArmies()
+    local factions = import('/lua/factions.lua')
+
+    local bCreateInitial = ShouldCreateInitialArmyUnits()
+
+    ScenarioInfo.CampaignMode = true
+    Sync.CampaignMode = true
+    import('/lua/sim/simuistate.lua').IsCampaign(true)
+
+
+    for iArmy, strArmy in pairs(tblArmy) do
+        
+        local tblData = Scenario.Armies[strArmy]
+
+        tblGroups[ strArmy ] = {}
+
+        if tblData then
+
+            LOG('*DEBUG: InitializeScenarioArmies, army = ', strArmy)
+
+            SetArmyEconomy( strArmy, tblData.Economy.mass, tblData.Economy.energy)
+
+            if tblData.faction != nil then
+                
+                if ScenarioInfo.ArmySetup[strArmy].Human then
+					ScenarioFramework.AddRestriction(strArmy, (categories.WALL))
+                    local factionIndex = math.min(math.max(ScenarioInfo.ArmySetup[strArmy].Faction, 1), table.getsize(factions.Factions))
+                    SetArmyFactionIndex( strArmy, factionIndex - 1 )
+                else
+                    local factionIndex = math.min(math.max(tblData.faction, 0), table.getsize(factions.Factions))
+                    SetArmyFactionIndex( strArmy, factionIndex )
+                    GetArmyBrain(strArmy):SetCurrentPlan()
+                end
+            end
+
+            if tblData.color != nil then
+                SetArmyColorIndex( strArmy, tblData.color)
+            end
+
+            if tblData.personality != nil then
+                SetArmyAIPersonality( strArmy, tblData.personality)
+            end
+
+            if bCreateInitial then
+                tblGroups[strArmy] = CreateInitialArmyGroup( strArmy )
+            end
+
+            local wreckageGroup = FindUnitGroup('WRECKAGE', Scenario.Armies[strArmy].Units)
+            if wreckageGroup then
+                local platoonList, tblResult, treeResult = CreatePlatoons(strArmy, wreckageGroup )
+                for num,unit in tblResult do
+                    unit:CreateWreckageProp(0)
+                    unit:Destroy()
+                end
+            end
+
+            #--[ eemerson                                                         ]--
+            #--[ Override alliances with custom alliance settings                 ]--
+            if tblData.Alliances != nil then
+               for iEnemy,iAlliance in pairs(tblData.Alliances) do
+					if iArmy != iEnemy then
+						for _,v in pairs(tblArmy) do
+							if v == iEnemy then
+								SetAllianceOneWay( strArmy, iEnemy, iAlliance )
+							end
+						end
+                   end
+               end
+           end
+
+            GetArmyBrain(strArmy):InitializePlatoonBuildManager()
+            LoadArmyPBMBuilders(strArmy)
+
+        end
+
+    end
+
+    return tblGroups
+end
+
+#--[ AssignOrders                                                                ]--
+#--[                                                                             ]--
+#--[                                                                             ]--
+function AssignOrders( strQueue, tblUnit, target)
+    local tblOrder = Scenario.Orders[ strQueue ]
+    for i, order in pairs(tblOrder) do
+        order.cmd(tblUnit,target)
+    end
+end
+
+
+#--[ SpawnPlatoon                                                                ]--
+#--[ Spawns unit group and assigns to platoon it is a part of                    ]--
+function SpawnPlatoon( strArmy, strGroup )
+    local tblNode = FindUnitGroup( strGroup, Scenario.Armies[strArmy].Units )
+    if nil == tblNode then
+        error('SCENARIO UTILITIES WARNING: No Group found for Army- ' .. strArmy .. ' Group- ' .. strGroup, 2)
+        return false
+    end
+
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    local platoonName
+    if nil ~= tblNode.platoon and '' != tblNode.platoon then
+        platoonName = tblNode.platoon
+    end
+
+    local platoonList, tblResult, treeResult = CreatePlatoons(strArmy, tblNode)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    if tblResult == nil then
+        error('SCENARIO UTILITIES WARNING: No units found for for Army- ' .. strArmy .. ' Group- ' .. strGroup, 2)
+    end
+    return platoonList[platoonName], platoonList, tblResult, treeResult
+end
+
+function SpawnTableOfPlatoons( strArmy, strGroup )
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    local platoonList, tblResult, treeResult = CreatePlatoons(strArmy,
+                                                              FindUnitGroup( strGroup, Scenario.Armies[strArmy].Units))
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    if tblResult == nil then
+        error('SCENARIO UTILITIES WARNING: No units found for for Army- ' .. strArmy .. ' Group- ' .. strGroup, 2)
+    end
+    return platoonList, tblResult, treeResult
+end
+
+function CountChildUnits(tblNode)
+    local count = 0
+    
+    for k,v in pairs(tblNode.Units) do
+        if v.type == 'GROUP' then
+            count = count + CountChildUnits(v)
+        else
+            count = count + 1
+        end
+    end
+    
+    tblNode.TotalUnits = count
+    
+    return count
+end
+
+function CreatePlatoons( strArmy, tblNode, tblResult, platoonList, currPlatoon, treeResult, balance )
+    tblResult = tblResult or {}
+    platoonList = platoonList or {}
+    treeResult = treeResult or {}
+    currPlatoon = currPlatoon or false
+    local treeLocal = {}
+
+    if nil == tblNode then
+        return nil
+    end
+
+    local brain = GetArmyBrain(strArmy)
+    local armyIndex = brain:GetArmyIndex()
+    local currTemplate
+    local numRows
+    local reversePlatoon = false
+    local reverseRows
+    local reverseTemplate
+    if nil ~= tblNode.platoon and '' != tblNode.platoon and tblNode ~= currPlatoon
+        and not platoonList[tblNode.platoon] then
+        currTemplate = Scenario.Platoons[tblNode.platoon]
+        if currTemplate then
+            platoonList[tblNode.platoon] = brain:MakePlatoon('', currTemplate[2])
+            platoonList[tblNode.platoon].squadCounter = {}
+            currPlatoon = tblNode.platoon
+        end
+    end
+    if currPlatoon then
+        currTemplate = Scenario.Platoons[currPlatoon]
+        numRows = table.getn(currTemplate)
+    end
+
+    local unit = nil
+
+    --local timePerChild = nil
+
+    --[[
+    if timeLeft and not tblNode.TotalUnits then 
+        --Calculate the number of units 
+        local totalUnits = CountChildUnits(tblNode)
+    end
+    
+    if timeLeft then 
+        timePerChild = (timeLeft/tblNode.TotalUnits)
+    end
+    ]]-- 
+
+    for strName, tblData in pairs(tblNode.Units) do        
+        if 'GROUP' == tblData.type then
+            --[[
+            if timeLeft and tblData.TotalUnits > 0 then 
+                timePerChild = (timeLeft/tblNode.TotalUnits)*tblData.TotalUnits
+            end
+            --]]--  
+            
+            platoonList, tblResult, treeResult[strName] = CreatePlatoons(strArmy, tblData, tblResult,
+                                                                         platoonList, currPlatoon, treeResult[strName], balance)  
+                                                                         
+        else            
+            unit = CreateUnitHPR( tblData.type,
+                                 strArmy,
+                                 tblData.Position[1], tblData.Position[2], tblData.Position[3],
+                                 tblData.Orientation[1], tblData.Orientation[2], tblData.Orientation[3]
+                             )
+            if unit:GetBlueprint().Physics.FlattenSkirt then
+                unit:CreateTarmac(true, true, true, false, false)
+            end                               
+            table.insert(tblResult, unit)
+            treeResult[strName] = unit
+            if ScenarioInfo.UnitNames[armyIndex] then
+                ScenarioInfo.UnitNames[armyIndex][strName] = unit
+            end
+            unit.UnitName = strName
+            if tblData.platoon ~= nil and tblData.platoon ~= '' and tblData.platoon ~= currPlatoon then
+                reversePlatoon = currPlatoon
+                reverseRows = numRows
+                reverseTemplate = currTemplate
+                if not platoonList[tblData.platoon] then
+                    currTemplate = Scenario.Platoons[tblData.platoon]
+                    platoonList[tblData.platoon] = brain:MakePlatoon('', currTemplate[2])
+                    platoonList[tblData.platoon].squadCounter = {}
+                end
+                currPlatoon = tblData.platoon
+                currTemplate = Scenario.Platoons[currPlatoon]
+                numRows = table.getn(currTemplate)
+            end
+            if currPlatoon then
+                local i = 3
+                local inserted = false
+                while i <= numRows and not inserted do
+                    if platoonList[currPlatoon].squadCounter[i] == nil then
+                        platoonList[currPlatoon].squadCounter[i] = 0
+                    end
+                    if tblData.type == currTemplate[i][1] and
+                            platoonList[currPlatoon].squadCounter[i] < currTemplate[i][3] then
+                        platoonList[currPlatoon].squadCounter[i] = platoonList[currPlatoon].squadCounter[i] + 1
+                        brain:AssignUnitsToPlatoon(platoonList[currPlatoon],{unit},currTemplate[i][4],currTemplate[i][5] )
+                        inserted = true
+                    end
+                    i = i + 1
+                end
+                if reversePlatoon then
+                    currPlatoon = reversePlatoon
+                    numRows = reverseRows
+                    currTemplate = reverseTemplate
+                    reversePlatoon = false
+                end
+            end
+            
+            if balance then
+                --Accumulate for one tick so we don't get too much overhead from thread switching...
+                --ScenarioInfo.LoadBalance.Accumulator = ScenarioInfo.LoadBalance.Accumulator + timePerChild
+                ScenarioInfo.LoadBalance.Accumulator = ScenarioInfo.LoadBalance.Accumulator + 1
+                
+                if ScenarioInfo.LoadBalance.Accumulator > ScenarioInfo.LoadBalance.UnitThreshold then
+                    WaitSeconds(0)
+                    ScenarioInfo.LoadBalance.Accumulator = 0
+                end
+            end
+        end
+    end
+
+    return platoonList, tblResult, treeResult
+end
+
+
+
+#--[  CreateArmyGroup                                                            ]--
+#--[                                                                             ]--
+#--[  Creates the specified group in game.                                       ]--
+function CreateArmyGroup(strArmy,strGroup,wreckage, balance)
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    local platoonList, tblResult, treeResult = CreatePlatoons(strArmy,
+                                                              FindUnitGroup( strGroup, Scenario.Armies[strArmy].Units ), nil, nil, nil, nil, balance )
+
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    if tblResult == nil and strGroup ~= 'INITIAL' then
+        error('SCENARIO UTILITIES WARNING: No units found for for Army- ' .. strArmy .. ' Group- ' .. strGroup, 2)
+    end
+    if wreckage then
+        for num, unit in tblResult do
+            unit:CreateWreckageProp()
+            unit:Destroy()
+        end
+        return
+    end
+    return tblResult, treeResult, platoonList
+end
+
+# CreateArmyTree
+#
+# Returns tree of units created by the editor. 2nd return is table of units
+function CreateArmyTree(strArmy, strGroup)
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    local platoonList, tblResult, treeResult = CreatePlatoons(strArmy,
+                                                              FindUnitGroup(strGroup, Scenario.Armies[strArmy].Units) )
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    if tblResult == nil then
+        error('SCENARIO UTILITIES WARNING: No units found for for Army- ' .. strArmy .. ' Group- ' .. strGroup, 2)
+    end
+    return treeResult, tblResult, platoonList
+end
+
+
+function CreateArmyGroupAsPlatoonBalanced(strArmy, strGroup, formation, OnFinishedCallback)
+    ScenarioInfo.LoadBalance.Accumulator = 0
+    local units = CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, nil, nil, true)
+
+    OnFinishedCallback(units)
+end
+
+
+# CreateArmyGroupAsPlatoonCoopBalanced
+#
+# Returns a platoon that is created out of all units in a group and its sub groups.
+function CreateArmyGroupAsPlatoonCoopBalanced(strArmy, strGroup, formation, tblNode, platoon, balance)
+    if ScenarioInfo.LoadBalance.Enabled then
+        --note that tblNode in this case is actually the callback function
+        table.insert(ScenarioInfo.LoadBalance.PlatoonGroups, {strArmy, strGroup, formation, tblNode})
+        return
+    end
+    
+    local tblNode = tblNode or FindUnitGroup(strGroup, Scenario.Armies[strArmy].Units)
+    if not tblNode then
+        error('*SCENARIO UTILS ERROR: No group named- ' .. strGroup .. ' found for army- ' .. strArmy, 2)
+    end
+    if not formation then
+        error('*SCENARIO UTILS ERROR: No formation given to CreateArmyGroupAsPlatoon')
+    end
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    local platoon = platoon or brain:MakePlatoon('','')
+    local armyIndex = brain:GetArmyIndex()
+
+    local unit = nil
+    for strName, tblData in pairs(tblNode.Units) do
+		for k, player in ScenarioInfo.HumanPlayers do
+			if 'GROUP' == tblData.type then
+				platoon = CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, tblData, platoon)
+				if not brain.IgnoreArmyCaps then
+					SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+				end
+			else
+				unit = CreateUnitHPR( tblData.type,
+									 strArmy,
+									 tblData.Position[1], tblData.Position[2], tblData.Position[3],
+									 tblData.Orientation[1], tblData.Orientation[2], tblData.Orientation[3]
+								 )
+				if unit:GetBlueprint().Physics.FlattenSkirt then
+					unit:CreateTarmac(true, true, true, false, false)
+				end                               
+				if ScenarioInfo.UnitNames[armyIndex] then
+					ScenarioInfo.UnitNames[armyIndex][strName] = unit
+				end
+				unit.UnitName = strName
+				brain:AssignUnitsToPlatoon(platoon, {unit}, 'Attack', formation)
+				
+				if balance then
+					ScenarioInfo.LoadBalance.Accumulator = ScenarioInfo.LoadBalance.Accumulator + 1
+					
+					if ScenarioInfo.LoadBalance.Accumulator > ScenarioInfo.LoadBalance.UnitThreshold/5 then
+						WaitSeconds(0)
+						ScenarioInfo.LoadBalance.Accumulator = 0
+					end
+				end
+			end
+		end
+    end
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    return platoon
+end
+
+
+
+# CreateArmyGroupAsPlatoon
+#
+# Returns a platoon that is created out of all units in a group and its sub groups.
+function CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, tblNode, platoon, balance)
+    if ScenarioInfo.LoadBalance.Enabled then
+        --note that tblNode in this case is actually the callback function
+        table.insert(ScenarioInfo.LoadBalance.PlatoonGroups, {strArmy, strGroup, formation, tblNode})
+        return
+    end
+    
+    local tblNode = tblNode or FindUnitGroup(strGroup, Scenario.Armies[strArmy].Units)
+    if not tblNode then
+        error('*SCENARIO UTILS ERROR: No group named- ' .. strGroup .. ' found for army- ' .. strArmy, 2)
+    end
+    if not formation then
+        error('*SCENARIO UTILS ERROR: No formation given to CreateArmyGroupAsPlatoon')
+    end
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    local platoon = platoon or brain:MakePlatoon('','')
+    local armyIndex = brain:GetArmyIndex()
+
+    local unit = nil
+    for strName, tblData in pairs(tblNode.Units) do
+        if 'GROUP' == tblData.type then
+            platoon = CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, tblData, platoon)
+            if not brain.IgnoreArmyCaps then
+                SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+            end
+        else
+            unit = CreateUnitHPR( tblData.type,
+                                 strArmy,
+                                 tblData.Position[1], tblData.Position[2], tblData.Position[3],
+                                 tblData.Orientation[1], tblData.Orientation[2], tblData.Orientation[3]
+                             )
+            if unit:GetBlueprint().Physics.FlattenSkirt then
+                unit:CreateTarmac(true, true, true, false, false)
+            end                               
+            if ScenarioInfo.UnitNames[armyIndex] then
+                ScenarioInfo.UnitNames[armyIndex][strName] = unit
+            end
+            unit.UnitName = strName
+            brain:AssignUnitsToPlatoon(platoon, {unit}, 'Attack', formation)
+            
+            if balance then
+                ScenarioInfo.LoadBalance.Accumulator = ScenarioInfo.LoadBalance.Accumulator + 1
+                
+                if ScenarioInfo.LoadBalance.Accumulator > ScenarioInfo.LoadBalance.UnitThreshold/5 then
+                    WaitSeconds(0)
+                    ScenarioInfo.LoadBalance.Accumulator = 0
+                end
+            end
+        end
+    end
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    return platoon
+end
+
+# Creates an army group at a certain veteran level for coop
+function CreateArmyGroupAsPlatoonCoopBalancedVeteran(strArmy, strGroup, formation, veteranLevel)
+    local plat = CreateArmyGroupAsPlatoonCoopBalanced(strArmy, strGroup, formation)
+    veteranLevel = veteranLevel or 5
+    for k,v in plat:GetPlatoonUnits() do
+        v:SetVeterancy(veteranLevel)
+    end
+    return plat
+end  
+
+# Creates an army group at a certain veteran level
+function CreateArmyGroupAsPlatoonVeteran(strArmy, strGroup, formation, veteranLevel)
+    local plat = CreateArmyGroupAsPlatoon(strArmy, strGroup, formation)
+    veteranLevel = veteranLevel or 5
+    for k,v in plat:GetPlatoonUnits() do
+        v:SetVeterancy(veteranLevel)
+    end
+    return plat
+end  
+    
+function FlattenTreeGroup( strArmy, strGroup, tblData, unitGroup )
+    tblData = tblData or FindUnitGroup( strGroup, Scenario.Armies[strArmy].Units )
+    unitGroup = unitGroup or {}
+    for strName, tblData in pairs(tblData.Units) do
+        if 'GROUP' == tblData.type then
+            FlattenTreeGroup( strArmy, strGroup, tblData, unitGroup )
+        else
+            table.insert( unitGroup, tblData )
+        end
+    end
+    return unitGroup
+end
+
+# LoadArmyPBMBuilders
+#
+# Loads an Army Brain's PBM Builders from the save file
+function LoadArmyPBMBuilders(strArmy)
+    local aiBrain = GetArmyBrain(strArmy)
+    if Scenario.Armies[strArmy].PlatoonBuilders.Builders then
+        local nonGlobalOSB = {}
+        for buildName, builderData in Scenario.Armies[strArmy].PlatoonBuilders.Builders do
+            if builderData.PlatoonData then
+                for k,v in builderData.PlatoonData do
+                    if type(k) ~= 'string' then
+                        builderData.PlatoonData = RebuildDataTable(builderData.PlatoonData)
+                    end
+                    break
+                end
+            end
+            if builderData.BuildConditions then
+                for num,conditionData in builderData.BuildConditions do
+                    local tempBuildData = {}
+                    table.insert(tempBuildData,conditionData[1])
+                    table.insert(tempBuildData,conditionData[2])
+                    table.insert(tempBuildData,conditionData[3])
+                    builderData.BuildConditions[num] = tempBuildData
+                end
+            end
+            if string.sub(buildName, 1, 11) == 'OSB_Master_' or string.sub(buildName, 1, 10) == 'OSB_Child_' then
+                nonGlobalOSB[buildName] = builderData
+            elseif string.sub(buildName, 1, 4) == 'OSB_' then
+                LoadOSB(buildName, strArmy, builderData)
+            elseif not builderData.PlatoonData.AMMasterPlatoon then
+                local spec = {}
+                for k, v in builderData do
+                    spec[k] = v
+                end
+                spec.PlatoonTemplate = table.deepcopy(Scenario.Platoons[builderData.PlatoonTemplate])
+                spec.BuilderName = buildName
+                spec.PlatoonData.BuilderName = buildName
+                if spec.BuildTimeOut and spec.BuildTimeOut < 0 then
+                    spec.GenerateTimeOut = true
+                end
+                aiBrain:PBMAddPlatoon(spec)
+            else
+                if aiBrain.AttackData['AttackManagerState'] ~= 'ACTIVE' then
+                    aiBrain:InitializeAttackManager()
+                end
+                local spec = {}
+                if builderData.BuildConditions then
+                    spec.AttackConditions = builderData.BuildConditions
+                else
+                    spec.AttackConditions = {}
+                end
+                spec.PlatoonData = builderData.PlatoonData
+                spec.Priority = builderData.Priority
+                if builderData.PlatoonAIFunction then
+                    spec.AIThread = builderData.PlatoonAIFunction
+                end
+                if spec.PlatoonData.AIName then
+                    spec.AIName = spec.PlatoonData.AIName
+                end
+                if builderData.PlatoonAddFunctions then
+                    spec.FormCallbacks = builderData.PlatoonAddFunctions
+                end
+                if builderData.PlatoonBuildCallbacks then
+                    spec.DestroyCallbacks = builderData.PlatoonBuildCallbacks
+                end
+                if builderData.PlatoonTemplate and not spec.AIName then
+                    if Scenario.Platoons[builderData.PlatoonTemplate][2] ~= '' then
+                        spec.AIName = Scenario.Platoons[builderData.PlatoonTemplate][2]
+                    end
+                end
+                spec.PlatoonType = builderData.PlatoonType
+                spec.PlatoonName = buildName
+                spec.LocationType = builderData.LocationType
+                spec.BuilderName = buildName
+                if spec.PlatoonData.UsePool ~= nil then
+                    spec.UsePool = spec.PlatoonData.UsePool
+                end
+                aiBrain:AMAddPlatoon(spec)
+            end
+        end
+        for buildName, builderData in nonGlobalOSB do
+            UpdateOSB(buildName, strArmy, builderData)
+        end
+    end
+end
+
+function RebuildDataTable(table)
+    local newTable = {}
+    for k,v in table do
+        local checkType = type(v.value)
+        if type(v.value) == 'table' then
+            newTable[v.name] = RebuildDataTable(v.value)
+        else
+            newTable[v.name] = v.value
+        end
+    end
+    return newTable
+end
+
+function InitializeStartLocation(strArmy)
+    local start = GetMarker(strArmy)
+    if start then
+        SetArmyStart(strArmy, start.position[1], start.position[3])
+    else
+        GenerateArmyStart(strArmy)
+    end
+end
+
+function SetPlans(strArmy)
+    if Scenario.Armies[strArmy] then
+        SetArmyPlans(strArmy, Scenario.Armies[strArmy].plans)
+    end
+end
+
+function UpdateOSB(buildName, strArmy, builderData)
+#    local buildNameNew, location, globalName, childPart = SplitUpdateOSBName(buildName)
+    local aiBrain = GetArmyBrain(strArmy)
+#    local amMasterName = 'OSB_Master_' .. globalName .. '_' .. strArmy
+#    if location then
+#        amMasterName = amMasterName .. '_' .. location
+#    end
+#
+#    # Find builder in brain
+#    local builderName = buildName
+#    builderName = builderName .. '_' .. strArmy
+#    if location then
+#        builderName = builderName .. '_' .. location
+#    end
+#    local found = false
+#    local builderEdit = false
+    for type, bTable in aiBrain.PBM.Platoons do
+        for bCount, bData in bTable do
+            local bName = bData.BuilderName
+            if bName == buildName then
+                UpdateGivenOSB(bData, builderData)
+            end
+        end
+    end
+end
+
+function UpdateGivenOSB(builderEdit, builderData)
+    # Update data in builder in brain
+    for dName, data in builderData.PlatoonData do
+        if dName ~= 'PlatoonMultiplier' and dName ~= 'TransportCount' then
+            builderEdit.PlatoonData[dName] = data
+        end
+    end
+    if builderData.PlatoonData.PlatoonMultiplier and not builderEdit.PlatoonTemplate.MultiplierApplied then
+        builderEdit.PlatoonTemplate.MultiplierApplied = true
+        local squadNum = 3
+        while squadNum <= table.getn(builderEdit.PlatoonTemplate) do
+            if builderEdit.PlatoonTemplate[squadNum][2] < 0 then
+                local num = builderEdit.PlatoonTemplate[squadNum][2] * builderData.PlatoonData.PlatoonMultiplier
+                builderEdit.PlatoonTemplate[squadNum][2] = -( math.ceil( math.abs( num ) ) )
+            end
+            squadNum = squadNum + 1
+        end
+    end
+    if builderData.Priority ~= 0 then
+        if builderData.Priority == -1 then
+            builderEdit.Priority = 0
+        else
+            builderEdit.Priority = builderData.Priority
+        end
+    end
+    if builderData.BuildConditions then
+        for bcNum, bcData in builderData.BuildConditions do
+            if childPart then
+                table.insert(builderEdit.BuildConditions, bcData)
+            else
+                table.insert(builderEdit.AttackConditions, bcData)
+            end
+        end
+    end
+    if builderData.PlatoonBuildCallbacks then
+        for buildNum, buildData in builderData.PlatoonBuildCallbacks do
+            if childPart then
+                table.insert(builderEdit.PlatoonBuildCallbacks, buildData)
+            else
+                table.insert(builderEdit.DestroyCallbacks, buildData)
+            end
+        end
+    end
+    if builderData.PlatoonAddFunctions then
+        for addNum, addData in builderData.PlatoonAddFunctions do
+            if childPart then
+                table.insert(builderEdit.PlatoonAddFunctions, buildData)
+            else
+                table.insert(builderEdit.FormCallbacks, buildData)
+            end
+        end
+    end
+    if builderData.PlatoonAIFunction then
+        if childPart then
+            builderEdit.PlatoonAIFunction = builderData.PlatoonAIFunction
+        else
+            builderEdit.AIThread = builderData.PlatoonAIFunction
+        end
+    end
+end
+
+function LoadOSB(buildName, strArmy, builderData)
+    local buildNameNew, location, globalName, childPart
+    local saveFile
+    
+    if type(buildName) == 'table' then
+        saveFile = {Scenario = buildName}
+        
+        buildNameNew = 'OSB_' .. saveFile.Scenario.Name
+        globalName = saveFile.Scenario.Name
+        location = false --string.gsub(builderData.LocationType, '_', '')
+        childPart = false
+    else
+        buildNameNew, location, globalName, childPart = SplitOSBName(buildName)
+        local fileName = '/lua/ai/OpAI/' .. globalName .. '_save.lua'
+        saveFile = import(fileName)
+    end
+   
+    local platoons = saveFile.Scenario.Platoons
+    local aiBrain = GetArmyBrain(strArmy)
+    if not aiBrain.OSBuilders then
+        aiBrain.OSBuilders = {}
+    end
+    local factionIndex = aiBrain:GetFactionIndex()
+    local builders = saveFile.Scenario.Armies['ARMY_1'].PlatoonBuilders.Builders
+    local basePriority = builders['OSB_Master_'..globalName].Priority
+    local amMasterName = 'OSB_Master_' .. globalName .. '_' .. strArmy
+    if location then
+        amMasterName =  amMasterName .. '_' .. location
+    end
+    if not builders then
+        error('*OpAI ERROR: No OpAI Global named: '..globalName, 2)
+    end
+    for k,v in builders do
+        local spec = {}
+        local insert = true
+
+        local pData = RebuildDataTable(v.PlatoonData)
+        spec.PlatoonData = {}
+
+        # Store builder name
+        if location then
+            spec.BuilderName = k .. '_' .. strArmy .. '_' .. location
+            spec.PlatoonData.BuilderName = k .. '_' .. strArmy .. '_' .. location
+        else
+            spec.BuilderName = k .. '_' .. strArmy
+            spec.PlatoonData.BuilderName = k .. '_' .. strArmy
+        end
+
+        if ScenarioInfo.OSPlatoonCounter[spec.BuilderName] then
+            UpdateOSB(spec.BuilderName, strArmy, builderData)
+        else
+            if string.sub(k, 1, 11) == 'OSB_Master_' then
+                for name, data in builderData.PlatoonData do
+                    if name ~= 'PlatoonMultiplier' and name ~= 'TransportCount' and name ~= 'PlatoonSize' then
+                        spec.PlatoonData[name] = data
+                    end
+                end
+            end
+            if pData.AMPlatoons then
+                spec.PlatoonData.AMPlatoons = {}
+                for name, pName in pData.AMPlatoons do
+                    local appendString = ''
+                    if string.sub(name, 1, 6) == 'APPEND' then
+                        appendString = string.sub(name, 7)
+                    end
+                    if location then
+                        table.insert(spec.PlatoonData.AMPlatoons, pName..'_'..strArmy..'_'..location..appendString)
+                    else
+                        table.insert(spec.PlatoonData.AMPlatoons, pName .. '_' .. strArmy .. appendString)
+                    end
+                end
+            end
+
+
+            # Set priority
+            if builderData.Priority < 0 then
+                insert = false
+                spec.Priority = builderData.Priority
+            elseif builderData.Priority ~= 0 then
+                spec.Priority = builderData.Priority - (basePriority - v.Priority)
+                if spec.Priority <= 0 then
+                    spec.Priority = 1
+                end
+            else
+                spec.Priority = v.Priority
+            end
+            if spec.LocationType ~= 'ALL' then
+                spec.LocationType = builderData.LocationType
+                spec.PlatoonData.LocationType = builderData.LocationType
+            end
+            spec.PlatoonType = v.PlatoonType
+
+            # Set platoon template
+            if Scenario.Platoons['OST_' .. string.sub(spec.BuilderName, 5)] then
+                spec.PlatoonTemplate = FactionConvert(table.deepcopy(Scenario.Platoons['OST_' .. string.sub(spec.BuilderName, 5)]), factionIndex)
+            elseif Scenario.Platoons[v.PlatoonTemplate] then
+                if type(buildName) ~= "table" then
+                    spec.PlatoonTemplate = FactionConvert(table.deepcopy(Scenario.Platoons[v.PlatoonTemplate]), factionIndex)
+                else
+                    spec.PlatoonTemplate = table.deepcopy(Scenario.Platoons[v.PlatoonTemplate])
+                end
+            else
+                if type(buildName) ~= "table" then
+                    spec.PlatoonTemplate = FactionConvert(table.deepcopy(platoons[v.PlatoonTemplate]), factionIndex)
+                else
+                    spec.PlatoonTemplate = table.deepcopy(platoons[v.PlatoonTemplate])
+                end
+                
+                
+            end
+            if builderData.PlatoonData.PlatoonMultiplier then
+                local squadNum = 3
+                while squadNum <= table.getn(spec.PlatoonTemplate) do
+                    spec.PlatoonTemplate[squadNum][2] = spec.PlatoonTemplate[squadNum][2] * builderData.PlatoonData.PlatoonMultiplier
+                    spec.PlatoonTemplate[squadNum][3] = spec.PlatoonTemplate[squadNum][3] * builderData.PlatoonData.PlatoonMultiplier
+                    squadNum = squadNum + 1
+                end
+            end
+            if builderData.PlatoonData.PlatoonSize then
+                local squadNum = 3
+                while squadNum <= table.getn(spec.PlatoonTemplate) do
+                    spec.PlatoonTemplate[squadNum][2] = 1
+                    spec.PlatoonTemplate[squadNum][3] = builderData.PlatoonData.PlatoonSize
+                    squadNum = squadNum + 1
+                end
+            end
+
+            # Set buildout to
+            if (v.BuildTimeOut and v.BuildTimeOut < 0 ) or ( spec.PlatoonTemplate[3] and spec.PlatoonTemplate[3][2] < 0 ) then
+                spec.GenerateTimeOut = true
+            end
+            spec.BuildTimeOut = v.BuildTimeOut
+
+            # Add AI Function to OSB global if needed
+            if string.sub(k, 1, 11) == 'OSB_Master_' and builderData.PlatoonAIFunction then
+                spec.PlatoonAIFunction = builderData.PlatoonAIFunction
+            elseif v.PlatoonAIFunction then
+                spec.PlatoonAIFunction = v.PlatoonAIFunction
+            end
+
+            # Add Build Conditions
+            spec.BuildConditions = {}
+            if v.BuildConditions then
+                for num, bCond in v.BuildConditions do
+                    local addCond = table.deepcopy(bCond)
+                    for sNum, pVal in addCond[3] do
+                        if pVal == 'OSB_Master_' .. string.sub(buildNameNew,5) then
+                            pVal = amMasterName
+                        elseif pVal == 'default_master' then
+                            addCond[3][sNum] = amMasterName
+                        elseif pVal == 'default_army' then
+                            addCond[3][sNum] = strArmy
+                        elseif pVal == 'default_location' and location then
+                            addCond[3][sNum] = location
+                        elseif pVal == 'default_location_type' then
+                            addCond[3][sNum] = spec.LocationType
+                        elseif pVal == 'default_builder_name' then
+                            addCond[3][sNum] = spec.BuilderName
+                        elseif pVal == 'default_transport_count' then
+                            if builderData.PlatoonData.TransportCount then
+                                addCond[3][sNum] = builderData.PlatoonData.TransportCount
+                            end
+                        end
+                    end
+                    table.insert(spec.BuildConditions, addCond)
+                end
+            end
+            # Add build/form conditions to ALL builders
+            if builderData.BuildConditions then
+                for num, bCond in builderData.BuildConditions do
+                    if bCond[3][1] == 'Remove' then
+                        for bcNum,bcData in spec.BuildConditions do
+                            if bcData[2] == bCond[2] then
+                                table.remove(spec.BuildConditions, bcNum)
+                            end
+                        end
+                    else
+                        local addCond = table.deepcopy(bCond)
+                        for sNum, pVal in addCond[3] do
+                            if pVal == buildNameNew then
+                                pVal = amMasterName
+                            elseif pVal == 'default_master' then
+                                addCond[3][sNum] = amMasterName
+                            elseif pVal == 'default_army' then
+                                addCond[3][sNum] = strArmy
+                            elseif pVal == 'default_location' and location then
+                                addCond[3][sNum] = location
+                            elseif pVal == 'default_location_type' then
+                                addCond[3][sNum] = spec.LocationType
+                            elseif pVal == 'default_builder_name' then
+                                addCond[3][sNum] = spec.BuilderName
+                            elseif pVal == 'default_transport_count' then
+                                if builderData.PlatoonData.TransportCount then
+                                    addCond[3][sNum] = builderData.PlatoonData.TransportCount
+                                end
+                            end
+                        end
+                        table.insert(spec.BuildConditions, addCond)
+                    end
+                end
+            end
+            # Check for faction specific builders
+            for num, cond in spec.BuildConditions do
+                if cond[2] == 'FactionIndex' then
+                    local params = {}
+                    for subNum, val in cond[3] do
+                        table.insert(params, val)
+                    end
+                    table.remove(params, 1)
+                    insert = import(cond[1])[cond[2]](aiBrain, unpack(params))
+                end
+            end
+
+            # Add BuildCallbacks
+            spec.PlatoonBuildCallbacks = {}
+            if v.PlatoonBuildCallbacks then
+                for num, pbCallback in v.PlatoonBuildCallbacks do
+                    table.insert(spec.PlatoonBuildCallbacks, pbCallback)
+                end
+            end
+            # Add DestroyCallbacks to Masters
+            if builderData.PlatoonBuildCallbacks and string.sub(k,1,11) == 'OSB_Master_' then
+                FilterFunctions(spec.PlatoonBuildCallbacks, builderData.PlatoonBuildCallbacks)
+            end
+
+            # Add AddFunctions (Har!)
+            spec.PlatoonAddFunctions = {}
+            if v.PlatoonAddFunctions then
+                for fNum, fData in v.PlatoonAddFunctions do
+                    table.insert(spec.PlatoonAddFunctions, fData)
+                end
+            end
+            if builderData.PlatoonAddFunctions and string.sub(k,1,11) == 'OSB_Master_' then
+                FilterFunctions(spec.PlatoonAddFunctions, builderData.PlatoonAddFunctions)
+            end
+
+
+            # Masters
+            if pData.AMMasterPlatoon and insert then
+                if string.sub(k,1,26) == 'OSB_Master_LeftoverCleanup' then
+                    spec.PlatoonName = spec.LocationType..'_LeftoverUnits'
+                else
+                    spec.PlatoonName = spec.BuilderName
+                end
+
+                # Add data to Masters
+                if builderData.PlatoonData and string.sub(k,1,11) == 'OSB_Master_' then
+                    if aiBrain.AttackData['AttackManagerState'] ~= 'ACTIVE' then
+                        aiBrain:InitializeAttackManager()
+                    end
+                end
+
+                spec.AttackConditions = spec.BuildConditions
+                spec.DestroyCallbacks = spec.PlatoonBuildCallbacks
+                spec.FormCallbacks = spec.PlatoonAddFunctions
+                spec.AIThread = spec.PlatoonAIFunction
+
+                if pData.AIName then
+                    spec.AIName = pData.AIName
+                end
+                if spec.PlatoonTemplate and not spec.AIName then
+                    if spec.PlatoonTemplate[2] ~= '' then
+                        spec.AIName = spec.PlatoonTemplate[2]
+                    end
+                end
+
+                # Set if needed to draw from pool
+                if pData.UsePool ~= nil then
+                    spec.UsePool = pData.UsePool
+                end
+                aiBrain:AMAddPlatoon(spec)
+
+                # Children
+            elseif insert then
+                spec.RequiresConstruction = v.RequiresConstruction
+
+                # Add spec to brain
+                spec.InstanceCount = v.InstanceCount
+                aiBrain:PBMAddPlatoon(spec)
+            end
+        end
+    end
+end
+
+-- TODO: This really ought to be hooked.... this file needs to be made game agnostic as it's in mohodata
+function FactionConvert(template, factionIndex)
+    local i = 3
+    while i <= table.getn(template) do
+        if factionIndex == 2 then
+            if template[i][1] == 'uel0203' then
+                template[i][1] = 'xal0203'
+            elseif template[i][1] == 'uea0305' then
+                template[i][1] = 'xaa0305'
+            elseif template[i][1] == 'xel0305' then
+                template[i][1] = 'xal0305'
+            else
+                template[i][1] = string.gsub(template[i][1], 'ue', 'ua')
+            end
+        elseif factionIndex == 3 then
+            if template[i][1] == 'uea0305' then
+                template[i][1] = 'xra0305'
+            elseif template[i][1] == 'xel0305' then
+                template[i][1] = 'xrl0305'
+            else
+                template[i][1] = string.gsub(template[i][1], 'ue', 'ur')
+            end
+        elseif factionIndex == 4 then
+            if template[i][1] == 'uel0106' then
+                template[i][1] = 'xsl0201'
+            elseif template[i][1] == 'xel0305' then
+                template[i][1] = 'xsl0305'
+            else
+                template[i][1] = string.gsub(template[i][1], 'ue', 'xs')
+            end
+        end
+        i = i + 1
+    end
+    return template
+end
+
+function SplitUpdateOSBName(buildName)
+    # OSB_<bname>_location
+    local startCheck = 5
+    local specificBuilder = false
+    if string.sub(buildName, 1, 11) == 'OSB_Master_' then
+        startCheck = 12
+    elseif string.sub(buildName, 1, 10) == 'OSB_Child_' then
+        startCheck = 11
+    end
+    local pos = string.find(buildName, '_', startCheck)
+    local location = false
+    local retName = buildName
+    local globName = false
+    local childPart = false
+    if pos then
+        globName = string.sub(buildName, startCheck, pos-1)
+        retName = string.sub(buildName, 1, pos-1)
+    else
+        globName = string.sub(buildName, startCheck)
+        retName = buildName
+    end
+    if startCheck <= 5 and pos then
+        location = string.sub(buildName, pos+1)
+    elseif pos then
+        local pos2 = string.find(buildName, '_', pos+1)
+        if pos2 then
+            childPart = string.sub(buildName, pos+1, pos2-1)
+            location = string.sub(buildName, pos2+1 )
+        else
+            childPart = string.sub(buildName, pos+1)
+        end
+    end
+    return retName, location, globName, childPart
+end
+
+function SplitOSBName(buildName)
+    # OSB_<bname>_location
+    local startCheck = 5
+    local specificBuilder = false
+    if string.sub(buildName, 1, 11) == 'OSB_Master_' then
+        startCheck = 12
+    elseif string.sub(buildName, 1, 10) == 'OSB_Child_' then
+        startCheck = 11
+    end
+    local pos = string.find(buildName, '_', startCheck)
+    local location = false
+    local retName = buildName
+    local globName = false
+    local childPart = false
+    if pos then
+        globName = string.sub(buildName, startCheck, pos-1)
+        retName = string.sub(buildName, 1, pos-1)
+    else
+        globName = string.sub(buildName, startCheck)
+        retName = buildName
+    end
+    if startCheck <= 5 and pos then
+        location = string.sub(buildName, pos+1)
+    elseif pos then
+        local pos2 = string.find(buildName, '_', pos+1)
+        if pos2 then
+            location = string.sub(buildName, pos+1, pos2-1)
+            childPart = string.sub(buildName, pos2+1 )
+        else
+            location = string.sub(buildName, pos+1)
+        end
+    end
+    return retName, location, globName, childPart
+end
+
+function FilterFunctions(tableOne, tableTwo)
+    for t2Num, t2Data in tableTwo do
+        if t2Data[3][1] == 'Remove' then
+            for t1Num,t1Data in tableOne do
+                if t2Data[2] == t1Data[2] then
+                    table.remove(tableOne, t1Num)
+                end
+            end
+        else
+            table.insert(tableOne, t2Data)
+        end
+    end
+    return tableOne
+end

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -1,11 +1,11 @@
-#--[                                                                             ]--
-#--[  File     : ScenarioUtilities.lua                                           ]--
-#--[  Author(s): Ivan Rumsey                                                     ]--
-#--[                                                                             ]--
-#--[  Summary  : Utility functions for use with scenario save file.              ]--
-#--[             Created from examples provided by Jeff Petkau.                  ]--
-#--[                                                                             ]--
-#--[  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.             ]--
+----[                                                                             ]--
+----[  File     : ScenarioUtilities.lua                                           ]--
+----[  Author(s): Ivan Rumsey                                                     ]--
+----[                                                                             ]--
+----[  Summary  : Utility functions for use with scenario save file.              ]--
+----[             Created from examples provided by Jeff Petkau.                  ]--
+----[                                                                             ]--
+----[  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.             ]--
 local Entity = import('/lua/sim/Entity.lua').Entity
 local ScenarioFramework = import('/lua/ScenarioFramework.lua')
 
@@ -71,9 +71,9 @@ function ChainToPositions(chainName)
     return positionTable
 end
 
-#--[  FindParentChain                                                ]--
-#--[                                                                      ]--
-#--[  Gets the parent chain that the supplied marker belongs to           ]--
+----[  FindParentChain                                                ]--
+----[                                                                      ]--
+----[  Gets the parent chain that the supplied marker belongs to           ]--
 function FindParentChain(markerName)
     for cName,chain in Scenario.Chains do
         for mNum,marker in chain.Markers do
@@ -95,9 +95,9 @@ function GetMarkerChain(name)
     return chain
 end
 
-#--[  MarkerToPosition                                                           ]--
-#--[                                                                             ]--
-#--[  Converts a marker as specified in *_save.lua file to a position.           ]--
+----[  MarkerToPosition                                                           ]--
+----[                                                                             ]--
+----[  Converts a marker as specified in *_save.lua file to a position.           ]--
 function MarkerToPosition(strMarker)
     local marker = GetMarker(strMarker)
         if not marker then
@@ -106,9 +106,9 @@ function MarkerToPosition(strMarker)
     return marker.position
 end
 
-#--[  AreaToRect                                                                 ]--
-#--[                                                                             ]--
-#--[  Converts an area as specified in *_save.lua file to a rectangle.           ]--
+----[  AreaToRect                                                                 ]--
+----[                                                                             ]--
+----[  Converts an area as specified in *_save.lua file to a rectangle.           ]--
 function AreaToRect(strArea)
     local area = Scenario.Areas[strArea]
     if not area then
@@ -123,9 +123,9 @@ function InRect( vectorPos, rect )
            vectorPos[3] > rect.y0 and vectorPos[3] < rect.y1
 end
 
-#--[  AssembleUnitGroup                                                          ]--
-#--[                                                                             ]--
-#--[  Returns all units (leaf nodes) under the specified group.                  ]--
+----[  AssembleUnitGroup                                                          ]--
+----[                                                                             ]--
+----[  Returns all units (leaf nodes) under the specified group.                  ]--
 function AssembleUnitGroup(tblNode,tblResult)
     tblResult = tblResult or {}
 
@@ -144,9 +144,9 @@ function AssembleUnitGroup(tblNode,tblResult)
     return tblResult
 end
 
-#--[  AssemblePlatoons                                                           ]--
-#--[                                                                             ]--
-#--[  Returns all platoon template names specified under group.                  ]--
+----[  AssemblePlatoons                                                           ]--
+----[                                                                             ]--
+----[  Returns all platoon template names specified under group.                  ]--
 function AssemblePlatoons(tblNode,tblResult)
     tblResult = tblResult or {}
 
@@ -167,9 +167,9 @@ function AssemblePlatoons(tblNode,tblResult)
     return tblResult
 end
 
-#--[  FindUnit                                                                   ]--
-#--[                                                                             ]--
-#--[  Finds the unit with the specified name.                                    ]--
+----[  FindUnit                                                                   ]--
+----[                                                                             ]--
+----[  Finds the unit with the specified name.                                    ]--
 function FindUnit(strUnit,tblNode)
     if nil == tblNode then
         return nil
@@ -192,9 +192,9 @@ function FindUnit(strUnit,tblNode)
     return tblResult
 end
 
-#--[  CreateArmyUnit                                                             ]--
-#--[                                                                             ]--
-#--[  Creates a named unit in an army.                                           ]--
+----[  CreateArmyUnit                                                             ]--
+----[                                                                             ]--
+----[  Creates a named unit in an army.                                           ]--
 function CreateArmyUnit(strArmy,strUnit)
     local tblUnit = FindUnit(strUnit,Scenario.Armies[strArmy].Units)
     local brain = GetArmyBrain(strArmy)
@@ -240,9 +240,9 @@ function CreateArmyUnit(strArmy,strUnit)
     return nil
 end
 
-#--[  FindUnitGroup                                                              ]--
-#--[                                                                             ]--
-#--[  Finds the unit group with the specified name.                              ]--
+----[  FindUnitGroup                                                              ]--
+----[                                                                             ]--
+----[  Finds the unit group with the specified name.                              ]--
 function FindUnitGroup(strGroup,tblNode)
     if nil == tblNode then
         return nil
@@ -266,16 +266,16 @@ function FindUnitGroup(strGroup,tblNode)
     return tblResult
 end
 
-#--[  AssembleArmyGroup                                                          ]--
-#--[                                                                             ]--
-#--[  Returns a table of units in the group owned by the specified army.         ]--
+----[  AssembleArmyGroup                                                          ]--
+----[                                                                             ]--
+----[  Returns a table of units in the group owned by the specified army.         ]--
 function AssembleArmyGroup(strArmy,strGroup)
     return AssembleUnitGroup(FindUnitGroup(strGroup,Scenario.Armies[strArmy].Units))
 end
 
-#--[  CreateArmySubGroup                                                                      ]--
-#--[                                                                                          ]--
-#--[  Creates Army groups from a number of groups specified in order from the Units Hierarchy ]--
+----[  CreateArmySubGroup                                                                      ]--
+----[                                                                                          ]--
+----[  Creates Army groups from a number of groups specified in order from the Units Hierarchy ]--
 function CreateArmySubGroup(strArmy,strGroup,...)
     local tblNode = Scenario.Armies[strArmy].Units
     local tblResult = {}
@@ -305,9 +305,9 @@ function CreateArmySubGroup(strArmy,strGroup,...)
     return tblResult, treeResult, platoonList
 end
 
-#--[  CreateSubGroup                                                                      ]--
-#--[                                                                                      ]--
-#--[  Used by CreateArmySubGroup                                                          ]--
+----[  CreateSubGroup                                                                      ]--
+----[                                                                                      ]--
+----[  Used by CreateArmySubGroup                                                          ]--
 function CreateSubGroup(tblNode, strArmy, strGroup, ...)
     local tblResult = {}
     local treeResult = {}
@@ -327,8 +327,8 @@ function CreateSubGroup(tblNode, strArmy, strGroup, ...)
 end
 
 
-#--[  CreateInitialArmyGroup                                                     ]--
-#--[                                                                             ]--
+----[  CreateInitialArmyGroup                                                     ]--
+----[                                                                             ]--
 function CreateInitialArmyGroup(strArmy, createCommander)
     local tblGroup = CreateArmyGroup( strArmy, 'INITIAL')
     local cdrUnit = false
@@ -353,9 +353,9 @@ function CommanderWarpDelay(cdrUnit, delay)
     cdrUnit:PlayCommanderWarpInEffect()
 end
 
-#--[  CreateProps                                                                ]--
-#--[                                                                             ]--
-#--[                                                                             ]--
+----[  CreateProps                                                                ]--
+----[                                                                             ]--
+----[                                                                             ]--
 function CreateProps()
     for i, tblData in pairs(Scenario['Props']) do
         CreatePropHPR(
@@ -366,9 +366,9 @@ function CreateProps()
     end
 end
 
-#--[  CreateResources                                                            ]--
-#--[                                                                             ]--
-#--[                                                                             ]--
+----[  CreateResources                                                            ]--
+----[                                                                             ]--
+----[                                                                             ]--
 function CreateResources()
     local markers = GetMarkers()
     for i, tblData in pairs(markers) do
@@ -379,7 +379,7 @@ function CreateResources()
                 tblData.size
             )
 
-            # fixme: texture names should come from editor
+            -- fixme: texture names should come from editor
             local albedo, sx, sz, lod
             if tblData.type == "Mass" then
                 albedo = "/env/common/splats/mass_marker.dds"
@@ -402,38 +402,38 @@ function CreateResources()
                     Random(0,360), 0, 0
                 )
             end
-            # Decal - (position, heading, textureName1, textureName2, type, sizeX, sizeZ, lodParam, duration, army)
-            # Splat - (position, heading, textureName1, textureName2, type, sizeX, sizeZ, lodParam, duration, army)
-#            if not ScenarioInfo.MapData.Decals then
-#                ScenarioInfo.MapData.Decals = {}
-#            end
-#            table.insert( ScenarioInfo.MapData.Decals, CreateDecal(
-#                tblData.position, # position
-#                0, # heading
-#                albedo, "", # TEX1, TEX2
-#                "Albedo", # TYPE
-#                sx, sz, # SIZE
-#                lod, # LOD
-#                0, # DURACTION
-#                -1 # ARMY
-#            ) )
+            -- Decal - (position, heading, textureName1, textureName2, type, sizeX, sizeZ, lodParam, duration, army)
+            -- Splat - (position, heading, textureName1, textureName2, type, sizeX, sizeZ, lodParam, duration, army)
+--            if not ScenarioInfo.MapData.Decals then
+--                ScenarioInfo.MapData.Decals = {}
+--            end
+--            table.insert( ScenarioInfo.MapData.Decals, CreateDecal(
+--                tblData.position, -- position
+--                0, -- heading
+--                albedo, "", -- TEX1, TEX2
+--                "Albedo", -- TYPE
+--                sx, sz, -- SIZE
+--                lod, -- LOD
+--                0, -- DURACTION
+--                -1 -- ARMY
+--            ) )
             CreateSplat(
-                tblData.position,           # Position
-                0,                          # Heading (rotation)
-                albedo,                     # Texture name for albedo
-                sx, sz,                     # SizeX/Z
-                lod,                        # LOD
-                0,                          # Duration (0 == does not expire)
-                -1 ,                         # army (-1 == not owned by any single army)
+                tblData.position,           -- Position
+                0,                          -- Heading (rotation)
+                albedo,                     -- Texture name for albedo
+                sx, sz,                     -- SizeX/Z
+                lod,                        -- LOD
+                0,                          -- Duration (0 == does not expire)
+                -1 ,                         -- army (-1 == not owned by any single army)
                 0
             )
         end
     end
 end
 
-#--[  InitializeArmies                                                           ]--
-#--[                                                                             ]--
-#--[                                                                             ]--
+----[  InitializeArmies                                                           ]--
+----[                                                                             ]--
+----[                                                                             ]--
 function InitializeArmies()
     local tblGroups = {}
     local tblArmy = ListArmies()
@@ -449,15 +449,15 @@ function InitializeArmies()
 
         if tblData then
 
-            #--[ If an actual starting position is defined, overwrite the        ]--
-            #--[ randomly generated one.                                         ]--
+            ----[ If an actual starting position is defined, overwrite the        ]--
+            ----[ randomly generated one.                                         ]--
 
-            #LOG('*DEBUG: InitializeArmies, army = ', strArmy)
+            --LOG('*DEBUG: InitializeArmies, army = ', strArmy)
 
             SetArmyEconomy( strArmy, tblData.Economy.mass, tblData.Economy.energy)
             
-            #GetArmyBrain(strArmy):InitializePlatoonBuildManager()
-            #LoadArmyPBMBuilders(strArmy)
+            --GetArmyBrain(strArmy):InitializePlatoonBuildManager()
+            --LoadArmyPBMBuilders(strArmy)
             if GetArmyBrain(strArmy).SkirmishSystems then
                 GetArmyBrain(strArmy):InitializeSkirmishSystems()
             end
@@ -484,8 +484,8 @@ function InitializeArmies()
 
 
 
-            #--[ irumsey                                                         ]--
-            #--[ Temporary defaults.  Make sure some fighting will break out.    ]--
+            ----[ irumsey                                                         ]--
+            ----[ Temporary defaults.  Make sure some fighting will break out.    ]--
             for iEnemy, strEnemy in pairs(tblArmy) do
                 local enemyIsCiv = ScenarioInfo.ArmySetup[strEnemy].Civilian
 
@@ -509,9 +509,9 @@ function InitializeArmies()
 end
 
 
-#--[  InitializeScenarioArmies                                                   ]--
-#--[                                                                             ]--
-#--[                                                                             ]--
+----[  InitializeScenarioArmies                                                   ]--
+----[                                                                             ]--
+----[                                                                             ]--
 function InitializeScenarioArmies()
     local tblGroups = {}
     local tblArmy = ListArmies()
@@ -537,7 +537,7 @@ function InitializeScenarioArmies()
             if tblData.faction != nil then
                 
                 if ScenarioInfo.ArmySetup[strArmy].Human then
-					ScenarioFramework.AddRestriction(strArmy, (categories.WALL))
+                    ScenarioFramework.AddRestriction(strArmy, (categories.WALL))
                     local factionIndex = math.min(math.max(ScenarioInfo.ArmySetup[strArmy].Faction, 1), table.getsize(factions.Factions))
                     SetArmyFactionIndex( strArmy, factionIndex - 1 )
                 else
@@ -568,16 +568,16 @@ function InitializeScenarioArmies()
                 end
             end
 
-            #--[ eemerson                                                         ]--
-            #--[ Override alliances with custom alliance settings                 ]--
+            ----[ eemerson                                                         ]--
+            ----[ Override alliances with custom alliance settings                 ]--
             if tblData.Alliances != nil then
                for iEnemy,iAlliance in pairs(tblData.Alliances) do
-					if iArmy != iEnemy then
-						for _,v in pairs(tblArmy) do
-							if v == iEnemy then
-								SetAllianceOneWay( strArmy, iEnemy, iAlliance )
-							end
-						end
+                    if iArmy != iEnemy then
+                        for _,v in pairs(tblArmy) do
+                            if v == iEnemy then
+                                SetAllianceOneWay( strArmy, iEnemy, iAlliance )
+                            end
+                        end
                    end
                end
            end
@@ -592,9 +592,9 @@ function InitializeScenarioArmies()
     return tblGroups
 end
 
-#--[ AssignOrders                                                                ]--
-#--[                                                                             ]--
-#--[                                                                             ]--
+----[ AssignOrders                                                                ]--
+----[                                                                             ]--
+----[                                                                             ]--
 function AssignOrders( strQueue, tblUnit, target)
     local tblOrder = Scenario.Orders[ strQueue ]
     for i, order in pairs(tblOrder) do
@@ -603,8 +603,8 @@ function AssignOrders( strQueue, tblUnit, target)
 end
 
 
-#--[ SpawnPlatoon                                                                ]--
-#--[ Spawns unit group and assigns to platoon it is a part of                    ]--
+----[ SpawnPlatoon                                                                ]--
+----[ Spawns unit group and assigns to platoon it is a part of                    ]--
 function SpawnPlatoon( strArmy, strGroup )
     local tblNode = FindUnitGroup( strGroup, Scenario.Armies[strArmy].Units )
     if nil == tblNode then
@@ -790,9 +790,9 @@ end
 
 
 
-#--[  CreateArmyGroup                                                            ]--
-#--[                                                                             ]--
-#--[  Creates the specified group in game.                                       ]--
+----[  CreateArmyGroup                                                            ]--
+----[                                                                             ]--
+----[  Creates the specified group in game.                                       ]--
 function CreateArmyGroup(strArmy,strGroup,wreckage, balance)
     local brain = GetArmyBrain(strArmy)
     if not brain.IgnoreArmyCaps then
@@ -817,9 +817,9 @@ function CreateArmyGroup(strArmy,strGroup,wreckage, balance)
     return tblResult, treeResult, platoonList
 end
 
-# CreateArmyTree
-#
-# Returns tree of units created by the editor. 2nd return is table of units
+-- CreateArmyTree
+--
+-- Returns tree of units created by the editor. 2nd return is table of units
 function CreateArmyTree(strArmy, strGroup)
     local brain = GetArmyBrain(strArmy)
     if not brain.IgnoreArmyCaps then
@@ -845,9 +845,9 @@ function CreateArmyGroupAsPlatoonBalanced(strArmy, strGroup, formation, OnFinish
 end
 
 
-# CreateArmyGroupAsPlatoonCoopBalanced
-#
-# Returns a platoon that is created out of all units in a group and its sub groups.
+-- CreateArmyGroupAsPlatoonCoopBalanced
+--
+-- Returns a platoon that is created out of all units in a group and its sub groups.
 function CreateArmyGroupAsPlatoonCoopBalanced(strArmy, strGroup, formation, tblNode, platoon, balance)
     if ScenarioInfo.LoadBalance.Enabled then
         --note that tblNode in this case is actually the callback function
@@ -871,37 +871,37 @@ function CreateArmyGroupAsPlatoonCoopBalanced(strArmy, strGroup, formation, tblN
 
     local unit = nil
     for strName, tblData in pairs(tblNode.Units) do
-		for k, player in ScenarioInfo.HumanPlayers do
-			if 'GROUP' == tblData.type then
-				platoon = CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, tblData, platoon)
-				if not brain.IgnoreArmyCaps then
-					SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
-				end
-			else
-				unit = CreateUnitHPR( tblData.type,
-									 strArmy,
-									 tblData.Position[1], tblData.Position[2], tblData.Position[3],
-									 tblData.Orientation[1], tblData.Orientation[2], tblData.Orientation[3]
-								 )
-				if unit:GetBlueprint().Physics.FlattenSkirt then
-					unit:CreateTarmac(true, true, true, false, false)
-				end                               
-				if ScenarioInfo.UnitNames[armyIndex] then
-					ScenarioInfo.UnitNames[armyIndex][strName] = unit
-				end
-				unit.UnitName = strName
-				brain:AssignUnitsToPlatoon(platoon, {unit}, 'Attack', formation)
-				
-				if balance then
-					ScenarioInfo.LoadBalance.Accumulator = ScenarioInfo.LoadBalance.Accumulator + 1
-					
-					if ScenarioInfo.LoadBalance.Accumulator > ScenarioInfo.LoadBalance.UnitThreshold/5 then
-						WaitSeconds(0)
-						ScenarioInfo.LoadBalance.Accumulator = 0
-					end
-				end
-			end
-		end
+        for k, player in ScenarioInfo.HumanPlayers do
+            if 'GROUP' == tblData.type then
+                platoon = CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, tblData, platoon)
+                if not brain.IgnoreArmyCaps then
+                    SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+                end
+            else
+                unit = CreateUnitHPR( tblData.type,
+                                     strArmy,
+                                     tblData.Position[1], tblData.Position[2], tblData.Position[3],
+                                     tblData.Orientation[1], tblData.Orientation[2], tblData.Orientation[3]
+                                 )
+                if unit:GetBlueprint().Physics.FlattenSkirt then
+                    unit:CreateTarmac(true, true, true, false, false)
+                end                               
+                if ScenarioInfo.UnitNames[armyIndex] then
+                    ScenarioInfo.UnitNames[armyIndex][strName] = unit
+                end
+                unit.UnitName = strName
+                brain:AssignUnitsToPlatoon(platoon, {unit}, 'Attack', formation)
+                
+                if balance then
+                    ScenarioInfo.LoadBalance.Accumulator = ScenarioInfo.LoadBalance.Accumulator + 1
+                    
+                    if ScenarioInfo.LoadBalance.Accumulator > ScenarioInfo.LoadBalance.UnitThreshold/5 then
+                        WaitSeconds(0)
+                        ScenarioInfo.LoadBalance.Accumulator = 0
+                    end
+                end
+            end
+        end
     end
     if not brain.IgnoreArmyCaps then
         SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
@@ -911,9 +911,9 @@ end
 
 
 
-# CreateArmyGroupAsPlatoon
-#
-# Returns a platoon that is created out of all units in a group and its sub groups.
+-- CreateArmyGroupAsPlatoon
+--
+-- Returns a platoon that is created out of all units in a group and its sub groups.
 function CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, tblNode, platoon, balance)
     if ScenarioInfo.LoadBalance.Enabled then
         --note that tblNode in this case is actually the callback function
@@ -973,7 +973,7 @@ function CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, tblNode, platoon
     return platoon
 end
 
-# Creates an army group at a certain veteran level for coop
+-- Creates an army group at a certain veteran level for coop
 function CreateArmyGroupAsPlatoonCoopBalancedVeteran(strArmy, strGroup, formation, veteranLevel)
     local plat = CreateArmyGroupAsPlatoonCoopBalanced(strArmy, strGroup, formation)
     veteranLevel = veteranLevel or 5
@@ -983,7 +983,7 @@ function CreateArmyGroupAsPlatoonCoopBalancedVeteran(strArmy, strGroup, formatio
     return plat
 end  
 
-# Creates an army group at a certain veteran level
+-- Creates an army group at a certain veteran level
 function CreateArmyGroupAsPlatoonVeteran(strArmy, strGroup, formation, veteranLevel)
     local plat = CreateArmyGroupAsPlatoon(strArmy, strGroup, formation)
     veteranLevel = veteranLevel or 5
@@ -1006,9 +1006,9 @@ function FlattenTreeGroup( strArmy, strGroup, tblData, unitGroup )
     return unitGroup
 end
 
-# LoadArmyPBMBuilders
-#
-# Loads an Army Brain's PBM Builders from the save file
+-- LoadArmyPBMBuilders
+--
+-- Loads an Army Brain's PBM Builders from the save file
 function LoadArmyPBMBuilders(strArmy)
     local aiBrain = GetArmyBrain(strArmy)
     if Scenario.Armies[strArmy].PlatoonBuilders.Builders then
@@ -1121,21 +1121,21 @@ function SetPlans(strArmy)
 end
 
 function UpdateOSB(buildName, strArmy, builderData)
-#    local buildNameNew, location, globalName, childPart = SplitUpdateOSBName(buildName)
+--    local buildNameNew, location, globalName, childPart = SplitUpdateOSBName(buildName)
     local aiBrain = GetArmyBrain(strArmy)
-#    local amMasterName = 'OSB_Master_' .. globalName .. '_' .. strArmy
-#    if location then
-#        amMasterName = amMasterName .. '_' .. location
-#    end
-#
-#    # Find builder in brain
-#    local builderName = buildName
-#    builderName = builderName .. '_' .. strArmy
-#    if location then
-#        builderName = builderName .. '_' .. location
-#    end
-#    local found = false
-#    local builderEdit = false
+--    local amMasterName = 'OSB_Master_' .. globalName .. '_' .. strArmy
+--    if location then
+--        amMasterName = amMasterName .. '_' .. location
+--    end
+--
+--    -- Find builder in brain
+--    local builderName = buildName
+--    builderName = builderName .. '_' .. strArmy
+--    if location then
+--        builderName = builderName .. '_' .. location
+--    end
+--    local found = false
+--    local builderEdit = false
     for type, bTable in aiBrain.PBM.Platoons do
         for bCount, bData in bTable do
             local bName = bData.BuilderName
@@ -1147,7 +1147,7 @@ function UpdateOSB(buildName, strArmy, builderData)
 end
 
 function UpdateGivenOSB(builderEdit, builderData)
-    # Update data in builder in brain
+    -- Update data in builder in brain
     for dName, data in builderData.PlatoonData do
         if dName ~= 'PlatoonMultiplier' and dName ~= 'TransportCount' then
             builderEdit.PlatoonData[dName] = data
@@ -1246,7 +1246,7 @@ function LoadOSB(buildName, strArmy, builderData)
         local pData = RebuildDataTable(v.PlatoonData)
         spec.PlatoonData = {}
 
-        # Store builder name
+        -- Store builder name
         if location then
             spec.BuilderName = k .. '_' .. strArmy .. '_' .. location
             spec.PlatoonData.BuilderName = k .. '_' .. strArmy .. '_' .. location
@@ -1281,7 +1281,7 @@ function LoadOSB(buildName, strArmy, builderData)
             end
 
 
-            # Set priority
+            -- Set priority
             if builderData.Priority < 0 then
                 insert = false
                 spec.Priority = builderData.Priority
@@ -1299,7 +1299,7 @@ function LoadOSB(buildName, strArmy, builderData)
             end
             spec.PlatoonType = v.PlatoonType
 
-            # Set platoon template
+            -- Set platoon template
             if Scenario.Platoons['OST_' .. string.sub(spec.BuilderName, 5)] then
                 spec.PlatoonTemplate = FactionConvert(table.deepcopy(Scenario.Platoons['OST_' .. string.sub(spec.BuilderName, 5)]), factionIndex)
             elseif Scenario.Platoons[v.PlatoonTemplate] then
@@ -1334,20 +1334,20 @@ function LoadOSB(buildName, strArmy, builderData)
                 end
             end
 
-            # Set buildout to
+            -- Set buildout to
             if (v.BuildTimeOut and v.BuildTimeOut < 0 ) or ( spec.PlatoonTemplate[3] and spec.PlatoonTemplate[3][2] < 0 ) then
                 spec.GenerateTimeOut = true
             end
             spec.BuildTimeOut = v.BuildTimeOut
 
-            # Add AI Function to OSB global if needed
+            -- Add AI Function to OSB global if needed
             if string.sub(k, 1, 11) == 'OSB_Master_' and builderData.PlatoonAIFunction then
                 spec.PlatoonAIFunction = builderData.PlatoonAIFunction
             elseif v.PlatoonAIFunction then
                 spec.PlatoonAIFunction = v.PlatoonAIFunction
             end
 
-            # Add Build Conditions
+            -- Add Build Conditions
             spec.BuildConditions = {}
             if v.BuildConditions then
                 for num, bCond in v.BuildConditions do
@@ -1374,7 +1374,7 @@ function LoadOSB(buildName, strArmy, builderData)
                     table.insert(spec.BuildConditions, addCond)
                 end
             end
-            # Add build/form conditions to ALL builders
+            -- Add build/form conditions to ALL builders
             if builderData.BuildConditions then
                 for num, bCond in builderData.BuildConditions do
                     if bCond[3][1] == 'Remove' then
@@ -1408,7 +1408,7 @@ function LoadOSB(buildName, strArmy, builderData)
                     end
                 end
             end
-            # Check for faction specific builders
+            -- Check for faction specific builders
             for num, cond in spec.BuildConditions do
                 if cond[2] == 'FactionIndex' then
                     local params = {}
@@ -1420,19 +1420,19 @@ function LoadOSB(buildName, strArmy, builderData)
                 end
             end
 
-            # Add BuildCallbacks
+            -- Add BuildCallbacks
             spec.PlatoonBuildCallbacks = {}
             if v.PlatoonBuildCallbacks then
                 for num, pbCallback in v.PlatoonBuildCallbacks do
                     table.insert(spec.PlatoonBuildCallbacks, pbCallback)
                 end
             end
-            # Add DestroyCallbacks to Masters
+            -- Add DestroyCallbacks to Masters
             if builderData.PlatoonBuildCallbacks and string.sub(k,1,11) == 'OSB_Master_' then
                 FilterFunctions(spec.PlatoonBuildCallbacks, builderData.PlatoonBuildCallbacks)
             end
 
-            # Add AddFunctions (Har!)
+            -- Add AddFunctions (Har!)
             spec.PlatoonAddFunctions = {}
             if v.PlatoonAddFunctions then
                 for fNum, fData in v.PlatoonAddFunctions do
@@ -1444,7 +1444,7 @@ function LoadOSB(buildName, strArmy, builderData)
             end
 
 
-            # Masters
+            -- Masters
             if pData.AMMasterPlatoon and insert then
                 if string.sub(k,1,26) == 'OSB_Master_LeftoverCleanup' then
                     spec.PlatoonName = spec.LocationType..'_LeftoverUnits'
@@ -1452,7 +1452,7 @@ function LoadOSB(buildName, strArmy, builderData)
                     spec.PlatoonName = spec.BuilderName
                 end
 
-                # Add data to Masters
+                -- Add data to Masters
                 if builderData.PlatoonData and string.sub(k,1,11) == 'OSB_Master_' then
                     if aiBrain.AttackData['AttackManagerState'] ~= 'ACTIVE' then
                         aiBrain:InitializeAttackManager()
@@ -1473,17 +1473,17 @@ function LoadOSB(buildName, strArmy, builderData)
                     end
                 end
 
-                # Set if needed to draw from pool
+                -- Set if needed to draw from pool
                 if pData.UsePool ~= nil then
                     spec.UsePool = pData.UsePool
                 end
                 aiBrain:AMAddPlatoon(spec)
 
-                # Children
+                -- Children
             elseif insert then
                 spec.RequiresConstruction = v.RequiresConstruction
 
-                # Add spec to brain
+                -- Add spec to brain
                 spec.InstanceCount = v.InstanceCount
                 aiBrain:PBMAddPlatoon(spec)
             end
@@ -1528,7 +1528,7 @@ function FactionConvert(template, factionIndex)
 end
 
 function SplitUpdateOSBName(buildName)
-    # OSB_<bname>_location
+    -- OSB_<bname>_location
     local startCheck = 5
     local specificBuilder = false
     if string.sub(buildName, 1, 11) == 'OSB_Master_' then
@@ -1563,7 +1563,7 @@ function SplitUpdateOSBName(buildName)
 end
 
 function SplitOSBName(buildName)
-    # OSB_<bname>_location
+    -- OSB_<bname>_location
     local startCheck = 5
     local specificBuilder = false
     if string.sub(buildName, 1, 11) == 'OSB_Master_' then

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -532,8 +532,6 @@ function InitializeScenarioArmies()
 
         if tblData then
 
-            LOG('*DEBUG: InitializeScenarioArmies, army = ', strArmy)
-
             SetArmyEconomy( strArmy, tblData.Economy.mass, tblData.Economy.energy)
 
             if tblData.faction != nil then

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -62,7 +62,7 @@ end
 function ChainToPositions(chainName)
     local chain = Scenario.Chains[chainName]
     if not chain then
-        error('ERROR: Invalid Chain Named- ' .. chainName, 2)
+        error('ERROR: Invalid Chain Named- ' .. repr(chainName), 2)
     end
     local positionTable = {}
     for num, marker in chain.Markers do

--- a/lua/ui/game/avatars.lua
+++ b/lua/ui/game/avatars.lua
@@ -132,8 +132,9 @@ function CreateAvatar(unit)
 
     bg.icon = Bitmap(bg)
     LayoutHelpers.AtLeftTopIn(bg.icon, bg, 5, 5)
-    if DiskGetFileInfo('/textures/ui/common/icons/units/'..bg.Blueprint.BlueprintId..'_icon.dds') then
-        bg.icon:SetTexture('/textures/ui/common/icons/units/'..bg.Blueprint.BlueprintId..'_icon.dds')
+    local icon = UIUtil.UIFile('/icons/units/'..bg.Blueprint.BlueprintId..'_icon.dds')
+    if DiskGetFileInfo(icon) then
+        bg.icon:SetTexture(icon)
     else
         bg.icon:SetTexture(UIUtil.UIFile('/icons/units/default_icon.dds'))
     end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1494,7 +1494,7 @@ local function TryLaunch(stillAllowObservers, stillAllowLockedTeams, skipNoObser
         if totalPlayers == 1 and coopGame == false then
             valid = false
         end
-        if not allFFA and not moreThanOneTeam then
+        if not allFFA and not moreThanOneTeam and coopGame == false then
             valid = false
         end
         if not valid then

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1467,10 +1467,10 @@ local function TryLaunch(stillAllowObservers, stillAllowLockedTeams, skipNoObser
             lastTeam = player.Team
         end
     end
-
+    
     if gameInfo.GameOptions['Victory'] ~= 'sandbox' then
         local valid = true
-        if totalPlayers == 1 then
+        if totalPlayers == 1 and MapUtil.LoadScenario(gameInfo.GameOptions.ScenarioFile).type != "campaign_coop" then
             valid = false
         end
         if not allFFA and not moreThanOneTeam then

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -68,28 +68,28 @@ local teamIcons = {
 DebugEnabled = Prefs.GetFromCurrentProfile('LobbyDebug') or ''
 local HideDefaultOptions = Prefs.GetFromCurrentProfile('LobbyHideDefaultOptions') == 'true'
 function LOGX(text, ttype)
-	-- onlyChat = for debug only in the Chat
-	-- onlyLOG = for debug only in the LOG
-	-- CLEAR = for disable the debug
-	-- Country, RuleTitle, Background
-	-- Disconnected, Connecting, UpdateGame
-	local text = tostring(text)
-	local onlyLOG = string.find(DebugEnabled, 'onlyLOG') or nil
-	local onlyChat = string.find(DebugEnabled, 'onlyChat') or nil
-	if ttype == nil then
-		LOG(text)
-	else
-		if string.find(DebugEnabled, ttype) and ttype ~= nil then
-			if onlyLOG ~= nil then
-				LOG(text)
-			elseif onlyChat ~= nil then
-				AddChatText(text)
-			else
-				LOG(text)
-				AddChatText(text)
-			end
-		end
-	end
+    -- onlyChat = for debug only in the Chat
+    -- onlyLOG = for debug only in the LOG
+    -- CLEAR = for disable the debug
+    -- Country, RuleTitle, Background
+    -- Disconnected, Connecting, UpdateGame
+    local text = tostring(text)
+    local onlyLOG = string.find(DebugEnabled, 'onlyLOG') or nil
+    local onlyChat = string.find(DebugEnabled, 'onlyChat') or nil
+    if ttype == nil then
+        LOG(text)
+    else
+        if string.find(DebugEnabled, ttype) and ttype ~= nil then
+            if onlyLOG ~= nil then
+                LOG(text)
+            elseif onlyChat ~= nil then
+                AddChatText(text)
+            else
+                LOG(text)
+                AddChatText(text)
+            end
+        end
+    end
 end
 -- Table of Tooltip Country
 local PrefLanguageTooltipTitle={}
@@ -177,16 +177,16 @@ local function ParseWhisper(params)
 end
 
 local function LOGXWhisper(params)
-	-- Exemple : Country Background useChat'
-	if string.find(params, 'CLEAR') then
-		DebugEnabled = ''
-		Prefs.SetToCurrentProfile('LobbyDebug', '')
-		AddChatText('Debug disabled')
-	else
+    -- Exemple : Country Background useChat'
+    if string.find(params, 'CLEAR') then
+        DebugEnabled = ''
+        Prefs.SetToCurrentProfile('LobbyDebug', '')
+        AddChatText('Debug disabled')
+    else
         DebugEnabled = params
-		Prefs.SetToCurrentProfile('LobbyDebug', params)
-		AddChatText('Debug actived : '..params)
-	end
+        Prefs.SetToCurrentProfile('LobbyDebug', params)
+        AddChatText('Debug actived : '..params)
+    end
 end
 
 local commands = {
@@ -206,7 +206,7 @@ local commands = {
         key = 'whisper',
         action = ParseWhisper,
     },
-	{
+    {
         key = 'debug',
         action = LOGXWhisper,
     },
@@ -549,7 +549,7 @@ function CreateLobby(protocol, localPort, desiredPlayerName, localPlayerUID, nat
         GUI.slots = {}
 
         GUI.connectdialog = UIUtil.ShowInfoDialog(GUI, Strings.TryingToConnect, Strings.AbortConnect, ReturnToMenu)
-		GUI.connectdialog.Depth:Set(GetFrame(GUI:GetRootFrame():GetTargetHead()):GetTopmostDepth() + 999)
+        GUI.connectdialog.Depth:Set(GetFrame(GUI:GetRootFrame():GetTargetHead()):GetTopmostDepth() + 999)
 
         InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, natTraversalProvider)
 
@@ -579,11 +579,11 @@ end
 function ConnectToPeer(addressAndPort,name,uid)
     if not string.find(addressAndPort, '127.0.0.1') then
         LOG("ConnectToPeer (name=" .. name .. ", uid=" .. uid .. ", address=" .. addressAndPort ..")")
-		LOGX('>> ConnectToPeer > name='..tostring(name), 'Connecting')
+        LOGX('>> ConnectToPeer > name='..tostring(name), 'Connecting')
     else
         DisconnectFromPeer(uid)
         LOG("ConnectToPeer (name=" .. name .. ", uid=" .. uid .. ", address=" .. addressAndPort ..", USE PROXY)")
-		LOGX('>> ConnectToPeer > name='..tostring(name)..' (with PROXY)', 'Connecting')
+        LOGX('>> ConnectToPeer > name='..tostring(name)..' (with PROXY)', 'Connecting')
         table.insert(ConnectedWithProxy, uid)
     end
     lobbyComm:ConnectToPeer(addressAndPort,name,uid)
@@ -594,7 +594,7 @@ function DisconnectFromPeer(uid)
     if wasConnected(uid) then
         table.remove(connectedTo, uid)
     end
-	LOGX('>> DisconnectFromPeer > name='..tostring(FindNameForID(uid)), 'Disconnected')
+    LOGX('>> DisconnectFromPeer > name='..tostring(FindNameForID(uid)), 'Disconnected')
     GpgNetSend('Disconnected', string.format("%d", uid))
     lobbyComm:DisconnectFromPeer(uid)
 end
@@ -671,11 +671,11 @@ end
 
 -- update the data in a player slot
 function SetSlotInfo(slot, playerInfo)
-	if (GUI.connectdialog ~= false) then -- Remove the ConnectDialog
-		GUI.connectdialog:Destroy()
-		GUI.connectdialog = false
-	end
-	local isLocallyOwned = IsLocallyOwned(slot)
+    if (GUI.connectdialog ~= false) then -- Remove the ConnectDialog
+        GUI.connectdialog:Destroy()
+        GUI.connectdialog = false
+    end
+    local isLocallyOwned = IsLocallyOwned(slot)
     if isLocallyOwned then
         if gameInfo.PlayerOptions[slot]['Ready'] then
             DisableSlot(slot, true)
@@ -1642,7 +1642,7 @@ local function TryLaunch(stillAllowObservers, stillAllowLockedTeams, skipNoObser
         if coopGame == true then
             gameInfo.GameOptions['Difficulty'] = 3
             
-    		scenarioArmies = {}
+            scenarioArmies = {}
             for index, teamConfig in scenarioInfo.Configurations.standard.teams do
                 if teamConfig.name and (teamConfig.name == 'FFA') then
                     scenarioArmies =teamConfig.armies
@@ -2173,7 +2173,7 @@ function HostTryAddPlayer(senderID, slot, requestedPlayerName, human, aiPersonal
     if newSlot == -1 then
         PrivateChat( senderID, LOC("<LOC lobui_0237>No slots available, attempting to make you an observer"))
         if human then
-			HostTryAddObserver( senderID, requestedPlayerName, requestedPL, requestedColor, requestedFaction, requestedCOUNTRY )
+            HostTryAddObserver( senderID, requestedPlayerName, requestedPL, requestedColor, requestedFaction, requestedCOUNTRY )
         end
         return
     end
@@ -2291,14 +2291,14 @@ function HostTryAddObserver( senderID, requestedObserverName, RequestedPL, Reque
     end
 
     LOGX('>> HostTryAddObserver > requestedObserverName='..tostring(requestedObserverName), 'Connecting')
-	local observerName = lobbyComm:MakeValidPlayerName(senderID,requestedObserverName)
+    local observerName = lobbyComm:MakeValidPlayerName(senderID,requestedObserverName)
     gameInfo.Observers[index] = {
         PlayerName = observerName,
         OwnerID = senderID,
-		PL = RequestedPL,
-		oldColor = RequestedColor,
+        PL = RequestedPL,
+        oldColor = RequestedColor,
         oldFaction = RequestedFaction,
-		oldCountry= RequestedCOUNTRY,
+        oldCountry= RequestedCOUNTRY,
     }
 
     lobbyComm:BroadcastData(
@@ -4215,8 +4215,8 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
 
         if wantToBeObserver then
             -- Ok, I'm connected to the host. Now request to become an observer
-            lobbyComm:SendData( hostID, { Type = 'AddObserver', RequestedObserverName = localPlayerName, RequestedPL = playerRating, RequestedColor = Prefs.GetFromCurrentProfile('LastColor'), RequestedFaction = requestedFaction, RequestedCOUNTRY = argv.PrefLanguage, } )
-			LOGX('>> ConnectionToHostEstablished//SendData//playerRating='..tostring(playerRating), 'Connecting')
+            lobbyComm:SendData( hostID, { Type = 'AddObserver', RequestedObserverName = localPlayerName, RequestedPL = playerRating, RequestedColor = Prefs.GetFromCurrentProfile('LastColor'), RequestedFaction = requestedFaction, RequestedCOUNTRY = PrefLanguage, } )
+            LOGX('>> ConnectionToHostEstablished//SendData//playerRating='..tostring(playerRating), 'Connecting')
         else
             -- Ok, I'm connected to the host. Now request to become a player
             local requestedFaction = Prefs.GetFromCurrentProfile('LastFaction')
@@ -4292,7 +4292,7 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
             AddChatText("<<"..data.SenderName..">> "..data.Text)
             --// RULE TITLE
         elseif data.Type == 'Rule_Title_MSG' then
-			LOGX('>> RECEIVE MSG Rule_Title_MSG : result='..data.Result1..' result2='..data.Result2, 'RuleTitle')
+            LOGX('>> RECEIVE MSG Rule_Title_MSG : result='..data.Result1..' result2='..data.Result2, 'RuleTitle')
             RuleTitle_SetText(data.Result1 or "", data.Result2 or "")
             --\\ Stop RULE TITLE
             -- CPU benchmark code
@@ -4371,7 +4371,7 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
                 GUI.becomeObserver:Enable()
                 SetPlayerOption(FindSlotForID(FindIDForName(localPlayerName)), 'Ready', false)
             elseif data.Type == 'Peer_Really_Disconnected' then
-				LOGX('>> DATA RECEIVE : Peer_Really_Disconnected (slot:'..data.Slot..')', 'Disconnected')
+                LOGX('>> DATA RECEIVE : Peer_Really_Disconnected (slot:'..data.Slot..')', 'Disconnected')
                 if data.Options.OwnerID == localPlayerID then
                     lobbyComm:SendData( hostID, {Type = "GetGameInfo"} )
                 else
@@ -4597,7 +4597,7 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
     end
 
     lobbyComm.PeerDisconnected = function(self,peerName,peerID) -- Lost connection or try connect with proxy
-		LOGX('>> PeerDisconnected : peerName='..peerName..' peerID='..peerID, 'Disconnected')
+        LOGX('>> PeerDisconnected : peerName='..peerName..' peerID='..peerID, 'Disconnected')
         
          -- Search and Remove the peer disconnected
         for k, v in CurrentConnection do
@@ -5234,7 +5234,7 @@ function ChangeBackgroundLobby(faction)
     local LobbyBackground = Prefs.GetFromCurrentProfile('LobbyBackground') or 1
     if GUI.background and GUI.background2 then
         if LobbyBackground == 1 then -- Factions
-			LOGX('>> Background FACTION', 'Background')
+            LOGX('>> Background FACTION', 'Background')
             GUI.background:Show()
             GUI.background2:Hide()
             faction = faction or Prefs.GetFromCurrentProfile('LastFaction') or 0
@@ -5246,13 +5246,13 @@ function ChangeBackgroundLobby(faction)
             end
 
         elseif LobbyBackground == 2 then -- Concept art
-			LOGX('>> Background ART', 'Background')
+            LOGX('>> Background ART', 'Background')
             GUI.background:Show()
             GUI.background2:Hide()
             GUI.background:SetTexture("/textures/ui/common/BACKGROUND/art/art-background-paint0"..math.random(1, 5).."_bmp.dds")
 
         elseif LobbyBackground == 3 then -- Screenshot
-			LOGX('>> Background SCREENSHOT', 'Background')
+            LOGX('>> Background SCREENSHOT', 'Background')
             GUI.background:Show()
             GUI.background2:Hide()
             GUI.background:SetTexture("/textures/ui/common/BACKGROUND/scrn/scrn-background-paint"..math.random(1, 14).."_bmp.dds")
@@ -5332,24 +5332,25 @@ function CreateOptionLobbyDialog()
         Prefs.SetToCurrentProfile("LobbyBackground", index)
         ChangeBackgroundLobby()
     end
-	--
-	local Slider = import('/lua/maui/slider.lua').Slider
-	local currentFontSize = Prefs.GetFromCurrentProfile('LobbyChatFontSize') or 14
-	local slider_Chat_SizeFont_TEXT = UIUtil.CreateText(dialog2, LOC("<LOC lobui_0404> ").. currentFontSize, 14, 'Arial', true)
+    --
+    local Slider = import('/lua/maui/slider.lua').Slider
+    local currentFontSize = Prefs.GetFromCurrentProfile('LobbyChatFontSize') or 14
+    local slider_Chat_SizeFont_TEXT = UIUtil.CreateText(dialog2, LOC("<LOC lobui_0404> ").. currentFontSize, 14, 'Arial', true)
     LayoutHelpers.AtRightTopIn(slider_Chat_SizeFont_TEXT, dialog2, 27, 136)
 
-	local slider_Chat_SizeFont = Slider(dialog2, false, 9, 18, UIUtil.SkinnableFile('/slider02/slider_btn_up.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_over.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_down.dds'), UIUtil.SkinnableFile('/slider02/slider-back_bmp.dds'))
+    local slider_Chat_SizeFont = Slider(dialog2, false, 9, 18, UIUtil.SkinnableFile('/slider02/slider_btn_up.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_over.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_down.dds'), UIUtil.SkinnableFile('/slider02/slider-back_bmp.dds'))
     LayoutHelpers.AtRightTopIn(slider_Chat_SizeFont, dialog2, 20, 156)
     slider_Chat_SizeFont:SetValue(currentFontSize)
 
-	slider_Chat_SizeFont.OnValueChanged = function(self, newValue)
+    slider_Chat_SizeFont.OnValueChanged = function(self, newValue)
         local sliderValue = math.floor(slider_Chat_SizeFont._currentValue())
         slider_Chat_SizeFont_TEXT:SetText(LOC("<LOC lobui_0404> ").. sliderValue)
         GUI.chatDisplay:SetFont(UIUtil.bodyFont, sliderValue)
         Prefs.SetToCurrentProfile('LobbyChatFontSize', sliderValue)
 	end
-	--
+
     local cbox_WindowedLobby = UIUtil.CreateCheckboxStd(dialog2, '/CHECKBOX/', LOC("<LOC lobui_0402>"))
+
     LayoutHelpers.AtRightTopIn(cbox_WindowedLobby, dialog2, 20, 42)
     Tooltip.AddCheckboxTooltip(cbox_WindowedLobby, {text='Windowed mode', body=LOC("<LOC lobui_0403>")})
     cbox_WindowedLobby.OnCheck = function(self, checked)
@@ -5394,7 +5395,7 @@ function CreateOptionLobbyDialog()
 		-- Already set Windowed in Game
 		cbox_WindowedLobby:Disable()
 	end
-    --
+
     local LobbyBackgroundStretch = Prefs.GetFromCurrentProfile('LobbyBackgroundStretch') or 'true'
     cbox_StretchBG:SetCheck(LobbyBackgroundStretch == 'true', true)
 end
@@ -5632,9 +5633,9 @@ function GUI_PRESET_INPUT(tyype)
     LayoutHelpers.AtBottomIn(ExitButton, GUI_Preset_InputBox2, 10)
     ExitButton.OnClick = function(self)
         GUI_Preset_InputBox:Destroy()
-		if tyype == -1 then
-			GUI_Preset:Destroy()
-		end
+        if tyype == -1 then
+            GUI_Preset:Destroy()
+        end
     end
 
     -- Ok button
@@ -6042,16 +6043,16 @@ end
 
 -- Changelog dialog
 function Need_Changelog()
-	local Changelog = import('/lua/ui/lobby/changelog.lua').changelog
-	local Last_Changelog_Version = Prefs.GetFromCurrentProfile('LobbyChangelog') or 0
-	local result = false
-	for i, d in Changelog do
-		if Last_Changelog_Version < d.version then
-			result = true
-			break
-		end
-	end
-	return result
+    local Changelog = import('/lua/ui/lobby/changelog.lua').changelog
+    local Last_Changelog_Version = Prefs.GetFromCurrentProfile('LobbyChangelog') or 0
+    local result = false
+    for i, d in Changelog do
+        if Last_Changelog_Version < d.version then
+            result = true
+            break
+        end
+    end
+    return result
 end
 
 function GUI_Changelog()
@@ -6077,29 +6078,29 @@ function GUI_Changelog()
     InfoList.Width:Set(498)
     InfoList.Height:Set(260)
     LayoutHelpers.AtLeftIn(InfoList, dialog2, 10)
-	LayoutHelpers.AtRightIn(InfoList, dialog2, 26)
+    LayoutHelpers.AtRightIn(InfoList, dialog2, 26)
     LayoutHelpers.AtTopIn(InfoList, dialog2, 38)
     UIUtil.CreateLobbyVertScrollbar(InfoList)
-	InfoList.OnClick = function(self)
-	end
-	-- See only new Changelog by version
-	local Changelog = import('/lua/ui/lobby/changelog.lua')
-	local Last_Changelog_Version = Prefs.GetFromCurrentProfile('LobbyChangelog') or 0
-	for i, d in Changelog.changelog do
-		if Last_Changelog_Version < d.version then
-			InfoList:AddItem(d.name)
-			for k, v in d.description do
-				InfoList:AddItem(v)
-			end
-			InfoList:AddItem('')
-		end
-	end
+    InfoList.OnClick = function(self)
+    end
+    -- See only new Changelog by version
+    local Changelog = import('/lua/ui/lobby/changelog.lua')
+    local Last_Changelog_Version = Prefs.GetFromCurrentProfile('LobbyChangelog') or 0
+    for i, d in Changelog.changelog do
+        if Last_Changelog_Version < d.version then
+            InfoList:AddItem(d.name)
+            for k, v in d.description do
+                InfoList:AddItem(v)
+            end
+            InfoList:AddItem('')
+        end
+    end
     -- OK button --
     local OkButton = UIUtil.CreateButtonWithDropshadow(dialog2, '/BUTTON/medium/', "Ok")
-	LayoutHelpers.AtLeftIn(OkButton, dialog2, 0)
+    LayoutHelpers.AtLeftIn(OkButton, dialog2, 0)
     LayoutHelpers.AtBottomIn(OkButton, dialog2, 10)
     OkButton.OnClick = function(self)
         Prefs.SetToCurrentProfile('LobbyChangelog', Changelog.last_version)
-		GROUP_Changelog:Destroy()
+        GROUP_Changelog:Destroy()
     end
 end

--- a/lua/ui/maputil.lua
+++ b/lua/ui/maputil.lua
@@ -1,0 +1,229 @@
+--*****************************************************************************
+--* File: lua/modules/ui/maputil.lua
+--* Author: Chris Blackwell
+--* Summary: Functions for loading maps and map info
+--*
+--* Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+--*****************************************************************************
+
+-- this table indicates the order prefixes will be sorted in the map select window
+local defaultPrefixOrder = {
+    scmp = 1,
+    scca = 2,
+    map = 3,
+    demo = 4,
+    art = 5,
+    test = 6,
+    dev = 7,
+}
+
+-- load a scenario based on a scenario file name
+function LoadScenario(scenName)
+    -- TODO - expose FILE_IsAbsolute and if it's not, add the path and the _scenario.lua
+
+    if not DiskGetFileInfo(scenName) then
+        return nil
+    end
+
+    local env = {}
+    doscript('/lua/dataInit.lua', env)
+    doscript(scenName, env)
+
+    if not env.ScenarioInfo then
+        return nil
+    end
+
+    # Backward compatibility
+    if env.version == 1 then
+        local temp = env
+        env = {
+            ScenarioInfo = temp,
+        }
+    end
+
+    local optionsFileName = string.sub(scenName, 1, string.len(scenName) - string.len("scenario.lua")) .. "options.lua"
+    if DiskGetFileInfo(optionsFileName) then
+        local optionsEnv = {}
+        doscript(optionsFileName, optionsEnv)
+        if optionsEnv.options != nil then
+            env.ScenarioInfo.options = optionsEnv.options
+        end
+    end
+    
+    env.ScenarioInfo.file = scenName -- stuff the file name in so we have that
+    return env.ScenarioInfo
+end
+
+-- the default scenario enumerator sort method
+local function DefaultScenarioSorter(compa, compb)
+    local tSize = table.getsize(defaultPrefixOrder)
+
+    -- checks the prefix and returns a sort order if found
+    local function Classify(str)
+        for prefix, value in defaultPrefixOrder do
+            if string.find(string.lower(str), string.lower(prefix), 1, true) == 1 then   -- do a plain pattern match, a bit faster as no magic chars
+                return value    -- found it at position 1, return the compare value
+            end
+        end
+        return tSize + 1    -- if not found, return table size + 1 to get sorted to bottom
+    end
+
+    local aval = Classify(compa)
+    local bval = Classify(compb)
+
+    -- if class is equal, just do a string sort, otherwise use the sore val
+    if aval == bval then
+        return compa < compb
+    else
+        return aval < bval
+    end
+end
+
+-- given a scenario, determines if it can be played in skirmish mode
+function IsScenarioPlayable(scenario)
+    if not scenario.Configurations.standard.teams[1].armies then
+        return false
+    end
+
+    return true
+end
+
+-- EnumerateScenarios returns an array of scenario names
+--  nameFilter can be passed in to narrow the enumaration, for example
+--      EnumerateScenarios("SCMP*") will find all maps that start with SCMP
+--      if nameFilter is nil, all maps will be returned
+--  sortFunc is a function which, given two scenario names, will return true for the file name to come first
+--      if no sortFunc is defined the default sorter will be used
+function EnumerateSkirmishScenarios(nameFilter, sortFunc)
+    nameFilter = nameFilter or '*'
+    sortFunc = sortFunc or DefaultScenarioSorter
+
+    -- retrieve the map file names
+    local scenFiles = DiskFindFiles('/maps', nameFilter .. '_scenario.lua')
+
+    -- load each map in to a table and store in our data structure
+    local scenarios = {}
+    for index, fileName in scenFiles do
+        local scen = LoadScenario(fileName)
+        if IsScenarioPlayable(scen) and scen.type == "skirmish" then
+            table.insert(scenarios, scen)
+        end
+    end
+
+    -- sort based on name
+    table.sort(scenarios, function(a, b) return sortFunc(a.name, b.name) end)
+
+    return scenarios
+end
+
+function EnumerateCampaignScenarios(nameFilter, sortFunc)
+    nameFilter = nameFilter or '*'
+    sortFunc = sortFunc or DefaultScenarioSorter
+
+    -- retrieve the map file names
+    local scenFiles = DiskFindFiles('/maps', nameFilter .. '_scenario.lua')
+
+    -- load each map in to a table and store in our data structure
+    local scenarios = {}
+    for index, fileName in scenFiles do
+        local scen = LoadScenario(fileName)
+        if IsScenarioPlayable(scen) and scen.type == "campaign_coop" then
+            table.insert(scenarios, scen)
+        end
+    end
+
+    -- sort based on name
+    table.sort(scenarios, function(a, b) return sortFunc(a.name, b.name) end)
+
+    return scenarios
+end
+
+-- given a scenario table, loads the save file and puts all the start positions in a table
+-- I've made this function so it works with the old data format and the new
+-- Returning an empty table means scenario data was ill formed
+function GetStartPositions(scenario)
+    local saveData = {}
+    doscript('/lua/dataInit.lua', saveData)
+    doscript(scenario.save, saveData)
+
+    local armyPositions = {}
+
+    -- try new data first
+    if scenario.Configurations.standard and scenario.Configurations.standard.teams then
+        -- find the "FFA" team
+        for index, teamConfig in scenario.Configurations.standard.teams do
+            if teamConfig.name and (teamConfig.name == 'FFA') then
+                for armyIndex, armyName in teamConfig.armies do
+                    armyPositions[armyName] = {}
+                end
+                break
+            end
+        end
+        if table.getsize(armyPositions) == 0 then
+            WARN("Unable to find FFA configuration in " .. scenario.file)
+        end
+    end
+
+    -- try old data if nothing added to army positions
+    if table.getsize(armyPositions) == 0 then
+        -- figure out all the armies in this map
+        -- make sure old data is there
+        if scenario.Games then
+            for index, game in scenario.Games do
+                for k, army in game do
+                    armyPositions[army] = {}
+                end
+            end
+        end
+    end
+
+    -- if we found armies, then get the positions
+    if table.getsize(armyPositions) > 0 then
+        for army, position in armyPositions do
+            if saveData.Scenario.MasterChain['_MASTERCHAIN_'].Markers[army] then
+                pos = saveData.Scenario.MasterChain['_MASTERCHAIN_'].Markers[army].position
+                -- x and z value are of interest so ignore y (index 2)
+                position[1] = pos[1]
+                position[2] = pos[3]
+            else
+                WARN("No initial position marker for army " .. army .. " found in " .. scenario.save)
+                position[1] = 0
+                position[2] = 0
+            end
+        end
+    else
+        WARN("No start positions defined in " .. scenario.file)
+    end
+
+    return armyPositions
+end
+
+-- enumerates and returns to key name for all the armies for this map
+function GetArmies(scenario)
+    local retArmies = nil
+
+    if scenario.Configurations.standard and scenario.Configurations.standard.teams then
+        -- find the "FFA" team
+        for index, teamConfig in scenario.Configurations.standard.teams do
+            if teamConfig.name and (teamConfig.name == 'FFA') then
+                retArmies = teamConfig.armies
+            end
+            break
+        end
+    end
+
+    if (retArmies == nil) or (table.getn(retArmies) == 0) then
+        WARN("No starting armies defined in " .. scenario.file)
+    end
+
+    return retArmies
+end
+function GetExtraArmies(scenario)
+    if scenario.Configurations.standard and scenario.Configurations.standard.teams then
+        local teams = scenario.Configurations.standard.teams
+        if teams.ExtraArmies then
+            local armies = STR_GetTokens(teams.ExtraArmies,' ')
+            return armies
+        end
+    end
+end

--- a/lua/ui/maputil.lua
+++ b/lua/ui/maputil.lua
@@ -105,7 +105,7 @@ function EnumerateSkirmishScenarios(nameFilter, sortFunc)
     local scenarios = {}
     for index, fileName in scenFiles do
         local scen = LoadScenario(fileName)
-        if IsScenarioPlayable(scen) and scen.type == "skirmish" then
+        if IsScenarioPlayable(scen) and (scen.type == "skirmish" or scen.type == "campaign_coop") then
             table.insert(scenarios, scen)
         end
     end

--- a/lua/ui/maputil.lua
+++ b/lua/ui/maputil.lua
@@ -186,7 +186,6 @@ function GetStartPositions(scenario)
                 position[1] = pos[1]
                 position[2] = pos[3]
             else
-                WARN("No initial position marker for army " .. army .. " found in " .. scenario.save)
                 position[1] = 0
                 position[2] = 0
             end

--- a/lua/ui/maputil.lua
+++ b/lua/ui/maputil.lua
@@ -33,7 +33,7 @@ function LoadScenario(scenName)
         return nil
     end
 
-    # Backward compatibility
+    -- Backward compatibility
     if env.version == 1 then
         local temp = env
         env = {


### PR DESCRIPTION
This is the first step on the road to my proposed handling of Coop Mode and featured mods: Kill them. Coop mode can be done better as I'm about to lay out here, and mods should always have remained mods.

This code is the first step on allowing the normal game lobby to be able to launch the coop maps. There is no reason to have coop use a file system different to that of normal FAF, which only leads to update issues like we've seen recently, and to coop branch being left behind in terms of features and exploits.

This currently allows coop maps to launch, play the starting movie, and get to an active game state.

THERE WILL BE BUGS. We need to play through every mission using cheats, completing all objectives, as every faction in order to flush out as many as possible. The bugs may well be with the maps themselves, as all the actual campaign data is stored there and they may be making bad function calls. Thankfully, we can easily edit the maps too. 

Ultimately, I'd like to see the Coop tab launch buttons in the client simply direct to the normal FAF branch, download the appropriate map, etc etc. The end user should see no difference at all, other than a total lack of bugs relative to normal FAF, and the fact that the coop maps will be visible and launchable from their normal custom games too. If they choose to do that, the only difference will be that their game time etc won't be reported to the leaderboards, however that works. I'd also like to see all the maps renamed to something sensible at some point, so people can find them. 