### PR TITLE
disable build ability of acu before warping in

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2189,7 +2189,6 @@ CommandUnit = Class(WalkingLandUnit) {
         self:HideBone(0, true)
         self:SetUnSelectable(true)
         self:SetBusy(true)
-        self:SetBlockCommandQueue(true)
         self:ForkThread(self.WarpInEffectThread, bones)
     end,
 

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -355,6 +355,7 @@ function CreateInitialArmyGroup(strArmy, createCommander)
 end
 
 function CommanderWarpDelay(cdrUnit, delay)
+    cdrUnit:SetBlockCommandQueue(true)
     WaitSeconds(delay)
     cdrUnit:PlayCommanderWarpInEffect()
 end


### PR DESCRIPTION
fixes #2147

due to the short delay before the acu is warped in, the acu was able to
start building stuff before the animation is played.