### PR TITLE
Increase kills unitstat of killer

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1289,7 +1289,7 @@ Unit = Class(moho.unit_methods) {
             self:AddXP(DEFAULT_XP)
         end
 
-        ArmyBrains[self:GetArmy()]:AddUnitStat(unitKilled:GetUnitId(), "kills", 1)
+        ArmyBrains[self:GetArmy()]:AddUnitStat(self:GetUnitId(), "kills", 1)
     end,
 
     DoDeathWeapon = function(self)


### PR DESCRIPTION
I am assuming you have to give 'kills' to the killer instead of to the victim.
If not, then this shouldn't really be in OnKilledUnit..