### PR TITLE
Fix invisible CPU of recently joined players bug

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3913,6 +3913,11 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
             AddChatText("<<"..LOCF("<LOC lobui_0442>From %s", data.SenderName)..">> "..data.Text)
         elseif data.Type == 'CPUBenchmark' then
             -- CPU benchmark code
+            local newInfo = false
+            if data.PlayerName and CPU_Benchmarks[data.PlayerName] ~= data.Result then
+                newInfo = true
+            end
+            
             local benchmarks = {}
             if data.PlayerName then
                 benchmarks[data.PlayerName] = data.Result
@@ -3929,6 +3934,11 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
                 else
                     refreshObserverList()
                 end
+            end
+            
+            -- Host broadcasts new CPU benchmark information to give the info to clients that are not directly connected to data.PlayerName yet.
+            if lobbyComm:IsHost() and newInfo then
+                lobbyComm:BroadcastData({Type='CPUBenchmark', Benchmarks=CPU_Benchmarks})
             end
         elseif data.Type == 'SetPlayerNotReady' then
             EnableSlot(data.Slot)


### PR DESCRIPTION
Players currently broadcast their CPUbenchmark upon join, but i'm guessing this happens before anyone except the host is connected to that player, so only the host gets this information.
So i tried to use the host to indirectly communicate this CPUbenchmark to the other players aswell.
(I thought why not just send everything so everybody has the same data even if something got lost)

fixes #1798 