### PR TITLE
counterintel disableing intel unintentionally

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2396,11 +2396,9 @@ Unit = Class(moho.unit_methods) {
         local function DisableOneIntel(disabler, intel)
             local intDisabled = false
             if Set.Empty(self.IntelDisables[intel]) then
-                local intel_bp = self:GetBlueprint().Intel
-                for _, inteltype in intel_bp.ActiveIntel do
-                    if intel == inteltype then
-                        return
-                    end
+                local active = self:GetBlueprint().Intel.ActiveIntel
+                if active and active[intel] then
+                    return
                 end
                 self:DisableIntel(intel)
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2397,11 +2397,9 @@ Unit = Class(moho.unit_methods) {
             local intDisabled = false
             if Set.Empty(self.IntelDisables[intel]) then
                 local intel_bp = self:GetBlueprint().Intel
-                if intel_bp.AlwaysActiveIntel then
-                    for _, inteltype in intel_bp.ActiveIntel do
-                        if intel == inteltype then
-                            return
-                        end
+                for _, inteltype in intel_bp.ActiveIntel do
+                    if intel == inteltype then
+                        return
                     end
                 end
                 self:DisableIntel(intel)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2396,11 +2396,19 @@ Unit = Class(moho.unit_methods) {
         local function DisableOneIntel(disabler, intel)
             local intDisabled = false
             if Set.Empty(self.IntelDisables[intel]) then
+                local intel_bp = self:GetBlueprint().Intel
+                if intel_bp.AlwaysActiveIntel then
+                    for _, inteltype in intel_bp.ActiveIntel do
+                        if intel == inteltype then
+                            return
+                        end
+                    end
+                end
                 self:DisableIntel(intel)
 
                 -- Handle the cloak FX timing
                 if intel == 'Cloak' or intel == 'CloakField' then
-                    if disabler ~= 'NotInitialized' and self:GetBlueprint().Intel[intel] then
+                    if disabler ~= 'NotInitialized' and intel_bp[intel] then
                         self:UpdateCloakEffect(false, intel)
                     end
                 end

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2404,7 +2404,7 @@ Unit = Class(moho.unit_methods) {
 
                 -- Handle the cloak FX timing
                 if intel == 'Cloak' or intel == 'CloakField' then
-                    if disabler ~= 'NotInitialized' and intel_bp[intel] then
+                    if disabler ~= 'NotInitialized' and self:GetBlueprint().Intel[intel] then
                         self:UpdateCloakEffect(false, intel)
                     end
                 end

--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -694,6 +694,8 @@ UnitBlueprint {
         UnitWeight = 0,
     },
     Intel = {
+        AlwaysActiveIntel = true,
+        ActiveIntel = {'Omni'},
         FreeIntel = false,
         JamRadius = {
             Max = 26,

--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -694,7 +694,7 @@ UnitBlueprint {
         UnitWeight = 0,
     },
     Intel = {
-        ActiveIntel = {'Omni' = true},
+        ActiveIntel = {'Omni' = True},
         FreeIntel = false,
         JamRadius = {
             Max = 26,

--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -694,7 +694,9 @@ UnitBlueprint {
         UnitWeight = 0,
     },
     Intel = {
-        ActiveIntel = {'Omni' = True},
+        ActiveIntel = {
+            Omni = True,
+        },
         FreeIntel = false,
         JamRadius = {
             Max = 26,

--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -694,7 +694,7 @@ UnitBlueprint {
         UnitWeight = 0,
     },
     Intel = {
-        ActiveIntel = {'Omni'},
+        ActiveIntel = {'Omni' = true},
         FreeIntel = false,
         JamRadius = {
             Max = 26,

--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -694,7 +694,6 @@ UnitBlueprint {
         UnitWeight = 0,
     },
     Intel = {
-        AlwaysActiveIntel = true,
         ActiveIntel = {'Omni'},
         FreeIntel = false,
         JamRadius = {

--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -695,7 +695,7 @@ UnitBlueprint {
     },
     Intel = {
         ActiveIntel = {
-            Omni = True,
+            Omni = true,
         },
         FreeIntel = false,
         JamRadius = {

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -697,7 +697,10 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        ActiveIntel = {'Omni' = True, 'Sonar' = True},
+        ActiveIntel = {
+            Omni = True,
+            Sonar = True,
+        },
         Cloak = true,
         FreeIntel = false,
         OmniRadius = 26,

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -697,7 +697,7 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        ActiveIntel = {'Omni' = true, 'Sonar' = true},
+        ActiveIntel = {'Omni' = True, 'Sonar' = True},
         Cloak = true,
         FreeIntel = false,
         OmniRadius = 26,

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -697,7 +697,7 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        ActiveIntel = {'Omni', 'Sonar'},
+        ActiveIntel = {'Omni' = true, 'Sonar' = true},
         Cloak = true,
         FreeIntel = false,
         OmniRadius = 26,

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -698,8 +698,8 @@ UnitBlueprint {
     },
     Intel = {
         ActiveIntel = {
-            Omni = True,
-            Sonar = True,
+            Omni = true,
+            Sonar = true,
         },
         Cloak = true,
         FreeIntel = false,

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -697,7 +697,6 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        AlwaysActiveIntel = true,
         ActiveIntel = {'Omni', 'Sonar'},
         Cloak = true,
         FreeIntel = false,

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -697,6 +697,8 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
+        AlwaysActiveIntel = true,
+        ActiveIntel = {'Omni', 'Sonar'},
         Cloak = true,
         FreeIntel = false,
         OmniRadius = 26,

--- a/units/URL0301/URL0301_unit.bp
+++ b/units/URL0301/URL0301_unit.bp
@@ -617,7 +617,7 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        ActiveIntel = {'Omni' = true},
+        ActiveIntel = {'Omni' = True},
         Cloak = true,
         FreeIntel = false,
         OmniRadius = 16,

--- a/units/URL0301/URL0301_unit.bp
+++ b/units/URL0301/URL0301_unit.bp
@@ -617,7 +617,7 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        ActiveIntel = {'Omni'},
+        ActiveIntel = {'Omni' = true},
         Cloak = true,
         FreeIntel = false,
         OmniRadius = 16,

--- a/units/URL0301/URL0301_unit.bp
+++ b/units/URL0301/URL0301_unit.bp
@@ -617,6 +617,8 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
+        AlwaysActiveIntel = true,
+        ActiveIntel = {'Omni'},
         Cloak = true,
         FreeIntel = false,
         OmniRadius = 16,

--- a/units/URL0301/URL0301_unit.bp
+++ b/units/URL0301/URL0301_unit.bp
@@ -617,7 +617,6 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        AlwaysActiveIntel = true,
         ActiveIntel = {'Omni'},
         Cloak = true,
         FreeIntel = false,

--- a/units/URL0301/URL0301_unit.bp
+++ b/units/URL0301/URL0301_unit.bp
@@ -617,7 +617,9 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        ActiveIntel = {'Omni' = True},
+        ActiveIntel = {
+            Omni = true,
+        },
         Cloak = true,
         FreeIntel = false,
         OmniRadius = 16,

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -262,7 +262,7 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        ActiveIntel = {'Sonar'},
+        ActiveIntel = {'Sonar' = true},
         RadarStealth = true,
         RadarStealthField = true,
         RadarStealthFieldRadius = 30,

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -262,7 +262,7 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        ActiveIntel = {'Sonar' = true},
+        ActiveIntel = {'Sonar' = True},
         RadarStealth = true,
         RadarStealthField = true,
         RadarStealthFieldRadius = 30,

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -262,7 +262,6 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        AlwaysActiveIntel = true,
         ActiveIntel = {'Sonar'},
         RadarStealth = true,
         RadarStealthField = true,

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -262,7 +262,9 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        ActiveIntel = {'Sonar' = True},
+        ActiveIntel = {
+            Sonar = True,
+        },
         RadarStealth = true,
         RadarStealthField = true,
         RadarStealthFieldRadius = 30,

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -262,6 +262,8 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
+        AlwaysActiveIntel = true,
+        ActiveIntel = {'Sonar'},
         RadarStealth = true,
         RadarStealthField = true,
         RadarStealthFieldRadius = 30,

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -263,7 +263,7 @@ UnitBlueprint {
     },
     Intel = {
         ActiveIntel = {
-            Sonar = True,
+            Sonar = true,
         },
         RadarStealth = true,
         RadarStealthField = true,


### PR DESCRIPTION
This commit fixes the following two issues:

The monkeylord loses its sonar capabilities in case of a powerstall when
the stealthfield is active. If it is deactivated, the sonar continues to
work. fixes #896

If the cybran acu, sacu or the uef sacu has a counter intel upgrade
(stealth, cloak, jamming) and the player powerstalls, the omni of the
unit will be deactivated.