### PR TITLE
Fix Rendering Weapon trails through Fog of War

### DIFF
--- a/effects/emitters/aeon_heavy_artillery_trail_01_emit.bp
+++ b/effects/emitters/aeon_heavy_artillery_trail_01_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'aeon_heavy_artillery_trail_01',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = -1.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/muzzle_flash_add_03.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_06.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=24.736,y=1.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=24.340,y=9.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=21.970,y=4.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.528,y=0.010,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=24.802,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=23.420,y=1.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.500,z=0.000 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=23.420,y=2.800,z=0.750 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.130,y=0.000,z=60.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.500,z=1.000 },
+		},
+	},
+}
+

--- a/effects/emitters/aeon_heavy_artillery_trail_01_emit.bp
+++ b/effects/emitters/aeon_heavy_artillery_trail_01_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = -1.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/aeon_heavy_artillery_trail_01_emit.bp
+++ b/effects/emitters/aeon_heavy_artillery_trail_01_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'aeon_heavy_artillery_trail_01',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = true,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = -1.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/muzzle_flash_add_03.dds]],
-	RampTexture = [[/textures/particles/ramp_blue_06.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=24.736,y=1.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=24.340,y=9.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=21.970,y=4.000,z=0.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.528,y=0.010,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=24.802,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=23.420,y=1.000,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.500,z=0.000 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=23.420,y=2.800,z=0.750 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.130,y=0.000,z=60.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.500,z=1.000 },
-		},
-	},
+    BlueprintId = 'aeon_heavy_artillery_trail_01',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = true,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = -1.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/muzzle_flash_add_03.dds]],
+    RampTexture = [[/textures/particles/ramp_blue_06.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=24.736,y=1.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=24.340,y=9.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=21.970,y=4.000,z=0.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.528,y=0.010,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=24.802,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=23.420,y=1.000,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.500,z=0.000 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=23.420,y=2.800,z=0.750 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.130,y=0.000,z=60.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.500,z=1.000 },
+        },
+    },
 }
 

--- a/effects/emitters/aeon_quanticcluster_fxtrail_01_emit.bp
+++ b/effects/emitters/aeon_quanticcluster_fxtrail_01_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'aeon_quanticcluster_fxtrail_01',
+	Lifetime = -1.00,
+	Repeattime = 0.10,
+	TextureFramecount = 1.00,
+	Blendmode = 0.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = -1.00,
+	EmitIfVisible = false,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/cloud_smoke_alpha_14.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_20.dds]],
+	XDirectionCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.049,y=5.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=15.000,z=5.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.027,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.031,y=0.750,z=1.000 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.031,y=2.500,z=2.500 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/aeon_quanticcluster_fxtrail_01_emit.bp
+++ b/effects/emitters/aeon_quanticcluster_fxtrail_01_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = -1.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = false,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/aeon_quanticcluster_fxtrail_01_emit.bp
+++ b/effects/emitters/aeon_quanticcluster_fxtrail_01_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'aeon_quanticcluster_fxtrail_01',
-	Lifetime = -1.00,
-	Repeattime = 0.10,
-	TextureFramecount = 1.00,
-	Blendmode = 0.00,
-	LocalVelocity = false,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = -1.00,
-	EmitIfVisible = false,
-	CatchupEmit = false,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/cloud_smoke_alpha_14.dds]],
-	RampTexture = [[/textures/particles/ramp_blue_20.dds]],
-	XDirectionCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.049,y=5.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=15.000,z=5.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.027,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.031,y=0.750,z=1.000 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.031,y=2.500,z=2.500 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'aeon_quanticcluster_fxtrail_01',
+    Lifetime = -1.00,
+    Repeattime = 0.10,
+    TextureFramecount = 1.00,
+    Blendmode = 0.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = -1.00,
+    EmitIfVisible = false,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/cloud_smoke_alpha_14.dds]],
+    RampTexture = [[/textures/particles/ramp_blue_20.dds]],
+    XDirectionCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.049,y=5.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=15.000,z=5.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.027,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.031,y=0.750,z=1.000 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.031,y=2.500,z=2.500 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/aeon_quanticcluster_fxtrail_02_emit.bp
+++ b/effects/emitters/aeon_quanticcluster_fxtrail_02_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'aeon_quanticcluster_fxtrail_02',
+	Lifetime = -1.00,
+	Repeattime = 0.10,
+	TextureFramecount = 1.00,
+	Blendmode = 0.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = -1.00,
+	EmitIfVisible = false,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/cloud_smoke_alpha_14.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_20.dds]],
+	XDirectionCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.049,y=2.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=12.000,z=5.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.027,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.031,y=0.650,z=0.350 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.031,y=1.750,z=1.250 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 0.10,
+		Keys = {
+			{ x=0.050,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/aeon_quanticcluster_fxtrail_02_emit.bp
+++ b/effects/emitters/aeon_quanticcluster_fxtrail_02_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'aeon_quanticcluster_fxtrail_02',
-	Lifetime = -1.00,
-	Repeattime = 0.10,
-	TextureFramecount = 1.00,
-	Blendmode = 0.00,
-	LocalVelocity = false,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = -1.00,
-	EmitIfVisible = false,
-	CatchupEmit = false,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/cloud_smoke_alpha_14.dds]],
-	RampTexture = [[/textures/particles/ramp_blue_20.dds]],
-	XDirectionCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.049,y=2.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=12.000,z=5.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.027,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.031,y=0.650,z=0.350 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.031,y=1.750,z=1.250 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 0.10,
-		Keys = {
-			{ x=0.050,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'aeon_quanticcluster_fxtrail_02',
+    Lifetime = -1.00,
+    Repeattime = 0.10,
+    TextureFramecount = 1.00,
+    Blendmode = 0.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = -1.00,
+    EmitIfVisible = false,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/cloud_smoke_alpha_14.dds]],
+    RampTexture = [[/textures/particles/ramp_blue_20.dds]],
+    XDirectionCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.049,y=2.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=12.000,z=5.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.027,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.031,y=0.650,z=0.350 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.031,y=1.750,z=1.250 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 0.10,
+        Keys = {
+            { x=0.050,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/aeon_quanticcluster_fxtrail_02_emit.bp
+++ b/effects/emitters/aeon_quanticcluster_fxtrail_02_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = -1.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = false,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/mortar_munition_03_emit.bp
+++ b/effects/emitters/mortar_munition_03_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'mortar_munition_03',
+	Lifetime = -1.00,
+	Repeattime = 1.00,
+	TextureFramecount = 1.00,
+	Blendmode = 0.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 100.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = true,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 4.00,
+	SortOrder = -10.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/cloud_smoke_alpha_13.dds]],
+	RampTexture = [[/textures/particles/ramp_black_grey_01.dds]],
+	XDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.490,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.250,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.417,y=12.571,z=4.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.504,y=13.571,z=10.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.010,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=-0.100,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.517,y=0.023,z=0.040 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.503,y=0.135,z=0.230 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=2.000,z=4.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/mortar_munition_03_emit.bp
+++ b/effects/emitters/mortar_munition_03_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 100.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = true,

