### PR TITLE
Balance:Nerf UEF MML

### DIFF
--- a/units/UEL0111/UEL0111_unit.bp
+++ b/units/UEL0111/UEL0111_unit.bp
@@ -240,7 +240,7 @@ UnitBlueprint {
             MinRadius = 5,
             MuzzleChargeDelay = 0.5,
             MuzzleSalvoDelay = 1.8,
-            MuzzleSalvoSize = 3,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 3,
             ProjectileId = '/projectiles/TIFMissileCruise03/TIFMissileCruise03_proj.bp',
             ProjectileLifetime = 20,


### PR DESCRIPTION
brings the UEF MML in line with the MMLs of other factions in terms of dps by reducing the salvo size from 3 to 2