### PR TITLE
Remove Deploy ability from aeon t3 arty

### DIFF
--- a/units/UAL0304/UAL0304_unit.bp
+++ b/units/UAL0304/UAL0304_unit.bp
@@ -63,9 +63,6 @@ UnitBlueprint {
     },
     Description = '<LOC ual0304_desc>Mobile Heavy Artillery',
     Display = {
-        Abilities = {
-            '<LOC ability_deploys>Deploys',
-        },
         Mesh = {
             IconFadeInZoom = 130,
             LODs = {


### PR DESCRIPTION
it doesnt deploy. so it doesnt need to have this ability. its pretty
misleading. no gameplay changes, this is only a ui mistake.