### PR TITLE
Fix Warning message

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1459,7 +1459,7 @@ Unit = Class(moho.unit_methods) {
         end
 
         --Create some ambient wreckage smoke
-        --explosion.CreateWreckageEffects(self,prop)
+        explosion.CreateWreckageEffects(self,prop)
 
         return prop
     end,
@@ -1607,12 +1607,12 @@ Unit = Class(moho.unit_methods) {
 
         -- BOOM!
         if self.PlayDestructionEffects then
-            --self:CreateDestructionEffects(overkillRatio)
+            self:CreateDestructionEffects(overkillRatio)
         end
 
         -- Flying bits of metal and whatnot. More bits for more overkill.
         if self.ShowUnitDestructionDebris and overkillRatio then
-            --self.CreateUnitDestructionDebris(self, true, true, overkillRatio > 2)
+            self.CreateUnitDestructionDebris(self, true, true, overkillRatio > 2)
         end
 
         if shallSink then

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -4331,7 +4331,10 @@ end
 
 function SetPlayerOptions(slot, options, ignoreRefresh)
     if not IsLocallyOwned(slot) and not lobbyComm:IsHost() then
-        WARN("Hey you can't set a player option on a slot you don't own. (slot:"..tostring(slot).." / key:"..tostring(key).." / val:"..tostring(val)..")")
+        WARN("Hey you can't set a player option on a slot you don't own:")
+        for key, val in options do
+            WARN("(slot:"..tostring(slot).." / key:"..tostring(key).." / val:"..tostring(val)..")")
+        end
         return
     end
 


### PR DESCRIPTION
That warning message uses `key `and `val` variables, so need a for loop to get them from the table.
