### PR TITLE
Fix Omen's (*and Exodus) turrets

### DIFF
--- a/units/UAS0201/UAS0201_unit.bp
+++ b/units/UAS0201/UAS0201_unit.bp
@@ -285,7 +285,7 @@ UnitBlueprint {
             RateOfFire = 0.2,
             SlavedToBody = true,
             SlavedToBodyArcRange = 155,
-            TargetCheckInterval = 4,
+            TargetCheckInterval = 2,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
                 'NAVAL MOBILE',

--- a/units/UAS0302/UAS0302_unit.bp
+++ b/units/UAS0302/UAS0302_unit.bp
@@ -298,7 +298,7 @@ UnitBlueprint {
             RateOfFire = 0.17,
             SlavedToBody = true,
             SlavedToBodyArcRange = 155,
-            TargetCheckInterval = 8,
+            TargetCheckInterval = 2,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
                 'NAVAL MOBILE',
@@ -386,7 +386,7 @@ UnitBlueprint {
             RateOfFire = 0.17,
             SlavedToBody = true,
             SlavedToBodyArcRange = 155,
-            TargetCheckInterval = 8,
+            TargetCheckInterval = 2,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
                 'NAVAL MOBILE',
@@ -474,7 +474,7 @@ UnitBlueprint {
             RateOfFire = 0.17,
             SlavedToBody = true,
             SlavedToBodyArcRange = 155,
-            TargetCheckInterval = 8,
+            TargetCheckInterval = 2,
             TargetPriorities = {
                 'SPECIALHIGHPRI',
                 'NAVAL MOBILE',


### PR DESCRIPTION
TargetCheckInterval is more than RateOfFire.

Comparison with cybran:

![bs](https://user-images.githubusercontent.com/36897892/42784136-d8c9d856-8956-11e8-9df2-a3bb7abffac7.png)

So Omen's turrets just idling most of the time if you don't give them direct orders to attack smth. 
Replay ID: 8258690 (25 - 30 min, Robogear's navy)


*added Exodus. It has 4 sec interval and 5 sec reload time which is far from ideal too =)