### PR TITLE
Added player rating label on top map preview

### DIFF
--- a/lua/ui/controls/resmappreview.lua
+++ b/lua/ui/controls/resmappreview.lua
@@ -211,6 +211,7 @@ ResourceMapPreview = Class(Group) {
             -- Create Labels above markers to show rating of player or AI names
             self.ratingLabel[slot] = UIUtil.CreateText(self.mapPreview, '', 10, 'Arial Gras', true)
             LayoutHelpers.AtLeftTopIn(self.ratingLabel[slot], self.mapPreview, markerWidth-9, markerHeight-11)
+            --self.ratingLabels[slot]:Hide()
 
             startPositions[slot] = marker
         end

--- a/lua/ui/controls/resmappreview.lua
+++ b/lua/ui/controls/resmappreview.lua
@@ -31,7 +31,6 @@ ResourceMapPreview = Class(Group) {
         self.hydromarkers = {}
         self.wreckagemarkers = {}
         self.startPositions = {}
-        self.ratingLabel = {}
 
         self.mapPreview = MapPreview(self)
         self.mapPreview.Width:Set(size)
@@ -57,14 +56,9 @@ ResourceMapPreview = Class(Group) {
             v:Destroy()
         end
 
-        for k, v in pairs(self.ratingLabel) do
-            v:Destroy()
-        end
-
         self.massmarkers = {}
         self.hydromarkers = {}
         self.startPositions = {}
-        self.ratingLabel = {}
     end,
 
     --- Delete all resource markers and clear the map preview.
@@ -204,13 +198,10 @@ ResourceMapPreview = Class(Group) {
 
             -- Create an ACUButton for each start position.
             local marker = ACUButton(self.mapPreview, not self.buttonsDisabled)
-            local markerWidth = xOffset + ((pos[1] / mWidth) * self.size * xFactor) - (marker.Width() / 2)
-            local markerHeight = yOffset + ((pos[2] / mHeight) * self.size * yFactor) - (marker.Height() / 2)
-            LayoutHelpers.AtLeftTopIn(marker, self.mapPreview, markerWidth, markerHeight)
 
-            -- Create Labels above markers to show rating of player or AI names
-            self.ratingLabel[slot] = UIUtil.CreateText(self.mapPreview, '', 10, 'Arial Gras', true)
-            LayoutHelpers.AtLeftTopIn(self.ratingLabel[slot], self.mapPreview, markerWidth-9, markerHeight-11)
+            LayoutHelpers.AtLeftTopIn(marker, self.mapPreview,
+                xOffset + ((pos[1] / mWidth) * self.size * xFactor) - (marker.Width() / 2),
+                yOffset + ((pos[2] / mHeight) * self.size * yFactor) - (marker.Height() / 2))
 
             startPositions[slot] = marker
         end

--- a/lua/ui/controls/resmappreview.lua
+++ b/lua/ui/controls/resmappreview.lua
@@ -31,7 +31,6 @@ ResourceMapPreview = Class(Group) {
         self.hydromarkers = {}
         self.wreckagemarkers = {}
         self.startPositions = {}
-        self.ratingLabel = {}
 
         self.mapPreview = MapPreview(self)
         self.mapPreview.Width:Set(size)
@@ -57,14 +56,9 @@ ResourceMapPreview = Class(Group) {
             v:Destroy()
         end
 
-        for k, v in pairs(self.ratingLabel) do
-            v:Destroy()
-        end
-
         self.massmarkers = {}
         self.hydromarkers = {}
         self.startPositions = {}
-        self.ratingLabel = {}
     end,
 
     --- Delete all resource markers and clear the map preview.
@@ -204,14 +198,10 @@ ResourceMapPreview = Class(Group) {
 
             -- Create an ACUButton for each start position.
             local marker = ACUButton(self.mapPreview, not self.buttonsDisabled)
-            local markerWidth = xOffset + ((pos[1] / mWidth) * self.size * xFactor) - (marker.Width() / 2)
-            local markerHeight = yOffset + ((pos[2] / mHeight) * self.size * yFactor) - (marker.Height() / 2)
-            LayoutHelpers.AtLeftTopIn(marker, self.mapPreview, markerWidth, markerHeight)
 
-            -- Create Labels above markers to show rating of player or AI names
-            self.ratingLabel[slot] = UIUtil.CreateText(self.mapPreview, '', 10, 'Arial Gras', true)
-            LayoutHelpers.AtLeftTopIn(self.ratingLabel[slot], self.mapPreview, markerWidth-9, markerHeight-11)
-            --self.ratingLabels[slot]:Hide()
+            LayoutHelpers.AtLeftTopIn(marker, self.mapPreview,
+                xOffset + ((pos[1] / mWidth) * self.size * xFactor) - (marker.Width() / 2),
+                yOffset + ((pos[2] / mHeight) * self.size * yFactor) - (marker.Height() / 2))
 
             startPositions[slot] = marker
         end

--- a/lua/ui/controls/resmappreview.lua
+++ b/lua/ui/controls/resmappreview.lua
@@ -31,6 +31,7 @@ ResourceMapPreview = Class(Group) {
         self.hydromarkers = {}
         self.wreckagemarkers = {}
         self.startPositions = {}
+        self.ratingLabel = {}
 
         self.mapPreview = MapPreview(self)
         self.mapPreview.Width:Set(size)
@@ -56,9 +57,14 @@ ResourceMapPreview = Class(Group) {
             v:Destroy()
         end
 
+        for k, v in pairs(self.ratingLabel) do
+            v:Destroy()
+        end
+
         self.massmarkers = {}
         self.hydromarkers = {}
         self.startPositions = {}
+        self.ratingLabel = {}
     end,
 
     --- Delete all resource markers and clear the map preview.
@@ -198,10 +204,14 @@ ResourceMapPreview = Class(Group) {
 
             -- Create an ACUButton for each start position.
             local marker = ACUButton(self.mapPreview, not self.buttonsDisabled)
+            local markerWidth = xOffset + ((pos[1] / mWidth) * self.size * xFactor) - (marker.Width() / 2)
+            local markerHeight = yOffset + ((pos[2] / mHeight) * self.size * yFactor) - (marker.Height() / 2)
+            LayoutHelpers.AtLeftTopIn(marker, self.mapPreview, markerWidth, markerHeight)
 
-            LayoutHelpers.AtLeftTopIn(marker, self.mapPreview,
-                xOffset + ((pos[1] / mWidth) * self.size * xFactor) - (marker.Width() / 2),
-                yOffset + ((pos[2] / mHeight) * self.size * yFactor) - (marker.Height() / 2))
+            -- Create Labels above markers to show rating of player or AI names
+            self.ratingLabel[slot] = UIUtil.CreateText(self.mapPreview, '', 10, 'Arial Gras', true)
+            LayoutHelpers.AtLeftTopIn(self.ratingLabel[slot], self.mapPreview, markerWidth-9, markerHeight-11)
+            --self.ratingLabels[slot]:Hide()
 
             startPositions[slot] = marker
         end

--- a/lua/ui/controls/resmappreview.lua
+++ b/lua/ui/controls/resmappreview.lua
@@ -31,6 +31,7 @@ ResourceMapPreview = Class(Group) {
         self.hydromarkers = {}
         self.wreckagemarkers = {}
         self.startPositions = {}
+        self.ratingLabel = {}
 
         self.mapPreview = MapPreview(self)
         self.mapPreview.Width:Set(size)
@@ -56,9 +57,14 @@ ResourceMapPreview = Class(Group) {
             v:Destroy()
         end
 
+        for k, v in pairs(self.ratingLabel) do
+            v:Destroy()
+        end
+
         self.massmarkers = {}
         self.hydromarkers = {}
         self.startPositions = {}
+        self.ratingLabel = {}
     end,
 
     --- Delete all resource markers and clear the map preview.
@@ -198,10 +204,13 @@ ResourceMapPreview = Class(Group) {
 
             -- Create an ACUButton for each start position.
             local marker = ACUButton(self.mapPreview, not self.buttonsDisabled)
+            local markerWidth = xOffset + ((pos[1] / mWidth) * self.size * xFactor) - (marker.Width() / 2)
+            local markerHeight = yOffset + ((pos[2] / mHeight) * self.size * yFactor) - (marker.Height() / 2)
+            LayoutHelpers.AtLeftTopIn(marker, self.mapPreview, markerWidth, markerHeight)
 
-            LayoutHelpers.AtLeftTopIn(marker, self.mapPreview,
-                xOffset + ((pos[1] / mWidth) * self.size * xFactor) - (marker.Width() / 2),
-                yOffset + ((pos[2] / mHeight) * self.size * yFactor) - (marker.Height() / 2))
+            -- Create Labels above markers to show rating of player or AI names
+            self.ratingLabel[slot] = UIUtil.CreateText(self.mapPreview, '', 10, 'Arial Gras', true)
+            LayoutHelpers.AtLeftTopIn(self.ratingLabel[slot], self.mapPreview, markerWidth-9, markerHeight-11)
 
             startPositions[slot] = marker
         end

--- a/lua/ui/controls/resmappreview.lua
+++ b/lua/ui/controls/resmappreview.lua
@@ -211,7 +211,6 @@ ResourceMapPreview = Class(Group) {
             -- Create Labels above markers to show rating of player or AI names
             self.ratingLabel[slot] = UIUtil.CreateText(self.mapPreview, '', 10, 'Arial Gras', true)
             LayoutHelpers.AtLeftTopIn(self.ratingLabel[slot], self.mapPreview, markerWidth-9, markerHeight-11)
-            --self.ratingLabels[slot]:Hide()
 
             startPositions[slot] = marker
         end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1006,6 +1006,7 @@ local function GetRandomFactionIndex()
     return randomfaction
 end
 
+
 local function AssignRandomFactions()
     local randomFactionID = table.getn(FactionData.Factions) + 1
     for index, player in gameInfo.PlayerOptions do

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1006,7 +1006,6 @@ local function GetRandomFactionIndex()
     return randomfaction
 end
 
-
 local function AssignRandomFactions()
     local randomFactionID = table.getn(FactionData.Factions) + 1
     for index, player in gameInfo.PlayerOptions do

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -360,7 +360,8 @@ local function DoSlotBehavior(slot, key, name)
     elseif key == 'occupy' then
         if IsPlayer(localPlayerID) then
             if lobbyComm:IsHost() then
-                HostUtils.MovePlayerToEmptySlot(FindSlotForID(localPlayerID), slot)
+                local currentSlot = FindSlotForID(localPlayerID)
+                HostUtils.MovePlayerToEmptySlot(currentSlot, slot)
             else
                 lobbyComm:SendData(hostID, {Type = 'MovePlayer', CurrentSlot = FindSlotForID(localPlayerID),
                                    RequestedSlot = slot})
@@ -414,7 +415,7 @@ local function DoSlotBehavior(slot, key, name)
             HostUtils.AddAI(name, key, slot)
         end
     end
-    LblPlayerRatingMapview()
+
 end --\\ End DoSlotBehavior()
 
 local function IsModAvailable(modId)
@@ -722,6 +723,7 @@ function SetSlotInfo(slotNum, playerInfo)
     local slot = GUI.slots[slotNum]
     local isHost = lobbyComm:IsHost()
     local isLocallyOwned = IsLocallyOwned(slotNum)
+    local ratingLabel = GUI.mapView.ratingLabel[slotNum]
 
     -- Set enabledness of controls according to host privelage etc.
     -- Yeah, we set it twice. No, it's not brilliant. Blurgh.
@@ -815,6 +817,15 @@ function SetSlotInfo(slotNum, playerInfo)
     slot.ratingText:SetText(playerInfo.PL)
     slot.ratingText:SetColor(playerInfo.RC)
 
+    -- Showing the rating labels on the map preview
+    ratingLabel:Show()
+    if slotState == 'ai' then
+        ratingLabel:SetText(playerInfo.PlayerName)
+    else
+        ratingLabel:SetText(playerInfo.PL)
+    end
+
+
     slot.numGamesText:Show()
     slot.numGamesText:SetText(playerInfo.NG)
 
@@ -897,11 +908,11 @@ function SetSlotInfo(slotNum, playerInfo)
 
     ShowGameQuality()
     RefreshMapPositionForAllControls(slotNum)
-    LblPlayerRatingMapview()
 end
 
 function ClearSlotInfo(slotIndex)
     local slot = GUI.slots[slotIndex]
+    local ratingLabel = GUI.mapView.ratingLabel[slotIndex]
 
     local hostKey
     if lobbyComm:IsHost() then
@@ -945,11 +956,11 @@ function ClearSlotInfo(slotIndex)
     end
 
     slot:HideControls()
+    ratingLabel:Hide()
 
     UpdateSlotBackground(slotIndex)
     ShowGameQuality()
     RefreshMapPositionForAllControls(slotIndex)
-    LblPlayerRatingMapview()
 end
 
 function IsColorFree(colorIndex)
@@ -994,7 +1005,6 @@ local function GetRandomFactionIndex()
     end
     return randomfaction
 end
-
 
 local function AssignRandomFactions()
     local randomFactionID = table.getn(FactionData.Factions) + 1
@@ -5434,133 +5444,4 @@ function InitHostUtils()
             return -1
         end
     }
-end
-
-
-function DestroyLblPlayerRatingMapPreview()
-    if GUI.mapViewPlayerRating_1 then GUI.mapViewPlayerRating_1:Destroy() end
-    if GUI.mapViewPlayerRating_2 then GUI.mapViewPlayerRating_2:Destroy() end
-    if GUI.mapViewPlayerRating_3 then GUI.mapViewPlayerRating_3:Destroy() end
-    if GUI.mapViewPlayerRating_4 then GUI.mapViewPlayerRating_4:Destroy() end
-    if GUI.mapViewPlayerRating_5 then GUI.mapViewPlayerRating_5:Destroy() end
-    if GUI.mapViewPlayerRating_6 then GUI.mapViewPlayerRating_6:Destroy() end
-    if GUI.mapViewPlayerRating_7 then GUI.mapViewPlayerRating_7:Destroy() end
-    if GUI.mapViewPlayerRating_8 then GUI.mapViewPlayerRating_8:Destroy() end
-    if GUI.mapViewPlayerRating_9 then GUI.mapViewPlayerRating_9:Destroy() end
-    if GUI.mapViewPlayerRating_10 then GUI.mapViewPlayerRating_10:Destroy() end
-    if GUI.mapViewPlayerRating_11 then GUI.mapViewPlayerRating_11:Destroy() end
-    if GUI.mapViewPlayerRating_12 then GUI.mapViewPlayerRating_12:Destroy() end
-end
-
-function LblPlayerRatingMapview()
-
-    local scenarioInfo
-
-    --Check if scenario is selected
-    if gameInfo.GameOptions.ScenarioFile and (gameInfo.GameOptions.ScenarioFile ~= "") then
-        scenarioInfo = MapUtil.LoadScenario(gameInfo.GameOptions.ScenarioFile)
-    else
-        DestroyLblPlayerRatingMapPreview()
-        return
-    end
-
-    -- ugly destruction of all existing labels on the map preview
-    DestroyLblPlayerRatingMapPreview()
-    if gameInfo.GameOptions['TeamSpawn'] == 'random' then
-        return
-    end
-
-    local marker_left = 0
-    local marker_top = 0
-    local rating = 0
-
-    for slots, player in gameInfo.PlayerOptions:pairs() do
-        --check if peer
-        if player.Human and player.OwnerID ~= localPlayerID then
-            local peer = lobbyComm:GetPeer(player.OwnerID)
-            local peerSlot = FindSlotForID(peer.id)
-            local playerInfo = gameInfo.PlayerOptions[peerSlot]
-            local PeerRating = playerInfo.PL
-            rating = PeerRating
-        elseif player.Human and (player.OwnerID == localPlayerID) then --check if local player
-            local myPlayerData = GetLocalPlayerData()
-            rating = myPlayerData.PL
-        else --what is left should be AI, so just insert name instead of rank
-            rating = player.PlayerName
-        end
-
-        if not slots then
-            return
-        end
-
-        -- we need to do this because of windows resizing
-        marker_left     = GUI.mapView.startPositions[slots].Left()-((GUI.Width()-GUI.panel.Width())/2) -9
-        marker_top      = GUI.mapView.startPositions[slots].Top()-((GUI.Height()-GUI.panel.Height())/2) -11
-
-        local lblDepth  = 4
-        local ratingLabelTextSize = 10
-
-        ---Create labels, it's dumb, but it works
-        ---lets hope there are never more than 12 players on a map
-        if slots == 1 then
-        GUI.mapViewPlayerRating_1 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_1, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_1, GUI.mapPanel, lblDepth)
-        end
-        if slots == 2 then
-        GUI.mapViewPlayerRating_2 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_2, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_2, GUI.mapPanel, lblDepth)
-        end
-        if slots == 3 then
-        GUI.mapViewPlayerRating_3 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_3, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_3, GUI.mapPanel, lblDepth)
-        end
-        if slots == 4 then
-        GUI.mapViewPlayerRating_4 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_4, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_4, GUI.mapPanel, lblDepth)
-        end
-        if slots == 5 then
-        GUI.mapViewPlayerRating_5 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_5, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_5, GUI.mapPanel, lblDepth)
-        end
-        if slots == 6 then
-        GUI.mapViewPlayerRating_6 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_6, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_6, GUI.mapPanel, lblDepth)
-        end
-        if slots == 7 then
-        GUI.mapViewPlayerRating_7 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_7, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_7, GUI.mapPanel, lblDepth)
-        end
-        if slots == 8 then
-        GUI.mapViewPlayerRating_8 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_8, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_8, GUI.mapPanel, lblDepth)
-        end
-        if slots == 9 then
-        GUI.mapViewPlayerRating_9 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_9, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_9, GUI.mapPanel, lblDepth)
-        end
-        if slots == 10 then
-        GUI.mapViewPlayerRating_10 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_10, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_10, GUI.mapPanel, lblDepth)
-        end
-        if slots == 11 then
-        GUI.mapViewPlayerRating_11 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_11, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_11, GUI.mapPanel, lblDepth)
-        end
-        if slots == 12 then
-        GUI.mapViewPlayerRating_12 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_12, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_12, GUI.mapPanel, lblDepth)
-        end
-    end
 end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -360,8 +360,7 @@ local function DoSlotBehavior(slot, key, name)
     elseif key == 'occupy' then
         if IsPlayer(localPlayerID) then
             if lobbyComm:IsHost() then
-                local currentSlot = FindSlotForID(localPlayerID)
-                HostUtils.MovePlayerToEmptySlot(currentSlot, slot)
+                HostUtils.MovePlayerToEmptySlot(FindSlotForID(localPlayerID), slot)
             else
                 lobbyComm:SendData(hostID, {Type = 'MovePlayer', CurrentSlot = FindSlotForID(localPlayerID),
                                    RequestedSlot = slot})
@@ -415,7 +414,7 @@ local function DoSlotBehavior(slot, key, name)
             HostUtils.AddAI(name, key, slot)
         end
     end
-
+    LblPlayerRatingMapview()
 end --\\ End DoSlotBehavior()
 
 local function IsModAvailable(modId)
@@ -723,7 +722,6 @@ function SetSlotInfo(slotNum, playerInfo)
     local slot = GUI.slots[slotNum]
     local isHost = lobbyComm:IsHost()
     local isLocallyOwned = IsLocallyOwned(slotNum)
-    local ratingLabel = GUI.mapView.ratingLabel[slotNum]
 
     -- Set enabledness of controls according to host privelage etc.
     -- Yeah, we set it twice. No, it's not brilliant. Blurgh.
@@ -817,15 +815,6 @@ function SetSlotInfo(slotNum, playerInfo)
     slot.ratingText:SetText(playerInfo.PL)
     slot.ratingText:SetColor(playerInfo.RC)
 
-    -- Showing the rating labels on the map preview
-    ratingLabel:Show()
-    if slotState == 'ai' then
-        ratingLabel:SetText(playerInfo.PlayerName)
-    else
-        ratingLabel:SetText(playerInfo.PL)
-    end
-
-
     slot.numGamesText:Show()
     slot.numGamesText:SetText(playerInfo.NG)
 
@@ -908,11 +897,11 @@ function SetSlotInfo(slotNum, playerInfo)
 
     ShowGameQuality()
     RefreshMapPositionForAllControls(slotNum)
+    LblPlayerRatingMapview()
 end
 
 function ClearSlotInfo(slotIndex)
     local slot = GUI.slots[slotIndex]
-    local ratingLabel = GUI.mapView.ratingLabel[slotIndex]
 
     local hostKey
     if lobbyComm:IsHost() then
@@ -956,11 +945,11 @@ function ClearSlotInfo(slotIndex)
     end
 
     slot:HideControls()
-    ratingLabel:Hide()
 
     UpdateSlotBackground(slotIndex)
     ShowGameQuality()
     RefreshMapPositionForAllControls(slotIndex)
+    LblPlayerRatingMapview()
 end
 
 function IsColorFree(colorIndex)
@@ -5445,4 +5434,133 @@ function InitHostUtils()
             return -1
         end
     }
