### PR TITLE
buff XP Vet Regen

### DIFF
--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -78,11 +78,11 @@ UnitBlueprint {
     },
     Buffs = {
         Regen = {
-            Level1 = 15,
-            Level2 = 30,
-            Level3 = 45,
-            Level4 = 60,
-            Level5 = 75,
+            Level1 = 10,
+            Level2 = 45,
+            Level3 = 80,
+            Level4 = 115,
+            Level5 = 145,
         },
     },
     BuildIconSortPriority = 110,

--- a/units/UAL0401/UAL0401_unit.bp
+++ b/units/UAL0401/UAL0401_unit.bp
@@ -46,11 +46,11 @@ UnitBlueprint {
     },
     Buffs = {
         Regen = {
-            Level1 = 15,
-            Level2 = 30,
-            Level3 = 45,
-            Level4 = 60,
-            Level5 = 75,
+            Level1 = 10,
+            Level2 = 60,
+            Level3 = 115,
+            Level4 = 165,
+            Level5 = 215,
         },
     },
     BuildIconSortPriority = 100,

--- a/units/UAS0401/UAS0401_unit.bp
+++ b/units/UAS0401/UAS0401_unit.bp
@@ -71,11 +71,11 @@ UnitBlueprint {
     },
     Buffs = {
         Regen = {
-            Level1 = 15,
-            Level2 = 30,
-            Level3 = 45,
-            Level4 = 60,
-            Level5 = 75,
+            Level1 = 10,
+            Level2 = 45,
+            Level3 = 80,
+            Level4 = 115,
+            Level5 = 150,
         },
     },
     BuildIconSortPriority = 120,

--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -96,11 +96,11 @@ UnitBlueprint {
     },
     Buffs = {
         Regen = {
-            Level1 = 10,
-            Level2 = 25,
-            Level3 = 40,
-            Level4 = 55,
-            Level5 = 70,
+            Level1 = 15,
+            Level2 = 35,
+            Level3 = 55,
+            Level4 = 75,
+            Level5 = 95,
         },
     },
     BuildIconSortPriority = 10,

--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -96,11 +96,11 @@ UnitBlueprint {
     },
     Buffs = {
         Regen = {
-            Level1 = 20,
-            Level2 = 40,
-            Level3 = 60,
-            Level4 = 80,
-            Level5 = 100,
+            Level1 = 10,
+            Level2 = 25,
+            Level3 = 40,
+            Level4 = 55,
+            Level5 = 70,
         },
     },
     BuildIconSortPriority = 10,

--- a/units/UES0401/UES0401_unit.bp
+++ b/units/UES0401/UES0401_unit.bp
@@ -70,11 +70,11 @@ UnitBlueprint {
     },
     Buffs = {
         Regen = {
-            Level1 = 15,
-            Level2 = 30,
-            Level3 = 45,
-            Level4 = 60,
-            Level5 = 75,
+            Level1 = 10,
+            Level2 = 35,
+            Level3 = 65,
+            Level4 = 90,
+            Level5 = 115,
         },
     },
     BuildIconSortPriority = 20,

--- a/units/URA0401/URA0401_unit.bp
+++ b/units/URA0401/URA0401_unit.bp
@@ -83,11 +83,11 @@ UnitBlueprint {
     AverageDensity = 1,
     Buffs = {
         Regen = {
-            Level1 = 15,
-            Level2 = 30,
-            Level3 = 45,
-            Level4 = 60,
-            Level5 = 75,
+            Level1 = 10,
+            Level2 = 55,
+            Level3 = 105,
+            Level4 = 155,
+            Level5 = 200,
         },
     },
     BuildIconSortPriority = 100,

--- a/units/URL0401/URL0401_unit.bp
+++ b/units/URL0401/URL0401_unit.bp
@@ -46,11 +46,11 @@ UnitBlueprint {
     },
     Buffs = {
         Regen = {
-            Level1 = 15,
-            Level2 = 30,
+            Level1 = 10,
+            Level2 = 25,
             Level3 = 45,
             Level4 = 60,
-            Level5 = 75,
+            Level5 = 80,
         },
     },
     BuildIconSortPriority = 10,

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -54,11 +54,11 @@ UnitBlueprint {
     },
     Buffs = {
         Regen = {
-            Level1 = 15,
-            Level2 = 30,
-            Level3 = 45,
-            Level4 = 60,
-            Level5 = 75,
+            Level1 = 10,
+            Level2 = 40,
+            Level3 = 70,
+            Level4 = 95,
+            Level5 = 125,
         },
     },
     BuildIconSortPriority = 20,

--- a/units/XRL0403/XRL0403_unit.bp
+++ b/units/XRL0403/XRL0403_unit.bp
@@ -62,11 +62,11 @@ UnitBlueprint {
     },
     Buffs = {
         Regen = {
-            Level1 = 15,
-            Level2 = 30,
-            Level3 = 45,
-            Level4 = 60,
-            Level5 = 75,
+            Level1 = 10,
+            Level2 = 65,
+            Level3 = 120,
+            Level4 = 180,
+            Level5 = 235,
         },
     },
     BuildIconSortPriority = 30,

--- a/units/XSA0402/XSA0402_unit.bp
+++ b/units/XSA0402/XSA0402_unit.bp
@@ -92,11 +92,11 @@ UnitBlueprint {
     },
     Buffs = {
         Regen = {
-            Level1 = 20,
-            Level2 = 40,
-            Level3 = 60,
-            Level4 = 80,
-            Level5 = 100,
+            Level1 = 15,
+            Level2 = 50,
+            Level3 = 90,
+            Level4 = 125,
+            Level5 = 160,
         },
     },
     BuildIconSortPriority = 10,

--- a/units/XSL0401/XSL0401_unit.bp
+++ b/units/XSL0401/XSL0401_unit.bp
@@ -42,11 +42,11 @@ UnitBlueprint {
     },
     Buffs = {
         Regen = {
-            Level1 = 20,
-            Level2 = 40,
-            Level3 = 60,
-            Level4 = 80,
-            Level5 = 100,
+            Level1 = 15,
+            Level2 = 60,
+            Level3 = 100,
+            Level4 = 145,
+            Level5 = 185,
         },
     },
     BuildIconSortPriority = 30,


### PR DESCRIPTION
Buff Regen from vet to replace the instant healing from higher vet levels which was reduced greatly.

Regen/s = original regen/s from vet + regen/s required to replace the instant healing which was removed in 4 minutes.