### PR TITLE
Remove non-working 15, 30 NoRush options

### DIFF
--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -326,7 +326,7 @@ globalOpts = {
                 help = "<LOC lobui_0319>Rules not enforced",
                 key = 'Off',
             },
-            '5', '10', '15', '20', '30'
+            '5', '10', '20'
         },
     },
     {


### PR DESCRIPTION
Surprisingly enough the engine only accepts, 5, 10, 20. Must be hard-coded somewhere

Fixes #1618