+end
+
+
+function DestroyLblPlayerRatingMapPreview()
+    if GUI.mapViewPlayerRating_1 then GUI.mapViewPlayerRating_1:Destroy() end
+    if GUI.mapViewPlayerRating_2 then GUI.mapViewPlayerRating_2:Destroy() end
+    if GUI.mapViewPlayerRating_3 then GUI.mapViewPlayerRating_3:Destroy() end
+    if GUI.mapViewPlayerRating_4 then GUI.mapViewPlayerRating_4:Destroy() end
+    if GUI.mapViewPlayerRating_5 then GUI.mapViewPlayerRating_5:Destroy() end
+    if GUI.mapViewPlayerRating_6 then GUI.mapViewPlayerRating_6:Destroy() end
+    if GUI.mapViewPlayerRating_7 then GUI.mapViewPlayerRating_7:Destroy() end
+    if GUI.mapViewPlayerRating_8 then GUI.mapViewPlayerRating_8:Destroy() end
+    if GUI.mapViewPlayerRating_9 then GUI.mapViewPlayerRating_9:Destroy() end
+    if GUI.mapViewPlayerRating_10 then GUI.mapViewPlayerRating_10:Destroy() end
+    if GUI.mapViewPlayerRating_11 then GUI.mapViewPlayerRating_11:Destroy() end
+    if GUI.mapViewPlayerRating_12 then GUI.mapViewPlayerRating_12:Destroy() end
+end
+
+function LblPlayerRatingMapview()
+
+    local scenarioInfo
+
+    --Check if scenario is selected
+    if gameInfo.GameOptions.ScenarioFile and (gameInfo.GameOptions.ScenarioFile ~= "") then
+        scenarioInfo = MapUtil.LoadScenario(gameInfo.GameOptions.ScenarioFile)
+    else
+        DestroyLblPlayerRatingMapPreview()
+        return
+    end
+
+    -- ugly destruction of all existing labels on the map preview
+    DestroyLblPlayerRatingMapPreview()
+    if gameInfo.GameOptions['TeamSpawn'] == 'random' then
+        return
+    end
+
+    local marker_left = 0
+    local marker_top = 0
+    local rating = 0
+
+    for slots, player in gameInfo.PlayerOptions:pairs() do
+        --check if peer
+        if player.Human and player.OwnerID ~= localPlayerID then
+            local peer = lobbyComm:GetPeer(player.OwnerID)
+            local peerSlot = FindSlotForID(peer.id)
+            local playerInfo = gameInfo.PlayerOptions[peerSlot]
+            local PeerRating = playerInfo.PL
+            rating = PeerRating
+        elseif player.Human and (player.OwnerID == localPlayerID) then --check if local player
+            local myPlayerData = GetLocalPlayerData()
+            rating = myPlayerData.PL
+        else --what is left should be AI, so just insert name instead of rank
+            rating = player.PlayerName
+        end
+
+        if not slots then
+            return
+        end
+
+        -- we need to do this because of windows resizing
+        marker_left     = GUI.mapView.startPositions[slots].Left()-((GUI.Width()-GUI.panel.Width())/2) -9
+        marker_top      = GUI.mapView.startPositions[slots].Top()-((GUI.Height()-GUI.panel.Height())/2) -11
+
+        local lblDepth  = 4
+        local ratingLabelTextSize = 10
+
+        ---Create labels, it's dumb, but it works
+        ---lets hope there are never more than 12 players on a map
+        if slots == 1 then
+        GUI.mapViewPlayerRating_1 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_1, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_1, GUI.mapPanel, lblDepth)
+        end
+        if slots == 2 then
+        GUI.mapViewPlayerRating_2 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_2, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_2, GUI.mapPanel, lblDepth)
+        end
+        if slots == 3 then
+        GUI.mapViewPlayerRating_3 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_3, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_3, GUI.mapPanel, lblDepth)
+        end
+        if slots == 4 then
+        GUI.mapViewPlayerRating_4 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_4, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_4, GUI.mapPanel, lblDepth)
+        end
+        if slots == 5 then
+        GUI.mapViewPlayerRating_5 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_5, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_5, GUI.mapPanel, lblDepth)
+        end
+        if slots == 6 then
+        GUI.mapViewPlayerRating_6 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_6, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_6, GUI.mapPanel, lblDepth)
+        end
+        if slots == 7 then
+        GUI.mapViewPlayerRating_7 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_7, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_7, GUI.mapPanel, lblDepth)
+        end
+        if slots == 8 then
+        GUI.mapViewPlayerRating_8 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_8, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_8, GUI.mapPanel, lblDepth)
+        end
+        if slots == 9 then
+        GUI.mapViewPlayerRating_9 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_9, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_9, GUI.mapPanel, lblDepth)
+        end
+        if slots == 10 then
+        GUI.mapViewPlayerRating_10 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_10, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_10, GUI.mapPanel, lblDepth)
+        end
+        if slots == 11 then
+        GUI.mapViewPlayerRating_11 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_11, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_11, GUI.mapPanel, lblDepth)
+        end
+        if slots == 12 then
+        GUI.mapViewPlayerRating_12 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_12, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_12, GUI.mapPanel, lblDepth)
+        end
+    end
 end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -360,7 +360,8 @@ local function DoSlotBehavior(slot, key, name)
     elseif key == 'occupy' then
         if IsPlayer(localPlayerID) then
             if lobbyComm:IsHost() then
