### PR TITLE
Fix builder hook message (warning)

### DIFF
--- a/lua/system/GlobalBaseTemplate.lua
+++ b/lua/system/GlobalBaseTemplate.lua
@@ -47,7 +47,7 @@ BaseBuilderTemplateDefMeta.__call = function(...)
     end
 
     if BaseBuilderTemplates[arg[2].BaseTemplateName] then
-        WARN('Duplicate BaseBuilderTemplate detected - overriding/appending old: ', arg[2].BaseTemplateName)
+        LOG('Hooked BaseBuilderTemplate: ', arg[2].BaseTemplateName)
         for k,v in arg[2] do
             BaseBuilderTemplates[arg[2].BaseTemplateName][k] = v
         end

--- a/lua/system/GlobalBaseTemplate.lua
+++ b/lua/system/GlobalBaseTemplate.lua
@@ -1,0 +1,61 @@
+#****************************************************************************
+#**
+#**  File     :  /lua/system/GlobalBaseTemplate.lua
+#**
+#**  Summary  :  Global base table and template methods
+#**
+#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+
+# Global list of all BaseBuilderTemplates found in the system.
+BaseBuilderTemplates = {}
+
+# 
+BaseBuilderTemplate = {}
+BaseBuilderTemplateDefMeta = {}
+
+BaseBuilderTemplateDefMeta.__index = BaseBuilderTemplateDefMeta
+BaseBuilderTemplateDefMeta.__call = function(...)
+    if type(arg[2]) ~= 'table' then
+        LOG('Invalid BaseBuilderTemplate: ', repr(arg))
+        return
+    end
+    
+    if not arg[2].BaseTemplateName then
+        WARN('Missing BaseTemplateName for BaseBuilderTemplate definition: ',repr(arg))
+        return
+    end
+    
+    if not arg[2].Builders then
+        WARN('Missing Builders for BaseBuilderTemplate definition - BaseTemplateName = ' .. arg[2].BaseTemplateName)
+        return
+    end
+    for k,v in arg[2].Builders do
+        if not BuilderGroups[v] then
+            WARN('Invalid BuilderGroup named - ' .. v .. ' - in BaseBuilderTemplate: ' .. arg[2].BaseTemplateName)
+        end
+    end
+    
+    if not arg[2].ExpansionFunction then
+        WARN('Missing Builders for ExpansionFunction definition - BaseTemplateName = ' .. arg[2].BaseTemplateName)
+        return
+    end
+    
+    if not arg[2].BaseSettings then
+        WARN('Missing BaseSettings for BaseBuilderTemplate definition - BaseTemplateName = ' .. arg[2].BaseTemplateName)
+        return
+    end
+    
+    if BaseBuilderTemplates[arg[2].BaseTemplateName] then
+        WARN('Duplicate BaseBuilderTemplate detected - overriding/appending old: ', arg[2].BaseTemplateName)
+        for k,v in arg[2] do
+            BaseBuilderTemplates[arg[2].BaseTemplateName][k] = v
+        end
+    else
+        BaseBuilderTemplates[arg[2].BaseTemplateName] = arg[2]
+    end
+    #SPEW('BaseBuilderTemplate Registered: ', arg[2].BaseTemplateName)
+    return arg[2].BaseTemplateName
+end
+
+setmetatable(BaseBuilderTemplate, BaseBuilderTemplateDefMeta)

--- a/lua/system/GlobalBaseTemplate.lua
+++ b/lua/system/GlobalBaseTemplate.lua
@@ -1,16 +1,16 @@
-#****************************************************************************
-#**
-#**  File     :  /lua/system/GlobalBaseTemplate.lua
-#**
-#**  Summary  :  Global base table and template methods
-#**
-#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+----------------------------------------------------------------------------
+--
+--  File     :  /lua/system/GlobalBaseTemplate.lua
+--
+--  Summary  :  Global base table and template methods
+--
+--  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+----------------------------------------------------------------------------
 
-# Global list of all BaseBuilderTemplates found in the system.
+-- Global list of all BaseBuilderTemplates found in the system.
 BaseBuilderTemplates = {}
 
-# 
+--
 BaseBuilderTemplate = {}
 BaseBuilderTemplateDefMeta = {}
 
