### PR TITLE
Cleanup the mechanism for setting default options

### DIFF
--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -730,7 +730,7 @@ function SetupOptionsPanel(parent, singlePlayer, curOptions)
                 if data.data.default then realDefValue = data.data.default end
                 line.combo:AddItems(itemArray, defValue, realDefValue, true) -- For all (true for enable (default) label)
                 line.combo.OnClick = function(self, index, text)
-                    changedOptions[data.data.key] = {value = data.data.values[index].key, pref = data.data.pref, index = index}
+                    changedOptions[data.data.key] = {value = data.data.values[index].key, index = index}
                     if line.combo.EnableColor then
                         line.combo._text:SetColor('DBBADB')
                     end

--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -3,7 +3,7 @@
 --* Author: Chris Blackwell
 --* Summary: Dialog to facilitate map selection
 --*
---* Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--* Copyright ï¿½ 2005 Gas Powered Games, Inc.  All rights reserved.
 --*****************************************************************************
 
 local UIUtil = import('/lua/ui/uiutil.lua')
@@ -23,9 +23,7 @@ local Mods = import('/lua/mods.lua')
 local Combo = import('/lua/ui/controls/combo.lua').Combo
 local Tooltip = import('/lua/ui/game/tooltip.lua')
 local ModManager = import('/lua/ui/dialogs/modmanager.lua')
-###New local - Start
 local EnhancedLobby = import('/lua/EnhancedLobby.lua')
-###New local - End
 
 local scenarios = MapUtil.EnumerateSkirmishScenarios()
 local selectedScenario = false
@@ -45,10 +43,8 @@ local currentFilters = {
     ['map_select_size'] = 0,
     ['map_select_supportedplayers_limiter'] = "equal",
     ['map_select_size_limiter'] = "equal",
-	['map_type'] = 0,
-	###New - Start
-	['map_ai_markers'] = 0,
-	###New - End
+    ['map_type'] = 0,
+    ['map_ai_markers'] = 0,
 }
 
 local scenarioKeymap = {}
