### PR TITLE
Hint the targeting AI where to hit cybran sonar

### DIFF
--- a/units/URB3102/URB3102_unit.bp
+++ b/units/URB3102/URB3102_unit.bp
@@ -1,4 +1,9 @@
 UnitBlueprint {
+    AI = {
+        TargetBones = {
+            'Deck04'
+        },
+    },
     Audio = {
         Destroyed = Sound {
             Bank = 'URLDestroy',

--- a/units/URB3202/URB3202_unit.bp
+++ b/units/URB3202/URB3202_unit.bp
@@ -1,4 +1,9 @@
 UnitBlueprint {
+    AI = {
+        TargetBones = {
+            'Deck02'
+        },
+    },
     Audio = {
         Destroyed = Sound {
             Bank = 'URLDestroy',


### PR DESCRIPTION
This helps Seraphim Destroyer to hit the cybran sonar correctly.

@aeoncleanse: 
You have a hitbox patch for 3642 right? Maybe this solves some of the trouble without having to raise the actual units after completion. What do you think?