### PR TITLE
Fix Notify overlay problems in replays

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4233,7 +4233,9 @@ Unit = Class(moho.unit_methods) {
 
     -- Utility Functions
     SendNotifyMessage = function(self, trigger, source)
-        if self:GetArmy() == GetFocusArmy() then
+        local focusArmy = GetFocusArmy()
+        local army = self:GetArmy()
+        if focusArmy == -1 or focusArmy == army then
             local id
             local unitType
             local category
@@ -4270,7 +4272,7 @@ Unit = Class(moho.unit_methods) {
                 end
             else
                 if not Sync.EnhanceMessage then Sync.EnhanceMessage = {} end
-                local message = {source = source or unitType, trigger = trigger, category = category, id = id}
+                local message = {source = source or unitType, trigger = trigger, category = category, id = id, army = army}
                 table.insert(Sync.EnhanceMessage, message)
             end
         end

--- a/lua/ui/notify/notifyoverlay.lua
+++ b/lua/ui/notify/notifyoverlay.lua
@@ -1,6 +1,5 @@
 -- This file contains the functions which deal with creating and updating ETA overlay for ACU upgrades
 
-local FindClients = import('/lua/ui/game/chat.lua').FindClients
 local Bitmap = import('/lua/maui/bitmap.lua').Bitmap
 local defaultMessages = import('/lua/ui/notify/defaultmessages.lua').defaultMessages
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
@@ -213,7 +212,7 @@ function generateEnhancementMessage(data)
             data.pos = pos
             data.last_message = seconds
             msg.data = table.merged(msg.data, {progress = percent, eta = eta, pos = pos})
-            SessionSendChatMessage(FindClients(), msg)
+            import('/lua/ui/notify/notify.lua').sendMessage(msg)
         end
     end
 
@@ -224,5 +223,5 @@ end
 
 function sendDestroyOverlayMessage(id)
     local msg = {to = 'allies', NotifyOverlay = true, data = {id = id, destroy = true}}
-    SessionSendChatMessage(FindClients(), msg)
+    import('/lua/ui/notify/notify.lua').sendMessage(msg)
 end

--- a/schook/lua/UserSync.lua
+++ b/schook/lua/UserSync.lua
@@ -7,6 +7,7 @@ OnSync = function()
     if Sync.FocusArmyChanged then
         import('/lua/ui/game/avatars.lua').FocusArmyChanged()
         import('/lua/ui/game/multifunction.lua').FocusArmyChanged()
+        import('/lua/ui/notify/notify.lua').focusArmyChanged()
     end
 
     if Sync.CampaignMode then


### PR DESCRIPTION
Currently Notify overlays don't show in replays when watching from a player's perspective. Switching to observer after starting the enhancement is even worse because it creates an overlay that never goes away.

This allows all observers to see all players' Notify stuff as well as fixing the overlay when watching a replay from a player's perspective.