### PR TITLE
Add Alt+RMB label to attack move

### DIFF
--- a/modules/hotkeylabels.lua
+++ b/modules/hotkeylabels.lua
@@ -40,6 +40,7 @@ local textSizes = {
     -- Depends on amount of characters in the key name
     [1] = 18,
     [2] = 14,
+    [3] = 14,
 }
 
 local orderDelegations = {
@@ -95,6 +96,14 @@ local orderDelegations = {
     toggle_intel =          {"toggle_radar", "toggle_sonar", "toggle_omni"},
     toggle_scrying =        {"toggle_scrying"},
     scry_target =           {"scry_target"},
+}
+
+local immutableOrderKeys = {
+    attack_move =
+        {
+            ["key"] = 'RMB',
+            ["colour"] = colours[2],
+        }
 }
 
 function init()
@@ -172,7 +181,9 @@ function getKeyTables()
             }
         end
     end
-
+    
+    orderKeys = table.merged(orderKeys, immutableOrderKeys)
+    
     -- Rename signs
     for id0, metagroup in {idRelations, orderKeys} do
         for id1, group in metagroup do

--- a/modules/hotkeylabelsUI.lua
+++ b/modules/hotkeylabelsUI.lua
@@ -6,7 +6,11 @@ function addLabel(control, parent, key)
     control.hotbuildKeyBg = Bitmap(parent)
     control.hotbuildKeyBg.Depth:Set(99)
     control.hotbuildKeyBg.Height:Set(20)
-    control.hotbuildKeyBg.Width:Set(20)
+    if string.len(key.key) <= 2 then
+        control.hotbuildKeyBg.Width:Set(20)
+    else
+        control.hotbuildKeyBg.Width:Set(30)
+    end
     LayoutHelpers.AtRightTopIn(control.hotbuildKeyBg, parent, 0, parent.Height() - 20)
     control.hotbuildKeyBg:SetTexture('/textures/ui/bg.png')
     control.hotbuildKeyBg:DisableHitTest()


### PR DESCRIPTION
Needed to change some extra things because current version didn't support labels with strings longer than 2.