### PR TITLE
Fix #883 - Return early from DoDamage if no damage

### DIFF
--- a/lua/sim/CollisionBeam.lua
+++ b/lua/sim/CollisionBeam.lua
@@ -86,6 +86,8 @@ CollisionBeam = Class(moho.CollisionBeamEntity) {
 
     DoDamage = function(self, instigator, damageData, targetEntity)
         local damage = damageData.DamageAmount or 0
+        if damage <= 0 then return end
+        
         local dmgmod = 1
         if self.Weapon.DamageModifiers then
             for k, v in self.Weapon.DamageModifiers do
@@ -93,7 +95,8 @@ CollisionBeam = Class(moho.CollisionBeamEntity) {
             end
         end
         damage = damage * dmgmod
-        if instigator and damage > 0 then
+        
+        if instigator then
             local radius = damageData.DamageRadius
             if radius and radius > 0 then
                 if not damageData.DoTTime or damageData.DoTTime <= 0 then

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -44,6 +44,8 @@ if options.gui_templates_factory ~= 0 then
     allFactories = false
 end
 
+local missingIcons = {}
+
 local dragging = false
 local index = nil --index of the item in the queue currently being dragged
 local originalIndex = false --original index of selected item (so that UpdateBuildQueue knows where to modify it from)
@@ -984,7 +986,8 @@ function StratIconReplacement(control)
             LayoutHelpers.ResetBottom(control.StratIcon)
             LayoutHelpers.ResetLeft(control.StratIcon)
             control.StratIcon:SetAlpha(0.8)
-        else
+        elseif not missingIcons[iconName] then
+            missingIcons[iconName] = true
             LOG('Strat Icon Mod Error: updated strat icon required for: ', iconName)
         end
     end


### PR DESCRIPTION
The DoDamage function caused logspam due to a logic error that would
conclude a fault condition whenever there was no damage to be done.
We fix this by returning early.