### PR TITLE
Fix/Optimization: Identify Sorian AI with variable instead of string find

### DIFF
--- a/lua/AI/aiarchetype-managerloader.lua
+++ b/lua/AI/aiarchetype-managerloader.lua
@@ -54,7 +54,7 @@ function ExecutePlan(aiBrain)
 
         local per = ScenarioInfo.ArmySetup[aiBrain.Name].AIPersonality
 
-        if string.find(per, 'sorian') then
+        if aiBrain.Sorian then
             aiBrain:SetupUnderEnergyStatTriggerSorian(0.1)
             aiBrain:SetupUnderMassStatTriggerSorian(0.1)
         else
@@ -76,7 +76,7 @@ function ExecutePlan(aiBrain)
             end
         end
 
-        if string.find(per, 'sorian') then
+        if aiBrain.Sorian then
             ForkThread(UnitCapWatchThreadSorian, aiBrain)
             ForkThread(behaviors.NukeCheck, aiBrain)
         else

--- a/lua/AI/aiarchetype-managerloader.lua
+++ b/lua/AI/aiarchetype-managerloader.lua
@@ -52,8 +52,6 @@ function ExecutePlan(aiBrain)
     if not aiBrain.BuilderManagers.MAIN.FactoryManager:HasBuilderList() then
         aiBrain:SetResourceSharing(true)
 
-        local per = ScenarioInfo.ArmySetup[aiBrain.Name].AIPersonality
-
         if aiBrain.Sorian then
             aiBrain:SetupUnderEnergyStatTriggerSorian(0.1)
             aiBrain:SetupUnderMassStatTriggerSorian(0.1)

--- a/lua/AI/aiattackutilities.lua
+++ b/lua/AI/aiattackutilities.lua
@@ -277,10 +277,9 @@ function GetBestThreatTarget(aiBrain, platoon, bSkipPathability)
 
     local maxRange = false
     local turretPitch = nil
-    local per = ScenarioInfo.ArmySetup[aiBrain.Name].AIPersonality
     if platoon.MovementLayer == 'Water' then
 
-        if string.find(per, 'sorian') then
+        if aiBrain.Sorian then
             maxRange, selectedWeaponArc, turretPitch = GetNavalPlatoonMaxRangeSorian(aiBrain, platoon)
         else
             maxRange, selectedWeaponArc = GetNavalPlatoonMaxRange(aiBrain, platoon)
@@ -310,7 +309,7 @@ function GetBestThreatTarget(aiBrain, platoon, bSkipPathability)
                 end
             else
                 local bestPos
-                if string.find(per, 'sorian') then
+                if aiBrain.Sorian then
                     bestPos = CheckNavalPathingSorian(aiBrain, platoon, {threat[1], 0, threat[2]}, maxRange, selectedWeaponArc, turretPitch)
                 else
                     bestPos = CheckNavalPathing(aiBrain, platoon, {threat[1], 0, threat[2]}, maxRange, selectedWeaponArc)
