### PR TITLE
Siren ground fire target priority fix

### DIFF
--- a/units/URS0202/URS0202_unit.bp
+++ b/units/URS0202/URS0202_unit.bp
@@ -611,12 +611,7 @@ UnitBlueprint {
             TargetCheckInterval = 0.3,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
-                'AIR MOBILE HIGHPRIAIR',
-                'AIR MOBILE TECH3 BOMBER',
-                'AIR MOBILE BOMBER',
-                'AIR MOBILE GROUNDATTACK',
-                'AIR MOBILE TRANSPORTATION',
-                'AIR MOBILE',
+                'NAVAL MOBILE',
                 'SPECIALLOWPRI',
                 'ALLUNITS',
             },


### PR DESCRIPTION
While was changed toggle weapon to equilibrium style was copypast AA
target priority also to ground fire weapon. This fix it to naval
standards.
#BalanceTerroristsInvadingYourCode