### PR TITLE
Improve Spread Attack

### DIFF
--- a/lua/spreadattack.lua
+++ b/lua/spreadattack.lua
@@ -58,7 +58,7 @@ function MakeShadowCopyOrders(command)
   
   local Order = {
     CommandType = TranslatedOrder[command.CommandType],
-    position = command.target.Position,
+    Position = command.target.Position,
     EntityId = nil,
   }
   if command.target.Type == "Entity" then
@@ -104,7 +104,7 @@ local function FixOrders(unit)
   for _,command in ipairs(queue) do
     local Order = {
       CommandType = TranslatedOrder[command.type],
-      position = command.position,
+      Position = command.position,
     }
     if Order.CommandType then
       table.insert(filteredQueue, Order)
@@ -191,7 +191,7 @@ local function FixOrders(unit)
         -- Fix the positions of any moved orders.
         for i = 0, nextOrderIndex - orderIndex - 1, 1 do
           if not unitOrders[i + orderIndex].EntityId then
-            unitOrders[i + orderIndex].position = filteredQueue[i + queueIndex].position
+            unitOrders[i + orderIndex].Position = filteredQueue[i + queueIndex].Position
           end
         end
       else
@@ -207,7 +207,7 @@ local function FixOrders(unit)
         for i = orderIndex, nextOrderIndex - 1, 1 do
           local match = false
           local priority = 2
-          local position = unitOrders[i].position
+          local position = unitOrders[i].Position
           if unitOrders[i].EntityId then
             priority = 3
             local target = GetUnitById(unitOrders[i].EntityId)
@@ -217,7 +217,7 @@ local function FixOrders(unit)
             end
           end      
           for j = lastMatchQueueIndex + 1, nextQueueIndex - 1, 1 do
-            if VDist3Sq(position, filteredQueue[j].position) <= 0.0001 then
+            if VDist3Sq(position, filteredQueue[j].Position) <= 0.0001 then
               -- If the shadow orders and command queue have the same number of entries since the last match,
               -- mark any mismatches in between as matches since no orders were removed.
               if i - j == lastMatchAlignment and j > lastMatchQueueIndex + 1 then
@@ -264,7 +264,7 @@ local function FixOrders(unit)
             if not Matches[i + 1].Match then
               Matches[i + 1].Match = positionIndex
             end
-            unitOrders[i + orderIndex].position = filteredQueue[Matches[i + 1].Match].position
+            unitOrders[i + orderIndex].Position = filteredQueue[Matches[i + 1].Match].Position
           end
           positionIndex = (Matches[i + 1].Match or positionIndex) + 1
         end
@@ -274,7 +274,7 @@ local function FixOrders(unit)
       -- No orders were deleted so just fix any moved orders with position targets.
       for i = 0, nextOrderIndex - orderIndex - 1, 1 do
         if not unitOrders[i + orderIndex].EntityId then
-          unitOrders[i + orderIndex].position = filteredQueue[i + queueIndex].position
+          unitOrders[i + orderIndex].Position = filteredQueue[i + queueIndex].Position
         end
       end
     end
@@ -436,7 +436,7 @@ function GiveOrders(Data)
                 continue
             end
 			
-            local target = order.position
+            local target = order.Position
             if order.EntityId then
                 target = GetEntityById(order.EntityId)
             end

--- a/lua/spreadattack.lua
+++ b/lua/spreadattack.lua
@@ -58,11 +58,11 @@ function MakeShadowCopyOrders(command)
   
   local Order = {
     CommandType = TranslatedOrder[command.CommandType],
-    Position = command.target.Position,
+    Position = command.Target.Position,
     EntityId = nil,
   }
-  if command.target.Type == "Entity" then
-    Order.EntityId = command.target.EntityId
+  if command.Target.Type == "Entity" then
+    Order.EntityId = command.Target.EntityId
   end
   
   -- Add this order to each individual unit.
@@ -114,7 +114,6 @@ local function FixOrders(unit)
   local numOrders = table.getn(unitOrders)
   
   -- We can't trust the shadow orders if commands were added without getting a copy.
-  -- Orders could still be 
   if numOrders < table.getn(filteredQueue) then
     WARN("Spreadattack: Command queue is longer than the shadow order list.")
     return

--- a/lua/spreadattack.lua
+++ b/lua/spreadattack.lua
@@ -21,27 +21,27 @@ ShadowOrders = {}
 -- Some orders need to be changed for them to work when garbling orders.
 -- Note that the Stop command is handled implicitly by the clear bit being set.
 TranslatedOrder = {
- ["Move"]               = "Move",
- ["Attack"]             = "Attack",
  ["AggressiveMove"]     = "AggressiveMove",
- ["FormMove"]           = "Move",                -- Form actions currently not supported
- ["FormAttack"]         = "Attack",              -- Form actions currently not supported
+ ["Attack"]             = "Attack",
+ ["Capture"]            = "Capture",
+ ["Guard"]              = "Guard",
+ ["Move"]               = "Move",
+ ["Nuke"]               = "Nuke",
+ ["OverCharge"]         = "OverCharge",
+ ["Patrol"]             = "Patrol",
+ ["Reclaim"]            = "Reclaim",
+ ["Repair"]             = "Repair",
+ ["Tactical"]           = "Tactical",
  ["FormAggressiveMove"] = "AggressiveMove",      -- Form actions currently not supported
+ ["FormAttack"]         = "Attack",              -- Form actions currently not supported
+ ["FormMove"]           = "Move",                -- Form actions currently not supported
+ ["FormPatrol"]         = "Patrol",              -- Form actions currently not supported
 }
 
 -- This function makes a shadow copy of the orders given to the units.
 -- Due to it's use, only a subset of the orders will be kept.
 function MakeShadowCopyOrders(command)
-
-  -- The following subset of order is kept:
-  -- - Move
-  -- - Stop               : Special, it will not be shadow copied, but it's clear orders command will be executed
-  -- - Attack
-  -- - AggressiveMove
-  -- - FormMove           : These orders are copied, but will be renamed to normal Move orders
-  -- - FormAttack         : These orders are copied, but will be renamed to normal Attack orders
-  -- - FormAggressiveMove : These orders are copied, but will be renamed to normal AggressiveMove orders
-
+  
   -- If the order has the Clear bit set, then all previously issued orders will be removed first,
   -- even if the specific order will not be handled below.
   -- This conveniently also handles the Stop order (= clear all orders).
@@ -52,26 +52,24 @@ function MakeShadowCopyOrders(command)
   end
 
   -- Skip handling the order if it does not belong to the given subset.
