### PR TITLE
UEF, Cybran T2 air fighter template for AI

### DIFF
--- a/lua/AI/OpAI/AirAttacks_save.lua
+++ b/lua/AI/OpAI/AirAttacks_save.lua
@@ -1410,11 +1410,7 @@ Scenario = {
                                 {'default_brain','default_builder_name', 2 },
                                 {'default_brain','default_builder_name','2'}
                             },
-                            [3] = {'/lua/editor/otherarmyunitcountbuildconditions.lua', 'BrainGreaterThanNumCategory',
-                                {'default_brain','Player', 5 , categories.NAVAL * categories.MOBILE },
-                                {'default_brain','Player','5','categories.NAVAL * categories.MOBILE'}
-                            },
-                            [4] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
                                 {'default_brain', 2, 0 },
                                 {'default_brain', '2','0' }
                             },
@@ -1451,11 +1447,7 @@ Scenario = {
                                 {'default_brain','default_builder_name', 2 },
                                 {'default_brain','default_builder_name','2'}
                             },
-                            [3] = {'/lua/editor/otherarmyunitcountbuildconditions.lua', 'BrainGreaterThanNumCategory',
-                                {'default_brain','Player', 5 , categories.NAVAL * categories.MOBILE },
-                                {'default_brain','Player','5','categories.NAVAL * categories.MOBILE'}
-                            },
-                            [4] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
                                 {'default_brain', 2, 0 },
                                 {'default_brain', '2','0' }
                             },

