### PR TITLE
Randomize starting positions

### DIFF
--- a/etc/faf/blacklist.lua
+++ b/etc/faf/blacklist.lua
@@ -12,7 +12,6 @@ Blacklist = {
     ['C707618F-D9B3-43CE-A181-1AC80D582078'] = HARMFUL, -- PWN Desync
     ['EF3ADDB4-9D34-437F-B1C8-440DAF896802'] = HARMFUL, -- UI Mass Fab Manager FA by Goom (Causes UI lag because it uses polling rather than interrupts)
     ['b2cde810-15d0-4bfa-af66-ec2d6ecd561d'] = HARMFUL, -- UI Idle Engineers by camelCase (Causes UI lag because it uses polling rather than interrupts)
-    ['b0d9ac94-c5e6-11e5-9912-ba0be0483c18'] = HARMFUL, -- Reveal Positions (Breaks the UI and gives cheaty info when players have random positions/factions)
 
     -- Auto-adjust netlag (causes desyncs due to interesting race conditions).
     ['9033139e-2701-4ac1-b330-ec984ebc23f9'] = HARMFUL,

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -31,6 +31,39 @@ end
 -- Set up the sync table and some globals for use by scenario functions
 doscript '/lua/SimSync.lua'
 
+function ShuffleStartPositions()
+    local markers = ScenarioInfo.Env.Scenario.MasterChain._MASTERCHAIN_.Markers
+    local teams = {}
+    local armies = {}
+    local t, marker
+
+    for name, army in ScenarioInfo.ArmySetup do
+        if not army.Civilian then
+            marker = markers[name]
+            if marker and marker.position then
+                t = teams[army.Team]
+                if not t then
+                    t = {starts={}, names={}}
+                    teams[army.Team] = t
+                end
+                table.insert(t.starts, marker.position)
+                table.insert(t.names, name)
+            end
+        end
+    end
+
+    local pos
+    for _, t in teams do
+        if t.starts[1] then
+            t.starts = table.shuffle(t.starts)
+            for _, name in t.names do
+                pos = table.remove(t.starts, 1)
+                ScenarioInfo.Env.Scenario.MasterChain._MASTERCHAIN_.Markers[name].position = pos
+            end
+        end
+    end
+end
+
 --SetupSession will be called by the engine after ScenarioInfo is set
 --but before any armies are created.
 function SetupSession()
@@ -136,7 +169,13 @@ function SetupSession()
 
     Scenario = ScenarioInfo.Env.Scenario
 
-    LOG('Loading script file: ',ScenarioInfo.script)
+    local spawn = ScenarioInfo.Options.TeamSpawn
+    if spawn and table.find({'random', 'balanced', 'balanced_flex'}, spawn) then
+        -- prevents players from knowing start positions at start
+        ShuffleStartPositions()
+    end
+
+    LOG('Loading script file: ', ScenarioInfo.script)
     doscript(ScenarioInfo.script, ScenarioInfo.Env)
 
     ResetSyncTable()

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -33,32 +33,27 @@ doscript '/lua/SimSync.lua'
 
 function ShuffleStartPositions()
     local markers = ScenarioInfo.Env.Scenario.MasterChain._MASTERCHAIN_.Markers
-    local teams = {}
-    local armies = {}
-    local t, marker
-
-    for name, army in ScenarioInfo.ArmySetup do
-        if not army.Civilian then
-            marker = markers[name]
-            if marker and marker.position then
-                t = teams[army.Team]
-                if not t then
-                    t = {starts={}, names={}}
-                    teams[army.Team] = t
-                end
-                table.insert(t.starts, marker.position)
-                table.insert(t.names, name)
-            end
-        end
+    local positionGroups = ScenarioInfo.Options.RandomPositionGroups
+    local positions = {}
+    if not positionGroups then
+        return
     end
 
-    local pos
-    for _, t in teams do
-        if t.starts[1] then
-            t.starts = table.shuffle(t.starts)
-            for _, name in t.names do
-                pos = table.remove(t.starts, 1)
-                ScenarioInfo.Env.Scenario.MasterChain._MASTERCHAIN_.Markers[name].position = pos
+    for _, group in positionGroups do
+        for _, num in group do
+            local name = 'ARMY_' .. num
+            local marker = markers[name]
+            if marker and marker.position then
+                positions[num] = {pos = marker.position, name = name}
+            end
+        end
+
+        local shuffledGroup = table.shuffle(group)
+        for i = 1, table.getn(group) do
+            local pos = positions[shuffledGroup[i]].pos
+            local name = positions[group[i]].name
+            if pos and markers[name] then
+                markers[name].position = pos
             end
         end
     end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -1388,6 +1388,7 @@ local function AssignRandomStartSpots()
     end
 
     local AutoTeams = gameInfo.GameOptions.AutoTeams
+    local positionGroups = {}
     local teams = {}
 
     -- Used to actualise the virtual teams produced by the "Team -" no-team team.
@@ -1395,6 +1396,7 @@ local function AssignRandomStartSpots()
     for i = 1, numAvailStartSpots do
         if not gameInfo.ClosedSlots[i] then
             local team = nil
+            local group = nil
 
             if AutoTeams == 'lvsr' then
                 local midLine = GUI.mapView.Left() + (GUI.mapView.Width() / 2)
@@ -1424,7 +1426,14 @@ local function AssignRandomStartSpots()
                 team = gameInfo.AutoTeams[i]
             else -- none
                 team = gameInfo.PlayerOptions[i].Team
+                group = 1
             end
+
+            group = group or team
+            if not positionGroups[group] then
+                positionGroups[group] = {}
+            end
+            table.insert(positionGroups[group], i)
 
             if team ~= nil then
                 -- Team 1 secretly represents "No team", so give them a real team (but one that
@@ -1437,6 +1446,8 @@ local function AssignRandomStartSpots()
             end
         end
     end
+    gameInfo.GameOptions.RandomPositionGroups = positionGroups
+
     -- shuffle the array for randomness.
     for i, team in teams do
         teams[i] = table.shuffle(team)


### PR DESCRIPTION
This is the start position part of #1810, #1284, and #1215. It's now updated to include empty slots in the random pool and switch spots between different teams when auto teams are disabled like in a free for all.