### PR TITLE
Fix missing reference in Ythotha script

### DIFF
--- a/units/XSL0401/XSL0401_Script.lua
+++ b/units/XSL0401/XSL0401_Script.lua
@@ -12,6 +12,7 @@ local SDFAireauWeapon = WeaponsFile.SDFAireauWeapon
 local SDFSinnuntheWeapon = WeaponsFile.SDFSinnuntheWeapon
 local SAAOlarisCannonWeapon = WeaponsFile.SAAOlarisCannonWeapon
 local utilities = import('/lua/utilities.lua')
+local EffectUtil = import('/lua/EffectUtilities.lua')
 local explosion = import('/lua/defaultexplosions.lua')
 
 XSL0401 = Class(SWalkingLandUnit) {


### PR DESCRIPTION
Removing this causes an error in StartBeingBuiltEffects where EffectUtil is used.