### PR TITLE
add failsafe to Buildstate of cybran drones

### DIFF
--- a/units/URA0001/URA0001_script.lua
+++ b/units/URA0001/URA0001_script.lua
@@ -103,7 +103,7 @@ URA0001 = Class(CAirUnit) {
         Main = function(self)
             local focus = self.spawnedBy:GetFocusUnit()
 
-            if not focus then
+            if not focus or focus.Dead then
                 ChangeState(self, self.IdleState)
             end
 

--- a/units/URA0001/URA0001_script.lua
+++ b/units/URA0001/URA0001_script.lua
@@ -103,7 +103,7 @@ URA0001 = Class(CAirUnit) {
         Main = function(self)
             local focus = self.spawnedBy:GetFocusUnit()
 
-            if not focus or focus.Dead then
+            if not focus or focus:BeenDestroyed() then
                 ChangeState(self, self.IdleState)
             end
 

--- a/units/URA0001/URA0001_script.lua
+++ b/units/URA0001/URA0001_script.lua
@@ -103,7 +103,7 @@ URA0001 = Class(CAirUnit) {
         Main = function(self)
             local focus = self.spawnedBy:GetFocusUnit()
 
-            if not focus or focus:BeenDestroyed() then
+            if not focus or focus:BeenDestroyed() or focus.Dead then
                 ChangeState(self, self.IdleState)
             end
 


### PR DESCRIPTION
add additional check to the cybran drones if the assisted unit is dead
or not

potentially fixes #2167