### PR TITLE
round clocktime for reload bar

### DIFF
--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -590,13 +590,13 @@ DefaultProjectileWeapon = Class(Weapon) {
 
         -- Render the fire recharge bar
         RenderClockThread = function(self, rof)
-            local clockTime = 10*rof
+            local clockTime = math.round(10*rof)
             local totalTime = clockTime
-            while clockTime >= 0.0 and
+            while clockTime >= 0 and
                   not self:BeenDestroyed() and
                   not self.unit.Dead do
                 self.unit:SetWorkProgress(1 - clockTime / totalTime)
-                clockTime = math.floor(clockTime - 1)
+                clockTime = clockTime - 1
                 WaitSeconds(0.1)
             end
         end,

--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -590,13 +590,13 @@ DefaultProjectileWeapon = Class(Weapon) {
 
         -- Render the fire recharge bar
         RenderClockThread = function(self, rof)
-            local clockTime = rof
+            local clockTime = 10*rof
             local totalTime = clockTime
-            while clockTime > 0.0 and
+            while clockTime >= 0.0 and
                   not self:BeenDestroyed() and
                   not self.unit.Dead do
                 self.unit:SetWorkProgress(1 - clockTime / totalTime)
-                clockTime = clockTime - 0.1
+                clockTime = math.floor(clockTime - 1)
                 WaitSeconds(0.1)
             end
         end,


### PR DESCRIPTION
prevents early exits of the reload bar rendering which caused the bar to stop at 98%

fixes #2198