### PR TITLE
Allow ED4 to be built by T3 engineers and commanders

### DIFF
--- a/units/URB4205/URB4205_unit.bp
+++ b/units/URB4205/URB4205_unit.bp
@@ -114,7 +114,7 @@ UnitBlueprint {
     Economy = {
         BuildCostEnergy = 17000,
         BuildCostMass = 1260,
-        BuildRate = 12.23,
+        BuildRate = 30.575,
         BuildTime = 1067,
         BuildableCategory = {
             'urb4206',

--- a/units/URB4206/URB4206_unit.bp
+++ b/units/URB4206/URB4206_unit.bp
@@ -117,7 +117,7 @@ UnitBlueprint {
         BuildCostEnergy = 41000,
         BuildCostMass = 2460,
         BuildRate = 11.81,
-        BuildTime = 1467,
+        BuildTime = 3667,
         BuildableCategory = {
             'urb4207',
         },

--- a/units/URB4206/URB4206_unit.bp
+++ b/units/URB4206/URB4206_unit.bp
@@ -30,10 +30,12 @@ UnitBlueprint {
     Categories = {
         'PRODUCTSC1',
         'SELECTABLE',
+        'BUILTBYTIER3ENGINEER',
+        'BUILTBYTIER3COMMANDER',
         'CYBRAN',
         'STRUCTURE',
         'DEFENSE',
-        'TECH2',
+        'TECH3',
         'SHIELD',
         'DRAGBUILD',
         'SIZE12',

--- a/units/URB4207/URB4207_unit.bp
+++ b/units/URB4207/URB4207_unit.bp
@@ -33,7 +33,7 @@ UnitBlueprint {
         'CYBRAN',
         'STRUCTURE',
         'DEFENSE',
-        'TECH2',
+        'TECH3',
         'SHIELD',
         'DRAGBUILD',
         'SIZE12',


### PR DESCRIPTION
Allow ED4 to be built by T3 engineers and commanders and adjust the built time to be in line with other t3 shields.