@@ -1277,10 +1276,8 @@ function PlatoonGenerateSafePathTo(aiBrain, platoonLayer, start, destination, op
     local finalPath = {}
     local testPath = false
 
-    local per = ScenarioInfo.ArmySetup[aiBrain.Name].AIPersonality
-
     #If it is a Sorian AI or Duncane AI and not a water unit.
-    if (string.find(per, 'sorian') or DiskGetFileInfo('/lua/AI/altaiutilities.lua')) and platoonLayer != "Water" then
+    if (aiBrain.Sorian or aiBrain.Duncan) and platoonLayer != "Water" then
         testPath = true
     end
 

--- a/lua/editor/SorianBuildConditions.lua
+++ b/lua/editor/SorianBuildConditions.lua
@@ -714,10 +714,9 @@ function AIOutnumbered(aiBrain, bool)
     local myTeam = ScenarioInfo.ArmySetup[aiBrain.Name].Team
     #LOG('*AI DEBUG: '..aiBrain.Nickname..' I am on team '..myTeam)
     local largestEnemyTeam = false
-    local teams = {0,0,0,0}
+    local teams = {0,0,0,0,0,0,0,0}
 
-    local cheatAI = string.find(aiBrain.Nickname, 'AIx:')
-    if cheatAI then
+    if aiBrain.CheatEnabled then
         teams[myTeam] = teams[myTeam] + (1 * cheatAdjustment)
     else
         teams[myTeam] = teams[myTeam] + 1
@@ -727,8 +726,7 @@ function AIOutnumbered(aiBrain, bool)
         if not v:IsDefeated() and aiBrain:GetArmyIndex() ~= v:GetArmyIndex() and not ArmyIsCivilian(v:GetArmyIndex()) then
             local armyTeam = ScenarioInfo.ArmySetup[v.Name].Team
             #LOG('*AI DEBUG: '..v.Nickname..' is on team '..armyTeam)
-            cheatAI = string.find(v.Nickname, 'AIx:')
-            if cheatAI then
+            if v.CheatEnabled then
                 teams[armyTeam] = teams[armyTeam] + (1 * cheatAdjustment)
             else
                 teams[armyTeam] = teams[armyTeam] + 1

--- a/lua/editor/SorianInstantBuildConditions.lua
+++ b/lua/editor/SorianInstantBuildConditions.lua
@@ -281,10 +281,9 @@ function LessThanEconTrend(aiBrain, mTrend, eTrend)
     end
     local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
     local cheatmult = tonumber(ScenarioInfo.Options.CheatMult) or 2
-    local cheatAI = string.find(aiBrain.Nickname, 'AIx:')
-    if cheatAI and (econ.MassTrend < mTrend * cheatmult and econ.EnergyTrend < eTrend * cheatmult) then
+    if aiBrain.CheatEnabled and (econ.MassTrend < mTrend * cheatmult and econ.EnergyTrend < eTrend * cheatmult) then
         return true
-    elseif not cheatAI and (econ.MassTrend < mTrend and econ.EnergyTrend < eTrend) then
+    elseif not aiBrain.CheatEnabled and (econ.MassTrend < mTrend and econ.EnergyTrend < eTrend) then
         return true
     else
         return false

--- a/lua/sim/EngineerManager.lua
+++ b/lua/sim/EngineerManager.lua
@@ -715,8 +715,7 @@ EngineerManager = Class(BuilderManager) {
         local guards = unit:GetGuards()
         for k,v in guards do
             if not v.Dead and v.AssistPlatoon then
-                local per = ScenarioInfo.ArmySetup[self.Brain.Name].AIPersonality
-                if string.find(per, 'sorian') and self.Brain:PlatoonExists(v.AssistPlatoon) then
+                if self.Brain.Sorian and self.Brain:PlatoonExists(v.AssistPlatoon) then
                     v.AssistPlatoon:ForkThread(v.AssistPlatoon.SorianEconAssistBody)
                 elseif self.Brain:PlatoonExists(v.AssistPlatoon) then
                     v.AssistPlatoon:ForkThread(v.AssistPlatoon.EconAssistBody)
@@ -807,8 +806,7 @@ EngineerManager = Class(BuilderManager) {
         local guards = unit:GetGuards()
         for k,v in guards do
             if not v.Dead and v.AssistPlatoon then
-                local per = ScenarioInfo.ArmySetup[self.Brain.Name].AIPersonality
-                if string.find(per, 'sorian') and self.Brain:PlatoonExists(v.AssistPlatoon) then
+                if self.Brain.Sorian and self.Brain:PlatoonExists(v.AssistPlatoon) then
                     v.AssistPlatoon:ForkThread(v.AssistPlatoon.SorianEconAssistBody)
                 elseif self.Brain:PlatoonExists(v.AssistPlatoon) then
                     v.AssistPlatoon:ForkThread(v.AssistPlatoon.EconAssistBody)


### PR DESCRIPTION
Sorian Ai was identified by a string.find in some functions like this:
```
local per = ScenarioInfo.ArmySetup[self.Name].AIPersonality
if string.find(per, 'sorian') then
   [...]
end
```
Now it's stored inside a variable while calling `OnCreateAI`:
```
self.Sorian = true
```

And can be accessed without a string find:

```
if aibrain.Sorian then
    [...]
end
```

The Duncan Ai was identified by a file search:

```
if DiskGetFileInfo('/lua/AI/altaiutilities.lua') then
    [...]
end
```

Now it can be accessed like the Sorian AI with:
```
if aibrain.Duncan then
    [...]
end
```

Also AIx are now identified by aiBrain.CheatEnabled instead of string.find().
It was not working in german translation, because "AIx" is in german "KIx"

And fixed a small bug if more then 5 teams are assigned to Sorian AI's