### PR TITLE
Lobby: remove unnecessary and harmfull SetPlayerOption

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1690,7 +1690,6 @@ function UpdateAvailableSlots( numAvailStartSpots, scenario )
                 end
             else
                 GUI.slots[i].faction:SetItem(playerFactionIndex)
-                SetPlayerOption(i, 'Faction', playerFactionIndex)
                 gameInfo.PlayerOptions[i].Faction = playerFactionIndex
             end
         end


### PR DESCRIPTION
Remove SetPlayerOptions which should only be used for local slots or hosts.
Every player will do SetPlayerOption for himself so not everyone else should do it for others anyway.