### PR TITLE
Simplify random map logic

### DIFF
--- a/lua/EnhancedLobby.lua
+++ b/lua/EnhancedLobby.lua
@@ -1,8 +1,8 @@
 function GetAIList()
-	#Table of AI Names to return
+	--Table of AI Names to return
 	local aitypes = {}
 	
-	#Defualt GPG AIs
+	--Defualt GPG AIs
     table.insert(aitypes, { key = 'easy', name = "<LOC lobui_0347>AI: Easy" })
     table.insert(aitypes, { key = 'medium', name = "<LOC lobui_0349>AI: Normal" })
     table.insert(aitypes, { key = 'adaptive', name = "<LOC lobui_0368>AI: Adaptive" })
@@ -14,7 +14,7 @@ function GetAIList()
 	local AIFiles = DiskFindFiles('/lua/AI/CustomAIs_v2', '*.lua')
 	local AIFilesold = DiskFindFiles('/lua/AI/CustomAIs', '*.lua')
 	
-	#Load Custom AIs - old style
+	--Load Custom AIs - old style
 	for i, v in AIFilesold do
         local tempfile = import(v).AIList
 		for s, t in tempfile do	
@@ -22,7 +22,7 @@ function GetAIList()
 		end
 	end
 	
-	#Load Custom AIs
+	--Load Custom AIs
 	for i, v in AIFiles do
         local tempfile = import(v).AI
 		if tempfile.AIList then
@@ -32,14 +32,14 @@ function GetAIList()
 		end
 	end
 	
-	#Default GPG Cheating AIs
+	--Default GPG Cheating AIs
     table.insert(aitypes, { key = 'adaptivecheat', name = "<LOC lobui_0379>AIx: Adaptive" })
     table.insert(aitypes, { key = 'rushcheat', name = "<LOC lobui_0380>AIx: Rush" })
     table.insert(aitypes, { key = 'turtlecheat', name = "<LOC lobui_0384>AIx: Turtle" })
     table.insert(aitypes, { key = 'techcheat', name = "<LOC lobui_0385>AIx: Tech" })
     table.insert(aitypes, { key = 'randomcheat', name = "<LOC lobui_0395>AIx: Random" })
 	
-    #Load Custom Cheating AIs - old style
+    --Load Custom Cheating AIs - old style
 	for i, v in AIFilesold do
         local tempfile = import(v).CheatAIList
 		for s, t in tempfile do	
@@ -47,7 +47,7 @@ function GetAIList()
 		end
 	end
 	
-	#Load Custom Cheating AIs
+	--Load Custom Cheating AIs
     for i, v in AIFiles do
         local tempfile = import(v).AI
 		if tempfile.CheatAIList then
@@ -60,16 +60,10 @@ function GetAIList()
 	return aitypes
 end
 
-###New Items - Begin
-#-----------------------------------------------------
-#   Function: CheckMapHasMarkers
-#   Args:
-#       scenario	- scenario info
-#   Description:
-#       Checks a map for Land Path nodes.
-#   Returns:  
-#       true or false
-#-----------------------------------------------------
+--- Checks a map for Land Path nodes.
+--
+-- @param scenario Scenario info
+-- @return true if the map has Land Path nodes, false otherwise.
 function CheckMapHasMarkers(scenario)
 	if not DiskGetFileInfo(scenario.save) then
 		return false
@@ -78,10 +72,10 @@ function CheckMapHasMarkers(scenario)
     doscript('/lua/dataInit.lua', saveData)
     doscript(scenario.save, saveData)
 
-	if saveData and saveData.Scenario and saveData.Scenario.MasterChain and
-	saveData.Scenario.MasterChain['_MASTERCHAIN_'] and saveData.Scenario.MasterChain['_MASTERCHAIN_'].Markers then
-		for marker,data in saveData.Scenario.MasterChain['_MASTERCHAIN_'].Markers do
-			if string.find( string.lower(marker), 'landpn') then
+    if saveData and saveData.Scenario and saveData.Scenario.MasterChain and
+    saveData.Scenario.MasterChain['_MASTERCHAIN_'] and saveData.Scenario.MasterChain['_MASTERCHAIN_'].Markers then
+               for marker,data in saveData.Scenario.MasterChain['_MASTERCHAIN_'].Markers do
+                           if string.find( string.lower(marker), 'landpn') then
 				return true
 			end
 		end
