### PR TITLE
Hotfix/1043

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2036,15 +2036,6 @@ ConstructionUnit = Class(MobileUnit) {
             self.BuildingOpenAnimManip:SetRate(-(self:GetBlueprint().Display.AnimationBuildRate or 1))
         end
     end,
-
-
-    CheckBuildRestriction = function(self, target_bp)
-        if self:CanBuild(target_bp.BlueprintId) then
-            return true
-        else
-            return false
-        end
-    end,
 }
 
 

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -820,11 +820,14 @@ FactoryUnit = Class(StructureUnit) {
     end,
 
     CheckBuildRestriction = function(self, target_bp)
-        if self:CanBuild(target_bp.BlueprintId) then
-            return true
-        else
+        -- Check basic build restrictions first (Unit.CheckBuildRestriction but we only go up one inheritance level)
+        if not StructureUnit.CheckBuildRestriction(self, target_bp) then
             return false
         end
+        -- Factories never build factories (this does not break Upgrades since CheckBuildRestriction is never called for Upgrades)
+        -- Note: We check for the primary category, since e.g. AircraftCarriers have the FACTORY category.
+        -- TODO: This is a hotfix for #1043, remove when engymod design is properly fixed
+        return target_bp.General.Category ~= 'Factory'
     end,
 
     OnFailedToBuild = function(self)


### PR DESCRIPTION
Introduces a new build restriction set that stop factories from building
(not upgrading) factories.

This is a workaround to fix #1043 until engymod can be fixed properly.

While we're at it, I also removed a useless CheckBuildRestriction override.

Please check that it doesn't mess with anything.

To test:

[x] There are no units with the `Factory` **primary** category built from `FactoryUnit` factories
[ ] Removal of the CheckBuildRestriction function from `ConstructionUnit` doesn't screw something up
[x] Aircraft carriers still work as expected, tested with Cybran Carrier
[x] Megalith eggs still work as expected