### PR TITLE
Lobby: fix bug with observers being Ready

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5790,6 +5790,7 @@ function InitHostUtils()
                 index = index + 1
             end
 
+            HostUtils.SetPlayerNotReady(playerSlot)
             local ownerID = gameInfo.PlayerOptions[playerSlot].OwnerID
             gameInfo.Observers[index] = gameInfo.PlayerOptions[playerSlot]
             gameInfo.PlayerOptions[playerSlot] = nil


### PR DESCRIPTION
fixes #2100
Just need to set player to not ready before turning him into observer.