### PR TITLE
Check if gunship has a cargo properly

### DIFF
--- a/units/UEA0203/UEA0203_script.lua
+++ b/units/UEA0203/UEA0203_script.lua
@@ -45,8 +45,8 @@ UEA0203 = Class(AirTransport, TAirUnit) {
         -- Since this is the only unit capable of carrying another into a transport
         -- We need to disable the weapon on that unit in case it's a LAB
         -- Use SetEnabled rather than SetOnTransport to ignore units like LABs which can fire from transports
-        local unit = self:GetCargo()
-        if unit then
+        local units = self:GetCargo()
+        if units[1] then
             for i = 1, unit:GetWeaponCount() do
                 local wep = unit:GetWeapon(i)
                 wep:SetEnabled(not bool)


### PR DESCRIPTION
`GetCargo()` returns empty table if the gunship has no cargo which is
taken as true in the condition below
Fixes #2010