### PR TITLE
Prioritize assisting buildings over repair

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -88,6 +88,7 @@ Other
   behaviour where they should be
 - Added templates for all support factories. AI in coop missions is now able to
   rebuild support factories
+- Assist now prioritize building over repair
 
 Contributors
 ------------

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2117,17 +2117,17 @@ Unit = Class(moho.unit_methods) {
         end
     end,
 
-    OnStartBuild = function(self, unitBeingBuilt, order)
+    OnStartBuild = function(self, built, order)
         -- We just started a construction (and haven't just been tasked to work on a half-done
         -- project.)
-        if unitBeingBuilt:GetHealth() == 1 then
-            self:SetRebuildProgress(unitBeingBuilt)
+        if built:GetHealth() == 1 then
+            self:SetRebuildProgress(built)
             self.EngineIsDeletingWreck = nil
         end
 
         if order == 'Repair' then
-            if unitBeingBuilt.WorkItem ~= self.WorkItem then
-                self:InheritWork(unitBeingBuilt)
+            if built.WorkItem ~= self.WorkItem then
+                self:InheritWork(built)
             end
             self:SetUnitState('Repairing', true)
 
@@ -2146,24 +2146,24 @@ Unit = Class(moho.unit_methods) {
 
         local bp = self:GetBlueprint()
         if order ~= 'Upgrade' or bp.Display.ShowBuildEffectsDuringUpgrade then
-            self:StartBuildingEffects(unitBeingBuilt, order)
+            self:StartBuildingEffects(built, order)
         end
         self:SetActiveConsumptionActive()
-        self:DoOnStartBuildCallbacks(unitBeingBuilt)
+        self:DoOnStartBuildCallbacks(built)
         self:PlayUnitSound('Construct')
         self:PlayUnitAmbientSound('ConstructLoop')
 
-        local bp = unitBeingBuilt:GetBlueprint()
+        local bp = built:GetBlueprint()
         if order == 'Upgrade' and bp.General.UpgradesFrom == self:GetUnitId() then
-            unitBeingBuilt.DisallowCollisions = true
-            unitBeingBuilt:SetCanTakeDamage(false)
+            built.DisallowCollisions = true
+            built:SetCanTakeDamage(false)
         end
     end,
 
-    OnStopBuild = function(self, unitBeingBuilt)
-        self:StopBuildingEffects(unitBeingBuilt)
+    OnStopBuild = function(self, built)
+        self:StopBuildingEffects(built)
         self:SetActiveConsumptionInactive()
-        self:DoOnUnitBuiltCallbacks(unitBeingBuilt)
+        self:DoOnUnitBuiltCallbacks(built)
         self:StopUnitAmbientSound('ConstructLoop')
         self:PlayUnitSound('ConstructStop')
     end,
@@ -2189,14 +2189,14 @@ Unit = Class(moho.unit_methods) {
     OnBuildProgress = function(self, unit, oldProg, newProg)
     end,
 
-    StartBuildingEffects = function(self, unitBeingBuilt, order)
-        self.BuildEffectsBag:Add( self:ForkThread( self.CreateBuildEffects, unitBeingBuilt, order ) )
+    StartBuildingEffects = function(self, built, order)
+        self.BuildEffectsBag:Add( self:ForkThread( self.CreateBuildEffects, built, order ) )
     end,
 
-    CreateBuildEffects = function( self, unitBeingBuilt, order )
+    CreateBuildEffects = function( self, built, order )
     end,
 
-    StopBuildingEffects = function(self, unitBeingBuilt)
+    StopBuildingEffects = function(self, built)
         self.BuildEffectsBag:Destroy()
         if self.buildBots then
             for _, b in self.buildBots do


### PR DESCRIPTION
When assisting a damaged unit the current engine behavior is to prioritize
repair, for instance repairing the ACU instead of helping it build a pd.

With this change, if you want to repair a unit over assisting a builder you
need to give explicit repair command.

There are known minor quirks with this fix so the engineers don't behave
exactly as if they assisted an undamaged builder (if not in build range they
walk near the building before starting to assist). Still way better than the current behavior.

*Got this idea while messing around with the "Prevent assist on upgrading factories" #640  (which is unsolved for the moment)*