### PR TITLE
Lobby: Autobalance functions don't crash on uneven teams anymore

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1092,6 +1092,7 @@ local function autobalance_bestworst(players, teams_arg)
             local team = t['team']
             local slots = t['slots']
             local slot = table.remove(slots, 1)
+            if not slot then continue end
             local player
 
             if best then
@@ -1131,6 +1132,7 @@ local function autobalance_avg(players, teams_arg)
             local team = t['team']
             local slots = t['slots']
             local slot = table.remove(slots, 1)
+            if not slot then continue end
             local player
             local player_key
 
@@ -1170,10 +1172,10 @@ local function autobalance_rr(players, teams)
 
     while table.getsize(players) > 0 do
         for i, pick in team_picks do
+            local slot = table.remove(teams[pick.team], 1)
+            if not slot then continue end
             local player = table.remove(players, 1)
             if not player then break end
-            local slot = table.remove(teams[pick.team], 1)
-            if not slot then break end
             pick.sum = pick.sum + i
 
             table.insert(result, {player=player.pos, rating=player.rating, team=pick.team, slot=slot})
@@ -1200,6 +1202,7 @@ local function autobalance_random(players, teams_arg)
         for _, t in teams do
             local team = t['team']
             local slot = table.remove(t['slots'], 1)
+            if not slot then continue end
             local player = table.remove(players, 1)
 
             if not player then break end


### PR DESCRIPTION
So apparantly random and balance functions couldn't handle uneven teams.
Not sure about their balancing performance in these cases, but atleast they don't crash anymore.