### PR TITLE
Fix garbage collection of wrecks

### DIFF
--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -20,6 +20,42 @@ local Utilities = import('/lua/Utilities.lua') # enabled so we can hide strat ic
 PingGroups = import('/lua/SimPingGroup.lua')
 Objectives = import('/lua/SimObjectives.lua')
 
+local MAX_WRECKS = 2000
+local NumWrecks = 0
+
+function GCWreckID(wreck)
+    NumWrecks = NumWrecks + 1
+    wreck.CreatedTick = GetGameTick()
+
+    if NumWrecks > MAX_WRECKS then
+        GCWrecks()
+    end
+end
+
+function GCWrecks()
+    local x, y = GetMapSize()
+    local reclaimables = GetReclaimablesInRect(0, 0, x, y)
+    local wrecks = {}
+    local current_tick = GetGameTick()
+
+    for _, r in reclaimables do
+        -- exclude wrecks created last 2 minutes
+        if r.IsWreckage and current_tick > r.CreatedTick + 1200 then
+            table.insert(wrecks, r)
+        end
+    end
+
+    local HEADROOM = 100
+    NumWrecks = table.getsize(wrecks)
+    if NumWrecks > MAX_WRECKS then
+        table.sort(wrecks, function(a, b) return a.MaxMassReclaim > b.MaxMassReclaim end)
+        for i=MAX_WRECKS-HEADROOM, NumWrecks do -- GC <headroom> extra wreck to reduce GC calls
+            wrecks[i]:Destroy()
+        end
+        NumWrecks = MAX_WRECKS - HEADROOM
+    end
+end
+
 # Cause the game to exit immediately
 function ExitGame()
     Sync.RequestingExit = true
@@ -1936,7 +1972,7 @@ end
 function GenerateOffMapAreas()
 	local playablearea = {}
 	local OffMapAreas = {}
-	
+
 	if  ScenarioInfo.MapData.PlayableRect then
 		playablearea = ScenarioInfo.MapData.PlayableRect
 	else
@@ -1944,49 +1980,49 @@ function GenerateOffMapAreas()
 		playablearea = {0,0,ScenarioInfo.size[1],ScenarioInfo.size[2]}
 	end
 	#local playablearea = {x0,y0,x1,y1}
-	
+
 	LOG('playable area coordinates are ' .. repr(playablearea))
-	
+
 	local x0 = playablearea[1]
 	local y0 = playablearea[2]
 	local x1 = playablearea[3]
 	local y1 = playablearea[4]
-	
+
 	#This is a rectangle above the playable area that is longer, left to right, than the playable area
 	local OffMapArea1 = {}
-	OffMapArea1.x0 = (x0 - 100) 
+	OffMapArea1.x0 = (x0 - 100)
 	OffMapArea1.y0 = (y0 - 100)
 	OffMapArea1.x1 = (x1 + 100)
 	OffMapArea1.y1 = y0
-	
+
 	#This is a rectangle below the playable area that is longer, left to right, than the playable area
 	local OffMapArea2 = {}
-	OffMapArea2.x0 = (x0 - 100) 
+	OffMapArea2.x0 = (x0 - 100)
 	OffMapArea2.y0 = (y1)
 	OffMapArea2.x1 = (x1 + 100)
 	OffMapArea2.y1 = (y1 + 100)
-	
+
 	#This is a rectangle to the left of the playable area, that is the same height (up to down) as the playable area
 	local OffMapArea3 = {}
-	OffMapArea3.x0 = (x0 - 100) 
+	OffMapArea3.x0 = (x0 - 100)
 	OffMapArea3.y0 = y0
 	OffMapArea3.x1 = x0
 	OffMapArea3.y1 = y1
-	
+
 	#This is a rectangle to the right of the playable area, that is the same height (up to down) as the playable area
 	local OffMapArea4 = {}
-	OffMapArea4.x0 = x1 
+	OffMapArea4.x0 = x1
 	OffMapArea4.y0 = y0
 	OffMapArea4.x1 = (x1 + 100)
-	OffMapArea4.y1 = y1 
-	
+	OffMapArea4.y1 = y1
+
 	OffMapAreas = {OffMapArea1,OffMapArea2,OffMapArea3,OffMapArea4}