-                HostUtils.MovePlayerToEmptySlot(FindSlotForID(localPlayerID), slot)
+                local currentSlot = FindSlotForID(localPlayerID)
+                HostUtils.MovePlayerToEmptySlot(currentSlot, slot)
             else
                 lobbyComm:SendData(hostID, {Type = 'MovePlayer', CurrentSlot = FindSlotForID(localPlayerID),
                                    RequestedSlot = slot})
@@ -414,7 +415,7 @@ local function DoSlotBehavior(slot, key, name)
             HostUtils.AddAI(name, key, slot)
         end
     end
-    LblPlayerRatingMapview()
+
 end --\\ End DoSlotBehavior()
 
 local function IsModAvailable(modId)
@@ -722,6 +723,7 @@ function SetSlotInfo(slotNum, playerInfo)
     local slot = GUI.slots[slotNum]
     local isHost = lobbyComm:IsHost()
     local isLocallyOwned = IsLocallyOwned(slotNum)
+    local ratingLabel = GUI.mapView.ratingLabel[slotNum]
 
     -- Set enabledness of controls according to host privelage etc.
     -- Yeah, we set it twice. No, it's not brilliant. Blurgh.
@@ -815,6 +817,15 @@ function SetSlotInfo(slotNum, playerInfo)
     slot.ratingText:SetText(playerInfo.PL)
     slot.ratingText:SetColor(playerInfo.RC)
 
