### PR TITLE
Bugfix/disappearing wreck

### DIFF
--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -13,7 +13,7 @@
 local Entity = import('/lua/sim/Entity.lua').Entity
 local EffectUtil = import('/lua/EffectUtilities.lua')
 
-RECLAIMLABEL_MIN_MASS = 20
+local RECLAIMLABEL_MIN_MASS = import('/lua/sim/ScenarioUtilities.lua').RECLAIMLABEL_MIN_MASS
 
 Prop = Class(moho.prop_methods, Entity) {
 

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -8,6 +8,8 @@
 ----[  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.             ]--
 local Entity = import('/lua/sim/Entity.lua').Entity
 
+RECLAIMLABEL_MIN_MASS = 20
+
 function EnableLoadBalance(enabled, unitThreshold) --distributeTime)
     if not ScenarioInfo.LoadBalance then
         ScenarioInfo.LoadBalance =

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -1,0 +1,1531 @@
+#--[                                                                             ]--
+#--[  File     : ScenarioUtilities.lua                                           ]--
+#--[  Author(s): Ivan Rumsey                                                     ]--
+#--[                                                                             ]--
+#--[  Summary  : Utility functions for use with scenario save file.              ]--
+#--[             Created from examples provided by Jeff Petkau.                  ]--
+#--[                                                                             ]--
+#--[  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.             ]--
+local Entity = import('/lua/sim/Entity.lua').Entity
+
+function EnableLoadBalance(enabled, unitThreshold) --distributeTime)
+    if not ScenarioInfo.LoadBalance then 
+        ScenarioInfo.LoadBalance = 
+        {
+            Accumulator = 0,
+            Enabled = false,
+            SpawnGroups = {},
+            PlatoonGroups = {},
+        }
+    end
+    
+    if enabled == ScenarioInfo.LoadBalance.Enabled then return end
+    
+    ScenarioInfo.LoadBalance.Enabled = enabled 
+    
+    if enabled then
+        ScenarioInfo.LoadBalance.UnitThreshold = unitThreshold or 50
+    else
+        ForkThread(function()       
+            --local timePerGroup = ScenarioInfo.DistributeTime/table.getn(ScenarioInfo.LoadBalance.SpawnGroups)
+            
+            --Get time
+            local time = GetSystemTimeSecondsOnlyForProfileUse()
+            
+            --Spawn bases
+            while table.getn(ScenarioInfo.LoadBalance.SpawnGroups) > 0 do
+                local base, name, uncapturable = unpack(table.remove( ScenarioInfo.LoadBalance.SpawnGroups, 1))
+                base:SpawnGroup( name, uncapturable, true )
+            end
+            
+            --Spawn units
+            while table.getn(ScenarioInfo.LoadBalance.PlatoonGroups) > 0 do
+                local strArmy, strGroup, formation, callback = unpack(table.remove( ScenarioInfo.LoadBalance.PlatoonGroups, 1)) 
+                CreateArmyGroupAsPlatoonBalanced(strArmy, strGroup, formation, callback)
+            end
+            
+            --Report time taken
+            LOG("Time to spawn: " .. (GetSystemTimeSecondsOnlyForProfileUse() - time))
+        end)
+    end
+end
+
+function GetMarkers()
+    return Scenario.MasterChain._MASTERCHAIN_.Markers
+end
+
+function GetMarker(name)
+    return Scenario.MasterChain._MASTERCHAIN_.Markers[name]
+end
+
+function ChainToPositions(chainName)
+    local chain = Scenario.Chains[chainName]
+    if not chain then
+        error('ERROR: Invalid Chain Named- ' .. chainName, 2)
+    end
+    local positionTable = {}
+    for num, marker in chain.Markers do
+        table.insert(positionTable, Scenario.MasterChain._MASTERCHAIN_.Markers[marker]['position'])
+    end
+    return positionTable
+end
+
+#--[  FindParentChain                                                ]--
+#--[                                                                      ]--
+#--[  Gets the parent chain that the supplied marker belongs to           ]--
+function FindParentChain(markerName)
+    for cName,chain in Scenario.Chains do
+        for mNum,marker in chain.Markers do
+            if marker == markerName then
+                return chain
+            end
+        end
+    end
+    return nil
+end
+
+
+
+function GetMarkerChain(name)
+    local chain = Scenario.Chains[name]
+    if not chain then
+        error('ERROR: Invalid Chain Named- ' .. name, 2)
+    end
+    return chain
+end
+
+#--[  MarkerToPosition                                                           ]--
+#--[                                                                             ]--
+#--[  Converts a marker as specified in *_save.lua file to a position.           ]--
+function MarkerToPosition(strMarker)
+    local marker = GetMarker(strMarker)
+        if not marker then
+            error('ERROR: Invalid marker name- '..strMarker)
+        end
+    return marker.position
+end
+
+#--[  AreaToRect                                                                 ]--
+#--[                                                                             ]--
+#--[  Converts an area as specified in *_save.lua file to a rectangle.           ]--
+function AreaToRect(strArea)
+    local area = Scenario.Areas[strArea]
+    if not area then
+        error('ERROR: Invalid area name')
+    end
+    local rectangle = area.rectangle
+    return Rect(rectangle[1],rectangle[2],rectangle[3],rectangle[4])
+end
+
+function InRect( vectorPos, rect )
+    return vectorPos[1] > rect.x0 and vectorPos[1] < rect.x1 and
+           vectorPos[3] > rect.y0 and vectorPos[3] < rect.y1
+end
+
+#--[  AssembleUnitGroup                                                          ]--
+#--[                                                                             ]--
+#--[  Returns all units (leaf nodes) under the specified group.                  ]--
+function AssembleUnitGroup(tblNode,tblResult)
+    tblResult = tblResult or {}
+
+    if nil == tblNode then
+        return tblResult
+    end
+
+    for strName, tblData in pairs(tblNode.Units) do
+        if 'GROUP' == tblData.type then
+            tblResult = AssembleUnitGroup(tblData,tblResult)
+        else
+            tblResult[strName] = tblData
+        end
+    end
+
+    return tblResult
+end
+
+#--[  AssemblePlatoons                                                           ]--
+#--[                                                                             ]--
+#--[  Returns all platoon template names specified under group.                  ]--
+function AssemblePlatoons(tblNode,tblResult)
+    tblResult = tblResult or {}
+
+    if nil == tblNode then
+        return tblResult
+    end
+
+    if nil != tblNode.platoon and '' != tblNode.platoon then
+        table.insert(tblResult,tblNode.platoon)
+    end
+
+    if 'GROUP' == tblNode.type then
+        for strName, tblData in pairs(tblNode.Units) do
+            tblResult = AssemblePlatoons(tblData,tblResult)
+        end
+    end
+
+    return tblResult
+end
+
+#--[  FindUnit                                                                   ]--
+#--[                                                                             ]--
+#--[  Finds the unit with the specified name.                                    ]--
+function FindUnit(strUnit,tblNode)
+    if nil == tblNode then
+        return nil
+    end
+
+    local tblResult = nil
+
+    for strName, tblData in pairs(tblNode.Units) do
+        if 'GROUP' == tblData.type then
+            tblResult = FindUnit(strUnit,tblData)
+        elseif strName == strUnit then
+            tblResult = tblData
+        end
+
+        if nil != tblResult then
+            break
+        end
+    end
+
+    return tblResult
+end
+
+#--[  CreateArmyUnit                                                             ]--
+#--[                                                                             ]--
+#--[  Creates a named unit in an army.                                           ]--
+function CreateArmyUnit(strArmy,strUnit)
+    local tblUnit = FindUnit(strUnit,Scenario.Armies[strArmy].Units)
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    if nil != tblUnit then
+        local unit = CreateUnitHPR(
+            tblUnit.type,
+            strArmy,
+            tblUnit.Position[1], tblUnit.Position[2], tblUnit.Position[3],
+            tblUnit.Orientation[1], tblUnit.Orientation[2], tblUnit.Orientation[3]
+        )
+        if unit:GetBlueprint().Physics.FlattenSkirt then
+            unit:CreateTarmac(true, true, true, false, false)
+        end             
+        local platoon
+        local brain = GetArmyBrain(strArmy)
+        if tblUnit.platoon ~= nil and tblUnit.platoon ~= '' then
+            local i = 3
+            while i <= table.getn(Scenario.Platoons[tblUnit.platoon]) do
+                if tblUnit.Type == currTemplate[i][1] then
+                    platoon = brain:MakePlatoon('None', 'None')
+                    brain:AssignUnitsToPlatoon(platoon, {unit}, currTemplate[i][4], currTemplate[i][5])
+                    break
+                end
+                i = i + 1
+            end
+        end
+        local armyIndex = brain:GetArmyIndex()
+        if ScenarioInfo.UnitNames[armyIndex] then
+            ScenarioInfo.UnitNames[armyIndex][strUnit] = unit
+        end
+        unit.UnitName = strUnit
+        if not brain.IgnoreArmyCaps then
+            SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+        end
+        return unit, platoon, tblUnit.platoon
+    end
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    return nil
+end
+
+#--[  FindUnitGroup                                                              ]--
+#--[                                                                             ]--
+#--[  Finds the unit group with the specified name.                              ]--
+function FindUnitGroup(strGroup,tblNode)
+    if nil == tblNode then
+        return nil
+    end
+
+    local tblResult = nil
+    for strName, tblData in pairs(tblNode.Units) do
+        if 'GROUP' == tblData.type then
+            if strName == strGroup then
+                tblResult = tblData
+            else
+                tblResult = FindUnitGroup(strGroup,tblData)
+            end
+        end
+
+        if nil != tblResult then
+            break
+        end
+    end
+
+    return tblResult
+end
+
+#--[  AssembleArmyGroup                                                          ]--
+#--[                                                                             ]--
+#--[  Returns a table of units in the group owned by the specified army.         ]--
+function AssembleArmyGroup(strArmy,strGroup)
+    return AssembleUnitGroup(FindUnitGroup(strGroup,Scenario.Armies[strArmy].Units))
+end
+
+#--[  CreateArmySubGroup                                                                      ]--
+#--[                                                                                          ]--
+#--[  Creates Army groups from a number of groups specified in order from the Units Hierarchy ]--
+function CreateArmySubGroup(strArmy,strGroup,...)
+    local tblNode = Scenario.Armies[strArmy].Units
+    local tblResult = {}
+    local treeResult = {}
+    local platoonList = {}
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    for strName, tblData in pairs(tblNode.Units) do
+        if 'GROUP' == tblData.type then
+            if strName == strGroup then
+                if arg['n'] >= 1 then
+                    platoonList, tblResult, treeResult = CreateSubGroup(tblNode.Units[strName], strArmy, unpack(arg))
+                else
+                    platoonList, tblResult, treeResult = CreatePlatoons( strArmy, tblNode.Units[strName] )
+                end
+            end
+        end
+    end
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    if tblResult == nil then
+        error('SCENARIO UTILITIES WARNING: No units found for for Army- ' .. strArmy .. ' Group- ' .. strGroup, 2)
+    end
+    return tblResult, treeResult, platoonList
+end
+
+#--[  CreateSubGroup                                                                      ]--
+#--[                                                                                      ]--
+#--[  Used by CreateArmySubGroup                                                          ]--
+function CreateSubGroup(tblNode, strArmy, strGroup, ...)
+    local tblResult = {}
+    local treeResult = {}
+    local platoonList = {}
+    for strName, tblData in pairs(tblNode.Units) do
+        if 'GROUP' == tblData.type then
+            if strName == strGroup then
+                if arg['n'] >= 1 then
+                    platoonList, tblResult, treeResult = CreateSubGroup(tblNode.Units[strName], strArmy, unpack(arg))
+                else
+                    platoonList, tblResult, treeResult = CreatePlatoons( strArmy, tblNode.Units[strName] )
+                end
+            end
+        end
+    end
+    return platoonList, tblResult, treeResult
+end
+
+
+#--[  CreateInitialArmyGroup                                                     ]--
+#--[                                                                             ]--
+function CreateInitialArmyGroup(strArmy, createCommander)
+    local tblGroup = CreateArmyGroup( strArmy, 'INITIAL')
+    local cdrUnit = false
+
+    if createCommander and ( tblGroup == nil or 0 == table.getn(tblGroup) ) then
+        local factionIndex = GetArmyBrain(strArmy):GetFactionIndex()
+        local initialUnitName = import('/lua/factions.lua').Factions[factionIndex].InitialUnit
+        cdrUnit = CreateInitialArmyUnit(strArmy, initialUnitName)
+        if EntityCategoryContains(categories.COMMAND, cdrUnit) then
+            if ScenarioInfo.Options['PrebuiltUnits'] == 'Off' then
+                cdrUnit:HideBone(0, true)
+                ForkThread(CommanderWarpDelay, cdrUnit, 3)
+            end
+        end
+    end
+
+    return tblGroup, cdrUnit
+end
+
+function CommanderWarpDelay(cdrUnit, delay)
+    WaitSeconds(delay)
+    cdrUnit:PlayCommanderWarpInEffect()
+end
+
+#--[  CreateProps                                                                ]--
+#--[                                                                             ]--
+#--[                                                                             ]--
+function CreateProps()
+    for i, tblData in pairs(Scenario['Props']) do
+        CreatePropHPR(
+            tblData.prop,
+            tblData.Position[1], tblData.Position[2], tblData.Position[3],
+            tblData.Orientation[1], tblData.Orientation[2], tblData.Orientation[3]
+        )
+    end
+end
+
+#--[  CreateResources                                                            ]--
+#--[                                                                             ]--
+#--[                                                                             ]--
+function CreateResources()
+    local markers = GetMarkers()
+    for i, tblData in pairs(markers) do
+        if tblData.resource then
+            CreateResourceDeposit(
+                tblData.type,
+                tblData.position[1], tblData.position[2], tblData.position[3],
+                tblData.size
+            )
+
+            # fixme: texture names should come from editor
+            local albedo, sx, sz, lod
+            if tblData.type == "Mass" then
+                albedo = "/env/common/splats/mass_marker.dds"
+                sx = 2
+                sz = 2
+                lod = 100
+                CreatePropHPR(
+                    '/env/common/props/massDeposit01_prop.bp',
+                    tblData.position[1], tblData.position[2], tblData.position[3],
+                    Random(0,360), 0, 0
+                )
+            else
+                albedo = "/env/common/splats/hydrocarbon_marker.dds"
+                sx = 6
+                sz = 6
+                lod = 200
+                CreatePropHPR(
+                    '/env/common/props/hydrocarbonDeposit01_prop.bp',
+                    tblData.position[1], tblData.position[2], tblData.position[3],
+                    Random(0,360), 0, 0
+                )
+            end
+            # Decal - (position, heading, textureName1, textureName2, type, sizeX, sizeZ, lodParam, duration, army)
+            # Splat - (position, heading, textureName1, textureName2, type, sizeX, sizeZ, lodParam, duration, army)
+#            if not ScenarioInfo.MapData.Decals then
+#                ScenarioInfo.MapData.Decals = {}
+#            end
+#            table.insert( ScenarioInfo.MapData.Decals, CreateDecal(
+#                tblData.position, # position
+#                0, # heading
+#                albedo, "", # TEX1, TEX2
+#                "Albedo", # TYPE
+#                sx, sz, # SIZE
+#                lod, # LOD
+#                0, # DURACTION
+#                -1 # ARMY
+#            ) )
+            CreateSplat(
+                tblData.position,           # Position
+                0,                          # Heading (rotation)
+                albedo,                     # Texture name for albedo
+                sx, sz,                     # SizeX/Z
+                lod,                        # LOD
+                0,                          # Duration (0 == does not expire)
+                -1 ,                         # army (-1 == not owned by any single army)
+                0
+            )
+        end
+    end
+end
+
+#--[  InitializeArmies                                                           ]--
+#--[                                                                             ]--
+#--[                                                                             ]--
+function InitializeArmies()
+    local tblGroups = {}
+    local tblArmy = ListArmies()
+
+    local civOpt = ScenarioInfo.Options.CivilianAlliance
+
+    local bCreateInitial = ShouldCreateInitialArmyUnits()
+
+    for iArmy, strArmy in pairs(tblArmy) do
+        local tblData = Scenario.Armies[strArmy]
+
+        tblGroups[ strArmy ] = {}
+
+        if tblData then
+
+            #--[ If an actual starting position is defined, overwrite the        ]--
+            #--[ randomly generated one.                                         ]--
+
+            #LOG('*DEBUG: InitializeArmies, army = ', strArmy)
+
+            SetArmyEconomy( strArmy, tblData.Economy.mass, tblData.Economy.energy)
+            
+            #GetArmyBrain(strArmy):InitializePlatoonBuildManager()
+            #LoadArmyPBMBuilders(strArmy)
+            if GetArmyBrain(strArmy).SkirmishSystems then
+                GetArmyBrain(strArmy):InitializeSkirmishSystems()
+            end
+
+            local armyIsCiv = ScenarioInfo.ArmySetup[strArmy].Civilian
+
+            if (not armyIsCiv and bCreateInitial) or (armyIsCiv and civOpt != 'removed') then
+                local commander = (not ScenarioInfo.ArmySetup[strArmy].Civilian)
+                local cdrUnit
+                tblGroups[strArmy], cdrUnit = CreateInitialArmyGroup( strArmy, commander)
+                if commander and cdrUnit and ArmyBrains[iArmy].Nickname then
+                    cdrUnit:SetCustomName( ArmyBrains[iArmy].Nickname )
+                end
+            end
+
+            local wreckageGroup = FindUnitGroup('WRECKAGE', Scenario.Armies[strArmy].Units)
+            if wreckageGroup then
+                local platoonList, tblResult, treeResult = CreatePlatoons(strArmy, wreckageGroup )
+                for num,unit in tblResult do
+                    unit:CreateWreckageProp(0)
+                    unit:Destroy()
+                end
+            end
+
+
+
+            #--[ irumsey                                                         ]--
+            #--[ Temporary defaults.  Make sure some fighting will break out.    ]--
+            for iEnemy, strEnemy in pairs(tblArmy) do
+                local enemyIsCiv = ScenarioInfo.ArmySetup[strEnemy].Civilian
+
+                if iArmy != iEnemy and strArmy != 'NEUTRAL_CIVILIAN' and strEnemy != 'NEUTRAL_CIVILIAN' then
+                    if (armyIsCiv or enemyIsCiv) and civOpt == 'neutral' then
+                        SetAlliance( iArmy, iEnemy, 'Neutral')
+                    else
+                        SetAlliance( iArmy, iEnemy, 'Enemy')
+                    end
+                elseif strArmy == 'NEUTRAL_CIVILIAN' or strEnemy == 'NEUTRAL_CIVILIAN' then
+                    SetAlliance( iArmy, iEnemy, 'Neutral')
+                end
+            end
+
+
+        end
+
+    end
+
+    return tblGroups
+end
+
+
+#--[  InitializeScenarioArmies                                                   ]--
+#--[                                                                             ]--
+#--[                                                                             ]--
+function InitializeScenarioArmies()
+    local tblGroups = {}
+    local tblArmy = ListArmies()
+    local factions = import('/lua/factions.lua')
+
+    local bCreateInitial = ShouldCreateInitialArmyUnits()
+
+    ScenarioInfo.CampaignMode = true
+    Sync.CampaignMode = true
+    import('/lua/sim/simuistate.lua').IsCampaign(true)
+
+    for iArmy, strArmy in pairs(tblArmy) do
+        
+        local tblData = Scenario.Armies[strArmy]
+
+        tblGroups[ strArmy ] = {}
+
+        if tblData then
+
+            LOG('*DEBUG: InitializeScenarioArmies, army = ', strArmy)
+
+            SetArmyEconomy( strArmy, tblData.Economy.mass, tblData.Economy.energy)
+
+            if tblData.faction != nil then
+                
+                if ScenarioInfo.ArmySetup[strArmy].Human then
+                    local factionIndex = math.min(math.max(ScenarioInfo.ArmySetup[strArmy].Faction, 1), table.getsize(factions.Factions))
+                    SetArmyFactionIndex( strArmy, factionIndex - 1 )
+                else
+                    local factionIndex = math.min(math.max(tblData.faction, 0), table.getsize(factions.Factions))
+                    SetArmyFactionIndex( strArmy, factionIndex )
+                    GetArmyBrain(strArmy):SetCurrentPlan()
+                end
+            end
+
+            if tblData.color != nil then
+                SetArmyColorIndex( strArmy, tblData.color)
+            end
+
+            if tblData.personality != nil then
+                SetArmyAIPersonality( strArmy, tblData.personality)
+            end
+
+            if bCreateInitial then
+                tblGroups[strArmy] = CreateInitialArmyGroup( strArmy )
+            end
+
+            local wreckageGroup = FindUnitGroup('WRECKAGE', Scenario.Armies[strArmy].Units)
+            if wreckageGroup then
+                local platoonList, tblResult, treeResult = CreatePlatoons(strArmy, wreckageGroup )
+                for num,unit in tblResult do
+                    unit:CreateWreckageProp(0)
+                    unit:Destroy()
+                end
+            end
+
+            #--[ eemerson                                                         ]--
+            #--[ Override alliances with custom alliance settings                 ]--
+            if tblData.Alliances != nil then
+               for iEnemy,iAlliance in pairs(tblData.Alliances) do
+                   if iArmy != iEnemy then
+                       SetAllianceOneWay( strArmy, iEnemy, iAlliance )
+                   end
+               end
+           end
+
+            GetArmyBrain(strArmy):InitializePlatoonBuildManager()
+            LoadArmyPBMBuilders(strArmy)
+
+        end
+
+    end
+
+    return tblGroups
+end
+
+#--[ AssignOrders                                                                ]--
+#--[                                                                             ]--
+#--[                                                                             ]--
+function AssignOrders( strQueue, tblUnit, target)
+    local tblOrder = Scenario.Orders[ strQueue ]
+    for i, order in pairs(tblOrder) do
+        order.cmd(tblUnit,target)
+    end
+end
+
+
+#--[ SpawnPlatoon                                                                ]--
+#--[ Spawns unit group and assigns to platoon it is a part of                    ]--
+function SpawnPlatoon( strArmy, strGroup )
+    local tblNode = FindUnitGroup( strGroup, Scenario.Armies[strArmy].Units )
+    if nil == tblNode then
+        error('SCENARIO UTILITIES WARNING: No Group found for Army- ' .. strArmy .. ' Group- ' .. strGroup, 2)
+        return false
+    end
+
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    local platoonName
+    if nil ~= tblNode.platoon and '' != tblNode.platoon then
+        platoonName = tblNode.platoon
+    end
+
+    local platoonList, tblResult, treeResult = CreatePlatoons(strArmy, tblNode)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    if tblResult == nil then
+        error('SCENARIO UTILITIES WARNING: No units found for for Army- ' .. strArmy .. ' Group- ' .. strGroup, 2)
+    end
+    return platoonList[platoonName], platoonList, tblResult, treeResult
+end
+
+function SpawnTableOfPlatoons( strArmy, strGroup )
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    local platoonList, tblResult, treeResult = CreatePlatoons(strArmy,
+                                                              FindUnitGroup( strGroup, Scenario.Armies[strArmy].Units))
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    if tblResult == nil then
+        error('SCENARIO UTILITIES WARNING: No units found for for Army- ' .. strArmy .. ' Group- ' .. strGroup, 2)
+    end
+    return platoonList, tblResult, treeResult
+end
+
+function CountChildUnits(tblNode)
+    local count = 0
+    
+    for k,v in pairs(tblNode.Units) do
+        if v.type == 'GROUP' then
+            count = count + CountChildUnits(v)
+        else
+            count = count + 1
+        end
+    end
+    
+    tblNode.TotalUnits = count
+    
+    return count
+end
+
+function CreatePlatoons( strArmy, tblNode, tblResult, platoonList, currPlatoon, treeResult, balance )
+    tblResult = tblResult or {}
+    platoonList = platoonList or {}
+    treeResult = treeResult or {}
+    currPlatoon = currPlatoon or false
+    local treeLocal = {}
+
+    if nil == tblNode then
+        return nil
+    end
+
+    local brain = GetArmyBrain(strArmy)
+    local armyIndex = brain:GetArmyIndex()
+    local currTemplate
+    local numRows
+    local reversePlatoon = false
+    local reverseRows
+    local reverseTemplate
+    if nil ~= tblNode.platoon and '' != tblNode.platoon and tblNode ~= currPlatoon
+        and not platoonList[tblNode.platoon] then
+        currTemplate = Scenario.Platoons[tblNode.platoon]
+        if currTemplate then
+            platoonList[tblNode.platoon] = brain:MakePlatoon('', currTemplate[2])
+            platoonList[tblNode.platoon].squadCounter = {}
+            currPlatoon = tblNode.platoon
+        end
+    end
+    if currPlatoon then
+        currTemplate = Scenario.Platoons[currPlatoon]
+        numRows = table.getn(currTemplate)
+    end
+
+    local unit = nil
+
+    --local timePerChild = nil
+
+    --[[
+    if timeLeft and not tblNode.TotalUnits then 
+        --Calculate the number of units 
+        local totalUnits = CountChildUnits(tblNode)
+    end
+    
+    if timeLeft then 
+        timePerChild = (timeLeft/tblNode.TotalUnits)
+    end
+    ]]-- 
+
+    for strName, tblData in pairs(tblNode.Units) do        
+        if 'GROUP' == tblData.type then
+            --[[
+            if timeLeft and tblData.TotalUnits > 0 then 
+                timePerChild = (timeLeft/tblNode.TotalUnits)*tblData.TotalUnits
+            end
+            --]]--  
+            
+            platoonList, tblResult, treeResult[strName] = CreatePlatoons(strArmy, tblData, tblResult,
+                                                                         platoonList, currPlatoon, treeResult[strName], balance)  
+                                                                         
+        else            
+            unit = CreateUnitHPR( tblData.type,
+                                 strArmy,
+                                 tblData.Position[1], tblData.Position[2], tblData.Position[3],
+                                 tblData.Orientation[1], tblData.Orientation[2], tblData.Orientation[3]
+                             )
+            if unit:GetBlueprint().Physics.FlattenSkirt then
+                unit:CreateTarmac(true, true, true, false, false)
+            end                               
+            table.insert(tblResult, unit)
+            treeResult[strName] = unit
+            if ScenarioInfo.UnitNames[armyIndex] then
+                ScenarioInfo.UnitNames[armyIndex][strName] = unit
+            end
+            unit.UnitName = strName
+            if tblData.platoon ~= nil and tblData.platoon ~= '' and tblData.platoon ~= currPlatoon then
+                reversePlatoon = currPlatoon
+                reverseRows = numRows
+                reverseTemplate = currTemplate
+                if not platoonList[tblData.platoon] then
+                    currTemplate = Scenario.Platoons[tblData.platoon]
+                    platoonList[tblData.platoon] = brain:MakePlatoon('', currTemplate[2])
+                    platoonList[tblData.platoon].squadCounter = {}
+                end
+                currPlatoon = tblData.platoon
+                currTemplate = Scenario.Platoons[currPlatoon]
+                numRows = table.getn(currTemplate)
+            end
+            if currPlatoon then
+                local i = 3
+                local inserted = false
+                while i <= numRows and not inserted do
+                    if platoonList[currPlatoon].squadCounter[i] == nil then
+                        platoonList[currPlatoon].squadCounter[i] = 0
+                    end
+                    if tblData.type == currTemplate[i][1] and
+                            platoonList[currPlatoon].squadCounter[i] < currTemplate[i][3] then
+                        platoonList[currPlatoon].squadCounter[i] = platoonList[currPlatoon].squadCounter[i] + 1
+                        brain:AssignUnitsToPlatoon(platoonList[currPlatoon],{unit},currTemplate[i][4],currTemplate[i][5] )
+                        inserted = true
+                    end
+                    i = i + 1
+                end
+                if reversePlatoon then
+                    currPlatoon = reversePlatoon
+                    numRows = reverseRows
+                    currTemplate = reverseTemplate
+                    reversePlatoon = false
+                end
+            end
+            
+            if balance then
+                --Accumulate for one tick so we don't get too much overhead from thread switching...
+                --ScenarioInfo.LoadBalance.Accumulator = ScenarioInfo.LoadBalance.Accumulator + timePerChild
+                ScenarioInfo.LoadBalance.Accumulator = ScenarioInfo.LoadBalance.Accumulator + 1
+                
+                if ScenarioInfo.LoadBalance.Accumulator > ScenarioInfo.LoadBalance.UnitThreshold then
+                    WaitSeconds(0)
+                    ScenarioInfo.LoadBalance.Accumulator = 0
+                end
+            end
+        end
+    end
+
+    return platoonList, tblResult, treeResult
+end
+
+
+
+#--[  CreateArmyGroup                                                            ]--
+#--[                                                                             ]--
+#--[  Creates the specified group in game.                                       ]--
+function CreateArmyGroup(strArmy,strGroup,wreckage, balance)
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    local platoonList, tblResult, treeResult = CreatePlatoons(strArmy,
+                                                              FindUnitGroup( strGroup, Scenario.Armies[strArmy].Units ), nil, nil, nil, nil, balance )
+
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    if tblResult == nil and strGroup ~= 'INITIAL' then
+        error('SCENARIO UTILITIES WARNING: No units found for for Army- ' .. strArmy .. ' Group- ' .. strGroup, 2)
+    end
+    if wreckage then
+        for num, unit in tblResult do
+            unit:CreateWreckageProp()
+            unit:Destroy()
+        end
+        return
+    end
+    return tblResult, treeResult, platoonList
+end
+
+# CreateArmyTree
+#
+# Returns tree of units created by the editor. 2nd return is table of units
+function CreateArmyTree(strArmy, strGroup)
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    local platoonList, tblResult, treeResult = CreatePlatoons(strArmy,
+                                                              FindUnitGroup(strGroup, Scenario.Armies[strArmy].Units) )
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    if tblResult == nil then
+        error('SCENARIO UTILITIES WARNING: No units found for for Army- ' .. strArmy .. ' Group- ' .. strGroup, 2)
+    end
+    return treeResult, tblResult, platoonList
+end
+
+
+function CreateArmyGroupAsPlatoonBalanced(strArmy, strGroup, formation, OnFinishedCallback)
+    ScenarioInfo.LoadBalance.Accumulator = 0
+    local units = CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, nil, nil, true)
+
+    OnFinishedCallback(units)
+end
+
+# CreateArmyGroupAsPlatoon
+#
+# Returns a platoon that is created out of all units in a group and its sub groups.
+function CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, tblNode, platoon, balance)
+    if ScenarioInfo.LoadBalance.Enabled then
+        --note that tblNode in this case is actually the callback function
+        table.insert(ScenarioInfo.LoadBalance.PlatoonGroups, {strArmy, strGroup, formation, tblNode})
+        return
+    end
+    
+    local tblNode = tblNode or FindUnitGroup(strGroup, Scenario.Armies[strArmy].Units)
+    if not tblNode then
+        error('*SCENARIO UTILS ERROR: No group named- ' .. strGroup .. ' found for army- ' .. strArmy, 2)
+    end
+    if not formation then
+        error('*SCENARIO UTILS ERROR: No formation given to CreateArmyGroupAsPlatoon')
+    end
+    local brain = GetArmyBrain(strArmy)
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+    end
+    local platoon = platoon or brain:MakePlatoon('','')
+    local armyIndex = brain:GetArmyIndex()
+
+    local unit = nil
+    for strName, tblData in pairs(tblNode.Units) do
+        if 'GROUP' == tblData.type then
+            platoon = CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, tblData, platoon)
+            if not brain.IgnoreArmyCaps then
+                SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
+            end
+        else
+            unit = CreateUnitHPR( tblData.type,
+                                 strArmy,
+                                 tblData.Position[1], tblData.Position[2], tblData.Position[3],
+                                 tblData.Orientation[1], tblData.Orientation[2], tblData.Orientation[3]
+                             )
+            if unit:GetBlueprint().Physics.FlattenSkirt then
+                unit:CreateTarmac(true, true, true, false, false)
+            end                               
+            if ScenarioInfo.UnitNames[armyIndex] then
+                ScenarioInfo.UnitNames[armyIndex][strName] = unit
+            end
+            unit.UnitName = strName
+            brain:AssignUnitsToPlatoon(platoon, {unit}, 'Attack', formation)
+            
+            if balance then
+                ScenarioInfo.LoadBalance.Accumulator = ScenarioInfo.LoadBalance.Accumulator + 1
+                
+                if ScenarioInfo.LoadBalance.Accumulator > ScenarioInfo.LoadBalance.UnitThreshold/5 then
+                    WaitSeconds(0)
+                    ScenarioInfo.LoadBalance.Accumulator = 0
+                end
+            end
+        end
+    end
+    if not brain.IgnoreArmyCaps then
+        SetIgnoreArmyUnitCap(brain:GetArmyIndex(), false)
+    end
+    return platoon
+end
+
+# Creates an army group at a certain veteran level
+function CreateArmyGroupAsPlatoonVeteran(strArmy, strGroup, formation, veteranLevel)
+    local plat = CreateArmyGroupAsPlatoon(strArmy, strGroup, formation)
+    veteranLevel = veteranLevel or 5
+    for k,v in plat:GetPlatoonUnits() do
+        v:SetVeterancy(veteranLevel)
+    end
+    return plat
+end  
+    
+function FlattenTreeGroup( strArmy, strGroup, tblData, unitGroup )
+    tblData = tblData or FindUnitGroup( strGroup, Scenario.Armies[strArmy].Units )
+    unitGroup = unitGroup or {}
+    for strName, tblData in pairs(tblData.Units) do
+        if 'GROUP' == tblData.type then
+            FlattenTreeGroup( strArmy, strGroup, tblData, unitGroup )
+        else
+            table.insert( unitGroup, tblData )
+        end
+    end
+    return unitGroup
+end
+
+# LoadArmyPBMBuilders
+#
+# Loads an Army Brain's PBM Builders from the save file
+function LoadArmyPBMBuilders(strArmy)
+    local aiBrain = GetArmyBrain(strArmy)
+    if Scenario.Armies[strArmy].PlatoonBuilders.Builders then
+        local nonGlobalOSB = {}
+        for buildName, builderData in Scenario.Armies[strArmy].PlatoonBuilders.Builders do
+            if builderData.PlatoonData then
+                for k,v in builderData.PlatoonData do
+                    if type(k) ~= 'string' then
+                        builderData.PlatoonData = RebuildDataTable(builderData.PlatoonData)
+                    end
+                    break
+                end
+            end
+            if builderData.BuildConditions then
+                for num,conditionData in builderData.BuildConditions do
+                    local tempBuildData = {}
+                    table.insert(tempBuildData,conditionData[1])
+                    table.insert(tempBuildData,conditionData[2])
+                    table.insert(tempBuildData,conditionData[3])
+                    builderData.BuildConditions[num] = tempBuildData
+                end
+            end
+            if string.sub(buildName, 1, 11) == 'OSB_Master_' or string.sub(buildName, 1, 10) == 'OSB_Child_' then
+                nonGlobalOSB[buildName] = builderData
+            elseif string.sub(buildName, 1, 4) == 'OSB_' then
+                LoadOSB(buildName, strArmy, builderData)
+            elseif not builderData.PlatoonData.AMMasterPlatoon then
+                local spec = {}
+                for k, v in builderData do
+                    spec[k] = v
+                end
+                spec.PlatoonTemplate = table.deepcopy(Scenario.Platoons[builderData.PlatoonTemplate])
+                spec.BuilderName = buildName
+                spec.PlatoonData.BuilderName = buildName
+                if spec.BuildTimeOut and spec.BuildTimeOut < 0 then
+                    spec.GenerateTimeOut = true
+                end
+                aiBrain:PBMAddPlatoon(spec)
+            else
+                if aiBrain.AttackData['AttackManagerState'] ~= 'ACTIVE' then
+                    aiBrain:InitializeAttackManager()
+                end
+                local spec = {}
+                if builderData.BuildConditions then
+                    spec.AttackConditions = builderData.BuildConditions
+                else
+                    spec.AttackConditions = {}
+                end
+                spec.PlatoonData = builderData.PlatoonData
+                spec.Priority = builderData.Priority
+                if builderData.PlatoonAIFunction then
+                    spec.AIThread = builderData.PlatoonAIFunction
+                end
+                if spec.PlatoonData.AIName then
+                    spec.AIName = spec.PlatoonData.AIName
+                end
+                if builderData.PlatoonAddFunctions then
+                    spec.FormCallbacks = builderData.PlatoonAddFunctions
+                end
+                if builderData.PlatoonBuildCallbacks then
+                    spec.DestroyCallbacks = builderData.PlatoonBuildCallbacks
+                end
+                if builderData.PlatoonTemplate and not spec.AIName then
+                    if Scenario.Platoons[builderData.PlatoonTemplate][2] ~= '' then
+                        spec.AIName = Scenario.Platoons[builderData.PlatoonTemplate][2]
+                    end
+                end
+                spec.PlatoonType = builderData.PlatoonType
+                spec.PlatoonName = buildName
+                spec.LocationType = builderData.LocationType
+                spec.BuilderName = buildName
+                if spec.PlatoonData.UsePool ~= nil then
+                    spec.UsePool = spec.PlatoonData.UsePool
+                end
+                aiBrain:AMAddPlatoon(spec)
+            end
+        end
+        for buildName, builderData in nonGlobalOSB do
+            UpdateOSB(buildName, strArmy, builderData)
+        end
+    end
+end
+
+function RebuildDataTable(table)
+    local newTable = {}
+    for k,v in table do
+        local checkType = type(v.value)
+        if type(v.value) == 'table' then
+            newTable[v.name] = RebuildDataTable(v.value)
+        else
+            newTable[v.name] = v.value
+        end
+    end
+    return newTable
+end
+
+function InitializeStartLocation(strArmy)
+    local start = GetMarker(strArmy)
+    if start then
+        SetArmyStart(strArmy, start.position[1], start.position[3])
+    else
+        GenerateArmyStart(strArmy)
+    end
+end
+
+function SetPlans(strArmy)
+    if Scenario.Armies[strArmy] then
+        SetArmyPlans(strArmy, Scenario.Armies[strArmy].plans)
+    end
+end
+
+function UpdateOSB(buildName, strArmy, builderData)
+#    local buildNameNew, location, globalName, childPart = SplitUpdateOSBName(buildName)
+    local aiBrain = GetArmyBrain(strArmy)
+#    local amMasterName = 'OSB_Master_' .. globalName .. '_' .. strArmy
+#    if location then
+#        amMasterName = amMasterName .. '_' .. location
+#    end
+#
+#    # Find builder in brain
+#    local builderName = buildName
+#    builderName = builderName .. '_' .. strArmy
+#    if location then
+#        builderName = builderName .. '_' .. location
+#    end
+#    local found = false
+#    local builderEdit = false
+    for type, bTable in aiBrain.PBM.Platoons do
+        for bCount, bData in bTable do
+            local bName = bData.BuilderName
+            if bName == buildName then
+                UpdateGivenOSB(bData, builderData)
+            end
+        end
+    end
+end
+
+function UpdateGivenOSB(builderEdit, builderData)
+    # Update data in builder in brain
+    for dName, data in builderData.PlatoonData do
+        if dName ~= 'PlatoonMultiplier' and dName ~= 'TransportCount' then
+            builderEdit.PlatoonData[dName] = data
+        end
+    end
+    if builderData.PlatoonData.PlatoonMultiplier and not builderEdit.PlatoonTemplate.MultiplierApplied then
+        builderEdit.PlatoonTemplate.MultiplierApplied = true
+        local squadNum = 3
+        while squadNum <= table.getn(builderEdit.PlatoonTemplate) do
+            if builderEdit.PlatoonTemplate[squadNum][2] < 0 then
+                local num = builderEdit.PlatoonTemplate[squadNum][2] * builderData.PlatoonData.PlatoonMultiplier
+                builderEdit.PlatoonTemplate[squadNum][2] = -( math.ceil( math.abs( num ) ) )
+            end
+            squadNum = squadNum + 1
+        end
+    end
+    if builderData.Priority ~= 0 then
+        if builderData.Priority == -1 then
+            builderEdit.Priority = 0
+        else
+            builderEdit.Priority = builderData.Priority
+        end
+    end
+    if builderData.BuildConditions then
+        for bcNum, bcData in builderData.BuildConditions do
+            if childPart then
+                table.insert(builderEdit.BuildConditions, bcData)
+            else
+                table.insert(builderEdit.AttackConditions, bcData)
+            end
+        end
+    end
+    if builderData.PlatoonBuildCallbacks then
+        for buildNum, buildData in builderData.PlatoonBuildCallbacks do
+            if childPart then
+                table.insert(builderEdit.PlatoonBuildCallbacks, buildData)
+            else
+                table.insert(builderEdit.DestroyCallbacks, buildData)
+            end
+        end
+    end
+    if builderData.PlatoonAddFunctions then
+        for addNum, addData in builderData.PlatoonAddFunctions do
+            if childPart then
+                table.insert(builderEdit.PlatoonAddFunctions, buildData)
+            else
+                table.insert(builderEdit.FormCallbacks, buildData)
+            end
+        end
+    end
+    if builderData.PlatoonAIFunction then
+        if childPart then
+            builderEdit.PlatoonAIFunction = builderData.PlatoonAIFunction
+        else
+            builderEdit.AIThread = builderData.PlatoonAIFunction
+        end
+    end
+end
+
+function LoadOSB(buildName, strArmy, builderData)
+    local buildNameNew, location, globalName, childPart
+    local saveFile
+    
+    if type(buildName) == 'table' then
+        saveFile = {Scenario = buildName}
+        
+        buildNameNew = 'OSB_' .. saveFile.Scenario.Name
+        globalName = saveFile.Scenario.Name
+        location = false --string.gsub(builderData.LocationType, '_', '')
+        childPart = false
+    else
+        buildNameNew, location, globalName, childPart = SplitOSBName(buildName)
+        local fileName = '/lua/ai/OpAI/' .. globalName .. '_save.lua'
+        saveFile = import(fileName)
+    end
+   
+    local platoons = saveFile.Scenario.Platoons
+    local aiBrain = GetArmyBrain(strArmy)
+    if not aiBrain.OSBuilders then
+        aiBrain.OSBuilders = {}
+    end
+    local factionIndex = aiBrain:GetFactionIndex()
+    local builders = saveFile.Scenario.Armies['ARMY_1'].PlatoonBuilders.Builders
+    local basePriority = builders['OSB_Master_'..globalName].Priority
+    local amMasterName = 'OSB_Master_' .. globalName .. '_' .. strArmy
+    if location then
+        amMasterName =  amMasterName .. '_' .. location
+    end
+    if not builders then
+        error('*OpAI ERROR: No OpAI Global named: '..globalName, 2)
+    end
+    for k,v in builders do
+        local spec = {}
+        local insert = true
+
+        local pData = RebuildDataTable(v.PlatoonData)
+        spec.PlatoonData = {}
+
+        # Store builder name
+        if location then
+            spec.BuilderName = k .. '_' .. strArmy .. '_' .. location
+            spec.PlatoonData.BuilderName = k .. '_' .. strArmy .. '_' .. location
+        else
+            spec.BuilderName = k .. '_' .. strArmy
+            spec.PlatoonData.BuilderName = k .. '_' .. strArmy
+        end
+
+        if ScenarioInfo.OSPlatoonCounter[spec.BuilderName] then
+            UpdateOSB(spec.BuilderName, strArmy, builderData)
+        else
+            if string.sub(k, 1, 11) == 'OSB_Master_' then
+                for name, data in builderData.PlatoonData do
+                    if name ~= 'PlatoonMultiplier' and name ~= 'TransportCount' and name ~= 'PlatoonSize' then
+                        spec.PlatoonData[name] = data
+                    end
+                end
+            end
+            if pData.AMPlatoons then
+                spec.PlatoonData.AMPlatoons = {}
+                for name, pName in pData.AMPlatoons do
+                    local appendString = ''
+                    if string.sub(name, 1, 6) == 'APPEND' then
+                        appendString = string.sub(name, 7)
+                    end
+                    if location then
+                        table.insert(spec.PlatoonData.AMPlatoons, pName..'_'..strArmy..'_'..location..appendString)
+                    else
+                        table.insert(spec.PlatoonData.AMPlatoons, pName .. '_' .. strArmy .. appendString)
+                    end
+                end
+            end
+
+
+            # Set priority
+            if builderData.Priority < 0 then
+                insert = false
+                spec.Priority = builderData.Priority
+            elseif builderData.Priority ~= 0 then
+                spec.Priority = builderData.Priority - (basePriority - v.Priority)
+                if spec.Priority <= 0 then
+                    spec.Priority = 1
+                end
+            else
+                spec.Priority = v.Priority
+            end
+            if spec.LocationType ~= 'ALL' then
+                spec.LocationType = builderData.LocationType
+                spec.PlatoonData.LocationType = builderData.LocationType
+            end
+            spec.PlatoonType = v.PlatoonType
+
+            # Set platoon template
+            if Scenario.Platoons['OST_' .. string.sub(spec.BuilderName, 5)] then
+                spec.PlatoonTemplate = FactionConvert(table.deepcopy(Scenario.Platoons['OST_' .. string.sub(spec.BuilderName, 5)]), factionIndex)
+            elseif Scenario.Platoons[v.PlatoonTemplate] then
+                if type(buildName) ~= "table" then
+                    spec.PlatoonTemplate = FactionConvert(table.deepcopy(Scenario.Platoons[v.PlatoonTemplate]), factionIndex)
+                else
+                    spec.PlatoonTemplate = table.deepcopy(Scenario.Platoons[v.PlatoonTemplate])
+                end
+            else
+                if type(buildName) ~= "table" then
+                    spec.PlatoonTemplate = FactionConvert(table.deepcopy(platoons[v.PlatoonTemplate]), factionIndex)
+                else
+                    spec.PlatoonTemplate = table.deepcopy(platoons[v.PlatoonTemplate])
+                end
+                
+                
+            end
+            if builderData.PlatoonData.PlatoonMultiplier then
+                local squadNum = 3
+                while squadNum <= table.getn(spec.PlatoonTemplate) do
+                    spec.PlatoonTemplate[squadNum][2] = spec.PlatoonTemplate[squadNum][2] * builderData.PlatoonData.PlatoonMultiplier
+                    spec.PlatoonTemplate[squadNum][3] = spec.PlatoonTemplate[squadNum][3] * builderData.PlatoonData.PlatoonMultiplier
+                    squadNum = squadNum + 1
+                end
+            end
+            if builderData.PlatoonData.PlatoonSize then
+                local squadNum = 3
+                while squadNum <= table.getn(spec.PlatoonTemplate) do
+                    spec.PlatoonTemplate[squadNum][2] = 1
+                    spec.PlatoonTemplate[squadNum][3] = builderData.PlatoonData.PlatoonSize
+                    squadNum = squadNum + 1
+                end
+            end
+
+            # Set buildout to
+            if (v.BuildTimeOut and v.BuildTimeOut < 0 ) or ( spec.PlatoonTemplate[3] and spec.PlatoonTemplate[3][2] < 0 ) then
+                spec.GenerateTimeOut = true
+            end
+            spec.BuildTimeOut = v.BuildTimeOut
+
+            # Add AI Function to OSB global if needed
+            if string.sub(k, 1, 11) == 'OSB_Master_' and builderData.PlatoonAIFunction then
+                spec.PlatoonAIFunction = builderData.PlatoonAIFunction
+            elseif v.PlatoonAIFunction then
+                spec.PlatoonAIFunction = v.PlatoonAIFunction
+            end
+
+            # Add Build Conditions
+            spec.BuildConditions = {}
+            if v.BuildConditions then
+                for num, bCond in v.BuildConditions do
+                    local addCond = table.deepcopy(bCond)
+                    for sNum, pVal in addCond[3] do
+                        if pVal == 'OSB_Master_' .. string.sub(buildNameNew,5) then
+                            pVal = amMasterName
+                        elseif pVal == 'default_master' then
+                            addCond[3][sNum] = amMasterName
+                        elseif pVal == 'default_army' then
+                            addCond[3][sNum] = strArmy
+                        elseif pVal == 'default_location' and location then
+                            addCond[3][sNum] = location
+                        elseif pVal == 'default_location_type' then
+                            addCond[3][sNum] = spec.LocationType
+                        elseif pVal == 'default_builder_name' then
+                            addCond[3][sNum] = spec.BuilderName
+                        elseif pVal == 'default_transport_count' then
+                            if builderData.PlatoonData.TransportCount then
+                                addCond[3][sNum] = builderData.PlatoonData.TransportCount
+                            end
+                        end
+                    end
+                    table.insert(spec.BuildConditions, addCond)
+                end
+            end
+            # Add build/form conditions to ALL builders
+            if builderData.BuildConditions then
+                for num, bCond in builderData.BuildConditions do
+                    if bCond[3][1] == 'Remove' then
+                        for bcNum,bcData in spec.BuildConditions do
+                            if bcData[2] == bCond[2] then
+                                table.remove(spec.BuildConditions, bcNum)
+                            end
+                        end
+                    else
+                        local addCond = table.deepcopy(bCond)
+                        for sNum, pVal in addCond[3] do
+                            if pVal == buildNameNew then
+                                pVal = amMasterName
+                            elseif pVal == 'default_master' then
+                                addCond[3][sNum] = amMasterName
+                            elseif pVal == 'default_army' then
+                                addCond[3][sNum] = strArmy
+                            elseif pVal == 'default_location' and location then
+                                addCond[3][sNum] = location
+                            elseif pVal == 'default_location_type' then
+                                addCond[3][sNum] = spec.LocationType
+                            elseif pVal == 'default_builder_name' then
+                                addCond[3][sNum] = spec.BuilderName
+                            elseif pVal == 'default_transport_count' then
+                                if builderData.PlatoonData.TransportCount then
+                                    addCond[3][sNum] = builderData.PlatoonData.TransportCount
+                                end
+                            end
+                        end
+                        table.insert(spec.BuildConditions, addCond)
+                    end
+                end
+            end
+            # Check for faction specific builders
+            for num, cond in spec.BuildConditions do
+                if cond[2] == 'FactionIndex' then
+                    local params = {}
+                    for subNum, val in cond[3] do
+                        table.insert(params, val)
+                    end
+                    table.remove(params, 1)
+                    insert = import(cond[1])[cond[2]](aiBrain, unpack(params))
+                end
+            end
+
+            # Add BuildCallbacks
+            spec.PlatoonBuildCallbacks = {}
+            if v.PlatoonBuildCallbacks then
+                for num, pbCallback in v.PlatoonBuildCallbacks do
+                    table.insert(spec.PlatoonBuildCallbacks, pbCallback)
+                end
+            end
+            # Add DestroyCallbacks to Masters
+            if builderData.PlatoonBuildCallbacks and string.sub(k,1,11) == 'OSB_Master_' then
+                FilterFunctions(spec.PlatoonBuildCallbacks, builderData.PlatoonBuildCallbacks)
+            end
+
+            # Add AddFunctions (Har!)
+            spec.PlatoonAddFunctions = {}
+            if v.PlatoonAddFunctions then
+                for fNum, fData in v.PlatoonAddFunctions do
+                    table.insert(spec.PlatoonAddFunctions, fData)
+                end
+            end
+            if builderData.PlatoonAddFunctions and string.sub(k,1,11) == 'OSB_Master_' then
+                FilterFunctions(spec.PlatoonAddFunctions, builderData.PlatoonAddFunctions)
+            end
+
+
+            # Masters
+            if pData.AMMasterPlatoon and insert then
+                if string.sub(k,1,26) == 'OSB_Master_LeftoverCleanup' then
+                    spec.PlatoonName = spec.LocationType..'_LeftoverUnits'
+                else
+                    spec.PlatoonName = spec.BuilderName
+                end
+
+                # Add data to Masters
+                if builderData.PlatoonData and string.sub(k,1,11) == 'OSB_Master_' then
+                    if aiBrain.AttackData['AttackManagerState'] ~= 'ACTIVE' then
+                        aiBrain:InitializeAttackManager()
+                    end
+                end
+
+                spec.AttackConditions = spec.BuildConditions
+                spec.DestroyCallbacks = spec.PlatoonBuildCallbacks
+                spec.FormCallbacks = spec.PlatoonAddFunctions
+                spec.AIThread = spec.PlatoonAIFunction
+
+                if pData.AIName then
+                    spec.AIName = pData.AIName
+                end
+                if spec.PlatoonTemplate and not spec.AIName then
+                    if spec.PlatoonTemplate[2] ~= '' then
+                        spec.AIName = spec.PlatoonTemplate[2]
+                    end
+                end
+
+                # Set if needed to draw from pool
+                if pData.UsePool ~= nil then
+                    spec.UsePool = pData.UsePool
+                end
+                aiBrain:AMAddPlatoon(spec)
+
+                # Children
+            elseif insert then
+                spec.RequiresConstruction = v.RequiresConstruction
+
+                # Add spec to brain
+                spec.InstanceCount = v.InstanceCount
+                aiBrain:PBMAddPlatoon(spec)
+            end
+        end
+    end
+end
+
+-- TODO: This really ought to be hooked.... this file needs to be made game agnostic as it's in mohodata
+function FactionConvert(template, factionIndex)
+    local i = 3
+    while i <= table.getn(template) do
+        if factionIndex == 2 then
+            if template[i][1] == 'uel0203' then
+                template[i][1] = 'xal0203'
+            elseif template[i][1] == 'uea0305' then
+                template[i][1] = 'xaa0305'
+            elseif template[i][1] == 'xel0305' then
+                template[i][1] = 'xal0305'
+            else
+                template[i][1] = string.gsub(template[i][1], 'ue', 'ua')
+            end
+        elseif factionIndex == 3 then
+            if template[i][1] == 'uea0305' then
+                template[i][1] = 'xra0305'
+            elseif template[i][1] == 'xel0305' then
+                template[i][1] = 'xrl0305'
+            else
+                template[i][1] = string.gsub(template[i][1], 'ue', 'ur')
+            end
+        elseif factionIndex == 4 then
+            if template[i][1] == 'uel0106' then
+                template[i][1] = 'xsl0201'
+            elseif template[i][1] == 'xel0305' then
+                template[i][1] = 'xsl0305'
+            else
+                template[i][1] = string.gsub(template[i][1], 'ue', 'xs')
+            end
+        end
+        i = i + 1
+    end
+    return template
+end
+
+function SplitUpdateOSBName(buildName)
+    # OSB_<bname>_location
+    local startCheck = 5
+    local specificBuilder = false
+    if string.sub(buildName, 1, 11) == 'OSB_Master_' then
+        startCheck = 12
+    elseif string.sub(buildName, 1, 10) == 'OSB_Child_' then
+        startCheck = 11
+    end
+    local pos = string.find(buildName, '_', startCheck)
+    local location = false
+    local retName = buildName
+    local globName = false
+    local childPart = false
+    if pos then
+        globName = string.sub(buildName, startCheck, pos-1)
+        retName = string.sub(buildName, 1, pos-1)
+    else
+        globName = string.sub(buildName, startCheck)
+        retName = buildName
+    end
+    if startCheck <= 5 and pos then
+        location = string.sub(buildName, pos+1)
+    elseif pos then
+        local pos2 = string.find(buildName, '_', pos+1)
+        if pos2 then
+            childPart = string.sub(buildName, pos+1, pos2-1)
+            location = string.sub(buildName, pos2+1 )
+        else
+            childPart = string.sub(buildName, pos+1)
+        end
+    end
+    return retName, location, globName, childPart
+end
+
+function SplitOSBName(buildName)
+    # OSB_<bname>_location
+    local startCheck = 5
+    local specificBuilder = false
+    if string.sub(buildName, 1, 11) == 'OSB_Master_' then
+        startCheck = 12
+    elseif string.sub(buildName, 1, 10) == 'OSB_Child_' then
+        startCheck = 11
+    end
+    local pos = string.find(buildName, '_', startCheck)
+    local location = false
+    local retName = buildName
+    local globName = false
+    local childPart = false
+    if pos then
+        globName = string.sub(buildName, startCheck, pos-1)
+        retName = string.sub(buildName, 1, pos-1)
+    else
+        globName = string.sub(buildName, startCheck)
+        retName = buildName
+    end
+    if startCheck <= 5 and pos then
+        location = string.sub(buildName, pos+1)
+    elseif pos then
+        local pos2 = string.find(buildName, '_', pos+1)
+        if pos2 then
+            location = string.sub(buildName, pos+1, pos2-1)
+            childPart = string.sub(buildName, pos2+1 )
+        else
+            location = string.sub(buildName, pos+1)
+        end
+    end
+    return retName, location, globName, childPart
+end
+
+function FilterFunctions(tableOne, tableTwo)
+    for t2Num, t2Data in tableTwo do
+        if t2Data[3][1] == 'Remove' then
+            for t1Num,t1Data in tableOne do
+                if t2Data[2] == t1Data[2] then
+                    table.remove(tableOne, t1Num)
+                end
+            end
+        else
+            table.insert(tableOne, t2Data)
+        end
+    end
+    return tableOne
+end

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -1,16 +1,16 @@
-#--[                                                                             ]--
-#--[  File     : ScenarioUtilities.lua                                           ]--
-#--[  Author(s): Ivan Rumsey                                                     ]--
-#--[                                                                             ]--
-#--[  Summary  : Utility functions for use with scenario save file.              ]--
-#--[             Created from examples provided by Jeff Petkau.                  ]--
-#--[                                                                             ]--
-#--[  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.             ]--
+----[                                                                             ]--
+----[  File     : ScenarioUtilities.lua                                           ]--
+----[  Author(s): Ivan Rumsey                                                     ]--
+----[                                                                             ]--
+----[  Summary  : Utility functions for use with scenario save file.              ]--
+----[             Created from examples provided by Jeff Petkau.                  ]--
+----[                                                                             ]--
+----[  Copyright Â© 2005 Gas Powered Games, Inc.  All rights reserved.             ]--
 local Entity = import('/lua/sim/Entity.lua').Entity
 
 function EnableLoadBalance(enabled, unitThreshold) --distributeTime)
