### PR TITLE
Bugfix - Error running lua script  aibuildstructures.lua attempt to perform arithmetic on field

### DIFF
--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -2230,8 +2230,7 @@ Platoon = Class(moho.platoon_methods) {
             reference, refName = AIUtils.AIGetClosestThreatMarkerLoc(aiBrain, cons.NearMarkerType, pos[1], pos[3],
                                                             cons.ThreatMin, cons.ThreatMax, cons.ThreatRings)
             if not reference then
-                relative = true
-                reference = true
+                reference = pos
             end
             table.insert( baseTmplList, AIBuildStructures.AIBuildBaseTemplateFromLocation( baseTmpl, reference ) )
             buildFunction = AIBuildStructures.AIExecuteBuildStructure


### PR DESCRIPTION
This PR fixed the following bug:

```LUA
WARNING: Error running lua script: ...mdata\faforever\repo\fa\lua\ai\aibuildstructures.lua(227): attempt to perform arithmetic on field `?' (a nil value)
         stack traceback:
         	...mdata\faforever\repo\fa\lua\ai\aibuildstructures.lua(227): in function `AIBuildBaseTemplateFromLocation'
         	c:\programdata\faforever\repo\fa\lua\platoon.lua(2236): in function <c:\programdata\faforever\repo\fa\lua\platoon.lua:2031>
```

AIBuildBaseTemplateFromLocation(arg1,arg2) needs as 2nd arg a Unit / Map Position.
Fixed by using the position of the engineer, if other targets are not aviable.
