### PR TITLE
Reduce load on render thread

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -93,6 +93,7 @@ Patch 3652 (pending)
 - Tweaks to hive build effects to reduce performance impact
 - Cleanup of enhancement sync code to make it faster and more secure
 - Entities now re-use repeated sound FX instead of creating new ones every time
+- Reduce load on render thread
 
 **Other**
 - Added game-side support for future achievement system

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -6,6 +6,7 @@
 --* Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --*****************************************************************************
 
+local utils = import('/lua/system/utils.lua')
 local UIUtil = import('/lua/ui/uiutil.lua')
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 local Group = import('/lua/maui/group.lua').Group
@@ -247,6 +248,22 @@ function CreateUI(isReplay)
     RegisterChatFunc(SendResumedBy, 'SendResumedBy')
 end
 
+-- Current SC_FrameTimeClamp settings allows up to 100 fps as default (some users probably set this to 0 to "increase fps" which would be counter-productive)
+-- Lets find out max hz capability of adapter so we don't render unecessary frames, should help a bit with render thread at 100%
+function AdjustFrameRate()
+    if options.vsync == 1 then return end
+
+    local video = options.video
+    local fps = 100
+
+    if type(options.primary_adapter) == 'string' then
+        local data = utils.StringSplit(options.primary_adapter, ',')
+        fps = math.max(60, math.min(100, data[3]))
+    end
+
+    ConExecute("SC_FrameTimeClamp " .. (1000 / fps ))
+end
+
 local provider = false
 
 local function LoadDialog(parent)
@@ -385,6 +402,7 @@ function CreateWldUIProvider()
         end
         supressExitDialog = false
         FlushEvents()
+        AdjustFrameRate()
     end
 
     provider.DestroyGameInterface = function(self)


### PR DESCRIPTION
Current clamp is set at max 100 fps, users running with vsync off but with an
adapter @ 60 hz could get a waste up to 40 fps. With this change we try to find out the current adapter's hz setting so we don't render unecessarily.

A test with 1000 patrolling UEF planes where I had 100 fps @ 60 hz  (render thread maxxed out @ 100% CPU) resulted in 30% less cpu usage for that thread. This was on a 4-core / 8 ht machine so someone running 2 cores or less would probably see even more.

This will also take care of crazy users who manually set it to 0 to "max out fps" while not understanding that they will just stall cpu while rendering stuff which isn't shown anyway due to adapter limit.

TA should be happy.