### PR TITLE
Make mapselect not spaz out after changing mods

### DIFF
--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -974,7 +974,8 @@ function PopulateMapList()
 
         if passedFiltering then
             -- Make sure we finish up with the right map selected.
-            if string.lower(sceninfo.file) == string.lower(selectedScenario.file) then
+            
+            if selectedScenario and string.lower(sceninfo.file) == string.lower(selectedScenario.file) then
                 selectedRow = count - 1
             end
 


### PR DESCRIPTION
When the map list changed, e.g. when switching from normal FAF to Coop,
resulting in the previously selected map not being available anymore, the
missing check for scenarioInfo being set caused the UI to bug out.

- Check for scenarioInfo being set