@@ -20,12 +20,12 @@ BaseBuilderTemplateDefMeta.__call = function(...)
         LOG('Invalid BaseBuilderTemplate: ', repr(arg))
         return
     end
-    
+
     if not arg[2].BaseTemplateName then
         WARN('Missing BaseTemplateName for BaseBuilderTemplate definition: ',repr(arg))
         return
     end
-    
+
     if not arg[2].Builders then
         WARN('Missing Builders for BaseBuilderTemplate definition - BaseTemplateName = ' .. arg[2].BaseTemplateName)
         return
@@ -35,17 +35,17 @@ BaseBuilderTemplateDefMeta.__call = function(...)
             WARN('Invalid BuilderGroup named - ' .. v .. ' - in BaseBuilderTemplate: ' .. arg[2].BaseTemplateName)
         end
     end
-    
+
     if not arg[2].ExpansionFunction then
         WARN('Missing Builders for ExpansionFunction definition - BaseTemplateName = ' .. arg[2].BaseTemplateName)
         return
     end
-    
+
     if not arg[2].BaseSettings then
         WARN('Missing BaseSettings for BaseBuilderTemplate definition - BaseTemplateName = ' .. arg[2].BaseTemplateName)
         return
     end
-    
+
     if BaseBuilderTemplates[arg[2].BaseTemplateName] then
         WARN('Duplicate BaseBuilderTemplate detected - overriding/appending old: ', arg[2].BaseTemplateName)
         for k,v in arg[2] do
@@ -54,7 +54,7 @@ BaseBuilderTemplateDefMeta.__call = function(...)
     else
         BaseBuilderTemplates[arg[2].BaseTemplateName] = arg[2]
     end
-    #SPEW('BaseBuilderTemplate Registered: ', arg[2].BaseTemplateName)
+    --SPEW('BaseBuilderTemplate Registered: ', arg[2].BaseTemplateName)
     return arg[2].BaseTemplateName
 end
 

--- a/lua/system/GlobalBuilderGroup.lua
+++ b/lua/system/GlobalBuilderGroup.lua
@@ -1,32 +1,32 @@
-#****************************************************************************
-#**
-#**  File     :  /lua/system/GlobalBuilderGroup.lua
-#**
-#**  Summary  :  Global builder group table and blueprint methods
-#**
-#**  Copyright © 2008 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+----------------------------------------------------------------------------
+--
+--  File     :  /lua/system/GlobalBuilderGroup.lua
+--
+--  Summary  :  Global builder group table and blueprint methods
+--
+--  Copyright © 2008 Gas Powered Games, Inc.  All rights reserved.
+----------------------------------------------------------------------------
 
-# Global list of all buffs found in the system.
+-- Global list of all buffs found in the system.
 BuilderGroups = {}
 
-# Buff blueprints are created by invoking BuffBlueprint() with a table
-# as the buff data. Buffs can be defined in any module at any time.
-# e.g.
-#
-# BuffBlueprint {
-#    Name = HealingOverTime1,
-#    DisplayName = 'Healing Over Time',
-#    [...]
-#    Affects = {
-#        Health = {
-#            Add = 10,
-#        },
-#    },
-# }
-#
-#
-#
+-- Buff blueprints are created by invoking BuffBlueprint() with a table
+-- as the buff data. Buffs can be defined in any module at any time.
+-- e.g.
+--
+-- BuffBlueprint {
+--    Name = HealingOverTime1,
+--    DisplayName = 'Healing Over Time',
+--    [...]
+--    Affects = {
+--        Health = {
+--            Add = 10,
+--        },
+--    },
+-- }
+--
+--
+--
 BuilderGroup = {}
 BuilderGroupDefMeta = {}
 
@@ -36,22 +36,22 @@ BuilderGroupDefMeta.__call = function(...)
         LOG('Invalid BuilderGroup: ', repr(arg))
         return
     end
-    
+
     if not arg[2].BuilderGroupName then
         WARN('Missing BuilderGroupName for BuilderGroup definition: ',repr(arg))
         return
     end
-    
+
     if not arg[2].BuildersType then
         WARN('Missing BuildersType for BuilderGroup definition - BuilderGroupName = ' .. arg[2].BuilderGroupName)
         return
     end