-    if not ScenarioInfo.LoadBalance then 
-        ScenarioInfo.LoadBalance = 
+    if not ScenarioInfo.LoadBalance then
+        ScenarioInfo.LoadBalance =
         {
             Accumulator = 0,
             Enabled = false,
@@ -18,32 +18,32 @@ function EnableLoadBalance(enabled, unitThreshold) --distributeTime)
             PlatoonGroups = {},
         }
     end
-    
+
     if enabled == ScenarioInfo.LoadBalance.Enabled then return end
-    
-    ScenarioInfo.LoadBalance.Enabled = enabled 
-    
+
+    ScenarioInfo.LoadBalance.Enabled = enabled
+
     if enabled then
         ScenarioInfo.LoadBalance.UnitThreshold = unitThreshold or 50
     else
-        ForkThread(function()       
+        ForkThread(function()
             --local timePerGroup = ScenarioInfo.DistributeTime/table.getn(ScenarioInfo.LoadBalance.SpawnGroups)
-            
+
             --Get time
             local time = GetSystemTimeSecondsOnlyForProfileUse()
-            
+
             --Spawn bases
             while table.getn(ScenarioInfo.LoadBalance.SpawnGroups) > 0 do
                 local base, name, uncapturable = unpack(table.remove( ScenarioInfo.LoadBalance.SpawnGroups, 1))
                 base:SpawnGroup( name, uncapturable, true )
             end
-            
+
             --Spawn units
             while table.getn(ScenarioInfo.LoadBalance.PlatoonGroups) > 0 do
-                local strArmy, strGroup, formation, callback = unpack(table.remove( ScenarioInfo.LoadBalance.PlatoonGroups, 1)) 
+                local strArmy, strGroup, formation, callback = unpack(table.remove( ScenarioInfo.LoadBalance.PlatoonGroups, 1))
                 CreateArmyGroupAsPlatoonBalanced(strArmy, strGroup, formation, callback)
             end
-            
+
             --Report time taken
             LOG("Time to spawn: " .. (GetSystemTimeSecondsOnlyForProfileUse() - time))
         end)
@@ -70,9 +70,9 @@ function ChainToPositions(chainName)
     return positionTable
 end
 
-#--[  FindParentChain                                                ]--
-#--[                                                                      ]--
-#--[  Gets the parent chain that the supplied marker belongs to           ]--
+----[  FindParentChain                                                ]--
+----[                                                                      ]--
+----[  Gets the parent chain that the supplied marker belongs to           ]--
 function FindParentChain(markerName)
     for cName,chain in Scenario.Chains do
         for mNum,marker in chain.Markers do
@@ -94,9 +94,9 @@ function GetMarkerChain(name)
     return chain
 end
 
-#--[  MarkerToPosition                                                           ]--
-#--[                                                                             ]--
-#--[  Converts a marker as specified in *_save.lua file to a position.           ]--
+----[  MarkerToPosition                                                           ]--
+----[                                                                             ]--
+----[  Converts a marker as specified in *_save.lua file to a position.           ]--
 function MarkerToPosition(strMarker)
     local marker = GetMarker(strMarker)
         if not marker then
@@ -105,9 +105,9 @@ function MarkerToPosition(strMarker)
     return marker.position
 end
 
-#--[  AreaToRect                                                                 ]--
-#--[                                                                             ]--
-#--[  Converts an area as specified in *_save.lua file to a rectangle.           ]--
+----[  AreaToRect                                                                 ]--
+----[                                                                             ]--
+----[  Converts an area as specified in *_save.lua file to a rectangle.           ]--
 function AreaToRect(strArea)
     local area = Scenario.Areas[strArea]
     if not area then
@@ -122,9 +122,9 @@ function InRect( vectorPos, rect )
            vectorPos[3] > rect.y0 and vectorPos[3] < rect.y1
 end
 
-#--[  AssembleUnitGroup                                                          ]--
-#--[                                                                             ]--
-#--[  Returns all units (leaf nodes) under the specified group.                  ]--
+----[  AssembleUnitGroup                                                          ]--
+----[                                                                             ]--
+----[  Returns all units (leaf nodes) under the specified group.                  ]--
 function AssembleUnitGroup(tblNode,tblResult)
     tblResult = tblResult or {}
 
@@ -143,9 +143,9 @@ function AssembleUnitGroup(tblNode,tblResult)
     return tblResult
 end
 
-#--[  AssemblePlatoons                                                           ]--
-#--[                                                                             ]--
-#--[  Returns all platoon template names specified under group.                  ]--
+----[  AssemblePlatoons                                                           ]--
+----[                                                                             ]--
+----[  Returns all platoon template names specified under group.                  ]--
 function AssemblePlatoons(tblNode,tblResult)
     tblResult = tblResult or {}
 
@@ -153,7 +153,7 @@ function AssemblePlatoons(tblNode,tblResult)
         return tblResult
     end
 
-    if nil != tblNode.platoon and '' != tblNode.platoon then
+    if nil ~= tblNode.platoon and '' ~= tblNode.platoon then
         table.insert(tblResult,tblNode.platoon)
     end
 
@@ -166,9 +166,9 @@ function AssemblePlatoons(tblNode,tblResult)
     return tblResult
 end
 
-#--[  FindUnit                                                                   ]--
-#--[                                                                             ]--
-#--[  Finds the unit with the specified name.                                    ]--
+----[  FindUnit                                                                   ]--
+----[                                                                             ]--
+----[  Finds the unit with the specified name.                                    ]--
 function FindUnit(strUnit,tblNode)
     if nil == tblNode then
         return nil
@@ -183,7 +183,7 @@ function FindUnit(strUnit,tblNode)
             tblResult = tblData
         end
 
-        if nil != tblResult then
+        if nil ~= tblResult then
             break
         end
     end
@@ -191,16 +191,16 @@ function FindUnit(strUnit,tblNode)
     return tblResult
 end
 
-#--[  CreateArmyUnit                                                             ]--
-#--[                                                                             ]--
-#--[  Creates a named unit in an army.                                           ]--
+----[  CreateArmyUnit                                                             ]--
+----[                                                                             ]--
+----[  Creates a named unit in an army.                                           ]--
 function CreateArmyUnit(strArmy,strUnit)
     local tblUnit = FindUnit(strUnit,Scenario.Armies[strArmy].Units)
     local brain = GetArmyBrain(strArmy)
     if not brain.IgnoreArmyCaps then
         SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
     end
-    if nil != tblUnit then
+    if nil ~= tblUnit then
         local unit = CreateUnitHPR(
             tblUnit.type,
             strArmy,
@@ -209,7 +209,7 @@ function CreateArmyUnit(strArmy,strUnit)
         )
         if unit:GetBlueprint().Physics.FlattenSkirt then
             unit:CreateTarmac(true, true, true, false, false)
-        end             
+        end
         local platoon
         local brain = GetArmyBrain(strArmy)
         if tblUnit.platoon ~= nil and tblUnit.platoon ~= '' then
@@ -239,9 +239,9 @@ function CreateArmyUnit(strArmy,strUnit)
     return nil
 end
 
-#--[  FindUnitGroup                                                              ]--
-#--[                                                                             ]--
-#--[  Finds the unit group with the specified name.                              ]--
+----[  FindUnitGroup                                                              ]--
+----[                                                                             ]--
+----[  Finds the unit group with the specified name.                              ]--
 function FindUnitGroup(strGroup,tblNode)
     if nil == tblNode then
         return nil
@@ -257,7 +257,7 @@ function FindUnitGroup(strGroup,tblNode)
             end
         end
 
-        if nil != tblResult then
+        if nil ~= tblResult then
             break
         end
     end
@@ -265,16 +265,16 @@ function FindUnitGroup(strGroup,tblNode)
     return tblResult
 end
 
-#--[  AssembleArmyGroup                                                          ]--
-#--[                                                                             ]--
-#--[  Returns a table of units in the group owned by the specified army.         ]--
+----[  AssembleArmyGroup                                                          ]--
+----[                                                                             ]--
+----[  Returns a table of units in the group owned by the specified army.         ]--
 function AssembleArmyGroup(strArmy,strGroup)
     return AssembleUnitGroup(FindUnitGroup(strGroup,Scenario.Armies[strArmy].Units))
 end
 
-#--[  CreateArmySubGroup                                                                      ]--
-#--[                                                                                          ]--
-#--[  Creates Army groups from a number of groups specified in order from the Units Hierarchy ]--
+----[  CreateArmySubGroup                                                                      ]--
+----[                                                                                          ]--
+----[  Creates Army groups from a number of groups specified in order from the Units Hierarchy ]--
 function CreateArmySubGroup(strArmy,strGroup,...)
     local tblNode = Scenario.Armies[strArmy].Units
     local tblResult = {}
@@ -304,9 +304,9 @@ function CreateArmySubGroup(strArmy,strGroup,...)
     return tblResult, treeResult, platoonList
 end
 
-#--[  CreateSubGroup                                                                      ]--
-#--[                                                                                      ]--
-#--[  Used by CreateArmySubGroup                                                          ]--
+----[  CreateSubGroup                                                                      ]--
+----[                                                                                      ]--
+----[  Used by CreateArmySubGroup                                                          ]--
 function CreateSubGroup(tblNode, strArmy, strGroup, ...)
     local tblResult = {}
     local treeResult = {}
@@ -326,8 +326,8 @@ function CreateSubGroup(tblNode, strArmy, strGroup, ...)
 end
 
 
-#--[  CreateInitialArmyGroup                                                     ]--
-#--[                                                                             ]--
+----[  CreateInitialArmyGroup                                                     ]--
+----[                                                                             ]--
 function CreateInitialArmyGroup(strArmy, createCommander)
     local tblGroup = CreateArmyGroup( strArmy, 'INITIAL')
     local cdrUnit = false
@@ -352,9 +352,9 @@ function CommanderWarpDelay(cdrUnit, delay)
     cdrUnit:PlayCommanderWarpInEffect()
 end
 
-#--[  CreateProps                                                                ]--
-#--[                                                                             ]--
-#--[                                                                             ]--
+----[  CreateProps                                                                ]--
+----[                                                                             ]--
+----[                                                                             ]--
 function CreateProps()
     for i, tblData in pairs(Scenario['Props']) do
         CreatePropHPR(
@@ -378,7 +378,7 @@ function CreateResources()
                 tblData.size
             )
 
-            # fixme: texture names should come from editor
+            -- fixme: texture names should come from editor
             local albedo, sx, sz, lod
             if tblData.type == "Mass" then
                 albedo = "/env/common/splats/mass_marker.dds"
@@ -401,38 +401,38 @@ function CreateResources()
                     Random(0,360), 0, 0
                 )
             end
