### PR TITLE
Increase T1 bomber BreakOffDistance to 24

### DIFF
--- a/units/UAA0103/UAA0103_unit.bp
+++ b/units/UAA0103/UAA0103_unit.bp
@@ -7,7 +7,7 @@ UnitBlueprint {
         AutoLandTime = 1,
         BankFactor = 3,
         BankForward = false,
-        BreakOffDistance = 20,
+        BreakOffDistance = 24,
         BreakOffIfNearNewTarget = true,
         BreakOffTrigger = 20,
         CanFly = true,

--- a/units/UEA0103/UEA0103_unit.bp
+++ b/units/UEA0103/UEA0103_unit.bp
@@ -7,7 +7,7 @@ UnitBlueprint {
         AutoLandTime = 1,
         BankFactor = 3,
         BankForward = false,
-        BreakOffDistance = 20,
+        BreakOffDistance = 24,
         BreakOffIfNearNewTarget = true,
         BreakOffTrigger = 20,
         CanFly = true,

--- a/units/URA0103/URA0103_unit.bp
+++ b/units/URA0103/URA0103_unit.bp
@@ -7,7 +7,7 @@ UnitBlueprint {
         AutoLandTime = 1,
         BankFactor = 3,
         BankForward = false,
-        BreakOffDistance = 20,
+        BreakOffDistance = 24,
         BreakOffIfNearNewTarget = true,
         BreakOffTrigger = 20,
         CanFly = true,

--- a/units/XSA0103/XSA0103_unit.bp
+++ b/units/XSA0103/XSA0103_unit.bp
@@ -7,7 +7,7 @@ UnitBlueprint {
         AutoLandTime = 1,
         BankFactor = 3,
         BankForward = false,
-        BreakOffDistance = 20,
+        BreakOffDistance = 24,
         BreakOffIfNearNewTarget = true,
         BreakOffTrigger = 20,
         CanFly = true,


### PR DESCRIPTION
Increase the time T1 bombers take to circle over their target as they
attack.