### PR TITLE
Fix only one engineer trying to rebuild wreckage

### DIFF
--- a/lua/wreckage.lua
+++ b/lua/wreckage.lua
@@ -73,7 +73,9 @@ Wreckage = Class(Prop) {
 
         if not rebuilders[1] then return end
         local pos = self:GetPosition()
-        IssueBuildMobile(rebuilders, pos, bpid, {})
+        for _, u in rebuilders do
+            IssueBuildMobile({u}, pos, bpid, {})
+        end
         if assisters[1] then
             IssueGuard(assisters, pos)
         end


### PR DESCRIPTION
Issuing a repair command on the wreckage of a building gives an order to rebuild it. Currently that order is issued to all builders at once but for some reason it can only affect one, leaving the rest of the group sitting idle. Giving the order to each builder individually works as originally intended, except that the order can't be moved or deleted as easily as if it was correctly given to all builders as a group.