### PR TITLE
Base manager improvements

### DIFF
--- a/lua/AI/OpAI/AirAttacks_save.lua
+++ b/lua/AI/OpAI/AirAttacks_save.lua
@@ -261,6 +261,10 @@ Scenario = {
             'OST_AirAttacks_T2AeonPlatoon3', '',
             { 'xaa0202', -1, 1, 'attack', 'AttackFormation' },  #XPack Combat Fighter
         },
+        ['OST_AirAttacks_T2AeonPlatoon4'] = {
+            'OST_AirAttacks_T2AeonPlatoon4', '',
+            { 'daa0206', -1, 1, 'attack', 'AttackFormation' },  #Mercy
+        },
 
         #### T3
         ['OST_AirAttacks_T3AeonAntiNaval1'] = {
@@ -1529,6 +1533,43 @@ Scenario = {
                             }},
                         },
                         ChildrenType = {'CombatFighters'},
+                    },
+                    ['OSB_Child_AirAttacks_T2AeonPlatoon4'] =  {
+                        PlatoonTemplate = 'OST_AirAttacks_T2AeonPlatoon4',
+                        Priority = 696,
+                        InstanceCount = 3,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Air',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/airattacks_editorfunctions.lua', 'AirAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/platooncountbuildconditions.lua', 'NumBuildersLessThanOSCounter',
+                                {'default_brain','default_builder_name', 2 },
+                                {'default_brain','default_builder_name','2'}
+                            },
+                            [3] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 0 },
+                                {'default_brain', '2','0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_AirAttacks'},
+                                {type = 2, name = 'APPEND_PlatoonChild', value = 'OSB_Master_AirAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'GuidedMissiles'},
                     },
             #### T3
                     ['OSB_Child_AirAttacks_T3AeonAntiNaval1'] =  {

--- a/lua/AI/OpAI/BaseManager.lua
+++ b/lua/AI/OpAI/BaseManager.lua
@@ -157,7 +157,7 @@ BaseManager = Class {
             NumAssisting = 0,           -- Number of engies assisting the conditional build
             MaxAssisting = 1,           -- Maximum units to assist the current conditional build
             Unit = false,            -- The actual unit being constructed currently
-            MainBuilder = false;     -- False if there is currently not a main conditional builder, else the unit building
+            MainBuilder = false,     -- False if there is currently not a main conditional builder, else the unit building
             Index = 0,               -- Stores the index of the current conditional being built
             WaitSecondsAfterDeath = false, -- Time to wait after conditional build's death before starting a new one.
 
@@ -184,11 +184,11 @@ BaseManager = Class {
     -- Level Table format
     -- {
     --     GroupName = Priority, -- Name not in quotes
-    --}
+    -- }
     Initialize = function(self, brain, baseName, markerName, radius, levelTable, diffultySeparate)
         self.Active = true
         if self.Initialized then
-            error('*AI ERROR: BaseManager named "'..baseName..'" has already been initialized', 2)
+            error('*AI ERROR: BaseManager named "' .. baseName .. '" has already been initialized', 2)
         end
 
         self.Initialized = true
@@ -1253,7 +1253,7 @@ BaseManager = Class {
         AirScoutingActive = function(self, val)
             self.FunctionalityStates.AirScouting = val
         end,
-   },
+    },
 
     -- Enable/Disable building of buildings and stuff
     SetBuild = function(self, buildType, val)
@@ -1425,7 +1425,7 @@ BaseManager = Class {
             self.BuildTable['MassStorage'] = val
             self.BuildTable['EnergyStorage'] = val
         end,
-   },
+    },
 
     -------------------------------------
     -- Default builders for base managers

