### PR TITLE
Bugfix Enhancement Tooltips sometimes not shown.

### DIFF
--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -779,7 +779,7 @@ function CommonLogic()
             control.LowFuel:SetNeedsFrameUpdate(false)
             control.BuildKey = nil
             if control.Data.Disabled then
-                --control:Disable()
+                control:Enable()
                 control.Data.TooltipOnly = true
                 if not control.Data.Selected then
                     control.Icon:SetSolidColor('aa000000')


### PR DESCRIPTION
Make sure, enhancement icons are enabled, even if they are greyed out.
We need this to have an active button handler to show the tooltip.