### PR TITLE
Enhance game options random maps

### DIFF
--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -366,7 +366,11 @@ function CreateDialog(selectBehavior, exitBehavior, over, singlePlayer, defaultS
 
     -- TODO: This logic is duplicated in lobby.lua (where there's another button to do the same job)
     randomMapButton.OnClick = function(self, modifiers)
-        local randomMapIndex = math.floor(math.random(1, mapList:GetItemCount()))
+        local currentMap = mapList:GetSelection()
+        local randomMapIndex = currentMap
+        while randomMapIndex == currentMap do
+            randomMapIndex = math.random(0, (mapList:GetItemCount() - 1))
+        end
         mapList:OnClick(randomMapIndex)
     end
     function randomAutoMap(official)


### PR DESCRIPTION
This fixes the non-crash aspects #460

The problem arose from a missmatch. mapList's registered content is
numbers 0, 1, 2, 3... while GetItemCount() was being used for the random
number generator. For example, with 81*81, ItemCount returns 3 items, correctly, so the generator went looking for 1 -> 3. However, the numbers were 0 -> 2. The false map selections were happening when it selected a number which didn't exist.

I also made it not select the same map twice in a row.

Behaviour should probably be replicated for the remaining two random map functions (Button in lobby, mystery map game option we should bring back to do the same thing as lobby button) ?