### PR TITLE
Readded TabelCat( ... )

### DIFF
--- a/lua/utilities.lua
+++ b/lua/utilities.lua
@@ -145,3 +145,16 @@ function UserConRequest(string)
     end
     table.insert(Sync.UserConRequests, string)
 end
+
+#Backwards compatibility.
+function TableCat( ... )
+    local ret = {}
+    for index = 1, table.getn(arg) do
+        if arg[index] != nil then
+            for k, v in arg[index] do
+                table.insert( ret, v )
+            end
+        end
+    end
+    return ret
+end


### PR DESCRIPTION
Readded TabelCat( ... ) for backward compatibility reasons. Mods use it and unnecessarily crash with FAF.