### PR TITLE
Bugfix/ghost reclaim

### DIFF
--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -161,6 +161,8 @@ WorldView = Class(moho.UIWorldView, Control) {
             GetCursor():Reset()
             self.LastCursor = nil
             self:ResetDecals()
+        elseif event.Type == 'WheelRotation' then
+            self.zoomed = true
         end
 
         return false

--- a/lua/ui/game/reclaim.lua
+++ b/lua/ui/game/reclaim.lua
@@ -68,8 +68,13 @@ function CreateReclaimLabel(view, r)
 
     label:DisableHitTest(true)
     label.Update = function(self)
-        local view = self.parent.view
+        if self.isHidden then
+            LayoutHelpers.AtLeftTopIn(self, self.parent, -200, -200)
+            self:SetNeedsFrameUpdate(false)
+            return
+        end
 
+        local view = self.parent.view
         local proj = view:Project(self.position)
         LayoutHelpers.AtLeftTopIn(self, self.parent, proj.x - self.Width() / 2, proj.y - self.Height() / 2 + 1)
         self.proj = {x=proj.x, y=proj.y}
@@ -105,15 +110,16 @@ function UpdateLabels()
             if not label then
                 label = CreateReclaimLabel(view.ReclaimGroup, r)
                 view.ReclaimGroup.ReclaimLabels[id] = label
-            else
-                label:Show()
+            elseif label.isHidden then
                 label:SetNeedsFrameUpdate(true)
+                label.isHidden = false
+                label:Show()
             end
 
             n_visible = n_visible + 1
-        elseif label then
+        elseif label and not label.isHidden then
+            label.isHidden = true
             label:Hide()
-            label:SetNeedsFrameUpdate(false)
         end
 
         if label and r.updated then

--- a/lua/ui/game/reclaim.lua
+++ b/lua/ui/game/reclaim.lua
@@ -69,7 +69,7 @@ function CreateReclaimLabel(view, r)
     label:DisableHitTest(true)
     label.Update = function(self)
         local view = self.parent.view
-        local proj = view:Project(pos)
+        local proj = view:Project(self.position)
         LayoutHelpers.AtLeftTopIn(self, self.parent, proj.x - self.Width() / 2, proj.y - self.Height() / 2 + 1)
         self.proj = {x=proj.x, y=proj.y}
     end

--- a/lua/ui/game/reclaim.lua
+++ b/lua/ui/game/reclaim.lua
@@ -69,9 +69,6 @@ function CreateReclaimLabel(view, r)
     label:DisableHitTest(true)
     label.Update = function(self)
         local view = self.parent.view
-        if not view.ShowingReclaim then
-            self:SetNeedsFrameUpdate(false)
-        end
 
         local proj = view:Project(self.position)
         LayoutHelpers.AtLeftTopIn(self, self.parent, proj.x - self.Width() / 2, proj.y - self.Height() / 2 + 1)

--- a/lua/ui/game/reclaim.lua
+++ b/lua/ui/game/reclaim.lua
@@ -6,21 +6,17 @@ local Prefs = import('/lua/user/prefs.lua')
 
 local Reclaim = {}
 
--- called from schook/lua/UserSync.lua
-local NeedUpdate = false
+-- called from /lua/UserSync.lua
 function UpdateReclaim(r)
     r.updated = true
     Reclaim[r.id] = r
 end
 
-local OldZoom
-function SameZoom(camera)
-    if not OldZoom or camera:GetZoom() == OldZoom then
-        return true
-    end
+local MAX_ON_SCREEN = 1000
 
-    return false
-end
+local ZoomHide = false
+local OldZoom
+local NumVisible = 0
 
 function OnScreen(view, pos)
     local proj = view:Project(Vector(pos[1], pos[2], pos[3]))
@@ -49,9 +45,7 @@ local WorldLabel = Class(Group) {
     end,
 
     OnFrame = function(self, delta)
-        if not self:IsHidden() then
-            self:Update()
-        end
+        self:Update()
     end
 }
 
@@ -74,14 +68,10 @@ function CreateReclaimLabel(view, r)
 
     label:DisableHitTest(true)
     label.Update = function(self)
-        if self.parent:IsHidden() then return end
-
         local view = self.parent.view
         local proj = view:Project(pos)
-        if not self.proj or self.proj.x ~= proj.x or self.proj.y ~= self.proj.y then
-            LayoutHelpers.AtLeftTopIn(self, self.parent, proj.x - self.Width() / 2, proj.y - self.Height() / 2 + 1)
-            self.proj = proj
-        end
+        LayoutHelpers.AtLeftTopIn(self, self.parent, proj.x - self.Width() / 2, proj.y - self.Height() / 2 + 1)
+        self.proj = {x=proj.x, y=proj.y}
     end
 
     label.UpdateMass = function(self, r)
@@ -116,8 +106,9 @@ function UpdateLabels()
                 view.ReclaimGroup.ReclaimLabels[id] = label
             else
                 label:Show()
-                n_visible = n_visible + 1
             end
+
+            n_visible = n_visible + 1
         elseif label then
             label:Hide()
         end
@@ -125,11 +116,12 @@ function UpdateLabels()
         if label and r.updated then
             label:UpdateMass(r)
             r.updated = false
-            NeedUpdate = true
         end
     end
 
-    return view.ReclaimGroup.ReclaimLabels, n_visible
+    NumVisible = n_visible
+
+    return view.ReclaimGroup.ReclaimLabels
 end
 
 local ReclaimThread
@@ -146,7 +138,7 @@ function ShowReclaim(show)
     end
 end
 
-function InitReclaimGroup(view, camera)
+function InitReclaimGroup(view)
     if not view.ReclaimGroup or IsDestroyed(view.ReclaimGroup) then
         local rgroup = Group(view)
         rgroup.view = view
@@ -155,19 +147,16 @@ function InitReclaimGroup(view, camera)
         rgroup:Show()
         rgroup.ReclaimLabels = {}
 
-        rgroup.OnFrame = function(self)
-            if not self.update then return end
-            if SameZoom(camera) then
-                self:Show()
-                self:SetNeedsFrameUpdate(false)
-                self.update = false
-            else
+        view.ReclaimGroup = rgroup
+
+        rgroup.OnFrame = function(self, delta)
+            if view.zoomed and NumVisible > MAX_ON_SCREEN then
+                ZoomHide = true
                 self:Hide()
             end
         end
 
-        view.ReclaimGroup = rgroup
-        NeedUpdate = true
+        rgroup:SetNeedsFrameUpdate(true)
     else
         view.ReclaimGroup:Show()
     end
@@ -176,33 +165,35 @@ end
 
 function ShowReclaimThread(watch_key)
     local i = 0
-    local camera = GetCamera("WorldCamera")
     local view = import('/lua/ui/game/worldview.lua').viewLeft
+    local camera = GetCamera("WorldCamera")
 
-    InitReclaimGroup(view, camera)
-    OldZoom = nil
+    InitReclaimGroup(view)
 
     while view.ShowingReclaim and (not watch_key or IsKeyDown(watch_key)) do
         if not view or IsDestroyed(view) then
             view = import('/lua/ui/game/worldview.lua').viewLeft
             camera = GetCamera("WorldCamera")
-            InitReclaimGroup(view, camera)
+            InitReclaimGroup(view)
         end
 
-        local sameZoom = SameZoom(camera)
-        local doUpdate = NeedUpdate or not sameZoom
+        local labels = UpdateLabels()
 
-        if doUpdate then
-            local labels, n_visible = UpdateLabels()
-            if not sameZoom and n_visible > 1000 then
-                view.ReclaimGroup:Hide()
-                view.ReclaimGroup.update = true
-                view.ReclaimGroup:SetNeedsFrameUpdate(true)
+        if ZoomHide then
+            local zoom = camera:GetZoom()
+            if zoom == OldZoom then
+                ZoomHide = false
+            else
+                OldZoom = zoom
             end
-            NeedUpdate = false
         end
 
-        OldZoom = camera:GetZoom()
+        if not ZoomHide then
+            view.zoomed = false
+            view.ReclaimGroup:Show()
+            OldZoom = nil
+        end
+
         WaitSeconds(.1)
     end
 

--- a/lua/ui/game/reclaim.lua
+++ b/lua/ui/game/reclaim.lua
@@ -28,7 +28,7 @@ local WorldLabel = Class(Group) {
         Group.__init(self, parent)
         self.parent = parent
         self.proj = nil
-        if position then self:SetPosition(position) end
+        self:SetPosition(position)
 
         self.Top:Set(0)
         self.Left:Set(0)
@@ -41,7 +41,7 @@ local WorldLabel = Class(Group) {
     end,
 
     SetPosition = function(self, position)
-        self.position = position
+        self.position = position or {}
     end,
 
     OnFrame = function(self, delta)
@@ -74,11 +74,11 @@ function CreateReclaimLabel(view, r)
         self.proj = {x=proj.x, y=proj.y}
     end
 
-    label.UpdateMass = function(self, r)
+    label.UpdateReclaim = function(self, r)
         local mass = tostring(math.floor(0.5+r.mass))
-        if mass ~= self.text:GetText() then
-            self.text:SetText(mass)
-        end
+        self.text:SetText(mass)
+        -- Wrecks have static positions but the engine reuses entity IDs which could mean a label needs to be re-positioned
+        self:SetPosition(Vector(r.position[1], r.position[2], r.position[3]))
     end
 
     label:Update()
@@ -114,7 +114,7 @@ function UpdateLabels()
         end
 
         if label and r.updated then
-            label:UpdateMass(r)
+            label:UpdateReclaim(r)
             r.updated = false
         end
     end

--- a/lua/ui/game/reclaim.lua
+++ b/lua/ui/game/reclaim.lua
@@ -69,6 +69,10 @@ function CreateReclaimLabel(view, r)
     label:DisableHitTest(true)
     label.Update = function(self)
         local view = self.parent.view
+        if not view.ShowingReclaim then
+            self:SetNeedsFrameUpdate(false)
+        end
+
         local proj = view:Project(self.position)
         LayoutHelpers.AtLeftTopIn(self, self.parent, proj.x - self.Width() / 2, proj.y - self.Height() / 2 + 1)
         self.proj = {x=proj.x, y=proj.y}
@@ -106,11 +110,13 @@ function UpdateLabels()
                 view.ReclaimGroup.ReclaimLabels[id] = label
             else
                 label:Show()
+                label:SetNeedsFrameUpdate(true)
             end
 
             n_visible = n_visible + 1
         elseif label then
             label:Hide()
+            label:SetNeedsFrameUpdate(false)
         end
 
         if label and r.updated then


### PR DESCRIPTION
Wrecks can actually "move", the engine reuses wreck-IDs on sim side which the earlier version didn't know about. Haven't done extensive testing yet but I think this may have been the problem if the engine reuses an ID for a label the player has seen at least once.

By always setting the position for a label when a non-delete update comes in we bypass this problem. The 
"ghost label" is then moved to wherever it belongs at the moment.

I'm not sure if the earlier zoom change is cherry-picked somewhere already so I added that as well.
