### PR TITLE
Fix Global Icon Support for ACU enhancements

### DIFF
--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -506,7 +506,7 @@ function UpdateEnhancementIcons(info)
         local texture = GetEnhancementPrefix(bpId, enhancementBp.Icon) .. '_btn_up.dds'
 
         enhancement:Show()
-        enhancement:SetTexture(UIUtil.UIFile(texture))
+        enhancement:SetTexture(UIUtil.UIFile(texture, true))
         enhancement.Width:Set(30)
         enhancement.Height:Set(30)
     end


### PR DESCRIPTION
Related to #2306

There are some problems with ACU enhancments icons, if you switch a player with [ALT]+[F2] and/or if you use Black Ops ACU's :
![acuenh1](https://user-images.githubusercontent.com/17804547/32638220-959a1070-c5be-11e7-884d-dcf66d4dad3b.png)

To fix this i added the "true" argument to UIUtil.UIFile. (see commit)
This way UIUtil.UIFile is also ckecking mods to find the icon :
![acuenh2](https://user-images.githubusercontent.com/17804547/32638258-c2199eb8-c5be-11e7-9ea9-04f332b4f12c.png)
