### PR TITLE
remove Campaign

### DIFF
--- a/lua/ui/menus/main.lua
+++ b/lua/ui/menus/main.lua
@@ -105,7 +105,7 @@ function CreateUI()
         {
             name = '<LOC _Campaign>',
             tooltip = 'mainmenu_campaign',
-            action = function() ButtonCampaign() end,
+            action = function() ButtonSkirmish() end,
         },
         {
             name = '<LOC _Skirmish>',


### PR DESCRIPTION
changes the Campaign button to load the Skirmish menu since the Campaign
doesn't work anyway and coop missions should be loaded via the
skirmish/multiplayer menu