### PR TITLE
Fix #1743 reclaim label default value

### DIFF
--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -691,7 +691,7 @@ options = {
                 set = function(key, value, startup)
                     import('/lua/ui/game/reclaim.lua').updateMaxLabels(value)
                 end,
-                default = 10,
+                default = 1000,
                 custom = {
                     min = 500,
                     max = 5000,


### PR DESCRIPTION
Should we deploy this? Or should we increase the default, eg. to 1000 or 2000? I think 1000 run still run very smoothly for most players.