### PR TITLE
Feature/transport wrecks

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1840,6 +1840,7 @@ BaseTransport = Class() {
     end,
 
     DetachCargo = function(self)
+        if self.Dead then return end --due to overkill damage this can get called when trans is hit after it dies and cause errors since it doesnt have any cargo
         local units = self:GetCargo()
         for k, v in units do
             if EntityCategoryContains(categories.TRANSPORTATION, v) then
@@ -1848,12 +1849,16 @@ BaseTransport = Class() {
                 end
             end
             v:DetachFrom()
+            v.falling = true --set flag to kill units on impact.
         end
     end
 }
 
 --- Base class for air transports.
 AirTransport = Class(AirUnit, BaseTransport) {
+
+    DestroyNoFallRandomChance = 1, --tbh i have no idea what this does
+    
     OnTransportAborted = function(self)
     end,
 
@@ -1876,6 +1881,11 @@ AirTransport = Class(AirUnit, BaseTransport) {
         for k, v in self:GetCargo() do
             v:OnStorageChange(loading)
         end
+    end,
+    
+    Kill = function(self, ...) --pure black magic thats called when the unit is killed. not on insta ctrl-k mind you
+        self:DetachCargo()
+        AirUnit.Kill(self, unpack(arg))
     end,
 }
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2778,6 +2778,12 @@ Unit = Class(moho.unit_methods) {
         if self.LayerChangeTrigger then
             self:LayerChangeTrigger(new, old)
         end
+        
+		--for units falling out of a dead transport - they are destined to die, so we kill them and leave the wreck.
+		if self.falling and (new == 'Land' or new == 'Water') and old == 'Air' then
+			self.falling = nil
+            self:Kill()
+		end
     end,
 
     OnMotionHorzEventChange = function( self, new, old )

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2742,6 +2742,13 @@ Unit = Class(moho.unit_methods) {
         -- the C object. Any functions down this line which expect a live C object (self:CreateAnimator())
         -- for example, will throw an error.
         if self.Dead then return end
+        
+		--for units falling out of a dead transport - they are destined to die, so we kill them and leave the wreck.
+		if self.falling and (new == 'Land' or new == 'Water' or new == 'Seabed' or new == 'Sub') and old == 'Air' then
+			self.falling = nil
+            self:Kill()
+            return --we kill the unit so no need to go through the function anymore
+		end
 
         for i = 1, self:GetWeaponCount() do
             self:GetWeapon(i):SetValidTargetsForCurrentLayer(new)
@@ -2778,12 +2785,6 @@ Unit = Class(moho.unit_methods) {
         if self.LayerChangeTrigger then
             self:LayerChangeTrigger(new, old)
         end
-        
-		--for units falling out of a dead transport - they are destined to die, so we kill them and leave the wreck.
-		if self.falling and (new == 'Land' or new == 'Water') and old == 'Air' then
-			self.falling = nil
-            self:Kill()
-		end
     end,
 
     OnMotionHorzEventChange = function( self, new, old )


### PR DESCRIPTION
So now when a transport dies the units its carrying arent deleted. they fall with the transport and die on impact, leaving wrecks. neato
should look like this:
https://puu.sh/t66hI/7caa9b7954.jpg
http://puu.sh/t66oa/1d847ce574.jpg

note: this uses some absurd black magic, by hooking the Kill function which i didnt even know existed, dunno what it even does but this works. this catches the transport before its table is cleared and detaches all the units, and flags them to die on layer change.
for some reason OnImpact didnt work when i tried it but yeah.
monor bug - things like the acu and units that walk on the seabed - collide with that and die on that and not the water surface, which i why i tried to use OnImpact. ah well.

#FixedInEquilibrium
#BalanceOnslaughtNeverStups