--- a/effects/emitters/mortar_munition_03_emit.bp
+++ b/effects/emitters/mortar_munition_03_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'mortar_munition_03',
-	Lifetime = -1.00,
-	Repeattime = 1.00,
-	TextureFramecount = 1.00,
-	Blendmode = 0.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 100.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = true,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 4.00,
-	SortOrder = -10.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/cloud_smoke_alpha_13.dds]],
-	RampTexture = [[/textures/particles/ramp_black_grey_01.dds]],
-	XDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.490,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.250,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.417,y=12.571,z=4.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.504,y=13.571,z=10.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.010,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=-0.100,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.517,y=0.023,z=0.040 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.503,y=0.135,z=0.230 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=2.000,z=4.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'mortar_munition_03',
+    Lifetime = -1.00,
+    Repeattime = 1.00,
+    TextureFramecount = 1.00,
+    Blendmode = 0.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 100.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = true,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 4.00,
+    SortOrder = -10.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/cloud_smoke_alpha_13.dds]],
+    RampTexture = [[/textures/particles/ramp_black_grey_01.dds]],
+    XDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.490,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.250,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.417,y=12.571,z=4.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.504,y=13.571,z=10.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.010,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=-0.100,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.517,y=0.023,z=0.040 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.503,y=0.135,z=0.230 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=2.000,z=4.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/nuke_munition_launch_trail_04_emit.bp
+++ b/effects/emitters/nuke_munition_launch_trail_04_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'nuke_munition_launch_trail_04',
+	Lifetime = -1.00,
+	Repeattime = 1.00,
+	TextureFramecount = 1.00,
+	Blendmode = 0.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = -1.00,
+	EmitIfVisible = false,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/cloud_smoke_alpha_10.dds]],
+	RampTexture = [[/textures/particles/ramp_white_02.dds]],
+	XDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.307,y=15.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=40.000,z=10.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.235,y=0.154,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.231,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.154,z=0.020 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.286,z=0.100 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.508,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=2.000,z=4.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/nuke_munition_launch_trail_04_emit.bp
+++ b/effects/emitters/nuke_munition_launch_trail_04_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'nuke_munition_launch_trail_04',
-	Lifetime = -1.00,
-	Repeattime = 1.00,
-	TextureFramecount = 1.00,
-	Blendmode = 0.00,
-	LocalVelocity = false,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = -1.00,
-	EmitIfVisible = false,
-	CatchupEmit = false,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/cloud_smoke_alpha_10.dds]],
-	RampTexture = [[/textures/particles/ramp_white_02.dds]],
-	XDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.307,y=15.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=40.000,z=10.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.235,y=0.154,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.231,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.154,z=0.020 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.286,z=0.100 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.508,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=2.000,z=4.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'nuke_munition_launch_trail_04',
+    Lifetime = -1.00,
+    Repeattime = 1.00,
+    TextureFramecount = 1.00,
+    Blendmode = 0.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = -1.00,
+    EmitIfVisible = false,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/cloud_smoke_alpha_10.dds]],
+    RampTexture = [[/textures/particles/ramp_white_02.dds]],
+    XDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.307,y=15.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=40.000,z=10.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.235,y=0.154,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.231,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.154,z=0.020 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.286,z=0.100 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.508,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=2.000,z=4.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/nuke_munition_launch_trail_04_emit.bp
+++ b/effects/emitters/nuke_munition_launch_trail_04_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = -1.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = false,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/nuke_munition_launch_trail_05_emit.bp
+++ b/effects/emitters/nuke_munition_launch_trail_05_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'nuke_munition_launch_trail_05',
+	Lifetime = 25.00,
+	Repeattime = 25.00,
+	TextureFramecount = 1.00,
+	Blendmode = 0.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = -1.00,
+	EmitIfVisible = false,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/cloud_smoke_alpha_10.dds]],
+	RampTexture = [[/textures/particles/ramp_white_02.dds]],
+	XDirectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=7.675,y=15.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=40.000,z=10.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=5.875,y=0.185,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=5.775,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.750,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.750,y=0.283,z=0.020 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.750,y=1.500,z=0.100 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.700,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.750,y=0.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=2.000,z=4.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/nuke_munition_launch_trail_05_emit.bp
+++ b/effects/emitters/nuke_munition_launch_trail_05_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'nuke_munition_launch_trail_05',
-	Lifetime = 25.00,
-	Repeattime = 25.00,
-	TextureFramecount = 1.00,
-	Blendmode = 0.00,
-	LocalVelocity = false,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = -1.00,
-	EmitIfVisible = false,
-	CatchupEmit = false,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/cloud_smoke_alpha_10.dds]],
-	RampTexture = [[/textures/particles/ramp_white_02.dds]],
-	XDirectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=7.675,y=15.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=40.000,z=10.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=5.875,y=0.185,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=5.775,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.750,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.750,y=0.283,z=0.020 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.750,y=1.500,z=0.100 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.700,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.750,y=0.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=2.000,z=4.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'nuke_munition_launch_trail_05',
+    Lifetime = 25.00,
+    Repeattime = 25.00,
+    TextureFramecount = 1.00,
+    Blendmode = 0.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = -1.00,
+    EmitIfVisible = false,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/cloud_smoke_alpha_10.dds]],
+    RampTexture = [[/textures/particles/ramp_white_02.dds]],
+    XDirectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=7.675,y=15.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=40.000,z=10.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=5.875,y=0.185,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=5.775,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.750,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.750,y=0.283,z=0.020 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.750,y=1.500,z=0.100 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.700,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.750,y=0.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=2.000,z=4.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/nuke_munition_launch_trail_05_emit.bp
+++ b/effects/emitters/nuke_munition_launch_trail_05_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = -1.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = false,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/nuke_munition_launch_trail_06_emit.bp
+++ b/effects/emitters/nuke_munition_launch_trail_06_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'nuke_munition_launch_trail_06',
+	Lifetime = -1.00,
+	Repeattime = 25.00,
+	TextureFramecount = 1.00,
+	Blendmode = 5.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = -1.00,
+	EmitIfVisible = false,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ring_distort_01.dds]],
+	RampTexture = [[/textures/particles/ramp_white_23.dds]],
+	XDirectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.434,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=8.015,y=7.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=7.000,z=8.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=5.838,y=1.731,z=0.077 },
+		},
+	},
+	XPosCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.830,y=-1.349,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.566,y=0.254,z=0.285 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.632,y=1.013,z=0.413 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.700,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.750,y=0.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=2.000,z=4.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/nuke_munition_launch_trail_06_emit.bp
+++ b/effects/emitters/nuke_munition_launch_trail_06_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'nuke_munition_launch_trail_06',
-	Lifetime = -1.00,
-	Repeattime = 25.00,
-	TextureFramecount = 1.00,
-	Blendmode = 5.00,
-	LocalVelocity = true,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = -1.00,
-	EmitIfVisible = false,
-	CatchupEmit = false,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ring_distort_01.dds]],
-	RampTexture = [[/textures/particles/ramp_white_23.dds]],
-	XDirectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.434,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=8.015,y=7.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=7.000,z=8.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=5.838,y=1.731,z=0.077 },
-		},
-	},
-	XPosCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.830,y=-1.349,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.566,y=0.254,z=0.285 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.632,y=1.013,z=0.413 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.700,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.750,y=0.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=2.000,z=4.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'nuke_munition_launch_trail_06',
+    Lifetime = -1.00,
+    Repeattime = 25.00,
+    TextureFramecount = 1.00,
+    Blendmode = 5.00,
+    LocalVelocity = true,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = -1.00,
+    EmitIfVisible = false,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ring_distort_01.dds]],
+    RampTexture = [[/textures/particles/ramp_white_23.dds]],
+    XDirectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.434,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=8.015,y=7.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=7.000,z=8.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=5.838,y=1.731,z=0.077 },
+        },
+    },
+    XPosCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.830,y=-1.349,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.566,y=0.254,z=0.285 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.632,y=1.013,z=0.413 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.700,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.750,y=0.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=2.000,z=4.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/nuke_munition_launch_trail_06_emit.bp
+++ b/effects/emitters/nuke_munition_launch_trail_06_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = -1.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = false,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/nuke_munition_launch_trail_07_emit.bp
+++ b/effects/emitters/nuke_munition_launch_trail_07_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'nuke_munition_launch_trail_07',
+	Lifetime = -1.00,
+	Repeattime = 25.00,
+	TextureFramecount = 1.00,
+	Blendmode = 5.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = -1.00,
+	EmitIfVisible = false,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ring_distort_01.dds]],
+	RampTexture = [[/textures/particles/ramp_white_01.dds]],
+	XDirectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=25.000,y=0.143,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=8.015,y=3.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=15.000,z=10.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=6.069,y=0.900,z=0.077 },
+		},
+	},
+	XPosCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.830,y=-1.349,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.566,y=0.540,z=0.020 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.632,y=1.750,z=0.132 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.700,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.750,y=0.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=2.000,z=4.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 25.00,
+		Keys = {
+			{ x=12.500,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/nuke_munition_launch_trail_07_emit.bp
+++ b/effects/emitters/nuke_munition_launch_trail_07_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = -1.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = false,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/nuke_munition_launch_trail_07_emit.bp
+++ b/effects/emitters/nuke_munition_launch_trail_07_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'nuke_munition_launch_trail_07',
-	Lifetime = -1.00,
-	Repeattime = 25.00,
-	TextureFramecount = 1.00,
-	Blendmode = 5.00,
-	LocalVelocity = true,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = -1.00,
-	EmitIfVisible = false,
-	CatchupEmit = false,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ring_distort_01.dds]],
-	RampTexture = [[/textures/particles/ramp_white_01.dds]],
-	XDirectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=25.000,y=0.143,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=8.015,y=3.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=15.000,z=10.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=6.069,y=0.900,z=0.077 },
-		},
-	},
-	XPosCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.830,y=-1.349,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.566,y=0.540,z=0.020 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.632,y=1.750,z=0.132 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.700,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.750,y=0.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=2.000,z=4.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 25.00,
-		Keys = {
-			{ x=12.500,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'nuke_munition_launch_trail_07',
+    Lifetime = -1.00,
+    Repeattime = 25.00,
+    TextureFramecount = 1.00,
+    Blendmode = 5.00,
+    LocalVelocity = true,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = -1.00,
+    EmitIfVisible = false,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ring_distort_01.dds]],
+    RampTexture = [[/textures/particles/ramp_white_01.dds]],
+    XDirectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=25.000,y=0.143,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=8.015,y=3.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=15.000,z=10.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=6.069,y=0.900,z=0.077 },
+        },
+    },
+    XPosCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.830,y=-1.349,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.566,y=0.540,z=0.020 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.632,y=1.750,z=0.132 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.700,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.750,y=0.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=2.000,z=4.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 25.00,
+        Keys = {
+            { x=12.500,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_01_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_01_emit.bp
@@ -1,0 +1,164 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_chronotron_cannon_overcharge_projectile_fxtrail_01',
+	Lifetime = -50.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 100.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 4.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/line_white_add_11.dds]],
+	RampTexture = [[/textures/particles/ramp_yellow_blue_01.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.456,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.391,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.720,y=0.050,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=27.200,y=60.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.150,y=5.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=9.763,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=15.303,y=0.100,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=-0.050,z=0.000 },
+			{ x=0.066,y=-0.243,z=0.000 },
+			{ x=0.198,y=-0.322,z=0.000 },
+			{ x=0.528,y=-0.355,z=0.000 },
+			{ x=0.923,y=-0.360,z=0.000 },
+			{ x=1.319,y=-0.275,z=0.000 },
+			{ x=1.781,y=-0.141,z=0.000 },
+			{ x=2.836,y=-0.050,z=0.000 },
+			{ x=4.683,y=-0.001,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=14.578,y=0.500,z=0.200 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.300,z=0.000 },
+			{ x=0.900,y=0.020,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=5.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_01_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_01_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 100.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_01_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_01_emit.bp
@@ -1,164 +1,164 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_chronotron_cannon_overcharge_projectile_fxtrail_01',
-	Lifetime = -50.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = true,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 100.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 4.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/line_white_add_11.dds]],
-	RampTexture = [[/textures/particles/ramp_yellow_blue_01.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.456,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.391,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.720,y=0.050,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=27.200,y=60.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.150,y=5.000,z=0.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=9.763,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=15.303,y=0.100,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=-0.050,z=0.000 },
-			{ x=0.066,y=-0.243,z=0.000 },
-			{ x=0.198,y=-0.322,z=0.000 },
-			{ x=0.528,y=-0.355,z=0.000 },
-			{ x=0.923,y=-0.360,z=0.000 },
-			{ x=1.319,y=-0.275,z=0.000 },
-			{ x=1.781,y=-0.141,z=0.000 },
-			{ x=2.836,y=-0.050,z=0.000 },
-			{ x=4.683,y=-0.001,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=14.578,y=0.500,z=0.200 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.300,z=0.000 },
-			{ x=0.900,y=0.020,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=5.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_chronotron_cannon_overcharge_projectile_fxtrail_01',
+    Lifetime = -50.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = true,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 100.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 4.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/line_white_add_11.dds]],
+    RampTexture = [[/textures/particles/ramp_yellow_blue_01.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.456,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.391,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.720,y=0.050,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=27.200,y=60.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.150,y=5.000,z=0.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=9.763,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=15.303,y=0.100,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=-0.050,z=0.000 },
+            { x=0.066,y=-0.243,z=0.000 },
+            { x=0.198,y=-0.322,z=0.000 },
+            { x=0.528,y=-0.355,z=0.000 },
+            { x=0.923,y=-0.360,z=0.000 },
+            { x=1.319,y=-0.275,z=0.000 },
+            { x=1.781,y=-0.141,z=0.000 },
+            { x=2.836,y=-0.050,z=0.000 },
+            { x=4.683,y=-0.001,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=14.578,y=0.500,z=0.200 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.300,z=0.000 },
+            { x=0.900,y=0.020,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=5.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_02_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_02_emit.bp
@@ -1,0 +1,163 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_chronotron_cannon_overcharge_projectile_fxtrail_02',
+	Lifetime = -50.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 100.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 4.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/line_white_add_11.dds]],
+	RampTexture = [[/textures/particles/ramp_yellow_blue_01.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.050,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=16.100,y=60.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=6.332,y=5.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=12.467,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.050,z=0.000 },
+			{ x=0.132,y=0.319,z=0.000 },
+			{ x=0.462,y=0.367,z=0.000 },
+			{ x=0.923,y=0.360,z=0.000 },
+			{ x=1.319,y=0.275,z=0.000 },
+			{ x=1.781,y=0.141,z=0.000 },
+			{ x=2.836,y=0.050,z=0.000 },
+			{ x=4.485,y=0.001,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.500,z=0.200 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.300,z=0.000 },
+			{ x=0.900,y=0.020,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=14.776,y=1.000,z=5.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_02_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_02_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 100.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_02_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_02_emit.bp
@@ -1,163 +1,163 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_chronotron_cannon_overcharge_projectile_fxtrail_02',
-	Lifetime = -50.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = true,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 100.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 4.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/line_white_add_11.dds]],
-	RampTexture = [[/textures/particles/ramp_yellow_blue_01.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.050,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=16.100,y=60.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=6.332,y=5.000,z=0.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=12.467,y=0.000,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.050,z=0.000 },
-			{ x=0.132,y=0.319,z=0.000 },
-			{ x=0.462,y=0.367,z=0.000 },
-			{ x=0.923,y=0.360,z=0.000 },
-			{ x=1.319,y=0.275,z=0.000 },
-			{ x=1.781,y=0.141,z=0.000 },
-			{ x=2.836,y=0.050,z=0.000 },
-			{ x=4.485,y=0.001,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.500,z=0.200 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.300,z=0.000 },
-			{ x=0.900,y=0.020,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=14.776,y=1.000,z=5.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_chronotron_cannon_overcharge_projectile_fxtrail_02',
+    Lifetime = -50.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = true,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 100.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 4.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/line_white_add_11.dds]],
+    RampTexture = [[/textures/particles/ramp_yellow_blue_01.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.050,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=16.100,y=60.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=6.332,y=5.000,z=0.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=12.467,y=0.000,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.050,z=0.000 },
+            { x=0.132,y=0.319,z=0.000 },
+            { x=0.462,y=0.367,z=0.000 },
+            { x=0.923,y=0.360,z=0.000 },
+            { x=1.319,y=0.275,z=0.000 },
+            { x=1.781,y=0.141,z=0.000 },
+            { x=2.836,y=0.050,z=0.000 },
+            { x=4.485,y=0.001,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.500,z=0.200 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.300,z=0.000 },
+            { x=0.900,y=0.020,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=14.776,y=1.000,z=5.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_03_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_03_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_chronotron_cannon_overcharge_projectile_fxtrail_03',
+	Lifetime = -50.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 100.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma07.dds]],
+	RampTexture = [[/textures/particles/ramp_white_premod_03_even.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.456,y=0.200,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.391,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.720,y=0.050,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=27.200,y=10.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.150,y=5.000,z=3.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=9.763,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=15.303,y=0.100,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=4.683,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=14.578,y=1.000,z=0.200 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=15.172,y=2.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_03_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_03_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 100.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_03_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_fxtrail_03_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_chronotron_cannon_overcharge_projectile_fxtrail_03',
-	Lifetime = -50.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 100.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma07.dds]],
-	RampTexture = [[/textures/particles/ramp_white_premod_03_even.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.456,y=0.200,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.391,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.720,y=0.050,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=27.200,y=10.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.150,y=5.000,z=3.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=9.763,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=15.303,y=0.100,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=4.683,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=14.578,y=1.000,z=0.200 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=15.172,y=2.000,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_chronotron_cannon_overcharge_projectile_fxtrail_03',
+    Lifetime = -50.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 100.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma07.dds]],
+    RampTexture = [[/textures/particles/ramp_white_premod_03_even.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.456,y=0.200,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.391,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.720,y=0.050,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=27.200,y=10.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.150,y=5.000,z=3.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=9.763,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=15.303,y=0.100,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=4.683,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=14.578,y=1.000,z=0.200 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=15.172,y=2.000,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_expnuke_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_expnuke_fxtrails_01_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_expnuke_fxtrails_01',
+	Lifetime = -1.00,
+	Repeattime = 1.00,
+	TextureFramecount = 1.00,
+	Blendmode = 1.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = true,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 4.00,
+	SortOrder = 10.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma11.dds]],
+	RampTexture = [[/textures/particles/ramp_white_premod_03.dds]],
+	XDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.010 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.010 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.010 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.400,y=8.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=20.000,z=5.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.030,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.103,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.145,y=0.500,z=0.250 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.328,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=2.000,z=4.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_expnuke_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_expnuke_fxtrails_01_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_expnuke_fxtrails_01',
-	Lifetime = -1.00,
-	Repeattime = 1.00,
-	TextureFramecount = 1.00,
-	Blendmode = 1.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = false,
-	CreateIfVisible = false,
-	SnapToWaterline = true,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 4.00,
-	SortOrder = 10.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma11.dds]],
-	RampTexture = [[/textures/particles/ramp_white_premod_03.dds]],
-	XDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.010 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.010 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.010 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.400,y=8.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=20.000,z=5.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.030,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.103,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.145,y=0.500,z=0.250 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.000,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.328,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=2.000,z=4.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_expnuke_fxtrails_01',
+    Lifetime = -1.00,
+    Repeattime = 1.00,
+    TextureFramecount = 1.00,
+    Blendmode = 1.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = true,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 4.00,
+    SortOrder = 10.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma11.dds]],
+    RampTexture = [[/textures/particles/ramp_white_premod_03.dds]],
+    XDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.010 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.010 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.010 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.400,y=8.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=20.000,z=5.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.030,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.103,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.145,y=0.500,z=0.250 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.000,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.328,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=2.000,z=4.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_expnuke_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_expnuke_fxtrails_01_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = false,
     CreateIfVisible = false,
     SnapToWaterline = true,

