### PR TITLE
Dont delete restricted units when captured in coop

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1962,7 +1962,7 @@ Unit = Class(moho.unit_methods) {
         local id = self:GetUnitId()
         local bp = self:GetBlueprint()
         local index = self:GetArmy()
-        if Game.IsRestricted(id, index) then
+        if not ScenarioInfo.CampaignMode and Game.IsRestricted(id, index) then
             WARN('Unit.OnStopBeingBuilt() Army ' ..index.. ' cannot create restricted unit: ' .. (bp.Description or id))
             if self ~= nil then self:Destroy() end 
             return false -- report failure of OnStopBeingBuilt


### PR DESCRIPTION
`ScenarioInfo.CampaignMode` is set at campaign game start https://github.com/FAForever/fa/blob/develop/lua/sim/ScenarioUtilities.lua#L553 so no way to cheat it in without using a sim mod