### PR TITLE
Fix replay UI problems

### DIFF
--- a/lua/skins/skins.lua
+++ b/lua/skins/skins.lua
@@ -89,7 +89,7 @@ skins = {
         tooltipTitleColor = "FF725b1a" --#FF725b1a
     },
     random = {
-        default = "default",
+        default = "uef",
         texturesPath = "/textures/ui/random",
         imagerMesh = "/meshes/game/map-border_squ_uef_mesh",
         imagerMeshHorz = "/meshes/game/map-border_hor_uef_mesh",

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -132,6 +132,7 @@ function OnFirstUpdate()
             end
         end
     end
+    UIUtil.UpdateCurrentSkin()
 end
 
 function CreateUI(isReplay)


### PR DESCRIPTION
When watching a replay you can have the incomplete 'random' skin selected if you were random in a lobby but didn't start the game, causing #2059. Even if that doesn't happen, the skin isn't properly loaded when starting as observer, causing chat window problems like #2082. This fixes the 'random' skin by basing it on the UEF skin instead of default, and the chat problems by properly refreshing the UI when starting.