### PR TITLE
Have ACU main weapon target mobile units before other ACUs. Have Snipers target ACUs.

### DIFF
--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -918,6 +918,7 @@ UnitBlueprint {
             TargetPriorities = {
                 'SPECIALHIGHPRI',
                 'MOBILE',
+                'COMMAND',
                 'STRUCTURE DEFENSE',
                 'SPECIALLOWPRI',
                 'ALLUNITS',

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -985,6 +985,7 @@ UnitBlueprint {
             TargetPriorities = {
                 'SPECIALHIGHPRI',
                 'MOBILE',
+                'COMMAND',
                 'STRUCTURE DEFENSE',
                 'SPECIALLOWPRI',
                 'ALLUNITS',

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -819,6 +819,7 @@ UnitBlueprint {
             TargetPriorities = {
                 'SPECIALHIGHPRI',
                 'MOBILE',
+                'COMMAND',
                 'STRUCTURE DEFENSE',
                 'SPECIALLOWPRI',
                 'ALLUNITS',

--- a/units/XAL0305/XAL0305_unit.bp
+++ b/units/XAL0305/XAL0305_unit.bp
@@ -271,6 +271,7 @@ UnitBlueprint {
             TargetCheckInterval = 3,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
+                'COMMAND',
                 'TECH3 MOBILE',
                 'TECH2 MOBILE',
                 'STRUCTURE DEFENSE',

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -936,6 +936,7 @@ UnitBlueprint {
             TargetPriorities = {
                 'SPECIALHIGHPRI',
                 'MOBILE',
+                'COMMAND',
                 'STRUCTURE DEFENSE',
                 'SPECIALLOWPRI',
                 'ALLUNITS',

--- a/units/XSL0305/XSL0305_unit.bp
+++ b/units/XSL0305/XSL0305_unit.bp
@@ -305,6 +305,7 @@ UnitBlueprint {
             TargetCheckInterval = 3,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
+                'COMMAND',
                 'TECH3 MOBILE',
                 'TECH2 MOBILE',
                 'STRUCTURE DEFENSE',
@@ -376,6 +377,7 @@ UnitBlueprint {
             TargetCheckInterval = 3,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
+                'COMMAND',
                 'TECH3 MOBILE',
                 'TECH2 MOBILE',
                 'STRUCTURE DEFENSE',


### PR DESCRIPTION
This change makes it so that when walking your ACU, it will automatically prioritise enemy units rather than an enemy unit. This behaviour is already seen on the auto-OC gun.

For cases when you DO want to focus down an enemy ACU, simply giving a manual targeting command will tell the gun that's the highest priority target using the priority retainer system. So you can manually target, then give move commands and it will still focus in on the ACU.

Also have Sniperbots target ACUs above other targets, so they can kite and chase without wasting shots on unimportant targets.