### PR TITLE
Restrict number of hive buildbots #704

### DIFF
--- a/lua/EffectUtilities.lua
+++ b/lua/EffectUtilities.lua
@@ -416,6 +416,11 @@ end
 
 function SpawnBuildBots( builder, unitBeingBuilt, BuildEffectsBag)
     local numBots = math.ceil((10+builder:GetBuildRate()) / 15)
+    -- Do not spam the heck out of buildbots if build power > 150
+    if numBots > 10 then
+        numBots = 10
+    end
+    
     if not builder.buildBots then
         builder.buildBots = {}
     end


### PR DESCRIPTION
Hive buildbot number scales with buildpower. This creates huge spam and
performance problems if the build power is modded above the standard
values. This commit clamps the number to 10. Fixed #704 