### PR TITLE
Coop - send right information to the server for leaderboards

### DIFF
--- a/schook/lua/UserSync.lua
+++ b/schook/lua/UserSync.lua
@@ -131,7 +131,7 @@ OnSync = function()
 
     if Sync.OperationComplete then
         if Sync.OperationComplete.success then
-            GpgNetSend('OperationComplete', Sync.OperationComplete.campaignID, Sync.OperationComplete.difficulty, Sync.OperationComplete.allPrimary, Sync.OperationComplete.allSecondary, GetGameTime())
+            GpgNetSend('OperationComplete', Sync.OperationComplete.allPrimary, Sync.OperationComplete.allSecondary, GetGameTime())
         end
         import('/lua/ui/campaign/campaignmanager.lua').OperationVictory(Sync.OperationComplete)
     end


### PR DESCRIPTION
After some digging in the old coop code I found that it was never
sending campaignID or difficulty. Difficulty will have to be included in
the future since it can be actually chanced now.

For now this could fix the leaderboards until they are reworked.

Server code:
https://github.com/FAForever/server/blob/08708002094aa1a9ca79065a436bdaa53287fa78/server/gameconnection.py#L337

Needs to be tested since I don't understand the server code. I guess someone with a test server acces is needed @micheljung :)