### PR TITLE
Fix UIFile() warnmessage

### DIFF
--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -435,13 +435,15 @@ function UIFile(filespec, checkMods)
         end
 
         if not found then
-            SPEW('[uiutil.lua, function UIFile()] - Unable to find file:'.. origPath .. filespec)
+            -- don't print error message if "filespec" is a valid path
+            if not DiskGetFileInfo(filespec) then
+                SPEW('[uiutil.lua, function UIFile()] - Unable to find file:'.. origPath .. filespec)
+            end
             found = filespec
         end
 
         UIFileCache[origPath .. filespec] = found
     end
-
     return UIFileCache[origPath .. filespec]
 end
 


### PR DESCRIPTION
In case the filspec has already a valid filepath we don't need a warning.

Will fix this error:

```
debug: [uiutil.lua, function UIFile()] - Unable to find file:/textures/ui/uef/textures/ui/common/hotstats/bt_sca.dds
```

In this case filspec is holding a valid filepath: `/textures/ui/common/hotstats/bt_sca.dds`.