### PR TITLE
Seraphim Destroyer no longer submerged when gifted or built

### DIFF
--- a/units/XSS0201/XSS0201_script.lua
+++ b/units/XSS0201/XSS0201_script.lua
@@ -48,6 +48,11 @@ XSS0201 = Class(SSubUnit) {
         end
 
         SSubUnit.OnKilled(self, instigator, type, overkillRatio)
+		
+		OnStopBeingBuilt = function(self, builder, layer)
+			SSubUnit.OnStopBeingBuilt(self, builder, layer)
+			if self:GetIsSubmerged == -1 then
+				self:IssueDive
     end,
     
     OnMotionVertEventChange = function( self, new, old )


### PR DESCRIPTION
Checks if currently submerged before issuing dive command, addresses #806 and #611 