### PR TITLE
Lobby: fix some chat issues

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3641,10 +3641,11 @@ function AddChatText(text)
         LOG("text=" .. repr(text))
         return
     end
-
+    
+    local scrolledToBottom = GUI.chatPanel.top >= GUI.chatDisplay:GetItemCount()-13
+    
     GUI.chatDisplay:AppendLine(text)
-
-    if GUI.chatPanel.top >= GUI.chatDisplay:GetItemCount()-14 then
+    if scrolledToBottom then
         GUI.chatPanel:ScrollSetTop(nil,GUI.chatDisplay:GetItemCount()-13)
     else
         GUI.newMessageArrow:Enable()


### PR DESCRIPTION
Last patch 3680 introduced some issues with lobby chat. 
ie : multi-line messages make is so chat isn't completely scrolled down.

People wanted it to be scrolled down immediatly when you write yourself.

Make it work with multiple font sizes. (didn't know this was a thing)