### PR TITLE
Balance:reduce fobo speed on water

### DIFF
--- a/units/XSL0103/XSL0103_unit.bp
+++ b/units/XSL0103/XSL0103_unit.bp
@@ -255,6 +255,7 @@ UnitBlueprint {
         TurnFacingRate = 120,
         TurnRadius = 2,
         TurnRate = 90,
+        WaterSpeedMultiplier = 0.9,
     },
     SelectionSizeX = 0.35,
     SelectionSizeZ = 0.5,


### PR DESCRIPTION
reduces the speed on water by 10% (same as other hover units such as the riptide or blaze