### PR TITLE
Bugfix for Template Icons and names

### DIFF
--- a/lua/ui/game/build_templates.lua
+++ b/lua/ui/game/build_templates.lua
@@ -1,0 +1,118 @@
+#*****************************************************************************
+#* File: lua/modules/ui/game/build_templates.lua
+#* Author: Ted Snook
+#* Summary: Build Templates UI
+#*
+#* Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+#*****************************************************************************
+
+local Prefs = import('/lua/user/prefs.lua')
+local templates = Prefs.GetFromCurrentProfile('build_templates') or {}
+local UIUtil = import('/lua/ui/uiutil.lua')
+
+function CreateBuildTemplate()
+    GenerateBuildTemplateFromSelection()
+    local template = GetActiveBuildTemplate()
+    ClearBuildTemplates()
+    if table.getsize(template) > 0 then
+        AddTemplate(template)
+    end
+end
+
+function Init()
+    import('/lua/ui/game/gamemain.lua').RegisterChatFunc(ReceiveTemplate, 'Template')
+end
+
+function ReceiveTemplate(sender, msg)
+    if Prefs.GetOption('accept_build_templates') == 'yes' then
+        local tab = import('/lua/ui/game/construction.lua').GetTabByID('templates')
+        if tab then
+            import('/lua/ui/game/announcement.lua').CreateAnnouncement(LOC('<LOC template_0000>Build Template Received'), tab, LOCF('<LOC template_0001>From %s', sender))
+        end
+        AddTemplate(msg.data)
+    end
+end
+
+function GetInitialName(template)
+    for _, entry in template do
+        if type(entry) != 'table' then continue end
+        return (string.gsub(__blueprints[entry[1]].Description, '^<[^>]*>', '')) -- removes <LOC xyz_desc> from name
+    end
+end
+
+function GetInitialIcon(template)
+    for _, entry in template do
+        if type(entry) != 'table' then continue end
+        if DiskGetFileInfo('/textures/ui/common/icons/units/'..entry[1]..'_icon.dds') then
+            return entry[1] -- Original unit found
+        else
+            local UIUtil = import('/lua/ui/uiutil.lua')
+            if UIUtil.UIFile('/icons/units/' .. entry[1] .. '_icon.dds', true) then
+                return entry[1] -- Modded unit found.
+            end
+        end
+    end
+    return 'default' -- If we don't find a valid IconName; return string 'default'
+end
+
+function AddTemplate(newTemplate)
+    table.insert(templates, {templateData = newTemplate, name = GetInitialName(newTemplate), icon = GetInitialIcon(newTemplate)})
+    Prefs.SetToCurrentProfile('build_templates', templates)
+end
+
+function GetTemplates()
+    return Prefs.GetFromCurrentProfile('build_templates')
+end
+
+function ResetTemplates()
+    Prefs.SetToCurrentProfile('build_templates', false)
+end
+
+function RemoveTemplate(templateID)
+    table.remove(templates, templateID)
+    Prefs.SetToCurrentProfile('build_templates', templates)
+end
+
+function RenameTemplate(templateID, name)
+    templates[templateID].name = name
+    Prefs.SetToCurrentProfile('build_templates', templates)
+end
+
+function SetTemplateIcon(templateID, iconPath)
+    templates[templateID].icon = iconPath
+    Prefs.SetToCurrentProfile('build_templates', templates)
+end
+
+function SendTemplate(templateID, armyIndex)
+    armyIndex = armyIndex
+    if table.getn(templates[templateID].templateData) > 22 then
+        UIUtil.QuickDialog(GetFrame(0), "<LOC build_templates_0000>You may only send build templates with 20 or less buildings.", 
+            "<LOC _Ok>", nil, nil, nil, nil, nil,
+            true,  {worldCover = true, enterButton = 1, escapeButton = 1})
+    else
+        SessionSendChatMessage(armyIndex, {Template = true, data = templates[templateID].templateData})
+    end
+end
+
+function SetTemplateKey(templateID, key)
+    local used = false
+    for i, template in templates do
+        if i == templateID then continue end
+        if template.key and template.key == key then
+            used = true
+            break
+        end
+    end
+    if used then
+        return false
+    else
+        templates[templateID].key = key
+        Prefs.SetToCurrentProfile('build_templates', templates)
+        return true
+    end
+end
+
+function ClearTemplateKey(templateID)
+    templates[templateID].key = nil
+    Prefs.SetToCurrentProfile('build_templates', templates)
+end

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -485,10 +485,13 @@ function GetBackgroundTextures(unitID)
     local bp = __blueprints[unitID]
     local validIcons = { land = true, air = true, sea = true, amph = true }
     local icon = "land"
