### PR TITLE
Bugfix/Round Deviation of New Rating Tooltip

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -872,7 +872,7 @@ function SetSlotInfo(slotNum, playerInfo)
     -- dynamic tooltip to show rating and deviation for each player
     local tooltipText = {}
     tooltipText['text'] = "Rating"
-    tooltipText['body'] = LOCF("<LOC lobui_0768>Your Rating is %s +/- %s", playerInfo.PL, playerInfo.DEV)
+    tooltipText['body'] = LOCF("<LOC lobui_0768>Your Rating is %s +/- %s", playerInfo.PL, math.ceil(playerInfo.DEV))
     slot.tooltiprating = Tooltip.AddControlTooltip(slot.ratingText, tooltipText)
 
     slot.numGamesText:Show()


### PR DESCRIPTION
In the current beta, the player deviation shown in the new tooltip has about 10 decimal places.
This rounds player deviation via math.ceil() to the next bigger number.