### PR TITLE
Making UI prefetch more aggressive

### DIFF
--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -222,7 +222,9 @@ function CreateUI(isReplay)
     end
 
     Prefetcher:Update(prefetchTable)
-
+    -- UI assets should be loaded fast into memory to prevent stutter
+    ConExecute('res_AfterPrefetchDelay 100')
+    ConExecute('res_PrefetcherActivityDelay 1')
 
     ##below added for FAF
     import("/modules/displayrings.lua").Init()	##added for acu and engineer build radius ui mod


### PR DESCRIPTION
Prefetch is currently only used for UI textures, these should be loaded as fast as possible to prevent stutter. Currently the prefetcher pauses for 3 seconds every time there is disk load (which is constantly due to replay / log saving).

This patch makes the asset load much faster into memory.

The prefetcher never release memory anyway so this won't change total memory usage, it just makes sure the textures end up faster into memory. 