### PR TITLE
Prevent weapons from getting stuck at targets

### DIFF
--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -566,6 +566,12 @@ DefaultProjectileWeapon = Class(Weapon) {
             if bp.CountedProjectile == true  or bp.AnimationReload then
                 ChangeState(self, self.RackSalvoFiringState)
             end
+
+            -- To prevent weapon getting stuck targeting something out of fire range but withing tracking radius
+            WaitSeconds(5)
+
+            -- Check if there is a better target nearby
+            self:ResetTarget()
         end,
 
         OnFire = function(self)


### PR DESCRIPTION
Seems like there isn't a way to prevent #913 from happening by just changing values in the blueprint.

This fix will prevent weapons from getting stuck indefinitely at a target out of range.

Normally the weapon goes over to RackSalvoFiringState immediately and the scan for a new target won't happen.