### PR TITLE
ACU kills now trigger a GPGNet-command to enforce ratings server-side

### DIFF
--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -77,4 +77,8 @@ function OnSync()
             import('/lua/ui/dialogs/teamkill.lua').CreateDialog(Sync.Teamkill)
         end
     end
+	
+    if Sync.EnforceRating then
+        GpgNetSend('EnforceRating')
+    end
 end

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2163,6 +2163,10 @@ ACUUnit = Class(CommandUnit) {
         --If there is a killer, and it's not me
         if instigator and instigator:GetArmy() ~= self:GetArmy() then
             local instigatorBrain = ArmyBrains[instigator:GetArmy()]
+
+            Sync.EnforceRating = {}
+            WARN('ACU kill detected. Rating for ranked games is now enforced.')
+
             --if we are teamkilled
             if IsAlly(self:GetArmy(), instigator:GetArmy()) then
                 WARN('Teamkill detected')


### PR DESCRIPTION
In preparation for https://github.com/FAForever/server/issues/109

The trigger is sent for every ACU kill even though 1 time would be enough, but this can be handled server side.

Suggestions are welcome.