### PR TITLE
Fix UEF Gunship Stinger don't accept attack orders while on water

### DIFF
--- a/units/UEA0203/UEA0203_unit.bp
+++ b/units/UEA0203/UEA0203_unit.bp
@@ -291,6 +291,7 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Hells Fury Riot Gun',
             FireTargetLayerCapsTable = {
+                Water = 'Air|Land|Water|Seabed',
                 Air = 'Air|Land|Water|Seabed',
                 Land = 'Air|Land|Water|Seabed',
             },


### PR DESCRIPTION
See issue #1392

This PR simply adds the Layer `Water` to `FireTargetLayerCapsTable`.
So the stinger will accept attackorders while floating on water.