### PR TITLE
Fix bug with civs not always revealing

### DIFF
--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -398,9 +398,6 @@ AIBrain = Class(moho.aibrain_methods) {
     --   val: true or false
     -- calls callback function with blip it saw.
 
-
-
-
     OnIntelChange = function(self, blip, reconType, val)
         if self.IntelTriggerList then
             for k, v in self.IntelTriggerList do

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -509,9 +509,18 @@ function InitializeArmies()
                             ForkThread(function()
                                 WaitSeconds(.1)
                                 local real_state = IsAlly(a, e) and 'Ally' or IsEnemy(a, e) and 'Enemy' or 'Neutral'
+
+                                GetArmyBrain(e):SetupArmyIntelTrigger({
+                                    Category=categories.ALLUNITS,
+                                    Type='LOSNow',
+                                    Value=true,
+                                    OnceOnly=true,
+                                    TargetAIBrain=GetArmyBrain(a),
+                                    CallbackFunction=function()
+                                        SetAlliance(a, e, real_state)
+                                    end,
+                                })
                                 SetAlliance(a, e, 'Ally')
-                                WaitSeconds(1)
-                                SetAlliance(a, e, real_state)
                             end)
                         end
                     end


### PR DESCRIPTION
The intel system gets slower with more players in a game so instead of waiting 1 second for civs to reveal we use a trigger in OnIntelChange to get information when a player actually sees the civilians.

Fixes #1667