### PR TITLE
Stop LABs firing from carriers

### DIFF
--- a/units/UEA0203/UEA0203_script.lua
+++ b/units/UEA0203/UEA0203_script.lua
@@ -35,6 +35,24 @@ UEA0203 = Class(AirTransport, TAirUnit) {
             self.Trash:Add(v)
         end
     end,
+
+    -- Called when this unit is put into a transport. Since it is itself an Aircraft, that transport
+    -- has to be a staging pad or a carrier
+    MarkWeaponsOnTransport = function(self, bool)
+        -- Use the normal procedure to disable our own weapons
+        TAirUnit.MarkWeaponsOnTransport(self, bool)
+
+        -- Since this is the only unit capable of carrying another into a transport
+        -- We need to disable the weapon on that unit in case it's a LAB
+        -- Use SetEnabled rather than SetOnTransport to ignore units like LABs which can fire from transports
+        local unit = self:GetCargo()
+        if unit then
+            for i = 1, unit:GetWeaponCount() do
+                local wep = unit:GetWeapon(i)
+                wep:SetEnabled(not bool)
+            end
+        end
+    end,
 }
 
 TypeClass = UEA0203

--- a/units/UEA0203/UEA0203_script.lua
+++ b/units/UEA0203/UEA0203_script.lua
@@ -1,12 +1,9 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/UEA0203/UEA0203_script.lua
-#**  Author(s):  John Comes, David Tomandl, Jessica St. Croix, Gordon Duclos
-#**
-#**  Summary  :  UEF Gunship Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--------------------------------------------------------------------------
+-- File     :  /cdimage/units/UEA0203/UEA0203_script.lua
+-- Author(s):  John Comes, David Tomandl, Jessica St. Croix, Gordon Duclos
+-- Summary  :  UEF Gunship Script
+-- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--------------------------------------------------------------------------
 
 local TAirUnit = import('/lua/terranunits.lua').TAirUnit
 local AirTransport = import('/lua/defaultunits.lua').AirTransport
@@ -23,21 +20,20 @@ UEA0203 = Class(AirTransport, TAirUnit) {
         TAirUnit.OnStopBeingBuilt(self,builder,layer)
         self.EngineManipulators = {}
 
-        # create the engine thrust manipulators
+        -- Create the engine thrust manipulators
         for key, value in self.EngineRotateBones do
             table.insert(self.EngineManipulators, CreateThrustController(self, "thruster", value))
         end
 
-        # set up the thursting arcs for the engines
+        -- Set up the thrusting arcs for the engines
         for key,value in self.EngineManipulators do
-            #                          XMAX, XMIN, YMAX,YMIN, ZMAX,ZMIN, TURNMULT, TURNSPEED
-            value:SetThrustingParam( -0.0, 0.0, -0.25, 0.25, -0.1, 0.1, 1.0,      0.25 )
+            -- XMAX, XMIN, YMAX, YMIN, ZMAX, ZMIN, TURNMULT, TURNSPEED
+            value:SetThrustingParam(-0.0, 0.0, -0.25, 0.25, -0.1, 0.1, 1.0, 0.25)
         end
         
         for k, v in self.EngineManipulators do
             self.Trash:Add(v)
         end
-
     end,
 }
 


### PR DESCRIPTION
The only way this can occur is if they are carried in by the UEF T2 Gunship (Normal transports cannot enter carriers). So on Gunship loading, disable carried unit weapons.

Fixes https://github.com/FAForever/fa/issues/1457