### PR TITLE
Hotfix/layer change

### DIFF
--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -208,7 +208,7 @@ function OverrideKilled(self, instigator, type, overkillRatio)
         self:DoDeathWeapon()
     end
     self:DisableShield()
-    self:DisableUnitIntel()
+    self:DisableUnitIntel('Killed')
     self:ForkThread(self.DeathThread, overkillRatio , instigator)
 end
 

--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -25,6 +25,7 @@ local ShieldStructureUnit = DefaultUnitsFile.ShieldStructureUnit
 local StructureUnit = DefaultUnitsFile.StructureUnit
 local QuantumGateUnit = DefaultUnitsFile.QuantumGateUnit
 local RadarJammerUnit = DefaultUnitsFile.RadarJammerUnit
+local CommandUnit = DefaultUnitsFile.CommandUnit
 
 local Util = import('utilities.lua')
 local EffectTemplate = import('/lua/EffectTemplates.lua')
@@ -554,5 +555,36 @@ CConstructionStructureUnit = Class(CStructureUnit) {
 
     CreateCaptureEffects = function( self, target )
         EffectUtil.PlayCaptureEffects( self, target, self:GetBlueprint().General.BuildBones.BuildEffectBones or {0,}, self.CaptureEffectsBag )
+    end,
+}
+
+----------------------------------------------------------------------------------------------------------------------------
+--  CCommandUnit
+--
+--  Cybran Command Units (ACU and SCU) have stealth and cloak enhancements, toggles can be handled in one class
+----------------------------------------------------------------------------------------------------------------------------
+CCommandUnit = Class(CommandUnit) {
+    OnScriptBitSet = function(self, bit)
+        if bit == 8 then -- cloak toggle
+            self:StopUnitAmbientSound( 'ActiveLoop' )
+            self:SetMaintenanceConsumptionInactive()
+            self:DisableUnitIntel('ToggleBit8', 'Cloak')
+            self:DisableUnitIntel('ToggleBit8', 'RadarStealth')
+            self:DisableUnitIntel('ToggleBit8', 'RadarStealthField')
+            self:DisableUnitIntel('ToggleBit8', 'SonarStealth')
+            self:DisableUnitIntel('ToggleBit8', 'SonarStealthField')
+        end
+    end,
+
+    OnScriptBitClear = function(self, bit)
+        if bit == 8 then -- cloak toggle
+            self:PlayUnitAmbientSound( 'ActiveLoop' )
+            self:SetMaintenanceConsumptionActive()
+            self:EnableUnitIntel('ToggleBit8', 'Cloak')
+            self:EnableUnitIntel('ToggleBit8', 'RadarStealth')
+            self:EnableUnitIntel('ToggleBit8', 'RadarStealthField')
+            self:EnableUnitIntel('ToggleBit8', 'SonarStealth')
+            self:EnableUnitIntel('ToggleBit8', 'SonarStealthField')
+        end
     end,
 }

