### PR TITLE
Rotate ACU towards mid

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -69,6 +69,7 @@ Patch 3652 (pending)
 - Enemy civilians are now colored in a unique red color
 - Fix bomb drop code and enable it for Janus, and UEF/Cybran T1 Bombers to attempt improvement to bomb drop characteristics
 - Allowed Aeon Aircraft Carrier to build Bombers and Gunships, same as the others.
+- ACUs start rotated at middle of map as default
 
 **Bugs**
 - Fixed free mass exploit with Megalith eggs

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -340,6 +340,7 @@ function CreateInitialArmyGroup(strArmy, createCommander)
                 cdrUnit:HideBone(0, true)
                 ForkThread(CommanderWarpDelay, cdrUnit, 3)
             end
+            cdrUnit:RotateTowardsMid()
         end
     end
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1819,6 +1819,17 @@ Unit = Class(moho.unit_methods) {
         self:SetRotation(angle + current_yaw)
     end,
 
+    RotateTowards = function(self, tpos)
+        local pos = self:GetPosition()
+        local rad = math.atan2(tpos[1]-pos[1], tpos[3]-pos[3])
+        self:SetRotation(rad * (180 / math.pi))
+    end,
+
+    RotateTowardsMid = function(self)
+        local x, y = GetMapSize()
+        self:RotateTowards({x/2, 0, y/2})
+    end,
+
     OnStartBeingBuilt = function(self, builder, layer)
         self:StartBeingBuiltEffects(builder, layer)
         local aiBrain = self:GetAIBrain()


### PR DESCRIPTION
To make start position more equal, otherwise north has a slight advantage when maps is about walking immediately to mid