-    
-    if arg[2].BuildersType != 'EngineerBuilder' and arg[2].BuildersType != 'FactoryBuilder' and arg[2].BuildersType != 'PlatoonFormBuilder' and arg[2].BuildersType != 'StrategyBuilder' then
+
+    if arg[2].BuildersType ~= 'EngineerBuilder' and arg[2].BuildersType ~= 'FactoryBuilder' and arg[2].BuildersType ~= 'PlatoonFormBuilder' and arg[2].BuildersType ~= 'StrategyBuilder' then
         WARN('Invalid BuildersType for BuilderGroup definition - BuilderGroupName = ' .. arg[2].BuilderGroupName)
         return
     end
-    
+
     if BuilderGroups[arg[2].BuilderGroupName] then
         WARN('Duplicate PlatoonTemplate detected - overriding/appending old: ', arg[2].BuilderGroupName)
         for k,v in arg[2] do
@@ -60,7 +60,7 @@ BuilderGroupDefMeta.__call = function(...)
     else
         BuilderGroups[arg[2].BuilderGroupName] = arg[2]
     end
-    #SPEW('BuilderGroup Registered: ', arg[2].BuilderGroupName)
+    --SPEW('BuilderGroup Registered: ', arg[2].BuilderGroupName)
     return arg[2].BuilderGroupName
 end
 

--- a/lua/system/GlobalBuilderGroup.lua
+++ b/lua/system/GlobalBuilderGroup.lua
@@ -53,7 +53,7 @@ BuilderGroupDefMeta.__call = function(...)
     end
 
     if BuilderGroups[arg[2].BuilderGroupName] then
-        WARN('Duplicate PlatoonTemplate detected - overriding/appending old: ', arg[2].BuilderGroupName)
+        LOG('Hooked PlatoonTemplate: ', arg[2].BuilderGroupName)
         for k,v in arg[2] do
             BuilderGroups[arg[2].BuilderGroupName][k] = v
         end

--- a/lua/system/GlobalBuilderTemplate.lua
+++ b/lua/system/GlobalBuilderTemplate.lua
@@ -37,7 +37,7 @@ BuilderDefMeta.__call = function(...)
     end
 
     if Builders[arg[2].BuilderName] then
-        WARN('Duplicate Builder detected - overriding/appending old: ', arg[2].BuilderName)
+        LOG('Hooked Builder: ', arg[2].BuilderName)
         for k,v in arg[2] do
             Builders[arg[2].BuilderName][k] = v
         end

--- a/lua/system/GlobalBuilderTemplate.lua
+++ b/lua/system/GlobalBuilderTemplate.lua
@@ -1,16 +1,16 @@
-#****************************************************************************
-#**
-#**  File     :  /lua/system/GlobalBuilderTemplate.lua
-#**
-#**  Summary  :  Global builder table and template methods
-#**
-#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+----------------------------------------------------------------------------
+--
+--  File     :  /lua/system/GlobalBuilderTemplate.lua
+--
+--  Summary  :  Global builder table and template methods
+--
+--  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+----------------------------------------------------------------------------
 
-# Global list of all buffs found in the system.
+-- Global list of all buffs found in the system.
 Builders = {}
 
-# 
+--
 Builder = {}
 BuilderDefMeta = {}
 
@@ -20,22 +20,22 @@ BuilderDefMeta.__call = function(...)
         LOG('Invalid Builder: ', repr(arg))
         return
     end
-    
+
     if not arg[2].BuilderName then
         WARN('Missing BuilderName for Builder definition: ',repr(arg))
         return
     end
-    
+
     if not arg[2].Priority then
         WARN('Missing Priority for Builder definition - BuilderName = ' .. arg[2].BuilderName)
         return
     end
-    
+
     if not arg[2].BuilderType then
         WARN('Missing BuilderType for Builder definition - BuilderName = ' .. arg[2].BuilderName)
         return
     end
-    
+
     if Builders[arg[2].BuilderName] then
         WARN('Duplicate Builder detected - overriding/appending old: ', arg[2].BuilderName)
         for k,v in arg[2] do
@@ -44,11 +44,11 @@ BuilderDefMeta.__call = function(...)
     else
         Builders[arg[2].BuilderName] = arg[2]
     end
