### PR TITLE
Removing "Radar" Ability from Tech 1 Bombers as part of Balance Patch.

### DIFF
--- a/units/UAA0103/UAA0103_unit.bp
+++ b/units/UAA0103/UAA0103_unit.bp
@@ -123,7 +123,6 @@ UnitBlueprint {
     Display = {
         Abilities = {
             '<LOC ability_stun>EMP Weapon',
-            '<LOC ability_radar>Radar',
         },
         LayerChangeEffects = {
             AirLand = {

--- a/units/UEA0103/UEA0103_unit.bp
+++ b/units/UEA0103/UEA0103_unit.bp
@@ -120,9 +120,6 @@ UnitBlueprint {
     },
     Description = '<LOC uea0103_desc>Attack Bomber',
     Display = {
-        Abilities = {
-            '<LOC ability_radar>Radar',
-        },
         LayerChangeEffects = {
             AirLand = {
                 Effects = {

--- a/units/URA0103/URA0103_unit.bp
+++ b/units/URA0103/URA0103_unit.bp
@@ -121,9 +121,6 @@ UnitBlueprint {
     },
     Description = '<LOC ura0103_desc>Attack Bomber',
     Display = {
-        Abilities = {
-            '<LOC ability_radar>Radar',
-        },
         LayerChangeEffects = {
             AirLand = {
                 Effects = {

--- a/units/XSA0103/XSA0103_unit.bp
+++ b/units/XSA0103/XSA0103_unit.bp
@@ -132,9 +132,6 @@ UnitBlueprint {
     },
     Description = '<LOC xsa0103_desc>Attack Bomber',
     Display = {
-        Abilities = {
-            '<LOC ability_radar>Radar',
-        },
         LayerChangeEffects = {
             AirLand = {
                 Effects = {


### PR DESCRIPTION
Saw a post on Slack that the UEF Tech 1 Bomber is showing that it has a Radar Ability when it doesn't. This was done for Balance Patch.