### PR TITLE
Yield smarter in WaitSeconds on UI side

### DIFF
--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -35,18 +35,6 @@ local sendChat = import('/lua/ui/game/chat.lua').ReceiveChatFromSim
 local oldData = {}
 local lastObserving
 
-function UpdateAverageFPS()
-    local now
-    local wait_frames
-
-    while true do
-        now = CurrentTime()
-        wait_frames = AvgFPS * 10
-        WaitFrames(wait_frames)
-        AvgFPS = math.max(10, math.min(200, math.ceil(wait_frames / (CurrentTime() - now))))
-    end
-end
-
 -- Hotbuild stuff
 modifiersKeys = {}
 -- Adding modifiers shorcuts on the fly.
@@ -249,8 +237,6 @@ function CreateUI(isReplay)
     if options.gui_render_enemy_lifebars == 1 or options.gui_render_custom_names == 0 then
         import('/modules/console_commands.lua').Init()
     end
-
-    ForkThread(UpdateAverageFPS)
 end
 
 local provider = false

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -35,6 +35,18 @@ local sendChat = import('/lua/ui/game/chat.lua').ReceiveChatFromSim
 local oldData = {}
 local lastObserving
 
+function UpdateAverageFPS()
+    local now
+    local wait_frames
+
+    while true do
+        now = CurrentTime()
+        wait_frames = AvgFPS * 10
+        WaitFrames(wait_frames)
+        AvgFPS = math.max(10, math.min(200, math.ceil(wait_frames / (CurrentTime() - now))))
+    end
+end
+
 -- Hotbuild stuff
 modifiersKeys = {}
 -- Adding modifiers shorcuts on the fly.
@@ -237,6 +249,8 @@ function CreateUI(isReplay)
     if options.gui_render_enemy_lifebars == 1 or options.gui_render_custom_names == 0 then
         import('/modules/console_commands.lua').Init()
     end
+
+    ForkThread(UpdateAverageFPS)
 end
 
 local provider = false

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -10,17 +10,25 @@ __language = GetPreference('options_overrides.language', '')
 -- Do global init
 doscript '/lua/globalInit.lua'
 
-AvgFPS = 60
+local AvgFPS = 60
 WaitFrames = coroutine.yield
 
 function WaitSeconds(n)
-    local goal = CurrentTime() + n
+    local start = CurrentTime()
+    local elapsed_frames = 0
+    local elapsed_time = 0
     local wait_frames
+
     repeat
         wait_frames = math.ceil(math.max(1, AvgFPS*0.1, n * AvgFPS))
         WaitFrames(wait_frames)
-        n = goal - CurrentTime()
-    until n < 0.01
+        elapsed_frames = elapsed_frames + wait_frames
+        elapsed_time = CurrentTime() - start
+    until elapsed_time >= n
+
+    if elapsed_time >= 1 then
+        AvgFPS = math.max(10, math.min(200, math.ceil(elapsed_frames / elapsed_time)))
+    end
 end
 
 

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -1,26 +1,30 @@
-# Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#
-# This is the user-specific top-level lua initialization file. It is run at initialization time
-# to set up all lua state for the user layer.
+-- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--
+-- This is the user-specific top-level lua initialization file. It is run at initialization time
+-- to set up all lua state for the user layer.
 
-# Init our language from prefs. This applies to both front-end and session init; for
-# the Sim init, the engine sets __language for us.
+-- Init our language from prefs. This applies to both front-end and session init; for
+-- the Sim init, the engine sets __language for us.
 __language = GetPreference('options_overrides.language', '')
 
-# Do global init
+-- Do global init
 doscript '/lua/globalInit.lua'
 
+AvgFPS = 60
 WaitFrames = coroutine.yield
 
 function WaitSeconds(n)
-    local later = CurrentTime() + n
-    WaitFrames(1)
-    while CurrentTime() < later do
-        WaitFrames(1)
-    end
+    local goal = CurrentTime() + n
+    local wait_frames
+    repeat
+        wait_frames = math.ceil(math.max(1, AvgFPS*0.1, n * AvgFPS))
+        WaitFrames(wait_frames)
+        n = goal - CurrentTime()
+    until n < 0.01
 end
 
-# a table designed to allow communication from different user states to the front end lua state
+
+-- a table designed to allow communication from different user states to the front end lua state
 FrontEndData = {}
 
 -- Prefetch user side data


### PR DESCRIPTION
Instead of always yielding 1 frame at a time, decide the amount of frames to yield by using the average fps number. With lots  of UI co-routines running this should reduce the context switching substantially