### PR TITLE
Balance/shieldspill

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -55,7 +55,7 @@ Shield = Class(moho.shield_methods, Entity) {
         self:SetMaxHealth(spec.ShieldMaxHealth)
         self:SetHealth(self, spec.ShieldMaxHealth)
         self:SetType('Bubble')
-        self:SetSpillOverDmgMod(spec.SpillOverDamageMod or 0.15)
+        self.SpillOverDmgMod = math.max(spec.SpillOverDamageMod or 0.15, 0)
 
         -- Show our 'lifebar'
         self:UpdateShieldRatio(1.0)
@@ -103,10 +103,6 @@ Shield = Class(moho.shield_methods, Entity) {
 
     SetType = function(self, type)
         self.ShieldType = type
-    end,
-
-    SetSpillOverDmgMod = function(self, dmgMod)
-        self.SpillOverDmgMod = math.max(dmgMod, 0)
     end,
 
     UpdateShieldRatio = function(self, value)

--- a/units/UAL0307/UAL0307_unit.bp
+++ b/units/UAL0307/UAL0307_unit.bp
@@ -73,7 +73,7 @@ UnitBlueprint {
             ShieldRegenRate = 58,
             ShieldRegenStartTime = 3,
             ShieldSize = 15,
-            ShieldSpillOverDamageMod = 0.5,
+            ShieldSpillOverDamageMod = 0.4,
             ShieldVerticalOffset = -3,
         },
         SubThreatLevel = 0,

--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -535,7 +535,7 @@ UnitBlueprint {
             ShieldRegenRate = 150,
             ShieldRegenStartTime = 1,
             ShieldSize = 20,
-            ShieldSpillOverDamageMod = 0.5,
+            ShieldSpillOverDamageMod = 0.3,
             ShieldVerticalOffset = -3,
             Slot = 'Back',
             UpgradeUnitAmbientBones = {

--- a/units/UEL0307/UEL0307_unit.bp
+++ b/units/UEL0307/UEL0307_unit.bp
@@ -82,7 +82,7 @@ UnitBlueprint {
             ShieldRegenRate = 55,
             ShieldRegenStartTime = 3,
             ShieldSize = 17,
-            ShieldSpillOverDamageMod = 0.5,
+            ShieldSpillOverDamageMod = 0.4,
             ShieldVerticalOffset = -3,
         },
         SubThreatLevel = 0,

--- a/units/XEA0306/XEA0306_unit.bp
+++ b/units/XEA0306/XEA0306_unit.bp
@@ -152,7 +152,7 @@ UnitBlueprint {
             ShieldRegenRate = 30,
             ShieldRegenStartTime = 1,
             ShieldSize = 8.5,
-            ShieldSpillOverDamageMod = 0.5,
+            ShieldSpillOverDamageMod = 0.4,
             ShieldVerticalOffset = -1,
             TransportShield = true
         },

--- a/units/XSL0307/XSL0307_unit.bp
+++ b/units/XSL0307/XSL0307_unit.bp
@@ -72,7 +72,7 @@ UnitBlueprint {
             ShieldRegenRate = 133,
             ShieldRegenStartTime = 3,
             ShieldSize = 20,
-            ShieldSpillOverDamageMod = 0.5,
+            ShieldSpillOverDamageMod = 0.3,
             ShieldVerticalOffset = -3,
         },
         SubThreatLevel = 0,


### PR DESCRIPTION
Updating the shield spillover multiplier (Amount of damage _sent_ when this shield gets hit), which hasn't been touched since initial numbers were put in at implementation. The initial numbers were a little extreme.

- T2 mobile shields and Contintental from 0.5 to 0.4, a standard decrease.
- Sera T3 mobile shield and UEF SCU bubble from 0.5 to 0.3. A larger decrease to set these units apart as a bit more special (Similar to Fatboy and UEF ACU having it at 0).