### PR TITLE
BugFix lobbycolor incompatible with vanilla and steam

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -340,7 +340,7 @@ function GetLocalPlayerData()
             PlayerName = localPlayerName,
             OwnerID = localPlayerID,
             Human = true,
-            PlayerColor = Prefs.GetFromCurrentProfile('LastColor'),
+            PlayerColor = Prefs.GetFromCurrentProfile('LastColorFAF'),
             Faction = GetSanitisedLastFaction(),
             PlayerClan = argv.playerClan,
             PL = playerRating,
@@ -927,7 +927,7 @@ function SetSlotInfo(slotNum, playerInfo)
     slot.ready:SetCheck(playerInfo.Ready, true)
 
     if isLocallyOwned and playerInfo.Human then
-        Prefs.SetToCurrentProfile('LastColor', playerInfo.PlayerColor)
+        Prefs.SetToCurrentProfile('LastColorFAF', playerInfo.PlayerColor)
         Prefs.SetToCurrentProfile('LastFaction', playerInfo.Faction)
     end
 


### PR DESCRIPTION
Issue #1436
This change is for compatibility from FAF with vanilla and steam game
version. FAF is using more colors inside the Lobby then vanilla and steam can handle, so
we use a own variable now for it.