### PR TITLE
Global icon support for Idle factory Tab

### DIFF
--- a/lua/ui/game/avatars.lua
+++ b/lua/ui/game/avatars.lua
@@ -132,7 +132,9 @@ function CreateAvatar(unit)
 
     bg.icon = Bitmap(bg)
     LayoutHelpers.AtLeftTopIn(bg.icon, bg, 5, 5)
-    if DiskGetFileInfo(UIUtil.UIFile('/icons/units/'..bg.Blueprint.BlueprintId..'_icon.dds', true)) then
+
+    -- Commander icon
+    if UIUtil.UIFile('/icons/units/'..bg.Blueprint.BlueprintId..'_icon.dds', true) then
         bg.icon:SetTexture(UIUtil.UIFile('/icons/units/'..bg.Blueprint.BlueprintId..'_icon.dds', true))
     else
         bg.icon:SetTexture(UIUtil.UIFile('/icons/units/default_icon.dds'))
@@ -278,8 +280,9 @@ function CreateIdleTab(unitData, id, expandFunc)
             while i > 0 do
                 if table.getn(sortedUnits[i]) > 0 then
                     if needIcon then
-                        if Factions[currentFaction].IdleEngTextures[keyToIcon[i]] and DiskGetFileInfo('/textures/ui/common'..Factions[currentFaction].IdleEngTextures[keyToIcon[i]]) then
-                            self.icon:SetTexture('/textures/ui/common'..Factions[currentFaction].IdleEngTextures[keyToIcon[i]])
+                        -- Idle engineer icons
+                        if Factions[currentFaction].IdleEngTextures[keyToIcon[i]] and UIUtil.UIFile(Factions[currentFaction].IdleEngTextures[keyToIcon[i]],true) then
+                            self.icon:SetTexture(UIUtil.UIFile(Factions[currentFaction].IdleEngTextures[keyToIcon[i]],true))
                         else
                             self.icon:SetTexture(UIUtil.UIFile(Factions[currentFaction].IdleEngTextures['T2']))
                         end
@@ -307,8 +310,9 @@ function CreateIdleTab(unitData, id, expandFunc)
                 for curCat = 1, 3 do
                     if table.getn(sortedFactories[curCat][i]) > 0 then
                         if needIcon then
-                            if DiskGetFileInfo('/textures/ui/common'..Factions[currentFaction].IdleFactoryTextures[categoryTable[curCat]][i]) then
-                                self.icon:SetTexture('/textures/ui/common'..Factions[currentFaction].IdleFactoryTextures[categoryTable[curCat]][i])
+                            -- Idle factory icons
+                            if UIUtil.UIFile(Factions[currentFaction].IdleFactoryTextures[categoryTable[curCat]][i],true) then
+                                self.icon:SetTexture(UIUtil.UIFile(Factions[currentFaction].IdleFactoryTextures[categoryTable[curCat]][i],true))
                             else
                                 self.icon:SetTexture(UIUtil.UIFile('/icons/units/default_icon.dds'))
                             end
@@ -501,8 +505,9 @@ function CreateIdleEngineerList(parent, units)
             local entry = Group(self)
 
             entry.icon = Bitmap(entry)
-            if DiskGetFileInfo('/textures/ui/common'..icontexture) then
-                entry.icon:SetTexture('/textures/ui/common'..icontexture)
+            -- Iddle engineer icons groupwindow
+            if UIUtil.UIFile(icontexture,true) then
+                entry.icon:SetTexture(UIUtil.UIFile(icontexture,true))
             else
                 entry.icon:SetTexture(UIUtil.UIFile('/icons/units/default_icon.dds'))
             end
@@ -660,8 +665,9 @@ function CreateIdleFactoryList(parent, units)
     for type, category in iconData do
         local function CreateIcon(texture)
             local icon = Bitmap(bg)
-            if DiskGetFileInfo('/textures/ui/common'..texture) then
-                icon:SetTexture('/textures/ui/common'..texture)
+            -- Idle facory icons groupwindow
+            if UIUtil.UIFile(texture,true) then
+                icon:SetTexture(UIUtil.UIFile(texture,true))
             else
                 icon:SetTexture(UIUtil.UIFile('/icons/units/default_icon.dds'))
             end

--- a/lua/ui/game/avatars.lua
+++ b/lua/ui/game/avatars.lua
@@ -325,6 +325,17 @@ function CreateIdleTab(unitData, id, expandFunc)
                 end
                 i = i - 1
             end
+           if needIcon == true then
+               local ExpFactories = EntityCategoryFilterDown(categories.EXPERIMENTAL, self.allunits)
+               if table.getn(ExpFactories) > 0 then
+                   local FactoryUnitId = ExpFactories[1]:GetUnitId()
+                   if UIUtil.UIFile('/icons/units/' .. FactoryUnitId .. '_icon.dds', true) then
+                       self.icon:SetTexture(UIUtil.UIFile('/icons/units/' .. FactoryUnitId .. '_icon.dds', true))
+                   else
+                       self.icon:SetTexture(UIUtil.UIFile('/icons/units/default_icon.dds'))
+                   end
+               end
+           end
         end
         self.count:SetText(table.getsize(self.allunits))
 


### PR DESCRIPTION
Adding global iconsupport for avatars.lua and Idle Tab icon for modded factories.

![facidle](https://cloud.githubusercontent.com/assets/17804547/18414870/a2f9f10a-77da-11e6-87db-8a48f8e8dd40.png)

