### PR TITLE
fix modmanager handling of incomplete modinfo files

### DIFF
--- a/lua/ui/lobby/ModsManager.lua
+++ b/lua/ui/lobby/ModsManager.lua
@@ -487,7 +487,7 @@ function RefreshModsList()
         mod.title = GetModNameVersion(mod)
         if mod.ui_only then
             mod.type = 'UI'
-        elseif mod.ui_only == false then
+        else
             mod.type = 'GAME'
         end
 


### PR DESCRIPTION
the mod manager sorts the mods by UI and SIM mods. That requires to have the UI_Only parameter set in the modinfo file.

Some mods dont have this parameter set at all and thus break the modmanager.

fixes #2128 