### PR TITLE
Add optional reasons to kick dialog

### DIFF
--- a/lua/ui/controls/popups/inputdialog.lua
+++ b/lua/ui/controls/popups/inputdialog.lua
@@ -6,7 +6,7 @@ local Popup = import('/lua/ui/controls/popups/popup.lua').Popup
 
 --- A popup that asks the user for a string.
 InputDialog = Class(Popup) {
-    __init = function(self, parent, title, fallbackInputbox)
+    __init = function(self, parent, title, fallbackInputbox, str)
         -- For ridiculous reasons, the lobby *must* keep keyboard focus on the chat input, or
         -- in-game keybindings can be called and cause the world to end.
         -- This parameter allows you to pass the box you insist we always keep focus on to the input
@@ -34,6 +34,10 @@ InputDialog = Class(Popup) {
         nameEdit.Width:Set(334)
         nameEdit.Height:Set(24)
         nameEdit:AcquireFocus()
+
+        if str then
+           nameEdit:SetText(str)
+        end
 
         nameEdit.OnLoseKeyboardFocus = function(self)
             nameEdit:AcquireFocus()

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -406,17 +406,19 @@ local function DoSlotBehavior(slot, key, name)
         end
     elseif key == 'remove_to_kik' then
         if gameInfo.PlayerOptions[slot].Human then
-            UIUtil.QuickDialog(GUI, "<LOC lobui_0166>Are you sure?",
-                               "<LOC lobui_0167>Kick Player",
-                               function()
-                                   SendSystemMessage("lobui_0756", gameInfo.PlayerOptions[slot].PlayerName)
-                                   lobbyComm:EjectPeer(gameInfo.PlayerOptions[slot].OwnerID, "KickedByHost")
-                               end
-                               ,
-                               "<LOC _Cancel>", nil,
-                               nil, nil,
-                               true,
-                               {worldCover = false, enterButton = 1, escapeButton = 2})
+            local kickMessage = function(self, str)
+                    local msg
+
+                    if str == "" then
+                        msg = "\n Kicked by host"
+                    else
+                        msg = "\n Kicked by host. \n Reason: " .. str
+                    end
+
+                    SendSystemMessage("lobui_0756", gameInfo.PlayerOptions[slot].PlayerName)
+                    lobbyComm:EjectPeer(gameInfo.PlayerOptions[slot].OwnerID, msg)
+                end
+            CreateInputDialog(GUI, "Kick the player?", kickMessage)
         else
             if lobbyComm:IsHost() then
                 HostUtils.RemoveAI(slot)

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -418,7 +418,7 @@ local function DoSlotBehavior(slot, key, name)
                     SendSystemMessage("lobui_0756", gameInfo.PlayerOptions[slot].PlayerName)
                     lobbyComm:EjectPeer(gameInfo.PlayerOptions[slot].OwnerID, msg)
                 end
-            CreateInputDialog(GUI, "Kick the player?", kickMessage, "Reason (optional)")
+            CreateInputDialog(GUI, "<LOC lobui_0166>Are you sure?", kickMessage, "Reason (optional)")
         else
             if lobbyComm:IsHost() then
                 HostUtils.RemoveAI(slot)

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -409,7 +409,7 @@ local function DoSlotBehavior(slot, key, name)
             local kickMessage = function(self, str)
                     local msg
 
-                    if str == "" then
+                    if str == "" or str == "Reason (optional)" then
                         msg = "\n Kicked by host"
                     else
                         msg = "\n Kicked by host. \n Reason: " .. str
@@ -418,7 +418,7 @@ local function DoSlotBehavior(slot, key, name)
                     SendSystemMessage("lobui_0756", gameInfo.PlayerOptions[slot].PlayerName)
                     lobbyComm:EjectPeer(gameInfo.PlayerOptions[slot].OwnerID, msg)
                 end
-            CreateInputDialog(GUI, "Kick the player?", kickMessage)
+            CreateInputDialog(GUI, "Kick the player?", kickMessage, "Reason (optional)")
         else
             if lobbyComm:IsHost() then
                 HostUtils.RemoveAI(slot)
@@ -4657,8 +4657,8 @@ function SavePresetsList(list)
 end
 
 --- Delegate to UIUtil's CreateInputDialog, adding the ridiculus chatEdit hack.
-function CreateInputDialog(parent, title, listener)
-    UIUtil.CreateInputDialog(parent, title, listener, GUI.chatEdit)
+function CreateInputDialog(parent, title, listener, str)
+    UIUtil.CreateInputDialog(parent, title, listener, GUI.chatEdit, str)
 end
 
 -- Show the lobby preset UI.

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -1093,8 +1093,8 @@ function GetReplayId()
 end
 
 -- Create an input dialog with the given title and listener function.
-function CreateInputDialog(parent, title, listener, fallbackBox)
-    local dialog = InputDialog(parent, title, fallbackBox)
+function CreateInputDialog(parent, title, listener, fallbackBox, str)
+    local dialog = InputDialog(parent, title, fallbackBox, str)
     dialog.OnInput = listener
 
     return dialog


### PR DESCRIPTION
Replaces quick dialog for kicking players in the game lobby with an input dialog. So the host can type in a reason for the kicked player to read when ejected from the game lobby. 

To state a reason is entirely optional.

Hopefully reduces annoying "Why was I kicked?" messages.