-	
+
 	ScenarioInfo.OffMapAreas = OffMapAreas
 	ScenarioInfo.PlayableArea = playablearea
-	
+
 	LOG('Offmapareas are ' .. repr(OffMapAreas))
-	
+
 end
 
 function AntiOffMapMainThread()
@@ -1995,11 +2031,11 @@ function AntiOffMapMainThread()
 	local OffMapAreas = {}
 	local UnitsThatAreOffMap = {}
 	#WARN(repr(ScenarioInfo.ArmySetup))
-	
+
 	while ScenarioInfo.OffMapPreventionThreadAllowed == true do
 		OffMapAreas = ScenarioInfo.OffMapAreas
 		NewUnitsThatAreOffMap = {}
-		
+
 		for index,OffMapArea in OffMapAreas do
 			local UnitsThatAreInOffMapRect = GetUnitsInRect(OffMapArea)
 				if UnitsThatAreInOffMapRect then
@@ -2009,44 +2045,44 @@ function AntiOffMapMainThread()
 						end
 					end
 				else
-				
+
 				end
 		end
-		
+
 		local NumberOfUnitsOffMap = table.getn(NewUnitsThatAreOffMap)
-		
+
 		#WARN('the number of new units that are off map is ' .. repr(NumberOfUnitsOffMap))
-		
+
 		for index,NewUnitThatIsOffMap in NewUnitsThatAreOffMap do
 			if not NewUnitThatIsOffMap.IAmOffMap then
 				NewUnitThatIsOffMap.IAmOffMap = true
 			end
 			#this is to make sure that we only do this check for air units
 			if not NewUnitThatIsOffMap.IAmOffMapThread and EntityCategoryContains( categories.AIR, NewUnitThatIsOffMap) then
-				
-				
+
+
 				#this is to make it so it only impacts player armies, not AI or civilian or mission map armies
 				if IsHumanUnit(NewUnitThatIsOffMap) then
 					NewUnitThatIsOffMap.IAmOffMapThread = NewUnitThatIsOffMap:ForkThread(IAmOffMap)
-				else 
+				else
 					#So that we don't bother checking each AI unit more than once
 					NewUnitThatIsOffMap.IAmOffMapThread = true
 				end
 			end
 		end
-		
-		
+
+
 		WaitSeconds(1)
 		NewUnitsThatAreOffMap = nil
 	end
-	
+
 
 end
 
 IsHumanUnit = function(self)
 	local ArmyTable = ScenarioInfo.ArmySetup
 	local ArmyIndex = self:GetArmy()
-	
+
 	for ArmyName,Army in ArmyTable do
 		if Army.ArmyIndex == ArmyIndex then
 			if Army.Human == true then
@@ -2054,7 +2090,7 @@ IsHumanUnit = function(self)
 			else
 				return false
 			end
-			
+
 		end
 	end
 
@@ -2070,11 +2106,11 @@ function IsUnitInPlayableArea(unit)
 	if  position[1] > playableArea[1] and position[1] < playableArea[3] and  position[3] > playableArea[2] and position[3] < playableArea[4] then
 		#WARN('unit is in playable area')
 		return true
-	else 
+	else
 		#WARN('unit remains in unplayable area')
 		return false
 	end
-	
+
 end
 
 #this is for bad units who choose to go off map, shame on them
@@ -2086,20 +2122,20 @@ function IAmOffMap(self)
 		#local playableArea = ScenarioInfo.PlayableArea
 		if IsUnitInPlayableArea(self) then
 			self.TimeIHaveBeenOnMap = (self.TimeIHaveBeenOnMap + 1)
-			
-			if self.TimeIHaveBeenOnMap > 5 then 
+
+			if self.TimeIHaveBeenOnMap > 5 then
 				self:ForkThread(KillIAmOffMapThread)
 			end
 		else
 			self.TimeIHaveBeenOffMap = (self.TimeIHaveBeenOffMap + 1)
 			#WARN('time I have been off map is ' .. repr(self.TimeIHaveBeenOffMap))
 		end
-		
+
 		if self.TimeIHaveBeenOffMap > self.TimeIAmAllowedToBeOffMap then
 			self:ForkThread(IAmABadUnit)
