### PR TITLE
Only show reclaim in the playable area

### DIFF
--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -1192,6 +1192,7 @@ function SetPlayableArea(rect, voFlag)
     end
 
     import('/lua/SimSync.lua').SyncPlayableRect(rect)
+    Sync.NewPlayableArea = {x0, y0, x1, y1}
     ForkThread(GenerateOffMapAreas)
 end
 

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -10,8 +10,10 @@ PreviousSync = {}
 -- the Sync.UnitData table into this table each sync (if there's new data)
 UnitData = {}
 
-local UpdateReclaim = import('/lua/ui/game/reclaim.lua').UpdateReclaim
+local reclaim = import('/lua/ui/game/reclaim.lua')
+local UpdateReclaim = reclaim.UpdateReclaim
 local sendEnhancementMessage = import('/lua/ui/notify/notify.lua').sendEnhancementMessage
+local SetPlayableArea = reclaim.SetPlayableArea
 
 -- Here's an opportunity for user side script to examine the Sync table for the new tick
 function OnSync()
@@ -91,5 +93,9 @@ function OnSync()
         for _, messageTable in Sync.EnhanceMessage do
             sendEnhancementMessage(messageTable)
         end
+    end
+    
+    if Sync.NewPlayableArea then
+        SetPlayableArea(Sync.NewPlayableArea)
     end
 end

--- a/lua/ui/game/reclaim.lua
+++ b/lua/ui/game/reclaim.lua
@@ -13,6 +13,8 @@ local LabelPool = {} -- Stores labels up too MaxLabels
 local OldZoom
 local OldPosition
 local ReclaimChanged = true
+local PlayableArea
+local OutsidePlayableAreaReclaim = {}
 
 -- Stores/updates a reclaim entity's data using EntityId as key
 -- called from /lua/UserSync.lua
@@ -21,10 +23,39 @@ function UpdateReclaim(syncTable)
     for id, data in syncTable do
         if not data.mass then
             Reclaim[id] = nil
+            OutsidePlayableAreaReclaim[id] = nil
         else
-            Reclaim[id] = data
+            data.inPlayableArea = InPlayableArea(data.position)
+            if data.inPlayableArea then
+                Reclaim[id] = data
+                OutsidePlayableAreaReclaim[id] = nil
+            else
+                Reclaim[id] = nil
+                OutsidePlayableAreaReclaim[id] = data
+            end
         end
     end
+end
+
+function SetPlayableArea(rect)
+    ReclaimChanged = true
+    PlayableArea = rect
+    
+    local newReclaim = {}
+    local newOutsidePlayableAreaReclaim = {}
+    local ReclaimLists = {Reclaim, OutsidePlayableAreaReclaim}
+    for _,reclaimList in ReclaimLists do 
+        for id,r in reclaimList do
+            r.inPlayableArea = InPlayableArea(r.position)
+            if r.inPlayableArea then
+                newReclaim[id] = r
+            else
+                newOutsidePlayableAreaReclaim[id] = r
+            end
+        end
+    end
+    Reclaim = newReclaim
+    OutsidePlayableAreaReclaim = newOutsidePlayableAreaReclaim
 end
 
 function updateMinAmount(value)
@@ -44,6 +75,13 @@ end
 function OnScreen(view, pos)
     local proj = view:Project(Vector(pos[1], pos[2], pos[3]))
     return not (proj.x < 0 or proj.y < 0 or proj.x > view.Width() or proj.y > view:Height())
+end
+
+function InPlayableArea(pos)
+    if PlayableArea then
+        return not (pos[1] < PlayableArea[1] or pos[3] < PlayableArea[2] or pos[1] > PlayableArea[3] or pos[3] > PlayableArea[4])
+    end
+    return true
 end
 
 local WorldLabel = Class(Group) {


### PR DESCRIPTION
fixes #2032

I couldn't find anyway to get playable area from UI, so I made a new Sync for UserSync.
If anyone has a better way to do it, then let me know.

![reclaimoutside](https://cloud.githubusercontent.com/assets/20644178/26633953/59b10f38-4615-11e7-9591-b67243427ad7.png)
![playableareaonly](https://cloud.githubusercontent.com/assets/20644178/26633968/6110d286-4615-11e7-9534-a88a070d7704.png)
