### PR TITLE
Fix LODCutoff for Seraphim ACU weapon trail

### DIFF
--- a/effects/emitters/seraphim_chronotron_cannon_projectile_fxtrail_01_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_projectile_fxtrail_01_emit.bp
@@ -1,164 +1,164 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_chronotron_cannon_projectile_fxtrail_01',
-	Lifetime = -50.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = true,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 1200.00,
-	EmitIfVisible = true,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 4.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/line_white_add_11.dds]],
-	RampTexture = [[/textures/particles/ramp_blue_yellow_01.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.456,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.391,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.720,y=0.050,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=27.200,y=60.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.150,y=3.000,z=0.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=9.763,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=15.303,y=0.100,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=-0.050,z=0.000 },
-			{ x=0.066,y=-0.243,z=0.000 },
-			{ x=0.198,y=-0.322,z=0.000 },
-			{ x=0.528,y=-0.355,z=0.000 },
-			{ x=0.923,y=-0.360,z=0.000 },
-			{ x=1.319,y=-0.275,z=0.000 },
-			{ x=1.781,y=-0.141,z=0.000 },
-			{ x=2.836,y=-0.050,z=0.000 },
-			{ x=4.683,y=-0.001,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=14.578,y=0.300,z=0.150 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.300,z=0.000 },
-			{ x=0.900,y=0.020,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=5.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_chronotron_cannon_projectile_fxtrail_01',
+    Lifetime = -50.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = true,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 175.00,
+    EmitIfVisible = true,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 4.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/line_white_add_11.dds]],
+    RampTexture = [[/textures/particles/ramp_blue_yellow_01.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.456,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.391,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.720,y=0.050,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=27.200,y=60.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.150,y=3.000,z=0.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=9.763,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=15.303,y=0.100,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=-0.050,z=0.000 },
+            { x=0.066,y=-0.243,z=0.000 },
+            { x=0.198,y=-0.322,z=0.000 },
+            { x=0.528,y=-0.355,z=0.000 },
+            { x=0.923,y=-0.360,z=0.000 },
+            { x=1.319,y=-0.275,z=0.000 },
+            { x=1.781,y=-0.141,z=0.000 },
+            { x=2.836,y=-0.050,z=0.000 },
+            { x=4.683,y=-0.001,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=14.578,y=0.300,z=0.150 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.300,z=0.000 },
+            { x=0.900,y=0.020,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=5.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_chronotron_cannon_projectile_fxtrail_02_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_projectile_fxtrail_02_emit.bp
@@ -10,7 +10,7 @@ EmitterBlueprint {
 	AlignRotation = true,
 	AlignToBone = false,
 	Flat = false,
-	LODCutoff = 1200.00,
+	LODCutoff = 175.00,
 	EmitIfVisible = true,
 	CatchupEmit = true,
 	CreateIfVisible = false,

--- a/effects/emitters/seraphim_chronotron_cannon_projectile_fxtrail_03_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_projectile_fxtrail_03_emit.bp
@@ -10,7 +10,7 @@ EmitterBlueprint {
 	AlignRotation = false,
 	AlignToBone = false,
 	Flat = false,
-	LODCutoff = 1200.00,
+	LODCutoff = 175.00,
 	EmitIfVisible = true,
 	CatchupEmit = true,
 	CreateIfVisible = false,


### PR DESCRIPTION
Optimizing a change in https://github.com/FAForever/fa/commit/8a987da5fab49c61409a5b9b71b82abff32381e4

The LODCutoff for the weaponemitter of the Serapim ACU was set to 1200.
But the ACU Unit itself has a LODCutoff of 175.

This will lead to show the weapopntrail while full zoomed out without showing the ACU unit.
So i reduced the visibilty of the weapon to the same zoom level as the unit.

seraphim_chronotron_cannon_projectile_fxtrail_01_emit.bp
Changed from 1200 to 175 (was 100 in vanilla)

seraphim_chronotron_cannon_projectile_fxtrail_02_emit.bp
Changed from 1200 to 175 (was 100 in vanilla)

seraphim_chronotron_cannon_projectile_fxtrail_03_emit.bp
Changed from 1200 to 175 (was 100 in vanilla)