### PR TITLE
add targetbones to t1 subs

### DIFF
--- a/units/UAS0203/UAS0203_unit.bp
+++ b/units/UAS0203/UAS0203_unit.bp
@@ -1,6 +1,9 @@
 UnitBlueprint {
     AI = {
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 130,        
+        TargetBones = {
+            'UAS0203',
+        },
     },
     Audio = {
         AmbientMove = Sound {

--- a/units/UES0203/UES0203_unit.bp
+++ b/units/UES0203/UES0203_unit.bp
@@ -1,6 +1,10 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 130,
+        TargetBones = {
+            'Spinner',
+            'UES0203',
+        },
     },
     Audio = {
         AmbientMove = Sound {

--- a/units/URS0203/URS0203_unit.bp
+++ b/units/URS0203/URS0203_unit.bp
@@ -1,6 +1,10 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 130,
+        TargetBones = {
+            'Turret',
+            'URS0203',
+        },
     },
     Audio = {
         AmbientMove = Sound {


### PR DESCRIPTION
fixes #1280

hover/direct fire units were unable to hit any of the vanilla subs when surfaced. Adding targetbones fixes the issue.