### PR TITLE
Intel fix

### DIFF
--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -398,9 +398,6 @@ AIBrain = Class(moho.aibrain_methods) {
     --   val: true or false
     -- calls callback function with blip it saw.
 
-
-
-
     OnIntelChange = function(self, blip, reconType, val)
         if self.IntelTriggerList then
             for k, v in self.IntelTriggerList do

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -436,21 +436,16 @@ StructureUnit = Class(Unit) {
 
     -- Refresh intel on a destroyed / upgraded unit by setting vision on the actual blip.
     -- The expired blip will actually be destroyed right after when the intel system notices it's no longer there
-    RefreshIntel = function(self)
+    RefreshIntel = function(self, was_upgrade)
         local army = self:GetArmy()
+        local x, y, z = self:GetUnitSizes()
+
         for i, brain in ArmyBrains do
             if army ~= i and not IsAlly(i, army) then
                 local blip = self:GetBlip(i)
 
                 if blip then
-                    if not blip:IsSeenEver(i) and (blip:IsOnRadar(i) or blip:IsOnSonar(i)) then
-                        -- Remove dead radar blip out of map so we don't reveal what's under it
-                        blip:SetPosition(Vector(-100, 0, -100), true)
-                    end
-
-                    -- expired blip will disappear with this
-                    blip:InitIntel(i, 'Vision', 2)
-                    blip:EnableIntel('Vision')
+                    blip:FlashIntel(i, was_upgrade)
                 end
             end
         end

--- a/lua/sim/Blip.lua
+++ b/lua/sim/Blip.lua
@@ -1,0 +1,38 @@
+#****************************************************************************
+#**
+#**  File     :  /lua/blip.lua
+#**  Author(s):
+#**
+#**  Summary  : The recon blip lua module
+#**
+#**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+
+Blip = Class(moho.blip_methods) {
+
+    AddDestroyHook = function(self,hook)
+        if not self.DestroyHooks then
+            self.DestroyHooks = {}
+        end
+        table.insert(self.DestroyHooks,hook)
+    end,
+
+    RemoveDestroyHook = function(self,hook)
+        if self.DestroyHooks then
+            for k,v in self.DestroyHooks do
+                if v == hook then
+                    table.remove(self.DestroyHooks,k)
+                    return
+                end
+            end
+        end
+    end,
+
+    OnDestroy = function(self)
+        if self.DestroyHooks then
+            for k,v in self.DestroyHooks do
+                v(self)
+            end
+        end
+    end,
+}

--- a/lua/sim/Blip.lua
+++ b/lua/sim/Blip.lua
@@ -1,14 +1,58 @@
-#****************************************************************************
-#**
-#**  File     :  /lua/blip.lua
-#**  Author(s):
-#**
-#**  Summary  : The recon blip lua module
-#**
-#**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /lua/blip.lua
+--**  Author(s):
+--**
+--**  Summary  : The recon blip lua module
+--**
+--**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
+
+local FlashedBlips = {}
+local ClearThread = nil
+
+-- Thread running as long as there is blips that need manual clear after 5 ticks
+function ClearFlashedThread(army)
+    local tick = GetGameTick()
+
+    while table.getsize(FlashedBlips) > 0 do
+        WaitSeconds(.5)
+
+        for i, blip in FlashedBlips do
+            if blip:BeenDestroyed() then
+                blip.flash = nil
+            elseif blip.flash and tick - blip.flash > 5 then
+                blip.flash = nil
+                blip:DisableIntel('Vision')
+            end
+
+            if not blip.flash then
+                FlashedBlips[i] = nil
+            end
+        end
+    end
+
+    ClearThread = nil
+end
 
 Blip = Class(moho.blip_methods) {
+    FlashIntel = function(self, army, was_upgrade)
+        if not self:IsSeenEver(army) and (self:IsOnRadar(army) or self:IsOnSonar(self)) then
+            -- Remove dead radar blip out of map so we don't reveal what's under it
+            self:SetPosition(Vector(-100, 0, -100), true)
+        end
+
+        self:InitIntel(army, 'Vision', 2)
+        self:EnableIntel('Vision')
+
+        if was_upgrade then -- need to make sure upgraded blips are cleared
+            self.flash = GetGameTick()
+            table.insert(FlashedBlips, self)
+            if not ClearThread then
+                ClearThread = ForkThread(ClearFlashedThread)
+            end
+        end
+    end,
 
     AddDestroyHook = function(self,hook)
         if not self.DestroyHooks then

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1700,7 +1700,7 @@ Unit = Class(moho.unit_methods) {
         ChangeState(self, self.DeadState)
     end,
 
-    RefreshIntel = function(self)
+    RefreshIntel = function(self, was_upgrade)
     end,
 
     HideLandBones = function(self)
@@ -1871,7 +1871,7 @@ Unit = Class(moho.unit_methods) {
             self.DisallowCollisions = false
             self:SetCanTakeDamage(true)
             self:RevertCollisionShape()
-            builder:RefreshIntel()
+            builder:RefreshIntel(true)
             self.IsUpgrade = nil
         end
 


### PR DESCRIPTION
Make sure vision for upgraded blips isn't permanent …

If a blip for some reason survives over 5 ticks we manually delete it. Old blips of upgraded units sometime survive for some unknown reason, maybe the blip structure are reused by the engine or similar.

Only one clear thread is spawned regardless of how many blips are cleared so should be effective.

#1245 