### PR TITLE
Adding a 0 Damage Weapon to Guide Weaponfire of LABs

### DIFF
--- a/units/UAA0104/UAA0104_script.lua
+++ b/units/UAA0104/UAA0104_script.lua
@@ -25,6 +25,7 @@ UAA0104 = Class(AirTransport) {
         SonicPulseBattery2 = Class(AAASonicPulseBatteryWeapon) {},
         SonicPulseBattery3 = Class(AAASonicPulseBatteryWeapon) {},
         SonicPulseBattery4 = Class(AAASonicPulseBatteryWeapon) {},
+        GuidanceSystem = Class(AAASonicPulseBatteryWeapon) {},
     },
 
     -- Override air destruction effects so we can do something custom here

--- a/units/UAA0104/UAA0104_unit.bp
+++ b/units/UAA0104/UAA0104_unit.bp
@@ -546,6 +546,36 @@ UnitBlueprint {
             Turreted = true,
             WeaponCategory = 'Anti Air',
         },
+        {
+            Damage = 0,
+            DisplayName = 'Weapon Guidance System',
+            FireTargetLayerCapsTable = {
+                Air = 'Land|Water|Seabed',
+                Land = 'Land|Water|Seabed',
+            },
+            Label = 'GuidanceSystem',
+            MaxRadius = 22,
+            MuzzleSalvoDelay = 1,
+            MuzzleSalvoSize = 0,
+            ProjectileId = '/projectiles/AAASonicPulse02/AAASonicPulse02_proj.bp',
+            RackBones = {
+                {
+                    MuzzleBones = {
+                        'Muzzle_R',
+                    },
+                    RackBone = 'Turret_Right',
+                },
+            },
+            RackRecoilDistance = 0,
+            RangeCategory = 'UWRC_DirectFire',
+            TargetRestrictDisallow = 'UNTARGETABLE AIR',
+            TurretPitch = 0,
+            TurretPitchRange = 45,
+            TurretPitchSpeed = 360,
+            TurretYaw = 0,
+            TurretYawRange = 180,
+            TurretYawSpeed = 360,
+        },
     },
     Wreckage = {
         Blueprint = '/props/DefaultWreckage/DefaultWreckage_prop.bp',


### PR DESCRIPTION
More Info: #1336

I added a Weapon with 0 damage to the Aeon Transporter to guide the weaponfire from loaded units.

Dont know if there is a better way, but at least it works :)