### PR TITLE
Remove TAirUnit from the UEF Gunship class

### DIFF
--- a/units/UEA0203/UEA0203_script.lua
+++ b/units/UEA0203/UEA0203_script.lua
@@ -9,7 +9,7 @@ local TAirUnit = import('/lua/terranunits.lua').TAirUnit
 local AirTransport = import('/lua/defaultunits.lua').AirTransport
 local TDFRiotWeapon = import('/lua/terranweapons.lua').TDFRiotWeapon
 
-UEA0203 = Class(AirTransport, TAirUnit) {
+UEA0203 = Class(AirTransport) {
     EngineRotateBones = {'Jet_Front', 'Jet_Back',},
 
     Weapons = {


### PR DESCRIPTION
TAirUnit is inside AirTransport class so it's not needed here.
I don't see any functionality removed by this.

Ive encountered ambiguous class definition error with RK explosion mod, it's hooking AirUnit class inside defaultunits.lua . The mod worked fine for all units except the UEF gunhips. Removing this ^^ seems to fix the problem and I dont think it's removing anyting from the gunship.
More tests are welcome.