### PR TITLE
Bugfix/wreck values

### DIFF
--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -33,7 +33,7 @@ function OnSync()
     if Sync.ToggleLifeBarsOn then
         ConExecute('UI_RenderUnitBars true')
     end
-	
+
 	if not table.empty(Sync.AIChat) then
 		for k, v in Sync.AIChat do
 			import('/lua/AIChatSorian.lua').AIChat(v.group, v.text, v.sender)
@@ -45,15 +45,15 @@ function OnSync()
             ConExecute(execRequest)
         end
     end
-    
+
     if not table.empty(Sync.UnitData) then
         UnitData = table.merged(UnitData,Sync.UnitData)
     end
-    
+
     for id,v in Sync.ReleaseIds do
         UnitData[id] = nil
     end
-    
+
     if Sync.NukeLaunchData then
 		import('/modules/nukelaunchping.lua').DoNukePing(Sync.NukeLaunchData)
 	end

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -60,7 +60,7 @@ function OnSync()
 
     if Sync.Reclaim then
         for _, r in Sync.Reclaim do
-            if r.destroy then
+            if not r.mass or r.mass < 1 then
                 import('/modules/reclaim.lua').RemoveReclaim(r)
             else
                 import('/modules/reclaim.lua').AddReclaim(r)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -788,6 +788,9 @@ Unit = Class(moho.unit_methods) {
         self:StopReclaimEffects(target)
         self:StopUnitAmbientSound('ReclaimLoop')
         self:PlayUnitSound('StopReclaim')
+        if target.MaxMassReclaim then -- this is a prop
+            target:UpdateReclaimLeft()
+        end
     end,
 
     StartReclaimEffects = function( self, target )

--- a/lua/system/class.lua
+++ b/lua/system/class.lua
@@ -411,25 +411,25 @@ function startClass(...)   ------added for shipwreck mod
 	local proto = {}
 	-- original caller environment
 	local env = getfenv(2)
-	
+
 	-- the default 'endClass' function
 	-- the metamethod for __newindex above will override this if the user behaves
 	-- if this gets called, they _aren't_ behaving, so error
 	function proto.endClass()
 		error("Attempted to create a class without assigning it to anything!")
-	end	
+	end
 
 	-- metatable for prototype
 	local mt = {}
-	
+
 	-- __index: retain access to global variables
 	mt.__index = env
-	
+
 	-- __newindex: trap the first assignment so that MyClass = startClass(...) works
 	function mt:__newindex(key, value)
 		-- delete ourselves; we only want to trigger on the first assignment
 		mt.__newindex = nil
-		
+
 		-- new endClass() function that does the real work
 		function proto.endClass()
 			-- restore original environment
@@ -451,7 +451,7 @@ function startClass(...)   ------added for shipwreck mod
 			end
 		end
 	end
-	
+
 	setmetatable(proto, mt)
 	setfenv(2, proto)
 end

--- a/lua/wreckage.lua
+++ b/lua/wreckage.lua
@@ -15,42 +15,22 @@ Wreckage = Class(Prop) {
         self.IsWreckage = true
         self.OrientationCache = self:GetOrientation()
     end,
-    
+
     OnDamage = function(self, instigator, amount, vector, damageType)
         self:DoTakeDamage(instigator, amount, vector, damageType)
-    end,
-
-    --- Set the reclaim value of the prop to an appropriate fraction of its health.
-    SetReclaimValuesByHealth = function(self)
-        local healthRatio = self:GetHealth() / self:GetMaxHealth()
-
-        self:SetReclaimValues(
-            self.MaxReclaimTimeMult * healthRatio,
-            self.MaxMassReclaim * healthRatio,
-            self.MaxEnergyReclaim * healthRatio
-        )
-    end,
-
-    --- Set the mass/energy value of this wreck when at full health, and the time coefficients
-    -- that determine how quickly it can be reclaimed.
-    -- These values are used to set te real reclaim values as fractions of the health as the wreck
-    -- takes damage.
-    SetMaxReclaimValues = function(self, time, mass, energy)
-        self.MaxMassReclaim = mass
-        self.MaxEnergyReclaim = energy
-        self.MaxReclaimTimeMult = time
     end,
 
     DoTakeDamage = function(self, instigator, amount, vector, damageType)
         self:AdjustHealth(instigator, -amount)
         local health = self:GetHealth()
-        if health > 0 then
-            self:SetReclaimValuesByHealth()
-        elseif health <= 0 then
+
+        if health <= 0 then
             self:Destroy()
+        else
+            self:UpdateReclaimLeft()
         end
     end,
-    
+
     OnCollisionCheck = function(self, other)
         if IsUnit(other) then
             return false
@@ -65,22 +45,13 @@ Wreckage = Class(Prop) {
     -- this means we have to calculate the health from the reclaim values, instead of going the
     -- other way.
     Clone = function(self)
-        local clone = CreateWreckage(self.UnitBlueprint, self.CachePosition, self.OrientationCache, self.MassReclaim, self.EnergyReclaim, self.ReclaimTimeMassMult)
+        local clone = CreateWreckage(__blueprints[self.AssociatedBP], self.CachePosition, self.OrientationCache, self.MaxMassReclaim, self.MaxEnergyReclaim, self.TimeReclaim)
 
         -- Figure out the health this wreck had before it was deleted. We can't use any native
-        -- functions like GetHealth(), so we work backwards what what we do have: the reclaim value.
-        local healthFraction
-        if self.MassReclaim > 0 then
-            healthFraction = self.MassReclaim/self.MaxMassReclaim
-        elseif self.EnergyReclaim then
-            healthFraction = self.EnergyReclaim/self.MaxEnergyReclaim
-        else
-            -- This wreck had no value anyway. We don't care about recreating it.
-            return
-        end
+        -- functions like GetHealth(), so we use the latest known value
 
-        clone:SetHealth(nil, clone:GetMaxHealth() * healthFraction)
-        clone:SetReclaimValuesByHealth()
+        clone:SetHealth(nil, clone:GetMaxHealth() * (self.ReclaimLeft or 1))
+        clone:UpdateReclaimLeft()
 
         return clone
     end
@@ -99,9 +70,7 @@ function CreateWreckage(bp, position, orientation, mass, energy, time)
 
     prop:SetMaxHealth(bp.Defense.Health)
     prop:SetHealth(nil, bp.Defense.Health * (bp.Wreckage.HealthMult or 1))
-
     prop:SetMaxReclaimValues(time, mass, energy)
-    prop:SetReclaimValuesByHealth()
 
     --FIXME: SetVizToNeurals('Intel') is correct here, so you can't see enemy wreckage appearing
     -- under the fog. However the engine has a bug with prop intel that makes the wreckage
@@ -113,7 +82,6 @@ function CreateWreckage(bp, position, orientation, mass, energy, time)
 
     -- This field cannot be renamed or the magical native code that detects rebuild bonuses breaks.
     prop.AssociatedBP = bp.BlueprintId
-    prop.UnitBlueprint = bp
 
     return prop
 end

--- a/modules/reclaim.lua
+++ b/modules/reclaim.lua
@@ -7,6 +7,7 @@ local options = Prefs.GetFromCurrentProfile('options')
 local reclaim = {}
 
 function AddReclaim(r)
+    DestroyReclaimLabel(r)
     reclaim[r.id] = r
 end
 


### PR DESCRIPTION
Nice work with the wreck refactoring, your code ended up being much more streamlined than my version. There is some problems though with how the wreck values are calculated, the latest refactoring caused wrong values for wrecks due to engine blackbox behavior:

The engine assumes that GetReclaimCosts() returns the max reclaim value of
a prop. It then calculates the actual reclaim value by taking:
`<max mass> * <health ratio> * <fraction reclaimed>`

So by returning an already lowered ReclaimMass when a wreck is damaged the actual calculation happens twice (both lua and engine side). 

This behavior also explains why the 0.9 was needed in the UI to get the correct numbers (all
wrecks starts with 90% health). 

Instead of keeping track of ReclaimMass we now just keep track of ReclaimLeft, which then can be used if you need to calculate how much reclaim is left of a wreck.  ReclaimLeft is updated when a wreck is damaged, destroyed or reclaimed.
