### PR TITLE
Give Factories AttackMove cursor when pressing alt.

### DIFF
--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -192,7 +192,8 @@ WorldView = Class(moho.UIWorldView, Control) {
                 local availableOrders,_,_ = GetUnitCommandData(units)
                 for _, availOrder in availableOrders do
                     if (availOrder == 'RULEUCC_RetaliateToggle' and table.getn(EntityCategoryFilterDown(categories.MOBILE, units)) > 0) 
-                        or table.getn(EntityCategoryFilterDown(categories.ENGINEER - categories.POD, units)) > 0 then
+                        or table.getn(EntityCategoryFilterDown(categories.ENGINEER - categories.POD, units)) > 0
+                        or table.getn(EntityCategoryFilterDown(categories.FACTORY + categories.STRUCTURE, units)) > 0 then
                         self.Cursor = {UIUtil.GetCursor('ATTACK_MOVE')}
                         break
                     end


### PR DESCRIPTION
Like the title says: Factories also have the attackmove cursor when you hold alt even though they can't use the button itself. 
(factory AggressiveMove works different somehow so we don't know how to make it work with a button at the moment)