--- a/effects/emitters/seraphim_expnuke_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_expnuke_fxtrails_02_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_expnuke_fxtrails_02',
+	Lifetime = -1.00,
+	Repeattime = 1.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = true,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = -10.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/glow_02.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_16.dds]],
+	XDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.010 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.010 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.010 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.400,y=30.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=4.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.030,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.103,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.145,y=0.250,z=0.100 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.269,y=0.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.328,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=2.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_expnuke_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_expnuke_fxtrails_02_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = false,
     CreateIfVisible = false,
     SnapToWaterline = true,

--- a/effects/emitters/seraphim_expnuke_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_expnuke_fxtrails_02_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_expnuke_fxtrails_02',
-	Lifetime = -1.00,
-	Repeattime = 1.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = false,
-	CreateIfVisible = false,
-	SnapToWaterline = true,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = -10.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/glow_02.dds]],
-	RampTexture = [[/textures/particles/ramp_blue_16.dds]],
-	XDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.010 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.010 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.010 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.400,y=30.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=4.000,z=0.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.030,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.103,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.145,y=0.250,z=0.100 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.269,y=0.000,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.328,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=2.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_expnuke_fxtrails_02',
+    Lifetime = -1.00,
+    Repeattime = 1.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = true,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = -10.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/glow_02.dds]],
+    RampTexture = [[/textures/particles/ramp_blue_16.dds]],
+    XDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.010 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.010 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.010 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.400,y=30.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=4.000,z=0.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.030,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.103,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.145,y=0.250,z=0.100 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.269,y=0.000,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.328,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=2.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_inaino_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_inaino_fxtrails_01_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_inaino_fxtrails_01',
+	Lifetime = -1.00,
+	Repeattime = 1.00,
+	TextureFramecount = 1.00,
+	Blendmode = 1.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = true,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 4.00,
+	SortOrder = 10.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma11.dds]],
+	RampTexture = [[/textures/particles/ramp_white_premod_03.dds]],
+	XDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.010 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.010 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.010 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.400,y=12.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=20.000,z=5.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.030,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.103,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.145,y=0.200,z=0.100 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.328,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=2.000,z=4.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_inaino_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_inaino_fxtrails_01_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_inaino_fxtrails_01',
-	Lifetime = -1.00,
-	Repeattime = 1.00,
-	TextureFramecount = 1.00,
-	Blendmode = 1.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = false,
-	CreateIfVisible = false,
-	SnapToWaterline = true,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 4.00,
-	SortOrder = 10.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma11.dds]],
-	RampTexture = [[/textures/particles/ramp_white_premod_03.dds]],
-	XDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.010 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.010 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.010 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.400,y=12.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=20.000,z=5.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.030,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.103,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.145,y=0.200,z=0.100 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.000,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.328,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=2.000,z=4.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_inaino_fxtrails_01',
+    Lifetime = -1.00,
+    Repeattime = 1.00,
+    TextureFramecount = 1.00,
+    Blendmode = 1.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = true,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 4.00,
+    SortOrder = 10.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma11.dds]],
+    RampTexture = [[/textures/particles/ramp_white_premod_03.dds]],
+    XDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.010 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.010 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.010 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.400,y=12.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=20.000,z=5.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.030,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.103,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.145,y=0.200,z=0.100 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.000,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.328,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=2.000,z=4.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_inaino_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_inaino_fxtrails_01_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = false,
     CreateIfVisible = false,
     SnapToWaterline = true,

