### PR TITLE
Fix AI teams being changeable with auto teams enabled

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -844,13 +844,13 @@ function SetSlotInfo(slotNum, playerInfo)
     --
     -- The predicate was getting unpleasantly long to read.
     local function teamSelectionEnabled(autoTeams, ready, locallyOwned, isHost)
-        if isHost and not playerInfo.Human then
-            return true
-        end
-
         -- If autoteams has control, no selector for you.
         if autoTeams ~= 'none' then
             return false
+        end
+
+        if isHost and not playerInfo.Human then
+            return true
         end
 
         -- You can control your own one when you're not ready.


### PR DESCRIPTION
Enabling auto teams doesn't currently disable use of the team selector on AIs, but changes have no effect. That can result in deceptive and confusing behavior when someone doesn't realize they have auto teams on while playing with AI.