### PR TITLE
remove "quick tip" prefix

### DIFF
--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -303,8 +303,7 @@ local function LoadDialog(parent)
                 local tipsTbl = import('/lua/ui/help/loadingtips.lua').Tips
                 local tipsSize = table.getn(tipsTbl)
                 while WorldIsLoading() do
-                    local tipText = LOCF('%s', tipsTbl[Random(1, tipsSize)])
-                    control:SetText(tipText)
+                    control:SetText(LOC(tipsTbl[Random(1, tipsSize)]))
                     control:SetDropShadow(true)
                     WaitSeconds(7)
                 end

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -303,7 +303,7 @@ local function LoadDialog(parent)
                 local tipsTbl = import('/lua/ui/help/loadingtips.lua').Tips
                 local tipsSize = table.getn(tipsTbl)
                 while WorldIsLoading() do
-                    local tipText = LOCF('%s: %s', '<LOC loadingtip_0000>Quick Tip', tipsTbl[Random(1, tipsSize)])
+                    local tipText = LOCF('%s', tipsTbl[Random(1, tipsSize)])
                     control:SetText(tipText)
                     control:SetDropShadow(true)
                     WaitSeconds(7)


### PR DESCRIPTION
removes the quick tip prefix of the quick tips since its quite obvious
that they are tips.
fixes #2048