### PR TITLE
Fix Hives instantly capturing units

### DIFF
--- a/units/URA0001/URA0001_script.lua
+++ b/units/URA0001/URA0001_script.lua
@@ -27,6 +27,10 @@ URA0001 = Class(CAirUnit) {
         CreateCybranBuildBeams(self, unitBeingBuilt, {'Muzzle_03',}, self.BuildEffectsBag)
     end,
 
+    OnStartCapture = function(self, target)
+        IssueStop({self}) -- You can't capture!
+    end,
+
     OnStartReclaim = function(self, target)
         IssueStop({self}) -- You can't reclaim!
     end,

--- a/units/URA0001/URA0001_unit.bp
+++ b/units/URA0001/URA0001_unit.bp
@@ -63,7 +63,7 @@ UnitBlueprint {
     Economy = {
         BuildCostEnergy = 0,
         BuildCostMass = 0,
-        BuildRate = 0,
+        BuildRate = 0.0001,
         BuildTime = 0,
         BuildableCategory = {
             'BUILTBYTIER1ENGINEER CYBRAN',


### PR DESCRIPTION
Fixes #2116 for the low, low cost of buffing all Cybran build power by 0.00067%. It seems that in rare cases the little laser drones are somehow being told to help capture a unit. That results in a division by 0 when calculating capture time, which causes the unit to be instantly captured.