### PR TITLE
Fix gametime logger is printing wrong times

### DIFF
--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -292,8 +292,11 @@ end
 function GameTimeLogger()
     local time
     while true do
-        time = GetGameTimeSeconds()
-        SPEW(string.format('Current gametime: %02d:%02d:%02d', math.floor(time/3600), math.floor(time/60), math.mod(time, 60)))
+        GTS = GetGameTimeSeconds()
+        hours   = math.floor(GTS / 3600);
+        minutes = math.floor((GTS - (hours * 3600)) / 60);
+        seconds = GTS - (hours * 3600) - (minutes * 60);
+        SPEW(string.format('Current gametime: %02d:%02d:%02d', hours, minutes, seconds))
         WaitSeconds(30)
     end
 end


### PR DESCRIPTION
Issue #2241

Debuglog now shows the correct minutes.

Before:
DEBUG: Current gametime: 01:61:17

After:
DEBUG: Current gametime: 01:01:17
