### PR TITLE
Assist t2/t3 mex with engineers -> build MS

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -84,11 +84,10 @@ Callbacks.CapMex = function(data, units)
     local mex = GetEntityById(data.target)
     if not mex or not EntityCategoryContains(categories.MASSEXTRACTION * categories.STRUCTURE, mex) then return end
     local pos = mex:GetPosition()
-    local bpid = mex:GetBlueprint().BlueprintId
-    local msid = string.sub(bpid, 0, 3) .. '1106'
+    local msid
 
     for _, u in units do
-        -- TODO, race specific prefix per builder, see lua/ui/construction.lua
+        msid = string.sub(u:GetBlueprint().BlueprintId, 0, 2) .. 'b1106'
         IssueBuildMobile({u}, Vector(pos.x, pos.y, pos.z-2), msid, {})
         IssueBuildMobile({u}, Vector(pos.x+2, pos.y, pos.z), msid, {})
         IssueBuildMobile({u}, Vector(pos.x, pos.y, pos.z+2), msid, {})

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -78,6 +78,24 @@ Callbacks.ClearCommands = function(data, units)
     IssueClearCommands(safe)
 end
 
+Callbacks.CapMex = function(data, units)
+    local units = EntityCategoryFilterDown(categories.ENGINEER, SecureUnits(units))
+    if not units[1] then return end
+    local mex = GetEntityById(data.target)
+    if not mex or not EntityCategoryContains(categories.MASSEXTRACTION * categories.STRUCTURE, mex) then return end
+    local pos = mex:GetPosition()
+    local bpid = mex:GetBlueprint().BlueprintId
+    local msid = string.sub(bpid, 0, 3) .. '1106'
+
+    for _, u in units do
+        -- TODO, race specific prefix per builder, see lua/ui/construction.lua
+        IssueBuildMobile({u}, Vector(pos.x, pos.y, pos.z-2), msid, {})
+        IssueBuildMobile({u}, Vector(pos.x+2, pos.y, pos.z), msid, {})
+        IssueBuildMobile({u}, Vector(pos.x, pos.y, pos.z+2), msid, {})
+        IssueBuildMobile({u}, Vector(pos.x-2, pos.y, pos.z), msid, {})
+    end
+end
+
 Callbacks.BreakAlliance = SimUtils.BreakAlliance
 
 Callbacks.GiveUnitsToPlayer = SimUtils.GiveUnitsToPlayer

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -468,6 +468,14 @@ StructureUnit = Class(Unit) {
     end,
 
     OnKilled = function(self, instigator, type, overKillRatio)
+        local scus = EntityCategoryFilterDown(categories.SUBCOMMANDER, self:GetGuards())
+        if scus[1] then
+            for _, u in scus do
+                u:SetFocusEntity(self)
+                self.Repairers[u:GetEntityId()] = u
+            end
+        end
+
         Unit.OnKilled(self, instigator, type, overKillRatio)
     end,
 
@@ -478,7 +486,8 @@ StructureUnit = Class(Unit) {
                 self.Repairers[id] = nil
             else
                 local focus = u:GetFocusUnit()
-                if focus == self and u:IsUnitState('Repairing') and not u:GetGuardedUnit() then -- not assist
+                if focus == self and ((u:IsUnitState('Repairing') and not u:GetGuardedUnit()) or
+                                      EntityCategoryContains(categories.SUBCOMMANDER, u)) then
                     table.insert(units, u)
                 end
             end

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -256,6 +256,18 @@ options = {
                     },
                 },
             },
+            {
+                title = "Assist Mex to Build Mass Storages",
+                key = 'assist_mex',
+                type = 'toggle',
+                default = false,
+                custom = {
+                    states = {
+                        {text = "<LOC _Off>", key = false},
+                        {text = "<LOC _On>", key = true},
+                    },
+                },
+            }
         },
     },
     ui = {

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -136,17 +136,18 @@ function AddCommandFeedbackByType(pos, type)
         return false;
     else
         AddCommandFeedbackBlip({
-                    Position = pos, 
+                    Position = pos,
                     MeshName = commandMeshResources[type][1],
                     TextureName = commandMeshResources[type][2],
                     ShaderName = 'CommandFeedback',
                     UniformScale = 0.125,
                 }, 0.7)
     end
-        
+
     return true;
 end
 
+local lastMex = nil
 function AssistMex(command)
     local units = EntityCategoryFilterDown(categories.ENGINEER, command.Units)
     if not units[1] then return end
@@ -162,12 +163,8 @@ function AssistMex(command)
     local focus = mex:GetFocus()
 
     if focus then -- upgrading
-        for _, u in units do
-            if u:GetFocus() == focus then
-                cap = true
-                break
-            end
-        end
+        cap = IsKeyDown('Shift') and lastMex == mex
+        lastMex = mex
     elseif not mex:IsInCategory('TECH1')  then
         cap = true
     end

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -168,7 +168,7 @@ function AssistMex(command)
                 break
             end
         end
-    elseif mex:IsInCategory('TECH2') then
+    elseif not mex:IsInCategory('TECH1')  then
         cap = true
     end
 

--- a/units/UAL0301/UAL0301_unit.bp
+++ b/units/UAL0301/UAL0301_unit.bp
@@ -135,7 +135,6 @@ UnitBlueprint {
         'CONSTRUCTION',
         'REPAIR',
         'RECLAIM',
-        'REBUILDER',
         'BUILTBYQUANTUMGATE',
         'CAPTURE',
         'VISIBLETORECON',

--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         'CONSTRUCTION',
         'REPAIR',
         'RECLAIM',
-        'REBUILDER',
         'BUILTBYQUANTUMGATE',
         'PODSTAGINGPLATFORM',
         'ENGINEER',

--- a/units/URL0301/URL0301_unit.bp
+++ b/units/URL0301/URL0301_unit.bp
@@ -118,7 +118,6 @@ UnitBlueprint {
         'CONSTRUCTION',
         'REPAIR',
         'RECLAIM',
-        'REBUILDER',
         'BUILTBYQUANTUMGATE',
         'CAPTURE',
         'VISIBLETORECON',

--- a/units/XSL0301/XSL0301_unit.bp
+++ b/units/XSL0301/XSL0301_unit.bp
@@ -140,7 +140,6 @@ UnitBlueprint {
         'REPAIR',
         'SILO',
         'RECLAIM',
-        'REBUILDER',
         'BUILTBYQUANTUMGATE',
         'CAPTURE',
         'VISIBLETORECON',


### PR DESCRIPTION
Rebase of #1226

Assist mex with engineer(s) to order them build mass storages, needs to be turned on in options.

* Checks if mex is already capped
* If mex currently is upgrading, you need to shift-right click twice on the mex to get the engineers to also build mass storages. This to prevent unwanted build order when you only want to assist upgrade
* Won't trigger on non-upgrading T1 mex

All above behavior is in UI so people can mod it to their liking.
