### PR TITLE
Refresh UI-mods in lobby

### DIFF
--- a/lua/MODS.LUA
+++ b/lua/MODS.LUA
@@ -213,7 +213,6 @@ function SetSelectedMods(s)
         end
 
         SetPreference('active_mods', s)
-        UpdateUIMods()
     end
 end
 
@@ -413,11 +412,4 @@ function GetDependencies(uid)
     if table.empty(ret.missing) then ret.missing = nil end
     if table.empty(ret.conflicts) then ret.conflicts = nil end
     return ret
-end
-
-function UpdateUIMods()
-    __active_mods = {}
-    for i,m in ipairs(GetUiMods()) do
-        table.insert(__active_mods, m)
-    end
 end


### PR DESCRIPTION
#510 rebased to release/3641

Another take at making UI-mods refresh correctly in lobby so you don't
have to rejoin to make them active / inactive

PrefetchSession() seems to be a null operation if called on a map already
prefetched. This results in UI-mods being non-changeable unless you also
change the map at the same time.

By not calling PrefetchSession() at all we prevent this and
sessionInit.lua is called at game launch instead