-    
+
     if not arg[2].BuilderData then
         arg[2].BuilderData = {}
     end
-    #SPEW('Builder Registered: ', arg[2].BuilderName)
+    --SPEW('Builder Registered: ', arg[2].BuilderName)
     return arg[2].BuilderName
 end
 

--- a/lua/system/GlobalBuilderTemplate.lua
+++ b/lua/system/GlobalBuilderTemplate.lua
@@ -1,0 +1,55 @@
+#****************************************************************************
+#**
+#**  File     :  /lua/system/GlobalBuilderTemplate.lua
+#**
+#**  Summary  :  Global builder table and template methods
+#**
+#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+
+# Global list of all buffs found in the system.
+Builders = {}
+
+# 
+Builder = {}
+BuilderDefMeta = {}
+
+BuilderDefMeta.__index = BuilderDefMeta
+BuilderDefMeta.__call = function(...)
+    if type(arg[2]) ~= 'table' then
+        LOG('Invalid Builder: ', repr(arg))
+        return
+    end
+    
+    if not arg[2].BuilderName then
+        WARN('Missing BuilderName for Builder definition: ',repr(arg))
+        return
+    end
+    
+    if not arg[2].Priority then
+        WARN('Missing Priority for Builder definition - BuilderName = ' .. arg[2].BuilderName)
+        return
+    end
+    
+    if not arg[2].BuilderType then
+        WARN('Missing BuilderType for Builder definition - BuilderName = ' .. arg[2].BuilderName)
+        return
+    end
+    
+    if Builders[arg[2].BuilderName] then
+        WARN('Duplicate Builder detected - overriding/appending old: ', arg[2].BuilderName)
+        for k,v in arg[2] do
+            Builders[arg[2].BuilderName][k] = v
+        end
+    else
+        Builders[arg[2].BuilderName] = arg[2]
+    end
+    
+    if not arg[2].BuilderData then
+        arg[2].BuilderData = {}
+    end
+    #SPEW('Builder Registered: ', arg[2].BuilderName)
+    return arg[2].BuilderName
+end
+
+setmetatable(Builder, BuilderDefMeta)

--- a/lua/system/GlobalPlatoonTemplate.lua
+++ b/lua/system/GlobalPlatoonTemplate.lua
@@ -1,41 +1,41 @@
-#****************************************************************************
-#**
-#**  File     :  /lua/system/GlobalPlatoonTemplate.lua
-#**
-#**  Summary  :  Global buff table and blueprint methods
-#**
-#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+----------------------------------------------------------------------------
+--
+--  File     :  /lua/system/GlobalPlatoonTemplate.lua
+--
+--  Summary  :  Global buff table and blueprint methods
+--
+--  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+----------------------------------------------------------------------------
 
-# Global list of all buffs found in the system.
+-- Global list of all buffs found in the system.
 PlatoonTemplates = {}
 
-# 
+--
 PlatoonTemplate = {}
 PlatoonTemplateDefMeta = {}
 
 PlatoonTemplateDefMeta.__index = PlatoonTemplateDefMeta
 PlatoonTemplateDefMeta.__call = function(...)
-    
+
     if type(arg[2]) ~= 'table' then
         LOG('Invalid PlatoonTemplate: ', repr(arg))
         return
     end
-    
+
     if not arg[2].Name then
         LOG('Missing name for PlatoonTemplate definition: ',repr(arg))
         return
     end
-    
+
     if not arg[2].GlobalSquads and not arg[2].FactionSquads then
         LOG('Missing GlobalSquads and FactionSquads for PlatoonTemplate definition - requires one: ',repr(arg))
         return
     end
-    
+
     local oldFactionSquads = false
     if InitialRegistration and PlatoonTemplates[arg[2].Name] then
         WARN('Duplicate PlatoonTemplate detected - overriding old: ', arg[2].Name)
-        # Save out any old faction squads in case they aren't being overwritten
+        -- Save out any old faction squads in case they aren't being overwritten
         oldFactionSquads = PlatoonTemplates[arg[2].Name]
     end
 
@@ -43,11 +43,11 @@ PlatoonTemplateDefMeta.__call = function(...)
         PlatoonTemplates[arg[2].Name] = {}
     end
 
