### PR TITLE
hide maps if newer versions are available locally

### DIFF
--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -238,19 +238,21 @@ mapFilters = {
         FilterFactory = {
             SelectedKey = 1,
             Filters = {
-                function(scenInfo) 
-                    local newestVersion = true
-                    if scenInfo.map_version ~= nil then
-                        for _,comparisionlist in scenarios do
-                            if LOC(scenInfo.name) == LOC(comparisionlist.name) then
-                                if scenInfo.map_version < (comparisionlist.map_version or 1) then
-                                    newestVersion = false
-                                    break
+                function(scenInfo)
+                    if scenInfo.Outdated then
+                        return false
+                    end
+                    local version = scenInfo.map_version or 0
+                    for _,comparisionlist in scenarios do
+                        if scenInfo.name == comparisionlist.name then
+                            if comparisionlist.map_version then
+                                if version < comparisionlist.map_version then
+                                    return false
                                 end
                             end
                         end
                     end
-                    return not (scenInfo.Outdated or not newestVersion)
+                    return true
                 end
             },
             Build = function(self)

--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -238,7 +238,20 @@ mapFilters = {
         FilterFactory = {
             SelectedKey = 1,
             Filters = {
-                function(scenInfo) return not scenInfo.Outdated end
+                function(scenInfo) 
+                    local newestVersion = true
+                    if scenInfo.map_version ~= nil then
+                        for _,comparisionlist in scenarios do
+                            if LOC(scenInfo.name) == LOC(comparisionlist.name) then
+                                if scenInfo.map_version < (comparisionlist.map_version or 1) then
+                                    newestVersion = false
+                                    break
+                                end
+                            end
+                        end
+                    end
+                    return not (scenInfo.Outdated or not newestVersion)
+                end
             },
             Build = function(self)
                 return self.Filters[self.SelectedKey]
@@ -1015,17 +1028,6 @@ function PopulateMapList()
             -- Name filter needs special treatment
             if nameFilter and nameFilter:GetText() ~= "" then
                 passedFiltering = passedFiltering and string.lower(sceninfo.name):find(string.lower(nameFilter:GetText()))
-            end
-        end
-        -- hide maps that are not on the blacklist but have newer versions available if obsolete maps are hidden
-        if currentFilters['map_obsolete'] ~= nil and sceninfo.map_version ~= nil then
-            for _,comparisionlist in scenarios do
-                if LOC(sceninfo.name) == LOC(comparisionlist.name) then
-                    if sceninfo.map_version < (comparisionlist.map_version or 1) then
-                        passedFiltering = false
-                        break
-                    end
-                end
             end
         end
         

--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -1030,7 +1030,7 @@ function PopulateMapList()
                 passedFiltering = passedFiltering and string.lower(sceninfo.name):find(string.lower(nameFilter:GetText()))
             end
         end
-        
+
         if passedFiltering then
             -- Make sure we finish up with the right map selected.
             scenarioKeymap[count] = i

--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -1017,7 +1017,18 @@ function PopulateMapList()
                 passedFiltering = passedFiltering and string.lower(sceninfo.name):find(string.lower(nameFilter:GetText()))
             end
         end
-
+        -- hide maps that are not on the blacklist but have newer versions available if obsolete maps are hidden
+        if currentFilters['map_obsolete'] ~= nil and sceninfo.map_version ~= nil then
+            for _,comparisionlist in scenarios do
+                if LOC(sceninfo.name) == LOC(comparisionlist.name) then
+                    if sceninfo.map_version < (comparisionlist.map_version or 1) then
+                        passedFiltering = false
+                        break
+                    end
+                end
+            end
+        end
+        
         if passedFiltering then
             -- Make sure we finish up with the right map selected.
             scenarioKeymap[count] = i


### PR DESCRIPTION
extends the "hide obsolete" function in the map select window to hide maps where higher versions with the same name are available locally.
Currently it only hides maps on the blacklist.