### PR TITLE
Fade out wreckage when reclaiming it

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -97,6 +97,8 @@ Patch 3652 (pending)
 - Log-spam from various known events heavily reduced
 - Lots of work adapting and improving AI behavior for coop gameplay (speed2)
 - Scale aeon build effects according to build progress 
+- Fade away wreckage when it is being reclaimed
+- Show wreckage debris in reclaim beam
 
 **Contributors**
 - Sheeo

--- a/effects/emitters/reclaim_beam_04_emit.bp
+++ b/effects/emitters/reclaim_beam_04_emit.bp
@@ -1,0 +1,12 @@
+BeamBlueprint {
+    Lifetime = 2,
+    TextureName = '/textures/particles/debris_alpha_03.dds',
+    Thickness = 0.2,
+    StartColor = {x=1,y=1,z=1,w=0}, # R,G,B,A
+    EndColor = {x=0.5,y=0.5,z=0.5,w=0}, # R,G,B,A
+    Length = 8,
+    Blendmode = 1,
+    RepeatRate = 0.3,
+    UShift = 0.0,
+    VShift = 0.3,
+}

--- a/effects/emitters/reclaim_beam_05_emit.bp
+++ b/effects/emitters/reclaim_beam_05_emit.bp
@@ -1,0 +1,12 @@
+BeamBlueprint {
+    Lifetime = 2,
+    TextureName = '/textures/particles/debris_alpha_01.dds',
+    Thickness = 0.2,
+    StartColor = {x=1,y=1,z=1,w=0}, # R,G,B,A
+    EndColor = {x=0,y=0,z=0,w=0}, # R,G,B,A
+    Length = 8,
+    Blendmode = 1,
+    RepeatRate = 0.5,
+    UShift = 0.0,
+    VShift = 0.1,
+}

--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -2409,7 +2409,7 @@ float4 WreckagePS( NORMALMAPPED_VERTEX vertex) : COLOR0
     else
         color *= specular.b * 2;
 
-	return float4( color, glowMinimum );
+	return float4( color, sqrt(sqrt(vertex.material.y)) * albedo.a);
 }
 
 float4 WreckagePS_LowFidelity(VERTEXNORMAL_VERTEX vertex) : COLOR0
@@ -5957,12 +5957,13 @@ technique Wreckage_MedFidelity
     string cartographicTechnique = "CartographicFeature";    
     string depthTechnique = "Depth";
     int renderStage = STAGE_DEPTH + STAGE_PREWATER + STAGE_PREEFFECT;
-    int parameter = PARAM_UNUSED;
+    int parameter = PARAM_FRACTIONCOMPLETE;
 >
 {
     pass P0
     {
-		RasterizerState( Rasterizer_Cull_CW )
+		AlphaState( AlphaBlend_SrcAlpha_InvSrcAlpha_Write_RGB )
+        RasterizerState( Rasterizer_Cull_CW )
 
         VertexShader = compile vs_2_0 WreckageVS_HighFidelity();
         PixelShader = compile ps_2_0 WreckagePS();
@@ -5976,11 +5977,12 @@ technique Wreckage_LowFidelity
     
     string cartographicTechnique = "CartographicFeature";    
     int renderStage = STAGE_PREWATER + STAGE_PREEFFECT;
-    int parameter = PARAM_UNUSED;
+    int parameter = PARAM_FRACTIONCOMPLETE;
 >
 {
     pass P0
     {
+        AlphaState( AlphaBlend_SrcAlpha_InvSrcAlpha_Write_RGB )
 		RasterizerState( Rasterizer_Cull_CW )
 	
         VertexShader = compile vs_1_1 WreckageVS_LowFidelity();

--- a/lua/EffectTemplates.lua
+++ b/lua/EffectTemplates.lua
@@ -544,6 +544,8 @@ ReclaimBeams = {
     EmtBpPath .. 'reclaim_beam_01_emit.bp',
     EmtBpPath .. 'reclaim_beam_02_emit.bp',
     EmtBpPath .. 'reclaim_beam_03_emit.bp',	
+    EmtBpPath .. 'reclaim_beam_04_emit.bp',
+    EmtBpPath .. 'reclaim_beam_05_emit.bp',
 }
 
 ReclaimObjectAOE = { '/effects/emitters/reclaim_01_emit.bp' }


### PR DESCRIPTION
Shade the wreckages so they fade out (instead of popping out of existance) as they are being reclaimed, main part of fading occurs at the end of the reclaim.