-    #SPEW('PlatoonTemplate Registered: ', arg[2].Name)
-    
+    --SPEW('PlatoonTemplate Registered: ', arg[2].Name)
+
     PlatoonTemplates[arg[2].Name] = arg[2]
-    
-    # if there are old faction squads insert the ones that aren't being overridden
+
+    -- if there are old faction squads insert the ones that aren't being overridden
     if oldFactionSquads then
         for k,v in oldFactionSquads do
             if not PlatoonTemplates[arg[2].Name].FactionSquads[k] then
@@ -55,7 +55,7 @@ PlatoonTemplateDefMeta.__call = function(...)
             end
         end
     end
-    
+
     return arg[2].Name
 end
 

--- a/lua/system/GlobalPlatoonTemplate.lua
+++ b/lua/system/GlobalPlatoonTemplate.lua
@@ -34,7 +34,7 @@ PlatoonTemplateDefMeta.__call = function(...)
 
     local oldFactionSquads = false
     if InitialRegistration and PlatoonTemplates[arg[2].Name] then
-        WARN('Duplicate PlatoonTemplate detected - overriding old: ', arg[2].Name)
+        LOG('Hooked PlatoonTemplate: ', arg[2].Name)
         -- Save out any old faction squads in case they aren't being overwritten
         oldFactionSquads = PlatoonTemplates[arg[2].Name]
     end

--- a/lua/system/GlobalPlatoonTemplate.lua
+++ b/lua/system/GlobalPlatoonTemplate.lua
@@ -1,0 +1,62 @@
+#****************************************************************************
+#**
+#**  File     :  /lua/system/GlobalPlatoonTemplate.lua
+#**
+#**  Summary  :  Global buff table and blueprint methods
+#**
+#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+
+# Global list of all buffs found in the system.
+PlatoonTemplates = {}
+
+# 
+PlatoonTemplate = {}
+PlatoonTemplateDefMeta = {}
+
+PlatoonTemplateDefMeta.__index = PlatoonTemplateDefMeta
+PlatoonTemplateDefMeta.__call = function(...)
+    
+    if type(arg[2]) ~= 'table' then
+        LOG('Invalid PlatoonTemplate: ', repr(arg))
+        return
+    end
+    
+    if not arg[2].Name then
+        LOG('Missing name for PlatoonTemplate definition: ',repr(arg))
+        return
+    end
+    
+    if not arg[2].GlobalSquads and not arg[2].FactionSquads then
+        LOG('Missing GlobalSquads and FactionSquads for PlatoonTemplate definition - requires one: ',repr(arg))
+        return
+    end
+    
+    local oldFactionSquads = false
+    if InitialRegistration and PlatoonTemplates[arg[2].Name] then
+        WARN('Duplicate PlatoonTemplate detected - overriding old: ', arg[2].Name)
+        # Save out any old faction squads in case they aren't being overwritten
+        oldFactionSquads = PlatoonTemplates[arg[2].Name]
+    end
+
+    if not PlatoonTemplates[arg[2].Name] then
+        PlatoonTemplates[arg[2].Name] = {}
+    end
+
+    #SPEW('PlatoonTemplate Registered: ', arg[2].Name)
+    
+    PlatoonTemplates[arg[2].Name] = arg[2]
+    
+    # if there are old faction squads insert the ones that aren't being overridden
+    if oldFactionSquads then
+        for k,v in oldFactionSquads do
+            if not PlatoonTemplates[arg[2].Name].FactionSquads[k] then
+                PlatoonTemplates[arg[2].Name].FactionSquads[k] = v
+            end
+        end
+    end
+    
+    return arg[2].Name
+end
+
+setmetatable(PlatoonTemplate, PlatoonTemplateDefMeta)


### PR DESCRIPTION
After hooking builders or platoons the game will post a warning about overwriting.
This looks like an error but is a normal hook and should only post a LOG message.

Example before:
`
WARNING: Duplicate PlatoonTemplate detected - overriding/appending old: \000ACUUpgrades - Gun improvements
`

and after the patch:
`
INFO: Hooked PlatoonTemplate: \000ACUUpgrades - Gun improvements
`
