### PR TITLE
Make it possible to pause all mobile units

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1355,6 +1355,16 @@ MobileUnit = Class(Unit) {
         Unit.OnKilled(self, instigator, type, overkillRatio)
     end,
 
+    OnPaused = function(self)
+        self:SetBlockCommandQueue(true)
+        Unit.OnPaused(self)
+    end,
+
+    OnUnpaused = function(self)
+        self:SetBlockCommandQueue(false)
+        Unit.OnUnpaused(self)
+    end,
+
     StartBeingBuiltEffects = function(self, builder, layer)
         Unit.StartBeingBuiltEffects(self, builder, layer)
         local bp = self:GetBlueprint()

--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -447,6 +447,11 @@ function PreModBlueprints(all_bps)
             }
         end
 
+        -- make it possible to pause all mobile units, stopping in this case means pause at next order in command queue
+        if cats.MOBILE then
+            bp.General.CommandCaps.RULEUCC_Pause = true
+        end
+
         -- mod in AI.GuardScanRadius = Weapon.MaxRadius + Intel.VisionRadius
         -- fixes move-attack range issues
         -- Most Air units have the GSR defined already, this is just making certain they don't get included


### PR DESCRIPTION
Pausing a unit will make it hold at next order in command queue.
The current order will be carried out though. It will also accept new orders in the queue so a good way to prepare orders without the units executing them immediately.

This is useful for many things, pausing transports to make sure all leave at the same time, bombers to sync attacks etc.

Suggestion was made here:
http://forums.faforever.com/forums/viewtopic.php?f=42&t=9547