### PR TITLE
Fix Submerge/Surface Button

### DIFF
--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -155,7 +155,7 @@ end
 local function CreateOrderButtonGrid()
     controls.orderButtonGrid = Grid(controls.bg, GameCommon.iconWidth, GameCommon.iconHeight)
     controls.orderButtonGrid:SetName("Orders Grid")
-	controls.orderButtonGrid:DeleteAll()
+    controls.orderButtonGrid:DeleteAll()
 end
 
 -- local logic data
@@ -248,9 +248,9 @@ end
 -- used by things that build weapons, etc
 local function BuildOrderBehavior(self, modifiers)
     if modifiers.Left then
-	    IssueCommand(GetUnitCommandFromCommandCap(self._order))
+        IssueCommand(GetUnitCommandFromCommandCap(self._order))
     elseif modifiers.Right then
-	    self:ToggleCheck()
+        self:ToggleCheck()
         if self:IsChecked() then
             self._curHelpText = self._data.helpText .. "_auto"
             self.autoBuildEffect = CreateAutoBuildEffect(self)
@@ -261,7 +261,7 @@ local function BuildOrderBehavior(self, modifiers)
         if controls.mouseoverDisplay.text then
             controls.mouseoverDisplay.text:SetText(self._curHelpText)
         end
-	    SetAutoMode(currentSelection, self:IsChecked())
+        SetAutoMode(currentSelection, self:IsChecked())
     end
 end
 
@@ -279,7 +279,7 @@ end
 -- used by subs that can dive/surface
 local function DiveOrderBehavior(self, modifiers)
     if modifiers.Left then
-	    IssueCommand(GetUnitCommandFromCommandCap(self._order))
+        IssueCommand(GetUnitCommandFromCommandCap(self._order))
         self:ToggleCheck()
     elseif modifiers.Right then
         if self._isAutoMode then
@@ -300,7 +300,7 @@ local function DiveOrderBehavior(self, modifiers)
         if controls.mouseoverDisplay.text then
             controls.mouseoverDisplay.text:SetText(self._curHelpText)
         end
-	    SetAutoSurfaceMode(currentSelection, self._isAutoMode)
+        SetAutoSurfaceMode(currentSelection, self._isAutoMode)
     end
 end
 
@@ -361,8 +361,8 @@ end
 -- pause button specific behvior
 -- TODO pause button will be moved to construction manager
 local function PauseOrderBehavior(self, modifiers)
-	Checkbox.OnClick(self)
-	SetPaused(currentSelection, self:IsChecked())
+    Checkbox.OnClick(self)
+    SetPaused(currentSelection, self:IsChecked())
 end
 
 local function PauseInitFunction(control, unitList)
@@ -414,7 +414,7 @@ local function ScriptButtonOrderBehavior(self, modifiers)
     if controls.mouseoverDisplay.text then
         controls.mouseoverDisplay.text:SetText(self._curHelpText)
     end
-	Checkbox.OnClick(self)
+    Checkbox.OnClick(self)
 end
 
 local function ScriptButtonInitFunction(control, unitList)

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -279,7 +279,31 @@ end
 -- used by subs that can dive/surface
 local function DiveOrderBehavior(self, modifiers)
     if modifiers.Left then
-        IssueCommand(GetUnitCommandFromCommandCap(self._order))
+        local unitList = GetSelectedUnits()
+        local submergedSUB = false
+        local surfacedSUB = false
+        -- Searching the unitlist for SUB's and memorizing submerged and surfaced state
+        for i, v in unitList do
+            if EntityCategoryContains(categories.SUBMERSIBLE, v) then
+                local submergedSUBState = GetIsSubmerged({v})
+                if submergedSUBState == 1 then
+                    submergedSUB = true
+                elseif submergedSUBState == -1 then
+                    surfacedSUB = true
+                end
+            end
+        end
+        -- if we have selected submerged and surfaced SUB's, let all surfaced SUB's dive.
+        if submergedSUB and surfacedSUB then 
+            for i, v in unitList do
+                local submergedSUBState = GetIsSubmerged({v})
+                if submergedSUBState == 1 then
+                    IssueUnitCommand({v}, GetUnitCommandFromCommandCap(self._order))
+                end
+            end
+        else
+            IssueCommand(GetUnitCommandFromCommandCap(self._order))
+        end
         self:ToggleCheck()
     elseif modifiers.Right then
         if self._isAutoMode then

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -287,9 +287,9 @@ local function DiveOrderBehavior(self, modifiers)
             if EntityCategoryContains(categories.SUBMERSIBLE, v) then
                 local submergedSUBState = GetIsSubmerged({v})
                 if submergedSUBState == 1 then
-                    submergedSUB = true
-                elseif submergedSUBState == -1 then
                     surfacedSUB = true
+                elseif submergedSUBState == -1 then
+                    submergedSUB = true
                 end
             end
         end

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -291,16 +291,21 @@ local function DiveOrderBehavior(self, modifiers)
                 elseif submergedSUBState == -1 then
                     submergedSUB = true
                 end
+                -- bail out if we know, we have mixed SUBs
+                if surfacedSUB and submergedSUB then
+                    break
+                end
             end
         end
         -- if we have selected submerged and surfaced SUB's, let all surfaced SUB's dive.
-        if submergedSUB and surfacedSUB then 
+        if submergedSUB and surfacedSUB then
+            local SurfacedSubs = {}
             for i, v in unitList do
-                local submergedSUBState = GetIsSubmerged({v})
-                if submergedSUBState == 1 then
-                    IssueUnitCommand({v}, GetUnitCommandFromCommandCap(self._order))
+                if GetIsSubmerged({v}) == 1 then
+                    table.insert(SurfacedSubs, v)
                 end
             end
+            IssueUnitCommand(SurfacedSubs, GetUnitCommandFromCommandCap(self._order))
         else
             IssueCommand(GetUnitCommandFromCommandCap(self._order))
         end


### PR DESCRIPTION
More information:
#1333

SUB's dive-toogle button has now the same behavior then Shield toogle

If submerged and surfaced SUB's are selected, the Dive button will first submerge all SUB's.
If you have other units inside the selction, they will be ignored. Only SUB's are processed.