### PR TITLE
Intel refresh at give / upgrade / destroy

### DIFF
--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -112,6 +112,7 @@ function TransferUnitsOwnership(units, ToArmyIndex)
         end
 
         -- changing owner
+        unit:RefreshIntel()
         unit = ChangeUnitArmy(unit,ToArmyIndex)
         if not unit then
             continue

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -383,6 +383,33 @@ StructureUnit = Class(Unit) {
 
     end,
 
+    -- Refresh intel on a destroyed / upgraded unit by setting vision on the actual blip.
+    -- The expired blip will actually be destroyed right after when the intel system notices it's no longer there
+    RefreshIntel = function(self)
+        local army = self:GetArmy()
+        for i, brain in ArmyBrains do
+            if army ~= i and not IsAlly(i, army) then
+                local blip = self:GetBlip(i)
+
+                if blip then
+                    if not blip:IsSeenEver(i) and (blip:IsOnRadar(i) or blip:IsOnSonar(i)) then
+                        -- Remove dead radar blip out of map so we don't reveal what's under it
+                        blip:SetPosition(Vector(-100, 0, -100), true)
+                    end
+
+                    -- expired blip will disappear with this
+                    blip:InitIntel(i, 'Vision', 2)
+                    blip:EnableIntel('Vision')
+                end
+            end
+        end
+    end,
+
+    DestroyUnit = function(self)
+        self:RefreshIntel()
+        Unit.DestroyUnit(self)
+    end,
+
     -- Adding into OnDestroy the ability to destroy the tarmac but put a new one down that looks exactly like it but
     -- will time out over the time spec'd or 300 seconds.
     OnDestroy = function(self)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1660,6 +1660,9 @@ Unit = Class(moho.unit_methods) {
         ChangeState(self, self.DeadState)
     end,
 
+    RefreshIntel = function(self)
+    end,
+
     HideLandBones = function(self)
         --Hide the bones for buildings built on land
         if self.LandBuiltHiddenBones and self:GetCurrentLayer() == 'Land' then
@@ -1815,6 +1818,7 @@ Unit = Class(moho.unit_methods) {
             self.DisallowCollisions = false
             self:SetCanTakeDamage(true)
             self:RevertCollisionShape()
+            builder:RefreshIntel()
         end
 
         --Turn off land bones if this unit has them.


### PR DESCRIPTION
There's a bug where intel blips for destroyed / upgraded / given structures
don't get upgraded for enemy brains. This is problematic because you
cannot target given / upgraded stuff.

This is a workaround for this. When a structure dies it checks the enemy
brains if someone has a blip for it, if so it gets a brief vision on the
unit to get the updated intel.

Fixes #98