### PR TITLE
fix ShieldSpillOverDamageMod

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -55,7 +55,7 @@ Shield = Class(moho.shield_methods, Entity) {
         self:SetMaxHealth(spec.ShieldMaxHealth)
         self:SetHealth(self, spec.ShieldMaxHealth)
         self:SetType('Bubble')
-        self.SpillOverDmgMod = math.max(spec.SpillOverDamageMod or 0.15, 0)
+        self.SpillOverDmgMod = math.max(spec.ShieldSpillOverDamageMod or 0.15, 0)
 
         -- Show our 'lifebar'
         self:UpdateShieldRatio(1.0)


### PR DESCRIPTION
Mobile shields have a line in their bp files ShieldSpillOverDamageMod which did nothing because of a typo. 
The affected units are T2 mobile shields, T3 mobile shield, Fatboy, UEF ACU bubble shield, Shieldboat, UEF SCU bubble shield and T3 transport. 