### PR TITLE
Refactor MovingArms sliders

### DIFF
--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -245,51 +245,6 @@ CSeaFactoryUnit = Class(SeaFactoryUnit) {
     StartBuildingEffects = function( self, unitBeingBuilt, order )
         self.BuildEffectsBag:Add( self:ForkThread( EffectUtil.CreateCybranBuildBeams, unitBeingBuilt, self:GetBlueprint().General.BuildBones.BuildEffectBones, self.BuildEffectsBag ) )
     end,
-
-    OnPaused = function(self)
-        SeaFactoryUnit.OnPaused(self)
-        self:StopArmsMoving()
-    end,
-
-    OnUnpaused = function(self)
-        SeaFactoryUnit.OnUnpaused(self)
-        if self:GetNumBuildOrders(categories.ALLUNITS) > 0 and not self:IsUnitState('Upgrading') and self:IsUnitState('Building') then
-            self:StartArmsMoving()
-        end
-    end,
-
-    OnStartBuild = function(self, unitBeingBuilt, order )
-        SeaFactoryUnit.OnStartBuild(self, unitBeingBuilt, order )
-        if order ~= 'Upgrade' then
-            self:StartArmsMoving()
-        end
-    end,
-
-    OnStopBuild = function(self, unitBuilding)
-        SeaFactoryUnit.OnStopBuild(self, unitBuilding)
-        self:StopArmsMoving()
-    end,
-
-    OnFailedToBuild = function(self)
-        SeaFactoryUnit.OnFailedToBuild(self)
-        if not self.Dead then
-            self:StopArmsMoving()
-        end
-    end,
-
-    StartArmsMoving = function(self)
-        self.ArmsThread = self:ForkThread(self.MovingArmsThread)
-    end,
-
-    MovingArmsThread = function(self)
-    end,
-
-    StopArmsMoving = function(self)
-        if self.ArmsThread then
-            KillThread(self.ArmsThread)
-            self.ArmsThread = nil
-        end
-    end,
 }
 
 ---------------------------------------------------------------

