### PR TITLE
Consumption bugfix

### DIFF
--- a/lua/sim/tasks/EnhanceTask.lua
+++ b/lua/sim/tasks/EnhanceTask.lua
@@ -39,9 +39,6 @@ EnhanceTask = Class(ScriptTask) {
             else
                 unit:OnWorkBegin(self.CommandData.Enhancement)
                 ChangeState(self, self.Enhancing)
-                if unit.UpdateAssistersConsumption then
-                    unit:UpdateAssistersConsumption()
-                end
                 return TASKSTATUS.Repeat
             end
         end,


### PR DESCRIPTION
Fixed a bug with engineers workitem not resetting when an upgrade unit
finished.  Also some cleanup and protection against recursive calls to
UpdateAssisters()

Fixes #521