### PR TITLE
Ignore non-live lua folders

### DIFF
--- a/run_lua_tests.sh
+++ b/run_lua_tests.sh
@@ -31,7 +31,7 @@ check_file() {
   fi
 }
 
-for file in `find . -name '*.lua' -o -name '*.bp'`; do
+for file in `find . \( -path engine -o -path testmaps \) -prune -o -name '*.lua' -o -name '*.bp'`; do
   check_file "$file"
 done
 


### PR DESCRIPTION
We don't (really) care about the lua files in `engine/` and `testmaps/` being syntax-checked