### PR TITLE
No lag in singleplayer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -93,6 +93,7 @@ Patch 3652 (pending)
 - Tweaks to hive build effects to reduce performance impact
 - Cleanup of enhancement sync code to make it faster and more secure
 - Entities now re-use repeated sound FX instead of creating new ones every time
+- 100% command responsiveness in singleplayer mode
 
 **Other**
 - Added game-side support for future achievement system

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -236,6 +236,12 @@ function CreateUI(isReplay)
         import('/lua/ui/game/economy.lua').ToggleEconPanel(false)
         import('/lua/ui/game/avatars.lua').ToggleAvatars(false)
         AddBeatFunction(UiBeat)
+    else
+        local clients = GetSessionClients()
+        if table.getsize(clients) <= 1 then
+            -- no need for unnecessary lag when playing alone
+            ConExecute('net_lag 0')
+        end
     end
 
     import('/modules/scumanager.lua').Init()


### PR DESCRIPTION
Removes command lag for singleplayer games (vs AI / sandbox etc).

One objection could be that uber-sandbox nerds complain their orders go through too fast compared to a real network game. Against AI that isn't an issue, could be alleviated by checking win conditions or some option in gameplay.