### PR TITLE
Hide start position / faction if random

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -76,6 +76,7 @@ Patch 3652 (pending)
 - Allowed Aeon Aircraft Carrier to build Bombers and Gunships, same as the others.
 - Fixed restriction system on Sim side such that it cannot be compromised by UI mods 
 - Fixed restriction system that prevented removing restrictions on already restricted units in scenario scripts
+- It is no longer possible to find out a player's starting position by using the connection window (F11)
 
 **Bugs**
 - Fixed free mass exploit with Megalith eggs

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -156,7 +156,7 @@ AIBrain = Class(moho.aibrain_methods) {
             self.AIPlansList = AIDefaultPlansList
         end
         self.RepeatExecution = false
-        
+
         if ScenarioInfo.type == 'campaign' then
             self:SetResourceSharing(false)
         end
@@ -216,6 +216,18 @@ AIBrain = Class(moho.aibrain_methods) {
         end
 
         self.PreBuilt = true
+    end,
+
+    HideFaction = function(self)
+        if self.realFaction then return end
+        self.realFaction = self:GetFactionIndex()
+        SetArmyFactionIndex(self.Name, 4)
+    end,
+
+    RevealFaction = function(self)
+        if not self.realFaction then return end
+        SetArmyFactionIndex(self.Name, self.realFaction-1)
+        self.realFaction = nil
     end,
 
     ------------------------------------------------------------------------------------------------------------------------------------------
@@ -342,7 +354,7 @@ AIBrain = Class(moho.aibrain_methods) {
         return false
     end,
 
-    
+
 
     ------------------------------------------------------------------------------------------------------------------------------------------
     ---- ------------- TRIGGERS BASED ON AN AI BRAIN       ------------- ----
@@ -416,6 +428,11 @@ AIBrain = Class(moho.aibrain_methods) {
                     end
                 end
             end
+        end
+
+        if self.realFaction and reconType == 'LOSNow' and val == true and
+            not IsAlly(blip:GetArmy(), self:GetArmy()) and GetGameTick() > 20 then
+            self:RevealFaction()
         end
     end,
 
@@ -784,7 +801,7 @@ AIBrain = Class(moho.aibrain_methods) {
 
         if not self.loadingTransport or self.loadingTransport.full then return end
         self.loadingTransport.transData.full = true
-        
+
         if EntityCategoryContains(categories.uaa0310, self.loadingTransport) then
             -- "CZAR FULL"
             cue = 'XGG_Computer_CV01_04753'

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -47,6 +47,9 @@ local Points = {
 AIBrain = Class(moho.aibrain_methods) {
     Result = nil,
 
+    -- unit:GetArmy() so why brain:GetArmyIndex() ?!
+    GetArmy = moho.aibrain_methods.GetArmyIndex,
+
    ------------------------------------------------------
    ----------- HUMAN BRAIN FUNCTIONS HANDLED HERE  ------
    ------------------------------------------------------

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -444,6 +444,7 @@ function InitializeArmies()
         tblGroups[ strArmy ] = {}
 
         if tblData then
+            local brain = GetArmyBrain(strArmy)
 
             ----[ If an actual starting position is defined, overwrite the        ]--
             ----[ randomly generated one.                                         ]--
@@ -454,8 +455,8 @@ function InitializeArmies()
 
             --GetArmyBrain(strArmy):InitializePlatoonBuildManager()
             --LoadArmyPBMBuilders(strArmy)
-            if GetArmyBrain(strArmy).SkirmishSystems then
-                GetArmyBrain(strArmy):InitializeSkirmishSystems()
+            if brain.SkirmishSystems then
+                brain:InitializeSkirmishSystems()
             end
 
             local armyIsCiv = ScenarioInfo.ArmySetup[strArmy].Civilian
@@ -471,6 +472,11 @@ function InitializeArmies()
                 if commander and cdrUnit and ArmyBrains[iArmy].Nickname then
                     cdrUnit:SetCustomName( ArmyBrains[iArmy].Nickname )
                 end
+            end
+
+            if ScenarioInfo.ArmySetup[strArmy].RandomFaction then
+                -- hide faction index from UI
+                brain:HideFaction()
             end
 
             local wreckageGroup = FindUnitGroup('WRECKAGE', Scenario.Armies[strArmy].Units)

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -1,5 +1,5 @@
 -- ==========================================================================================
--- * File       : lua/modules/ui/lobby/UnitsManager.lua 
+-- * File       : lua/modules/ui/lobby/UnitsManager.lua
 -- * Authors    : Gas Powered Games, FAF Community, HUSSAR
 -- * Summary    : This is the sim-specific top-level lua initialization file. It is run at initialization time to set up all lua state for the sim.
 -- * Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
@@ -45,7 +45,7 @@ function SetupSession()
     ScenarioInfo.PlatoonHandles = {}
     ScenarioInfo.UnitGroups = {}
     ScenarioInfo.UnitNames = {}
-    
+
     ScenarioInfo.VarTable = {}
     ScenarioInfo.OSPlatoonCounter = {}
     ScenarioInfo.BuilderTable = { Air = {}, Land = {}, Sea = {}, Gate = {} }
@@ -53,7 +53,7 @@ function SetupSession()
     ScenarioInfo.MapData = { PathingTable = { Amphibious = {}, Water = {}, Land = {}, }, IslandData = {} }
 
     -- ScenarioInfo.Env is the environment that the save file and scenario script file
-    -- are loaded into. We set it up here with some default functions that can be accessed 
+    -- are loaded into. We set it up here with some default functions that can be accessed
     -- from the scenario script.
     ScenarioInfo.Env = import('/lua/scenarioEnvironment.lua')
 
@@ -65,12 +65,12 @@ function SetupSession()
         table.print(restrictions, 'RestrictedCategories')
         local presets = import('/lua/ui/lobby/UnitsRestrictions.lua').GetPresetsData()
         for index, restriction in restrictions do
-            
-            local preset = presets[restriction]
-            if not preset then -- custom restriction  
-                LOG('restriction.custom: "'.. restriction ..'"') 
 
-                -- using hash table because it is faster to check for restrictions later in game    
+            local preset = presets[restriction]
+            if not preset then -- custom restriction
+                LOG('restriction.custom: "'.. restriction ..'"')
+
+                -- using hash table because it is faster to check for restrictions later in game
                 enhRestrictions[restriction] = true
 
                 if buildRestrictions then
@@ -78,15 +78,15 @@ function SetupSession()
                 else
                     buildRestrictions = "(" .. restriction .. ")"
                 end
-            else -- preset restriction  
+            else -- preset restriction
                 if preset.categories then
-                    LOG('restriction.preset "'.. preset.categories .. '"') 
+                    LOG('restriction.preset "'.. preset.categories .. '"')
                     if buildRestrictions then
                         buildRestrictions = buildRestrictions .. " + (" .. preset.categories .. ")"
                     else
                         buildRestrictions = "(" .. preset.categories .. ")"
                     end
-                end 
+                end
                 if preset.enhancements then
                     LOG('restriction.enhancement "'.. restriction .. '"')
                     table.print(preset.enhancements, 'restriction.enhancements ')
@@ -99,7 +99,7 @@ function SetupSession()
     end
 
     if buildRestrictions then
-        LOG('restriction.build '.. buildRestrictions) 
+        LOG('restriction.build '.. buildRestrictions)
         buildRestrictions = import('/lua/sim/Categoryutils.lua').ParseEntityCategoryProperly(buildRestrictions)
         -- add global build restrictions for all armies
         import('/lua/game.lua').AddRestriction(buildRestrictions)
@@ -120,7 +120,7 @@ function SetupSession()
 
     Scenario = ScenarioInfo.Env.Scenario
 
-    LOG('Loading script file: ',ScenarioInfo.script)
+    LOG('Loading script file: ', ScenarioInfo.script)
     doscript(ScenarioInfo.script, ScenarioInfo.Env)
 
     ResetSyncTable()
@@ -195,7 +195,7 @@ function BeginSession()
             ArmyBrains[index].RequestingAlliedVictory = true
         end
     end
-    
+
     -- Create any effect markers on map
     local markers = import('/lua/sim/ScenarioUtilities.lua').GetMarkers()
     local Entity = import('/lua/sim/Entity.lua').Entity
@@ -204,9 +204,9 @@ function BeginSession()
         for k, v in markers do
             if v.type == 'Effect' then
                 local EffectMarkerEntity = Entity()
-                Warp( EffectMarkerEntity, v.position )   
-                EffectMarkerEntity:SetOrientation(OrientFromDir(v.orientation), true)   
-                for k, v in EffectTemplate [v.EffectTemplate] do        
+                Warp( EffectMarkerEntity, v.position )
+                EffectMarkerEntity:SetOrientation(OrientFromDir(v.orientation), true)
+                for k, v in EffectTemplate [v.EffectTemplate] do
                     CreateEmitterAtBone(EffectMarkerEntity,-2,-1,v):ScaleEmitter(v.scale or 1):OffsetEmitter(v.offset.x or 0, v.offset.y or 0, v.offset.z or 0)
                 end
             end

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -64,9 +64,23 @@ function ShuffleStartPositions()
     end
 end
 
+function AssignRandomFactions()
+    local n_factions = table.getsize(import('/lua/factions.lua').Factions)
+
+    for name, army in ScenarioInfo.ArmySetup do
+        if not army.Civilian then
+            if army.Faction > n_factions then
+                army.Faction = Random(1, n_factions)
+                army.RandomFaction = true
+            end
+        end
+    end
+end
+
 --SetupSession will be called by the engine after ScenarioInfo is set
 --but before any armies are created.
 function SetupSession()
+    AssignRandomFactions()
 
     -- LOG('SetupSession: ', repr(ScenarioInfo))
 

--- a/lua/skins/skins.lua
+++ b/lua/skins/skins.lua
@@ -78,7 +78,7 @@ skins = {
         tooltipTitleColor = "FF725b1a",
     },
     random = {
-        default = "default",
+        default = "uef",
         texturesPath = "/textures/ui/random",
         imagerMesh = "/meshes/game/map-border_squ_uef_mesh",
         imagerMeshHorz = "/meshes/game/map-border_hor_uef_mesh",

--- a/lua/ui/game/score.lua
+++ b/lua/ui/game/score.lua
@@ -136,6 +136,7 @@ function SetupPlayerLines()
         if armyIndex ~= 0 and SessionIsReplay() then
             group.faction = Bitmap(group)
             if armyIndex ~= 0 then
+                group.factionIndex = data.faction
                 group.faction:SetTexture(UIUtil.UIFile(UIUtil.GetFactionIcon(data.faction)))
             else
                 group.faction:SetTexture(UIUtil.UIFile('/widgets/faction-icons-alpha_bmp/observer_ico.dds'))
@@ -422,6 +423,11 @@ function _OnBeat()
                         line.name:SetFont(UIUtil.bodyFont, 12)
                         line.score:SetFont(UIUtil.bodyFont, 12)
                     end
+
+                    if armiesInfo[index].faction ~= line.factionIndex then
+                        line.faction:SetTexture(UIUtil.UIFile(UIUtil.GetFactionIcon(armiesInfo[index].faction)))
+                    end
+
                     if armiesInfo[index].outOfGame then
                         if scoreData.general.score == -1 then
                             line.score:SetText(LOC("<LOC _Defeated>Defeated"))

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1624,7 +1624,6 @@ local function TryLaunch(skipNoObserversCheck)
 
         SetFrontEndData('NextOpBriefing', nil)
         -- assign random factions just as game is launched
-        AssignRandomFactions()
         AssignRandomStartSpots()
         AssignAINames()
         local allRatings = {}

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -26,6 +26,7 @@ local Popup = import('/lua/ui/controls/popups/popup.lua').Popup
 local NinePatch = import('/lua/ui/controls/ninepatch.lua').NinePatch
 local InputDialog = import('/lua/ui/controls/popups/inputdialog.lua').InputDialog
 local skins = import('/lua/skins/skins.lua').skins
+local Factions = import('/lua/factions.lua').Factions
 
 --* Handy global variables to assist skinning
 buttonFont = import('/lua/lazyvar.lua').Create()            -- default font used for button faces
@@ -1007,7 +1008,15 @@ function ShowInfoDialog(parent, dialogText, buttonText, buttonCallback, destroyO
 end
 
 function GetFactionIcon(factionIndex)
-    return import('/lua/factions.lua').Factions[factionIndex + 1].Icon
+    local icon
+
+    if Factions[factionIndex + 1] then
+        icon = import('/lua/factions.lua').Factions[factionIndex + 1].Icon
+    else
+        icon = "/faction_icon-sm/random_ico.dds"
+    end
+
+    return icon
 end
 
 function CreateDialogBrackets(parent, leftOffset, topOffset, rightOffset, bottomOffset, altTextures)


### PR DESCRIPTION
There are UI mods floating around which shows start position of a player by looking at the scenario files for ArmyID ->  position. Another easy way is to press F11 if you memorized the positions (Setons - 1, 2 for front .. 7, 8 air)

<Link href="http://forums.faforever.com/viewtopic.php?f=41&t=11577" target="_blank">http://forums.faforever.com/viewtopic.php?f=41&t=11577</Link>

With random / balanced spawns this should be considered an exploit. By shuffling the team positions sim side we prevent user side to pin down the start positions.

Another improvement could be a game option "Incognito" which completely hide the names of the enemies (show in replay / if players choose to reveal themselves during game). Random colors then also ofc. Currently high ranked players are ganked (and vice versa with weak players). Would be better if such strategies were a result of scouting an opponent's gameplay, not simply by looking at the commander name.

Finally, random faction players should probably be unknown faction until scouted.
