### PR TITLE
Feature/transport lock

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -19,12 +19,39 @@ function DoCallback(name, data, units)
     end
 end
 
+function SecureUnits(units)
+    local secure = {}
+    if units and type(units) ~= 'table' then
+        units = {units}
+    end
+
+    for _, u in units or {} do
+        if not IsEntity(u) then
+            u = GetEntityById(u)
+        end
+
+        if IsEntity(u) and OkayToMessWithArmy(u:GetArmy()) then
+            table.insert(secure, u)
+        end
+    end
+
+    return secure
+end
 
 
 local SimUtils = import('/lua/SimUtils.lua')
 local SimPing = import('/lua/SimPing.lua')
 local SimTriggers = import('/lua/scenariotriggers.lua')
 local SUtils = import('/lua/ai/sorianutilities.lua')
+
+Callbacks.TransportLock = function(data)
+    local units = SecureUnits(data.ids)
+    if not units[1] then return end
+
+    for _, u in units do
+        u:TransportLock(data.lock == true)
+    end
+end
 
 Callbacks.BreakAlliance = SimUtils.BreakAlliance
 

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1639,7 +1639,7 @@ AirUnit = Class(MobileUnit) {
 --- Mixin transports (air, sea, space, whatever). Sellotape onto concrete transport base classes as
 -- desired.
 BaseTransport = Class() {
-    OnTransportAttach = function(self, attachBone, unit)
+    OnTransportAttach = function(self, bone, unit)
         self:PlayUnitSound('Load')
         self:MarkWeaponsOnTransport(unit, true)
         if unit:ShieldIsOn() then
@@ -1647,10 +1647,15 @@ BaseTransport = Class() {
             unit:DisableDefaultToggleCaps()
         end
         self:RequestRefreshUI()
-        unit:OnAttachedToTransport(self, attachBone)
+        unit:OnAttachedToTransport(self, bone)
     end,
 
-    OnTransportDetach = function(self, attachBone, unit)
+    OnTransportDetach = function(self, bone, unit)
+        if unit.TransportLocked then
+            unit:AttachBoneTo('AttachPoint', self, bone)
+            return
+        end
+
         self:PlayUnitSound('Unload')
         self:MarkWeaponsOnTransport(unit, false)
         unit:EnableShield()

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1639,6 +1639,14 @@ AirUnit = Class(MobileUnit) {
 --- Mixin transports (air, sea, space, whatever). Sellotape onto concrete transport base classes as
 -- desired.
 BaseTransport = Class() {
+    AllCargoLocked = function(self)
+        for _, u in self:GetCargo() do
+            if not u.TransportLocked then return false end
+        end
+
+        return true
+    end,
+
     OnTransportAttach = function(self, bone, unit)
         self:PlayUnitSound('Load')
         self:MarkWeaponsOnTransport(unit, true)
@@ -1651,7 +1659,7 @@ BaseTransport = Class() {
     end,
 
     OnTransportDetach = function(self, bone, unit)
-        if unit.TransportLocked then
+        if unit.TransportLocked and not self:AllCargoLocked() then
             unit:AttachBoneTo('AttachPoint', self, bone)
             return
         end

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -3705,6 +3705,14 @@ Unit = Class(moho.unit_methods) {
         end
     end,
 
+    TransportLock = function(self, bool)
+        bool = bool == true
+        if bool ~= self.TransportLock then
+            self.Sync.locked = bool
+        end
+        self.TransportLocked = bool
+    end,
+
     -------------------------------------------------------------------------------------------
     -- TELEPORTING
     -------------------------------------------------------------------------------------------

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -163,32 +163,42 @@ function OnCommandIssued(command)
             end
         end
     elseif command.CommandType == 'BuildMobile' then
-		AddCommandFeedbackBlip({
-			Position = command.Target.Position, 
-			BlueprintID = command.Blueprint,			
-			TextureName = '/meshes/game/flag02d_albedo.dds',
-			ShaderName = 'CommandFeedback',
-			UniformScale = 1,
-		}, 0.7)	
-	else	
-		if AddCommandFeedbackByType(command.Target.Position, command.CommandType) == false then
-			AddCommandFeedbackBlip({
-				Position = command.Target.Position, 
-				MeshName = '/meshes/game/flag02d_lod0.scm',
-				TextureName = '/meshes/game/flag02d_albedo.dds',
-				ShaderName = 'CommandFeedback',
-				UniformScale = 0.5,
-			}, 0.7)		
-			
-			AddCommandFeedbackBlip({
-				Position = command.Target.Position, 
-				MeshName = '/meshes/game/crosshair02d_lod0.scm',
-				TextureName = '/meshes/game/crosshair02d_albedo.dds',
-				ShaderName = 'CommandFeedback2',
-				UniformScale = 0.5,
-			}, 0.75)		
-		end		
-	end
+        AddCommandFeedbackBlip({
+            Position = command.Target.Position, 
+            BlueprintID = command.Blueprint,            
+            TextureName = '/meshes/game/flag02d_albedo.dds',
+            ShaderName = 'CommandFeedback',
+            UniformScale = 1,
+        }, 0.7) 
+    elseif command.CommandType == 'TransportUnloadSpecificUnits' then
+        local ids = {}
+        local n = table.getsize(command.Units)
+        if n > 1 then
+            for i=2, n do
+                table.insert(ids, command.Units[i]:GetEntityId())
+            end
+        end
+        local cb = { Func = 'TransportLock', Args = { ids=ids, lock=false} }
+        SimCallback(cb, true)
+    else
+        if AddCommandFeedbackByType(command.Target.Position, command.CommandType) == false then
+            AddCommandFeedbackBlip({
+                Position = command.Target.Position, 
+                MeshName = '/meshes/game/flag02d_lod0.scm',
+                TextureName = '/meshes/game/flag02d_albedo.dds',
+                ShaderName = 'CommandFeedback',
+                UniformScale = 0.5,
+            }, 0.7)     
+            
+            AddCommandFeedbackBlip({
+                Position = command.Target.Position, 
+                MeshName = '/meshes/game/crosshair02d_lod0.scm',
+                TextureName = '/meshes/game/crosshair02d_albedo.dds',
+                ShaderName = 'CommandFeedback2',
+                UniformScale = 0.5,
+            }, 0.75)        
+        end     
+    end
 
-	import('/lua/spreadattack.lua').MakeShadowCopyOrders(command)
+    import('/lua/spreadattack.lua').MakeShadowCopyOrders(command)
 end

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -541,6 +541,11 @@ function CommonLogic()
             end
             control.Icon:Show()
             control:Enable()
+
+            if UnitData[control.Data.unit:GetEntityId()].locked then
+                control:SetOverrideTexture('')
+                control:ToggleOverride()
+            end
         end
     end
 
@@ -1165,6 +1170,7 @@ function OnClickHandler(button, modifiers)
     elseif item.type == 'attachedunit' then
         if modifiers.Left then
             -- Toggling selection of the entity
+            button:SetOverrideTexture(button.mActive)
             button:ToggleOverride()
 
             -- Add or Remove the entity to the session selection
@@ -1173,6 +1179,11 @@ function OnClickHandler(button, modifiers)
             else
                 RemoveFromSessionExtraSelectList(item.unit)
             end
+        elseif modifiers.Right then
+            local cb = { Func = 'TransportLock', Args = { ids = {item.unit:GetEntityId()}, lock=not button:GetOverrideEnabled()} }
+            SimCallback(cb, true)
+            button:SetOverrideTexture('')
+            button:ToggleOverride()
         end
     elseif item.type == 'templates' then
         ClearBuildTemplates()


### PR DESCRIPTION
With this feature, a locked unit won't get unloaded when ordering a transport to unload all units. Especially useful for mobile stealth or when you want to drop all except a few.

Right click a unit in a transport to lock it in place. Unlock by right clicking again or specifically select it and unload. Lock is ignored if you give unload order with only locked units in transport.

Need a texture background for locked units, maybe a red one?