### PR TITLE
Feature/player swap map preview

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5197,8 +5197,7 @@ function InitHostUtils()
 
             -- Move the observer into the slot the first player came from.
             HostUtils.ConvertObserverToPlayer(FindObserverSlotForID(toOpts.OwnerID), moveFrom, true)
-            WARN(fromOpts.PlayerName)
-            WARN(toOpts.PlayerName)
+
             -- %s has switched with %s
             SendSystemMessage("lobui_0417", fromOpts.PlayerName, toOpts.PlayerName)
         end,


### PR DESCRIPTION
Click on a not-empty slot in the map preview and click on a another not
empty slot to swap those players.
![lobbymagic](https://cloud.githubusercontent.com/assets/10554299/15512441/3f6d83a4-21e0-11e6-8662-e2274e0ec789.gif)
