### PR TITLE
 Check for destroyed units before EntityCategoryFilterDown in orders.lua

### DIFF
--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -1042,7 +1042,14 @@ local function CreateCommonOrders(availableOrders, init)
         end
     end
 
-    local units = currentSelection
+    local units = {}
+    if currentSelection and table.getn(currentSelection) > 0 then
+        for unit in currentSelection do
+            if not IsDestroyed(unit) then
+                table.insert(units, unit)
+            end
+        end
+    end
     if units and table.getn(units) > 0 and EntityCategoryFilterDown(categories.MOBILE - categories.STRUCTURE, units) then
         for _, availOrder in availableOrders do
             if (availOrder == 'RULEUCC_RetaliateToggle' and table.getn(EntityCategoryFilterDown(categories.MOBILE, units)) > 0)


### PR DESCRIPTION
Whenever the orders need to be redone, without there being a selection change (ie changed ui faction), it is possible that there are some destroyed units in the currentselection table. The function EntityCategoryFilterDown can't handle that. So we need to filter out the destroyed units before using it.

It causes an issue in coop when the acu dies while you have it selected and you can't go to the scorescreen anymore due to this issue.
https://github.com/FAForever/fa-coop/issues/68