### PR TITLE
Add terrain avoidance to tempest

### DIFF
--- a/units/UAS0401/UAS0401_script.lua
+++ b/units/UAS0401/UAS0401_script.lua
@@ -70,11 +70,8 @@ UAS0401 = Class(ASeaUnit) {
         
         if (new == 'Up' and old == 'Bottom') then --when starting to surface
             self.WatchDepth = false
-            if self.DiverThread then
-            end
         end
         if (new == 'Bottom' and old == 'Down') then --when finished diving
-            WARN('enabling slider')
             self.WatchDepth = true
             if not self.DiverThread then
                 self.DiverThread = self:ForkThread(self.DiveDepthThread)
@@ -94,7 +91,6 @@ UAS0401 = Class(ASeaUnit) {
             self.SinkSlider:SetSpeed(1)
             
             self.SinkSlider:SetGoal(0, difference, 0)
-            WARN('Setting slider:' .. difference)
             WaitSeconds(0.2)
         end
         self.SinkSlider:SetGoal(0, 0, 0) --reset the slider while we are not watching depth

--- a/units/UES0401/UES0401_script.lua
+++ b/units/UES0401/UES0401_script.lua
@@ -68,11 +68,51 @@ UES0401 = Class(TSeaUnit) {
         elseif new == 'Top' then
             self:PlayAllOpenAnims(true)
         end
+        
+        if (new == 'Up' and old == 'Bottom') then --when starting to surface
+            self.WatchDepth = false
+        end
+        if (new == 'Bottom' and old == 'Down') then --when finished diving
+            self.WatchDepth = true
+            if not self.DiverThread then
+                self.DiverThread = self:ForkThread(self.DiveDepthThread)
+            end
+        end
+    end,
+
+    DiveDepthThread = function(self)
+        -- takes the given location, adjusts the Y value to the surface height on that location, with an offset
+        local Yoffset = 1.2 --the default (built in) offset appears to be 0.25 - if the place where thats set is found, that would be epic.
+        -- 1.2 is for tempest to clear the torpedo tubes from most cases of ground clipping, keeping overall height minimal.
+        while self.WatchDepth == true do
+            local pos = self:GetPosition()
+            local seafloor = GetTerrainHeight(pos[1], pos[3]) + GetTerrainTypeOffset(pos[1], pos[3]) --target depth, in this case the seabed
+            --local difference = pos[2] - math.max((seafloor + Yoffset), self.elevation) -- saved for later, sets depth to elevation in bp
+            local difference = math.max(((seafloor + Yoffset) - pos[2]), -0.5) --doesnt sink too much, just maneuveres the bed better.
+            self.SinkSlider:SetSpeed(1)
+            
+            self.SinkSlider:SetGoal(0, difference, 0)
+            WaitSeconds(0.2)
+        end
+        self.SinkSlider:SetGoal(0, 0, 0) --reset the slider while we are not watching depth
+        WaitFor(self.SinkSlider)-- we have to wait for it to finish before killing the thread or it stops
+        
+        KillThread(self.DiverThread)
     end,
 
     OnStopBeingBuilt = function(self,builder,layer)
         TSeaUnit.OnStopBeingBuilt(self,builder,layer)
         ChangeState(self, self.IdleState)
+        
+        if not self.SinkSlider then --setup the slider and get blueprint values
+            self.SinkSlider = CreateSlider(self, 0, 0, 0, 0, 5, true) --create sink controller to overlay ontop of original collision detection
+            self.Trash:Add(self.SinkSlider)
+        end
+        
+        --local bp = self:GetBlueprint() -- saved for later, sets depth to elevation in bp
+        --self.elevation = bp.Physics.Elevation -- saved for later, sets depth to elevation in bp
+        self.WatchDepth = false
+        
     end,
 
     OnFailedToBuild = function(self)


### PR DESCRIPTION
it moves up when over terrain so its torpedo tubes dont clip into it and stop firing. when moving into deeper water it moves down a little bit, but not too much.

This is on a slider. this means the actual position of the unit doesn't change, so its ok for small movement but making it move way deeper would need more work.