-  if not(TranslatedOrder[command.CommandType]) then
+  if not TranslatedOrder[command.CommandType] then
     return
   end
-
+  
   local Order = {
-    CommandType = "",
-    Position    = {},
-    Target      = nil,
+    CommandType = TranslatedOrder[command.CommandType],
+    position = command.target.Position,
+    EntityId = nil,
   }
-
-  -- Fill in the Order table for the current order given
-  Order.CommandType = TranslatedOrder[command.CommandType]
-  Order.Position    = command.Target.Position
-  Order.Target      = command.Target.EntityId
-
+  if command.target.Type == "Entity" then
+    Order.EntityId = command.target.EntityId
+  end
+  
   -- Add this order to each individual unit.
   for _,unit in ipairs(command.Units) do
 
     -- Initialise the orders table, if needed.
-    if not(ShadowOrders[unit:GetEntityId()]) then
+    if not ShadowOrders[unit:GetEntityId()]  then
       ShadowOrders[unit:GetEntityId()] = {}
     end
     table.insert(ShadowOrders[unit:GetEntityId()],Order)
@@ -80,95 +78,312 @@ function MakeShadowCopyOrders(command)
 end -- function MakeShadowCopyorders(command)
 
 
+---------------------------
+-- Function FixOrders(unit)
+---------------------------
+
+-- This function tries to fix a unit's moved or deleted shadow orders
+-- based on its current command queue.
+-- It can only get ability names and positions of current orders,
+-- so it can't retarget orders with a changed entity target.
+local function FixOrders(unit)
+
+  -- The factory exclusion is because GetCommandQueue doesn't work right for them.
+  -- This means we can't fix orders for Fatboy, Megalith, Tempest, or carriers.
+  if not unit or unit:IsInCategory("FACTORY") then
+    return
+  end
+  
+  local unitOrders = ShadowOrders[unit:GetEntityId()]
+  if not unitOrders  or not unitOrders[1] then 
+    return
+  end
+  
+  local queue = unit:GetCommandQueue()
+  local filteredQueue = {}
+  for _,command in ipairs(queue) do
+    local Order = {
+      CommandType = TranslatedOrder[command.type],
+      position = command.position,
+    }
+    if Order.CommandType then
+      table.insert(filteredQueue, Order)
+    end
+  end
+  
+  local numOrders = table.getn(unitOrders)
+  
+  -- We can't trust the shadow orders if commands were added without getting a copy.
+  -- Orders could still be 
+  if numOrders < table.getn(filteredQueue) then
+    WARN("Spreadattack: Command queue is longer than the shadow order list.")
+    return
+  end
+  
+  -- First check for entire blocks of orders that have been deleted.
+  local orderIndex = 1
+  local queueIndex = 1
+  local orderType = false
+  local lastBlockType = false
+  while orderIndex <= numOrders do
+    orderType = unitOrders[orderIndex].CommandType
+    local nextOrderIndex = orderIndex + 1
+    while unitOrders[nextOrderIndex].CommandType == orderType do
+      nextOrderIndex = nextOrderIndex + 1
+    end
+    
+    if orderType == lastBlockType then
+      orderIndex = nextOrderIndex
+      continue
+    end
+    
+    local nextQueueIndex = queueIndex
+    while filteredQueue[nextQueueIndex].CommandType == orderType do
+      nextQueueIndex = nextQueueIndex + 1
+    end
+    
+     if nextQueueIndex == queueIndex then
+      -- Block not found.
+      for i = nextOrderIndex - 1, orderIndex, -1 do
+        table.remove(unitOrders, i)
+        numOrders = numOrders - 1
+      end
+      nextOrderIndex = orderIndex
+    else
+      lastBlockType = orderType
+    end
+    
+    orderIndex = nextOrderIndex
+    queueIndex = nextQueueIndex
+  end
+  
+  -- Now fix the orders within each block of the same type.
+  orderIndex = 1
+  queueIndex = 1
+  while orderIndex <= numOrders do
+    orderType = unitOrders[orderIndex].CommandType
+    local nextOrderIndex = orderIndex + 1
+    local numEntityTargets = 0
+    while unitOrders[nextOrderIndex].CommandType == orderType do
+      if unitOrders[nextOrderIndex].EntityId then
+        numEntityTargets = numEntityTargets + 1
+      end
+      nextOrderIndex = nextOrderIndex + 1
+    end
+    
+    local nextQueueIndex = queueIndex
+    while filteredQueue[nextQueueIndex].CommandType == orderType do
+      nextQueueIndex = nextQueueIndex + 1
+    end
+    
+    -- Check if orders were removed from the queue and try to identify them.
+    local numDeletedOrders = nextOrderIndex - orderIndex - (nextQueueIndex - queueIndex)
+    if numDeletedOrders ~= 0 then
+    
+      if numEntityTargets == 0 then
+        -- With only position targets it doesn't matter which orders we delete.
+        while numDeletedOrders > 0 do
+          table.remove(unitOrders, nextOrderIndex - 1)
+          numOrders = numOrders - 1
+          nextOrderIndex = nextOrderIndex - 1
+          numDeletedOrders = numDeletedOrders - 1
+        end
+        -- Fix the positions of any moved orders.
+        for i = 0, nextOrderIndex - orderIndex - 1, 1 do
+          if not unitOrders[i + orderIndex].EntityId then
+            unitOrders[i + orderIndex].position = filteredQueue[i + queueIndex].position
+          end
+        end
+      else
+        -- This part is only for the most complex situations and shouldn't be needed often in practice.
+        -- Here we go through the block of orders and try to determine which to remove. Priority for removal:
+        -- 1. Entity targets with a valid current position that don't match any command position (could have changed target)
+        -- 2. position targets that don't match any command position (could have moved)
+        -- 3. Entity targets with unknown current position that don't match any command position (could have moved or changed)
+        local Matches = {}
+        local lastMatchIndex = 0
+        local lastMatchQueueIndex = queueIndex - 1
+        local lastMatchAlignment = orderIndex - queueIndex
+        for i = orderIndex, nextOrderIndex - 1, 1 do
+          local match = false
+          local priority = 2
+          local position = unitOrders[i].position
+          if unitOrders[i].EntityId then
+            priority = 3
+            local target = GetUnitById(unitOrders[i].EntityId)
+            if target then
+              position = target:GetPosition()
+              priority = 1
+            end
+          end      
+          for j = lastMatchQueueIndex + 1, nextQueueIndex - 1, 1 do
+            if VDist3Sq(position, filteredQueue[j].position) <= 0.0001 then
+              -- If the shadow orders and command queue have the same number of entries since the last match,
+              -- mark any mismatches in between as matches since no orders were removed.
+              if i - j == lastMatchAlignment and j > lastMatchQueueIndex + 1 then
+                for k = 1, j - lastMatchQueueIndex - 1, 1 do
+                  Matches[k + lastMatchIndex].Priority = false
+                  Matches[k + lastMatchIndex].Match = k + lastMatchQueueIndex
+                end
+              else
+                lastMatchAlignment = i - j
+              end
+              match = j
+              priority = false
+              lastMatchQueueIndex = j
+              lastMatchIndex = table.getn(Matches) + 1
+              break
+            end
+          end
+          table.insert(Matches, {Match = match, Priority = priority})
+        end
+        
+        -- Delete unmatched commands by priority.
+        for priority = 1, 3, 1 do
+          if numDeletedOrders <= 0 then
+            break
+          end
+          for i = table.getn(Matches), 1, -1 do
+            if Matches[i].Priority == priority then
+              table.remove(Matches, i)
+              table.remove(unitOrders, i + orderIndex - 1)
+              numOrders = numOrders - 1
+              nextOrderIndex = nextOrderIndex - 1
+              numDeletedOrders = numDeletedOrders - 1
+              if numDeletedOrders <= 0 then
+                break
+              end
+            end
+          end
+        end
+        
+        -- Fix the positions of any moved orders.
+        local positionIndex = Matches[1].Match or queueIndex
+        for i = 0, nextOrderIndex - orderIndex - 1, 1 do
+          if not unitOrders[i + orderIndex].EntityId then
+            if not Matches[i + 1].Match then
+              Matches[i + 1].Match = positionIndex
+            end
+            unitOrders[i + orderIndex].position = filteredQueue[Matches[i + 1].Match].position
+          end
+          positionIndex = (Matches[i + 1].Match or positionIndex) + 1
+        end
+      end
+
+    else
+      -- No orders were deleted so just fix any moved orders with position targets.
+      for i = 0, nextOrderIndex - orderIndex - 1, 1 do
+        if not unitOrders[i + orderIndex].EntityId then
+          unitOrders[i + orderIndex].position = filteredQueue[i + queueIndex].position
+        end
+      end
+    end
+      
+    orderIndex = nextOrderIndex
+    queueIndex = nextQueueIndex
+  end
+end
+
+
 --------------------------
 -- Function SpreadAttack()
 --------------------------
 