-            # Decal - (position, heading, textureName1, textureName2, type, sizeX, sizeZ, lodParam, duration, army)
-            # Splat - (position, heading, textureName1, textureName2, type, sizeX, sizeZ, lodParam, duration, army)
-#            if not ScenarioInfo.MapData.Decals then
-#                ScenarioInfo.MapData.Decals = {}
-#            end
-#            table.insert( ScenarioInfo.MapData.Decals, CreateDecal(
-#                tblData.position, # position
-#                0, # heading
-#                albedo, "", # TEX1, TEX2
-#                "Albedo", # TYPE
-#                sx, sz, # SIZE
-#                lod, # LOD
-#                0, # DURACTION
-#                -1 # ARMY
-#            ) )
+            -- Decal - (position, heading, textureName1, textureName2, type, sizeX, sizeZ, lodParam, duration, army)
+            -- Splat - (position, heading, textureName1, textureName2, type, sizeX, sizeZ, lodParam, duration, army)
+--            if not ScenarioInfo.MapData.Decals then
+--                ScenarioInfo.MapData.Decals = {}
+--            end
+--            table.insert( ScenarioInfo.MapData.Decals, CreateDecal(
+--                tblData.position, -- position
+--                0, -- heading
+--                albedo, "", -- TEX1, TEX2
+--                "Albedo", -- TYPE
+--                sx, sz, -- SIZE
+--                lod, -- LOD
+--                0, -- DURACTION
+--                -1 -- ARMY
+--            ) )
             CreateSplat(
-                tblData.position,           # Position
-                0,                          # Heading (rotation)
-                albedo,                     # Texture name for albedo
-                sx, sz,                     # SizeX/Z
-                lod,                        # LOD
-                0,                          # Duration (0 == does not expire)
-                -1 ,                         # army (-1 == not owned by any single army)
+                tblData.position,           -- Position
+                0,                          -- Heading (rotation)
+                albedo,                     -- Texture name for albedo
+                sx, sz,                     -- SizeX/Z
+                lod,                        -- LOD
+                0,                          -- Duration (0 == does not expire)
+                -1 ,                         -- army (-1 == not owned by any single army)
                 0
             )
         end
     end
 end
 
