### PR TITLE
assist command for sonar

### DIFF
--- a/units/UAS0305/UAS0305_unit.bp
+++ b/units/UAS0305/UAS0305_unit.bp
@@ -117,7 +117,7 @@ UnitBlueprint {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,
             RULEUCC_Capture = false,
-            RULEUCC_Guard = false,
+            RULEUCC_Guard = true,
             RULEUCC_Move = true,
             RULEUCC_Nuke = false,
             RULEUCC_Patrol = true,

--- a/units/UES0305/UES0305_unit.bp
+++ b/units/UES0305/UES0305_unit.bp
@@ -145,7 +145,7 @@ UnitBlueprint {
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = false,
             RULEUCC_Capture = false,
-            RULEUCC_Guard = false,
+            RULEUCC_Guard = true,
             RULEUCC_Move = true,
             RULEUCC_Nuke = false,
             RULEUCC_Patrol = true,

--- a/units/URS0305/URS0305_unit.bp
+++ b/units/URS0305/URS0305_unit.bp
@@ -139,7 +139,7 @@ UnitBlueprint {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,
             RULEUCC_Capture = false,
-            RULEUCC_Guard = false,
+            RULEUCC_Guard = true,
             RULEUCC_Move = true,
             RULEUCC_Nuke = false,
             RULEUCC_Patrol = true,


### PR DESCRIPTION
allows you to use the guard/assist command with t3 sonar
very handy for cybran stealth/big maps where t3 sonar might not cover all the important parts of the map