### PR TITLE
Make structure wrecks/blips invisible to enemies

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -15,6 +15,7 @@ local Util = import('utilities.lua')
 local EffectUtil = import('EffectUtilities.lua')
 local EffectTemplate = import('/lua/EffectTemplates.lua')
 local ScenarioUtils = import('/lua/sim/ScenarioUtilities.lua')
+local ScenarioFramework = import('/lua/ScenarioFramework.lua')
 local EffectUtil = import('EffectUtilities.lua')
 local Entity = import('/lua/sim/Entity.lua').Entity
 local Buff = import('/lua/sim/Buff.lua')
@@ -515,6 +516,11 @@ StructureUnit = Class(Unit) {
                 self.AdjacencyBeamsBag[k] = nil
             end
         end
+    end,
+
+    OnDestroy = function(self)
+        Unit.OnDestroy(self)
+        ScenarioFramework.ClearIntel(self:GetPosition(), 2)
     end,
 }
 

--- a/lua/wreckage.lua
+++ b/lua/wreckage.lua
@@ -75,7 +75,8 @@ function CreateWreckage(bp, position, orientation, mass, energy, time)
     --FIXME: SetVizToNeurals('Intel') is correct here, so you can't see enemy wreckage appearing
     -- under the fog. However the engine has a bug with prop intel that makes the wreckage
     -- never appear at all, even when you drive up to it, so this is disabled for now.
-    --prop:SetVizToNeutrals('Intel')
+    prop:SetVizToNeutrals('Intel')
+    prop:SetVizToEnemies('Intel')
     if not bp.Wreckage.UseCustomMesh then
         prop:SetMesh(bp.Display.MeshBlueprintWrecked)
     end


### PR DESCRIPTION
GPG left a comment about buggy prop intel, but I'm unable to reproduce the bug.

This kills any intel blips when a structure unit is destroyed, encouraging scouting.

This is an alternative solutin to Crotalus' in #425. A problem remains with the mass reclaim labels being visible even for invisible wrecks.