### PR TITLE
Fixed exit game for FAF and desktop launch

### DIFF
--- a/lua/ui/dialogs/score.lua
+++ b/lua/ui/dialogs/score.lua
@@ -423,7 +423,14 @@ function CreateSkirmishScreen(victory, showCampaign, operationVictoryTable)
     LayoutHelpers.AtTopIn(bg.title, bg, 28)
 
     -- set controls that are global to the dialog
-    bg.continueBtn = UIUtil.CreateButtonStd(bg, '/scx_menu/large-no-bracket-btn/large', "<LOC _Exit_to_Windows>", 22, 2, 0, "UI_Menu_MouseDown", "UI_Opt_Affirm_Over")
+    if HasCommandLineArg("/gpgnet") then
+        bg.continueBtn = UIUtil.CreateButtonStd(bg, '/scx_menu/large-no-bracket-btn/large', "<LOC _Exit_to_FAF>Exit to FAF", 22, 2, 0, "UI_Menu_MouseDown", "UI_Opt_Affirm_Over")
+        Tooltip.AddButtonTooltip(bg.continueBtn, 'esc_exit')
+    else
+        bg.continueBtn = UIUtil.CreateButtonStd(bg, '/scx_menu/large-no-bracket-btn/large', "<LOC _Continue>", 22, 2, 0, "UI_Menu_MouseDown", "UI_Opt_Affirm_Over")
+        Tooltip.AddButtonTooltip(bg.continueBtn, 'PostScore_Quit')
+    end
+
     LayoutHelpers.AtRightIn(bg.continueBtn, bg, -10)
     LayoutHelpers.AtBottomIn(bg.continueBtn, bg, 20)
     bg.continueBtn:UseAlphaHitTest(false)
@@ -455,9 +462,14 @@ function CreateSkirmishScreen(victory, showCampaign, operationVictoryTable)
     bg.continueBtn.OnClick = function(self, modifiers)
         hotstats.clean_view()
         ConExecute("ren_Oblivion false")
-        EscapeHandler.SafeQuit()
+        if HasCommandLineArg("/gpgnet") then
+            -- Quit to desktop
+            EscapeHandler.SafeQuit()
+        else
+            -- Back to main menu
+            ExitGame()
+        end
     end
-    Tooltip.AddButtonTooltip(bg.continueBtn, 'esc_exit')
 
      -- Rehost button in case of failure
     if showCampaign and not operationVictoryTable.success then

