### PR TITLE
Stop Cybran drones leaving wrecks

### DIFF
--- a/units/URA0001/URA0001_script.lua
+++ b/units/URA0001/URA0001_script.lua
@@ -42,6 +42,12 @@ URA0001 = Class(CAirUnit) {
     OnKilled = function(self)
         self:StopBuildingEffects()
     end,
+    
+    -- Don't make wreckage
+    CreateWreckage = function (self, overkillRatio)
+        overkillRatio = 1.1
+        CAirUnit.CreateWreckage(self, overkillRatio)
+    end,
 
     -- Prevent the unit from reporting consumption values (avoids junk in the resource overlay)
     UpdateConsumptionValues = function(self) end,

--- a/units/URA0001/URA0001_script.lua
+++ b/units/URA0001/URA0001_script.lua
@@ -1,13 +1,9 @@
---****************************************************************************
---**
---**  File     :  /cdimage/units/URA0001/URA0001_script.lua
---**  Author(s):  Gordon Duclos
---**
---**  Summary  :  Cybran Builder bot units
---**
---**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
---****************************************************************************
-
+-----------------------------------------------------------------
+-- File     :  /cdimage/units/URA0001/URA0001_script.lua
+-- Author(s):  Gordon Duclos
+-- Summary  :  Cybran Builder bot units
+-- Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+-----------------------------------------------------------------
 local CAirUnit = import('/lua/cybranunits.lua').CAirUnit
 local CreateCybranBuildBeams = import('/lua/EffectUtilities.lua').CreateCybranBuildBeams
 
@@ -30,7 +26,7 @@ URA0001 = Class(CAirUnit) {
     end,
 
     OnStartReclaim = function(self, target)
-        IssueStop( {self} )  -- you can't reclaim!
+        IssueStop({self})  -- You can't reclaim!
     end,
 
     OnStopBuild = function(self, unitBeingBuilt)
@@ -38,7 +34,7 @@ URA0001 = Class(CAirUnit) {
         ChangeState(self, self.IdleState)
     end,
 
-    --- Don't explode when killed, merely fall out of the sky.
+    -- Don't explode when killed, merely fall out of the sky.
     OnKilled = function(self)
         self:StopBuildingEffects()
     end,


### PR DESCRIPTION
Fixes #940

In theory anyway. They should never leave a wreck with this code, but of course I cannot test gifted units in an offline test environment.