--- a/lua/AI/OpAI/AirAttacks_save.lua
+++ b/lua/AI/OpAI/AirAttacks_save.lua
@@ -1,0 +1,1656 @@
+--[[                                                                           ]]--
+--[[  Automatically generated code (do not edit)                               ]]--
+--[[                                                                           ]]--
+--[[                                                                           ]]--
+--[[  Scenario                                                                 ]]--
+--[[                                                                           ]]--
+Scenario = {
+    next_area_id = '1',
+    --[[                                                                           ]]--
+    --[[  Props                                                                    ]]--
+    --[[                                                                           ]]--
+    Props = {
+    },
+    --[[                                                                           ]]--
+    --[[  Areas                                                                    ]]--
+    --[[                                                                           ]]--
+    Areas = {
+    },
+    --[[                                                                           ]]--
+    --[[  Markers                                                                  ]]--
+    --[[                                                                           ]]--
+    MasterChain = {
+        ['_MASTERCHAIN_'] = {
+            Markers = {
+            },
+        },
+    },
+    Chains = {
+    },
+    --[[                                                                           ]]--
+    --[[  Orders                                                                   ]]--
+    --[[                                                                           ]]--
+    next_queue_id = '1',
+    Orders = {
+    },
+    --[[                                                                           ]]--
+    --[[  Platoons                                                                 ]]--
+    --[[                                                                           ]]--
+    next_platoon_id = '18',
+    Platoons =
+    {
+        ['OST_BLANK_TEMPLATE'] = {
+            'OST_BLANK_TEMPLATE',
+            '',
+        },
+        ['OST_AirAttacks_T1Platoon1'] = {
+            'OST_AirAttacks_T1Platoon1',
+            '',
+            { 'uea0103', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_AirAttacks_T1Platoon2'] = {
+            'OST_AirAttacks_T1Platoon2',
+            '',
+            { 'uea0102', -1, 1, 'attack', 'AttackFormation' },
+        },
+
+
+
+
+        ['OST_AirAttacks_T2Platoon1'] = {
+            'OST_AirAttacks_T2Platoon1',
+            '',
+            { 'uea0203', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0102', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_AirAttacks_T2Platoon2'] = {
+            'OST_AirAttacks_T2Platoon2',
+            '',
+            { 'uea0203', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0103', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_AirAttacks_T2Platoon3Naval'] = {
+            'OST_AirAttacks_T2Platoon3Naval',
+            '',
+            { 'uea0204', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0102', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_AirAttacks_T2Platoon4Naval'] = {
+            'OST_AirAttacks_T2Platoon4Naval',
+            '',
+            { 'uea0204', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0103', -1, 1, 'attack', 'AttackFormation' },
+        },
+
+
+
+        ['OST_AirAttack_T2Gunships'] = {
+            'OST_AirAttacks_T2Gunships',
+            '',
+            { 'uea0203', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_AirAttack_T2TorpedoBombers'] = {
+            'OST_AirAttacks_T2TorpedoBombers',
+            '',
+            { 'uea0204', -1, 1, 'attack', 'AttackFormation' },
+        },
+
+
+
+
+        ['OST_AirAttacks_T3Platoon1'] = {
+            'OST_AirAttacks_T3Platoon1',
+            '',
+            { 'uea0303', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0203', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0102', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_AirAttacks_T3Platoon2'] = {
+            'OST_AirAttacks_T3Platoon2',
+            '',
+            { 'uea0304', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0203', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0103', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_AirAttacks_T3Platoon3'] = {
+            'OST_AirAttacks_T3Platoon3',
+            '',
+            { 'uea0303', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0203', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0103', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_AirAttacks_T3Platoon4'] = {
+            'OST_AirAttacks_T3Platoon4',
+            '',
+            { 'uea0304', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0203', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0102', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_AirAttacks_T3Platoon5UEF'] = {
+            'OST_AirAttacks_T3Platoon5UEF',
+            '',
+            { 'uea0305', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0203', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0103', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_AirAttacks_T3Platoon6UEF'] = {
+            'OST_AirAttacks_T3Platoon6UEF',
+            '',
+            { 'uea0305', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0203', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0102', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_AirAttacks_T3Platoon7Naval'] = {
+            'OST_AirAttacks_T3Platoon7Naval',
+            '',
+            { 'uea0303', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0204', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0102', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_AirAttacks_T3Platoon8Naval'] = {
+            'OST_AirAttacks_T3Platoon8Naval',
+            '',
+            { 'uea0304', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0204', -1, 1, 'attack', 'AttackFormation' },
+            { 'uea0103', -1, 1, 'attack', 'AttackFormation' },
+        },
+
+
+
+        ['OST_AirAttacks_T3StrategicBombers'] = {
+            'OST_AirAttacks_T3StrategicBombers',
+            '',
+            { 'uea0304', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_AirAttacks_T3AirSuperiority'] = {
+            'OST_AirAttacks_T3AirSuperiority',
+            '',
+            { 'uea0303', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_AirAttacks_T3HeavyGunships'] = {
+            'OST_AirAttacks_T3HeavyGunships',
+            '',
+            { 'uea0305', -1, 1, 'attack', 'AttackFormation' },
+        },
+
+    #########################################################################
+    ####################### XPACK PLATOONS ##################################
+    #########################################################################
+
+    #### COMMON ####
+        #### T1
+
+        #### T2
+
+        #### T3
+        ['OST_AirAttacks_T3HeavyGunshipPlatoon1'] = {
+            'OST_AirAttacks_T3HeavyGunshipPlatoon1', '',
+            { 'uea0303', -1, 1, 'attack', 'AttackFormation' },  #Air Sup
+            { 'uea0305', -1, 1, 'attack', 'AttackFormation' },  #XPack T3 Gunship
+            { 'uea0102', -1, 1, 'attack', 'AttackFormation' },  #Interceptor
+        },
+        ['OST_AirAttacks_T3HeavyGunshipPlatoon2'] = {
+            'OST_AirAttacks_T3HeavyGunshipPlatoon2', '',
+            { 'uea0304', -1, 1, 'attack', 'AttackFormation' },  #Strat Bomber
+            { 'uea0305', -1, 1, 'attack', 'AttackFormation' },  #XPack T3 Gunship
+            { 'uea0103', -1, 1, 'attack', 'AttackFormation' },  #Bomber
+        },
+        ['OST_AirAttacks_T3HeavyGunshipPlatoon3'] = {
+            'OST_AirAttacks_T3HeavyGunshipPlatoon3', '',
+            { 'uea0303', -1, 1, 'attack', 'AttackFormation' },  #Air Sup
+            { 'uea0305', -1, 1, 'attack', 'AttackFormation' },  #XPack T3 Gunship
+            { 'uea0103', -1, 1, 'attack', 'AttackFormation' },  #Bomber
+        },
+        ['OST_AirAttacks_T3HeavyGunshipPlatoon4'] = {
+            'OST_AirAttacks_T3HeavyGunshipPlatoon4', '',
+            { 'uea0304', -1, 1, 'attack', 'AttackFormation' },  #Strat Bomber
+            { 'uea0305', -1, 1, 'attack', 'AttackFormation' },  #XPack T3 Gunship
+            { 'uea0102', -1, 1, 'attack', 'AttackFormation' },  #Interceptor
+        },
+
+
+        #### Seraphim T2
+        ['OST_AirAttacks_T2SeraphimPlatoon1'] = {
+            'OST_AirAttacks_T2SeraphimPlatoon1', '',
+            { 'uea0203', -1, 1, 'attack', 'AttackFormation' },  #Gunship
+            { 'xsa0202', -1, 1, 'attack', 'AttackFormation' },  #Combat Fighter
+        },
+        ['OST_AirAttacks_T2SeraphimPlatoon2'] = {
+            'OST_AirAttacks_T2SeraphimPlatoon2', '',
+            { 'xsa0202', -1, 1, 'attack', 'AttackFormation' },  #Combat Fighter
+            { 'uea0103', -1, 1, 'attack', 'AttackFormation' },  #Bomber
+        },
+        ['OST_AirAttacks_T2SeraphimPlatoon3'] = {
+            'OST_AirAttacks_T2SeraphimPlatoon3', '',
+            { 'xsa0202', -1, 1, 'attack', 'AttackFormation' },  #Combat Fighter
+        },
+
+
+    #### AEON SPECIFIC ####
+        #### T1
+
+        #### T2
+        ['OST_AirAttacks_T2AeonPlatoon1'] = {
+            'OST_AirAttacks_T2AeonPlatoon1', '',
+            { 'uea0203', -1, 1, 'attack', 'AttackFormation' },  #Gunship
+            { 'xaa0202', -1, 1, 'attack', 'AttackFormation' },  #XPack Combat Fighter
+        },
+        ['OST_AirAttacks_T2AeonPlatoon2'] = {
+            'OST_AirAttacks_T2AeonPlatoon2', '',
+            { 'xaa0202', -1, 1, 'attack', 'AttackFormation' },  #XPack Combat Fighter
+            { 'uea0103', -1, 1, 'attack', 'AttackFormation' },  #Bomber
+        },
+        ['OST_AirAttacks_T2AeonPlatoon3'] = {
+            'OST_AirAttacks_T2AeonPlatoon3', '',
+            { 'xaa0202', -1, 1, 'attack', 'AttackFormation' },  #XPack Combat Fighter
+        },
+
+        #### T3
+        ['OST_AirAttacks_T3AeonAntiNaval1'] = {
+            'OST_AirAttacks_T3AeonAntiNaval1', '',
+            { 'xaa0306', -1, 1, 'attack', 'AttackFormation' },  #XPack Torp Bomber
+        },
+        ['OST_AirAttacks_T3AeonAntiNaval2'] = {
+            'OST_AirAttacks_T3AeonAntiNaval2', '',
+            { 'xaa0306', -1, 1, 'attack', 'AttackFormation' },  #XPack Torp Bomber
+            { 'uea0305', -1, 1, 'attack', 'AttackFormation' },  #XPack T3 Gunship
+        },
+
+    #### CYBRAN SPECIFIC ####
+        #### T1
+        ['OST_AirAttacks_T1CybranPlatoon1'] = {
+            'OST_AirAttacks_T1CybranPlatoon1', '',
+            { 'uea0103', -1, 1, 'attack', 'AttackFormation' },  #Bomber
+            { 'xra0105', -1, 1, 'attack', 'AttackFormation' },  #XPack Light Gunships
+        },
+        ['OST_AirAttacks_T1CybranPlatoon2'] = {
+            'OST_AirAttacks_T1CybranPlatoon2', '',
+            { 'uea0102', -1, 1, 'attack', 'AttackFormation' },  #Interceptor
+            { 'xra0105', -1, 1, 'attack', 'AttackFormation' },  #XPack Light Gunships
+        },
+        ['OST_AirAttacks_T1CybranPlatoon3'] = {
+            'OST_AirAttacks_T1CybranPlatoon3', '',
+            { 'xra0105', -1, 1, 'attack', 'AttackFormation' },  #XPack Light Gunships
+        },
+        ['OST_AirAttacks_T1CybranPlatoon4'] = {
+            'OST_AirAttacks_T1CybranPlatoon4', '',
+            { 'uea0103', -1, 1, 'attack', 'AttackFormation' },  #Bomber
+            { 'uea0102', -1, 1, 'attack', 'AttackFormation' },  #Interceptor
+            { 'xra0105', -1, 1, 'attack', 'AttackFormation' },  #XPack Light Gunship
+        },
+
+        #### T2
+
+        #### T3
+    },
+    --[[                                                                           ]]--
+    --[[  Armies                                                                   ]]--
+    --[[                                                                           ]]--
+    next_army_id = '2',
+    next_group_id = '1',
+    next_unit_id = '1',
+    Armies =
+    {
+        --[[                                                                           ]]--
+        --[[  Army                                                                     ]]--
+        --[[                                                                           ]]--
+        ['ARMY_1'] =
+        {
+            personality = '',
+            plans = '',
+            color = 0,
+            faction = 0,
+            Economy = {
+                mass = 0,
+                energy = 0,
+            },
+            Alliances = {
+            },
+            ['Units'] = GROUP {
+                orders = '',
+                platoon = '',
+                Units = {
+                    ['INITIAL'] = GROUP {
+                        orders = '',
+                        platoon = '',
+                        Units = {
+                        },
+                    },
+                },
+            },
+            PlatoonBuilders = {
+                next_platoon_builder_id = '10',
+                Builders = {
+                    ['OSB_Child_AirAttacks_T1Platoon1'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T1Platoon1',
+                        Priority = 693,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'Bombers', },
+                    },
+                    ['OSB_Child_AirAttacks_T1Platoon2'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T1Platoon2',
+                        Priority = 693,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'Interceptors', },
+                    },
+
+
+
+                    ['OSB_Child_AirAttacks_T2Platoon1'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2Platoon1',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'Gunships', 'Interceptors', },
+                    },
+                    ['OSB_Child_AirAttacks_T2Platoon2'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2Platoon2',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'Gunships', 'Bombers', },
+                    },
+                    ['OSB_Child_AirAttacks_T2Platoon3Naval'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2Platoon3Naval',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/otherarmyunitcountbuildconditions.lua', 'BrainGreaterThanNumCategory',
+                                {'default_brain','Player', 5 , categories.NAVAL * categories.MOBILE },
+                                {'default_brain','Player','5','categories.NAVAL * categories.MOBILE'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'TorpedoBombers', 'Interceptors', },
+                    },
+                    ['OSB_Child_AirAttacks_T2Platoon4Naval'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2Platoon3Naval',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/otherarmyunitcountbuildconditions.lua', 'BrainGreaterThanNumCategory',
+                                {'default_brain','Player', 5 , categories.NAVAL * categories.MOBILE },
+                                {'default_brain','Player','5','categories.NAVAL * categories.MOBILE'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'TorpedoBombers', 'Bombers', },
+                    },
+
+
+
+
+                    ['OSB_Child_AirAttacks_T2TorpedoBombers'] =  {
+                        PlatoonTemplate = 'OST_AirAttack_T2TorpedoBombers',
+                        Priority = 695,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            #[3] = {'/lua/editor/otherarmyunitcountbuildconditions.lua', 'BrainGreaterThanNumCategory',
+                            #    {'default_brain','Player', 5 , categories.NAVAL * categories.MOBILE },
+                            #    {'default_brain','Player','5','categories.NAVAL * categories.MOBILE'}
+                            #},
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'TorpedoBombers', },
+                    },
+                    ['OSB_Child_AirAttacks_T2Gunships'] =  {
+                        PlatoonTemplate = 'OST_AirAttack_T2Gunships',
+                        Priority = 695,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'Gunships', },
+                    },
+
+
+
+
+
+                    ['OSB_Child_AirAttacks_T3Platoon1'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3Platoon1',
+                        Priority = 699,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 1 },
+                                {'default_brain','default_builder_name','1'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'AirSuperiority', 'Gunships', 'Interceptors', },
+                    },
+                    ['OSB_Child_AirAttacks_T3Platoon2'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3Platoon2',
+                        Priority = 699,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 1 },
+                                {'default_brain','default_builder_name','1'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'StratBombers', 'Gunships', 'Bombers',  },
+                    },
+                    ['OSB_Child_AirAttacks_T3Platoon3'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3Platoon3',
+                        Priority = 699,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 1 },
+                                {'default_brain','default_builder_name','1'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'AirSuperiority', 'Gunships', 'Interceptors', },
+                    },
+                    ['OSB_Child_AirAttacks_T3Platoon4'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3Platoon4',
+                        Priority = 699,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 1 },
+                                {'default_brain','default_builder_name','1'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'StratBombers', 'Gunships', 'Interceptors', },
+                    },
+                    ['OSB_Child_AirAttacks_T3Platoon5UEF'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3Platoon5UEF',
+                        Priority = 699,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 1 },
+                                {'default_brain','default_builder_name','1'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1 , 0 },
+                                {'default_brain','1','0'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                                --{type = 2, name = 'APPEND_BomberChildren',  value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'HeavyGunships', 'Gunships', 'Bombers', },
+                    },
+                    ['OSB_Child_AirAttacks_T3Platoon6UEF'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3Platoon6UEF',
+                        Priority = 699,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 1 },
+                                {'default_brain','default_builder_name','1'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1 , 0 },
+                                {'default_brain','1','0'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                                --{type = 2, name = 'APPEND_BomberChildren',  value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'HeavyGunships', 'Gunships', 'Interceptors', },
+                    },
+                    ['OSB_Child_AirAttacks_T3Platoon7Naval'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3Platoon7Naval',
+                        Priority = 699,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/otherarmyunitcountbuildconditions.lua', 'BrainGreaterThanNumCategory',
+                                {'default_brain','Player', 5 , categories.NAVAL * categories.MOBILE },
+                                {'default_brain','Player','5','categories.NAVAL * categories.MOBILE'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'AirSuperiority', 'TorpedoBombers', 'Interceptors', },
+                    },
+                    ['OSB_Child_AirAttacks_T3Platoon8Naval'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3Platoon8Naval',
+                        Priority = 699,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/otherarmyunitcountbuildconditions.lua', 'BrainGreaterThanNumCategory',
+                                {'default_brain','Player', 5 , categories.NAVAL * categories.MOBILE },
+                                {'default_brain','Player','5','categories.NAVAL * categories.MOBILE'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'StratBombers', 'TorpedoBombers', 'Bombers', },
+                    },
+
+
+
+
+
+                    ['OSB_Child_AirAttacks_T3StrategicBombers'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3StrategicBombers',
+                        Priority = 698,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 1 },
+                                {'default_brain','default_builder_name','1'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                                --{type = 2, name = 'APPEND_BomberChildren',  value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'StratBombers', },
+                    },
+                    ['OSB_Child_AirAttacks_T3AirSuperiority'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3AirSuperiority',
+                        Priority = 698,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 1 },
+                                {'default_brain','default_builder_name','1'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                                --{type = 2, name = 'APPEND_BomberChildren',  value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'AirSuperiority', },
+                    },
+                    ['OSB_Child_AirAttacks_T3HeavyGunships'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3HeavyGunships',
+                        Priority = 698,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 1 },
+                                {'default_brain','default_builder_name','1'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 2, 3 },
+                                {'default_brain','1', '2', '3'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                                --{type = 2, name = 'APPEND_BomberChildren',  value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'HeavyGunships', },
+                    },
+
+
+    #########################################################################
+    ####################### XPACK PLATOONS ##################################
+    #########################################################################
+
+    #### COMMON ####
+            #### T1
+
+            #### T2
+
+            #### T3
+                    ['OSB_Child_AirAttacks_T3HeavyGunshipPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3HeavyGunshipPlatoon1',
+                        Priority = 699,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 1 },
+                                {'default_brain','default_builder_name','1'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 2 , 3 },
+                                {'default_brain', '1', '2','3' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'AirSuperiority', 'HeavyGunships', 'Interceptors', },
+                    },
+                    ['OSB_Child_AirAttacks_T3HeavyGunshipPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3HeavyGunshipPlatoon2',
+                        Priority = 699,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 1 },
+                                {'default_brain','default_builder_name','1'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 2 , 3 },
+                                {'default_brain', '1', '2','3' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'StratBombers', 'HeavyGunships', 'Bombers', },
+                    },
+                    ['OSB_Child_AirAttacks_T3HeavyGunshipPlatoon3'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3HeavyGunshipPlatoon3',
+                        Priority = 699,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 1 },
+                                {'default_brain','default_builder_name','1'},
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 2, 3 },
+                                {'default_brain', '1', '2', '3' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'AirSuperiority', 'HeavyGunships', 'Bombers', },
+                    },
+                    ['OSB_Child_AirAttacks_T3HeavyGunshipPlatoon4'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3HeavyGunshipPlatoon4',
+                        Priority = 699,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 1 },
+                                {'default_brain','default_builder_name','1'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 2, 3 },
+                                {'default_brain', '1', '2','3' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'StratBombers', 'HeavyGunships', 'Interceptors', },
+                    },
+
+
+
+                ########## Seraphim stuff.
+                    ['OSB_Child_AirAttacks_T2SeraphimPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2SeraphimPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain',4, 0 },
+                                {'default_brain', '4','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'Gunships', 'CombatFighters', },
+                    },
+                    ['OSB_Child_AirAttacks_T2SeraphimPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2SeraphimPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 4, 0 },
+                                {'default_brain', '4','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Bombers', 'CombatFighters'},
+                    },
+                    ['OSB_Child_AirAttacks_T2SeraphimPlatoon3'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2SeraphimPlatoon3',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 4, 0 },
+                                {'default_brain', '4','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'CombatFighters'},
+                    },
+
+    #### AEON SPECIFIC ####
+            #### T1
+
+            #### T2
+                    ['OSB_Child_AirAttacks_T2AeonPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2AeonPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 0 },
+                                {'default_brain', '2','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'Gunships', 'CombatFighters', },
+                    },
+                    ['OSB_Child_AirAttacks_T2AeonPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2AeonPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 0 },
+                                {'default_brain', '2','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Bombers', 'CombatFighters'},
+                    },
+                    ['OSB_Child_AirAttacks_T2AeonPlatoon3'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2AeonPlatoon3',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 0 },
+                                {'default_brain', '2','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'CombatFighters'},
+                    },
+            #### T3
+                    ['OSB_Child_AirAttacks_T3AeonAntiNaval1'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3AeonAntiNaval1',
+                        Priority = 699,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/otherarmyunitcountbuildconditions.lua', 'BrainGreaterThanNumCategory',
+                                {'default_brain','Player', 5 , categories.NAVAL * categories.MOBILE },
+                                {'default_brain','Player','5','categories.NAVAL * categories.MOBILE'}
+                            },
+                            [4] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 0 },
+                                {'default_brain', '2','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'HeavyTorpedoBombers' },
+                    },
+                    ['OSB_Child_AirAttacks_T3AeonAntiNaval2'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T3AeonAntiNaval2',
+                        Priority = 699,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/otherarmyunitcountbuildconditions.lua', 'BrainGreaterThanNumCategory',
+                                {'default_brain','Player', 5 , categories.NAVAL * categories.MOBILE },
+                                {'default_brain','Player','5','categories.NAVAL * categories.MOBILE'}
+                            },
+                            [4] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 0 },
+                                {'default_brain', '2','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'HeavyTorpedoBombers', 'HeavyGunships', },
+                    },
+
+    #### CYBRAN SPECIFIC ####
+            #### T1
+
+            #### T2
+
+            #### T3
+                    ['OSB_Child_AirAttacks_T1CybranPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T1CybranPlatoon1',
+                        Priority = 693,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 3, 0 },
+                                {'default_brain', '3','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'Bombers', 'LightGunships' },
+                    },
+                    ['OSB_Child_AirAttacks_T1CybranPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T1CybranPlatoon2',
+                        Priority = 693,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 3, 0 },
+                                {'default_brain', '3','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'Interceptors', 'LightGunships'},
+                    },
+                    ['OSB_Child_AirAttacks_T1CybranPlatoon3'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T1CybranPlatoon3',
+                        Priority = 693,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 3, 0 },
+                                {'default_brain', '3','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'LightGunships'},
+                    },
+                    ['OSB_Child_AirAttacks_T1CybranPlatoon4'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T1CybranPlatoon4',
+                        Priority = 693,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 3, 0 },
+                                {'default_brain', '3','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'Bombers', 'Interceptors', 'LightGunships'},
+                    },
+
+########################################################################################
+
+                    ['OSB_Master_AirAttacks'] =  {
+                        PlatoonTemplate = 'OST_BLANK_TEMPLATE',
+                        Priority = 700,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        BuildTimeOut = 500,
+                        PlatoonType = 'Air',
+                        RequiresConstruction = false,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'PlatoonAttackHighestThreat',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackMasterCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonBuildCallbacks = {
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMUnlockPlatoon',
+                                {'default_brain','default_platoon'},
+                                {'default_brain','default_platoon'}
+                            },
+                        },
+                        PlatoonAddFunctions = {
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMLockPlatoon',
+                                {'default_platoon'},
+                                {'default_platoon'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 3, name = 'AMMasterPlatoon',  value = true},
+                            {type = 3, name = 'UsePool', value = false},
+                        },
+                    },
+                },
+            },
+        },
+    },
+}

--- a/lua/AI/OpAI/AirAttacks_save.lua
+++ b/lua/AI/OpAI/AirAttacks_save.lua
@@ -226,6 +226,23 @@ Scenario = {
         },
 
 
+    #### UEF SPECIFC ####
+        #### T2
+        ['OST_AirAttacks_T2UEFPlatoon1'] = {
+            'OST_AirAttacks_T2UEFPlatoon1', '',
+            { 'uea0203', -1, 1, 'attack', 'AttackFormation' },  #Gunship
+            { 'dea0202', -1, 1, 'attack', 'AttackFormation' },  #XPack Combat Fighter
+        },
+        ['OST_AirAttacks_T2UEFPlatoon2'] = {
+            'OST_AirAttacks_T2UEFPlatoon2', '',
+            { 'dea0202', -1, 1, 'attack', 'AttackFormation' },  #XPack Combat Fighter
+            { 'uea0103', -1, 1, 'attack', 'AttackFormation' },  #Bomber
+        },
+        ['OST_AirAttacks_T2UEFPlatoon3'] = {
+            'OST_AirAttacks_T2UEFPlatoon3', '',
+            { 'dea0202', -1, 1, 'attack', 'AttackFormation' },  #XPack Combat Fighter
+        },
+
     #### AEON SPECIFIC ####
         #### T1
 
@@ -280,6 +297,20 @@ Scenario = {
         },
 
         #### T2
+        ['OST_AirAttacks_T2CybranPlatoon1'] = {
+            'OST_AirAttacks_T2CybranPlatoon1', '',
+            { 'ura0203', -1, 1, 'attack', 'AttackFormation' },  #Gunship
+            { 'dra0202', -1, 1, 'attack', 'AttackFormation' },  #XPack Combat Fighter
+        },
+        ['OST_AirAttacks_T2CybranPlatoon2'] = {
+            'OST_AirAttacks_T2CybranPlatoon2', '',
+            { 'dra0202', -1, 1, 'attack', 'AttackFormation' },  #XPack Combat Fighter
+            { 'ura0103', -1, 1, 'attack', 'AttackFormation' },  #Bomber
+        },
+        ['OST_AirAttacks_T2CybranPlatoon3'] = {
+            'OST_AirAttacks_T2CybranPlatoon3', '',
+            { 'dra0202', -1, 1, 'attack', 'AttackFormation' },  #XPack Combat Fighter
+        },
 
         #### T3
     },
@@ -1270,6 +1301,120 @@ Scenario = {
                         ChildrenType = {'CombatFighters'},
                     },
 
+    #### UEF SPECIFIC ####
+            #### T2
+                    ['OSB_Child_AirAttacks_T2UEFPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2UEFPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 0 },
+                                {'default_brain', '1','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'Gunships', 'CombatFighters', },
+                    },
+                    ['OSB_Child_AirAttacks_T2UEFPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2UEFPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 0 },
+                                {'default_brain', '1','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Bombers', 'CombatFighters'},
+                    },
+                    ['OSB_Child_AirAttacks_T2UEFPlatoon3'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2UEFPlatoon3',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 0 },
+                                {'default_brain', '1','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'CombatFighters'},
+                    }, 
+
     #### AEON SPECIFIC ####
             #### T1
 
@@ -1463,10 +1608,6 @@ Scenario = {
 
     #### CYBRAN SPECIFIC ####
             #### T1
-
-            #### T2
-
-            #### T3
                     ['OSB_Child_AirAttacks_T1CybranPlatoon1'] =  {
                         PlatoonTemplate = 'OST_AirAttacks_T1CybranPlatoon1',
                         Priority = 693,
@@ -1599,6 +1740,121 @@ Scenario = {
                         },
                         ChildrenType = { 'Bombers', 'Interceptors', 'LightGunships'},
                     },
+
+            #### T2
+                    ['OSB_Child_AirAttacks_T2CybranPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2CybranPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 3, 0 },
+                                {'default_brain', '3','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = { 'Gunships', 'CombatFighters', },
+                    },
+                    ['OSB_Child_AirAttacks_T2CybranPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2CybranPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 3, 0 },
+                                {'default_brain', '3','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Bombers', 'CombatFighters'},
+                    },
+                    ['OSB_Child_AirAttacks_T2CybranPlatoon3'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2CybranPlatoon3',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 3, 0 },
+                                {'default_brain', '3','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'CombatFighters'},
+                    },
+
+            #### T3
 
 ########################################################################################
 


### PR DESCRIPTION
Platoon templates for campaign AI that will allow it to build UEF and Cybran T2 air fighters. Also removed build condition for T3 torp bombers so AI can build it even if player has no navy.