### PR TITLE
Fix/shieldtimer

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -328,17 +328,7 @@ Shield = Class(moho.shield_methods, Entity) {
 
     -- Basically run a timer, but with visual bar movement
     ChargingUp = function(self, curProgress, time)
-        local owner = self.Owner
-        local position = owner:GetPosition()
-        local shieldbp = self.Owner:GetBlueprint().Defense.Shield
-        local shieldRadius = shieldbp.ShieldSize
-        local aiBrain = owner:GetAIBrain()
-        local otherShields = aiBrain:GetUnitsAroundPoint((categories.SHIELD * categories.DEFENSE), position, shieldRadius, 'Ally')
-        local rechargeTime = time + ((table.getn(otherShields) - 1) * .2 * time)
-        if rechargeTime > time * 3 then
-            rechargeTime = time
-        end
-        while curProgress < rechargeTime do
+        while curProgress < time do
             local fraction = self.Owner:GetResourceConsumed()
             curProgress = curProgress + (fraction / 10)
             curProgress = math.min(curProgress, rechargeTime)

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -210,7 +210,7 @@ Shield = Class(moho.shield_methods, Entity) {
 
             self:UpdateShieldRatio(-1)
 
-            WaitSeconds(1)
+            WaitTicks(2)
         end
     end,
 


### PR DESCRIPTION
Removes ZeP's original attempt at curtailing stacked shields by affecting their recharge cycles. This code is unknown, unpredictable, badly designed, and has been long superceded by shield damage spillover.

Also makes shields regen per 0.2s from per 1s, just for smoothness.