### PR TITLE
Turn off deflate compression

### DIFF
--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -13,6 +13,8 @@ doscript '/lua/globalInit.lua'
 local AvgFPS = 10
 WaitFrames = coroutine.yield
 
+ConExecute('net_CompressionMethod 0')
+
 function WaitSeconds(n)
     local start = CurrentTime()
     local elapsed_frames = 0


### PR DESCRIPTION
Some players crash due to deflate compression algorithm trying to unpack corrupt packets.

Some reports:
http://forums.faforever.com/viewtopic.php?f=3&t=12552
https://forums.faforever.com/viewtopic.php?f=3&t=9811
https://forums.faforever.com/viewtopic.php?f=3&t=10542

If we need compression we can do that in the FAF client instead, multicore ftw ;) (although I guess FA probably runs this in own thread)