-			
+
 		end
-		
+
 		WaitSeconds(1)
 	end
 end
@@ -2109,12 +2145,12 @@ function IAmABadUnit(self)
 	local position = self:GetPosition()
 	local playableArea = ScenarioInfo.PlayableArea
 	local NearestOnPlayableAreaPointToMe = {}
-	
+
 	#format is x0,y0,x1,y1 for rect, x,y,z for position
 	#to conver position to rect, z is y, and y is height
-		
-	NearestOnPlayableAreaPointToMe[2] = position[2]	
-		
+
+	NearestOnPlayableAreaPointToMe[2] = position[2]
+
 	if position[1] > playableArea[1] and position[1] < playableArea[3] then
 		NearestOnPlayableAreaPointToMe[1] = position[1]
 	elseif position[1] < playableArea[1] then
@@ -2122,8 +2158,8 @@ function IAmABadUnit(self)
 	elseif position[1] > playableArea[3] then
 		NearestOnPlayableAreaPointToMe[1] = (playableArea[3] - 5)
 	end
-	
-	
+
+
 	if position[3] > playableArea[2] and position[3] < playableArea[4] then
 		NearestOnPlayableAreaPointToMe[3] = position[3]
 	elseif position[3] < playableArea[2] then
@@ -2131,31 +2167,31 @@ function IAmABadUnit(self)
 	elseif position[3] > playableArea[4] then
 		NearestOnPlayableAreaPointToMe[3] = (playableArea[4] - 5)
 	end
-	
+
 	IssueClearCommands({self})
 	IssueMove({self},position)
 	#WARN('Unit was off map too long, so has been cleared of all orders')
-	
+
 end
 
 function GetTimeIAmAllowedToBeOffMap(self)
-	
+
 	local airspeed = self:GetBlueprint().Air.MaxAirspeed
 	local value = airspeed
 
 	if EntityCategoryContains( categories.BOMBER, self ) then
 		value = airspeed / 5
 	elseif EntityCategoryContains( categories.TRANSPORTATION, self ) then
-		value = 2	
+		value = 2
 	end
-	
+
 	for i = 1, self:GetWeaponCount() do
 		local wep = self:GetWeapon(i)
 		if wep.Label != 'DeathWeapon' and wep.Label != 'DeathImpact' then
 			if wep:GetCurrentTarget()  then
 				value = airspeed * 2
 			end
-			
+
 		end
 	end
 	return value

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1358,7 +1358,7 @@ Unit = Class(moho.unit_methods) {
         local prop = CreateProp( pos, wreck )
 
         --Keep track of the global wreckage count to avoid performance issues
-        prop:AddBoundedProp(mass)
+        --prop:AddBoundedProp(mass)
 
         prop:SetScale(bp.Display.UniformScale)
         prop:SetOrientation(self:GetOrientation(), true)
@@ -1394,6 +1394,7 @@ Unit = Class(moho.unit_methods) {
         --Create some ambient wreckage smoke
         explosion.CreateWreckageEffects(self,prop)
         prop.IsWreckage = true
+        import('/lua/ScenarioFramework.lua').GCWreckID(prop)
         return prop
     end,
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1384,7 +1384,7 @@ Unit = Class(moho.unit_methods) {
         -- Attempt to copy our animation pose to the prop. Only works if
         -- the mesh and skeletons are the same, but will not produce an error if not.
 
-        if layer ~= 'Air' then
+        if layer ~= 'Air' and self.PlayDeathAnimation then
             TryCopyPose(self, prop, true)
         end
 


### PR DESCRIPTION
Seems like the first attempt to fix pose errors didn't work.

More testing of the error reveals that it's due to some form of
garbage collection of wrecks. When there's been enough of unit deaths on
the field it starts to remove random wrecks.

This results in wrecks sometimes getting removed in the same tick as they are
created. This causes the error with TryCopyPose() when it tries to set a
pose of a deleted wreck.

It's unnecessary to copy pose of units that didn't animate at death so
this fix at least reduce the amount of spam in log

I've not found out a way to raise the bar of the garbage collect. ~~Maybe we
should implement our own GC of wrecks and delete the oldest ones instead,
this would prevent newly created wrecks to insta-disappear~~ (see below)