### PR TITLE
Fix #874

### DIFF
--- a/lua/maui/text.lua
+++ b/lua/maui/text.lua
@@ -68,6 +68,7 @@ Text = Class(moho.text_methods, Control) {
 
 
     StreamText = function(self, text, speed)
+        if not speed then speed = 20 end
         local goalText = text
         self:SetText('')
         self:SetNeedsFrameUpdate(true)

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1853,7 +1853,7 @@ function ShowGameQuality()
 
     if quality > 0 then
         gameInfo.GameOptions.Quality = quality
-        GUI.GameQualityLabel:StreamText(LOCF("<LOC lobui_0418>Game quality: %s%%", quality))
+        GUI.GameQualityLabel:StreamText(LOCF("<LOC lobui_0418>Game quality: %s%%", quality), 20)
     end
 end
 


### PR DESCRIPTION
A parameter got dropped while redoing the lobby localization.

This PR fixes that and makes StreamText more robust against future occurrences of this.