### PR TITLE
Set ground fire as default for mobile units

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -18,6 +18,7 @@ local ScenarioUtils = import('/lua/sim/ScenarioUtilities.lua')
 local Entity = import('/lua/sim/Entity.lua').Entity
 local Buff = import('/lua/sim/Buff.lua')
 local AdjacencyBuffs = import('/lua/sim/AdjacencyBuffs.lua')
+local FireState = import('/lua/game.lua').FireState
 
 local CreateBuildCubeThread = EffectUtil.CreateBuildCubeThread
 local CreateAeonBuildBaseThread = EffectUtil.CreateAeonBuildBaseThread
@@ -1490,6 +1491,7 @@ MobileUnit = Class(Unit) {
     OnCreate = function(self)
         Unit.OnCreate(self)
         self:updateBuildRestrictions()
+        self:SetFireState(FireState.GROUND_FIRE)
     end,
 
     OnKilled = function(self, instigator, type, overkillRatio)

--- a/lua/game.lua
+++ b/lua/game.lua
@@ -5,6 +5,12 @@
 -- * Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 -- ==========================================================================================
 
+FireState = {
+    RETURN_FIRE = 0,
+    HOLD_FIRE = 1,
+    GROUND_FIRE = 2,
+}
+
 VeteranDefault = {
     Level1 = 25,
     Level2 = 100,


### PR DESCRIPTION
We could make this a gameplay option also per player basis. What's needed then is a SimCallback which provide the default firestate at start of game / whenever player changes that option.
