### PR TITLE
Have shields check for 1 Energy not 0

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -387,7 +387,7 @@ Shield = Class(moho.shield_methods,Entity) {
                 self:UpdateShieldRatio(-1)
 
                 fraction = self.Owner:GetResourceConsumed()
-                if fraction != 1 and aiBrain:GetEconomyStored('ENERGY') <= 0 then
+                if fraction != 1 and aiBrain:GetEconomyStored('ENERGY') <= 1 then
                     if test then
                         on = false
                     else


### PR DESCRIPTION
Fixes shields sometimes not turning off properly on low energy. Was most apt with personal shields, as their lower consumption meant sometimes their share of E was <1 itself, possibly leading to not turning off on power cycle (Theory).