### PR TITLE
Fix reclaim value of prop on EOTS

### DIFF
--- a/env/Aeon/Props/Aeon_Fence_prop.bp
+++ b/env/Aeon/Props/Aeon_Fence_prop.bp
@@ -1,0 +1,41 @@
+PropBlueprint {
+    Categories = {
+        'RECLAIMABLE',
+    },
+    Defense = {
+        Health = 50,
+        MaxHealth = 50,
+    },
+    Display = {
+        Mesh = {
+            IconFadeInZoom = 4,
+            LODs = {
+                {
+
+                    AlbedoName = 'aeon_fence_Albedo.dds',
+	  	    		SpecName = 'aeon_fence_SpecTeam.dds',
+                    LODCutoff = 200,
+                    ShaderName = 'Unit',
+                },
+            },
+        },
+        UniformScale = 0.2,
+    },
+    Economy = {
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0.5,
+        ReclaimTime = 5,
+    },
+    Footprint = {
+        OccupancyCaps = 3,
+    },
+    Interface = {
+        HelpText = 'Aeon Fence',
+    },
+    Physics = {
+        BlockPath = true,
+    },
+    SizeX = .5,
+    SizeY = .5,
+    SizeZ = 1,
+}


### PR DESCRIPTION
This one was the 300 mass bullshit near every starting position that is totally not obvious. Changed
it to 0.5 as other faction fence.