### PR TITLE
Fixed bug with consumption and paused builders

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2132,16 +2132,20 @@ Unit = Class(moho.unit_methods) {
             self:CheckAssistersFocus()
         end
 
-
-
         local bp = self:GetBlueprint()
         if order ~= 'Upgrade' or bp.Display.ShowBuildEffectsDuringUpgrade then
             self:StartBuildingEffects(built, order)
         end
-        self:SetActiveConsumptionActive()
+
+        -- OnStartBuild() is called on paused, assisting engineers, in that case, don't start
+        -- actual consumption
+        if not self:IsPaused() then
+            self:SetActiveConsumptionActive()
+            self:PlayUnitSound('Construct')
+            self:PlayUnitAmbientSound('ConstructLoop')
+        end
+
         self:DoOnStartBuildCallbacks(built)
-        self:PlayUnitSound('Construct')
-        self:PlayUnitAmbientSound('ConstructLoop')
 
         local bp = built:GetBlueprint()
         if order == 'Upgrade' and bp.General.UpgradesFrom == self:GetUnitId() then
@@ -2433,11 +2437,14 @@ Unit = Class(moho.unit_methods) {
         self.WorkItemBuildCostMass = tempEnhanceBp.BuildCostEnergy
         self.WorkItemBuildTime = tempEnhanceBp.BuildTime
         self.WorkProgress = 0
-        self:SetActiveConsumptionActive()
+
         self:PlayUnitSound('EnhanceStart')
         self:PlayUnitAmbientSound('EnhanceLoop')
-        self:UpdateConsumptionValues()
         self:CreateEnhancementEffects(work)
+        if not self:IsPaused() then
+            self:SetActiveConsumptionActive()
+        end
+
         ChangeState(self, self.WorkingState)
     end,
 

--- a/lua/sim/tasks/EnhanceTask.lua
+++ b/lua/sim/tasks/EnhanceTask.lua
@@ -91,6 +91,11 @@ EnhanceTask = Class(ScriptTask) {
             end
 
             unit:OnWorkEnd(self.CommandData.Enhancement)
+
+            if unit:IsPaused() then
+                unit:SetPaused(false)
+            end
+
             self.Success = true
 
             return TASKSTATUS.Done

--- a/lua/sim/tasks/EnhanceTask.lua
+++ b/lua/sim/tasks/EnhanceTask.lua
@@ -16,7 +16,7 @@ EnhanceTask = Class(ScriptTask) {
         self.LastProgress = 0
         ChangeState(self, self.Stopping)
     end,
-    
+
     OnDestroy = function(self)
         self:GetUnit():SetUnitState('Enhancing',false)
         self:GetUnit():SetUnitState('Upgrading',false)
@@ -28,11 +28,11 @@ EnhanceTask = Class(ScriptTask) {
             self:GetUnit():OnWorkFail(self.CommandData.Enhancement)
         end
     end,
-    
+
     Stopping = State {
         TaskTick = function(self)
             local unit = self:GetUnit()
-            
+
             if unit:IsMobile() and unit:IsMoving() then
                 unit:GetNavigator():AbortMove()
                 return TASKSTATUS.Wait
@@ -43,18 +43,12 @@ EnhanceTask = Class(ScriptTask) {
             end
         end,
     },
-    
+
     Enhancing = State {
         TaskTick = function(self)
             local unit = self:GetUnit()
-	    --[[
-            if unit:IsPaused() then
-                return TASKSTATUS.Wait
-            end
-	    ]]
-            
             local current = unit.WorkProgress
-            
+
             if not unit:IsPaused() then
                 local obtained = unit:GetResourceConsumed()
                 if obtained > 0 then
@@ -63,24 +57,24 @@ EnhanceTask = Class(ScriptTask) {
                     unit.WorkProgress = current
                 end
             end
-            
+
             if( ( self.LastProgress < 0.25 and current >= 0.25 ) or
                 ( self.LastProgress < 0.50 and current >= 0.50 ) or
                 ( self.LastProgress < 0.75 and current >= 0.75 ) ) then
                     unit:OnBuildProgress(self.LastProgress,current)
             end
-            
+
             self.LastProgress = current
             unit:SetWorkProgress(current)
-            
+
             if( current < 1.0 ) then
                 return TASKSTATUS.Wait
             end
-            
+
             unit:OnWorkEnd(self.CommandData.Enhancement)
             self.Success = true
 
-            return TASKSTATUS.Done            
+            return TASKSTATUS.Done
         end,
     },
 }

--- a/lua/version.lua
+++ b/lua/version.lua
@@ -1,3 +1,3 @@
 function GetVersion()
-    return "3644"
+    return "3645"
 end

--- a/mod_info.lua
+++ b/mod_info.lua
@@ -3,7 +3,7 @@
 -- Documentation for the extended FAF mod_info.lua format can be found here:
 -- https://github.com/FAForever/fa/wiki/mod_info.lua-documentation
 name = "Forged Alliance Forever"
-version = 3644
+version = 3645
 _faf_modname='faf'
 copyright = "Forged Alliance Forever Community"
 description = "Forged Alliance Forever extends Forged Alliance, bringing new patches, game modes, units, ladder, and much more!"

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ master|develop
  ------------ | -------------
 [![Build Status](https://travis-ci.org/FAForever/fa.svg?branch=master)](https://travis-ci.org/FAForever/fa) | [![Build Status](https://travis-ci.org/FAForever/fa.svg?branch=develop)](https://travis-ci.org/FAForever/fa)
 
-Current patch is: 3643
+Current patch is: 3645
 
 Changelog can be found [here](changelog.md).
 


### PR DESCRIPTION
A long standing (pre 3640) bug which caused paused engineer to still drain
resources but not contributing to the actual process of the building.

This was also a problem with paused commanders and starting upgrades. They
then drained resources without adding progress.

Replay 3694494 shows the bug

Fixes #829