-    if unitID and unitID ~= 'default' and not validIcons[bp.General.Icon] then
-        if bp.General.Icon then WARN(debug.traceback(nil, "Invalid icon" .. bp.General.Icon .. " for unit " .. tostring(unitID))) end
-        bp.General.Icon = "land"
-        icon = bp.General.Icon
+    if unitID and unitID ~= 'default' then
+		if not validIcons[bp.General.Icon] then
+			if bp.General.Icon then WARN(debug.traceback(nil, "Invalid icon" .. bp.General.Icon .. " for unit " .. tostring(unitID))) end
+			bp.General.Icon = "land"
+		else
+			icon = bp.General.Icon
+		end
     end
     return UIUtil.UIFile('/icons/units/' .. icon .. '_up.dds'),
            UIUtil.UIFile('/icons/units/' .. icon .. '_down.dds'),

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -486,12 +486,12 @@ function GetBackgroundTextures(unitID)
     local validIcons = { land = true, air = true, sea = true, amph = true }
     local icon = "land"
     if unitID and unitID ~= 'default' then
-		if not validIcons[bp.General.Icon] then
-			if bp.General.Icon then WARN(debug.traceback(nil, "Invalid icon" .. bp.General.Icon .. " for unit " .. tostring(unitID))) end
-			bp.General.Icon = "land"
-		else
-			icon = bp.General.Icon
-		end
+        if not validIcons[bp.General.Icon] then
+            if bp.General.Icon then WARN(debug.traceback(nil, "Invalid icon" .. bp.General.Icon .. " for unit " .. tostring(unitID))) end
+            bp.General.Icon = "land"
+        else
+            icon = bp.General.Icon
+        end
     end
     return UIUtil.UIFile('/icons/units/' .. icon .. '_up.dds'),
            UIUtil.UIFile('/icons/units/' .. icon .. '_down.dds'),

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -484,15 +484,16 @@ end
 function GetBackgroundTextures(unitID)
     local bp = __blueprints[unitID]
     local validIcons = { land = true, air = true, sea = true, amph = true }
-    if not validIcons[bp.General.Icon] then
+    local icon = "land"
+    if unitID and unitID ~= 'default' and not validIcons[bp.General.Icon] then
         if bp.General.Icon then WARN(debug.traceback(nil, "Invalid icon" .. bp.General.Icon .. " for unit " .. tostring(unitID))) end
         bp.General.Icon = "land"
+        icon = bp.General.Icon
     end
-
-    return UIUtil.UIFile('/icons/units/' .. bp.General.Icon .. '_up.dds'),
-           UIUtil.UIFile('/icons/units/' .. bp.General.Icon .. '_down.dds'),
-           UIUtil.UIFile('/icons/units/' .. bp.General.Icon .. '_over.dds'),
-           UIUtil.UIFile('/icons/units/' .. bp.General.Icon .. '_up.dds')
+    return UIUtil.UIFile('/icons/units/' .. icon .. '_up.dds'),
+           UIUtil.UIFile('/icons/units/' .. icon .. '_down.dds'),
+           UIUtil.UIFile('/icons/units/' .. icon .. '_over.dds'),
+           UIUtil.UIFile('/icons/units/' .. icon .. '_up.dds')
 end
 
 function GetEnhancementPrefix(unitID, iconID)

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -422,7 +422,7 @@ function UIFile(filespec, checkMods)
         end
         
         if not found then
-            WARN(debug.traceback(nil, "Warning: Unable to find file: " .. origPath .. filespec))
+            SPEW('[uiutil.lua, function UIFile()] - Unable to find file:'.. origPath .. filespec)
             found = filespec
         end
 


### PR DESCRIPTION
Fixed a crash, when a icon is aleady saved as "false" inside build_templates
Added search for modded unit icons while saving build_templates to Game.prefs
Removed prefix in template names.
Changed Warning "Warning: Unable to find file..dds" to Debug text.

For detailed description see issue #1228