### PR TITLE
Fix UI corruption when watching replays

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -518,7 +518,8 @@ function CreateLobby(protocol, localPort, desiredPlayerName, localPlayerUID, nat
     if IsSyncReplayServer then
         SetFrontEndData('syncreplayid',localPlayerUID)
         dl = UIUtil.QuickDialog(GetFrame(0), "Downloading the replay file...")
-        LaunchReplaySession('gpgnet://' .. GetCommandLineArg('/gpgnet',1)[1] .. '/' .. import('/lua/user/prefs.lua').GetFromCurrentProfile('Name'))
+        UIUtil.SetCurrentSkin("uef")
+        LaunchReplaySession('gpgnet://' .. GetCommandLineArg('/gpgnet',1)[1] .. '/' .. Prefs.GetFromCurrentProfile('Name'))
         dl:Destroy()
         UIUtil.QuickDialog(GetFrame(0), "You dont have this map.", "Exit", function() ExitApplication() end)
     else


### PR DESCRIPTION
The "random" skin shall not be loaded in-game. This is enforced at game start (when the player who selected "random" is switched to the factional configuration that their randomness resolves to), and during skin rotation, but not when starting a replay, where it uses the skin for your last-used faction, which might be "random".

... So this ought to fix #416. Probably.