### PR TITLE
ACU/SCU tac missile upgrade rebalance

### DIFF
--- a/projectiles/SIFLaanseTacticalMissileCDR/SIFLaanseTacticalMissileCDR_proj.bp
+++ b/projectiles/SIFLaanseTacticalMissileCDR/SIFLaanseTacticalMissileCDR_proj.bp
@@ -1,0 +1,65 @@
+ProjectileBlueprint {
+    Audio = {
+        Impact = Sound {
+            Bank = 'Impacts',
+            Cue = 'XSS_Missile_Impact',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+        ImpactTerrain = Sound {
+            Bank = 'Impacts',
+            Cue = 'XSS_Missile_Impact',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+        ImpactWater = Sound {
+            Bank = 'Impacts',
+            Cue = 'Impact_Water_Splash_AEON',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+    },
+    Categories = {
+        'SERAPHIM',
+        'PROJECTILE',
+        'INDIRECTFIRE',
+        'TACTICAL',
+        'MISSILE',
+        'NOSPLASHDAMAGE',
+    },
+    Defense = {
+        Health = 3,
+        MaxHealth = 3,
+    },
+    Display = {
+        CameraFollowTimeout = 2,
+        CameraFollowsProjectile = true,
+        ImpactEffects = {
+            Type = 'Medium01',
+        },
+        MeshBlueprint = '/projectiles/SIFLaanseTacticalMissile01/SIFLaanseTacticalMissile01_mesh.bp',
+        StrategicIconSize = 2,
+    },
+    Economy = {
+        BuildCostEnergy = 3600,
+        BuildCostMass = 180,
+        BuildTime = 840, #300
+    },
+    General = {
+        Category = 'Missile',
+        Faction = 'Seraphim',
+    },
+    Interface = {
+        HelpText = 0,
+    },
+    Physics = {
+        Acceleration = 3,
+        DestroyOnWater = false,
+        InitialSpeed = 3,
+        MaxSpeed = 12,
+        RotationalVelocity = 0,
+        RotationalVelocityRange = 0,
+        TrackTarget = true,
+        TrackTargetGround = true,
+        TurnRate = 0,
+        UseGravity = false,
+        VelocityAlign = true,
+    },
+}

--- a/projectiles/SIFLaanseTacticalMissileCDR/SIFLaanseTacticalMissileCDR_script.lua
+++ b/projectiles/SIFLaanseTacticalMissileCDR/SIFLaanseTacticalMissileCDR_script.lua
@@ -1,0 +1,63 @@
+#****************************************************************************
+#**
+#**  File     :  /data/projectiles/SIFLaanseTacticalMissile01/SIFLaanseTacticalMissileCDR_script.lua
+#**  Author(s):  Gordon Duclos, Aaron Lundquist
+#**
+#**  Summary  :  Laanse Tactical Missile Projectile script, XSL0001
+#**
+#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+
+local SLaanseTacticalMissile = import('/lua/seraphimprojectiles.lua').SLaanseTacticalMissile
+
+SIFLaanseTacticalMissileCDR = Class(SLaanseTacticalMissile) {
+    
+    OnCreate = function(self)
+        SLaanseTacticalMissile.OnCreate(self)
+        self:SetCollisionShape('Sphere', 0, 0, 0, 2)
+        self.MoveThread = self:ForkThread(self.MovementThread)
+    end,
+
+    MovementThread = function(self)        
+        self.WaitTime = 0.1
+        self:SetTurnRate(8)
+        WaitSeconds(0.3)        
+        while not self:BeenDestroyed() do
+            self:SetTurnRateByDist()
+            self:SetDestroyOnWater(true)
+            WaitSeconds(self.WaitTime)
+        end
+    end,
+
+    SetTurnRateByDist = function(self)
+        local dist = self:GetDistanceToTarget()
+        #Get the nuke as close to 90 deg as possible
+        if dist > 50 then        
+            #Freeze the turn rate as to prevent steep angles at long distance targets
+            WaitSeconds(2)
+            self:SetTurnRate(20)
+        elseif dist > 30 and dist <= 150 then
+			# Increase check intervals
+			self:SetTurnRate(30)
+			WaitSeconds(1.5)
+            self:SetTurnRate(30)
+        elseif dist > 10 and dist <= 30 then
+			# Further increase check intervals
+            WaitSeconds(0.3)
+            self:SetTurnRate(50)
+		elseif dist > 0 and dist <= 10 then
+			# Further increase check intervals            
+            self:SetTurnRate(100)   
+            KillThread(self.MoveThread)         
+        end
+    end,        
+
+    GetDistanceToTarget = function(self)
+        local tpos = self:GetCurrentTargetPosition()
+        local mpos = self:GetPosition()
+        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
+        return dist
+    end,
+}
+TypeClass = SIFLaanseTacticalMissileCDR
+

--- a/projectiles/SIFLaanseTacticalMissileSCU/SIFLaanseTacticalMissileSCU_proj.bp
+++ b/projectiles/SIFLaanseTacticalMissileSCU/SIFLaanseTacticalMissileSCU_proj.bp
@@ -1,0 +1,65 @@
+ProjectileBlueprint {
+    Audio = {
+        Impact = Sound {
+            Bank = 'Impacts',
+            Cue = 'XSS_Missile_Impact',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+        ImpactTerrain = Sound {
+            Bank = 'Impacts',
+            Cue = 'XSS_Missile_Impact',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+        ImpactWater = Sound {
+            Bank = 'Impacts',
+            Cue = 'Impact_Water_Splash_AEON',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+    },
+    Categories = {
+        'SERAPHIM',
+        'PROJECTILE',
+        'INDIRECTFIRE',
+        'TACTICAL',
+        'MISSILE',
+        'NOSPLASHDAMAGE',
+    },
+    Defense = {
+        Health = 3,
+        MaxHealth = 3,
+    },
+    Display = {
+        CameraFollowTimeout = 2,
+        CameraFollowsProjectile = true,
+        ImpactEffects = {
+            Type = 'Medium01',
+        },
+        MeshBlueprint = '/projectiles/SIFLaanseTacticalMissile01/SIFLaanseTacticalMissile01_mesh.bp',
+        StrategicIconSize = 2,
+    },
+    Economy = {
+        BuildCostEnergy = 3600,
+        BuildCostMass = 180,
+        BuildTime = 840, #1800
+    },
+    General = {
+        Category = 'Missile',
+        Faction = 'Seraphim',
+    },
+    Interface = {
+        HelpText = 0,
+    },
+    Physics = {
+        Acceleration = 3,
+        DestroyOnWater = false,
+        InitialSpeed = 3,
+        MaxSpeed = 12,
+        RotationalVelocity = 0,
+        RotationalVelocityRange = 0,
+        TrackTarget = true,
+        TrackTargetGround = true,
+        TurnRate = 0,
+        UseGravity = false,
+        VelocityAlign = true,
+    },
+}

--- a/projectiles/SIFLaanseTacticalMissileSCU/SIFLaanseTacticalMissileSCU_script.lua
+++ b/projectiles/SIFLaanseTacticalMissileSCU/SIFLaanseTacticalMissileSCU_script.lua
@@ -1,9 +1,9 @@
 #****************************************************************************
 #**
-#**  File     :  /data/projectiles/SIFLaanseTacticalMissile01/SIFLaanseTacticalMissile01_script.lua
+#**  File     :  /data/projectiles/SIFLaanseTacticalMissile01/SIFLaanseTacticalMissileSCU_script.lua
 #**  Author(s):  Gordon Duclos, Aaron Lundquist
 #**
-#**  Summary  :  Laanse Tactical Missile Projectile script, XSL0111
+#**  Summary  :  Laanse Tactical Missile Projectile script, XSL0301
 #**
 #**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 #****************************************************************************

--- a/projectiles/SIFLaanseTacticalMissileSCU/SIFLaanseTacticalMissileSCU_script.lua
+++ b/projectiles/SIFLaanseTacticalMissileSCU/SIFLaanseTacticalMissileSCU_script.lua
@@ -1,0 +1,63 @@
+#****************************************************************************
+#**
+#**  File     :  /data/projectiles/SIFLaanseTacticalMissile01/SIFLaanseTacticalMissile01_script.lua
+#**  Author(s):  Gordon Duclos, Aaron Lundquist
+#**
+#**  Summary  :  Laanse Tactical Missile Projectile script, XSL0111
+#**
+#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+
+local SLaanseTacticalMissile = import('/lua/seraphimprojectiles.lua').SLaanseTacticalMissile
+
+SIFLaanseTacticalMissile01 = Class(SLaanseTacticalMissile) {
+    
+    OnCreate = function(self)
+        SLaanseTacticalMissile.OnCreate(self)
+        self:SetCollisionShape('Sphere', 0, 0, 0, 2)
+        self.MoveThread = self:ForkThread(self.MovementThread)
+    end,
+
+    MovementThread = function(self)        
+        self.WaitTime = 0.1
+        self:SetTurnRate(8)
+        WaitSeconds(0.3)        
+        while not self:BeenDestroyed() do
+            self:SetTurnRateByDist()
+            self:SetDestroyOnWater(true)
+            WaitSeconds(self.WaitTime)
+        end
+    end,
+
+    SetTurnRateByDist = function(self)
+        local dist = self:GetDistanceToTarget()
+        #Get the nuke as close to 90 deg as possible
+        if dist > 50 then        
+            #Freeze the turn rate as to prevent steep angles at long distance targets
+            WaitSeconds(2)
+            self:SetTurnRate(20)
+        elseif dist > 30 and dist <= 150 then
+			# Increase check intervals
+			self:SetTurnRate(30)
+			WaitSeconds(1.5)
+            self:SetTurnRate(30)
+        elseif dist > 10 and dist <= 30 then
+			# Further increase check intervals
+            WaitSeconds(0.3)
+            self:SetTurnRate(50)
+		elseif dist > 0 and dist <= 10 then
+			# Further increase check intervals            
+            self:SetTurnRate(100)   
+            KillThread(self.MoveThread)         
+        end
+    end,        
+
+    GetDistanceToTarget = function(self)
+        local tpos = self:GetCurrentTargetPosition()
+        local mpos = self:GetPosition()
+        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
+        return dist
+    end,
+}
+TypeClass = SIFLaanseTacticalMissile01
+

--- a/projectiles/TIFMissileCruiseCDR/TIFMissileCruiseCDR_Script.lua
+++ b/projectiles/TIFMissileCruiseCDR/TIFMissileCruiseCDR_Script.lua
@@ -1,0 +1,76 @@
+#
+# Terran Land-Based Cruise Missile
+#
+local TMissileCruiseProjectile = import('/lua/terranprojectiles.lua').TMissileCruiseProjectile02
+local Explosion = import('/lua/defaultexplosions.lua')
+local EffectTemplate = import('/lua/EffectTemplates.lua')
+
+TIFMissileCruiseCDR = Class(TMissileCruiseProjectile) {
+
+	FxAirUnitHitScale = 1.65,
+    FxLandHitScale = 1.65,
+    FxNoneHitScale = 1.65,
+    FxPropHitScale = 1.65,
+    FxProjectileHitScale = 1.65,
+    FxProjectileUnderWaterHitScale = 1.65,
+    FxShieldHitScale = 1.65,
+    FxUnderWaterHitScale = 1.65,
+    FxUnitHitScale = 1.65,
+    FxWaterHitScale = 1.65,
+    FxOnKilledScale = 1.65,
+
+    FxTrails = EffectTemplate.TMissileExhaust01,
+    
+    OnCreate = function(self)
+        TMissileCruiseProjectile.OnCreate(self)
+        self:SetCollisionShape('Sphere', 0, 0, 0, 2)        
+        self.MoveThread = self:ForkThread(self.MovementThread)
+    end,
+
+    MovementThread = function(self)        
+        self.WaitTime = 0.1
+        self:SetTurnRate(8)
+        WaitSeconds(0.3)        
+        while not self:BeenDestroyed() do
+            self:SetTurnRateByDist()
+            WaitSeconds(self.WaitTime)
+        end
+    end,
+
+    SetTurnRateByDist = function(self)
+        local dist = self:GetDistanceToTarget()
+        #Get the nuke as close to 90 deg as possible
+        if dist > 50 then        
+            #Freeze the turn rate as to prevent steep angles at long distance targets
+            WaitSeconds(2)
+            self:SetTurnRate(20)
+        elseif dist > 30 and dist <= 150 then
+			# Increase check intervals
+			self:SetTurnRate(30)
+			WaitSeconds(1.5)
+            self:SetTurnRate(30)
+        elseif dist > 10 and dist <= 30 then
+			# Further increase check intervals
+            WaitSeconds(0.3)
+            self:SetTurnRate(50)
+		elseif dist > 0 and dist <= 10 then
+			# Further increase check intervals            
+            self:SetTurnRate(100)   
+            KillThread(self.MoveThread)         
+        end
+    end,        
+
+    GetDistanceToTarget = function(self)
+        local tpos = self:GetCurrentTargetPosition()
+        local mpos = self:GetPosition()
+        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
+        return dist
+    end,
+    
+    OnEnterWater = function(self)
+        TMissileCruiseProjectile.OnEnterWater(self)
+        self:SetDestroyOnWater(true)
+    end,
+}
+TypeClass = TIFMissileCruiseCDR
+

--- a/projectiles/TIFMissileCruiseCDR/TIFMissileCruiseCDR_proj.bp
+++ b/projectiles/TIFMissileCruiseCDR/TIFMissileCruiseCDR_proj.bp
@@ -1,0 +1,71 @@
+ProjectileBlueprint {
+    Audio = {
+        Impact = Sound {
+            Bank = 'Impacts',
+            Cue = 'UEF_Expl_Med_Impact',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+        ImpactTerrain = Sound {
+            Bank = 'Impacts',
+            Cue = 'Impact_Land_Gen_UEF',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+        ImpactWater = Sound {
+            Bank = 'Impacts',
+            Cue = 'Impact_Water_Splash_UEF',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+    },
+    Categories = {
+        'UEF',
+        'PROJECTILE',
+        'INDIRECTFIRE',
+        'TACTICAL',
+        'MISSILE',
+        'NOSPLASHDAMAGE',
+    },
+    Defense = {
+        Health = 3,
+        MaxHealth = 3,
+    },
+    Display = {
+        CameraFollowTimeout = 2,
+        CameraFollowsProjectile = true,
+        Mesh = {
+            LODs = {
+                {
+                    AlbedoName = '/projectiles/tifmissilecruise01/tifmissilecruise01_albedo.dds',
+                    MeshName = '/projectiles/tifmissilecruise01/tifmissilecruise01_lod0.scm',
+                    ShaderName = 'TMeshAlpha',
+                },
+            },
+        },
+        StrategicIconSize = 2,
+        UniformScale = 0.15,
+    },
+    Economy = {
+        BuildCostEnergy = 3600,
+        BuildCostMass = 180,
+        BuildTime = 840, #300
+    },
+    General = {
+        Category = 'Missile',
+        Faction = 'UEF',
+    },
+    Interface = {
+        HelpText = 0,
+    },
+    Physics = {
+        Acceleration = 3,
+        DestroyOnWater = false,
+        InitialSpeed = 3,
+        MaxSpeed = 12,
+        RotationalVelocity = 0,
+        RotationalVelocityRange = 0,
+        TrackTarget = true,
+        TrackTargetGround = true,
+        TurnRate = 0,
+        UseGravity = false,
+        VelocityAlign = true,
+    },
+}


### PR DESCRIPTION
Altered the trajectory of missiles to not fly as high and the build time of missiles changed to 840, from 300 for ACU and 1800 with SCU. Currently takes 7 seconds to make a missile with T2 suite unassisted--can get many missiles off before victim can move an engineer into a good position to start TMD, and since the missiles fly so high, they were difficult for Aeon to defend against.

Change forces the players to have multiple engineers assisting to get similar or greater effect, affecting the viability of being dropped alone in the sea to get a better angle around TMD.

Missiles still have 3 HP, with no change to the trajectory of missiles when fired at targets near the generously low minimum range.