### PR TITLE
Fix for Seraphim and UEF ACU attack circle

### DIFF
--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -49,7 +49,7 @@ local function GetSelectedWeaponsWithReticules(filterFunc)
             local bp = u:GetBlueprint()
             for k, v in bp.Weapon do
                 if filterFunc(v) then
-                    weapons[bp.BlueprintId] = v
+                    weapons[bp.BlueprintId .. v.Label] = v
                 end
             end
         end
@@ -59,7 +59,7 @@ local function GetSelectedWeaponsWithReticules(filterFunc)
 end
 
 --- A generic decal function that maximises the available DamageRadius values.
-local function RadiusDecalFuntion(filterFunc)
+local function RadiusDecalFunction(filterFunc)
     local weapons = GetSelectedWeaponsWithReticules(filterFunc)
 
     -- The maximum damage radius of a selected missile weapon.
@@ -113,7 +113,7 @@ local function NukeDecalFunc()
 end
 
 local function TacticalDecalFunc()
-    return RadiusDecalFuntion(
+    return RadiusDecalFunction(
         function(w)
             return w.WeaponCategory == 'Missile' and w.DamageRadius
         end
@@ -121,7 +121,11 @@ local function TacticalDecalFunc()
 end
 
 local function AttackDecalFunc(mode)
-    return RadiusDecalFuntion(function() return true end)
+    return RadiusDecalFunction(
+        function(w)
+            return w.ManualFire == false and w.WeaponCategory ~= 'Teleport'
+        end
+    )
 end
 
 DecalFunctions = {

--- a/units/UAB2303/UAB2303_unit.bp
+++ b/units/UAB2303/UAB2303_unit.bp
@@ -43,6 +43,7 @@ UnitBlueprint {
         'SIZE4',
         'VISIBLETORECON',
         'RECLAIMABLE',
+        'SHOWATTACKRETICLE',
         'OVERLAYINDIRECTFIRE',
         'SORTSTRATEGIC',
     },


### PR DESCRIPTION
Fixed an issue where UEF and Seraphim ACU would incorrectly show a
radius circle for regular ground attacks and wouldn't show a circle for
tac missiles.