### PR TITLE
Bugfix (final) GameOptions.Quality is saved as -1#INF

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1209,7 +1209,7 @@ end
 
 function autobalance_quality(players)
     local teams = nil
-    local quality = nil
+    local quality = 0
 
     for _, p in players do
         local i = p['player']
@@ -1225,7 +1225,7 @@ function autobalance_quality(players)
         teams:addPlayer(team, player)
     end
 
-    if teams then
+    if teams and table.getn(teams:getTeams()) > 1 then
         quality = Trueskill.computeQuality(teams)
     end
 

--- a/lua/ui/lobby/trueskill.lua
+++ b/lua/ui/lobby/trueskill.lua
@@ -460,7 +460,5 @@ function computeQuality(team)
 
 
     local result = math.exp(expPart) * math.sqrt(sqrtPart)
-
-    if not result >= 0 and not result <= 100 then return 0 end
     return round((result * 100), 2)
 end


### PR DESCRIPTION
Don't try to computeQuality with only 1 team

To reproduce the error select "Optimal balance" as Spawn option and start as single player.

After knowing this, the fix was easy.
Just verfying we have at least 2 teams before try to compute a quality.

I also removed the failsave from trueskill.lua
 (`if not result >= 0 and not result <= 100 then return 0 end`)
It was not working anyways...