--- a/lua/ui/game/tabs.lua
+++ b/lua/ui/game/tabs.lua
@@ -165,11 +165,6 @@ local menus = {
         },
         lan = {
             {
-                action = 'RehostGame',
-                label = '<LOC _Rehost_Game>Rehost Game',
-                tooltip = 'esc_rehost',
-            },
-            {
                 action = 'ShowObj',
                 label='<LOC _Show_Scenario_Info>Scenario',
                 tooltip = 'show_scenario',
@@ -315,7 +310,7 @@ local actions = {
     ExitSPGame = function()
         UIUtil.QuickDialog(GetFrame(0), "<LOC EXITDLG_0003>Are you sure you'd like to exit?",
             "<LOC _Yes>", function()
-                ExitApplication()
+                EscapeHandler.SafeQuit()
             end,
             "<LOC _Save>", ExitGameSaveWindow,
             "<LOC _No>", nil,

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -538,7 +538,13 @@ function ReallyCreateLobby(protocol, localPort, desiredPlayerName, localPlayerUI
             "<LOC lobby_0000>Exit game lobby?",
             "<LOC _Yes>", function()
                 ReturnToMenu(false)
-                EscapeHandler.PopEscapeHandler()
+                if HasCommandLineArg("/gpgnet") then
+                    -- Quit to desktop
+                    EscapeHandler.SafeQuit()
+                else
+                    -- Back to main menu
+                    EscapeHandler.PopEscapeHandler()
+                end
             end,
 
             -- Fight to keep our focus on the chat input box, to prevent keybinding madness.
@@ -2970,7 +2976,13 @@ function CreateUI(maxPlayers)
     GUI.chatEdit.OnEscPressed = function(self, text)
         -- The default behaviour buggers up our escape handlers. Just delegate the escape push to
         -- the escape handling mechanism.
-        EscapeHandler.HandleEsc(true)
+        if HasCommandLineArg("/gpgnet") then
+            -- Quit to desktop
+            EscapeHandler.HandleEsc(true)
+        else
+            -- Back to main menu
+            GUI.exitButton.OnClick()
+        end
 
         -- Don't clear the textbox, either.
         return true
@@ -3223,10 +3235,20 @@ function CreateUI(maxPlayers)
 
     -- Exit Button
     GUI.exitButton = UIUtil.CreateButtonWithDropshadow(GUI.chatPanel, '/BUTTON/medium/', LOC("<LOC tooltipui0285>Exit"))
-    GUI.exitButton.label:SetText(LOC("<LOC _Exit>"))
     LayoutHelpers.AtLeftIn(GUI.exitButton, GUI.chatPanel, 33)
     LayoutHelpers.AtVerticalCenterIn(GUI.exitButton, launchGameButton, 7)
+    if HasCommandLineArg("/gpgnet") then
+        -- Quit to desktop
+        GUI.exitButton.label:SetText(LOC("<LOC _Exit>"))
+        Tooltip.AddButtonTooltip(GUI.exitButton, 'esc_exit')
+    else
+        -- Back to main menu
+        GUI.exitButton.label:SetText(LOC("<LOC _Back>"))
+        Tooltip.AddButtonTooltip(GUI.exitButton, 'esc_quit')
+    end
+
     GUI.exitButton.OnClick = GUI.exitLobbyEscapeHandler
+
 
     -- Small buttons are 100 wide, 44 tall
 

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -537,13 +537,13 @@ function ReallyCreateLobby(protocol, localPort, desiredPlayerName, localPlayerUI
         local quitDialog = UIUtil.QuickDialog(GUI,
             "<LOC lobby_0000>Exit game lobby?",
             "<LOC _Yes>", function()
-                ReturnToMenu(false)
+                EscapeHandler.PopEscapeHandler()
                 if HasCommandLineArg("/gpgnet") then
                     -- Quit to desktop
                     EscapeHandler.SafeQuit()
                 else
                     -- Back to main menu
-                    EscapeHandler.PopEscapeHandler()
+                    ReturnToMenu(false)
                 end
             end,
 


### PR DESCRIPTION
Related issues: #248 #619 #790

This is a fix for exiting the game.
FAF needs the game to fall back to the desktop (FAF Lobby).
But without FAF the game should exit to the main menu, not the desktop.

This is how it works now:

Game launched from FAF will return to desktop on exit.(SafeQuit()->ExitApplication())
Game launched from Desktop will return to the ingame menu on exit.(ExitGame())

Also fixed:
Ingamelobby shows now "exit" instead of "back" button if launched from FAF.
(added tooltip to exit and back button)
Scorescreen shows now "exit to FAF" instead of "continue" if launched from FAF
(fixed tooltip for "exit to FAF" button, added tooltip to "continue" button)
Removed Rehost button from LAN Multiplayer menu.
Added EscapeHandler.SafeQuit() to singleplayer game exit.


All tests are done with gameoption "Quick Exit" ON and OFF (different function calls!!!)
(FormClosingEvent == means klicking "x" in the right top corner of the game window.)


LOCATION Main menu:

ACTION menu "Exit" button:
- local start: Back to Desktop - ExitApplication()
- FAF-Lobby start:  Back to Desktop - ExitApplication()

ACTION FormClosingEvent:
- local start: Back to Desktop - SafeQuit()->ExitApplication()
- FAF-Lobby start:  Back to Desktop - SafeQuit()->ExitApplication()

ACTION [ALT]+[F4]
- local start: Back to Desktop - SafeQuit()->ExitApplication()
- FAF-Lobby start:  Back to Desktop - SafeQuit()->ExitApplication()



LOCATION Playing Multiplayer:

ACTION menu "Exit to Windows" / "Exit to FAF" button
- local start: Back to Desktop - SafeQuit()->ExitApplication()
- FAF-Lobby start:  Back to Desktop - SafeQuit()->ExitApplication()

ACTION menu Rehost
- local start: Rehost button removed.
- FAF-Lobby start:  Back to Desktop - SafeQuit()->ExitApplication()

ACTION FormClosingEvent:
- local start: Back to Desktop - SafeQuit()->ExitApplication()
- FAF-Lobby start:  Back to Desktop - SafeQuit()->ExitApplication()

ACTION [ALT]+[F4]
- local start: Back to Desktop - SafeQuit()->ExitApplication()
- FAF-Lobby start:  Back to Desktop - SafeQuit()->ExitApplication()



LOCATION Scorescreen:

ACTION Continue / Exit to FAF
- local start: (Continue button) Back to ingame main menu - ExitGame()
- FAF-Lobby start: (Exit to FAF button) Back to Desktop - SafeQuit()->ExitApplication()

ACTION FormClosingEvent:
- local start: Back to Desktop - SafeQuit()->ExitApplication()
- FAF-Lobby start:  Back to Desktop - SafeQuit()->ExitApplication()

ACTION [ALT]+[F4]
- local start: Back to Desktop - SafeQuit()->ExitApplication()
- FAF-Lobby start:  Back to Desktop - SafeQuit()->ExitApplication()

ACTION ESC key
- local start: Back to ingame main menu - ExitGame()
- FAF-Lobby start:  Back to Desktop - SafeQuit()->ExitApplication()



LOCATION Ingame Lobby (chat)

ACTION ESC key
- local start: Back to ingame main menu - GUI.exitButton.OnClick()
- FAF-Lobby start:  Back to Desktop - SafeQuit()->ExitApplication()

ACTION Back / Exit button
- local start: (back button) Back to ingame main menu - ReturnToMenu(false)
- FAF-Lobby start: (exit button) Back to Desktop - SafeQuit()->ExitApplication()



