### PR TITLE
Improve map selection window

### DIFF
--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -239,7 +239,7 @@ mapFilters = {
             SelectedKey = 1,
             Filters = {
                 function(scenInfo)
-                    if CheckMapIsOfficial(scenInfo.name) then
+                    if CheckMapIsOfficial(scenInfo) then
                         return true
                     end
                     if scenInfo.Outdated then

--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -239,6 +239,9 @@ mapFilters = {
             SelectedKey = 1,
             Filters = {
                 function(scenInfo)
+                    if CheckMapIsOfficial(scenInfo.name) then
+                        return true
+                    end
                     if scenInfo.Outdated then
                         return false
                     end

--- a/lua/ui/maputil.lua
+++ b/lua/ui/maputil.lua
@@ -237,17 +237,21 @@ function CheckMapHasMarkers(scenario)
     doscript('/lua/dataInit.lua', saveData)
     doscript(scenario.save, saveData)
 
-    if saveData and saveData.Scenario and saveData.Scenario.MasterChain and
-            saveData.Scenario.MasterChain['_MASTERCHAIN_'] and saveData.Scenario.MasterChain['_MASTERCHAIN_'].Markers then
-        for marker, data in saveData.Scenario.MasterChain['_MASTERCHAIN_'].Markers do
-            if data.adjacentTo then
-                if string.find(data.adjacentTo, ' ') then
-                    return true
-                end
-            end
-        end
-    else
-        WARN('Map '..scenario.name..' has no marker chain')
+    
+    local markers = saveData and 
+                    saveData.Scenario and 
+                    saveData.Scenario.MasterChain and
+                    saveData.Scenario.MasterChain['_MASTERCHAIN_'] and
+                    saveData.Scenario.MasterChain['_MASTERCHAIN_'].Markers or false
+ 
+    if not markers then 
+       WARN('Map '.. scenario.name..' has no markers') return false 
+    else 
+       for marker, data in markers do
+          if data.adjacentTo and string.find(data.adjacentTo, ' ') then
+             return true
+          end
+       end
     end
     return false
 end

--- a/lua/ui/maputil.lua
+++ b/lua/ui/maputil.lua
@@ -240,8 +240,10 @@ function CheckMapHasMarkers(scenario)
     if saveData and saveData.Scenario and saveData.Scenario.MasterChain and
             saveData.Scenario.MasterChain['_MASTERCHAIN_'] and saveData.Scenario.MasterChain['_MASTERCHAIN_'].Markers then
         for marker, data in saveData.Scenario.MasterChain['_MASTERCHAIN_'].Markers do
-            if string.find(string.lower(marker), 'landpn') then
-                return true
+            if data.adjacentTo then
+                if string.find(data.adjacentTo, ' ') then
+                    return true
+                end
             end
         end
     else


### PR DESCRIPTION
this PR contains two changes to the map selection window:

1. the way the AI compatibility is tested for maps
instead of searching for a land path node with a specific name, search for a marker that has other markers listed as "adjacent" markers. These markers are usually path nodes (not necessarily land pathnodes). Markers with only one entry for this property correspond to chains, so searching for the separator (space) in this property yields markers with multiple adjacent markers.

2. fixes official maps being hidden by the outdated map filter

