### PR TITLE
Make sure originalBuilder still works on focus

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -999,7 +999,7 @@ Unit = Class(moho.unit_methods) {
             elseif focus then --Handling upgrades
                 if self:IsUnitState('Upgrading') then
                     baseData = self:GetBlueprint().Economy --Upgrading myself, substract ev. baseCost
-                elseif focus.originalBuilder and not focus.originalBuilder.Dead and focus.originalBuilder:IsUnitState('Upgrading') then
+                elseif focus.originalBuilder and not focus.originalBuilder.Dead and focus.originalBuilder:IsUnitState('Upgrading') and focus.originalBuilder:GetFocusUnit() == focus then
                     baseData = focus.originalBuilder:GetBlueprint().Economy
                 end
 


### PR DESCRIPTION
Need to make sure an upgrading, original builder is actually upgrading (building) the focus unit instead of itself. 

Fix for #1159 

