### PR TITLE
Set GRR to 3 as default

### DIFF
--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -493,6 +493,9 @@ function PreModBlueprints(all_bps)
             if br then
                 if not bp.AI then bp.AI = {} end
                 bp.AI.GuardScanRadius = br
+                if not bp.AI.GuardReturnRadius then
+                    bp.AI.GuardReturnRadius = 3
+                end
             end
         end
 


### PR DESCRIPTION
This helps with units running after a faster moving unit while on attack
move (or assist ground) while getting shot by other units. It will
instead give up and find a new target along its ordered path.

As a test, put a destroyer on attack move into a group of frigates, after the destroyer locks onto the nearest frigate, move that unit out of the destroyer's reach. Without this patch it will go after like a moron, pointing the gun at the out of range frigate and only fire torpedos at the other ones.
