### PR TITLE
Fix for factory build templates icons

### DIFF
--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -1587,8 +1587,14 @@ function CreateTemplateOptionMenu(button, templateObj)
                 local controls = {}
                 for _, entry in theTemplate.templateData do
                     if type(entry) == 'table' then
-                        if not contents[entry[1]] then
-                            contents[entry[1]] = true
+                        if entry.id then
+                            if not contents[entry.id] then
+                                contents[entry.id] = true
+                            end
+                        else
+                            if not contents[entry[1]] then
+                                contents[entry[1]] = true
+                            end
                         end
                     end
                 end

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -1587,15 +1587,7 @@ function CreateTemplateOptionMenu(button, templateObj)
                 local controls = {}
                 for _, entry in theTemplate.templateData do
                     if type(entry) == 'table' then
-                        if entry.id then
-                            if not contents[entry.id] then
-                                contents[entry.id] = true
-                            end
-                        else
-                            if not contents[entry[1]] then
-                                contents[entry[1]] = true
-                            end
-                        end
+                        contents[entry.id or entry[1]] = true
                     end
                 end
                 for iconType, _ in contents do

--- a/lua/ui/templates_factory.lua
+++ b/lua/ui/templates_factory.lua
@@ -1,5 +1,6 @@
 local Prefs = import('/lua/user/prefs.lua')
 local templates = Prefs.GetFromCurrentProfile('build_templates_factory') or {}
+local UIUtil = import('/lua/ui/uiutil.lua')
 
 -- Utils
 function GetInitialName()
@@ -20,13 +21,11 @@ end
 
 function GetInitialIcon(buildQueue)
     for _, entry in buildQueue do
-        if type(entry) != 'table' then continue end
-        if DiskGetFileInfo('/textures/ui/common/icons/units/'..entry.id..'_icon.dds') then
-            return entry.id
-        else
-            return false
+        if type(entry) == 'table' and UIUtil.UIFile('/icons/units/' .. entry.id .. '_icon.dds', true) then
+            return entry.id -- Original or modded unit found
         end
     end
+    return 'default' -- If we don't find a valid IconName; return string 'default'
 end
 
 -- Main functions


### PR DESCRIPTION
Fixed: Factorytemplates was not supporting icons from mod units.

![factorytemplateicon](https://user-images.githubusercontent.com/17804547/27714373-c07ed574-5d30-11e7-96e9-636ca04e9447.png)


Fixed: Selecting a new icon to the template was not working because of a
different array structure from normal buildtemplates.

Structure of normal engineer buildtemplate:
```  templateData={ 3, 3, { "ueb2101", 936, 0, 0 }, },```

And this is how the factory buildtemplate looks:
```templateData={ { count=5, id="brnt1mt" } },```

To get the icon from the factory buildtemplate we need to use `templateData.id` instead of getting the first array entry with `templateData[1]`