### PR TITLE
Add Self Destruct Confirmation

### DIFF
--- a/etc/faf/blacklist.lua
+++ b/etc/faf/blacklist.lua
@@ -94,6 +94,9 @@ Blacklist = {
     ['1749EEN4-DE86-5CC2-39AC-35692BDE76XF'] = UPGRADE,
     ['EEFFA8C6-96D9-11E4-9DA1-460D1D5D46B0'] = UPGRADE,
 
+    -- Suicide Confirmation
+    ['BB236B78-CB23-4E78-8CD7-BA55AE987545'] = INTEGRATED,
+
     -- ==================================================================
     -- INTEGRATED mods due to added preset restrictions in Units Manager:
     -- ==================================================================

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -671,6 +671,20 @@ options = {
                     },
                 },
             },
+
+            {
+                title = "<LOC OPTIONS_0247>Confirm Self Destruct",
+                key = "confirm_self_destruct",
+                type = 'toggle',
+                default = 1,
+                custom = {
+                    states = {
+                        {text = "<LOC _Off>", key = 0 },
+                        {text = "Only for ACU", key = 1},
+                        {text = "<LOC _On>", key = 2 },
+                    },
+                },
+            },
         },
     },
     video = {

--- a/lua/ui/game/confirmunitdestroy.lua
+++ b/lua/ui/game/confirmunitdestroy.lua
@@ -1,0 +1,27 @@
+
+local UIUtil = import('/lua/ui/uiutil.lua')
+local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
+local Group = import('/lua/maui/group.lua').Group
+local Prefs = import('/lua/user/prefs.lua')
+
+local destructingUnits = {}
+local controls = {}
+local countdownThreads = {}
+
+function ConfirmUnitDestruction()
+    if import('/lua/ui/campaign/campaignmanager.lua').campaignMode and table.getn(EntityCategoryFilterDown(categories.COMMAND, GetSelectedUnits())) > 0 then
+        UIUtil.QuickDialog(GetFrame(0), '<LOC confirm_0001>You cannot self destruct during an operation!', '<LOC _Ok>', nil, 
+            nil,  nil, 
+            nil, nil,
+            true, {worldCover = false, enterButton = 1, escapeButton = 1})
+    else
+        local units = GetSelectedUnits()
+        if units then
+            local unitIds = {}
+            for _, unit in units do
+                table.insert(unitIds, unit:GetEntityId())
+            end
+            SimCallback({Func = 'ToggleSelfDestruct', Args = {units = unitIds, owner = GetFocusArmy()}})
+        end
+    end
+end

--- a/lua/ui/game/confirmunitdestroy.lua
+++ b/lua/ui/game/confirmunitdestroy.lua
@@ -3,6 +3,7 @@ local UIUtil = import('/lua/ui/uiutil.lua')
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 local Group = import('/lua/maui/group.lua').Group
 local Prefs = import('/lua/user/prefs.lua')
+local options = Prefs.GetFromCurrentProfile('options')
 
 local destructingUnits = {}
 local controls = {}
@@ -16,12 +17,37 @@ function ConfirmUnitDestruction()
             true, {worldCover = false, enterButton = 1, escapeButton = 1})
     else
         local units = GetSelectedUnits()
+
         if units then
-            local unitIds = {}
-            for _, unit in units do
-                table.insert(unitIds, unit:GetEntityId())
+            local dialogue = nil
+
+            if options.confirm_self_destruct == 1 and table.getn(EntityCategoryFilterDown(categories.COMMAND, units)) > 0 then
+                dialogue = '<LOC confirm_0002>You are going to self destruct your ACU, are you sure?'
+            elseif options.confirm_self_destruct == 2 and table.getn(EntityCategoryFilterDown(categories.COMMAND, units)) > 0 then
+                dialogue = '<LOC confirm_0003>Your ACU is among the selected units for self destruction, do you wish to proceed?'
+            elseif options.confirm_self_destruct == 2 then
+                dialogue = '<LOC confirm_0004>Are you sure you wish to destroy the selected unit(s)?'
             end
-            SimCallback({Func = 'ToggleSelfDestruct', Args = {units = unitIds, owner = GetFocusArmy()}})
+
+            if dialogue then
+                UIUtil.QuickDialog(GetFrame(0), dialogue, 
+                '<LOC _Yes>', function()
+                    local unitIds = {}
+                    for _, unit in units do
+                        table.insert(unitIds, unit:GetEntityId())
+                    end
+                    SimCallback({Func = 'ToggleSelfDestruct', Args = {units = unitIds, owner = GetFocusArmy()}})
+                end,
+                '<LOC _No>', nil,
+                nil, nil,
+                true, {worldCover = false, enterButton = 1, escapeButton = 2})
+            else
+                local unitIds = {}
+                for _, unit in units do
+                    table.insert(unitIds, unit:GetEntityId())
+                end
+                SimCallback({Func = 'ToggleSelfDestruct', Args = {units = unitIds, owner = GetFocusArmy()}})
+            end
         end
     end
 end

--- a/lua/ui/help/tooltips.lua
+++ b/lua/ui/help/tooltips.lua
@@ -2084,4 +2084,8 @@ Tooltips = {
         title = 'Zoom Pop Distance',
         description = 'Adjusts distance to which Zoom Pop zooms to.',
     },
+    options_confirm_self_destruct = {
+        title = 'Confirm Self Destruct',
+        description = 'Asks for confirmation before self destructing selected units.',
+    },
 }


### PR DESCRIPTION
Fixes #1341 
Asks before self destruction selected units. By default asks only when ACU is selected. Can be turned on for all units or turned off completelly.
