### PR TITLE
Bugfix for "you dont have the mod without name" Error.

### DIFF
--- a/lua/MODS.LUA
+++ b/lua/MODS.LUA
@@ -229,8 +229,21 @@ function GetLocallyAvailableMods()
     return result
 end
 
+-- Get List of selected mods and check if they still exist.
 function GetSelectedMods()
-    return GetPreference('active_mods') or {}
+    local ModsFromGamePrefs = GetPreference('active_mods') or {}
+    local ModsFromDisk= {}
+    for modid,moddata in AllMods() do
+        ModsFromDisk[moddata.uid] = true
+    end
+    for modid in ModsFromGamePrefs do
+        if not ModsFromDisk[modid] then
+            SPEW('Mod ID='..modid..' is selected as active mod, but missing on Disk!')
+            ModsFromGamePrefs[modid] = nil
+            SetPreference('active_mods', ModsFromGamePrefs)
+        end
+    end
+    return ModsFromGamePrefs
 end
 
 function GetSelectedSimMods()


### PR DESCRIPTION
If the host has updated a mod and start to host a game, no one can join the game. There is an error message about a missing mod, but no modname etc. Neither the host or the client know, what mod is missing.

This is caused by an unsynced active_mods array saved inside game.prefs.

To reproduce the error:
Close the game and update a Mod. (the mod id must change.)
Or go to game.prefs, search for the active_mods Array. Should look like this:
```LUA
active_mods = {
    ['9e8ea941-c306-4751-b367-e10000000104'] = true,
    ['zcbf6277-24e3-437a-b968-Common-v1'] = true,
    ['ecbf6277-24e3-437a-b968-EcoManager-v7'] = true,
    ['9e8ea941-c306-aaaf-b367-f00000000005'] = true,
    ['9e8ea941-c306-4751-b367-e00000000302'] = true,
 }
```
Now Change a mod ID. Its the same as installing a mod with a new ID.

Now Host a game and don't go to options.
The game will load the active_mods array and check it agains all clients.
Off course no one can have the Mod with unknow id that is still saved in active_mods array.
And you can't get a name for the error message from a non existing mod.

To prevent the error we have to validate the active_mods array on loading and check the id's against the actuall installed mod's.

So i changed the function GetSelectedMods() inside MOD.lua to validate those id's.
