### PR TITLE
Prevent default options from being improperly set on blank profiles

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3816,33 +3816,23 @@ function RefreshOptionDisplayData(scenarioInfo)
             tooltip = { text = optData.label, body = optData.help }
         }
 
-        -- Options are stored as keys from values array in optData. We want to display the
+        -- Options are stored as keys from the values array in optData. We want to display the
         -- descriptive string in the UI, so let's go dig it out.
 
-        -- If the is value is unset, it is definitely its default so we directly lookup what we want.
-        if not gameOption then
-            local val = optData.values[optData.default]
+        -- Scan the values array to find the one with the key matching our value for that option.
+        for k, val in optData.values do
+            if val.key == gameOption then
+                option.value = val.text
+                option.valueTooltip = {text = optData.label, body = val.help }
 
-            option.value = val.text
-            option.valueTooltip = {text = optData.label, body = val.help }
+                table.insert(formattedOptions, option)
 
-            table.insert(formattedOptions, option)
-        else
-            -- Scan the values array to find the one with the key matching our value for that option.
-            for k, val in optData.values do
-                if val.key == gameOption then
-                    option.value = val.text
-                    option.valueTooltip = {text = optData.label, body = val.help }
-
-                    table.insert(formattedOptions, option)
-
-                    -- Add this option to the non-default set for the UI.
-                    if k ~= optData.default then
-                        table.insert(nonDefaultFormattedOptions, option)
-                    end
-
-                    break
+                -- Add this option to the non-default set for the UI.
+                if k ~= optData.default then
+                    table.insert(nonDefaultFormattedOptions, option)
                 end
+
+                break
             end
         end
     end
@@ -4461,7 +4451,7 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
         -- Given an option key, find the value stored in the profile (if any) and assign either it,
         -- or that option's default value, to the current game state.
         local setOptionsFromPref = function(option)
-            local defValue = Prefs.GetFromCurrentProfile("LobbyOpt_" .. option.key) or option.default
+            local defValue = Prefs.GetFromCurrentProfile("LobbyOpt_" .. option.key) or option.values[option.default].key
             SetGameOption(option.key, defValue, true)
         end
 


### PR DESCRIPTION
Currently, if a host hosts a game using a profile that doesn't have sensible values for default options set on it, the options would be set to values equal to the index in the corresponding lobbyOptions value array where the default value lives.
This would prevent the game from starting, as the resulting values weren't valid settings. This would also prevent options from showing up in the box summarising game options.