### PR TITLE
Bring back vanishing checkboxes

### DIFF
--- a/lua/ui/controls/radiobutton.lua
+++ b/lua/ui/controls/radiobutton.lua
@@ -43,7 +43,7 @@ RadioButton = Class(Group) {
             end
 
 
-            local checkbox = UIUtil.CreateCheckboxStd(self, buttonTexturePath, button.label, labelRight)
+            local checkbox = UIUtil.CreateCheckbox(self, buttonTexturePath, button.label, labelRight)
 
             if button.label then
                 checkbox.label:SetFont(font, fontSize)

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -625,7 +625,7 @@ end
 		group.Height:Set(function() return group.edit.Height() end)
 		
 		local function CreateTestBtn(text)
-			local btn = UIUtil.CreateCheckboxStd(group, '/dialogs/toggle_btn/toggle')
+			local btn = UIUtil.CreateCheckbox(group, '/dialogs/toggle_btn/toggle')
 			btn.Depth:Set(function() return group.Depth() + 10 end)
 			btn.OnClick = function(self, modifiers)
 				if self._checkState == "unchecked" then
@@ -1341,7 +1341,7 @@ function CreateConfigWindow()
         local group = Group(optionGroup)
         if data.type == 'filter' then
             group.name = UIUtil.CreateText(group, data.name, 14, "Arial")
-            group.check = UIUtil.CreateCheckboxStd(group, '/dialogs/check-box_btn/')
+            group.check = UIUtil.CreateCheckbox(group, '/dialogs/check-box_btn/')
             LayoutHelpers.AtLeftTopIn(group.check, group)
             LayoutHelpers.RightOf(group.name, group.check)
             LayoutHelpers.AtVerticalCenterIn(group.name, group.check)

--- a/lua/ui/lobby/ModsManager.lua
+++ b/lua/ui/lobby/ModsManager.lua
@@ -88,7 +88,7 @@ function NEW_MODS_GUI(parent, IsHost, modstatus, availableMods)
     LayoutHelpers.AtBottomIn(SaveButton, dialog2, 10)
         
     -- Checkbox UI mod filter
-    local cbox_UI = UIUtil.CreateCheckboxStd(dialog2, '/RADIOBOX/')
+    local cbox_UI = UIUtil.CreateCheckbox(dialog2, '/RADIOBOX/')
     LayoutHelpers.AtLeftIn(cbox_UI, dialog2, 20+130+10)
     LayoutHelpers.AtBottomIn(cbox_UI, dialog2, 16)
     Tooltip.AddCheckboxTooltip(cbox_UI, {text='UI Mods', body='UI mods are activated only for you. You can have a mod of this type activated without the enemy knowing'})
@@ -101,7 +101,7 @@ function NEW_MODS_GUI(parent, IsHost, modstatus, availableMods)
     cbox_UI:SetCheck(true, true)
             
     -- Checkbox game mod filter
-    local cbox_GAME = UIUtil.CreateCheckboxStd(dialog2, '/RADIOBOX/')
+    local cbox_GAME = UIUtil.CreateCheckbox(dialog2, '/RADIOBOX/')
     LayoutHelpers.AtLeftIn(cbox_GAME, dialog2, 20+130+100)
     LayoutHelpers.AtBottomIn(cbox_GAME, dialog2, 16)
     Tooltip.AddCheckboxTooltip(cbox_GAME, {text='Game Mods', body='Game mods are activated for all players, and all players must have the same version of the mod'})
@@ -114,7 +114,7 @@ function NEW_MODS_GUI(parent, IsHost, modstatus, availableMods)
     cbox_GAME:SetCheck(false, true)
             
     -- Checkbox hide unselectable mods
-    local cbox_Act = UIUtil.CreateCheckboxStd(dialog2, '/CHECKBOX/')
+    local cbox_Act = UIUtil.CreateCheckbox(dialog2, '/CHECKBOX/')
     LayoutHelpers.AtLeftIn(cbox_Act, dialog2, 20+130+120+100)
     LayoutHelpers.AtBottomIn(cbox_Act, dialog2, 23)
     Tooltip.AddCheckboxTooltip(cbox_Act, {text='Hide Unselectable', body='Hide mods which are unselectable due to compatibility issues, or because a player in the lobby does not have them'})
@@ -127,7 +127,7 @@ function NEW_MODS_GUI(parent, IsHost, modstatus, availableMods)
     cbox_Act:SetCheck(true, true)
             
     -- Checkbox condensed list
-    local cbox_Act2 = UIUtil.CreateCheckboxStd(dialog2, '/CHECKBOX/')
+    local cbox_Act2 = UIUtil.CreateCheckbox(dialog2, '/CHECKBOX/')
     LayoutHelpers.AtLeftIn(cbox_Act2, dialog2, 20+130+120+100)
     LayoutHelpers.AtBottomIn(cbox_Act2, dialog2, 6)
     Tooltip.AddCheckboxTooltip(cbox_Act2, {text='Condensed View', body='Displays mods as a simplified list'})

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2770,7 +2770,7 @@ function CreateSlotsUI(makeLabel)
         newSlot.multiSpace.Top:Set(newSlot.Top)
 
         -- Ready Checkbox
-        local readyBox = UIUtil.CreateCheckboxStd(newSlot.multiSpace, '/CHECKBOX/')
+        local readyBox = UIUtil.CreateCheckbox(newSlot.multiSpace, '/CHECKBOX/')
         newSlot.ready = readyBox
         LayoutHelpers.AtVerticalCenterIn(readyBox, newSlot.multiSpace, 8)
         LayoutHelpers.AtLeftIn(readyBox, newSlot.multiSpace, 0)
@@ -3005,7 +3005,7 @@ function CreateUI(maxPlayers)
 
     -- Checkbox Show changed Options
     -- TODO: Localise!
-    local cbox_ShowChangedOption = UIUtil.CreateCheckboxStd(GUI.optionsPanel, '/CHECKBOX/', 'Hide default Options', true, 11)
+    local cbox_ShowChangedOption = UIUtil.CreateCheckbox(GUI.optionsPanel, '/CHECKBOX/', 'Hide default Options', true, 11)
     LayoutHelpers.AtLeftTopIn(cbox_ShowChangedOption, GUI.optionsPanel, 3, 0)
 
     Tooltip.AddCheckboxTooltip(cbox_ShowChangedOption, {text='Hide default Options', body='Show only changed Options and Advanced Map Options'})
@@ -3431,7 +3431,7 @@ function CreateUI(maxPlayers)
     -- set up observer and limbo grid
     ---------------------------------------------------------------------------
 
-    GUI.allowObservers = UIUtil.CreateCheckboxStd(GUI.buttonPanelTop, '/CHECKBOX/', 'Observers in Game', true, 11)
+    GUI.allowObservers = UIUtil.CreateCheckbox(GUI.buttonPanelTop, '/CHECKBOX/', 'Observers in Game', true, 11)
     LayoutHelpers.AtLeftTopIn(GUI.allowObservers, GUI.buttonPanelTop)
     Tooltip.AddControlTooltip(GUI.allowObservers, 'lob_observers_allowed')
     GUI.allowObservers:SetCheck(false)
@@ -3627,7 +3627,7 @@ function CreateUI(maxPlayers)
     end
 
     if lobbyComm:IsHost() and not singlePlayer then
-        local autoKickBox = UIUtil.CreateCheckboxStd(GUI.buttonPanelTop, '/CHECKBOX/', "Auto kick", true, 11)
+        local autoKickBox = UIUtil.CreateCheckbox(GUI.buttonPanelTop, '/CHECKBOX/', "Auto kick", true, 11)
         LayoutHelpers.CenteredRightOf(autoKickBox, GUI.allowObservers, 10)
         Tooltip.AddControlTooltip(autoKickBox, 'lob_auto_kick')
         autoKick = true
@@ -5275,7 +5275,7 @@ function CreateOptionLobbyDialog()
         Prefs.SetToCurrentProfile('LobbyChatFontSize', sliderValue)
 	end
 	--
-    local cbox_WindowedLobby = UIUtil.CreateCheckboxStd(dialog2, '/CHECKBOX/', LOC("<LOC lobui_0402>"))
+    local cbox_WindowedLobby = UIUtil.CreateCheckbox(dialog2, '/CHECKBOX/', LOC("<LOC lobui_0402>"))
     LayoutHelpers.AtRightTopIn(cbox_WindowedLobby, dialog2, 20, 42)
     Tooltip.AddCheckboxTooltip(cbox_WindowedLobby, {text='Windowed mode', body=LOC("<LOC lobui_0403>")})
     cbox_WindowedLobby.OnCheck = function(self, checked)
@@ -5289,7 +5289,7 @@ function CreateOptionLobbyDialog()
         SetWindowedLobby(checked)
     end
     --
-    local cbox_StretchBG = UIUtil.CreateCheckboxStd(dialog2, '/CHECKBOX/', LOC("<LOC lobui_0400>"))
+    local cbox_StretchBG = UIUtil.CreateCheckbox(dialog2, '/CHECKBOX/', LOC("<LOC lobui_0400>"))
     LayoutHelpers.AtRightTopIn(cbox_StretchBG, dialog2, 20, 68)
     Tooltip.AddCheckboxTooltip(cbox_StretchBG, {text='Stretch Background', body=LOC("<LOC lobui_0401>")})
     cbox_StretchBG.OnCheck = function(self, checked)

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -521,7 +521,13 @@ function CreateButtonWithDropshadow(parent, filename, label, textOffsetVert, tex
         )
 end
 
-function CreateCheckboxStd(parent, texturePath, label, labelRight, labelSize, clickCue, rollCue)
+-- Create a checkbox using the default checkbox texture. Kept as its own entry point for the benefit
+-- of retarded GPG code that things "radiobtn" is a sensible name for a checkbox texture.
+function CreateCheckboxStd(parent)
+    return CreateCheckbox(parent, '/dialogs/check-box_btn/')
+end
+
+function CreateCheckbox(parent, texturePath, label, labelRight, labelSize, clickCue, rollCue)
     local checkbox = Checkbox(parent,
         SkinnableFile(texturePath .. 'd_up.dds'),
         SkinnableFile(texturePath .. 's_up.dds'),


### PR DESCRIPTION
Some GPG code we're not currently modifying was failing to create checkboxes because it was relying on the old naming convention.
The old convention named checkboxes "radio", which seems irritating. Here, we neatly dodge this problem by entirely ignoring the parameter GPG's calls to CreateCheckboxStd gives us. They always want to create a checkbox with the default textures, so let's rename our fancy checkbox-creating method to something else and turn the one GPG's untouched code uses into a single-argument default-checkboxes-only one.