### PR TITLE
Reduce energy drain with adjacency

### DIFF
--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -192,7 +192,7 @@ DefaultProjectileWeapon = Class(Weapon) {
     -- Determine how much Energy should be drained per second
     GetWeaponEnergyDrain = function(self)
         local bp = self:GetBlueprint()
-        local weapNRG = (bp.EnergyDrainPerSecond or 0)
+        local weapNRG = (bp.EnergyDrainPerSecond or 0) * (self.AdjEnergyMod or 1)
         return weapNRG
     end,
 


### PR DESCRIPTION
Change energy drain as well with adjacency so we get the UI to show the actual
energy cost reduction for a weapon with adjacency.

Fixes #1185