### PR TITLE
Fix #1272 (Sera ACU gun upgrade)

### DIFF
--- a/units/XSL0001/XSL0001_script.lua
+++ b/units/XSL0001/XSL0001_script.lua
@@ -393,7 +393,7 @@ XSL0001 = Class(ACUUnit) {
             local oc = self:GetWeaponByLabel('OverCharge')
             oc:ChangeMaxRadius(bp.NewMaxRadius or 44)
             local aoc = self:GetWeaponByLabel('AutoOverCharge')
-            aoc:ChangeMaxRadius(bpDisrupt or 44)
+            aoc:ChangeMaxRadius(bp.NewMaxRadius or 44)
         elseif enh == 'RateOfFireRemove' then
             local wep = self:GetWeaponByLabel('ChronotronCannon')
             local bpDisrupt = self:GetBlueprint().Weapon[1].RateOfFire


### PR DESCRIPTION
Copy-paste error in fccd55 broke Sera ACU Gun upgrade.
Put in correct value for new Auto-OC range.

Should maybe be hot-fixed.