### PR TITLE
fix incomplete ships not being destroyed

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1657,7 +1657,11 @@ Unit = Class(moho.unit_methods) {
 
             if isNaval and self:GetBlueprint().Display.AnimationDeath then
                 -- Waits for wreck to hit bottom or end of animation
-                self:SeabedWatcher()
+                if self:GetFractionComplete() > 0.5 then
+                    self:SeabedWatcher()
+                else
+                    self:DestroyUnit(overkillRatio)
+                end
             else
                 -- A non-naval unit or boat with no sinking animation dying over water needs to sink, but lacks an animation for it. Let's make one up.
                 local this = self


### PR DESCRIPTION
naval units have a death animation which is only played when they are
more than 50% completed. In the DeathThread the degree of completion is
not checked again, just the existence of this animation. If the unit is
not sufficiently completed, it doesnt sink with its animation and thus
the SeaBedWatcher function doesnt terminate since the unit is not
sinking with the normal sinkerthread.

fixes #2076
fixes #1045