@@ -72,10 +68,10 @@ mapFilters = {
             {text = "<LOC MAPSEL_0015>6", key = 6},
             {text = "<LOC MAPSEL_0016>7", key = 7},
             {text = "<LOC MAPSEL_0017>8", key = 8},
-			{text = "<LOC lobui_0714>9", key = 9},
-			{text = "<LOC lobui_0715>10", key = 10},
-			{text = "<LOC lobui_0716>11", key = 11},
-			{text = "<LOC lobui_0717>12", key = 12},
+            {text = "<LOC lobui_0714>9", key = 9},
+            {text = "<LOC lobui_0715>10", key = 10},
+            {text = "<LOC lobui_0716>11", key = 11},
+            {text = "<LOC lobui_0717>12", key = 12},
         }
     },
     {
@@ -93,25 +89,23 @@ mapFilters = {
     {
         FilterName = "<LOC lobui_0575>Map Type",
         FilterKey = 'map_type',
-		NoDelimiter = true,
+        NoDelimiter = true,
         Options = {
-			{text = "<LOC MAPSEL_0025>All", key = 0},
+            {text = "<LOC MAPSEL_0025>All", key = 0},
             {text = "<LOC lobui_0576>Official", key = 1},
             {text = "<LOC lobui_0577>Custom", key = 2},
         }
     },
-	###New mapFilters - Start
-	{
+    {
         FilterName = "<LOC lobui_0585>AI Markers",
         FilterKey = 'map_ai_markers',
-		NoDelimiter = true,
+        NoDelimiter = true,
         Options = {
-			{text = "<LOC MAPSEL_0025>All", key = 0},
+            {text = "<LOC MAPSEL_0025>All", key = 0},
             {text = "<LOC lobui_0587>Yes", key = 1},
             {text = "<LOC lobui_0588>No", key = 2},
         }
     },
-	###New mapFilters - End
 }
 
 -- Create a filter dropdown and title from the table above
@@ -145,28 +139,28 @@ function CreateFilter(parent, filterData)
     end
 
     if not filterData.NoDelimiter then
-		group.comboFilter = Combo(group, 14, 10, nil, nil, "UI_Tab_Click_01", "UI_Tab_Rollover_01")
-		LayoutHelpers.AtVerticalCenterIn(group.comboFilter, group.title)
-		group.comboFilter.Right:Set(function() return group.combo.Left() - 5 end)
-		group.comboFilter.Width:Set(60)
+        group.comboFilter = Combo(group, 14, 10, nil, nil, "UI_Tab_Click_01", "UI_Tab_Rollover_01")
+        LayoutHelpers.AtVerticalCenterIn(group.comboFilter, group.title)
+        group.comboFilter.Right:Set(function() return group.combo.Left() - 5 end)
+        group.comboFilter.Width:Set(60)
 
-		local filterArray = {
-			{text = "=", key = "equal"},
-			{text = ">=", key = "greater"},
-			{text = "<=", key = "less"}}
-		local tempText = {}
-		group.comboFilter.keyMap = {}
-		for index, val in filterArray do
-			tempText[index] = val.text
-			group.comboFilter.keyMap[index] = val.key
-		end
-		group.comboFilter.Key = filterData.FilterKey.."_limiter"
-		group.comboFilter:AddItems(tempText, 1)
+        local filterArray = {
+            {text = "=", key = "equal"},
+            {text = ">=", key = "greater"},
+            {text = "<=", key = "less"}}
+        local tempText = {}
+        group.comboFilter.keyMap = {}
+        for index, val in filterArray do
+            tempText[index] = val.text
+            group.comboFilter.keyMap[index] = val.key
+        end
+        group.comboFilter.Key = filterData.FilterKey.."_limiter"
+        group.comboFilter:AddItems(tempText, 1)
 
-		group.comboFilter.OnClick = function(self, index, text)
-			currentFilters[self.Key] = self.keyMap[index]
-			PopulateMapList()
-		end
+        group.comboFilter.OnClick = function(self, index, text)
+            currentFilters[self.Key] = self.keyMap[index]
+            PopulateMapList()
+        end
     end
 
     group.Height:Set(group.title.Height())
@@ -180,8 +174,8 @@ local function ResetFilters()
         ['map_select_size'] = 0,
         ['map_select_supportedplayers_limiter'] = "equal",
         ['map_select_size_limiter'] = "equal",
-		['map_type'] = 0,
-		['map_ai_markers'] = 0,
+        ['map_type'] = 0,
+        ['map_ai_markers'] = 0,
     }
     changedOptions = {}
     selectedScenario = nil
@@ -218,25 +212,23 @@ local function ShowMapPositions(mapCtrl, scenario)
     end
 end
 
---function to check if the map is a official map
 function CheckMapIsOfficial(scenario)
-	local mapsList = {'Burial Mounds', 'Concord Lake', "Drake's Ravine", 'Emerald Crater', "Gentleman's Reef", "Ian's Cross", 'Open Palms', 'Seraphim Glaciers',
-		"Seton's Clutch", 'Sung Island', 'The Great Void', 'Theta Passage', 'Winter Duel', 'The Bermuda Locket', 'Fields of Isis', 'Canis River', 'Syrtis Major',
-		'Sentry Point', "Finn's Revenge", 'Roanoke Abyss', 'Alpha 7 Quarantine', 'Arctic Refuge', 'Varga Pass', 'Crossfire Canal', 'Saltrock Colony',
-		'Vya-3 Protectorate', 'The Scar', 'Hanna Oasis', 'Betrayal Ocean', 'Frostmill Ruins', 'Four-Leaf Clover', 'The Wilderness', 'White Fire', 'High Noon',
-		'Paradise', 'Blasted Rock', 'Sludge', 'Ambush Pass', 'Four-Corners', 'The Ditch', 'Crag Dunes', "Williamson's Bridge", 'Snoey Triangle', 'Haven Reef',
-		'The Dark Heart', "Daroza's Sanctuary", 'Strip Mine', 'Thawing Glacier', 'Liberiam Battles', 'Shards', 'Shuriken Island', 'Debris', 'Flooded Strip Mine', 'Eye of the Storm'}
-	for i, map in mapsList do
-		if scenario.name == map then
-			return true
-		end
-	end
-	return false
+    local mapsList = {'Burial Mounds', 'Concord Lake', "Drake's Ravine", 'Emerald Crater', "Gentleman's Reef", "Ian's Cross", 'Open Palms', 'Seraphim Glaciers',
+        "Seton's Clutch", 'Sung Island', 'The Great Void', 'Theta Passage', 'Winter Duel', 'The Bermuda Locket', 'Fields of Isis', 'Canis River', 'Syrtis Major',
+        'Sentry Point', "Finn's Revenge", 'Roanoke Abyss', 'Alpha 7 Quarantine', 'Arctic Refuge', 'Varga Pass', 'Crossfire Canal', 'Saltrock Colony',
+        'Vya-3 Protectorate', 'The Scar', 'Hanna Oasis', 'Betrayal Ocean', 'Frostmill Ruins', 'Four-Leaf Clover', 'The Wilderness', 'White Fire', 'High Noon',
+        'Paradise', 'Blasted Rock', 'Sludge', 'Ambush Pass', 'Four-Corners', 'The Ditch', 'Crag Dunes', "Williamson's Bridge", 'Snoey Triangle', 'Haven Reef',
+        'The Dark Heart', "Daroza's Sanctuary", 'Strip Mine', 'Thawing Glacier', 'Liberiam Battles', 'Shards', 'Shuriken Island', 'Debris', 'Flooded Strip Mine', 'Eye of the Storm'}
+    for i, map in mapsList do
+        if scenario.name == map then
+            return true
+        end
+    end
+    return false
 end
---end
 
 function CreateDialog(selectBehavior, exitBehavior, over, singlePlayer, defaultScenarioName, curOptions, availableMods, OnModsChanged)
--- control layout
+    -- control layout
     local parent = nil
     local background = nil
     if over then
@@ -277,7 +269,7 @@ function CreateDialog(selectBehavior, exitBehavior, over, singlePlayer, defaultS
     Tooltip.AddButtonTooltip(modButton, "Lobby_Mods")
     modButton.OnClick = function(self, modifiers)
         TheAvailableMods = import('/lua/ui/lobby/ModsManager.lua').HostModStatus(availableMods)
-		import('/lua/ui/lobby/ModsManager.lua').NEW_MODS_GUI(panel, true, nil, TheAvailableMods)
+        import('/lua/ui/lobby/ModsManager.lua').NEW_MODS_GUI(panel, true, nil, TheAvailableMods)
     end
 
     local restrictedUnitsButton = UIUtil.CreateButtonStd(modButton, '/scx_menu/small-btn/small', "<LOC sel_map_0006>Unit Manager", 16, 2)
@@ -299,98 +291,97 @@ function CreateDialog(selectBehavior, exitBehavior, over, singlePlayer, defaultS
             true)
     end
 
-	--start of random map code by Moritz
-	local doNotRepeatMap
-	local randomMapButton = UIUtil.CreateButtonStd(modButton, '/scx_menu/small-btn/small', "<LOC lobui_0503>Random Map", 16, 2)
-	LayoutHelpers.AtLeftTopIn(randomMapButton, panel, 385, 645)
-	Tooltip.AddButtonTooltip(randomMapButton, 'lob_click_randmap')
+    local doNotRepeatMap
+    local randomMapButton = UIUtil.CreateButtonStd(modButton, '/scx_menu/small-btn/small', "<LOC lobui_0503>Random Map", 16, 2)
+    LayoutHelpers.AtLeftTopIn(randomMapButton, panel, 385, 645)
+    Tooltip.AddButtonTooltip(randomMapButton, 'lob_click_randmap')
 
-	randomMapButton.OnClick = function(self, modifiers)
-		if randMapList != 0 then
-			local randomMapMessage
-			local nummapa
-			nummapa = math.random(1, randMapList)
-			if randMapList >= 2 and nummapa == doNotRepeatMap then
-				repeat
-					nummapa = math.random(1, randMapList)
-				until nummapa != doNotRepeatMap
-			end
-			doNotRepeatMap = nummapa
-			local scen = scenarios[scenarioKeymap[nummapa]]
-			selectedScenario = scen
-			if not singlePlayer then
-				rMapName = scenarios[scenarioKeymap[nummapa]].name
-				rMapSize1 = scenarios[scenarioKeymap[nummapa]].size[1]/50
-				rMapSize2 = scenarios[scenarioKeymap[nummapa]].size[2]/50
-				rMapSizeFilLim = currentFilters.map_select_size_limiter
-				rMapSizeFil = currentFilters.map_select_size/50
-				rMapPlayersFilLim = currentFilters.map_select_supportedplayers_limiter
-				rMapPlayersFil = currentFilters.map_select_supportedplayers
-				rMapTypeFil = currentFilters.map_type
-			end
-			selectBehavior(selectedScenario, changedOptions, restrictedCategories)
-			ResetFilters()
-			if not singlePlayer then
-				randomMapMessage = import('/lua/ui/lobby/lobby.lua').sendRandMapMessage()
-			end
-		end
-	end
-	if not singlePlayer then
-		function randomLobbyMap()
-			local randomMapMessage
-			local nummapa
-			nummapa = math.random(1, randMapList)
-			if randMapList >= 2 and nummapa == doNotRepeatMap then
-				repeat
-					nummapa = math.random(1, randMapList)
-				until nummapa != doNotRepeatMap
-			end
-			doNotRepeatMap = nummapa
-			local scen = scenarios[scenarioKeymap[nummapa]]
-			selectedScenario = scen
-			rMapName = scenarios[scenarioKeymap[nummapa]].name
-			rMapSize1 = scenarios[scenarioKeymap[nummapa]].size[1]/50
-			rMapSize2 = scenarios[scenarioKeymap[nummapa]].size[2]/50
-			selectBehavior(selectedScenario, changedOptions, restrictedCategories)
-			ResetFilters()
-			randomMapMessage = import('/lua/ui/lobby/lobby.lua').sendRandMapMessage()
-		end
-	end
-	function randomAutoMap(official)
-		local nummapa
-		nummapa = math.random(1, randMapList)
-		if randMapList >= 2 and nummapa == doNotRepeatMap then
-			repeat
-				nummapa = math.random(1, randMapList)
-			until nummapa != doNotRepeatMap
-		end
-		doNotRepeatMap = nummapa
-		local scen = scenarios[scenarioKeymap[nummapa]]
-		if official then
-			local officialMap = CheckMapIsOfficial(scen)
-			if not officialMap then
-				return randomAutoMap(true)
-			end
-		end
-		selectedScenario = scen
-		selectBehavior(selectedScenario, changedOptions, restrictedCategories)
-		ResetFilters()
-	end
-	--end of random map code
+    randomMapButton.OnClick = function(self, modifiers)
+        if randMapList ~= 0 then
+            local randomMapMessage
+            local nummapa
+            nummapa = math.random(1, randMapList)
+            if randMapList >= 2 and nummapa == doNotRepeatMap then
+                repeat
+                    nummapa = math.random(1, randMapList)
+                until nummapa ~= doNotRepeatMap
+            end
+            doNotRepeatMap = nummapa
+            local scen = scenarios[scenarioKeymap[nummapa]]
+            selectedScenario = scen
+            if not singlePlayer then
+                rMapName = scenarios[scenarioKeymap[nummapa]].name
+                rMapSize1 = scenarios[scenarioKeymap[nummapa]].size[1]/50
+                rMapSize2 = scenarios[scenarioKeymap[nummapa]].size[2]/50
+                rMapSizeFilLim = currentFilters.map_select_size_limiter
+                rMapSizeFil = currentFilters.map_select_size/50
+                rMapPlayersFilLim = currentFilters.map_select_supportedplayers_limiter
+                rMapPlayersFil = currentFilters.map_select_supportedplayers
+                rMapTypeFil = currentFilters.map_type
+            end
+            selectBehavior(selectedScenario, changedOptions, restrictedCategories)
+            ResetFilters()
+            if not singlePlayer then
+                randomMapMessage = import('/lua/ui/lobby/lobby.lua').sendRandMapMessage()
+            end
+        end
+    end
+    if not singlePlayer then
+        function randomLobbyMap()
+            local randomMapMessage
+            local nummapa
+            nummapa = math.random(1, randMapList)
+            if randMapList >= 2 and nummapa == doNotRepeatMap then
+                repeat
+                    nummapa = math.random(1, randMapList)
+                until nummapa ~= doNotRepeatMap
+            end
+            doNotRepeatMap = nummapa
+            local scen = scenarios[scenarioKeymap[nummapa]]
+            selectedScenario = scen
+            rMapName = scenarios[scenarioKeymap[nummapa]].name
+            rMapSize1 = scenarios[scenarioKeymap[nummapa]].size[1]/50
+            rMapSize2 = scenarios[scenarioKeymap[nummapa]].size[2]/50
+            selectBehavior(selectedScenario, changedOptions, restrictedCategories)
+            ResetFilters()
+            randomMapMessage = import('/lua/ui/lobby/lobby.lua').sendRandMapMessage()
+        end
+    end
+    function randomAutoMap(official)
+        local nummapa
+        nummapa = math.random(1, randMapList)
+        if randMapList >= 2 and nummapa == doNotRepeatMap then
+            repeat
+                nummapa = math.random(1, randMapList)
+            until nummapa ~= doNotRepeatMap
+        end
+        doNotRepeatMap = nummapa
+        local scen = scenarios[scenarioKeymap[nummapa]]
+        if official then
+            local officialMap = CheckMapIsOfficial(scen)
+            if not officialMap then
+                return randomAutoMap(true)
+            end
+        end
+        selectedScenario = scen
+        selectBehavior(selectedScenario, changedOptions, restrictedCategories)
+        ResetFilters()
+    end
 
     UIUtil.MakeInputModal(panel)
 
     mapListTitle = UIUtil.CreateText(panel, "<LOC sel_map_0005>Maps", 18)
-    LayoutHelpers.AtLeftTopIn(mapListTitle, panel, 360, 207)###New - Change value, originals: 360, 177--Notes: Title movement down
+    LayoutHelpers.AtLeftTopIn(mapListTitle, panel, 360, 207)
 
     mapList = ItemList(panel, "mapselect:mapList")
     mapList:SetFont(UIUtil.bodyFont, 14)
     mapList:SetColors(UIUtil.fontColor, "00000000", "FF000000",  UIUtil.highlightColor, "ffbcfffe")
     mapList:ShowMouseoverItem(true)
     mapList.Width:Set(258)
-    mapList.Height:Set(409)###New - Change value, original: 438--Notes: Height of map selection scroll
-    LayoutHelpers.AtLeftTopIn(mapList, panel, 360, 232)###New - Change value, originals: 360, 202--Notes: Masp selection scroll move down
-    mapList.Depth:Set(function() return panel.Depth() + 10 end) --TODO what is this getting under when it's in over state?
+    mapList.Height:Set(409)
+    LayoutHelpers.AtLeftTopIn(mapList, panel, 360, 232)
+    --TODO what is this getting under when it's in over state?
+    mapList.Depth:Set(function() return panel.Depth() + 10 end)
     mapList:AcquireKeyboardFocus(true)
     mapList.OnDestroy = function(control)
         mapList:AbandonKeyboardFocus()
@@ -449,11 +440,11 @@ function CreateDialog(selectBehavior, exitBehavior, over, singlePlayer, defaultS
         end
     end
 
--- initialize controls
+    -- initialize controls
     PopulateMapList()
     SetupOptionsPanel(panel, singlePlayer, curOptions)
 
---  control behvaior
+    --  control behvaior
     if exitButton then
         exitButton.OnClick = function(self)
             exitBehavior()
@@ -462,10 +453,10 @@ function CreateDialog(selectBehavior, exitBehavior, over, singlePlayer, defaultS
     end
 
     selectButton.OnClick = function(self, modifiers)
-		rMapSizeFilLim = currentFilters.map_select_size_limiter
-		rMapSizeFil = currentFilters.map_select_size/50
-		rMapPlayersFilLim = currentFilters.map_select_supportedplayers_limiter
-		rMapPlayersFil = currentFilters.map_select_supportedplayers
+        rMapSizeFilLim = currentFilters.map_select_size_limiter
+        rMapSizeFil = currentFilters.map_select_size/50
+        rMapPlayersFilLim = currentFilters.map_select_supportedplayers_limiter
+        rMapPlayersFil = currentFilters.map_select_supportedplayers
         selectBehavior(selectedScenario, changedOptions, restrictedCategories)
         ResetFilters()
     end
@@ -554,14 +545,11 @@ function RefreshOptions(skipRefresh, singlePlayer)
     -- so we'll used this flag to reset the options sources so they can set up for multiplayer
     if skipRefresh then
         OptionSource[1] = {title = "<LOC uilobby_0001>Team Options", options = import('/lua/ui/lobby/lobbyOptions.lua').teamOptions}
-		OptionSource[2] = {title = "<LOC uilobby_0002>Game Options", options = import('/lua/ui/lobby/lobbyOptions.lua').globalOpts}
-		OptionSource[3] = {title = "AI Options", options = import('/lua/ui/lobby/lobbyOptions.lua').AIOpts}
---~         table.sort(OptionSource[1].options, function(a, b) return LOC(a.label) < LOC(b.label) end)
---~         table.sort(OptionSource[2].options, function(a, b) return LOC(a.label) < LOC(b.label) end)
---~         table.sort(OptionSource[3].options, function(a, b) return LOC(a.label) < LOC(b.label) end)
+        OptionSource[2] = {title = "<LOC uilobby_0002>Game Options", options = import('/lua/ui/lobby/lobbyOptions.lua').globalOpts}
+        OptionSource[3] = {title = "AI Options", options = import('/lua/ui/lobby/lobbyOptions.lua').AIOpts}
     end
-	OptionSource[4] = {}
-	OptionSource[4] = {title = "<LOC lobui_0164>Advanced", options = advOptions or {}}
+    OptionSource[4] = {}
+    OptionSource[4] = {title = "<LOC lobui_0164>Advanced", options = advOptions or {}}
 
     Options = {}
 
@@ -569,8 +557,8 @@ function RefreshOptions(skipRefresh, singlePlayer)
         if table.getsize(OptionTable.options) > 0 then
             table.insert(Options, {type = 'title', text = OptionTable.title})
             for optionIndex, optionData in OptionTable.options do
-				if not(singlePlayer and optionData.mponly == true) then
-					table.insert(Options, {type = 'option', text = optionData.label, data = optionData, default = optionData.default}) -- option1 for teamOptions for exemple
+                if not(singlePlayer and optionData.mponly == true) then
+                    table.insert(Options, {type = 'option', text = optionData.label, data = optionData, default = optionData.default}) -- option1 for teamOptions for exemple
                 end
             end
         end
@@ -605,7 +593,7 @@ function SetupOptionsPanel(parent, singlePlayer, curOptions)
         local tooltipTable = {}
         Tooltip.AddComboTooltip(combo, tooltipTable, combo._list)
         combo.UpdateValue = function(key)
-			combo:SetItem(combo.keyMap[key])
+            combo:SetItem(combo.keyMap[key])
         end
 
         return combo
@@ -654,7 +642,6 @@ function SetupOptionsPanel(parent, singlePlayer, curOptions)
     -- aixs can be "Vert" or "Horz"
     OptionContainer.GetScrollValues = function(self, axis)
         local size = DataSize()
-        --LOG(size, ":", self.top, ":", math.min(self.top + numLines, size))
         return 0, size, self.top, math.min(self.top + numLines(), size)
     end
 
@@ -681,10 +668,10 @@ function SetupOptionsPanel(parent, singlePlayer, curOptions)
     OptionContainer.IsScrollable = function(self, axis)
         return true
     end
+
     -- determines what controls should be visible or not
     OptionContainer.CalcVisible = function(self)
-        --LOG("### CalcVisible !")
-		local function SetTextLine(line, data, lineID)
+        local function SetTextLine(line, data, lineID)
             if data.type == 'title' then
                 line.text:SetText(LOC(data.text))
                 line.text:SetFont(UIUtil.titleFont, 14, 3)
@@ -707,76 +694,52 @@ function SetupOptionsPanel(parent, singlePlayer, curOptions)
                 local itemArray = {}
                 line.combo.keyMap = {}
                 local tooltipTable = {}
-				
-				local defValue = false
-				local realDefValue = false
                 
-				--LOG("XINNONY //////////////////////////////////////////")
-				for index, val in data.data.values do
-					--LOG(data.text..' << val.text:'..val.text..' << val.key:'..val.key..' (index:'..index..')')
-					--
-					itemArray[index] = val.text
-                    line.combo.keyMap[tostring(val.key)] = index -- = 1 ou 2 ..
-                    tooltipTable[index]={text=data.data.label,body=val.help}--= 'lob_'..data.data.key..'_'..val.key
-					--
-					if curOptions[data.data.key] and val.key == curOptions[data.data.key] then -- curOptions = gameInfo.GameOptions
-						--LOG('FIND on curOptions : key='..val.key..', index='..index)
-						defValue = index
-					end
+                local defValue = false
+                local realDefValue = false
+                
+                for index, val in data.data.values do
+                    itemArray[index] = val.text
+                    line.combo.keyMap[tostring(val.key)] = index
+                    tooltipTable[index]={text=data.data.label,body=val.help}
+                    --
+                    if curOptions[data.data.key] and val.key == curOptions[data.data.key] then
+                        defValue = index
+                    end
                 end
-				--// Set SelectedOption or Default Option or ... -- Fix AdvancedOption by Xinnony
-				--LOG('Option name : '..data.text)
-				--LOG('Number of SubOption Values : '..table.getsize(data.data.values))
-				--LOG('Default : '..tostring(data.default)..' ('..tostring(data.data.default)..')')
-				--LOG('changedOptions.index : '..tostring(changedOptions[data.data.key].index))
-				--LOG('curOptions : '..tostring(curOptions[data.data.key])) -- = gameInfo.GameOptions
---------------------------------------------------------------------------------------------------------------------------------
-				if data.default == 0 or data.default > table.getsize(data.data.values) then -- THE MAP OPTIONS IS NOT RESPECTED
-					LOG('THE MAP OPTIONS IS NOT RESPECTED, NEED FIX BY THE AUTHOR OF THIS MAP (default value is Index !)')
-				end
-				if changedOptions[data.data.key].index then -- IF already set&clicked in Combo
-					--LOG('> 2')
-					defValue = changedOptions[data.data.key].index
-				elseif defValue then -- IF already set and saved (curOptions exist)
-					--LOG('> 1')
-					defValue = defValue
-				else
-					--LOG('> 3')
-					if data.default != nil and data.default <= table.getsize(data.data.values) then
-						--LOG('> 3 > 1')
-						if line.combo.keyMap[curOptions[data.data.key]] != nil then
-							--LOG('> 3 > 1 > 1')
-						else
-							--LOG('> 3 > 1 > 2')
-						end
-						defValue = changedOptions[data.data.key].index or line.combo.keyMap[curOptions[data.data.key]] or data.default or 1
-						if data.default == 0 then -- THE MAP OPTIONS IS NOT RESPECTED
-							--LOG('> 3 > 1 > 3')
-							--LOG("default : 0 (set to 1 because is index)")
-							defValue = line.combo.keyMap[curOptions[data.data.key]] or 1
-						end
-					else
-						--LOG('> 4 > Not have a default value (set to the first Item)')
-						defValue = changedOptions[data.data.key].index or line.combo.keyMap[curOptions[data.data.key]] or 1
-					end
-					--LOG("FINALY, defValue = "..tostring(defValue))
-					--LOG("XINNONY \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\")
-				end
-				--
-				--if data.type == 'option1' or data.type == 'option2' or data.type == 'option3' then -- For enable label (default) just or global/team/ai options
-				if data.data.default then realDefValue = data.data.default end
-				line.combo:AddItems(itemArray, defValue, realDefValue, true) -- For all (true for enable (default) label)
+
+                if data.default == 0 or data.default > table.getsize(data.data.values) then
+                    -- TODO: This should probably be shown in the actual UI...
+                    WARN('THE MAP OPTIONS IS NOT RESPECTED, NEED FIX BY THE AUTHOR OF THIS MAP (default value is Index !)')
+                end
+                if changedOptions[data.data.key].index then
+                    defValue = changedOptions[data.data.key].index
+                elseif defValue then -- IF already set and saved (curOptions exist)
+                    defValue = defValue
+                else
+                    if data.default ~= nil and data.default <= table.getsize(data.data.values) then
+                        defValue = changedOptions[data.data.key].index or line.combo.keyMap[curOptions[data.data.key]] or data.default or 1
+                        if data.default == 0 then -- THE MAP OPTIONS IS NOT RESPECTED
+                            defValue = line.combo.keyMap[curOptions[data.data.key]] or 1
+                        end
+                    else
+                        defValue = changedOptions[data.data.key].index or line.combo.keyMap[curOptions[data.data.key]] or 1
+                    end
+                end
+                --
+                if data.data.default then realDefValue = data.data.default end
+                line.combo:AddItems(itemArray, defValue, realDefValue, true) -- For all (true for enable (default) label)
                 line.combo.OnClick = function(self, index, text)
-					--LOG('>> OnClick > '..index..' > '..text)
                     changedOptions[data.data.key] = {value = data.data.values[index].key, pref = data.data.pref, index = index}
-					if line.combo.EnableColor then line.combo._text:SetColor('DBBADB') end
-					--LOG('>> changedOptions > '..changedOptions[data.data.key].value..' > '..changedOptions[data.data.key].pref..' > '..changedOptions[data.data.key].index)
+                    if line.combo.EnableColor then
+                        line.combo._text:SetColor('DBBADB')
+                    end
                 end
                 line.HandleEvent = Group.HandleEvent
-                Tooltip.AddControlTooltip(line, {text=data.data.label,body=data.data.help})--(line, data.data.pref)
+                Tooltip.AddControlTooltip(line, {text=data.data.label,body=data.data.help})
                 Tooltip.AddComboTooltip(line.combo, tooltipTable, line.combo._list)
                 line.combo.UpdateValue = function(key)
-					line.combo:SetItem(line.combo.keyMap[key])
+                    line.combo:SetItem(line.combo.keyMap[key])
                 end
             end
         end
@@ -790,7 +753,6 @@ function SetupOptionsPanel(parent, singlePlayer, curOptions)
             end
         end
     end
---\\ Stop
 
     OptionContainer:CalcVisible()
 
@@ -833,13 +795,11 @@ function SetDescription(scen)
         description:AddItem(LOCF("<LOC map_select_0005>NO START SPOTS DEFINED"))
         errors = true
     end
-	###New SetDescription - Start
-	if EnhancedLobby.CheckMapHasMarkers(scen) then
-		description:AddItem("AI Markers: Yes")
-	else
-		description:AddItem("AI Markers: No")
-	end
-	###New SetDescription - End
+    if EnhancedLobby.CheckMapHasMarkers(scen) then
+        description:AddItem("AI Markers: Yes")
+    else
+        description:AddItem("AI Markers: No")
+    end
     description:AddItem("")
     if scen.description then
         local textBoxWidth = description.Width()
@@ -867,7 +827,7 @@ function PopulateMapList()
         local validMapSize = false
         local validMapPlayers = false
         local index = i
-        if currentFilters.map_select_supportedplayers != 0 then
+        if currentFilters.map_select_supportedplayers ~= 0 then
             if CompareFunc(table.getsize(sceninfo.Configurations.standard.teams[1].armies),
                 currentFilters.map_select_supportedplayers,
                 currentFilters.map_select_supportedplayers_limiter) then
@@ -876,32 +836,30 @@ function PopulateMapList()
         else
             validMapSize = true
         end
-        if currentFilters.map_select_size != 0 then
+        if currentFilters.map_select_size ~= 0 then
             if CompareFunc(sceninfo.size[1], currentFilters.map_select_size, currentFilters.map_select_size_limiter) then
                 validMapPlayers = true
             end
         else
             validMapPlayers = true
         end
-		if currentFilters.map_type != 0 then
-			local officialMap = CheckMapIsOfficial(sceninfo)
-			if not officialMap and currentFilters.map_type == 1 then
-				continue
-			end
-			if officialMap and currentFilters.map_type == 2 then
-				continue
-			end
-		end
-		###New scenario - Start
-		if currentFilters.map_ai_markers != 0 then
-			if not EnhancedLobby.CheckMapHasMarkers(sceninfo) and currentFilters.map_ai_markers == 1 then
-				continue
-			end
-			if EnhancedLobby.CheckMapHasMarkers(sceninfo) and currentFilters.map_ai_markers == 2 then
-				continue
-			end
-		end
-		###New scenario - End
+        if currentFilters.map_type ~= 0 then
+            local officialMap = CheckMapIsOfficial(sceninfo)
+            if not officialMap and currentFilters.map_type == 1 then
+                continue
+            end
+            if officialMap and currentFilters.map_type == 2 then
+                continue
+            end
+        end
+        if currentFilters.map_ai_markers ~= 0 then
+            if not EnhancedLobby.CheckMapHasMarkers(sceninfo) and currentFilters.map_ai_markers == 1 then
+                continue
+            end
+            if EnhancedLobby.CheckMapHasMarkers(sceninfo) and currentFilters.map_ai_markers == 2 then
+                continue
+            end
+        end
         if validMapSize and validMapPlayers then
             table.insert(tempMaps, sceninfo)
             scenarioKeymap[count] = index
@@ -911,22 +869,22 @@ function PopulateMapList()
 
     for i,sceninfo in tempMaps do
         local name = sceninfo.name
-		local officialMap = CheckMapIsOfficial(sceninfo)
-		if not officialMap then
-			name = name .. " (" .. LOC("<LOC MAINMENU_0011>Custom") .. ")"
-		end
+        local officialMap = CheckMapIsOfficial(sceninfo)
+        if not officialMap then
+            name = name .. " (" .. LOC("<LOC MAINMENU_0011>Custom") .. ")"
+        end
         mapList:AddItem(LOC(name))
     end
 
-	randMapList = count - 1
+    randMapList = count - 1
 
-	if randMapList == 0 then
-		mapListTitle:SetText(LOCF("<LOC lobui_0579>No Map Available", randMapList))
-	elseif randMapList == 1 then
-		mapListTitle:SetText(LOCF("<LOC lobui_0580>%d Map Available", randMapList))
-	else
-		mapListTitle:SetText(LOCF("<LOC lobui_0581>%d Maps Available", randMapList))
-	end
+    if randMapList == 0 then
+        mapListTitle:SetText(LOCF("<LOC lobui_0579>No Map Available", randMapList))
+    elseif randMapList == 1 then
+        mapListTitle:SetText(LOCF("<LOC lobui_0580>%d Map Available", randMapList))
+    else
+        mapListTitle:SetText(LOCF("<LOC lobui_0581>%d Maps Available", randMapList))
+    end
 end
 
 function CompareFunc(valA, valB, operatorVar)

--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -889,22 +889,10 @@ end
 
 function CompareFunc(valA, valB, operatorVar)
     if operatorVar == 'equal' then
-        if valA == valB then
-            return true
-        else
-            return false
-        end
+        return valA == valB
     elseif operatorVar == 'less' then
-        if valA <= valB then
-            return true
-        else
-            return false
-        end
+        return valA <= valB
     elseif operatorVar == 'greater' then
-        if valA >= valB then
-            return true
-        else
-            return false
-        end
+        return valA >= valB
     end
 end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2561,12 +2561,12 @@ function CreateSlotsUI(makeLabel)
         -- capture the index in the current closure so it's accessible on callbacks
         local curRow = i
 
-        GUI.slots[i] = Group(GUI.playerPanel, "playerSlot " .. tostring(i))
-        GUI.slots[i].closed = false
+        local newSlot = Group(GUI.playerPanel, "playerSlot " .. tostring(i))
+        newSlot.closed = false
         --TODO these need layout from art when available
-        GUI.slots[i].Width:Set(GUI.labelGroup.Width)
-        GUI.slots[i].Height:Set(GUI.labelGroup.Height)
-        GUI.slots[i]._slot = i
+        newSlot.Width:Set(GUI.labelGroup.Width)
+        newSlot.Height:Set(GUI.labelGroup.Height)
+        newSlot._slot = i
 
         -- Default mouse behaviours for the slot.
         local defaultHandler = function(self, event)
@@ -2584,74 +2584,83 @@ function CreateSlotsUI(makeLabel)
 
             return Group.HandleEvent(self, event)
         end
-        GUI.slots[i].HandleEvent = defaultHandler
+        newSlot.HandleEvent = defaultHandler
 
-        local bg = GUI.slots[i]
+        local bg = newSlot
 
         --// Slot Background
-        GUI.slots[i].SlotBackground = Bitmap(GUI, UIUtil.SkinnableFile("/SLOT/slot-dis.dds"))
-        LayoutHelpers.AtBottomIn(GUI.slots[i].SlotBackground, GUI.slots[i], -6)
-        LayoutHelpers.AtLeftIn(GUI.slots[i].SlotBackground, GUI.slots[i], 0)
+        newSlot.SlotBackground = Bitmap(GUI, UIUtil.SkinnableFile("/SLOT/slot-dis.dds"))
+        LayoutHelpers.AtBottomIn(newSlot.SlotBackground, newSlot, -6)
+        LayoutHelpers.AtLeftIn(newSlot.SlotBackground, newSlot, 0)
         --\\ Stop Slot Background
 
         --// COUNTRY
         -- Added a bitmap on the left of Rating, the bitmap is a Flag of Country
-        GUI.slots[i].KinderCountry = Bitmap(bg, UIUtil.SkinnableFile("/countries/world.dds"))
-        GUI.slots[i].KinderCountry.Width:Set(20)
-        GUI.slots[i].KinderCountry.Height:Set(17-2) -- 15=2pix marging || 17=1pix marging
-        LayoutHelpers.AtBottomIn(GUI.slots[i].KinderCountry, GUI.slots[i], -4) -- -5
-        LayoutHelpers.AtLeftIn(GUI.slots[i].KinderCountry, GUI.slots[i], 2) -- 1
+        local flag = Bitmap(bg, UIUtil.SkinnableFile("/countries/world.dds"))
+        newSlot.KinderCountry = flag
+        flag.Width:Set(20)
+        flag.Height:Set(15)
+        LayoutHelpers.AtBottomIn(flag, newSlot, -4)
+        LayoutHelpers.AtLeftIn(flag, newSlot, 2)
         --\\ Stop COUNTRY
 
         -- TODO: Factorise this boilerplate.
         --// Rating
-        GUI.slots[i].ratingGroup = Group(bg)
-        GUI.slots[i].ratingGroup.Width:Set(slotColumnSizes.rating.width)
-        GUI.slots[i].ratingGroup.Height:Set(GUI.slots[i].Height)
-        LayoutHelpers.AtLeftIn(GUI.slots[i].ratingGroup, GUI.panel, slotColumnSizes.rating.x)
-        LayoutHelpers.AtVerticalCenterIn(GUI.slots[i].ratingGroup, GUI.slots[i], 6)
-        GUI.slots[i].ratingText = UIUtil.CreateText(GUI.slots[i].ratingGroup, "", 14, 'Arial')--14, UIUtil.bodyFont)
-        GUI.slots[i].ratingText:SetColor('B9BFB9')
-        GUI.slots[i].ratingText:SetDropShadow(true)
-        LayoutHelpers.AtBottomIn(GUI.slots[i].ratingText, GUI.slots[i].ratingGroup, 2)
-        LayoutHelpers.AtRightIn(GUI.slots[i].ratingText, GUI.slots[i].ratingGroup, 9)
-        GUI.slots[i].tooltiprating = Tooltip.AddControlTooltip(GUI.slots[i].ratingText, 'rating')
+        local ratingGroup = Group(bg)
+        newSlot.ratingGroup = ratingGroup
+        ratingGroup.Width:Set(slotColumnSizes.rating.width)
+        ratingGroup.Height:Set(newSlot.Height)
+        LayoutHelpers.AtLeftIn(ratingGroup, GUI.panel, slotColumnSizes.rating.x)
+        LayoutHelpers.AtVerticalCenterIn(ratingGroup, newSlot, 6)
+
+        local ratingText = UIUtil.CreateText(ratingGroup, "", 14, 'Arial')
+        newSlot.ratingText = ratingText
+        ratingText:SetColor('B9BFB9')
+        ratingText:SetDropShadow(true)
+        LayoutHelpers.AtBottomIn(ratingText, ratingGroup, 2)
+        LayoutHelpers.AtRightIn(ratingText, ratingGroup, 9)
+        newSlot.tooltiprating = Tooltip.AddControlTooltip(ratingText, 'rating')
 
         --// NumGame
-        GUI.slots[i].numGamesGroup = Group(bg)
-        GUI.slots[i].numGamesGroup.Width:Set(slotColumnSizes.games.width)
-        GUI.slots[i].numGamesGroup.Height:Set(GUI.slots[i].Height)
-        LayoutHelpers.AtLeftIn(GUI.slots[i].numGamesGroup, GUI.panel, slotColumnSizes.games.x)
-        LayoutHelpers.AtVerticalCenterIn(GUI.slots[i].numGamesGroup, GUI.slots[i], 6)
-        GUI.slots[i].numGamesText = UIUtil.CreateText(GUI.slots[i].numGamesGroup, "", 14, 'Arial')--14, UIUtil.bodyFont)
-        GUI.slots[i].numGamesText:SetColor('B9BFB9')
-        GUI.slots[i].numGamesText:SetDropShadow(true)
-        Tooltip.AddControlTooltip(GUI.slots[i].numGamesText, 'num_games')
-        LayoutHelpers.AtBottomIn(GUI.slots[i].numGamesText, GUI.slots[i].numGamesGroup, 2)
-        LayoutHelpers.AtRightIn(GUI.slots[i].numGamesText, GUI.slots[i].numGamesGroup, 9)
+        local numGamesGroup = Group(bg)
+        newSlot.numGamesGroup = numGamesGroup
+        numGamesGroup.Width:Set(slotColumnSizes.games.width)
+        numGamesGroup.Height:Set(newSlot.Height)
+        LayoutHelpers.AtLeftIn(numGamesGroup, GUI.panel, slotColumnSizes.games.x)
+        LayoutHelpers.AtVerticalCenterIn(numGamesGroup, newSlot, 6)
+
+        local numGamesText = UIUtil.CreateText(numGamesGroup, "", 14, 'Arial')
+        newSlot.numGamesText = numGamesText
+        numGamesText:SetColor('B9BFB9')
+        numGamesText:SetDropShadow(true)
+        Tooltip.AddControlTooltip(numGamesText, 'num_games')
+        LayoutHelpers.AtBottomIn(numGamesText, numGamesGroup, 2)
+        LayoutHelpers.AtRightIn(numGamesText, numGamesGroup, 9)
 
         --// Name
-        GUI.slots[i].name = Combo(bg, 14, 12, true, nil, "UI_Tab_Rollover_01", "UI_Tab_Click_01")
-        GUI.slots[i].name._text:SetFont('Arial Gras', 15)
-        GUI.slots[i].name._text:SetDropShadow(true)
-        LayoutHelpers.AtVerticalCenterIn(GUI.slots[i].name, GUI.slots[i], 8)
-        LayoutHelpers.AtLeftIn(GUI.slots[i].name, GUI.panel, slotColumnSizes.player.x)
-        GUI.slots[i].name.Width:Set(slotColumnSizes.player.width)
-        GUI.slots[i].name.row = i
+        local nameLabel = Combo(bg, 14, 12, true, nil, "UI_Tab_Rollover_01", "UI_Tab_Click_01")
+        newSlot.name = nameLabel
+        nameLabel._text:SetFont('Arial Gras', 15)
+        nameLabel._text:SetDropShadow(true)
+        LayoutHelpers.AtVerticalCenterIn(nameLabel, newSlot, 8)
+        LayoutHelpers.AtLeftIn(nameLabel, GUI.panel, slotColumnSizes.player.x)
+        nameLabel.Width:Set(slotColumnSizes.player.width)
+        nameLabel.row = i
         -- left deal with name clicks
-        GUI.slots[i].name.OnEvent = defaultHandler
-        GUI.slots[i].name.OnClick = function(self, index, text)
+        nameLabel.OnEvent = defaultHandler
+        nameLabel.OnClick = function(self, index, text)
             DoSlotBehavior(self.row, self.slotKeys[index], text)
         end
 
         -- Color
-        GUI.slots[i].color = BitmapCombo(bg, gameColors.PlayerColors, 1, true, nil, "UI_Tab_Rollover_01", "UI_Tab_Click_01")
+        local colorSelector = BitmapCombo(bg, gameColors.PlayerColors, 1, true, nil, "UI_Tab_Rollover_01", "UI_Tab_Click_01")
+        newSlot.color = colorSelector
 
-        LayoutHelpers.AtLeftIn(GUI.slots[i].color, GUI.panel, slotColumnSizes.color.x)
-        LayoutHelpers.AtVerticalCenterIn(GUI.slots[i].color, GUI.slots[i], 8)
-        GUI.slots[i].color.Width:Set(slotColumnSizes.color.width)
-        GUI.slots[i].color.row = i
-        GUI.slots[i].color.OnClick = function(self, index)
+        LayoutHelpers.AtLeftIn(colorSelector, GUI.panel, slotColumnSizes.color.x)
+        LayoutHelpers.AtVerticalCenterIn(colorSelector, newSlot, 8)
+        colorSelector.Width:Set(slotColumnSizes.color.width)
+        colorSelector.row = i
+        colorSelector.OnClick = function(self, index)
             if not lobbyComm:IsHost() then
                 lobbyComm:SendData(hostID, { Type = 'RequestColor', Color = index, Slot = self.row } )
                 gameInfo.PlayerOptions[self.row].PlayerColor = index
@@ -2668,72 +2677,77 @@ function CreateSlotsUI(makeLabel)
                 end
             end
         end
-        GUI.slots[i].color.OnEvent = defaultHandler
-        Tooltip.AddControlTooltip(GUI.slots[i].color, 'lob_color')
-        GUI.slots[i].color.row = i
+        colorSelector.OnEvent = defaultHandler
+        Tooltip.AddControlTooltip(colorSelector, 'lob_color')
+        colorSelector.row = i
 
         --// Faction
-        GUI.slots[i].faction = BitmapCombo(bg, factionBmps, table.getn(factionBmps), nil, nil, "UI_Tab_Rollover_01", "UI_Tab_Click_01")
-        LayoutHelpers.AtLeftIn(GUI.slots[i].faction, GUI.panel, slotColumnSizes.faction.x)
-        LayoutHelpers.AtVerticalCenterIn(GUI.slots[i].faction, GUI.slots[i], 8)
-        GUI.slots[i].faction.Width:Set(slotColumnSizes.faction.width)
-        GUI.slots[i].faction.OnClick = function(self, index)
+        local factionSelector = BitmapCombo(bg, factionBmps, table.getn(factionBmps), nil, nil, "UI_Tab_Rollover_01", "UI_Tab_Click_01")
+        newSlot.faction = factionSelector
+        LayoutHelpers.AtLeftIn(factionSelector, GUI.panel, slotColumnSizes.faction.x)
+        LayoutHelpers.AtVerticalCenterIn(factionSelector, newSlot, 8)
+        factionSelector.Width:Set(slotColumnSizes.faction.width)
+        factionSelector.OnClick = function(self, index)
             SetPlayerOption(self.row,'Faction',index)
             if curRow == FindSlotForID(FindIDForName(localPlayerName)) then
                 SetCurrentFactionTo_Faction_Selector()
             end
             Tooltip.DestroyMouseoverDisplay()
         end
-        Tooltip.AddControlTooltip(GUI.slots[i].faction, 'lob_faction')
-        Tooltip.AddComboTooltip(GUI.slots[i].faction, factionTooltips)
-        GUI.slots[i].faction.row = i
-        GUI.slots[i].faction.OnEvent = defaultHandler
+        Tooltip.AddControlTooltip(factionSelector, 'lob_faction')
+        Tooltip.AddComboTooltip(factionSelector, factionTooltips)
+        factionSelector.row = i
+        factionSelector.OnEvent = defaultHandler
         if not hasSupcom then
-            GUI.slots[i].faction:SetItem(4)
+            factionSelector:SetItem(4)
         end
 
         --// Team
-        GUI.slots[i].team = BitmapCombo(bg, teamIcons, 1, false, nil, "UI_Tab_Rollover_01", "UI_Tab_Click_01")
-        LayoutHelpers.AtLeftIn(GUI.slots[i].team, GUI.panel, slotColumnSizes.team.x)
-        LayoutHelpers.AtVerticalCenterIn(GUI.slots[i].team, GUI.slots[i], 8)
-        GUI.slots[i].team.Width:Set(slotColumnSizes.team.width)
-        GUI.slots[i].team.row = i
-        GUI.slots[i].team.OnClick = function(self, index, text)
+        local teamSelector = BitmapCombo(bg, teamIcons, 1, false, nil, "UI_Tab_Rollover_01", "UI_Tab_Click_01")
+        newSlot.team = teamSelector
+        LayoutHelpers.AtLeftIn(teamSelector, GUI.panel, slotColumnSizes.team.x)
+        LayoutHelpers.AtVerticalCenterIn(teamSelector, newSlot, 8)
+        teamSelector.Width:Set(slotColumnSizes.team.width)
+        teamSelector.row = i
+        teamSelector.OnClick = function(self, index, text)
             Tooltip.DestroyMouseoverDisplay()
             SetPlayerOption(self.row,'Team',index)
         end
-        Tooltip.AddControlTooltip(GUI.slots[i].team, 'lob_team')
-        Tooltip.AddComboTooltip(GUI.slots[i].team, teamTooltips)
-        GUI.slots[i].team.OnEvent = defaultHandler
+        Tooltip.AddControlTooltip(teamSelector, 'lob_team')
+        Tooltip.AddComboTooltip(teamSelector, teamTooltips)
+        teamSelector.OnEvent = defaultHandler
 
         -- Ping
-        GUI.slots[i].pingGroup = Group(bg)
-        GUI.slots[i].pingGroup.Width:Set(slotColumnSizes.ping.width)
-        GUI.slots[i].pingGroup.Height:Set(GUI.slots[i].Height)
-        LayoutHelpers.AtLeftIn(GUI.slots[i].pingGroup, GUI.panel, slotColumnSizes.ping.x)
-        LayoutHelpers.AtVerticalCenterIn(GUI.slots[i].pingGroup, GUI.slots[i], 6)
+        local pingGroup = Group(bg)
+        newSlot.pingGroup = pingGroup
+        pingGroup.Width:Set(slotColumnSizes.ping.width)
+        pingGroup.Height:Set(newSlot.Height)
+        LayoutHelpers.AtLeftIn(pingGroup, GUI.panel, slotColumnSizes.ping.x)
+        LayoutHelpers.AtVerticalCenterIn(pingGroup, newSlot, 6)
 
-        GUI.slots[i].pingStatus = StatusBar(GUI.slots[i].pingGroup, 0, 1000, false, false,
+        local pingStatus = StatusBar(pingGroup, 0, 1000, false, false,
             UIUtil.SkinnableFile('/game/unit_bmp/bar-back_bmp.dds'),
             UIUtil.SkinnableFile('/game/unit_bmp/bar-01_bmp.dds'),
             true)
-        LayoutHelpers.AtTopIn(GUI.slots[i].pingStatus, GUI.slots[i].pingGroup, 5)
-        LayoutHelpers.AtLeftIn(GUI.slots[i].pingStatus, GUI.slots[i].pingGroup, 0)
-        LayoutHelpers.AtRightIn(GUI.slots[i].pingStatus, GUI.slots[i].pingGroup, 0)
+        newSlot.pingStatus = pingStatus
+        LayoutHelpers.AtTopIn(pingStatus, pingGroup, 5)
+        LayoutHelpers.AtLeftIn(pingStatus, pingGroup, 0)
+        LayoutHelpers.AtRightIn(pingStatus, pingGroup, 0)
 
         -- depending on if this is single player or multiplayer this displays different info
-        GUI.slots[i].multiSpace = Group(bg, "multiSpace " .. tonumber(i))
-        GUI.slots[i].multiSpace.Width:Set(slotColumnSizes.ready.width)
-        GUI.slots[i].multiSpace.Height:Set(GUI.slots[i].Height)
-        LayoutHelpers.AtLeftIn(GUI.slots[i].multiSpace, GUI.panel, slotColumnSizes.ready.x)
-        GUI.slots[i].multiSpace.Top:Set(GUI.slots[i].Top)
+        newSlot.multiSpace = Group(bg, "multiSpace " .. tonumber(i))
+        newSlot.multiSpace.Width:Set(slotColumnSizes.ready.width)
+        newSlot.multiSpace.Height:Set(newSlot.Height)
+        LayoutHelpers.AtLeftIn(newSlot.multiSpace, GUI.panel, slotColumnSizes.ready.x)
+        newSlot.multiSpace.Top:Set(newSlot.Top)
 
         -- Ready Checkbox
-        GUI.slots[i].ready = UIUtil.CreateCheckboxStd(GUI.slots[i].multiSpace, '/CHECKBOX/radio')
-        GUI.slots[i].ready.row = i
-        LayoutHelpers.AtVerticalCenterIn(GUI.slots[i].ready, GUI.slots[i].multiSpace, 8)
-        LayoutHelpers.AtLeftIn(GUI.slots[i].ready, GUI.slots[i].multiSpace, 0)
-        GUI.slots[i].ready.OnCheck = function(self, checked)
+        local readyBox = UIUtil.CreateCheckboxStd(newSlot.multiSpace, '/CHECKBOX/radio')
+        newSlot.ready = readyBox
+        readyBox.row = i
+        LayoutHelpers.AtVerticalCenterIn(readyBox, newSlot.multiSpace, 8)
+        LayoutHelpers.AtLeftIn(readyBox, newSlot.multiSpace, 0)
+        readyBox.OnCheck = function(self, checked)
             UIUtil.setEnabled(GUI.becomeObserver, not checked)
             if checked then
                 DisableSlot(self.row, true)
@@ -2745,17 +2759,19 @@ function CreateSlotsUI(makeLabel)
 
         if singlePlayer then
             -- TODO: Use of groups may allow this to be simplified...
-            GUI.slots[i].ready:Hide()
-            GUI.slots[i].pingGroup:Hide()
-            GUI.slots[i].pingStatus:Hide()
+            readyBox:Hide()
+            pingGroup:Hide()
+            pingStatus:Hide()
         end
 
 
         if i == 1 then
-            LayoutHelpers.Below(GUI.slots[i], GUI.labelGroup, -5)
+            LayoutHelpers.Below(newSlot, GUI.labelGroup, -5)
         else
-            LayoutHelpers.Below(GUI.slots[i], GUI.slots[i - 1], 3)
+            LayoutHelpers.Below(newSlot, GUI.slots[i - 1], 3)
         end
+
+        GUI.slots[i] = newSlot
 
         ClearSlotInfo(i)
     end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3426,8 +3426,8 @@ function CreateUI(maxPlayers)
 
     -- FIXME : this is not needed anymore.
     if lobbyComm:IsHost() then
-        SetGameOption('RandomMap', 'Off', false, true) --make sure always create lobby with Random Map off
-        SetGameOption('RankedGame', 'Off', false, true) --make sure always create lobby with Ranked Game off
+        SetGameOption('RandomMap', 'Off', true) --make sure always create lobby with Random Map off
+        SetGameOption('RankedGame', 'Off', true) --make sure always create lobby with Ranked Game off
     end
 
     GUI.allowObservers = UIUtil.CreateCheckboxStd(GUI.buttonPanelTop, '/CHECKBOX/radio')
@@ -3438,7 +3438,7 @@ function CreateUI(maxPlayers)
     Tooltip.AddControlTooltip(GUI.observerLabel, 'lob_describe_observers')
     GUI.allowObservers:SetCheck(false)
     if lobbyComm:IsHost() then
-        SetGameOption("AllowObservers", false, false, true)
+        SetGameOption("AllowObservers", false, true)
         GUI.allowObservers.OnCheck = function(self, checked)
             SetGameOption("AllowObservers", checked)
         end
@@ -3517,15 +3517,15 @@ function CreateUI(maxPlayers)
             Prefs.SetToCurrentProfile('Lobby_Gen_Cap', 8)
             Prefs.SetToCurrentProfile('Lobby_Prebuilt_Units', 1)
             Prefs.SetToCurrentProfile('Lobby_NoRushOption', 1)
-            SetGameOption('Victory', 'demoralization', false, true)
-            SetGameOption('Timeouts', '3', false, true)
-            SetGameOption('CheatsEnabled', 'false', false, true)
-            SetGameOption('CivilianAlliance', 'enemy', false, true)
-            SetGameOption('GameSpeed', 'normal', false, true)
-            SetGameOption('FogOfWar', 'explored', false, true)
-            SetGameOption('UnitCap', '1000', false, true)
-            SetGameOption('PrebuiltUnits', 'Off', false, true)
-            SetGameOption('NoRushOption', 'Off', false, true)
+            SetGameOption('Victory', 'demoralization', true)
+            SetGameOption('Timeouts', '3', true)
+            SetGameOption('CheatsEnabled', 'false', true)
+            SetGameOption('CivilianAlliance', 'enemy', true)
+            SetGameOption('GameSpeed', 'normal', true)
+            SetGameOption('FogOfWar', 'explored', true)
+            SetGameOption('UnitCap', '1000', true)
+            SetGameOption('PrebuiltUnits', 'Off',  true)
+            SetGameOption('NoRushOption', 'Off', true)
             lobbyComm:BroadcastData( { Type = "SetAllPlayerNotReady" } )
             UpdateGame()
         end
@@ -4595,26 +4595,26 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
         -- set default lobby values
         for index, option in globalOpts do
             local defValue = Prefs.GetFromCurrentProfile(option.pref) or option.default
-            SetGameOption(option.key,option.values[defValue].key, false, true)
+            SetGameOption(option.key,option.values[defValue].key, true)
         end
 
         for index, option in teamOpts do
             local defValue = Prefs.GetFromCurrentProfile(option.pref) or option.default
-            SetGameOption(option.key,option.values[defValue].key, false, true)
+            SetGameOption(option.key,option.values[defValue].key, true)
         end
 
         for index, option in AIOpts do
             local defValue = Prefs.GetFromCurrentProfile(option.pref) or option.default
-            SetGameOption(option.key,option.values[defValue].key, false, true)
+            SetGameOption(option.key,option.values[defValue].key, true)
         end
 
         if self.desiredScenario and self.desiredScenario ~= "" then
             Prefs.SetToCurrentProfile('LastScenario', self.desiredScenario)
-            SetGameOption('ScenarioFile',self.desiredScenario, false, true)
+            SetGameOption('ScenarioFile',self.desiredScenario, true)
         else
             local scen = Prefs.GetFromCurrentProfile('LastScenario')
             if scen and scen ~= "" then
-                SetGameOption('ScenarioFile',scen, false, true)
+                SetGameOption('ScenarioFile',scen, true)
             end
         end
 
@@ -4759,15 +4759,9 @@ function SetPlayerOption(slot, key, val, ignoreRefresh)
     end
 end
 
-function SetGameOption(key, val, ignoreNilValue, ignoreRefresh)
+function SetGameOption(key, val, ignoreRefresh)
     local scenarioInfo = nil
-    ignoreNilValue = ignoreNilValue or false
     ignoreRefresh = ignoreRefresh or false
-
-    if (not ignoreNilValue) and ((key == nil) or (val == nil)) then
-        WARN('Attempt to set nil lobby game option: ' .. tostring(key) .. ' ' .. tostring(val))
-        return
-    end
 
     if not lobbyComm:IsHost() then
         WARN('Attempt to set game option by a non-host')
@@ -6221,7 +6215,7 @@ function LOAD_PRESET_IN_PREF() -- GET OPTIONS IN PRESET AND SET TO LOBBY
         RuleTitle_SendMSG()
         --AddChatText('> PRESET > MapPath : '..profiles[Selected_Preset].MapPath)
         if check_Map_Exist(profiles[Selected_Preset].MapPath) == true then
-            SetGameOption('ScenarioFile', profiles[Selected_Preset].MapPath, false, true)
+            SetGameOption('ScenarioFile', profiles[Selected_Preset].MapPath, true)
         else
             AddChatText('MAP NOT EXIST !')
         end
@@ -6238,10 +6232,10 @@ function LOAD_PRESET_IN_PREF() -- GET OPTIONS IN PRESET AND SET TO LOBBY
                 --AddChatText('> PRESET > UnitsRestricts : '..k..' // '..tostring(profiles[Selected_Preset].UnitsRestricts[k])) -->>> PRESET UnitsRestricts : AIR = true
                 table.insert(urestrict, k)
             end
-            SetGameOption('RestrictedCategories', urestrict, false, true)
+            SetGameOption('RestrictedCategories', urestrict, true)
         else
             -- Clear Restricted
-            SetGameOption('RestrictedCategories', {}, false, true)
+            SetGameOption('RestrictedCategories', {}, true)
         end
 
         --
@@ -6270,9 +6264,9 @@ function LOAD_PRESET_IN_PREF() -- GET OPTIONS IN PRESET AND SET TO LOBBY
                 --AddChatText('> PRESET > Settings : '..k..' // v : '..tostring(v)) -->>> PRESET Settings : UnitCap = disabled
                 --LOG('> PRESET > Settings : '..k..' // v : '..tostring(v)) -->>> PRESET Settings : UnitCap = disabled
                 if k == "AllowObservers" then
-                    SetGameOption("AllowObservers", v, false, true)
+                    SetGameOption("AllowObservers", v, true)
                 else
-                    SetGameOption(k, v, false, true)
+                    SetGameOption(k, v, true)
                 end
             end
         end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2743,22 +2743,21 @@ function CreateUI(maxPlayers)
             quickRandMap = false
             local function selectBehavior(selectedScenario, changedOptions, restrictedCategories)
                 if autoRandMap then
-                    Prefs.SetToCurrentProfile('LastScenario', selectedScenario.file)
                     gameInfo.GameOptions['ScenarioFile'] = selectedScenario.file
                 else
-                    Prefs.SetToCurrentProfile('LastScenario', selectedScenario.file)
                     mapSelectDialog:Destroy()
                     GUI.chatEdit:AcquireFocus()
                     for optionKey, data in changedOptions do
-                        Prefs.SetToCurrentProfile(data.pref, data.index)
                         SetGameOption(optionKey, data.value)
                     end
-                    --SendSystemMessage(selectedScenario.file)
 
-                    SetGameOption('ScenarioFile',selectedScenario.file)
+                    -- TODO: Merge with changedOptions so we don't do this work if the map hasn't
+                    -- really changed.
+                    SetGameOption('ScenarioFile', selectedScenario.file)
 
                     SetGameOption('RestrictedCategories', restrictedCategories, true)
-                    ClearBadMapFlags()  -- every new map, clear the flags, and clients will report if a new map is bad
+                    -- every new map, clear the flags, and clients will report if a new map is bad
+                    ClearBadMapFlags()
                     HostUpdateMods()
                     UpdateGame()
                 end
@@ -3476,23 +3475,18 @@ function CreateUI(maxPlayers)
     else
         GUI.randTeam.OnClick = function(self, modifiers)
             if gameInfo.GameOptions['AutoTeams'] == 'none' then
-                Prefs.SetToCurrentProfile('Lobby_Auto_Teams', 2)
                 SetGameOption('AutoTeams', 'tvsb')
                 SendSystemMessage("Auto Teams option set: Top vs Bottom")
             elseif gameInfo.GameOptions['AutoTeams'] == 'tvsb' then
-                Prefs.SetToCurrentProfile('Lobby_Auto_Teams', 3)
                 SetGameOption('AutoTeams', 'lvsr')
                 SendSystemMessage("Auto Teams option set: Left vs Right")
             elseif gameInfo.GameOptions['AutoTeams'] == 'lvsr' then
-                Prefs.SetToCurrentProfile('Lobby_Auto_Teams', 4)
                 SetGameOption('AutoTeams', 'pvsi')
                 SendSystemMessage("Auto Teams option set: Even Slots vs Odd Slots")
             elseif gameInfo.GameOptions['AutoTeams'] == 'pvsi' then
-                Prefs.SetToCurrentProfile('Lobby_Auto_Teams', 5)
                 SetGameOption('AutoTeams', 'manual')
                 SendSystemMessage("Auto Teams option set: Manual Select")
             else
-                Prefs.SetToCurrentProfile('Lobby_Auto_Teams', 1)
                 SetGameOption('AutoTeams', 'none')
                 SendSystemMessage("Auto Teams option set: None")
             end
@@ -3508,15 +3502,6 @@ function CreateUI(maxPlayers)
         GUI.rankedOptions:Disable()
     else
         GUI.rankedOptions.OnClick = function()
-            Prefs.SetToCurrentProfile('Lobby_Gen_Victory', 1)
-            Prefs.SetToCurrentProfile('Lobby_Gen_Timeouts', 2)
-            Prefs.SetToCurrentProfile('Lobby_Gen_CheatsEnabled', 1)
-            Prefs.SetToCurrentProfile('Lobby_Gen_Civilians', 1)
-            Prefs.SetToCurrentProfile('Lobby_Gen_GameSpeed', 1)
-            Prefs.SetToCurrentProfile('Lobby_Gen_Fog', 1)
-            Prefs.SetToCurrentProfile('Lobby_Gen_Cap', 8)
-            Prefs.SetToCurrentProfile('Lobby_Prebuilt_Units', 1)
-            Prefs.SetToCurrentProfile('Lobby_NoRushOption', 1)
             SetGameOption('Victory', 'demoralization', true)
             SetGameOption('Timeouts', '3', true)
             SetGameOption('CheatsEnabled', 'false', true)
@@ -3556,14 +3541,11 @@ function CreateUI(maxPlayers)
             quickRandMap = false
             local function selectBehavior(selectedScenario, changedOptions, restrictedCategories)
                 if autoRandMap then
-                    Prefs.SetToCurrentProfile('LastScenario', selectedScenario.file)
                     gameInfo.GameOptions['ScenarioFile'] = selectedScenario.file
                 else
-                    Prefs.SetToCurrentProfile('LastScenario', selectedScenario.file)
                     mapSelectDialog:Destroy()
                     GUI.chatEdit:AcquireFocus()
                     for optionKey, data in changedOptions do
-                        Prefs.SetToCurrentProfile(data.pref, data.index)
                         SetGameOption(optionKey, data.value)
                     end
 
@@ -4592,30 +4574,28 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
             gameInfo.PlayerOptions[1].Faction = 4
         end
 
+        -- Given an option key, find the value stored in the profile (if any) and assign either it,
+        -- or that option's default value, to the current game state.
+        local setOptionsFromPref = function(option)
+            local defValue = Prefs.GetFromCurrentProfile("LobbyOpt_" .. option.key) or option.default
+            SetGameOption(option.key, defValue, true)
+        end
+
         -- set default lobby values
         for index, option in globalOpts do
-            local defValue = Prefs.GetFromCurrentProfile(option.pref) or option.default
-            SetGameOption(option.key,option.values[defValue].key, true)
+            setOptionsFromPref(option)
         end
 
         for index, option in teamOpts do
-            local defValue = Prefs.GetFromCurrentProfile(option.pref) or option.default
-            SetGameOption(option.key,option.values[defValue].key, true)
+            setOptionsFromPref(option)
         end
 
         for index, option in AIOpts do
-            local defValue = Prefs.GetFromCurrentProfile(option.pref) or option.default
-            SetGameOption(option.key,option.values[defValue].key, true)
+            setOptionsFromPref(option)
         end
 
         if self.desiredScenario and self.desiredScenario ~= "" then
-            Prefs.SetToCurrentProfile('LastScenario', self.desiredScenario)
             SetGameOption('ScenarioFile',self.desiredScenario, true)
-        else
-            local scen = Prefs.GetFromCurrentProfile('LastScenario')
-            if scen and scen ~= "" then
-                SetGameOption('ScenarioFile',scen, true)
-            end
         end
 
         UpdateGame()
@@ -4768,6 +4748,7 @@ function SetGameOption(key, val, ignoreRefresh)
         return
     end
 
+    Prefs.SetToCurrentProfile('LobbyOpt_' .. key, val)
     gameInfo.GameOptions[key] = val
 
     lobbyComm:BroadcastData {
@@ -6219,8 +6200,6 @@ function LOAD_PRESET_IN_PREF() -- GET OPTIONS IN PRESET AND SET TO LOBBY
         else
             AddChatText('MAP NOT EXIST !')
         end
-        --gameInfo.GameOptions['ScenarioFile'] = profiles[Selected_Preset].MapPath
-        --Prefs.SetToCurrentProfile('LastScenario', profiles[Selected_Preset].MapPath)
 
         --
 

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2566,7 +2566,6 @@ function CreateSlotsUI(makeLabel)
         --TODO these need layout from art when available
         newSlot.Width:Set(GUI.labelGroup.Width)
         newSlot.Height:Set(GUI.labelGroup.Height)
-        newSlot._slot = i
 
         -- Default mouse behaviours for the slot.
         local defaultHandler = function(self, event)
@@ -2645,11 +2644,10 @@ function CreateSlotsUI(makeLabel)
         LayoutHelpers.AtVerticalCenterIn(nameLabel, newSlot, 8)
         LayoutHelpers.AtLeftIn(nameLabel, GUI.panel, slotColumnSizes.player.x)
         nameLabel.Width:Set(slotColumnSizes.player.width)
-        nameLabel.row = i
         -- left deal with name clicks
         nameLabel.OnEvent = defaultHandler
         nameLabel.OnClick = function(self, index, text)
-            DoSlotBehavior(self.row, self.slotKeys[index], text)
+            DoSlotBehavior(curRow, self.slotKeys[index], text)
         end
 
         -- Color
@@ -2659,27 +2657,25 @@ function CreateSlotsUI(makeLabel)
         LayoutHelpers.AtLeftIn(colorSelector, GUI.panel, slotColumnSizes.color.x)
         LayoutHelpers.AtVerticalCenterIn(colorSelector, newSlot, 8)
         colorSelector.Width:Set(slotColumnSizes.color.width)
-        colorSelector.row = i
         colorSelector.OnClick = function(self, index)
             if not lobbyComm:IsHost() then
-                lobbyComm:SendData(hostID, { Type = 'RequestColor', Color = index, Slot = self.row } )
-                gameInfo.PlayerOptions[self.row].PlayerColor = index
-                gameInfo.PlayerOptions[self.row].ArmyColor = index
+                lobbyComm:SendData(hostID, { Type = 'RequestColor', Color = index, Slot = curRow } )
+                gameInfo.PlayerOptions[curRow].PlayerColor = index
+                gameInfo.PlayerOptions[curRow].ArmyColor = index
                 UpdateGame()
             else
                 if IsColorFree(index) then
-                    lobbyComm:BroadcastData( { Type = 'SetColor', Color = index, Slot = self.row } )
-                    gameInfo.PlayerOptions[self.row].PlayerColor = index
-                    gameInfo.PlayerOptions[self.row].ArmyColor = index
+                    lobbyComm:BroadcastData( { Type = 'SetColor', Color = index, Slot = curRow } )
+                    gameInfo.PlayerOptions[curRow].PlayerColor = index
+                    gameInfo.PlayerOptions[curRow].ArmyColor = index
                     UpdateGame()
                 else
-                    self:SetItem( gameInfo.PlayerOptions[self.row].PlayerColor )
+                    self:SetItem( gameInfo.PlayerOptions[curRow].PlayerColor )
                 end
             end
         end
         colorSelector.OnEvent = defaultHandler
         Tooltip.AddControlTooltip(colorSelector, 'lob_color')
-        colorSelector.row = i
 
         --// Faction
         local factionSelector = BitmapCombo(bg, factionBmps, table.getn(factionBmps), nil, nil, "UI_Tab_Rollover_01", "UI_Tab_Click_01")
@@ -2688,15 +2684,15 @@ function CreateSlotsUI(makeLabel)
         LayoutHelpers.AtVerticalCenterIn(factionSelector, newSlot, 8)
         factionSelector.Width:Set(slotColumnSizes.faction.width)
         factionSelector.OnClick = function(self, index)
-            SetPlayerOption(self.row,'Faction',index)
+            SetPlayerOption(curRow, 'Faction', index)
             if curRow == FindSlotForID(FindIDForName(localPlayerName)) then
                 SetCurrentFactionTo_Faction_Selector()
             end
+
             Tooltip.DestroyMouseoverDisplay()
         end
         Tooltip.AddControlTooltip(factionSelector, 'lob_faction')
         Tooltip.AddComboTooltip(factionSelector, factionTooltips)
-        factionSelector.row = i
         factionSelector.OnEvent = defaultHandler
         if not hasSupcom then
             factionSelector:SetItem(4)
@@ -2708,10 +2704,9 @@ function CreateSlotsUI(makeLabel)
         LayoutHelpers.AtLeftIn(teamSelector, GUI.panel, slotColumnSizes.team.x)
         LayoutHelpers.AtVerticalCenterIn(teamSelector, newSlot, 8)
         teamSelector.Width:Set(slotColumnSizes.team.width)
-        teamSelector.row = i
         teamSelector.OnClick = function(self, index, text)
             Tooltip.DestroyMouseoverDisplay()
-            SetPlayerOption(self.row,'Team',index)
+            SetPlayerOption(curRow, 'Team', index)
         end
         Tooltip.AddControlTooltip(teamSelector, 'lob_team')
         Tooltip.AddComboTooltip(teamSelector, teamTooltips)
@@ -2744,17 +2739,16 @@ function CreateSlotsUI(makeLabel)
         -- Ready Checkbox
         local readyBox = UIUtil.CreateCheckboxStd(newSlot.multiSpace, '/CHECKBOX/radio')
         newSlot.ready = readyBox
-        readyBox.row = i
         LayoutHelpers.AtVerticalCenterIn(readyBox, newSlot.multiSpace, 8)
         LayoutHelpers.AtLeftIn(readyBox, newSlot.multiSpace, 0)
         readyBox.OnCheck = function(self, checked)
             UIUtil.setEnabled(GUI.becomeObserver, not checked)
             if checked then
-                DisableSlot(self.row, true)
+                DisableSlot(curRow, true)
             else
-                EnableSlot(self.row)
+                EnableSlot(curRow)
             end
-            SetPlayerOption(self.row,'Ready',checked)
+            SetPlayerOption(curRow,'Ready',checked)
         end
 
         if singlePlayer then
@@ -2763,7 +2757,6 @@ function CreateSlotsUI(makeLabel)
             pingGroup:Hide()
             pingStatus:Hide()
         end
-
 
         if i == 1 then
             LayoutHelpers.Below(newSlot, GUI.labelGroup, -5)

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -4769,45 +4769,46 @@ function SetGameOption(key, val, ignoreNilValue, ignoreRefresh)
         return
     end
 
-    if lobbyComm:IsHost() then
-        gameInfo.GameOptions[key] = val
+    if not lobbyComm:IsHost() then
+        WARN('Attempt to set game option by a non-host')
+        return
+    end
 
-        lobbyComm:BroadcastData {
-            Type = 'GameOption',
-            Key = key,
-            Value = val,
-        }
+    gameInfo.GameOptions[key] = val
 
-        LOG('SetGameOption(key='..repr(key)..',val='..repr(val)..')')
+    lobbyComm:BroadcastData {
+        Type = 'GameOption',
+        Key = key,
+        Value = val,
+    }
 
-        -- don't want to send all restricted categories to gpgnet, so just send bool
-        -- note if more things need to be translated to gpgnet, a translation table would be a better implementation
-        -- but since there's only one, we'll call it out here
-        if key == 'RestrictedCategories' then
-            local restrictionsEnabled = false
-            if val ~= nil then
-                if table.getn(val) ~= 0 then
-                    restrictionsEnabled = true
-                end
+    LOG('SetGameOption(key='..repr(key)..',val='..repr(val)..')')
+
+    -- don't want to send all restricted categories to gpgnet, so just send bool
+    -- note if more things need to be translated to gpgnet, a translation table would be a better implementation
+    -- but since there's only one, we'll call it out here
+    if key == 'RestrictedCategories' then
+        local restrictionsEnabled = false
+        if val ~= nil then
+            if table.getn(val) ~= 0 then
+                restrictionsEnabled = true
             end
-            GpgNetSend('GameOption', key, restrictionsEnabled)
-        elseif key == 'ScenarioFile' then
-            GpgNetSend('GameOption', key, val)
-            if gameInfo.GameOptions.ScenarioFile and (gameInfo.GameOptions.ScenarioFile ~= '') then
-                scenarioInfo = MapUtil.LoadScenario(gameInfo.GameOptions.ScenarioFile)
-                if scenarioInfo and scenarioInfo.map and (scenarioInfo.map ~= '') then
-                    GpgNetSend('GameOption', 'Slots', table.getsize(scenarioInfo.Configurations.standard.teams[1].armies))
-                end
-            end
-        else
-            GpgNetSend('GameOption', key, val)
         end
-
-        if not ignoreRefresh then
-            UpdateGame()
+        GpgNetSend('GameOption', key, restrictionsEnabled)
+    elseif key == 'ScenarioFile' then
+        GpgNetSend('GameOption', key, val)
+        if gameInfo.GameOptions.ScenarioFile and (gameInfo.GameOptions.ScenarioFile ~= '') then
+            scenarioInfo = MapUtil.LoadScenario(gameInfo.GameOptions.ScenarioFile)
+            if scenarioInfo and scenarioInfo.map and (scenarioInfo.map ~= '') then
+                GpgNetSend('GameOption', 'Slots', table.getsize(scenarioInfo.Configurations.standard.teams[1].armies))
+            end
         end
     else
-        WARN('Attempt to set game option by a non-host')
+        GpgNetSend('GameOption', key, val)
+    end
+
+    if not ignoreRefresh then
+        UpdateGame()
     end
 end
 

--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -9,7 +9,7 @@
 teamOptions =
 {
     {
-        default = 1,
+        default = 2,
         label = "<LOC lobui_0088>Spawn",
         help = "<LOC lobui_0089>Determine what positions players spawn on the map",
         key = 'TeamSpawn',
@@ -81,7 +81,7 @@ teamOptions =
 
 globalOpts = {
     {
-        default = 4,
+        default = 8,
         label = "<LOC lobui_0102>Unit Cap",
         help = "<LOC lobui_0103>Set the maximum number of units that can be in play",
         key = 'UnitCap',

--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -2,7 +2,7 @@
 --* File: lua/modules/ui/lobby/lobbyOptions.lua
 --* Summary: Lobby options
 --*
---* Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+--* Copyright ï¿½ 2006 Gas Powered Games, Inc.  All rights reserved.
 --*****************************************************************************
 
 -- options that show up in the team options panel
@@ -13,7 +13,6 @@ teamOptions =
         label = "<LOC lobui_0088>Spawn",
         help = "<LOC lobui_0089>Determine what positions players spawn on the map",
         key = 'TeamSpawn',
-        pref = 'Lobby_Team_Spawn',
         values = {
             {
                 text = "<LOC lobui_0090>Random",
@@ -32,7 +31,6 @@ teamOptions =
         label = "<LOC lobui_0096>Team",
         help = "<LOC lobui_0097>Determines if players may switch teams while in game",
         key = 'TeamLock',
-        pref = 'Lobby_Team_Lock',
         values = {
             {
                 text = "<LOC lobui_0098>Locked",
@@ -51,7 +49,6 @@ teamOptions =
         label = "<LOC lobui_0532>Auto Teams",
         help = "<LOC lobui_0533>Auto ally the players before the game starts",
         key = 'AutoTeams',
-        pref = 'Lobby_Auto_Teams',
         values = {
             {
                 text = "<LOC lobui_0244>None",
@@ -88,7 +85,6 @@ globalOpts = {
         label = "<LOC lobui_0102>Unit Cap",
         help = "<LOC lobui_0103>Set the maximum number of units that can be in play",
         key = 'UnitCap',
-        pref = 'Lobby_Gen_Cap',
         values = {
           {
                 text = "<LOC lobui_0719>125",
@@ -147,7 +143,6 @@ globalOpts = {
         label = "Share Unit Cap at Death",
         help = "Enable this to share unitcap when a player dies",
         key = 'ShareUnitCap',
-        pref = 'Lobby_Gen_Share_Cap',
         values = {
           {
                 text = "None",
@@ -171,7 +166,6 @@ globalOpts = {
         label = "<LOC lobui_0112>Fog of War",
         help = "<LOC lobui_0113>Set up how fog of war will be visualized",
         key = 'FogOfWar',
-        pref = 'Lobby_Gen_Fog',
         values = {
             {
                 text = "<LOC lobui_0114>Explored",
@@ -190,7 +184,6 @@ globalOpts = {
         label = "<LOC lobui_0120>Victory Condition",
         help = "<LOC lobui_0121>Determines how a victory can be achieved",
         key = 'Victory',
-        pref = 'Lobby_Gen_Victory',
         values = {
             {
                 text = "<LOC lobui_0122>Assassination",
@@ -219,7 +212,6 @@ globalOpts = {
         label = "<LOC lobui_0242>Timeouts",
         help = "<LOC lobui_0243>Sets the number of timeouts each player can request",
         key = 'Timeouts',
-        pref = 'Lobby_Gen_Timeouts',
         mponly = true,
         values = {
             {
@@ -244,7 +236,6 @@ globalOpts = {
         label = "<LOC lobui_0258>Game Speed",
         help = "<LOC lobui_0259>Set the game speed",
         key = 'GameSpeed',
-        pref = 'Lobby_Gen_GameSpeed',
         values = {
             {
                 text = "<LOC lobui_0260>Normal",
@@ -268,7 +259,6 @@ globalOpts = {
         label = "<LOC lobui_0208>Cheating",
         help = "<LOC lobui_0209>Enable cheat codes",
         key = 'CheatsEnabled',
-        pref = 'Lobby_Gen_CheatsEnabled',
         values = {
             {
                 text = "<LOC _Off>Off",
@@ -287,7 +277,6 @@ globalOpts = {
         label = "<LOC lobui_0291>Civilians",
         help = "<LOC lobui_0292>Set how civilian units are used",
         key = 'CivilianAlliance',
-        pref = 'Lobby_Gen_Civilians',
         values = {
             {
                 text = "<LOC lobui_0293>Enemy",
@@ -311,7 +300,6 @@ globalOpts = {
         label = "<LOC lobui_0310>Prebuilt Units",
         help = "<LOC lobui_0311>Set whether the game starts with prebuilt units or not",
         key = 'PrebuiltUnits',
-        pref = 'Lobby_Prebuilt_Units',
         values = {
             {
                 text = "<LOC lobui_0312>Off",
@@ -330,7 +318,6 @@ globalOpts = {
         label = "<LOC lobui_0316>No Rush Option",
         help = "<LOC lobui_0317>Enforce No Rush rules for a certain period of time",
         key = 'NoRushOption',
-        pref = 'Lobby_NoRushOption',
         values = {
             {
                 text = "<LOC lobui_0318>Off",
@@ -359,7 +346,6 @@ globalOpts = {
         label = "<LOC lobui_0545>Random Map",
         help = "<LOC lobui_0546>If enabled, the game will selected a random map just before the game launch",
         key = 'RandomMap',
-        pref = 'Lobby_Random_Map',
         values = {
             {
                 text = "<LOC lobui_0312>Off",
@@ -383,7 +369,6 @@ globalOpts = {
         label = "<LOC lobui_0727>Score",
         help = "<LOC lobui_0728>Set score on or off during the game",
         key = 'Score',
-        pref = 'Lobby_Score',
         values = {
             {
                 text = "<LOC _On>On",
@@ -402,7 +387,6 @@ globalOpts = {
         label = "<LOC lobui_0740>Share Conditions",
         help = "<LOC lobui_0741>Kill all the units you shared to your allies and send back the units your allies shared with you when you die",
         key = 'Share',
-        pref = 'Lobby_Share',
         values = {
             {
                 text = "<LOC lobui_0742>Full Share",
@@ -424,7 +408,6 @@ AIOpts = {
         label = "AIx Cheat Multiplier",
         help = "Set the cheat multiplier for the cheating AIs.",
         key = 'CheatMult',
-        pref = 'Lobby_Cheat_Mult',
         values = {
             {
                 text = "1.0",
@@ -687,7 +670,6 @@ AIOpts = {
         label = "AIx Build Multiplier",
         help = "Set the build rate multiplier for the cheating AIs.",
         key = 'BuildMult',
-        pref = 'Lobby_Build_Mult',
         values = {
             {
                 text = "1.0",
@@ -950,7 +932,6 @@ AIOpts = {
         label = "AI TML Randomization",
         help = "Sets the randomization for the AI\'s TMLs making them miss more. Higher means less accurate.",
         key = 'TMLRandom',
-        pref = 'Lobby_TML_Randomization',
         values = {
             {
                 text = "None",
@@ -1003,7 +984,6 @@ AIOpts = {
         label = "AI Land Expansion Limit",
         help = "Set the limit for the number of land expansions that each AI can have (will still be modified by the number of AIs).",
         key = 'LandExpansionsAllowed',
-        pref = 'Lobby_Land_Expansions_Allowed',
         values = {
             {
                 text = "None",
@@ -1061,7 +1041,6 @@ AIOpts = {
         label = "AI Naval Expansion Limit",
         help = "Set the limit for the number of naval expansions that each AI can have.",
         key = 'NavalExpansionsAllowed',
-        pref = 'Lobby_Naval_Expansions_Allowed',
         values = {
             {
                 text = "None",
@@ -1119,7 +1098,6 @@ AIOpts = {
         label = "AIx Omni Setting",
         help = "Set the build rate multiplier for the cheating AIs.",
         key = 'OmniCheat',
-        pref = 'Lobby_Omni_Cheat',
         values = {
             {
                 text = "On",


### PR DESCRIPTION
This switches specifying the set of options deemed acceptable for a game to be "ranked" to a neater, more declarative solution.
Some miscellaneous cleanup of CreateUI was required to get the upvalue count down: Sorry for the slightly offtopic commits.
Some cherry-picking from the tangled mess that is PR #339 occurred.

Noteworthy changes:
- Game options are stored in the profile *by value* now, not by key. Yes, this will break existing saved data, no, I don't care - it simplifies things a lot and nobody will be bothered about resetting their options once.
- A set of values for each game option can now be specified as being acceptable for a game to be considered "ranked".

It's unclear where, if anywhere, the determination of rankness of a game is actually *used*. @Sheeo: perhaps you can clarify this one loose end?