### PR TITLE
reintroduce tracking to cybran autocannon projectile

### DIFF
--- a/projectiles/CAAAutocannon01/CAAAutocannon01_proj.bp
+++ b/projectiles/CAAAutocannon01/CAAAutocannon01_proj.bp
@@ -42,6 +42,7 @@ ProjectileBlueprint {
         DestroyOnWater = true,
         InitialSpeed = 35,
         Lifetime = 1.5,
+        TrackTarget = true,
         TurnRate = 25,
         UseGravity = false,
         VelocityAlign = true,


### PR DESCRIPTION
Bring back tracking to fix the carrier missing a large amount of its shots. 

Fixes #2404 