### PR TITLE
Personal stealth units in transport

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1761,6 +1761,7 @@ BaseTransport = Class() {
             unit:DisableShield()
             unit:DisableDefaultToggleCaps()
         end
+        unit:EnableIntel('RadarStealth')
         self:RequestRefreshUI()
         unit:OnAttachedToTransport(self, bone)
     end,
@@ -1776,6 +1777,9 @@ BaseTransport = Class() {
         unit:EnableShield()
         unit:EnableDefaultToggleCaps()
         self:RequestRefreshUI()
+        if unit:GetBlueprint().Intel.StealthOnlyForTransport then
+            unit:DisableIntel('RadarStealth')
+        end
         unit:TransportAnimation(-1)
         unit:TransportLock(false)
         unit:OnDetachedToTransport(self)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2288,8 +2288,13 @@ Unit = Class(moho.unit_methods) {
     end,
 
     EnableUnitIntel = function(self, disabler, intel)
+        local transportOnly = self:GetBlueprint().Intel.StealthOnlyForTransport
         local function EnableOneIntel(disabler, intel)
             local intEnabled = false
+            if intel == 'RadarStealth' and transportOnly then
+                return
+            end
+            
             if self.IntelDisables[intel][disabler] then -- must check for explicit true contained
                 self.IntelDisables[intel][disabler] = nil
                 if Set.Empty(self.IntelDisables[intel]) then

--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -446,6 +446,11 @@ function PreModBlueprints(all_bps)
                 },
             }
         end
+        
+        if bp.Intel and not bp.Intel.RadarStealth then
+            bp.Intel.RadarStealth = true
+            bp.Intel.StealthOnlyForTransport = true
+        end
 
         -- Mod in AI.GuardScanRadius = Longest weapon range * longest tracking radius
         -- Takes ACU/SCU enhancements into account


### PR DESCRIPTION
Stops transports being obvious as such from their radar signature. A loaded transport now appears as a normal plane, a single signature.