### PR TITLE
Allow Airborne AA to hit water landed transports

### DIFF
--- a/mod_info.lua
+++ b/mod_info.lua
@@ -3,7 +3,7 @@
 -- Documentation for the extended FAF mod_info.lua format can be found here:
 -- https://github.com/FAForever/fa/wiki/mod_info.lua-documentation
 name = "Forged Alliance Forever"
-version = 3641
+version = 3642
 copyright = "Forged Alliance Forever Community"
 description = "Forged Alliance Forever extends Forged Alliance, bringing new patches, game modes, units, ladder, and much more!"
 author = "Forged Alliance Forever Community"
@@ -13,6 +13,7 @@ selectable = false
 exclusive = false
 ui_only = false
 conflicts = {}
+_faf_modname = 'balancetesting'
 mountpoints = {
     ENV = "/env",
     LOC = '/loc',

--- a/units/DEA0202/DEA0202_unit.bp
+++ b/units/DEA0202/DEA0202_unit.bp
@@ -13,7 +13,7 @@ UnitBlueprint {
         CanFly = true,
         CombatTurnSpeed = 1.5,
         EngageDistance = 50,
-        KLift = 2, # 3
+        KLift = 2,
         KLiftDamping = 2.5,
         KMove = 1,
         KMoveDamping = 1,
@@ -21,7 +21,7 @@ UnitBlueprint {
         KRollDamping = 1,
         KTurn = 1,
         KTurnDamping = 1.5,
-        LiftFactor = 10, # 7
+        LiftFactor = 10,
         MaxAirspeed = 15,
         MinAirspeed = 10,
         PredictAheadForBombDrop = 4,
@@ -299,8 +299,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Linked Railgun',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 1,
             Label = 'LeftBeam',
@@ -377,8 +377,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Linked Railgun',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 1,
             Label = 'RightBeam',
@@ -451,7 +451,7 @@ UnitBlueprint {
             BallisticArc = 'RULEUBA_None',
             BombDropThreshold = 4,
             CollideFriendly = false,
-            Damage = 5, # 10
+            Damage = 5,
             DamageFriendly = true,
             DamageRadius = 3,
             DamageType = 'Normal',
@@ -465,9 +465,9 @@ UnitBlueprint {
             },
             FiringRandomness = 0.1,
             FiringTolerance = 6,
-            InitialDamage = 75, # added
+            InitialDamage = 75,
             Label = 'Bomb',
-            MaxRadius = 60, # 45
+            MaxRadius = 60,
             MuzzleSalvoDelay = 0.25,
             MuzzleSalvoSize = 8,
             MuzzleVelocity = 0,

--- a/units/DRA0202/DRA0202_unit.bp
+++ b/units/DRA0202/DRA0202_unit.bp
@@ -282,8 +282,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Nanite Missile System',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 2,
             Label = 'AntiAirMissiles',
@@ -366,7 +366,7 @@ UnitBlueprint {
             FiringTolerance = 6,
             Label = 'GroundMissile',
             LeadTarget = true,
-            MaxRadius = 40, # 45
+            MaxRadius = 40,
             MuzzleSalvoDelay = 0.05,
             MuzzleSalvoSize = 4,
             MuzzleVelocity = 35,

--- a/units/UAA0102/UAA0102_unit.bp
+++ b/units/UAA0102/UAA0102_unit.bp
@@ -290,8 +290,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Sonic Pulse Battery',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0,
             Label = 'SonicPulseBattery1',
@@ -363,8 +363,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Sonic Pulse Battery',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0,
             Label = 'SonicPulseBattery2',

--- a/units/UAA0104/UAA0104_unit.bp
+++ b/units/UAA0104/UAA0104_unit.bp
@@ -283,8 +283,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Sonic Pulse Battery',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0.5,
             Label = 'SonicPulseBattery1',
@@ -352,8 +352,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Sonic Pulse Battery',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0.5,
             Label = 'SonicPulseBattery2',
@@ -422,8 +422,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Sonic Pulse Battery',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0.5,
             Label = 'SonicPulseBattery3',
@@ -492,8 +492,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Sonic Pulse Battery',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0.5,
             Label = 'SonicPulseBattery4',

--- a/units/UAA0303/UAA0303_unit.bp
+++ b/units/UAA0303/UAA0303_unit.bp
@@ -282,8 +282,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Displacement Cannon',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 2, # 0
             Label = 'AutoCannon1',

--- a/units/UEA0102/UEA0102_unit.bp
+++ b/units/UEA0102/UEA0102_unit.bp
@@ -290,8 +290,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Linked Railgun',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0,
             Label = 'LinkedRailGun',

--- a/units/UEA0104/UEA0104_unit.bp
+++ b/units/UEA0104/UEA0104_unit.bp
@@ -432,8 +432,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Linked Railgun',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 2,
             Label = 'FrontLinkedRailGun',
@@ -507,8 +507,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Linked Railgun',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 2,
             Label = 'BackLinkedRailGun',

--- a/units/UEA0303/UEA0303_unit.bp
+++ b/units/UEA0303/UEA0303_unit.bp
@@ -288,8 +288,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Ginsu Pulse Beam',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0,
             Label = 'LeftBeam',
@@ -361,8 +361,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Ginsu Pulse Beam',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0,
             Label = 'RightBeam',

--- a/units/UEA0304/UEA0304_unit.bp
+++ b/units/UEA0304/UEA0304_unit.bp
@@ -304,8 +304,8 @@ UnitBlueprint {
                 Land = 'Land|Water|Seabed',
             },
             FiringRandomness = 0,
-            FiringTolerance = 6, # [102]
-            FixBombTrajectory = true, # [152]
+            FiringTolerance = 6,
+            FixBombTrajectory = true,
             Label = 'Bomb',
             MaxRadius = 90,
             MuzzleSalvoDelay = 0,
@@ -363,8 +363,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Linked Railgun',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0,
             Label = 'LinkedRailGun1',
@@ -433,8 +433,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Linked Railgun',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0,
             Label = 'LinkedRailGun2',

--- a/units/UEA0305/UEA0305_unit.bp
+++ b/units/UEA0305/UEA0305_unit.bp
@@ -214,9 +214,9 @@ UnitBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        BuildCostEnergy = 42000,		#52500
-        BuildCostMass = 1260,			#1680
-        BuildTime = 6300,			#8400
+        BuildCostEnergy = 42000,
+        BuildCostMass = 1260,
+        BuildTime = 6300,
     },
     Footprint = {
         MaxSlope = 0.25,
@@ -352,7 +352,7 @@ UnitBlueprint {
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = 'UWRC_DirectFire',
-            RateOfFire = 2.5,				#3
+            RateOfFire = 2.5,
             TargetCheckInterval = 0.27,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
@@ -393,8 +393,8 @@ UnitBlueprint {
             DisplayName = 'Linked Railgun',
             EffectiveRadius = 0,
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 2,
             Label = 'AAGun',

--- a/units/URA0102/URA0102_unit.bp
+++ b/units/URA0102/URA0102_unit.bp
@@ -269,8 +269,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Electron Autocannon',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0.1,
             Label = 'AutoCannon',
@@ -341,8 +341,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Electron Autocannon',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0.1,
             Label = 'AutoCannon2',

--- a/units/URA0104/URA0104_unit.bp
+++ b/units/URA0104/URA0104_unit.bp
@@ -379,8 +379,8 @@ UnitBlueprint {
             DisplayName = 'Electron Autocannon',
             EffectiveRadius = 17,
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0.2,
             Label = 'AAAutocannon',

--- a/units/URA0104/URA0104_unit.bp
+++ b/units/URA0104/URA0104_unit.bp
@@ -347,7 +347,7 @@ UnitBlueprint {
                 'SPECIALLOWPRI',
                 'ALLUNITS',
             },
-            TargetRestrictDisallow = 'HIGHALTAIR, UNTARGETABLE',
+            TargetRestrictDisallow = 'UNTARGETABLE',
             TrackingRadius = 1.4,
             TurretBoneMuzzle = 'Front_Down_Turret_Muzzle',
             TurretBonePitch = 'Front_Down_Turret',

--- a/units/URA0303/URA0303_unit.bp
+++ b/units/URA0303/URA0303_unit.bp
@@ -288,8 +288,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Nanite Missile System',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 2,
             Label = 'Missiles1',
@@ -362,8 +362,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Nanite Missile System',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 2,
             Label = 'Missiles2',

--- a/units/URA0304/URA0304_unit.bp
+++ b/units/URA0304/URA0304_unit.bp
@@ -316,8 +316,8 @@ UnitBlueprint {
                 Land = 'Land|Water|Seabed',
             },
             FiringRandomness = 0,
-            FiringTolerance = 6, # [102]
-            FixBombTrajectory = true, # [152]
+            FiringTolerance = 6,
+            FixBombTrajectory = true,
             Label = 'Bomb',
             MaxRadius = 90,
             MuzzleSalvoDelay = 0,
@@ -372,8 +372,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Electron Autocannon',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringRandomness = 0,
             FiringTolerance = 0,
@@ -443,8 +443,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Electron Autocannon',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringRandomness = 0,
             FiringTolerance = 0,

--- a/units/XAA0202/XAA0202_unit.bp
+++ b/units/XAA0202/XAA0202_unit.bp
@@ -283,8 +283,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Light Displacement Missile',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 2,
             Label = 'AutoCannon1',

--- a/units/XAA0305/XAA0305_unit.bp
+++ b/units/XAA0305/XAA0305_unit.bp
@@ -160,7 +160,7 @@ UnitBlueprint {
     Economy = {
         BuildCostEnergy = 64000,
         BuildCostMass = 1200,
-        BuildTime = 6000,			#4800
+        BuildTime = 6000,
     },
     Footprint = {
         MaxSlope = 0.25,
@@ -324,8 +324,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Zealot AA Missile',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 180,
             Label = 'AAGun01',
@@ -397,8 +397,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Zealot AA Missile',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 180,
             Label = 'AAGun02',

--- a/units/XEA0306/XEA0306_unit.bp
+++ b/units/XEA0306/XEA0306_unit.bp
@@ -475,8 +475,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Flayer SAM Launcher',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 10,
             HeadingArcCenter = 90,
@@ -581,8 +581,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Flayer SAM Launcher',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 10,
             HeadingArcCenter = 90,
@@ -688,8 +688,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Flayer SAM Launcher',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 10,
             HeadingArcCenter = 270,
@@ -795,8 +795,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Flayer SAM Launcher',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 10,
             HeadingArcCenter = 270,

--- a/units/XRA0305/XRA0305_unit.bp
+++ b/units/XRA0305/XRA0305_unit.bp
@@ -191,9 +191,9 @@ UnitBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        BuildCostEnergy = 42000,		#52500
-        BuildCostMass = 1260,			#1680
-        BuildTime = 6300,			#8400
+        BuildCostEnergy = 42000,
+        BuildCostMass = 1260,
+        BuildTime = 6300,
         MaintenanceConsumptionPerSecondEnergy = 25,
     },
     Footprint = {
@@ -301,7 +301,7 @@ UnitBlueprint {
             BallisticArc = 'RULEUBA_LowArc',
             ChargeDelay = 0.5,
             CollideFriendly = false,
-            Damage = 140,					#150
+            Damage = 140,
             DamageType = 'Normal',
             DisplayName = 'Disintegrator Pulse Laser',
             FireTargetLayerCapsTable = {
@@ -340,7 +340,7 @@ UnitBlueprint {
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = 'UWRC_DirectFire',
-            RateOfFire = 1.6,					#2
+            RateOfFire = 1.6,
             TargetCheckInterval = 0.5,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
@@ -382,8 +382,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Nanite Missile Launcher',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 2,
             Label = 'Missiles1',

--- a/units/XSA0102/XSA0102_unit.bp
+++ b/units/XSA0102/XSA0102_unit.bp
@@ -291,8 +291,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Shleo AA AutoGun',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0,
             Label = 'SonicPulseBattery',

--- a/units/XSA0104/XSA0104_unit.bp
+++ b/units/XSA0104/XSA0104_unit.bp
@@ -310,8 +310,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Shleo AA AutoGun',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 2,
             Label = 'AALeft',
@@ -386,8 +386,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Shleo AA AutoGun',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 2,
             Label = 'AARight',

--- a/units/XSA0202/XSA0202_unit.bp
+++ b/units/XSA0202/XSA0202_unit.bp
@@ -297,8 +297,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Shleo AA Autogun',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0,
             Label = 'ShleoAAGun01',
@@ -372,8 +372,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Shleo AA Autogun',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 0,
             Label = 'ShleoAAGun02',

--- a/units/XSA0303/XSA0303_unit.bp
+++ b/units/XSA0303/XSA0303_unit.bp
@@ -284,8 +284,8 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Losaare AA Autocannon',
             FireTargetLayerCapsTable = {
-                Air = 'Air|Land',
-                Land = 'Air|Land',
+                Air = 'Air|Land|Water',
+                Land = 'Air|Land|Water',
             },
             FiringTolerance = 2, # 0
             Label = 'AutoCannon1',


### PR DESCRIPTION
Fixes #662

I see no logical reason they should be able to target landed gunships, bombers, transports which are on land, but not transports landed on water. I think this is simply an oversight by GPG, who forgot that Transports could land on water (They have to in order to be able to pick things up from water, I think), and so restricted AA to only Land/Air (The only two layers anything but transports can find themselves)

This also has a commit which changes the targeting restrictions of the Cybran T2 Transport EMP weapon, for reasons outlined in the commit.