### PR TITLE
Let the Ahwassa projectile burn straight through ASF without being blocked

### DIFF
--- a/lua/armordefinition.lua
+++ b/lua/armordefinition.lua
@@ -69,7 +69,6 @@ armordefinition = {
         # Armor Definition
         'Normal 1.0',        
         'CzarBeam 0.25',
-        'OtheTacticalBomb 0.1',   
     },
     {
         # Armor Type name

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -156,10 +156,15 @@ Projectile = Class(moho.projectile_methods, Entity) {
     end,
 
     OnCollisionCheck = function(self, other)
+        local same_army = self:GetArmy() == other:GetArmy()
+
+        if not EntityCategoryContains(categories.PROJECTILE, other) then -- called from Unit:OnCollisionCheck
+            return not same_army or self:GetCollideFriendly() == true
+        end
+
         -- If we return false the thing hitting us has no idea that it came into contact with us.
         -- By default, anything hitting us should know about it so we return true.
-
-        if self:GetArmy() == other:GetArmy() then return false end
+        if same_army then return false end
 
         local dnc_cats = categories.TORPEDO + categories.MISSILE + categories.DIRECTFIRE
         if EntityCategoryContains(dnc_cats, self) and EntityCategoryContains(dnc_cats, other) then

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1304,8 +1304,8 @@ Unit = Class(moho.unit_methods) {
             return false
         end
         if EntityCategoryContains(categories.PROJECTILE, other) then
-            if self:GetArmy() == other:GetArmy() then
-                return other:GetCollideFriendly()
+            if not other:OnCollisionCheck(self) then
+                return false
             end
         end
 

--- a/projectiles/SBOOhwalliStrategicBomb01/SBOOhwalliStrategicBomb01_proj.bp
+++ b/projectiles/SBOOhwalliStrategicBomb01/SBOOhwalliStrategicBomb01_proj.bp
@@ -1,0 +1,48 @@
+ProjectileBlueprint {
+    Audio = {
+        Impact = Sound {
+            Bank = 'XSA_Destroy',
+            Cue = 'XSA_Strag_Bomb_Explosion',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+        ImpactTerrain = Sound {
+            Bank = 'XSA_Destroy',
+            Cue = 'XSA_Strag_Bomb_Explosion',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+        ImpactWater = Sound {
+            Bank = 'XSA_Destroy',
+            Cue = 'XSA_Strag_Bomb_Explosion',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+    },
+    Categories = {
+        'SERAPHIM',
+        'PROJECTILE',
+        'INDIRECTFIRE',
+    },
+    Display = {
+        CameraFollowTimeout = 2,
+        CameraFollowsProjectile = true,
+        ImpactEffects = {
+            Type = 'Small01',
+        },
+        StrategicIconSize = 3,
+    },
+    General = {
+        Category = 'Bomb',
+        Faction = 'Seraphim',
+        TechLevel = 1,
+        Weapon = 'Ohwalli Strategic Bomb',
+    },
+    Interface = {
+        HelpText = 0,
+    },
+    Physics = {
+        DestroyOnWater = true,
+        RealisticOrdinance = true,
+        TrackTarget = false,
+        TurnRate = 0,
+        VelocityAlign = true,
+    },
+}

--- a/projectiles/SBOOhwalliStrategicBomb01/SBOOhwalliStrategicBomb01_script.lua
+++ b/projectiles/SBOOhwalliStrategicBomb01/SBOOhwalliStrategicBomb01_script.lua
@@ -1,0 +1,18 @@
+#****************************************************************************
+#**
+#**  File     :  /data/projectiles/SBOOhwalliStategicBomb01/SBOOhwalliStategicBomb01_script.lua
+#**  Author(s):  Greg Kohne, Gordon Duclos, Matt Vainio
+#**
+#**  Summary  :  Ohwalli-Strategic Bomb script, used on XSA402
+#**
+#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+local SOhwalliStrategicBombProjectile = import('/lua/seraphimprojectiles.lua').SOhwalliStrategicBombProjectile
+
+SBOOhwalliStategicBomb01 = Class(SOhwalliStrategicBombProjectile){
+    OnImpact = function(self, TargetType, TargetEntity)
+        self:CreateProjectile('/effects/entities/SBOOhwalliBombEffectController01/SBOOhwalliBombEffectController01_proj.bp', 0, 0, 0, 0, 0, 0):SetCollision(false)
+        SOhwalliStrategicBombProjectile.OnImpact(self, TargetType, TargetEntity) 
+    end,
+}
+TypeClass = SBOOhwalliStategicBomb01

--- a/projectiles/SBOOhwalliStrategicBomb01/SBOOhwalliStrategicBomb01_script.lua
+++ b/projectiles/SBOOhwalliStrategicBomb01/SBOOhwalliStrategicBomb01_script.lua
@@ -1,12 +1,12 @@
-#****************************************************************************
-#**
-#**  File     :  /data/projectiles/SBOOhwalliStategicBomb01/SBOOhwalliStategicBomb01_script.lua
-#**  Author(s):  Greg Kohne, Gordon Duclos, Matt Vainio
-#**
-#**  Summary  :  Ohwalli-Strategic Bomb script, used on XSA402
-#**
-#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /data/projectiles/SBOOhwalliStategicBomb01/SBOOhwalliStategicBomb01_script.lua
+--**  Author(s):  Greg Kohne, Gordon Duclos, Matt Vainio
+--**
+--**  Summary  :  Ohwalli-Strategic Bomb script, used on XSA402
+--**
+--**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 local SOhwalliStrategicBombProjectile = import('/lua/seraphimprojectiles.lua').SOhwalliStrategicBombProjectile
 
 SBOOhwalliStategicBomb01 = Class(SOhwalliStrategicBombProjectile){

--- a/projectiles/SBOOhwalliStrategicBomb01/SBOOhwalliStrategicBomb01_script.lua
+++ b/projectiles/SBOOhwalliStrategicBomb01/SBOOhwalliStrategicBomb01_script.lua
@@ -9,10 +9,25 @@
 --****************************************************************************
 local SOhwalliStrategicBombProjectile = import('/lua/seraphimprojectiles.lua').SOhwalliStrategicBombProjectile
 
-SBOOhwalliStategicBomb01 = Class(SOhwalliStrategicBombProjectile){
+SBOOhwalliStategicBomb01 = Class(SOhwalliStrategicBombProjectile) {
+    Collisions = {},
+    OnCreate = function(self)
+        SOhwalliStrategicBombProjectile.OnCreate(self)
+        self:SetCollisionShape('Sphere', 0, 0, 0, 2)
+        self:CollideEntity(true)
+    end,
+
     OnImpact = function(self, TargetType, TargetEntity)
         self:CreateProjectile('/effects/entities/SBOOhwalliBombEffectController01/SBOOhwalliBombEffectController01_proj.bp', 0, 0, 0, 0, 0, 0):SetCollision(false)
         SOhwalliStrategicBombProjectile.OnImpact(self, TargetType, TargetEntity) 
+    end,
+
+    OnCollisionCheck = function(self, other)
+        if other ~= self and not self.Collisions[other:GetEntityId()] and EntityCategoryContains(categories.AIR, other) then
+            Damage(self:GetLauncher() or self, self:GetPosition(), other, self.DamageData.DamageAmount, 'Normal')
+        end
+        
+        return SOhwalliStrategicBombProjectile.OnCollisionCheck(self, other)
     end,
 }
 TypeClass = SBOOhwalliStategicBomb01

--- a/units/XSA0402/XSA0402_unit.bp
+++ b/units/XSA0402/XSA0402_unit.bp
@@ -299,7 +299,7 @@ UnitBlueprint {
             AutoInitiateAttackCommand = true,
             BallisticArc = 'RULEUBA_None',
             BombDropThreshold = 4,
-            CollideFriendly = false,
+            CollideFriendly = true,
             Damage = 11000,
             DamageFriendly = true,
             DamageRadius = 20,

--- a/units/XSA0402/XSA0402_unit.bp
+++ b/units/XSA0402/XSA0402_unit.bp
@@ -108,7 +108,7 @@ UnitBlueprint {
         'SERAPHIM',
         'MOBILE',
         'AIR',
-	'BOMBER',
+        'BOMBER',
         'HIGHALTAIR',
         'EXPERIMENTAL',
         'NEEDMOBILEBUILD',
@@ -311,7 +311,7 @@ UnitBlueprint {
             },
             FiringRandomness = 3,
             FiringTolerance = 6,
-			FixBombTrajectory = true, # [152]
+            FixBombTrajectory = true,
             Label = 'Bomb',
             MaxRadius = 90,
             MuzzleSalvoDelay = 0,
@@ -337,7 +337,7 @@ UnitBlueprint {
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RateOfFire = 0.0714,
-	    RenderFireClock = true,
+            RenderFireClock = true,
             TargetCheckInterval = 3,
             TargetPriorities = {
                 'SPECIALHIGHPRI',


### PR DESCRIPTION
Rebase of #933 

With this change it won't be possible to block off the bomb with ASF, the projectile will fly straight through and deal some damage on the asf flying into it. The radius is small though so no death of the whole cloud.