### PR TITLE
Fix #891

### DIFF
--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -12,13 +12,6 @@ local CalculateBallisticAcceleration = import('/lua/sim/CalcBallisticAcceleratio
 -- Most weapons derive from this class, including beam weapons later in this file
 DefaultProjectileWeapon = Class(Weapon) {
 
-    -- Record the initial damage of the weapon for future use
-    GetDamageTable = function(self)
-        local table = Weapon.GetDamageTable(self)
-        table.InitialDamageAmount = self:GetBlueprint().InitialDamage or 0
-        return table
-    end,
-
     FxRackChargeMuzzleFlash = {},
     FxRackChargeMuzzleFlashScale = 1,
     FxChargeMuzzleFlash = {},

--- a/schook/lua/sim/weapon.lua
+++ b/schook/lua/sim/weapon.lua
@@ -1,0 +1,1 @@
+-- empty file to shadow original game file


### PR DESCRIPTION
Due to faulty table manipulation, disabled buffs wouldn't get cleared from
the damageTable.

- Remove unneeded GetDamageTable override in DefaultProjectileWeapon
- Shadow unneeded Weapon schook with empty file
- Add the stuff those two did into the main Weapon class
- Turn Weapon.BuffDisablers into a proper set (Fixes #973)
- Change weirdness-based addition and subsequent incorrect removal of
  buffs to efficiently not adding disabled buffs in the first place