### PR TITLE
Bugfix/make map name filter in game option menu more obv

### DIFF
--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -581,7 +581,9 @@ function CreateDialog(selectBehavior, exitBehavior, over, singlePlayer, defaultS
     filterName.Height:Set(22)
     filterName:SetFont(UIUtil.bodyFont, 16)
     filterName:SetForegroundColor(UIUtil.fontColor)
-    filterName:ShowBackground(false)
+    filterName:ShowBackground(true)
+    filterName:SetBackgroundColor('77778888')
+    filterName:SetCaretColor('ffff9999')
     filterName:SetDropShadow(true)
     LayoutHelpers.Below(filterName, namefilterTitle)
 


### PR DESCRIPTION
Cursor color changed to a whitish red, background enabled and set to a greenish grey
Fixes #1526 

![namefilter](https://cloud.githubusercontent.com/assets/10554299/18692524/2fdcc0ee-7f9b-11e6-9347-ffb8e4bbb2e6.jpg)
