### PR TITLE
Add Warp In Effects for sACUs

### DIFF
--- a/units/UAL0301/UAL0301_script.lua
+++ b/units/UAL0301/UAL0301_script.lua
@@ -14,6 +14,7 @@ local AWeapons = import('/lua/aeonweapons.lua')
 local ADFReactonCannon = AWeapons.ADFReactonCannon
 local SCUDeathWeapon = import('/lua/sim/defaultweapons.lua').SCUDeathWeapon
 local EffectUtil = import('/lua/EffectUtilities.lua')
+local EffectTemplate = import('/lua/EffectTemplates.lua')
 local Buff = import('/lua/sim/Buff.lua')
 
 UAL0301 = Class(CommandUnit) {
@@ -46,6 +47,37 @@ UAL0301 = Class(CommandUnit) {
 
     CreateBuildEffects = function( self, unitBeingBuilt, order )
         EffectUtil.CreateAeonCommanderBuildingEffects( self, unitBeingBuilt, self:GetBlueprint().General.BuildBones.BuildEffectBones, self.BuildEffectsBag )
+    end,
+
+    PlayCommanderWarpInEffect = function(self)
+        self:HideBone(0, true)
+        self:SetUnSelectable(true)
+        self:SetBusy(true)
+        self:SetBlockCommandQueue(true)
+        self:ForkThread(self.WarpInEffectThread)
+    end,
+
+    WarpInEffectThread = function(self)
+        self:PlayUnitSound('CommanderArrival')
+        self:CreateProjectile('/effects/entities/UnitTeleport01/UnitTeleport01_proj.bp', 0, 1.35, 0, nil, nil, nil):SetCollision(false)
+        WaitSeconds(2.1)
+        self:SetMesh('/units/ual0301/UAL0301_PersonalShield_mesh', true)
+        self:ShowBone(0, true)
+        self:SetUnSelectable(false)
+        self:SetBusy(false)
+        self:SetBlockCommandQueue(false)
+        self:HideBone('Turbine', true)
+        
+        local totalBones = self:GetBoneCount() - 1
+        local army = self:GetArmy()
+        for k, v in EffectTemplate.UnitTeleportSteam01 do
+            for bone = 1, totalBones do
+                CreateAttachedEmitter(self,bone,army, v)
+            end
+        end
+
+        WaitSeconds(6)
+        self:SetMesh(self:GetBlueprint().Display.MeshBlueprint, true)
     end,
 
     CreateEnhancement = function(self, enh)

--- a/units/UEL0301/UEL0301_script.lua
+++ b/units/UEL0301/UEL0301_script.lua
@@ -6,6 +6,7 @@
 -----------------------------------------------------------------
 local Shield = import('/lua/shield.lua').Shield
 local EffectUtil = import('/lua/EffectUtilities.lua')
+local EffectTemplate = import('/lua/EffectTemplates.lua')
 local CommandUnit = import('/lua/defaultunits.lua').CommandUnit
 local TWeapons = import('/lua/terranweapons.lua')
 local TDFHeavyPlasmaCannonWeapon = TWeapons.TDFHeavyPlasmaCannonWeapon
@@ -79,6 +80,38 @@ UEL0301 = Class(CommandUnit) {
         else
             self:CreateEnhancement('PodRemove')
         end
+    end,
+
+    PlayCommanderWarpInEffect = function(self)
+        self:HideBone(0, true)
+        self:SetUnSelectable(true)
+        self:SetBusy(true)
+        self:SetBlockCommandQueue(true)
+        self:ForkThread(self.WarpInEffectThread)
+    end,
+
+    WarpInEffectThread = function(self)
+        self:PlayUnitSound('CommanderArrival')
+        self:CreateProjectile('/effects/entities/UnitTeleport01/UnitTeleport01_proj.bp', 0, 1.35, 0, nil, nil, nil):SetCollision(false)
+        WaitSeconds(2.1)
+        self:SetMesh('/units/uel0301/UEL0301_PersonalShield_mesh', true)
+        self:ShowBone(0, true)
+        self:SetUnSelectable(false)
+        self:SetBusy(false)
+        self:SetBlockCommandQueue(false)
+        self:HideBone('Jetpack', true)
+        self:HideBone('SAM', true)
+        
+        local totalBones = self:GetBoneCount() - 1
+        local army = self:GetArmy()
+        for k, v in EffectTemplate.UnitTeleportSteam01 do
+            for bone = 1, totalBones do
+                CreateAttachedEmitter(self,bone,army, v)
+            end
+        end
+
+        WaitSeconds(6)
+        self:SetMesh(self:GetBlueprint().Display.MeshBlueprint, true)
     end,
 
     CreateEnhancement = function(self, enh)

--- a/units/URL0301/URL0301_PhaseShield_mesh.bp
+++ b/units/URL0301/URL0301_PhaseShield_mesh.bp
@@ -1,0 +1,14 @@
+MeshBlueprint {
+    IconFadeInZoom = 130,
+    LODs = {
+        {
+            MeshName = 'url0301_lod0.scm',
+            AlbedoName = 'url0301_albedo.dds',
+            NormalsName = 'url0301_normalsTS.dds',
+            SpecularName = 'url0301_specteam.dds',
+            LookupName = '/effects/entities/PhaseShield/PhaseShieldLookup.dds',
+            ShaderName = 'PhaseShield',
+            LODCutoff = 195,
+        },
+    },
+}

--- a/units/URL0301/URL0301_script.lua
+++ b/units/URL0301/URL0301_script.lua
@@ -10,6 +10,7 @@
 local CCommandUnit = import('/lua/cybranunits.lua').CCommandUnit
 local CWeapons = import('/lua/cybranweapons.lua')
 local EffectUtil = import('/lua/EffectUtilities.lua')
+local EffectTemplate = import('/lua/EffectTemplates.lua')
 local Buff = import('/lua/sim/Buff.lua')
 
 local CAAMissileNaniteWeapon = CWeapons.CAAMissileNaniteWeapon
@@ -72,6 +73,41 @@ URL0301 = Class(CCommandUnit) {
         self:DisableUnitIntel('Enhancement', 'Cloak')
         self.LeftArmUpgrade = 'EngineeringArm'
         self.RightArmUpgrade = 'Disintegrator'
+    end,
+
+    PlayCommanderWarpInEffect = function(self)
+        self:HideBone(0, true)
+        self:SetUnSelectable(true)
+        self:SetBusy(true)
+        self:SetBlockCommandQueue(true)
+        self:ForkThread(self.WarpInEffectThread)
+    end,
+
+    WarpInEffectThread = function(self)
+        self:PlayUnitSound('CommanderArrival')
+        self:CreateProjectile('/effects/entities/UnitTeleport01/UnitTeleport01_proj.bp', 0, 1.35, 0, nil, nil, nil):SetCollision(false)
+        WaitSeconds(2.1)
+        self:SetMesh('/units/url0301/URL0301_PhaseShield_mesh', true)
+        self:ShowBone(0, true)
+        self:SetUnSelectable(false)
+        self:SetBusy(false)
+        self:SetBlockCommandQueue(false)
+        self:HideBone('AA_Gun', true)
+        self:HideBone('Power_Pack', true)
+        self:HideBone('Rez_Protocol', true)
+        self:HideBone('Torpedo', true)
+        self:HideBone('Turbine', true)
+        
+        local totalBones = self:GetBoneCount() - 1
+        local army = self:GetArmy()
+        for k, v in EffectTemplate.UnitTeleportSteam01 do
+            for bone = 1, totalBones do
+                CreateAttachedEmitter(self,bone,army, v)
+            end
+        end
+
+        WaitSeconds(6)
+        self:SetMesh(self:GetBlueprint().Display.MeshBlueprint, true)
     end,
 
     -- ************


### PR DESCRIPTION
Same effect as for ACUs, PhaseShield mesh that is added for few seconds
is just a personal sheild, so only one missing was for cybran sACU.