-#--[  InitializeArmies                                                           ]--
-#--[                                                                             ]--
-#--[                                                                             ]--
+----[  InitializeArmies                                                           ]--
+----[                                                                             ]--
+----[                                                                             ]--
 function InitializeArmies()
     local tblGroups = {}
     local tblArmy = ListArmies()
@@ -448,22 +448,22 @@ function InitializeArmies()
 
         if tblData then
 
-            #--[ If an actual starting position is defined, overwrite the        ]--
-            #--[ randomly generated one.                                         ]--
+            ----[ If an actual starting position is defined, overwrite the        ]--
+            ----[ randomly generated one.                                         ]--
 
-            #LOG('*DEBUG: InitializeArmies, army = ', strArmy)
+            --LOG('*DEBUG: InitializeArmies, army = ', strArmy)
 
             SetArmyEconomy( strArmy, tblData.Economy.mass, tblData.Economy.energy)
-            
-            #GetArmyBrain(strArmy):InitializePlatoonBuildManager()
-            #LoadArmyPBMBuilders(strArmy)
+
+            --GetArmyBrain(strArmy):InitializePlatoonBuildManager()
+            --LoadArmyPBMBuilders(strArmy)
             if GetArmyBrain(strArmy).SkirmishSystems then
                 GetArmyBrain(strArmy):InitializeSkirmishSystems()
             end
 
             local armyIsCiv = ScenarioInfo.ArmySetup[strArmy].Civilian
 
