### PR TITLE
Feature/persist ferry

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -19,12 +19,37 @@ function DoCallback(name, data, units)
     end
 end
 
+function SecureUnits(units)
+    local secure = {}
+
+    for _, u in units do 
+        if OkayToMessWithArmy(u:GetArmy()) then
+            table.insert(secure, u)
+        end
+    end
+
+    return secure
+end
+
 
 
 local SimUtils = import('/lua/SimUtils.lua')
 local SimPing = import('/lua/SimPing.lua')
 local SimTriggers = import('/lua/scenariotriggers.lua')
 local SUtils = import('/lua/ai/sorianutilities.lua')
+
+Callbacks.PersistFerry = function(data, units)
+    local transports = EntityCategoryFilterDown(categories.TRANSPORTATION, SecureUnits(units))
+    if table.getsize(transports) == 0 then return end
+    local start = data.route[1]
+
+    local helper = CreateUnit('hel0001', units[1]:GetArmy(), start[1], start[2], start[3], 1, 1, 1, 1, 'Air')
+    table.insert(units, helper)
+    IssueClearCommands(units)
+    for _, r in data.route do
+        IssueFerry(units, r)
+    end
+end
 
 Callbacks.BreakAlliance = SimUtils.BreakAlliance
 

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -78,6 +78,8 @@ local issuedOneCommand = false
 local startBehaviors = {}
 local endBehaviors = {}
 
+local ferryRoute= {}
+
 function OnCommandModeBeat()
     if issuedOneCommand and not IsKeyDown('Shift') then
         EndCommandMode(true)
@@ -191,4 +193,16 @@ function OnCommandIssued(command)
 	end
 
 	import('/lua/spreadattack.lua').MakeShadowCopyOrders(command)
+
+
+    if command.CommandType == 'Ferry' then
+        local pos = command.Target.Position
+        table.insert(ferryRoute, {pos[1], pos[2], pos[3]})
+    end
+
+    if table.getsize(ferryRoute) > 1 and not IsKeyDown('Shift') then
+        local cb = { Func = 'PersistFerry', Args = { route = ferryRoute} }
+        SimCallback(cb, true)
+        ferryRoute = {}
+    end
 end

--- a/units/HEL0001/HEL0001_script.lua
+++ b/units/HEL0001/HEL0001_script.lua
@@ -1,0 +1,13 @@
+HEL0001 = Class(moho.unit_methods) {
+	OnDamage = function(self, instigator, amount, vector, damageType)
+    end,
+
+    OnCreate = function(self)
+        self:SetCapturable(false)
+        self:SetReclaimable(false)
+        self:SetIsValidTarget(false)
+        self:SetCollisionShape('None')
+    end,
+}
+
+TypeClass = HEL0001

--- a/units/HEL0001/HEL0001_unit.bp
+++ b/units/HEL0001/HEL0001_unit.bp
@@ -1,0 +1,79 @@
+UnitBlueprint {
+    AI = {
+        --BeaconName = 'UAB5102'
+    },
+    Categories = {
+        'UNTARGETABLE',
+        'TRANSPORTATION',
+    },
+    Defense = {
+        AirThreatLevel = 0,
+        ArmorType = 'Normal',
+        EconomyThreatLevel = 0,
+        Health = 1,
+        MaxHealth = 1,
+        RegenRate = 0,
+        SubThreatLevel = 0,
+        SurfaceThreatLevel = 0,
+    },
+    Description = 'Ferry helper',
+    Economy = {
+        BuildCostEnergy = 0,
+        BuildCostMass = 0,
+        BuildRate = 0,
+        BuildTime = 0,
+        BuildableCategory = {
+        },
+        ConsumptionPerSecondEnergy = 0,
+        ConsumptionPerSecondMass = 0,
+        MaxBuildDistance = 0,
+    },
+    Footprint = {
+        MaxSlope = 0,
+        SizeX = 0,
+        SizeZ = 0,
+    },
+    General = {
+        CapCost = 0,
+        Category = 'Transport',
+        Classification = 'RULEUC_MiscSupport',
+        CommandCaps = {
+            RULEUCC_Attack = false,
+            RULEUCC_CallTransport = true,
+            RULEUCC_Capture = false,
+            RULEUCC_Ferry = true,
+            RULEUCC_Guard = false,
+            RULEUCC_Move = false,
+            RULEUCC_Nuke = false,
+            RULEUCC_Patrol = false,
+            RULEUCC_Reclaim = false,
+            RULEUCC_Repair = false,
+            RULEUCC_RetaliateToggle = false,
+            RULEUCC_Stop = false,
+            RULEUCC_Transport = true,
+        },
+    },
+    Intel = {
+        VisionRadius = 0,
+    },
+    Interface = {
+        HelpText = 'Ferry helper',
+    },
+    LifeBarRender = false,
+    Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
+        MotionType = 'RULEUMT_None',
+    },
+    SelectionThickness = 0,
+    SizeX = 0,
+    SizeY = 0,
+    SizeZ = 0,
+    StrategicIconSortPriority = 0,
+}


### PR DESCRIPTION
Irritating when ferry beacons disappear when the last transport of a ferry order dies. By letting an invisible ferry helper unit be part of the ferry order we go around this problem.

This concept could also be used with persistent build orders so you can have them surviving even if the engineers die.

Still rough in the edges but needs discussion before wasting anymore time with it.