--- This function rearranges all attack orders randomly for every unit.
+-- This function rearranges all targeted orders randomly for every unit.
 function SpreadAttack()
 
   -- Get the currently selected units.
   local curSelection = GetSelectedUnits()
 
-  if not (curSelection) then
+  if not curSelection then
     return
   end
 
   -- Switch the orders for each unit.
   for index,unit in ipairs(curSelection) do
-    local unitorders = ShadowOrders[unit:GetEntityId()]
+    FixOrders(unit)
+    local unitOrders = ShadowOrders[unit:GetEntityId()]
 
     -- Only mix orders if this unit has any orders to mix.
-    if not(unitorders) and not(unitorders[1]) then
+    if not unitOrders or not unitOrders[1] then 
       continue
     end
+  
+    -- Find all consecutive mixable orders, and only mix those.
+    local beginAction,endAction,action,counter,actionAlwaysMixed = nil,nil,nil,1,false
+    local alwaysMix = {"Attack", "Nuke", "Tactical"}
 
-    -- Find all consecutive Attack orders, and only mix those.
-    local beginAttack,endAttack,counter = nil,nil,1
-
-    while unitorders[counter] ~= nil  do
-
-      beginAttack = nil
-      -- Search for the first entry of an Attack order.
-      while beginAttack == nil and unitorders[counter] ~= nil do
-        if unitorders[counter].CommandType == "Attack" then
-          beginAttack = counter
+    while unitOrders[counter] ~= nil  do
+      beginAction = nil
+      -- Search for the first entry of a mixable order.
+      while beginAction == nil and unitOrders[counter] ~= nil do
+        for _,v in ipairs(alwaysMix) do
+          if unitOrders[counter].CommandType == v then
+            beginAction = counter
+            action = unitOrders[counter].CommandType
+            actionAlwaysMixed = true
+            break
+          elseif unitOrders[counter].EntityId then
+            beginAction = counter
+            action = unitOrders[counter].CommandType
+            actionAlwaysMixed = false
+          end
         end
         counter = counter + 1
       end
 
-      endAttack = beginAttack
-      -- Search for the last entry of an Attack order in this series.
-      while unitorders[counter] ~= nil do
-        if unitorders[counter].CommandType == "Attack" then
-          endAttack = counter
+      endAction = beginAction
+      -- Search for the last entry of a mixable order in this series.
+      while unitOrders[counter] ~= nil do
+        if unitOrders[counter].CommandType == action and (actionAlwaysMixed or unitOrders[counter].EntityId) then
+          endAction = counter
           counter = counter + 1
         else
           break
         end
       end
