### PR TITLE
Fix coop missions stuck on Operation Complete

### DIFF
--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -31,12 +31,12 @@ end
 --   bool _allSecondary - true if all secondary objectives completed, otherwise, false
 function EndOperation(_success, _allPrimary, _allSecondary)
     Sync.OperationComplete = {
-        opKey = ScenarioInfo.campaignInfo.opKey or '',
+        opKey = ScenarioInfo.campaignInfo and ScenarioInfo.campaignInfo.opKey or '',
         success = _success,
-        difficulty = ScenarioInfo.campaignInfo.difficulty or '',
+        difficulty = ScenarioInfo.campaignInfo and ScenarioInfo.campaignInfo.difficulty or ScenarioInfo.Options.Difficulty,
         allPrimary = _allPrimary,
         allSecondary = _allSecondary,
-        campaignID = ScenarioInfo.campaignInfo.campaignID or ScenarioInfo.Options.FACampaignFaction or '',
+        campaignID = ScenarioInfo.campaignInfo and ScenarioInfo.campaignInfo.campaignID or ScenarioInfo.Options.FACampaignFaction or '',
     }
     -- EndGame()
 end
@@ -688,6 +688,7 @@ end
 function PlayDialogue()
     while table.getn(ScenarioInfo.DialogueQueue) > 0 do
         local dTable = table.remove(ScenarioInfo.DialogueQueue, 1)
+        if not dTable then WARN('dTable is nil, ScenarioInfo.DialogueQueue len is '..repr(table.getn(ScenarioInfo.DialogueQueue))) end
         if not dTable.Flushed and ( not ScenarioInfo.OpEnded or dTable.Critical ) then
             for k,v in dTable do
                 if v ~= nil and not dTable.Flushed and ( not ScenarioInfo.OpEnded or dTable.Critical ) then


### PR DESCRIPTION
Heavy-Duty refactoring broke coop in as of yet unknown ways. Here's a
hotfix that avoids attempts to load the _operation.lua file when the
ScenarioInfo.campaignInfo table is missing and thus there is no opKey.