### PR TITLE
Fix for modded units with no factionname

### DIFF
--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -493,7 +493,7 @@ function PreModBlueprints(all_bps)
             end
         end
 
-        bp.FactionCategory = string.upper(bp.General.FactionName)
+        bp.FactionCategory = string.upper(bp.General.FactionName or 'Unknown')
 
         -- Mod in AI.GuardScanRadius = Longest weapon range * longest tracking radius
         -- Takes ACU/SCU enhancements into account


### PR DESCRIPTION
http://forums.faforever.com/viewtopic.php?f=3&t=15002&p=153183#p153183
One of the last patch broke the BrewLan mod.

Just a small issue;
some brewLan units don't have a factionname, and causes an error in this line:
`bp.FactionCategory = string.upper(bp.General.FactionName)`