### PR TITLE
Formation Improvements

### DIFF
--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -369,12 +369,27 @@ local AttackChevronBlock = {
     RepeatAllRows = false,
     HomogenousBlocks = true,
     { ChevronSlot, },
-    { ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, }, -- 1 -> 3 at 20 units
     { ChevronSlot, ChevronSlot, ChevronSlot, },
-    { ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, }, -- 3 -> 5 at 60 units
     { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
     { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, }, -- 5 -> 7 at 170 units
     { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, }, -- 7 -> 9 at 390 units
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, }, -- 9 -> 11 at 760 units
 }
 
 local GrowthChevronBlock = {
@@ -382,9 +397,25 @@ local GrowthChevronBlock = {
     HomogenousBlocks = true,
     { ChevronSlot, },
     { ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, }, -- 1 -> 3 at 25 units
     { ChevronSlot, ChevronSlot, ChevronSlot, },
     { ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, }, -- 3 -> 5 at 95 units
     { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, }, -- 5 -> 7 at 255 units
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
+    { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, }, -- 7 -> 9 at 545 units
 }
 
 
@@ -1179,7 +1210,6 @@ end
 function BlockBuilderAir(unitsList, airBlock, spacing)
     spacing = (spacing or 1) * unitsList.Scale
     local numRows = table.getn(airBlock)
-    local i = 1
     local whichRow = 1
     local whichCol = 1
     local chevronPos = 1
@@ -1187,13 +1217,44 @@ function BlockBuilderAir(unitsList, airBlock, spacing)
     local chevronSize = airBlock.ChevronSize or 5
     local chevronType = false
     local formationLength = 0
+    
+    if unitsList.AreaTotal > unitsList.UnitTotal then -- If there are any units of size > 1 deal with them here
+        local largeUnitPositions = GetLargeAirPositions(unitsList, airBlock)
+        for _, data in largeUnitPositions do
+            local currSlot = airBlock[data.row][data.col]
+            for _, type in currSlot do
+                for _, group in type do
+                    for fs, groupData in unitsList[group] do
+                        size = unitsList.FootprintSizes[fs]
+                        if groupData.Count > 0 and size == data.size then
+                            table.insert(FormationPos, {data.xPos * spacing, data.yPos * spacing, groupData.Filter, 0, true})
+                            groupData.Count = groupData.Count - 1
+                            if groupData.Count <= 0 then
+                                unitsList[group][fs] = nil
+                            end
+                            unitsList.UnitTotal = unitsList.UnitTotal - 1
+                            break
+                        end
+                    end
+                end
+            end
+        end
+    end
+    
+    if unitsList.UnitTotal < chevronSize and math.mod(unitsList.UnitTotal, 2) == 0 then
+        chevronPos = 2
+    end
 
-    while unitsList.UnitTotal >= i do
+    while unitsList.UnitTotal > 0 do
         if chevronPos > chevronSize then
-            chevronPos = 1
+            if unitsList.UnitTotal < chevronSize and math.mod(unitsList.UnitTotal, 2) == 0 then
+                chevronPos = 2
+            else
+                chevronPos = 1
+            end
             chevronType = false
-            if whichCol == currRowLen then
-                if whichRow == numRows then
+            if whichCol >= currRowLen or unitsList.UnitTotal < chevronSize or unitsList.UnitTotal < chevronSize * 2 and math.mod(whichCol, 2) == 1 then
+                if whichRow >= numRows then
                     if airBlock.RepeatAllRows then
                         whichRow = 1
                         currRowLen = table.getn(airBlock[whichRow])
@@ -1208,19 +1269,18 @@ function BlockBuilderAir(unitsList, airBlock, spacing)
                 whichCol = whichCol + 1
             end
         end
+        
         local currSlot = airBlock[whichRow][whichCol]
         local inserted = false
-        for numType, type in currSlot do
+        for _, type in currSlot do
             if inserted then
                 break
             end
-            for numGroup, group in type do
+            for _, group in type do
                 if not airBlock.HomogenousBlocks or chevronType == false or chevronType == type then
                     local fs = 0
-                    local size = 0
                     local groupData = nil
                     for k, v in unitsList[group] do
-                        size = unitsList.FootprintSizes[k]
                         if v.Count > 0 then
                             fs = k
                             groupData = v
@@ -1228,11 +1288,11 @@ function BlockBuilderAir(unitsList, airBlock, spacing)
                         end
                     end
                     if groupData then
-                        local xPos, yPos = GetChevronPosition(chevronPos, whichCol, currRowLen, formationLength)
+                        local xPos, yPos = GetChevronPosition(chevronPos, whichCol, formationLength)
                         if airBlock.HomogenousBlocks and not chevronType then
                             chevronType = type
                         end
-                        table.insert(FormationPos, {xPos * spacing, yPos * spacing, groupData.Filter, yPos, true})
+                        table.insert(FormationPos, {xPos * spacing, yPos * spacing, groupData.Filter, 0, true})
                         inserted = true
                         
                         groupData.Count = groupData.Count - 1
@@ -1245,27 +1305,98 @@ function BlockBuilderAir(unitsList, airBlock, spacing)
             end
         end
         if inserted then
-            i = i + 1
+            unitsList.UnitTotal = unitsList.UnitTotal - 1
         end
         chevronPos = chevronPos + 1
     end
     return FormationPos
 end
 
-function GetChevronPosition(chevronPos, currCol, currRowLen, formationLen)
-    local offset = math.floor(chevronPos / 2) * .75
-    local xPos = offset
-    if math.mod(chevronPos, 2) == 0 then
-        xPos = -offset
+function GetLargeAirPositions(unitsList, airBlock)
+    local sizeCounts = {}
+    for fs, count in unitsList.FootprintCounts do
+        local size = unitsList.FootprintSizes[fs]
+        if size > 1 then
+            sizeCounts[size] = (sizeCounts[size] or 0) + count
+        end
     end
-    local yPos = -offset + math.floor(currCol / 2) * 2.25
-    yPos = yPos - formationLen * 1.5
-    --local firstBlockOffset = (math.mod(currRowLen, 2) - 1) * 1.875
-    local blockOff = math.floor(currCol / 2) * 3.75
+    
+    local numRows = table.getn(airBlock)
+    local whichRow = 0
+    local whichCol = 0
+    local currRowLen = 0
+    local wideRow = false
+    local formationLength = -1
+    local results = {}
+    local numResults = 0
+    for size, count in sizeCounts do
+        local radius = size / 2
+        while count > 0 do
+            if whichCol >= currRowLen or count == 1 then
+                if whichRow >= numRows then
+                    if airBlock.RepeatAllRows then
+                        whichRow = 1
+                        currRowLen = table.getn(airBlock[whichRow])
+                    end
+                else
+                    whichRow = whichRow + 1
+                    currRowLen = table.getn(airBlock[whichRow])
+                end
+                formationLength = formationLength + 1
+                whichCol = 1
+                local x, y = GetChevronPosition(1, currRowLen, formationLength)
+                wideRow = math.abs(x) >= radius
+            else
+                whichCol = whichCol + 2
+            end
+            
+            if count == 2 and whichCol == 1 and wideRow then
+                continue
+            end
+            
+            local xPos, yPos = GetChevronPosition(1, whichCol, formationLength)
+            if whichCol ~= 1 and math.abs(xPos) < radius then
+                continue
+            end
+            
+            -- Exponential complexity isn't fun but this should run in under 0.03 seconds on a slow CPU with 500 CZARs.
+            local blocked = false
+            for i = numResults, 1, -1 do -- Don't change this to a simple forward loop or it can take 15x as long with large numbers.
+                local data = results[i]
+                if VDist2(xPos, yPos, data.xPos, data.yPos) < radius + data.size / 2 then
+                    blocked = true
+                    break
+                end
+            end
+            if not blocked then
+                table.insert(results, {row = whichRow, col = whichCol, xPos = xPos, yPos = yPos, size = size})
+                count = count - 1
+                numResults = numResults + 1
+                if whichCol ~= 1 then
+                    table.insert(results, {row = whichRow, col = whichCol - 1, xPos = -xPos, yPos = yPos, size = size})
+                    count = count - 1
+                    numResults = numResults + 1
+                end
+            end
+        end
+    end
+    return results
+end
+
+function GetChevronPosition(chevronPos, currCol, formationLen)
+    local offset = math.floor(chevronPos / 2)
+    local xPos = offset * 0.5
+    if math.mod(chevronPos, 2) == 0 then
+        xPos = -xPos
+    end
+    local column = math.floor(currCol / 2)
+    local yPos = (-offset + column * column) * 0.86603
+    yPos = yPos - formationLen * 1.73205
+    local blockOff = math.floor(currCol / 2) * 2.5
     if math.mod(currCol, 2) == 1 then
         blockOff = -blockOff
     end
-    xPos = xPos + blockOff --+ firstBlockOffset
+    xPos = xPos + blockOff
     return xPos, yPos
 end
 
@@ -1434,9 +1565,9 @@ function CalculateSizes(unitsList)
         },
         
         Air = {
-            GridSizeFraction = 1.75,
+            GridSizeFraction = 1.3,
             GridSizeAbsolute = 2,
-            MinSeparationFraction = 1.75,
+            MinSeparationFraction = 1,
         },
         
         Naval = {

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -110,7 +110,7 @@ local TankFirst = { Tanks, Bots, Art, AA, Shield, Com, Util, RemainingCategory }
 local ShieldFirst = { Shield, AA, T1Art, DF, Com, Util, RemainingCategory }
 local AAFirst = { AA, DF, T1Art, Art, Shield, Com, Util, RemainingCategory }
 local ArtFirst = { Art, AA, DF, Shield, Com, Util, RemainingCategory }
-local T1ArtFirst = { T1Art, AA, DF, Shield, Com, Util, RemainingCategory }
+local T1ArtFirst = { T1Art, DF, AA, Shield, Com, Util, RemainingCategory }
 local UtilFirst = { Util, AA, T1Art, DF, Shield, Com, RemainingCategory }
 
 
@@ -163,15 +163,15 @@ local SevenWideAttackFormationBlock = {
     -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, },
     -- second Row
-    { DFFirst, ShieldFirst, DFFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, },
+    { DFFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, },
     -- third row
-    { UtilFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, UtilFirst, },
+    { DFFirst, UtilFirst, AAFirst, DFFirst, AAFirst, UtilFirst, DFFirst, },
     -- fourth row
-    { AAFirst, ShieldFirst, AAFirst, T1ArtFirst, ShieldFirst, AAFirst, DFFirst, },
+    { DFFirst, ShieldFirst, AAFirst, T1ArtFirst, AAFirst, ShieldFirst, DFFirst, },
     -- fifth row
-    { DFFirst, AAFirst, T1ArtFirst, T1ArtFirst, AAFirst, T1ArtFirst, DFFirst, },
+    { DFFirst, T1ArtFirst, AAFirst, ShieldFirst, AAFirst, T1ArtFirst, DFFirst, },
     -- sixth row
-    { UtilFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, UtilFirst, },
+    { ArtFirst, UtilFirst, ArtFirst, AAFirst, ArtFirst, UtilFirst, ArtFirst, },
 }
 
 -- === 8 Wide Attack Block ===
@@ -179,15 +179,15 @@ local EightWideAttackFormationBlock = {
     -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, },
     -- second Row
-    { DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, },
+    { DFFirst, ShieldFirst, DFFirst, ShieldFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, },
     -- third row
-    { UtilFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, UtilFirst, },
+    { DFFirst, UtilFirst, AAFirst, DFFirst, DFFirst, AAFirst, UtilFirst, DFFirst, },
     -- fourth row
-    { DFFirst, AAFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, },
+    { DFFirst, ShieldFirst, T1ArtFirst, AAFirst, AAFirst, T1ArtFirst, ShieldFirst, DFFirst, },
     -- fifth row
     { DFFirst, T1ArtFirst, AAFirst, T1ArtFirst, T1ArtFirst, AAFirst, T1ArtFirst, DFFirst, },
     -- sixth row
-    { UtilFirst, AAFirst, ShieldFirst, ArtFirst, ArtFirst, ShieldFirst, AAFirst, UtilFirst, },
+    { DFFirst, ShieldFirst, UtilFirst, ShieldFirst, ShieldFirst, UtilFirst, ShieldFirst, DFFirst, },
     -- seventh row
     { DFFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, DFFirst, },
 }
@@ -209,7 +209,7 @@ local TwoRowAttackFormationBlock = {
     -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
     -- second row
-    { UtilFirst, AAFirst, ShieldFirst, ArtFirst, ArtFirst, ShieldFirst, AAFirst, UtilFirst },
+    { AAFirst, UtilFirst, ShieldFirst, ArtFirst, ArtFirst, ShieldFirst, UtilFirst, AAFirst },
 }
 
 -- === 3 Row Attack Block - 10 units wide ===
@@ -217,9 +217,9 @@ local ThreeRowAttackFormationBlock = {
     -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
     -- second row
-    { UtilFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, AAFirst, ShieldFirst, UtilFirst },
+    { AAFirst, ShieldFirst, UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst, ShieldFirst, AAFirst },
     -- third row
-    { DFFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, ArtFirst, AAFirst, DFFirst },
+    { DFFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, DFFirst },
 }
 
 -- === 4 Row Attack Block - 12 units wide ===
@@ -227,11 +227,11 @@ local FourRowAttackFormationBlock = {
     -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
     -- second row
-    { UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst },
+    { DFFirst, ShieldFirst, DFFirst, UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst, DFFirst, ShieldFirst, DFFirst },
     -- third row
-    { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst },
+    { DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst },
     -- fourth row
-    { AAFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, ArtFirst, ArtFirst, ShieldFirst, ArtFirst, AAFirst, ShieldFirst, AAFirst },
+    { AAFirst, ShieldFirst, DFFirst, ArtFirst, ShieldFirst, ArtFirst, ArtFirst, ShieldFirst, ArtFirst, DFFirst, ShieldFirst, AAFirst },
 }
 
 -- === 5 Row Attack Block - 14 units wide ===
@@ -239,11 +239,11 @@ local FiveRowAttackFormationBlock = {
     -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
     -- second row
-    { UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst },
+    { UtilFirst, ShieldFirst, DFFirst, ShieldFirst, UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst, ShieldFirst, DFFirst, ShieldFirst, UtilFirst },
     -- third row
     { DFFirst, AAFirst, DFFirst, AAFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, AAFirst, DFFirst, AAFirst, DFFirst },
     -- fourth row
-    { AAFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, AAFirst },
+    { AAFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, AAFirst, AAFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, AAFirst },
     -- five row
     { ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst },
 }
@@ -253,13 +253,13 @@ local SixRowAttackFormationBlock = {
     -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
     -- second row
-    { UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst },
+    { UtilFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, UtilFirst },
     -- third row
-    { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst },
+    { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst },
     -- fourth row
-    { AAFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, ShieldFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, AAFirst },
+    { AAFirst, ShieldFirst, AAFirst, DFFirst, AAFirst, AAFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, AAFirst, AAFirst, DFFirst, AAFirst, ShieldFirst, AAFirst },
     -- fifth row
-    { UtilFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, UtilFirst },
+    { DFFirst, AAFirst, DFFirst, UtilFirst, ShieldFirst, DFFirst, DFFirst, AAFirst, AAFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst, DFFirst, AAFirst, DFFirst },
     -- sixth row
     { AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst },
 }
@@ -269,58 +269,39 @@ local SevenRowAttackFormationBlock = {
     -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
     -- second row
-    { UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst },
+    { UtilFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, UtilFirst },
     -- third row
-    { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst },
+    { DFFirst, DFFirst, AAFirst, DFFirst, AAFirst, DFFirst, DFFirst, DFFirst, AAFirst, AAFirst, DFFirst, DFFirst, DFFirst, AAFirst, DFFirst, AAFirst, DFFirst, DFFirst },
     -- fourth row
-    { AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst },
+    { DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst },
     -- fifth row
     { UtilFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, UtilFirst },
     -- sixth row
-    { AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst },
+    { DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, UtilFirst, DFFirst, ShieldFirst, AAFirst, AAFirst, ShieldFirst, DFFirst, UtilFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst },
     -- seventh row
-    { ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst },
+    { ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst },
 }
 
