### PR TITLE
Just move away / delete old blip

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -443,11 +443,7 @@ StructureUnit = Class(Unit) {
                 local blip = self:GetBlip(i)
 
                 if blip then
-                    if not blip:IsSeenEver(i) and (blip:IsOnRadar(i) or blip:IsOnSonar(i)) then
-                        -- Remove dead radar blip out of map so we don't reveal what's under it
-                        blip:SetPosition(Vector(-100, 0, -100), true)
-                    end
-
+                    blip:SetPosition(Vector(-100, 0, -100), true)
                     -- expired blip will disappear with this
                     blip:InitIntel(i, 'Vision', 2)
                     blip:EnableIntel('Vision')


### PR DESCRIPTION
Alternative to flashing vision at the location of dead blips, we just move the dead blip away and blip it outside of map.

Downside with this is that "zoomed-in-vision" of upgraded building is unknown until
scouted but strategic icon still show what it is.

Issue #1245