+    -- Showing the rating labels on the map preview
+    ratingLabel:Show()
+    if slotState == 'ai' then
+        ratingLabel:SetText(playerInfo.PlayerName)
+    else
+        ratingLabel:SetText(playerInfo.PL)
+    end
+
+
     slot.numGamesText:Show()
     slot.numGamesText:SetText(playerInfo.NG)
 
@@ -897,11 +908,11 @@ function SetSlotInfo(slotNum, playerInfo)
 
     ShowGameQuality()
     RefreshMapPositionForAllControls(slotNum)
-    LblPlayerRatingMapview()
 end
 
 function ClearSlotInfo(slotIndex)
     local slot = GUI.slots[slotIndex]
+    local ratingLabel = GUI.mapView.ratingLabel[slotIndex]
 
     local hostKey
     if lobbyComm:IsHost() then
@@ -945,11 +956,11 @@ function ClearSlotInfo(slotIndex)
     end
 
     slot:HideControls()
+    ratingLabel:Hide()
 
     UpdateSlotBackground(slotIndex)
     ShowGameQuality()
     RefreshMapPositionForAllControls(slotIndex)
-    LblPlayerRatingMapview()
 end
 
 function IsColorFree(colorIndex)
@@ -5434,133 +5445,4 @@ function InitHostUtils()
             return -1
         end
     }