--- === 8 Row Attack Block - 18 units wide ===
+-- === 8 Row Attack Block - 20 units wide ===
 local EightRowAttackFormationBlock = {
     -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
     -- second row
-    { UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst },
+    { DFFirst, ShieldFirst, UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst, ShieldFirst, DFFirst },
     -- third row
-    { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst },
+    { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst },
     -- fourth row
-    { AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst },
+    { DFFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, ShieldFirst, AAFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, AAFirst, ShieldFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, DFFirst },
     -- fifth row
-    { UtilFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, AAFirst, UtilFirst },
+    { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, AAFirst, AAFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst },
     -- sixth row
-    { AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst },
+    { UtilFirst, ShieldFirst, ArtFirst, ShieldFirst, ArtFirst, UtilFirst, ShieldFirst, ArtFirst, ShieldFirst, AAFirst, AAFirst, ShieldFirst, ArtFirst, ShieldFirst, UtilFirst, ArtFirst, ShieldFirst, ArtFirst, ShieldFirst, UtilFirst },
     -- seventh row
-    { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, DFFirst, DFFirst, DFFirst },
+    { DFFirst, AAFirst, DFFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, DFFirst, AAFirst, DFFirst },
     -- eight row
-    { AAFirst, ShieldFirst, ArtFirst, AAFirst, ShieldFirst, ArtFirst, AAFirst, ShieldFirst, ArtFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, AAFirst },
+    { AAFirst, ShieldFirst, ArtFirst, AAFirst, ShieldFirst, ArtFirst, ShieldFirst, AAFirst, ShieldFirst, ArtFirst, ArtFirst, ShieldFirst, AAFirst, ShieldFirst, ArtFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, AAFirst },
 }
 
