### PR TITLE
Replace GetUnitBeingBuilt() with UnitBeingBuilt

### DIFF
--- a/lua/AI/AIBehaviors.lua
+++ b/lua/AI/AIBehaviors.lua
@@ -37,7 +37,7 @@ function CDRRunAway( aiBrain, cdr )
         local nmeHardcore = aiBrain:GetUnitsAroundPoint( categories.EXPERIMENTAL, cdrPos, 25, 'Enemy' )
         if nmeAir > 3 or nmeLand > 3 or nmeHardcore > 0 then
             if cdr:IsUnitState('Building') then
-                cdr.UnitBeingBuiltBehavior = cdr:GetUnitBeingBuilt()
+                cdr.UnitBeingBuiltBehavior = cdr.UnitBeingBuilt
             end
             local canTeleport = cdr:HasEnhancement( 'Teleporter' )
             CDRRevertPriorityChange( aiBrain, cdr )
@@ -137,9 +137,9 @@ function CDROverCharge( aiBrain, cdr )
     
     if numUnits > 0 or ( not cdr.DistressCall and distressLoc and Utilities.XZDistanceTwoVectors( distressLoc, cdrPos ) < distressRange ) then
         #CDRRevertPriorityChange( aiBrain, cdr )
-        if cdr:GetUnitBeingBuilt() then
+        if cdr.UnitBeingBuilt then
             #LOG('*AI DEBUG: ARMY ' .. aiBrain:GetArmyIndex() .. ': CDR was building something')
-            cdr.UnitBeingBuiltBehavior = cdr:GetUnitBeingBuilt()
+            cdr.UnitBeingBuiltBehavior = cdr.UnitBeingBuilt
         end
         local plat = aiBrain:MakePlatoon( '', '' )
         aiBrain:AssignUnitsToPlatoon( plat, {cdr}, 'support', 'None' )
@@ -1019,7 +1019,7 @@ function FatBoyBuildCheck(self)
     
     local unitBeingBuilt = false
     repeat 
-        unitBeingBuilt = unitBeingBuilt or experimental:GetUnitBeingBuilt()
+        unitBeingBuilt = unitBeingBuilt or experimental.UnitBeingBuilt
         WaitSeconds(1)
     until experimental.Dead or unitBeingBuilt or aiBrain:GetArmyStat("UnitCap_MaxCap", 0.0).Value - aiBrain:GetArmyStat("UnitCap_Current", 0.0).Value < 10
     
@@ -1138,7 +1138,7 @@ TempestBehavior = function(self)
             local building
             repeat
                 WaitSeconds(5)
-                unitBeingBuilt = unit:GetUnitBeingBuilt()
+                unitBeingBuilt = unit.UnitBeingBuilt
                 building = false
                 for k,v in self:GetPlatoonUnits() do
                     if not v.Dead and v:IsUnitState('Building') then
@@ -1665,8 +1665,8 @@ function CDRRunAwaySorian( aiBrain, cdr )
         local nmeLand = aiBrain:GetNumUnitsAroundPoint( categories.COMMAND + categories.LAND - categories.ENGINEER - categories.SCOUT - categories.TECH1, cdrPos, 40, 'Enemy' )
 		local nmaShield = aiBrain:GetNumUnitsAroundPoint( categories.SHIELD * categories.STRUCTURE, cdrPos, 100, 'Ally' )
         if nmeAir > 4 or nmeLand > 9 or nmeT3 > 4 or nmeHardcore > 0 or cdr:GetHealthPercent() < .70 or shieldPercent < .30 then
-			if cdr:GetUnitBeingBuilt() then
-				cdr.UnitBeingBuiltBehavior = cdr:GetUnitBeingBuilt()
+			if cdr.UnitBeingBuilt then
+				cdr.UnitBeingBuiltBehavior = cdr.UnitBeingBuilt
 			end
 			cdr.GoingHome = true
 			cdr.Fighting = false
@@ -1820,9 +1820,9 @@ function CDROverChargeSorian( aiBrain, cdr) #, Mult )
     
     if (cdr:GetHealthPercent() > .85 and shieldPercent > .35) and (( totalUnits > 0 and numUnits1 < 15 and numUnits2 < 10 and numUnits3 < 5 and numUnits4 < 1 and numUnitsDF1 < 3 and numUnitsDF < 1 and numUnitsIF < 1) or ( not cdr.DistressCall and distressLoc and commanderResponse and Utilities.XZDistanceTwoVectors( distressLoc, cdrPos ) < distressRange )) then
         CDRRevertPriorityChange( aiBrain, cdr )
-        if cdr:GetUnitBeingBuilt() then
+        if cdr.UnitBeingBuilt then
             #LOG('*AI DEBUG: ARMY ' .. aiBrain:GetArmyIndex() .. ': CDR was building something')
-            cdr.UnitBeingBuiltBehavior = cdr:GetUnitBeingBuilt()
+            cdr.UnitBeingBuiltBehavior = cdr.UnitBeingBuilt
         end
 		cdr.Fighting = true
 		cdr.GoingHome = false

