### PR TITLE
Enhancement: Enable Tooltip on queuestack, unitstack and attachedunit

### DIFF
--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -1051,9 +1051,8 @@ function OnRolloverHandler(button, state)
                 button.dragMarker:Destroy()
                 button.dragMarker = false
             end
-            UnitViewDetail.Hide()
         end
-    else
+    end
         if state == 'enter' then
             if item.type == 'item' or item.type == 'queuestack' or item.type == 'unitstack' or item.type == 'attachedunit' then
                 UnitViewDetail.Show(__blueprints[item.id], sortedOptions.selection[1], item.id)
@@ -1063,7 +1062,7 @@ function OnRolloverHandler(button, state)
         else
             UnitViewDetail.Hide()
         end
-    end
+    
 end
 
 function OnClickHandler(button, modifiers)

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -1055,7 +1055,7 @@ function OnRolloverHandler(button, state)
         end
     else
         if state == 'enter' then
-            if item.type == 'item' then
+            if item.type == 'item' or item.type == 'queuestack' or item.type == 'unitstack' or item.type == 'attachedunit' then
                 UnitViewDetail.Show(__blueprints[item.id], sortedOptions.selection[1], item.id)
             elseif item.type == 'enhancement' then
                 UnitViewDetail.ShowEnhancement(item.enhTable, item.unitID, item.icon, GetEnhancementPrefix(item.unitID, item.icon), sortedOptions.selection[1])


### PR DESCRIPTION
This will enable Tooltips to UnitIcons at:
- build cue (ACU, SACU, Engineer, Factories, mobile factories)
- selection panel (singel Unit, multiple units, UnitUpgrades)
- attached units on transporter

If a Unit has a construction panel, click  on "Selection and Storage" Tab to see the Unit Icon and Tooltip. (ACU, SACU etc.)
