### PR TITLE
Fix network stats opening but not closing when alone

### DIFF
--- a/lua/ui/game/connectivity.lua
+++ b/lua/ui/game/connectivity.lua
@@ -82,7 +82,6 @@ function PingUpdate()
 end
 
 function CreateUI()
-    ConExecute('ren_shownetworkstats true')
     if not SessionIsMultiplayer() then
         return
     end
@@ -90,6 +89,8 @@ function CreateUI()
         CloseWindow()
         return
     end
+
+    ConExecute('ren_shownetworkstats true')
 
     local _,isSession = UIUtil.GetNetworkBool()
     if not isSession then return end


### PR DESCRIPTION
When pressing F11 in a replay or singleplayer game, the network stats overlay opens, but pressing the key again doesn't close it.