### PR TITLE
Use default scenario from uiutil if map is missing

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5640,8 +5640,8 @@ function InitHostUtils()
                 SendSystemMessage("lobui_0330", name, gameInfo.GameOptions.ScenarioFile)
                 LOG('>> '..name..' is missing map '..gameInfo.GameOptions.ScenarioFile)
                 if name == localPlayerName then
-                    LOG('>> '..gameInfo.GameOptions.ScenarioFile..' replaced with '..'SCMP_009')
-                    SetGameOption('ScenarioFile', '/maps/scmp_009/scmp_009_scenario.lua')
+                    LOG('>> '..gameInfo.GameOptions.ScenarioFile..' replaced with '.. UIUtil.defaultScenario)
+                    SetGameOption('ScenarioFile', UIUtil.defaultScenario)
                 end
             end
         end,


### PR DESCRIPTION
This way the default map can be easily changed, without complicated
hooking, for mods like coop, tutorials or any mod that doesn't use
skirmish maps.