### PR TITLE
fixes the distance for attackmove

### DIFF
--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -500,7 +500,7 @@ function PreModBlueprints(all_bps)
         -- fixes move-attack range issues
         -- Most Air units have the GSR defined already, this is just making certain they don't get included
         local modGSR = not (bp.AI and bp.AI.GuardScanRadius) and (
-                       (bp.CategoriesHash.MOBILE and (bp.CategoriesHash.LAND or bp.CategoriesHash.NAVAL) and (bp.CategoriesHash.DIRECTFIRE or bp.CategoriesHash.INDIRECTFIRE or bp.CategoriesHash.ENGINEER)) or
+                       (bp.CategoriesHash.MOBILE and (bp.CategoriesHash.LAND or bp.CategoriesHash.NAVAL) and (bp.CategoriesHash.DIRECTFIRE or bp.CategoriesHash.INDIRECTFIRE or bp.CategoriesHash.ENGINEER) or bp.CategoriesHash.ANTINAVY) or
                        (bp.CategoriesHash.STRUCTURE and (bp.CategoriesHash.DIRECTFIRE or bp.CategoriesHash.INDIRECTFIRE) and (bp.CategoriesHash.DEFENSE or bp.CategoriesHash.ARTILLERY)) or bp.CategoriesHash.DUMMYGSRWEAPON
                        )
 

--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -500,7 +500,7 @@ function PreModBlueprints(all_bps)
         -- fixes move-attack range issues
         -- Most Air units have the GSR defined already, this is just making certain they don't get included
         local modGSR = not (bp.AI and bp.AI.GuardScanRadius) and (
-                       (bp.CategoriesHash.MOBILE and (bp.CategoriesHash.LAND or bp.CategoriesHash.NAVAL) and (bp.CategoriesHash.DIRECTFIRE or bp.CategoriesHash.INDIRECTFIRE or bp.CategoriesHash.ENGINEER) or bp.CategoriesHash.ANTINAVY) or
+                       (bp.CategoriesHash.MOBILE and (bp.CategoriesHash.LAND or bp.CategoriesHash.NAVAL) and (bp.CategoriesHash.DIRECTFIRE or bp.CategoriesHash.INDIRECTFIRE or bp.CategoriesHash.ANTINAVY or bp.CategoriesHash.ENGINEER)) or
                        (bp.CategoriesHash.STRUCTURE and (bp.CategoriesHash.DIRECTFIRE or bp.CategoriesHash.INDIRECTFIRE) and (bp.CategoriesHash.DEFENSE or bp.CategoriesHash.ARTILLERY)) or bp.CategoriesHash.DUMMYGSRWEAPON
                        )
 

--- a/units/XSS0304/XSS0304_unit.bp
+++ b/units/XSS0304/XSS0304_unit.bp
@@ -1,8 +1,6 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 130,
-        GuardRadius = 65,
-        GuardScanRadius = 80,
     },
     Audio = {
         AmbientMove = Sound {
@@ -339,7 +337,7 @@ UnitBlueprint {
             RateOfFire = 0.25,
             SlavedToBody = true,
             SlavedToBodyArcRange = 10,
-            TargetCheckInterval = 2,
+            TargetCheckInterval = 0.5,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
                 'MOBILE',

--- a/units/XSS0304/XSS0304_unit.bp
+++ b/units/XSS0304/XSS0304_unit.bp
@@ -1,6 +1,8 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 130,
+        GuardRadius = 65,
+        GuardScanRadius = 80,
     },
     Audio = {
         AmbientMove = Sound {


### PR DESCRIPTION
Currently the T3 Subhunter tends to stop at 32 range (it's torp def range) when using the attack move command which prevents it from using it's range properly.
This change should fix that problem.