### PR TITLE
Repair wreckage / unit -> rebuild it

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -19,7 +19,24 @@ function DoCallback(name, data, units)
     end
 end
 
+function SecureUnits(units)
+    local secure = {}
+    if units and type(units) ~= 'table' then
+        units = {units}
+    end
 
+    for _, u in units or {} do
+        if not IsEntity(u) then
+            u = GetEntityById(u)
+        end
+
+        if IsEntity(u) and OkayToMessWithArmy(u:GetArmy()) then
+            table.insert(secure, u)
+        end
+    end
+
+    return secure
+end
 
 local SimUtils = import('/lua/SimUtils.lua')
 local SimPing = import('/lua/SimPing.lua')
@@ -56,6 +73,18 @@ Callbacks.SimDialogueButtonPress = import('/lua/SimDialogue.lua').OnButtonPress
 Callbacks.AIChat = SUtils.FinishAIChat
 
 Callbacks.DiplomacyHandler = import('/lua/SimDiplomacy.lua').DiplomacyHandler
+
+Callbacks.Rebuild = function(data, units)
+    local wreck = GetEntityById(data.entity)
+    if not wreck.AssociatedBP then return end
+    local units = SecureUnits(units)
+    if not units[1] then return end
+    if data.Clear then
+        IssueClearCommands(units)
+    end
+
+    wreck:Rebuild(units)
+end
 
 --Callbacks.GetUnitHandle = import('/lua/debugai.lua').GetHandle
 

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -393,6 +393,32 @@ StructureUnit = Class(Unit) {
         self:CreateTarmac(true, true, true, orient, currentBP, currentBP.DeathLifetime or 300)
     end,
 
+    OnKilled = function(self, instigator, type, overKillRatio)
+        Unit.OnKilled(self, instigator, type, overKillRatio)
+    end,
+
+    CheckRepairersForRebuild = function(self, wreckage)
+        local units = {}
+        for id, u in self.Repairers do
+            local focus = u:GetFocusUnit()
+            if u:IsUnitState('Repairing') and focus == self and not u:GetGuardedUnit() then -- not assist
+                table.insert(units, u)
+            end
+        end
+
+        if not units[1] then return end
+
+        wreckage:Rebuild(units)
+    end,
+
+    CreateWreckage = function(self, overkillRatio)
+        local wreckage = Unit.CreateWreckage(self, overkillRatio)
+        if wreckage then
+            self:CheckRepairersForRebuild(wreckage)
+        end
+
+        return wreckage
+    end,
     ----------------------------------------------------------------------------------------------
     --  Adjacency
     ----------------------------------------------------------------------------------------------

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -190,5 +190,13 @@ function OnCommandIssued(command)
 		end		
 	end
 
+    if command.CommandType == 'Repair' then
+        local target = command.Target
+        if target.Type == 'Entity' or target.Type == 'Position' then -- repair wreck/ground to rebuild
+            local cb = {Func="Rebuild", Args={entity=target.EntityId, Clear=command.Clear}}
+            SimCallback(cb, true)
+        end
+    end
+
 	import('/lua/spreadattack.lua').MakeShadowCopyOrders(command)
 end

--- a/lua/wreckage.lua
+++ b/lua/wreckage.lua
@@ -54,8 +54,28 @@ Wreckage = Class(Prop) {
         clone:UpdateReclaimLeft()
 
         return clone
-    end
+    end,
 
+    Rebuild = function(self, units)
+        local rebuilders = {}
+        local assisters = {}
+        local bpid = self.AssociatedBP
+
+        for _, u in units do
+            if u:CanBuild(bpid) then
+                table.insert(rebuilders, u)
+            else
+                table.insert(assisters, u)
+            end
+        end
+
+        if not rebuilders[1] then return end
+        local pos = self:GetPosition()
+        IssueBuildMobile(rebuilders, pos, bpid, {})
+        if assisters[1] then
+            IssueGuard(assisters, pos)
+        end
+    end,
 }
 
 --- Create a wreckage prop.


### PR DESCRIPTION
* Order repair on a wreckage to rebuild it.

* A structure which is repaired and dies will automatically, if possible, be rebuilt by the repairers. A normal right-click order (assist) on a damaged structure won't cause rebuild though.

~~Planning to add support for repair ground also, which would mean to repair / rebuild anything within range (GuardScanRadius) of the ordered units.~~