### PR TITLE
Fix for the omni radius buff definition.

### DIFF
--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -297,7 +297,7 @@ function BuffAffectUnit(unit, buffName, instigator, afterRemove)
                 unit:DisableIntel('Radar')
             end
         elseif atype == 'OmniRadius' then
-            local val = BuffCalculate(unit, buffName, 'OmniRadius', unit:GetBlueprint().Intel.RadarRadius or 0)
+            local val = BuffCalculate(unit, buffName, 'OmniRadius', unit:GetBlueprint().Intel.OmniRadius or 0)
             if not unit:IsIntelEnabled('Omni') then
                 unit:InitIntel(unit:GetArmy(),'Omni', val)
                 unit:EnableIntel('Omni')


### PR DESCRIPTION
Omni buff used to check the units base radar radius rather than its omni radius, leading to the omni suddenly becoming the same as a units radar as altered by the buffs.