### PR TITLE
Stop cloak FX flickering on all intel units. Fixes #1674

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+Patch 3663 (November 12th, 2016)
+============================
+**Bugs**
+- Fixed a small oversight which led to non-cloaked units getting the cloak FX in a power stall
+- Added cloak FX support for cloakfields (Mods only, FAF itself has no unit with this ability)
+
+
 Patch 3662 (November 9th, 2016)
 ============================
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2336,7 +2336,7 @@ Unit = Class(moho.unit_methods) {
 
                 -- Handle the cloak FX timing
                 if intel == 'Cloak' then
-                    if disabler ~= 'NotInitialized' then
+                    if disabler ~= 'NotInitialized' and self:GetBlueprint().Intel[intel] then
                         self:UpdateCloakEffect(false)
                     end
                 end
@@ -2378,7 +2378,7 @@ Unit = Class(moho.unit_methods) {
 
                     -- Handle the cloak FX timing
                     if intel == 'Cloak' then
-                        if disabler ~= 'NotInitialized' then
+                        if disabler ~= 'NotInitialized' and self:GetBlueprint().Intel[intel] then
                             self:UpdateCloakEffect(true)
                         end
                     end

--- a/lua/version.lua
+++ b/lua/version.lua
@@ -1,4 +1,4 @@
-local Version = '3662'
+local Version = '3663'
 function GetVersion()
     LOG('Supreme Commander: Forged Alliance version ' .. Version)
     return Version

--- a/mod_info.lua
+++ b/mod_info.lua
@@ -3,7 +3,7 @@
 -- Documentation for the extended FAF mod_info.lua format can be found here:
 -- https://github.com/FAForever/fa/wiki/mod_info.lua-documentation
 name = "Forged Alliance Forever"
-version = 3662
+version = 3663
 _faf_modname='balancetesting'
 copyright = "Forged Alliance Forever Community"
 description = "Forged Alliance Forever extends Forged Alliance, bringing new patches, game modes, units, ladder, and much more!"


### PR DESCRIPTION
This happens in the no power state. Having no power cycles through
all of the intel types, not just the ones you should be able to use.
This accidentally triggers the cloak FX function. Checking that the
unit was meant to have cloak fixes it.

Note - This fix won't work with cloakfield units (The FX didn't anyway)
Will need to find a solution for BlackOps and other mods who use that
broken function...