### PR TITLE
Fixed Sounds inside Unitblueprints

### DIFF
--- a/units/UAS0401/UAS0401_unit.bp
+++ b/units/UAS0401/UAS0401_unit.bp
@@ -440,7 +440,7 @@ UnitBlueprint {
         {
             Audio = {
                 Fire = Sound {
-                    Bank = 'UALWeapon',
+                    Bank = 'UASWeapon',
                     Cue = 'UAS0201_Depth_Charge',
                     LodCutoff = 'Weapon_LodCutoff',
                 },

--- a/units/UES0305/UES0305_unit.bp
+++ b/units/UES0305/UES0305_unit.bp
@@ -18,7 +18,7 @@ UnitBlueprint {
         },
         Killed = Sound {
             Bank = 'UESDestroy',
-            Cue = 'UES0305_Destroy',
+            Cue = 'UES_Expl_Underwater',
             LodCutoff = 'UnitMove_LodCutoff',
         },
         StartMove = Sound {

--- a/units/URA0203/URA0203_unit.bp
+++ b/units/URA0203/URA0203_unit.bp
@@ -65,7 +65,7 @@ UnitBlueprint {
         },
         Thruster = Sound {
             Bank = 'URA',
-            Cue = 'URA0203_Move_Thruster',
+            Cue = 'URA0103_Move_Thruster',
             LodCutoff = 'UnitMove_LodCutoff',
         },
         UISelection = Sound {

--- a/units/XEA0002/XEA0002_unit.bp
+++ b/units/XEA0002/XEA0002_unit.bp
@@ -47,7 +47,7 @@ UnitBlueprint {
         },
         Thruster = Sound {
             Bank = 'XEA',
-            Cue = 'XEA0002_Move_Thruster',
+            Cue = 'XEA0306_Move_Thruster',
             LodCutoff = 'UnitMove_LodCutoff',
         },
         UISelection = Sound {


### PR DESCRIPTION
1 Unitsound only had the wrong Soundbank.
3 unitsounds are missing. I replaced them with similar sound.

Changes:

```
Unit ura0203 Name: Renegade (Gunship)
Cue 'URA0203_Move_Thruster' does not exist in bank 'URA'
Using URA0103_Move_Thruster instead.

Unit xea0002 (Defense Satellite)
Cue 'XEA0002_Move_Thruster' does not exist in bank 'XEA'
Using XEA0306_Move_Thruster instead.

Unit uas0401 Name: Tempest (Experimental Battleship)
Weapon: Harmonic Depth Charge
cue 'UAS0201_Depth_Charge' does not exist in bank 'UALWeapon'
Using correct bank UASWeapon

Unit ues0305 Name: SP3 - 3000 (Sonar Platform)
cue 'UES0305_Destroy' does not exist in bank 'UESDestroy'
Using UES_Expl_Underwater instead.

```