-            if (not armyIsCiv and bCreateInitial) or (armyIsCiv and civOpt != 'removed') then
+            if (not armyIsCiv and bCreateInitial) or (armyIsCiv and civOpt ~= 'removed') then
                 local commander = (not ScenarioInfo.ArmySetup[strArmy].Civilian)
                 local cdrUnit
                 tblGroups[strArmy], cdrUnit = CreateInitialArmyGroup( strArmy, commander)
@@ -483,12 +483,12 @@ function InitializeArmies()
 
 
 
-            #--[ irumsey                                                         ]--
-            #--[ Temporary defaults.  Make sure some fighting will break out.    ]--
+            ----[ irumsey                                                         ]--
+            ----[ Temporary defaults.  Make sure some fighting will break out.    ]--
             for iEnemy, strEnemy in pairs(tblArmy) do
                 local enemyIsCiv = ScenarioInfo.ArmySetup[strEnemy].Civilian
 
-                if iArmy != iEnemy and strArmy != 'NEUTRAL_CIVILIAN' and strEnemy != 'NEUTRAL_CIVILIAN' then
+                if iArmy ~= iEnemy and strArmy ~= 'NEUTRAL_CIVILIAN' and strEnemy ~= 'NEUTRAL_CIVILIAN' then
                     if (armyIsCiv or enemyIsCiv) and civOpt == 'neutral' then
                         SetAlliance( iArmy, iEnemy, 'Neutral')
                     else
