### PR TITLE
Optimizing storage of who killed the last unit or commander

### DIFF
--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -611,10 +611,10 @@ AIBrain = Class(moho.aibrain_methods) {
                     RemovePlatoonHandleFromUnit(units)
 
                     if victoryOption == 'demoralization' then
-                        KillerIndex = ArmyBrains[selfIndex].unitStats.LastKilled.COM or selfIndex
+                        KillerIndex = ArmyBrains[selfIndex].CommanderKilledBy or selfIndex
                         TransferUnitsOwnership(units, KillerIndex)
                     else
-                        KillerIndex = ArmyBrains[selfIndex].unitStats.LastKilled.unit or selfIndex
+                        KillerIndex = ArmyBrains[selfIndex].LastUnitKilledBy or selfIndex
                         TransferUnitsOwnership(units, KillerIndex)
                     end
                 end

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2249,9 +2249,9 @@ ACUUnit = Class(CommandUnit) {
                     instigatorBrain:ReportScore()
                 end)
             end
-            ArmyBrains[self:GetArmy()]:SetUnitStat('LastKilled', "COM", instigator:GetArmy())
+            ArmyBrains[self:GetArmy()].CommanderKilledBy = instigator:GetArmy()
         else
-            ArmyBrains[self:GetArmy()]:SetUnitStat('LastKilled', "COM", self:GetArmy())
+            ArmyBrains[self:GetArmy()].CommanderKilledBy = self:GetArmy()
         end
     end,
 

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2249,10 +2249,8 @@ ACUUnit = Class(CommandUnit) {
                     instigatorBrain:ReportScore()
                 end)
             end
-            ArmyBrains[self:GetArmy()].CommanderKilledBy = instigator:GetArmy()
-        else
-            ArmyBrains[self:GetArmy()].CommanderKilledBy = self:GetArmy()
         end
+        ArmyBrains[self:GetArmy()].CommanderKilledBy = (instigator or self):GetArmy()
     end,
 
     ResetRightArm = function(self)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1233,10 +1233,10 @@ Unit = Class(moho.unit_methods) {
 
         --Notify instigator of kill
         if instigator and IsUnit(instigator) then
-            ArmyBrains[self:GetArmy()]:SetUnitStat('LastKilled', "unit", instigator:GetArmy())
+            ArmyBrains[self:GetArmy()].LastUnitKilledBy = instigator:GetArmy()
             instigator:OnKilledUnit(self)
         else
-            ArmyBrains[self:GetArmy()]:SetUnitStat('LastKilled', "unit", self:GetArmy())
+        ArmyBrains[self:GetArmy()].LastUnitKilledBy = self:GetArmy()
         end
         if self.DeathWeaponEnabled ~= false then
             self:DoDeathWeapon()

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1233,11 +1233,10 @@ Unit = Class(moho.unit_methods) {
 
         --Notify instigator of kill
         if instigator and IsUnit(instigator) then
-            ArmyBrains[self:GetArmy()].LastUnitKilledBy = instigator:GetArmy()
             instigator:OnKilledUnit(self)
-        else
-        ArmyBrains[self:GetArmy()].LastUnitKilledBy = self:GetArmy()
         end
+        ArmyBrains[self:GetArmy()].LastUnitKilledBy = (instigator or self):GetArmy()
+
         if self.DeathWeaponEnabled ~= false then
             self:DoDeathWeapon()
         end


### PR DESCRIPTION
Information about who killed the commander or the last unit is now
stored directly inside Armybrains without using "SetUnitStats".
While losing the ability to use the information inside hotstats history
(was planed but not implemented yet) it will be using less memory and
because we don't need to execute a function "SetunitStats" its way
faster then before.