### PR TITLE
nerf uef t1 bomber

### DIFF
--- a/units/UEA0103/UEA0103_unit.bp
+++ b/units/UEA0103/UEA0103_unit.bp
@@ -274,7 +274,7 @@ UnitBlueprint {
             DamageType = 'Normal',
             DisplayName = 'Napalm Carpet Bomb',
             DoTPulses = 10,
-            DoTTime = 1.5,
+            DoTTime = 4.2,
             FireTargetLayerCapsTable = {
                 Air = 'Land|Water|Seabed',
                 Land = 'Land|Water|Seabed',


### PR DESCRIPTION
Increase the DoTTime to prevent uef bomber one-shotting moving t1 land units.