### PR TITLE
Attempt to address 'ghost' reclaim labels: #1628

### DIFF
--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -57,8 +57,9 @@ function OnSync()
 		import('/modules/nukelaunchping.lua').DoNukePing(Sync.NukeLaunchData)
 	end
 
-    for _, r in Sync.Reclaim or {} do
-        import('/lua/ui/game/reclaim.lua').UpdateReclaim(r)
+    -- Each sync, update the user-side data for any prop created, damaged, or destroyed
+    for _, data in Sync.Reclaim or {} do
+        import('/lua/ui/game/reclaim.lua').UpdateReclaim(data)
     end
 
     if Sync.Teamkill and not SessionIsReplay() then

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -58,8 +58,8 @@ function OnSync()
 	end
 
     -- Each sync, update the user-side data for any prop created, damaged, or destroyed
-    for _, data in Sync.Reclaim or {} do
-        import('/lua/ui/game/reclaim.lua').UpdateReclaim(data)
+    for id, data in Sync.Reclaim or {} do
+        import('/lua/ui/game/reclaim.lua').UpdateReclaim(id, data)
     end
 
     if Sync.Teamkill and not SessionIsReplay() then

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -120,7 +120,8 @@ Prop = Class(moho.prop_methods, Entity) {
     end,
 
     SyncMassLabel = function(self)
-        local data = {id = self:GetEntityId()}
+        local data = {}
+        local id = self:GetEntityId()
 
         if self:BeenDestroyed() then
             data.mass = 0
@@ -134,8 +135,8 @@ Prop = Class(moho.prop_methods, Entity) {
             end
         end
 
-        if data.mass then
-            table.insert(Sync.Reclaim, data)
+        if data.mass and id then
+            Sync.Reclaim[id] = data
         end
     end,
 

--- a/lua/ui/game/reclaim.lua
+++ b/lua/ui/game/reclaim.lua
@@ -11,9 +11,9 @@ local NeedUpdate = false
 local minimumLabelMass = 20
 
 -- Stores/updates a reclaim entity's data using EntityId as key
-function UpdateReclaim(data)
+function UpdateReclaim(id, data)
     data.updated = true
-    Reclaim[data.id] = data
+    Reclaim[id] = data
 end
 
 local OldZoom

--- a/lua/ui/game/reclaim.lua
+++ b/lua/ui/game/reclaim.lua
@@ -8,9 +8,12 @@ local Reclaim = {}
 
 -- called from schook/lua/UserSync.lua
 local NeedUpdate = false
-function UpdateReclaim(r)
-    r.updated = true
-    Reclaim[r.id] = r
+local minimumLabelMass = 20
+
+-- Stores/updates a reclaim entity's data using EntityId as key
+function UpdateReclaim(data)
+    data.updated = true
+    Reclaim[data.id] = data
 end
 
 local OldZoom
@@ -97,13 +100,13 @@ function CreateReclaimLabel(view, r)
 end
 
 function UpdateLabels()
-    local view = import('/lua/ui/game/worldview.lua').viewLeft
+    local view = import('/lua/ui/game/worldview.lua').viewLeft -- Left screen's camera
     local n_visible = 0
 
     for id, r in Reclaim do
-        local label = view.ReclaimGroup.ReclaimLabels[id]
+        local label = view.ReclaimGroup.ReclaimLabels[id] -- nil if not set yet
 
-        if not r.mass or r.mass < 1 then
+        if not r.mass or r.mass < minimumLabelMass then -- It's too small to display, remove from tables
             if label then
                 label:Destroy()
                 view.ReclaimGroup.ReclaimLabels[id] = nil
@@ -118,7 +121,7 @@ function UpdateLabels()
                 label:Show()
                 n_visible = n_visible + 1
             end
-        elseif label then
+        elseif label then -- Don't show labels off the screen
             label:Hide()
         end
 


### PR DESCRIPTION
This is a first attempt to follow the reclaim logic view through and try to identify the fault. I believe I identified one potential vulnerability: When a prop was destroyed, if it happened such that self.MaxMassReclaim had already been cleaned up, it would return nil and skip the creation of the data block to be synced, leading to the label never being called for destruction.