### PR TITLE
Air contrails

### DIFF
--- a/effects/emitters/air_move_trail_beam_03_emit.bp
+++ b/effects/emitters/air_move_trail_beam_03_emit.bp
@@ -1,0 +1,10 @@
+BeamBlueprint {
+    Lifetime = 1.0,
+    TextureName = '/textures/particles/beam_exhaust_stream_blue_01.dds',
+    Thickness = 0.05,
+    StartColor = {x=1,y=1,z=1,w=0}, # R,G,B,A
+    EndColor = {x=0.0,y=0.0,z=0,w=0}, # R,G,B,A
+    Length = 0.6,
+    UShift = 0.0,
+    VShift = -0.65,
+}

--- a/effects/emitters/air_move_trail_beam_03_emit.bp
+++ b/effects/emitters/air_move_trail_beam_03_emit.bp
@@ -1,10 +1,14 @@
 BeamBlueprint {
     Lifetime = 1.0,
     TextureName = '/textures/particles/beam_exhaust_stream_blue_01.dds',
-    Thickness = 0.05,
+    Thickness = 0.1,
     StartColor = {x=1,y=1,z=1,w=0}, # R,G,B,A
     EndColor = {x=0.0,y=0.0,z=0,w=0}, # R,G,B,A
-    Length = 0.6,
+    Length = 1,
     UShift = 0.0,
     VShift = -0.65,
+    LowFidelity = false,
+    MedFidelity = true,
+    HighFidelity = true,
+    LODCutoff = 128.00,
 }

--- a/effects/emitters/contrail_delayed_mist_01_emit.bp
+++ b/effects/emitters/contrail_delayed_mist_01_emit.bp
@@ -1,0 +1,145 @@
+EmitterBlueprint {
+	BlueprintId = 'contrail_delayed_mist_01',
+	Lifetime = -1.00,
+	Repeattime = 1.00,
+	TextureFramecount = 1.00,
+	Blendmode = 0.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 0.00,
+	EmitIfVisible = true,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	Texture = [[/textures/particles/cloud_smoke_alpha_10.dds]],
+	RampTexture = [[/textures/particles/ramp_white_19.dds]],
+	XDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.49,y=0.00,z=0.00 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=0.00,z=0.00 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=0.00,z=0.00 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=3.50,z=4.00 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.48,y=30.00,z=10.00 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=1.00,z=0.00 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=0.00,z=0.00 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=0.00,z=0.00 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=0.00,z=0.00 },
+		},
+	},
+	SizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=0.20,z=0.20 },
+		},
+	},
+	XPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=0.00,z=0.20 },
+		},
+	},
+	YPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=-0.20,z=0.20 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=2.00,z=0.00 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=0.25,z=0.20 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.52,y=0.55,z=0.40 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=180.00,z=360.00 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=0.00,z=1.00 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=1.00,z=0.00 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.50,y=0.00,z=0.00 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.53,y=0.0,z=0.00 },
+		},
+	},
+}
+

--- a/effects/emitters/contrail_delayed_mist_01_emit.bp
+++ b/effects/emitters/contrail_delayed_mist_01_emit.bp
@@ -10,7 +10,7 @@ EmitterBlueprint {
 	AlignRotation = false,
 	AlignToBone = false,
 	Flat = false,
-	LODCutoff = 0.00,
+	LODCutoff = 128.00,
 	EmitIfVisible = true,
 	CatchupEmit = false,
 	CreateIfVisible = false,
@@ -19,6 +19,9 @@ EmitterBlueprint {
 	InterpolateEmission = true,
 	TextureStripcount = 1.00,
 	SortOrder = 0.00,
+	LowFidelity = false,
+	MedFidelity = true,
+	HighFidelity = true,
 	Texture = [[/textures/particles/cloud_smoke_alpha_10.dds]],
 	RampTexture = [[/textures/particles/ramp_white_19.dds]],
 	XDirectionCurve = {
@@ -42,19 +45,19 @@ EmitterBlueprint {
 	EmitRateCurve = {
 		XRange = 1.00,
 		Keys = {
-			{ x=0.50,y=3.50,z=4.00 },
+			{ x=0.50,y=2.50,z=1 },
 		},
 	},
 	LifetimeCurve = {
 		XRange = 1.00,
 		Keys = {
-			{ x=0.48,y=30.00,z=10.00 },
+			{ x=0.48,y=20.00,z=5.00 },
 		},
 	},
 	VelocityCurve = {
 		XRange = 1.00,
 		Keys = {
-			{ x=0.50,y=1.00,z=0.00 },
+			{ x=0.50,y=1.50,z=0.50 },
 		},
 	},
 	XAccelCurve = {
@@ -108,7 +111,7 @@ EmitterBlueprint {
 	EndSizeCurve = {
 		XRange = 1.00,
 		Keys = {
-			{ x=0.52,y=0.55,z=0.40 },
+			{ x=0.52,y=1.00,z=1.00 },
 		},
 	},
 	InitialRotationCurve = {
@@ -120,7 +123,7 @@ EmitterBlueprint {
 	RotationRateCurve = {
 		XRange = 1.00,
 		Keys = {
-			{ x=0.50,y=0.00,z=1.00 },
+			{ x=0.50,y=0.00,z=2.00 },
 		},
 	},
 	FrameRateCurve = {

--- a/effects/emitters/contrail_polytrail_01_emit.bp
+++ b/effects/emitters/contrail_polytrail_01_emit.bp
@@ -1,0 +1,13 @@
+TrailEmitterBlueprint {
+	BlueprintId = 'contrail_polytrail_01',
+	Lifetime = -1.00,
+    TrailLength = 15,
+    Size = 0.1,
+    SortOrder = 0,
+    BlendMode = 3,
+    TextureRepeatRate = 1,
+    LODCutoff = 160,
+	RepeatTexture = [[/textures/particles/air_contrail_02.dds]],
+	RampTexture = [[/textures/particles/ramp_white_03.dds]],
+}
+

--- a/effects/emitters/contrail_polytrail_01_emit.bp
+++ b/effects/emitters/contrail_polytrail_01_emit.bp
@@ -7,6 +7,9 @@ TrailEmitterBlueprint {
     BlendMode = 3,
     TextureRepeatRate = 1,
     LODCutoff = 160,
+    LowFidelity = false,
+    MedFidelity = true,
+    HighFidelity = true,
 	RepeatTexture = [[/textures/particles/air_contrail_02.dds]],
 	RampTexture = [[/textures/particles/ramp_white_03.dds]],
 }

--- a/units/UEA0303/UEA0303_unit.bp
+++ b/units/UEA0303/UEA0303_unit.bp
@@ -171,7 +171,7 @@ UnitBlueprint {
                         Bones = {
                             'Exhaust',
                         },
-                        Type = 'AirExhaust01',
+                        Type = 'AirMoveExhaust01',
                     },
                 },
             },


### PR DESCRIPTION
#517 moved to develop

Reduce the impact of massive groups of ASF by adding LOD 128 to the exhaust clouds / top speed beams and not render the exhaust if user is on low fidelity.

Made exhaust beam a bit more visible also and added missing smoke (typo) in UEF ASF blueprint