### PR TITLE
Notify: Add the ability to limit the number of times a message is shown and fix mod breaking

### DIFF
--- a/etc/faf/blacklist.lua
+++ b/etc/faf/blacklist.lua
@@ -120,10 +120,6 @@ Blacklist = {
     ['ecbf6277-24e3-437a-b968-EcoManager-v6'] = UPGRADE,
     ['ecbf6277-24e3-437a-b968-EcoManager-v7'] = UPGRADE,
 
-    -- Selection Cost UI (old versions that break the UI)
-    ['2018eaac-e8ed-11e4-b02c-1681e6b88ec4'] = UPGRADE,
-    ['2018eaac-e8ed-11e4-b02c-1681e6b88ec5'] = UPGRADE,
-
     -- Supreme economy (old ones)
     ['f8d8c95a-71e7-4978-921e-8765beb328e8'] = UPGRADE,
     ['89BF1572-9EA8-11DC-1313-635F56D89591'] = UPGRADE,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2047,6 +2047,7 @@ Unit = Class(moho.unit_methods) {
     end,
 
     OnFailedToBeBuilt = function(self)
+        self:SendNotifyMessage('cancelled')
         self:ForkThread(function()
             WaitTicks(1)
             self:Destroy()

--- a/lua/ui/notify/notifyoverlay.lua
+++ b/lua/ui/notify/notifyoverlay.lua
@@ -7,7 +7,6 @@ local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 local UIUtil = import('/lua/ui/uiutil.lua')
 local Prefs = import('/lua/user/prefs.lua')
 local AddChatCommand = import('/lua/ui/notify/commands.lua').AddChatCommand
-local RegisterChatFunc = import('/lua/ui/game/gamemain.lua').RegisterChatFunc
 
 local overlayDisabled
 local overlayLockedOut
@@ -15,7 +14,7 @@ local customMessagesDisabled
 overlays = {}
 
 function init()
-    RegisterChatFunc(processNotification, 'NotifyOverlay')
+    import('/lua/ui/game/gamemain.lua').RegisterChatFunc(processNotification, 'NotifyOverlay') -- Imported here to avoid loading the file before the game is fully initialized
     AddChatCommand('enablenotifyoverlay', toggleOverlayTemporary)
     AddChatCommand('disablenotifyoverlay', toggleOverlayTemporary)
 


### PR DESCRIPTION
This stops showing non-enhancement messages after a certain number. That way if you start mass producing experimentals or factory HQs it won't spam allies for every single one completed.

Currently the limits are hard-coded at 1 message per factory HQ and 3 per nuke/arty/experimental. If the numbers should be changed let me know. I looked at allowing the numbers to be changed in the customizer, but I can't think of a way to do it that wouldn't just clutter up the window.