### PR TITLE
Don't try to flash player's icon if score panel is disabled

### DIFF
--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -289,7 +289,7 @@ WorldView = Class(moho.UIWorldView, Control) {
 
             -- Find the UI element we need to flash.
             local scoreBoardControls = import('/lua/ui/game/score.lua').controls
-            for _, line in scoreBoardControls.armyLines do
+            for _, line in scoreBoardControls.armyLines or {} do
                 if line.armyID == pingOwnerIndex then
                     toFlash = line.faction
                     break
@@ -310,7 +310,9 @@ WorldView = Class(moho.UIWorldView, Control) {
                 end
             end
 
-			ForkThread(pingSourceIndicator)
+			if toFlash then
+                ForkThread(pingSourceIndicator)
+            end
 		end
 		
         if not self:IsHidden() and pingData.Location then


### PR DESCRIPTION
Fixes https://github.com/FAForever/fa-coop/issues/21
In coop, score panel is disabled and it was causing warnings in logs.
by Washy