### PR TITLE
 	Make Aeon T2 generator ball spin like the T3 version

### DIFF
--- a/units/UAB1201/UAB1201_script.lua
+++ b/units/UAB1201/UAB1201_script.lua
@@ -11,6 +11,13 @@ local AEnergyCreationUnit = import('/lua/aeonunits.lua').AEnergyCreationUnit
 
 UAB1201 = Class(AEnergyCreationUnit) {
     AmbientEffects = 'AT2PowerAmbient',
+
+    OnStopBeingBuilt = function(self, builder, layer)
+        AEnergyCreationUnit.OnStopBeingBuilt(self, builder, layer)
+        self.Trash:Add(CreateRotator(self, 'Sphere', 'x', nil, 0, 15, 80 + Random(0, 20)))
+        self.Trash:Add(CreateRotator(self, 'Sphere', 'y', nil, 0, 15, 80 + Random(0, 20)))
+        self.Trash:Add(CreateRotator(self, 'Sphere', 'z', nil, 0, 15, 80 + Random(0, 20)))
+    end,
 }
 
 TypeClass = UAB1201

--- a/units/UAB1201/UAB1201_script.lua
+++ b/units/UAB1201/UAB1201_script.lua
@@ -1,0 +1,16 @@
+#****************************************************************************
+#**
+#**  File     :  /cdimage/units/UAB1201/UAB1201_script.lua
+#**  Author(s):  John Comes, Dave Tomandl, Jessica St. Croix
+#**
+#**  Summary  :  Aeon T2 Power Generator Script
+#**
+#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+local AEnergyCreationUnit = import('/lua/aeonunits.lua').AEnergyCreationUnit
+
+UAB1201 = Class(AEnergyCreationUnit) {
+    AmbientEffects = 'AT2PowerAmbient',
+}
+
+TypeClass = UAB1201


### PR DESCRIPTION
The Aeon T2 generator has a little ball hovering above it much like the T3 generator, but that ball is static. Given the Aeon love of spinning balls, it seemed like it should move. The T1 version also has a static ball that can be made to spin, but it's a solid color so the spinning is practically unnoticeable.