### PR TITLE
Bomber speed fix.

### DIFF
--- a/units/DEA0202/DEA0202_Script.lua
+++ b/units/DEA0202/DEA0202_Script.lua
@@ -24,10 +24,14 @@ DEA0202 = Class(TAirUnit) {
     end,
                 
     OnGotTarget = function(self)
-        self.unit:SetBreakOffTriggerMult(2.0)
-        self.unit:SetBreakOffDistanceMult(8.0)
-        self.unit:SetSpeedMult(0.67)
-        TIFCarpetBombWeapon.IdleState.OnGotTarget(self)
+        if self.unit:IsUnitState('Moving') then
+           self.unit:SetSpeedMult(1.0)
+        else
+           self.unit:SetBreakOffTriggerMult(2.0)
+           self.unit:SetBreakOffDistanceMult(8.0)
+           self.unit:SetSpeedMult(0.67)
+           TIFCarpetBombWeapon.IdleState.OnGotTarget(self)
+        end
     end,
     OnFire = function(self)
         self.unit:RotateWings(self:GetCurrentTarget())
@@ -41,10 +45,14 @@ DEA0202 = Class(TAirUnit) {
     end,
                     
     OnGotTarget = function(self)
-        self.unit:SetBreakOffTriggerMult(2.0)
-        self.unit:SetBreakOffDistanceMult(8.0)
-        self.unit:SetSpeedMult(0.67)
-        TIFCarpetBombWeapon.OnGotTarget(self)
+        if self.unit:IsUnitState('Moving') then
+           self.unit:SetSpeedMult(1.0)
+        else
+           self.unit:SetBreakOffTriggerMult(2.0)
+           self.unit:SetBreakOffDistanceMult(8.0)
+           self.unit:SetSpeedMult(0.67)
+           TIFCarpetBombWeapon.OnGotTarget(self)
+        end
     end,
         
     OnLostTarget = function(self)

--- a/units/DEA0202/DEA0202_Script.lua
+++ b/units/DEA0202/DEA0202_Script.lua
@@ -1,0 +1,123 @@
+#****************************************************************************
+#**
+#**  File     :  /cdimage/units/DEA0202/DEA0202_script.lua
+#**  Author(s):  John Comes, David Tomandl, Jessica St. Croix, Matt Vainio
+#**
+#**  Summary  :  UEF Supersonic Fighter Script
+#**
+#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+
+local TAirUnit = import('/lua/terranunits.lua').TAirUnit
+local TAirToAirLinkedRailgun = import('/lua/terranweapons.lua').TAirToAirLinkedRailgun
+local TIFCarpetBombWeapon = import('/lua/terranweapons.lua').TIFCarpetBombWeapon
+
+DEA0202 = Class(TAirUnit) {
+    Weapons = {
+        RightBeam = Class(TAirToAirLinkedRailgun) {},
+        LeftBeam = Class(TAirToAirLinkedRailgun) {},
+        Bomb = Class(TIFCarpetBombWeapon) {
+
+            IdleState = State (TIFCarpetBombWeapon.IdleState) {
+                Main = function(self)
+                    TIFCarpetBombWeapon.IdleState.Main(self)
+                end,
+                
+                OnGotTarget = function(self)
+                    self.unit:SetBreakOffTriggerMult(2.0)
+                    self.unit:SetBreakOffDistanceMult(8.0)
+                    self.unit:SetSpeedMult(0.67)
+                    TIFCarpetBombWeapon.IdleState.OnGotTarget(self)
+                end,
+                OnFire = function(self)
+                    self.unit:RotateWings(self:GetCurrentTarget())
+                    TIFCarpetBombWeapon.IdleState.OnFire(self)
+                end,                
+            },
+            
+            OnFire = function(self)
+                self.unit:RotateWings(self:GetCurrentTarget())
+                TIFCarpetBombWeapon.OnFire(self)
+            end,
+                    
+            OnGotTarget = function(self)
+                self.unit:SetBreakOffTriggerMult(2.0)
+                self.unit:SetBreakOffDistanceMult(8.0)
+                self.unit:SetSpeedMult(0.67)
+                TIFCarpetBombWeapon.OnGotTarget(self)
+            end,
+        
+            OnLostTarget = function(self)
+                self.unit:SetBreakOffTriggerMult(1.0)
+                self.unit:SetBreakOffDistanceMult(1.0)
+                self.unit:SetSpeedMult(1.0)
+                TIFCarpetBombWeapon.OnLostTarget(self)
+            end,        
+        },
+    },
+    
+    
+    RotateWings = function(self, target)
+        if not self.LWingRotator then
+            self.LWingRotator = CreateRotator(self, 'Left_Wing', 'y')
+            self.Trash:Add(self.LWingRotator)
+        end
+        if not self.RWingRotator then
+            self.RWingRotator = CreateRotator(self, 'Right_Wing', 'y')
+            self.Trash:Add(self.RWingRotator)
+        end
+        local fighterAngle = -105
+        local bomberAngle = 0
+        local wingSpeed = 45
+        if target and EntityCategoryContains(categories.AIR, target) then
+            if self.LWingRotator then
+                self.LWingRotator:SetSpeed(wingSpeed)
+                self.LWingRotator:SetGoal(-fighterAngle)
+            end
+            if self.RWingRotator then
+                self.RWingRotator:SetSpeed(wingSpeed)
+                self.RWingRotator:SetGoal(fighterAngle)
+            end
+        else
+            if self.LWingRotator then
+                self.LWingRotator:SetSpeed(wingSpeed)
+                self.LWingRotator:SetGoal(-bomberAngle)
+            end
+            if self.RWingRotator then
+                self.RWingRotator:SetSpeed(wingSpeed)
+                self.RWingRotator:SetGoal(bomberAngle)
+            end                
+        end  
+    end,
+    
+    OnCreate = function(self)
+        TAirUnit.OnCreate(self)
+        self:ForkThread(self.MonitorWings)
+    end,
+    
+    MonitorWings = function(self)
+        local airTargetRight
+        local airTargetLeft
+        while self and not self:IsDead() do
+            WaitSeconds(1)
+            local airTargetWeapon = self:GetWeaponByLabel('RightBeam')
+            if airTargetWeapon then     
+                airTargetRight = airTargetWeapon:GetCurrentTarget()
+            end
+            airTargetWeapon = self:GetWeaponByLabel('LeftBeam')
+            if airTargetWeapon then
+                airTargetLeft = airTargetWeapon:GetCurrentTarget()
+            end
+            
+            if airTargetRight then
+                self:RotateWings(airTargetRight)              
+            elseif airTargetLeft then
+                self:RotateWings(airTargetLeft)             
+            else
+                self:RotateWings(nil)
+            end
+        end
+    end,
+}
+
+TypeClass = DEA0202

--- a/units/DEA0202/DEA0202_Script.lua
+++ b/units/DEA0202/DEA0202_Script.lua
@@ -1,12 +1,12 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/DEA0202/DEA0202_script.lua
-#**  Author(s):  John Comes, David Tomandl, Jessica St. Croix, Matt Vainio
-#**
-#**  Summary  :  UEF Supersonic Fighter Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/DEA0202/DEA0202_script.lua
+--**  Author(s):  John Comes, David Tomandl, Jessica St. Croix, Matt Vainio
+--**
+--**  Summary  :  UEF Supersonic Fighter Script
+--**
+--**  Copyright Â© 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local TAirUnit = import('/lua/terranunits.lua').TAirUnit
 local TAirToAirLinkedRailgun = import('/lua/terranweapons.lua').TAirToAirLinkedRailgun
@@ -18,41 +18,41 @@ DEA0202 = Class(TAirUnit) {
         LeftBeam = Class(TAirToAirLinkedRailgun) {},
         Bomb = Class(TIFCarpetBombWeapon) {
 
-            IdleState = State (TIFCarpetBombWeapon.IdleState) {
-                Main = function(self)
-                    TIFCarpetBombWeapon.IdleState.Main(self)
-                end,
+    IdleState = State (TIFCarpetBombWeapon.IdleState) {
+        Main = function(self)
+        TIFCarpetBombWeapon.IdleState.Main(self)
+    end,
                 
-                OnGotTarget = function(self)
-                    self.unit:SetBreakOffTriggerMult(2.0)
-                    self.unit:SetBreakOffDistanceMult(8.0)
-                    self.unit:SetSpeedMult(0.67)
-                    TIFCarpetBombWeapon.IdleState.OnGotTarget(self)
-                end,
-                OnFire = function(self)
-                    self.unit:RotateWings(self:GetCurrentTarget())
-                    TIFCarpetBombWeapon.IdleState.OnFire(self)
-                end,                
-            },
+    OnGotTarget = function(self)
+        self.unit:SetBreakOffTriggerMult(2.0)
+        self.unit:SetBreakOffDistanceMult(8.0)
+        self.unit:SetSpeedMult(0.67)
+        TIFCarpetBombWeapon.IdleState.OnGotTarget(self)
+    end,
+    OnFire = function(self)
+        self.unit:RotateWings(self:GetCurrentTarget())
+        TIFCarpetBombWeapon.IdleState.OnFire(self)
+    end,                
+    },
             
-            OnFire = function(self)
-                self.unit:RotateWings(self:GetCurrentTarget())
-                TIFCarpetBombWeapon.OnFire(self)
-            end,
+    OnFire = function(self)
+        self.unit:RotateWings(self:GetCurrentTarget())
+        TIFCarpetBombWeapon.OnFire(self)
+    end,
                     
-            OnGotTarget = function(self)
-                self.unit:SetBreakOffTriggerMult(2.0)
-                self.unit:SetBreakOffDistanceMult(8.0)
-                self.unit:SetSpeedMult(0.67)
-                TIFCarpetBombWeapon.OnGotTarget(self)
-            end,
+    OnGotTarget = function(self)
+        self.unit:SetBreakOffTriggerMult(2.0)
+        self.unit:SetBreakOffDistanceMult(8.0)
+        self.unit:SetSpeedMult(0.67)
+        TIFCarpetBombWeapon.OnGotTarget(self)
+    end,
         
-            OnLostTarget = function(self)
-                self.unit:SetBreakOffTriggerMult(1.0)
-                self.unit:SetBreakOffDistanceMult(1.0)
-                self.unit:SetSpeedMult(1.0)
-                TIFCarpetBombWeapon.OnLostTarget(self)
-            end,        
+    OnLostTarget = function(self)
+        self.unit:SetBreakOffTriggerMult(1.0)
+        self.unit:SetBreakOffDistanceMult(1.0)
+        self.unit:SetSpeedMult(1.0)
+        TIFCarpetBombWeapon.OnLostTarget(self)
+    end,        
         },
     },
     

--- a/units/DRA0202/DRA0202_Script.lua
+++ b/units/DRA0202/DRA0202_Script.lua
@@ -1,0 +1,112 @@
+#****************************************************************************
+#**
+#**  File     :  /cdimage/units/DRA0202/DRA0202_script.lua
+#**  Author(s):  Dru Staltman, Eric Williamson
+#**
+#**  Summary  :  Cybran Bomber Fighter Script
+#**
+#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+
+local CAirUnit = import('/lua/cybranunits.lua').CAirUnit
+local CAAMissileNaniteWeapon = import('/lua/cybranweapons.lua').CAAMissileNaniteWeapon
+local CIFMissileCorsairWeapon = import('/lua/cybranweapons.lua').CIFMissileCorsairWeapon
+
+DRA0202 = Class(CAirUnit) {
+    Weapons = {
+        AntiAirMissiles = Class(CAAMissileNaniteWeapon) {},
+        GroundMissile = Class(CIFMissileCorsairWeapon) {
+        
+            IdleState = State (CIFMissileCorsairWeapon.IdleState) {
+                Main = function(self)
+                    CIFMissileCorsairWeapon.IdleState.Main(self)
+                end,
+                
+                OnGotTarget = function(self)
+                    self.unit:SetBreakOffTriggerMult(2.0)
+                    self.unit:SetBreakOffDistanceMult(8.0)
+                    self.unit:SetSpeedMult(0.67)
+                    CIFMissileCorsairWeapon.IdleState.OnGotTarget(self)
+                end,            
+            },
+        
+            OnGotTarget = function(self)
+                self.unit:SetBreakOffTriggerMult(2.0)
+                self.unit:SetBreakOffDistanceMult(8.0)
+                self.unit:SetSpeedMult(0.67)
+                CIFMissileCorsairWeapon.OnGotTarget(self)
+            end,
+        
+            OnLostTarget = function(self)
+                self.unit:SetBreakOffTriggerMult(1.0)
+                self.unit:SetBreakOffDistanceMult(1.0)
+                self.unit:SetSpeedMult(1.0)
+                CIFMissileCorsairWeapon.OnLostTarget(self)
+            end,
+        },
+    },
+    OnStopBeingBuilt = function(self,builder,layer)
+        CAirUnit.OnStopBeingBuilt(self,builder,layer)
+        self:SetMaintenanceConsumptionInactive()
+        self:SetScriptBit('RULEUTC_StealthToggle', true)
+        self:RequestRefreshUI()
+    end,
+ 
+    RotateWings = function(self, target)
+        if not self.LWingRotator then
+            self.LWingRotator = CreateRotator(self, 'B01', 'x')
+            self.Trash:Add(self.LWingRotator)
+        end
+        if not self.RWingRotator then
+            self.RWingRotator = CreateRotator(self, 'B03', 'x')
+            self.Trash:Add(self.RWingRotator)
+        end
+        local fighterAngle = 0
+        local bomberAngle = -90
+        local wingSpeed = 45
+        if target and EntityCategoryContains(categories.AIR, target) then
+            if self.LWingRotator then
+                self.LWingRotator:SetSpeed(wingSpeed)
+                self.LWingRotator:SetGoal(-fighterAngle)
+            end
+            if self.RWingRotator then
+                self.RWingRotator:SetSpeed(wingSpeed)
+                self.RWingRotator:SetGoal(fighterAngle)
+            end
+        else
+            if self.LWingRotator then
+                self.LWingRotator:SetSpeed(wingSpeed)
+                self.LWingRotator:SetGoal(-bomberAngle)
+            end
+            if self.RWingRotator then
+                self.RWingRotator:SetSpeed(wingSpeed)
+                self.RWingRotator:SetGoal(bomberAngle)
+            end                
+        end  
+    end, 
+ 
+    OnCreate = function(self)
+        CAirUnit.OnCreate(self)
+        self:ForkThread(self.MonitorWings)
+    end,
+    
+    MonitorWings = function(self)
+        local airTarget
+        while self and not self:IsDead() do
+            WaitSeconds(1)
+            local airTargetWeapon = self:GetWeaponByLabel('AntiAirMissiles')
+            if airTargetWeapon then     
+                airTarget = airTargetWeapon:GetCurrentTarget()
+            end
+
+            if airTarget then
+                self:RotateWings(airTarget)                            
+            else
+                self:RotateWings(nil)
+            end
+        end
+    end, 
+    
+}
+
+TypeClass = DRA0202

--- a/units/DRA0202/DRA0202_Script.lua
+++ b/units/DRA0202/DRA0202_Script.lua
@@ -1,12 +1,12 @@
-#****************************************************************************
-#**
-#**  File     :  /cdimage/units/DRA0202/DRA0202_script.lua
-#**  Author(s):  Dru Staltman, Eric Williamson
-#**
-#**  Summary  :  Cybran Bomber Fighter Script
-#**
-#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/DRA0202/DRA0202_script.lua
+--**  Author(s):  Dru Staltman, Eric Williamson
+--**
+--**  Summary  :  Cybran Bomber Fighter Script
+--**
+--**  Copyright Â© 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
 local CAirUnit = import('/lua/cybranunits.lua').CAirUnit
 local CAAMissileNaniteWeapon = import('/lua/cybranweapons.lua').CAAMissileNaniteWeapon
@@ -17,32 +17,32 @@ DRA0202 = Class(CAirUnit) {
         AntiAirMissiles = Class(CAAMissileNaniteWeapon) {},
         GroundMissile = Class(CIFMissileCorsairWeapon) {
         
-            IdleState = State (CIFMissileCorsairWeapon.IdleState) {
-                Main = function(self)
-                    CIFMissileCorsairWeapon.IdleState.Main(self)
-                end,
+    IdleState = State (CIFMissileCorsairWeapon.IdleState) {
+    Main = function(self)
+        CIFMissileCorsairWeapon.IdleState.Main(self)
+    end,
                 
-                OnGotTarget = function(self)
-                    self.unit:SetBreakOffTriggerMult(2.0)
-                    self.unit:SetBreakOffDistanceMult(8.0)
-                    self.unit:SetSpeedMult(0.67)
-                    CIFMissileCorsairWeapon.IdleState.OnGotTarget(self)
-                end,            
-            },
+    OnGotTarget = function(self)
+        self.unit:SetBreakOffTriggerMult(2.0)
+        self.unit:SetBreakOffDistanceMult(8.0)
+        self.unit:SetSpeedMult(0.67)
+        CIFMissileCorsairWeapon.IdleState.OnGotTarget(self)
+    end,            
+    },
         
-            OnGotTarget = function(self)
-                self.unit:SetBreakOffTriggerMult(2.0)
-                self.unit:SetBreakOffDistanceMult(8.0)
-                self.unit:SetSpeedMult(0.67)
-                CIFMissileCorsairWeapon.OnGotTarget(self)
-            end,
+    OnGotTarget = function(self)
+        self.unit:SetBreakOffTriggerMult(2.0)
+        self.unit:SetBreakOffDistanceMult(8.0)
+        self.unit:SetSpeedMult(0.67)
+        CIFMissileCorsairWeapon.OnGotTarget(self)
+    end,
         
-            OnLostTarget = function(self)
-                self.unit:SetBreakOffTriggerMult(1.0)
-                self.unit:SetBreakOffDistanceMult(1.0)
-                self.unit:SetSpeedMult(1.0)
-                CIFMissileCorsairWeapon.OnLostTarget(self)
-            end,
+    OnLostTarget = function(self)
+        self.unit:SetBreakOffTriggerMult(1.0)
+        self.unit:SetBreakOffDistanceMult(1.0)
+        self.unit:SetSpeedMult(1.0)
+        CIFMissileCorsairWeapon.OnLostTarget(self)
+    end,
         },
     },
     OnStopBeingBuilt = function(self,builder,layer)

--- a/units/DRA0202/DRA0202_Script.lua
+++ b/units/DRA0202/DRA0202_Script.lua
@@ -23,18 +23,26 @@ DRA0202 = Class(CAirUnit) {
     end,
                 
     OnGotTarget = function(self)
-        self.unit:SetBreakOffTriggerMult(2.0)
-        self.unit:SetBreakOffDistanceMult(8.0)
-        self.unit:SetSpeedMult(0.67)
-        CIFMissileCorsairWeapon.IdleState.OnGotTarget(self)
+        if self.unit:IsUnitState('Moving') then
+           self.unit:SetSpeedMult(1.0)
+        else
+           self.unit:SetBreakOffTriggerMult(2.0)
+           self.unit:SetBreakOffDistanceMult(8.0)
+           self.unit:SetSpeedMult(0.67)
+           CIFMissileCorsairWeapon.IdleState.OnGotTarget(self)
+        end
     end,            
     },
         
     OnGotTarget = function(self)
-        self.unit:SetBreakOffTriggerMult(2.0)
-        self.unit:SetBreakOffDistanceMult(8.0)
-        self.unit:SetSpeedMult(0.67)
-        CIFMissileCorsairWeapon.OnGotTarget(self)
+        if self.unit:IsUnitState('Moving') then
+           self.unit:SetSpeedMult(1.0)
+        else
+           self.unit:SetBreakOffTriggerMult(2.0)
+           self.unit:SetBreakOffDistanceMult(8.0)
+           self.unit:SetSpeedMult(0.67)
+           CIFMissileCorsairWeapon.OnGotTarget(self)
+        end
     end,
         
     OnLostTarget = function(self)

--- a/units/XSA0202/XSA0202_Script.lua
+++ b/units/XSA0202/XSA0202_Script.lua
@@ -1,0 +1,54 @@
+#****************************************************************************
+#**
+#**  File     :  /data/units/XSA0202/XSA0202_script.lua
+#**  Author(s):  Jessica St. Croix, Gordon Duclos, Matt Vainio, Aaron Lundquist
+#**
+#**  Summary  :  Seraphim Fighter/Bomber Script
+#**
+#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+local SAirUnit = import('/lua/seraphimunits.lua').SAirUnit
+local SeraphimWeapons = import('/lua/seraphimweapons.lua')
+local SAAShleoCannonWeapon = SeraphimWeapons.SAAShleoCannonWeapon
+local SDFBombOtheWeapon = SeraphimWeapons.SDFBombOtheWeapon
+
+XSA0202 = Class(SAirUnit) {
+    Weapons = {
+        ShleoAAGun01 = Class(SAAShleoCannonWeapon) {
+			FxMuzzleFlash = {'/effects/emitters/sonic_pulse_muzzle_flash_02_emit.bp',},
+        },
+        ShleoAAGun02 = Class(SAAShleoCannonWeapon) {
+			FxMuzzleFlash = {'/effects/emitters/sonic_pulse_muzzle_flash_02_emit.bp',},
+        },
+        Bomb = Class(SDFBombOtheWeapon) {
+                
+            IdleState = State (SDFBombOtheWeapon.IdleState) {
+                Main = function(self)
+                    SDFBombOtheWeapon.IdleState.Main(self)
+                end,
+                
+                OnGotTarget = function(self)
+                    self.unit:SetBreakOffTriggerMult(2.0)
+                    self.unit:SetBreakOffDistanceMult(8.0)
+                    self.unit:SetSpeedMult(0.67)
+                    SDFBombOtheWeapon.OnGotTarget(self)
+                end,                
+            },
+        
+            OnGotTarget = function(self)
+                self.unit:SetBreakOffTriggerMult(2.0)
+                self.unit:SetBreakOffDistanceMult(8.0)
+                self.unit:SetSpeedMult(0.67)
+                SDFBombOtheWeapon.OnGotTarget(self)
+            end,
+        
+            OnLostTarget = function(self)
+                self.unit:SetBreakOffTriggerMult(1.0)
+                self.unit:SetBreakOffDistanceMult(1.0)
+                self.unit:SetSpeedMult(1.0)
+                SDFBombOtheWeapon.OnLostTarget(self)
+            end,  	
+        },
+    },
+}
+TypeClass = XSA0202

--- a/units/XSA0202/XSA0202_Script.lua
+++ b/units/XSA0202/XSA0202_Script.lua
@@ -28,18 +28,26 @@ XSA0202 = Class(SAirUnit) {
                 end,
                 
         OnGotTarget = function(self)
-            self.unit:SetBreakOffTriggerMult(2.0)
-            self.unit:SetBreakOffDistanceMult(8.0)
-            self.unit:SetSpeedMult(0.67)
-            SDFBombOtheWeapon.OnGotTarget(self)
+            if self.unit:IsUnitState('Moving') then
+               self.unit:SetSpeedMult(1.0)
+            else
+               self.unit:SetBreakOffTriggerMult(2.0)
+               self.unit:SetBreakOffDistanceMult(8.0)
+               self.unit:SetSpeedMult(0.67)
+               SDFBombOtheWeapon.OnGotTarget(self)
+            end
         end,                
             },
         
         OnGotTarget = function(self)
-            self.unit:SetBreakOffTriggerMult(2.0)
-            self.unit:SetBreakOffDistanceMult(8.0)
-            self.unit:SetSpeedMult(0.67)
-            SDFBombOtheWeapon.OnGotTarget(self)
+            if self.unit:IsUnitState('Moving') then
+               self.unit:SetSpeedMult(1.0)
+            else
+               self.unit:SetBreakOffTriggerMult(2.0)
+               self.unit:SetBreakOffDistanceMult(8.0)
+               self.unit:SetSpeedMult(0.67)
+               SDFBombOtheWeapon.OnGotTarget(self)
+            end
         end,
         
         OnLostTarget = function(self)

--- a/units/XSA0202/XSA0202_Script.lua
+++ b/units/XSA0202/XSA0202_Script.lua
@@ -1,12 +1,12 @@
-#****************************************************************************
-#**
-#**  File     :  /data/units/XSA0202/XSA0202_script.lua
-#**  Author(s):  Jessica St. Croix, Gordon Duclos, Matt Vainio, Aaron Lundquist
-#**
-#**  Summary  :  Seraphim Fighter/Bomber Script
-#**
-#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /data/units/XSA0202/XSA0202_script.lua
+--**  Author(s):  Jessica St. Croix, Gordon Duclos, Matt Vainio, Aaron Lundquist
+--**
+--**  Summary  :  Seraphim Fighter/Bomber Script
+--**
+--**  Copyright Â© 2007 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 local SAirUnit = import('/lua/seraphimunits.lua').SAirUnit
 local SeraphimWeapons = import('/lua/seraphimweapons.lua')
 local SAAShleoCannonWeapon = SeraphimWeapons.SAAShleoCannonWeapon
@@ -22,32 +22,32 @@ XSA0202 = Class(SAirUnit) {
         },
         Bomb = Class(SDFBombOtheWeapon) {
                 
-            IdleState = State (SDFBombOtheWeapon.IdleState) {
-                Main = function(self)
+        IdleState = State (SDFBombOtheWeapon.IdleState) {
+        Main = function(self)
                     SDFBombOtheWeapon.IdleState.Main(self)
                 end,
                 
-                OnGotTarget = function(self)
-                    self.unit:SetBreakOffTriggerMult(2.0)
-                    self.unit:SetBreakOffDistanceMult(8.0)
-                    self.unit:SetSpeedMult(0.67)
-                    SDFBombOtheWeapon.OnGotTarget(self)
-                end,                
+        OnGotTarget = function(self)
+            self.unit:SetBreakOffTriggerMult(2.0)
+            self.unit:SetBreakOffDistanceMult(8.0)
+            self.unit:SetSpeedMult(0.67)
+            SDFBombOtheWeapon.OnGotTarget(self)
+        end,                
             },
         
-            OnGotTarget = function(self)
-                self.unit:SetBreakOffTriggerMult(2.0)
-                self.unit:SetBreakOffDistanceMult(8.0)
-                self.unit:SetSpeedMult(0.67)
-                SDFBombOtheWeapon.OnGotTarget(self)
-            end,
+        OnGotTarget = function(self)
+            self.unit:SetBreakOffTriggerMult(2.0)
+            self.unit:SetBreakOffDistanceMult(8.0)
+            self.unit:SetSpeedMult(0.67)
+            SDFBombOtheWeapon.OnGotTarget(self)
+        end,
         
-            OnLostTarget = function(self)
-                self.unit:SetBreakOffTriggerMult(1.0)
-                self.unit:SetBreakOffDistanceMult(1.0)
-                self.unit:SetSpeedMult(1.0)
-                SDFBombOtheWeapon.OnLostTarget(self)
-            end,  	
+        OnLostTarget = function(self)
+            self.unit:SetBreakOffTriggerMult(1.0)
+            self.unit:SetBreakOffDistanceMult(1.0)
+            self.unit:SetSpeedMult(1.0)
+            SDFBombOtheWeapon.OnLostTarget(self)
+        end,  	
         },
     },
 }


### PR DESCRIPTION
Issue: https://github.com/FAForever/fa/issues/2321 and https://github.com/FAForever/fa/issues/2322

Description: The Notha, Corsair and Janus no longer slow down on the move order. Other commands will cause slow down. 
There is also similar script for t1 bombers, however I did not touch this in currect PR. 
Corsairs will no longer attack ground units on the movem whence not slow down. They will attack with patrol, attackmove, attack, or idle. 
Other bombers did not have corsair problem, but they were still slowing down in enemy range for no reason (on move command). 

I know, that you guys dont have time to review my PRs or test them, so i made i video to enhance the first one.
https://www.youtube.com/watch?v=yqKmcBocXDg&feature=youtu.be