--- a/lua/AI/aibuildstructures.lua
+++ b/lua/AI/aibuildstructures.lua
@@ -172,7 +172,7 @@ function DoHackyLogic(buildingType, builder)
         builder:ForkThread(function()
             while true do
                 if not unitInstance then
-                    unitInstance = builder:GetUnitBeingBuilt()
+                    unitInstance = builder.UnitBeingBuilt
                 end
                 aiBrain = builder:GetAIBrain()
                 if unitInstance then

--- a/lua/AI/sorianutilities.lua
+++ b/lua/AI/sorianutilities.lua
@@ -1249,7 +1249,7 @@ function GetGuards(aiBrain, Unit)
 	local count = 0
 	local UpgradesFrom = Unit:GetBlueprint().General.UpgradesFrom
 	for k,v in engs do
-		if v:GetUnitBeingBuilt() == Unit then
+		if v.UnitBeingBuilt == Unit then
 			count = count + 1
 		end
 	end

--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -484,14 +484,14 @@ CConstructionStructureUnit = Class(CStructureUnit) {
         self:StopUnitAmbientSound( 'ConstructLoop' )
         CStructureUnit.OnPaused(self)
         if self.BuildingUnit then
-            CStructureUnit.StopBuildingEffects(self, self:GetUnitBeingBuilt())
+            CStructureUnit.StopBuildingEffects(self, self.UnitBeingBuilt)
         end
     end,
 
     OnUnpaused = function(self)
         if self.BuildingUnit then
             self:PlayUnitAmbientSound( 'ConstructLoop' )
-            CStructureUnit.StartBuildingEffects(self, self:GetUnitBeingBuilt(), self.UnitBuildOrder)
+            CStructureUnit.StartBuildingEffects(self, self.UnitBeingBuilt, self.UnitBuildOrder)
         end
         CStructureUnit.OnUnpaused(self)
     end,

--- a/lua/editor/SorianInstantBuildConditions.lua
+++ b/lua/editor/SorianInstantBuildConditions.lua
@@ -222,7 +222,7 @@ function HaveLessThanUnitsInCategoryBeingBuilt(aiBrain, numunits, category)
 	local numBuilding = 0
     for unitNum, unit in unitsBuilding do
         if not unit:BeenDestroyed() and unit:IsUnitState('Building') then
-            local buildingUnit = unit:GetUnitBeingBuilt()
+            local buildingUnit = unit.UnitBeingBuilt
             if buildingUnit and not buildingUnit.Dead and EntityCategoryContains( category, buildingUnit ) then
 				numBuilding = numBuilding + 1	
             end
@@ -254,7 +254,7 @@ function HaveGreaterThanUnitsInCategoryBeingBuilt(aiBrain, numunits, category)
 	local numBuilding = 0
     for unitNum, unit in unitsBuilding do
         if not unit:BeenDestroyed() and unit:IsUnitState('Building') then
-            local buildingUnit = unit:GetUnitBeingBuilt()
+            local buildingUnit = unit.UnitBeingBuilt
             if buildingUnit and not buildingUnit.Dead and EntityCategoryContains( category, buildingUnit ) then
 				numBuilding = numBuilding + 1	
             end
@@ -304,7 +304,7 @@ function GreaterThanEconEfficiencyOverTimeExp(aiBrain, MassEfficiency, EnergyEff
 	local numBuilding = 0
     for unitNum, unit in unitsBuilding do
         if not unit:BeenDestroyed() and unit:IsUnitState('Building') then
-            local buildingUnit = unit:GetUnitBeingBuilt()
+            local buildingUnit = unit.UnitBeingBuilt
             if buildingUnit and not buildingUnit.Dead and EntityCategoryContains( categories.EXPERIMENTAL, buildingUnit ) then
 				numBuilding = numBuilding + 1	
             end

--- a/lua/editor/UnitCountBuildConditions.lua
+++ b/lua/editor/UnitCountBuildConditions.lua
@@ -1153,7 +1153,7 @@ function GetGuards(aiBrain, Unit)
 	local count = 0
 	local UpgradesFrom = Unit:GetBlueprint().General.UpgradesFrom
 	for k,v in engs do
-		if v:GetUnitBeingBuilt() == Unit then
+		if v.UnitBeingBuilt == Unit then
 			count = count + 1
 		end
 	end

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -1799,8 +1799,8 @@ Platoon = Class(moho.platoon_methods) {
         self:EconUnfinishedBody()
 		WaitSeconds(20)
 		local eng = self:GetPlatoonUnits()[1]
-		if eng:GetUnitBeingBuilt() then
-			beingBuilt = eng:GetUnitBeingBuilt()
+		if eng.UnitBeingBuilt then
+			beingBuilt = eng.UnitBeingBuilt
 		end
 		if beingBuilt then
 			while not beingBuilt:BeenDestroyed() and beingBuilt:GetFractionComplete() < 1 do
@@ -1979,7 +1979,7 @@ Platoon = Class(moho.platoon_methods) {
                     local buildCat = ParseEntityCategory(buildeeCat)
                     for unitNum, unit in unitsBuilding do
                         if not unit.Dead and ( unit:IsUnitState('Building') or unit:IsUnitState('Upgrading') ) then
-                            local buildingUnit = unit:GetUnitBeingBuilt()
+                            local buildingUnit = unit.UnitBeingBuilt
                             if buildingUnit and not buildingUnit.Dead and EntityCategoryContains( buildCat, buildingUnit ) then
                                 local unitPos = unit:GetPosition()
                                 if unitPos and platoonPos and VDist2(platoonPos[1], platoonPos[3], unitPos[1], unitPos[3]) < assistRange then
@@ -5546,8 +5546,8 @@ Platoon = Class(sorianoldPlatoon) {
         self:EconUnfinishedBody()
 		WaitSeconds(20)
 		local eng = self:GetPlatoonUnits()[1]
-		if eng:GetUnitBeingBuilt() then
-			beingBuilt = eng:GetUnitBeingBuilt()
+		if eng.UnitBeingBuilt then
+			beingBuilt = eng.UnitBeingBuilt
 		end
 		if beingBuilt then
 			while not beingBuilt:BeenDestroyed() and beingBuilt:GetFractionComplete() < 1 do

--- a/lua/sim/EngineerManager.lua
+++ b/lua/sim/EngineerManager.lua
@@ -57,12 +57,12 @@ EngineerManager = Class(BuilderManager) {
             return false
         end
         if unit:IsUnitState('Building') then
-            beingBuilt = unit:GetUnitBeingBuilt()
+            beingBuilt = unit.UnitBeingBuilt
             return false
         elseif unit:IsUnitState('Guarding') then
             local guardedUnit = unit:GetGuardedUnit() 
             if guardedUnit and not guardedUnit.Dead and IsUnit(guardedUnit) and guardedUnit:IsUnitState('Building') then
-                beingBuilt = guardedUnit:GetUnitBeingBuilt()
+                beingBuilt = guardedUnit.UnitBeingBuilt
             end
         end
         # If built unit is of the category passed in return true
@@ -81,7 +81,7 @@ EngineerManager = Class(BuilderManager) {
         if unit:IsUnitState('Guarding') then
             local guardedUnit = unit:GetGuardedUnit() 
             if guardedUnit and not guardedUnit.Dead and IsUnit(guardedUnit) and guardedUnit:IsUnitState('Building') then
-                beingBuilt = guardedUnit:GetUnitBeingBuilt()
+                beingBuilt = guardedUnit.UnitBeingBuilt
             end
         end
         # If built unit is of the category passed in return true
@@ -283,12 +283,12 @@ EngineerManager = Class(BuilderManager) {
             return false
         end
         if unit:IsUnitState('Building') then
-            beingBuilt = unit:GetUnitBeingBuilt()
+            beingBuilt = unit.UnitBeingBuilt
             #return false
         elseif unit:IsUnitState('Guarding') then
             local guardedUnit = unit:GetGuardedUnit() 
             if guardedUnit and not guardedUnit.Dead and IsUnit(guardedUnit) and guardedUnit:IsUnitState('Building') then
-                beingBuilt = guardedUnit:GetUnitBeingBuilt()
+                beingBuilt = guardedUnit.UnitBeingBuilt
             end
         end
         # If built unit is of the category passed in return true
@@ -579,7 +579,7 @@ EngineerManager = Class(BuilderManager) {
                 continue
             end
             
-            local beingBuiltUnit = v:GetUnitBeingBuilt()
+            local beingBuiltUnit = v.UnitBeingBuilt
             if not beingBuiltUnit or beingBuiltUnit.Dead then
                 continue
             end

--- a/lua/sim/FactoryBuilderManager.lua
+++ b/lua/sim/FactoryBuilderManager.lua
@@ -126,7 +126,7 @@ FactoryBuilderManager = Class(BuilderManager) {
                 continue
             end
             
-            local beingBuiltUnit = v:GetUnitBeingBuilt()
+            local beingBuiltUnit = v.UnitBeingBuilt
             if not beingBuiltUnit or beingBuiltUnit.Dead then
                 continue
             end

--- a/lua/sim/PlatoonFormManager.lua
+++ b/lua/sim/PlatoonFormManager.lua
@@ -80,7 +80,7 @@ PlatoonFormManager = Class(BuilderManager) {
             end
             
             # Check for unit being built compatibility
-            local beingBuiltUnit = v:GetUnitBeingBuilt()
+            local beingBuiltUnit = v.UnitBeingBuilt
             if not beingBuiltUnit or not EntityCategoryContains( buildingCategory, beingBuiltUnit ) then
                 continue
             end


### PR DESCRIPTION
There's also calls by original scripts not hooked in FAF repository, what should be done about those?

Either we hook / replace in those or we simply remove / reduce the warning in GetUnitBeingBuilt(), maybe reduce it to one notification per game (log spamming causes performance degradation)

