### PR TITLE
Fix air units sinking forever after bouncing off shield

### DIFF
--- a/projectiles/Sinker/Sinker_script.lua
+++ b/projectiles/Sinker/Sinker_script.lua
@@ -34,7 +34,15 @@ Sinker = Class(Projectile) {
     end,
 
     StartSinking = function(self, targetEntity, targetBone)
-        Warp(self, targetEntity:GetPosition(targetBone), targetEntity:GetOrientation())
+        local pos = targetEntity:GetPosition(targetBone)
+        local seafloor = GetTerrainHeight(pos[1], pos[3]) + GetTerrainTypeOffset(pos[1], pos[3])
+        if pos[2] <= seafloor then
+            self:Destroy()
+            ForkThread(self.callback)
+            return
+        end
+
+        Warp(self, pos, targetEntity:GetOrientation())
         targetEntity:AttachBoneTo(targetBone, self, 'anchor')
 
         if not targetEntity:BeenDestroyed() then


### PR DESCRIPTION
Due to the collision detection in the bounce system, it's possible for an air unit to land near the shore with  bone 0 underground and the collision classified as a water crash. That causes it to create a Sinker under the seafloor, which is a problem. This adds a check when creating a Sinker to prevent that and similar situations.

Fixes #1985 and should fix #2012.