### PR TITLE
include hook directory in mod_info.lua

### DIFF
--- a/mod_info.lua
+++ b/mod_info.lua
@@ -27,3 +27,6 @@ mountpoints = {
     textures = '/textures',
     units = '/units'
 }
+hooks = {
+    '/schook',
+}


### PR DESCRIPTION
so some uplords working on a git patcher and since faf wants to have
schook defined, this is it happening. no other changes bscly, cannot possible fail right?