### PR TITLE
disable vision for submerged amphibious units

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2840,6 +2840,14 @@ Unit = Class(moho.unit_methods) {
         if self.LayerChangeTrigger then
             self:LayerChangeTrigger(new, old)
         end
+        
+        if new == 'Seabed' then
+            if self:GetBlueprint().Intel.OmniRadius == 0 then
+                self:DisableIntel('Vision')
+            end
+        else
+            self:EnableIntel('Vision')
+        end
     end,
 
     OnMotionHorzEventChange = function(self, new, old)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2842,7 +2842,7 @@ Unit = Class(moho.unit_methods) {
         end
         
         if new == 'Seabed' then
-            if self:GetBlueprint().Intel.OmniRadius == 0 then
+            if not self:GetBlueprint().Intel.OmniRadius > 0 then
                 self:DisableIntel('Vision')
             end
         else


### PR DESCRIPTION
fixes #2056

the vision is still enabled for acus and sacus (and other units with
omni sensors)