### PR TITLE
Make presets and default reset restrictions + bugfixes

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2125,6 +2125,9 @@ local OptionUtils = {
     -- Set all game options to their default values.
     SetDefaults = function()
         local options = {}
+        for index, option in teamOpts do
+            options[option.key] = option.values[option.default].key or option.values[option.default]
+        end
         for index, option in globalOpts do
             -- Exception to make AllowObservers work because the engine requires
             -- the keys to be bool. Custom options should use 'True' or 'False'
@@ -2138,7 +2141,9 @@ local OptionUtils = {
         for index, option in AIOpts do
             options[option.key] = option.values[option.default].key or option.values[option.default]
         end
-
+        
+        options.RestrictedCategories = {}
+        
         SetGameOptions(options)
     end
 }
@@ -5437,7 +5442,11 @@ end
 -- Load the given preset
 function LoadPreset(presetIndex)
     local preset = LoadPresetsList()[presetIndex]
-
+    
+    if not preset.GameOptions.RestrictedCategories then
+        preset.GameOptions.RestrictedCategories = {}
+    end
+    
     SetGameOptions(preset.GameOptions, true)
 
     rehostPlayerOptions = preset.PlayerOptions

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2060,6 +2060,11 @@ local function UpdateGame()
 
     SetRuleTitleText(gameInfo.GameOptions.GameRules or "")
     SetGameTitleText(gameInfo.GameOptions.Title or LOC("<LOC lobui_0427>FAF Game Lobby"))
+    
+    if not singlePlayer and isHost and GUI.autoTeams then
+        GUI.autoTeams:SetState(gameInfo.GameOptions.AutoTeams,true)
+        Tooltip.DestroyMouseoverDisplay()
+    end
 end
 
 --- Update the game quality display


### PR DESCRIPTION
fixes #2041
Now unit restrictions will get removed when you click on default settings and have preset with no restrictions.

I added that default-settings-button also defaults team options. (Spawn,Team,AutoTeams)

The autoteams button now updates to match the currently selected autoteam option.
(previously it would only update when you clicked on it)