-
-      -- Skip if there was no Attack found, or only one attack (can't swap one command).
-      if beginAttack == nil or endAttack == beginAttack then
+      
+      -- Skip if there was no mixable order found, or only one order (can't swap one command).
+      if beginAction == nil or endAction == beginAction then
         break
       end
-
-      -- Rearrange the first few attack orders (equal to the number of targets) so that the targets are uniformly attacked on the first pass.
+      
+      -- Rearrange the first few mixable orders (equal to the number of targets) so that the targets are uniformly distributed on the first pass.
       -- For example, 3 units attacking 8 units (? denotes random target):
       -- Unit 1: 1, 4, 7, ?, ?, ?, ?, ?
       -- Unit 2: 2, 5, 8, ?, ?, ?, ?, ?
       -- Unit 3: 3, 6, ?, ?, ?, ?, ?, ?
       local unitCount = table.getn(curSelection)
-      local orderCount = endAttack - beginAttack + 1
+      local numOrders = endAction - beginAction + 1
       -- "and 1 or 0" is lua's ugly alternative to the ternary operator. Same as (...) ? 1 : 0
-      local stableAttackNum = math.floor(orderCount / unitCount) + ((math.mod(orderCount, unitCount) >= index) and 1 or 0)
-      for i = 0, stableAttackNum - 1 do
-        -- For if the targets outnumber the units attacking them.
+      local stableTargetNum = math.floor(numOrders / unitCount) + ((math.mod(numOrders, unitCount) >= index) and 1 or 0)
+      for i = 0, stableTargetNum - 1 do
+        -- For if the targets outnumber the units targeting them.
         local targetBlock = i * unitCount
-        unitorders[i + beginAttack],unitorders[targetBlock + beginAttack + index - 1]
-            = unitorders[targetBlock + beginAttack + index - 1],unitorders[i + beginAttack]
+        unitOrders[i + beginAction],unitOrders[targetBlock + beginAction + index - 1]
+            = unitOrders[targetBlock + beginAction + index - 1],unitOrders[i + beginAction]
       end
-      beginAttack = beginAttack + stableAttackNum
+      beginAction = beginAction + stableTargetNum
 
-      -- Randomize the remaining attack orders.
-      for i = beginAttack,endAttack do
-        local randomorder = math.random(beginAttack,endAttack)
+      -- Randomize the remaining mixable orders.
+      for i = beginAction,endAction do
+        local randomorder = math.random(beginAction,endAction)
         if randomorder ~= i then
-          unitorders[i],unitorders[randomorder] = unitorders[randomorder],unitorders[i]
+          unitOrders[i],unitOrders[randomorder] = unitOrders[randomorder],unitOrders[i]
         end
       end
 
 
-      -- Repeat this loop and search for more Attack series.
+      -- Repeat this loop and search for more mixable order series.
     end
-
-    -- All Attack orders have been mixed, now it's time to reassign those orders.
+  
+    -- All targeted orders have been mixed, now it's time to reassign those orders.
     -- Since giving orders is a Sim-side command, use a SimCallback function.
-    SimCallback({ Func = "GiveOrders",
-                   Args = { unit_orders = unitorders,
+    SimCallback( { Func = "GiveOrders",
+                   Args = { unit_orders = unitOrders,
                             unit_id     = unit:GetEntityId(),
-                            From = GetFocusArmy()},
-                 }, false)
+                            From = GetFocusArmy()}, 
+                 }, false )
 
     -- Handle the next unit.
   end
@@ -181,13 +396,33 @@ end -- Function SpreadAttack()
 -- Function GiveOrders(Data)
 ----------------------------
 
+local IssueOrderFunctions = nil
+
 -- This function re-issues all shadow orders to the selected units.
 -- Since the orders herein are Sim-side commands, this function needs to be called through a SimCallback.
 function GiveOrders(Data)
+    -- Doing this here ensures it's done in sim code instead of UI code.
+    if not IssueOrderFunctions then    
+        IssueOrderFunctions = {
+         ["AggressiveMove"]     = IssueAggressiveMove,
+         ["Attack"]             = IssueAttack,
+         ["Capture"]            = IssueCapture,
+         ["Guard"]              = IssueGuard,
+         ["Move"]               = IssueMove,
+         ["Nuke"]               = IssueNuke,
+         ["OverCharge"]         = IssueOverCharge,
+         ["Patrol"]             = IssuePatrol,
+         ["Repair"]             = IssueRepair,
+         ["Reclaim"]            = IssueReclaim,
+         ["Repair"]             = IssueRepair,
+         ["Tactical"]           = IssueTactical,
+        }
+    end
+    
     if OkayToMessWithArmy(Data.From) then --Check for cheats/exploits
         local unit = GetEntityById(Data.unit_id)
         -- Skip units with no valid shadow orders.
-        if not(Data.unit_orders) or not(Data.unit_orders[1]) then
+        if not Data.unit_orders or not Data.unit_orders[1] then
             return
         end
 
@@ -196,21 +431,18 @@ function GiveOrders(Data)
 
         -- Re-issue all orders.
         for _,order in ipairs(Data.unit_orders) do
-
-            -- Currently supported 3 orders are: Attack, Move and AggressiveMove
-            if order.CommandType == "Attack" then
-                local victim = GetEntityById(order.Target)
-                IssueAttack({ unit },victim)
+            local Function = IssueOrderFunctions[order.CommandType]
+            if not Function then
+                continue
             end
-
-            if order.CommandType == "Move" then
-                IssueMove({ unit },order.Position)
+			
+            local target = order.position
+            if order.EntityId then
+                target = GetEntityById(order.EntityId)
             end
-
-            if order.CommandType == "AggressiveMove" then
-                IssueAggressiveMove({ unit },order.Position)
-            end
+            
+            Function({unit}, target)
         end
     end
 
-end -- function GiveOrders(Data,Units)
+end -- function GiveOrders(Data)

--- a/lua/spreadattack.lua
+++ b/lua/spreadattack.lua
@@ -21,59 +21,59 @@ ShadowOrders = {}
 -- Some orders need to be changed for them to work when garbling orders.
 -- Note that the Stop command is handled implicitly by the clear bit being set.
 TranslatedOrder = {
- ["AggressiveMove"]     = "AggressiveMove",
- ["Attack"]             = "Attack",
- ["Capture"]            = "Capture",
- ["Guard"]              = "Guard",
- ["Move"]               = "Move",
- ["Nuke"]               = "Nuke",
- ["OverCharge"]         = "OverCharge",
- ["Patrol"]             = "Patrol",
- ["Reclaim"]            = "Reclaim",
- ["Repair"]             = "Repair",
- ["Tactical"]           = "Tactical",
- ["FormAggressiveMove"] = "AggressiveMove",      -- Form actions currently not supported
- ["FormAttack"]         = "Attack",              -- Form actions currently not supported
- ["FormMove"]           = "Move",                -- Form actions currently not supported
- ["FormPatrol"]         = "Patrol",              -- Form actions currently not supported
+    ["AggressiveMove"]     = "AggressiveMove",
+    ["Attack"]             = "Attack",
+    ["Capture"]            = "Capture",
+    ["Guard"]              = "Guard",
+    ["Move"]               = "Move",
+    ["Nuke"]               = "Nuke",
+    ["OverCharge"]         = "OverCharge",
+    ["Patrol"]             = "Patrol",
+    ["Reclaim"]            = "Reclaim",
+    ["Repair"]             = "Repair",
+    ["Tactical"]           = "Tactical",
+    ["FormAggressiveMove"] = "AggressiveMove",      -- Form actions currently not supported
+    ["FormAttack"]         = "Attack",              -- Form actions currently not supported
+    ["FormMove"]           = "Move",                -- Form actions currently not supported
+    ["FormPatrol"]         = "Patrol",              -- Form actions currently not supported
 }
 
 -- This function makes a shadow copy of the orders given to the units.
 -- Due to it's use, only a subset of the orders will be kept.
 function MakeShadowCopyOrders(command)
-  
-  -- If the order has the Clear bit set, then all previously issued orders will be removed first,
-  -- even if the specific order will not be handled below.
-  -- This conveniently also handles the Stop order (= clear all orders).
-  if command.Clear == true then
+    
+    -- If the order has the Clear bit set, then all previously issued orders will be removed first,
+    -- even if the specific order will not be handled below.
+    -- This conveniently also handles the Stop order (= clear all orders).
+    if command.Clear == true then
+        for _,unit in ipairs(command.Units) do
+            ShadowOrders[unit:GetEntityId()] = {}
+        end
+    end
+
+    -- Skip handling the order if it does not belong to the given subset.
+    if not TranslatedOrder[command.CommandType] then
+        return
+    end
+    
+    local Order = {
+        CommandType = TranslatedOrder[command.CommandType],
+        Position = command.Target.Position,
+        EntityId = nil,
+    }
+    if command.Target.Type == "Entity" then
+        Order.EntityId = command.Target.EntityId
+    end
+    
+    -- Add this order to each individual unit.
     for _,unit in ipairs(command.Units) do
-      ShadowOrders[unit:GetEntityId()] = {}
-    end
-  end
 
-  -- Skip handling the order if it does not belong to the given subset.
-  if not TranslatedOrder[command.CommandType] then
-    return
-  end
-  
-  local Order = {
-    CommandType = TranslatedOrder[command.CommandType],
-    Position = command.Target.Position,
-    EntityId = nil,
-  }
-  if command.Target.Type == "Entity" then
-    Order.EntityId = command.Target.EntityId
-  end
-  
-  -- Add this order to each individual unit.
-  for _,unit in ipairs(command.Units) do
-
-    -- Initialise the orders table, if needed.
-    if not ShadowOrders[unit:GetEntityId()]  then
-      ShadowOrders[unit:GetEntityId()] = {}
+        -- Initialise the orders table, if needed.
+        if not ShadowOrders[unit:GetEntityId()]  then
+            ShadowOrders[unit:GetEntityId()] = {}
+        end
+        table.insert(ShadowOrders[unit:GetEntityId()],Order)
     end
-    table.insert(ShadowOrders[unit:GetEntityId()],Order)
-  end
 
 end -- function MakeShadowCopyorders(command)
 
@@ -88,199 +88,199 @@ end -- function MakeShadowCopyorders(command)
 -- so it can't retarget orders with a changed entity target.
 local function FixOrders(unit)
 
-  -- The factory exclusion is because GetCommandQueue doesn't work right for them.
-  -- This means we can't fix orders for Fatboy, Megalith, Tempest, or carriers.
-  if not unit or unit:IsInCategory("FACTORY") then
-    return
-  end
-  
-  local unitOrders = ShadowOrders[unit:GetEntityId()]
-  if not unitOrders  or not unitOrders[1] then 
-    return
-  end
-  
-  local queue = unit:GetCommandQueue()
-  local filteredQueue = {}
-  for _,command in ipairs(queue) do
-    local Order = {
-      CommandType = TranslatedOrder[command.type],
-      Position = command.position,
-    }
-    if Order.CommandType then
-      table.insert(filteredQueue, Order)
-    end
-  end
-  
-  local numOrders = table.getn(unitOrders)
-  
-  -- We can't trust the shadow orders if commands were added without getting a copy.
-  if numOrders < table.getn(filteredQueue) then
-    WARN("Spreadattack: Command queue is longer than the shadow order list.")
-    return
-  end
-  
-  -- First check for entire blocks of orders that have been deleted.
-  local orderIndex = 1
-  local queueIndex = 1
-  local orderType = false
-  local lastBlockType = false
-  while orderIndex <= numOrders do
-    orderType = unitOrders[orderIndex].CommandType
-    local nextOrderIndex = orderIndex + 1
-    while unitOrders[nextOrderIndex].CommandType == orderType do
-      nextOrderIndex = nextOrderIndex + 1
+    -- The factory exclusion is because GetCommandQueue doesn't work right for them.
+    -- This means we can't fix orders for Fatboy, Megalith, Tempest, or carriers.
+    if not unit or unit:IsInCategory("FACTORY") then
+        return
     end
     
-    if orderType == lastBlockType then
-      orderIndex = nextOrderIndex
-      continue
+    local unitOrders = ShadowOrders[unit:GetEntityId()]
+    if not unitOrders  or not unitOrders[1] then
+        return
     end
     
-    local nextQueueIndex = queueIndex
-    while filteredQueue[nextQueueIndex].CommandType == orderType do
-      nextQueueIndex = nextQueueIndex + 1
-    end
-    
-     if nextQueueIndex == queueIndex then
-      -- Block not found.
-      for i = nextOrderIndex - 1, orderIndex, -1 do
-        table.remove(unitOrders, i)
-        numOrders = numOrders - 1
-      end
-      nextOrderIndex = orderIndex
-    else
-      lastBlockType = orderType
-    end
-    
-    orderIndex = nextOrderIndex
-    queueIndex = nextQueueIndex
-  end
-  
-  -- Now fix the orders within each block of the same type.
-  orderIndex = 1
-  queueIndex = 1
-  while orderIndex <= numOrders do
-    orderType = unitOrders[orderIndex].CommandType
-    local nextOrderIndex = orderIndex + 1
-    local numEntityTargets = 0
-    while unitOrders[nextOrderIndex].CommandType == orderType do
-      if unitOrders[nextOrderIndex].EntityId then
-        numEntityTargets = numEntityTargets + 1
-      end
-      nextOrderIndex = nextOrderIndex + 1
-    end
-    
-    local nextQueueIndex = queueIndex
-    while filteredQueue[nextQueueIndex].CommandType == orderType do
-      nextQueueIndex = nextQueueIndex + 1
-    end
-    
-    -- Check if orders were removed from the queue and try to identify them.
-    local numDeletedOrders = nextOrderIndex - orderIndex - (nextQueueIndex - queueIndex)
-    if numDeletedOrders ~= 0 then
-    
-      if numEntityTargets == 0 then
-        -- With only position targets it doesn't matter which orders we delete.
-        while numDeletedOrders > 0 do
-          table.remove(unitOrders, nextOrderIndex - 1)
-          numOrders = numOrders - 1
-          nextOrderIndex = nextOrderIndex - 1
-          numDeletedOrders = numDeletedOrders - 1
+    local queue = unit:GetCommandQueue()
+    local filteredQueue = {}
+    for _,command in ipairs(queue) do
+        local Order = {
+            CommandType = TranslatedOrder[command.type],
+            Position = command.position,
+        }
+        if Order.CommandType then
+            table.insert(filteredQueue, Order)
         end
-        -- Fix the positions of any moved orders.
-        for i = 0, nextOrderIndex - orderIndex - 1, 1 do
-          if not unitOrders[i + orderIndex].EntityId then
-            unitOrders[i + orderIndex].Position = filteredQueue[i + queueIndex].Position
-          end
+    end
+    
+    local numOrders = table.getn(unitOrders)
+    
+    -- We can't trust the shadow orders if commands were added without getting a copy.
+    if numOrders < table.getn(filteredQueue) then
+        WARN("Spreadattack: Command queue is longer than the shadow order list.")
+        return
+    end
+    
+    -- First check for entire blocks of orders that have been deleted.
+    local orderIndex = 1
+    local queueIndex = 1
+    local orderType = false
+    local lastBlockType = false
+    while orderIndex <= numOrders do
+        orderType = unitOrders[orderIndex].CommandType
+        local nextOrderIndex = orderIndex + 1
+        while unitOrders[nextOrderIndex].CommandType == orderType do
+            nextOrderIndex = nextOrderIndex + 1
         end
-      else
-        -- This part is only for the most complex situations and shouldn't be needed often in practice.
-        -- Here we go through the block of orders and try to determine which to remove. Priority for removal:
-        -- 1. Entity targets with a valid current position that don't match any command position (could have changed target)
-        -- 2. position targets that don't match any command position (could have moved)
-        -- 3. Entity targets with unknown current position that don't match any command position (could have moved or changed)
-        local Matches = {}
-        local lastMatchIndex = 0
-        local lastMatchQueueIndex = queueIndex - 1
-        local lastMatchAlignment = orderIndex - queueIndex
-        for i = orderIndex, nextOrderIndex - 1, 1 do
-          local match = false
-          local priority = 2
-          local position = unitOrders[i].Position
-          if unitOrders[i].EntityId then
-            priority = 3
-            local target = GetUnitById(unitOrders[i].EntityId)
-            if target then
-              position = target:GetPosition()
-              priority = 1
+        
+        if orderType == lastBlockType then
+            orderIndex = nextOrderIndex
+            continue
+        end
+        
+        local nextQueueIndex = queueIndex
+        while filteredQueue[nextQueueIndex].CommandType == orderType do
+            nextQueueIndex = nextQueueIndex + 1
+        end
+        
+         if nextQueueIndex == queueIndex then
+            -- Block not found.
+            for i = nextOrderIndex - 1, orderIndex, -1 do
+                table.remove(unitOrders, i)
+                numOrders = numOrders - 1
             end
-          end      
-          for j = lastMatchQueueIndex + 1, nextQueueIndex - 1, 1 do
-            if VDist3Sq(position, filteredQueue[j].Position) <= 0.0001 then
-              -- If the shadow orders and command queue have the same number of entries since the last match,
-              -- mark any mismatches in between as matches since no orders were removed.
-              if i - j == lastMatchAlignment and j > lastMatchQueueIndex + 1 then
-                for k = 1, j - lastMatchQueueIndex - 1, 1 do
-                  Matches[k + lastMatchIndex].Priority = false
-                  Matches[k + lastMatchIndex].Match = k + lastMatchQueueIndex
+            nextOrderIndex = orderIndex
+        else
+            lastBlockType = orderType
+        end
+        
+        orderIndex = nextOrderIndex
+        queueIndex = nextQueueIndex
+    end
+    
+    -- Now fix the orders within each block of the same type.
+    orderIndex = 1
+    queueIndex = 1
+    while orderIndex <= numOrders do
+        orderType = unitOrders[orderIndex].CommandType
+        local nextOrderIndex = orderIndex + 1
+        local numEntityTargets = 0
+        while unitOrders[nextOrderIndex].CommandType == orderType do
+            if unitOrders[nextOrderIndex].EntityId then
+                numEntityTargets = numEntityTargets + 1
+            end
+            nextOrderIndex = nextOrderIndex + 1
+        end
+        
+        local nextQueueIndex = queueIndex
+        while filteredQueue[nextQueueIndex].CommandType == orderType do
+            nextQueueIndex = nextQueueIndex + 1
+        end
+        
+        -- Check if orders were removed from the queue and try to identify them.
+        local numDeletedOrders = nextOrderIndex - orderIndex - (nextQueueIndex - queueIndex)
+        if numDeletedOrders ~= 0 then
+        
+            if numEntityTargets == 0 then
+                -- With only position targets it doesn't matter which orders we delete.
+                while numDeletedOrders > 0 do
+                    table.remove(unitOrders, nextOrderIndex - 1)
+                    numOrders = numOrders - 1
+                    nextOrderIndex = nextOrderIndex - 1
+                    numDeletedOrders = numDeletedOrders - 1
                 end
-              else
-                lastMatchAlignment = i - j
-              end
-              match = j
-              priority = false
-              lastMatchQueueIndex = j
-              lastMatchIndex = table.getn(Matches) + 1
-              break
+                -- Fix the positions of any moved orders.
+                for i = 0, nextOrderIndex - orderIndex - 1, 1 do
+                    if not unitOrders[i + orderIndex].EntityId then
+                        unitOrders[i + orderIndex].Position = filteredQueue[i + queueIndex].Position
+                    end
+                end
+            else
+                -- This part is only for the most complex situations and shouldn't be needed often in practice.
+                -- Here we go through the block of orders and try to determine which to remove. Priority for removal:
+                -- 1. Entity targets with a valid current position that don't match any command position (could have changed target)
+                -- 2. position targets that don't match any command position (could have moved)
+                -- 3. Entity targets with unknown current position that don't match any command position (could have moved or changed)
+                local Matches = {}
+                local lastMatchIndex = 0
+                local lastMatchQueueIndex = queueIndex - 1
+                local lastMatchAlignment = orderIndex - queueIndex
+                for i = orderIndex, nextOrderIndex - 1, 1 do
+                    local match = false
+                    local priority = 2
+                    local position = unitOrders[i].Position
+                    if unitOrders[i].EntityId then
+                        priority = 3
+                        local target = GetUnitById(unitOrders[i].EntityId)
+                        if target then
+                            position = target:GetPosition()
+                            priority = 1
+                        end
+                    end
+                    for j = lastMatchQueueIndex + 1, nextQueueIndex - 1, 1 do
+                        if VDist3Sq(position, filteredQueue[j].Position) <= 0.0001 then
+                            -- If the shadow orders and command queue have the same number of entries since the last match,
+                            -- mark any mismatches in between as matches since no orders were removed.
+                            if i - j == lastMatchAlignment and j > lastMatchQueueIndex + 1 then
+                                for k = 1, j - lastMatchQueueIndex - 1, 1 do
+                                    Matches[k + lastMatchIndex].Priority = false
+                                    Matches[k + lastMatchIndex].Match = k + lastMatchQueueIndex
+                                end
+                            else
+                                lastMatchAlignment = i - j
+                            end
+                            match = j
+                            priority = false
+                            lastMatchQueueIndex = j
+                            lastMatchIndex = table.getn(Matches) + 1
+                            break
+                        end
+                    end
+                    table.insert(Matches, {Match = match, Priority = priority})
+                end
+                
+                -- Delete unmatched commands by priority.
+                for priority = 1, 3, 1 do
+                    if numDeletedOrders <= 0 then
+                        break
+                    end
+                    for i = table.getn(Matches), 1, -1 do
+                        if Matches[i].Priority == priority then
+                            table.remove(Matches, i)
+                            table.remove(unitOrders, i + orderIndex - 1)
+                            numOrders = numOrders - 1
+                            nextOrderIndex = nextOrderIndex - 1
+                            numDeletedOrders = numDeletedOrders - 1
+                            if numDeletedOrders <= 0 then
+                                break
+                            end
+                        end
+                    end
+                end
+                
+                -- Fix the positions of any moved orders.
+                local positionIndex = Matches[1].Match or queueIndex
+                for i = 0, nextOrderIndex - orderIndex - 1, 1 do
+                    if not unitOrders[i + orderIndex].EntityId then
+                        if not Matches[i + 1].Match then
+                            Matches[i + 1].Match = positionIndex
+                        end
+                        unitOrders[i + orderIndex].Position = filteredQueue[Matches[i + 1].Match].Position
+                    end
+                    positionIndex = (Matches[i + 1].Match or positionIndex) + 1
+                end
             end
-          end
-          table.insert(Matches, {Match = match, Priority = priority})
-        end
-        
-        -- Delete unmatched commands by priority.
-        for priority = 1, 3, 1 do
-          if numDeletedOrders <= 0 then
-            break
-          end
-          for i = table.getn(Matches), 1, -1 do
-            if Matches[i].Priority == priority then
-              table.remove(Matches, i)
-              table.remove(unitOrders, i + orderIndex - 1)
-              numOrders = numOrders - 1
-              nextOrderIndex = nextOrderIndex - 1
-              numDeletedOrders = numDeletedOrders - 1
-              if numDeletedOrders <= 0 then
-                break
-              end
-            end
-          end
-        end
-        
-        -- Fix the positions of any moved orders.
-        local positionIndex = Matches[1].Match or queueIndex
-        for i = 0, nextOrderIndex - orderIndex - 1, 1 do
-          if not unitOrders[i + orderIndex].EntityId then
-            if not Matches[i + 1].Match then
-              Matches[i + 1].Match = positionIndex
-            end
-            unitOrders[i + orderIndex].Position = filteredQueue[Matches[i + 1].Match].Position
-          end
-          positionIndex = (Matches[i + 1].Match or positionIndex) + 1
-        end
-      end
 
-    else
-      -- No orders were deleted so just fix any moved orders with position targets.
-      for i = 0, nextOrderIndex - orderIndex - 1, 1 do
-        if not unitOrders[i + orderIndex].EntityId then
-          unitOrders[i + orderIndex].Position = filteredQueue[i + queueIndex].Position
+        else
+            -- No orders were deleted so just fix any moved orders with position targets.
+            for i = 0, nextOrderIndex - orderIndex - 1, 1 do
+                if not unitOrders[i + orderIndex].EntityId then
+                    unitOrders[i + orderIndex].Position = filteredQueue[i + queueIndex].Position
+                end
+            end
         end
-      end
+            
+        orderIndex = nextOrderIndex
+        queueIndex = nextQueueIndex
     end
-      
-    orderIndex = nextOrderIndex
-    queueIndex = nextQueueIndex
-  end
 end
 
 
@@ -291,102 +291,103 @@ end
 -- This function rearranges all targeted orders randomly for every unit.
 function SpreadAttack()
 
-  -- Get the currently selected units.
-  local curSelection = GetSelectedUnits()
+    -- Get the currently selected units.
+    local curSelection = GetSelectedUnits()
 
-  if not curSelection then
-    return
-  end
-
-  -- Switch the orders for each unit.
-  for index,unit in ipairs(curSelection) do
-    FixOrders(unit)
-    local unitOrders = ShadowOrders[unit:GetEntityId()]
-
-    -- Only mix orders if this unit has any orders to mix.
-    if not unitOrders or not unitOrders[1] then 
-      continue
+    if not curSelection then
+        return
     end
-  
-    -- Find all consecutive mixable orders, and only mix those.
-    local beginAction,endAction,action,counter,actionAlwaysMixed = nil,nil,nil,1,false
-    local alwaysMix = {"Attack", "Nuke", "Tactical"}
 
-    while unitOrders[counter] ~= nil  do
-      beginAction = nil
-      -- Search for the first entry of a mixable order.
-      while beginAction == nil and unitOrders[counter] ~= nil do
-        for _,v in ipairs(alwaysMix) do
-          if unitOrders[counter].CommandType == v then
-            beginAction = counter
-            action = unitOrders[counter].CommandType
-            actionAlwaysMixed = true
-            break
-          elseif unitOrders[counter].EntityId then
-            beginAction = counter
-            action = unitOrders[counter].CommandType
-            actionAlwaysMixed = false
-          end
+    -- Switch the orders for each unit.
+    for index,unit in ipairs(curSelection) do
+        FixOrders(unit)
+        local unitOrders = ShadowOrders[unit:GetEntityId()]
+
+        -- Only mix orders if this unit has any orders to mix.
+        if not unitOrders or not unitOrders[1] then
+            continue
         end
-        counter = counter + 1
-      end
+    
+        -- Find all consecutive mixable orders, and only mix those.
+        local beginAction,endAction,action,counter,actionAlwaysMixed = nil,nil,nil,1,false
+        local alwaysMix = {"Attack", "Nuke", "Tactical"}
 
-      endAction = beginAction
-      -- Search for the last entry of a mixable order in this series.
-      while unitOrders[counter] ~= nil do
-        if unitOrders[counter].CommandType == action and (actionAlwaysMixed or unitOrders[counter].EntityId) then
-          endAction = counter
-          counter = counter + 1
-        else
-          break
+        while unitOrders[counter] ~= nil  do
+            beginAction = nil
+            -- Search for the first entry of a mixable order.
+            while beginAction == nil and unitOrders[counter] ~= nil do
+                for _,v in ipairs(alwaysMix) do
+                    if unitOrders[counter].CommandType == v then
+                        beginAction = counter
+                        action = unitOrders[counter].CommandType
+                        actionAlwaysMixed = true
+                        break
+                    elseif unitOrders[counter].EntityId then
+                        beginAction = counter
+                        action = unitOrders[counter].CommandType
+                        actionAlwaysMixed = false
+                    end
+                end
+                counter = counter + 1
+            end
+
+            endAction = beginAction
+            -- Search for the last entry of a mixable order in this series.
+            while unitOrders[counter] ~= nil do
+                if unitOrders[counter].CommandType == action and (actionAlwaysMixed or unitOrders[counter].EntityId) then
+                    endAction = counter
+                    counter = counter + 1
+                else
+                    break
+                end
+            end
+            
+            -- Skip if there was no mixable order found, or only one order (can't swap one command).
+            if beginAction == nil or endAction == beginAction then
+                break
+            end
+            
+            -- Rearrange the first few mixable orders (equal to the number of targets) so that the targets are uniformly distributed on the first pass.
+            -- For example, 3 units attacking 8 units (? denotes random target):
+            -- Unit 1: 1, 4, 7, ?, ?, ?, ?, ?
+            -- Unit 2: 2, 5, 8, ?, ?, ?, ?, ?
+            -- Unit 3: 3, 6, ?, ?, ?, ?, ?, ?
+            local unitCount = table.getn(curSelection)
+            local numOrders = endAction - beginAction + 1
+            -- "and 1 or 0" is lua's ugly alternative to the ternary operator. Same as (...) ? 1 : 0
+            local stableTargetNum = math.floor(numOrders / unitCount) + ((math.mod(numOrders, unitCount) >= index) and 1 or 0)
+            for i = 0, stableTargetNum - 1 do
+                -- For if the targets outnumber the units targeting them.
+                local targetBlock = i * unitCount
+                unitOrders[i + beginAction],unitOrders[targetBlock + beginAction + index - 1]
+                        = unitOrders[targetBlock + beginAction + index - 1],unitOrders[i + beginAction]
+            end
+            beginAction = beginAction + stableTargetNum
+
+            -- Randomize the remaining mixable orders.
+            for i = beginAction,endAction do
+                local randomorder = math.random(beginAction,endAction)
+                if randomorder ~= i then
+                    unitOrders[i],unitOrders[randomorder] = unitOrders[randomorder],unitOrders[i]
+                end
+            end
+
+            -- Repeat this loop and search for more mixable order series.
         end
-      end
-      
-      -- Skip if there was no mixable order found, or only one order (can't swap one command).
-      if beginAction == nil or endAction == beginAction then
-        break
-      end
-      
-      -- Rearrange the first few mixable orders (equal to the number of targets) so that the targets are uniformly distributed on the first pass.
-      -- For example, 3 units attacking 8 units (? denotes random target):
-      -- Unit 1: 1, 4, 7, ?, ?, ?, ?, ?
-      -- Unit 2: 2, 5, 8, ?, ?, ?, ?, ?
-      -- Unit 3: 3, 6, ?, ?, ?, ?, ?, ?
-      local unitCount = table.getn(curSelection)
-      local numOrders = endAction - beginAction + 1
-      -- "and 1 or 0" is lua's ugly alternative to the ternary operator. Same as (...) ? 1 : 0
-      local stableTargetNum = math.floor(numOrders / unitCount) + ((math.mod(numOrders, unitCount) >= index) and 1 or 0)
-      for i = 0, stableTargetNum - 1 do
-        -- For if the targets outnumber the units targeting them.
-        local targetBlock = i * unitCount
-        unitOrders[i + beginAction],unitOrders[targetBlock + beginAction + index - 1]
-            = unitOrders[targetBlock + beginAction + index - 1],unitOrders[i + beginAction]
-      end
-      beginAction = beginAction + stableTargetNum
+    
+        -- All targeted orders have been mixed, now it's time to reassign those orders.
+        -- Since giving orders is a Sim-side command, use a SimCallback function.
+        SimCallback( {
+                Func = "GiveOrders",
+                Args = { 
+                    unit_orders = unitOrders,
+                    unit_id     = unit:GetEntityId(),
+                    From = GetFocusArmy()
+                }
+            }, false)
 
-      -- Randomize the remaining mixable orders.
-      for i = beginAction,endAction do
-        local randomorder = math.random(beginAction,endAction)
-        if randomorder ~= i then
-          unitOrders[i],unitOrders[randomorder] = unitOrders[randomorder],unitOrders[i]
-        end
-      end
-
-
-      -- Repeat this loop and search for more mixable order series.
+        -- Handle the next unit.
     end
-  
-    -- All targeted orders have been mixed, now it's time to reassign those orders.
-    -- Since giving orders is a Sim-side command, use a SimCallback function.
-    SimCallback( { Func = "GiveOrders",
-                   Args = { unit_orders = unitOrders,
-                            unit_id     = unit:GetEntityId(),
-                            From = GetFocusArmy()}, 
-                 }, false )
-
-    -- Handle the next unit.
-  end
-
 
 end -- Function SpreadAttack()
 
@@ -401,7 +402,7 @@ local IssueOrderFunctions = nil
 -- Since the orders herein are Sim-side commands, this function needs to be called through a SimCallback.
 function GiveOrders(Data)
     -- Doing this here ensures it's done in sim code instead of UI code.
-    if not IssueOrderFunctions then    
+    if not IssueOrderFunctions then
         IssueOrderFunctions = {
          ["AggressiveMove"]     = IssueAggressiveMove,
          ["Attack"]             = IssueAttack,
@@ -434,14 +435,13 @@ function GiveOrders(Data)
             if not Function then
                 continue
             end
-			
+            
             local target = order.Position
             if order.EntityId then
                 target = GetEntityById(order.EntityId)
             end
             
-            Function({unit}, target)
+            Function({ unit }, target)
         end
     end
-
 end -- function GiveOrders(Data)


### PR DESCRIPTION
* Adds handling for moved or deleted orders to partially fix #1177. Due to limitations of the data returned by UserUnit.GetCommandQueue() this can't be used for factory units (Fatboy, Megalith, Tempest, Czar, Atlantis, carriers) or for handling changed entity targets. I tried a callback with the sim version of GetCommandQueue and it seemed to return no usable data at all.
* Adds support for more order types. This now allows splitting Patrol orders and spreading targets for ground Attack, Capture, Guard (useful for distributing scouts throughout a group), Nuke, OverCharge, Reclaim, Repair, and Tactical missile.