### PR TITLE
Fix Cybran SACU projectile lifetime not allowing it to use its full range

### DIFF
--- a/units/URL0301/URL0301_unit.bp
+++ b/units/URL0301/URL0301_unit.bp
@@ -752,7 +752,7 @@ UnitBlueprint {
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 18,
             ProjectileId = '/projectiles/CDFLaserDisintegrator03/CDFLaserDisintegrator03_proj.bp',
-            ProjectileLifetimeUsesMultiplier = 1.30,
+            ProjectileLifetimeUsesMultiplier = 2.4,
             ProjectilesPerOnFire = 1,
             RackBones = {
                 {


### PR DESCRIPTION
This addresses #2020 and allows the SACU to hit targets at the edge of its range and/or running away at speeds of up to 8.