### PR TITLE
Disable assist while factory is upgrading

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -624,7 +624,10 @@ FactoryUnit = Class(StructureUnit) {
         if order ~= 'Upgrade' then
             ChangeState(self, self.BuildingState)
             self.BuildingUnit = false
+        else
+            self:RemoveCommandCap('RULEUCC_Guard')
         end
+
         self.FactoryBuildFailed = false
     end,
 
@@ -638,6 +641,11 @@ FactoryUnit = Class(StructureUnit) {
             self:StopBuildFx()
             self:ForkThread(self.FinishBuildThread, unitBeingBuilt, order )
         end
+
+        if order == 'Upgrade' then
+            self:AddCommandCap('RULEUCC_Guard')
+        end
+
         self.BuildingUnit = false
     end,
 

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -389,18 +389,18 @@ StructureUnit = Class(Unit) {
         -- Does the unit have any adjacency buffs to use?
         local adjBuffs = self:GetBlueprint().Adjacency
         if not adjBuffs then return end
- 
+
         -- Apply each buff needed to you and/or adjacent unit
         for k,v in AdjacencyBuffs[adjBuffs] do
             Buff.ApplyBuff(adjacentUnit, v, self)
         end
-        
+
         -- Keep track of adjacent units
         if not self.AdjacentUnits then
             self.AdjacentUnits = {}
         end
         table.insert(self.AdjacentUnits, adjacentUnit)
-        
+
         self:RequestRefreshUI()
         adjacentUnit:RequestRefreshUI()
      end,
@@ -413,7 +413,7 @@ StructureUnit = Class(Unit) {
         end
 
         local adjBuffs = self:GetBlueprint().Adjacency
-        
+
         if adjBuffs and AdjacencyBuffs[adjBuffs] then
             for k,v in AdjacencyBuffs[adjBuffs] do
                 if Buff.HasBuff(adjacentUnit, v) then
@@ -422,7 +422,7 @@ StructureUnit = Class(Unit) {
             end
         end
         self:DestroyAdjacentEffects()
-        
+
         -- Keep track of units losing adjacent structures
         for k,u in self.AdjacentUnits do
             if u == adjacentUnit then
@@ -432,16 +432,16 @@ StructureUnit = Class(Unit) {
         end
         self:RequestRefreshUI()
     end,
-    
+
     ------------------------------------
     --Add/Remove Adjacency Functionality
     ------------------------------------
-    
+
     -- Applies all appropriate buffs to all adjacent units
     ApplyAdjacencyBuffs = function(self)
         local adjBuffs = self:GetBlueprint().Adjacency
         if not adjBuffs then return end
-        
+
         -- There won't be any adjacentUnit if this is a producer just built...
         if self.AdjacentUnits then
             for k, adjacentUnit in self.AdjacentUnits do
@@ -453,12 +453,12 @@ StructureUnit = Class(Unit) {
             self:RequestRefreshUI()
         end
     end,
-    
+
     -- Removes all appropriate buffs from all adjacent units
     RemoveAdjacencyBuffs = function(self)
         local adjBuffs = self:GetBlueprint().Adjacency
         if not adjBuffs then return end
-		
+
         if self.AdjacentUnits then
             for k, adjacentUnit in self.AdjacentUnits do
                 for key, v in AdjacencyBuffs[adjBuffs] do
@@ -492,7 +492,7 @@ StructureUnit = Class(Unit) {
 
     DestroyAdjacentEffects = function(self, adjacentUnit)
         if not self.AdjacencyBeamsBag then return end
-        
+
         for k, v in self.AdjacencyBeamsBag do
             if v.Unit:BeenDestroyed() or v.Unit:IsDead() then
                 v.Trash:Destroy()
@@ -893,7 +893,7 @@ MassCollectionUnit = Class(StructureUnit) {
         self:RemoveAdjacencyBuffs()
         self._productionActive = false
     end,
-    
+
     OnCreate = function(self)
         StructureUnit.OnCreate(self)
         local markers = ScenarioUtils.GetMarkers()
@@ -1020,7 +1020,7 @@ MassFabricationUnit = Class(StructureUnit) {
         self:SetMaintenanceConsumptionActive()
         self:SetProductionActive(true)
         self:ApplyAdjacencyBuffs()
-        self._productionActive = true        
+        self._productionActive = true
     end,
 
     OnConsumptionInActive = function(self)
@@ -1028,7 +1028,7 @@ MassFabricationUnit = Class(StructureUnit) {
         self:SetMaintenanceConsumptionInactive()
         self:SetProductionActive(false)
         self:RemoveAdjacencyBuffs()
-        self._productionActive = false        
+        self._productionActive = false
     end,
 
     OnPaused = function(self)


### PR DESCRIPTION
Assisting with an upgrading factory results in cancelling the current
upgrade which probably isn't what the user wants.