--- a/effects/emitters/seraphim_inaino_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_inaino_fxtrails_02_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_inaino_fxtrails_02',
+	Lifetime = -1.00,
+	Repeattime = 1.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = true,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = -10.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma07.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_16.dds]],
+	XDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.010 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.010 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.010 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.400,y=30.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=10.000,z=5.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.030,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.103,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.145,y=0.250,z=0.100 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.269,y=0.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.328,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.510,y=0.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=2.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 1.00,
+		Keys = {
+			{ x=0.500,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_inaino_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_inaino_fxtrails_02_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_inaino_fxtrails_02',
-	Lifetime = -1.00,
-	Repeattime = 1.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = false,
-	CreateIfVisible = false,
-	SnapToWaterline = true,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = -10.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma07.dds]],
-	RampTexture = [[/textures/particles/ramp_blue_16.dds]],
-	XDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.010 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.010 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.010 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.400,y=30.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=10.000,z=5.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.030,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.103,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.145,y=0.250,z=0.100 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.269,y=0.000,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.328,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.510,y=0.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=2.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 1.00,
-		Keys = {
-			{ x=0.500,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_inaino_fxtrails_02',
+    Lifetime = -1.00,
+    Repeattime = 1.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = true,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = -10.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma07.dds]],
+    RampTexture = [[/textures/particles/ramp_blue_16.dds]],
+    XDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.010 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.010 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.010 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.400,y=30.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=10.000,z=5.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.030,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.103,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.145,y=0.250,z=0.100 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.269,y=0.000,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.328,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.510,y=0.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=2.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 1.00,
+        Keys = {
+            { x=0.500,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_inaino_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_inaino_fxtrails_02_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = false,
     CreateIfVisible = false,
     SnapToWaterline = true,

--- a/effects/emitters/seraphim_khu_anti_nuke_fxtrail_01_emit.bp
+++ b/effects/emitters/seraphim_khu_anti_nuke_fxtrail_01_emit.bp
@@ -1,0 +1,159 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_khu_anti_nuke_fxtrail_01',
+	Lifetime = -3.00,
+	Repeattime = 3.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 1000.00,
+	EmitIfVisible = false,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/plasma_white_add_01.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_22.dds]],
+	XDirectionCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.500,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.504,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.484,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=0.625,y=30.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.551,y=1.500,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.488,y=0.900,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.500,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.500,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.500,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.500,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.500,y=0.100,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.500,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.500,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.500,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=0.000,y=1.750,z=0.000 },
+			{ x=0.669,y=0.892,z=0.000 },
+			{ x=1.512,y=1.385,z=0.000 },
+			{ x=2.299,y=0.892,z=0.000 },
+			{ x=3.000,y=1.750,z=0.000 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.516,y=0.100,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.500,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.500,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.500,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.500,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 3.00,
+		Keys = {
+			{ x=1.500,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_khu_anti_nuke_fxtrail_01_emit.bp
+++ b/effects/emitters/seraphim_khu_anti_nuke_fxtrail_01_emit.bp
@@ -1,159 +1,159 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_khu_anti_nuke_fxtrail_01',
-	Lifetime = -3.00,
-	Repeattime = 3.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = false,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 1000.00,
-	EmitIfVisible = false,
-	CatchupEmit = false,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/plasma_white_add_01.dds]],
-	RampTexture = [[/textures/particles/ramp_blue_22.dds]],
-	XDirectionCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.500,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.504,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.484,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=0.625,y=30.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.551,y=1.500,z=0.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.488,y=0.900,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.500,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.500,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.500,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.500,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.500,y=0.100,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.500,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.500,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.500,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=0.000,y=1.750,z=0.000 },
-			{ x=0.669,y=0.892,z=0.000 },
-			{ x=1.512,y=1.385,z=0.000 },
-			{ x=2.299,y=0.892,z=0.000 },
-			{ x=3.000,y=1.750,z=0.000 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.516,y=0.100,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.500,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.500,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.500,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.500,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 3.00,
-		Keys = {
-			{ x=1.500,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_khu_anti_nuke_fxtrail_01',
+    Lifetime = -3.00,
+    Repeattime = 3.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 1000.00,
+    EmitIfVisible = false,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/plasma_white_add_01.dds]],
+    RampTexture = [[/textures/particles/ramp_blue_22.dds]],
+    XDirectionCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.500,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.504,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.484,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=0.625,y=30.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.551,y=1.500,z=0.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.488,y=0.900,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.500,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.500,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.500,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.500,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.500,y=0.100,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.500,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.500,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.500,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=0.000,y=1.750,z=0.000 },
+            { x=0.669,y=0.892,z=0.000 },
+            { x=1.512,y=1.385,z=0.000 },
+            { x=2.299,y=0.892,z=0.000 },
+            { x=3.000,y=1.750,z=0.000 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.516,y=0.100,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.500,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.500,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.500,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.500,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 3.00,
+        Keys = {
+            { x=1.500,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_khu_anti_nuke_fxtrail_01_emit.bp
+++ b/effects/emitters/seraphim_khu_anti_nuke_fxtrail_01_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 1000.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = false,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_khu_anti_nuke_fxtrail_02_emit.bp
+++ b/effects/emitters/seraphim_khu_anti_nuke_fxtrail_02_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_khu_anti_nuke_fxtrail_02',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 1000.00,
+	EmitIfVisible = false,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/quantum_plasma_01.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_16.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.066,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=24.736,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=3.034,y=21.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.858,y=1.300,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=24.802,y=0.900,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=18.668,y=0.380,z=0.100 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.264,y=0.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_khu_anti_nuke_fxtrail_02_emit.bp
+++ b/effects/emitters/seraphim_khu_anti_nuke_fxtrail_02_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 1000.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = false,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_khu_anti_nuke_fxtrail_02_emit.bp
+++ b/effects/emitters/seraphim_khu_anti_nuke_fxtrail_02_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_khu_anti_nuke_fxtrail_02',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = false,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 1000.00,
-	EmitIfVisible = false,
-	CatchupEmit = false,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/quantum_plasma_01.dds]],
-	RampTexture = [[/textures/particles/ramp_blue_16.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.066,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=24.736,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=3.034,y=21.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.858,y=1.300,z=0.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=24.802,y=0.900,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=18.668,y=0.380,z=0.100 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.264,y=0.000,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_khu_anti_nuke_fxtrail_02',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 1000.00,
+    EmitIfVisible = false,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/quantum_plasma_01.dds]],
+    RampTexture = [[/textures/particles/ramp_blue_16.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.066,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=24.736,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=3.034,y=21.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.858,y=1.300,z=0.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=24.802,y=0.900,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=18.668,y=0.380,z=0.100 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.264,y=0.000,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_01_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_01_emit.bp
@@ -1,0 +1,165 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_01',
+	Lifetime = -50.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 100.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 4.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/line_white_add_11.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_yellow_01.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.456,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.391,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.720,y=0.050,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=50.000,y=30.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.150,y=3.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=9.763,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=15.303,y=0.100,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=-0.050,z=0.000 },
+			{ x=0.066,y=-0.243,z=0.000 },
+			{ x=0.198,y=-0.322,z=0.000 },
+			{ x=0.528,y=-0.355,z=0.000 },
+			{ x=0.923,y=-0.360,z=0.000 },
+			{ x=1.319,y=-0.275,z=0.000 },
+			{ x=1.781,y=-0.141,z=0.000 },
+			{ x=2.836,y=-0.050,z=0.000 },
+			{ x=4.683,y=-0.001,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.900,z=0.119 },
+			{ x=50.000,y=0.400,z=0.150 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.300,z=0.000 },
+			{ x=0.900,y=0.020,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=5.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_01_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_01_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 100.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_01_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_01_emit.bp
@@ -1,165 +1,165 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_01',
-	Lifetime = -50.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = true,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 100.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 4.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/line_white_add_11.dds]],
-	RampTexture = [[/textures/particles/ramp_blue_yellow_01.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.456,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.391,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.720,y=0.050,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=50.000,y=30.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.150,y=3.000,z=0.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=9.763,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=15.303,y=0.100,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=-0.050,z=0.000 },
-			{ x=0.066,y=-0.243,z=0.000 },
-			{ x=0.198,y=-0.322,z=0.000 },
-			{ x=0.528,y=-0.355,z=0.000 },
-			{ x=0.923,y=-0.360,z=0.000 },
-			{ x=1.319,y=-0.275,z=0.000 },
-			{ x=1.781,y=-0.141,z=0.000 },
-			{ x=2.836,y=-0.050,z=0.000 },
-			{ x=4.683,y=-0.001,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.900,z=0.119 },
-			{ x=50.000,y=0.400,z=0.150 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.300,z=0.000 },
-			{ x=0.900,y=0.020,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=5.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_01',
+    Lifetime = -50.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = true,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 100.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 4.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/line_white_add_11.dds]],
+    RampTexture = [[/textures/particles/ramp_blue_yellow_01.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.456,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.391,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.720,y=0.050,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=50.000,y=30.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.150,y=3.000,z=0.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=9.763,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=15.303,y=0.100,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=-0.050,z=0.000 },
+            { x=0.066,y=-0.243,z=0.000 },
+            { x=0.198,y=-0.322,z=0.000 },
+            { x=0.528,y=-0.355,z=0.000 },
+            { x=0.923,y=-0.360,z=0.000 },
+            { x=1.319,y=-0.275,z=0.000 },
+            { x=1.781,y=-0.141,z=0.000 },
+            { x=2.836,y=-0.050,z=0.000 },
+            { x=4.683,y=-0.001,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.900,z=0.119 },
+            { x=50.000,y=0.400,z=0.150 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.300,z=0.000 },
+            { x=0.900,y=0.020,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=5.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_02_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_02_emit.bp
@@ -1,0 +1,164 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_02',
+	Lifetime = -50.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 100.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 4.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/line_white_add_11.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_yellow_01.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.050,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=30.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=6.332,y=3.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=12.467,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.050,z=0.000 },
+			{ x=0.132,y=0.319,z=0.000 },
+			{ x=0.462,y=0.367,z=0.000 },
+			{ x=0.923,y=0.360,z=0.000 },
+			{ x=1.319,y=0.275,z=0.000 },
+			{ x=1.781,y=0.141,z=0.000 },
+			{ x=2.836,y=0.050,z=0.000 },
+			{ x=4.485,y=0.001,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.900,z=0.150 },
+			{ x=50.000,y=0.400,z=0.150 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.300,z=0.000 },
+			{ x=0.900,y=0.020,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=14.776,y=1.000,z=5.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_02_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_02_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 100.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_02_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_02_emit.bp
@@ -1,164 +1,164 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_02',
-	Lifetime = -50.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = true,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 100.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 4.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/line_white_add_11.dds]],
-	RampTexture = [[/textures/particles/ramp_blue_yellow_01.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.050,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=30.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=6.332,y=3.000,z=0.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=12.467,y=0.000,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.050,z=0.000 },
-			{ x=0.132,y=0.319,z=0.000 },
-			{ x=0.462,y=0.367,z=0.000 },
-			{ x=0.923,y=0.360,z=0.000 },
-			{ x=1.319,y=0.275,z=0.000 },
-			{ x=1.781,y=0.141,z=0.000 },
-			{ x=2.836,y=0.050,z=0.000 },
-			{ x=4.485,y=0.001,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.900,z=0.150 },
-			{ x=50.000,y=0.400,z=0.150 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.300,z=0.000 },
-			{ x=0.900,y=0.020,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=14.776,y=1.000,z=5.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_light_chronotron_cannon_overcharge_projectile_fxtrail_02',
+    Lifetime = -50.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = true,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 100.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 4.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/line_white_add_11.dds]],
+    RampTexture = [[/textures/particles/ramp_blue_yellow_01.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.050,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=30.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=6.332,y=3.000,z=0.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=12.467,y=0.000,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.050,z=0.000 },
+            { x=0.132,y=0.319,z=0.000 },
+            { x=0.462,y=0.367,z=0.000 },
+            { x=0.923,y=0.360,z=0.000 },
+            { x=1.319,y=0.275,z=0.000 },
+            { x=1.781,y=0.141,z=0.000 },
+            { x=2.836,y=0.050,z=0.000 },
+            { x=4.485,y=0.001,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.900,z=0.150 },
+            { x=50.000,y=0.400,z=0.150 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.300,z=0.000 },
+            { x=0.900,y=0.020,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=14.776,y=1.000,z=5.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_01_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_01_emit.bp
@@ -1,0 +1,165 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_light_chronotron_cannon_projectile_fxtrail_01',
+	Lifetime = -50.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 100.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 4.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/line_white_add_11.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_yellow_01.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.456,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.391,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.720,y=0.050,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=50.000,y=15.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.150,y=3.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=9.763,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=15.303,y=0.100,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=-0.050,z=0.000 },
+			{ x=0.066,y=-0.243,z=0.000 },
+			{ x=0.198,y=-0.322,z=0.000 },
+			{ x=0.528,y=-0.355,z=0.000 },
+			{ x=0.923,y=-0.360,z=0.000 },
+			{ x=1.319,y=-0.275,z=0.000 },
+			{ x=1.781,y=-0.141,z=0.000 },
+			{ x=2.836,y=-0.050,z=0.000 },
+			{ x=4.683,y=-0.001,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.400,z=0.150 },
+			{ x=50.000,y=0.300,z=0.150 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.300,z=0.000 },
+			{ x=0.900,y=0.020,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=5.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_01_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_01_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 100.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_01_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_01_emit.bp
@@ -1,165 +1,165 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_light_chronotron_cannon_projectile_fxtrail_01',
-	Lifetime = -50.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = true,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 100.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 4.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/line_white_add_11.dds]],
-	RampTexture = [[/textures/particles/ramp_blue_yellow_01.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.456,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.391,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.720,y=0.050,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=50.000,y=15.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.150,y=3.000,z=0.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=9.763,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=15.303,y=0.100,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=-0.050,z=0.000 },
-			{ x=0.066,y=-0.243,z=0.000 },
-			{ x=0.198,y=-0.322,z=0.000 },
-			{ x=0.528,y=-0.355,z=0.000 },
-			{ x=0.923,y=-0.360,z=0.000 },
-			{ x=1.319,y=-0.275,z=0.000 },
-			{ x=1.781,y=-0.141,z=0.000 },
-			{ x=2.836,y=-0.050,z=0.000 },
-			{ x=4.683,y=-0.001,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.400,z=0.150 },
-			{ x=50.000,y=0.300,z=0.150 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.300,z=0.000 },
-			{ x=0.900,y=0.020,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=5.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_light_chronotron_cannon_projectile_fxtrail_01',
+    Lifetime = -50.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = true,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 100.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 4.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/line_white_add_11.dds]],
+    RampTexture = [[/textures/particles/ramp_blue_yellow_01.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.456,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.391,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.720,y=0.050,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=50.000,y=15.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.150,y=3.000,z=0.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=9.763,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=15.303,y=0.100,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=-0.050,z=0.000 },
+            { x=0.066,y=-0.243,z=0.000 },
+            { x=0.198,y=-0.322,z=0.000 },
+            { x=0.528,y=-0.355,z=0.000 },
+            { x=0.923,y=-0.360,z=0.000 },
+            { x=1.319,y=-0.275,z=0.000 },
+            { x=1.781,y=-0.141,z=0.000 },
+            { x=2.836,y=-0.050,z=0.000 },
+            { x=4.683,y=-0.001,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.400,z=0.150 },
+            { x=50.000,y=0.300,z=0.150 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.300,z=0.000 },
+            { x=0.900,y=0.020,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=5.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_02_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_02_emit.bp
@@ -1,0 +1,164 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_light_chronotron_cannon_projectile_fxtrail_02',
+	Lifetime = -50.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 100.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 4.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/line_white_add_11.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_yellow_01.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.050,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=15.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=6.332,y=3.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=12.467,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.050,z=0.000 },
+			{ x=0.132,y=0.319,z=0.000 },
+			{ x=0.462,y=0.367,z=0.000 },
+			{ x=0.923,y=0.360,z=0.000 },
+			{ x=1.319,y=0.275,z=0.000 },
+			{ x=1.781,y=0.141,z=0.000 },
+			{ x=2.836,y=0.050,z=0.000 },
+			{ x=4.485,y=0.001,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.400,z=0.150 },
+			{ x=50.000,y=0.300,z=0.150 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.300,z=0.000 },
+			{ x=0.900,y=0.020,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=14.776,y=1.000,z=5.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_02_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_02_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 100.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_02_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_02_emit.bp
@@ -1,164 +1,164 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_light_chronotron_cannon_projectile_fxtrail_02',
-	Lifetime = -50.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = true,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 100.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 4.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/line_white_add_11.dds]],
-	RampTexture = [[/textures/particles/ramp_blue_yellow_01.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.050,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=15.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=6.332,y=3.000,z=0.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=12.467,y=0.000,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.050,z=0.000 },
-			{ x=0.132,y=0.319,z=0.000 },
-			{ x=0.462,y=0.367,z=0.000 },
-			{ x=0.923,y=0.360,z=0.000 },
-			{ x=1.319,y=0.275,z=0.000 },
-			{ x=1.781,y=0.141,z=0.000 },
-			{ x=2.836,y=0.050,z=0.000 },
-			{ x=4.485,y=0.001,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.400,z=0.150 },
-			{ x=50.000,y=0.300,z=0.150 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.300,z=0.000 },
-			{ x=0.900,y=0.020,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=14.776,y=1.000,z=5.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_light_chronotron_cannon_projectile_fxtrail_02',
+    Lifetime = -50.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = true,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 100.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 4.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/line_white_add_11.dds]],
+    RampTexture = [[/textures/particles/ramp_blue_yellow_01.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.050,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=15.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=6.332,y=3.000,z=0.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=12.467,y=0.000,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.050,z=0.000 },
+            { x=0.132,y=0.319,z=0.000 },
+            { x=0.462,y=0.367,z=0.000 },
+            { x=0.923,y=0.360,z=0.000 },
+            { x=1.319,y=0.275,z=0.000 },
+            { x=1.781,y=0.141,z=0.000 },
+            { x=2.836,y=0.050,z=0.000 },
+            { x=4.485,y=0.001,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.400,z=0.150 },
+            { x=50.000,y=0.300,z=0.150 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.300,z=0.000 },
+            { x=0.900,y=0.020,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=14.776,y=1.000,z=5.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_03_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_03_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_light_chronotron_cannon_projectile_fxtrail_03',
+	Lifetime = -50.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 100.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma07.dds]],
+	RampTexture = [[/textures/particles/ramp_white_25.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.456,y=0.200,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.391,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.720,y=0.050,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=27.200,y=10.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.150,y=5.000,z=3.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=9.763,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=15.303,y=0.100,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=4.683,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=14.578,y=1.000,z=0.200 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=15.172,y=2.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_03_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_03_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_light_chronotron_cannon_projectile_fxtrail_03',
-	Lifetime = -50.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 100.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma07.dds]],
-	RampTexture = [[/textures/particles/ramp_white_25.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.456,y=0.200,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.391,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.720,y=0.050,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=27.200,y=10.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.150,y=5.000,z=3.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=9.763,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=15.303,y=0.100,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=4.683,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=14.578,y=1.000,z=0.200 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=15.172,y=2.000,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_light_chronotron_cannon_projectile_fxtrail_03',
+    Lifetime = -50.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 100.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma07.dds]],
+    RampTexture = [[/textures/particles/ramp_white_25.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.456,y=0.200,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.391,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.720,y=0.050,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=27.200,y=10.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.150,y=5.000,z=3.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=9.763,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=15.303,y=0.100,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=4.683,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=14.578,y=1.000,z=0.200 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=15.172,y=2.000,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_03_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_projectile_fxtrail_03_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 100.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_01_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_01',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 2.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/line_white_add_10.dds]],
+	RampTexture = [[/textures/particles/ramp_white_premod_01.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.143 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=3.826,y=30.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=10.997,y=2.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=10.158,y=0.800,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.939,y=1.250,z=0.250 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=9.235,y=0.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.130,y=0.000,z=0.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_01_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_01',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 2.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/line_white_add_10.dds]],
-	RampTexture = [[/textures/particles/ramp_white_premod_01.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.143 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=3.826,y=30.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=10.997,y=2.000,z=0.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=10.158,y=0.800,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.939,y=1.250,z=0.250 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=9.235,y=0.000,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.130,y=0.000,z=0.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_01',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 2.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/line_white_add_10.dds]],
+    RampTexture = [[/textures/particles/ramp_white_premod_01.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.143 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=3.826,y=30.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=10.997,y=2.000,z=0.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=10.158,y=0.800,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.939,y=1.250,z=0.250 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=9.235,y=0.000,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.130,y=0.000,z=0.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_01_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_02_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_02',
+	Lifetime = -1.00,
+	Repeattime = 16.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma02.dds]],
+	RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
+	XDirectionCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=2.533,y=30.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=2.660,y=3.500,z=1.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.060,y=0.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=5.107,y=1.500,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=4.011,y=1.000,z=0.500 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=3.757,y=0.500,z=0.250 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.040,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_02_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_02_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_02',
-	Lifetime = -1.00,
-	Repeattime = 16.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma02.dds]],
-	RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
-	XDirectionCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=2.533,y=30.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=2.660,y=3.500,z=1.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.060,y=0.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=5.107,y=1.500,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=4.011,y=1.000,z=0.500 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=3.757,y=0.500,z=0.250 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.040,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_02',
+    Lifetime = -1.00,
+    Repeattime = 16.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma02.dds]],
+    RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
+    XDirectionCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=2.533,y=30.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=2.660,y=3.500,z=1.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.060,y=0.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=5.107,y=1.500,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=4.011,y=1.000,z=0.500 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=3.757,y=0.500,z=0.250 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.040,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_03_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_03_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_03',
+	Lifetime = -0.40,
+	Repeattime = 0.40,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = true,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = true,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma07.dds]],
+	RampTexture = [[/textures/particles/ramp_white_07.dds]],
+	XDirectionCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.210,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.020,y=11.119,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.230,y=9.500,z=5.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=0.500,z=0.200 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=0.000,z=0.100 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=0.000,z=0.100 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=0.000,z=0.100 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.102,y=1.385,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.124,y=0.750,z=0.250 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.127,y=2.000,z=0.500 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=0.000,z=0.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 0.40,
+		Keys = {
+			{ x=0.200,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_03_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_03_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_03',
-	Lifetime = -0.40,
-	Repeattime = 0.40,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = false,
-	LocalAcceleration = false,
-	Gravity = true,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = false,
-	CreateIfVisible = false,
-	SnapToWaterline = true,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma07.dds]],
-	RampTexture = [[/textures/particles/ramp_white_07.dds]],
-	XDirectionCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.210,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.020,y=11.119,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.230,y=9.500,z=5.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=0.500,z=0.200 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=0.000,z=0.100 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=0.000,z=0.100 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=0.000,z=0.100 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.102,y=1.385,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.124,y=0.750,z=0.250 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.127,y=2.000,z=0.500 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=0.000,z=0.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 0.40,
-		Keys = {
-			{ x=0.200,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_03',
+    Lifetime = -0.40,
+    Repeattime = 0.40,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = true,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = true,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma07.dds]],
+    RampTexture = [[/textures/particles/ramp_white_07.dds]],
+    XDirectionCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.210,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.020,y=11.119,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.230,y=9.500,z=5.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=0.500,z=0.200 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=0.000,z=0.100 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=0.000,z=0.100 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=0.000,z=0.100 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.102,y=1.385,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.124,y=0.750,z=0.250 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.127,y=2.000,z=0.500 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=0.000,z=0.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 0.40,
+        Keys = {
+            { x=0.200,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_03_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_03_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = false,
     CreateIfVisible = false,
     SnapToWaterline = true,

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_04_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_04_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_04',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/sparkle_white_add_01.dds]],
+	RampTexture = [[/textures/particles/ramp_ser_11.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.143 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=3.826,y=3.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=4.030,y=1.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=10.158,y=1.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.939,y=12.000,z=3.000 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=9.235,y=0.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.130,y=0.000,z=0.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_04_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_04_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_04_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_04_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_04',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/sparkle_white_add_01.dds]],
-	RampTexture = [[/textures/particles/ramp_ser_11.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.143 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=3.826,y=3.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=4.030,y=1.000,z=0.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=10.158,y=1.000,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.939,y=12.000,z=3.000 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=9.235,y=0.000,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.130,y=0.000,z=0.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_04',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/sparkle_white_add_01.dds]],
+    RampTexture = [[/textures/particles/ramp_ser_11.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.143 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=3.826,y=3.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=4.030,y=1.000,z=0.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=10.158,y=1.000,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.939,y=12.000,z=3.000 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=9.235,y=0.000,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.130,y=0.000,z=0.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_05_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_05_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_05',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 0.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/glow_02.dds]],
+	RampTexture = [[/textures/particles/ramp_black_03.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.425,y=20.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=8.836,y=4.000,z=1.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.425,y=2.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=15.616,y=1.250,z=0.650 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=9.235,y=0.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.130,y=0.000,z=0.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_05_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_05_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_05_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_05_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_05',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 0.00,
-	LocalVelocity = true,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/glow_02.dds]],
-	RampTexture = [[/textures/particles/ramp_black_03.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.425,y=20.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=8.836,y=4.000,z=1.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.425,y=2.000,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=15.616,y=1.250,z=0.650 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=9.235,y=0.000,z=0.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.130,y=0.000,z=0.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_05',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 0.00,
+    LocalVelocity = true,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/glow_02.dds]],
+    RampTexture = [[/textures/particles/ramp_black_03.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.425,y=20.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=8.836,y=4.000,z=1.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.425,y=2.000,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=15.616,y=1.250,z=0.650 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=9.235,y=0.000,z=0.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.130,y=0.000,z=0.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_06_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_06_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_06',
+	Lifetime = -1.00,
+	Repeattime = 16.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ring_03.dds]],
+	RampTexture = [[/textures/particles/ramp_white_03.dds]],
+	XDirectionCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=2.765,y=10.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=2.660,y=7.000,z=3.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.060,y=0.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=5.107,y=0.200,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=4.686,y=2.000,z=0.500 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=3.757,y=4.000,z=1.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.040,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 16.00,
+		Keys = {
+			{ x=8.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_06_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_06_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_06_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_fxtrails_06_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_06',
-	Lifetime = -1.00,
-	Repeattime = 16.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ring_03.dds]],
-	RampTexture = [[/textures/particles/ramp_white_03.dds]],
-	XDirectionCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=2.765,y=10.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=2.660,y=7.000,z=3.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.060,y=0.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=5.107,y=0.200,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=4.686,y=2.000,z=0.500 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=3.757,y=4.000,z=1.000 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.040,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 16.00,
-		Keys = {
-			{ x=8.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_ohwalli_strategic_bomb_fxtrails_06',
+    Lifetime = -1.00,
+    Repeattime = 16.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ring_03.dds]],
+    RampTexture = [[/textures/particles/ramp_white_03.dds]],
+    XDirectionCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=2.765,y=10.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=2.660,y=7.000,z=3.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.060,y=0.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=5.107,y=0.200,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=4.686,y=2.000,z=0.500 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=3.757,y=4.000,z=1.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.040,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 16.00,
+        Keys = {
+            { x=8.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_01_emit.bp
@@ -1,0 +1,160 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_01',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma10.dds]],
+	RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.300,z=0.300 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=18.272,y=21.000,z=7.500 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=5.000,z=2.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=6.266,y=1.077,z=0.615 },
+			{ x=9.763,y=0.538,z=0.000 },
+			{ x=14.842,y=1.077,z=0.539 },
+			{ x=19.921,y=0.692,z=0.000 },
+			{ x=29.024,y=1.231,z=0.538 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=8.641,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=-0.750,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=7.500,y=1.000,z=0.500 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.609,y=0.000,z=0.500 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.350,y=0.857,z=0.200 },
+			{ x=34.700,y=0.020,z=0.100 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_01_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_01_emit.bp
@@ -1,160 +1,160 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_01',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = true,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma10.dds]],
-	RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.300,z=0.300 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=18.272,y=21.000,z=7.500 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=5.000,z=2.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=6.266,y=1.077,z=0.615 },
-			{ x=9.763,y=0.538,z=0.000 },
-			{ x=14.842,y=1.077,z=0.539 },
-			{ x=19.921,y=0.692,z=0.000 },
-			{ x=29.024,y=1.231,z=0.538 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=8.641,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=-0.750,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=7.500,y=1.000,z=0.500 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.609,y=0.000,z=0.500 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.350,y=0.857,z=0.200 },
-			{ x=34.700,y=0.020,z=0.100 },
-		},
-	},
+    BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_01',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = true,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma10.dds]],
+    RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.300,z=0.300 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=18.272,y=21.000,z=7.500 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=5.000,z=2.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=6.266,y=1.077,z=0.615 },
+            { x=9.763,y=0.538,z=0.000 },
+            { x=14.842,y=1.077,z=0.539 },
+            { x=19.921,y=0.692,z=0.000 },
+            { x=29.024,y=1.231,z=0.538 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=8.641,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=-0.750,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=7.500,y=1.000,z=0.500 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.609,y=0.000,z=0.500 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.350,y=0.857,z=0.200 },
+            { x=34.700,y=0.020,z=0.100 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_02_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_02',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma09.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_16.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.500,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.148,y=10.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.412,y=3.500,z=0.500 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=14.908,y=0.750,z=0.750 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.939,y=0.200,z=0.200 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=30.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_02_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_02_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_02',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = false,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma09.dds]],
-	RampTexture = [[/textures/particles/ramp_blue_16.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.500,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.148,y=10.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.412,y=3.500,z=0.500 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=14.908,y=0.750,z=0.750 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.939,y=0.200,z=0.200 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=30.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_02',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma09.dds]],
+    RampTexture = [[/textures/particles/ramp_blue_16.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.500,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.148,y=10.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.412,y=3.500,z=0.500 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=14.908,y=0.750,z=0.750 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.939,y=0.200,z=0.200 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=30.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_03_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_03_emit.bp
@@ -1,0 +1,160 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_03',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma07.dds]],
+	RampTexture = [[/textures/particles/ramp_white_premod_01.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=10.950,y=-1.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.675,y=0.000,z=0.250 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=18.272,y=10.000,z=4.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=2.000,z=1.571 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=12.929,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=6.003,y=1.462,z=1.000 },
+			{ x=9.763,y=0.538,z=0.000 },
+			{ x=14.116,y=1.154,z=0.462 },
+			{ x=19.921,y=0.692,z=0.000 },
+			{ x=28.892,y=1.000,z=0.692 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.412,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=-0.100,z=0.093 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=7.500,y=0.750,z=0.159 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.495,z=0.106 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.350,y=0.857,z=0.200 },
+			{ x=34.700,y=0.020,z=0.100 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_03_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_03_emit.bp
@@ -1,160 +1,160 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_03',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma07.dds]],
-	RampTexture = [[/textures/particles/ramp_white_premod_01.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=10.950,y=-1.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.675,y=0.000,z=0.250 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=18.272,y=10.000,z=4.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=2.000,z=1.571 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=12.929,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=6.003,y=1.462,z=1.000 },
-			{ x=9.763,y=0.538,z=0.000 },
-			{ x=14.116,y=1.154,z=0.462 },
-			{ x=19.921,y=0.692,z=0.000 },
-			{ x=28.892,y=1.000,z=0.692 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.412,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=-0.100,z=0.093 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=7.500,y=0.750,z=0.159 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.495,z=0.106 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.350,y=0.857,z=0.200 },
-			{ x=34.700,y=0.020,z=0.100 },
-		},
-	},
+    BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_03',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma07.dds]],
+    RampTexture = [[/textures/particles/ramp_white_premod_01.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=10.950,y=-1.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.675,y=0.000,z=0.250 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=18.272,y=10.000,z=4.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=2.000,z=1.571 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=12.929,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=6.003,y=1.462,z=1.000 },
+            { x=9.763,y=0.538,z=0.000 },
+            { x=14.116,y=1.154,z=0.462 },
+            { x=19.921,y=0.692,z=0.000 },
+            { x=28.892,y=1.000,z=0.692 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.412,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=-0.100,z=0.093 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=7.500,y=0.750,z=0.159 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.495,z=0.106 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.350,y=0.857,z=0.200 },
+            { x=34.700,y=0.020,z=0.100 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_03_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_03_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_04_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_04_emit.bp
@@ -1,0 +1,160 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_04',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma07.dds]],
+	RampTexture = [[/textures/particles/ramp_white_premod_01.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=10.950,y=1.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.675,y=0.000,z=0.250 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=18.272,y=10.000,z=4.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=2.000,z=1.571 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=6.003,y=1.462,z=1.000 },
+			{ x=9.763,y=0.538,z=0.000 },
+			{ x=14.116,y=1.154,z=0.462 },
+			{ x=19.921,y=0.692,z=0.000 },
+			{ x=28.892,y=1.000,z=0.692 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=8.641,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=-0.100,z=0.093 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=7.500,y=0.750,z=0.159 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.500,z=0.106 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.350,y=0.857,z=0.200 },
+			{ x=34.700,y=0.020,z=0.100 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_04_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_04_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_04_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_04_emit.bp
@@ -1,160 +1,160 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_04',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma07.dds]],
-	RampTexture = [[/textures/particles/ramp_white_premod_01.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=10.950,y=1.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.675,y=0.000,z=0.250 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=18.272,y=10.000,z=4.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=2.000,z=1.571 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=6.003,y=1.462,z=1.000 },
-			{ x=9.763,y=0.538,z=0.000 },
-			{ x=14.116,y=1.154,z=0.462 },
-			{ x=19.921,y=0.692,z=0.000 },
-			{ x=28.892,y=1.000,z=0.692 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=8.641,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=-0.100,z=0.093 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=7.500,y=0.750,z=0.159 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.500,z=0.106 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.350,y=0.857,z=0.200 },
-			{ x=34.700,y=0.020,z=0.100 },
-		},
-	},
+    BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_04',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma07.dds]],
+    RampTexture = [[/textures/particles/ramp_white_premod_01.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=10.950,y=1.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.675,y=0.000,z=0.250 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=18.272,y=10.000,z=4.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=2.000,z=1.571 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=6.003,y=1.462,z=1.000 },
+            { x=9.763,y=0.538,z=0.000 },
+            { x=14.116,y=1.154,z=0.462 },
+            { x=19.921,y=0.692,z=0.000 },
+            { x=28.892,y=1.000,z=0.692 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=8.641,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=-0.100,z=0.093 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=7.500,y=0.750,z=0.159 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.500,z=0.106 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.350,y=0.857,z=0.200 },
+            { x=34.700,y=0.020,z=0.100 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_05_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_05_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_05',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 1.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 10.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma09.dds]],
+	RampTexture = [[/textures/particles/ramp_white_premod_01.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.500,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.148,y=10.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.412,y=3.500,z=0.500 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=14.908,y=0.550,z=0.500 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.939,y=0.200,z=0.200 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=30.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_05_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_05_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_05_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_05_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_05',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 1.00,
-	LocalVelocity = false,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 10.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma09.dds]],
-	RampTexture = [[/textures/particles/ramp_white_premod_01.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.500,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.148,y=10.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.412,y=3.500,z=0.500 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=14.908,y=0.550,z=0.500 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.939,y=0.200,z=0.200 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=30.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_05',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 1.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 10.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma09.dds]],
+    RampTexture = [[/textures/particles/ramp_white_premod_01.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.500,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.148,y=10.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.412,y=3.500,z=0.500 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=14.908,y=0.550,z=0.500 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.939,y=0.200,z=0.200 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=30.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_06_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_06_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_06',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/miasma_mod_01.dds]],
+	RampTexture = [[/textures/particles/ramp_white_07.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.500,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.148,y=1.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=12.071,y=12.000,z=0.500 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.500,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=14.182,y=2.000,z=0.750 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.456,y=4.000,z=0.200 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_06_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_06_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_06_emit.bp
+++ b/effects/emitters/seraphim_rifter_artillery_projectile_fxtrails_06_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_06',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = false,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/miasma_mod_01.dds]],
-	RampTexture = [[/textures/particles/ramp_white_07.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.500,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.148,y=1.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=12.071,y=12.000,z=0.500 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.500,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=14.182,y=2.000,z=0.750 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.456,y=4.000,z=0.200 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_rifter_artillery_projectile_fxtrails_06',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/miasma_mod_01.dds]],
+    RampTexture = [[/textures/particles/ramp_white_07.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.500,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.148,y=1.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=12.071,y=12.000,z=0.500 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.500,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=14.182,y=2.000,z=0.750 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.456,y=4.000,z=0.200 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_01_emit.bp
@@ -1,0 +1,160 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_01',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma04.dds]],
+	RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.200,z=0.150 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=18.272,y=12.000,z=4.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=5.000,z=2.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=6.266,y=0.150,z=0.200 },
+			{ x=9.763,y=0.000,z=0.000 },
+			{ x=15.237,y=0.150,z=0.200 },
+			{ x=19.921,y=0.000,z=0.000 },
+			{ x=29.881,y=0.150,z=0.200 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=12.401,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=8.641,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=-0.750,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.306,y=0.100,z=0.100 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.609,y=0.000,z=0.250 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.350,y=0.857,z=0.200 },
+			{ x=34.700,y=0.020,z=0.100 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_01_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_01_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_01_emit.bp
@@ -1,160 +1,160 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_01',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = true,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma04.dds]],
-	RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.200,z=0.150 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=18.272,y=12.000,z=4.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=5.000,z=2.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=6.266,y=0.150,z=0.200 },
-			{ x=9.763,y=0.000,z=0.000 },
-			{ x=15.237,y=0.150,z=0.200 },
-			{ x=19.921,y=0.000,z=0.000 },
-			{ x=29.881,y=0.150,z=0.200 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=12.401,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=8.641,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=-0.750,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.306,y=0.100,z=0.100 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.609,y=0.000,z=0.250 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.350,y=0.857,z=0.200 },
-			{ x=34.700,y=0.020,z=0.100 },
-		},
-	},
+    BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_01',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = true,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma04.dds]],
+    RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.200,z=0.150 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=18.272,y=12.000,z=4.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=5.000,z=2.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=6.266,y=0.150,z=0.200 },
+            { x=9.763,y=0.000,z=0.000 },
+            { x=15.237,y=0.150,z=0.200 },
+            { x=19.921,y=0.000,z=0.000 },
+            { x=29.881,y=0.150,z=0.200 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=12.401,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=8.641,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=-0.750,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.306,y=0.100,z=0.100 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.609,y=0.000,z=0.250 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.350,y=0.857,z=0.200 },
+            { x=34.700,y=0.020,z=0.100 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_02_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_02',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma02.dds]],
+	RampTexture = [[/textures/particles/ramp_white_07.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.500,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.148,y=30.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.412,y=3.500,z=0.500 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.259,y=0.300,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.852,y=0.200,z=0.100 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.939,y=0.050,z=0.050 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=30.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_02_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_02_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_02_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_02',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = false,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma02.dds]],
-	RampTexture = [[/textures/particles/ramp_white_07.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.500,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.148,y=30.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.412,y=3.500,z=0.500 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.259,y=0.300,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.852,y=0.200,z=0.100 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.939,y=0.050,z=0.050 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=30.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_02',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma02.dds]],
+    RampTexture = [[/textures/particles/ramp_white_07.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.500,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.148,y=30.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.412,y=3.500,z=0.500 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.259,y=0.300,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.852,y=0.200,z=0.100 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.939,y=0.050,z=0.050 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=30.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_03_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_03_emit.bp
@@ -1,0 +1,160 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_03',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma03.dds]],
+	RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=10.950,y=-1.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=5.871,y=0.150,z=0.100 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=18.272,y=10.000,z=4.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=6.728,y=2.000,z=1.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=12.929,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=6.003,y=0.500,z=1.000 },
+			{ x=9.763,y=0.200,z=0.000 },
+			{ x=14.116,y=0.500,z=0.462 },
+			{ x=19.921,y=0.200,z=0.000 },
+			{ x=28.892,y=0.500,z=0.692 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=6.069,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=-0.100,z=0.093 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=14.578,y=0.200,z=0.100 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.000,y=0.100,z=0.100 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.350,y=0.857,z=0.200 },
+			{ x=34.700,y=0.020,z=0.100 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_03_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_03_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_03_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_03_emit.bp
@@ -1,160 +1,160 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_03',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = true,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma03.dds]],
-	RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=10.950,y=-1.000,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=5.871,y=0.150,z=0.100 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=18.272,y=10.000,z=4.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=6.728,y=2.000,z=1.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=12.929,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=6.003,y=0.500,z=1.000 },
-			{ x=9.763,y=0.200,z=0.000 },
-			{ x=14.116,y=0.500,z=0.462 },
-			{ x=19.921,y=0.200,z=0.000 },
-			{ x=28.892,y=0.500,z=0.692 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=6.069,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=-0.100,z=0.093 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=14.578,y=0.200,z=0.100 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.000,y=0.100,z=0.100 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.350,y=0.857,z=0.200 },
-			{ x=34.700,y=0.020,z=0.100 },
-		},
-	},
+    BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_03',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = true,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma03.dds]],
+    RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=10.950,y=-1.000,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=5.871,y=0.150,z=0.100 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=18.272,y=10.000,z=4.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=6.728,y=2.000,z=1.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=12.929,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=6.003,y=0.500,z=1.000 },
+            { x=9.763,y=0.200,z=0.000 },
+            { x=14.116,y=0.500,z=0.462 },
+            { x=19.921,y=0.200,z=0.000 },
+            { x=28.892,y=0.500,z=0.692 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=6.069,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=-0.100,z=0.093 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=14.578,y=0.200,z=0.100 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.000,y=0.100,z=0.100 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.350,y=0.857,z=0.200 },
+            { x=34.700,y=0.020,z=0.100 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_04_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_04_emit.bp
@@ -1,0 +1,160 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_04',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma03.dds]],
+	RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.478,y=0.500,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.675,y=0.000,z=0.250 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=7.718,y=10.000,z=4.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=10.818,y=2.000,z=1.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=6.003,y=0.500,z=1.000 },
+			{ x=9.763,y=0.200,z=0.000 },
+			{ x=14.116,y=0.500,z=0.462 },
+			{ x=19.921,y=0.200,z=0.000 },
+			{ x=28.892,y=0.500,z=0.692 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=8.641,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=-0.100,z=0.093 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=7.500,y=0.200,z=0.100 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.193,y=0.100,z=0.100 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=0.350,y=0.857,z=0.200 },
+			{ x=34.700,y=0.020,z=0.100 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_04_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_04_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_04_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_04_emit.bp
@@ -1,160 +1,160 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_04',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = true,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma03.dds]],
-	RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.478,y=0.500,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.675,y=0.000,z=0.250 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=7.718,y=10.000,z=4.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=10.818,y=2.000,z=1.000 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=6.003,y=0.500,z=1.000 },
-			{ x=9.763,y=0.200,z=0.000 },
-			{ x=14.116,y=0.500,z=0.462 },
-			{ x=19.921,y=0.200,z=0.000 },
-			{ x=28.892,y=0.500,z=0.692 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=8.641,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=-0.100,z=0.093 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=7.500,y=0.200,z=0.100 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.193,y=0.100,z=0.100 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=0.350,y=0.857,z=0.200 },
-			{ x=34.700,y=0.020,z=0.100 },
-		},
-	},
+    BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_04',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = true,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/ser_plasma03.dds]],
+    RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.478,y=0.500,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.675,y=0.000,z=0.250 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=7.718,y=10.000,z=4.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=10.818,y=2.000,z=1.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=6.003,y=0.500,z=1.000 },
+            { x=9.763,y=0.200,z=0.000 },
+            { x=14.116,y=0.500,z=0.462 },
+            { x=19.921,y=0.200,z=0.000 },
+            { x=28.892,y=0.500,z=0.692 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=8.641,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=-0.100,z=0.093 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=7.500,y=0.200,z=0.100 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.193,y=0.100,z=0.100 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=0.350,y=0.857,z=0.200 },
+            { x=34.700,y=0.020,z=0.100 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_05_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_05_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_05',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 1.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 10.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/smoke.dds]],
+	RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.500,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.148,y=6.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.412,y=2.250,z=0.500 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.350,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=14.908,y=0.100,z=0.050 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.939,y=0.050,z=0.050 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=30.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_05_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_05_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_05_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_05_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_05',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 1.00,
-	LocalVelocity = false,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 10.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/smoke.dds]],
-	RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.500,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.148,y=6.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.412,y=2.250,z=0.500 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.350,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=14.908,y=0.100,z=0.050 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.939,y=0.050,z=0.050 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=30.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_05',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 1.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 10.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/smoke.dds]],
+    RampTexture = [[/textures/particles/ramp_white_premod_02.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.500,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.148,y=6.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.412,y=2.250,z=0.500 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.350,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=14.908,y=0.100,z=0.050 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.939,y=0.050,z=0.050 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=30.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_06_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_06_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_06',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 500.00,
+	EmitIfVisible = false,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/miasma_mod_01.dds]],
+	RampTexture = [[/textures/particles/ramp_white_08.dds]],
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.500,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.148,y=1.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=12.071,y=12.000,z=0.500 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=14.182,y=0.600,z=0.200 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.456,y=1.750,z=0.200 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_06_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_06_emit.bp
@@ -11,7 +11,7 @@ EmitterBlueprint {
     AlignToBone = false,
     Flat = false,
     LODCutoff = 500.00,
-    EmitIfVisible = false,
+    EmitIfVisible = true,
     CatchupEmit = true,
     CreateIfVisible = false,
     SnapToWaterline = false,

--- a/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_06_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_projectile_fxtrails_06_emit.bp
@@ -1,155 +1,155 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_06',
-	Lifetime = -1.00,
-	Repeattime = 50.00,
-	TextureFramecount = 1.00,
-	Blendmode = 3.00,
-	LocalVelocity = false,
-	LocalAcceleration = false,
-	Gravity = false,
-	AlignRotation = false,
-	AlignToBone = false,
-	Flat = false,
-	LODCutoff = 500.00,
-	EmitIfVisible = false,
-	CatchupEmit = true,
-	CreateIfVisible = false,
-	SnapToWaterline = false,
-	OnlyEmitOnWater = false,
-	ParticleResistance = false,
-	InterpolateEmission = true,
-	TextureStripcount = 1.00,
-	SortOrder = 0.00,
-	LowFidelity = true,
-	MedFidelity = true,
-	HighFidelity = true,
-	Texture = [[/textures/particles/miasma_mod_01.dds]],
-	RampTexture = [[/textures/particles/ramp_white_08.dds]],
-	XDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.500,z=0.000 },
-		},
-	},
-	ZDirectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	EmitRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=11.148,y=1.000,z=0.000 },
-		},
-	},
-	LifetimeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=12.071,y=12.000,z=0.500 },
-		},
-	},
-	VelocityCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	XAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZAccelCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ResistanceCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	SizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	XPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	YPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	ZPosCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	StartSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=14.182,y=0.600,z=0.200 },
-		},
-	},
-	EndSizeCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=13.456,y=1.750,z=0.200 },
-		},
-	},
-	InitialRotationCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=180.000,z=360.000 },
-		},
-	},
-	RotationRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=10.000 },
-		},
-	},
-	FrameRateCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=1.000,z=0.000 },
-		},
-	},
-	TextureSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
-	RampSelectionCurve = {
-		XRange = 50.00,
-		Keys = {
-			{ x=25.000,y=0.000,z=0.000 },
-		},
-	},
+    BlueprintId = 'seraphim_rifter_mobileartillery_projectile_fxtrails_06',
+    Lifetime = -1.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 3.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 500.00,
+    EmitIfVisible = false,
+    CatchupEmit = true,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 1.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = [[/textures/particles/miasma_mod_01.dds]],
+    RampTexture = [[/textures/particles/ramp_white_08.dds]],
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.500,z=0.000 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=11.148,y=1.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=12.071,y=12.000,z=0.500 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=14.182,y=0.600,z=0.200 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=13.456,y=1.750,z=0.200 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=10.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
 }
 


### PR DESCRIPTION
issue #793

Thanks to @bamboofats who had the idea.
Changed EmitIfVisible to true inside emitter blueprints to hide them in the fog of war.