### PR TITLE
Remove auto-rand-map function

### DIFF
--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -297,34 +297,8 @@ function CreateDialog(selectBehavior, exitBehavior, over, singlePlayer, defaultS
     Tooltip.AddButtonTooltip(randomMapButton, 'lob_click_randmap')
 
     randomMapButton.OnClick = function(self, modifiers)
-        if randMapList ~= 0 then
-            local randomMapMessage
-            local nummapa
-            nummapa = math.random(1, randMapList)
-            if randMapList >= 2 and nummapa == doNotRepeatMap then
-                repeat
-                    nummapa = math.random(1, randMapList)
-                until nummapa ~= doNotRepeatMap
-            end
-            doNotRepeatMap = nummapa
-            local scen = scenarios[scenarioKeymap[nummapa]]
-            selectedScenario = scen
-            if not singlePlayer then
-                rMapName = scenarios[scenarioKeymap[nummapa]].name
-                rMapSize1 = scenarios[scenarioKeymap[nummapa]].size[1]/50
-                rMapSize2 = scenarios[scenarioKeymap[nummapa]].size[2]/50
-                rMapSizeFilLim = currentFilters.map_select_size_limiter
-                rMapSizeFil = currentFilters.map_select_size/50
-                rMapPlayersFilLim = currentFilters.map_select_supportedplayers_limiter
-                rMapPlayersFil = currentFilters.map_select_supportedplayers
-                rMapTypeFil = currentFilters.map_type
-            end
-            selectBehavior(selectedScenario, changedOptions, restrictedCategories)
-            ResetFilters()
-            if not singlePlayer then
-                randomMapMessage = import('/lua/ui/lobby/lobby.lua').sendRandMapMessage()
-            end
-        end
+        local randomMapIndex = math.floor(math.random(1, mapList:GetItemCount()))
+        mapList:OnClick(randomMapIndex)
     end
     if not singlePlayer then
         function randomLobbyMap()
@@ -489,22 +463,18 @@ function CreateDialog(selectBehavior, exitBehavior, over, singlePlayer, defaultS
         end
     end
 
-    mapList.OnKeySelect = function(self,row)
+    -- Called when the selected map is changed.
+    local onItemChanged = function(self, row, noSound)
         mapList:SetSelection(row)
         PreloadMap(row)
-        local sound = Sound({Cue = "UI_Skirmish_Map_Select", Bank = "Interface",})
-        PlaySound(sound)
-    end
-
-    mapList.OnClick = function(self, row, noSound)
-        mapList:SetSelection(row)
-        PreloadMap(row)
-        local sound = Sound({Cue = "UI_Skirmish_Map_Select", Bank = "Interface",})
+        local sound = Sound({Cue = "UI_Skirmish_Map_Select", Bank = "Interface"})
         if not noSound then
             PlaySound(sound)
         end
     end
 
+    mapList.OnKeySelect = onItemChanged
+    mapList.OnClick = onItemChanged
     mapList.OnDoubleClick = function(self, row)
         mapList:SetSelection(row)
         PreloadMap(row)

--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -321,26 +321,6 @@ function CreateDialog(selectBehavior, exitBehavior, over, singlePlayer, defaultS
             randomMapMessage = import('/lua/ui/lobby/lobby.lua').sendRandMapMessage()
         end
     end
-    function randomAutoMap(official)
-        local nummapa
-        nummapa = math.random(1, randMapList)
-        if randMapList >= 2 and nummapa == doNotRepeatMap then
-            repeat
-                nummapa = math.random(1, randMapList)
-            until nummapa ~= doNotRepeatMap
-        end
-        doNotRepeatMap = nummapa
-        local scen = scenarios[scenarioKeymap[nummapa]]
-        if official then
-            local officialMap = CheckMapIsOfficial(scen)
-            if not officialMap then
-                return randomAutoMap(true)
-            end
-        end
-        selectedScenario = scen
-        selectBehavior(selectedScenario, changedOptions, restrictedCategories)
-        ResetFilters()
-    end
 
     UIUtil.MakeInputModal(panel)
 

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1136,11 +1136,7 @@ local function AssignRandomStartSpots(gameInfo)
         if scenarioInfo then
             local armyTable = MapUtil.GetArmies(scenarioInfo)
             if armyTable then
-                if gameInfo.GameOptions['RandomMap'] == 'Off' then
-                    numAvailStartSpots = table.getn(armyTable)
-                else
-                    numAvailStartSpots = numberOfPlayers
-                end
+                numAvailStartSpots = table.getn(armyTable)
             end
         else
             WARN("Can't assign random start spots, no scenario selected.")
@@ -1296,7 +1292,7 @@ local function AssignAutoTeams(gameInfo)
                 end
             end
         end
-    elseif gameInfo.GameOptions['AutoTeams'] == 'pvsi' or gameInfo.GameOptions['RandomMap'] ~= 'Off' then
+    elseif gameInfo.GameOptions['AutoTeams'] == 'pvsi' then
         for i = 1, LobbyComm.maxPlayerSlots do
             if not gameInfo.ClosedSlots[i] and gameInfo.PlayerOptions[i] then
 
@@ -1576,11 +1572,6 @@ local function TryLaunch(stillAllowObservers, stillAllowLockedTeams, skipNoObser
     numberOfPlayers = totalPlayers
 
     local function LaunchGame()
-        if gameInfo.GameOptions['RandomMap'] ~= 'Off' then
-            autoRandMap = true
-            autoMap()
-        end
-
         SetFrontEndData('NextOpBriefing', nil)
         -- assign random factions just as game is launched
         AssignRandomFactions(gameInfo)
@@ -2357,15 +2348,6 @@ function HostRemoveAI(slot)
     UpdateGame()
 end
 
-function autoMap()
-    local randomAutoMap
-    if gameInfo.GameOptions['RandomMap'] == 'Official' then
-        randomAutoMap = import('/lua/ui/dialogs/mapselect.lua').randomAutoMap(true)
-    else
-        randomAutoMap = import('/lua/ui/dialogs/mapselect.lua').randomAutoMap(false)
-    end
-end
-
 function randomString(Length, CharSet)
     -- Length (number)
     -- CharSet (string, optional); e.g. %l%d for lower case letters and digits
@@ -2985,28 +2967,23 @@ function CreateUI(maxPlayers)
         GUI.gameoptionsButton.OnClick = function(self)
             local mapSelectDialog
 
-            autoRandMap = false
             quickRandMap = false
             local function selectBehavior(selectedScenario, changedOptions, restrictedCategories)
-                if autoRandMap then
-                    gameInfo.GameOptions['ScenarioFile'] = selectedScenario.file
-                else
-                    mapSelectDialog:Destroy()
-                    GUI.chatEdit:AcquireFocus()
-                    for optionKey, data in changedOptions do
-                        SetGameOption(optionKey, data.value)
-                    end
-
-                    -- TODO: Merge with changedOptions so we don't do this work if the map hasn't
-                    -- really changed.
-                    SetGameOption('ScenarioFile', selectedScenario.file)
-
-                    SetGameOption('RestrictedCategories', restrictedCategories, true)
-                    -- every new map, clear the flags, and clients will report if a new map is bad
-                    ClearBadMapFlags()
-                    HostUpdateMods()
-                    UpdateGame()
+                mapSelectDialog:Destroy()
+                GUI.chatEdit:AcquireFocus()
+                for optionKey, data in changedOptions do
+                    SetGameOption(optionKey, data.value)
                 end
+
+                -- TODO: Merge with changedOptions so we don't do this work if the map hasn't
+                -- really changed.
+                SetGameOption('ScenarioFile', selectedScenario.file)
+
+                SetGameOption('RestrictedCategories', restrictedCategories, true)
+                -- every new map, clear the flags, and clients will report if a new map is bad
+                ClearBadMapFlags()
+                HostUpdateMods()
+                UpdateGame()
             end
 
             local function exitBehavior()
@@ -3434,25 +3411,20 @@ function CreateUI(maxPlayers)
 
             --In order for the RandMap button to work on lobby init, the PC needs a copy of the mapSelectDialog in memory.
             --Destroy the window after it's loaded, so the player never sees it when clicking the random map button.
-            autoRandMap = false
             quickRandMap = false
             local function selectBehavior(selectedScenario, changedOptions, restrictedCategories)
-                if autoRandMap then
-                    gameInfo.GameOptions['ScenarioFile'] = selectedScenario.file
-                else
-                    mapSelectDialog:Destroy()
-                    GUI.chatEdit:AcquireFocus()
-                    for optionKey, data in changedOptions do
-                        SetGameOption(optionKey, data.value)
-                    end
-
-                    SetGameOption('ScenarioFile',selectedScenario.file)
-
-                    SetGameOption('RestrictedCategories', restrictedCategories, true)
-                    ClearBadMapFlags()  -- every new map, clear the flags, and clients will report if a new map is bad
-                    HostUpdateMods()
-                    UpdateGame()
+                mapSelectDialog:Destroy()
+                GUI.chatEdit:AcquireFocus()
+                for optionKey, data in changedOptions do
+                    SetGameOption(optionKey, data.value)
                 end
+
+                SetGameOption('ScenarioFile',selectedScenario.file)
+
+                SetGameOption('RestrictedCategories', restrictedCategories, true)
+                ClearBadMapFlags()  -- every new map, clear the flags, and clients will report if a new map is bad
+                HostUpdateMods()
+                UpdateGame()
             end
 
             local function exitBehavior()

--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -343,29 +343,6 @@ globalOpts = {
     },
     {
         default = 1,
-        label = "<LOC lobui_0545>Random Map",
-        help = "<LOC lobui_0546>If enabled, the game will selected a random map just before the game launch",
-        key = 'RandomMap',
-        values = {
-            {
-                text = "<LOC lobui_0312>Off",
-                help = "<LOC lobui_0556>No random map",
-                key = 'Off',
-            },
-         {
-                text = "<LOC lobui_0553>Official Maps Only",
-                help = "<LOC lobui_0555>Random map set",
-                key = 'Official',
-            },
-            {
-                text = "<LOC lobui_0554>All Maps",
-                help = "<LOC lobui_0555>Random map set",
-                key = 'All',
-            },
-        },
-    },
-   {
-        default = 1,
         label = "<LOC lobui_0727>Score",
         help = "<LOC lobui_0728>Set score on or off during the game",
         key = 'Score',


### PR DESCRIPTION
This feature was strange:
- The map would be randomised when the game is launched.
- It was still possible to select a particular map from the map selection screen in the usual way, but this selection would be overridden by the start-time randomisation.
- The map preview would show the map selected in the map select screen, not indicating that the real map is random.
- The randomly-chosen map would make no account of the number of players needed, causing excess players to end up as observers.
- Some of the interactions between this and auto-teams and "random"(auto-balanced) spawns mechanisms were undefined.
- It was a tangled unmaintainable mess.

We might want to reimplement this in a less insane way later. For now, let's cull it.