-end
-
-
-function DestroyLblPlayerRatingMapPreview()
-    if GUI.mapViewPlayerRating_1 then GUI.mapViewPlayerRating_1:Destroy() end
-    if GUI.mapViewPlayerRating_2 then GUI.mapViewPlayerRating_2:Destroy() end
-    if GUI.mapViewPlayerRating_3 then GUI.mapViewPlayerRating_3:Destroy() end
-    if GUI.mapViewPlayerRating_4 then GUI.mapViewPlayerRating_4:Destroy() end
-    if GUI.mapViewPlayerRating_5 then GUI.mapViewPlayerRating_5:Destroy() end
-    if GUI.mapViewPlayerRating_6 then GUI.mapViewPlayerRating_6:Destroy() end
-    if GUI.mapViewPlayerRating_7 then GUI.mapViewPlayerRating_7:Destroy() end
-    if GUI.mapViewPlayerRating_8 then GUI.mapViewPlayerRating_8:Destroy() end
-    if GUI.mapViewPlayerRating_9 then GUI.mapViewPlayerRating_9:Destroy() end
-    if GUI.mapViewPlayerRating_10 then GUI.mapViewPlayerRating_10:Destroy() end
-    if GUI.mapViewPlayerRating_11 then GUI.mapViewPlayerRating_11:Destroy() end
-    if GUI.mapViewPlayerRating_12 then GUI.mapViewPlayerRating_12:Destroy() end
-end
-
-function LblPlayerRatingMapview()
-
-    local scenarioInfo
-
-    --Check if scenario is selected
-    if gameInfo.GameOptions.ScenarioFile and (gameInfo.GameOptions.ScenarioFile ~= "") then
-        scenarioInfo = MapUtil.LoadScenario(gameInfo.GameOptions.ScenarioFile)
-    else
-        DestroyLblPlayerRatingMapPreview()
-        return
-    end
-
-    -- ugly destruction of all existing labels on the map preview
-    DestroyLblPlayerRatingMapPreview()
-    if gameInfo.GameOptions['TeamSpawn'] == 'random' then
-        return
-    end
-
-    local marker_left = 0
-    local marker_top = 0
-    local rating = 0
-
-    for slots, player in gameInfo.PlayerOptions:pairs() do
-        --check if peer
-        if player.Human and player.OwnerID ~= localPlayerID then
-            local peer = lobbyComm:GetPeer(player.OwnerID)
-            local peerSlot = FindSlotForID(peer.id)
-            local playerInfo = gameInfo.PlayerOptions[peerSlot]
-            local PeerRating = playerInfo.PL
-            rating = PeerRating
-        elseif player.Human and (player.OwnerID == localPlayerID) then --check if local player
-            local myPlayerData = GetLocalPlayerData()
-            rating = myPlayerData.PL
-        else --what is left should be AI, so just insert name instead of rank
-            rating = player.PlayerName
-        end
-
-        if not slots then
-            return
-        end
-
-        -- we need to do this because of windows resizing
-        marker_left     = GUI.mapView.startPositions[slots].Left()-((GUI.Width()-GUI.panel.Width())/2) -9
-        marker_top      = GUI.mapView.startPositions[slots].Top()-((GUI.Height()-GUI.panel.Height())/2) -11
-
-        local lblDepth  = 4
-        local ratingLabelTextSize = 10
-
-        ---Create labels, it's dumb, but it works
-        ---lets hope there are never more than 12 players on a map
-        if slots == 1 then
-        GUI.mapViewPlayerRating_1 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_1, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_1, GUI.mapPanel, lblDepth)
-        end
-        if slots == 2 then
-        GUI.mapViewPlayerRating_2 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_2, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_2, GUI.mapPanel, lblDepth)
-        end
-        if slots == 3 then
-        GUI.mapViewPlayerRating_3 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_3, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_3, GUI.mapPanel, lblDepth)
-        end
-        if slots == 4 then
-        GUI.mapViewPlayerRating_4 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_4, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_4, GUI.mapPanel, lblDepth)
-        end
-        if slots == 5 then
-        GUI.mapViewPlayerRating_5 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_5, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_5, GUI.mapPanel, lblDepth)
-        end
-        if slots == 6 then
-        GUI.mapViewPlayerRating_6 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_6, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_6, GUI.mapPanel, lblDepth)
-        end
-        if slots == 7 then
-        GUI.mapViewPlayerRating_7 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_7, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_7, GUI.mapPanel, lblDepth)
-        end
-        if slots == 8 then
-        GUI.mapViewPlayerRating_8 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_8, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_8, GUI.mapPanel, lblDepth)
-        end
-        if slots == 9 then
-        GUI.mapViewPlayerRating_9 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_9, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_9, GUI.mapPanel, lblDepth)
-        end
-        if slots == 10 then
-        GUI.mapViewPlayerRating_10 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_10, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_10, GUI.mapPanel, lblDepth)
-        end
-        if slots == 11 then
-        GUI.mapViewPlayerRating_11 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_11, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_11, GUI.mapPanel, lblDepth)
-        end
-        if slots == 12 then
-        GUI.mapViewPlayerRating_12 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
-        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_12, GUI.panel, marker_left, marker_top)
-        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_12, GUI.mapPanel, lblDepth)
-        end
-    end
 end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -414,6 +414,7 @@ local function DoSlotBehavior(slot, key, name)
             HostUtils.AddAI(name, key, slot)
         end
     end