@@ -508,9 +508,9 @@ function InitializeArmies()
 end
 
 
-#--[  InitializeScenarioArmies                                                   ]--
-#--[                                                                             ]--
-#--[                                                                             ]--
+----[  InitializeScenarioArmies                                                   ]--
+----[                                                                             ]--
+----[                                                                             ]--
 function InitializeScenarioArmies()
     local tblGroups = {}
     local tblArmy = ListArmies()
@@ -523,7 +523,7 @@ function InitializeScenarioArmies()
     import('/lua/sim/simuistate.lua').IsCampaign(true)
 
     for iArmy, strArmy in pairs(tblArmy) do
-        
+
         local tblData = Scenario.Armies[strArmy]
 
         tblGroups[ strArmy ] = {}
@@ -534,8 +534,8 @@ function InitializeScenarioArmies()
 
             SetArmyEconomy( strArmy, tblData.Economy.mass, tblData.Economy.energy)
 
-            if tblData.faction != nil then
-                
+            if tblData.faction ~= nil then
+
                 if ScenarioInfo.ArmySetup[strArmy].Human then
                     local factionIndex = math.min(math.max(ScenarioInfo.ArmySetup[strArmy].Faction, 1), table.getsize(factions.Factions))
                     SetArmyFactionIndex( strArmy, factionIndex - 1 )
