### PR TITLE
Give Seraphim T1 artillery more aim leeway

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,7 +15,8 @@ Changelog for patch 3641
 - Disable build effect beams on sinking engineers
 - Projectiles no longer collide with sinking units
 - Fixed share until death bug with dual-given units
-- Fixed bug with insta-disappearing wrecks due to garbage collect 
+- Fixed bug with insta-disappearing wrecks due to garbage collect
+- Fixed Seraphim T1 Mobile Artillery not firing at fast targets properly
 
 *Enhancements*
 - Scathis now has Amphibious build icon

--- a/units/XSL0103/XSL0103_unit.bp
+++ b/units/XSL0103/XSL0103_unit.bp
@@ -294,7 +294,7 @@ UnitBlueprint {
                 Water = 'Land|Water|Seabed',
             },
             FiringRandomness = 1,
-            FiringTolerance = 0,
+            FiringTolerance = 1,
             Label = 'MainGun',
             MaxRadius = 30,
             MinRadius = 8,
@@ -303,7 +303,6 @@ UnitBlueprint {
             MuzzleVelocity = 14,
             MuzzleVelocityReduceDistance = 28,
             ProjectileId = '/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_proj.bp',
-            ProjectilesPerOnFire = 5,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -322,7 +321,7 @@ UnitBlueprint {
             RangeCategory = 'UWRC_IndirectFire',
             RateOfFire = 0.35,
             SlavedToBody = true,
-            SlavedToBodyArcRange = 40,
+            SlavedToBodyArcRange = 45,
             TargetCheckInterval = 1,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
@@ -337,11 +336,11 @@ UnitBlueprint {
             TurretBoneYaw = 'Turret',
             TurretDualManipulators = false,
             TurretPitch = 45,
-            TurretPitchRange = 90, # fixes t1 artillery sometimes not shooting at target in range bug [125]
+            TurretPitchRange = 90,
             TurretPitchSpeed = 70,
             TurretYaw = 0,
             TurretYawRange = 45,
-            TurretYawSpeed = 60,
+            TurretYawSpeed = 70,
             Turreted = true,
             WeaponCategory = 'Artillery',
         },
@@ -355,9 +354,9 @@ UnitBlueprint {
         WreckageLayers = {
             Air = false,
             Land = true,
-            Seabed = true, #from false
-            Sub = true, #from false
-            Water = true, #from false
+            Seabed = true,
+            Sub = true,
+            Water = true,
         },
     },
 }


### PR DESCRIPTION
Addresses #610 

The big change is the FiringTolerance, means it no longer requires a 100% certainty of aim. Also of note is that the SlavedToBodyArcRange and TurretYawRange should be the same usually, and that TurretYawSpeed should allow it to keep up with the faster-moving targets. I compared to the Lobo to see what that was doing.