### PR TITLE
Make content of storages count

### DIFF
--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -65,7 +65,7 @@ function TransferUnitsOwnership(units, ToArmyIndex)
     table.sort(units, function (a, b) return a:GetBlueprint().Economy.BuildCostMass > b:GetBlueprint().Economy.BuildCostMass end)
 
     local newUnits = {}
-    for k,v in units do
+    for k, v in units do
         local owner = v:GetArmy()
         -- Only allow units not attached to be given. This is because units will give all of it's children over
         -- aswell, so we only want the top level units to be given.
@@ -165,7 +165,9 @@ function TransferUnitsOwnership(units, ToArmyIndex)
         if EntityCategoryContains(categories.ENGINEERSTATION, unit) then
             unit:SetPaused(true)
         end
+        v:HandleStorage(ToArmyIndex)
     end
+
     return newUnits
 end
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1169,6 +1169,7 @@ Unit = Class(moho.unit_methods) {
             self.DisallowCollisions = true
         end
 
+        self:HandleStorage()
         self:DoUnitCallbacks( 'OnKilled' )
 
         if self.UnitBeingTeleported and not self.UnitBeingTeleported.Dead then
@@ -1236,6 +1237,27 @@ Unit = Class(moho.unit_methods) {
                     self:ForkThread(self.DeathWeaponDamageThread, v.DamageRadius, v.Damage, v.DamageType, v.DamageFriendly)
                 end
                 break
+            end
+        end
+    end,
+
+    HandleStorage = function(self, to_army)
+        if EntityCategoryContains(categories.MOBILE, self) then
+            return -- Exclude SCU / sparky
+        end
+
+        local bp = self:GetBlueprint()
+        local brain = GetArmyBrain(self:GetArmy())
+        for _, t in {'Mass', 'Energy'} do
+            if bp.Economy['Storage' .. t] then
+                local type = string.upper(t)
+                local amount = bp.Economy['Storage' .. t] * brain:GetEconomyStoredRatio(type)
+
+                brain:TakeResource(type, amount)
+                if to_army then
+                    local to = GetArmyBrain(to_army)
+                    to:GiveResource(type, amount)
+                end
             end
         end
     end,


### PR DESCRIPTION
When your storages are killed / captured / given away the actual content
in the storage unit goes with it.

The actual wreck of mass-storages should maybe contain some fraction of the stored mass to make it even more fun.

Suggestion thread here:
http://forums.faforever.com/forums/viewtopic.php?f=42&t=9860