### PR TITLE
Change the way the Selen toggle works

### DIFF
--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -432,16 +432,16 @@ function AddOnUIDestroyedFunction(func)
     table.insert(OnDestroyFuncs, func)
 end
 
--- Function to remove hidden selens from a selection which includes units other than hidden selens
+-- Function to remove low priority units from a selection which includes units other than low priority ones
 function DeselectSelens(selection)
-    local hiddenSelens = false
+    local LowPriorityUnits = false
     local otherUnits = false
 
-    -- Find any selens with the hidden flag
+    -- Find any units with the low priority flag
     for id, unit in selection do
-        -- Stupid-ass UnitData table uses string numbers as keys. Because reasons?
-        if unit:IsInCategory("xsl0101") and unit:IsIdle() and GetFireState({unit}) == 1 then -- Is Unit an activated Selen?
-            hiddenSelens = true
+        -- Stupid-ass UnitData table uses string number IDs as keys
+        if UnitData[unit:GetEntityId()].LowPriority then
+            LowPriorityUnits = true
         else
             if not otherUnits then otherUnits = {} end -- Ugly hack to make later logic easier
             table.insert(otherUnits, unit)
@@ -449,10 +449,10 @@ function DeselectSelens(selection)
     end
 
     -- Return original selection with no-change key if nothing has changed
-    if (otherUnits and not hiddenSelens) or (not otherUnits and hiddenSelens) then
+    if (otherUnits and not LowPriorityUnits) or (not otherUnits and LowPriorityUnits) then
         return selection, false
     end
-    
+
     return otherUnits, true
 end
 

--- a/units/XSL0101/XSL0101_unit.bp
+++ b/units/XSL0101/XSL0101_unit.bp
@@ -138,7 +138,7 @@ UnitBlueprint {
         },
         TransportDropAnimation = {
             {
-                Animation = '[...]XSL0101_aunfold.sca', # /units/XSL0101/XSL0101_aunfold.sca   [146]
+                Animation = '[...]XSL0101_aunfold.sca',
                 Weight = 100,
             },
         },
@@ -172,6 +172,11 @@ UnitBlueprint {
         },
         FactionName = 'Seraphim',
         Icon = 'land',
+        OrderOverrides = {
+            RULEUTC_CloakToggle = {
+                helpText = '<LOC xsl0101_toggle>Toggle Selection Priority',
+            },
+        },
         TechLevel = 'RULEUTL_Basic',
         ToggleCaps = {
             RULEUTC_CloakToggle = true,


### PR DESCRIPTION
Unit spawns with the toggle off. It behaves as a normal scout/LAB, no special abilities.

Toggle the unit's ability on, and it will drop to low selection priority and enable the stealth system, which is back to being motion-based. 