### PR TITLE
Hotfixes for 3660 (ping / reclaim labels)

### DIFF
--- a/lua/SimPing.lua
+++ b/lua/SimPing.lua
@@ -17,6 +17,11 @@ function AnimatePingMesh(entity)
 end
 
 function SpawnPing(data)
+    if data.Owner < 1 then
+        WARN("SpawnPing: data.Owner cannot be less than 1")
+        return
+    end
+
     if data.Marker and PingMarkers[data.Owner] and table.getsize(PingMarkers[data.Owner]) >= MaxPingMarkers then
         return
     elseif data.Marker and not PingMarkers[data.Owner] then

--- a/lua/SimPing.lua
+++ b/lua/SimPing.lua
@@ -29,7 +29,9 @@ function SpawnPing(data)
     else
         local Entity = import('/lua/sim/Entity.lua').Entity
         data.Location[2] = data.Location[2]+2
-        local pingSpec = {Owner = data.Owner, Location = data.Location}
+
+        -- Entity.Owner needs armyIndex - 1 internally, so here we actually needs to offset when creating a special ping entity
+        local pingSpec = {Owner = data.Owner - 1, Location = data.Location}
         local ping = Entity(pingSpec)
         Warp(ping, Vector(data.Location[1], data.Location[2], data.Location[3]))
         ping:SetVizToFocusPlayer('Always')


### PR DESCRIPTION
Ok, there is one place where armyIndex-1 needs to be set, when creating an entity with spec table the Owner field is actually armyIndex-1.  In this case it's for the zoomed in ping entity that's spawned when pinging.

I will add the reclaim label bugfix here when I manage to see what's wrong so wait to merge this PR until it's added here.

