### PR TITLE
Bugfix/#1613 beams ff

### DIFF
--- a/lua/sim/CollisionBeam.lua
+++ b/lua/sim/CollisionBeam.lua
@@ -316,7 +316,7 @@ CollisionBeam = Class(moho.CollisionBeamEntity) {
     end,
 
     GetCollideFriendly = function(self)
-        return self.DamageData.CollideFriendly
+        return self.CollideFriendly
     end,
 
     SetDamageTable = function(self)
@@ -330,6 +330,7 @@ CollisionBeam = Class(moho.CollisionBeamEntity) {
         self.DamageTable.DoTTime = weaponBlueprint.DoTTime
         self.DamageTable.DoTPulses = weaponBlueprint.DoTPulses
         self.DamageTable.Buffs = weaponBlueprint.Buffs
+        self.CollideFriendly = self.DamageData.CollideFriendly == true
     end,
 
     -- When this beam impacts with the target, do any buffs that have been passed to it.

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -29,8 +29,8 @@ Projectile = Class(moho.projectile_methods, Entity) {
         self.DamageData.MetaImpactRadius = DamageData.MetaImpactRadius
         self.DamageData.Buffs = DamageData.Buffs
         self.DamageData.ArtilleryShieldBlocks = DamageData.ArtilleryShieldBlocks
-
         self.DamageData.InitialDamageAmount = DamageData.InitialDamageAmount
+        self.CollideFriendly = self.DamageData.CollideFriendly
     end,
 
     DoDamage = function(self, instigator, DamageData, targetEntity)
@@ -444,7 +444,7 @@ Projectile = Class(moho.projectile_methods, Entity) {
     end,
 
     GetCollideFriendly = function(self)
-        return self.DamageData.CollideFriendly
+        return self.CollideFriendly
     end,
 
     PassData = function(self, data)

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -281,7 +281,11 @@ Projectile = Class(moho.projectile_methods, Entity) {
     end,
 
     OnCollisionCheckWeapon = function(self, firingWeapon)
-		-- if this unit category is on the weapon's do-not-collide list, skip!
+        if not firingWeapon.CollideFriendly and self:GetArmy() == firingWeapon.unit:GetArmy() then
+            return false
+        end
+
+        -- if this unit category is on the weapon's do-not-collide list, skip!
 		local weaponBP = firingWeapon:GetBlueprint()
 		if weaponBP.DoNotCollideList then
 			for k, v in pairs(weaponBP.DoNotCollideList) do

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1308,7 +1308,7 @@ Unit = Class(moho.unit_methods) {
         end
         if EntityCategoryContains(categories.PROJECTILE, other) then
             if self:GetArmy() == other:GetArmy() then
-                return other:GetCollideFriendly()
+                return other.CollideFriendly
             end
         end
 

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -42,6 +42,8 @@ Weapon = Class(moho.weapon_methods) {
             end
             self:ForkThread(self.AmmoThread, nuke, bp.InitialProjectileStorage)
         end
+
+        self.CollideFriendly = bp.CollideFriendly == true
     end,
 
     AmmoThread = function(self, nuke, amount)


### PR DESCRIPTION
CollisionBeam doesn't trigger OnCollisionCheck on the projectile so it didn't respect CollideFriendly. The check is now done in OnCollisionCheckWeapon

Fixes #1613
