### PR TITLE
Change ping lockout to be per player instead of global

### DIFF
--- a/lua/SimPing.lua
+++ b/lua/SimPing.lua
@@ -1,6 +1,9 @@
 local SUtils = import('/lua/ai/sorianutilities.lua')
 
-local PingLocked = false
+local PingLimit = 3 -- Maximum number of pings per army, within PingTimeout seconds
+local ExtraMarkers = 1 -- How many extra markers an army can make beyond the normal ping limit
+local PingTimeout = 15 -- How long a ping counts toward an army's limit
+local PingsRemaining = {}
 local PingMarkers = {}
 MaxPingMarkers = 15
 --On first ping, send data to the user layer telling it the maximum allowable markers per army
@@ -18,13 +21,17 @@ function AnimatePingMesh(entity)
 end
 
 function SpawnPing(data)
-    if not PingLocked then
+    if not PingsRemaining[data.Owner] then
+        PingsRemaining[data.Owner] = PingLimit
+    end
+    
+    if PingsRemaining[data.Owner] > 0 or data.Marker and PingsRemaining[data.Owner] > -ExtraMarkers then
         if data.Marker and PingMarkers[data.Owner] and table.getsize(PingMarkers[data.Owner]) >= MaxPingMarkers then
             return
         elseif data.Marker and not PingMarkers[data.Owner] then
             PingMarkers[data.Owner] = {}
         end
-        PingLocked = true
+        PingsRemaining[data.Owner] = PingsRemaining[data.Owner] - 1
 
         if data.Marker and GetPingID(data.Owner) then
             data.ID = GetPingID(data.Owner)
@@ -60,7 +67,7 @@ function SpawnPing(data)
             end
         end
 
-        ForkThread(function() WaitSeconds(1) PingLocked = false end)
+        ForkThread(function(owner) WaitSeconds(PingTimeout) PingsRemaining[owner] = PingsRemaining[owner] + 1 end, data.Owner)
     end
 end
 

--- a/lua/SimPing.lua
+++ b/lua/SimPing.lua
@@ -1,8 +1,7 @@
 local SUtils = import('/lua/ai/sorianutilities.lua')
 
-local PingLimit = 3 -- Maximum number of pings per army, within PingTimeout seconds
-local ExtraMarkers = 1 -- How many extra markers an army can make beyond the normal ping limit
-local PingTimeout = 15 -- How long a ping counts toward an army's limit
+local PingLimit = 1 -- Maximum number of pings per army, within PingTimeout seconds
+local PingTimeout = 1 -- How many seconds a ping counts toward an army's limit
 local PingsRemaining = {}
 local PingMarkers = {}
 MaxPingMarkers = 15
@@ -25,7 +24,7 @@ function SpawnPing(data)
         PingsRemaining[data.Owner] = PingLimit
     end
     
-    if PingsRemaining[data.Owner] > 0 or data.Marker and PingsRemaining[data.Owner] > -ExtraMarkers then
+    if PingsRemaining[data.Owner] > 0 then
         if data.Marker and PingMarkers[data.Owner] and table.getsize(PingMarkers[data.Owner]) >= MaxPingMarkers then
             return
         elseif data.Marker and not PingMarkers[data.Owner] then


### PR DESCRIPTION
Addresses #1982 by changing the limit to be per player. It allows 3 pings with a 15 second cooldown. It also allows an additional marker after reaching the limit, to be a little more accommodating if someone takes the time to type out a message. The marker still adds to the cooldown to prevent low effort marker spam.