### PR TITLE
Stop beetles exploding in the air, and simplify

### DIFF
--- a/lua/cybranweapons.lua
+++ b/lua/cybranweapons.lua
@@ -446,31 +446,6 @@ CMobileKamikazeBombWeapon = Class(KamikazeWeapon){
         for k, v in self.FxDeath do
             CreateEmitterAtBone(self.unit,-2,army,v)
         end
-        --CreateLightParticle( self.unit, -1, -1, 15, 10, 'flare_lens_add_02', 'ramp_red_10' )
 		KamikazeWeapon.OnFire(self)
     end,
 }
-
-CMobileKamikazeBombDeathWeapon = Class(BareBonesWeapon) {
-	FxDeath = EffectTemplate.CMobileKamikazeBombDeathExplosion,
-
-    OnCreate = function(self)
-        BareBonesWeapon.OnCreate(self)
-        self:SetWeaponEnabled(false)
-    end,
-
-
-    OnFire = function(self)
-    end,
-
-    Fire = function(self)
-		local army = self.unit:GetArmy()
-        for k, v in self.FxDeath do
-            CreateEmitterAtBone(self.unit,-2,army,v)
-        end
-        --CreateLightParticle( self.unit, -1, -1, 15, 10, 'flare_lens_add_02', 'ramp_red_10' )
-		local myBlueprint = self:GetBlueprint()
-        DamageArea(self.unit, self.unit:GetPosition(), myBlueprint.DamageRadius, myBlueprint.Damage, myBlueprint.DamageType or 'Normal', myBlueprint.DamageFriendly or false)
-    end,
-}
-

--- a/units/XRL0302/XRL0302_Script.lua
+++ b/units/XRL0302/XRL0302_Script.lua
@@ -1,30 +1,19 @@
-#****************************************************************************
-#**
-#**  File     :  /data/units/XRL0302/XRL0302_script.lua
-#**  Author(s):  Jessica St. Croix, Gordon Duclos
-#**
-#**  Summary  :  Cybran Mobile Bomb Script
-#**
-#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+----------------------------------------------------------------
+-- File     :  /data/units/XRL0302/XRL0302_script.lua
+-- Author(s):  Jessica St. Croix, Gordon Duclos
+-- Summary  :  Cybran Mobile Bomb Script
+-- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+-----------------------------------------------------------------
 local CWalkingLandUnit = import('/lua/cybranunits.lua').CWalkingLandUnit
 local CMobileKamikazeBombWeapon = import('/lua/cybranweapons.lua').CMobileKamikazeBombWeapon
-local CMobileKamikazeBombDeathWeapon = import('/lua/cybranweapons.lua').CMobileKamikazeBombDeathWeapon
-
 
 XRL0302 = Class(CWalkingLandUnit) {
-    Weapons = {
 
-        DeathWeapon = Class(CMobileKamikazeBombDeathWeapon) {},
-        
-        Suicide = Class(CMobileKamikazeBombWeapon) {   
-			OnFire = function(self)		
-				self.unit:SetDeathWeaponEnabled(false)
-				CMobileKamikazeBombWeapon.OnFire(self)
-			end,
-        },
+    Weapons = {        
+        Suicide = Class(CMobileKamikazeBombWeapon) {},
     },
 
+    -- Allow the trigger button to blow the weapon
 	OnProductionPaused = function(self)
         local wep = self:GetWeapon(1)
         wep.OnFire(wep)
@@ -32,14 +21,9 @@ XRL0302 = Class(CWalkingLandUnit) {
 	
 	OnKilled = function(self, instigator, type, overkillRatio)
         CWalkingLandUnit.OnKilled(self, instigator, type, overkillRatio)
-		if not instigator and self.DeathWeaponEnabled != false then
+		if instigator then -- Firing the Suicide weapon (Button, CRTL-K, Attacking) kills us with no instigator
 			self:GetWeaponByLabel('Suicide'):FireWeapon()
 		end
     end,
-
-    OnLayerChange = function(self, new, old)
-        WARN(new)
-        self:SetDeathWeaponEnabled(new == "Seabed" or new == "Land")
-    end
 }
 TypeClass = XRL0302

--- a/units/XRL0302/XRL0302_unit.bp
+++ b/units/XRL0302/XRL0302_unit.bp
@@ -201,7 +201,6 @@ UnitBlueprint {
             DisplayName = 'Suicide',
             FireOnSelfDestruct = true,
             FireTargetLayerCapsTable = {
-                Air = 'Land|Water|Seabed',
                 Land = 'Land|Water|Seabed',
                 Water = 'Land|Water|Seabed',
             },


### PR DESCRIPTION
#730 

Now then, I cannot actually pull off the whole air-detonation trick, so if you can, please test this and tell me if the change works or not. It *should*.

This also cleans up the way the beetle works, which was a mess of GPG's use of the deathweapon, and FAF slowly introducing a second, activated weapon. This *should* be nonfunctional, though neater, but if you see any problems with it, tell me.