### PR TITLE
Don't display BuildCost in 'queuestack', 'unitstack' and 'attachedunit'

### DIFF
--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -1096,8 +1096,10 @@ function OnRolloverHandler(button, state)
     end
 
     if state == 'enter' then
-        if item.type == 'item' or item.type == 'queuestack' or item.type == 'unitstack' or item.type == 'attachedunit' then
+        if item.type == 'item' then
             UnitViewDetail.Show(__blueprints[item.id], sortedOptions.selection[1], item.id)
+        elseif item.type == 'queuestack' or item.type == 'unitstack' or item.type == 'attachedunit' then
+            UnitViewDetail.Show(__blueprints[item.id], nil, item.id)
         elseif item.type == 'enhancement' then
             UnitViewDetail.ShowEnhancement(item.enhTable, item.unitID, item.icon, GetEnhancementPrefix(item.unitID, item.icon), sortedOptions.selection[1])
         end


### PR DESCRIPTION
#2005
(http://forums.faforever.com/viewtopic.php?f=3&t=14602)

Removed the display of Buildcost inside Unitdetail window if you hover the mouse over `queuestack', 'unitstack' and 'attachedunit'

To do so, i used the fact, that we have already an if/then request inside function `unitviewDetail.lua.show()` to check if we have an buildingUnit.
If no buildingUnit is present, we don't display economy.

So i call 'Show' without an buildingUnit: (nil = buildingUnit)
```UnitViewDetail.Show(__blueprints[item.id], nil, item.id)```