### PR TITLE
Added new option: AI Replacement (Fixed)

### DIFF
--- a/lua/AI/sorianlang.lua
+++ b/lua/AI/sorianlang.lua
@@ -314,4 +314,9 @@ AIChatText = {
         'I got it.',
         'No problem.',
     },
+    takingcontrol = {
+        'Taking control of this army!',
+        'Don\'t panic, I am here!',
+        'The other Commander has been relieved, let\'s get this party started.',
+    }
 }

--- a/lua/AI/sorianlang.lua
+++ b/lua/AI/sorianlang.lua
@@ -314,9 +314,4 @@ AIChatText = {
         'I got it.',
         'No problem.',
     },
-    takingcontrol = {
-        'Taking control of this army!',
-        'Don\'t panic, I am here!',
-        'The other Commander has been relieved, let\'s get this party started.',
-    }
 }

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -3410,31 +3410,7 @@ AIBrain = Class(moho.aibrain_methods) {
 
     AbandonedByPlayer = function(self)
         if not IsGameOver() then
-            if ScenarioInfo.Options.AIReplacement == 'AIReplacementOff' then
-                self:OnDefeat()
-            else
-                ForkThread(function()
-                    local oldName = ArmyBrains[self:GetArmyIndex()].Nickname
-
-                    WaitSeconds(1)
-
-                    -- Reassign all Army attributes to better suit the AI.
-                    self.BrainType = 'AI'
-                    self.ConditionsMonitor = BrainConditionsMonitor.CreateConditionsMonitor(self)
-                    self.NumBases = 1
-                    self.BuilderManagers = {}
-                    self:AddBuilderManagers(self:GetStartVector3f(), 100, 'MAIN', false)
-                    SUtils.AddCustomUnitSupport(self)
-
-                    ArmyBrains[self:GetArmyIndex()].Nickname = 'CMDR Sorian..(was '..oldName..')'
-                    ScenarioInfo.ArmySetup[self.Name].AIPersonality = 'sorianadaptive'
-
-                    SUtils.AISendChat('all', ArmyBrains[self:GetArmyIndex()].Nickname, 'takingcontrol')
-
-                    self:InitializeSkirmishSystems()
-                    self:OnCreateAI(planName)
-                end)
-            end
+            self:OnDefeat()
         end
     end,
 

--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -418,6 +418,24 @@ globalOpts = {
             },
         },
     },
+    {
+    	default = 2,
+        label = "AI Replacement",
+        help = "Toggle AI Replacement if a player disconnects.",
+        key = 'AIReplacement',
+        values = {
+            {
+                text = "<LOC _On>On",
+                help = "If a player disconnects and the ACU is still active, an AI will be created to take control of units that belonged to the player who disconnected.",
+                key = 'AIReplacementOn',
+            },
+            {
+                text = "<LOC _Off>Off",
+                help = "A disconnected player will cause the destruction of their units based on share conditions.",
+                key = 'AIReplacementOff',
+            },
+        },
+	},
 }
 
 AIOpts = {

--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -418,24 +418,6 @@ globalOpts = {
             },
         },
     },
-    {
-    	default = 2,
-        label = "AI Replacement",
-        help = "Toggle AI Replacement if a player disconnects.",
-        key = 'AIReplacement',
-        values = {
-            {
-                text = "<LOC _On>On",
-                help = "If a player disconnects and the ACU is still active, an AI will be created to take control of units that belonged to the player who disconnected.",
-                key = 'AIReplacementOn',
-            },
-            {
-                text = "<LOC _Off>Off",
-                help = "A disconnected player will cause the destruction of their units based on share conditions.",
-                key = 'AIReplacementOff',
-            },
-        },
-	},
 }
 
 AIOpts = {

--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -418,6 +418,24 @@ globalOpts = {
             },
         },
     },
+    {
+        default = 2,
+        label = "AI Replacement",
+        help = "Toggle AI Replacement if a player disconnects.",
+        key = 'AIReplacement',
+        values = {
+            {
+                text = "<LOC _On>On",
+                help = "If a player disconnects and the ACU is still active, an AI will be created to take control of units that belonged to the player who disconnected.",
+                key = 'AIReplacementOn',
+            },
+            {
+                text = "<LOC _Off>Off",
+                help = "A disconnected player will cause the destruction of their units based on share conditions.",
+                key = 'AIReplacementOff',
+            },
+        },
+    },
 }
 
 AIOpts = {


### PR DESCRIPTION
Okay, so as of recently, I have been thinking about how disconnections mid-game could cause some major issues during games. Thinking about it, I realised that there are games out there that replace the disconnected player with an AI of max difficulty. Games like Gears of War have this kind of system. I discussed it with a few members on our Slack and decided I would attempt to implement a new option which can be enabled through your game lobby. This idea is mainly targetting lower rated games or "All Welcome Games". 

I've made some good progress with this idea. When a player disconnects from the game, they are replaced by a Sorian Adaptive AI which takes control of the army and units around. A chat message is sent out by the AI informing team mates that the disconnected player has been replaced by an active AI.

Here are some images to show an example:
![image](https://user-images.githubusercontent.com/17053495/41191140-e709d290-6be2-11e8-8072-fa4c8cd06912.png)
![image](https://user-images.githubusercontent.com/17053495/41191142-eaf5371e-6be2-11e8-828b-3bf1d8d5ef6f.png)
![image](https://user-images.githubusercontent.com/17053495/41191145-edfcb64e-6be2-11e8-865d-629779a3d0cf.png)