### PR TITLE
fix "hide_obsolete" filter in map selection disabled by default

### DIFF
--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -264,6 +264,9 @@ function InitFilters()
             SelectedKey = 1 -- Enable obsolete map filtering by default.
         }
     }
+    savedFilterState['map_obsolete'] = {
+        SelectedKey = 1 -- Enable obsolete map filtering by default.
+    }
 
     -- savedFilterState is an array of tables of filter options
     for filterKey, v in savedFilterState do


### PR DESCRIPTION
if the game prefs file contains a section (usually empty) of the form
stored_filter_state = {  },
then the map_obsolete flag is not set to 1 and thus all maps are shown
even if the option for the filter sais "hide outdated maps".

part of #2024