### PR TITLE
Improve the new Attack Move Button

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -237,5 +237,4 @@ Callbacks.AttackMove = function(data, units)
         IssueClearCommands(units)
     end
     IssueFormAggressiveMove(units, data.Target,'AttackFormation' , data.Rotation)
-    
 end

--- a/lua/sim/tasks/AttackMove.lua
+++ b/lua/sim/tasks/AttackMove.lua
@@ -8,17 +8,8 @@ local TASKSTATUS = import('/lua/sim/ScriptTask.lua').TASKSTATUS
 local AIRESULT = import('/lua/sim/ScriptTask.lua').AIRESULT
 
 AttackMove = Class(ScriptTask) {
-    
-    OnCreate = function(self,commandData)
-        ScriptTask.OnCreate(self,commandData)
-    end,
-    
     TaskTick = function(self)
         self:SetAIResult(AIRESULT.Success)
         return TASKSTATUS.Done
-    end,
-
-    IsInRange = function(self)
-        return true
     end,
 }

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -180,7 +180,17 @@ WorldView = Class(moho.UIWorldView, Control) {
         local command_mode, command_data = unpack(import('/lua/ui/game/commandmode.lua').GetCommandMode())
 
         if not command_mode then -- no current command command_mode
-            if self:HasHighlightCommand() then
+            local units = GetSelectedUnits()
+            if IsKeyDown(18) and units and table.getn(units) > 0 then
+                local availableOrders,_,_ = GetUnitCommandData(units)
+                for _, availOrder in availableOrders do
+                    if (availOrder == 'RULEUCC_RetaliateToggle' and table.getn(EntityCategoryFilterDown(categories.MOBILE, units)) > 0) 
+                        or table.getn(EntityCategoryFilterDown(categories.ENGINEER - categories.POD, units)) > 0 then
+                        self.Cursor = {UIUtil.GetCursor('ATTACK_MOVE')}
+                        break
+                    end
+                end
+            elseif self:HasHighlightCommand() then
                 if self:ShowConvertToPatrolCursor() then
                     self.Cursor = {UIUtil.GetCursor("MOVE2PATROLCOMMAND")}
                 else

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -147,6 +147,24 @@ function AddCommandFeedbackByType(pos, type)
     return true;
 end
 
+function AddDefaultCommandFeedbackBlips(pos)
+    AddCommandFeedbackBlip({
+        Position = pos, 
+        MeshName = '/meshes/game/flag02d_lod0.scm',
+        TextureName = '/meshes/game/flag02d_albedo.dds',
+        ShaderName = 'CommandFeedback',
+        UniformScale = 0.5,
+    }, 0.7)		
+
+    AddCommandFeedbackBlip({
+        Position = pos, 
+        MeshName = '/meshes/game/crosshair02d_lod0.scm',
+        TextureName = '/meshes/game/crosshair02d_albedo.dds',
+        ShaderName = 'CommandFeedback2',
+        UniformScale = 0.5,
+    }, 0.75)
+end
+
 local lastMex = nil
 function AssistMex(command)
     local units = EntityCategoryFilterDown(categories.ENGINEER, command.Units)
@@ -196,13 +214,13 @@ function OnCommandIssued(command)
             if options['assist_mex'] then AssistMex(command) end
         end
     elseif command.CommandType == 'BuildMobile' then
-		AddCommandFeedbackBlip({
-			Position = command.Target.Position, 
-			BlueprintID = command.Blueprint,			
-			TextureName = '/meshes/game/flag02d_albedo.dds',
-			ShaderName = 'CommandFeedback',
-			UniformScale = 1,
-		}, 0.7)
+    AddCommandFeedbackBlip({
+        Position = command.Target.Position, 
+        BlueprintID = command.Blueprint,
+        TextureName = '/meshes/game/flag02d_albedo.dds',
+        ShaderName = 'CommandFeedback',
+        UniformScale = 1,
+    }, 0.7)
     elseif command.CommandType == 'Repair' then
         local target = command.Target
         if target.Type == 'Entity' then -- repair wreck to rebuild
@@ -229,25 +247,12 @@ function OnCommandIssued(command)
         end
         local cb = {Func="AttackMove", Args={Target=command.Target.Position, Rotation = rotation, Clear=command.Clear}}
         SimCallback(cb, true)
-	else	
-		if AddCommandFeedbackByType(command.Target.Position, command.CommandType) == false then
-			AddCommandFeedbackBlip({
-				Position = command.Target.Position, 
-				MeshName = '/meshes/game/flag02d_lod0.scm',
-				TextureName = '/meshes/game/flag02d_albedo.dds',
-				ShaderName = 'CommandFeedback',
-				UniformScale = 0.5,
-			}, 0.7)		
-			
-			AddCommandFeedbackBlip({
-				Position = command.Target.Position, 
-				MeshName = '/meshes/game/crosshair02d_lod0.scm',
-				TextureName = '/meshes/game/crosshair02d_albedo.dds',
-				ShaderName = 'CommandFeedback2',
-				UniformScale = 0.5,
-			}, 0.75)		
-		end		
-	end
+        AddDefaultCommandFeedbackBlips(command.Target.Position)
+    else
+        if AddCommandFeedbackByType(command.Target.Position, command.CommandType) == false then
+            AddDefaultCommandFeedbackBlips(command.Target.Position)
+        end
+    end
 
-	import('/lua/spreadattack.lua').MakeShadowCopyOrders(command)
+    import('/lua/spreadattack.lua').MakeShadowCopyOrders(command)
 end

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -1061,7 +1061,8 @@ local function CreateAltOrders(availableOrders, availableToggles, units)
     end
     if units and table.getn(units) > 0 and EntityCategoryFilterDown(categories.MOBILE - categories.STRUCTURE, units) then
         for _, availOrder in availableOrders do
-            if availOrder == 'RULEUCC_RetaliateToggle' or EntityCategoryFilterDown(categories.ENGINEER, units) then
+            if (availOrder == 'RULEUCC_RetaliateToggle' and table.getn(EntityCategoryFilterDown(categories.MOBILE, units)) > 0) 
+                    or table.getn(EntityCategoryFilterDown(categories.ENGINEER - categories.POD, units)) > 0 then
                 table.insert(availableOrders, 'AttackMove')
                 standardOrdersTable['AttackMove'] = import('/lua/abilitydefinition.lua').abilities['AttackMove']
                 standardOrdersTable['AttackMove'].behavior = AbilityButtonBehavior


### PR DESCRIPTION
- Clean up whitespace, dead function and some other code niggles
- alt-rmb, when clicked, not only places the order, it spawns a blue "Going here" flash with a downward arrow. The new command should also do this
- The new command turns into a new cursor. alt-rmb should have this cursor while mousing over blank map space