### PR TITLE
Remove expired economy events more quickly

### DIFF
--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -176,6 +176,11 @@ DefaultProjectileWeapon = Class(Weapon) {
                 end
                 self.EconDrain = CreateEconomyEvent(self.unit, nrgReq, 0, time)
                 self.FirstShot = true
+                self.unit:ForkThread(function()
+                    WaitFor(self.EconDrain)
+                    RemoveEconomyEvent(self.unit, self.EconDrain)
+                    self.EconDrain = nil
+                end)
             end
         end
     end,
@@ -550,8 +555,6 @@ DefaultProjectileWeapon = Class(Weapon) {
             if self.EconDrain then
                 self.WeaponCanFire = false
                 WaitFor(self.EconDrain)
-                RemoveEconomyEvent(self.unit, self.EconDrain)
-                self.EconDrain = nil
                 self.WeaponCanFire = true
             end
 

--- a/units/UEL0001/UEL0001_script.lua
+++ b/units/UEL0001/UEL0001_script.lua
@@ -88,6 +88,7 @@ UEL0001 = Class(ACUUnit) {
                 self:RequestRefreshUI()
                 WaitFor(self.RebuildingPod)
                 self:SetWorkProgress(0.0)
+                RemoveEconomyEvent(self, self.RebuildingPod)
                 self.RebuildingPod = nil
                 local location = self:GetPosition('AttachSpecial02')
                 local pod = CreateUnitHPR('UEA0001', self:GetArmy(), location[1], location[2], location[3], 0, 0, 0)
@@ -106,6 +107,7 @@ UEL0001 = Class(ACUUnit) {
                 self:RequestRefreshUI()
                 WaitFor(self.RebuildingPod2)
                 self:SetWorkProgress(0.0)
+                RemoveEconomyEvent(self, self.RebuildingPod2)
                 self.RebuildingPod2 = nil
                 local location = self:GetPosition('AttachSpecial01')
                 local pod = CreateUnitHPR('UEA0001', self:GetArmy(), location[1], location[2], location[3], 0, 0, 0)

--- a/units/UEL0301/UEL0301_script.lua
+++ b/units/UEL0301/UEL0301_script.lua
@@ -62,6 +62,7 @@ UEL0301 = Class(CommandUnit) {
             self:RequestRefreshUI()
             WaitFor(self.RebuildingPod)
             self:SetWorkProgress(0.0)
+            RemoveEconomyEvent(self, self.RebuildingPod)
             self.RebuildingPod = nil
             local location = self:GetPosition('AttachSpecial01')
             local pod = CreateUnitHPR('UEA0003', self:GetArmy(), location[1], location[2], location[3], 0, 0, 0)


### PR DESCRIPTION
This reduces the duration of #717 and compliments #2157 and #2192. The inaccurate display is caused by the engine ignoring other resource consumption when a unit has an economy event, whether it's active or expired. This makes sure economy events are removed as soon as they finish to reduce the time displayed values are incorrect.