### PR TITLE
Fix factory unit not being destroyed

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -383,10 +383,10 @@ StructureUnit = Class(Unit) {
 
     end,
 
-    -- Adding into OnKilled the ability to destroy the tarmac but put a new one down that looks exactly like it but
+    -- Adding into OnDestroy the ability to destroy the tarmac but put a new one down that looks exactly like it but
     -- will time out over the time spec'd or 300 seconds.
-    OnKilled = function(self, instigator, type, overkillRatio)
-        Unit.OnKilled(self, instigator, type, overkillRatio)
+    OnDestroy = function(self)
+        Unit.OnDestroy(self)
         local orient = self.TarmacBag.Orientation
         local currentBP = self.TarmacBag.CurrentBP
         self:DestroyTarmac()

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -531,6 +531,16 @@ FactoryUnit = Class(StructureUnit) {
         StructureUnit.OnCreate(self)
         self.BuildingUnit = false
     end,
+    
+    DestroyUnitBeingBuilt = function(self)
+        if self.UnitBeingBuilt and not self.UnitBeingBuilt.Dead and self.UnitBeingBuilt:GetFractionComplete() < 1 then
+            if self.UnitBeingBuilt:GetFractionComplete() > 0.5 then
+                self.UnitBeingBuilt:Kill()
+            else
+                self.UnitBeingBuilt:Destroy()
+            end
+        end
+    end, 
 
     OnDestroy = function(self)
         -- Figure out if we're a research station
@@ -544,6 +554,8 @@ FactoryUnit = Class(StructureUnit) {
         end
 
         StructureUnit.OnDestroy(self)
+        
+        self.DestroyUnitBeingBuilt(self)
     end,
 
     OnPaused = function(self)
@@ -831,18 +843,6 @@ FactoryUnit = Class(StructureUnit) {
             self:RolloffBody()
         end,
     },
-
-    OnKilled = function(self, instigator, type, overkillRatio)
-        StructureUnit.OnKilled(self, instigator, type, overkillRatio)
-
-        if self.UnitBeingBuilt and not self.UnitBeingBuilt.Dead and self.UnitBeingBuilt:GetFractionComplete() < 1 then
-            if self.UnitBeingBuilt:GetFractionComplete() > 0.5 then
-                self.UnitBeingBuilt:Kill()
-            else
-                self.UnitBeingBuilt:Destroy()
-            end
-        end
-    end,
 }
 
 
@@ -1269,11 +1269,8 @@ SeaFactoryUnit = Class(FactoryUnit) {
 
     StopRocking = function(self)
     end,
-
-    -- Sinking causes problems with incomplete units, so we just delete the half-built unit in all
-    -- cases for naval factories.
-    OnKilled = function(self, instigator, type, overkillRatio)
-        StructureUnit.OnKilled(self, instigator, type, overkillRatio)
+    
+    DestroyUnitBeingBuilt = function(self)
         if self.UnitBeingBuilt and not self.UnitBeingBuilt.Dead and self.UnitBeingBuilt:GetFractionComplete() < 1 then
             self.UnitBeingBuilt:Destroy()
         end


### PR DESCRIPTION
Stops the unit currently being built from persisting when reclaiming or
transferring a factory. OnDestroy is a much better location for these things, as it's called in more situations than OnKilled. It's also called in the same code path as OnKilled.

Fixes tarmac on buildings lasting forever if the building is reclaimed.