### PR TITLE
New option: Show reclaim value of wreckage / props

### DIFF
--- a/SCHOOK/lua/SimSync.lua
+++ b/SCHOOK/lua/SimSync.lua
@@ -22,6 +22,8 @@ ResetSyncTable = function()
     # Player to player queries that can affect the Sim
     Sync.PlayerQueries = {}
     Sync.QueryResults = {}
+
+    Sync.Reclaim = {}
 end
 
 SimUnitEnhancements = {}

--- a/SCHOOK/lua/ui/game/commandgraph.lua
+++ b/SCHOOK/lua/ui/game/commandgraph.lua
@@ -1,0 +1,7 @@
+local oldOnCommandGraphShow = OnCommandGraphShow
+
+function OnCommandGraphShow(show)
+    oldOnCommandGraphShow(show)
+
+    import('/modules/reclaim.lua').ShowReclaim(show)
+end

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -57,4 +57,14 @@ function OnSync()
     if Sync.NukeLaunchData then
 		import('/modules/nukelaunchping.lua').DoNukePing(Sync.NukeLaunchData)
 	end
+
+    if Sync.Reclaim then
+        for _, r in Sync.Reclaim do
+            if r.destroy then
+                import('/modules/reclaim.lua').DestroyReclaimLabel(r.id)
+            else
+                import('/modules/reclaim.lua').CreateReclaimLabel(r)
+            end
+        end
+    end
 end

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -671,6 +671,20 @@ options = {
                     },
                 },
             },
+
+            {
+                title = "Show reclaim mass value",
+                tip = "Ctrl+Shift shows value of reclaim on map",
+                key = 'gui_show_reclaim',
+                type = 'toggle',
+                default = 0,
+                custom = {
+                    states = {
+                        {text = "<LOC _Off>", key = 0 },
+                        {text = "<LOC _On>", key = 1 },
+                    },
+                },
+            },
         },
     },
     video = {

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -23,6 +23,8 @@ local Buff = import('/lua/sim/buff.lua')
 local AIUtils = import('/lua/ai/aiutilities.lua')
 local BuffFieldBlueprints = import('/lua/sim/BuffField.lua').BuffFieldBlueprints
 
+local RECLAIMLABEL_MIN_MASS = import('/lua/sim/prop.lua').RECLAIMLABEL_MIN_MASS
+
 SyncMeta = {
     __index = function(t,key)
         local id = rawget(t,'id')
@@ -1394,6 +1396,11 @@ Unit = Class(moho.unit_methods) {
         --Create some ambient wreckage smoke
         explosion.CreateWreckageEffects(self,prop)
         prop.IsWreckage = true
+
+        if prop.MaxMassReclaim > RECLAIMLABEL_MIN_MASS then
+            table.insert(Sync.Reclaim, {id=prop:GetEntityId(), mass=prop.MassReclaim*0.9, position={pos[1], pos[2], pos[3]}})
+        end
+
         return prop
     end,
 

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -226,7 +226,7 @@ function BeginSession()
         end
     end
 
-#for off-map prevention
+    #for off-map prevention
     OnStartOffMapPreventionThread()
     
 end

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -242,6 +242,8 @@ function CreateUI(isReplay)
         import('/modules/console_commands.lua').Init()
     end
 
+    import('/modules/reclaim.lua').Init()
+
 end
 
 local provider = false

--- a/modules/reclaim.lua
+++ b/modules/reclaim.lua
@@ -1,0 +1,109 @@
+local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
+local Bitmap = import('/lua/maui/bitmap.lua').Bitmap
+local UIUtil = import('/lua/ui/uiutil.lua')
+local Prefs = import('/lua/user/prefs.lua')
+local options = Prefs.GetFromCurrentProfile('options')
+
+local labels = {}
+local queued = {}
+
+local showingReclaim = false
+
+function Init()
+    if queued then -- queued due to worldView not created
+        for _, q in queued do
+            CreateReclaimLabel(q)
+        end
+        queued = {}
+    end
+end
+
+-- Called from commandgraph.lua:OnCommandGraphShow()
+function ShowReclaim(show)
+    if show and options.gui_show_reclaim then
+        import('/lua/ui/game/gamemain.lua').AddBeatFunction(ShowReclaimBeat)
+    else
+        import('/lua/ui/game/gamemain.lua').RemoveBeatFunction(ShowReclaimBeat)
+        ShowReclaimBeat('Hide')
+    end
+end
+
+function ShowReclaimBeat(action)
+    local keydown
+
+    if not action then
+        if options.gui_show_reclaim == 0 then
+            keydown = false
+        else
+            keydown = IsKeyDown('Control')
+        end
+
+        if showingReclaim and not keydown then
+            action = 'Hide'
+        elseif keydown and not showingReclaim then
+            action = 'Show'
+        end
+    end
+
+    if action then
+        showingReclaim = action == 'Show'
+        for _, l in labels do
+            l[action](l)
+            l:SetNeedsFrameUpdate(showingReclaim)
+        end
+    end
+end
+
+
+function CreateReclaimLabel(reclaim)
+    local worldView = import('/lua/ui/game/worldview.lua').viewLeft
+
+    if not worldView then
+        table.insert(queued, reclaim)
+        return
+    end
+
+    local label = Bitmap(worldView)
+    local pos = reclaim.position
+    local position = Vector(pos[1], pos[2], pos[3])
+
+    label.mass = Bitmap(label)
+    label.mass:SetTexture(UIUtil.UIFile('/game/build-ui/icon-mass_bmp.dds'))
+    LayoutHelpers.AtLeftIn(label.mass, label)
+    LayoutHelpers.AtVerticalCenterIn(label.mass, label)
+    label.mass.Height:Set(14)
+    label.mass.Width:Set(14)
+
+    label.text = UIUtil.CreateText(label, math.floor(0.5+reclaim.mass), 10, UIUtil.bodyFont)
+    label.text:SetColor('ffc7ff8f')
+    label.text:SetDropShadow(true)
+    LayoutHelpers.AtLeftIn(label.text, label, 16)
+    LayoutHelpers.AtVerticalCenterIn(label.text, label)
+
+    label:SetNeedsFrameUpdate(false)
+    label:Hide()
+
+    label.OnFrame = function(self, delta)
+        local pos = worldView:Project(position)
+        LayoutHelpers.AtLeftTopIn(label, worldView, pos.x - label.Width() / 2, pos.y - label.Height() / 2 + 1)
+    end
+
+
+    labels[reclaim.id] = label
+end
+
+function DestroyReclaimLabel(id)
+    local label = labels[id]
+
+    if label then
+        label:Destroy()
+        labels[id] = nil
+    end
+end
+
+function DestroyLabels()
+    for id, l in labels do
+        l:Destroy()
+        labels[id] = nil
+    end
+end


### PR DESCRIPTION
PR #476 -> `release/3641`

If this is enabled, value of props / wreckage are shown if Ctrl+Shift is
pressed simultaneously.

The value will be the initial value of the reclaim and partial reclaim
won't change it.

Especially useful when playing new maps without knowing where the reclaim
is.

Reclaim with mass value below 20 isn't shown