### PR TITLE
Make sure we only flash blips once

### DIFF
--- a/lua/sim/Blip.lua
+++ b/lua/sim/Blip.lua
@@ -50,6 +50,9 @@ end
 
 Blip = Class(moho.blip_methods) {
     FlashIntel = function(self, army, new_unit)
+        if self.flashed then return end
+        self.flashed = true
+
         if not self:IsSeenEver(army) and (self:IsOnRadar(army) or self:IsOnSonar(army)) then
             -- Remove dead radar blip out of map so we don't reveal what's under it
             self:SetPosition(Vector(-100, 0, -100), true)


### PR DESCRIPTION
If a blip is destroyed by 2+ vision entities getting vision over it at the same time the game will crash. Probably an engine bug when trying to destroy the C-object twice.

Thanks to @Uveso who managed to reproduce the error for debugging.

Fixes #1559.