### PR TITLE
fix/ ships with death animation sinking on land

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1404,7 +1404,7 @@ Unit = Class(moho.unit_methods) {
             if animBlock.Mesh then
                 self:SetMesh(animBlock.Mesh)
             end
-            if animBlock.Animation then
+            if animBlock.Animation and self:ShallSink() then
                 local sinkAnim = CreateAnimator(self)
                 self:StopRocking()
                 self.DeathAnimManip = sinkAnim


### PR DESCRIPTION
sometimes ships glitch on land and then get destroyed. When they have a death animation specified they start sinking through the ground.

This PR doesnt fix the glitch that they get on land, but it fixes the sinking.