### PR TITLE
Feature/newvet lite

### DIFF
--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -86,7 +86,7 @@ function TransferUnitsOwnership(units, ToArmyIndex)
         -- B E F O R E
         local numNukes = unit:GetNukeSiloAmmoCount()  -- looks like one of these 2 works for SMDs also
         local numTacMsl = unit:GetTacticalSiloAmmoCount()
-        local xp = unit.xp
+        local massKilled = unit.Sync.totalMassKilled
         local unitHealth = unit:GetHealth()
         local shieldIsOn = false
         local ShieldHealth = 0
@@ -136,8 +136,8 @@ function TransferUnitsOwnership(units, ToArmyIndex)
         end
 
         -- A F T E R
-        if xp and xp > 0 then
-            unit:AddXP(xp)
+        if massKilled and massKilled > 0 then
+            unit:CalculateVeterancyLevel(massKilled)
         end
         if enh and table.getn(enh) > 0 then
             for k, v in enh do

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1762,8 +1762,8 @@ AirUnit = Class(MobileUnit) {
             proj:Start(self, 0)
             self.Trash:Add(proj)
 
-            if instigator and IsUnit(instigator) then
-                instigator:OnKilledUnit(self)
+            if instigator and IsUnit(instigator) and self.totalDamageTaken > 0 and instigator.gainsVeterancy then
+                self:VeterancyDispersal()
             end
         else
             MobileUnit.OnKilled(self, instigator, type, overkillRatio)

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2328,6 +2328,18 @@ ACUUnit = Class(CommandUnit) {
         self:GetAIBrain():GiveResource('Mass', self:GetBlueprint().Economy.StorageMass)
     end,
 
+    OnKilledUnit = function(self, unitKilled, massKilled)
+        -- Adjust mass based on unit killed for ACU
+        local techIndex = function()
+            for k, tech in pairs({'TECH1', 'TECH2', 'TECH3', 'EXPERIMENTAL', 'COMMAND'}) do
+                if tech == unitKilled.techCategory then return k end
+            end
+        end
+        massKilled = massKilled / techIndex()
+
+        CommandUnit.OnKilledUnit(self, unitKilled, massKilled)
+    end,
+
     BuildDisable = function(self)
         while self:IsUnitState('Building') or self:IsUnitState('Enhancing') or self:IsUnitState('Upgrading') or
                 self:IsUnitState('Repairing') or self:IsUnitState('Reclaiming') do

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2330,12 +2330,17 @@ ACUUnit = Class(CommandUnit) {
 
     OnKilledUnit = function(self, unitKilled, massKilled)
         -- Adjust mass based on unit killed for ACU
-        local techIndex = function()
-            for k, tech in pairs({'TECH1', 'TECH2', 'TECH3', 'EXPERIMENTAL', 'COMMAND'}) do
-                if tech == unitKilled.techCategory then return k end
-            end
+        if unitKilled.techCategory then
+            local techMultipliers = {
+                TECH1 = 1,
+                TECH2 = 0.5,
+                TECH3 = 0.333334,
+                SUBCOMMANDER = 0.3,
+                EXPERIMENTAL = 0.25,
+                COMMAND = 0.2,
+            }
+            massKilled = massKilled * (techMultipliers[unitKilled.techCategory] or 1)
         end
-        massKilled = massKilled / techIndex()
 
         CommandUnit.OnKilledUnit(self, unitKilled, massKilled)
     end,

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -403,9 +403,8 @@ function BuffCalculate(unit, buffName, affectType, initialVal, initialBool)
         end
     end
 
-    -- Adds are calculated first, then the mults.  May want to expand that later.
-    local returnVal = false
-    returnVal = (initialVal + adds + multsTotal) * mults
+    -- Adds are calculated first, then the mults.
+    local returnVal = (initialVal + adds + multsTotal) * mults
 
     return returnVal, bool
 end

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2042,6 +2042,8 @@ Unit = Class(moho.unit_methods) {
             return false
         end
 
+        local bp = self:GetBlueprint()
+
         -- Set up Veterancy tracking here. Avoids needing to check completion later.
         -- Do all this here so we only have to do for things which get completed
         -- Don't need to track damage for things which cannot attack!
@@ -2057,7 +2059,6 @@ Unit = Class(moho.unit_methods) {
             self.Sync.myValue = math.floor(bp.Economy.BuildCostMass * (bp.VeteranMassMult or defaultMult))
         end
 
-        local bp = self:GetBlueprint()
         self:EnableUnitIntel('NotInitialized', nil)
         self:ForkThread(self.StopBeingBuiltEffects, builder, layer)
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1109,7 +1109,7 @@ Unit = Class(moho.unit_methods) {
         local preAdjHealth = self:GetHealth()
 
         -- Keep track of instigators, but only if it is a unit
-        if instigator and IsUnit(instigator) then
+        if instigator and IsUnit(instigator) and instigator.gainsVeterancy then
             amountForVet = math.min(amount, preAdjHealth) -- Don't let massive alpha (OC, Percy etc) skew which unit gets vet
             self.Instigators[instigator] = (self.Instigators[instigator] or 0) + amountForVet
             self.totalDamageTaken = self.totalDamageTaken + amountForVet

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1108,11 +1108,16 @@ Unit = Class(moho.unit_methods) {
     DoTakeDamage = function(self, instigator, amount, vector, damageType)
         local preAdjHealth = self:GetHealth()
 
-        -- Keep track of instigators, but only if it is a unit
-        if instigator and IsUnit(instigator) and instigator.gainsVeterancy then
+        -- Keep track of incoming damage, but only if it is from a unit
+        if instigator and IsUnit(instigator) and not instigator == self then
             amountForVet = math.min(amount, preAdjHealth) -- Don't let massive alpha (OC, Percy etc) skew which unit gets vet
-            self.Instigators[instigator] = (self.Instigators[instigator] or 0) + amountForVet
             self.totalDamageTaken = self.totalDamageTaken + amountForVet
+
+            -- We want to keep track of damage from things that cannot gain vet (deathweps etc)
+            -- But not enter them into the table to have credit dispersed later
+            if instigator.gainsVeterancy then
+                self.Instigators[instigator] = (self.Instigators[instigator] or 0) + amountForVet
+            end
         end
 
         self:AdjustHealth(instigator, -amount)
@@ -1248,7 +1253,7 @@ Unit = Class(moho.unit_methods) {
         -- We prevent any vet spreading if the instigator isn't part of the vet system (EG - Self destruct)
         -- This is so that you can bring a damaged Experimental back to base, kill, and rebuild, without granting
         -- instant vet to the enemy army, as well as other obscure reasons
-        if instigator and IsUnit(instigator) and self.totalDamageTaken > 0 and instigator.gainsVeterancy then
+        if instigator and IsUnit(instigator) and self.totalDamageTaken > 0 then
             self:VeterancyDispersal()
         end
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1279,7 +1279,7 @@ Unit = Class(moho.unit_methods) {
         local mass = bp.Economy.BuildCostMass * self:GetFractionComplete()
 
         -- Allow units to count for more or less than their real mass if needed.
-        mass = mass * (bp.Veteran.ImportanceMult or 1)
+        mass = mass * (bp.Veteran.ImportanceMult or 1) + (self.cargoMass or 0)
 
         for unit, damageDealt in self.Instigators do
             -- Make sure the unit is something which can vet, and is not maxed

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -27,23 +27,8 @@ local Set = import('/lua/system/setutils.lua')
 
 -- Localised global functions for speed. ~10% for single references, ~30% for double (eg table.insert)
 
-
 -- Deprecated function warning flags
 local GetUnitBeingBuiltWarning = false
-
-
--- TODO: We should really introduce a veterancy module at some point.
--- XP gained for killing various unit types.
-local WALL_XP = 0.1
-local STRUCTURE_XP = 1
-local TECH1_XP = 1
-local TECH2_XP = 3
-local TECH3_XP = 6
-local COMMAND_XP = 6
-local EXPERIMENTAL_XP = 50
-
--- For killing any unit that doesn't match any of the other categories.
-local DEFAULT_XP = 1
 
 SyncMeta = {
     __index = function(t, key)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1276,7 +1276,7 @@ Unit = Class(moho.unit_methods) {
     -- Tell any living instigators that they need to gain some veterancy
     VeterancyDispersal = function(self)
         local bp = self:GetBlueprint()
-        local mass = bp.Economy.BuildCostMass
+        local mass = bp.Economy.BuildCostMass * self:GetFractionComplete()
 
         -- Allow units to count for more or less than their real mass if needed.
         mass = mass * (bp.Veteran.ImportanceMult or 1)
@@ -2056,7 +2056,7 @@ Unit = Class(moho.unit_methods) {
             -- Allow units to require more or less mass to level up. Decimal multipliers mean
             -- faster leveling, >1 mean slower. Doing this here means doing it once instead of every kill.
             local defaultMult = 1.25
-            self.Sync.myValue = math.floor(bp.Economy.BuildCostMass * (bp.VeteranMassMult or defaultMult))
+            self.Sync.myValue = math.max(math.floor(bp.Economy.BuildCostMass * (bp.VeteranMassMult or defaultMult)), 1)
         end
 
         self:EnableUnitIntel('NotInitialized', nil)

--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -44,7 +44,7 @@ function CalculateBrainScore(brain)
 
     -- score components calculated
     local resourceProduction = ((massSpent) + (energySpent / energyValueCoefficient)) / 2
-    local battleResults = (((massValueDestroyed - massValueLost- (commanderKills * 18000)) + ((energyValueDestroyed - energyValueLost - (commanderKills * 5000000)) / energyValueCoefficient)) / 2)
+    local battleResults = (((massValueDestroyed - massValueLost- (commanderKills * 1000)) + ((energyValueDestroyed - energyValueLost - (commanderKills * 5000000)) / energyValueCoefficient)) / 2)
     if battleResults < 0 then
         battleResults = 0
     end

--- a/lua/ui/game/layouts/unitview_mini.lua
+++ b/lua/ui/game/layouts/unitview_mini.lua
@@ -89,27 +89,7 @@ function SetLayout()
     LayoutHelpers.AtCenterIn(controls.health, controls.healthBar)
     controls.health:SetDropShadow(true)
 
-    local iconPositions = {
-        [1] = {Left = 70, Top = 60},
-        [2] = {Left = 70, Top = 80},
-        [3] = {Left = 190, Top = 60},
-        [4] = {Left = 130, Top = 60},
-        [5] = {Left = 130, Top = 80},
-        [6] = {Left = 130, Top = 80},
-        [7] = {Left = 190, Top = 90},
-    }
-
-    local iconTextures = {
-        UIUtil.UIFile('/game/unit_view_icons/mass.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/energy.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/kills.dds'),
-		UIUtil.UIFile('/game/unit_view_icons/kills.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/missiles.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/shield.dds'),
-        UIUtil.UIFile('/game/unit_view_icons/fuel.dds'),
-    }
-
-    for index = 1, 7 do
+    for index = 1, table.getn(iconPositions) do
         local i = index
         if iconPositions[i] then
             LayoutHelpers.AtLeftTopIn(controls.statGroups[i].icon, controls.bg, iconPositions[i].Left, iconPositions[i].Top)

--- a/lua/ui/game/layouts/unitview_mini.lua
+++ b/lua/ui/game/layouts/unitview_mini.lua
@@ -84,7 +84,7 @@ function SetLayout()
     LayoutHelpers.Below(controls.nextVet, controls.vetBar)
     controls.nextVet:SetDropShadow(true)
     LayoutHelpers.Above(controls.vetTitle, controls.vetBar)
-    controls.nextVet:SetDropShadow(true)
+    controls.vetTitle:SetDropShadow(true)
 
     LayoutHelpers.AtCenterIn(controls.health, controls.healthBar)
     controls.health:SetDropShadow(true)

--- a/lua/ui/game/layouts/unitview_mini.lua
+++ b/lua/ui/game/layouts/unitview_mini.lua
@@ -74,10 +74,42 @@ function SetLayout()
     controls.fuelBar.Height:Set(2)
     controls.fuelBar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_bg.dds'))
     controls.fuelBar._bar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/fuelbar.dds'))
+
+    LayoutHelpers.AtLeftTopIn(controls.vetBar, controls.bg, 192, 68)
+    controls.vetBar.Width:Set(56)
+    controls.vetBar.Height:Set(3)
+    controls.vetBar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/healthbar_bg.dds'))
+    controls.vetBar._bar:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/fuelbar.dds'))
+
+    LayoutHelpers.Below(controls.nextVet, controls.vetBar)
+    controls.nextVet:SetDropShadow(true)
+    LayoutHelpers.Above(controls.vetTitle, controls.vetBar)
+    controls.nextVet:SetDropShadow(true)
+
     LayoutHelpers.AtCenterIn(controls.health, controls.healthBar)
     controls.health:SetDropShadow(true)
 
-    for index = 1, table.getn(iconPositions) do
+    local iconPositions = {
+        [1] = {Left = 70, Top = 60},
+        [2] = {Left = 70, Top = 80},
+        [3] = {Left = 190, Top = 60},
+        [4] = {Left = 130, Top = 60},
+        [5] = {Left = 130, Top = 80},
+        [6] = {Left = 130, Top = 80},
+        [7] = {Left = 190, Top = 90},
+    }
+
+    local iconTextures = {
+        UIUtil.UIFile('/game/unit_view_icons/mass.dds'),
+        UIUtil.UIFile('/game/unit_view_icons/energy.dds'),
+        UIUtil.UIFile('/game/unit_view_icons/kills.dds'),
+		UIUtil.UIFile('/game/unit_view_icons/kills.dds'),
+        UIUtil.UIFile('/game/unit_view_icons/missiles.dds'),
+        UIUtil.UIFile('/game/unit_view_icons/shield.dds'),
+        UIUtil.UIFile('/game/unit_view_icons/fuel.dds'),
+    }
+
+    for index = 1, 7 do
         local i = index
         if iconPositions[i] then
             LayoutHelpers.AtLeftTopIn(controls.statGroups[i].icon, controls.bg, iconPositions[i].Left, iconPositions[i].Top)

--- a/lua/ui/game/layouts/unitview_mini.lua
+++ b/lua/ui/game/layouts/unitview_mini.lua
@@ -8,10 +8,10 @@ local iconPositions = {
     [1] = {Left = 70, Top = 55},
     [2] = {Left = 70, Top = 70},
     [3] = {Left = 190, Top = 60},
-    [4] = {Left = 130, Top = 60},
-    [5] = {Left = 130, Top = 80},
-    [6] = {Left = 130, Top = 80},
-    [7] = {Left = 190, Top = 80},
+    [4] = {Left = 130, Top = 55},
+    [5] = {Left = 130, Top = 85},
+    [6] = {Left = 130, Top = 70},
+    [7] = {Left = 190, Top = 85},
     [8] = {Left = 70, Top = 85},
 }
 local iconTextures = {

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -314,9 +314,9 @@ function UpdateWindow(info)
         end
 
         -- Control the veterancy stars
-        local currentLevel = UnitData[info.entityId].Sync.VeteranLevel
-        local massKilled = UnitData[info.entityId].Sync.totalMassKilled
-        local myValue = UnitData[info.entityId].Sync.myValue
+        local currentLevel = UnitData[info.entityId].VeteranLevel
+        local massKilled = UnitData[info.entityId].totalMassKilled
+        local myValue = UnitData[info.entityId].myValue
 
         for level = 1, 5 do
             local l = level

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -319,12 +319,11 @@ function UpdateWindow(info)
         local myValue = UnitData[info.entityId].myValue
 
         for level = 1, 5 do
-            local l = level
-            if currentLevel >= l then
-                controls.vetIcons[l]:Show()
-                controls.vetIcons[l]:SetTexture(UIUtil.UIFile(Factions.Factions[Factions.FactionIndexMap[string.lower(bp.General.FactionName)]].VeteranIcon))
+            if currentLevel >= level then
+                controls.vetIcons[level]:Show()
+                controls.vetIcons[level]:SetTexture(UIUtil.UIFile(Factions.Factions[Factions.FactionIndexMap[string.lower(bp.General.FactionName)]].VeteranIcon))
             else
-                controls.vetIcons[1]:Hide()
+                controls.vetIcons[level]:Hide()
             end
         end
 

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -205,6 +205,7 @@ function UpdateWindow(info)
         controls.healthBar:Hide()
         controls.shieldBar:Hide()
         controls.fuelBar:Hide()
+        controls.vetBar:Hide()
         controls.actionIcon:Hide()
         controls.actionText:Hide()
         controls.abilities:Hide()
@@ -281,6 +282,7 @@ function UpdateWindow(info)
 
         controls.shieldBar:Hide()
         controls.fuelBar:Hide()
+        controls.vetBar:Hide()
 
         if info.shieldRatio > 0 then
             controls.shieldBar:Show()
@@ -310,16 +312,37 @@ function UpdateWindow(info)
         else
             controls.healthBar:Hide()
         end
-        local veterancyLevels = bp.Veteran or veterancyDefaults
-        for index = 1, 5 do
-            local i = index
-            if UnitData[info.entityId].xp >= veterancyLevels[string.format('Level%d', i)] then
-                controls.vetIcons[i]:Show()
-                controls.vetIcons[i]:SetTexture(UIUtil.UIFile(Factions.Factions[Factions.FactionIndexMap[string.lower(bp.General.FactionName)]].VeteranIcon))
+
+        -- Control the veterancy stars
+        local currentLevel = UnitData[info.entityId].Sync.VeteranLevel
+        local massKilled = UnitData[info.entityId].Sync.totalMassKilled
+        local myValue = UnitData[info.entityId].Sync.myValue
+
+        for level = 1, 5 do
+            local l = level
+            if currentLevel >= l then
+                controls.vetIcons[l]:Show()
+                controls.vetIcons[l]:SetTexture(UIUtil.UIFile(Factions.Factions[Factions.FactionIndexMap[string.lower(bp.General.FactionName)]].VeteranIcon))
             else
-                controls.vetIcons[i]:Hide()
+                controls.vetIcons[1]:Hide()
             end
         end
+
+        -- Control the veterancy progress bar
+        if massKilled and myValue then
+            local progress = math.min(massKilled / myValue, 5) - currentLevel
+            if progress then
+                if currentLevel < 5 then
+                    controls.vetBar:Show()
+                    controls.vetBar:SetValue(progress)
+                    local text = massKilled .. '/' .. (myValue * (currentLevel + 1))
+                    controls.nextVet:SetText(text)
+                else
+                    controls.vetBar:Hide()
+                end
+            end
+        end
+
         local unitQueue = false
         if info.userUnit then
             unitQueue = info.userUnit:GetCommandQueue()
@@ -505,6 +528,10 @@ function CreateUI()
     controls.shieldBar = StatusBar(controls.bg, 0, 1, false, false, nil, nil, true)
     controls.fuelBar = StatusBar(controls.bg, 0, 1, false, false, nil, nil, true)
     controls.health = UIUtil.CreateText(controls.healthBar, '', 14, UIUtil.bodyFont)
+    controls.vetBar = StatusBar(controls.bg, 0, 1, false, false, nil, nil, true)
+    controls.nextVet = UIUtil.CreateText(controls.vetBar, '', 10, UIUtil.bodyFont)
+    controls.vetTitle = UIUtil.CreateText(controls.vetBar, 'Veterancy', 10, UIUtil.bodyFont)
+
     controls.statGroups = {}
     for i = 1, table.getn(statFuncs) do
         controls.statGroups[i] = {}

--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -7,7 +7,6 @@ UnitBlueprint {
         RepairConsumeEnergy = 5,
         RepairConsumeMass = 0.5,
         TargetBones = {
-#            'UAA0310',
             'Attachpoint01',
             'Attachpoint02',
             'Attachpoint03',
@@ -225,8 +224,8 @@ UnitBlueprint {
         },
         Elevation = 25,
 
-        # FuelRechargeRate = 150,
-        # FuelUseTime = 30000,
+        -- FuelRechargeRate = 150,
+        -- FuelUseTime = 30000,
         MaxAcceleration = 1,
         MaxSpeed = 1,
         MaxSteerForce = 100,
@@ -286,17 +285,17 @@ UnitBlueprint {
             },
             AutoInitiateAttackCommand = true,
             BallisticArc = 'RULEUBA_None',
-            BeamCollisionDelay = 0,	#0.2
+            BeamCollisionDelay = 0,
             BeamLifetime = 0,
             CollideFriendly = false,
-            Damage = 333,			#1000
+            Damage = 333,
             DamageRadius = 4,
-            DamageType = 'CzarBeam',  # Normal
+            DamageType = 'CzarBeam',
             DisplayName = 'Quantum Beam Generator',
             FireTargetLayerCapsTable = {
                 Air = 'Land|Water|Seabed',
             },
-            FiringTolerance = 30,					#0
+            FiringTolerance = 30,
             Label = 'QuantumBeamGeneratorWeapon',
             MaxRadius = 30,
             MaximumBeamLength = 50,
@@ -318,8 +317,8 @@ UnitBlueprint {
             RackSalvoReloadTime = 0,
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
-            RateOfFire = 10,						#0.2
-            TargetCheckInterval = 0.1,					#2.5
+            RateOfFire = 10,
+            TargetCheckInterval = 0.1,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
                 'STRUCTURE',
@@ -332,7 +331,7 @@ UnitBlueprint {
             TargetRestrictDisallow = 'UNTARGETABLE',
             Turreted = false,
             WeaponCategory = 'Direct Fire Experimental',
-            WeaponRepackTimeout = 0,					#10
+            WeaponRepackTimeout = 0,
             WeaponUnpacks = false,
         },
         {

--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -263,6 +263,7 @@ UnitBlueprint {
         Level4 = 160,
         Level5 = 200,
     },
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterTargetsOnly = true,

--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -301,7 +301,7 @@ UnitBlueprint {
     Economy = {
         -- If modifying Energy or Mass costs, modify Score component in aibrain.lua search battleResults
         BuildCostEnergy = 5000000,
-        BuildCostMass = 18000,
+        BuildCostMass = 1000,
         BuildRate = 10,
         BuildTime = 6000000,
         BuildableCategory = {

--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -866,6 +866,7 @@ UnitBlueprint {
         0.4,
         0.5,
     },
+    VeteranMassMult = 1,
     Weapon = {
         {
             AboveWaterFireOnly = true,

--- a/units/UAL0401/UAL0401_unit.bp
+++ b/units/UAL0401/UAL0401_unit.bp
@@ -267,6 +267,7 @@ UnitBlueprint {
         Level4 = 360,
         Level5 = 450,
     },
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterFireOnly = true,

--- a/units/UAL0401/UAL0401_unit.bp
+++ b/units/UAL0401/UAL0401_unit.bp
@@ -8,7 +8,7 @@ UnitBlueprint {
             'Right_Leg_B01',
         },
         AddTargetBones = {
-            'AttachSpecial01',  # added to make unit targetable even when almost submerged [141]
+            'AttachSpecial01',
             'AttachSpecial02',
         },
     },
@@ -342,8 +342,8 @@ UnitBlueprint {
                 'EXPERIMENTAL',
                 'SUBCOMMANDER',
                 'TECH3 MOBILE',
-                'STRUCTURE DEFENSE',#
-        'TECH3 STRUCTURE',#
+                'STRUCTURE DEFENSE',
+                'TECH3 STRUCTURE',
                 'TECH2 MOBILE',
                 'TECH1 MOBILE',
                 'SPECIALLOWPRI',
@@ -424,8 +424,6 @@ UnitBlueprint {
                 'ALLUNITS',
             },
             TargetRestrictDisallow = 'UNTARGETABLE',
-
-            # TrackingRadius = 45,
             TurretBoneMuzzle = 'Right_Arm_Muzzle01',
             TurretBonePitch = 'Right_Arm_B02',
             TurretBoneYaw = 'Right_Arm_B01',
@@ -515,8 +513,6 @@ UnitBlueprint {
                 'ALLUNITS',
             },
             TargetRestrictDisallow = 'UNTARGETABLE',
-
-            # TrackingRadius = 45,
             TurretBoneMuzzle = 'Left_Arm_Muzzle01',
             TurretBonePitch = 'Left_Arm_B02',
             TurretBoneYaw = 'Left_Arm_B01',
@@ -554,8 +550,8 @@ UnitBlueprint {
             Air = false,
             Land = true,
             Seabed = true,
-            Sub = true, #from false
-            Water = true, #from false
+            Sub = true,
+            Water = true,
         },
     },
 }

--- a/units/UAS0401/UAS0401_unit.bp
+++ b/units/UAS0401/UAS0401_unit.bp
@@ -348,6 +348,7 @@ UnitBlueprint {
         Level4 = 128,
         Level5 = 160,
     },
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterTargetsOnly = true,

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -333,7 +333,7 @@ UnitBlueprint {
     Economy = {
         -- If modifying Energy or Mass costs, modify Score component in aibrain.lua search battleResults
         BuildCostEnergy = 5000000,
-        BuildCostMass = 18000,
+        BuildCostMass = 1000,
         BuildRate = 10,
         BuildTime = 6000000,
         BuildableCategory = {

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -932,6 +932,7 @@ UnitBlueprint {
         0.4,
         0.5,
     },
+    VeteranMassMult = 1,
     Weapon = {
         {
             AboveWaterFireOnly = true,

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -172,8 +172,6 @@ UnitBlueprint {
             '<LOC ability_omni>Omni Sensor',
             '<LOC ability_deathaoe>Volatile',
         },
-
-        -- AnimationIdle = '/units/uel0001/uel0001_a002.sca',
         AnimationWalk = '/units/uel0001/uel0001_a001.sca',
         AnimationWalkRate = 1.7,
         AttackReticleSize = 55,

--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -426,6 +426,7 @@ UnitBlueprint {
         Level4 = 160,
         Level5 = 200,
     },
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterFireOnly = true,

--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -228,11 +228,7 @@ UnitBlueprint {
                 Effects = {
                     {
                         Bones = {
-
-                            # 'Exhaust_Left01',
                             'Exhaust_Left02',
-
-                            # 'Exhaust_Right01',
                             'Exhaust_Right02',
                         },
                         Type = 'GroundKickup02',

--- a/units/UES0401/UES0401_script.lua
+++ b/units/UES0401/UES0401_script.lua
@@ -5,13 +5,13 @@
 -- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
-local TSeaUnit = import('/lua/terranunits.lua').TSeaUnit
+local AircraftCarrier = import('/lua/defaultunits.lua').AircraftCarrier
 local TANTorpedoAngler = import('/lua/terranweapons.lua').TANTorpedoAngler
 local TSAMLauncher = import('/lua/terranweapons.lua').TSAMLauncher
 local EffectUtil = import('/lua/EffectUtilities.lua')
 local CreateBuildCubeThread = EffectUtil.CreateBuildCubeThread
 
-UES0401 = Class(TSeaUnit) {
+UES0401 = Class(AircraftCarrier) {
     BuildAttachBone = 'UES0401',
 
     Weapons = {
@@ -26,11 +26,11 @@ UES0401 = Class(TSeaUnit) {
     },
 
     OnKilled = function(self, instigator, type, overkillRatio)
-        TSeaUnit.OnKilled(self, instigator, type, overkillRatio)
+        AircraftCarrier.OnKilled(self, instigator, type, overkillRatio)
     end,
 
     OnCreate = function(self)
-        TSeaUnit.OnCreate(self)
+        AircraftCarrier.OnCreate(self)
         self.OpenAnimManips = {}
         self.OpenAnimManips[1] = CreateAnimator(self):PlayAnim('/units/ues0401/ues0401_aopen.sca'):SetRate(-1)
         for i = 2, 6 do
@@ -65,7 +65,7 @@ UES0401 = Class(TSeaUnit) {
     end,
 
     OnMotionVertEventChange = function(self, new, old)
-        TSeaUnit.OnMotionVertEventChange(self, new, old)
+        AircraftCarrier.OnMotionVertEventChange(self, new, old)
 
         if new == 'Down' then
             self:PlayAllOpenAnims(false)
@@ -106,7 +106,7 @@ UES0401 = Class(TSeaUnit) {
     end,
 
     OnStopBeingBuilt = function(self,builder,layer)
-        TSeaUnit.OnStopBeingBuilt(self,builder,layer)
+        AircraftCarrier.OnStopBeingBuilt(self,builder,layer)
         ChangeState(self, self.IdleState)
 
         if not self.SinkSlider then -- Setup the slider and get blueprint values
@@ -118,7 +118,7 @@ UES0401 = Class(TSeaUnit) {
     end,
 
     OnFailedToBuild = function(self)
-        TSeaUnit.OnFailedToBuild(self)
+        AircraftCarrier.OnFailedToBuild(self)
         ChangeState(self, self.IdleState)
     end,
 
@@ -129,7 +129,7 @@ UES0401 = Class(TSeaUnit) {
         end,
 
         OnStartBuild = function(self, unitBuilding, order)
-            TSeaUnit.OnStartBuild(self, unitBuilding, order)
+            AircraftCarrier.OnStartBuild(self, unitBuilding, order)
             self.UnitBeingBuilt = unitBuilding
             ChangeState(self, self.BuildingState)
         end,
@@ -145,7 +145,7 @@ UES0401 = Class(TSeaUnit) {
         end,
 
         OnStopBuild = function(self, unitBeingBuilt)
-            TSeaUnit.OnStopBuild(self, unitBeingBuilt)
+            AircraftCarrier.OnStopBuild(self, unitBeingBuilt)
             ChangeState(self, self.FinishedBuildingState)
         end,
     },

--- a/units/UES0401/UES0401_unit.bp
+++ b/units/UES0401/UES0401_unit.bp
@@ -382,6 +382,7 @@ UnitBlueprint {
         Level4 = 120,
         Level5 = 150,
     },
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             Audio = {

--- a/units/URA0401/URA0401_unit.bp
+++ b/units/URA0401/URA0401_unit.bp
@@ -111,7 +111,7 @@ UnitBlueprint {
         'OVERLAYDIRECTFIRE',
         'CANNOTUSEAIRSTAGING',
     },
-    CollisionOffsetY = 0.9, #1.75 -- temporary fix so that the Sera T3 mobile AA can hit the Soul Ripper
+    CollisionOffsetY = 0.9,
     Defense = {
         AirThreatLevel = 50,
         ArmorType = 'Light',
@@ -250,9 +250,6 @@ UnitBlueprint {
             LAYER_Water = false,
         },
         Elevation = 12,
-
-        # FuelRechargeRate = 150,
-        # FuelUseTime = 5000,
         MaxSpeed = 0.5,
         MotionType = 'RULEUMT_Air',
         SkirtOffsetX = -1.5,

--- a/units/URA0401/URA0401_unit.bp
+++ b/units/URA0401/URA0401_unit.bp
@@ -277,6 +277,7 @@ UnitBlueprint {
         Level4 = 320,
         Level5 = 400,
     },
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterTargetsOnly = true,

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -305,7 +305,7 @@ UnitBlueprint {
     Economy = {
         -- If modifying Energy or Mass costs, modify Score component in aibrain.lua search battleResults
         BuildCostEnergy = 5000000,
-        BuildCostMass = 18000,
+        BuildCostMass = 1000,
         BuildRate = 10,
         BuildTime = 6000000,
         BuildableCategory = {

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -765,6 +765,7 @@ UnitBlueprint {
         0.4,
         0.5,
     },
+    VeteranMassMult = 1,
     Weapon = {
         {
             AboveWaterFireOnly = true,

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -323,6 +323,7 @@ UnitBlueprint {
         Level4 = 180,
         Level5 = 225,
     },
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterFireOnly = true,

--- a/units/XRL0403/XRL0403_unit.bp
+++ b/units/XRL0403/XRL0403_unit.bp
@@ -312,6 +312,7 @@ UnitBlueprint {
         Level4 = 360,
         Level5 = 450,
     },
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterFireOnly = true,

--- a/units/XRL0403/XRL0403_unit.bp
+++ b/units/XRL0403/XRL0403_unit.bp
@@ -354,7 +354,7 @@ UnitBlueprint {
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 65,
             ProjectileId = '/projectiles/CDFProtonCannon05/CDFProtonCannon05_proj.bp',
-            ProjectileLifetime = 0.9, -- fix for Megalith huge range bug [126]
+            ProjectileLifetime = 0.9,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -444,7 +444,7 @@ UnitBlueprint {
             MuzzleVelocity = 65,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/CDFProtonCannon05/CDFProtonCannon05_proj.bp',
-            ProjectileLifetime = 0.9, -- fix for Megalith huge range bug [126]
+            ProjectileLifetime = 0.9,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -512,7 +512,7 @@ UnitBlueprint {
             },
             FiringTolerance = 2,
             Label = 'Torpedo01',
-            MaxRadius = 64, -- Fix for Megalith not attacking a naval target because it stays in range of primary weapon
+            MaxRadius = 64,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 5,

--- a/units/XSA0402/XSA0402_unit.bp
+++ b/units/XSA0402/XSA0402_unit.bp
@@ -310,7 +310,7 @@ UnitBlueprint {
             },
             FiringRandomness = 3,
             FiringTolerance = 6,
-            FixBombTrajectory = true, # [152]
+            FixBombTrajectory = true,
             Label = 'Bomb',
             MaxRadius = 90,
             MuzzleSalvoDelay = 0,

--- a/units/XSA0402/XSA0402_unit.bp
+++ b/units/XSA0402/XSA0402_unit.bp
@@ -285,6 +285,7 @@ UnitBlueprint {
         Level4 = 400,
         Level5 = 500,
     },
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterTargetsOnly = true,

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -323,7 +323,7 @@ UnitBlueprint {
     Economy = {
         -- If modifying Energy or Mass costs, modify Score component in aibrain.lua search battleResults
         BuildCostEnergy = 5000000,
-        BuildCostMass = 18000,
+        BuildCostMass = 1000,
         BuildRate = 10,
         BuildTime = 6000000,
         BuildableCategory = {

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -884,6 +884,7 @@ UnitBlueprint {
         0.4,
         0.5,
     },
+    VeteranMassMult = 1,
     Weapon = {
         {
             AboveWaterFireOnly = true,

--- a/units/XSL0401/XSL0401_unit.bp
+++ b/units/XSL0401/XSL0401_unit.bp
@@ -279,6 +279,7 @@ UnitBlueprint {
         Level4 = 280,
         Level5 = 350,
     },
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterFireOnly = true,


### PR DESCRIPTION
Simplified version of vetmod owing to the fact that vet on experimentals was recently changed to be weaker when a bug was fixed.

This affects only the distribution of veterancy. That is, the HP and regen rewards stay the same, but we move from a very basic xp system (T1 give 1, T2 give 3, etc) to a mass-value-based system (Units gain xp based on the _value of mass_ they have contributed _damage_ to). It's powerful, flexible, and has been tested in EQ for a good 2 years now (Alongside other changes to the rewards, again, not copied here)
 