### PR TITLE
Walls double click fix

### DIFF
--- a/units/UAB5101/UAB5101_unit.bp
+++ b/units/UAB5101/UAB5101_unit.bp
@@ -30,7 +30,6 @@ UnitBlueprint {
         'DEFENSE',
         'DRAGBUILD',
         'TECH1',
-        'WALL',
         'BENIGN',
         'VISIBLETORECON',
         'RECLAIMABLE',

--- a/units/UEB5101/UEB5101_unit.bp
+++ b/units/UEB5101/UEB5101_unit.bp
@@ -28,7 +28,6 @@ UnitBlueprint {
         'STRUCTURE',
         'DEFENSE',
         'TECH1',
-        'WALL',
         'DRAGBUILD',
         'BENIGN',
         'VISIBLETORECON',

--- a/units/URB5101/URB5101_unit.bp
+++ b/units/URB5101/URB5101_unit.bp
@@ -28,7 +28,6 @@ UnitBlueprint {
         'STRUCTURE',
         'DEFENSE',
         'TECH1',
-        'WALL',
         'DRAGBUILD',
         'BENIGN',
         'VISIBLETORECON',

--- a/units/XSB5101/XSB5101_unit.bp
+++ b/units/XSB5101/XSB5101_unit.bp
@@ -34,7 +34,6 @@ UnitBlueprint {
         'DEFENSE',
         'DRAGBUILD',
         'TECH1',
-        'WALL',
         'BENIGN',
         'VISIBLETORECON',
         'RECLAIMABLE',


### PR DESCRIPTION
Issue: FAForever#2292

End result:
All walls in the camera view will be selected by double click. I have tested this and can confirm that there are no drawbacks in removing the 'Wall' flag.

P.S I think that GPG have added this flag intentionaly, but if we want to fix this, this is the only solution possible. 