### PR TITLE
Lobby: Update factionselector when becoming observer as non-host

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -4032,6 +4032,7 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
                 gameInfo.PlayerOptions[data.OldSlot] = nil
                 ClearSlotInfo(data.OldSlot)
                 refreshObserverList()
+                UpdateFactionSelectorForPlayer(gameInfo.Observers[data.NewSlot])
             elseif data.Type == 'SetColor' then
                 SetPlayerColor(gameInfo.PlayerOptions[data.Slot], data.Color)
                 SetSlotInfo(data.Slot, gameInfo.PlayerOptions[data.Slot])


### PR DESCRIPTION
Faction selector didn't disably when you become observer as non-host, so yeah, need to update it.

This should fix all the issues that non-host has with faction selector.