### PR TITLE
fix 'Game object has been destroyed'

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2032,7 +2032,7 @@ ConstructionUnit = Class(MobileUnit) {
         -- as it doesn't know it's doing something bad. To fix it, we temporarily make the unit immobile when it starts construction.
         if self:IsMoving() then
             self:SetImmobile(true)
-            ForkThread(function() WaitTicks(1) self:SetImmobile(false) end)
+            ForkThread(function() WaitTicks(1) if not self:BeenDestroyed() then self:SetImmobile(false) end end)
         end
     end,
 
@@ -2145,7 +2145,7 @@ CommandUnit = Class(WalkingLandUnit) {
         -- as it doesn't know it's doing something bad. To fix it, we temporarily make the unit immobile when it starts construction.
         if self:IsMoving() then
             self:SetImmobile(true)
-            ForkThread(function() WaitTicks(1) self:SetImmobile(false) end)
+            ForkThread(function() WaitTicks(1) if not self:BeenDestroyed() then self:SetImmobile(false) end end)
         end
     end,
 


### PR DESCRIPTION
http://forums.faforever.com/viewtopic.php?f=3&t=16275

![bug](https://user-images.githubusercontent.com/36897892/40880796-01dbd5e6-66c0-11e8-9aa2-579b55b1285c.png)

Unit can die during this "WaitTicks(1)", so check is needed.

There are some more bugs in this log (see Exotic's post). But as long as this bugs don't cause crashes - "don't touch it" :D



