### PR TITLE
Fix tiling of rotated templates

### DIFF
--- a/lua/keymap/hotbuild.lua
+++ b/lua/keymap/hotbuild.lua
@@ -410,6 +410,8 @@ function buildActionTemplate(modifier)
                 if event.Modifiers.Middle then
                     ClearBuildTemplates()
                     local tempTemplate = table.deepcopy(template.templateData)
+                    template.templateData[1] = tempTemplate[2]
+                    template.templateData[2] = tempTemplate[1]
                     for i = 3, table.getn(template.templateData) do
                         local index = i
                         template.templateData[index][3] = 0 - tempTemplate[index][4]

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -1307,6 +1307,8 @@ function OnClickHandler(button, modifiers)
                     if event.Modifiers.Middle then
                         ClearBuildTemplates()
                         local tempTemplate = table.deepcopy(activeTemplate)
+                        activeTemplate[1] = tempTemplate[2]
+                        activeTemplate[2] = tempTemplate[1]
                         for i = 3, table.getn(activeTemplate) do
                             local index = i
                             activeTemplate[index][3] = 0 - tempTemplate[index][4]


### PR DESCRIPTION
When rotating a template with middle click, the width and height numbers remain unchanged. That causes spacing problems when trying to drag out a line of the template after rotating 90° or 270°.