### PR TITLE
Fix shield regen rate

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -202,11 +202,11 @@ Shield = Class(moho.shield_methods, Entity) {
         WaitSeconds(self.RegenStartTime)
         while self:GetHealth() < self:GetMaxHealth() do
 
-            self:AdjustHealth(self.Owner, self.RegenRate)
+            self:AdjustHealth(self.Owner, self.RegenRate / 10)
 
             self:UpdateShieldRatio(-1)
 
-            WaitTicks(2)
+            WaitTicks(1)
         end
     end,
 


### PR DESCRIPTION
When changing the shield regen steps from every 10 ticks to every 2 ticks (actually 9 ticks to 1, see #2268) the amount per step wasn't reduced to compensate.