### PR TITLE
Fix spawn marker lazyvar error

### DIFF
--- a/lua/ui/game/worldview.lua
+++ b/lua/ui/game/worldview.lua
@@ -31,6 +31,8 @@ local function CreatePositionMarker(army, worldView)
 
     local marker = Bitmap(worldView)
     marker:DisableHitTest()
+    marker.Left:Set(-1000)
+    marker.Top:Set(-1000)
     marker.Depth:Set(13)
     marker:SetSolidColor('black')
     marker:SetNeedsFrameUpdate(true)


### PR DESCRIPTION
If the bounds of a marker were evaluated before the first frame it was shown, bad things would happen due to invalid default bounds.