### PR TITLE
fix bugs with "close - spawn mex"

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1639,7 +1639,8 @@ function UpdateAvailableSlots( numAvailStartSpots )
         end
         DisableSlot(i)
         GUI.slots[i]:Hide()
-        gameInfo.ClosedSlots[i] = nil
+        gameInfo.ClosedSlots[i] = true
+        gameInfo.SpawnMex[i] = nil
     end
 end
 

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1593,10 +1593,12 @@ function UpdateAvailableSlots( numAvailStartSpots )
     -- if number of available slots has changed, update it
     if numOpenSlots == numAvailStartSpots then
         -- Remove closed_spawn_mex if necessary
-        for i = 1, numAvailStartSpots do
-            if gameInfo.ClosedSlots[i] and gameInfo.SpawnMex[i] then
-                ClearSlotInfo(i)
-                gameInfo.SpawnMex[i] = nil
+        if not gameInfo.AdaptiveMap then
+            for i = 1, numAvailStartSpots do
+                if gameInfo.ClosedSlots[i] and gameInfo.SpawnMex[i] then
+                    ClearSlotInfo(i)
+                    gameInfo.SpawnMex[i] = nil
+                end
             end
         end
         return
@@ -3917,11 +3919,11 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
                 import('/lua/ui/lobby/ModsManager.lua').UpdateClientModStatus(gameInfo.GameMods)
             elseif data.Type == 'SlotClosed' then
                 gameInfo.ClosedSlots[data.Slot] = data.Closed
-                gameInfo.SpawnMex[slot] = false
+                gameInfo.SpawnMex[data.Slot] = false
                 ClearSlotInfo(data.Slot)
             elseif data.Type == 'SlotClosedSpawnMex' then
                 gameInfo.ClosedSlots[data.Slot] = data.Closed
-                gameInfo.SpawnMex[slot] = true
+                gameInfo.SpawnMex[data.Slot] = true
                 ClearSlotInfo(data.Slot)
             end
         end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1639,7 +1639,7 @@ function UpdateAvailableSlots( numAvailStartSpots )
         end
         DisableSlot(i)
         GUI.slots[i]:Hide()
-        gameInfo.ClosedSlots[i] = true
+        gameInfo.ClosedSlots[i] = nil
     end
 end
 


### PR DESCRIPTION
fixes:
1) close - spawn mex is changed to close when "options" is clicked without changing the map
2) clients not showing closed spots