+    LblPlayerRatingMapview()
 end --\\ End DoSlotBehavior()
 
 local function IsModAvailable(modId)
@@ -896,6 +897,7 @@ function SetSlotInfo(slotNum, playerInfo)
 
     ShowGameQuality()
     RefreshMapPositionForAllControls(slotNum)
+    LblPlayerRatingMapview()
 end
 
 function ClearSlotInfo(slotIndex)
@@ -947,6 +949,7 @@ function ClearSlotInfo(slotIndex)
     UpdateSlotBackground(slotIndex)
     ShowGameQuality()
     RefreshMapPositionForAllControls(slotIndex)
+    LblPlayerRatingMapview()
 end
 
 function IsColorFree(colorIndex)
@@ -5431,4 +5434,133 @@ function InitHostUtils()
             return -1
         end
     }
+end
+
+
+function DestroyLblPlayerRatingMapPreview()
+    if GUI.mapViewPlayerRating_1 then GUI.mapViewPlayerRating_1:Destroy() end
+    if GUI.mapViewPlayerRating_2 then GUI.mapViewPlayerRating_2:Destroy() end
+    if GUI.mapViewPlayerRating_3 then GUI.mapViewPlayerRating_3:Destroy() end
+    if GUI.mapViewPlayerRating_4 then GUI.mapViewPlayerRating_4:Destroy() end
+    if GUI.mapViewPlayerRating_5 then GUI.mapViewPlayerRating_5:Destroy() end
+    if GUI.mapViewPlayerRating_6 then GUI.mapViewPlayerRating_6:Destroy() end
+    if GUI.mapViewPlayerRating_7 then GUI.mapViewPlayerRating_7:Destroy() end
+    if GUI.mapViewPlayerRating_8 then GUI.mapViewPlayerRating_8:Destroy() end
+    if GUI.mapViewPlayerRating_9 then GUI.mapViewPlayerRating_9:Destroy() end
+    if GUI.mapViewPlayerRating_10 then GUI.mapViewPlayerRating_10:Destroy() end
+    if GUI.mapViewPlayerRating_11 then GUI.mapViewPlayerRating_11:Destroy() end
+    if GUI.mapViewPlayerRating_12 then GUI.mapViewPlayerRating_12:Destroy() end
+end
+
+function LblPlayerRatingMapview()
+
+    local scenarioInfo
+
+    --Check if scenario is selected
+    if gameInfo.GameOptions.ScenarioFile and (gameInfo.GameOptions.ScenarioFile ~= "") then
+        scenarioInfo = MapUtil.LoadScenario(gameInfo.GameOptions.ScenarioFile)
+    else
+        DestroyLblPlayerRatingMapPreview()
+        return
+    end
+
+    -- ugly destruction of all existing labels on the map preview
+    DestroyLblPlayerRatingMapPreview()
+    if gameInfo.GameOptions['TeamSpawn'] == 'random' then
+        return
+    end
+
+    local marker_left = 0
+    local marker_top = 0
+    local rating = 0
+
+    for slots, player in gameInfo.PlayerOptions:pairs() do
+        --check if peer
+        if player.Human and player.OwnerID ~= localPlayerID then
+            local peer = lobbyComm:GetPeer(player.OwnerID)
+            local peerSlot = FindSlotForID(peer.id)
+            local playerInfo = gameInfo.PlayerOptions[peerSlot]
+            local PeerRating = playerInfo.PL
+            rating = PeerRating
+        elseif player.Human and (player.OwnerID == localPlayerID) then --check if local player
+            local myPlayerData = GetLocalPlayerData()
+            rating = myPlayerData.PL
+        else --what is left should be AI, so just insert name instead of rank
+            rating = player.PlayerName
+        end
+
+        if not slots then
+            return
+        end
+
+        -- we need to do this because of windows resizing
+        marker_left     = GUI.mapView.startPositions[slots].Left()-((GUI.Width()-GUI.panel.Width())/2) -9
+        marker_top      = GUI.mapView.startPositions[slots].Top()-((GUI.Height()-GUI.panel.Height())/2) -11
+
+        local lblDepth  = 4
+        local ratingLabelTextSize = 10
+
+        ---Create labels, it's dumb, but it works
+        ---lets hope there are never more than 12 players on a map
+        if slots == 1 then
+        GUI.mapViewPlayerRating_1 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_1, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_1, GUI.mapPanel, lblDepth)
+        end
+        if slots == 2 then
+        GUI.mapViewPlayerRating_2 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_2, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_2, GUI.mapPanel, lblDepth)
+        end
+        if slots == 3 then
+        GUI.mapViewPlayerRating_3 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_3, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_3, GUI.mapPanel, lblDepth)
+        end
+        if slots == 4 then
+        GUI.mapViewPlayerRating_4 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_4, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_4, GUI.mapPanel, lblDepth)
+        end
+        if slots == 5 then
+        GUI.mapViewPlayerRating_5 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_5, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_5, GUI.mapPanel, lblDepth)
+        end
+        if slots == 6 then
+        GUI.mapViewPlayerRating_6 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_6, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_6, GUI.mapPanel, lblDepth)
+        end
+        if slots == 7 then
+        GUI.mapViewPlayerRating_7 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_7, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_7, GUI.mapPanel, lblDepth)
+        end
+        if slots == 8 then
+        GUI.mapViewPlayerRating_8 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_8, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_8, GUI.mapPanel, lblDepth)
+        end
+        if slots == 9 then
+        GUI.mapViewPlayerRating_9 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_9, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_9, GUI.mapPanel, lblDepth)
+        end
+        if slots == 10 then
+        GUI.mapViewPlayerRating_10 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_10, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_10, GUI.mapPanel, lblDepth)
+        end
+        if slots == 11 then
+        GUI.mapViewPlayerRating_11 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_11, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_11, GUI.mapPanel, lblDepth)
+        end
+        if slots == 12 then
+        GUI.mapViewPlayerRating_12 = UIUtil.CreateText(GUI.panel, rating, ratingLabelTextSize, 'Arial Gras', true)
+        LayoutHelpers.AtLeftTopIn(GUI.mapViewPlayerRating_12, GUI.panel, marker_left, marker_top)
+        LayoutHelpers.DepthOverParent(GUI.mapViewPlayerRating_12, GUI.mapPanel, lblDepth)
+        end
+    end
 end


### PR DESCRIPTION
**LblPlayerRatingMapview()** Checks if scenario is selected, checks if there are any exisiting labels and deletes them, then it creates a rating label on top of map preview for every player currently in the lobby (including AI)

**DestroyLblPlayerRatingMapPreview()** In case we need to destroy the labels without executing the whole function

**LblPlayerRatingMapview()** gets called in **SetSlotInfo()**, **ClearSlotInfo()** and **DoSlotBehaviour()** since these functions handel the events we need to look at if we want to add or remove the labels. They also already check if random spawn is selected in the options.