### PR TITLE
fix t3 Arty targeting when shooting at higher ground

### DIFF
--- a/units/UAB2302/UAB2302_unit.bp
+++ b/units/UAB2302/UAB2302_unit.bp
@@ -243,7 +243,7 @@ UnitBlueprint {
             MuzzleChargeDelay = 2.5,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 65,
+            MuzzleVelocity = 75,
             MuzzleVelocityReduceDistance = 800,
             ProjectileId = '/projectiles/AIFSonanceShell02/AIFSonanceShell02_proj.bp',
             ProjectileLifetime = 120,

--- a/units/UEB2302/UEB2302_unit.bp
+++ b/units/UEB2302/UEB2302_unit.bp
@@ -230,7 +230,7 @@ UnitBlueprint {
             MinRadius = 150,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 65,
+            MuzzleVelocity = 75,
             MuzzleVelocityReduceDistance = 800,
             ProjectileId = '/projectiles/TIFAntiMatterShells01/TIFAntiMatterShells01_proj.bp',
             ProjectileLifetime = 120,

--- a/units/URB2302/URB2302_unit.bp
+++ b/units/URB2302/URB2302_unit.bp
@@ -219,7 +219,7 @@ UnitBlueprint {
             MinRadius = 150,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 65,
+            MuzzleVelocity = 75,
             MuzzleVelocityReduceDistance = 800,
             ProjectileId = '/projectiles/CIFArtilleryProton01/CIFArtilleryProton01_proj.bp',
             ProjectileLifetime = 120,

--- a/units/XSB2302/XSB2302_unit.bp
+++ b/units/XSB2302/XSB2302_unit.bp
@@ -251,7 +251,7 @@ UnitBlueprint {
             MuzzleChargeDelay = 0.5,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 65,
+            MuzzleVelocity = 75,
             MuzzleVelocityReduceDistance = 800,
             ProjectileId = '/projectiles/SIFSuthanusArtilleryShell02/SIFSuthanusArtilleryShell02_proj.bp',
             ProjectileLifetime = 120,


### PR DESCRIPTION
allows arty to shoot at higher ground
was possible before the last balance patch - so this is just a regression fix