--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -106,15 +106,14 @@ CConstructionUnit = Class(ConstructionUnit){
 
     OnLayerChange = function(self, new, old)
         ConstructionUnit.OnLayerChange(self, new, old)
+
         if self:GetBlueprint().Display.AnimationWater then
             if self.TerrainLayerTransitionThread then
                 self.TerrainLayerTransitionThread:Destroy()
                 self.TerrainLayerTransitionThread = nil
             end
-            if (new == 'Land') and (old ~= 'None') then
-                self.TerrainLayerTransitionThread = self:ForkThread(self.TransformThread, false)
-            elseif (new == 'Water') then
-                self.TerrainLayerTransitionThread = self:ForkThread(self.TransformThread, true)
+            if (old ~= 'None') then
+                self.TerrainLayerTransitionThread = self:ForkThread(self.TransformThread, (new == 'Water'))
             end
         end
     end,

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1157,24 +1157,24 @@ RadarJammerUnit = Class(StructureUnit) {
     OnStartBuild = function(self, unitbuilding, order)
         StructureUnit.OnStartBuild(self, unitbuilding, order)
         self:SetMaintenanceConsumptionInactive()
-        self:DisableIntel('Jammer')
-        self:DisableIntel('RadarStealthField')
+        self:DisableUnitIntel('Construction', 'Jammer')
+        self:DisableUnitIntel('Construction', 'RadarStealthField')
     end,
 
     -- If we abort the upgrade, re-enable the intel
     OnStopBuild = function(self, unitBeingBuilt)
         StructureUnit.OnStopBuild(self, unitBeingBuilt)
         self:SetMaintenanceConsumptionActive()
-        self:EnableIntel('Jammer')
-        self:EnableIntel('RadarStealthField')
+        self:EnableUnitIntel('Construction', 'Jammer')
+        self:EnableUnitIntel('Construction', 'RadarStealthField')
     end,
 
     -- If we abort the upgrade, re-enable the intel
     OnFailedToBuild = function(self)
         StructureUnit.OnStopBuild(self)
         self:SetMaintenanceConsumptionActive()
-        self:EnableIntel('Jammer')
-        self:EnableIntel('RadarStealthField')
+        self:EnableUnitIntel('Construction', 'Jammer')
+        self:EnableUnitIntel('Construction', 'RadarStealthField')
     end,
 
     OnStopBeingBuilt = function(self,builder,layer)

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1428,6 +1428,14 @@ MobileUnit = Class(Unit) {
     CreateCaptureEffects = function( self, target )
         EffectUtil.PlayCaptureEffects( self, target, self:GetBlueprint().General.BuildBones.BuildEffectBones or {0,}, self.CaptureEffectsBag )
     end,
+
+    -- Units with layer change effects (amphibious units like Megalith) need
+    -- those changes applied when build ends, so we need to trigger the
+    -- layer change event
+    OnStopBeingBuilt = function(self,builder,layer)
+       Unit.OnStopBeingBuilt(self,builder,layer)
+       self:OnLayerChange(layer, 'None')
+    end,
 }
 
 --------------------------------------------------------------

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -1168,7 +1168,7 @@ Platoon = Class(moho.platoon_methods) {
         #aiBrain:BuildScoutLocations()
         
         if scout:TestToggleCaps('RULEUTC_CloakToggle') then
-            scout:EnableUnitIntel('Cloak')
+            scout:EnableUnitIntel('Toggle', 'Cloak')
         end
         
         while not scout.Dead do

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -23,6 +23,7 @@ local Buff = import('/lua/sim/buff.lua')
 local AIUtils = import('/lua/ai/aiutilities.lua')
 local BuffFieldBlueprints = import('/lua/sim/BuffField.lua').BuffFieldBlueprints
 local Wreckage = import('/lua/wreckage.lua')
+local Set = import('/lua/system/setutils.lua')
 
 -- TODO: We should really introduce a veterancy module at some point.
 -- XP gained for killing various unit types.
@@ -2534,10 +2535,10 @@ Unit = Class(moho.unit_methods) {
             self:GetWeapon(i):SetValidTargetsForCurrentLayer(new)
         end
 
-        if old == 'Seabed' and new == 'Land' then
+        if (old == 'Seabed' or old == 'None') and new == 'Land' then
             self:EnableIntel('Vision')
             self:DisableIntel('WaterVision')
-        elseif old == 'Land' and new == 'Seabed' then
+        elseif (old == 'Land' or old == 'None') and new == 'Seabed' then
             self:EnableIntel('WaterVision')
         end
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -113,6 +113,20 @@ Unit = Class(moho.unit_methods) {
             self.Trash = TrashBag()
         end
 
+        self.IntelDisables = {
+            Radar = {NotInitialized=true},
+            Sonar = {NotInitialized=true},
+            Omni = {NotInitialized=true},
+            RadarStealth = {NotInitialized=true},
+            SonarStealth = {NotInitialized=true},
+            RadarStealthField = {NotInitialized=true},
+            SonarStealthField = {NotInitialized=true},
+            Cloak = {NotInitialized=true},
+            CloakField = {NotInitialized=true},
+            Spoof = {NotInitialized=true},
+            Jammer = {NotInitialized=true},
+        }
+
         self.EventCallbacks = {
             OnKilled = {},
             OnUnitBuilt = {},
@@ -486,30 +500,30 @@ Unit = Class(moho.unit_methods) {
         elseif bit == 2 then --Jamming toggle
             self:StopUnitAmbientSound( 'ActiveLoop' )
             self:SetMaintenanceConsumptionInactive()
-            self:DisableUnitIntel('Jammer')
+            self:DisableUnitIntel('ToggleBit2', 'Jammer')
         elseif bit == 3 then --Intel toggle
             self:StopUnitAmbientSound( 'ActiveLoop' )
             self:SetMaintenanceConsumptionInactive()
-            self:DisableUnitIntel('RadarStealth')
-            self:DisableUnitIntel('RadarStealthField')
-            self:DisableUnitIntel('SonarStealth')
-            self:DisableUnitIntel('SonarStealthField')
-            self:DisableUnitIntel('Sonar')
-            self:DisableUnitIntel('Omni')
-            self:DisableUnitIntel('Cloak')
-            self:DisableUnitIntel('CloakField')
-            self:DisableUnitIntel('Spoof')
-            self:DisableUnitIntel('Jammer')
-            self:DisableUnitIntel('Radar')
+            self:DisableUnitIntel('ToggleBit3', 'RadarStealth')
+            self:DisableUnitIntel('ToggleBit3', 'RadarStealthField')
+            self:DisableUnitIntel('ToggleBit3', 'SonarStealth')
+            self:DisableUnitIntel('ToggleBit3', 'SonarStealthField')
+            self:DisableUnitIntel('ToggleBit3', 'Sonar')
+            self:DisableUnitIntel('ToggleBit3', 'Omni')
+            self:DisableUnitIntel('ToggleBit3', 'Cloak')
+            self:DisableUnitIntel('ToggleBit3', 'CloakField')
+            self:DisableUnitIntel('ToggleBit3', 'Spoof')
+            self:DisableUnitIntel('ToggleBit3', 'Jammer')
+            self:DisableUnitIntel('ToggleBit3', 'Radar')
         elseif bit == 4 then --Production toggle
             self:OnProductionPaused()
         elseif bit == 5 then --Stealth toggle
             self:StopUnitAmbientSound( 'ActiveLoop' )
             self:SetMaintenanceConsumptionInactive()
-            self:DisableUnitIntel('RadarStealth')
-            self:DisableUnitIntel('RadarStealthField')
-            self:DisableUnitIntel('SonarStealth')
-            self:DisableUnitIntel('SonarStealthField')
+            self:DisableUnitIntel('ToggleBit5', 'RadarStealth')
+            self:DisableUnitIntel('ToggleBit5', 'RadarStealthField')
+            self:DisableUnitIntel('ToggleBit5', 'SonarStealth')
+            self:DisableUnitIntel('ToggleBit5', 'SonarStealthField')
         elseif bit == 6 then --Generic pause toggle
             self:SetPaused(true)
         elseif bit == 7 then --Special toggle
@@ -517,7 +531,7 @@ Unit = Class(moho.unit_methods) {
         elseif bit == 8 then --Cloak toggle
             self:StopUnitAmbientSound( 'ActiveLoop' )
             self:SetMaintenanceConsumptionInactive()
-            self:DisableUnitIntel('Cloak')
+            self:DisableUnitIntel('ToggleBit8', 'Cloak')
         end
     end,
 
@@ -529,30 +543,30 @@ Unit = Class(moho.unit_methods) {
         elseif bit == 2 then --Jamming toggle
             self:PlayUnitAmbientSound( 'ActiveLoop' )
             self:SetMaintenanceConsumptionActive()
-            self:EnableUnitIntel('Jammer')
+            self:EnableUnitIntel('ToggleBit2', 'Jammer')
         elseif bit == 3 then --Intel toggle
             self:PlayUnitAmbientSound( 'ActiveLoop' )
             self:SetMaintenanceConsumptionActive()
-            self:EnableUnitIntel('Radar')
-            self:EnableUnitIntel('RadarStealth')
-            self:EnableUnitIntel('RadarStealthField')
-            self:EnableUnitIntel('SonarStealth')
-            self:EnableUnitIntel('SonarStealthField')
-            self:EnableUnitIntel('Sonar')
-            self:EnableUnitIntel('Omni')
-            self:EnableUnitIntel('Cloak')
-            self:EnableUnitIntel('CloakField')
-            self:EnableUnitIntel('Spoof')
-            self:EnableUnitIntel('Jammer')
+            self:EnableUnitIntel('ToggleBit3', 'Radar')
+            self:EnableUnitIntel('ToggleBit3', 'RadarStealth')
+            self:EnableUnitIntel('ToggleBit3', 'RadarStealthField')
+            self:EnableUnitIntel('ToggleBit3', 'SonarStealth')
+            self:EnableUnitIntel('ToggleBit3', 'SonarStealthField')
+            self:EnableUnitIntel('ToggleBit3', 'Sonar')
+            self:EnableUnitIntel('ToggleBit3', 'Omni')
+            self:EnableUnitIntel('ToggleBit3', 'Cloak')
+            self:EnableUnitIntel('ToggleBit3', 'CloakField')
+            self:EnableUnitIntel('ToggleBit3', 'Spoof')
+            self:EnableUnitIntel('ToggleBit3', 'Jammer')
         elseif bit == 4 then --Production toggle
             self:OnProductionUnpaused()
         elseif bit == 5 then --Stealth toggle
             self:PlayUnitAmbientSound( 'ActiveLoop' )
             self:SetMaintenanceConsumptionActive()
-            self:EnableUnitIntel('RadarStealth')
-            self:EnableUnitIntel('RadarStealthField')
-            self:EnableUnitIntel('SonarStealth')
-            self:EnableUnitIntel('SonarStealthField')
+            self:EnableUnitIntel('ToggleBit5', 'RadarStealth')
+            self:EnableUnitIntel('ToggleBit5', 'RadarStealthField')
+            self:EnableUnitIntel('ToggleBit5', 'SonarStealth')
+            self:EnableUnitIntel('ToggleBit5', 'SonarStealthField')
         elseif bit == 6 then --Generic pause toggle
             self:SetPaused(false)
         elseif bit == 7 then --Special toggle
@@ -560,7 +574,7 @@ Unit = Class(moho.unit_methods) {
         elseif bit == 8 then --Cloak toggle
             self:PlayUnitAmbientSound( 'ActiveLoop' )
             self:SetMaintenanceConsumptionActive()
-            self:EnableUnitIntel('Cloak')
+            self:EnableUnitIntel('ToggleBit8', 'Cloak')
         end
     end,
 
@@ -1184,7 +1198,7 @@ Unit = Class(moho.unit_methods) {
             self:DoDeathWeapon()
         end
         self:DisableShield()
-        self:DisableUnitIntel()
+        self:DisableUnitIntel('Killed')
         self:ForkThread(self.DeathThread, overkillRatio , instigator)
     end,
 
@@ -1772,12 +1786,12 @@ Unit = Class(moho.unit_methods) {
 
     OnStopBeingBuilt = function(self, builder, layer)
         local bp = self:GetBlueprint()
-        self:SetupIntel()
+        self:EnableUnitIntel('NotInitialized', nil)
         self:ForkThread( self.StopBeingBuiltEffects, builder, layer )
 
         if ( self:GetCurrentLayer() == 'Water' ) then
             self:StartRocking()
-            local surfaceAnim = self:GetBlueprint().Display.AnimationSurface
+            local surfaceAnim = bp.Display.AnimationSurface
             if not self.SurfaceAnimator and surfaceAnim then
                 self.SurfaceAnimator = CreateAnimator(self)
             end
@@ -2186,75 +2200,73 @@ Unit = Class(moho.unit_methods) {
     -------------------------------------------------------------------------------------------
     -- INTEL
     -------------------------------------------------------------------------------------------
-    --Setup the initial intelligence of the unit.  Return true if it can, false if it can't.
-    SetupIntel = function(self)
-        local bp = self:GetBlueprint().Intel
-        self:EnableIntel('Vision')
-        if bp then
-            self.IntelDisables = {
-                Radar = 1,
-                Sonar = 1,
-                Omni = 1,
-                RadarStealth = 1,
-                SonarStealth = 1,
-                RadarStealthField = 1,
-                SonarStealthField = 1,
-                Cloak = 1,
-                CloakField = 1,
-                Spoof = 1,
-                Jammer = 1,
-            }
-            self:EnableUnitIntel(nil)
-            return true
-        end
-        return false
-    end,
+    --
+    -- There are several ways to disable a unit's intel: The intel actually being part of an upgrade
+    -- (enhancement) that is not present, the intel requiring energy and energy being stalled, etc.
+    -- The intel is turned on using the EnableIntel engine call if all disablers are removed.
+    -- As an optimisation, EnableIntel and DisableIntel are only called when going from one disabler
+    -- present to zero, and when going from zero disablers to one.
 
-    DisableUnitIntel = function(self, intel)
-        local intDisabled = false
-        if not self.IntelDisables then return end
-        if intel then
-            self.IntelDisables[intel] = self.IntelDisables[intel] + 1
-            if self.IntelDisables[intel] == 1 then
+    DisableUnitIntel = function(self, disabler, intel)
+        local function DisableOneIntel(disabler, intel)
+            local intDisabled = false
+            if Set.Empty(self.IntelDisables[intel]) then
                 self:DisableIntel(intel)
                 intDisabled = true
             end
+            self.IntelDisables[intel][disabler] = true
+            return intDisabled
+        end
+    
+        local intDisabled = false
+        
+        -- We need this guard because the engine emits an early OnLayerChange event that would screw us up here with certain units that have Intel changes on layer change 
+        -- The NotInitialized disabler is removed in OnStopBeingBuilt, when the Unit's intel engine state is properly initialized.
+        if self.IntelDisables['Radar']['NotInitialized'] then
+            return
+        end
+
+        if intel then
+            intDisabled = DisableOneIntel(disabler, intel)
         else
-            for k, v in self.IntelDisables do
-                self.IntelDisables[k] = v + 1
-                if self.IntelDisables[k] == 1 then
-                    self:DisableIntel(k)
-                    intDisabled = true
-                end
+            -- Loop over all intels and add disabler
+            for intel, v in self.IntelDisables do
+                intDisabled = DisableOneIntel(disabler, intel) or intDisabled -- beware of short-circuiting
             end
         end
         if intDisabled then
-            self:OnIntelDisabled()
+            self:OnIntelDisabled(disabler, intel)
         end
     end,
 
-    EnableUnitIntel = function(self, intel)
-        local layer = self:GetCurrentLayer()
-        local bp = self:GetBlueprint()
-        local intEnabled = false
-        if layer == 'Seabed' or layer == 'Sub' or layer == 'Water' then
-            self:EnableIntel('WaterVision')
-        end
-        if intel then
-            if self.IntelDisables[intel] == 1 then
-                self:EnableIntel(intel)
-                intEnabled = true
-            end
-            self.IntelDisables[intel] = self.IntelDisables[intel] - 1
-        else
-            for k, v in self.IntelDisables do
-                if v == 1 then
-                    self:EnableIntel(k)
-                    if self:IsIntelEnabled(k) then
-                        intEnabled = true
-                    end
+    EnableUnitIntel = function(self, disabler, intel)
+        local function EnableOneIntel(disabler, intel)
+            local intEnabled = false
+            if self.IntelDisables[intel][disabler] then -- must check for explicit true contained
+                self.IntelDisables[intel][disabler] = nil
+                if Set.Empty(self.IntelDisables[intel]) then
+                    self:EnableIntel(intel)
+                    intEnabled = true
                 end
-                self.IntelDisables[k] = v - 1
+            end
+            return intEnabled
+        end
+    
+        local intEnabled = false
+        
+        -- We need this guard because the engine emits an early OnLayerChange event that would screw us up here.
+        -- The NotInitialized disabler is removed in OnStopBeingBuilt, when the Unit's intel engine state is properly initialized.
+        if self.IntelDisables['Radar']['NotInitialized'] == true and disabler ~= 'NotInitialized' then
+            SPEW('Leaving EnableUnitIntel because NotInitialized. This should only happen once per unit spawned.')
+            return
+        end
+
+        if intel then
+            intEnabled = EnableOneIntel(disabler, intel)
+        else
+            -- Loop over all intels and remove disabler
+            for intel, v in self.IntelDisables do
+                intEnabled = EnableOneIntel(disabler, intel) or intEnabled -- beware of short-circuiting
             end
         end
 
@@ -2330,9 +2342,9 @@ Unit = Class(moho.unit_methods) {
         while self:ShouldWatchIntel() do
             WaitSeconds(0.5)
             if aiBrain:GetEconomyStored( 'ENERGY' ) < 1 then  --Checking for less than 1 because sometimes there's more
-                self:DisableUnitIntel(nil)                    --than 0 and less than 1 in stock and that last bit of
+                self:DisableUnitIntel('Energy', nil)          --than 0 and less than 1 in stock and that last bit of
                 WaitSeconds(recharge)                         --energy isn't used. This results in the radar being
-                self:EnableUnitIntel(nil)                     --on even though there's no energy to run it. Shields
+                self:EnableUnitIntel('Energy', nil)                     --on even though there's no energy to run it. Shields
             end                                               --have a similar bug with a similar fix. Brute51
         end
         if self.IntelThread then

--- a/lua/system/setutils.lua
+++ b/lua/system/setutils.lua
@@ -73,3 +73,13 @@ function PredicateFilter(A, p)
 
     return s
 end
+
+--- Returns true iff A is the empty set
+function Empty(A)
+  for k, v in A do
+    if v then
+        return false
+    end
+  end
+  return true
+end

--- a/lua/terranunits.lua
+++ b/lua/terranunits.lua
@@ -141,10 +141,8 @@ TConstructionUnit = Class(ConstructionUnit) {
                 self.TerrainLayerTransitionThread:Destroy()
                 self.TerrainLayerTransitionThread = nil
             end
-            if (new == 'Land') and (old  ~= 'None') then
-                self.TerrainLayerTransitionThread = self:ForkThread(self.TransformThread, false)
-            elseif (new == 'Water') then
-                self.TerrainLayerTransitionThread = self:ForkThread(self.TransformThread, true)
+            if (old ~= 'None') then
+                self.TerrainLayerTransitionThread = self:ForkThread(self.TransformThread, (new == 'Water'))
             end
         end
     end,

--- a/units/UEL0301/UEL0301_script.lua
+++ b/units/UEL0301/UEL0301_script.lua
@@ -44,7 +44,8 @@ UEL0301 = Class(CommandUnit) {
     
     OnStopBeingBuilt = function(self, builder, layer)
         CommandUnit.OnStopBeingBuilt(self, builder, layer)
-        self:DisableUnitIntel('Jammer')
+        -- Block Jammer until Enhancement is built
+        self:DisableUnitIntel('Enhancement', 'Jammer')
     end,
 
     CreateBuildEffects = function( self, unitBeingBuilt, order )
@@ -150,12 +151,12 @@ UEL0301 = Class(CommandUnit) {
         elseif enh == 'RadarJammer' then
             self:SetIntelRadius('Jammer', bp.NewJammerRadius or 26)
             self.RadarJammerEnh = true 
-            self:EnableUnitIntel('Jammer')
+            self:EnableUnitIntel('Enhancement', 'Jammer')
             self:AddToggleCap('RULEUTC_JammingToggle')              
         elseif enh == 'RadarJammerRemove' then
             local bpIntel = self:GetBlueprint().Intel
             self:SetIntelRadius('Jammer', 0)
-            self:DisableUnitIntel('Jammer')
+            self:DisableUnitIntel('Enhancement', 'Jammer')
             self.RadarJammerEnh = false
             self:RemoveToggleCap('RULEUTC_JammingToggle')
         elseif enh =='AdvancedCoolingUpgrade' then

--- a/units/URL0001/URL0001_script.lua
+++ b/units/URL0001/URL0001_script.lua
@@ -9,6 +9,7 @@
 --****************************************************************************
 
 local ACUUnit = import('/lua/defaultunits.lua').ACUUnit
+local CCommandUnit = import('/lua/cybranunits.lua').CCommandUnit
 local CWeapons = import('/lua/cybranweapons.lua')
 local EffectUtil = import('/lua/EffectUtilities.lua')
 
@@ -22,7 +23,7 @@ local CDFOverchargeWeapon = CWeapons.CDFOverchargeWeapon
 local CANTorpedoLauncherWeapon = CWeapons.CANTorpedoLauncherWeapon
 local Entity = import('/lua/sim/Entity.lua').Entity
 
-URL0001 = Class(ACUUnit) {
+URL0001 = Class(ACUUnit, CCommandUnit) {
     Weapons = {
         DeathWeapon = Class(CIFCommanderDeathWeapon) {},
         RightRipper = Class(CCannonMolecularWeapon) {},
@@ -72,10 +73,11 @@ URL0001 = Class(ACUUnit) {
         self:SetWeaponEnabledByLabel('MLG', false)
         self:SetWeaponEnabledByLabel('Torpedo', false)
         self:SetMaintenanceConsumptionInactive()
-        self:DisableUnitIntel('RadarStealth')
-        self:DisableUnitIntel('SonarStealth')
-        self:DisableUnitIntel('Cloak')
-        self:DisableUnitIntel('Sonar')
+        -- Block enhancement-based Intel functions until enhancements are built
+        self:DisableUnitIntel('Enhancement', 'RadarStealth')
+        self:DisableUnitIntel('Enhancement', 'SonarStealth')
+        self:DisableUnitIntel('Enhancement', 'Cloak')
+        self:DisableUnitIntel('Enhancement', 'Sonar')
         self:HideBone('Back_Upgrade', true)
         self:HideBone('Right_Upgrade', true)
         self:ForkThread(self.GiveInitialResources)
@@ -120,29 +122,7 @@ URL0001 = Class(ACUUnit) {
         self:SetMesh(self:GetBlueprint().Display.MeshBlueprint, true)
     end,
 
-    OnScriptBitSet = function(self, bit)
-        if bit == 8 then -- cloak toggle
-            self:StopUnitAmbientSound( 'ActiveLoop' )
-            self:SetMaintenanceConsumptionInactive()
-            self:DisableUnitIntel('Cloak')
-            self:DisableUnitIntel('RadarStealth')
-            self:DisableUnitIntel('RadarStealthField')
-            self:DisableUnitIntel('SonarStealth')
-            self:DisableUnitIntel('SonarStealthField')
-        end
-    end,
 
-    OnScriptBitClear = function(self, bit)
-        if bit == 8 then -- cloak toggle
-            self:PlayUnitAmbientSound( 'ActiveLoop' )
-            self:SetMaintenanceConsumptionActive()
-            self:EnableUnitIntel('Cloak')
-            self:EnableUnitIntel('RadarStealth')
-            self:EnableUnitIntel('RadarStealthField')
-            self:EnableUnitIntel('SonarStealth')
-            self:EnableUnitIntel('SonarStealthField')
-        end
-    end,
 
     -- *************
     -- Build/Upgrade
@@ -168,12 +148,12 @@ URL0001 = Class(ACUUnit) {
             end
             self.CloakEnh = false
             self.StealthEnh = true
-            self:EnableUnitIntel('RadarStealth')
-            self:EnableUnitIntel('SonarStealth')
+            self:EnableUnitIntel('Enhancement', 'RadarStealth')
+            self:EnableUnitIntel('Enhancement', 'SonarStealth')
         elseif enh == 'StealthGeneratorRemove' then
             self:RemoveToggleCap('RULEUTC_CloakToggle')
-            self:DisableUnitIntel('RadarStealth')
-            self:DisableUnitIntel('SonarStealth')
+            self:DisableUnitIntel('Enhancement', 'RadarStealth')
+            self:DisableUnitIntel('Enhancement', 'SonarStealth')
             self.StealthEnh = false
             self.CloakEnh = false
             self.StealthFieldEffects = false
@@ -193,7 +173,7 @@ URL0001 = Class(ACUUnit) {
             if not bp then return end
             self.StealthEnh = false
 			self.CloakEnh = true
-            self:EnableUnitIntel('Cloak')
+            self:EnableUnitIntel('Enhancement', 'Cloak')
             if not Buffs['CybranACUCloakBonus'] then
                BuffBlueprint {
                     Name = 'CybranACUCloakBonus',
@@ -215,7 +195,7 @@ URL0001 = Class(ACUUnit) {
             Buff.ApplyBuff(self, 'CybranACUCloakBonus')
         elseif enh == 'CloakingGeneratorRemove' then
             self:RemoveToggleCap('RULEUTC_CloakToggle')
-            self:DisableUnitIntel('Cloak')
+            self:DisableUnitIntel('Enhancement', 'Cloak')
             self.CloakEnh = false
             if Buff.HasBuff( self, 'CybranACUCloakBonus' ) then
                 Buff.RemoveBuff( self, 'CybranACUCloakBonus' )
@@ -330,10 +310,10 @@ URL0001 = Class(ACUUnit) {
             self:SetWeaponEnabledByLabel('MLG', false)
         elseif enh == 'NaniteTorpedoTube' then
             self:SetWeaponEnabledByLabel('Torpedo', true)
-            self:EnableUnitIntel('Sonar')
+            self:EnableUnitIntel('Enhancement', 'Sonar')
         elseif enh == 'NaniteTorpedoTubeRemove' then
             self:SetWeaponEnabledByLabel('Torpedo', false)
-			self:DisableUnitIntel('Sonar')
+			self:DisableUnitIntel('Enhancement', 'Sonar')
         end
     end,
 

--- a/units/URL0402/URL0402_script.lua
+++ b/units/URL0402/URL0402_script.lua
@@ -64,9 +64,9 @@ URL0402 = Class(CWalkingLandUnit) {
 		CWalkingLandUnit.OnLayerChange(self, new, old)
         self:CreateUnitAmbientEffect(new)
         if new == 'Seabed' then
-            self:EnableUnitIntel('Sonar')
+            self:EnableUnitIntel('Layer', 'Sonar')
         else
-            self:DisableUnitIntel('Sonar')
+            self:DisableUnitIntel('Layer', 'Sonar')
         end
 	end,
 	

--- a/units/XRL0302/XRL0302_Script.lua
+++ b/units/XRL0302/XRL0302_Script.lua
@@ -38,6 +38,7 @@ XRL0302 = Class(CWalkingLandUnit) {
     end,
 
     OnLayerChange = function(self, new, old)
+        CWalkingLandUnit:OnLayerChange(new, old)
         self:SetDeathWeaponEnabled(new == "Seabed" or new == "Land")
     end
 }

--- a/units/XRL0403/XRL0403_script.lua
+++ b/units/XRL0403/XRL0403_script.lua
@@ -72,18 +72,6 @@ XRL0403 = Class(CWalkingLandUnit) {
     
     OnStopBeingBuilt = function(self,builder,layer)
         CWalkingLandUnit.OnStopBeingBuilt(self,builder,layer)
-        local layer = self:GetCurrentLayer()
-        -- If created with F2 on land, then play the transform anim.
-        if(layer == 'Land') then
-	        self:SetWeaponEnabledByLabel('AAGun', true)       
-			-- Disable Torpedo
-	        self:SetWeaponEnabledByLabel('Torpedo01', false)
-        elseif (layer == 'Seabed') then
-            self:EnableUnitIntel('SonarStealth')
-			-- Enable Torpedo
-	        self:SetWeaponEnabledByLabel('Torpedo01', true)      
-        end
-        self.WeaponsEnabled = true
         
         if self:IsValidBone('Missile_Turret') then
             self:HideBone('Missile_Turret', true)
@@ -103,23 +91,18 @@ XRL0403 = Class(CWalkingLandUnit) {
 
 	OnLayerChange = function(self, new, old)
 		CWalkingLandUnit.OnLayerChange(self, new, old)
-		if self.WeaponsEnabled then
-			local LandSpeedMult = self:GetBlueprint().Physics.WaterSpeedMultiplier
-			if( new == 'Land' ) then
-                self:DisableUnitIntel('Sonar')
-			    -- Disable Torpedo
-	            self:SetWeaponEnabledByLabel('Torpedo01', false)
-    	        self:SetWeaponEnabledByLabel('AAGun', true)
-	 	  	    -- Set movement speed back to default
-                self:SetSpeedMult(1)
-			elseif ( new == 'Seabed' ) then
-                self:EnableUnitIntel('Sonar')
-				-- Enable Torpedo
-	            self:SetWeaponEnabledByLabel('Torpedo01', true)
-	 			-- Increase speed while in water
-                self:SetSpeedMult(LandSpeedMult)
-			end
-		end
+
+        --LOG("Mega Layerchange from ", old, " to ", new)
+
+        if new == 'Land' then
+            self:DisableUnitIntel('Layer', 'Sonar')
+            -- Set movement speed to default
+            self:SetSpeedMult(1)
+        elseif new == 'Seabed' then
+            self:EnableUnitIntel('Layer', 'Sonar')
+            -- Increase speed while in water
+            self:SetSpeedMult(self:GetBlueprint().Physics.WaterSpeedMultiplier)
+        end
 	end,
 	
     CreateDamageEffects = function(self, bone, army )


### PR DESCRIPTION
To make amphibious units behave properly regardless of whether built on
land or underwater, the MobileUnit base class now has a OnStopBeingBuilt
handler that calls OnLayerChange.
Additionally we clean up the layer logic for Cybran Destroyer, Monkeylord
and Megalith, the main units affected by this.
Fixes #860 and #869