### PR TITLE
Bugfix Cloaking

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2458,7 +2458,7 @@ Unit = Class(moho.unit_methods) {
                 local units = brain:GetUnitsAroundPoint(categories.ALLUNITS, pos, radius, 'Ally')
 
                 for _, unit in units do
-                    if unit and not unit.Dead and unit ~= self then
+                    if unit and not unit.Dead and not unit:IsIntelEnabled('Cloak') then
                         if unit.CloakFXWatcherThread then
                             KillThread(unit.CloakFXWatcherThread)
                             unit.CloakFXWatcherThread = nil
@@ -2476,8 +2476,7 @@ Unit = Class(moho.unit_methods) {
 
     CloakFXWatcher = function(self)
         WaitTicks(5)
-
-        if self and not self.Dead then
+        if self and not self.Dead and not self:IsIntelEnabled('Cloak') then
             self:UpdateCloakEffect(false, 'Cloak')
         end
     end,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2469,13 +2469,13 @@ Unit = Class(moho.unit_methods) {
                     end
                 end
 
-                WaitTicks(5)
+                WaitTicks(10)
             end
         end
     end,
 
     CloakFXWatcher = function(self)
-        WaitTicks(5)
+        WaitTicks(12)
         if self and not self.Dead and not self:IsIntelEnabled('Cloak') then
             self:UpdateCloakEffect(false, 'Cloak')
         end


### PR DESCRIPTION
Fixed CloakFXWatcherThread to cloak the source unit and don't cloak already cloaked units.
Fixed Disabled cloak in case a unit has left a cloakfiled with its own cloak activated.
Checktime for cloak-renew is now 10 ticks and cloakfield is lasting 2 ticks longer then cloak-refresh timer to prevent unit flickering.
