### PR TITLE
BugFix for ui-option-VerifyDialog

### DIFF
--- a/lua/ui/dialogs/options.lua
+++ b/lua/ui/dialogs/options.lua
@@ -1,0 +1,510 @@
+--*****************************************************************************
+--* File: lua/modules/ui/dialogs/options.lua
+--* Author: Chris Blackwell
+--* Summary: Manages the options dialog
+--*
+--* Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+--*****************************************************************************
+
+local UIUtil = import('/lua/ui/uiutil.lua')
+local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
+local Bitmap = import('/lua/maui/bitmap.lua').Bitmap
+local Text = import('/lua/maui/text.lua').Text
+local Button = import('/lua/maui/button.lua').Button
+local MenuCommon = import('/lua/ui/menus/menucommon.lua')
+local Group = import('/lua/maui/group.lua').Group
+local Grid = import('/lua/maui/grid.lua').Grid
+local Slider = import('/lua/maui/slider.lua').Slider
+local Combo = import('/lua/ui/controls/combo.lua').Combo
+local IntegerSlider = import('/lua/maui/slider.lua').IntegerSlider
+local OptionsLogic = import('/lua/options/optionslogic.lua')
+local Tooltip = import('/lua/ui/game/tooltip.lua')
+
+-- this will hold the working set of options, which won't be valid until applied
+local currentOptionsSet = false
+
+local currentTabButton = false
+local currentTabBitmap = false
+
+-- contains a map of current option controls keyed by their option keys
+local optionKeyToControlMap = false
+
+-- this table is keyed with the different types of controls that can be created
+-- each key's value is the function that actually creates the type
+-- the signature of the function is: fucntion(parent, optionItemData) and should return it's base control
+-- note that each control should create a change function that allows the control to have its value changed
+-- not that each control should create a SetCustomData(newCustomData, newDefault) function that will initialize the control with new custom data
+local controlTypeCreate = {
+    toggle = function(parent, optionItemData)
+        local combo = Combo(parent, 14, 10, nil, nil, "UI_Tab_Click_01", "UI_Tab_Rollover_01")
+        combo.Width:Set(250)
+
+        combo.SetCustomData = function(newCustomData, newDefault)
+            local itemArray = {}
+            local default = 1
+            local matchedCurrentValue = false
+            combo:ClearItems()
+            combo.keyMap = {}
+            for index, val in newCustomData.states do
+                if currentOptionsSet[optionItemData.key] == val.key then
+                    default = index
+                    matchedCurrentValue = true
+                end
+                itemArray[index] = val.text
+                combo.keyMap[index] = val.key
+            end
+            combo.Key = newDefault
+            combo:AddItems(itemArray, default)
+            if table.getsize(itemArray) == 1 then
+                combo:Disable()
+            else
+                combo:Enable()
+            end
+            -- if we didn't find a match for our current value, we need to set the value to default
+            if not matchedCurrentValue then
+                currentOptionsSet[optionItemData.key] = newDefault
+            end
+        end
+        
+        combo.SetCustomData(optionItemData.custom, optionItemData.default)
+       
+        combo.OnClick = function(self, index, text, skipUpdate) 
+            self.Key = index
+            currentOptionsSet[optionItemData.key] = combo.keyMap[index]
+            if optionItemData.update and not skipUpdate then
+                optionItemData.update(self,combo.keyMap[index])
+            end
+        end
+        
+        combo.OnDestroy = function(self)
+			optionItemData.control = nil
+			optionItemData.change = nil
+        end
+        
+        optionItemData.control = combo
+        optionItemData.change = function(control, value, skipUpdate)
+            -- find key in control
+            for index, key in control.keyMap do
+                if key == value then
+                    -- don't do anything if we're already set to this key
+                    if control:GetItem() != index then
+                        control:SetItem(index)
+                        control:OnClick(index, nil, skipUpdate)
+                        return
+                    end
+                end
+            end
+        end
+        
+        return combo
+    end,
+    
+    button = function(parent, optionItemData)
+        local bg = Bitmap(parent, UIUtil.SkinnableFile('/dialogs/options-02/content-btn-line_bmp.dds'))
+        bg._button = UIUtil.CreateButtonStd(bg, '/dialogs/standard-small_btn/standard-small', optionItemData.custom.text, 12, 2, 0, "UI_Opt_Mini_Button_Click", "UI_Opt_Mini_Button_Over")
+        LayoutHelpers.AtCenterIn(bg._button, bg)
+        bg._button.OnClick = function(self, modifiers)
+            if optionItemData.update then
+                optionItemData.update(self, 0)
+            end
+        end
+		optionItemData.control = bg
+        optionItemData.change = function(control, value)
+            if optionItemData.update then
+                optionItemData.update(control, value)
+            end
+        end
+        bg.OnDestroy = function(self)
+			optionItemData.control = nil
+			optionItemData.change = nil
+        end
+        
+        bg.SetCustomData = function(newCustomData, newDefault)
+            bg._button.label:SetText(newCustomData)
+        end
+        
+        return bg
+    end,
+    
+    slider = function(parent, optionItemData)
+        local sliderGroup = Group(parent)
+        sliderGroup.Width:Set(parent.Width)
+        sliderGroup.Height:Set(parent.Height)
+
+        sliderGroup._slider = false
+        if optionItemData.custom.inc == 0 then
+            sliderGroup._slider = Slider(sliderGroup, false, optionItemData.custom.min, optionItemData.custom.max, UIUtil.SkinnableFile('/slider02/slider_btn_up.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_over.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_down.dds'), UIUtil.SkinnableFile('/slider02/slider-back_bmp.dds'))    
+        else
+            sliderGroup._slider = IntegerSlider(sliderGroup, false, optionItemData.custom.min, optionItemData.custom.max, optionItemData.custom.inc, UIUtil.SkinnableFile('/slider02/slider_btn_up.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_over.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_down.dds'), UIUtil.SkinnableFile('/dialogs/options-02/slider-back_bmp.dds'))    
+        end
+
+        LayoutHelpers.AtLeftTopIn(sliderGroup._slider, sliderGroup)
+        
+        sliderGroup._value = UIUtil.CreateText(sliderGroup, "", 12)
+        LayoutHelpers.RightOf(sliderGroup._value, sliderGroup._slider)
+        
+        sliderGroup._slider.OnValueChanged = function(self, newValue)
+            sliderGroup._value:SetText(math.floor(tostring(newValue)))
+        end
+        
+        sliderGroup._slider.OnValueSet = function(self, newValue)
+            if optionItemData.update then
+                optionItemData.update(self, newValue)
+            end
+            currentOptionsSet[optionItemData.key] = newValue
+        end
+
+        sliderGroup._slider.OnBeginChange = function(self)
+            if optionItemData.beginChange then
+                optionItemData.beginChange(self)
+            end
+        end
+
+        sliderGroup._slider.OnEndChange = function(self)
+            if optionItemData.endChange then
+                optionItemData.endChange(self)
+            end
+        end
+        
+        sliderGroup._slider.OnScrub = function(self,value)
+            if optionItemData.update then
+                optionItemData.update(self,value)
+            end
+        end
+
+		optionItemData.control = sliderGroup._slider
+        optionItemData.change = function(control, value, skipUpdate)
+			if not skipUpdate then
+			    control:SetValue(value)
+			end
+        end
+        
+        sliderGroup.OnDestroy = function(self)
+			optionItemData.control = nil
+			optionItemData.change = nil
+        end
+        
+        -- set initial value
+        sliderGroup._slider:SetValue(currentOptionsSet[optionItemData.key])
+
+        sliderGroup.SetCustomData = function(newCustomData, newDefault)
+            -- this isn't really correct as it should check the indent, and recreate the control if needed
+            -- and set the indent (which isn't exposed in slider, doh!) but this isn't really used
+            -- at this point, so it's not worth putting work in to
+            sliderGroup._slider:SetStartValue(newCustomData.min)
+            sliderGroup._slider:SetEndValue(newCustomData.max)
+        end
+        
+        return sliderGroup
+    end,
+}
+
+
+local function CreateOption(parent, optionItemData)
+    local bg = Bitmap(parent, UIUtil.SkinnableFile('/dialogs/options-02/content-box_bmp.dds'))
+    
+    bg._label = UIUtil.CreateText(bg, optionItemData.title, 16, UIUtil.bodyFont)
+    LayoutHelpers.AtLeftTopIn(bg._label, bg, 9, 6)
+    bg._label._tipText = optionItemData.key
+
+    bg._label.HandleEvent = function(self, event)
+        if event.Type == 'MouseEnter' then
+            Tooltip.CreateMouseoverDisplay(self, "options_" .. bg._label._tipText, .5, true)
+        elseif event.Type == 'MouseExit' then
+            Tooltip.DestroyMouseoverDisplay()
+        end
+    end
+    
+    -- this is here to help position the control
+    --TODO get this data from layout!
+    local controlGroup = Group(bg)
+    LayoutHelpers.AtLeftTopIn(controlGroup, bg, 338, 5)
+    controlGroup.Width:Set(252)
+    controlGroup.Height:Set(24)
+
+    if controlTypeCreate[optionItemData.type] then
+        bg._control = controlTypeCreate[optionItemData.type](controlGroup, optionItemData)
+    else
+        LOG("Warning: Option item data [" .. optionItemData.key .. "] contains an unknown control type: " .. optionItemData.type .. ". Valid types are")
+        for k,v in controlTypeCreate do
+            LOG(k)
+        end
+    end
+    
+    if bg._control then
+        LayoutHelpers.AtCenterIn(bg._control, controlGroup)
+    end
+    
+    optionKeyToControlMap[optionItemData.key] = bg._control
+    
+    return bg
+end
+
+local dialog = false
+
+function CreateDialog(over, exitBehavior)
+	currentOptionsSet = OptionsLogic.GetCurrent()
+    
+    local parent = false
+
+    -- lots of state
+    local function KillDialog()
+        currentTabButton = false
+        currentTabBitmap = false
+
+        OptionsLogic.SetCustomDataChangedCallback(nil)
+        OptionsLogic.SetSummonRestartDialogCallback(nil)
+        OptionsLogic.SetSummonVerifyDialogCallback(nil)
+        OptionsLogic.Repopulate()
+
+        if over then
+            dialog:Destroy()
+        else
+            parent:Destroy()
+        end
+    end
+    
+    if over then
+        parent = over
+    else
+        parent = UIUtil.CreateScreenGroup(GetFrame(0), "Options ScreenGroup")
+        local background = MenuCommon.SetupBackground(GetFrame(0))
+    end
+    
+    dialog = Bitmap(parent, UIUtil.UIFile('/scx_menu/options/panel_bmp.dds'))
+    LayoutHelpers.AtCenterIn(dialog, parent)
+    
+    dialog.brackets = UIUtil.CreateDialogBrackets(dialog, 41, 24, 41, 24)
+    
+    local title = UIUtil.CreateText(dialog, "<LOC _Options>", 24, UIUtil.titleFont)
+    LayoutHelpers.AtTopIn(title, dialog, 30)
+    LayoutHelpers.AtHorizontalCenterIn(title, dialog)
+    
+    if over then
+        dialog.Depth:Set(GetFrame(over:GetRootFrame():GetTargetHead()):GetTopmostDepth() + 1)
+    end
+    
+    local function roHandler(self, event)
+        if event == 'enter' then
+            self.label:SetColor('ff000000')
+        elseif event == 'exit' then
+            self.label:SetColor(UIUtil.fontColor)
+        end
+    end
+    
+    -- layout buttons
+    local applyBtn = Button(dialog, 
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_up.dds'),
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_down.dds'),
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_over.dds'),
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_dis.dds'),
+        "UI_Opt_Yes_No", "UI_Opt_Affirm_Over")
+    LayoutHelpers.AtRightTopIn(applyBtn, dialog, 15, 515)
+    applyBtn.label = UIUtil.CreateText(applyBtn, LOC("<LOC _Apply>"), 16)
+    LayoutHelpers.AtCenterIn(applyBtn.label, applyBtn)
+    Tooltip.AddButtonTooltip(applyBtn, 'options_tab_apply')
+    applyBtn.OnRolloverEvent = roHandler
+    
+    dialog.cancelBtn = Button(dialog, 
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_up.dds'),
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_down.dds'),
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_over.dds'),
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_dis.dds'),
+        "UI_Opt_Yes_No", "UI_Opt_Affirm_Over")
+    dialog.cancelBtn.label = UIUtil.CreateText(dialog.cancelBtn, LOC("<LOC _Cancel>"), 16)
+    LayoutHelpers.AtCenterIn(dialog.cancelBtn.label, dialog.cancelBtn)
+    LayoutHelpers.LeftOf(dialog.cancelBtn, applyBtn, -6)
+    dialog.cancelBtn.OnRolloverEvent = roHandler
+    
+    local okBtn = Button(dialog, 
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_up.dds'),
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_down.dds'),
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_over.dds'),
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_dis.dds'),
+        "UI_Opt_Yes_No", "UI_Opt_Affirm_Over")
+    okBtn.label = UIUtil.CreateText(okBtn, LOC("<LOC _Ok>"), 16)
+    LayoutHelpers.AtCenterIn(okBtn.label, okBtn)
+    LayoutHelpers.LeftOf(okBtn, dialog.cancelBtn, -6)
+    okBtn.OnRolloverEvent = roHandler
+
+    
+    local resetBtn = Button(dialog, 
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_up.dds'),
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_down.dds'),
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_over.dds'),
+        UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_dis.dds'),
+        "UI_Opt_Yes_No", "UI_Opt_Affirm_Over")
+    resetBtn.label = UIUtil.CreateText(resetBtn, LOC("<LOC _Reset>"), 16)
+    LayoutHelpers.AtCenterIn(resetBtn.label, resetBtn)
+    LayoutHelpers.LeftOf(resetBtn, okBtn, -6)
+    Tooltip.AddButtonTooltip(resetBtn, 'options_reset_all')
+    resetBtn.OnRolloverEvent = roHandler
+
+    
+    -- set up button logic
+    okBtn.OnClick = function(self, modifiers)
+        OptionsLogic.SetCurrent(currentOptionsSet)
+        KillDialog()
+        if exitBehavior then exitBehavior() end
+    end
+
+    dialog.cancelBtn.OnClick = function(self, modifiers)
+        if currentTabButton then
+            for index,option in currentTabButton.tabData.items do
+                if option.cancel then
+                    option.cancel()
+                end
+            end
+        end        
+        
+        KillDialog()
+        if exitBehavior then exitBehavior() end
+    end
+
+    applyBtn.OnClick = function(self, modifiers)
+        OptionsLogic.SetCurrent(currentOptionsSet)
+    end
+
+    resetBtn.OnClick = function(self, modifiers)
+        local function DoReset()
+            OptionsLogic.ResetToDefaults()
+            -- creating the dialog will reload the old options without saving the new ones and will reset all the controls
+            KillDialog()
+            if exitBehavior then exitBehavior() end
+        end
+
+        UIUtil.QuickDialog(dialog, "<LOC options_0002>Are you sure you want to reset to default values?", 
+            "<LOC _Yes>", DoReset, 
+            "<LOC _No>", nil,  
+            nil, nil, 
+            true,
+            {escapeButton = 2, enterButton = 1, worldCover = false})
+    end
+    
+    UIUtil.MakeInputModal(dialog, function() okBtn.OnClick(okBtn) end, function() dialog.cancelBtn.OnClick(dialog.cancelBtn) end)
+    
+    -- set up option grid
+    local elementWidth, elementHeight = GetTextureDimensions(UIUtil.UIFile('/dialogs/options-02/content-box_bmp.dds'))
+    local optionGrid = Grid(dialog, elementWidth, elementHeight)
+    LayoutHelpers.RelativeTo(optionGrid, dialog, UIUtil.SkinnableFile('/dialogs/options-02/options-02_layout.lua'), 'gameplay_bmp', 'panel_bmp')
+    LayoutHelpers.DimensionsRelativeTo(optionGrid, UIUtil.SkinnableFile('/dialogs/options-02/options-02_layout.lua'), 'gameplay_bmp')
+    local scrollbar = UIUtil.CreateVertScrollbarFor(optionGrid, -4)
+    
+    -- set up a page
+    function SetNewPage(tabControl)
+        -- kill any other page
+        if currentTabBitmap then
+            currentTabBitmap:Destroy()
+            currentTabBitmap = false
+            currentTabButton:Show()
+        end
+
+        -- store the tab data for this tab for easy access
+        local tabData = tabControl.tabData
+
+        -- show the "selected" state of the tab, which hides the button and shows a bitmap
+        currentTabButton = tabControl
+        currentTabButton:Hide()
+        currentTabBitmap = Bitmap(dialog, UIUtil.SkinnableFile('/scx_menu/tab_btn/tab_btn_selected.dds'))
+        LayoutHelpers.AtCenterIn(currentTabBitmap, currentTabButton)
+        local tabLabel = UIUtil.CreateText(currentTabBitmap, tabData.title, 16, UIUtil.titleFont)
+        LayoutHelpers.AtCenterIn(tabLabel, currentTabBitmap)
+        
+        -- remove controls and populate grid
+        optionGrid:DeleteAndDestroyAll(true)
+        optionGrid:AppendCols(1, true)
+        
+        -- initialzie key to control map each time page is changed, as controls get destroyed
+        optionKeyToControlMap = {}
+
+        for index, option in tabData.items do
+            optionGrid:AppendRows(1, true)
+            local optCtrl = CreateOption(optionGrid, option) 
+            optionGrid:SetItem(optCtrl, 1, index, true)
+            if option.init then
+                option.init()
+            end
+        end
+                
+        optionGrid:EndBatch()
+    end
+    
+    -- tab layout
+    local prev = false
+    local defaultTab = false
+
+    -- get the tab data
+    local options = import('/lua/options/options.lua').options
+    local optionsOrder = import('/lua/options/options.lua').optionsOrder
+    
+    for index, key in optionsOrder do
+        tabData = options[key]
+        local curButton = UIUtil.CreateButtonStd(dialog, '/scx_menu/tab_btn/tab', tabData.title, 16, 0, 0, "UI_Tab_Click_01", "UI_Tab_Rollover_01")
+        curButton.label:SetDropShadow(true)
+        if prev then
+            LayoutHelpers.RightOf(curButton, prev, -10)
+        else
+            LayoutHelpers.AtLeftTopIn(curButton, dialog, 10, 64)
+            defaultTab = curButton
+        end
+        prev = curButton
+
+        curButton.OnClick = function(self, modifiers)
+            SetNewPage(self)
+        end
+        
+        curButton.tabData = tabData
+    end
+    
+    SetNewPage(defaultTab)
+    
+    if not optionGrid:IsScrollable("Vert") then
+        scrollbar:Hide()
+    end
+
+    OptionsLogic.SetCustomDataChangedCallback(function(optionKey, newCustomData, newDefault)
+        if optionKeyToControlMap and optionKeyToControlMap[optionKey] then
+            optionKeyToControlMap[optionKey].SetCustomData(newCustomData, newDefault)
+        end
+    end)
+    
+    local function OptionRestartFunc(proceedFunc, cancelFunc)
+        UIUtil.QuickDialog(GetFrame(0) , "<LOC options_0001>You have modified an option which requires you to restart Forged Alliance. Selecting OK will exit the game, selecting Cancel will revert the option to its prior setting."
+            , "<LOC _OK>", proceedFunc
+            ,"<LOC _Cancel>", cancelFunc
+            , nil, nil
+            , true
+            , {escapeButton = 2, enterButton = 1, worldCover = false}
+        )
+    end
+    OptionsLogic.SetSummonRestartDialogCallback(OptionRestartFunc)
+    
+    local function VerifyFunc(undoFunc)
+        local secondsToWait = 15
+        local thread
+
+        local dlg = UIUtil.QuickDialog(GetFrame(0), "<LOC options_0003>Click OK to accept these settings."
+            , LOC("<LOC _Ok>") .. " [" .. secondsToWait .. "]", function() KillThread(thread) end
+            , "<LOC _Cancel>", function() KillThread(thread) undoFunc() end
+            , nil, nil
+            , true
+            , {escapeButton = 2, enterButton = 1, worldCover = false}
+        )
+        
+        thread = ForkThread(function()
+            for sec = 1, secondsToWait do
+                WaitSeconds(1)
+                dlg._button1.label:SetText(LOC("<LOC _Ok>") .. " [" .. (secondsToWait - sec) .. "]")
+            end
+            dlg:Destroy()
+            undoFunc()
+        end)
+    end
+    OptionsLogic.SetSummonVerifyDialogCallback(VerifyFunc)
+end
+
+function OnNISBegin()
+    if dialog then
+        dialog.cancelBtn:OnClick()
+    end
+end

--- a/lua/ui/dialogs/options.lua
+++ b/lua/ui/dialogs/options.lua
@@ -493,7 +493,7 @@ function CreateDialog(over, exitBehavior)
         thread = ForkThread(function()
             for sec = 1, secondsToWait do
                 WaitSeconds(1)
-                dlg._button1.label:SetText(LOC("<LOC _Ok>") .. " [" .. (secondsToWait - sec) .. "]")
+                dlg.content._button1.label:SetText(LOC("<LOC _Ok>") .. " [" .. (secondsToWait - sec) .. "]")
             end
             dlg:Destroy()
             undoFunc()

--- a/lua/ui/dialogs/options.lua
+++ b/lua/ui/dialogs/options.lua
@@ -22,7 +22,6 @@ local Tooltip = import('/lua/ui/game/tooltip.lua')
 
 -- this will hold the working set of options, which won't be valid until applied
 local currentOptionsSet = false
-
 local currentTabButton = false
 local currentTabBitmap = false
 
@@ -65,29 +64,29 @@ local controlTypeCreate = {
                 currentOptionsSet[optionItemData.key] = newDefault
             end
         end
-        
+
         combo.SetCustomData(optionItemData.custom, optionItemData.default)
-       
-        combo.OnClick = function(self, index, text, skipUpdate) 
+
+        combo.OnClick = function(self, index, text, skipUpdate)
             self.Key = index
             currentOptionsSet[optionItemData.key] = combo.keyMap[index]
             if optionItemData.update and not skipUpdate then
                 optionItemData.update(self,combo.keyMap[index])
             end
         end
-        
+
         combo.OnDestroy = function(self)
-			optionItemData.control = nil
-			optionItemData.change = nil
+            optionItemData.control = nil
+            optionItemData.change = nil
         end
-        
+
         optionItemData.control = combo
         optionItemData.change = function(control, value, skipUpdate)
             -- find key in control
             for index, key in control.keyMap do
                 if key == value then
                     -- don't do anything if we're already set to this key
-                    if control:GetItem() != index then
+                    if control:GetItem() ~= index then
                         control:SetItem(index)
                         control:OnClick(index, nil, skipUpdate)
                         return
@@ -95,10 +94,10 @@ local controlTypeCreate = {
                 end
             end
         end
-        
+
         return combo
     end,
-    
+
     button = function(parent, optionItemData)
         local bg = Bitmap(parent, UIUtil.SkinnableFile('/dialogs/options-02/content-btn-line_bmp.dds'))
         bg._button = UIUtil.CreateButtonStd(bg, '/dialogs/standard-small_btn/standard-small', optionItemData.custom.text, 12, 2, 0, "UI_Opt_Mini_Button_Click", "UI_Opt_Mini_Button_Over")
@@ -108,24 +107,24 @@ local controlTypeCreate = {
                 optionItemData.update(self, 0)
             end
         end
-		optionItemData.control = bg
+        optionItemData.control = bg
         optionItemData.change = function(control, value)
             if optionItemData.update then
                 optionItemData.update(control, value)
             end
         end
         bg.OnDestroy = function(self)
-			optionItemData.control = nil
-			optionItemData.change = nil
+            optionItemData.control = nil
+            optionItemData.change = nil
         end
-        
+
         bg.SetCustomData = function(newCustomData, newDefault)
             bg._button.label:SetText(newCustomData)
         end
-        
+
         return bg
     end,
-    
+
     slider = function(parent, optionItemData)
         local sliderGroup = Group(parent)
         sliderGroup.Width:Set(parent.Width)
@@ -133,20 +132,20 @@ local controlTypeCreate = {
 
         sliderGroup._slider = false
         if optionItemData.custom.inc == 0 then
-            sliderGroup._slider = Slider(sliderGroup, false, optionItemData.custom.min, optionItemData.custom.max, UIUtil.SkinnableFile('/slider02/slider_btn_up.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_over.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_down.dds'), UIUtil.SkinnableFile('/slider02/slider-back_bmp.dds'))    
+            sliderGroup._slider = Slider(sliderGroup, false, optionItemData.custom.min, optionItemData.custom.max, UIUtil.SkinnableFile('/slider02/slider_btn_up.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_over.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_down.dds'), UIUtil.SkinnableFile('/slider02/slider-back_bmp.dds'))
         else
-            sliderGroup._slider = IntegerSlider(sliderGroup, false, optionItemData.custom.min, optionItemData.custom.max, optionItemData.custom.inc, UIUtil.SkinnableFile('/slider02/slider_btn_up.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_over.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_down.dds'), UIUtil.SkinnableFile('/dialogs/options-02/slider-back_bmp.dds'))    
+            sliderGroup._slider = IntegerSlider(sliderGroup, false, optionItemData.custom.min, optionItemData.custom.max, optionItemData.custom.inc, UIUtil.SkinnableFile('/slider02/slider_btn_up.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_over.dds'), UIUtil.SkinnableFile('/slider02/slider_btn_down.dds'), UIUtil.SkinnableFile('/dialogs/options-02/slider-back_bmp.dds'))
         end
 
         LayoutHelpers.AtLeftTopIn(sliderGroup._slider, sliderGroup)
-        
+
         sliderGroup._value = UIUtil.CreateText(sliderGroup, "", 12)
         LayoutHelpers.RightOf(sliderGroup._value, sliderGroup._slider)
-        
+
         sliderGroup._slider.OnValueChanged = function(self, newValue)
             sliderGroup._value:SetText(math.floor(tostring(newValue)))
         end
-        
+
         sliderGroup._slider.OnValueSet = function(self, newValue)
             if optionItemData.update then
                 optionItemData.update(self, newValue)
@@ -165,25 +164,25 @@ local controlTypeCreate = {
                 optionItemData.endChange(self)
             end
         end
-        
+
         sliderGroup._slider.OnScrub = function(self,value)
             if optionItemData.update then
                 optionItemData.update(self,value)
             end
         end
 
-		optionItemData.control = sliderGroup._slider
+        optionItemData.control = sliderGroup._slider
         optionItemData.change = function(control, value, skipUpdate)
-			if not skipUpdate then
-			    control:SetValue(value)
-			end
+            if not skipUpdate then
+                control:SetValue(value)
+            end
         end
-        
+
         sliderGroup.OnDestroy = function(self)
-			optionItemData.control = nil
-			optionItemData.change = nil
+            optionItemData.control = nil
+            optionItemData.change = nil
         end
-        
+
         -- set initial value
         sliderGroup._slider:SetValue(currentOptionsSet[optionItemData.key])
 
@@ -194,7 +193,7 @@ local controlTypeCreate = {
             sliderGroup._slider:SetStartValue(newCustomData.min)
             sliderGroup._slider:SetEndValue(newCustomData.max)
         end
-        
+
         return sliderGroup
     end,
 }
@@ -202,7 +201,7 @@ local controlTypeCreate = {
 
 local function CreateOption(parent, optionItemData)
     local bg = Bitmap(parent, UIUtil.SkinnableFile('/dialogs/options-02/content-box_bmp.dds'))
-    
+
     bg._label = UIUtil.CreateText(bg, optionItemData.title, 16, UIUtil.bodyFont)
     LayoutHelpers.AtLeftTopIn(bg._label, bg, 9, 6)
     bg._label._tipText = optionItemData.key
@@ -214,7 +213,7 @@ local function CreateOption(parent, optionItemData)
             Tooltip.DestroyMouseoverDisplay()
         end
     end
-    
+
     -- this is here to help position the control
     --TODO get this data from layout!
     local controlGroup = Group(bg)
@@ -230,21 +229,21 @@ local function CreateOption(parent, optionItemData)
             LOG(k)
         end
     end
-    
+
     if bg._control then
         LayoutHelpers.AtCenterIn(bg._control, controlGroup)
     end
-    
+
     optionKeyToControlMap[optionItemData.key] = bg._control
-    
+
     return bg
 end
 
 local dialog = false
 
 function CreateDialog(over, exitBehavior)
-	currentOptionsSet = OptionsLogic.GetCurrent()
-    
+    currentOptionsSet = OptionsLogic.GetCurrent()
+
     local parent = false
 
     -- lots of state
@@ -263,27 +262,27 @@ function CreateDialog(over, exitBehavior)
             parent:Destroy()
         end
     end
-    
+
     if over then
         parent = over
     else
         parent = UIUtil.CreateScreenGroup(GetFrame(0), "Options ScreenGroup")
         local background = MenuCommon.SetupBackground(GetFrame(0))
     end
-    
+
     dialog = Bitmap(parent, UIUtil.UIFile('/scx_menu/options/panel_bmp.dds'))
     LayoutHelpers.AtCenterIn(dialog, parent)
-    
+
     dialog.brackets = UIUtil.CreateDialogBrackets(dialog, 41, 24, 41, 24)
-    
+
     local title = UIUtil.CreateText(dialog, "<LOC _Options>", 24, UIUtil.titleFont)
     LayoutHelpers.AtTopIn(title, dialog, 30)
     LayoutHelpers.AtHorizontalCenterIn(title, dialog)
-    
+
     if over then
         dialog.Depth:Set(GetFrame(over:GetRootFrame():GetTargetHead()):GetTopmostDepth() + 1)
     end
-    
+
     local function roHandler(self, event)
         if event == 'enter' then
             self.label:SetColor('ff000000')
@@ -291,9 +290,9 @@ function CreateDialog(over, exitBehavior)
             self.label:SetColor(UIUtil.fontColor)
         end
     end
-    
+
     -- layout buttons
-    local applyBtn = Button(dialog, 
+    local applyBtn = Button(dialog,
         UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_up.dds'),
         UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_down.dds'),
         UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_over.dds'),
@@ -304,8 +303,8 @@ function CreateDialog(over, exitBehavior)
     LayoutHelpers.AtCenterIn(applyBtn.label, applyBtn)
     Tooltip.AddButtonTooltip(applyBtn, 'options_tab_apply')
     applyBtn.OnRolloverEvent = roHandler
-    
-    dialog.cancelBtn = Button(dialog, 
+
+    dialog.cancelBtn = Button(dialog,
         UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_up.dds'),
         UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_down.dds'),
         UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_over.dds'),
@@ -315,8 +314,8 @@ function CreateDialog(over, exitBehavior)
     LayoutHelpers.AtCenterIn(dialog.cancelBtn.label, dialog.cancelBtn)
     LayoutHelpers.LeftOf(dialog.cancelBtn, applyBtn, -6)
     dialog.cancelBtn.OnRolloverEvent = roHandler
-    
-    local okBtn = Button(dialog, 
+
+    local okBtn = Button(dialog,
         UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_up.dds'),
         UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_down.dds'),
         UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_over.dds'),
@@ -327,8 +326,8 @@ function CreateDialog(over, exitBehavior)
     LayoutHelpers.LeftOf(okBtn, dialog.cancelBtn, -6)
     okBtn.OnRolloverEvent = roHandler
 
-    
-    local resetBtn = Button(dialog, 
+
+    local resetBtn = Button(dialog,
         UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_up.dds'),
         UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_down.dds'),
         UIUtil.UIFile('/scx_menu/small-short-btn/small-btn_over.dds'),
@@ -340,7 +339,7 @@ function CreateDialog(over, exitBehavior)
     Tooltip.AddButtonTooltip(resetBtn, 'options_reset_all')
     resetBtn.OnRolloverEvent = roHandler
 
-    
+
     -- set up button logic
     okBtn.OnClick = function(self, modifiers)
         OptionsLogic.SetCurrent(currentOptionsSet)
@@ -355,8 +354,8 @@ function CreateDialog(over, exitBehavior)
                     option.cancel()
                 end
             end
-        end        
-        
+        end
+
         KillDialog()
         if exitBehavior then exitBehavior() end
     end
@@ -373,23 +372,23 @@ function CreateDialog(over, exitBehavior)
             if exitBehavior then exitBehavior() end
         end
 
-        UIUtil.QuickDialog(dialog, "<LOC options_0002>Are you sure you want to reset to default values?", 
-            "<LOC _Yes>", DoReset, 
-            "<LOC _No>", nil,  
-            nil, nil, 
+        UIUtil.QuickDialog(dialog, "<LOC options_0002>Are you sure you want to reset to default values?",
+            "<LOC _Yes>", DoReset,
+            "<LOC _No>", nil,
+            nil, nil,
             true,
             {escapeButton = 2, enterButton = 1, worldCover = false})
     end
-    
+
     UIUtil.MakeInputModal(dialog, function() okBtn.OnClick(okBtn) end, function() dialog.cancelBtn.OnClick(dialog.cancelBtn) end)
-    
+
     -- set up option grid
     local elementWidth, elementHeight = GetTextureDimensions(UIUtil.UIFile('/dialogs/options-02/content-box_bmp.dds'))
     local optionGrid = Grid(dialog, elementWidth, elementHeight)
     LayoutHelpers.RelativeTo(optionGrid, dialog, UIUtil.SkinnableFile('/dialogs/options-02/options-02_layout.lua'), 'gameplay_bmp', 'panel_bmp')
     LayoutHelpers.DimensionsRelativeTo(optionGrid, UIUtil.SkinnableFile('/dialogs/options-02/options-02_layout.lua'), 'gameplay_bmp')
     local scrollbar = UIUtil.CreateVertScrollbarFor(optionGrid, -4)
-    
+
     -- set up a page
     function SetNewPage(tabControl)
         -- kill any other page
@@ -409,26 +408,26 @@ function CreateDialog(over, exitBehavior)
         LayoutHelpers.AtCenterIn(currentTabBitmap, currentTabButton)
         local tabLabel = UIUtil.CreateText(currentTabBitmap, tabData.title, 16, UIUtil.titleFont)
         LayoutHelpers.AtCenterIn(tabLabel, currentTabBitmap)
-        
+
         -- remove controls and populate grid
         optionGrid:DeleteAndDestroyAll(true)
         optionGrid:AppendCols(1, true)
-        
+
         -- initialzie key to control map each time page is changed, as controls get destroyed
         optionKeyToControlMap = {}
 
         for index, option in tabData.items do
             optionGrid:AppendRows(1, true)
-            local optCtrl = CreateOption(optionGrid, option) 
+            local optCtrl = CreateOption(optionGrid, option)
             optionGrid:SetItem(optCtrl, 1, index, true)
             if option.init then
                 option.init()
             end
         end
-                
+
         optionGrid:EndBatch()
     end
-    
+
     -- tab layout
     local prev = false
     local defaultTab = false
@@ -436,7 +435,7 @@ function CreateDialog(over, exitBehavior)
     -- get the tab data
     local options = import('/lua/options/options.lua').options
     local optionsOrder = import('/lua/options/options.lua').optionsOrder
-    
+
     for index, key in optionsOrder do
         tabData = options[key]
         local curButton = UIUtil.CreateButtonStd(dialog, '/scx_menu/tab_btn/tab', tabData.title, 16, 0, 0, "UI_Tab_Click_01", "UI_Tab_Rollover_01")
@@ -452,12 +451,12 @@ function CreateDialog(over, exitBehavior)
         curButton.OnClick = function(self, modifiers)
             SetNewPage(self)
         end
-        
+
         curButton.tabData = tabData
     end
-    
+
     SetNewPage(defaultTab)
-    
+
     if not optionGrid:IsScrollable("Vert") then
         scrollbar:Hide()
     end
@@ -467,7 +466,7 @@ function CreateDialog(over, exitBehavior)
             optionKeyToControlMap[optionKey].SetCustomData(newCustomData, newDefault)
         end
     end)
-    
+
     local function OptionRestartFunc(proceedFunc, cancelFunc)
         UIUtil.QuickDialog(GetFrame(0) , "<LOC options_0001>You have modified an option which requires you to restart Forged Alliance. Selecting OK will exit the game, selecting Cancel will revert the option to its prior setting."
             , "<LOC _OK>", proceedFunc
@@ -478,7 +477,7 @@ function CreateDialog(over, exitBehavior)
         )
     end
     OptionsLogic.SetSummonRestartDialogCallback(OptionRestartFunc)
-    
+
     local function VerifyFunc(undoFunc)
         local secondsToWait = 15
         local thread
@@ -490,7 +489,7 @@ function CreateDialog(over, exitBehavior)
             , true
             , {escapeButton = 2, enterButton = 1, worldCover = false}
         )
-        
+
         thread = ForkThread(function()
             for sec = 1, secondsToWait do
                 WaitSeconds(1)


### PR DESCRIPTION
If you try to change the screen resulution of the game, you will get a requester with a 15 second count down:

![ok](https://cloud.githubusercontent.com/assets/17804547/25769001/a4edcadc-320f-11e7-9586-85fb7d62dcff.png)

But the time don't count down, instead you get an Error:

```
WARNING: Error running lua script: ...1.5.3603\gamedata\lua.scd\lua\ui\dialogs\options.lua(497): attempt to call method `SetText' (a nil value)
         stack traceback:
         	...1.5.3603\gamedata\lua.scd\lua\ui\dialogs\options.lua(497): in function <...1.5.3603\gamedata\lua.scd\lua\ui\dialogs\options.lua:494>
```

Line 497 is used to set the new text inside the button with the time count down:

`dlg._button1.label:SetText(LOC("<LOC _Ok>") .. " [" .. (secondsToWait - sec) .. "]")`

I added the "content" array level, now we can access the button again, and set the text:

`dlg.content._button1.label:SetText(LOC("<LOC _Ok>") .. " [" .. (secondsToWait - sec) .. "]")`

I dont know why the button is now inside `content` instead directly inside dlg.
But now the count down is running again without errors :)