### PR TITLE
Increase size of some units to reduce hitting the floor thanks to low-mounted weapons

### DIFF
--- a/units/URL0202/URL0202_unit.bp
+++ b/units/URL0202/URL0202_unit.bp
@@ -108,7 +108,7 @@ UnitBlueprint {
         },
         PlaceholderMeshName = 'UXL0001',
         SpawnRandomRotation = true,
-        UniformScale = 0.135,
+        UniformScale = 0.15,
     },
     Economy = {
         BuildCostEnergy = 1500,

--- a/units/XAL0305/XAL0305_unit.bp
+++ b/units/XAL0305/XAL0305_unit.bp
@@ -129,7 +129,7 @@ UnitBlueprint {
                 Weight = 100,
             },
         },
-        UniformScale = 0.07,
+        UniformScale = 0.08,
     },
     Economy = {
         BuildCostEnergy = 8000,
@@ -202,7 +202,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.5,
     SelectionThickness = 0.8,
     SizeX = 0.8,
-    SizeY = 1,
+    SizeY = 1.15,
     SizeZ = 0.6,
     StrategicIconName = 'icon_bot3_sniper',
     StrategicIconSortPriority = 115,

--- a/units/XAL0305/XAL0305_unit.bp
+++ b/units/XAL0305/XAL0305_unit.bp
@@ -1,7 +1,6 @@
 UnitBlueprint {
     AI = {
-        # GuardScanRadius = 30,
-        NeedUnpack = false,#from true
+        NeedUnpack = false,
     },
     Audio = {
         AmbientMove = Sound {
@@ -88,7 +87,7 @@ UnitBlueprint {
             },
         },
         AnimationWalk = '/units/xal0305/xal0305_awalk.sca',
-        AnimationWalkRate = 9,     #6.4
+        AnimationWalkRate = 9,     --6.4
         Mesh = {
             IconFadeInZoom = 130,
             LODs = {
@@ -239,7 +238,7 @@ UnitBlueprint {
                 Land = 'Land|Water|Seabed',
                 Water = 'Land|Water|Seabed',
             },
-            FiringTolerance = 0.5, # 2
+            FiringTolerance = 0.5, -- 2
             Label = 'MainGun',
             MaxRadius = 70,
             FiringRandomnessWhileMoving = 0.5,
@@ -289,14 +288,14 @@ UnitBlueprint {
             TurretPitchSpeed = 30,
             TurretYaw = 0,
             TurretYawRange = 180,
-            TurretYawSpeed = 90, # 75
+            TurretYawSpeed = 90,
             Turreted = true,
             WeaponCategory = 'Direct Fire',
             WeaponRepackTimeout = 0,
             WeaponUnpackAnimation = '/units/xal0305/xal0305_asetup.sca',
-            WeaponUnpackAnimationRate = 0,#from 1
-            WeaponUnpackLocksMotion = false,#from true
-            WeaponUnpacks = false,# from true
+            WeaponUnpackAnimationRate = 0,
+            WeaponUnpackLocksMotion = false,
+            WeaponUnpacks = false,
         },
     },
     Wreckage = {

--- a/units/XSL0303/XSL0303_unit.bp
+++ b/units/XSL0303/XSL0303_unit.bp
@@ -189,7 +189,7 @@ UnitBlueprint {
         },
         PlaceholderMeshName = 'UXL0001',
         SpawnRandomRotation = true,
-        UniformScale = 0.06,
+        UniformScale = 0.066,
     },
     Economy = {
         BuildCostEnergy = 9600,
@@ -262,9 +262,9 @@ UnitBlueprint {
     SelectionSizeX = 0.7,
     SelectionSizeZ = 1.4,
     SelectionThickness = 0.3,
-    SizeX = 0.7,
-    SizeY = 0.3,
-    SizeZ = 1.8,
+    SizeX = 0.8,
+    SizeY = 0.45,
+    SizeZ = 2.0,
     StrategicIconName = 'icon_land3_directfire',
     StrategicIconSortPriority = 115,
     Transport = {

--- a/units/XSL0303/XSL0303_unit.bp
+++ b/units/XSL0303/XSL0303_unit.bp
@@ -255,7 +255,7 @@ UnitBlueprint {
         MotionType = 'RULEUMT_Amphibious',
         RotateOnSpot = true,
         RotateOnSpotThreshold = 0.1,
-        StandUpright = false, -- bug fix for tank not following contours of terrain [139]
+        StandUpright = false,
         TurnRadius = 0,
         TurnRate = 75,
     },
@@ -567,9 +567,9 @@ UnitBlueprint {
         WreckageLayers = {
             Air = false,
             Land = true,
-            Seabed = true, #from false
-            Sub = true, #from false
-            Water = true, #from false
+            Seabed = true,
+            Sub = true,
+            Water = true,
         },
     },
 }

--- a/units/XSL0305/XSL0305_unit.bp
+++ b/units/XSL0305/XSL0305_unit.bp
@@ -45,7 +45,7 @@ UnitBlueprint {
         'LAND',
         'TECH3',
         'DIRECTFIRE',
-        'INDIRECTFIRE', #New, for range ring
+        'INDIRECTFIRE',
         'VISIBLETORECON',
         'RECLAIMABLE',
         'BOT',
@@ -270,7 +270,7 @@ UnitBlueprint {
                 Land = 'Land|Water|Seabed',
                 Water = 'Land|Water|Seabed',
             },
-            FiringTolerance = 0.5, # 2
+            FiringTolerance = 0.5, -- 2
             IgnoreIfDisabled = true,
             Label = 'MainGun',
             MaxRadius = 65,
@@ -300,8 +300,7 @@ UnitBlueprint {
             RangeCategory = 'UWRC_DirectFire',
             RateOfFire = 0.2,
             RenderFireClock = true,
-            SlavedToBody = false,#from true ; in order to allow better micro
-            #SlavedToBodyArcRange = 5,
+            SlavedToBody = false,
             TargetCheckInterval = 3,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
@@ -322,12 +321,11 @@ UnitBlueprint {
             TurretPitchRange = 50,
             TurretPitchSpeed = 30,
             TurretYaw = 0,
-            TurretYawRange = 180,#from 10 ; in order to allow better micro
+            TurretYawRange = 180,
             TurretYawSpeed = 90,
             Turreted = true,
             WeaponCategory = 'Direct Fire',
             WeaponRepackTimeout = 0,
-            # WeaponUnpackLocksMotion = true, --This was causing the unit not to fire until its weapons had been toggled. *shrug*
             WeaponUnpacks = false,
         },
         {
@@ -343,7 +341,7 @@ UnitBlueprint {
                 Land = 'Land|Water|Seabed',
                 Water = 'Land|Water|Seabed',
             },
-            FiringTolerance = 0.5, # 2
+            FiringTolerance = 0.5,
             IgnoreIfDisabled = true,
             Label = 'SniperGun',
             MaxRadius = 75,
@@ -370,11 +368,10 @@ UnitBlueprint {
             RackSalvoReloadTime = 0,
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
-            RangeCategory = 'UWRC_IndirectFire', #From direct, so the range ring will show
+            RangeCategory = 'UWRC_IndirectFire',
             RateOfFire = 0.07,
             RenderFireClock = true,
-            SlavedToBody = false,#from true ; in order to allow better micro
-            #SlavedToBodyArcRange = 5,
+            SlavedToBody = false,
             TargetCheckInterval = 3,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
@@ -395,12 +392,11 @@ UnitBlueprint {
             TurretPitchRange = 50,
             TurretPitchSpeed = 30,
             TurretYaw = 0,
-            TurretYawRange = 180,#from 10 ; in order to allow better micro
+            TurretYawRange = 180,
             TurretYawSpeed = 90,
             Turreted = true,
             WeaponCategory = 'Direct Fire',
             WeaponRepackTimeout = 0,
-            # WeaponUnpackLocksMotion = true, --This was causing the unit not to fire until its weapons had been toggled. *shrug*
             WeaponUnpacks = false,
         },
     },

--- a/units/XSL0305/XSL0305_unit.bp
+++ b/units/XSL0305/XSL0305_unit.bp
@@ -153,7 +153,7 @@ UnitBlueprint {
         },
         PlaceholderMeshName = 'UXL0001',
         SpawnRandomRotation = true,
-        UniformScale = 0.068,
+        UniformScale = 0.08,
     },
     Economy = {
         BuildCostEnergy = 8000,


### PR DESCRIPTION
Adjusts Rhino, Othuum, and both Snipers. Adjustments minor, so after a couple of minutes you won't even notice the difference.

Othuum and Aeon sniper required hitbox changes. Aeon one is very small, just to keep the bones contained. Othuum's hitbox is stupidly small anyway, this makes it fit the new model nicely.