@@ -546,11 +546,11 @@ function InitializeScenarioArmies()
                 end
             end
 
-            if tblData.color != nil then
+            if tblData.color ~= nil then
                 SetArmyColorIndex( strArmy, tblData.color)
             end
 
-            if tblData.personality != nil then
+            if tblData.personality ~= nil then
                 SetArmyAIPersonality( strArmy, tblData.personality)
             end
 
@@ -567,11 +567,11 @@ function InitializeScenarioArmies()
                 end
             end
 
-            #--[ eemerson                                                         ]--
-            #--[ Override alliances with custom alliance settings                 ]--
-            if tblData.Alliances != nil then
+            ----[ eemerson                                                         ]--
+            ----[ Override alliances with custom alliance settings                 ]--
+            if tblData.Alliances ~= nil then
                for iEnemy,iAlliance in pairs(tblData.Alliances) do
-                   if iArmy != iEnemy then
+                   if iArmy ~= iEnemy then
                        SetAllianceOneWay( strArmy, iEnemy, iAlliance )
                    end
                end
@@ -587,9 +587,9 @@ function InitializeScenarioArmies()
     return tblGroups
 end
 
-#--[ AssignOrders                                                                ]--
-#--[                                                                             ]--
-#--[                                                                             ]--
+----[ AssignOrders                                                                ]--
+----[                                                                             ]--
+----[                                                                             ]--
 function AssignOrders( strQueue, tblUnit, target)
     local tblOrder = Scenario.Orders[ strQueue ]
     for i, order in pairs(tblOrder) do
@@ -598,8 +598,8 @@ function AssignOrders( strQueue, tblUnit, target)
 end
 
 
-#--[ SpawnPlatoon                                                                ]--
-#--[ Spawns unit group and assigns to platoon it is a part of                    ]--
+----[ SpawnPlatoon                                                                ]--
+----[ Spawns unit group and assigns to platoon it is a part of                    ]--
 function SpawnPlatoon( strArmy, strGroup )
     local tblNode = FindUnitGroup( strGroup, Scenario.Armies[strArmy].Units )
     if nil == tblNode then
@@ -612,7 +612,7 @@ function SpawnPlatoon( strArmy, strGroup )
         SetIgnoreArmyUnitCap(brain:GetArmyIndex(), true)
     end
     local platoonName
-    if nil ~= tblNode.platoon and '' != tblNode.platoon then
+    if nil ~= tblNode.platoon and '' ~= tblNode.platoon then
         platoonName = tblNode.platoon
     end
 
@@ -644,7 +644,7 @@ end
 
 function CountChildUnits(tblNode)
     local count = 0
-    
+
     for k,v in pairs(tblNode.Units) do
         if v.type == 'GROUP' then
             count = count + CountChildUnits(v)
@@ -652,9 +652,9 @@ function CountChildUnits(tblNode)
             count = count + 1
         end
     end
-    
+
     tblNode.TotalUnits = count
-    
+
     return count
 end
 
@@ -676,7 +676,7 @@ function CreatePlatoons( strArmy, tblNode, tblResult, platoonList, currPlatoon, 
     local reversePlatoon = false
     local reverseRows
     local reverseTemplate
-    if nil ~= tblNode.platoon and '' != tblNode.platoon and tblNode ~= currPlatoon
+    if nil ~= tblNode.platoon and '' ~= tblNode.platoon and tblNode ~= currPlatoon
         and not platoonList[tblNode.platoon] then
         currTemplate = Scenario.Platoons[tblNode.platoon]
         if currTemplate then
@@ -695,28 +695,28 @@ function CreatePlatoons( strArmy, tblNode, tblResult, platoonList, currPlatoon, 
     --local timePerChild = nil
 
     --[[
-    if timeLeft and not tblNode.TotalUnits then 
-        --Calculate the number of units 
+    if timeLeft and not tblNode.TotalUnits then
+        --Calculate the number of units
         local totalUnits = CountChildUnits(tblNode)
     end
-    
-    if timeLeft then 
+
+    if timeLeft then
         timePerChild = (timeLeft/tblNode.TotalUnits)
     end
-    ]]-- 
+    ]]--
 
