### PR TITLE
Update teamkill detection

### DIFF
--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -69,6 +69,10 @@ function OnSync()
     end
 	
     if Sync.Teamkill then
+        local armiesInfo = GetArmiesTable()
+        local victimName = armiesInfo.armiesTable[Sync.Teamkill.victim].nickname
+        local killerName = armiesInfo.armiesTable[Sync.Teamkill.instigator].nickname
+        GpgNetSend('TeamkillHappened', Sync.Teamkill.killTime, victimName, killerName)
         if(GetFocusArmy() == Sync.Teamkill.victim) then
             import('/lua/ui/dialogs/teamkill.lua').CreateDialog(Sync.Teamkill)
         end

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2072,9 +2072,6 @@ ACUUnit = Class(CommandUnit) {
             if IsAlly(self:GetArmy(), instigator:GetArmy()) then
                 WARN('Teamkill detected')
                 Sync.Teamkill = { killTime = GetGameTimeSeconds(), instigator = instigator:GetArmy(), victim = self:GetArmy() }
-                WARN("Was teamkilled: army #" .. self:GetArmy())
-                WARN("At time: " .. GetGameTimeSeconds())
-                WARN("Killed by army #" .. instigator:GetArmy())
             end
         end
 

--- a/lua/ui/dialogs/teamkill.lua
+++ b/lua/ui/dialogs/teamkill.lua
@@ -56,7 +56,7 @@ function CreateDialog(teamkillTable)
         WARN("Was teamkilled: " .. victimName)
         WARN("At time: " .. killTime)
         WARN("Killed by: " .. killerName)
-        GpgNetSend('Teamkill',  killTime,victimName,killerName)
+        GpgNetSend('TeamkillReport',  killTime,victimName,killerName)
         dialog:Close()
     end
     


### PR DESCRIPTION
Update teamkill detection to have everyone send a report that a teamkill happened. Everyone sends a 'TeamkillHappened' message, but it probably only needs to be investigated if you get a 'TeamkillReport', which only gets sent if the victim wants to report the teamkill.

(also removed some duplicated warns from defaultunit)