### PR TITLE
Double Absolver's hover elevation

### DIFF
--- a/units/DAL0310/DAL0310_unit.bp
+++ b/units/DAL0310/DAL0310_unit.bp
@@ -188,7 +188,7 @@ UnitBlueprint {
             LAYER_Water = false,
         },
         DragCoefficient = 0.2,
-        Elevation = 0.25,
+        Elevation = 0.5,
         MaxAcceleration = 3.5,
         MaxBrake = 3.5,
         MaxSpeed = 3.5,


### PR DESCRIPTION
Reduces the frequency of shots from the very low-mounted gun simply
hitting the ground. A big problem thanks to such high range.