### PR TITLE
Assist t2/t3 mex with engineers to build mass storages

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -78,6 +78,22 @@ Callbacks.ClearCommands = function(data, units)
     IssueClearCommands(safe)
 end
 
+Callbacks.CapMex = function(data, units)
+    local units = EntityCategoryFilterDown(categories.ENGINEER, SecureUnits(units))
+    if not units[1] then return end
+    local mex = EntityCategoryFilterDown(categories.MASSEXTRACTION, SecureUnits(data.target))[1]
+    if not mex then return end
+
+    local pos = mex:GetPosition()
+    local bpid = mex:GetBlueprint().BlueprintId
+    local prefix = string.sub(bpid, 0, 3)
+
+    IssueBuildMobile(units, Vector(pos.x, pos.y, pos.z-2), prefix .. '1106', {})
+    IssueBuildMobile(units, Vector(pos.x+2, pos.y, pos.z), prefix .. '1106', {})
+    IssueBuildMobile(units, Vector(pos.x, pos.y, pos.z+2), prefix .. '1106', {})
+    IssueBuildMobile(units, Vector(pos.x-2, pos.y, pos.z), prefix .. '1106', {})
+end
+
 Callbacks.BreakAlliance = SimUtils.BreakAlliance
 
 Callbacks.GiveUnitsToPlayer = SimUtils.GiveUnitsToPlayer

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -86,12 +86,15 @@ Callbacks.CapMex = function(data, units)
 
     local pos = mex:GetPosition()
     local bpid = mex:GetBlueprint().BlueprintId
-    local prefix = string.sub(bpid, 0, 3)
+    local msid = string.sub(bpid, 0, 3) .. '1106'
 
-    IssueBuildMobile(units, Vector(pos.x, pos.y, pos.z-2), prefix .. '1106', {})
-    IssueBuildMobile(units, Vector(pos.x+2, pos.y, pos.z), prefix .. '1106', {})
-    IssueBuildMobile(units, Vector(pos.x, pos.y, pos.z+2), prefix .. '1106', {})
-    IssueBuildMobile(units, Vector(pos.x-2, pos.y, pos.z), prefix .. '1106', {})
+    for _, u in units do
+        -- TODO, race specific prefix per builder, see lua/ui/construction.lua
+        IssueBuildMobile({u}, Vector(pos.x, pos.y, pos.z-2), msid, {})
+        IssueBuildMobile({u}, Vector(pos.x+2, pos.y, pos.z), msid, {})
+        IssueBuildMobile({u}, Vector(pos.x, pos.y, pos.z+2), msid, {})
+        IssueBuildMobile({u}, Vector(pos.x-2, pos.y, pos.z), msid, {})
+    end
 end
 
 Callbacks.BreakAlliance = SimUtils.BreakAlliance

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -162,6 +162,11 @@ function OnCommandIssued(command)
                 SimCallback(cb, true)
             end
         end
+
+        if EntityCategoryContains(categories.STRUCTURE * categories.MASSEXTRACTION * (categories.TECH2+categories.TECH3), command.Blueprint) then
+            local cb = { Func = 'CapMex', Args = { target = command.Target.EntityId } }
+            SimCallback(cb, true)
+        end
     elseif command.CommandType == 'BuildMobile' then
 		AddCommandFeedbackBlip({
 			Position = command.Target.Position, 


### PR DESCRIPTION
To help building mass storages we could let an assist command on a non-capped T2/T3 mex result in a build mass storages command (mentioned here: #731)

This PR should be seen as a proof of concept, needs a bit of tuning (check for existing storages, if a unit really can build them to prevent invalid orders etc). Also needs to be an UI option so it can be turned off.