### PR TITLE
Make sure wrecks are destroyed after rebuild

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2128,6 +2128,12 @@ Unit = Class(moho.unit_methods) {
                 local progress = p:GetFractionComplete() * 0.5
                 -- set health according to how much is left of the wreck
                 unit:SetHealth(self, unit:GetMaxHealth() * progress)
+
+                -- Clear up wreck after rebuild bonus applied if engine won't
+                if not unit.EngineIsDeletingWreck then
+                    p:Destroy()
+                end
+
                 return
             end
         end


### PR DESCRIPTION
Factories which contain a wreck of a partial built unit got rebuild bonus without wreck being destroyed.

Fixes #1366