### PR TITLE
Delayed flash

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -126,6 +126,10 @@ StructureUnit = Class(Unit) {
     end,
 
     OnStopBeingBuilt = function(self,builder,layer)
+        if self.IsUpgrade and builder then
+            builder:RefreshIntel(true)
+        end
+
         Unit.OnStopBeingBuilt(self,builder,layer)
         -- Whaa why can't we have sane inheritance chains :/
         if self:GetBlueprint().General.FactionName == "Seraphim" then

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -453,7 +453,6 @@ StructureUnit = Class(Unit) {
     end,
 
     DestroyUnit = function(self, overkillRatio)
-        self:RefreshIntel()
         Unit.DestroyUnit(self, overkillRatio)
     end,
 

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -126,10 +126,6 @@ StructureUnit = Class(Unit) {
     end,
 
     OnStopBeingBuilt = function(self,builder,layer)
-        if self.IsUpgrade and builder then
-            builder:RefreshIntel(true)
-        end
-
         Unit.OnStopBeingBuilt(self,builder,layer)
         -- Whaa why can't we have sane inheritance chains :/
         if self:GetBlueprint().General.FactionName == "Seraphim" then
@@ -364,6 +360,7 @@ StructureUnit = Class(Unit) {
                 NotifyUpgrade(self, unitBuilding)
                 self:StopUpgradeEffects(unitBuilding)
                 self:PlayUnitSound('UpgradeEnd')
+                self:RefreshIntel(true)
                 self:Destroy()
             end
         end,

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -436,21 +436,17 @@ StructureUnit = Class(Unit) {
 
     -- Refresh intel on a destroyed / upgraded unit by setting vision on the actual blip.
     -- The expired blip will actually be destroyed right after when the intel system notices it's no longer there
-    RefreshIntel = function(self)
-        local army = self:GetArmy()
+    RefreshIntel = function(self, was_upgrade)
+        local unit_army = self:GetArmy()
+
         for i, brain in ArmyBrains do
-            if army ~= i and not IsAlly(i, army) then
-                local blip = self:GetBlip(i)
+            local army = brain:GetArmyIndex()
+
+            if army ~= unit_army and not IsAlly(army, unit_army) then
+                local blip = self:GetBlip(army)
 
                 if blip then
-                    if not blip:IsSeenEver(i) and (blip:IsOnRadar(i) or blip:IsOnSonar(i)) then
-                        -- Remove dead radar blip out of map so we don't reveal what's under it
-                        blip:SetPosition(Vector(-100, 0, -100), true)
-                    end
-
-                    -- expired blip will disappear with this
-                    blip:InitIntel(i, 'Vision', 2)
-                    blip:EnableIntel('Vision')
+                    blip:FlashIntel(army, was_upgrade)
                 end
             end
         end

--- a/lua/sim/Blip.lua
+++ b/lua/sim/Blip.lua
@@ -1,0 +1,38 @@
+#****************************************************************************
+#**
+#**  File     :  /lua/blip.lua
+#**  Author(s):
+#**
+#**  Summary  : The recon blip lua module
+#**
+#**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+
+Blip = Class(moho.blip_methods) {
+
+    AddDestroyHook = function(self,hook)
+        if not self.DestroyHooks then
+            self.DestroyHooks = {}
+        end
+        table.insert(self.DestroyHooks,hook)
+    end,
+
+    RemoveDestroyHook = function(self,hook)
+        if self.DestroyHooks then
+            for k,v in self.DestroyHooks do
+                if v == hook then
+                    table.remove(self.DestroyHooks,k)
+                    return
+                end
+            end
+        end
+    end,
+
+    OnDestroy = function(self)
+        if self.DestroyHooks then
+            for k,v in self.DestroyHooks do
+                v(self)
+            end
+        end
+    end,
+}

--- a/lua/sim/Blip.lua
+++ b/lua/sim/Blip.lua
@@ -1,14 +1,64 @@
-#****************************************************************************
-#**
-#**  File     :  /lua/blip.lua
-#**  Author(s):
-#**
-#**  Summary  : The recon blip lua module
-#**
-#**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /lua/blip.lua
+--**  Author(s):
+--**
+--**  Summary  : The recon blip lua module
+--**
+--**  Copyright Â© 2006 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
+
+local FlashBlips = {}
+local DelayThread = nil
+
+-- Thread flashing blips after a small delay to prevent upgraded units to inherit vision of builder blip
+function FlashDelayed()
+    local current_tick, blip, army
+    WaitSeconds(.5)
+
+    while table.getsize(FlashBlips) > 0 do
+        WaitSeconds(.1)
+        current_tick = GetGameTick()
+
+        for i, data in FlashBlips do
+            blip = data.blip
+            army = data.army
+
+            if blip:BeenDestroyed() or blip.flash < current_tick then
+                blip.flash = nil
+                if not blip:BeenDestroyed() then
+                    blip:Refresh(army)
+                end
+                FlashBlips[i] = nil
+            end
+        end
+    end
+
+    DelayThread = nil
+end
 
 Blip = Class(moho.blip_methods) {
+    Refresh = function(self, army)
+        if not self:IsSeenEver(army) and (self:IsOnRadar(army) or self:IsOnSonar(army)) then
+            -- Remove dead radar blip out of map so we don't reveal what's under it
+            self:SetPosition(Vector(-100, 0, -100), true)
+        end
+
+        self:InitIntel(army, 'Vision', 2)
+        self:EnableIntel('Vision')
+    end,
+
+    FlashIntel = function(self, army, delay)
+        if delay then
+            self.flash = GetGameTick() + 5;
+            table.insert(FlashBlips, {army=army, blip=self})
+            if not DelayThread then
+                DelayThread = ForkThread(FlashDelayed)
+            end
+        else
+            self:Refresh(army)
+        end
+    end,
 
     AddDestroyHook = function(self,hook)
         if not self.DestroyHooks then

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1871,9 +1871,6 @@ Unit = Class(moho.unit_methods) {
             self.DisallowCollisions = false
             self:SetCanTakeDamage(true)
             self:RevertCollisionShape()
-            -- new building inherits builder's blip, including vision so refresh must happen with a 1 tick delay
-            builder:RefreshIntel(true)
-            
             self.IsUpgrade = nil
         end
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1872,9 +1872,8 @@ Unit = Class(moho.unit_methods) {
             self:SetCanTakeDamage(true)
             self:RevertCollisionShape()
             -- new building inherits builder's blip, including vision so refresh must happen with a 1 tick delay
-            ForkThread(function()
-                builder:RefreshIntel()
-            end)
+            builder:RefreshIntel(true)
+            
             self.IsUpgrade = nil
         end
 


### PR DESCRIPTION
Need to keep track references of blips because the actual builder unit will be destroyed before we're refreshing...

Fixes permavision