-    for strName, tblData in pairs(tblNode.Units) do        
+    for strName, tblData in pairs(tblNode.Units) do
         if 'GROUP' == tblData.type then
             --[[
-            if timeLeft and tblData.TotalUnits > 0 then 
+            if timeLeft and tblData.TotalUnits > 0 then
                 timePerChild = (timeLeft/tblNode.TotalUnits)*tblData.TotalUnits
             end
-            --]]--  
-            
+            --]]--
+
             platoonList, tblResult, treeResult[strName] = CreatePlatoons(strArmy, tblData, tblResult,
-                                                                         platoonList, currPlatoon, treeResult[strName], balance)  
-                                                                         
-        else            
+                                                                         platoonList, currPlatoon, treeResult[strName], balance)
+
+        else
             unit = CreateUnitHPR( tblData.type,
                                  strArmy,
                                  tblData.Position[1], tblData.Position[2], tblData.Position[3],
@@ -724,7 +724,7 @@ function CreatePlatoons( strArmy, tblNode, tblResult, platoonList, currPlatoon, 
                              )
             if unit:GetBlueprint().Physics.FlattenSkirt then
                 unit:CreateTarmac(true, true, true, false, false)
-            end                               
+            end
             table.insert(tblResult, unit)
             treeResult[strName] = unit
             if ScenarioInfo.UnitNames[armyIndex] then
@@ -766,12 +766,12 @@ function CreatePlatoons( strArmy, tblNode, tblResult, platoonList, currPlatoon, 
                     reversePlatoon = false
                 end
             end
-            
+
             if balance then
                 --Accumulate for one tick so we don't get too much overhead from thread switching...
                 --ScenarioInfo.LoadBalance.Accumulator = ScenarioInfo.LoadBalance.Accumulator + timePerChild
                 ScenarioInfo.LoadBalance.Accumulator = ScenarioInfo.LoadBalance.Accumulator + 1
-                
+
                 if ScenarioInfo.LoadBalance.Accumulator > ScenarioInfo.LoadBalance.UnitThreshold then
                     WaitSeconds(0)
                     ScenarioInfo.LoadBalance.Accumulator = 0
@@ -785,9 +785,9 @@ end
 
 
 
-#--[  CreateArmyGroup                                                            ]--
-#--[                                                                             ]--
-#--[  Creates the specified group in game.                                       ]--
+----[  CreateArmyGroup                                                            ]--
+----[                                                                             ]--
+----[  Creates the specified group in game.                                       ]--
 function CreateArmyGroup(strArmy,strGroup,wreckage, balance)
     local brain = GetArmyBrain(strArmy)
     if not brain.IgnoreArmyCaps then
@@ -812,9 +812,9 @@ function CreateArmyGroup(strArmy,strGroup,wreckage, balance)
     return tblResult, treeResult, platoonList
 end
 
-# CreateArmyTree
-#
-# Returns tree of units created by the editor. 2nd return is table of units
+-- CreateArmyTree
+--
+-- Returns tree of units created by the editor. 2nd return is table of units
 function CreateArmyTree(strArmy, strGroup)
     local brain = GetArmyBrain(strArmy)
     if not brain.IgnoreArmyCaps then
@@ -839,16 +839,16 @@ function CreateArmyGroupAsPlatoonBalanced(strArmy, strGroup, formation, OnFinish
     OnFinishedCallback(units)
 end
 
-# CreateArmyGroupAsPlatoon
-#
-# Returns a platoon that is created out of all units in a group and its sub groups.
+-- CreateArmyGroupAsPlatoon
+--
+-- Returns a platoon that is created out of all units in a group and its sub groups.
 function CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, tblNode, platoon, balance)
     if ScenarioInfo.LoadBalance.Enabled then
         --note that tblNode in this case is actually the callback function
         table.insert(ScenarioInfo.LoadBalance.PlatoonGroups, {strArmy, strGroup, formation, tblNode})
         return
     end
-    
+
     local tblNode = tblNode or FindUnitGroup(strGroup, Scenario.Armies[strArmy].Units)
     if not tblNode then
         error('*SCENARIO UTILS ERROR: No group named- ' .. strGroup .. ' found for army- ' .. strArmy, 2)
@@ -878,16 +878,16 @@ function CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, tblNode, platoon
                              )
             if unit:GetBlueprint().Physics.FlattenSkirt then
                 unit:CreateTarmac(true, true, true, false, false)
-            end                               
+            end
             if ScenarioInfo.UnitNames[armyIndex] then
                 ScenarioInfo.UnitNames[armyIndex][strName] = unit
             end
             unit.UnitName = strName
             brain:AssignUnitsToPlatoon(platoon, {unit}, 'Attack', formation)
-            
+
             if balance then
                 ScenarioInfo.LoadBalance.Accumulator = ScenarioInfo.LoadBalance.Accumulator + 1
-                
+
                 if ScenarioInfo.LoadBalance.Accumulator > ScenarioInfo.LoadBalance.UnitThreshold/5 then
                     WaitSeconds(0)
                     ScenarioInfo.LoadBalance.Accumulator = 0
@@ -901,7 +901,7 @@ function CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, tblNode, platoon
     return platoon
 end
 
-# Creates an army group at a certain veteran level
+-- Creates an army group at a certain veteran level
 function CreateArmyGroupAsPlatoonVeteran(strArmy, strGroup, formation, veteranLevel)
     local plat = CreateArmyGroupAsPlatoon(strArmy, strGroup, formation)
     veteranLevel = veteranLevel or 5
@@ -909,8 +909,8 @@ function CreateArmyGroupAsPlatoonVeteran(strArmy, strGroup, formation, veteranLe
         v:SetVeterancy(veteranLevel)
     end
     return plat
-end  
-    
+end
+
 function FlattenTreeGroup( strArmy, strGroup, tblData, unitGroup )
     tblData = tblData or FindUnitGroup( strGroup, Scenario.Armies[strArmy].Units )
     unitGroup = unitGroup or {}
@@ -924,9 +924,9 @@ function FlattenTreeGroup( strArmy, strGroup, tblData, unitGroup )
     return unitGroup
 end
 
-# LoadArmyPBMBuilders
-#
-# Loads an Army Brain's PBM Builders from the save file
+-- LoadArmyPBMBuilders
+--
+-- Loads an Army Brain's PBM Builders from the save file
 function LoadArmyPBMBuilders(strArmy)
     local aiBrain = GetArmyBrain(strArmy)
     if Scenario.Armies[strArmy].PlatoonBuilders.Builders then
@@ -1039,21 +1039,21 @@ function SetPlans(strArmy)
 end
 
 function UpdateOSB(buildName, strArmy, builderData)
-#    local buildNameNew, location, globalName, childPart = SplitUpdateOSBName(buildName)
+--    local buildNameNew, location, globalName, childPart = SplitUpdateOSBName(buildName)
     local aiBrain = GetArmyBrain(strArmy)
-#    local amMasterName = 'OSB_Master_' .. globalName .. '_' .. strArmy
-#    if location then
-#        amMasterName = amMasterName .. '_' .. location
-#    end
-#
-#    # Find builder in brain
-#    local builderName = buildName
-#    builderName = builderName .. '_' .. strArmy
-#    if location then
-#        builderName = builderName .. '_' .. location
-#    end
-#    local found = false
-#    local builderEdit = false
+--    local amMasterName = 'OSB_Master_' .. globalName .. '_' .. strArmy
+--    if location then
+--        amMasterName = amMasterName .. '_' .. location
+--    end
+--
+--    -- Find builder in brain
+--    local builderName = buildName
+--    builderName = builderName .. '_' .. strArmy
+--    if location then
+--        builderName = builderName .. '_' .. location
+--    end
+--    local found = false
+--    local builderEdit = false
     for type, bTable in aiBrain.PBM.Platoons do
         for bCount, bData in bTable do
             local bName = bData.BuilderName
@@ -1065,7 +1065,7 @@ function UpdateOSB(buildName, strArmy, builderData)
 end
 
 function UpdateGivenOSB(builderEdit, builderData)
-    # Update data in builder in brain
+    -- Update data in builder in brain
     for dName, data in builderData.PlatoonData do
         if dName ~= 'PlatoonMultiplier' and dName ~= 'TransportCount' then
             builderEdit.PlatoonData[dName] = data
@@ -1128,10 +1128,10 @@ end
 function LoadOSB(buildName, strArmy, builderData)
     local buildNameNew, location, globalName, childPart
     local saveFile
-    
+
     if type(buildName) == 'table' then
         saveFile = {Scenario = buildName}
-        
+
         buildNameNew = 'OSB_' .. saveFile.Scenario.Name
         globalName = saveFile.Scenario.Name
         location = false --string.gsub(builderData.LocationType, '_', '')
@@ -1141,7 +1141,7 @@ function LoadOSB(buildName, strArmy, builderData)
         local fileName = '/lua/ai/OpAI/' .. globalName .. '_save.lua'
         saveFile = import(fileName)
     end
-   
+
     local platoons = saveFile.Scenario.Platoons
     local aiBrain = GetArmyBrain(strArmy)
     if not aiBrain.OSBuilders then
@@ -1164,7 +1164,7 @@ function LoadOSB(buildName, strArmy, builderData)
         local pData = RebuildDataTable(v.PlatoonData)
         spec.PlatoonData = {}
 
-        # Store builder name
+        -- Store builder name
         if location then
             spec.BuilderName = k .. '_' .. strArmy .. '_' .. location
             spec.PlatoonData.BuilderName = k .. '_' .. strArmy .. '_' .. location
@@ -1199,7 +1199,7 @@ function LoadOSB(buildName, strArmy, builderData)
             end
 
 
-            # Set priority
+            -- Set priority
             if builderData.Priority < 0 then
                 insert = false
                 spec.Priority = builderData.Priority
@@ -1217,7 +1217,7 @@ function LoadOSB(buildName, strArmy, builderData)
             end
             spec.PlatoonType = v.PlatoonType
 
-            # Set platoon template
+            -- Set platoon template
             if Scenario.Platoons['OST_' .. string.sub(spec.BuilderName, 5)] then
                 spec.PlatoonTemplate = FactionConvert(table.deepcopy(Scenario.Platoons['OST_' .. string.sub(spec.BuilderName, 5)]), factionIndex)
             elseif Scenario.Platoons[v.PlatoonTemplate] then
@@ -1232,8 +1232,8 @@ function LoadOSB(buildName, strArmy, builderData)
                 else
                     spec.PlatoonTemplate = table.deepcopy(platoons[v.PlatoonTemplate])
                 end
-                
-                
+
+
             end
             if builderData.PlatoonData.PlatoonMultiplier then
                 local squadNum = 3
@@ -1252,20 +1252,20 @@ function LoadOSB(buildName, strArmy, builderData)
                 end
             end
 
-            # Set buildout to
+            -- Set buildout to
             if (v.BuildTimeOut and v.BuildTimeOut < 0 ) or ( spec.PlatoonTemplate[3] and spec.PlatoonTemplate[3][2] < 0 ) then
                 spec.GenerateTimeOut = true
             end
             spec.BuildTimeOut = v.BuildTimeOut
 
-            # Add AI Function to OSB global if needed
+            -- Add AI Function to OSB global if needed
             if string.sub(k, 1, 11) == 'OSB_Master_' and builderData.PlatoonAIFunction then
                 spec.PlatoonAIFunction = builderData.PlatoonAIFunction
             elseif v.PlatoonAIFunction then
                 spec.PlatoonAIFunction = v.PlatoonAIFunction
             end
 
-            # Add Build Conditions
+            -- Add Build Conditions
             spec.BuildConditions = {}
             if v.BuildConditions then
                 for num, bCond in v.BuildConditions do
@@ -1292,7 +1292,7 @@ function LoadOSB(buildName, strArmy, builderData)
                     table.insert(spec.BuildConditions, addCond)
                 end
             end
-            # Add build/form conditions to ALL builders
+            -- Add build/form conditions to ALL builders
             if builderData.BuildConditions then
                 for num, bCond in builderData.BuildConditions do
                     if bCond[3][1] == 'Remove' then
@@ -1326,7 +1326,7 @@ function LoadOSB(buildName, strArmy, builderData)
                     end
                 end
             end
-            # Check for faction specific builders
+            -- Check for faction specific builders
             for num, cond in spec.BuildConditions do
                 if cond[2] == 'FactionIndex' then
                     local params = {}
@@ -1338,19 +1338,19 @@ function LoadOSB(buildName, strArmy, builderData)
                 end
             end
 
-            # Add BuildCallbacks
+            -- Add BuildCallbacks
             spec.PlatoonBuildCallbacks = {}
             if v.PlatoonBuildCallbacks then
                 for num, pbCallback in v.PlatoonBuildCallbacks do
                     table.insert(spec.PlatoonBuildCallbacks, pbCallback)
                 end
             end
-            # Add DestroyCallbacks to Masters
+            -- Add DestroyCallbacks to Masters
             if builderData.PlatoonBuildCallbacks and string.sub(k,1,11) == 'OSB_Master_' then
                 FilterFunctions(spec.PlatoonBuildCallbacks, builderData.PlatoonBuildCallbacks)
             end
 
-            # Add AddFunctions (Har!)
+            -- Add AddFunctions (Har!)
             spec.PlatoonAddFunctions = {}
             if v.PlatoonAddFunctions then
                 for fNum, fData in v.PlatoonAddFunctions do
@@ -1362,7 +1362,7 @@ function LoadOSB(buildName, strArmy, builderData)
             end
 
 
-            # Masters
+            -- Masters
             if pData.AMMasterPlatoon and insert then
                 if string.sub(k,1,26) == 'OSB_Master_LeftoverCleanup' then
                     spec.PlatoonName = spec.LocationType..'_LeftoverUnits'
@@ -1370,7 +1370,7 @@ function LoadOSB(buildName, strArmy, builderData)
                     spec.PlatoonName = spec.BuilderName
                 end
 
-                # Add data to Masters
+                -- Add data to Masters
                 if builderData.PlatoonData and string.sub(k,1,11) == 'OSB_Master_' then
                     if aiBrain.AttackData['AttackManagerState'] ~= 'ACTIVE' then
                         aiBrain:InitializeAttackManager()
@@ -1391,17 +1391,17 @@ function LoadOSB(buildName, strArmy, builderData)
                     end
                 end
 
-                # Set if needed to draw from pool
+                -- Set if needed to draw from pool
                 if pData.UsePool ~= nil then
                     spec.UsePool = pData.UsePool
                 end
                 aiBrain:AMAddPlatoon(spec)
 
-                # Children
+                -- Children
             elseif insert then
                 spec.RequiresConstruction = v.RequiresConstruction
 
-                # Add spec to brain
+                -- Add spec to brain
                 spec.InstanceCount = v.InstanceCount
                 aiBrain:PBMAddPlatoon(spec)
             end
@@ -1446,7 +1446,7 @@ function FactionConvert(template, factionIndex)
 end
 
 function SplitUpdateOSBName(buildName)
-    # OSB_<bname>_location
+    -- OSB_<bname>_location
     local startCheck = 5
     local specificBuilder = false
     if string.sub(buildName, 1, 11) == 'OSB_Master_' then
@@ -1481,7 +1481,7 @@ function SplitUpdateOSBName(buildName)
 end
 
 function SplitOSBName(buildName)
-    # OSB_<bname>_location
+    -- OSB_<bname>_location
     local startCheck = 5
     local specificBuilder = false
     if string.sub(buildName, 1, 11) == 'OSB_Master_' then

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1384,70 +1384,31 @@ Unit = Class(moho.unit_methods) {
         end
     end,
 
-    CreateWreckageProp = function( self, overkillRatio )
+    CreateWreckageProp = function(self, overKillRatio)
         local bp = self:GetBlueprint()
-        local wreck = bp.Wreckage.Blueprint
+        local propid = bp.Wreckage.Blueprint
 
-        if not wreck then
+        if not propid then
             return nil
         end
 
-        local mass = bp.Economy.BuildCostMass * (bp.Wreckage.MassMult or 0)
-        local energy = bp.Economy.BuildCostEnergy * (bp.Wreckage.EnergyMult or 0)
-        local time = (bp.Wreckage.ReclaimTimeMultiplier or 1)
         local pos = self:GetPosition()
         local layer = self:GetCurrentLayer()
-
-        if layer == 'Water' then
-            --Reduce the mass value of submerged wrecks
-            mass = mass * 0.5
-            energy = energy * 0.5
-        end
 
         if layer == 'Air' or EntityCategoryContains(categories.NAVAL - categories.STRUCTURE, self) then -- make sure air / naval wrecks stick to ground / seabottom
             pos[2] = GetTerrainHeight(pos[1], pos[3]) + GetTerrainTypeOffset(pos[1], pos[3])
         end
 
-        local prop = CreateProp( pos, wreck )
-
-        prop:SetScale(bp.Display.UniformScale)
-        prop:SetOrientation(self:GetOrientation(), true)
-        prop:SetPropCollision('Box', bp.CollisionOffsetX, bp.CollisionOffsetY, bp.CollisionOffsetZ, bp.SizeX* 0.5, bp.SizeY* 0.5, bp.SizeZ * 0.5)
-        prop:SetMaxReclaimValues(time, time, mass, energy)
-
-        mass = (mass - (mass * (overkillRatio or 1))) * self:GetFractionComplete()
-        energy = (energy - (energy * (overkillRatio or 1))) * self:GetFractionComplete()
-        time = time - (time * (overkillRatio or 1))
-
-        prop:SetReclaimValues(time, time, mass, energy)
-        prop:SetMaxHealth(bp.Defense.Health)
-        prop:SetHealth(self, bp.Defense.Health * (bp.Wreckage.HealthMult or 1))
-
-        --FIXME: SetVizToNeurals('Intel') is correct here, so you can't see enemy wreckage appearing
-        -- under the fog. However the engine has a bug with prop intel that makes the wreckage
-        -- never appear at all, even when you drive up to it, so this is disabled for now.
-        --prop:SetVizToNeutrals('Intel')
-        if not bp.Wreckage.UseCustomMesh then
-            prop:SetMesh(bp.Display.MeshBlueprintWrecked)
-        end
-
-        -- Attempt to copy our animation pose to the prop. Only works if
-        -- the mesh and skeletons are the same, but will not produce an error if not.
+        local max_fraction = layer == 'Water' and 0.5 or 1
+        local reclaimed = (1 - self:GetFractionComplete()) * (1 - (overKillRatio or 1))
+        local ori = self:GetOrientation()
+        local prop = import('/lua/sim/ScenarioUtilities.lua').CreateWreckage(propid, pos, ori, bp, max_fraction, reclaimed)
 
         if layer ~= 'Air' and self.PlayDeathAnimation then
             TryCopyPose(self, prop, true)
         end
 
-        --Prevent rebuild exploit
-        prop.AssociatedBP = self:GetBlueprint().BlueprintId
-
-        --Create some ambient wreckage smoke
         explosion.CreateWreckageEffects(self,prop)
-        prop.IsWreckage = true
-
-        if prop.MaxMassReclaim > RECLAIMLABEL_MIN_MASS then
-            table.insert(Sync.Reclaim, {id=prop:GetEntityId(), mass=prop.MassReclaim*0.9, position={pos[1], pos[2], pos[3]}})
-        end
 
         return prop
     end,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -23,7 +23,7 @@ local Buff = import('/lua/sim/buff.lua')
 local AIUtils = import('/lua/ai/aiutilities.lua')
 local BuffFieldBlueprints = import('/lua/sim/BuffField.lua').BuffFieldBlueprints
 
-local RECLAIMLABEL_MIN_MASS = import('/lua/sim/prop.lua').RECLAIMLABEL_MIN_MASS
+
 
 SyncMeta = {
     __index = function(t,key)


### PR DESCRIPTION
This is not the most beautiful solution to #623 but I can't come up with a better either. Input welcome!

So:

If a builder is about to rebuild something (decided by a call to GetRebuildBonus) we
check in SetRebuildProgress if the actual bonus never was triggered. This
means that there's a risk for a disappearing wreck.

We then search for the potential wrecks on the map, iff one of these wrecks
are getting destroyed right after (same tick) we just recreate it

This scan for wrecks will happen very, very seldom, thus should not impact the
overall performance of the sim

There is a minuscule risk that it recreates a wreck that disappeared for some other reason; garbage collected or that it was reclaimed the same tick - but shouldn't be a problem. The clone function sets the mass value of the wreck to the current reclaim progress so it would be worthless anyway. 

Fixes #623