--- a/lua/AI/OpAI/BaseManager.lua
+++ b/lua/AI/OpAI/BaseManager.lua
@@ -131,7 +131,7 @@ BaseManager = Class {
             Patrolling = true,
             SeaAttacks = true,
             Shields = true,
-            TML = true,
+            TMLs = true,
             Torpedos = true,
             Walls = true,
 
@@ -215,6 +215,7 @@ BaseManager = Class {
         self:LoadDefaultBaseSupportCDRs() -- sACU things
         self:LoadDefaultBaseEngineers() -- All other Engs
         self:LoadDefaultScoutingPlatoons() -- Load in default scouts
+        self:LoadDefaultBaseTMLs() -- TMLs
         self:SortGroupNames() -- Force sort since no sorting when adding groups earlier
         self:ForkThread(self.UpgradeCheckThread) -- Start the thread to see if any buildings need upgrades
 
@@ -1244,6 +1245,7 @@ BaseManager = Class {
         end,
 
         TMLActive = function(self, val)
+            self.FunctionalityStates.TMLs = val
         end,
 
         PatrolActive = function(self, val)
@@ -1643,6 +1645,38 @@ BaseManager = Class {
             InstanceCount = 1,
         }
         self.AIBrain:PBMAddPlatoon(defaultBuilder)
+    end,
+
+    LoadDefaultBaseTMLs = function(self)
+        local defaultBuilder = {
+            BuilderName = 'BaseManager_TMLPlatoon_' .. self.BaseName,
+            PlatoonTemplate = self:CreateTMLPlatoonTemplate(),
+            Priority = 300,
+            PlatoonType = 'Any',
+            RequiresConstruction = false,
+            LocationType = self.BaseName,
+            PlatoonAIFunction = {'/lua/ai/opai/BaseManagerPlatoonThreads.lua', 'BaseManagerTMLAI'},
+            BuildConditions = {
+                {BMBC, 'BaseActive', {self.BaseName}},
+                {BMBC, 'TMLsEnabled', {self.BaseName}},
+            },
+            PlatoonData = {
+                BaseName = self.BaseName,
+            },
+        }
+        self.AIBrain:PBMAddPlatoon(defaultBuilder)
+    end,
+
+    CreateTMLPlatoonTemplate = function(self)
+        local faction = self.AIBrain:GetFactionIndex()
+        local template = {
+            'TMLTemplate',
+            'NoPlan',
+            {'ueb2108', 1, 1, 'Attack', 'None'},
+        }
+        template = ScenarioUtils.FactionConvert(template, faction)
+
+        return template
     end,
 
     CreateLandScoutPlatoon = function(self)

--- a/lua/AI/OpAI/BaseManager.lua
+++ b/lua/AI/OpAI/BaseManager.lua
@@ -1506,7 +1506,7 @@ BaseManager = Class {
             RequiresConstruction = false,
             LocationType = self.BaseName,
             PlatoonAddFunctions = {
-                {'/lua/ai/opai/OpBehaviors.lua', 'CDROverchargeBehavior'},
+                -- {'/lua/ai/opai/OpBehaviors.lua', 'CDROverchargeBehavior'}, -- TODO: Re-add once it doesnt interfere with BM engineer thread
                 {BMPT, 'UnitUpgradeBehavior'},
             },
             PlatoonAIFunction = {'/lua/ai/opai/BaseManagerPlatoonThreads.lua', 'BaseManagerEngineerPlatoonSplit'},

--- a/lua/AI/OpAI/BaseManager.lua
+++ b/lua/AI/OpAI/BaseManager.lua
@@ -218,9 +218,17 @@ BaseManager = Class {
         self:SortGroupNames() -- Force sort since no sorting when adding groups earlier
         self:ForkThread(self.UpgradeCheckThread) -- Start the thread to see if any buildings need upgrades
 
-        -- Check for a default patrol chain for engineers
+        -- Check for a default chains for engineers' patrol and scouting
         if Scenario.Chains[baseName..'_EngineerChain'] then
             self:SetDefaultEngineerPatrolChain(baseName..'_EngineerChain')
+        end
+
+        if Scenario.Chains[baseName..'_AirScoutChain'] then
+            self:SetDefaultAirScoutPatrolChain(baseName..'_AirScoutChain')
+        end
+
+        if Scenario.Chains[baseName..'_LandScoutChain'] then
+            self:SetDefaultLandScoutPatrolChain(baseName..'_LandScoutChain')
         end
     end,
 

--- a/lua/AI/OpAI/BaseManager.lua
+++ b/lua/AI/OpAI/BaseManager.lua
@@ -515,7 +515,7 @@ BaseManager = Class {
     end,
 
     NeedPermanentFactoryAssist = function(self)
-        if self:GetPermanentAssistCount() > self:GetNumPermanentAssisting() then
+        if table.getn(self:GetAllBaseFactories()) >= 1 and self:GetPermanentAssistCount() > self:GetNumPermanentAssisting() then
             return true
         end
         return false

--- a/lua/AI/OpAI/BaseManager.lua
+++ b/lua/AI/OpAI/BaseManager.lua
@@ -127,7 +127,7 @@ BaseManager = Class {
             Intel = true,
             LandAttacks = true,
             LandScouting = false,
-            Nukes = true,
+            Nukes = false,
             Patrolling = true,
             SeaAttacks = true,
             Shields = true,
@@ -216,6 +216,7 @@ BaseManager = Class {
         self:LoadDefaultBaseEngineers() -- All other Engs
         self:LoadDefaultScoutingPlatoons() -- Load in default scouts
         self:LoadDefaultBaseTMLs() -- TMLs
+        self:LoadDefaultBaseNukes() -- Nukes
         self:SortGroupNames() -- Force sort since no sorting when adding groups earlier
         self:ForkThread(self.UpgradeCheckThread) -- Start the thread to see if any buildings need upgrades
 
@@ -1248,6 +1249,10 @@ BaseManager = Class {
             self.FunctionalityStates.TMLs = val
         end,
 
+        NukeActive = function(self, val)
+            self.FunctionalityStates.Nukes = val
+        end,
+
         PatrolActive = function(self, val)
             self.FunctionalityStates.Patrolling = val
         end,
@@ -1667,12 +1672,44 @@ BaseManager = Class {
         self.AIBrain:PBMAddPlatoon(defaultBuilder)
     end,
 
+    LoadDefaultBaseNukes = function(self)
+        local defaultBuilder = {
+            BuilderName = 'BaseManager_NukePlatoon_' .. self.BaseName,
+            PlatoonTemplate = self:CreateNukePlatoonTemplate(),
+            Priority = 400,
+            PlatoonType = 'Any',
+            RequiresConstruction = false,
+            LocationType = self.BaseName,
+            PlatoonAIFunction = {'/lua/ai/opai/BaseManagerPlatoonThreads.lua', 'BaseManagerNukeAI'},
+            BuildConditions = {
+                {BMBC, 'BaseActive', {self.BaseName}},
+                {BMBC, 'NukesEnabled', {self.BaseName}},
+            },
+            PlatoonData = {
+                BaseName = self.BaseName,
+            },
+        }
+        self.AIBrain:PBMAddPlatoon(defaultBuilder)
+    end,
+
     CreateTMLPlatoonTemplate = function(self)
         local faction = self.AIBrain:GetFactionIndex()
         local template = {
             'TMLTemplate',
             'NoPlan',
             {'ueb2108', 1, 1, 'Attack', 'None'},
+        }
+        template = ScenarioUtils.FactionConvert(template, faction)
+
+        return template
+    end,
+
+    CreateNukePlatoonTemplate = function(self)
+        local faction = self.AIBrain:GetFactionIndex()
+        local template = {
+            'NukeTemplate',
+            'NoPlan',
+            {'ueb2305', 1, 1, 'Attack', 'None'},
         }
         template = ScenarioUtils.FactionConvert(template, faction)
 

--- a/lua/AI/OpAI/BaseManager.lua
+++ b/lua/AI/OpAI/BaseManager.lua
@@ -1509,7 +1509,7 @@ BaseManager = Class {
                 -- {'/lua/ai/opai/OpBehaviors.lua', 'CDROverchargeBehavior'}, -- TODO: Re-add once it doesnt interfere with BM engineer thread
                 {BMPT, 'UnitUpgradeBehavior'},
             },
-            PlatoonAIFunction = {'/lua/ai/opai/BaseManagerPlatoonThreads.lua', 'BaseManagerEngineerPlatoonSplit'},
+            PlatoonAIFunction = {'/lua/ai/opai/BaseManagerPlatoonThreads.lua', 'BaseManagerSingleEngineerPlatoon'},
             BuildConditions = {
                 {BMBC, 'BaseActive', {self.BaseName}},
             },
@@ -1532,7 +1532,7 @@ BaseManager = Class {
             PlatoonAddFunctions = {
                 {BMPT, 'UnitUpgradeBehavior'},
             },
-            PlatoonAIFunction = {'/lua/ai/opai/BaseManagerPlatoonThreads.lua', 'BaseManagerEngineerPlatoonSplit'},
+            PlatoonAIFunction = {'/lua/ai/opai/BaseManagerPlatoonThreads.lua', 'BaseManagerSingleEngineerPlatoon'},
             BuildConditions = {
                 {BMBC, 'BaseActive', {self.BaseName}},
             },

--- a/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
+++ b/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
@@ -1247,25 +1247,14 @@ function UnitUpgradeThread(unit)
         unitType = 'DefaultSACU'
     end
 
-    local pool = aiBrain:GetPlatoonUniquelyNamed('ArmyPool')
     while not unit:IsDead() do
         if not bManager then
             bManager = aiBrain.BaseManagers[unit.PlatoonData.BaseName]
         end
         if bManager then
-            -- See if unit is in the pool
-            local found = false
-            for k, v in pool:GetPlatoonUnits() do
-                if v == unit then
-                    found = true
-                    break
-                end
-            end
-
-            -- If its in the pool and needs an upgrade
             local upgradeName = bManager:UnitNeedsUpgrade(unit, unitType)
 
-            if found and upgradeName then
+            if upgradeName and not unit:IsUnitState('Building') then
                 local platoon = aiBrain:MakePlatoon('', '')
                 aiBrain:AssignUnitsToPlatoon(platoon, {unit}, 'support', 'none')
 
@@ -1273,6 +1262,8 @@ function UnitUpgradeThread(unit)
                     TaskName = "EnhanceTask",
                     Enhancement = upgradeName
                 }
+                IssueStop({unit})
+                IssueClearCommands({unit})
                 IssueScript({unit}, order)
 
                 repeat

--- a/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
+++ b/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
@@ -1151,6 +1151,9 @@ function BaseManagerTMLAI(platoon)
     end
 end
 
+function BaseManagerNukeAI(platoon)
+end
+
 function AMUnlockBuildTimer(platoon)
     ForkThread(AMPlatoonHelperFunctions.UnlockTimer, platoon.PlatoonData.LockTimer, platoon.PlatoonData.PlatoonName)
 end

--- a/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
+++ b/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
@@ -487,7 +487,7 @@ function PermanentFactoryAssist(platoon)
             end
         end
         -- If the disparity between factories is more than 1, reorganize engineers
-        if not assisting or (high and low and lowFac and high > low + 1 and highFac == unit:GetGuardedUnit()) then
+        if (not assisting and lowFac) or (high and low and lowFac and high > low + 1 and highFac == unit:GetGuardedUnit()) then
             assisting = true
             platoon:Stop()
             IssueGuard({unit}, lowFac)

--- a/lua/AI/OpAI/BaseOpAI.lua
+++ b/lua/AI/OpAI/BaseOpAI.lua
@@ -371,8 +371,8 @@ OpAI = Class {
 
                     -- All keeptable children must be found to be kept as well.
                     if found then
-                        found = false
                         for num,name in keepTable do
+                            found = false
                             for cNun,cName in v.ChildrenType do
                                 -- child name found; move to the next
                                 if cName == name then

--- a/lua/AI/OpAI/BaseOpAI.lua
+++ b/lua/AI/OpAI/BaseOpAI.lua
@@ -404,11 +404,20 @@ OpAI = Class {
 
         OverrideTemplateSize = function(self, quantity)
             for k,v in self.ChildrenHandles do
-                local overrideNum = math.floor(quantity / (table.getn(v.ChildBuilder.PlatoonTemplate) - 2))
-                for sNum,sData in v.ChildBuilder.PlatoonTemplate do
-                    if sNum >= 3 then
-                        sData[2] = 1
-                        sData[3] = overrideNum
+                if type(quantity) == 'table' then
+                    for sNum,sData in v.ChildBuilder.PlatoonTemplate do
+                        if sNum >= 3 then
+                            sData[2] = 1
+                            sData[3] = quantity[sNum - 2] or 1
+                        end
+                    end
+                else
+                    local overrideNum = math.floor(quantity / (table.getn(v.ChildBuilder.PlatoonTemplate) - 2))
+                    for sNum,sData in v.ChildBuilder.PlatoonTemplate do
+                        if sNum >= 3 then
+                            sData[2] = 1
+                            sData[3] = overrideNum
+                        end
                     end
                 end
             end

--- a/lua/AI/OpAI/BasicLandAttack_save.lua
+++ b/lua/AI/OpAI/BasicLandAttack_save.lua
@@ -287,8 +287,8 @@ Scenario = {
     --[[-----------------------------------------------------------------]]--
         ['OST_BasicLandAttack_T2AeonHoverTanks'] = {
             'OST_BasicLandAttack_T2AeonHoverTanks', '',
-            { 'uel0203', -1, 1, 'attack', 'AttackFormation' },
             { 'uel0201', -1, 1, 'attack', 'AttackFormation' },
+            { 'uel0203', -1, 1, 'attack', 'AttackFormation' },
             { 'uel0205', -1, 1, 'attack', 'AttackFormation' },
         },
 
@@ -325,6 +325,22 @@ Scenario = {
             { 'xel0305', -1, 1, 'attack', 'AttackFormation' },
             { 'uel0205', -1, 1, 'attack', 'AttackFormation' },
             { 'uel0307', 1, 5, 'attack', 'AttackFormation' },
+        },
+        ['OST_BasicLandAttack_T2HoverAttack1'] = {
+            'OST_BasicLandAttack_T2HoverAttack1', '',
+            { 'uel0203', -1, 1, 'attack', 'AttackFormation' },
+            { 'uel0205', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_BasicLandAttack_T2HoverAttack2'] = {
+            'OST_BasicLandAttack_T2HoverAttack2', '',
+            { 'uel0203', -1, 1, 'attack', 'AttackFormation' },
+            { 'ual0307', -1, 1, 'attack', 'AttackFormation' },
+        },
+        ['OST_BasicLandAttack_T2HoverAttack3'] = {
+            'OST_BasicLandAttack_T2HoverAttack3', '',
+            { 'uel0203', -1, 1, 'attack', 'AttackFormation' },
+            { 'uel0205', -1, 1, 'attack', 'AttackFormation' },
+            { 'ual0307', -1, 1, 'attack', 'AttackFormation' },
         },
 
     --[[------[ CYBRAN SPECIFIC ]------]]--
@@ -382,11 +398,6 @@ Scenario = {
         },
 
     --[[------[ SERAPHIM SPECIFIC ]------]]--
-        ['OST_BasicLandAttack_T2SeraphimHoverAttack'] = {
-            'OST_BasicLandAttack_T2SeraphimHoverAttack', '',
-            { 'xsl0203', -1, 1, 'attack', 'AttackFormation' },
-            { 'xsl0205', -1, 1, 'attack', 'AttackFormation' },
-        },
         ['OST_BasicLandAttack_T3SeraphimMobileAA'] = {
             'OST_BasicLandAttack_T3SeraphimMobileAA', '',
             { 'dslk004', -1, 1, 'attack', 'GrowthFormation' },
@@ -1669,6 +1680,102 @@ Scenario = {
                         },
                         ChildrenType = {'MobileHeavyArtillery', 'MobileShields', 'HeavyBots', 'MobileFlak'},
                     },
+                    ['OSB_Child_BasicLandAttack_T2HoverAttack1'] =  {
+                        PlatoonTemplate = 'OST_BasicLandAttack_T2HoverAttack1',
+                        Priority = 498,
+                        InstanceCount = 5,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Land',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 4, 0},
+                                {'default_brain','2','4','0'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_BasicLandAttack'},
+                            }},
+                        },
+                        ChildrenType = {'AmphibiousTanks', 'MobileFlak'},
+                    },
+                    ['OSB_Child_BasicLandAttack_T2HoverAttack2'] =  {
+                        PlatoonTemplate = 'OST_BasicLandAttack_T2HoverAttack2',
+                        Priority = 498,
+                        InstanceCount = 5,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Land',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 4, 0},
+                                {'default_brain','2','4','0'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_BasicLandAttack'},
+                            }},
+                        },
+                        ChildrenType = {'AmphibiousTanks', 'MobileShields'},
+                    },
+                    ['OSB_Child_BasicLandAttack_T2HoverAttack3'] =  {
+                        PlatoonTemplate = 'OST_BasicLandAttack_T2HoverAttack3',
+                        Priority = 498,
+                        InstanceCount = 5,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Land',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 4, 0},
+                                {'default_brain','2','4','0'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_BasicLandAttack'},
+                            }},
+                        },
+                        ChildrenType = {'AmphibiousTanks', 'MobileFlak', 'MobileShields'},
+                    },
                     -- Cybran Stuff --
                     ['OSB_Child_BasicLandAttack_T2MobileBombsStealth'] =  {
                         PlatoonTemplate = 'OST_BasicLandAttack_T2MobileBombsStealth',
@@ -1932,38 +2039,6 @@ Scenario = {
                     },
 
                     -- Seraphim Stuff --
-                    ['OSB_Child_BasicLandAttack_T2SeraphimHoverAttack'] =  {
-                        PlatoonTemplate = 'OST_BasicLandAttack_T2SeraphimHoverAttack',
-                        Priority = 498,
-                        InstanceCount = 5,
-                        LocationType = 'MAIN',
-                        PlatoonType = 'Land',
-                        RequiresConstruction = true,
-                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
-                            {'default_platoon'},
-                            {'default_platoon'}
-                        },
-                        BuildConditions = {
-                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [1] = {'/lua/ai/opai/basiclandattack_editorfunctions.lua', 'BasicLandAttackChildCountDifficulty',
-                                {'default_brain','default_master'},
-                                {'default_brain','default_master'}
-                            },
-                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                {'default_brain', 4, 0},
-                                {'default_brain','4','0'}
-                            },
-                        },
-                        PlatoonData = {
-                            {type = 5, name = 'AMPlatoons', value = {
-                                {type = 2, name = 'String_0',  value = 'OSB_Master_BasicLandAttack'},
-                            }},
-                        },
-                        ChildrenType = {'AmphibiousTanks', 'MobileFlak'},
-                    },
                     ['OSB_Child_BasicLandAttack_T3SeraphimMobileAA'] =  {
                         PlatoonTemplate = 'OST_BasicLandAttack_T3SeraphimMobileAA',
                         Priority = 499,

--- a/lua/AI/OpAI/NavalAttacks_EditorFunctions.lua
+++ b/lua/AI/OpAI/NavalAttacks_EditorFunctions.lua
@@ -1,0 +1,62 @@
+-- #****************************************************************************
+-- #**
+-- #**  File     :  /lua/ai/OpAI/NavalAttacks_EditorFunctions
+-- #**  Author(s): speed2
+-- #**
+-- #**  Summary  : Generic AI Platoon Build Conditions
+-- #**             Build conditions always return true or false
+-- #**
+-- #****************************************************************************
+local ScenarioFramework = import('/lua/scenarioframework.lua')
+
+-- ##############################################################################################################
+-- # function: NavalAttacksChildCountDifficulty = BuildCondition   doc = "Please work function docs."
+-- #
+-- # parameter 0: string   aiBrain     = "default_brain"
+-- # parameter 1: string   master     = "default_master"
+-- #
+-- ##############################################################################################################
+function NavalAttacksChildCountDifficulty(aiBrain, master, number)
+    local counter = ScenarioFramework.AMPlatoonCounter(aiBrain, master)
+    local number = ScenarioInfo.OSPlatoonCounter[master..'_D'..ScenarioInfo.Options.Difficulty]
+    if not number then
+        if ScenarioInfo.Options.Difficulty == 1 then
+            number = 1
+        elseif ScenarioInfo.Options.Difficulty == 2 then
+            number = 2
+        else
+            number = 3
+        end
+    end
+    if counter < number then
+        return true
+    else
+        return false
+    end
+end
+
+-- ##############################################################################################################
+-- # function: NavalAttacksMasterCountDifficulty = BuildCondition   doc = "Please work function docs."
+-- #
+-- # parameter 0: string   aiBrain     = "default_brain"
+-- # parameter 1: string   master     = "default_master"
+-- #
+-- ##############################################################################################################
+function NavalAttacksMasterCountDifficulty(aiBrain, master, number)
+    local counter = ScenarioFramework.AMPlatoonCounter(aiBrain, master)
+    local number = ScenarioInfo.OSPlatoonCounter[master..'_D'..ScenarioInfo.Options.Difficulty]
+    if not number then
+        if ScenarioInfo.Options.Difficulty == 1 then
+            number = 1
+        elseif ScenarioInfo.Options.Difficulty == 2 then
+            number = 2
+        else
+            number = 3
+        end
+    end
+    if counter >= number then
+        return true
+    else
+        return false
+    end
+end

--- a/lua/AI/OpAI/NavalAttacks_save.lua
+++ b/lua/AI/OpAI/NavalAttacks_save.lua
@@ -1,0 +1,1690 @@
+--[[                                                                           ]]--
+--[[  Automatically generated code (do not edit)                               ]]--
+--[[                                                                           ]]--
+--[[                                                                           ]]--
+--[[  Scenario                                                                 ]]--
+--[[                                                                           ]]--
+Scenario = {
+    next_area_id = '1',
+    --[[                                                                           ]]--
+    --[[  Props                                                                    ]]--
+    --[[                                                                           ]]--
+    Props = {
+    },
+    --[[                                                                           ]]--
+    --[[  Areas                                                                    ]]--
+    --[[                                                                           ]]--
+    Areas = {
+    },
+    --[[                                                                           ]]--
+    --[[  Markers                                                                  ]]--
+    --[[                                                                           ]]--
+    MasterChain = {
+        ['_MASTERCHAIN_'] = {
+            Markers = {
+            },
+        },
+    },
+    Chains = {
+    },
+    --[[                                                                           ]]--
+    --[[  Orders                                                                   ]]--
+    --[[                                                                           ]]--
+    next_queue_id = '1',
+    Orders = {
+    },
+    --[[                                                                           ]]--
+    --[[  Platoons                                                                 ]]--
+    --[[                                                                           ]]--
+    next_platoon_id = '14',
+    Platoons =
+    {
+        ['OST_BLANK_TEMPLATE'] = {
+            'OST_BLANK_TEMPLATE',
+            '',
+        },
+        -- Common
+        ['OST_NavalAttacks_FrigatePlatoon'] = {
+            'OST_NavalAttacks_FrigatePlatoon',
+            '',
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+        },
+        ['OST_NavalAttacks_T1SubmarinePlatoon'] = {
+            'OST_NavalAttacks_T1SubmarinePlatoon',
+            '',
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T1Platoon1'] = {
+            'OST_NavalAttacks_T1Platoon1',
+            '',
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_DestroyerPlatoon'] = {
+            'OST_NavalAttacks_DestroyerPlatoon',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+        },
+        ['OST_NavalAttacks_CruiserPlatoon'] = {
+            'OST_NavalAttacks_CruiserPlatoon',
+            '',
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+        },
+        ['OST_NavalAttacks_T2Platoon1'] = {
+            'OST_NavalAttacks_T2Platoon1',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+        },
+        ['OST_NavalAttacks_T2Platoon2'] = {
+            'OST_NavalAttacks_T2Platoon2',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T2Platoon3'] = {
+            'OST_NavalAttacks_T2Platoon3',
+            '',
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T2Platoon4'] = {
+            'OST_NavalAttacks_T2Platoon4',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+        },
+        ['OST_NavalAttacks_T2Platoon5'] = {
+            'OST_NavalAttacks_T2Platoon5',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T2Platoon6'] = {
+            'OST_NavalAttacks_T2Platoon6',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_BattleshipPlatoon'] = {
+            'OST_NavalAttacks_BattleshipPlatoon',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+        },
+        ['OST_NavalAttacks_T3Platoon1'] = {
+            'OST_NavalAttacks_T3Platoon1',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+        },
+        ['OST_NavalAttacks_T3Platoon2'] = {
+            'OST_NavalAttacks_T3Platoon2',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+        },
+        ['OST_NavalAttacks_T3Platoon3'] = {
+            'OST_NavalAttacks_T3Platoon3',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+        ['OST_NavalAttacks_T3Platoon4'] = {
+            'OST_NavalAttacks_T3Platoon4',
+            '',
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0103', -1, 1, 'attack', 'AttackFormation' }, -- Frigates
+            { 'ues0203', -1, 1, 'attack', 'AttackFormation' }, -- Submarines
+        },
+
+
+        -- Mixed
+        ['OST_NavalAttacks_T2SubmarinePlatoon'] = {
+            'OST_NavalAttacks_T2SubmarinePlatoon',
+            '',
+            { 'xas0204', -1, 1, 'attack', 'AttackFormation' }, -- T2Submarines
+        },
+        ['OST_NavalAttacks_UtilityPlatoon'] = {
+            'OST_NavalAttacks_UtilityPlatoon',
+            '',
+            { 'xes0205', -1, 1, 'attack', 'AttackFormation' }, -- UtilityBoats
+        },
+        ['OST_NavalAttacks_CarrierPlatoon'] = {
+            'OST_NavalAttacks_CarrierPlatoon',
+            '',
+            { 'uas0303', -1, 1, 'attack', 'AttackFormation' }, -- Carriers
+        },
+        ['OST_NavalAttacks_NukeSubmarinePlatoon'] = {
+            'OST_NavalAttacks_NukeSubmarinePlatoon',
+            '',
+            { 'ues0304', -1, 1, 'attack', 'AttackFormation' }, -- NukeSubmarines
+        },
+        ['OST_NavalAttacks_T2MixedPlatoon1'] = {
+            'OST_NavalAttacks_T2MixedPlatoon1',
+            '',
+            { 'uas0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'xas0204', -1, 1, 'attack', 'AttackFormation' }, -- T2Submarines
+        },
+        ['OST_NavalAttacks_T2MixedPlatoon2'] = {
+            'OST_NavalAttacks_T2MixedPlatoon2',
+            '',
+            { 'uas0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'xas0204', -1, 1, 'attack', 'AttackFormation' }, -- T2Submarines
+        },
+        ['OST_NavalAttacks_T2MixedPlatoon3'] = {
+            'OST_NavalAttacks_T2MixedPlatoon3',
+            '',
+            { 'uas0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'uas0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'xas0204', -1, 1, 'attack', 'AttackFormation' }, -- T2Submarines
+        },
+        ['OST_NavalAttacks_T2MixedPlatoon4'] = {
+            'OST_NavalAttacks_T2MixedPlatoon4',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'xes0205', -1, 1, 'attack', 'AttackFormation' }, -- UtilityBoats
+        },
+        ['OST_NavalAttacks_T2MixedPlatoon5'] = {
+            'OST_NavalAttacks_T2MixedPlatoon5',
+            '',
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'xes0205', -1, 1, 'attack', 'AttackFormation' }, -- UtilityBoats
+        },
+        ['OST_NavalAttacks_T2MixedPlatoon6'] = {
+            'OST_NavalAttacks_T2MixedPlatoon6',
+            '',
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'xes0205', -1, 1, 'attack', 'AttackFormation' }, -- UtilityBoats
+        },
+        ['OST_NavalAttacks_T3MixedPlatoon1'] = {
+            'OST_NavalAttacks_T3MixedPlatoon1',
+            '',
+            { 'uas0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'uas0303', -1, 1, 'attack', 'AttackFormation' }, -- Carriers
+        },
+        ['OST_NavalAttacks_T3MixedPlatoon2'] = {
+            'OST_NavalAttacks_T3MixedPlatoon2',
+            '',
+            { 'uas0303', -1, 1, 'attack', 'AttackFormation' }, -- Carriers
+            { 'uas0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+        },
+
+
+
+        -- Aeon Specific
+        ['OST_NavalAttacks_AABoatPlatoon'] = {
+            'OST_NavalAttacks_AABoatPlatoon',
+            '',
+            { 'uas0102', -1, 1, 'attack', 'AttackFormation' }, -- AABoats
+        },
+        ['OST_NavalAttacks_MissileShipPlatoon'] = {
+            'OST_NavalAttacks_MissileShipPlatoon',
+            '',
+            { 'xas0306', -1, 1, 'attack', 'AttackFormation' }, -- MissleShips
+        },
+        ['OST_NavalAttacks_AAPlatoon'] = {
+            'OST_NavalAttacks_AAPlatoon',
+            '',
+            { 'uas0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+            { 'uas0102', -1, 1, 'attack', 'AttackFormation' }, -- AABoats
+        },
+        ['OST_NavalAttacks_T3AeonPlatoon1'] = {
+            'OST_NavalAttacks_T3AeonPlatoon1',
+            '',
+            { 'uas0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'xas0306', -1, 1, 'attack', 'AttackFormation' }, -- MissleShips
+        },
+        ['OST_NavalAttacks_T3AeonPlatoon2'] = {
+            'OST_NavalAttacks_T3AeonPlatoon2',
+            '',
+            { 'uas0303', -1, 1, 'attack', 'AttackFormation' }, -- Carriers
+            { 'xas0306', -1, 1, 'attack', 'AttackFormation' }, -- MissleShips
+        },
+        ['OST_NavalAttacks_T3AeonPlatoon3'] = {
+            'OST_NavalAttacks_T3AeonPlatoon3',
+            '',
+            { 'xas0306', -1, 1, 'attack', 'AttackFormation' }, -- MissleShips
+            { 'uas0202', -1, 1, 'attack', 'AttackFormation' }, -- Cruisers
+        },
+
+
+
+        -- Seraphim Specific
+        ['OST_NavalAttacks_T3SubmarinePlatoon'] = {
+            'OST_NavalAttacks_T3SubmarinePlatoon',
+            '',
+            { 'xss0304', -1, 1, 'attack', 'AttackFormation' }, -- T3Submarine
+        },
+        ['OST_NavalAttacks_T3SeraphimPlatoon1'] = {
+            'OST_NavalAttacks_T3SeraphimPlatoon1',
+            '',
+            { 'xss0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+            { 'xss0304', -1, 1, 'attack', 'AttackFormation' }, -- T3Submarine
+        },
+        ['OST_NavalAttacks_T3SeraphimPlatoon2'] = {
+            'OST_NavalAttacks_T3SeraphimPlatoon2',
+            '',
+            { 'xss0303', -1, 1, 'attack', 'AttackFormation' }, -- Carriers
+            { 'xss0304', -1, 1, 'attack', 'AttackFormation' }, -- T3Submarine
+        },
+        ['OST_NavalAttacks_T3SeraphimPlatoon3'] = {
+            'OST_NavalAttacks_T3SeraphimPlatoon3',
+            '',
+            { 'xss0304', -1, 1, 'attack', 'AttackFormation' }, -- T3Submarine
+            { 'xss0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+        },
+
+
+
+        -- UEF Specific
+        ['OST_NavalAttacks_TropBoatPlatoon'] = {
+            'OST_NavalAttacks_TropBoatPlatoon',
+            '',
+            { 'ues0202', -1, 1, 'attack', 'AttackFormation' }, -- TorpedoBoats
+        },
+        ['OST_NavalAttacks_BattleCruiserPlatoon'] = {
+            'OST_NavalAttacks_BattleCruiserPlatoon',
+            '',
+            { 'xes0307', -1, 1, 'attack', 'AttackFormation' }, -- BattleCruisers
+        },
+        ['OST_NavalAttacks_T3UEFPlatoon1'] = {
+            'OST_NavalAttacks_T3UEFPlatoon1',
+            '',
+            { 'xes0307', -1, 1, 'attack', 'AttackFormation' }, -- BattleCruisers
+            { 'ues0302', -1, 1, 'attack', 'AttackFormation' }, -- Battleships
+        },
+        ['OST_NavalAttacks_T3UEFPlatoon2'] = {
+            'OST_NavalAttacks_T3UEFPlatoon2',
+            '',
+            { 'xes0307', -1, 1, 'attack', 'AttackFormation' }, -- BattleCruisers
+            { 'ues0201', -1, 1, 'attack', 'AttackFormation' }, -- Destroyers
+        },
+    },
+    --[[                                                                           ]]--
+    --[[  Armies                                                                   ]]--
+    --[[                                                                           ]]--
+    next_army_id = '2',
+    next_group_id = '1',
+    next_unit_id = '1',
+    Armies =
+    {
+        --[[                                                                           ]]--
+        --[[  Army                                                                     ]]--
+        --[[                                                                           ]]--
+        ['ARMY_1'] =
+        {
+            personality = '',
+            plans = '',
+            color = 0,
+            faction = 0,
+            Economy = {
+                mass = 0,
+                energy = 0,
+            },
+            Alliances = {
+            },
+            ['Units'] = GROUP {
+                orders = '',
+                platoon = '',
+                Units = {
+                    ['INITIAL'] = GROUP {
+                        orders = '',
+                        platoon = '',
+                        Units = {
+                        },
+                    },
+                },
+            },
+            PlatoonBuilders = {
+                next_platoon_builder_id = '14',
+                Builders = {
+                    -- Common
+                    ['OSB_Child_NavalAttacks_FrigatePlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_FrigatePlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Frigates'},
+                    },
+                    ['OSB_Child_NavalAttacks_T1SubmarinePlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T1SubmarinePlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T1Platoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T1Platoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Frigates', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_DestroyerPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_DestroyerPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers'},
+                    },
+                    ['OSB_Child_NavalAttacks_CruiserPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_CruiserPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Cruisers'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2Platoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2Platoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Cruisers'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2Platoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2Platoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2Platoon3'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2Platoon3',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Cruisers', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2Platoon4'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2Platoon4',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Frigates'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2Platoon5'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2Platoon5',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Frigates', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2Platoon6'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2Platoon6',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Cruisers', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_BattleshipPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_BattleshipPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Destroyers'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Destroyers', 'Frigates'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon3'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon3',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Destroyers', 'Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3Platoon4'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3Platoon4',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Destroyers', 'Frigates', 'Submarines'},
+                    },
+
+
+
+                    -- Mixed
+                    ['OSB_Child_NavalAttacks_T2SubmarinePlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2SubmarinePlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 3, 0 },
+                                {'default_brain', '2','3', 0 }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'T2Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_UtilityPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_UtilityPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 3, 0 },
+                                {'default_brain', '1','3', 0 }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'UtilityBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_CarrierPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_CarrierPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 3, 4 },
+                                {'default_brain', '2','3','4' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Carriers'},
+                    },
+                    ['OSB_Child_NavalAttacks_NukeSubmarinePlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_NukeSubmarinePlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 2, 3 },
+                                {'default_brain', '1','2','3' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'NukeSubmarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2MixedPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2MixedPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 3, 0 },
+                                {'default_brain', '2','3', 0 }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'T2Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2MixedPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2MixedPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 3, 0 },
+                                {'default_brain', '2','3', 0 }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Cruisers', 'T2Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2MixedPlatoon3'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2MixedPlatoon3',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 3, 0 },
+                                {'default_brain', '2','3', 0 }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Cruisers', 'T2Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2MixedPlatoon4'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2MixedPlatoon4',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 3, 0 },
+                                {'default_brain', '1','3', 0 }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'UtilityBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2MixedPlatoon5'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2MixedPlatoon5',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 3, 0 },
+                                {'default_brain', '1','3', 0 }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Cruisers', 'UtilityBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T2MixedPlatoon6'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T2MixedPlatoon6',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 3, 0 },
+                                {'default_brain', '1','3', 0 }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Destroyers', 'Cruisers', 'UtilityBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3MixedPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3MixedPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 3, 0 },
+                                {'default_brain', '2','3', 0 }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'Carriers'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3MixedPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3MixedPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 3, 0 },
+                                {'default_brain', '2','3', 0 }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Carriers', 'Cruisers'},
+                    },
+
+
+
+                    -- Aeon Specific
+                    ['OSB_Child_NavalAttacks_AABoatPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_AABoatPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 0 },
+                                {'default_brain', '2', '0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'AABoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_MissileShipPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_MissileShipPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 0 },
+                                {'default_brain', '2', '0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'MissileShips'},
+                    },
+                    ['OSB_Child_NavalAttacks_AAPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_AAPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 0 },
+                                {'default_brain', '2', '0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Cruisers', 'AABoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3AeonPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3AeonPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 0 },
+                                {'default_brain', '2', '0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'MissleShips'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3AeonPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3AeonPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 0 },
+                                {'default_brain', '2', '0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Carriers', 'MissleShips'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3AeonPlatoon3'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3AeonPlatoon3',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 2, 0 },
+                                {'default_brain', '2', '0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'MissleShips', 'Cruisers'},
+                    },
+
+
+
+                    -- Seraphim Specific
+                    ['OSB_Child_NavalAttacks_T3SubmarinePlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3SubmarinePlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 4, 0 },
+                                {'default_brain', '4', '0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'T3Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3SeraphimPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3SeraphimPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 4, 0 },
+                                {'default_brain', '4', '0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Battleships', 'T3Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3SeraphimPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3SeraphimPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 4, 0 },
+                                {'default_brain', '4', '0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'Carriers', 'T3Submarines'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3SeraphimPlatoon3'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3SeraphimPlatoon3',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 4, 0 },
+                                {'default_brain', '4', '0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'T3Submarines', 'Destroyers'},
+                    },
+
+
+
+                    -- UEF Specific
+                    ['OSB_Child_NavalAttacks_TropBoatPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_TropBoatPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 0 },
+                                {'default_brain', '1', '0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'TorpedoBoats'},
+                    },
+                    ['OSB_Child_NavalAttacks_BattleCruiserPlatoon'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_BattleCruiserPlatoon',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 0 },
+                                {'default_brain', '1', '0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'BattleCruisers'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3UEFPlatoon1'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3UEFPlatoon1',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 0 },
+                                {'default_brain', '1', '0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'BattleCruisers', 'Battleships'},
+                    },
+                    ['OSB_Child_NavalAttacks_T3UEFPlatoon2'] =  {
+                        PlatoonTemplate = 'OST_NavalAttacks_T3UEFPlatoon2',
+                        Priority = 696,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        PlatoonType = 'Sea',
+                        RequiresConstruction = true,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'DefaultOSBasePatrol',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/ai/opai/navalattacks_editorfunctions.lua', 'NavalAttacksChildCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [2] = {'/lua/editor/miscbuildconditions.lua', 'FactionIndex',
+                                {'default_brain', 1, 0 },
+                                {'default_brain', '1', '0' }
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 5, name = 'AMPlatoons', value = {
+                                {type = 2, name = 'String_0',  value = 'OSB_Master_NavalAttacks'},
+                            }},
+                        },
+                        ChildrenType = {'BattleCruisers', 'Destroyers'},
+                    },
+
+
+
+                    ['OSB_Master_NavalAttacks'] =  {
+                        PlatoonTemplate = 'OST_BLANK_TEMPLATE',
+                        Priority = 500,
+                        InstanceCount = 1,
+                        LocationType = 'MAIN',
+                        BuildTimeOut = 240,
+                        PlatoonType = 'Any',
+                        RequiresConstruction = false,
+                        PlatoonAIFunction = {'/lua/ScenarioPlatoonAI.lua', 'PlatoonAttackHighestThreat',
+                            {'default_platoon'},
+                            {'default_platoon'}
+                        },
+                        BuildConditions = {
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMCheckPlatoonLock',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                            [1] = {'/lua/ai/opai/NavalAttacks_editorfunctions.lua', 'NavalAttacksMasterCountDifficulty',
+                                {'default_brain','default_master'},
+                                {'default_brain','default_master'}
+                            },
+                        },
+                        PlatoonBuildCallbacks = {
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMUnlockPlatoon',
+                                {'default_brain','default_platoon'},
+                                {'default_brain','default_platoon'}
+                            },
+                        },
+                        PlatoonAddFunctions = {
+                            [0] = {'/lua/editor/amplatoonhelperfunctions.lua', 'AMLockPlatoon',
+                                {'default_platoon'},
+                                {'default_platoon'}
+                            },
+                        },
+                        PlatoonData = {
+                            {type = 3, name = 'AMMasterPlatoon',  value = true},
+                            {type = 3, name = 'UsePool', value = false},
+                        },
+                    },
+                },
+            },
+        },
+    },
+}

--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -249,6 +249,12 @@ function CreateUnitDestroyedTrigger(cb, unit)
     CreateUnitDeathTrigger(cb, unit, true)
 end
 
+-- Single Line unit given trigger creation
+-- When <unit> is given it will call the <cb> function provided
+function CreateUnitGivenTrigger(cb, unit)
+    TriggerFile.CreateUnitGivenTrigger(cb, unit)
+end
+
 -- Single Line Unit built trigger
 -- Tests when <unit> builds a unit of type <category> calls <cb>
 function CreateUnitBuiltTrigger(cb, unit, category)

--- a/lua/ScenarioPlatoonAI.lua
+++ b/lua/ScenarioPlatoonAI.lua
@@ -588,8 +588,9 @@ function SplitPatrolThread(platoon)
     platoon:Stop()
     if data then
         if data.PatrolChains then
+            local num = table.getn(data.PatrolChains)
             for _, v in platoon:GetPlatoonUnits() do
-                local chain = Random(1, table.getn(data.PatrolChains))
+                local chain = Random(1, num)
                 ScenarioFramework.GroupPatrolChain({v}, data.PatrolChains[chain])
             end
         else

--- a/lua/cinematics.lua
+++ b/lua/cinematics.lua
@@ -68,9 +68,13 @@ function SetInvincible(area, invinBool)
                 table.insert(unitTable, unit)
             end
         end
-        ScenarioFramework.FlagUnkillableSelect(1, unitTable)
+        for _, v in ScenarioInfo.HumanPlayers do
+            ScenarioFramework.FlagUnkillableSelect(v, unitTable)
+        end
     else
-        ScenarioFramework.UnflagUnkillable(1)
+        for _, v in ScenarioInfo.HumanPlayers do
+            ScenarioFramework.UnflagUnkillable(v)
+        end
     end
 end
 

--- a/lua/editor/BaseManagerBuildConditions.lua
+++ b/lua/editor/BaseManagerBuildConditions.lua
@@ -452,3 +452,10 @@ function ExpansionBasesEnabled(aiBrain, baseName)
     if not bManager then return false end
     return bManager.FunctionalityStates.ExpansionBases
 end
+
+function TMLsEnabled(aiBrain, baseName)
+    local bManager = aiBrain.BaseManagers[baseName]
+    if not bManager then return false end
+    return bManager.FunctionalityStates.TMLs
+end
+

--- a/lua/editor/BaseManagerBuildConditions.lua
+++ b/lua/editor/BaseManagerBuildConditions.lua
@@ -459,3 +459,9 @@ function TMLsEnabled(aiBrain, baseName)
     return bManager.FunctionalityStates.TMLs
 end
 
+function NukesEnabled(aiBrain, baseName)
+    local bManager = aiBrain.BaseManagers[baseName]
+    if not bManager then return false end
+    return bManager.FunctionalityStates.Nukes
+end
+


### PR DESCRIPTION
Work in progress.
#JustCoopThings
- [x] Loads default scouting chain if they exist
- [x] Basic TML control
* Base manager can now operate TML launchers, even if they are rebuilt/newly built.
* They don't need to be activated via script anymore.
* Enabled by default, can be disabled via `bm:SetActive('TML', false)`
* On `Hard` difficulty they use sorian function for predicting mobile target location
- [x] Fixed issue with engineers trying to assist factories where they are non in the base
* Engineers wont initiate permanent assist on factories if there are no factories in the base
* Extra check in the perma assist function to not assist factory if there isnt one, the function should no longer end up with an error in that case.
- [x] Fixed ACU/sACU upgrading not working
* Upgrade thread is not properly set on the command units. If there are upgrades set in the base manager via `bm:SetUnitUpgrades` or `bm:SetACUUpgrades` or `bm:SetACUUpgrades` they will get upgraded.
- [x] Mercy Platoon for OpAI
- [x] Add new OpAI Naval Platoons
- [x] Fixes for OpAI Land Platoons
* Fixed wrong order of the units/children in the platoon.
* Added few new platoon templates
- [x] Fixed OpAI Childer check
* The Platoon build will now correctly keep only platoons that have all children
* Example: Desired platoon with children types `{'LightTanks', 'HeavyTanks'}` used to keep platoons with just 1 childer of that type, so platoon that has just `'LightTanks'` or `'HeavyTanks'` was kept enabled.
- [x] More control over OpAI platoon size
- [x] Units of all human armies are properly set invincible during cinematics

Fixes #1417