--- === 9 Row Attack Block - 18+ units wide ===
-local NineRowAttackFormationBlock = {
-    -- first row
-    { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
-    -- second row
-    { UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst },
-    -- third row
-    { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst },
-    -- fourth row
-    { AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst },
-    -- fifth row
-    { UtilFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, AAFirst, UtilFirst },
-    -- sixth row
-    { AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst },
-    -- seventh row
-    { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, DFFirst, DFFirst, DFFirst },
-    -- eight row
-    { AAFirst, ShieldFirst, ArtFirst, AAFirst, ShieldFirst, ArtFirst, AAFirst, ShieldFirst, ArtFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, AAFirst },
-}
 -- =========================================
 -- ================ AIR DATA ===============
 -- =========================================
@@ -717,10 +698,8 @@ function AttackFormation(formationUnits)
         landBlock = SixRowAttackFormationBlock
     elseif landUnitsList.AreaTotal <= 126 then -- 18 wide
         landBlock = SevenRowAttackFormationBlock
-    elseif landUnitsList.AreaTotal <= 160 then -- 20 wide
+    else -- 20 wide
         landBlock = EightRowAttackFormationBlock
-    else
-        landBlock = NineRowAttackFormationBlock
     end
     BlockBuilderLand(landUnitsList, landBlock, LandCategories, 1)
 
@@ -775,8 +754,6 @@ function GrowthFormation(formationUnits)
         landBlock = SixWideAttackFormationBlock
     elseif landUnitsList.AreaTotal <= 42 then
         landBlock = SevenWideAttackFormationBlock
-    elseif landUnitsList.AreaTotal <= 56 then
-        landBlock = EightWideAttackFormationBlock
     else
         landBlock = EightWideAttackFormationBlock
     end
@@ -985,18 +962,19 @@ end
 function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
     spacing = (spacing or 1) * unitsList.Scale
     local numRows = table.getn(formationBlock)
-    local i = 1
     local rowNum = 1
     local whichRow = 1
     local whichCol = 1
     local currRowLen = table.getn(formationBlock[whichRow])
+    local rowModifier = GetLandRowModifer(unitsList, categoryTable, currRowLen)
+    currRowLen = currRowLen - rowModifier
     local evenRowLen = math.mod(currRowLen, 2) == 0
     local rowType = false
     local formationLength = 0
     local inserted = false
     local occupiedSpaces = {}
 
-    while unitsList.UnitTotal >= i do
+    while unitsList.UnitTotal > 0 do
         if whichCol > currRowLen then
             rowNum = rowNum + 1
             if whichRow == numRows then
@@ -1008,6 +986,12 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
             whichCol = 1
             rowType = false
             currRowLen = table.getn(formationBlock[whichRow])
+            if occupiedSpaces[rowNum] then
+                rowModifier = 0
+            else
+                rowModifier = GetLandRowModifer(unitsList, categoryTable, currRowLen)
+            end
+            currRowLen = currRowLen - rowModifier
             evenRowLen = math.mod(currRowLen, 2) == 0
         end
         
@@ -1016,7 +1000,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
             continue
         end
         
-        local currColSpot = GetColSpot(currRowLen, whichCol) -- Translate whichCol to correct spot in row
+        local currColSpot = GetColSpot(currRowLen + rowModifier, whichCol + rowModifier) -- Translate whichCol to correct spot in row
         local currSlot = formationBlock[whichRow][currColSpot]
         for _, type in currSlot do
             if inserted then
@@ -1032,7 +1016,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
                         size = unitsList.FootprintSizes[k]
                         evenSize = math.mod(size, 2) == 0
                         if v.Count > 0 then
-                            if size > 1 and IsLandSpaceOccupied(occupiedSpaces, size, rowNum, whichCol, currRowLen) then
+                            if size > 1 and IsLandSpaceOccupied(occupiedSpaces, size, rowNum, whichCol, currRowLen, unitsList.UnitTotal) then
                                 continue
                             end
                             fs = k
@@ -1089,7 +1073,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
             end
         end
         if inserted then
-            i = i + 1
+            unitsList.UnitTotal = unitsList.UnitTotal - 1
             inserted = false
         end
         whichCol = whichCol + 1
@@ -1098,14 +1082,32 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
     return FormationPos
 end
 
-function IsLandSpaceOccupied(occupiedSpaces, size, rowNum, whichCol, currRowLen)
+function GetLandRowModifer(unitsList, categoryTable, currRowLen)
+    if unitsList.UnitTotal >= currRowLen or math.mod(unitsList.UnitTotal, 2) == math.mod(currRowLen, 2) then
+        return 0
+    end
+    
+    local sizeTotal = 0
+    for group, _ in categoryTable do
+        for fs, data in unitsList[group] do
+            sizeTotal = sizeTotal + unitsList.FootprintSizes[fs] * data.Count
+        end
+    end
+    if sizeTotal < currRowLen then -- This doesn't allow for large units hanging over the sides, but it's too hard to handle that correctly.
+        return 1
+    else
+        return 0
+    end
+end
+
+function IsLandSpaceOccupied(occupiedSpaces, size, rowNum, whichCol, currRowLen, remainingUnits)
     local evenRowLen = math.mod(currRowLen, 2) == 0
     local evenSize = math.mod(size, 2) == 0
     
-    if whichCol == 1 and (not evenRowLen) and evenSize then -- Don't put an even-sized unit in the middle of an odd-length row
+    if whichCol == 1 and (not evenRowLen) and evenSize and remainingUnits > 1 then -- Don't put an even-sized unit in the middle of an odd-length row unless it's the last unit
         return true
     end
-    if whichCol > currRowLen - math.floor(size / 2) * 2 and size <= math.floor(currRowLen / 4) then -- Don't put a large unit at the end of a row unless the row is too narrow
+    if whichCol > currRowLen - math.floor(size / 2) * 2 and size <= math.floor(currRowLen / 2) then -- Don't put a large unit at the end of a row unless the row is too narrow
         return true
     end
     for y = 0, size - 1, 1 do

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -197,7 +197,6 @@ local TravelSlot = { Bots, Tanks, AA, Art, Shield, Util, Com }
 local TravelFormationBlock = {
     HomogenousRows = true,
     UtilBlocks = true,
-    RowBreak = 0.5,
     { TravelSlot, TravelSlot, },
     { TravelSlot, TravelSlot, },
     { TravelSlot, TravelSlot, },
@@ -415,12 +414,12 @@ local GrowthChevronBlock = {
 
 local LightAttackNaval = categories.LIGHTBOAT
 local FrigateNaval = categories.FRIGATE
-local SubNaval = categories.T1SUBMARINE + categories.T2SUBMARINE + categories.xss0304 -- TODO: Deal with categories instead of hard-coding xss0304
+local SubNaval = categories.T1SUBMARINE + categories.T2SUBMARINE + (categories.NUKESUB * categories.ANTINAVY - categories.NUKE)
 local DestroyerNaval = categories.DESTROYER
 local CruiserNaval = categories.CRUISER
 local BattleshipNaval = categories.BATTLESHIP
 local CarrierNaval = categories.NAVALCARRIER
-local NukeSubNaval = categories.NUKESUB - categories.xss0304 -- TODO: See above
+local NukeSubNaval = categories.NUKESUB - SubNaval
 local MobileSonar = categories.MOBILESONAR
 local DefensiveBoat = categories.DEFENSIVEBOAT
 local RemainingNaval = categories.NAVAL - (LightAttackNaval + FrigateNaval + SubNaval + DestroyerNaval + CruiserNaval + BattleshipNaval +
@@ -467,26 +466,32 @@ local NukeSubs = { 'NukeSubCount', }
 local Carriers = { 'CarrierCount', }
 local Sonar = {'MobileSonarCount', }
 
--- === LAND BLOCK TYPES =
+-- === NAVAL BLOCK TYPES =
 local FrigatesFirst = { Frigates, Destroyers, Battleships, Cruisers, Carriers, NukeSubs, Sonar, RemainingCategory }
 local DestroyersFirst = { Destroyers, Frigates, Battleships, Cruisers, Carriers, NukeSubs, Sonar, RemainingCategory }
 local CruisersFirst = { Cruisers, Carriers, Battleships, Destroyers, Frigates, NukeSubs, Sonar, RemainingCategory }
 local BattleshipsFirst = { Battleships, Destroyers, Frigates, Cruisers, Carriers, NukeSubs, Sonar, RemainingCategory }
 local CarriersFirst = { Carriers, Cruisers, Battleships, Destroyers, Frigates, NukeSubs, Sonar, RemainingCategory }
+
+local LargestFirstDF = { Battleships, Carriers, Destroyers, Cruisers, Frigates, NukeSubs, Sonar, RemainingCategory }
+local SmallestFirstDF = { Frigates, Destroyers, Cruisers, Sonar, Battleships, Carriers, NukeSubs, RemainingCategory }
+local LargestFirstAA = { Carriers, Battleships, Cruisers, Destroyers, Frigates, NukeSubs, Sonar, RemainingCategory }
+local SmallestFirstAA = { Cruisers, Frigates, Destroyers, Sonar, Carriers, Battleships, NukeSubs, RemainingCategory }
+
 local Subs = { Subs, NukeSubs, RemainingCategory }
 local SonarFirst = { Sonar, Carriers, Cruisers, Battleships, Destroyers, Frigates, NukeSubs, Sonar, RemainingCategory }
 
--- === LAND BLOCKS ===
+-- === NAVAL BLOCKS ===
 
 -- === Three Naval Growth Formation Block ==
 local ThreeNavalGrowthFormation = {
     LineBreak = 0.5,
     -- first row
-    { FrigatesFirst, FrigatesFirst, FrigatesFirst, },
+    { FrigatesFirst, FrigatesFirst, FrigatesFirst },
     -- second row
-    { DestroyersFirst, SonarFirst, DestroyersFirst, },
+    { LargestFirstDF, SonarFirst, LargestFirstDF },
     -- third row
-    { DestroyersFirst, CruisersFirst, DestroyersFirst, },
+    { DestroyersFirst, CruisersFirst, DestroyersFirst },
 }
 
 -- === Five Naval Growth Formation Block ==
@@ -495,13 +500,13 @@ local FiveNavalGrowthFormation = {
     -- first row
     { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst },
     -- second row
-    { FrigatesFirst, SonarFirst, DestroyersFirst, SonarFirst, FrigatesFirst },
+    { FrigatesFirst, LargestFirstDF, DestroyersFirst, LargestFirstDF, FrigatesFirst },
     -- third row
-    { DestroyersFirst, SonarFirst, BattleshipsFirst, SonarFirst, DestroyersFirst },
+    { DestroyersFirst, SmallestFirstDF, SonarFirst, SmallestFirstDF, DestroyersFirst },
     -- fourth row
-    { DestroyersFirst, SonarFirst, CarriersFirst, SonarFirst, DestroyersFirst },
+    { DestroyersFirst, LargestFirstAA, CruisersFirst, LargestFirstAA, DestroyersFirst },
     -- fifth row
-    { DestroyersFirst, SonarFirst, CarriersFirst, SonarFirst, DestroyersFirst },
+    { DestroyersFirst, SmallestFirstAA, CruisersFirst, SmallestFirstAA, DestroyersFirst },
 
 }
 
@@ -511,17 +516,32 @@ local SevenNavalGrowthFormation = {
     -- first row
     { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst },
     -- second row
-    { FrigatesFirst, FrigatesFirst, SonarFirst, DestroyersFirst, SonarFirst, FrigatesFirst, FrigatesFirst },
+    { FrigatesFirst, SmallestFirstDF, DestroyersFirst, DestroyersFirst, DestroyersFirst, SmallestFirstDF, FrigatesFirst },
     -- third row
-    { DestroyersFirst, DestroyersFirst, SonarFirst, BattleshipsFirst, SonarFirst, DestroyersFirst, DestroyersFirst },
+    { DestroyersFirst, DestroyersFirst, LargestFirstDF, SonarFirst, LargestFirstDF, DestroyersFirst, DestroyersFirst },
     -- fourth row
-    { DestroyersFirst, BattleshipsFirst, SonarFirst, CarriersFirst, SonarFirst, BattleshipsFirst, DestroyersFirst },
+    { DestroyersFirst, SmallestFirstAA, SmallestFirstAA, CruisersFirst, SmallestFirstAA, SmallestFirstAA, DestroyersFirst },
     -- fifth row
-    { DestroyersFirst, CruisersFirst, SonarFirst, BattleshipsFirst, SonarFirst, CruisersFirst, DestroyersFirst },
+    { DestroyersFirst, CruisersFirst, LargestFirstAA, DestroyersFirst, LargestFirstAA, CruisersFirst, DestroyersFirst },
     -- sixth row
-    { DestroyersFirst, CruisersFirst, SonarFirst, CarriersFirst, SonarFirst, CruisersFirst, DestroyersFirst },
+    { DestroyersFirst, SmallestFirstAA, SmallestFirstAA, SonarFirst, SmallestFirstAA, SmallestFirstAA, DestroyersFirst },
     -- seventh row
-    { DestroyersFirst, CruisersFirst, SonarFirst, CarriersFirst, SonarFirst, CruisersFirst, DestroyersFirst },
+    { DestroyersFirst, CruisersFirst, LargestFirstDF, CruisersFirst, LargestFirstDF, CruisersFirst, DestroyersFirst },
+}
+
+-- === Nine Naval Growth Formation Block ==
+local NineNavalGrowthFormation = {
+    LineBreak = 0.5,
+    -- first row
+    { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst },
+    -- second row
+    { FrigatesFirst, LargestFirstDF, SonarFirst, LargestFirstDF, DestroyersFirst, LargestFirstDF, SonarFirst, LargestFirstDF, FrigatesFirst },
+    -- third row
+    { SmallestFirstDF, DestroyersFirst, SmallestFirstAA, SmallestFirstAA, SonarFirst, SmallestFirstAA, SmallestFirstAA, DestroyersFirst, SmallestFirstDF },
+    -- fourth row
+    { DestroyersFirst, LargestFirstAA, CruisersFirst, LargestFirstAA, CruisersFirst, LargestFirstAA, CruisersFirst, LargestFirstAA, DestroyersFirst },
+    -- fifth row
+    { DestroyersFirst, DestroyersFirst, SmallestFirstAA, SmallestFirstAA, CruisersFirst, SmallestFirstAA, SmallestFirstAA, DestroyersFirst, DestroyersFirst },
 }
 
 -- ==============================================
@@ -534,18 +554,18 @@ local FiveWideNavalAttackFormation = {
     -- first row
     { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst},
     -- second row
-    { DestroyersFirst, SonarFirst, CarriersFirst, SonarFirst, DestroyersFirst},
+    { DestroyersFirst, LargestFirstDF, CruisersFirst, LargestFirstDF, DestroyersFirst},
 }
 
 -- === Seven Wide Naval Attack Formation Block ==
 local SevenWideNavalAttackFormation = {
     LineBreak = 0.5,
     -- first row
-    { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, },
+    { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst },
     -- second row
-    { DestroyersFirst, BattleshipsFirst, SonarFirst, BattleshipsFirst, SonarFirst, BattleshipsFirst, DestroyersFirst},
-        -- third row
-    { DestroyersFirst, CruisersFirst, CarriersFirst, CarriersFirst, CruisersFirst, CruisersFirst, DestroyersFirst},
+    { DestroyersFirst, SonarFirst, LargestFirstDF, DestroyersFirst, LargestFirstDF, SonarFirst, DestroyersFirst },
+    -- third row
+    { SmallestFirstDF, SmallestFirstAA, SmallestFirstDF, CruisersFirst, SmallestFirstDF, SmallestFirstAA, SmallestFirstDF },
 }
 
 -- === Nine Wide Naval Attack Formation Block ==
@@ -554,9 +574,24 @@ local NineWideNavalAttackFormation = {
     -- first row
     { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst },
     -- second row
-    { DestroyersFirst, DestroyersFirst, SonarFirst, BattleshipsFirst, BattleshipsFirst, BattleshipsFirst, SonarFirst, DestroyersFirst, DestroyersFirst },
+    { DestroyersFirst, LargestFirstDF, SonarFirst, LargestFirstDF, DestroyersFirst, LargestFirstDF, SonarFirst, LargestFirstDF, DestroyersFirst },
     -- third row
-    { DestroyersFirst, CruisersFirst, SonarFirst, CarriersFirst, CarriersFirst, CarriersFirst, SonarFirst, CruisersFirst, DestroyersFirst },
+    { SmallestFirstDF, DestroyersFirst, SmallestFirstAA, SmallestFirstAA, SonarFirst, SmallestFirstAA, SmallestFirstAA, DestroyersFirst, SmallestFirstDF },
+    -- fourth row
+    { DestroyersFirst, SmallestFirstDF, CruisersFirst, LargestFirstAA, CruisersFirst, LargestFirstAA, CruisersFirst, SmallestFirstDF, DestroyersFirst },
+}
+
+-- === Eleven Wide Naval Attack Formation Block ==
+local ElevenWideNavalAttackFormation = {
+    LineBreak = 0.5,
+    -- first row
+    { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst },
+    -- second row
+    { DestroyersFirst, DestroyersFirst, LargestFirstDF, SmallestFirstDF, LargestFirstDF, DestroyersFirst, LargestFirstDF, SmallestFirstDF, LargestFirstDF, DestroyersFirst, DestroyersFirst },
+    -- third row
+    { SmallestFirstDF, DestroyersFirst, SmallestFirstAA, SmallestFirstAA, SmallestFirstAA, SonarFirst, SmallestFirstAA, SmallestFirstAA, SmallestFirstAA, DestroyersFirst, SmallestFirstDF },
+    -- fourth row
+    { DestroyersFirst, SmallestFirstAA, LargestFirstDF, SonarFirst, LargestFirstAA, CruisersFirst, LargestFirstAA, SonarFirst, LargestFirstDF, SmallestFirstAA, DestroyersFirst },
 }
 
 -- ==============================================
@@ -575,6 +610,15 @@ local SixWideSubGrowthFormation = {
     { Subs, Subs, Subs, Subs, Subs, Subs },
     { Subs, Subs, Subs, Subs, Subs, Subs },
     { Subs, Subs, Subs, Subs, Subs, Subs },
+}
+
+-- === Eight Wide Subs Formation ===
+local EightWideSubGrowthFormation = {
+    LineBreak = 0.5,
+    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
 }
 
 
@@ -604,6 +648,15 @@ local EightWideSubAttackFormation = {
     { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
     { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
     { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
+}
+
+-- === Ten Wide Subs Formation ===
+local TenWideSubAttackFormation = {
+    LineBreak = 0.5,
+    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
 }
 
 local EightNavalFormation = {
@@ -672,22 +725,24 @@ function AttackFormation(formationUnits)
     BlockBuilderLand(landUnitsList, landBlock, LandCategories, 1)
 
     local seaUnitsList = unitsList.Naval
+    local subUnitsList = unitsList.Subs
+    local seaArea = seaUnitsList.AreaTotal
+    local subArea = subUnitsList.AreaTotal
     local seaBlock
     local subBlock
-    local subUnitsList = unitsList.Subs
-    local seaArea = math.max(seaUnitsList.AreaTotal, subUnitsList.AreaTotal)
-    if seaArea <= 10 then
+    
+    if seaArea <= 10 and subArea <= 8 then
         seaBlock = FiveWideNavalAttackFormation
         subBlock = FourWideSubAttackFormation
-    elseif seaArea <= 25 then
+    elseif seaArea <= 21 and subArea <= 18 then
         seaBlock = SevenWideNavalAttackFormation
         subBlock = SixWideSubAttackFormation
-    elseif seaArea <= 50 then
+    elseif seaArea <= 36 and subArea <= 32 then
         seaBlock = NineWideNavalAttackFormation
         subBlock = EightWideSubAttackFormation
     else
-        seaBlock = NineWideNavalAttackFormation
-        subBlock = EightWideSubAttackFormation
+        seaBlock = ElevenWideNavalAttackFormation
+        subBlock = TenWideSubAttackFormation
     end
     BlockBuilderLand(seaUnitsList, seaBlock, NavalCategories, 1)
     BlockBuilderLand(subUnitsList, subBlock, SubCategories, 1)
@@ -729,22 +784,23 @@ function GrowthFormation(formationUnits)
 
     local seaUnitsList = unitsList.Naval
     local subUnitsList = unitsList.Subs
-    local seaArea = math.max(seaUnitsList.AreaTotal, subUnitsList.AreaTotal)
+    local seaArea = seaUnitsList.AreaTotal
+    local subArea = subUnitsList.AreaTotal
     local seaBlock
     local subBlock
     
-    if seaArea <= 9 then
+    if seaArea <= 9 and subArea <= 12 then
         seaBlock = ThreeNavalGrowthFormation
         subBlock = FourWideSubGrowthFormation
-    elseif seaArea <= 25 then
+    elseif seaArea <= 25 and subArea <= 20 then
         seaBlock = FiveNavalGrowthFormation
         subBlock = FourWideSubGrowthFormation
-    elseif seaArea <= 49 then
+    elseif seaArea <= 49 and subArea <= 42 then
         seaBlock = SevenNavalGrowthFormation
         subBlock = SixWideSubGrowthFormation
     else
-        seaBlock = SevenNavalGrowthFormation
-        subBlock = SixWideSubGrowthFormation
+        seaBlock = NineNavalGrowthFormation
+        subBlock = EightWideSubGrowthFormation
     end
     BlockBuilderLand(seaUnitsList, seaBlock, NavalCategories, 1)
     BlockBuilderLand(subUnitsList, subBlock, SubCategories, 1)
@@ -945,11 +1001,10 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
             rowNum = rowNum + 1
             if whichRow == numRows then
                 whichRow = 1
-                formationLength = formationLength + 1 + (formationBlock.RowBreak or 0) + (formationBlock.LineBreak or 0)
             else
                 whichRow = whichRow + 1
-                formationLength = formationLength + 1 + (formationBlock.LineBreak or 0)
             end
+            formationLength = formationLength + 1 + (formationBlock.LineBreak or 0)
             whichCol = 1
             rowType = false
             currRowLen = table.getn(formationBlock[whichRow])
@@ -963,11 +1018,11 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
         
         local currColSpot = GetColSpot(currRowLen, whichCol) -- Translate whichCol to correct spot in row
         local currSlot = formationBlock[whichRow][currColSpot]
-        for numType, type in currSlot do
+        for _, type in currSlot do
             if inserted then
                 break
             end
-            for numGroup, group in type do
+            for _, group in type do
                 if not formationBlock.HomogenousRows or (rowType == false or rowType == type) then
                     local fs = 0
                     local size = 0
@@ -976,30 +1031,9 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
                     for k, v in unitsList[group] do
                         size = unitsList.FootprintSizes[k]
                         evenSize = math.mod(size, 2) == 0
-                        if v.Count > 0 then --and (whichCol + (size - 1) * 2 <= currRowLen or currRowLen < size * 2) then
-                            if size > 1 then
-                                if whichCol == 1 and not evenRowLen and evenSize then -- Don't put an even-sized unit in the middle of an odd-length row
-                                    continue
-                                end
-                                local blocked = false
-                                for y = 0, size - 1, 1 do
-                                    local yPos = rowNum + y
-                                    if not occupiedSpaces[yPos] then
-                                        continue
-                                    end
-                                    for x = 0, size - 1, 1 do
-                                        if occupiedSpaces[yPos][whichCol + x * 2] then
-                                            blocked = true
-                                            break
-                                        end
-                                    end
-                                    if blocked then
-                                        break
-                                    end
-                                end
-                                if blocked then
-                                    continue
-                                end
+                        if v.Count > 0 then
+                            if size > 1 and IsLandSpaceOccupied(occupiedSpaces, size, rowNum, whichCol, currRowLen) then
+                                continue
                             end
                             fs = k
                             groupData = v
@@ -1017,21 +1051,8 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
                                 offsetX = (size - 1) / 2
                             end
                             offsetY = (size - 1) / 2 * (1 + (formationBlock.LineBreak or 0))
-                            for y = 0, size - 1, 1 do
-                                local yPos = rowNum + y
-                                if not occupiedSpaces[yPos] then
-                                    occupiedSpaces[yPos] = {}
-                                end
-                                if whichCol == 1 and evenRowLen == evenSize then
-                                    for x = 0, size - 1, 1 do
-                                        occupiedSpaces[yPos][whichCol + x] = true
-                                    end
-                                else
-                                    for x = 0, (size - 1) * 2, 2 do
-                                        occupiedSpaces[yPos][whichCol + x] = true
-                                    end
-                                end
-                            end
+                            
+                            OccupyLandSpace(occupiedSpaces, size, rowNum, whichCol, currRowLen)
                         end
                         
                         local xPos
@@ -1075,6 +1096,59 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
     end
 
     return FormationPos
+end
+
+function IsLandSpaceOccupied(occupiedSpaces, size, rowNum, whichCol, currRowLen)
+    local evenRowLen = math.mod(currRowLen, 2) == 0
+    local evenSize = math.mod(size, 2) == 0
+    
+    if whichCol == 1 and (not evenRowLen) and evenSize then -- Don't put an even-sized unit in the middle of an odd-length row
+        return true
+    end
+    if whichCol > currRowLen - math.floor(size / 2) * 2 and size <= math.floor(currRowLen / 4) then -- Don't put a large unit at the end of a row unless the row is too narrow
+        return true
+    end
+    for y = 0, size - 1, 1 do
+        local yPos = rowNum + y
+        if not occupiedSpaces[yPos] then
+            continue
+        end
+        if whichCol == 1 and evenRowLen == evenSize then
+            for x = 0, size - 1, 1 do
+                if occupiedSpaces[yPos][whichCol + x] then
+                    return true
+                end
+            end
+        else
+            for x = 0, (size - 1) * 2, 2 do
+                if occupiedSpaces[yPos][whichCol + x] then
+                    return true
+                end
+            end
+        end
+    end
+    return false
+end
+
+function OccupyLandSpace(occupiedSpaces, size, rowNum, whichCol, currRowLen)
+    local evenRowLen = math.mod(currRowLen, 2) == 0
+    local evenSize = math.mod(size, 2) == 0
+    
+    for y = 0, size - 1, 1 do
+        local yPos = rowNum + y
+        if not occupiedSpaces[yPos] then
+            occupiedSpaces[yPos] = {}
+        end
+        if whichCol == 1 and evenRowLen == evenSize then
+            for x = 0, size - 1, 1 do
+                occupiedSpaces[yPos][whichCol + x] = true
+            end
+        else
+            for x = 0, (size - 1) * 2, 2 do
+                occupiedSpaces[yPos][whichCol + x] = true
+            end
+        end
+    end
 end
 
 function GetColSpot(rowLen, col)

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -51,30 +51,30 @@ local RemainingCategory = { 'RemainingCategory', }
 
 -- === LAND CATEGORIES ===
 local DirectFire = ((categories.DIRECTFIRE - categories.CONSTRUCTION)) * categories.LAND
-local Construction = (categories.COMMAND + categories.CONSTRUCTION + categories.ENGINEER) * categories.LAND
-local Artillery = ((categories.ARTILLERY + categories.INDIRECTFIRE) - categories.ANTIAIR) * categories.LAND
-local AntiAir = (categories.ANTIAIR - (categories.EXPERIMENTAL + categories.DIRECTFIRE)) * categories.LAND
+local Artillery = ((categories.ARTILLERY + categories.INDIRECTFIRE)) * categories.LAND
+local AntiAir = (categories.ANTIAIR - (categories.EXPERIMENTAL + categories.DIRECTFIRE + Artillery)) * categories.LAND
+local Construction = ((categories.COMMAND + categories.CONSTRUCTION + categories.ENGINEER) - (DirectFire + Artillery)) * categories.LAND
 local UtilityCat = (((categories.RADAR + categories.COUNTERINTELLIGENCE) - categories.DIRECTFIRE) + categories.SCOUT) * categories.LAND
-local DFExp = DirectFire * categories.EXPERIMENTAL
 local ShieldCat = categories.uel0307 + categories.ual0307 + categories.xsl0307
 
 -- === TECH LEVEL LAND CATEGORIES ===
 local LandCategories = {
-    Experimentals = DFExp,
-    
     Shields = ShieldCat,
     
     Bot1 = (DirectFire * categories.TECH1) * categories.BOT - categories.SCOUT,
     Bot2 = (DirectFire * categories.TECH2) * categories.BOT - categories.SCOUT,
     Bot3 = (DirectFire * categories.TECH3) * categories.BOT - categories.SCOUT,
+    Bot4 = (DirectFire * categories.EXPERIMENTAL) * categories.BOT - categories.SCOUT,
 
     Tank1 = (DirectFire * categories.TECH1) - categories.BOT - categories.SCOUT,
     Tank2 = (DirectFire * categories.TECH2) - categories.BOT - categories.SCOUT,
     Tank3 = (DirectFire * categories.TECH3) - categories.BOT - categories.SCOUT,
+    Tank4 = (DirectFire * categories.EXPERIMENTAL) - categories.BOT - categories.SCOUT,
 
     Art1 = Artillery * categories.TECH1,
     Art2 = Artillery * categories.TECH2,
     Art3 = Artillery * categories.TECH3,
+    Art4 = Artillery * categories.EXPERIMENTAL,
 
     AA1 = AntiAir * categories.TECH1,
     AA2 = AntiAir * categories.TECH2,
@@ -82,30 +82,31 @@ local LandCategories = {
 
     Com1 = Construction * categories.TECH1,
     Com2 = Construction * categories.TECH2,
-    Com3 = Construction - (categories.TECH1 + categories.TECH2),
+    Com3 = Construction - (categories.TECH1 + categories.TECH2 + categories.EXPERIMENTAL),
+    Com4 = Construction * categories.EXPERIMENTAL,
 
     Util1 = (UtilityCat * categories.TECH1) + categories.OPERATION,
     Util2 = UtilityCat * categories.TECH2,
     Util3 = UtilityCat * categories.TECH3,
+    Util4 = UtilityCat * categories.EXPERIMENTAL,
 
-    RemainingCategory = categories.LAND - (DirectFire + Construction + Artillery + AntiAir + UtilityCat + DFExp + ShieldCat)
+    RemainingCategory = categories.LAND - (DirectFire + Construction + Artillery + AntiAir + UtilityCat + ShieldCat)
 }
 
 -- === SUB GROUP ORDERING ===
-local Bots = { 'Bot3', 'Bot2', 'Bot1', }
-local Tanks = { 'Tank3', 'Tank2', 'Tank1', }
-local DF = { 'Tank3', 'Bot3', 'Tank2', 'Bot2', 'Tank1', 'Bot1', }
-local Art = { 'Art3', 'Art2', 'Art1', }
-local T1Art = { 'Art1', 'Art2', 'Art3', }
+local Bots = { 'Bot4', 'Bot3', 'Bot2', 'Bot1', }
+local Tanks = { 'Tank4', 'Tank3', 'Tank2', 'Tank1', }
+local DF = { 'Tank4', 'Bot4', 'Tank3', 'Bot3', 'Tank2', 'Bot2', 'Tank1', 'Bot1', }
+local Art = { 'Art4', 'Art3', 'Art2', 'Art1', }
+local T1Art = { 'Art1', 'Art2', 'Art3', 'Art4', }
 local AA = { 'AA3', 'AA2', 'AA1', }
-local Util = { 'Util3', 'Util2', 'Util1', }
-local Com = { 'Com3', 'Com2', 'Com1', }
+local Util = { 'Util4', 'Util3', 'Util2', 'Util1', }
+local Com = { 'Com4', 'Com3', 'Com2', 'Com1', }
 local Shield = { 'Shields', }
-local Experimental = { 'Experimentals', }
 
 -- === LAND BLOCK TYPES =
-local DFFirst = { Experimental, DF, T1Art, AA, Shield, Com, Util, RemainingCategory }
-local TankFirst = { Experimental, Tanks, Bots, Art, AA, Shield, Com, Util, RemainingCategory }
+local DFFirst = { DF, T1Art, AA, Shield, Com, Util, RemainingCategory }
+local TankFirst = { Tanks, Bots, Art, AA, Shield, Com, Util, RemainingCategory }
 local ShieldFirst = { Shield, AA, T1Art, DF, Com, Util, RemainingCategory }
 local AAFirst = { AA, DF, T1Art, Art, Shield, Com, Util, RemainingCategory }
 local ArtFirst = { Art, AA, DF, Shield, Com, Util, RemainingCategory }
@@ -192,7 +193,7 @@ local EightWideAttackFormationBlock = {
 }
 
 -- === Travelling Block ===
-local TravelSlot = { Experimental, Bots, Tanks, AA, Art, Shield, Util, Com }
+local TravelSlot = { Bots, Tanks, AA, Art, Shield, Util, Com }
 local TravelFormationBlock = {
     HomogenousRows = true,
     UtilBlocks = true,
@@ -1446,14 +1447,13 @@ end
 function CategorizeUnits(formationUnits)
     local unitsList = {
         Land = {
-            Bot1 = {}, Bot2 = {}, Bot3 = {},
-            Tank1 = {}, Tank2 = {}, Tank3 = {},
-            Art1 = {}, Art2 = {}, Art3 = {},
+            Bot1 = {}, Bot2 = {}, Bot3 = {}, Bot4 = {},
+            Tank1 = {}, Tank2 = {}, Tank3 = {}, Tank4 = {},
+            Art1 = {}, Art2 = {}, Art3 = {}, Art4 = {},
             AA1 = {}, AA2 = {}, AA3 = {},
-            Com1 = {}, Com2 = {}, Com3 = {},
-            Util1 = {}, Util2 = {}, Util3 = {},
+            Com1 = {}, Com2 = {}, Com3 = {}, Com4 = {},
+            Util1 = {}, Util2 = {}, Util3 = {}, Util4 = {},
             Shields = {},
-            Experimentals = {},
             RemainingCategory = {},
             
             UnitTotal = 0,

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -73,10 +73,11 @@ end
 local RemainingCategory = { 'RemainingCategory', }
 
 -- === LAND CATEGORIES ===
-local DirectFire = ((categories.DIRECTFIRE - categories.CONSTRUCTION)) * categories.LAND
-local Artillery = ((categories.ARTILLERY + categories.INDIRECTFIRE)) * categories.LAND
-local AntiAir = (categories.ANTIAIR - (categories.EXPERIMENTAL + categories.DIRECTFIRE + Artillery)) * categories.LAND
-local Construction = ((categories.COMMAND + categories.CONSTRUCTION + categories.ENGINEER) - (DirectFire + Artillery)) * categories.LAND
+local DirectFire = (categories.DIRECTFIRE - (categories.CONSTRUCTION + categories.SNIPER)) * categories.LAND
+local Sniper = categories.SNIPER * categories.LAND
+local Artillery = (categories.ARTILLERY + categories.INDIRECTFIRE - categories.SNIPER) * categories.LAND
+local AntiAir = (categories.ANTIAIR - (categories.EXPERIMENTAL + categories.DIRECTFIRE + categories.SNIPER + Artillery)) * categories.LAND
+local Construction = ((categories.COMMAND + categories.CONSTRUCTION + categories.ENGINEER) - (DirectFire + Sniper + Artillery)) * categories.LAND
 local UtilityCat = (((categories.RADAR + categories.COUNTERINTELLIGENCE) - categories.DIRECTFIRE) + categories.SCOUT) * categories.LAND
 local ShieldCat = categories.uel0307 + categories.ual0307 + categories.xsl0307
 
@@ -93,6 +94,11 @@ local LandCategories = {
     Tank2 = (DirectFire * categories.TECH2) - categories.BOT - categories.SCOUT,
     Tank3 = (DirectFire * categories.TECH3) - categories.BOT - categories.SCOUT,
     Tank4 = (DirectFire * categories.EXPERIMENTAL) - categories.BOT - categories.SCOUT,
+    
+    Sniper1 = (Sniper * categories.TECH1) - categories.SCOUT,
+    Sniper2 = (Sniper * categories.TECH2) - categories.SCOUT,
+    Sniper3 = (Sniper * categories.TECH3) - categories.SCOUT,
+    Sniper4 = (Sniper * categories.EXPERIMENTAL) - categories.SCOUT,
 
     Art1 = Artillery * categories.TECH1,
     Art2 = Artillery * categories.TECH2,
@@ -113,15 +119,15 @@ local LandCategories = {
     Util3 = UtilityCat * categories.TECH3,
     Util4 = UtilityCat * categories.EXPERIMENTAL,
 
-    RemainingCategory = categories.LAND - (DirectFire + Construction + Artillery + AntiAir + UtilityCat + ShieldCat)
+    RemainingCategory = categories.LAND - (DirectFire + Sniper + Construction + Artillery + AntiAir + UtilityCat + ShieldCat)
 }
 
 -- === SUB GROUP ORDERING ===
 local Bots = { 'Bot4', 'Bot3', 'Bot2', 'Bot1', }
 local Tanks = { 'Tank4', 'Tank3', 'Tank2', 'Tank1', }
 local DF = { 'Tank4', 'Bot4', 'Tank3', 'Bot3', 'Tank2', 'Bot2', 'Tank1', 'Bot1', }
-local Art = { 'Art4', 'Art3', 'Art2', 'Art1', }
-local T1Art = { 'Art1', 'Art2', 'Art3', 'Art4', }
+local Art = { 'Art4', 'Sniper4', 'Art3', 'Sniper3', 'Art2', 'Sniper2', 'Art1', 'Sniper1', }
+local T1Art = { 'Sniper1', 'Art1', 'Sniper2', 'Art2', 'Sniper3', 'Art3', 'Sniper4', 'Art4', }
 local AA = { 'AA3', 'AA2', 'AA1', }
 local Util = { 'Util4', 'Util3', 'Util2', 'Util1', }
 local Com = { 'Com4', 'Com3', 'Com2', 'Com1', }
@@ -131,7 +137,7 @@ local Shield = { 'Shields', }
 local DFFirst = { DF, T1Art, AA, Shield, Com, Util, RemainingCategory }
 local ShieldFirst = { Shield, AA, DF, T1Art, Com, Util, RemainingCategory }
 local AAFirst = { AA, DF, T1Art, Shield, Com, Util, RemainingCategory }
-local ArtFirst = { Art, AA, DF, Shield, Com, Util, RemainingCategory }
+local ArtFirst = { Art, DF, AA, Shield, Com, Util, RemainingCategory }
 local T1ArtFirst = { T1Art, DF, AA, Shield, Com, Util, RemainingCategory }
 local UtilFirst = { Util, AA, Shield, DF, T1Art, Com, RemainingCategory }
 
@@ -1379,6 +1385,7 @@ function CategorizeUnits(formationUnits)
         Land = {
             Bot1 = {}, Bot2 = {}, Bot3 = {}, Bot4 = {},
             Tank1 = {}, Tank2 = {}, Tank3 = {}, Tank4 = {},
+            Sniper1 = {}, Sniper2 = {}, Sniper3 = {}, Sniper4 = {},
             Art1 = {}, Art2 = {}, Art3 = {}, Art4 = {},
             AA1 = {}, AA2 = {}, AA3 = {},
             Com1 = {}, Com2 = {}, Com3 = {}, Com4 = {},

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -129,7 +129,6 @@ local Shield = { 'Shields', }
 
 -- === LAND BLOCK TYPES =
 local DFFirst = { DF, T1Art, AA, Shield, Com, Util, RemainingCategory }
-local TankFirst = { Tanks, Bots, Art, AA, Shield, Com, Util, RemainingCategory }
 local ShieldFirst = { Shield, AA, DF, T1Art, Com, Util, RemainingCategory }
 local AAFirst = { AA, DF, T1Art, Shield, Com, Util, RemainingCategory }
 local ArtFirst = { Art, AA, DF, Shield, Com, Util, RemainingCategory }
@@ -213,18 +212,6 @@ local EightWideAttackFormationBlock = {
     { DFFirst, ShieldFirst, UtilFirst, ShieldFirst, ShieldFirst, UtilFirst, ShieldFirst, DFFirst, },
     -- seventh row
     { DFFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, DFFirst, },
-}
-
--- === Travelling Block ===
-local TravelSlot = { Bots, Tanks, AA, Art, Shield, Util, Com }
-local TravelFormationBlock = {
-    HomogenousRows = true,
-    UtilBlocks = true,
-    { TravelSlot, TravelSlot, },
-    { TravelSlot, TravelSlot, },
-    { TravelSlot, TravelSlot, },
-    { TravelSlot, TravelSlot, },
-    { TravelSlot, TravelSlot, },
 }
 
 -- === 2 Row Attack Block - 8 units wide ===
@@ -384,13 +371,6 @@ local EngAir = { 'AEngineer', }
 
 -- === Air Block Arrangement ===
 local ChevronSlot = { AntiAir, ExperAir, AntiNavy, GroundAttack, Bombers, Intel, Transports, EngAir, RemainingCategory }
-local InitialChevronBlock = {
-    RepeatAllRows = false,
-    HomogenousBlocks = true,
-    ChevronSize = 3,
-    { ChevronSlot },
-    { ChevronSlot, ChevronSlot },
-}
 
 local AttackChevronBlock = {
     RepeatAllRows = false,
@@ -464,15 +444,6 @@ local DefensiveBoat = categories.DEFENSIVEBOAT
 local RemainingNaval = categories.NAVAL - (LightAttackNaval + FrigateNaval + SubNaval + DestroyerNaval + CruiserNaval + BattleshipNaval +
                         CarrierNaval + NukeSubNaval + DefensiveBoat + MobileSonar)
 
--- Naval formation blocks
-local NavalSpacing = 1.2
-local StandardNavalBlock = {
-    { { {0, 0}, }, { 'Carriers', 'Battleships', 'Cruisers', 'Destroyers', 'Frigates', 'Submarines' }, },
-    { { {-1, 1.5}, {1, 1.5}, }, { 'Destroyers', 'Cruisers', 'Frigates', 'Submarines'}, },
-    { { {-2.5, 0}, {2.5, 0}, }, { 'Cruisers', 'Battleships', 'Destroyers', 'Frigates', 'Submarines' }, },
-    { { {-1, -1.5}, {1, -1.5}, }, { 'Frigates', 'Battleships', 'Submarines' }, },
-    { { {-3, 2}, {3, 2}, {-3, 0}, {3, 0}, }, { 'Submarines', }, },
-}
 
 -- === TECH LEVEL LAND CATEGORIES ===
 local NavalCategories = {
@@ -509,14 +480,10 @@ local Sonar = {'MobileSonarCount', }
 local FrigatesFirst = { Frigates, Destroyers, Battleships, Cruisers, Carriers, NukeSubs, Sonar, RemainingCategory }
 local DestroyersFirst = { Destroyers, Frigates, Battleships, Cruisers, Carriers, NukeSubs, Sonar, RemainingCategory }
 local CruisersFirst = { Cruisers, Carriers, Battleships, Destroyers, Frigates, NukeSubs, Sonar, RemainingCategory }
-local BattleshipsFirst = { Battleships, Destroyers, Frigates, Cruisers, Carriers, NukeSubs, Sonar, RemainingCategory }
-local CarriersFirst = { Carriers, Cruisers, Battleships, Destroyers, Frigates, NukeSubs, Sonar, RemainingCategory }
-
 local LargestFirstDF = { Battleships, Carriers, Destroyers, Cruisers, Frigates, NukeSubs, Sonar, RemainingCategory }
 local SmallestFirstDF = { Frigates, Destroyers, Cruisers, Sonar, Battleships, Carriers, NukeSubs, RemainingCategory }
 local LargestFirstAA = { Carriers, Battleships, Cruisers, Destroyers, Frigates, NukeSubs, Sonar, RemainingCategory }
 local SmallestFirstAA = { Cruisers, Frigates, Destroyers, Sonar, Carriers, Battleships, NukeSubs, RemainingCategory }
-
 local Subs = { Subs, NukeSubs, RemainingCategory }
 local SonarFirst = { Sonar, Carriers, Cruisers, Battleships, Destroyers, Frigates, NukeSubs, Sonar, RemainingCategory }
 
@@ -698,22 +665,6 @@ local TenWideSubAttackFormation = {
     { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
 }
 
-local EightNavalFormation = {
-    LineBreak = 0.5,
-    { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst },
-    -- second row
-    { DestroyersFirst, CruisersFirst, CruisersFirst, BattleshipsFirst, BattleshipsFirst, CruisersFirst, CruisersFirst, DestroyersFirst },
-    -- third row
-    { DestroyersFirst, BattleshipsFirst, CruisersFirst, CruisersFirst, CruisersFirst, CruisersFirst, BattleshipsFirst, DestroyersFirst },
-    -- fourth row
-    { DestroyersFirst, CruisersFirst, CarriersFirst, CarriersFirst, CarriersFirst, CarriersFirst, CruisersFirst, DestroyersFirst },
-}
-
-local EightNavalSubFormation = {
-    LineBreak = 0.5,
-    { Subs, Subs, Subs, Subs, Subs, Subs, Subs },
-}
-
 -- ============ Formation Pickers ============
 function PickBestTravelFormationIndex(typeName, distance)
     if typeName == 'AirFormations' then
@@ -840,73 +791,6 @@ function GrowthFormation(formationUnits)
     BlockBuilderAir(unitsList.Air, GrowthChevronBlock, 1)
 
     CacheResults(FormationPos, formationUnits, 'GrowthFormation')
-    return FormationPos
-end
-
-function BlockFormation(formationUnits) -- Doesn't appear to ever be used
-
-    FormationPos = {}
-
-    local rotate = true
-    local smallUnitsList = {}
-    local largeUnitsList = {}
-    local smallUnits = 0
-    local largeUnits = 0
-
-    for i, u in formationUnits do
-        local footPrintSize = u:GetFootPrintSize()
-        if footPrintSize > 3  then
-            largeUnitsList[largeUnits] = { u }
-            largeUnits = largeUnits + 1
-        else
-            smallUnitsList[smallUnits] = { u }
-            smallUnits = smallUnits + 1
-        end
-    end
-
-    local n = smallUnits + largeUnits
-    local width = math.ceil(math.sqrt(n))
-    local length = n / width
-
-    -- Put small units (Size 1 through 3) in front of the formation
-    for i in smallUnitsList do
-        local offsetX = ((math.mod(i, width)  - math.floor(width/2)) * 2) + 1
-        local offsetY = (math.floor(i/width) - math.floor(length/2)) * 2
-        local delay = 0.1 + (math.floor(i/width) * 3)
-        table.insert(FormationPos, { offsetX, -offsetY, categories.ALLUNITS, delay, rotate })
-    end
-
-    -- Put large units (Size >= 4) in the back of the formation
-    for i in largeUnitsList do
-        local adjIndex = smallUnits + i
-        local offsetX = ((math.mod(adjIndex, width)  - math.floor(width/2)) * 2) + 1
-        local offsetY = (math.floor(adjIndex/width) - math.floor(length/2)) * 2
-        local delay = 0.1 + (math.floor(adjIndex/width) * 3)
-        table.insert(FormationPos, { offsetX, -offsetY, categories.ALLUNITS, delay, rotate })
-    end
-
-    return FormationPos
-end
-
--- local function for performing lerp
-local function lerp(alpha, a, b)
-    return a + ((b-a) * alpha)
-end
-
-function CircleFormation(formationUnits) -- Doesn't appear to ever be used
-    FormationPos = {}
-
-    local rotate = false
-    local numUnits = table.getn(formationUnits)
-    local sizeMult = 2.0 + math.max(1.0, numUnits / 3.0)
-
-    -- make circle around center point
-    for i in formationUnits do
-        offsetX = sizeMult * math.sin(lerp(i/numUnits, 0.0, math.pi * 2.0))
-        offsetY = sizeMult * math.cos(lerp(i/numUnits, 0.0, math.pi * 2.0))
-        table.insert(FormationPos, { offsetX, offsetY, categories.ALLUNITS, 0, rotate })
-    end
-
     return FormationPos
 end
 
@@ -1411,154 +1295,6 @@ function GetChevronPosition(chevronPos, currCol, formationLen)
 end
 
 
-
--- =========== NAVAL UNIT BLOCKS ============
-function NavalBlocks(unitsList, navyType) -- Doesn't appear to ever be used
-    local Carriers = true
-    local Battleships = true
-    local Cruisers = true
-    local Destroyers = true
-    local unitNum = 1
-    for i, v in navyType do
-        for k, u in v[2] do
-            if u == 'Carriers' and Carriers and unitsList.CarrierCount > 0 then
-                for j, coord in v[1] do
-                    if unitsList.CarrierCount ~= 0 then
-                        table.insert(FormationPos, { coord[1]*NavalSpacing, coord[2]*NavalSpacing, categories.NAVAL * categories.AIRSTAGINGPLATFORM * (categories.TECH3 + categories.EXPERIMENTAL), 0, true })
-                        unitsList.CarrierCount = unitsList.CarrierCount - 1
-                        unitNum = unitNum + 1
-                    end
-                end
-                Carriers = false
-                break
-            elseif u == 'Battleships' and Battleships and unitsList.BattleshipCount > 0 then
-                for j, coord in v[1] do
-                    if unitsList.BattleshipCount ~= 0 then
-                        table.insert(FormationPos, { coord[1]*NavalSpacing, coord[2]*NavalSpacing, BattleshipNaval, 0, true })
-                        unitsList.BattleshipCount = unitsList.BattleshipCount - 1
-                        unitNum = unitNum + 1
-                    end
-                end
-                Battleships = false
-                break
-            elseif u == 'Cruisers' and Cruisers and unitsList.CruiserCount > 0 then
-                for j, coord in v[1] do
-                    if unitsList.CruiserCount ~= 0 then
-                        table.insert(FormationPos, { coord[1]*NavalSpacing, coord[2]*NavalSpacing, CruiserNaval, 0, true })
-                        unitNum = unitNum + 1
-                        unitsList.CruiserCount = unitsList.CruiserCount - 1
-                    end
-                end
-                Cruisers = false
-                break
-            elseif u == 'Destroyers' and Destroyers and unitsList.DestroyerCount > 0 then
-                for j, coord in v[1] do
-                    if unitsList.DestroyerCount > 0 then
-                        table.insert(FormationPos, { coord[1]*NavalSpacing, coord[2]*NavalSpacing, DestroyerNaval, 0, true })
-                        unitNum = unitNum + 1
-                        unitsList.DestroyerCount = unitsList.DestroyerCount - 1
-                    end
-                end
-                Destroyers = false
-                break
-            elseif u == 'Frigates' and unitsList.FrigateCount > 0 then
-                for j, coord in v[1] do
-                    if unitsList.FrigateCount > 0 then
-                        table.insert(FormationPos, { coord[1]*NavalSpacing, coord[2]*NavalSpacing, FrigateNaval, 0, true })
-                        unitNum = unitNum + 1
-                        unitsList.FrigateCount = unitsList.FrigateCount - 1
-                    end
-                end
-                break
-            elseif u == 'Frigates' and unitsList.LightCount > 0 then
-                for j, coord in v[1] do
-                    if unitsList.LightCount > 0 then
-                        table.insert(FormationPos, { coord[1]*NavalSpacing, coord[2]*NavalSpacing, LightAttackNaval, 0, true })
-                        unitNum = unitNum + 1
-                        unitsList.LightCount = unitsList.LightCount - 1
-                    end
-                end
-                break
-            elseif u == 'Submarines' and unitsList.SubCount > 0 then
-                for j, coord in v[1] do
-                    if (unitsList.SubCount + unitsList.NukeSubCount) > 0 then
-                        table.insert(FormationPos, { coord[1]*NavalSpacing, coord[2]*NavalSpacing, SubNaval + NukeSubNaval, 0, true })
-                        unitNum = unitNum + 1
-                        unitsList.SubCount = unitsList.SubCount - 1
-                    end
-                end
-                break
-            end
-        end
-    end
-
-    local sideTable = { 0, -2, 2 }
-    local sideIndex = 1
-    local length = -3
-
-    i = unitNum
-
-    -- Figure out how many left we have to assign
-    local numLeft = unitsList.UnitTotal - i + 1
-    if numLeft == 2 then
-        sideIndex = 2
-    end
-
-    while i <= unitsList.UnitTotal do
-        if unitsList.CarrierCount > 0 then
-            table.insert(FormationPos, { sideTable[sideIndex]*NavalSpacing, length*NavalSpacing, categories.NAVAL * categories.AIRSTAGINGPLATFORM * (categories.TECH3 + categories.EXPERIMENTAL), 0, true  })
-            unitNum = unitNum + 1
-            unitsList.CarrierCount = unitsList.CarrierCount - 1
-        elseif unitsList.BattleshipCount > 0 then
-            table.insert(FormationPos, { sideTable[sideIndex]*NavalSpacing, length*NavalSpacing, BattleshipNaval, 0, true })
-            unitNum = unitNum + 1
-            unitsList.BattleshipCount = unitsList.BattleshipCount - 1
-        elseif unitsList.CruiserCount > 0 then
-            table.insert(FormationPos, { sideTable[sideIndex]*NavalSpacing, length*NavalSpacing, CruiserNaval, 0, true })
-            unitNum = unitNum + 1
-            unitsList.CruiserCount = unitsList.CruiserCount - 1
-        elseif unitsList.DestroyerCount > 0 then
-            table.insert(FormationPos, { sideTable[sideIndex]*NavalSpacing, length*NavalSpacing, DestroyerNaval, 0, true })
-            unitNum = unitNum + 1
-            unitsList.DestroyerCount = unitsList.DestroyerCount - 1
-        elseif unitsList.FrigateCount > 0 then
-            table.insert(FormationPos, { sideTable[sideIndex]*NavalSpacing, length*NavalSpacing, FrigateNaval, 0, true })
-            unitNum = unitNum + 1
-            unitsList.FrigateCount = unitsList.FrigateCount - 1
-        elseif unitsList.LightCount > 0 then
-            table.insert(FormationPos, { sideTable[sideIndex]*NavalSpacing, length*NavalSpacing, LightAttackNaval, 0, true })
-            unitNum = unitNum + 1
-            unitsList.LightCount = unitsList.LightCount - 1
-        elseif (unitsList.SubCount + unitsList.NukeSubCount) > 0 then
-            table.insert(FormationPos, { sideTable[sideIndex]*NavalSpacing, length*NavalSpacing, SubNaval + NukeSubNaval, 0, true })
-            unitNum = unitNum + 1
-            unitsList.SubCount = unitsList.SubCount - 1
-        elseif (unitsList.MobileSonarCount) > 0 then
-            table.insert(FormationPos, { sideTable[sideIndex]*NavalSpacing, length*NavalSpacing, MobileSonar + DefensiveBoat, 0, true })
-            unitNum = unitNum + 1
-            unitsList.MobileSonarCount = unitsList.MobileSonarCount - 1
-        elseif (unitsList.RemainingCategory) > 0 then
-            table.insert(FormationPos, { sideTable[sideIndex]*NavalSpacing, length*NavalSpacing, NavalCategories.RemainingCategory, 0, true })
-            unitNum = unitNum + 1
-            unitsList.RemainingCategory = unitsList.RemainingCategory - 1
-        end
-
-        -- Figure out the next viable location for the naval unit
-        numLeft = numLeft - 1
-        sideIndex = sideIndex + 1
-        if sideIndex == 4 then
-            length = length - 2
-            if numLeft == 2 then
-                sideIndex = 2
-            else
-                sideIndex = 1
-            end
-        end
-
-        i = i + 1
-    end
-    return FormationPos
-end
 
 
 

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -546,28 +546,19 @@ local NineWideNavalAttackFormation = {
 -- ==============================================
 -- ============ Sub Growth Formation===========
 -- ==============================================
--- === Three Wide Growth Subs Formation ===
-local ThreeWideSubGrowthFormation = {
+-- === Four Wide Growth Subs Formation ===
+local FourWideSubGrowthFormation = {
     LineBreak = 0.5,
-    { Subs, Subs, Subs, },
-    { Subs, Subs, Subs, },
+    { Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs },
 }
 
--- === Five Wide Subs Formation ===
-local FiveWideSubGrowthFormation = {
+-- === Six Wide Subs Formation ===
+local SixWideSubGrowthFormation = {
     LineBreak = 0.5,
-    { Subs, Subs, Subs, Subs, Subs, },
-    { Subs, Subs, Subs, Subs, Subs, },
-    { Subs, Subs, Subs, Subs, Subs, },
-}
-
--- === Seven Wide Subs Formation ===
-local SevenWideSubGrowthFormation = {
-    LineBreak = 0.5,
-    { Subs, Subs, Subs, Subs, Subs, },
-    { Subs, Subs, Subs, Subs, Subs, },
-    { Subs, Subs, Subs, Subs, Subs, },
-    { Subs, Subs, Subs, Subs, Subs, },
+    { Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs },
 }
 
 
@@ -575,28 +566,28 @@ local SevenWideSubGrowthFormation = {
 -- ============ Sub Attack Formation===========
 -- ==============================================
 
--- === Five Wide Subs Formation ===
-local FiveWideSubAttackFormation = {
+-- === Four Wide Subs Formation ===
+local FourWideSubAttackFormation = {
     LineBreak = 0.5,
-    { Subs, Subs, Subs, Subs, Subs },
-    { Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs },
 }
 
--- === Seven Wide Subs Formation ===
-local SevenWideSubAttackFormation = {
+-- === Six Wide Subs Formation ===
+local SixWideSubAttackFormation = {
     LineBreak = 0.5,
-    { Subs, Subs, Subs, Subs, Subs, Subs, Subs },
-    { Subs, Subs, Subs, Subs, Subs, Subs, Subs },
-    { Subs, Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs },
 }
 
--- === Nine Wide Subs Formation ===
-local NineWideSubAttackFormation = {
+-- === Eight Wide Subs Formation ===
+local EightWideSubAttackFormation = {
     LineBreak = 0.5,
-    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
-    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
-    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
-    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
+    { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
 }
 
 local EightNavalFormation = {
@@ -671,16 +662,16 @@ function AttackFormation(formationUnits)
     local seaArea = math.max(seaUnitsList.AreaTotal, subUnitsList.AreaTotal)
     if seaArea <= 10 then
         seaBlock = FiveWideNavalAttackFormation
-        subBlock = FiveWideSubGrowthFormation
+        subBlock = FourWideSubAttackFormation
     elseif seaArea <= 25 then
         seaBlock = SevenWideNavalAttackFormation
-        subBlock = SevenWideSubAttackFormation
+        subBlock = SixWideSubAttackFormation
     elseif seaArea <= 50 then
         seaBlock = NineWideNavalAttackFormation
-        subBlock = NineWideSubAttackFormation
+        subBlock = EightWideSubAttackFormation
     else
         seaBlock = NineWideNavalAttackFormation
-        subBlock = NineWideSubAttackFormation
+        subBlock = EightWideSubAttackFormation
     end
     BlockBuilderLand(seaUnitsList, seaBlock, NavalCategories, 1)
     BlockBuilderLand(subUnitsList, subBlock, SubCategories, 1)
@@ -728,16 +719,16 @@ function GrowthFormation(formationUnits)
     local seaArea = math.max(seaUnitsList.AreaTotal, subUnitsList.AreaTotal)
     if seaArea <= 9 then
         seaBlock = ThreeNavalGrowthFormation
-        subBlock = ThreeWideSubGrowthFormation
+        subBlock = FourWideSubGrowthFormation
     elseif seaArea <= 25 then
         seaBlock = FiveNavalGrowthFormation
-        subBlock = FiveWideSubGrowthFormation
+        subBlock = FourWideSubGrowthFormation
     elseif seaArea <= 49 then
         seaBlock = SevenNavalGrowthFormation
-        subBlock = SevenWideSubGrowthFormation
+        subBlock = SixWideSubGrowthFormation
     else
         seaBlock = SevenNavalGrowthFormation
-        subBlock = SevenWideSubGrowthFormation
+        subBlock = SixWideSubGrowthFormation
     end
     BlockBuilderLand(seaUnitsList, seaBlock, NavalCategories, 1)
     BlockBuilderLand(subUnitsList, subBlock, SubCategories, 1)
@@ -856,8 +847,8 @@ function GuardFormation(formationUnits)
     for _, bp in blueprints do
         largestFootprint = math.max(largestFootprint, math.max(bp.Footprint.SizeX, bp.Footprint.SizeZ))
     end
-    local scale = 3 / math.min(largestFootprint + 2, 8)
     
+    local scale = 3 / math.min(largestFootprint + 2, 8) -- A distance of 1 in formation coordinates is translated to (largestFootprint + 2) world units.
     local rotate = false
     local sizeMult = 0.4
     local remainingUnits = table.getn(formationUnits)
@@ -868,7 +859,8 @@ function GuardFormation(formationUnits)
     local unitsPerShield = 0
     local nextShield = 0
 
-    -- make circle around center point
+    -- Form concentric circles around the assisted unit
+    -- Most of the numbers after this point are arbitrary. Don't go looking for the significance of 0.19 or the like because there is none.
     while remainingUnits > 0 do
         if unitCount > ringChange then
             ringChange = ringChange + 6
@@ -883,7 +875,7 @@ function GuardFormation(formationUnits)
             
             if ringCount == 1 then
                 shieldsInRing = math.min(ringChange, remainingShields)
-            elseif remainingShields >= (remainingUnits + ringChange + 6) * 0.19 then -- This is arbitrary but seems to give a good distrubution.
+            elseif remainingShields >= (remainingUnits + ringChange + 6) * 0.19 then
                 shieldsInRing = math.min(ringChange / 2, remainingShields)
             elseif remainingShields >= (remainingUnits + ringChange + 6) * 0.13 then
             shieldsInRing = math.min(ringChange / 3, remainingShields)

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1,15 +1,15 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/lua/formations.lua
-#**  Author(s):
-#**
-#**  Summary  :
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
-#
-# Basic create formation scripts
-#
+-- ****************************************************************************
+-- **
+-- **  File     :  /cdimage/lua/formations.lua
+-- **  Author(s):
+-- **
+-- **  Summary  :
+-- **
+-- **  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+-- ****************************************************************************
+--
+-- Basic create formation scripts
+
 
 SurfaceFormations = {
     'AttackFormation',
@@ -26,14 +26,14 @@ ComboFormations = {
     'GrowthFormation',
 }
 
-local FormationPos = {} # list to be returned
+local FormationPos = {} -- list to be returned
 
-#=========================================#
-#================ LAND DATA ==============#
-#=========================================#
+-- =========================================
+-- ================ LAND DATA ==============
+-- =========================================
 local RemainingCategory = { 'RemainingCategory', }
 
-#=== LAND CATEGORIES ===#
+-- === LAND CATEGORIES ===
 local DirectFire = ((categories.DIRECTFIRE - categories.CONSTRUCTION)) * categories.LAND
 local Construction = (categories.COMMAND + categories.CONSTRUCTION + categories.ENGINEER) * categories.LAND
 local Artillery = ((categories.ARTILLERY + categories.INDIRECTFIRE) - categories.ANTIAIR) * categories.LAND
@@ -42,7 +42,7 @@ local UtilityCat = (((categories.RADAR + categories.COUNTERINTELLIGENCE) - categ
 local DFExp = DirectFire * categories.EXPERIMENTAL
 local ShieldCat = categories.uel0307 + categories.ual0307 + categories.xsl0307
 
-#=== TECH LEVEL LAND CATEGORIES ===#
+-- === TECH LEVEL LAND CATEGORIES ===
 local LandCategories = {
     Bot1 = (DirectFire * categories.TECH1) * categories.BOT - categories.SCOUT,
     Bot2 = (DirectFire * categories.TECH2) * categories.BOT - categories.SCOUT,
@@ -75,10 +75,10 @@ local LandCategories = {
     RemainingCategory = categories.LAND - (DirectFire + Construction + Artillery + AntiAir + UtilityCat + DFExp + ShieldCat)
 }
 
-#=== SUB GROUP ORDERING ===#
+-- === SUB GROUP ORDERING ===
 local Bots = { 'Bot3', 'Bot2', 'Bot1', }
 local Tanks = { 'Tank3', 'Tank2', 'Tank1', }
-local DF = { 'Tank3', 'Bot3', 'Tank2', 'Bot2', 'Tank1', 'Bot1',}
+local DF = { 'Tank3', 'Bot3', 'Tank2', 'Bot2', 'Tank1', 'Bot1', }
 local Art = { 'Art3', 'Art2', 'Art1', }
 local T1Art = { 'Art1', 'Art2', 'Art3', }
 local AA = { 'AA3', 'AA2', 'AA1', }
@@ -87,7 +87,7 @@ local Com = { 'Com3', 'Com2', 'Com1', }
 local Shield = { 'Shields', }
 local Experimental = { 'Experimentals', }
 
-#=== LAND BLOCK TYPES =#
+-- === LAND BLOCK TYPES =
 local DFFirst = { Experimental, DF, T1Art, AA, Shield, Com, Util, RemainingCategory }
 local TankFirst = { Experimental, Tanks, Bots, Art, AA, Shield, Com, Util, RemainingCategory }
 local ShieldFirst = { Shield, AA, T1Art, DF, Com, Util, RemainingCategory }
@@ -97,85 +97,85 @@ local T1ArtFirst = { T1Art, AA, DF, Shield, Com, Util, RemainingCategory }
 local UtilFirst = { Util, AA, T1Art, DF, Shield, Com, Util, RemainingCategory }
 
 
-#=== LAND BLOCKS ===#
+-- === LAND BLOCKS ===
 
-#=== 3 Wide Attack Block / 3 Units ===#
+-- === 3 Wide Attack Block / 3 Units ===
 local ThreeWideAttackFormationBlock = {
-    ## first row
+    -- first row
     { DFFirst, DFFirst, DFFirst, },
 }
 
-#=== 4 Wide Attack Block / 12 Units ===#
+-- === 4 Wide Attack Block / 12 Units ===
 local FourWideAttackFormationBlock = {
-    ## first row
+    -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, },
-    ## second row
+    -- second row
     { UtilFirst, ShieldFirst, ShieldFirst, UtilFirst, },
-    ## third Row
+    -- third Row
     { AAFirst, ArtFirst, ArtFirst, AAFirst,  },
 }
 
-#=== 5 Wide Attack Block ===#
+-- === 5 Wide Attack Block ===
 local FiveWideAttackFormationBlock = {
-    ## first row
+    -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, },
-    ## second row
+    -- second row
     { DFFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, },
-    ## third row
+    -- third row
     { UtilFirst, ShieldFirst, DFFirst, ShieldFirst,  UtilFirst, },
-    ## fourth row
+    -- fourth row
     { AAFirst, DFFirst, ArtFirst, DFFirst, AAFirst, },
 }
 
-#=== 6 Wide Attack Block ===#
+-- === 6 Wide Attack Block ===
 local SixWideAttackFormationBlock = {
-    ## first row
+    -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, },
-    ## second row
+    -- second row
     { DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, },
-    ## third row
+    -- third row
     { UtilFirst, AAFirst, DFFirst, DFFirst, AAFirst,  UtilFirst, },
-    ## fourth row
+    -- fourth row
     { AAFirst, ShieldFirst, ArtFirst, ArtFirst, ShieldFirst, AAFirst, },
-    ## fifth row
+    -- fifth row
     { DFFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, DFFirst, },
 }
 
-#=== 7 Wide Attack Block ===#
+-- === 7 Wide Attack Block ===
 local SevenWideAttackFormationBlock = {
-    ## first row
+    -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, },
-    ## second Row
+    -- second Row
     { DFFirst, ShieldFirst, DFFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, },
-    ## third row
+    -- third row
     { UtilFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, UtilFirst, },
-    ## fourth row
+    -- fourth row
     { AAFirst, ShieldFirst, AAFirst, T1ArtFirst, ShieldFirst, AAFirst, DFFirst, },
-    ## fifth row
+    -- fifth row
     { DFFirst, AAFirst, T1ArtFirst, T1ArtFirst, AAFirst, T1ArtFirst, DFFirst, },
-    ## sixth row
+    -- sixth row
     { UtilFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, UtilFirst, },
 }
 
-#=== 8 Wide Attack Block ===#
+-- === 8 Wide Attack Block ===
 local EightWideAttackFormationBlock = {
-    ## first row
+    -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, },
-    ## second Row
+    -- second Row
     { DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, },
-    ## third row
+    -- third row
     { UtilFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, UtilFirst, },
-    ## fourth row
+    -- fourth row
     { DFFirst, AAFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, },
-    ## fifth row
+    -- fifth row
     { DFFirst, T1ArtFirst, AAFirst, T1ArtFirst, T1ArtFirst, AAFirst, T1ArtFirst, DFFirst, },
-    ## sixth row
+    -- sixth row
     { UtilFirst, AAFirst, ShieldFirst, ArtFirst, ArtFirst, ShieldFirst, AAFirst, UtilFirst, },
-    ## seventh row
+    -- seventh row
     { DFFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, DFFirst, },
 }
 
-#=== Travelling Block ===#
+-- === Travelling Block ===
 local TravelSlot = { Experimental, Bots, Tanks, AA, Art, Shield, Util, Com }
 local TravelFormationBlock = {
     HomogenousRows = true,
@@ -188,128 +188,128 @@ local TravelFormationBlock = {
     { TravelSlot, TravelSlot, },
 }
 
-#=== 2 Row Attack Block - 8 units wide ===#
+-- === 2 Row Attack Block - 8 units wide ===
 local TwoRowAttackFormationBlock = {
-    ## first row
+    -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
-    ## second row
+    -- second row
     { UtilFirst, AAFirst, ShieldFirst, ArtFirst, ArtFirst, ShieldFirst, AAFirst, UtilFirst },
 }
 
-#=== 3 Row Attack Block - 10 units wide ===#
+-- === 3 Row Attack Block - 10 units wide ===
 local ThreeRowAttackFormationBlock = {
-    ## first row
+    -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
-    ## second row
+    -- second row
     { UtilFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, AAFirst, ShieldFirst, UtilFirst },
-    ## third row
+    -- third row
     { DFFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, ArtFirst, AAFirst, DFFirst },
 }
 
-#=== 4 Row Attack Block - 12 units wide ===#
+-- === 4 Row Attack Block - 12 units wide ===
 local FourRowAttackFormationBlock = {
-    ## first row
+    -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
-    ## second row
+    -- second row
     { UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst },
-    ## third row
+    -- third row
     { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst },
-    ## fourth row
+    -- fourth row
     { AAFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, ArtFirst, ArtFirst, ShieldFirst, ArtFirst, AAFirst, ShieldFirst, AAFirst },
 }
 
-#=== 5 Row Attack Block - 14 units wide ===#
+-- === 5 Row Attack Block - 14 units wide ===
 local FiveRowAttackFormationBlock = {
-    ## first row
+    -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
-    ## second row
+    -- second row
     { UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst },
-    ## third row
+    -- third row
     { DFFirst, AAFirst, DFFirst, AAFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, AAFirst, DFFirst, AAFirst, DFFirst },
-    ## fourth row
+    -- fourth row
     { AAFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, AAFirst },
-    ## five row
+    -- five row
     { ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst },
 }
 
-#=== 6 Row Attack Block - 16 units wide ===#
+-- === 6 Row Attack Block - 16 units wide ===
 local SixRowAttackFormationBlock = {
-    ## first row
+    -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
-    ## second row
+    -- second row
     { UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst },
-    ## third row
+    -- third row
     { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst },
-    ## fourth row
+    -- fourth row
     { AAFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, ShieldFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, AAFirst },
-    ## fifth row
+    -- fifth row
     { UtilFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, UtilFirst },
-    ## sixth row
+    -- sixth row
     { AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst },
 }
 
-#=== 7 Row Attack Block - 18 units wide ===#
+-- === 7 Row Attack Block - 18 units wide ===
 local SevenRowAttackFormationBlock = {
-    ## first row
+    -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
-    ## second row
+    -- second row
     { UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst },
-    ## third row
+    -- third row
     { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst },
-    ## fourth row
+    -- fourth row
     { AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst },
-    ## fifth row
+    -- fifth row
     { UtilFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, UtilFirst },
-    ## sixth row
+    -- sixth row
     { AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst },
-    ## seventh row
+    -- seventh row
     { ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst },
 }
 
-#=== 8 Row Attack Block - 18 units wide ===#
+-- === 8 Row Attack Block - 18 units wide ===
 local EightRowAttackFormationBlock = {
-    ## first row
+    -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
-    ## second row
+    -- second row
     { UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst },
-    ## third row
+    -- third row
     { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst },
-    ## fourth row
+    -- fourth row
     { AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst },
-    ## fifth row
+    -- fifth row
     { UtilFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, AAFirst, UtilFirst },
-    ## sixth row
+    -- sixth row
     { AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst },
-    ## seventh row
+    -- seventh row
     { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, DFFirst, DFFirst, DFFirst },
-    ## eight row
+    -- eight row
     { AAFirst, ShieldFirst, ArtFirst, AAFirst, ShieldFirst, ArtFirst, AAFirst, ShieldFirst, ArtFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, AAFirst },
 }
 
-#=== 9 Row Attack Block - 18+ units wide ===#
+-- === 9 Row Attack Block - 18+ units wide ===
 local NineRowAttackFormationBlock = {
-    ## first row
+    -- first row
     { DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst, DFFirst },
-    ## second row
+    -- second row
     { UtilFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, DFFirst, DFFirst, ShieldFirst, UtilFirst },
-    ## third row
+    -- third row
     { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst },
-    ## fourth row
+    -- fourth row
     { AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst },
-    ## fifth row
+    -- fifth row
     { UtilFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, DFFirst, AAFirst, UtilFirst },
-    ## sixth row
+    -- sixth row
     { AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, AAFirst, ShieldFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst, DFFirst, ShieldFirst, AAFirst },
-    ## seventh row
+    -- seventh row
     { DFFirst, AAFirst, DFFirst, DFFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, ArtFirst, ArtFirst, AAFirst, DFFirst, DFFirst, DFFirst },
-    ## eight row
+    -- eight row
     { AAFirst, ShieldFirst, ArtFirst, AAFirst, ShieldFirst, ArtFirst, AAFirst, ShieldFirst, ArtFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, AAFirst },
 }
-#=========================================#
-#================ AIR DATA ===============#
-#=========================================#
+-- =========================================
+-- ================ AIR DATA ===============
+-- =========================================
 
-#=== AIR CATEGORIES ===#
+-- === AIR CATEGORIES ===
 local GroundAttackAir = (categories.AIR * categories.GROUNDATTACK) - categories.ANTIAIR
 local TransportationAir = categories.AIR * categories.TRANSPORTATION - categories.GROUNDATTACK
 local BomberAir = categories.AIR * categories.BOMBER
@@ -318,7 +318,7 @@ local AntiNavyAir = categories.AIR * categories.ANTINAVY
 local IntelAir = categories.AIR * (categories.SCOUT + categories.RADAR)
 local ExperimentalAir = categories.AIR * categories.EXPERIMENTAL
 
-#=== TECH LEVEL AIR CATEGORIES ===#
+-- === TECH LEVEL AIR CATEGORIES ===
 local AirCategories = {
     Ground1 = GroundAttackAir * categories.TECH1,
     Ground2 = GroundAttackAir * categories.TECH2,
@@ -349,7 +349,7 @@ local AirCategories = {
     RemainingCategory = categories.AIR - (GroundAttackAir + TransportationAir + BomberAir + AAAir + AntiNavyAir + IntelAir + ExperimentalAir)
 }
 
-#=== SUB GROUP ORDERING ===#
+-- === SUB GROUP ORDERING ===
 local GroundAttack = { 'Ground3', 'Ground2', 'Ground1', }
 local Transports = { 'Trans3', 'Trans2', 'Trans1', }
 local Bombers = { 'Bomb3', 'Bomb2', 'Bomb1', }
@@ -358,7 +358,7 @@ local AntiNavy = { 'AN3', 'AN2', 'AN1', }
 local Intel = { 'AIntel3', 'AIntel2', 'AIntel1', }
 local ExperAir = { 'AExper', }
 
-#=== Air Block Arrangement ===#
+-- === Air Block Arrangement ===
 local ChevronSlot = { AntiAir, ExperAir, AntiNavy, GroundAttack, Bombers, Intel, Transports, RemainingCategory }
 local InitialChevronBlock = {
     RepeatAllRows = false,
@@ -377,9 +377,9 @@ local StaggeredChevronBlock = {
 
 
 
-#=========================================#
-#============== NAVAL DATA ===============#
-#=========================================#
+-- =========================================
+-- ============== NAVAL DATA ===============
+-- =========================================
 
 local LightAttackNaval = categories.LIGHTBOAT
 local FrigateNaval = categories.FRIGATE
@@ -394,7 +394,7 @@ local DefensiveBoat = categories.DEFENSIVEBOAT
 local RemainingNaval = categories.NAVAL - (LightAttackNaval + FrigateNaval + SubNaval + DestroyerNaval + CruiserNaval + BattleshipNaval +
                         CarrierNaval + NukeSubNaval + DefensiveBoat + MobileSonar)
 
-#### Naval formation blocks #####
+-- Naval formation blocks 
 local NavalSpacing = 1.2
 local StandardNavalBlock = {
     { { {0, 0}, }, { 'Carriers', 'Battleships', 'Cruisers', 'Destroyers', 'Frigates', 'Submarines' }, },
@@ -404,7 +404,7 @@ local StandardNavalBlock = {
     { { {-3, 2}, {3, 2}, {-3, 0}, {3, 0}, }, { 'Submarines', }, },
 }
 
-#=== TECH LEVEL LAND CATEGORIES ===#
+-- === TECH LEVEL LAND CATEGORIES ===
 local NavalCategories = {
     LightCount = LightAttackNaval,
     FrigateCount = FrigateNaval,
@@ -425,7 +425,7 @@ local SubCategories = {
     SubCount = SubNaval,
 }
 
-#=== SUB GROUP ORDERING ===#
+-- === SUB GROUP ORDERING ===
 local Frigates = { 'FrigateCount', 'LightCount', }
 local Destroyers = { 'DestroyerCount', }
 local Cruisers = { 'CruiserCount', }
@@ -435,7 +435,7 @@ local NukeSubs = { 'NukeSubCount', }
 local Carriers = { 'CarrierCount', }
 local Sonar = {'MobileSonarCount', }
 
-#=== LAND BLOCK TYPES =#
+-- === LAND BLOCK TYPES =
 local FrigatesFirst = { Frigates, Destroyers, Battleships, Cruisers, Carriers, NukeSubs, Sonar, RemainingCategory }
 local DestroyersFirst = { Destroyers, Frigates, Battleships, Cruisers, Carriers, NukeSubs, Sonar, RemainingCategory }
 local CruisersFirst = { Cruisers, Carriers, Battleships, Destroyers, Frigates, NukeSubs, Sonar, RemainingCategory }
@@ -444,129 +444,129 @@ local CarriersFirst = { Carriers, Cruisers, Battleships, Destroyers, Frigates, N
 local Subs = { Subs, NukeSubs, RemainingCategory }
 local SonarFirst = { Sonar, Carriers, Cruisers, Battleships, Destroyers, Frigates, NukeSubs, Sonar, RemainingCategory }
 
-#=== LAND BLOCKS ===#
+-- === LAND BLOCKS ===
 
-#=== Three Naval Growth Formation Block ==#
+-- === Three Naval Growth Formation Block ==
 local ThreeNavalGrowthFormation = {
     LineBreak = 0.5,
-    ## first row
+    -- first row
     { FrigatesFirst, FrigatesFirst, FrigatesFirst, },
-    ## second row
+    -- second row
     { DestroyersFirst, SonarFirst, DestroyersFirst, },
-    ## third row
+    -- third row
     { DestroyersFirst, CruisersFirst, DestroyersFirst, },
 }
 
-#=== Five Naval Growth Formation Block ==#
+-- === Five Naval Growth Formation Block ==
 local FiveNavalGrowthFormation = {
     LineBreak = 0.5,
-    ## first row
+    -- first row
     { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst },
-    ## second row
+    -- second row
     { FrigatesFirst, SonarFirst, DestroyersFirst, SonarFirst, FrigatesFirst },
-    ## third row
+    -- third row
     { DestroyersFirst, SonarFirst, BattleshipsFirst, SonarFirst, DestroyersFirst },
-    ## fourth row
+    -- fourth row
     { DestroyersFirst, SonarFirst, CarriersFirst, SonarFirst, DestroyersFirst },
-    ## fifth row
+    -- fifth row
     { DestroyersFirst, SonarFirst, CarriersFirst, SonarFirst, DestroyersFirst },
 
 }
 
-#=== Seven Naval Growth Formation Block ==#
+-- === Seven Naval Growth Formation Block ==
 local SevenNavalGrowthFormation = {
     LineBreak = 0.5,
-    ## first row
+    -- first row
     { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst },
-    ## second row
+    -- second row
     { FrigatesFirst, FrigatesFirst, SonarFirst, DestroyersFirst, SonarFirst, FrigatesFirst, FrigatesFirst },
-    ## third row
+    -- third row
     { DestroyersFirst, DestroyersFirst, SonarFirst, BattleshipsFirst, SonarFirst, DestroyersFirst, DestroyersFirst },
-    ## fourth row
+    -- fourth row
     { DestroyersFirst, BattleshipsFirst, SonarFirst, CarriersFirst, SonarFirst, BattleshipsFirst, DestroyersFirst },
-    ## fifth row
+    -- fifth row
     { DestroyersFirst, CruisersFirst, SonarFirst, BattleshipsFirst, SonarFirst, CruisersFirst, DestroyersFirst },
-    ## sixth row
+    -- sixth row
     { DestroyersFirst, CruisersFirst, SonarFirst, CarriersFirst, SonarFirst, CruisersFirst, DestroyersFirst },
-    ## seventh row
+    -- seventh row
     { DestroyersFirst, CruisersFirst, SonarFirst, CarriersFirst, SonarFirst, CruisersFirst, DestroyersFirst },
 }
 
-#==============================================#
-#============ Naval Attack Formation===========#
-#==============================================#
+-- ==============================================
+-- ============ Naval Attack Formation===========
+-- ==============================================
 
-#=== Five Wide Naval Attack Formation Block ==#
+-- === Five Wide Naval Attack Formation Block ==
 local FiveWideNavalAttackFormation = {
     LineBreak = 0.5,
-    ## first row
+    -- first row
     { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst},
-    ## second row
+    -- second row
     { DestroyersFirst, SonarFirst, CarriersFirst, SonarFirst, DestroyersFirst},
 }
 
-#=== Seven Wide Naval Attack Formation Block ==#
+-- === Seven Wide Naval Attack Formation Block ==
 local SevenWideNavalAttackFormation = {
     LineBreak = 0.5,
-    ## first row
+    -- first row
     { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, },
-    ## second row
+    -- second row
     { DestroyersFirst, BattleshipsFirst, SonarFirst, BattleshipsFirst, SonarFirst, BattleshipsFirst, DestroyersFirst},
-        ## third row
+        -- third row
     { DestroyersFirst, CruisersFirst, CarriersFirst, CarriersFirst, CruisersFirst, CruisersFirst, DestroyersFirst},
 }
 
-#=== Nine Wide Naval Attack Formation Block ==#
+-- === Nine Wide Naval Attack Formation Block ==
 local NineWideNavalAttackFormation = {
     LineBreak = 0.5,
-    ## first row
+    -- first row
     { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst },
-    ## second row
+    -- second row
     { DestroyersFirst, DestroyersFirst, SonarFirst, BattleshipsFirst, BattleshipsFirst, BattleshipsFirst, SonarFirst, DestroyersFirst, DestroyersFirst },
-    ## third row
+    -- third row
     { DestroyersFirst, CruisersFirst, SonarFirst, CarriersFirst, CarriersFirst, CarriersFirst, SonarFirst, CruisersFirst, DestroyersFirst },
 }
 
-#==============================================#
-#============ Sub Growth Formation===========#
-#==============================================#
-#=== Three Wide Growth Subs Formation ===#
+-- ==============================================
+-- ============ Sub Growth Formation===========
+-- ==============================================
+-- === Three Wide Growth Subs Formation ===
 local ThreeWideSubGrowthFormation = {
     LineBreak = 0.5,
     { Subs, Subs, Subs, },
     { Subs, Subs, Subs, },
 }
 
-#=== Five Wide Subs Formation ===#
+-- === Five Wide Subs Formation ===
 local FiveWideSubGrowthFormation = {
     LineBreak = 0.5,
-    { Subs, Subs, Subs, Subs, Subs,},
-    { Subs, Subs, Subs, Subs, Subs,},
-    { Subs, Subs, Subs, Subs, Subs,},
+    { Subs, Subs, Subs, Subs, Subs, },
+    { Subs, Subs, Subs, Subs, Subs, },
+    { Subs, Subs, Subs, Subs, Subs, },
 }
 
-#=== Seven Wide Subs Formation ===#
+-- === Seven Wide Subs Formation ===
 local SevenWideSubGrowthFormation = {
     LineBreak = 0.5,
-    { Subs, Subs, Subs, Subs, Subs,},
-    { Subs, Subs, Subs, Subs, Subs,},
-    { Subs, Subs, Subs, Subs, Subs,},
-    { Subs, Subs, Subs, Subs, Subs,},
+    { Subs, Subs, Subs, Subs, Subs, },
+    { Subs, Subs, Subs, Subs, Subs, },
+    { Subs, Subs, Subs, Subs, Subs, },
+    { Subs, Subs, Subs, Subs, Subs, },
 }
 
 
-#==============================================#
-#============ Sub Attack Formation===========#
-#==============================================#
+-- ==============================================
+-- ============ Sub Attack Formation===========
+-- ==============================================
 
-#=== Five Wide Subs Formation ===#
+-- === Five Wide Subs Formation ===
 local FiveWideSubAttackFormation = {
     LineBreak = 0.5,
     { Subs, Subs, Subs, Subs, Subs },
     { Subs, Subs, Subs, Subs, Subs },
 }
 
-#=== Seven Wide Subs Formation ===#
+-- === Seven Wide Subs Formation ===
 local SevenWideSubAttackFormation = {
     LineBreak = 0.5,
     { Subs, Subs, Subs, Subs, Subs, Subs, Subs },
@@ -574,7 +574,7 @@ local SevenWideSubAttackFormation = {
     { Subs, Subs, Subs, Subs, Subs, Subs, Subs },
 }
 
-#=== Nine Wide Subs Formation ===#
+-- === Nine Wide Subs Formation ===
 local NineWideSubAttackFormation = {
     LineBreak = 0.5,
     { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
@@ -586,11 +586,11 @@ local NineWideSubAttackFormation = {
 local EightNavalFormation = {
     LineBreak = 0.5,
     { FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst, FrigatesFirst },
-    ## second row
+    -- second row
     { DestroyersFirst, CruisersFirst, CruisersFirst, BattleshipsFirst, BattleshipsFirst, CruisersFirst, CruisersFirst, DestroyersFirst },
-    ## third row
+    -- third row
     { DestroyersFirst, BattleshipsFirst, CruisersFirst, CruisersFirst, CruisersFirst, CruisersFirst, BattleshipsFirst, DestroyersFirst },
-    ## fourth row
+    -- fourth row
     { DestroyersFirst, CruisersFirst, CarriersFirst, CarriersFirst, CarriersFirst, CarriersFirst, CruisersFirst, DestroyersFirst },
 }
 
@@ -599,7 +599,7 @@ local EightNavalSubFormation = {
     { Subs, Subs, Subs, Subs, Subs, Subs, Subs },
 }
 
-#============ Formation Pickers ============#
+-- ============ Formation Pickers ============
 function PickBestTravelFormationIndex(typeName, distance)
     if typeName == 'AirFormations' then
         return 0;
@@ -613,27 +613,27 @@ function PickBestFinalFormationIndex(typeName, distance)
 end
 
 
-#================ THE GUTS ====================#
-#============ Formation Functions =============#
-#==============================================#
+-- ================ THE GUTS ====================
+-- ============ Formation Functions =============
+-- ==============================================
 function AttackFormation(formationUnits)
     FormationPos = {}
 
     local landUnitsList = CategorizeLandUnits(formationUnits)
     local landBlock
-    if landUnitsList.UnitTotal <= 16 then # 8 wide
+    if landUnitsList.UnitTotal <= 16 then -- 8 wide
         landBlock = TwoRowAttackFormationBlock
-    elseif landUnitsList.UnitTotal <= 30 then # 10 wide
+    elseif landUnitsList.UnitTotal <= 30 then -- 10 wide
         landBlock = ThreeRowAttackFormationBlock
-    elseif landUnitsList.UnitTotal <= 48 then # 12 wide
+    elseif landUnitsList.UnitTotal <= 48 then -- 12 wide
         landBlock = FourRowAttackFormationBlock
-    elseif landUnitsList.UnitTotal <= 70 then # 14 wide
+    elseif landUnitsList.UnitTotal <= 70 then -- 14 wide
         landBlock = FiveRowAttackFormationBlock
-    elseif landUnitsList.UnitTotal <= 96 then # 16 wide
+    elseif landUnitsList.UnitTotal <= 96 then -- 16 wide
         landBlock = SixRowAttackFormationBlock
-    elseif landUnitsList.UnitTotal <= 126 then # 18 wide
+    elseif landUnitsList.UnitTotal <= 126 then -- 18 wide
         landBlock = SevenRowAttackFormationBlock
-    elseif landUnitsList.UnitTotal <= 160 then # 20 wide
+    elseif landUnitsList.UnitTotal <= 160 then -- 20 wide
         landBlock = EightRowAttackFormationBlock
     else
         landBlock = NineRowAttackFormationBlock
@@ -735,7 +735,7 @@ function BlockFormation(formationUnits)
     local smallUnits = 0
     local largeUnits = 0
 
-    for i,u in formationUnits do
+    for i, u in formationUnits do
         local footPrintSize = u:GetFootPrintSize()
         if footPrintSize > 3  then
             largeUnitsList[largeUnits] = { u }
@@ -751,18 +751,18 @@ function BlockFormation(formationUnits)
     local width = math.ceil(math.sqrt(n))
     local length = n / width
 
-    # Put small units (Size 1 through 3) in front of the formation
+    -- Put small units (Size 1 through 3) in front of the formation
     for i in smallUnitsList do
-        local offsetX = ((math.mod(i,width)  - math.floor(width/2)) * 2) + 1
+        local offsetX = ((math.mod(i, width)  - math.floor(width/2)) * 2) + 1
         local offsetY = (math.floor(i/width) - math.floor(length/2)) * 2
         local delay = 0.1 + (math.floor(i/width) * 3)
         table.insert(FormationPos, { offsetX, -offsetY, categories.ALLUNITS, delay, rotate })
     end
 
-    # Put large units (Size >= 4) in the back of the formation
+    -- Put large units (Size >= 4) in the back of the formation
     for i in largeUnitsList do
         local adjIndex = smallUnits + i
-        local offsetX = ((math.mod(adjIndex,width)  - math.floor(width/2)) * 2) + 1
+        local offsetX = ((math.mod(adjIndex, width)  - math.floor(width/2)) * 2) + 1
         local offsetY = (math.floor(adjIndex/width) - math.floor(length/2)) * 2
         local delay = 0.1 + (math.floor(adjIndex/width) * 3)
         table.insert(FormationPos, { offsetX, -offsetY, categories.ALLUNITS, delay, rotate })
@@ -771,7 +771,7 @@ function BlockFormation(formationUnits)
     return FormationPos
 end
 
-# local function for performing lerp
+-- local function for performing lerp
 local function lerp(alpha, a, b)
     return a + ((b-a) * alpha)
 end
@@ -782,7 +782,7 @@ function CircleFormation(formationUnits)
     local numUnits = table.getn(formationUnits)
     local sizeMult = 2.0 + math.max(1.0, numUnits / 3.0)
 
-    # make circle around center point
+    -- make circle around center point
     for i in formationUnits do
         offsetX = sizeMult * math.sin(lerp(i/numUnits, 0.0, math.pi * 2.0))
         offsetY = sizeMult * math.cos(lerp(i/numUnits, 0.0, math.pi * 2.0))
@@ -799,7 +799,7 @@ function GuardFormation(formationUnits)
 
     local naval = false
     local sizeMult = 3
-    for k,v in formationUnits do
+    for k, v in formationUnits do
         if not v.Dead and EntityCategoryContains(categories.NAVAL * categories.MOBILE, v) then
             naval = true
             sizeMult = 8
@@ -810,7 +810,7 @@ function GuardFormation(formationUnits)
     local ringChange = 5
     local unitCount = 1
 
-    # make circle around center point
+    -- make circle around center point
     for i in formationUnits do
         if unitCount == ringChange then
             ringChange = ringChange + 5
@@ -821,9 +821,9 @@ function GuardFormation(formationUnits)
             end
             unitCount = 1
         end
-        offsetX = sizeMult * math.sin(lerp(unitCount/ringChange, 0.0, math.pi * 2.0)) # + math.pi / 16)
-        offsetY = sizeMult * math.cos(lerp(unitCount/ringChange, 0.0, math.pi * 2.0)) # + math.pi / 16)
-        #LOG('*FORMATION DEBUG: X=' .. offsetX .. ', Y=' .. offsetY)
+        offsetX = sizeMult * math.sin(lerp(unitCount/ringChange, 0.0, math.pi * 2.0)) -- + math.pi / 16)
+        offsetY = sizeMult * math.cos(lerp(unitCount/ringChange, 0.0, math.pi * 2.0)) -- + math.pi / 16)
+        -- LOG('*FORMATION DEBUG: X=' .. offsetX .. ', Y=' .. offsetY)
         table.insert(FormationPos, { offsetX - 10, offsetY, categories.ALLUNITS, 0, rotate })
         unitCount = unitCount + 1
     end
@@ -834,7 +834,7 @@ end
 
 
 
-#=========== LAND BLOCK BUILDING =================#
+-- =========== LAND BLOCK BUILDING =================
 function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
     spacing = spacing or 1
     local numRows = table.getn(formationBlock)
@@ -871,7 +871,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
             whichCol = 1
             currRowLen = table.getn(formationBlock[whichRow])
         end
-        local currColSpot = GetColSpot(currRowLen, whichCol) # Translate whichCol to correct spot in row
+        local currColSpot = GetColSpot(currRowLen, whichCol) -- Translate whichCol to correct spot in row
         local currSlot = formationBlock[whichRow][currColSpot]
         for numType, type in currSlot do
             if inserted then
@@ -880,7 +880,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
             for numGroup, group in type do
                 if not formationBlock.HomogenousRows or (rowType == false or rowType == type) then
                     if unitsList[group] > 0 then
-                        #local xPos = (math.ceil(whichCol/2)/2) - 0.25
+                        -- local xPos = (math.ceil(whichCol/2)/2) - 0.25
                         local xPos
                         if math.mod(currRowLen, 2) == 0 then
                             xPos = math.ceil(whichCol/2) - .5
@@ -919,7 +919,7 @@ end
 
 function GetColSpot(rowLen, col)
     local len = rowLen
-    if math.mod(rowLen,2) == 1 then
+    if math.mod(rowLen, 2) == 1 then
         len = rowLen + 1
     end
     local colType = 'left'
@@ -939,7 +939,7 @@ end
 
 
 
-#============ AIR BLOCK BUILDING =============#
+-- ============ AIR BLOCK BUILDING =============
 function BlockBuilderAir(unitsList, airBlock)
     local numRows = table.getn(airBlock)
     local i = 1
@@ -1018,17 +1018,17 @@ end
 function GetChevronPosition(chevronPos, currCol, currRowLen, formationLen)
     local offset = math.floor(chevronPos/2) * .375
     local xPos = offset
-    if math.mod(chevronPos,2) == 0 then
+    if math.mod(chevronPos, 2) == 0 then
         xPos = -1 * offset
     end
     local yPos = -offset
     yPos = yPos + (formationLen * -1.5)
     local firstBlockOffset = -2
-    if math.mod(currRowLen,2) == 1 then
+    if math.mod(currRowLen, 2) == 1 then
         firstBlockOffset = -1
     end
     local blockOff = math.floor(currCol/2) * 2
-    if math.mod(currCol,2) == 1 then
+    if math.mod(currCol, 2) == 1 then
         blockOff = -blockOff
     end
     xPos = xPos + blockOff + firstBlockOffset
@@ -1039,15 +1039,15 @@ end
 
 
 
-#=========== NAVAL UNIT BLOCKS ============#
+-- =========== NAVAL UNIT BLOCKS ============
 function NavalBlocks(unitsList, navyType)
     local Carriers = true
     local Battleships = true
     local Cruisers = true
     local Destroyers = true
     local unitNum = 1
-    for i,v in navyType do
-        for k,u in v[2] do
+    for i, v in navyType do
+        for k, u in v[2] do
             if u == 'Carriers' and Carriers and unitsList.CarrierCount > 0 then
                 for j, coord in v[1] do
                     if unitsList.CarrierCount ~= 0 then
@@ -1098,7 +1098,7 @@ function NavalBlocks(unitsList, navyType)
                 end
                 break
             elseif u == 'Frigates' and unitsList.LightCount > 0 then
-                for j,coord in v[1] do
+                for j, coord in v[1] do
                     if unitsList.LightCount > 0 then
                         table.insert(FormationPos, { coord[1]*NavalSpacing, coord[2]*NavalSpacing, LightAttackNaval, 0, true })
                         unitNum = unitNum + 1
@@ -1107,7 +1107,7 @@ function NavalBlocks(unitsList, navyType)
                 end
                 break
             elseif u == 'Submarines' and unitsList.SubCount > 0 then
-                for j,coord in v[1] do
+                for j, coord in v[1] do
                     if (unitsList.SubCount + unitsList.NukeSubCount) > 0 then
                         table.insert(FormationPos, { coord[1]*NavalSpacing, coord[2]*NavalSpacing, SubNaval + NukeSubNaval, 0, true })
                         unitNum = unitNum + 1
@@ -1125,7 +1125,7 @@ function NavalBlocks(unitsList, navyType)
 
     i = unitNum
 
-    # Figure out how many left we have to assign
+    -- Figure out how many left we have to assign
     local numLeft = unitsList.UnitTotal - i + 1
     if numLeft == 2 then
         sideIndex = 2
@@ -1170,7 +1170,7 @@ function NavalBlocks(unitsList, navyType)
             unitsList.RemainingCategory = unitsList.RemainingCategory - 1
         end
 
-        # Figure out the next viable location for the naval unit
+        -- Figure out the next viable location for the naval unit
         numLeft = numLeft - 1
         sideIndex = sideIndex + 1
         if sideIndex == 4 then
@@ -1189,10 +1189,10 @@ end
 
 
 
-#========= UNIT SORTING ==========#
+-- ========= UNIT SORTING ==========
 function CategorizeAirUnits(formationUnits)
     local unitsList = {
-        #### Air Lists
+        -- Air Lists
         Ground1 = 0, Ground2 = 0, Ground3 = 0,
         Trans1 = 0, Trans2 = 0, Trans3 = 0,
         Bomb1 = 0, Bomb2 = 0, Bomb3 = 0,
@@ -1203,8 +1203,8 @@ function CategorizeAirUnits(formationUnits)
         RemainingCategory = 0,
         UnitTotal = 0,
     }
-    for i,u in formationUnits do
-        for aircat,_ in AirCategories do
+    for i, u in formationUnits do
+        for aircat, _ in AirCategories do
             if EntityCategoryContains(AirCategories[aircat], u) then
                 unitsList[aircat] = unitsList[aircat] + 1
                 if AirCategories[aircat] == "RemainingCategory" then
@@ -1215,13 +1215,13 @@ function CategorizeAirUnits(formationUnits)
             end
         end
     end
-    #LOG('UnitsList=', repr(unitsList))
+    -- LOG('UnitsList=', repr(unitsList))
     return unitsList
 end
 
 function CategorizeSeaUnits(formationUnits)
     local unitsList = {
-        #### Naval Lists
+        -- Naval Lists
         UnitTotal = 0,
         CarrierCount = 0,
         BattleshipCount = 0,
@@ -1234,9 +1234,9 @@ function CategorizeSeaUnits(formationUnits)
         MobileSonarCount = 0,
         RemainingCategory = 0,
     }
-    #== NAVAL UNITS ==#
-    for i,u in formationUnits do
-        for navcat,_ in NavalCategories do
+    -- == NAVAL UNITS ==
+    for i, u in formationUnits do
+        for navcat, _ in NavalCategories do
             if EntityCategoryContains(NavalCategories[navcat], u) then
                 unitsList[navcat] = unitsList[navcat] + 1
                 if NavalCategories[navcat] == "RemainingCategory" then
@@ -1246,8 +1246,8 @@ function CategorizeSeaUnits(formationUnits)
                 break
             end
         end
-        #categorize subs
-        for subcat,_ in SubCategories do
+        -- categorize subs
+        for subcat, _ in SubCategories do
             if EntityCategoryContains(SubCategories[subcat], u) then
                 unitsList[subcat] = unitsList[subcat] + 1
                 if SubCategories[subcat] == "RemainingCategory" then
@@ -1263,7 +1263,7 @@ end
 
 function CategorizeLandUnits(formationUnits)
     local unitsList = {
-        #### Land Numbers
+        -- Land Numbers
         Bot1 = 0, Bot2 = 0, Bot3 = 0,
         Tank1 = 0, Tank2 = 0, Tank3 = 0,
         Art1 = 0, Art2 = 0, Art3 = 0,
@@ -1275,8 +1275,8 @@ function CategorizeLandUnits(formationUnits)
         UnitTotal = 0,
         RemainingCategory = 0,
     }
-    for i,u in formationUnits do
-        for landcat,_ in LandCategories do
+    for i, u in formationUnits do
+        for landcat, _ in LandCategories do
             if EntityCategoryContains(LandCategories[landcat], u) then
                 unitsList[landcat] = unitsList[landcat] + 1
                 if LandCategories[landcat] == "RemainingCategory" then

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -363,7 +363,7 @@ local AirCategories = {
 
     AExper = ExperimentalAir,
 
-    RemainingCategory = categories.AIR
+    RemainingCategory = categories.AIR - (GroundAttackAir + TransportationAir + BomberAir + AAAir + AntiNavyAir + IntelAir + ExperimentalAir)
 }
 
 -- === SUB GROUP ORDERING ===
@@ -916,6 +916,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
     spacing = (spacing or 1) * unitsList.Scale
     local numRows = table.getn(formationBlock)
     local i = 1
+    local rowNum = 1
     local whichRow = 1
     local whichCol = 1
     local currRowLen = table.getn(formationBlock[whichRow])
@@ -927,6 +928,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
 
     while unitsList.UnitTotal >= i do
         if whichCol > currRowLen then
+            rowNum = rowNum + 1
             if whichRow == numRows then
                 whichRow = 1
                 formationLength = formationLength + 1 + (formationBlock.RowBreak or 0) + (formationBlock.LineBreak or 0)
@@ -940,7 +942,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
             evenRowLen = math.mod(currRowLen, 2) == 0
         end
         
-        if occupiedSpaces[formationLength] and occupiedSpaces[formationLength][whichCol] then
+        if occupiedSpaces[rowNum] and occupiedSpaces[rowNum][whichCol] then
             whichCol = whichCol + 1
             continue
         end
@@ -967,7 +969,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
                                 end
                                 local blocked = false
                                 for y = 0, size - 1, 1 do
-                                    local yPos = formationLength + y + y * (formationBlock.LineBreak or 0)
+                                    local yPos = rowNum + y
                                     if not occupiedSpaces[yPos] then
                                         continue
                                     end
@@ -1002,7 +1004,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
                             end
                             offsetY = (size - 1) / 2 * (1 + (formationBlock.LineBreak or 0))
                             for y = 0, size - 1, 1 do
-                                local yPos = formationLength + y + y * (formationBlock.LineBreak or 0)
+                                local yPos = rowNum + y
                                 if not occupiedSpaces[yPos] then
                                     occupiedSpaces[yPos] = {}
                                 end
@@ -1167,10 +1169,7 @@ function GetChevronPosition(chevronPos, currCol, currRowLen, formationLen)
     end
     local yPos = -offset
     yPos = yPos + (formationLen * -1.5)
-    local firstBlockOffset = -2
-    if math.mod(currRowLen, 2) == 1 then
-        firstBlockOffset = -1
-    end
+    local firstBlockOffset = math.mod(currRowLen, 2) - 1
     local blockOff = math.floor(currCol/2) * 2
     if math.mod(currCol, 2) == 1 then
         blockOff = -blockOff

--- a/units/XAL0305/XAL0305_unit.bp
+++ b/units/XAL0305/XAL0305_unit.bp
@@ -48,6 +48,7 @@ UnitBlueprint {
         'LAND',
         'TECH3',
         'DIRECTFIRE',
+        'SNIPER',
         'VISIBLETORECON',
         'RECLAIMABLE',
         'BOT',

--- a/units/XRL0403/XRL0403_unit.bp
+++ b/units/XRL0403/XRL0403_unit.bp
@@ -83,6 +83,7 @@ UnitBlueprint {
     'FACTORY',
         'DIRECTFIRE',
         'ANTIAIR',
+        'SNIPER',
         'NEEDMOBILEBUILD',
         'SONAR',
         'VISIBLETORECON',

--- a/units/XSL0305/XSL0305_unit.bp
+++ b/units/XSL0305/XSL0305_unit.bp
@@ -46,6 +46,7 @@ UnitBlueprint {
         'TECH3',
         'DIRECTFIRE',
         'INDIRECTFIRE',
+        'SNIPER',
         'VISIBLETORECON',
         'RECLAIMABLE',
         'BOT',

--- a/units/drlk001/DRLK001_unit.bp
+++ b/units/drlk001/DRLK001_unit.bp
@@ -140,6 +140,10 @@ UnitBlueprint {
         TeleportMassMod = 1,
         TeleportTimeMod = 0.01,
     },
+    Footprint = {
+        SizeX = 1,
+        SizeZ = 1,
+    },
     General = {
         Category = 'Direct Fire',
         Classification = 'RULEUC_MilitaryVehicle',


### PR DESCRIPTION
Here's my work on improving formations. This is a work in progress and addresses the points in #2040. Any comments or suggestions are welcome, but please look at the checklist first.

Progress:
- [x] Stop large units from causing smaller units to spread out too much:
    - [x] Land
    - [x] Sea
    - [x] Air (done but they share space with the main formation since they normally have different altitude.)
    - [x] Guard (done but large units can get kind of cramped if there are also smaller units.)
    - [x] Make mixed-size formations look reasonably good in all situations (needs testing).
- [x] Update guard formation:
    - [x] Decrease the unit spread so they're not all over the place.
    - [x] Improve spacing of units in the outermost ring when there aren't enough for the full ring.
    - [x] Spread shields more evenly across the formation to protect the other units instead of clumping up.
- [x] Update sub formations to put them between surface units instead of directly under them.
- [x] Update air formations:
    - [x] Make formations centered instead of offset to the right of the destination.
    - [x] Adjust spacing (maybe even shape?) to reduce vulnerability to splash.
    - [x] Increase formation width (3/2 chevrons -> 3/4 or 5/4?) to accommodate the large groups often used at once.
- [x] Cache formation results so they aren't recalculated many times in a row for the same units.
    - [x] Extend caching to include when mixed air/land formations are split into two calls (might not be possible or efficient).
- [x] Fix unit categories:
    - [x] T3 sub hunter counts as a nuke sub rather than a torpedo sub.
    - [x] Scathis is excluded from all groups and thus never gets a spot in the formation.
    - [x] Seraphim sniper bots seem to be convinced they're T3 mobile arty, so they're assigned bot spots but steal arty spots and leave the arty with nowhere to go. (FAForever/faf-coop-maps#215)
    - [x] Sniper bots get normal bot positions, which are often too close to the front for such squishy units.
    - [x] Experimentals without DIRECTFIRE generally don't match any of the categories and get stuck at the back.
    - [x] Bouncer has a 2x2 footprint unlike every other T1-T3 land unit.
- [x] Cleanup:
    - [x] Remove unnecessary logging.
    - [x] Fix comments and formatting.