### PR TITLE
Cleanup seraphim builders

### DIFF
--- a/lua/seraphimunits.lua
+++ b/lua/seraphimunits.lua
@@ -233,27 +233,8 @@ SConstructionUnit = Class(ConstructionUnit) {
 
     CreateBuildEffects = function( self, unitBeingBuilt, order )
         EffectUtil.CreateSeraphimUnitEngineerBuildingEffects( self, unitBeingBuilt, self:GetBlueprint().General.BuildBones.BuildEffectBones, self.BuildEffectsBag )
-    end,    
-    
-    OnStartBuild = function(self, unitBeingBuilt, order)
-        local bp = self:GetBlueprint()
-        if order ~= 'Upgrade' or bp.Display.ShowBuildEffectsDuringUpgrade then
-            self:StartBuildingEffects(unitBeingBuilt, order)
-        end
-        self:DoOnStartBuildCallbacks(unitBeingBuilt)
-        self:SetActiveConsumptionActive()
-        self:PlayUnitSound('Construct')
-        self:PlayUnitAmbientSound('ConstructLoop')
-        if bp.General.UpgradesTo and unitBeingBuilt:GetUnitId() == bp.General.UpgradesTo and order == 'Upgrade' then
-            self.Upgrading = true
-            self.BuildingUnit = false        
-            unitBeingBuilt.DisallowCollisions = true
-        end
-        self.UnitBeingBuilt = unitBeingBuilt
-        self.UnitBuildOrder = order
-        self.BuildingUnit = true
-    end,    
-    
+    end,
+
     SetupBuildBones = function(self)
         local bp = self:GetBlueprint()
 

--- a/lua/seraphimunits.lua
+++ b/lua/seraphimunits.lua
@@ -44,7 +44,7 @@ local EffectUtil = import('/lua/EffectUtilities.lua')
 SAirFactoryUnit = Class(AirFactoryUnit) {
 
     StartBuildFx = function( self, unitBeingBuilt )
-		local BuildBones = self:GetBlueprint().General.BuildBones.BuildEffectBones
+        local BuildBones = self:GetBlueprint().General.BuildBones.BuildEffectBones
         local thread = self:ForkThread( EffectUtil.CreateSeraphimFactoryBuildingEffects, unitBeingBuilt, BuildBones, 'Attachpoint', self.BuildEffectsBag )
         unitBeingBuilt.Trash:Add( thread )
     end,
@@ -101,7 +101,7 @@ SAirFactoryUnit = Class(AirFactoryUnit) {
     RolloffBody = function(self)
         self:SetBusy(true)
         local unitBuilding = self.UnitBeingBuilt
-        
+
         -- If the unit being built isn't an engineer use normal rolloff
         if not EntityCategoryContains( categories.LAND, unitBuilding ) then
             AirFactoryUnit.RolloffBody(self)
@@ -132,8 +132,8 @@ SAirFactoryUnit = Class(AirFactoryUnit) {
             ChangeState(self, self.IdleState)
         end
     end,
-    
-    
+
+
     OnStartBuild = function(self, unitBeingBuilt, order )
         -- Set goal for rotator
         local unitid = self:GetBlueprint().General.UpgradesTo
@@ -149,7 +149,7 @@ SAirFactoryUnit = Class(AirFactoryUnit) {
                 unitBeingBuilt.Rotator2:SetCurrentAngle(0)
                 unitBeingBuilt.Rotator2:SetGoal(0)
             end
-            
+
             if (self.Rotator2) then
                 savedAngle = self.Rotator2:GetCurrentAngle()
                 self.Rotator2:SetGoal(savedAngle)
@@ -161,10 +161,10 @@ SAirFactoryUnit = Class(AirFactoryUnit) {
         end
         AirFactoryUnit.OnStartBuild(self,unitBeingBuilt,order)
     end,
-  
-  
-  
-    UpgradingState = State(AirFactoryUnit.UpgradingState) {   
+
+
+
+    UpgradingState = State(AirFactoryUnit.UpgradingState) {
         OnStopBuild = function(self, unitBuilding)
             if unitBuilding:GetFractionComplete() == 1 then
                 -- start halted rotators on upgraded unit
@@ -176,7 +176,7 @@ SAirFactoryUnit = Class(AirFactoryUnit) {
                 end
                 if (unitBuilding.Rotator3) then
                     unitBuilding.Rotator3:ClearGoal()
-                end                  
+                end
             end
             AirFactoryUnit.UpgradingState.OnStopBuild(self, unitBuilding)
         end,
@@ -188,13 +188,13 @@ SAirFactoryUnit = Class(AirFactoryUnit) {
                self.Rotator1:ClearGoal()
                self.Rotator1:SetSpeed(5)
            end
-           
+
             if (self.Rotator2) then
                self.Rotator2:ClearGoal()
                self.Rotator2:SetSpeed(5)
            end
         end,
-    }, 
+    },
 }
 
 --------------------------------------------------------------
@@ -220,7 +220,7 @@ SConcreteStructureUnit = Class(ConcreteStructureUnit) {
 --  Construction Units
 --------------------------------------------------------------
 SConstructionUnit = Class(ConstructionUnit) {
-         
+
     OnCreate = function(self)
         ConstructionUnit.OnCreate(self)
         if self.BuildingOpenAnim then
@@ -229,7 +229,7 @@ SConstructionUnit = Class(ConstructionUnit) {
             end
         end
     end,
-    
+
 
     CreateBuildEffects = function( self, unitBeingBuilt, order )
         EffectUtil.CreateSeraphimUnitEngineerBuildingEffects( self, unitBeingBuilt, self:GetBlueprint().General.BuildBones.BuildEffectBones, self.BuildEffectsBag )
@@ -256,7 +256,7 @@ SConstructionUnit = Class(ConstructionUnit) {
     
     SetupBuildBones = function(self)
         local bp = self:GetBlueprint()
-        
+
         ConstructionUnit.SetupBuildBones(self)
         local buildbones = bp.General.BuildBones
         if self.BuildArmManipulator then
@@ -283,7 +283,7 @@ SConstructionUnit = Class(ConstructionUnit) {
             self.BuildArm2Manipulator:Disable()
         end
     end,
-    
+
     WaitForBuildAnimation = function(self, enable)
         if self.BuildArmManipulator then
             WaitFor(self.BuildingOpenAnimManip)
@@ -298,8 +298,8 @@ SConstructionUnit = Class(ConstructionUnit) {
         if self.StoppedBuilding then
             self:BuildManipulatorSetEnabled(disable)
         end
-    end,      
-        
+    end,
+
 
 
 }
@@ -345,11 +345,11 @@ SHoverLandUnit = Class(DefaultUnitsFile.HoverLandUnit) {
 --------------------------------------------------------------
 SLandFactoryUnit = Class(LandFactoryUnit) {
     StartBuildFx = function( self, unitBeingBuilt )
-		local BuildBones = self:GetBlueprint().General.BuildBones.BuildEffectBones
+        local BuildBones = self:GetBlueprint().General.BuildBones.BuildEffectBones
         local thread = self:ForkThread( EffectUtil.CreateSeraphimFactoryBuildingEffects, unitBeingBuilt, BuildBones, 'Attachpoint', self.BuildEffectsBag )
         unitBeingBuilt.Trash:Add( thread )
     end,
-    
+
     OnStartBuild = function(self, unitBeingBuilt, order )
         -- Set goal for rotator
         local unitid = self:GetBlueprint().General.UpgradesTo
@@ -365,7 +365,7 @@ SLandFactoryUnit = Class(LandFactoryUnit) {
                 unitBeingBuilt.Rotator2:SetCurrentAngle(0)
                 unitBeingBuilt.Rotator2:SetGoal(0)
             end
-            
+
             if (self.Rotator2) then
                 savedAngle = self.Rotator2:GetCurrentAngle()
                 self.Rotator2:SetGoal(savedAngle)
@@ -377,10 +377,10 @@ SLandFactoryUnit = Class(LandFactoryUnit) {
         end
         LandFactoryUnit.OnStartBuild(self,unitBeingBuilt,order)
     end,
-  
-  
-  
-    UpgradingState = State(LandFactoryUnit.UpgradingState) {   
+
+
+
+    UpgradingState = State(LandFactoryUnit.UpgradingState) {
         OnStopBuild = function(self, unitBuilding)
             if unitBuilding:GetFractionComplete() == 1 then
                 -- start halted rotators on upgraded unit
@@ -392,7 +392,7 @@ SLandFactoryUnit = Class(LandFactoryUnit) {
                 end
                 if (unitBuilding.Rotator3) then
                     unitBuilding.Rotator3:ClearGoal()
-                end                  
+                end
             end
             LandFactoryUnit.UpgradingState.OnStopBuild(self, unitBuilding)
         end,
@@ -404,14 +404,14 @@ SLandFactoryUnit = Class(LandFactoryUnit) {
                self.Rotator1:ClearGoal()
                self.Rotator1:SetSpeed(5)
            end
-           
+
             if (self.Rotator2) then
                self.Rotator2:ClearGoal()
                self.Rotator2:SetSpeed(5)
            end
         end,
-    },  
-    
+    },
+
 }
 
 --------------------------------------------------------------
@@ -453,11 +453,11 @@ SSonarUnit = Class(SonarUnit) {}
 --------------------------------------------------------------
 SSeaFactoryUnit = Class(SeaFactoryUnit) {
     StartBuildFx = function( self, unitBeingBuilt )
-		local BuildBones = self:GetBlueprint().General.BuildBones.BuildEffectBones
+        local BuildBones = self:GetBlueprint().General.BuildBones.BuildEffectBones
         local thread = self:ForkThread( EffectUtil.CreateSeraphimFactoryBuildingEffects, unitBeingBuilt, BuildBones, 'Attachpoint', self.BuildEffectsBag )
         unitBeingBuilt.Trash:Add( thread )
     end,
-    
+
 
     OnStartBuild = function(self, unitBeingBuilt, order )
         -- Set goal for rotator
@@ -474,7 +474,7 @@ SSeaFactoryUnit = Class(SeaFactoryUnit) {
                 unitBeingBuilt.Rotator2:SetCurrentAngle(0)
                 unitBeingBuilt.Rotator2:SetGoal(0)
             end
-            
+
             if (self.Rotator2) then
                 savedAngle = self.Rotator2:GetCurrentAngle()
                 self.Rotator2:SetGoal(savedAngle)
@@ -486,10 +486,10 @@ SSeaFactoryUnit = Class(SeaFactoryUnit) {
         end
         SeaFactoryUnit.OnStartBuild(self,unitBeingBuilt,order)
     end,
-  
-  
-  
-    UpgradingState = State(SeaFactoryUnit.UpgradingState) {   
+
+
+
+    UpgradingState = State(SeaFactoryUnit.UpgradingState) {
         OnStopBuild = function(self, unitBuilding)
             if unitBuilding:GetFractionComplete() == 1 then
                 -- start halted rotators on upgraded unit
@@ -501,7 +501,7 @@ SSeaFactoryUnit = Class(SeaFactoryUnit) {
                 end
                 if (unitBuilding.Rotator3) then
                     unitBuilding.Rotator3:ClearGoal()
-                end                  
+                end
             end
             SeaFactoryUnit.UpgradingState.OnStopBuild(self, unitBuilding)
         end,
@@ -513,13 +513,13 @@ SSeaFactoryUnit = Class(SeaFactoryUnit) {
                self.Rotator1:ClearGoal()
                self.Rotator1:SetSpeed(5)
            end
-           
+
             if (self.Rotator2) then
                self.Rotator2:ClearGoal()
                self.Rotator2:SetSpeed(5)
            end
         end,
-    },      
+    },
 }
 
 
@@ -544,7 +544,7 @@ SShieldLandUnit = Class(ShieldLandUnit) {}
 SShieldStructureUnit = Class(ShieldStructureUnit) {
     OnShieldEnabled = function(self)
         ShieldStructureUnit.OnShieldEnabled(self)
-        
+
         if not self.AnimationManipulator then
             self.AnimationManipulator = CreateAnimator(self)
             self.Trash:Add(self.AnimationManipulator)
@@ -552,11 +552,11 @@ SShieldStructureUnit = Class(ShieldStructureUnit) {
         end
         self.AnimationManipulator:SetRate(1)
     end,
-    
+
     OnShieldDisabled = function(self)
         ShieldStructureUnit.OnShieldDisabled(self)
-		if not self.AnimationManipulator then return end
-		
+        if not self.AnimationManipulator then return end
+
         self.AnimationManipulator:SetRate(-1)
     end,
 }
@@ -611,7 +611,7 @@ SRadarJammerUnit = Class(RadarJammerUnit) {}
 --------------------------------------------------------------
 SEnergyBallUnit = Class(SHoverLandUnit) {
     timeAlive = 0,
-    
+
     OnCreate = function(self)
         SHoverLandUnit.OnCreate(self)
         self:SetCanTakeDamage(false)
@@ -620,16 +620,16 @@ SEnergyBallUnit = Class(SHoverLandUnit) {
         ChangeState( self, self.KillingState )
     end,
 
-    KillingState = State {            
+    KillingState = State {
         LifeThread = function(self)
             WaitSeconds( self:GetBlueprint().Lifetime)
             ChangeState( self, self.DeathState )
         end,
-        
+
         Main = function(self)
             local bp = self:GetBlueprint()
             local aiBrain = self:GetAIBrain()
-            
+
             --Queue up random moves
             local x,y,z = unpack(self:GetPosition())
             for i=1, 100 do
@@ -640,19 +640,19 @@ SEnergyBallUnit = Class(SHoverLandUnit) {
             local weaponMaxRange = bp.Weapon[1].MaxRadius
             local weaponMinRange = bp.Weapon[1].MinRadius or 0
             local beamLifetime = bp.Weapon[1].BeamLifetime or 1
-            
+
             local reaquireTime = bp.Weapon[1].RequireTime or 0.5
-            
+
             local weapon = self:GetWeapon(1)
 
             self:ForkThread(self.LifeThread)
 
-		    while true do
-		        local location = self:GetPosition()
-		        local targets = aiBrain:GetUnitsAroundPoint( categories.LAND - categories.UNTARGETABLE, location, weaponMaxRange )
-		        local filteredUnits = {}
-		        for k,v in targets do
-		            if VDist3( location, v:GetPosition() ) >= weaponMinRange and v ~= self then
+            while true do
+                local location = self:GetPosition()
+                local targets = aiBrain:GetUnitsAroundPoint( categories.LAND - categories.UNTARGETABLE, location, weaponMaxRange )
+                local filteredUnits = {}
+                for k,v in targets do
+                    if VDist3( location, v:GetPosition() ) >= weaponMinRange and v ~= self then
                         table.insert( filteredUnits, v )
                     end
                 end
@@ -666,18 +666,18 @@ SEnergyBallUnit = Class(SHoverLandUnit) {
                 WaitSeconds(.1)
                 self.timeAlive = self.timeAlive + .1
                 weapon:FireWeapon()
-                               
+
                 WaitSeconds(beamLifetime)
                 DefaultBeamWeapon.PlayFxBeamEnd(weapon,weapon.Beams[1].Beam)
                 WaitSeconds(reaquireTime)
                 --self:ComputeWaitTime()
-		    end
-		    -- ChangeState( self, self.DeathState )
+            end
+            -- ChangeState( self, self.DeathState )
         end,
-        
+
         ComputeWaitTime = function(self)
             local timeLeft = self:GetBlueprint().Lifetime - self.timeAlive
-            
+
             local maxWait = 75
             if timeLeft < 7.5 and timeLeft > 2.5 then
                 maxWait = timeLeft * 10
@@ -686,7 +686,7 @@ SEnergyBallUnit = Class(SHoverLandUnit) {
             if timeLeft > 2.5 then
                 waitTime = Random(5,maxWait)
             end
-            
+
             self.timeAlive = self.timeAlive + (waitTime * .1)
             WaitSeconds(waitTime * .1)
         end,
@@ -697,7 +697,7 @@ SEnergyBallUnit = Class(SHoverLandUnit) {
             self:SetCanBeKilled(true)
             if self:GetCurrentLayer() == 'Water' then
                 self:PlayUnitSound('HoverKilledOnWater')
-            end            
+            end
             self:PlayUnitSound('Destroyed')
             self:Destroy()
         end,

--- a/units/XSL0001/XSL0001_script.lua
+++ b/units/XSL0001/XSL0001_script.lua
@@ -53,25 +53,6 @@ XSL0001 = Class(ACUUnit) {
         self.ShieldEffectsBag = {}
     end,
 
-    OnStartBuild = function(self, unitBeingBuilt, order)
-        local bp = self:GetBlueprint()
-        if order != 'Upgrade' or bp.Display.ShowBuildEffectsDuringUpgrade then
-            self:StartBuildingEffects(unitBeingBuilt, order)
-        end
-        self:DoOnStartBuildCallbacks(unitBeingBuilt)
-        self:SetActiveConsumptionActive()
-        self:PlayUnitSound('Construct')
-        self:PlayUnitAmbientSound('ConstructLoop')
-        if bp.General.UpgradesTo and unitBeingBuilt:GetUnitId() == bp.General.UpgradesTo and order == 'Upgrade' then
-            self.Upgrading = true
-            self.BuildingUnit = false        
-            unitBeingBuilt.DisallowCollisions = true
-        end
-        self.UnitBeingBuilt = unitBeingBuilt
-        self.UnitBuildOrder = order
-        self.BuildingUnit = true
-    end,
-    
     PlayCommanderWarpInEffect = function(self)
         self:HideBone(0, true)
         self:SetUnSelectable(true)

--- a/units/XSL0001/XSL0001_script.lua
+++ b/units/XSL0001/XSL0001_script.lua
@@ -78,8 +78,8 @@ XSL0001 = Class(ACUUnit) {
         self:SetBusy(true)
         self:SetBlockCommandQueue(true)
         self:ForkThread(self.WarpInEffectThread)
-    end, 
-    
+    end,
+
     WarpInEffectThread = function(self)
         self:PlayUnitSound('CommanderArrival')
         self:CreateProjectile( '/effects/entities/UnitTeleport01/UnitTeleport01_proj.bp', 0, 1.35, 0, nil, nil, nil):SetCollision(false)
@@ -114,17 +114,17 @@ XSL0001 = Class(ACUUnit) {
         while not self.Dead do
             --Get friendly units in the area (including self)
             local units = AIUtils.GetOwnUnitsAroundPoint(self:GetAIBrain(), unitCat, self:GetPosition(), bp.Radius)
-            
+
             --Give them a 5 second regen buff
             for _,unit in units do
                 Buff.ApplyBuff(unit, 'SeraphimACURegenAura')
             end
-            
+
             --Wait 5 seconds
             WaitSeconds(5)
         end
     end,
-       
+
     AdvancedRegenBuffThread = function(self)
         local bp = self:GetBlueprint().Enhancements.AdvancedRegenAura
         local unitCat = ParseEntityCategory( bp.UnitCategory or 'BUILTBYTIER3FACTORY + BUILTBYQUANTUMGATE + NEEDMOBILEBUILD')
@@ -132,12 +132,12 @@ XSL0001 = Class(ACUUnit) {
         while not self.Dead do
             --Get friendly units in the area (including self)
             local units = AIUtils.GetOwnUnitsAroundPoint(self:GetAIBrain(), unitCat, self:GetPosition(), bp.Radius)
-            
+
             --Give them a 5 second regen buff
             for _,unit in units do
                 Buff.ApplyBuff(unit, 'SeraphimAdvancedACURegenAura')
             end
-            
+
             --Wait 5 seconds
             WaitSeconds(5)
         end
@@ -147,7 +147,7 @@ XSL0001 = Class(ACUUnit) {
         ACUUnit.CreateEnhancement(self, enh)
 
         local bp = self:GetBlueprint().Enhancements[enh]
-        
+
         -- Regenerative Aura
         if enh == 'RegenAura' then
 
@@ -187,7 +187,7 @@ XSL0001 = Class(ACUUnit) {
             Buff.ApplyBuff(self, 'SeraphimACURegenAuraSelfBuff')
             table.insert( self.ShieldEffectsBag, CreateAttachedEmitter( self, 'XSL0001', self:GetArmy(), '/effects/emitters/seraphim_regenerative_aura_01_emit.bp' ) )
             self.RegenThreadHandle = self:ForkThread(self.RegenBuffThread)
-                        
+
         elseif enh == 'RegenAuraRemove' then
             if self.ShieldEffectsBag then
                 for k, v in self.ShieldEffectsBag do
@@ -197,7 +197,7 @@ XSL0001 = Class(ACUUnit) {
 		    end
             KillThread(self.RegenThreadHandle)
             Buff.RemoveBuff(self, 'SeraphimACURegenAuraSelfBuff')
-            
+
         elseif enh == 'AdvancedRegenAura' then
             if self.RegenThreadHandle then
                 if self.ShieldEffectsBag then
@@ -207,7 +207,7 @@ XSL0001 = Class(ACUUnit) {
 		            self.ShieldEffectsBag = {}
 		        end
                 KillThread(self.RegenThreadHandle)
-                
+
             end
             Buff.RemoveBuff(self, 'SeraphimACURegenAuraSelfBuff')
 
@@ -229,7 +229,7 @@ XSL0001 = Class(ACUUnit) {
                             Add = 0,
                             Mult = bp.MaxHealthFactor or 1.0,
                             DoNoFill = true,
-                        },                        
+                        },
                     },
                 }
             end
@@ -304,12 +304,12 @@ XSL0001 = Class(ACUUnit) {
                             Mult = 1.0,
                         },
                     },
-                } 
+                }
             end
             if Buff.HasBuff( self, 'SeraphimACUDamageStabilization' ) then
                 Buff.RemoveBuff( self, 'SeraphimACUDamageStabilization' )
-            end  
-            Buff.ApplyBuff(self, 'SeraphimACUDamageStabilization')    
+            end
+            Buff.ApplyBuff(self, 'SeraphimACUDamageStabilization')
       	elseif enh == 'DamageStabilizationAdvanced' then
             if not Buffs['SeraphimACUDamageStabilizationAdv'] then
                BuffBlueprint {
@@ -328,12 +328,12 @@ XSL0001 = Class(ACUUnit) {
                             Mult = 1.0,
                         },
                     },
-                } 
+                }
             end
             if Buff.HasBuff( self, 'SeraphimACUDamageStabilizationAdv' ) then
                 Buff.RemoveBuff( self, 'SeraphimACUDamageStabilizationAdv' )
-            end  
-            Buff.ApplyBuff(self, 'SeraphimACUDamageStabilizationAdv')     	    
+            end
+            Buff.ApplyBuff(self, 'SeraphimACUDamageStabilizationAdv')
         elseif enh == 'DamageStabilizationAdvancedRemove' then
             -- since there's no way to just remove an upgrade anymore, if we're remove adv, were removing both
             if Buff.HasBuff( self, 'SeraphimACUDamageStabilizationAdv' ) then
@@ -341,11 +341,11 @@ XSL0001 = Class(ACUUnit) {
             end
             if Buff.HasBuff( self, 'SeraphimACUDamageStabilization' ) then
                 Buff.RemoveBuff( self, 'SeraphimACUDamageStabilization' )
-            end         
+            end
         elseif enh == 'DamageStabilizationRemove' then
             if Buff.HasBuff( self, 'SeraphimACUDamageStabilization' ) then
                 Buff.RemoveBuff( self, 'SeraphimACUDamageStabilization' )
-            end           
+            end
         --Teleporter
         elseif enh == 'Teleporter' then
             self:AddCommandCap('RULEUCC_Teleport')
@@ -354,11 +354,11 @@ XSL0001 = Class(ACUUnit) {
         -- Tactical Missile
         elseif enh == 'Missile' then
             self:AddCommandCap('RULEUCC_Tactical')
-            self:AddCommandCap('RULEUCC_SiloBuildTactical')        
+            self:AddCommandCap('RULEUCC_SiloBuildTactical')
             self:SetWeaponEnabledByLabel('Missile', true)
         elseif enh == 'MissileRemove' then
             self:RemoveCommandCap('RULEUCC_Tactical')
-            self:RemoveCommandCap('RULEUCC_SiloBuildTactical')        
+            self:RemoveCommandCap('RULEUCC_SiloBuildTactical')
             self:SetWeaponEnabledByLabel('Missile', false)
         --T2 Engineering
         elseif enh =='AdvancedEngineering' then
@@ -461,15 +461,15 @@ XSL0001 = Class(ACUUnit) {
             wep:ChangeRateOfFire(bp.NewRateOfFire or 2)
             wep:ChangeMaxRadius(bp.NewMaxRadius or 44)
             local oc = self:GetWeaponByLabel('OverCharge')
-            oc:ChangeMaxRadius(bp.NewMaxRadius or 44)            
+            oc:ChangeMaxRadius(bp.NewMaxRadius or 44)
         elseif enh == 'RateOfFireRemove' then
             local wep = self:GetWeaponByLabel('ChronotronCannon')
             local bpDisrupt = self:GetBlueprint().Weapon[1].RateOfFire
             wep:ChangeRateOfFire(bpDisrupt or 1)
-            bpDisrupt = self:GetBlueprint().Weapon[1].MaxRadius            
+            bpDisrupt = self:GetBlueprint().Weapon[1].MaxRadius
             wep:ChangeMaxRadius(bpDisrupt or 22)
             local oc = self:GetWeaponByLabel('OverCharge')
-            oc:ChangeMaxRadius(bpDisrupt or 22)                        
+            oc:ChangeMaxRadius(bpDisrupt or 22)
         end
     end,
 }

--- a/units/XSL0301/XSL0301_script.lua
+++ b/units/XSL0301/XSL0301_script.lua
@@ -62,11 +62,11 @@ XSL0301 = Class(CommandUnit) {
         self:HideBone('Back_Upgrade', true)
         self:SetupBuildBones()
     end,
-    
+
     CreateBuildEffects = function( self, unitBeingBuilt, order )
         EffectUtil.CreateSeraphimUnitEngineerBuildingEffects( self, unitBeingBuilt, self:GetBlueprint().General.BuildBones.BuildEffectBones, self.BuildEffectsBag )
-    end,  
-    
+    end,
+
     CreateEnhancement = function(self, enh)
         CommandUnit.CreateEnhancement(self, enh)
         local bp = self:GetBlueprint().Enhancements[enh]
@@ -166,16 +166,16 @@ XSL0301 = Class(CommandUnit) {
                             Mult = 1.0,
                         },
                     },
-                } 
+                }
             end
             if Buff.HasBuff( self, 'SeraphimSCUDamageStabilization' ) then
                 Buff.RemoveBuff( self, 'SeraphimSCUDamageStabilization' )
-            end  
-            Buff.ApplyBuff(self, 'SeraphimSCUDamageStabilization')            
+            end
+            Buff.ApplyBuff(self, 'SeraphimSCUDamageStabilization')
       	elseif enh == 'DamageStabilizationRemove' then
             if Buff.HasBuff( self, 'SeraphimSCUDamageStabilization' ) then
                 Buff.RemoveBuff( self, 'SeraphimSCUDamageStabilization' )
-            end  
+            end
         -- Enhanced Sensor Systems
         elseif enh == 'EnhancedSensors' then
             self:SetIntelRadius('Vision', bp.NewVisionRadius or 104)

--- a/units/XSL0301/XSL0301_script.lua
+++ b/units/XSL0301/XSL0301_script.lua
@@ -36,25 +36,6 @@ XSL0301 = Class(CommandUnit) {
         CommandUnit.__init(self, 'LightChronatronCannon')
     end,
 
-    OnStartBuild = function(self, unitBeingBuilt, order)
-        local bp = self:GetBlueprint()
-        if order ~= 'Upgrade' or bp.Display.ShowBuildEffectsDuringUpgrade then
-            self:StartBuildingEffects(unitBeingBuilt, order)
-        end
-        self:DoOnStartBuildCallbacks(unitBeingBuilt)
-        self:SetActiveConsumptionActive()
-        self:PlayUnitSound('Construct')
-        self:PlayUnitAmbientSound('ConstructLoop')
-        if bp.General.UpgradesTo and unitBeingBuilt:GetUnitId() == bp.General.UpgradesTo and order == 'Upgrade' then
-            self.Upgrading = true
-            self.BuildingUnit = false        
-            unitBeingBuilt.DisallowCollisions = true
-        end
-        self.UnitBeingBuilt = unitBeingBuilt
-        self.UnitBuildOrder = order
-        self.BuildingUnit = true
-    end,    
-
     OnCreate = function(self)
         CommandUnit.OnCreate(self)
         self:SetCapturable(false)


### PR DESCRIPTION
Seraphim builders had their own OnStartBuild, probably to override the tarmac behavior. The problem is that Unit.OnStartBuild has important checks for rebuild bonus etc. This wasn't activated on seraphim engineers.

Now that tarmacs are spawned on the actual built unit instead this method can safely be removed