### PR TITLE
Veterancy balance tweaks

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1833,8 +1833,7 @@ BaseTransport = Class() {
     SaveCargoMass = function(self)
         local mass = 0
         for _, unit in self:GetCargo() do
-            local bp = unit:GetBlueprint()
-            mass = mass + bp.Economy.BuildCostMass * unit:GetFractionComplete() * (bp.Veteran.ImportanceMult or 1)
+            mass = mass + unit:GetVeterancyValue()
         end
         self.cargoMass = mass
     end
@@ -2348,7 +2347,7 @@ ACUUnit = Class(CommandUnit) {
                 TECH3 = 0.333334,
                 SUBCOMMANDER = 0.3,
                 EXPERIMENTAL = 0.25,
-                COMMAND = 0.2,
+                COMMAND = 1,
             }
             massKilled = massKilled * (techMultipliers[unitKilled.techCategory] or 1)
         end

--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -44,7 +44,7 @@ function CalculateBrainScore(brain)
 
     -- score components calculated
     local resourceProduction = ((massSpent) + (energySpent / energyValueCoefficient)) / 2
-    local battleResults = (((massValueDestroyed - massValueLost- (commanderKills * 1000)) + ((energyValueDestroyed - energyValueLost - (commanderKills * 5000000)) / energyValueCoefficient)) / 2)
+    local battleResults = (((massValueDestroyed - massValueLost- (commanderKills * 2000)) + ((energyValueDestroyed - energyValueLost - (commanderKills * 5000000)) / energyValueCoefficient)) / 2)
     if battleResults < 0 then
         battleResults = 0
     end

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -334,7 +334,18 @@ function UpdateWindow(info)
                 if currentLevel < 5 then
                     controls.vetBar:Show()
                     controls.vetBar:SetValue(progress)
-                    local text = massKilled .. '/' .. (myValue * (currentLevel + 1))
+
+                    local nextLevel = myValue * (currentLevel + 1)
+                    local text
+                    if nextLevel >= 1000000 then
+                        text = string.format('%.2fM/%.2fM', massKilled / 1000000, nextLevel / 1000000)
+                    elseif nextLevel >= 100000 then
+                        text = string.format('%.0fK/%.0fK', massKilled / 1000, nextLevel / 1000)
+                    elseif nextLevel >= 10000 then
+                        text = string.format('%.1fK/%.1fK', massKilled / 1000, nextLevel / 1000)
+                    else
+                        text = massKilled .. '/' .. nextLevel
+                    end
                     controls.nextVet:SetText(text)
                 else
                     controls.vetBar:Hide()

--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -301,7 +301,7 @@ UnitBlueprint {
     Economy = {
         -- If modifying Energy or Mass costs, modify Score component in aibrain.lua search battleResults
         BuildCostEnergy = 5000000,
-        BuildCostMass = 1000,
+        BuildCostMass = 2000,
         BuildRate = 10,
         BuildTime = 6000000,
         BuildableCategory = {
@@ -866,7 +866,7 @@ UnitBlueprint {
         0.4,
         0.5,
     },
-    VeteranMassMult = 1,
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterFireOnly = true,

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -333,7 +333,7 @@ UnitBlueprint {
     Economy = {
         -- If modifying Energy or Mass costs, modify Score component in aibrain.lua search battleResults
         BuildCostEnergy = 5000000,
-        BuildCostMass = 1000,
+        BuildCostMass = 2000,
         BuildRate = 10,
         BuildTime = 6000000,
         BuildableCategory = {
@@ -932,7 +932,7 @@ UnitBlueprint {
         0.4,
         0.5,
     },
-    VeteranMassMult = 1,
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterFireOnly = true,

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -305,7 +305,7 @@ UnitBlueprint {
     Economy = {
         -- If modifying Energy or Mass costs, modify Score component in aibrain.lua search battleResults
         BuildCostEnergy = 5000000,
-        BuildCostMass = 1000,
+        BuildCostMass = 2000,
         BuildRate = 10,
         BuildTime = 6000000,
         BuildableCategory = {
@@ -765,7 +765,7 @@ UnitBlueprint {
         0.4,
         0.5,
     },
-    VeteranMassMult = 1,
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterFireOnly = true,

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -323,7 +323,7 @@ UnitBlueprint {
     Economy = {
         -- If modifying Energy or Mass costs, modify Score component in aibrain.lua search battleResults
         BuildCostEnergy = 5000000,
-        BuildCostMass = 1000,
+        BuildCostMass = 2000,
         BuildRate = 10,
         BuildTime = 6000000,
         BuildableCategory = {
@@ -884,7 +884,7 @@ UnitBlueprint {
         0.4,
         0.5,
     },
-    VeteranMassMult = 1,
+    VeteranMassMult = 0.5,
     Weapon = {
         {
             AboveWaterFireOnly = true,


### PR DESCRIPTION
* Set ACU mass cost to 2000 but keep their experience requirements the same
* Increase default experience requirements from 1.25 * mass to 2 * mass
* Remove experience penalty when an ACU kills another ACU
* Remove experience bonus when a unit kills a unit with more veterancy
* Standardize veterancy regen buffs across all units of a tier (except navy)
* Include enhancements in (S)ACU experience value
* Adjust text formatting in the UI to avoid expensive units getting unreadably long experience numbers