### PR TITLE
Update repairer consumption when a unit dies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -51,6 +51,7 @@ Other
 - Fixed bug with chat messages having wrong recipients in replay
 - Seraphim and Aeon T2 shields can now pause while upgrading to T3
 - Fixed RateOfFire buffs not being applied correctly
+- Engineers no longer drain resources to repair a unit which is in the process of blowing up
 
 Enhancements
 ------------

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1221,7 +1221,7 @@ Unit = Class(moho.unit_methods) {
             self.UnitBeingTeleported = nil
         end
 
-        --Notify instigator of kill
+        -- Notify instigator of kill
         if instigator and IsUnit(instigator) then
             instigator:OnKilledUnit(self)
         end
@@ -1233,12 +1233,12 @@ Unit = Class(moho.unit_methods) {
         self:ForkThread(self.DeathThread, overkillRatio , instigator)
     end,
 
-    --Argument val is true or false. False = cannot be killed
+    -- Argument val is true or false. False = cannot be killed
     SetCanBeKilled = function(self, val)
         self.CanBeKilled = val
     end,
 
-    --- Called when this unit kills another. Chiefly responsible for the veterancy system for now.
+    -- Called when this unit kills another. Chiefly responsible for the veterancy system for now.
     OnKilledUnit = function(self, unitKilled)
         -- No XP for friendly fire...
         if IsAlly(self:GetArmy(), unitKilled:GetArmy()) then
@@ -1295,7 +1295,7 @@ Unit = Class(moho.unit_methods) {
             end
         end
 
-        --Check for specific non-collisions
+        -- Check for specific non-collisions
         local bp = other:GetBlueprint()
         if bp.DoNotCollideList then
             for k, v in pairs(bp.DoNotCollideList) do
@@ -1322,7 +1322,7 @@ Unit = Class(moho.unit_methods) {
             return false
         end
         local weaponBP = firingWeapon:GetBlueprint()
-        --Skip friendly collisions
+        -- Skip friendly collisions
         local collide = weaponBP.CollideFriendly
         if collide == false then
             if self:GetArmy() == firingWeapon.unit:GetArmy() then
@@ -1330,7 +1330,7 @@ Unit = Class(moho.unit_methods) {
             end
         end
 
-        --Check for specific non-collisions
+        -- Check for specific non-collisions
         if weaponBP.DoNotCollideList then
             for k, v in pairs(weaponBP.DoNotCollideList) do
                 if EntityCategoryContains(ParseEntityCategory(v), self) then
@@ -1384,19 +1384,18 @@ Unit = Class(moho.unit_methods) {
         end
     end,
 
-    --Create a unit's wrecked mesh blueprint from its regular mesh blueprint, by changing the shader and albedo
-
+    -- Create a unit's wrecked mesh blueprint from its regular mesh blueprint, by changing the shader and albedo
     CreateWreckage = function (self, overkillRatio)
         if overkillRatio and overkillRatio > 1.0 then
             return
         end
-        --Check if wrecks are allowed
+        -- Check if wrecks are allowed
         if self:GetBlueprint().Wreckage.WreckageLayers[self:GetCurrentLayer()] then
              return self:CreateWreckageProp(overkillRatio)
         end
     end,
 
-    CreateWreckageProp = function( self, overkillRatio )
+    CreateWreckageProp = function(self, overkillRatio)
         local bp = self:GetBlueprint()
         local wreck = bp.Wreckage.Blueprint
 
@@ -1411,7 +1410,7 @@ Unit = Class(moho.unit_methods) {
         local layer = self:GetCurrentLayer()
 
         if layer == 'Water' then
-            --Reduce the mass value of submerged wrecks
+            -- Reduce the mass value of submerged wrecks
             mass = mass * 0.5
             energy = energy * 0.5
         elseif layer == 'Air' or EntityCategoryContains(categories.NAVAL - categories.STRUCTURE, self) then -- make sure air / naval wrecks stick to ground / seabottom
@@ -1475,11 +1474,11 @@ Unit = Class(moho.unit_methods) {
     end,
 
     CreateDestructionEffects = function(self, overKillRatio)
-        explosion.CreateScalableUnitExplosion( self, overKillRatio )
+        explosion.CreateScalableUnitExplosion(self, overKillRatio)
     end,
 
-    DeathWeaponDamageThread = function( self , damageRadius, damage, damageType, damageFriendly)
-        WaitSeconds( 0.1 )
+    DeathWeaponDamageThread = function(self, damageRadius, damage, damageType, damageFriendly)
+        WaitSeconds(0.1)
         DamageArea(self, self:GetPosition(), damageRadius or 1, damage or 1, damageType or 'Normal', damageFriendly or false)
     end,
 


### PR DESCRIPTION
Addresses #642 

This fix is ready, but not perfect. The build bar state persists until the unit's self:Destroy() is called, so if anyone has an idea how to do that, please help out. @Crotalus?

This whole situation is a mess. For some reason, calling self:Destroy tells any repairing/capturing/assisting units to go to idle etc, or to the next thing on the queue, but self:Kill() does not. It simply links you to OnKilled in the lua, and appears to do engine checks for the unit's own consumption/building state, and for units in the guard state (Assisters), but ignores repairs. 

However, since in the lua we sometimes hook into OnKilled with a long-lasting explosion, the delay between OnKilled and the final self:Destroy at the end of the sequence can be lengthy in some cases (UEF Quantum Gate, for example), with the Engineer continuing to repair and waste resources right to the end.