### PR TITLE
Adding Categories TRANSPORTFOCUS to uea0203(Stinger)

### DIFF
--- a/units/UEA0203/UEA0203_unit.bp
+++ b/units/UEA0203/UEA0203_unit.bp
@@ -109,6 +109,7 @@ UnitBlueprint {
         'TECH2',
         'GROUNDATTACK',
         'TRANSPORTATION',
+        'TRANSPORTFOCUS',
         'VISIBLETORECON',
         'RECLAIMABLE',
         'OVERLAYDIRECTFIRE',


### PR DESCRIPTION
For details see issu  #1292 

If TRANSPORTFOCUS is added to the stinger, the mousecursor will show a transport icon if hovered over a unit while the stinger is selected.