@@ -90,4 +84,3 @@ function CheckMapHasMarkers(scenario)
 	end
 	return false
 end
-###New Items - End

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -343,3 +343,20 @@ function table.shuffle(t)
     end
     return r
 end
+
+--- Filter a table using a function.
+--
+-- @param t Table to filter
+-- @param filterFunc Decision function to use to filter the table.
+-- @return A new table containing every mapping from t for which filterFunc returns `true` when
+--         passed the value.
+function table.filter(t, filterFunc)
+    local newTable = {}
+    for k, v in t do
+        if filterFunc(v) then
+            newTable[k] = v
+        end
+    end
+
+    return newTable
+end

--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -297,34 +297,8 @@ function CreateDialog(selectBehavior, exitBehavior, over, singlePlayer, defaultS
     Tooltip.AddButtonTooltip(randomMapButton, 'lob_click_randmap')
 
     randomMapButton.OnClick = function(self, modifiers)
-        if randMapList ~= 0 then
-            local randomMapMessage
-            local nummapa
-            nummapa = math.random(1, randMapList)
-            if randMapList >= 2 and nummapa == doNotRepeatMap then
-                repeat
-                    nummapa = math.random(1, randMapList)
-                until nummapa ~= doNotRepeatMap
-            end
-            doNotRepeatMap = nummapa
-            local scen = scenarios[scenarioKeymap[nummapa]]
-            selectedScenario = scen
-            if not singlePlayer then
-                rMapName = scenarios[scenarioKeymap[nummapa]].name
-                rMapSize1 = scenarios[scenarioKeymap[nummapa]].size[1]/50
-                rMapSize2 = scenarios[scenarioKeymap[nummapa]].size[2]/50
-                rMapSizeFilLim = currentFilters.map_select_size_limiter
-                rMapSizeFil = currentFilters.map_select_size/50
-                rMapPlayersFilLim = currentFilters.map_select_supportedplayers_limiter
-                rMapPlayersFil = currentFilters.map_select_supportedplayers
-                rMapTypeFil = currentFilters.map_type
-            end
-            selectBehavior(selectedScenario, changedOptions, restrictedCategories)
-            ResetFilters()
-            if not singlePlayer then
-                randomMapMessage = import('/lua/ui/lobby/lobby.lua').sendRandMapMessage()
-            end
-        end
+        local randomMapIndex = math.floor(math.random(1, mapList:GetItemCount()))
+        mapList:OnClick(randomMapIndex)
     end
     if not singlePlayer then
         function randomLobbyMap()
@@ -489,22 +463,18 @@ function CreateDialog(selectBehavior, exitBehavior, over, singlePlayer, defaultS
         end
     end
 
-    mapList.OnKeySelect = function(self,row)
+    -- Called when the selected map is changed.
+    local onItemChanged = function(self, row, noSound)
         mapList:SetSelection(row)
         PreloadMap(row)
-        local sound = Sound({Cue = "UI_Skirmish_Map_Select", Bank = "Interface",})
-        PlaySound(sound)
-    end
-
-    mapList.OnClick = function(self, row, noSound)
-        mapList:SetSelection(row)
-        PreloadMap(row)
-        local sound = Sound({Cue = "UI_Skirmish_Map_Select", Bank = "Interface",})
+        local sound = Sound({Cue = "UI_Skirmish_Map_Select", Bank = "Interface"})
         if not noSound then
             PlaySound(sound)
         end
     end
 
+    mapList.OnKeySelect = onItemChanged
+    mapList.OnClick = onItemChanged
     mapList.OnDoubleClick = function(self, row)
         mapList:SetSelection(row)
         PreloadMap(row)

--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -287,36 +287,6 @@ local function ResetFilters()
     restrictedCategories = nil
 end
 
-local function ShowMapPositions(mapCtrl, scenario)
-    if posGroup then
-        posGroup:Destroy()
-        posGroup = false
-    end
-
-    if not scenario.size then
-        LOG("MapSelect: Can't show map positions as size field isn't in scenario yet (must be resaved with new editor!)")
-        return
-    end
-
-    posGroup = Group(mapCtrl)
-    LayoutHelpers.FillParent(posGroup, mapCtrl)
-
-    local startPos = MapUtil.GetStartPositions(scenario)
-
-    local cHeight = posGroup:Height()
-    local cWidth = posGroup:Width()
-
-    local mWidth = scenario.size[1]
-    local mHeight = scenario.size[2]
-
-    for army, pos in startPos do
-        local marker = Bitmap(posGroup, UIUtil.UIFile('/dialogs/mapselect02/commander.dds'))
-        LayoutHelpers.AtLeftTopIn(marker, posGroup,
-            ((pos[1] / mWidth) * cWidth) - (marker.Width() / 2),
-            ((pos[2] / mHeight) * cHeight) - (marker.Height() / 2))
-    end
-end
-
 function CreateDialog(selectBehavior, exitBehavior, over, singlePlayer, defaultScenarioName, curOptions, availableMods, OnModsChanged)
     -- control layout
     local parent = nil

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -114,7 +114,6 @@ local selectedMods = nil
 local commandQueueIndex = 0
 local commandQueue = {}
 
-local quickRandMap = true
 local autoKick = true
 
 local lastUploadedMap = nil
@@ -1758,7 +1757,6 @@ local function UpdateGame()
 
         -- Launch button enabled if everyone is ready.
         UIUtil.setEnabled(GUI.launchGameButton, singlePlayer or not playerNotReady)
-        UIUtil.setEnabled(GUI.randMap, quickRandMap)
     end
 
     GUI.allowObservers:SetCheck(gameInfo.GameOptions.AllowObservers, true)
@@ -2986,7 +2984,6 @@ function CreateUI(maxPlayers)
             local mapSelectDialog
 
             autoRandMap = false
-            quickRandMap = false
             local function selectBehavior(selectedScenario, changedOptions, restrictedCategories)
                 if autoRandMap then
                     gameInfo.GameOptions['ScenarioFile'] = selectedScenario.file
@@ -3432,103 +3429,26 @@ function CreateUI(maxPlayers)
             local randomMap
             local mapSelectDialog
 
-            --In order for the RandMap button to work on lobby init, the PC needs a copy of the mapSelectDialog in memory.
-            --Destroy the window after it's loaded, so the player never sees it when clicking the random map button.
             autoRandMap = false
-            quickRandMap = false
-            local function selectBehavior(selectedScenario, changedOptions, restrictedCategories)
-                if autoRandMap then
-                    gameInfo.GameOptions['ScenarioFile'] = selectedScenario.file
-                else
-                    mapSelectDialog:Destroy()
-                    GUI.chatEdit:AcquireFocus()
-                    for optionKey, data in changedOptions do
-                        SetGameOption(optionKey, data.value)
-                    end
 
-                    SetGameOption('ScenarioFile',selectedScenario.file)
+            -- Load the set of all available maps, with a slight evil hack on the mapselect module.
+            local mapDialog = import('/lua/ui/dialogs/mapselect.lua')
+            local allMaps = mapDialog.LoadScenarios()  -- Result will be cached.
 
-                    SetGameOption('RestrictedCategories', restrictedCategories, true)
-                    ClearBadMapFlags()  -- every new map, clear the flags, and clients will report if a new map is bad
-                    HostUpdateMods()
-                    UpdateGame()
+            -- Only include maps which have enough slots for the players we have.
+            local filteredMaps = table.filter(allMaps,
+                function(scenInfo)
+                    local supportedPlayers = table.getsize(scenInfo.Configurations.standard.teams[1].armies)
+                    return supportedPlayers >= GetPlayerCount()
                 end
-            end
-
-            local function exitBehavior()
-                mapSelectDialog:Destroy()
-                GUI.chatEdit:AcquireFocus()
-                UpdateGame()
-            end
-
-            GUI.chatEdit:AbandonFocus()
-
-            mapSelectDialog = import('/lua/ui/dialogs/mapselect.lua').CreateDialog(
-                selectBehavior,
-                exitBehavior,
-                GUI,
-                singlePlayer,
-                gameInfo.GameOptions.ScenarioFile,
-                gameInfo.GameOptions,
-                availableMods,
-                OnModsChanged
             )
-            mapSelectDialog:Destroy()
-            GUI.chatEdit:AcquireFocus()
-            randomMap = import('/lua/ui/dialogs/mapselect.lua').randomLobbyMap()
-        end
-                    --
-        function sendRandMapMessage()
-            local rRankedLabel = import('/lua/ui/dialogs/mapselect.lua').rRankedLabel
-            local rMapSize1 = import('/lua/ui/dialogs/mapselect.lua').rMapSize1
-            local rMapSize2 = import('/lua/ui/dialogs/mapselect.lua').rMapSize2
-            local rMapSizeFil = import('/lua/ui/dialogs/mapselect.lua').rMapSizeFil
-            local rMapSizeFilLim = import('/lua/ui/dialogs/mapselect.lua').rMapSizeFilLim
-            local rMapPlayersFil = import('/lua/ui/dialogs/mapselect.lua').rMapPlayersFil
-            local rMapPlayersFilLim = import('/lua/ui/dialogs/mapselect.lua').rMapPlayersFilLim
-            local rMapTypeFil = import('/lua/ui/dialogs/mapselect.lua').rMapTypeFil
-            SendSystemMessage("-------------------------------------------------------------------------------"..
-            "--------------------")
-            SendSystemMessage(LOCF('%s %s', "<LOC lobui_0504>Randomly selected map: ", rRankedLabel))
-            SendSystemMessage(LOCF("<LOC map_select_0000>Map Size: %dkm x %dkm", rMapSize1, rMapSize2))
-            if rMapSizeFilLim == 'equal' then
-                rMapSizeFilLim = '='
-            elseif rMapSizeFilLim == 'less' then
-                rMapSizeFilLim = '<='
-            elseif rMapSizeFilLim == 'greater' then
-                rMapSizeFilLim = '>='
-            end
-            if rMapPlayersFilLim == 'equal' then
-                rMapPlayersFilLim = '='
-            elseif rMapPlayersFilLim == 'less' then
-                rMapPlayersFilLim = '<='
-            elseif rMapPlayersFilLim == 'greater' then
-                rMapPlayersFilLim = '>='
-            end
-            if rMapTypeFil == 1 then
-                rMapTypeFil = "<LOC lobui_0576>Official"
-            elseif rMapTypeFil == 2 then
-                rMapTypeFil = "<LOC lobui_0577>Custom"
-            end
-            if rMapSizeFil ~= 0 and rMapPlayersFil ~= 0 then
-                SendSystemMessage(LOCF("<LOC lobui_0516>Filters: Map Size is %s %dkm and Number of Players are %s %d",
-                    rMapSizeFilLim, rMapSizeFil, rMapPlayersFilLim, rMapPlayersFil))
-            elseif rMapSizeFil ~= 0 then
-                SendSystemMessage(LOCF("<LOC lobui_0517>Filters: Map Size is %s %dkm and Number of Players are ALL",
-                    rMapSizeFilLim, rMapSizeFil))
-            elseif rMapPlayersFil ~= 0 then
-                SendSystemMessage(LOCF("<LOC lobui_0518>Filters: Map Size is ALL and Number of Players are %s %d",
-                    rMapPlayersFilLim, rMapPlayersFil))
-            end
-            if rMapTypeFil ~= 0 then
-                SendSystemMessage(LOCF("<LOC lobui_0578>Map Type: %s", rMapTypeFil))
-            end
-            SendSystemMessage("---------------------------------------------------------------------------------------"..
-                "------------")
-            if not quickRandMap then
-                quickRandMap = true
-                UpdateGame()
-            end
+            local mapCount = table.getn(filteredMaps)
+            local selectedMap = filteredMaps[math.floor(math.random(1, mapCount))]
+
+            -- Set the new map.
+            SetGameOption('ScenarioFile', selectedMap.file)
+            ClearBadMapFlags()
+            UpdateGame()
         end
     end
 


### PR DESCRIPTION
The random map button in the lobby used to take about 3 seconds to do its job, as it would load the "game options" menu and click the button...

Here, we make that less insane. A random map is selected that has enough slots to hold the players currently in the game, in a sensible amount of time.

The random map button in the game options menu is simplified to simply select a random element from the current map list.

The logic for filtering maps is refactored to use a functional filter pattern, for noticeable performance win.