--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -355,7 +355,7 @@ CConstructionEggUnit = Class(CStructureUnit) {
         local buildUnit = bp.Economy.BuildUnit
         local pos = self:GetPosition()
         local aiBrain = self:GetAIBrain()
-        
+
         self.Spawn = CreateUnitHPR(
             buildUnit,
             aiBrain.Name,
@@ -367,20 +367,20 @@ CConstructionEggUnit = Class(CStructureUnit) {
                 self.Trash:Add(self.OpenAnimManip)
                 self.OpenAnimManip:PlayAnim(self:GetBlueprint().Display.AnimationOpen, false):SetRate(0.1)
                 self:PlaySound(bp.Audio['EggOpen'])
-                
+
                 WaitFor(self.OpenAnimManip)
 
                 self.EggSlider = CreateSlider(self, 0, 0, -20, 0, 5)
                 self.Trash:Add(self.EggSlider)
                 self:PlaySound(bp.Audio['EggSink'])
-                
+
                 WaitFor(self.EggSlider)
 
                 self:Destroy()
             end
         )
     end,
-    
+
     OnKilled = function(self, instigator, type, overkillRatio)
         if self.Spawn then overkillRatio = 1.1 end
         CStructureUnit.OnKilled(self, instigator, type, overkillRatio)

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1803,7 +1803,7 @@ BaseTransport = Class() {
                 unit.attachmentBone = i
             end
         end
-        
+
         unit:OnAttachedToTransport(self, attachBone)
     end,
 

--- a/lua/terranunits.lua
+++ b/lua/terranunits.lua
@@ -60,45 +60,22 @@ TAirFactoryUnit = Class(AirFactoryUnit) {
 
     OnPaused = function(self)
         AirFactoryUnit.OnPaused(self)
-        self:StopArmsMoving()
     end,
 
     OnUnpaused = function(self)
         AirFactoryUnit.OnUnpaused(self)
-        if self:GetNumBuildOrders(categories.ALLUNITS) > 0 and not self:IsUnitState('Upgrading') then
-            self:StartArmsMoving()
-        end
     end,
 
     OnStartBuild = function(self, unitBeingBuilt, order )
         AirFactoryUnit.OnStartBuild(self, unitBeingBuilt, order )
-        if order  ~= 'Upgrade' then
-            self:StartArmsMoving()
-        end
     end,
 
     OnStopBuild = function(self, unitBuilding)
         AirFactoryUnit.OnStopBuild(self, unitBuilding)
-        self:StopArmsMoving()
     end,
 
     OnFailedToBuild = function(self)
         AirFactoryUnit.OnFailedToBuild(self)
-        self:StopArmsMoving()
-    end,
-   
-    StartArmsMoving = function(self)
-        self.ArmsThread = self:ForkThread(self.MovingArmsThread)
-    end,
-
-    MovingArmsThread = function(self)
-    end,
-    
-    StopArmsMoving = function(self)
-        if self.ArmsThread then
-            KillThread(self.ArmsThread)
-            self.ArmsThread = nil
-        end
     end,
 }
 
@@ -274,45 +251,22 @@ TSeaFactoryUnit = Class(SeaFactoryUnit) {
 
     OnPaused = function(self)
         SeaFactoryUnit.OnPaused(self)
-        self:StopArmsMoving()
     end,
 
     OnUnpaused = function(self)
         SeaFactoryUnit.OnUnpaused(self)
-        if self:GetNumBuildOrders(categories.ALLUNITS) > 0 and not self:IsUnitState('Upgrading') then
-            self:StartArmsMoving()
-        end
     end,
 
     OnStartBuild = function(self, unitBeingBuilt, order )
         SeaFactoryUnit.OnStartBuild(self, unitBeingBuilt, order )
-        if order  ~= 'Upgrade' then
-            self:StartArmsMoving()
-        end
     end,
 
     OnStopBuild = function(self, unitBuilding)
         SeaFactoryUnit.OnStopBuild(self, unitBuilding)
-        self:StopArmsMoving()
     end,
 
     OnFailedToBuild = function(self)
         SeaFactoryUnit.OnFailedToBuild(self)
-        self:StopArmsMoving()
-    end,
-   
-    StartArmsMoving = function(self)
-        self.ArmsThread = self:ForkThread(self.MovingArmsThread)
-    end,
-
-    MovingArmsThread = function(self)
-    end,
-    
-    StopArmsMoving = function(self)
-        if self.ArmsThread then
-            KillThread(self.ArmsThread)
-            self.ArmsThread = nil
-        end
     end,
 }
 

--- a/lua/terranunits.lua
+++ b/lua/terranunits.lua
@@ -49,20 +49,20 @@ local CreateUEFBuildSliceBeams = EffectUtil.CreateUEFBuildSliceBeams
 --  AIR FACTORY STRUCTURES
 --------------------------------------------------------------
 TAirFactoryUnit = Class(AirFactoryUnit) {
-    
+
     CreateBuildEffects = function( self, unitBeingBuilt, order )
         WaitSeconds( 0.1 )
         for k, v in self:GetBlueprint().General.BuildBones.BuildEffectBones do
-            self.BuildEffectsBag:Add( CreateAttachedEmitter( self, v, self:GetArmy(), '/effects/emitters/flashing_blue_glow_01_emit.bp' ) )         
+            self.BuildEffectsBag:Add( CreateAttachedEmitter( self, v, self:GetArmy(), '/effects/emitters/flashing_blue_glow_01_emit.bp' ) )
             self.BuildEffectsBag:Add( self:ForkThread( EffectUtil.CreateDefaultBuildBeams, unitBeingBuilt, {v}, self.BuildEffectsBag ) )
         end
     end,
-   
+
     OnPaused = function(self)
         AirFactoryUnit.OnPaused(self)
         self:StopArmsMoving()
     end,
-    
+
     OnUnpaused = function(self)
         AirFactoryUnit.OnUnpaused(self)
         if self:GetNumBuildOrders(categories.ALLUNITS) > 0 and not self:IsUnitState('Upgrading') then
@@ -76,7 +76,7 @@ TAirFactoryUnit = Class(AirFactoryUnit) {
             self:StartArmsMoving()
         end
     end,
-   
+
     OnStopBuild = function(self, unitBuilding)
         AirFactoryUnit.OnStopBuild(self, unitBuilding)
         self:StopArmsMoving()
@@ -130,8 +130,8 @@ TConstructionUnit = Class(ConstructionUnit) {
         if (order == 'Repair' and not unitBeingBuilt:IsBeingBuilt()) or (UpgradesFrom and UpgradesFrom  ~= 'none' and self:IsUnitState('Guarding'))then
             EffectUtil.CreateDefaultBuildBeams( self, unitBeingBuilt, self:GetBlueprint().General.BuildBones.BuildEffectBones, self.BuildEffectsBag )
         else
-            CreateUEFBuildSliceBeams( self, unitBeingBuilt, self:GetBlueprint().General.BuildBones.BuildEffectBones, self.BuildEffectsBag )        
-        end           
+            CreateUEFBuildSliceBeams( self, unitBeingBuilt, self:GetBlueprint().General.BuildBones.BuildEffectBones, self.BuildEffectsBag )
+        end
     end,
 
     LayerChangeTrigger = function(self, new, old)
@@ -191,7 +191,7 @@ TLandFactoryUnit = Class(LandFactoryUnit) {
     CreateBuildEffects = function( self, unitBeingBuilt, order )
         WaitSeconds( 0.1 )
         for k, v in self:GetBlueprint().General.BuildBones.BuildEffectBones do
-            self.BuildEffectsBag:Add( CreateAttachedEmitter( self, v, self:GetArmy(), '/effects/emitters/flashing_blue_glow_01_emit.bp' ) ) 
+            self.BuildEffectsBag:Add( CreateAttachedEmitter( self, v, self:GetArmy(), '/effects/emitters/flashing_blue_glow_01_emit.bp' ) )
             self.BuildEffectsBag:Add( self:ForkThread( EffectUtil.CreateDefaultBuildBeams, unitBeingBuilt, {v}, self.BuildEffectsBag ) )
         end
     end,
@@ -215,10 +215,10 @@ TMassCollectionUnit = Class(MassCollectionUnit) {
     StartBeingBuiltEffects = function(self, builder, layer)
 		self:SetMesh(self:GetBlueprint().Display.BuildMeshBlueprint, true)
         if self:GetBlueprint().General.UpgradesFrom  ~= builder:GetUnitId() then
-			self:HideBone(0, true)        
+			self:HideBone(0, true)
             self.OnBeingBuiltEffectsBag:Add( self:ForkThread( CreateBuildCubeThread, builder, self.OnBeingBuiltEffectsBag ))
         end
-    end,    
+    end,
 }
 
 --------------------------------------------------------------
@@ -241,10 +241,10 @@ TMobileFactoryUnit = Class(LandUnit) {
     StartBeingBuiltEffects = function(self, builder, layer)
 		self:SetMesh(self:GetBlueprint().Display.BuildMeshBlueprint, true)
         if self:GetBlueprint().General.UpgradesFrom  ~= builder:GetUnitId() then
-			self:HideBone(0, true)        
+			self:HideBone(0, true)
             self.OnBeingBuiltEffectsBag:Add( self:ForkThread( CreateBuildCubeThread, builder, self.OnBeingBuiltEffectsBag ))
         end
-    end,   
+    end,
 }
 
 --------------------------------------------------------------
@@ -263,20 +263,20 @@ TSonarUnit = Class(SonarUnit) {
 --  SEA FACTORY STRUCTURES
 --------------------------------------------------------------
 TSeaFactoryUnit = Class(SeaFactoryUnit) {
-    
+
     CreateBuildEffects = function( self, unitBeingBuilt, order )
         WaitSeconds( 0.1 )
         for k, v in self:GetBlueprint().General.BuildBones.BuildEffectBones do
-            self.BuildEffectsBag:Add( CreateAttachedEmitter( self, v, self:GetArmy(), '/effects/emitters/flashing_blue_glow_01_emit.bp' ) )         
+            self.BuildEffectsBag:Add( CreateAttachedEmitter( self, v, self:GetArmy(), '/effects/emitters/flashing_blue_glow_01_emit.bp' ) )
             self.BuildEffectsBag:Add( self:ForkThread( EffectUtil.CreateDefaultBuildBeams, unitBeingBuilt, {v}, self.BuildEffectsBag ) )
         end
     end,
-   
+
     OnPaused = function(self)
         SeaFactoryUnit.OnPaused(self)
         self:StopArmsMoving()
     end,
-    
+
     OnUnpaused = function(self)
         SeaFactoryUnit.OnUnpaused(self)
         if self:GetNumBuildOrders(categories.ALLUNITS) > 0 and not self:IsUnitState('Upgrading') then
@@ -290,7 +290,7 @@ TSeaFactoryUnit = Class(SeaFactoryUnit) {
             self:StartArmsMoving()
         end
     end,
-   
+
     OnStopBuild = function(self, unitBuilding)
         SeaFactoryUnit.OnStopBuild(self, unitBuilding)
         self:StopArmsMoving()
@@ -334,7 +334,7 @@ TShieldStructureUnit = Class(ShieldStructureUnit) {
     	self:SetMesh(self:GetBlueprint().Display.BuildMeshBlueprint, true)
         if builder and EntityCategoryContains(categories.MOBILE, builder) then
             self:HideBone(0, true)
-            self.OnBeingBuiltEffectsBag:Add( self:ForkThread( CreateBuildCubeThread, builder, self.OnBeingBuiltEffectsBag )	)	
+            self.OnBeingBuiltEffectsBag:Add( self:ForkThread( CreateBuildCubeThread, builder, self.OnBeingBuiltEffectsBag )	)
         end
     end,
 }
@@ -354,7 +354,7 @@ TRadarJammerUnit = Class(RadarJammerUnit) {
         RadarJammerUnit.OnIntelEnabled(self)
         self.MySpinner:SetTargetSpeed(180)
     end,
-    
+
     OnIntelDisabled = function(self)
         RadarJammerUnit.OnIntelDisabled(self)
         self.MySpinner:SetTargetSpeed(0)
@@ -407,7 +407,7 @@ TPodTowerUnit = Class(TStructureUnit) {
         TStructureUnit.OnStopBeingBuilt(self, builder, layer)
         ChangeState( self, self.FinishedBeingBuilt )
     end,
-    
+
     PodTransfer = function(self, pod, podData)
         -- Set the pod as active, set new parent and creator for the pod, store the pod handle
         if not self.PodData[pod.PodName].Active then
@@ -419,7 +419,7 @@ TPodTowerUnit = Class(TStructureUnit) {
             pod:SetParent(self, pod.PodName)
         end
     end,
-    
+
     OnCaptured = function(self, captor)
         -- Iterate through pod data and set up callbacks for transfer of pods.
         -- We never get the handle to the new tower, so we set up a new unit capture trigger to do the same thing
@@ -427,12 +427,12 @@ TPodTowerUnit = Class(TStructureUnit) {
         for k,v in self.PodData do
             if v.Active then
                 v.Active = false
-            
+
                 -- store off the pod name so we can give to new unit
                 local podName = k
                 local newPod = import('/lua/ScenarioFramework.lua').GiveUnitToArmy( v.PodHandle, captor:GetArmy() )
                 newPod.PodName = podName
-                
+
                 -- create a callback for when the unit is flipped.  set creator for the new pod to the new tower
                 self:AddUnitCallback(
                     function(newUnit, captor)
@@ -442,11 +442,11 @@ TPodTowerUnit = Class(TStructureUnit) {
                 )
             end
         end
-        
+
         -- Calling the parent OnCaptured will cause all the callbacks to happen and happiness will reign !
         TStructureUnit.OnCaptured(self, captor)
     end,
-    
+
     OnDestroy = function(self)
         TStructureUnit.OnDestroy(self)
         -- Iterate through pod data, kill all the pods and set them inactive
@@ -458,7 +458,7 @@ TPodTowerUnit = Class(TStructureUnit) {
             end
         end
     end,
-    
+
     OnStartBuild = function(self, unitBeingBuilt, order )
         TStructureUnit.OnStartBuild(self,unitBeingBuilt,order)
         local unitid = self:GetBlueprint().General.UpgradesTo
@@ -467,16 +467,16 @@ TPodTowerUnit = Class(TStructureUnit) {
             ChangeState( self, self.UpgradingState )
         end
     end,
-    
+
     NotifyOfPodDeath = function(self,podName)
         self.PodData[podName].Active = false
     end,
-    
+
     NotifyOfPodStartBuild = function(self)
         if not self.OpeningAnimationStarted then
             self.OpeningAnimationStarted = true
             local bp = self:GetBlueprint()
-            if not bp.Display.AnimationOpen then return end    
+            if not bp.Display.AnimationOpen then return end
             if not self.OpenAnim then
                 self.OpenAnim = CreateAnimator(self)
                 self.Trash:Add(self.OpenAnim)
@@ -486,9 +486,9 @@ TPodTowerUnit = Class(TStructureUnit) {
             if not self.NowUpgrading then
                 self.OpenAnim:SetRate(0)
             end
-        end    
+        end
     end,
-    
+
     NotifyOfPodStopBuild = function(self)
         if self.OpeningAnimationStarted then
             local bp = self:GetBlueprint()
@@ -496,43 +496,43 @@ TPodTowerUnit = Class(TStructureUnit) {
             if not self.OpenAnim then return end
             self.OpenAnim:SetRate(1.5)
             self.OpeningAnimationStarted = false
-        end    
+        end
     end,
-    
+
     SetPodConsumptionRebuildRate = function(self, podData)
         local bp = self:GetBlueprint()
         -- Get build rate of tower
         local buildRate = bp.Economy.BuildRate
-        
+
         local energy_rate = ( podData.BuildCostEnergy / podData.BuildTime ) * buildRate
         local mass_rate = ( podData.BuildCostMass / podData.BuildTime ) * buildRate
-        
+
         -- Set Consumption - Buff system will replace this here
         self:SetConsumptionPerSecondEnergy(energy_rate)
         self:SetConsumptionPerSecondMass(mass_rate)
         self:SetConsumptionActive(true)
     end,
-    
+
     CreatePod = function(self, podName)
         local location = self:GetPosition( self.PodData[podName].PodAttachpoint )
         self.PodData[podName].PodHandle = CreateUnitHPR(self.PodData[podName].PodUnitID, self:GetArmy(), location[1], location[2], location[3], 0, 0, 0)
         self.PodData[podName].PodHandle:SetParent(self, podName)
         self.PodData[podName].Active = true
     end,
-    
+
     OnTransportAttach = function(self, bone, attachee)
         attachee:SetDoNotTarget(true)
     end,
-    
+
     OnTransportDetach = function(self, bone, attachee)
         attachee:SetDoNotTarget(false)
     end,
-    
+
     FinishedBeingBuilt = State {
         Main = function(self)
             -- Wait one tick to make sure this wasn't captured and we don't create an extra pod
             WaitSeconds(0.1)
-            
+
             -- Create the pod for the kennel.  DO NOT ADD TO TRASH.
             -- This pod may have to be passed to another unit after it upgrades.  We cannot let the trash clean it up
             -- when this unit is destroyed at the tail end of the upgrade.  Make sure the unit dies properly elsewhere.
@@ -572,12 +572,12 @@ TPodTowerUnit = Class(TStructureUnit) {
 
                         self.PodData[v.PodName].BuildCostEnergy = podBP.Economy.BuildCostEnergy
                         self.PodData[v.PodName].BuildCostMass = podBP.Economy.BuildCostMass
-                        
+
                         self.PodData[v.PodName].BuildTime = podBP.Economy.BuildTime
-                        
+
                         -- Enable consumption for the rebuilding
                         self:SetPodConsumptionRebuildRate(self.PodData[v.PodName])
-                       
+
                         -- Change to RebuildingPodState
                         self.Rebuilding = v.PodName
                         self:SetWorkProgress(0.01)
@@ -592,7 +592,7 @@ TPodTowerUnit = Class(TStructureUnit) {
             ChangeState( self, self.PausedState )
         end,
     },
-    
+
     RebuildingPodState = State {
         Main = function(self)
             local rebuildFinished = false
@@ -604,17 +604,17 @@ TPodTowerUnit = Class(TStructureUnit) {
                 local fraction = self:GetResourceConsumed()
                 local energy = self:GetConsumptionPerSecondEnergy() * fraction * 0.1
                 local mass = self:GetConsumptionPerSecondMass() * fraction * 0.1
-                
+
                 self.PodData[ self.Rebuilding ].EnergyRemain = self.PodData[ self.Rebuilding ].EnergyRemain - energy
                 self.PodData[ self.Rebuilding ].MassRemain = self.PodData[ self.Rebuilding ].MassRemain - mass
-                
+
                 self:SetWorkProgress( ( self.PodData[ self.Rebuilding ].BuildCostMass - self.PodData[ self.Rebuilding ].MassRemain ) / self.PodData[ self.Rebuilding ].BuildCostMass )
-                
+
                 if ( self.PodData[ self.Rebuilding ].EnergyRemain <= 0 ) and ( self.PodData[ self.Rebuilding ].MassRemain <= 0 ) then
                     rebuildFinished = true
                 end
             until rebuildFinished
-            
+
             -- create pod, deactivate consumption, clear building
             self:CreatePod( self.Rebuilding )
             self.Rebuilding = false
@@ -622,10 +622,10 @@ TPodTowerUnit = Class(TStructureUnit) {
             self:SetConsumptionPerSecondEnergy(0)
             self:SetConsumptionPerSecondMass(0)
             self:SetConsumptionActive(false)
-            
+
             ChangeState( self, self.MaintainPodsState )
         end,
-        
+
         OnProductionPaused = function(self)
             self:SetConsumptionPerSecondEnergy(0)
             self:SetConsumptionPerSecondMass(0)
@@ -633,7 +633,7 @@ TPodTowerUnit = Class(TStructureUnit) {
             ChangeState( self, self.PausedState )
         end,
     },
-    
+
     PausedState = State {
         Main = function(self)
             self.MaintainState = false
@@ -673,11 +673,11 @@ TPodTowerUnit = Class(TStructureUnit) {
         OnProductionPaused = function(self)
             self.MaintainState = false
         end,
-        
+
         OnProductionUnpaused = function(self)
             self.MaintainState = true
         end,
-        
+
         OnStopBuild = function(self, unitBuilding)
             TStructureUnit.OnStopBuild(self, unitBuilding)
             self:EnableDefaultToggleCaps()
@@ -712,6 +712,6 @@ TPodTowerUnit = Class(TStructureUnit) {
                 ChangeState(self, self.PausedState)
             end
         end,
-        
+
     },
 }

--- a/units/UEB0103/UEB0103_script.lua
+++ b/units/UEB0103/UEB0103_script.lua
@@ -1,44 +1,15 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/UEB0103/UEB0103_script.lua
-#**  Author(s):  David Tomandl
-#**
-#**  Summary  :  UEF Tier 1 Naval Factory Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/UEB0103/UEB0103_script.lua
+--**  Author(s):  David Tomandl
+--**
+--**  Summary  :  UEF Tier 1 Naval Factory Script
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local TSeaFactoryUnit = import('/lua/terranunits.lua').TSeaFactoryUnit
 
-UEB0103 = Class(TSeaFactoryUnit) {
-    StartArmsMoving = function(self)
-        TSeaFactoryUnit.StartArmsMoving(self)
-        if not self.ArmSlider then
-            self.ArmSlider = CreateSlider(self, 'Right_Arm')
-            self.Trash:Add(self.ArmSlider)
-        end
-        
-    end,
-
-    MovingArmsThread = function(self)
-        TSeaFactoryUnit.MovingArmsThread(self)
-        while true do
-            if not self.ArmSlider then return end
-            self.ArmSlider:SetGoal(0, 0, 40)
-            self.ArmSlider:SetSpeed(40)
-            WaitFor(self.ArmSlider)
-            self.ArmSlider:SetGoal(0, 0, 0)
-            WaitFor(self.ArmSlider)
-        end
-    end,
-    
-    StopArmsMoving = function(self)
-        TSeaFactoryUnit.StopArmsMoving(self)
-		if not self.ArmSlider then return end
-        self.ArmSlider:SetGoal(0, 0, 0)
-        self.ArmSlider:SetSpeed(40)
-    end,
-
-}
+UEB0103 = Class(TSeaFactoryUnit) {}
 
 TypeClass = UEB0103

--- a/units/UEB0103/UEB0103_script.lua
+++ b/units/UEB0103/UEB0103_script.lua
@@ -10,7 +10,7 @@
 
 local TSeaFactoryUnit = import('/lua/terranunits.lua').TSeaFactoryUnit
 
-UEB0103 = Class(TSeaFactoryUnit) {    
+UEB0103 = Class(TSeaFactoryUnit) {
     StartArmsMoving = function(self)
         TSeaFactoryUnit.StartArmsMoving(self)
         if not self.ArmSlider then

--- a/units/UEB0103/UEB0103_unit.bp
+++ b/units/UEB0103/UEB0103_unit.bp
@@ -78,6 +78,9 @@ UnitBlueprint {
             '<LOC ability_upgradable>Upgradeable',
         },
         AnimationUpgrade = '/units/ueb0103/ueb0103_aupgrade.sca',
+        ArmSliders = {
+            Right_Arm={0, 0, 50}
+        },
         BlinkingLights = {
             {
                 BLBone = 'Dock_Cover',

--- a/units/UEB0202/UEB0202_script.lua
+++ b/units/UEB0202/UEB0202_script.lua
@@ -1,57 +1,14 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/UEB0202/UEB0202_script.lua
-#**  Author(s):  John Comes, David Tomandl
-#**
-#**  Summary  :  UEF T2 Air Factory Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/UEB0202/UEB0202_script.lua
+--**  Author(s):  John Comes, David Tomandl
+--**
+--**  Summary  :  UEF T2 Air Factory Script
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local TAirFactoryUnit = import('/lua/terranunits.lua').TAirFactoryUnit
-
-
-UEB0202 = Class(TAirFactoryUnit) {
-    
-    StartArmsMoving = function(self)
-        TAirFactoryUnit.StartArmsMoving(self)
-        if not self.ArmSlider1 then
-            self.ArmSlider1 = CreateSlider(self, 'Arm01')
-            self.Trash:Add(self.ArmSlider1)
-        end
-        if not self.ArmSlider2 then
-            self.ArmSlider2 = CreateSlider(self, 'Arm02')
-            self.Trash:Add(self.ArmSlider2)
-        end
-    end,
-
-    MovingArmsThread = function(self)
-        TAirFactoryUnit.MovingArmsThread(self)
-        while true do
-            if not self.ArmSlider1 then return end
-            if not self.ArmSlider2 then return end
-            self.ArmSlider1:SetGoal(0, -6, 0)
-            self.ArmSlider1:SetSpeed(20)
-            self.ArmSlider2:SetGoal(0, 6, 0)
-            self.ArmSlider2:SetSpeed(20)
-            WaitFor(self.ArmSlider2)
-            self.ArmSlider1:SetGoal(0, 0, 0)
-            self.ArmSlider1:SetSpeed(20)
-            self.ArmSlider2:SetGoal(0, 0, 0)
-            self.ArmSlider2:SetSpeed(20)
-            WaitFor(self.ArmSlider2)
-        end
-    end,
-    
-    StopArmsMoving = function(self)
-        TAirFactoryUnit.StopArmsMoving(self)
-		if not self.ArmSlider1 then return end
-		if not self.ArmSlider2 then return end
-        self.ArmSlider1:SetGoal(0, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(0, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-    end,
-}
+UEB0202 = Class(TAirFactoryUnit) {}
 
 TypeClass = UEB0202

--- a/units/UEB0202/UEB0202_unit.bp
+++ b/units/UEB0202/UEB0202_unit.bp
@@ -132,7 +132,7 @@ UnitBlueprint {
         BuildCostMass = 840,
         BuildRate = 40,
         BuildTime = 1800,
-	DifferentialUpgradeCostCalculation = true, 
+	DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = {
             'ueb0202',
         },

--- a/units/UEB0202/UEB0202_unit.bp
+++ b/units/UEB0202/UEB0202_unit.bp
@@ -77,6 +77,10 @@ UnitBlueprint {
         },
         AnimationFinishBuildLand = '/units/ueb0202/ueb0202_aplatform.sca',
         AnimationUpgrade = '/units/ueb0202/ueb0202_aupgrade.sca',
+        ArmSliders = {
+            Arm01={{0, -7, 0}, {0, 1, 0}},
+            Arm02={{0, 7, 0}, {0, -1, 0}},
+        },
         BlinkingLights = {
             {
                 BLBone = 'Tower04',

--- a/units/UEB0203/UEB0203_script.lua
+++ b/units/UEB0203/UEB0203_script.lua
@@ -10,7 +10,7 @@
 
 local TSeaFactoryUnit = import('/lua/terranunits.lua').TSeaFactoryUnit
 
-UEB0203 = Class(TSeaFactoryUnit) {    
+UEB0203 = Class(TSeaFactoryUnit) {
     OnCreate = function(self)
         TSeaFactoryUnit.OnCreate(self)
         self.BuildPointSlider = CreateSlider(self, self:GetBlueprint().Display.BuildAttachBone or 0, -5, 0, 0, -1)

--- a/units/UEB0203/UEB0203_script.lua
+++ b/units/UEB0203/UEB0203_script.lua
@@ -1,12 +1,12 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/UEB0203/UEB0203_script.lua
-#**  Author(s):  David Tomandl
-#**
-#**  Summary  :  UEF Tier 2 Naval Factory Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/UEB0203/UEB0203_script.lua
+--**  Author(s):  David Tomandl
+--**
+--**  Summary  :  UEF Tier 2 Naval Factory Script
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local TSeaFactoryUnit = import('/lua/terranunits.lua').TSeaFactoryUnit
 
@@ -16,55 +16,6 @@ UEB0203 = Class(TSeaFactoryUnit) {
         self.BuildPointSlider = CreateSlider(self, self:GetBlueprint().Display.BuildAttachBone or 0, -5, 0, 0, -1)
         self.Trash:Add(self.BuildPointSlider)
     end,
-    
-    StartArmsMoving = function(self)
-        TSeaFactoryUnit.StartArmsMoving(self)
-        if not self.ArmSlider1 then
-            self.ArmSlider1 = CreateSlider(self, 'Right_Arm')
-            self.Trash:Add(self.ArmSlider1)
-        end
-        if not self.ArmSlider2 then
-            self.ArmSlider2 = CreateSlider(self, 'Center_Arm')
-            self.Trash:Add(self.ArmSlider2)
-        end
-    end,
-
-    MovingArmsThread = function(self)
-        TSeaFactoryUnit.MovingArmsThread(self)
-        if not self.ArmSlider1 then return end
-        if not self.ArmSlider2 then return end
-        self.ArmSlider1:SetGoal(0, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetGoal(30, 0, 0)
-        self.ArmSlider2:SetSpeed(40)
-        WaitFor(self.ArmSlider1)
-        while true do
-            self.ArmSlider1:SetGoal(15, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(15, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-            WaitFor(self.ArmSlider1)
-            WaitFor(self.ArmSlider2)
-            self.ArmSlider1:SetGoal(0, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(30, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-            WaitFor(self.ArmSlider1)
-            WaitFor(self.ArmSlider2)
-        end
-    end,
-    
-    StopArmsMoving = function(self)
-        TSeaFactoryUnit.StopArmsMoving(self)
-        if not self.ArmSlider1 then return end
-        if not self.ArmSlider2 then return end		
-        self.ArmSlider1:SetGoal(0, 0, 0)
-        self.ArmSlider2:SetGoal(0, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetSpeed(40)
-    end,
-
-
 }
 
 TypeClass = UEB0203

--- a/units/UEB0203/UEB0203_unit.bp
+++ b/units/UEB0203/UEB0203_unit.bp
@@ -93,7 +93,7 @@ UnitBlueprint {
         },
         BuildAttachBone = 'Attachpoint01',
         IdleEffects = {
-            Water = {	
+            Water = {
                 Effects = {
                     {
                         Bones = {
@@ -129,7 +129,7 @@ UnitBlueprint {
         BuildCostMass = 1670,
         BuildRate = 60,
         BuildTime = 2400,
-	DifferentialUpgradeCostCalculation = true, 
+        DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = {
             'ueb0203',
         },

--- a/units/UEB0203/UEB0203_unit.bp
+++ b/units/UEB0203/UEB0203_unit.bp
@@ -57,7 +57,7 @@ UnitBlueprint {
         'RECLAIMABLE',
         'SHOWQUEUE',
         'SORTCONSTRUCTION',
-	'RESEARCH',
+        'RESEARCH',
     },
     CollisionOffsetY = -1,
     CollisionOffsetZ = 0,
@@ -242,7 +242,7 @@ UnitBlueprint {
     SelectionSizeZ = 6.9,
     SelectionThickness = 0.26,
     SizeX = 4,
-    SizeY = 3, #from 2, for beam weapons
+    SizeY = 3,
     SizeZ = 10,
     StrategicIconName = 'icon_factoryhq2_naval',
     StrategicIconSortPriority = 215,

--- a/units/UEB0203/UEB0203_unit.bp
+++ b/units/UEB0203/UEB0203_unit.bp
@@ -77,6 +77,16 @@ UnitBlueprint {
             '<LOC ability_upgradable>Upgradeable',
         },
         AnimationUpgrade = '/units/ueb0203/ueb0203_aupgrade.sca',
+        ArmSliders = {
+            Right_Arm = {
+                {15, 0, 0},
+            },
+            Center_Arm = {
+                {30, 0, 0},
+                {15, 0, 0},
+            }
+        },
+
         BlinkingLights = {
             {
                 BLBone = 'Dock_Cover',

--- a/units/UEB0302/UEB0302_script.lua
+++ b/units/UEB0302/UEB0302_script.lua
@@ -1,68 +1,15 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/UEB0302/UEB0302_script.lua
-#**  Author(s):  John Comes, David Tomandl
-#**
-#**  Summary  :  UEF T3 Air Factory Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/UEB0302/UEB0302_script.lua
+--**  Author(s):  John Comes, David Tomandl
+--**
+--**  Summary  :  UEF T3 Air Factory Script
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local TAirFactoryUnit = import('/lua/terranunits.lua').TAirFactoryUnit
 
-
-UEB0302 = Class(TAirFactoryUnit) {
-    
-    StartArmsMoving = function(self)
-        TAirFactoryUnit.StartArmsMoving(self)
-        if not self.ArmSlider1 then
-            self.ArmSlider1 = CreateSlider(self, 'Arm01')
-            self.Trash:Add(self.ArmSlider1)
-        end
-        if not self.ArmSlider2 then
-            self.ArmSlider2 = CreateSlider(self, 'Arm02')
-            self.Trash:Add(self.ArmSlider2)
-        end
-        if not self.ArmSlider3 then
-            self.ArmSlider3 = CreateSlider(self, 'Arm03')
-            self.Trash:Add(self.ArmSlider3)
-        end
-    end,
-
-    MovingArmsThread = function(self)
-        TAirFactoryUnit.MovingArmsThread(self)
-        local dir = 1
-        while true do
-            if not self.ArmSlider1 then return end
-            if not self.ArmSlider2 then return end
-            if not self.ArmSlider3 then return end
-            self.ArmSlider1:SetGoal(0, -5, 0)
-            self.ArmSlider1:SetSpeed(20)
-            self.ArmSlider2:SetGoal(0, 2 * dir, 0)
-            self.ArmSlider2:SetSpeed(10)
-            self.ArmSlider3:SetGoal(0, 5, 0)
-            self.ArmSlider3:SetSpeed(20)
-            WaitFor(self.ArmSlider3)
-            self.ArmSlider1:SetGoal(0, 0, 0)
-            self.ArmSlider1:SetSpeed(20)
-            self.ArmSlider2:SetGoal(0, 0, 0)
-            self.ArmSlider2:SetSpeed(10)
-            self.ArmSlider3:SetGoal(0, 0, 0)
-            self.ArmSlider3:SetSpeed(20)
-            WaitFor(self.ArmSlider3)
-            dir = dir * -1
-        end
-    end,
-    
-    StopArmsMoving = function(self)
-        TAirFactoryUnit.StopArmsMoving(self)
-        self.ArmSlider1:SetGoal(0, 0, 0)
-        self.ArmSlider2:SetGoal(0, 0, 0)
-        self.ArmSlider3:SetGoal(0, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetSpeed(40)
-        self.ArmSlider3:SetSpeed(40)
-    end,
-}
+UEB0302 = Class(TAirFactoryUnit) {}
 
 TypeClass = UEB0302

--- a/units/UEB0302/UEB0302_unit.bp
+++ b/units/UEB0302/UEB0302_unit.bp
@@ -73,6 +73,16 @@ UnitBlueprint {
     Description = '<LOC ueb0302_desc>Air Factory HQ',
     Display = {
         AnimationFinishBuildLand = '/units/ueb0302/ueb0302_aplatform.sca',
+        ArmSliders = {
+            Arm01={
+                {0, -7, 0},
+                {0, 1, 0}
+            },
+            Arm03={
+                {0, 7, 0},
+                {0, -1, 0}
+            }
+        },
         BlinkingLights = {
             {
                 BLBone = 'Tower04',

--- a/units/UEB0302/UEB0302_unit.bp
+++ b/units/UEB0302/UEB0302_unit.bp
@@ -58,7 +58,7 @@ UnitBlueprint {
         'RECLAIMABLE',
         'SHOWQUEUE',
         'SORTCONSTRUCTION',
-	'RESEARCH',
+        'RESEARCH',
     },
     Defense = {
         AirThreatLevel = 0,
@@ -128,7 +128,7 @@ UnitBlueprint {
         BuildCostMass = 4090,
         BuildRate = 120,
         BuildTime = 10400,
-	DifferentialUpgradeCostCalculation = true, 
+    DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = {
             'ueb0302',
         },

--- a/units/UEB0303/UEB0303_script.lua
+++ b/units/UEB0303/UEB0303_script.lua
@@ -10,7 +10,7 @@
 
 local TSeaFactoryUnit = import('/lua/terranunits.lua').TSeaFactoryUnit
 
-UEB0303 = Class(TSeaFactoryUnit) {    
+UEB0303 = Class(TSeaFactoryUnit) {
     OnCreate = function(self)
         TSeaFactoryUnit.OnCreate(self)
         self.BuildPointSlider = CreateSlider(self, self:GetBlueprint().Display.BuildAttachBone or 0, -15, 0, 0, -1)

--- a/units/UEB0303/UEB0303_script.lua
+++ b/units/UEB0303/UEB0303_script.lua
@@ -1,12 +1,12 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/UEB0303/UEB0303_script.lua
-#**  Author(s):  David Tomandl
-#**
-#**  Summary  :  UEF Tier 3 Naval Factory Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/UEB0303/UEB0303_script.lua
+--**  Author(s):  David Tomandl
+--**
+--**  Summary  :  UEF Tier 3 Naval Factory Script
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local TSeaFactoryUnit = import('/lua/terranunits.lua').TSeaFactoryUnit
 
@@ -15,64 +15,6 @@ UEB0303 = Class(TSeaFactoryUnit) {
         TSeaFactoryUnit.OnCreate(self)
         self.BuildPointSlider = CreateSlider(self, self:GetBlueprint().Display.BuildAttachBone or 0, -15, 0, 0, -1)
         self.Trash:Add(self.BuildPointSlider)
-    end,
-    
-
-    StartArmsMoving = function(self)
-        TSeaFactoryUnit.StartArmsMoving(self)
-        if not self.ArmSlider1 then
-            self.ArmSlider1 = CreateSlider(self, 'Right_Arm')
-            self.Trash:Add(self.ArmSlider1)
-        end
-        if not self.ArmSlider2 then
-            self.ArmSlider2 = CreateSlider(self, 'Center_Arm')
-            self.Trash:Add(self.ArmSlider2)
-        end
-        if not self.ArmSlider3 then
-            self.ArmSlider3 = CreateSlider(self, 'Left_Arm')
-            self.Trash:Add(self.ArmSlider3)
-        end
-    end,
-
-    MovingArmsThread = function(self)
-        TSeaFactoryUnit.MovingArmsThread(self)
-        local dir = 1
-        if not self.ArmSlider1 then return end
-        if not self.ArmSlider2 then return end
-        self.ArmSlider1:SetGoal(0, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetGoal(10, 0, 0)
-        self.ArmSlider2:SetSpeed(40)
-        self.ArmSlider3:SetGoal(20, 0, 0)
-        self.ArmSlider3:SetSpeed(40)
-        WaitFor(self.ArmSlider1)
-        while true do
-            self.ArmSlider1:SetGoal(0, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(8 + 5 * dir, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-            self.ArmSlider3:SetGoal(10, 0, 0)
-            self.ArmSlider3:SetSpeed(40)
-            WaitFor(self.ArmSlider3)
-            self.ArmSlider1:SetGoal(10, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(10, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-            self.ArmSlider3:SetGoal(20, 0, 0)
-            self.ArmSlider3:SetSpeed(40)
-            WaitFor(self.ArmSlider3)
-            dir = dir * -1
-        end
-    end,
-    
-    StopArmsMoving = function(self)
-        TSeaFactoryUnit.StopArmsMoving(self)
-        self.ArmSlider1:SetGoal(0, 0, 0)
-        self.ArmSlider2:SetGoal(0, 0, 0)
-        self.ArmSlider3:SetGoal(0, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetSpeed(40)
-        self.ArmSlider3:SetSpeed(40)
     end,
 }
 

--- a/units/UEB0303/UEB0303_unit.bp
+++ b/units/UEB0303/UEB0303_unit.bp
@@ -58,7 +58,7 @@ UnitBlueprint {
         'RECLAIMABLE',
         'SHOWQUEUE',
         'SORTCONSTRUCTION',
-	'RESEARCH',
+        'RESEARCH',
     },
     CollisionOffsetX = 0,
     CollisionOffsetY = -1,
@@ -141,7 +141,7 @@ UnitBlueprint {
         BuildCostMass = 7120,
         BuildRate = 120,
         BuildTime = 9200,
-	DifferentialUpgradeCostCalculation = true, 
+        DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = {
             'ueb0303',
         },

--- a/units/UEB0303/UEB0303_unit.bp
+++ b/units/UEB0303/UEB0303_unit.bp
@@ -168,7 +168,8 @@ UnitBlueprint {
         },
         InitialRallyX = 0,
         InitialRallyZ = 10,
-        StorageEnergy = 0,        StorageMass = 320,
+        StorageEnergy = 0,
+        StorageMass = 320,
     },
     Footprint = {
         MinWaterDepth = 1.5,
@@ -258,7 +259,7 @@ UnitBlueprint {
     SelectionSizeZ = 6.9,
     SelectionThickness = 0.26,
     SizeX = 4,
-    SizeY = 3, #from 2, for beam weapons
+    SizeY = 3,
     SizeZ = 10,
     StrategicIconName = 'icon_factoryhq3_naval',
     StrategicIconSortPriority = 210,

--- a/units/UEB0303/UEB0303_unit.bp
+++ b/units/UEB0303/UEB0303_unit.bp
@@ -75,6 +75,21 @@ UnitBlueprint {
     },
     Description = '<LOC ueb0303_desc>Naval Factory HQ',
     Display = {
+        ArmSliders = {
+            Left_Arm = {
+                {20, 0, 0},
+                {10, 0, 0},
+            },
+            Center_Arm = {
+                {-5, 0, 0},
+                {15, 0, 0},
+            },
+            Right_Arm = {
+                {-3, 0, 0},
+                {5, 0, 0},
+            },
+
+        },
         BlinkingLights = {
             {
                 BLBone = 'Dock_Cover',

--- a/units/URB0103/URB0103_script.lua
+++ b/units/URB0103/URB0103_script.lua
@@ -1,0 +1,42 @@
+#****************************************************************************
+#**
+#**  File     :  /cdimage/units/URB0103/URB0103_script.lua
+#**  Author(s):  David Tomandl
+#**
+#**  Summary  :  Cybran T1 Naval Factory Script
+#**
+#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+
+local CSeaFactoryUnit = import('/lua/cybranunits.lua').CSeaFactoryUnit
+URB0103 = Class(CSeaFactoryUnit) {
+
+    StartArmsMoving = function(self)
+        CSeaFactoryUnit.StartArmsMoving(self)
+        if not self.ArmSlider then
+            self.ArmSlider = CreateSlider(self, 'Right_Arm03')
+            self.Trash:Add(self.ArmSlider)
+        end
+
+    end,
+
+    MovingArmsThread = function(self)
+        CSeaFactoryUnit.MovingArmsThread(self)
+        while true do
+            if not self.ArmSlider then return end
+            self.ArmSlider:SetGoal(40, 0, 0)
+            self.ArmSlider:SetSpeed(40)
+            WaitFor(self.ArmSlider)
+            self.ArmSlider:SetGoal(-30, 0, 0)
+            WaitFor(self.ArmSlider)
+        end
+    end,
+
+    StopArmsMoving = function(self)
+        CSeaFactoryUnit.StopArmsMoving(self)
+        self.ArmSlider:SetGoal(0, 0, 0)
+        self.ArmSlider:SetSpeed(40)
+    end,
+}
+
+TypeClass = URB0103

--- a/units/URB0103/URB0103_script.lua
+++ b/units/URB0103/URB0103_script.lua
@@ -1,42 +1,14 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/URB0103/URB0103_script.lua
-#**  Author(s):  David Tomandl
-#**
-#**  Summary  :  Cybran T1 Naval Factory Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/URB0103/URB0103_script.lua
+--**  Author(s):  David Tomandl
+--**
+--**  Summary  :  Cybran T1 Naval Factory Script
+--**
+--**  Copyright Â© 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local CSeaFactoryUnit = import('/lua/cybranunits.lua').CSeaFactoryUnit
-URB0103 = Class(CSeaFactoryUnit) {
-
-    StartArmsMoving = function(self)
-        CSeaFactoryUnit.StartArmsMoving(self)
-        if not self.ArmSlider then
-            self.ArmSlider = CreateSlider(self, 'Right_Arm03')
-            self.Trash:Add(self.ArmSlider)
-        end
-
-    end,
-
-    MovingArmsThread = function(self)
-        CSeaFactoryUnit.MovingArmsThread(self)
-        while true do
-            if not self.ArmSlider then return end
-            self.ArmSlider:SetGoal(40, 0, 0)
-            self.ArmSlider:SetSpeed(40)
-            WaitFor(self.ArmSlider)
-            self.ArmSlider:SetGoal(-30, 0, 0)
-            WaitFor(self.ArmSlider)
-        end
-    end,
-
-    StopArmsMoving = function(self)
-        CSeaFactoryUnit.StopArmsMoving(self)
-        self.ArmSlider:SetGoal(0, 0, 0)
-        self.ArmSlider:SetSpeed(40)
-    end,
-}
+URB0103 = Class(CSeaFactoryUnit) {}
 
 TypeClass = URB0103

--- a/units/URB0103/URB0103_unit.bp
+++ b/units/URB0103/URB0103_unit.bp
@@ -79,6 +79,9 @@ UnitBlueprint {
             '<LOC ability_upgradable>Upgradeable',
         },
         AnimationUpgrade = '/units/urb0103/urb0103_aupgrade.sca',
+        ArmSliders = {
+            Right_Arm03={{40, 0, 0}, {-30, 0, 0}}
+        },
         BlinkingLights = {
             {
                 BLBone = 'B03',

--- a/units/URB0203/URB0203_script.lua
+++ b/units/URB0203/URB0203_script.lua
@@ -1,55 +1,18 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/URB0203/URB0203_script.lua
-#**  Author(s):  John Comes, David Tomandl
-#**
-#**  Summary  :  Cybran T2 Naval Factory Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/URB0203/URB0203_script.lua
+--**  Author(s):  John Comes, David Tomandl
+--**
+--**  Summary  :  Cybran T2 Naval Factory Script
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local CSeaFactoryUnit = import('/lua/cybranunits.lua').CSeaFactoryUnit
 
 
 URB0203 = Class(CSeaFactoryUnit) {
-    
-    StartArmsMoving = function(self)
-        CSeaFactoryUnit.StartArmsMoving(self)
-        if not self.ArmSlider1 then
-            self.ArmSlider1 = CreateSlider(self, 'Right_Arm02')
-            self.Trash:Add(self.ArmSlider1)
-        end
-        if not self.ArmSlider2 then
-            self.ArmSlider2 = CreateSlider(self, 'Right_Arm03')
-            self.Trash:Add(self.ArmSlider2)
-        end
-    end,
 
-    MovingArmsThread = function(self)
-        CSeaFactoryUnit.MovingArmsThread(self)
-        while true do
-            if not self.ArmSlider1 then return end
-            if not self.ArmSlider2 then return end
-            self.ArmSlider1:SetGoal(20, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(-20, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-            WaitFor(self.ArmSlider2)
-            self.ArmSlider1:SetGoal(0, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(0, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-            WaitFor(self.ArmSlider2)
-        end
-    end,
-    
-    StopArmsMoving = function(self)
-        CSeaFactoryUnit.StopArmsMoving(self)
-        self.ArmSlider1:SetGoal(0, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetGoal(0, 0, 0)
-        self.ArmSlider2:SetSpeed(40)
-    end,
 }
 
 TypeClass = URB0203

--- a/units/URB0203/URB0203_unit.bp
+++ b/units/URB0203/URB0203_unit.bp
@@ -78,6 +78,16 @@ UnitBlueprint {
             '<LOC ability_upgradable>Upgradeable',
         },
         AnimationUpgrade = '/units/urb0203/urb0203_aupgrade.sca',
+        ArmSliders = {
+            Right_Arm02={
+                {35, 0, 0},
+                {5, 0, 0}
+            },
+            Right_Arm03={
+                {-20, 0, 0},
+                {10, 0, 0}
+            },
+        },
         BlinkingLights = {
             {
                 BLBone = 'B03',

--- a/units/URB0203/URB0203_unit.bp
+++ b/units/URB0203/URB0203_unit.bp
@@ -57,7 +57,7 @@ UnitBlueprint {
         'RECLAIMABLE',
         'SHOWQUEUE',
         'SORTCONSTRUCTION',
-	'RESEARCH',
+        'RESEARCH',
     },
     CollisionOffsetX = 0,
     CollisionOffsetY = -1,
@@ -146,7 +146,7 @@ UnitBlueprint {
         BuildCostMass = 1670,
         BuildRate = 60,
         BuildTime = 2400,
-	DifferentialUpgradeCostCalculation = true, 
+        DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = {
             'urb0203',
         },
@@ -245,7 +245,7 @@ UnitBlueprint {
     SelectionSizeZ = 8.1,
     SelectionThickness = 0.21,
     SizeX = 4,
-    SizeY = 3, #from 2, for beam weapons
+    SizeY = 3,
     SizeZ = 10,
     StrategicIconName = 'icon_factoryhq2_naval',
     StrategicIconSortPriority = 215,

--- a/units/URB0303/URB0303_script.lua
+++ b/units/URB0303/URB0303_script.lua
@@ -11,7 +11,7 @@
 local CSeaFactoryUnit = import('/lua/cybranunits.lua').CSeaFactoryUnit
 
 
-URB0303 = Class(CSeaFactoryUnit) {    
+URB0303 = Class(CSeaFactoryUnit) {
     StartArmsMoving = function(self)
         CSeaFactoryUnit.StartArmsMoving(self)
         if not self.ArmSlider1 then

--- a/units/URB0303/URB0303_script.lua
+++ b/units/URB0303/URB0303_script.lua
@@ -1,74 +1,15 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/URB0303/URB0303_script.lua
-#**  Author(s):  John Comes, David Tomandl
-#**
-#**  Summary  :  Cybran T3 Naval Factory Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/URB0303/URB0303_script.lua
+--**  Author(s):  John Comes, David Tomandl
+--**
+--**  Summary  :  Cybran T3 Naval Factory Script
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local CSeaFactoryUnit = import('/lua/cybranunits.lua').CSeaFactoryUnit
 
-
-URB0303 = Class(CSeaFactoryUnit) {
-    StartArmsMoving = function(self)
-        CSeaFactoryUnit.StartArmsMoving(self)
-        if not self.ArmSlider1 then
-            self.ArmSlider1 = CreateSlider(self, 'Right_Arm03')
-            self.Trash:Add(self.ArmSlider1)
-        end
-        if not self.ArmSlider2 then
-            self.ArmSlider2 = CreateSlider(self, 'Right_Arm02')
-            self.Trash:Add(self.ArmSlider2)
-        end
-        if not self.ArmSlider3 then
-            self.ArmSlider3 = CreateSlider(self, 'Right_Arm01')
-            self.Trash:Add(self.ArmSlider3)
-        end
-    end,
-
-    MovingArmsThread = function(self)
-        CSeaFactoryUnit.MovingArmsThread(self)
-        if not self.ArmSlider1 then return end
-        if not self.ArmSlider2 then return end
-        if not self.ArmSlider3 then return end
-        local dir = 1
-        self.ArmSlider1:SetGoal(-10, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetGoal(20, 0, 0)
-        self.ArmSlider2:SetSpeed(40)
-        self.ArmSlider3:SetGoal(50, 0, 0)
-        self.ArmSlider3:SetSpeed(60)
-        WaitFor(self.ArmSlider1)
-        while true do
-            self.ArmSlider1:SetGoal(0, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(0, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-            self.ArmSlider3:SetGoal(0, 0, 0)
-            self.ArmSlider3:SetSpeed(40)
-            WaitFor(self.ArmSlider3)
-            self.ArmSlider1:SetGoal(-10, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(20 + 30 * dir, 0, 0)
-            self.ArmSlider2:SetSpeed(60)
-            self.ArmSlider3:SetGoal(50, 0, 0)
-            self.ArmSlider3:SetSpeed(60)
-            WaitFor(self.ArmSlider3)
-            dir = dir * -1
-        end
-    end,
-    
-    StopArmsMoving = function(self)
-        CSeaFactoryUnit.StopArmsMoving(self)
-        self.ArmSlider1:SetGoal(0, 0, 0)
-        self.ArmSlider2:SetGoal(0, 0, 0)
-        self.ArmSlider3:SetGoal(0, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetSpeed(40)
-        self.ArmSlider3:SetSpeed(40)
-    end,
-}
+URB0303 = Class(CSeaFactoryUnit) {}
 
 TypeClass = URB0303

--- a/units/URB0303/URB0303_unit.bp
+++ b/units/URB0303/URB0303_unit.bp
@@ -74,6 +74,11 @@ UnitBlueprint {
     },
     Description = '<LOC urb0303_desc>Naval Factory HQ',
     Display = {
+        ArmSliders = {
+            Right_Arm01={{48, 0, 0}, {24, 0, 0}},
+            Right_Arm02={{5, 0, 0}, {30, 0, 0}},
+            Right_Arm03={{-15, 0, 0}, {10, 0, 0}},
+        },
         BlinkingLights = {
             {
                 BLBone = 'B03',

--- a/units/URB0303/URB0303_unit.bp
+++ b/units/URB0303/URB0303_unit.bp
@@ -57,7 +57,7 @@ UnitBlueprint {
         'RECLAIMABLE',
         'SHOWQUEUE',
         'SORTCONSTRUCTION',
-	'RESEARCH',
+        'RESEARCH',
     },
     CollisionOffsetX = 0,
     CollisionOffsetY = -1,
@@ -143,7 +143,7 @@ UnitBlueprint {
         BuildCostMass = 7120,
         BuildRate = 120,
         BuildTime = 9200,
-	DifferentialUpgradeCostCalculation = true, 
+        DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = {
             'urb0303',
         },
@@ -154,7 +154,8 @@ UnitBlueprint {
         },
         InitialRallyX = 0,
         InitialRallyZ = 10,
-        StorageEnergy = 0,        StorageMass = 320,
+        StorageEnergy = 0,
+        StorageMass = 320,
     },
     Footprint = {
         MinWaterDepth = 1.5,
@@ -242,7 +243,7 @@ UnitBlueprint {
     SelectionSizeZ = 8.1,
     SelectionThickness = 0.21,
     SizeX = 4,
-    SizeY = 3, #from 2, for beam weapons
+    SizeY = 3,
     SizeZ = 10,
     StrategicIconName = 'icon_factoryhq3_naval',
     StrategicIconSortPriority = 210,

--- a/units/ZEB9502/ZEB9502_script.lua
+++ b/units/ZEB9502/ZEB9502_script.lua
@@ -1,57 +1,15 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/ZEB9502/ZEB9502_script.lua
-#**  Author(s):  John Comes, David Tomandl
-#**
-#**  Summary  :  UEF T2 Air Factory Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/ZEB9502/ZEB9502_script.lua
+--**  Author(s):  John Comes, David Tomandl
+--**
+--**  Summary  :  UEF T2 Air Factory Script
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local TAirFactoryUnit = import('/lua/terranunits.lua').TAirFactoryUnit
 
-
-ZEB9502 = Class(TAirFactoryUnit) {
-    
-    StartArmsMoving = function(self)
-        TAirFactoryUnit.StartArmsMoving(self)
-        if not self.ArmSlider1 then
-            self.ArmSlider1 = CreateSlider(self, 'Arm01')
-            self.Trash:Add(self.ArmSlider1)
-        end
-        if not self.ArmSlider2 then
-            self.ArmSlider2 = CreateSlider(self, 'Arm02')
-            self.Trash:Add(self.ArmSlider2)
-        end
-    end,
-
-    MovingArmsThread = function(self)
-        TAirFactoryUnit.MovingArmsThread(self)
-        while true do
-            if not self.ArmSlider1 then return end
-            if not self.ArmSlider2 then return end
-            self.ArmSlider1:SetGoal(0, -6, 0)
-            self.ArmSlider1:SetSpeed(20)
-            self.ArmSlider2:SetGoal(0, 6, 0)
-            self.ArmSlider2:SetSpeed(20)
-            WaitFor(self.ArmSlider2)
-            self.ArmSlider1:SetGoal(0, 0, 0)
-            self.ArmSlider1:SetSpeed(20)
-            self.ArmSlider2:SetGoal(0, 0, 0)
-            self.ArmSlider2:SetSpeed(20)
-            WaitFor(self.ArmSlider2)
-        end
-    end,
-    
-    StopArmsMoving = function(self)
-        TAirFactoryUnit.StopArmsMoving(self)
-		if not self.ArmSlider1 then return end
-		if not self.ArmSlider2 then return end
-        self.ArmSlider1:SetGoal(0, 0, 0)
-		self.ArmSlider1:SetSpeed(40)
-		self.ArmSlider2:SetGoal(0, 0, 0)
-		self.ArmSlider2:SetSpeed(40)
-    end,
-}
+ZEB9502 = Class(TAirFactoryUnit) {}
 
 TypeClass = ZEB9502

--- a/units/ZEB9502/ZEB9502_unit.bp
+++ b/units/ZEB9502/ZEB9502_unit.bp
@@ -136,7 +136,7 @@ UnitBlueprint {
         BuildCostMass = 510,
         BuildRate = 40,
         BuildTime = 1300,
-	DifferentialUpgradeCostCalculation = true, 
+	DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = {
             'zeb9502',
         },

--- a/units/ZEB9502/ZEB9502_unit.bp
+++ b/units/ZEB9502/ZEB9502_unit.bp
@@ -81,6 +81,10 @@ UnitBlueprint {
         },
         AnimationFinishBuildLand = '/units/ueb0202/ueb0202_aplatform.sca',
         AnimationUpgrade = '/units/ueb0202/ueb0202_aupgrade.sca',
+        ArmSliders = {
+            Arm01={{0, -7, 0}, {0, 1, 0}},
+            Arm02={{0, 7, 0}, {0, -1, 0}},
+        },
         BlinkingLights = {
             {
                 BLBone = 'Tower04',

--- a/units/ZEB9503/ZEB9503_script.lua
+++ b/units/ZEB9503/ZEB9503_script.lua
@@ -1,12 +1,12 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/ZEB9503/ZEB9503_script.lua
-#**  Author(s):  David Tomandl
-#**
-#**  Summary  :  UEF Tier 2 Naval Factory Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/ZEB9503/ZEB9503_script.lua
+--**  Author(s):  David Tomandl
+--**
+--**  Summary  :  UEF Tier 2 Naval Factory Script
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local TSeaFactoryUnit = import('/lua/terranunits.lua').TSeaFactoryUnit
 
@@ -16,55 +16,6 @@ ZEB9503 = Class(TSeaFactoryUnit) {
         self.BuildPointSlider = CreateSlider(self, self:GetBlueprint().Display.BuildAttachBone or 0, -5, 0, 0, -1)
         self.Trash:Add(self.BuildPointSlider)
     end,
-    
-    StartArmsMoving = function(self)
-        TSeaFactoryUnit.StartArmsMoving(self)
-        if not self.ArmSlider1 then
-            self.ArmSlider1 = CreateSlider(self, 'Right_Arm')
-            self.Trash:Add(self.ArmSlider1)
-        end
-        if not self.ArmSlider2 then
-            self.ArmSlider2 = CreateSlider(self, 'Center_Arm')
-            self.Trash:Add(self.ArmSlider2)
-        end
-    end,
-
-    MovingArmsThread = function(self)
-        TSeaFactoryUnit.MovingArmsThread(self)
-        if not self.ArmSlider1 then return end
-        if not self.ArmSlider2 then return end
-        self.ArmSlider1:SetGoal(0, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetGoal(30, 0, 0)
-        self.ArmSlider2:SetSpeed(40)
-        WaitFor(self.ArmSlider1)
-        while true do
-            self.ArmSlider1:SetGoal(15, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(15, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-            WaitFor(self.ArmSlider1)
-            WaitFor(self.ArmSlider2)
-            self.ArmSlider1:SetGoal(0, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(30, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-            WaitFor(self.ArmSlider1)
-            WaitFor(self.ArmSlider2)
-        end
-    end,
-    
-    StopArmsMoving = function(self)
-        TSeaFactoryUnit.StopArmsMoving(self)
-        if not self.ArmSlider1 then return end
-        if not self.ArmSlider2 then return end
-        self.ArmSlider1:SetGoal(0, 0, 0)
-        self.ArmSlider2:SetGoal(0, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetSpeed(40)
-    end,
-
-
 }
 
 TypeClass = ZEB9503

--- a/units/ZEB9503/ZEB9503_script.lua
+++ b/units/ZEB9503/ZEB9503_script.lua
@@ -10,7 +10,7 @@
 
 local TSeaFactoryUnit = import('/lua/terranunits.lua').TSeaFactoryUnit
 
-ZEB9503 = Class(TSeaFactoryUnit) {    
+ZEB9503 = Class(TSeaFactoryUnit) {
     OnCreate = function(self)
         TSeaFactoryUnit.OnCreate(self)
         self.BuildPointSlider = CreateSlider(self, self:GetBlueprint().Display.BuildAttachBone or 0, -5, 0, 0, -1)

--- a/units/ZEB9503/ZEB9503_unit.bp
+++ b/units/ZEB9503/ZEB9503_unit.bp
@@ -81,6 +81,13 @@ UnitBlueprint {
             '<LOC ability_upgradable>Upgradeable',
         },
         AnimationUpgrade = '/units/zeb9503/zeb9503_aupgrade.sca',
+        ArmSliders = {
+            Right_Arm = {15, 0, 0},
+            Center_Arm = {
+                {30, 0, 0},
+                {15, 0, 0},
+            }
+        },
         BlinkingLights = {
             {
                 BLBone = 'Dock_Cover',

--- a/units/ZEB9503/ZEB9503_unit.bp
+++ b/units/ZEB9503/ZEB9503_unit.bp
@@ -61,7 +61,7 @@ UnitBlueprint {
         'RECLAIMABLE',
         'SHOWQUEUE',
         'SORTCONSTRUCTION',
-	'SUPPORTFACTORY',
+        'SUPPORTFACTORY',
     },
     CollisionOffsetY = -1,
     CollisionOffsetZ = 0,
@@ -133,7 +133,7 @@ UnitBlueprint {
         BuildCostMass = 800,
         BuildRate = 60,
         BuildTime = 2000,
-	DifferentialUpgradeCostCalculation = true, 
+    DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = {
             'zeb9503',
         },

--- a/units/ZEB9602/ZEB9602_script.lua
+++ b/units/ZEB9602/ZEB9602_script.lua
@@ -1,68 +1,14 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/ZEB9602/ZEB9602_script.lua
-#**  Author(s):  John Comes, David Tomandl
-#**
-#**  Summary  :  UEF T3 Air Factory Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/ZEB9602/ZEB9602_script.lua
+--**  Author(s):  John Comes, David Tomandl
+--**
+--**  Summary  :  UEF T3 Air Factory Script
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local TAirFactoryUnit = import('/lua/terranunits.lua').TAirFactoryUnit
-
-
-ZEB9602 = Class(TAirFactoryUnit) {
-    
-    StartArmsMoving = function(self)
-        TAirFactoryUnit.StartArmsMoving(self)
-        if not self.ArmSlider1 then
-            self.ArmSlider1 = CreateSlider(self, 'Arm01')
-            self.Trash:Add(self.ArmSlider1)
-        end
-        if not self.ArmSlider2 then
-            self.ArmSlider2 = CreateSlider(self, 'Arm02')
-            self.Trash:Add(self.ArmSlider2)
-        end
-        if not self.ArmSlider3 then
-            self.ArmSlider3 = CreateSlider(self, 'Arm03')
-            self.Trash:Add(self.ArmSlider3)
-        end
-    end,
-
-    MovingArmsThread = function(self)
-        TAirFactoryUnit.MovingArmsThread(self)
-        local dir = 1
-        while true do
-            if not self.ArmSlider1 then return end
-            if not self.ArmSlider2 then return end
-            if not self.ArmSlider3 then return end
-            self.ArmSlider1:SetGoal(0, -5, 0)
-            self.ArmSlider1:SetSpeed(20)
-            self.ArmSlider2:SetGoal(0, 2 * dir, 0)
-            self.ArmSlider2:SetSpeed(10)
-            self.ArmSlider3:SetGoal(0, 5, 0)
-            self.ArmSlider3:SetSpeed(20)
-            WaitFor(self.ArmSlider3)
-            self.ArmSlider1:SetGoal(0, 0, 0)
-            self.ArmSlider1:SetSpeed(20)
-            self.ArmSlider2:SetGoal(0, 0, 0)
-            self.ArmSlider2:SetSpeed(10)
-            self.ArmSlider3:SetGoal(0, 0, 0)
-            self.ArmSlider3:SetSpeed(20)
-            WaitFor(self.ArmSlider3)
-            dir = dir * -1
-        end
-    end,
-    
-    StopArmsMoving = function(self)
-        TAirFactoryUnit.StopArmsMoving(self)
-        self.ArmSlider1:SetGoal(0, 0, 0)
-        self.ArmSlider2:SetGoal(0, 0, 0)
-        self.ArmSlider3:SetGoal(0, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetSpeed(40)
-        self.ArmSlider3:SetSpeed(40)
-    end,
-}
+ZEB9602 = Class(TAirFactoryUnit) {}
 
 TypeClass = ZEB9602

--- a/units/ZEB9602/ZEB9602_unit.bp
+++ b/units/ZEB9602/ZEB9602_unit.bp
@@ -75,6 +75,16 @@ UnitBlueprint {
     Description = '<LOC zeb9602_desc>Air Factory',
     Display = {
         AnimationFinishBuildLand = '/units/zeb9602/zeb9602_aplatform.sca',
+        ArmSliders = {
+            Arm01={
+                {0, -7, 0},
+                {0, 1, 0}
+            },
+            Arm03={
+                {0, 7, 0},
+                {0, -1, 0}
+            }
+        },
         BlinkingLights = {
             {
                 BLBone = 'Tower04',

--- a/units/ZEB9602/ZEB9602_unit.bp
+++ b/units/ZEB9602/ZEB9602_unit.bp
@@ -60,7 +60,7 @@ UnitBlueprint {
         'RECLAIMABLE',
         'SHOWQUEUE',
         'SORTCONSTRUCTION',
-	'SUPPORTFACTORY',
+        'SUPPORTFACTORY',
     },
     Defense = {
         AirThreatLevel = 0,
@@ -130,7 +130,7 @@ UnitBlueprint {
         BuildCostMass = 1510,
         BuildRate = 120,
         BuildTime = 4000,
-	DifferentialUpgradeCostCalculation = true, 
+    DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = {
             'zeb9602',
         },

--- a/units/ZEB9603/ZEB9603_script.lua
+++ b/units/ZEB9603/ZEB9603_script.lua
@@ -10,7 +10,7 @@
 
 local TSeaFactoryUnit = import('/lua/terranunits.lua').TSeaFactoryUnit
 
-UEB0303 = Class(TSeaFactoryUnit) {    
+UEB0303 = Class(TSeaFactoryUnit) {
     OnCreate = function(self)
         TSeaFactoryUnit.OnCreate(self)
         self.BuildPointSlider = CreateSlider(self, self:GetBlueprint().Display.BuildAttachBone or 0, -15, 0, 0, -1)

--- a/units/ZEB9603/ZEB9603_script.lua
+++ b/units/ZEB9603/ZEB9603_script.lua
@@ -1,12 +1,12 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/UEB0303/UEB0303_script.lua
-#**  Author(s):  David Tomandl
-#**
-#**  Summary  :  UEF Tier 3 Naval Factory Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/UEB0303/UEB0303_script.lua
+--**  Author(s):  David Tomandl
+--**
+--**  Summary  :  UEF Tier 3 Naval Factory Script
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local TSeaFactoryUnit = import('/lua/terranunits.lua').TSeaFactoryUnit
 
@@ -15,64 +15,6 @@ UEB0303 = Class(TSeaFactoryUnit) {
         TSeaFactoryUnit.OnCreate(self)
         self.BuildPointSlider = CreateSlider(self, self:GetBlueprint().Display.BuildAttachBone or 0, -15, 0, 0, -1)
         self.Trash:Add(self.BuildPointSlider)
-    end,
-    
-
-    StartArmsMoving = function(self)
-        TSeaFactoryUnit.StartArmsMoving(self)
-        if not self.ArmSlider1 then
-            self.ArmSlider1 = CreateSlider(self, 'Right_Arm')
-            self.Trash:Add(self.ArmSlider1)
-        end
-        if not self.ArmSlider2 then
-            self.ArmSlider2 = CreateSlider(self, 'Center_Arm')
-            self.Trash:Add(self.ArmSlider2)
-        end
-        if not self.ArmSlider3 then
-            self.ArmSlider3 = CreateSlider(self, 'Left_Arm')
-            self.Trash:Add(self.ArmSlider3)
-        end
-    end,
-
-    MovingArmsThread = function(self)
-        TSeaFactoryUnit.MovingArmsThread(self)
-        local dir = 1
-        if not self.ArmSlider1 then return end
-        if not self.ArmSlider2 then return end
-        self.ArmSlider1:SetGoal(0, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetGoal(10, 0, 0)
-        self.ArmSlider2:SetSpeed(40)
-        self.ArmSlider3:SetGoal(20, 0, 0)
-        self.ArmSlider3:SetSpeed(40)
-        WaitFor(self.ArmSlider1)
-        while true do
-            self.ArmSlider1:SetGoal(0, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(8 + 5 * dir, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-            self.ArmSlider3:SetGoal(10, 0, 0)
-            self.ArmSlider3:SetSpeed(40)
-            WaitFor(self.ArmSlider3)
-            self.ArmSlider1:SetGoal(10, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(10, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-            self.ArmSlider3:SetGoal(20, 0, 0)
-            self.ArmSlider3:SetSpeed(40)
-            WaitFor(self.ArmSlider3)
-            dir = dir * -1
-        end
-    end,
-    
-    StopArmsMoving = function(self)
-        TSeaFactoryUnit.StopArmsMoving(self)
-        self.ArmSlider1:SetGoal(0, 0, 0)
-        self.ArmSlider2:SetGoal(0, 0, 0)
-        self.ArmSlider3:SetGoal(0, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetSpeed(40)
-        self.ArmSlider3:SetSpeed(40)
     end,
 }
 

--- a/units/ZEB9603/ZEB9603_unit.bp
+++ b/units/ZEB9603/ZEB9603_unit.bp
@@ -60,7 +60,7 @@ UnitBlueprint {
         'RECLAIMABLE',
         'SHOWQUEUE',
         'SORTCONSTRUCTION',
-	'SUPPORTFACTORY',
+        'SUPPORTFACTORY',
     },
     CollisionOffsetX = 0,
     CollisionOffsetY = -1,
@@ -143,7 +143,7 @@ UnitBlueprint {
         BuildCostMass = 1600,
         BuildRate = 120,
         BuildTime = 4000,
-	DifferentialUpgradeCostCalculation = true, 
+    DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = {
             'zeb9603',
         },

--- a/units/ZEB9603/ZEB9603_unit.bp
+++ b/units/ZEB9603/ZEB9603_unit.bp
@@ -77,6 +77,20 @@ UnitBlueprint {
     },
     Description = '<LOC zeb9603_desc>Naval Factory',
     Display = {
+        ArmSliders = {
+            Left_Arm = {
+                {20, 0, 0},
+                {10, 0, 0},
+            },
+            Center_Arm = {
+                {-5, 0, 0},
+                {15, 0, 0},
+            },
+            Right_Arm = {
+                {-3, 0, 0},
+                {5, 0, 0},
+            },
+        },
         BlinkingLights = {
             {
                 BLBone = 'Dock_Cover',

--- a/units/ZEB9603/ZEB9603_unit.bp
+++ b/units/ZEB9603/ZEB9603_unit.bp
@@ -169,7 +169,8 @@ UnitBlueprint {
         },
         InitialRallyX = 0,
         InitialRallyZ = 10,
-        StorageEnergy = 0,        StorageMass = 320,
+        StorageEnergy = 0,
+        StorageMass = 320,
     },
     Footprint = {
         MinWaterDepth = 1.5,
@@ -259,7 +260,7 @@ UnitBlueprint {
     SelectionSizeZ = 6.9,
     SelectionThickness = 0.26,
     SizeX = 4,
-    SizeY = 3, #from 2, for beam weapons
+    SizeY = 3,
     SizeZ = 10,
     StrategicIconName = 'icon_factory3_naval',
     StrategicIconSortPriority = 210,

--- a/units/ZRB9503/ZRB9503_script.lua
+++ b/units/ZRB9503/ZRB9503_script.lua
@@ -1,55 +1,15 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/ZRB9503/ZRB9503_script.lua
-#**  Author(s):  John Comes, David Tomandl
-#**
-#**  Summary  :  Cybran T2 Naval Factory Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/ZRB9503/ZRB9503_script.lua
+--**  Author(s):  John Comes, David Tomandl
+--**
+--**  Summary  :  Cybran T2 Naval Factory Script
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local CSeaFactoryUnit = import('/lua/cybranunits.lua').CSeaFactoryUnit
 
-
-ZRB9503 = Class(CSeaFactoryUnit) {
-    
-    StartArmsMoving = function(self)
-        CSeaFactoryUnit.StartArmsMoving(self)
-        if not self.ArmSlider1 then
-            self.ArmSlider1 = CreateSlider(self, 'Right_Arm02')
-            self.Trash:Add(self.ArmSlider1)
-        end
-        if not self.ArmSlider2 then
-            self.ArmSlider2 = CreateSlider(self, 'Right_Arm03')
-            self.Trash:Add(self.ArmSlider2)
-        end
-    end,
-
-    MovingArmsThread = function(self)
-        CSeaFactoryUnit.MovingArmsThread(self)
-        while true do
-            if not self.ArmSlider1 then return end
-            if not self.ArmSlider2 then return end
-            self.ArmSlider1:SetGoal(20, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(-20, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-            WaitFor(self.ArmSlider2)
-            self.ArmSlider1:SetGoal(0, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(0, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-            WaitFor(self.ArmSlider2)
-        end
-    end,
-    
-    StopArmsMoving = function(self)
-        CSeaFactoryUnit.StopArmsMoving(self)
-        self.ArmSlider1:SetGoal(0, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetGoal(0, 0, 0)
-        self.ArmSlider2:SetSpeed(40)
-    end,
-}
+ZRB9503 = Class(CSeaFactoryUnit) {}
 
 TypeClass = ZRB9503

--- a/units/ZRB9503/ZRB9503_unit.bp
+++ b/units/ZRB9503/ZRB9503_unit.bp
@@ -82,6 +82,10 @@ UnitBlueprint {
             '<LOC ability_upgradable>Upgradeable',
         },
         AnimationUpgrade = '/units/zrb9503/zrb9503_aupgrade.sca',
+        ArmSliders = {
+            Right_Arm02={{35, 0, 0}, {5, 0, 0}},
+            Right_Arm03={{-20, 0, 0}, {10, 0, 0}},
+        },
         BlinkingLights = {
             {
                 BLBone = 'B03',

--- a/units/ZRB9503/ZRB9503_unit.bp
+++ b/units/ZRB9503/ZRB9503_unit.bp
@@ -61,7 +61,7 @@ UnitBlueprint {
         'RECLAIMABLE',
         'SHOWQUEUE',
         'SORTCONSTRUCTION',
-	'SUPPORTFACTORY',
+        'SUPPORTFACTORY',
     },
     CollisionOffsetX = 0,
     CollisionOffsetY = -1,
@@ -144,7 +144,7 @@ UnitBlueprint {
         BuildCostMass = 800,
         BuildRate = 60,
         BuildTime = 2000,
-	DifferentialUpgradeCostCalculation = true, 
+        DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = {
             'zrb9503',
         },
@@ -243,7 +243,7 @@ UnitBlueprint {
     SelectionSizeZ = 8.1,
     SelectionThickness = 0.21,
     SizeX = 4,
-    SizeY = 3, #from 2, for beam weapons
+    SizeY = 3,
     SizeZ = 10,
     StrategicIconName = 'icon_factory2_naval',
     StrategicIconSortPriority = 215,

--- a/units/ZRB9603/ZRB9603_script.lua
+++ b/units/ZRB9603/ZRB9603_script.lua
@@ -11,7 +11,7 @@
 local CSeaFactoryUnit = import('/lua/cybranunits.lua').CSeaFactoryUnit
 
 
-ZRB0303 = Class(CSeaFactoryUnit) {    
+ZRB0303 = Class(CSeaFactoryUnit) {
     StartArmsMoving = function(self)
         CSeaFactoryUnit.StartArmsMoving(self)
         if not self.ArmSlider1 then

--- a/units/ZRB9603/ZRB9603_script.lua
+++ b/units/ZRB9603/ZRB9603_script.lua
@@ -1,74 +1,15 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/ZRB0303/ZRB0303_script.lua
-#**  Author(s):  John Comes, David Tomandl
-#**
-#**  Summary  :  Cybran T3 Naval Factory Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/ZRB0303/ZRB0303_script.lua
+--**  Author(s):  John Comes, David Tomandl
+--**
+--**  Summary  :  Cybran T3 Naval Factory Script
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local CSeaFactoryUnit = import('/lua/cybranunits.lua').CSeaFactoryUnit
 
-
-ZRB0303 = Class(CSeaFactoryUnit) {
-    StartArmsMoving = function(self)
-        CSeaFactoryUnit.StartArmsMoving(self)
-        if not self.ArmSlider1 then
-            self.ArmSlider1 = CreateSlider(self, 'Right_Arm03')
-            self.Trash:Add(self.ArmSlider1)
-        end
-        if not self.ArmSlider2 then
-            self.ArmSlider2 = CreateSlider(self, 'Right_Arm02')
-            self.Trash:Add(self.ArmSlider2)
-        end
-        if not self.ArmSlider3 then
-            self.ArmSlider3 = CreateSlider(self, 'Right_Arm01')
-            self.Trash:Add(self.ArmSlider3)
-        end
-    end,
-
-    MovingArmsThread = function(self)
-        CSeaFactoryUnit.MovingArmsThread(self)
-        if not self.ArmSlider1 then return end
-        if not self.ArmSlider2 then return end
-        if not self.ArmSlider3 then return end
-        local dir = 1
-        self.ArmSlider1:SetGoal(-10, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetGoal(20, 0, 0)
-        self.ArmSlider2:SetSpeed(40)
-        self.ArmSlider3:SetGoal(50, 0, 0)
-        self.ArmSlider3:SetSpeed(60)
-        WaitFor(self.ArmSlider1)
-        while true do
-            self.ArmSlider1:SetGoal(0, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(0, 0, 0)
-            self.ArmSlider2:SetSpeed(40)
-            self.ArmSlider3:SetGoal(0, 0, 0)
-            self.ArmSlider3:SetSpeed(40)
-            WaitFor(self.ArmSlider3)
-            self.ArmSlider1:SetGoal(-10, 0, 0)
-            self.ArmSlider1:SetSpeed(40)
-            self.ArmSlider2:SetGoal(20 + 30 * dir, 0, 0)
-            self.ArmSlider2:SetSpeed(60)
-            self.ArmSlider3:SetGoal(50, 0, 0)
-            self.ArmSlider3:SetSpeed(60)
-            WaitFor(self.ArmSlider3)
-            dir = dir * -1
-        end
-    end,
-    
-    StopArmsMoving = function(self)
-        CSeaFactoryUnit.StopArmsMoving(self)
-        self.ArmSlider1:SetGoal(0, 0, 0)
-        self.ArmSlider2:SetGoal(0, 0, 0)
-        self.ArmSlider3:SetGoal(0, 0, 0)
-        self.ArmSlider1:SetSpeed(40)
-        self.ArmSlider2:SetSpeed(40)
-        self.ArmSlider3:SetSpeed(40)
-    end,
-}
+ZRB0303 = Class(CSeaFactoryUnit) {}
 
 TypeClass = ZRB0303

--- a/units/ZRB9603/ZRB9603_unit.bp
+++ b/units/ZRB9603/ZRB9603_unit.bp
@@ -145,7 +145,7 @@ UnitBlueprint {
         BuildCostMass = 1600,
         BuildRate = 120,
         BuildTime = 4000,
-	DifferentialUpgradeCostCalculation = true, 
+        DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = {
             'zrb9603',
         },
@@ -156,7 +156,8 @@ UnitBlueprint {
         },
         InitialRallyX = 0,
         InitialRallyZ = 10,
-        StorageEnergy = 0,        StorageMass = 320,
+        StorageEnergy = 0,
+        StorageMass = 320,
     },
     Footprint = {
         MinWaterDepth = 1.5,
@@ -244,7 +245,7 @@ UnitBlueprint {
     SelectionSizeZ = 8.1,
     SelectionThickness = 0.21,
     SizeX = 4,
-    SizeY = 3, #from 2, for beam weapons
+    SizeY = 3,
     SizeZ = 10,
     StrategicIconName = 'icon_factory3_naval',
     StrategicIconSortPriority = 210,

--- a/units/ZRB9603/ZRB9603_unit.bp
+++ b/units/ZRB9603/ZRB9603_unit.bp
@@ -76,6 +76,11 @@ UnitBlueprint {
     },
     Description = '<LOC zrb9603_desc>Naval Factory',
     Display = {
+        ArmSliders = {
+            Right_Arm01={{48, 0, 0}, {24, 0, 0}},
+            Right_Arm02={{5, 0, 0}, {30, 0, 0}},
+            Right_Arm03={{-15, 0, 0}, {10, 0, 0}},
+        },
         BlinkingLights = {
             {
                 BLBone = 'B03',


### PR DESCRIPTION
Let FactoryUnit take care of it instead of each unit having near identical implementations.

The actual slider values are also defined in blueprints now instead of script (bp.Display.ArmSliders)