### PR TITLE
fix uef scu aoe upgrade removal incorrect numbers

### DIFF
--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -331,7 +331,8 @@ UnitBlueprint {
             },
             Icon = 'heo',
             Name = '<LOC enhancements_0064>Remove Heavy Plasma Refractor',
-            NewDamageRadius = -4,
+            NewDamageRadius = -2,
+            NewMaxRadius = 25,
             Prerequisite = 'HighExplosiveOrdnance',
             RemoveEnhancements = {
                 'HighExplosiveOrdnance',


### PR DESCRIPTION
well i dunno who is responsible but this should be a crime imo. anyway
when you add 2 and remove -4 then add 2 again you get 0 aoe so if you
try to get the upgrade, remove, and get it again it no longer works.
great.

now that's fixed, and also NewMaxRadius was missing in here, lukily it
was called with (bp.NewMaxRadius or 25) so it wasn't so terrible, but
still

enjoy your game knowing it had balance terrorists working on it )