### PR TITLE
SimSpeed patch.

### DIFF
--- a/lua/AI/AIBehaviors.lua
+++ b/lua/AI/AIBehaviors.lua
@@ -583,7 +583,7 @@ CommanderOverrideCheck = function(self)
     local weaponRange = mainWeapon:GetBlueprint().MaxRadius + 50 -- Look outside range.
 
     local commanders = aiBrain:GetUnitsAroundPoint(categories.COMMAND, self:GetPlatoonPosition(), weaponRange, 'Enemy')
-    if table.getn(commanders) == 0 or commanders[1]:IsDead() then
+    if table.getn(commanders) == 0 or commanders[1].Dead then
         return false
     end
 
@@ -2277,7 +2277,7 @@ CommanderOverrideCheckSorian = function(self)
     local aiBrain = self:GetBrain()
     local commanders = aiBrain:GetUnitsAroundPoint(categories.COMMAND, self:GetPlatoonPosition(), weaponRange, 'Enemy')
 
-    if table.getn(commanders) == 0 or commanders[1]:IsDead() or commanders[1]:GetCurrentLayer() == 'Seabed' then
+    if table.getn(commanders) == 0 or commanders[1].Dead or commanders[1]:GetCurrentLayer() == 'Seabed' then
         return false
     end
 

--- a/lua/AI/AIBuilders/AIAirAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AIAirAttackBuilders.lua
@@ -29,7 +29,7 @@ function AirAttackCondition(aiBrain, locationType, targetNumber)
     local engineerManager = aiBrain.BuilderManagers[locationType].EngineerManager
 
     local position = engineerManager:GetLocationCoords()
-    local radius = engineerManager:GetLocationRadius()
+    local radius = engineerManager.Radius
 
     local surfaceThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, position, radius)
     local airThreat = pool:GetPlatoonThreat('AntiAir', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, position, radius)

--- a/lua/AI/AIBuilders/AILandAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AILandAttackBuilders.lua
@@ -28,7 +28,7 @@ function LandAttackCondition(aiBrain, locationType, targetNumber)
     local engineerManager = aiBrain.BuilderManagers[locationType].EngineerManager
 
     local position = engineerManager:GetLocationCoords()
-    local radius = engineerManager:GetLocationRadius()
+    local radius = engineerManager.Radius
 
     local poolThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.LAND - categories.SCOUT - categories.ENGINEER, position, radius)
     if poolThreat > targetNumber then

--- a/lua/AI/AIBuilders/AISeaAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AISeaAttackBuilders.lua
@@ -29,7 +29,7 @@ function SeaAttackCondition(aiBrain, locationType, targetNumber)
     local engineerManager = aiBrain.BuilderManagers[locationType].EngineerManager
 
     local position = engineerManager:GetLocationCoords()
-    local radius = engineerManager:GetLocationRadius()
+    local radius = engineerManager.Radius
 
     local surfaceThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.NAVAL, position, radius)
     local subThreat = pool:GetPlatoonThreat('AntiSub', categories.MOBILE * categories.NAVAL, position, radius)

--- a/lua/AI/AIBuilders/SorianAirAttackBuilders.lua
+++ b/lua/AI/AIBuilders/SorianAirAttackBuilders.lua
@@ -40,7 +40,7 @@ function AirAttackCondition(aiBrain, locationType, targetNumber)
     end
 
     local position = engineerManager:GetLocationCoords()
-    local radius = engineerManager:GetLocationRadius()
+    local radius = engineerManager.Radius
 
     --local surfaceThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.AIR - categories.EXPERIMENTAL - categories.SCOUT - categories.INTELLIGENCE, position, radius)
     local surfaceThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.AIR - categories.EXPERIMENTAL - categories.SCOUT - categories.INTELLIGENCE)

--- a/lua/AI/AIBuilders/SorianExperimentalBuilders.lua
+++ b/lua/AI/AIBuilders/SorianExperimentalBuilders.lua
@@ -48,7 +48,7 @@ function T4LandAttackCondition(aiBrain, locationType, targetNumber)
     end
 
     local position = engineerManager:GetLocationCoords()
-    local radius = engineerManager:GetLocationRadius()
+    local radius = engineerManager.Radius
 
     --local surThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.LAND * categories.EXPERIMENTAL, position, radius * 2.5)
     local surThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.LAND * categories.EXPERIMENTAL)
@@ -80,7 +80,7 @@ function T4AirAttackCondition(aiBrain, locationType, targetNumber)
     end
 
     local position = engineerManager:GetLocationCoords()
-    local radius = engineerManager:GetLocationRadius()
+    local radius = engineerManager.Radius
 
     local surThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.AIR * categories.EXPERIMENTAL, position, radius * 2.5)
     if surThreat > targetNumber * .6 then

--- a/lua/AI/AIBuilders/SorianLandAttackBuilders.lua
+++ b/lua/AI/AIBuilders/SorianLandAttackBuilders.lua
@@ -42,7 +42,7 @@ function LandAttackCondition(aiBrain, locationType, targetNumber)
     end
 
     local position = engineerManager:GetLocationCoords()
-    local radius = engineerManager:GetLocationRadius()
+    local radius = engineerManager.Radius
 
     --local surThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.LAND - categories.EXPERIMENTAL - categories.SCOUT - categories.ENGINEER, position, radius)
     local surThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.LAND - categories.EXPERIMENTAL - categories.SCOUT - categories.ENGINEER)

--- a/lua/AI/AIBuilders/SorianSeaAttackBuilders.lua
+++ b/lua/AI/AIBuilders/SorianSeaAttackBuilders.lua
@@ -41,7 +41,7 @@ function SeaAttackCondition(aiBrain, locationType, targetNumber)
     #end
 
     local position = engineerManager:GetLocationCoords()
-    local radius = engineerManager:GetLocationRadius()
+    local radius = engineerManager.Radius
 
     --local surfaceThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.NAVAL, position, radius)
     --local subThreat = pool:GetPlatoonThreat('AntiSub', categories.MOBILE * categories.NAVAL, position, radius)

--- a/lua/AI/AIBuilders/SorianStrategyBuilders.lua
+++ b/lua/AI/AIBuilders/SorianStrategyBuilders.lua
@@ -867,9 +867,9 @@ BuilderGroup {
             local enemies = 0
             local allies = 0
             for k,v in ArmyBrains do
-                if not v:IsDefeated() and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
+                if not v.Result == "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
                     enemies = enemies + 1
-                elseif not v:IsDefeated() and not ArmyIsCivilian(v:GetArmyIndex()) and IsAlly(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
+                elseif not v.Result == "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsAlly(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
                     allies = allies + 1
                 end
             end

--- a/lua/AI/OpAI/BaseManager.lua
+++ b/lua/AI/OpAI/BaseManager.lua
@@ -472,7 +472,7 @@ BaseManager = Class {
     end,
 
     IsConstructionUnit = function(self, unit)
-        if not unit or unit:IsDead() then
+        if not unit or unit.Dead then
             return false
         end
 
@@ -677,7 +677,7 @@ BaseManager = Class {
 
     -- Determines if a specific unit needs upgrades, returns name of upgrade if needed
     UnitNeedsUpgrade = function(self, unit, unitType)
-        if unit:IsDead() then
+        if unit.Dead then
             return false
         end
 
@@ -759,7 +759,7 @@ BaseManager = Class {
 
     -- Check if a unit has upgrade
     CheckEnhancement = function(self, unit, upgrade)
-        if unit:IsDead() then
+        if unit.Dead then
             return false
         end
 
@@ -906,7 +906,7 @@ BaseManager = Class {
             if self.Active then
                 for k, v in self.UpgradeTable do
                     local unit = ScenarioInfo.UnitNames[armyIndex][v.UnitName]
-                    if unit and not unit:IsDead() then
+                    if unit and not unit.Dead then
                         -- Cybran engie stations are never in 'Idle' state but in 'AssistingCommander' state 
                         if not EntityCategoryContains(ParseEntityCategory(v.FinalUnit), unit) and (unit:IsIdleState() or unit:IsUnitState('AssistingCommander')) and not unit:IsBeingBuilt() then
                             self:ForkThread(self.BaseManagerUpgrade, unit, v.UnitName)
@@ -1047,10 +1047,10 @@ BaseManager = Class {
 
         local upgrading = true
         local newUnit = false
-        while not unit:IsDead() and upgrading do
+        while not unit.Dead and upgrading do
             WaitSeconds(3)
             upgrading = false
-            if unit and not unit:IsDead() then
+            if unit and not unit.Dead then
                 if not newUnit then
                     newUnit = unit.UnitBeingBuilt
                 end

--- a/lua/AI/aibuildstructures.lua
+++ b/lua/AI/aibuildstructures.lua
@@ -291,7 +291,7 @@ end
 function AINewExpansionBase(aiBrain, baseName, position, builder, constructionData)
     local radius = constructionData.ExpansionRadius or 100
     # PBM Style expansion bases here
-    if aiBrain:PBMHasPlatoonList() then
+    if aiBrain.HasPlatoonList then
     # Figure out what type of builders to import
         local expansionTypes = constructionData.ExpansionTypes
     if not expansionTypes then

--- a/lua/AI/aiutilities.lua
+++ b/lua/AI/aiutilities.lua
@@ -795,7 +795,7 @@ end
 
 function GetLocationNeedingWalls(aiBrain, radius, count, unitCategory, tMin, tMax, tRings, tType)
     local positions = {}
-    if aiBrain:PBMHasPlatoonList() then
+    if aiBrain.HasPlatoonList then
         for k, v in aiBrain.PBM.Locations do
             if v.LocationType ~= 'MAIN' then
                 table.insert(positions, v.Location)
@@ -832,7 +832,7 @@ end
 
 function AIGetReclaimablesAroundLocation(aiBrain, locationType)
     local position, radius
-    if aiBrain:PBMHasPlatoonList() then
+    if aiBrain.HasPlatoonList then
         for _, v in aiBrain.PBM.Locations do
             if v.LocationType == locationType then
                 position = v.Location
@@ -841,7 +841,7 @@ function AIGetReclaimablesAroundLocation(aiBrain, locationType)
             end
         end
     elseif aiBrain.BuilderManagers[locationType] then
-        radius = aiBrain.BuilderManagers[locationType].FactoryManager:GetLocationRadius()
+        radius = aiBrain.BuilderManagers[locationType].FactoryManager.Radius
         position = aiBrain.BuilderManagers[locationType].FactoryManager:GetLocationCoords()
     end
 
@@ -968,7 +968,7 @@ end
 
 function GetBasePatrolPoints(aiBrain, location, radius, layer)
     if type(location) == 'string' then
-        if aiBrain:PBMHasPlatoonList() then
+        if aiBrain.HasPlatoonList then
             for k, v in aiBrain.PBM.Locations do
                 if v.LocationType == location then
                     radius = v.Radius
@@ -977,7 +977,7 @@ function GetBasePatrolPoints(aiBrain, location, radius, layer)
                 end
             end
         elseif aiBrain.BuilderManagers[location] then
-            radius = aiBrain.BuilderManagers[location].FactoryManager:GetLocationRadius()
+            radius = aiBrain.BuilderManagers[location].FactoryManager.Radius
             location = aiBrain.BuilderManagers[location].FactoryManager:GetLocationCoords()
         end
         if not radius then
@@ -1958,7 +1958,7 @@ function GetUnitsBeingBuilt(aiBrain, locationType, assisteeCategory)
         return false
     end
 
-    local filterUnits = GetOwnUnitsAroundPoint(aiBrain, assisteeCategory, manager:GetLocationCoords(), manager:GetLocationRadius())
+    local filterUnits = GetOwnUnitsAroundPoint(aiBrain, assisteeCategory, manager:GetLocationCoords(), manager.Radius)
     local retUnits = {}
     for k, v in filterUnits do
         if v:IsUnitState('Building') or v:IsUnitState('Upgrading') then
@@ -1971,7 +1971,7 @@ end
 
 function GetBasePatrolPointsSorian(aiBrain, location, radius, layer)
     if type(location) == 'string' then
-        if aiBrain:PBMHasPlatoonList() then
+        if aiBrain.HasPlatoonList then
             for k, v in aiBrain.PBM.Locations do
                 if v.LocationType == location then
                     radius = v.Radius
@@ -1980,7 +1980,7 @@ function GetBasePatrolPointsSorian(aiBrain, location, radius, layer)
                 end
             end
         elseif aiBrain.BuilderManagers[location] then
-            radius = aiBrain.BuilderManagers[location].FactoryManager:GetLocationRadius()
+            radius = aiBrain.BuilderManagers[location].FactoryManager.Radius
             location = aiBrain.BuilderManagers[location].FactoryManager:GetLocationCoords()
         end
         if not radius then

--- a/lua/AI/sorianutilities.lua
+++ b/lua/AI/sorianutilities.lua
@@ -1210,7 +1210,7 @@ end
 -- -----------------------------------------------------
 function FindUnfinishedUnits(aiBrain, locationType, buildCat)
     local engineerManager = aiBrain.BuilderManagers[locationType].EngineerManager
-    local unfinished = aiBrain:GetUnitsAroundPoint(buildCat, engineerManager:GetLocationCoords(), engineerManager:GetLocationRadius(), 'Ally')
+    local unfinished = aiBrain:GetUnitsAroundPoint(buildCat, engineerManager:GetLocationCoords(), engineerManager.Radius, 'Ally')
     local retUnfinished = false
     for num, unit in unfinished do
         donePercent = unit:GetFractionComplete()
@@ -1235,7 +1235,7 @@ end
 -- -----------------------------------------------------
 function FindDamagedShield(aiBrain, locationType, buildCat)
     local engineerManager = aiBrain.BuilderManagers[locationType].EngineerManager
-    local shields = aiBrain:GetUnitsAroundPoint(buildCat, engineerManager:GetLocationCoords(), engineerManager:GetLocationRadius(), 'Ally')
+    local shields = aiBrain:GetUnitsAroundPoint(buildCat, engineerManager:GetLocationCoords(), engineerManager.Radius, 'Ally')
     local retShield = false
     for num, unit in shields do
         if not unit.Dead and unit:ShieldIsOn() then

--- a/lua/ScenarioPlatoonAI.lua
+++ b/lua/ScenarioPlatoonAI.lua
@@ -30,9 +30,9 @@ function PlatoonAttackClosestUnit(platoon)
     local cmd = platoon:AggressiveMoveToLocation(target:GetPosition())
     while aiBrain:PlatoonExists(platoon) do
         if target ~= nil then
-            if target:IsDead() or not platoon:IsCommandsActive(cmd) then
+            if target.Dead or not platoon:IsCommandsActive(cmd) then
                 target = platoon:FindClosestUnit('Attack', 'Enemy', true, categories.ALLUNITS-categories.WALL)
-                if target and not target:IsDead() then
+                if target and not target.Dead then
                     platoon:Stop()
                     cmd = platoon:AggressiveMoveToLocation(target:GetPosition())
                 end
@@ -50,7 +50,7 @@ end
 --------------------------------------------------------
 function BuildOnce(platoon)
     local aiBrain = platoon:GetBrain()
-    if aiBrain:PBMHasPlatoonList() then
+    if aiBrain.HasPlatoonList then
         aiBrain:PBMSetPriority(platoon, 0)
     else
         platoon.BuilderHandle:SetPriority(0)
@@ -382,7 +382,7 @@ function LandAssaultWithTransports(platoon)
             return
         end
         for num, unit in platoon:GetPlatoonUnits() do
-            if not unit:IsDead() and not EntityCategoryContains(categories.TRANSPORTATION, unit) and unit:IsUnitState('Attached') then
+            if not unit.Dead and not EntityCategoryContains(categories.TRANSPORTATION, unit) and unit:IsUnitState('Attached') then
                 attached = true
                 break
             end
@@ -646,9 +646,9 @@ function EngineersBuildPlatoon(platoon)
 
     -- Have all engineers guard main engineer
     if table.getn(engTable) > 0 then
-        if eng:IsDead() then -- Must check if a death occured since platoon was forked
+        if eng.Dead then -- Must check if a death occured since platoon was forked
             for num, unit in engTable do
-                if not unit:IsDead() then
+                if not unit.Dead then
                     eng = table.remove(engTable, num)
                     if table.getn(engTable) > 0 then
                         IssueGuard(engTable, eng)
@@ -667,7 +667,7 @@ function EngineersBuildPlatoon(platoon)
 
     while aiBrain:PlatoonExists(platoon) do
         -- Set new primary eng
-        if eng:IsDead() then
+        if eng.Dead then
             return
         end
         if not buildingPlatoon then
@@ -702,7 +702,7 @@ function EngineersBuildPlatoon(platoon)
 
                     repeat
                         WaitSeconds(5)
-                        if eng:IsDead() then
+                        if eng.Dead then
                             eng, engTable = AssistOtherEngineer(eng, engTable, unitBeingBuilt)
                         else
                             if not unitBeingBuilt then
@@ -712,7 +712,7 @@ function EngineersBuildPlatoon(platoon)
                                 end
                             end
                         end
-                    until not eng or eng:IsDead() or eng:IsIdleState()
+                    until not eng or eng.Dead or eng:IsIdleState()
                     if not aiBrain.EngBuiltPlatoonList[buildingPlatoon] then
                         plat = aiBrain:MakePlatoon('', '')
                         aiBrain.EngBuiltPlatoonList[buildingPlatoon] = plat
@@ -799,7 +799,7 @@ function CategoryHunterPlatoonAI(platoon)
                 if table.getn(unitList) > 0 then
                     local distance = 100000
                     for _, v in unitList do
-                        if not v:IsDead() then
+                        if not v.Dead then
                             local currDist = VDist3(platPos, v:GetPosition())
                             if currDist < distance then
                                 newTarget = v
@@ -822,7 +822,7 @@ function CategoryHunterPlatoonAI(platoon)
         -- If there are no targets, seek out and fight nearest enemy the platoon can find; no cheeting here
         if not newTarget then
             target = platoon:FindClosestUnit('Attack', 'Enemy', true, categories.ALLUNITS-categories.WALL)
-            if target and not target:IsDead() then
+            if target and not target.Dead then
                 platoon:Stop()
                 platoon:AggressiveMoveToLocation(target:GetPosition())
 
@@ -953,7 +953,7 @@ function StartBaseEngineerThread(platoon)
         error('*SCENARIO PLATOON AI ERROR: No Engineers found in platoon using StartBaseEngineer', 2)
     end
     -- Wait for eng to stop moving
-    while not eng:IsDead() and  eng:IsUnitState('Moving') do
+    while not eng.Dead and  eng:IsUnitState('Moving') do
         WaitSeconds(3)
         if not aiBrain:PlatoonExists(platoon) then
             return
@@ -980,9 +980,9 @@ function StartBaseEngineerThread(platoon)
 
     -- Have all engineers guard main engineer
     if table.getn(engTable) > 0 then
-        if eng:IsDead() then -- Must check if a death occured since platoon was forked
+        if eng.Dead then -- Must check if a death occured since platoon was forked
             for num, unit in engTable do
-                if not unit:IsDead() then
+                if not unit.Dead then
                     eng = table.remove(engTable, num)
                     if table.getn(engTable) > 0 then
                         IssueGuard(engTable, eng)
@@ -1170,7 +1170,7 @@ function StartBaseBuildUnits(eng, engTable, data, aiBrain)
                     end
                     repeat
                         WaitSeconds(5)
-                        if eng:IsDead() then
+                        if eng.Dead then
                             eng, engTable = AssistOtherEngineer(eng, engTable, unitBeingBuilt)
                             if not eng then
                                 return false
@@ -1211,7 +1211,7 @@ function StartBaseGroupOnceBuild(eng, engTable, data, aiBrain)
                 end
                 repeat
                     WaitSeconds(5)
-                    if eng:IsDead() then
+                    if eng.Dead then
                         eng, engTable = AssistOtherEngineer(eng, engTable, unitBeingBuilt)
                         if not eng then
                             return false
@@ -1254,7 +1254,7 @@ function StartBaseConstruction(eng, engTable, data, aiBrain)
             end
             repeat
                 WaitSeconds(7)
-                if eng:IsDead() then
+                if eng.Dead then
                     eng, engTable = AssistOtherEngineer(eng, engTable, unitBeingBuilt)
                     if not eng then
                         return false
@@ -1279,7 +1279,7 @@ function StartBaseBuildBase(eng, engTable, data, aiBrain)
             local allBuilt = false
             while not allBuilt do
                 local busy = false
-                if not eng:IsDead() then
+                if not eng.Dead then
                     if eng:IsUnitState('Building') or eng:IsUnitState('Repairing')
                         or eng:IsUnitState('Reclaiming') or eng:IsUnitState('Moving') then
                             busy = true
@@ -1297,7 +1297,7 @@ function StartBaseBuildBase(eng, engTable, data, aiBrain)
                     end
                 end
                 WaitSeconds(5)
-                if eng:IsDead() then
+                if eng.Dead then
                     eng, engTable = AssistOtherEngineer(eng, engTable, unitBeingBuilt)
                     if not eng then
                         return false
@@ -1328,7 +1328,7 @@ function StartBaseMaintainBase(platoon, eng, engTable, data, aiBrain)
     end
     while data.MaintainBaseTemplate do
         local busy = false
-        if eng and not eng:IsDead() then
+        if eng and not eng.Dead then
             if eng:IsUnitState('Building') or eng:IsUnitState('Reclaiming') or eng:IsUnitState('Repairing') or
                               (eng:IsUnitState('Moving') and not eng:IsUnitState('Patrolling')) then
                 busy = true
@@ -1377,7 +1377,7 @@ function StartBaseMaintainBase(platoon, eng, engTable, data, aiBrain)
         if not aiBrain:PlatoonExists(platoon) then
             return false
         end
-        if eng and eng:IsDead()  then
+        if eng and eng.Dead  then
             eng, engTable = AssistOtherEngineer(eng, engTable, unitBeingBuilt)
             if not eng then
                 return false
@@ -1425,18 +1425,18 @@ end
 function AssistOtherEngineer(eng, engTable, unitBeingBuilt)
     if engTable and table.getn(engTable) > 0 then
         for num, unit in engTable do
-            if not unit:IsDead() then
+            if not unit.Dead then
                 eng = table.remove(engTable, num)
                 if table.getn(engTable) > 0 then
                     IssueGuard(engTable, eng)
                 end
-                if unitBeingBuilt and not unitBeingBuilt:IsDead() then
+                if unitBeingBuilt and not unitBeingBuilt.Dead then
                     IssueRepair({eng}, unitBeingBuilt)
                 end
                 break
             end
         end
-        if eng:IsDead() then
+        if eng.Dead then
             return false
         end
     end
@@ -1546,7 +1546,7 @@ function EngineersAssistFactories(platoon, locationType)
             -- Check for dead factories
             local num = 1
             while num <= table.getn(platoon.PlatoonData.FactoryAssistList) do
-                if platoon.PlatoonData.FactoryAssistList[num].Factory:IsDead() then
+                if platoon.PlatoonData.FactoryAssistList[num].Factory.Dead then
                     reassignEngs = true
                     for engNum, eng in platoon.PlatoonData.FactoryAssistList[num].Engineers do
                         table.insert(reassignEngPool, eng)
@@ -1597,7 +1597,7 @@ function EngineersAssistFactories(platoon, locationType)
             local engNum = 1
             while engNum < table.getn(engTable) do
                 local eng = engTable[engNum]
-                if eng:IsDead() then
+                if eng.Dead then
                     table.remove(engTable, engNum)
                     -- Remove from platoon factory assist list
                     for facNum, facData in platoon.PlatoonData.FactoryAssistList do
@@ -1623,7 +1623,7 @@ function EngineersAssistFactories(platoon, locationType)
             -- If maintain base finished, reassign all engs
             if platoon.PlatoonData.ReassignAssist then
                 for num, unit in platoon:GetPlatoonUnits() do
-                    if not unit:IsDead() and EntityCategoryContains(categories.CONSTRUCTION, unit) then
+                    if not unit.Dead and EntityCategoryContains(categories.CONSTRUCTION, unit) then
                         table.insert(reassignEngPool, unit)
                     end
                 end
@@ -1690,7 +1690,7 @@ function ReorganizeEngineers(platoon, engTable)
             unbalanced = true
             if table.getn(facHighData.Engineers) > 0 then
                 for engNum, engData in facHighData.Engineers do
-                    if not engData:IsDead() then
+                    if not engData.Dead then
                         local moveEng = table.remove(facHighData.Engineers, engNum)
                         facHighData.NumEngs = facHighData.NumEngs - 1
                         -- Decrease number in global fac list
@@ -1725,7 +1725,7 @@ function EngAssist(platoon, engTable)
     local engNum = 1
     while engNum <= table.getn(engTable) do
         eng = engTable[engNum]
-        if not eng:IsDead() and not platoon.PlatoonData.Rebuilding then
+        if not eng.Dead and not platoon.PlatoonData.Rebuilding then
             local lowNum = -1
             local lowFac = false
             for facNum, fac in platoon.PlatoonData.FactoryAssistList do
@@ -1881,7 +1881,7 @@ function GetLoadTransports(platoon)
         end
         attached = true
         for _, v in monitorUnits do
-            if not v:IsDead() and not v:IsIdleState() then
+            if not v.Dead and not v:IsIdleState() then
                 attached = false
                 break
             end
@@ -2156,7 +2156,7 @@ function GetTransportsThread(platoon)
             tempNeeded.Large = neededTable.Large
             -- Find out how many units are needed currently
             for _, v in platoon:GetPlatoonUnits() do
-                if not v:IsDead() then
+                if not v.Dead then
                     if EntityCategoryContains(categories.TRANSPORTATION, v) then
                         local id = v:GetUnitId()
                         if not transSlotTable[id] then

--- a/lua/SimObjectives.lua
+++ b/lua/SimObjectives.lua
@@ -272,7 +272,7 @@ function Kill(Type, Complete, Title, Description, Target)
     end
 
     for _, unit in Target.Units do
-        if not unit:IsDead() then
+        if not unit.Dead then
             -- Mark the units unless MarkUnits == false
             if Target.MarkUnits == nil or Target.MarkUnits then
                 local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
@@ -357,7 +357,7 @@ function Capture(Type, Complete, Title, Description, Target)
     end
 
     for _, unit in Target.Units do
-        if not unit:IsDead() then
+        if not unit.Dead then
             -- Mark the units unless MarkUnits == false
             if Target.MarkUnits == nil or Target.MarkUnits then
                 local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
@@ -481,7 +481,7 @@ function KillOrCapture(Type, Complete, Title, Description, Target)
     end
 
     for _, unit in Target.Units do
-        if not unit:IsDead() then
+        if not unit.Dead then
             -- Mark the units unless MarkUnits == false
             if Target.MarkUnits == nil or Target.MarkUnits then
                 local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
@@ -706,7 +706,7 @@ function SpecificUnitsInArea(Type, Complete, Title, Description, Target)
         while objective.Active do
             local cnt = 0
             for _, unit in units do
-                if not unit:IsDead() then
+                if not unit.Dead then
                     if ScenarioUtils.InRect(unit:GetPosition(), rect) then
                         cnt = cnt + 1
                     end
@@ -820,7 +820,7 @@ function CategoriesInArea(Type, Complete, Title, Description, Action, Target)
                 local ArmiesList = CreateArmiesList(requirement.Armies)
                 if units then
                     for _, unit in units do
-                        if not unit:IsDead() and not unit:IsBeingBuilt() then
+                        if not unit.Dead and not unit:IsBeingBuilt() then
                             if not (requirement.ArmyIndex or requirement.Armies) or (requirement.ArmyIndex == unit:GetArmy()) or ArmiesList[unit:GetArmy()] then
                                 if EntityCategoryContains(requirement.Category, unit) then
                                     if not unit.Marked and objective.MarkUnits then
@@ -1318,7 +1318,7 @@ function Basic(Type, Complete, Title, Description, Image, Target)
         if target.Units then
             if target.MarkUnits then
                 for _, unit in target.Units do
-                    if not unit:IsDead() then
+                    if not unit.Dead then
                         local ObjectiveArrow = import('objectiveArrow.lua').ObjectiveArrow
                         local arrow = ObjectiveArrow {AttachTo = unit}
                         table.insert(objective.UnitMarkers, arrow)
@@ -1509,7 +1509,7 @@ function AddObjective(Type,         -- 'primary', 'bonus', etc
 
                                 -- If it's not mobile we can exit the thread since
                                 -- the blip won't move.
-                                if not unit:IsDead() and not unit:BeenDestroyed() and not EntityCategoryContains(categories.MOBILE, unit) then
+                                if not unit.Dead and not unit:BeenDestroyed() and not EntityCategoryContains(categories.MOBILE, unit) then
                                     return
                                 end
                             end
@@ -1576,7 +1576,7 @@ function AddObjective(Type,         -- 'primary', 'bonus', etc
                                     obj.Tag)
 
                     -- If it's not mobile we can exit the thread since the unit won't move.
-                    if not unit:IsDead() and not unit:BeenDestroyed() and not EntityCategoryContains(categories.MOBILE, unit) then
+                    if not unit.Dead and not unit:BeenDestroyed() and not EntityCategoryContains(categories.MOBILE, unit) then
                         return
                     end
 
@@ -1769,7 +1769,7 @@ function AddObjective(Type,         -- 'primary', 'bonus', etc
     if Target then
         if Target.Units then
             for _, v in Target.Units do
-                if v and v.IsDead and not v:IsDead() then
+                if v and v.IsDead and not v.Dead then
                     objective:AddUnitTarget(v)
                 end
             end

--- a/lua/aeonweapons.lua
+++ b/lua/aeonweapons.lua
@@ -140,7 +140,7 @@ ADFTractorClaw = Class(DefaultBeamWeapon) {
         WaitTicks(1)
         WaitFor(self.Slider)
 
-        if not target:IsDead() then
+        if not target.Dead then
             target.DestructionExplosionWaitDelayMin = 0
             target.DestructionExplosionWaitDelayMax = 0
 
@@ -155,7 +155,7 @@ ADFTractorClaw = Class(DefaultBeamWeapon) {
     end,
 
     TractorWatchThread = function(self, target)
-        while not target:IsDead() do
+        while not target.Dead do
             WaitTicks(1)
         end
         KillThread(self.TT1)

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -1952,7 +1952,7 @@ AIBrain = Class(moho.aibrain_methods) {
     end,
 
     PBMGetLocation = function(self, locationName)
-        if self:PBMHasPlatoonList() then
+        if self.HasPlatoonList then
             for _, v in self.PBM.Locations do
                 if v.LocationType == locationName then
                     return v
@@ -1966,7 +1966,7 @@ AIBrain = Class(moho.aibrain_methods) {
         if not loc then
             return false
         end
-        if self:PBMHasPlatoonList() then
+        if self.HasPlatoonList then
             for _, v in self.PBM.Locations do
                 if v.LocationType == loc then
                     local height = GetTerrainHeight(v.Location[1], v.Location[3])
@@ -1986,14 +1986,14 @@ AIBrain = Class(moho.aibrain_methods) {
         if not loc then
             return false
         end
-        if self:PBMHasPlatoonList() then
+        if self.HasPlatoonList then
             for k, v in self.PBM.Locations do
                 if v.LocationType == loc then
                    return v.Radius
                 end
             end
         elseif self.BuilderManagers[loc] then
-            return self.BuilderManagers[loc].FactoryManager:GetLocationRadius()
+            return self.BuilderManagers[loc].FactoryManager.Radius
         end
         return false
     end,
@@ -2364,7 +2364,7 @@ AIBrain = Class(moho.aibrain_methods) {
         local personality = self:GetPersonality()
         local armyIndex = self:GetArmyIndex()
         local numBuildOrders = nil
-        if location.PrimaryFactories[platoonType] and not location.PrimaryFactories[platoonType]:IsDead() then
+        if location.PrimaryFactories[platoonType] and not location.PrimaryFactories[platoonType].Dead then
             numBuildOrders = location.PrimaryFactories[platoonType]:GetNumBuildOrders(categories.ALLUNITS)
             if numBuildOrders == 0 then
                 local guards = location.PrimaryFactories[platoonType]:GetGuards()

--- a/lua/defaultantiprojectile.lua
+++ b/lua/defaultantiprojectile.lua
@@ -93,7 +93,7 @@ MissileRedirect = Class(Entity) {
             Main = function(self)
                 if not self or self:BeenDestroyed() or
                    not self.EnemyProj or self.EnemyProj:BeenDestroyed() or
-                   not self.Owner or self.Owner:IsDead() then
+                   not self.Owner or self.Owner.Dead then
                     if self then
                         ChangeState(self, self.WaitingState)
                     end

--- a/lua/editor/BaseManagerBuildConditions.lua
+++ b/lua/editor/BaseManagerBuildConditions.lua
@@ -65,7 +65,7 @@ function NumUnitsLessNearBase(aiBrain, baseName, category, varName)
         return false
     else
         local base = aiBrain.BaseManagers[baseName]
-        local unitList = aiBrain:GetUnitsAroundPoint(category, base:GetPosition(), base:GetRadius(), 'Ally')
+        local unitList = aiBrain:GetUnitsAroundPoint(category, base:GetPosition(), base.Radius, 'Ally')
         local count = 0
         for i, unit in unitList do
             if unit:GetAIBrain() == aiBrain then
@@ -94,7 +94,7 @@ function BaseManagerNeedsEngineers(aiBrain, baseName)
         return false
     end
     local bManager = aiBrain.BaseManagers[baseName]
-    if bManager:GetMaximumEngineers() > bManager:GetCurrentEngineerCount() then
+    if bManager.EngineerQuantity > bManager.CurrentEngineerCount then
         return true
     end
     return false
@@ -111,8 +111,8 @@ function ExpansionBasesNeedEngineers(aiBrain, baseName)
     for num, eData in bManager.ExpansionBaseData do
         local eBaseName = eData.BaseName
         local base = aiBrain.BaseManagers[eBaseName]
-        if base and base:GetPosition() and base:GetRadius() then
-            local count = base:GetCurrentEngineerCount()
+        if base and base:GetPosition() and base.Radius then
+            local count = base.CurrentEngineerCount
             count = count + eData.IncomingEngineers
             if count < eData.Engineers then
                 return true
@@ -134,8 +134,8 @@ function NumEngiesInExpansionBase(aiBrain, baseName, eBaseName)
     for num, eData in bManager.ExpansionBaseData do
         if eData.BaseName == eBaseName then
             local base = aiBrain.BaseManagers[eBaseName]
-            if base and base:GetPosition() and base:GetRadius() then
-                local count = base:GetCurrentEngineerCount()
+            if base and base:GetPosition() and base.Radius then
+                local count = base.CurrentEngineerCount
                 count = count + eData.IncomingEngineers
                 if count < eData.Engineers then
                     return true
@@ -245,7 +245,7 @@ function CategoriesBeingBuilt(aiBrain, baseName, catTable)
     end
 
     local basePos = aiBrain.BaseManagers[baseName]:GetPosition()
-    local baseRad = aiBrain.BaseManagers[baseName]:GetRadius()
+    local baseRad = aiBrain.BaseManagers[baseName].Radius
     if not basePos or not baseRad then
         return false
     end
@@ -276,8 +276,8 @@ function HighestFactoryLevel(aiBrain, level, baseName)
         return false
     end
 
-    local t3FacList = AIUtils.GetOwnUnitsAroundPoint(aiBrain, categories.FACTORY * categories.TECH3, bManager:GetPosition(), bManager:GetRadius())
-    local t2FacList = AIUtils.GetOwnUnitsAroundPoint(aiBrain, categories.FACTORY * categories.TECH2, bManager:GetPosition(), bManager:GetRadius())
+    local t3FacList = AIUtils.GetOwnUnitsAroundPoint(aiBrain, categories.FACTORY * categories.TECH3, bManager:GetPosition(), bManager.Radius)
+    local t2FacList = AIUtils.GetOwnUnitsAroundPoint(aiBrain, categories.FACTORY * categories.TECH2, bManager:GetPosition(), bManager.Radius)
     if t3FacList and table.getn(t3FacList) > 0 then
         if level == 3 then
             return true
@@ -301,7 +301,7 @@ function FactoryCountAndNeed(aiBrain, techLevel, engQuantity, pType, baseName)
     end
 
     local facCat = ParseEntityCategory('FACTORY * TECH'..techLevel)
-    local facList = AIUtils.GetOwnUnitsAroundPoint(aiBrain, facCat, bManager:GetPosition(), bManager:GetRadius())
+    local facList = AIUtils.GetOwnUnitsAroundPoint(aiBrain, facCat, bManager:GetPosition(), bManager.Radius)
     local typeCount = {Air = 0, Land = 0, Sea = 0, }
     for k, v in facList do
         if EntityCategoryContains(categories.AIR, v) then
@@ -314,11 +314,11 @@ function FactoryCountAndNeed(aiBrain, techLevel, engQuantity, pType, baseName)
     end
 
     if typeCount[pType] >= typeCount['Air'] and typeCount[pType] >= typeCount['Land'] and typeCount[pType] >= typeCount['Sea'] then
-        if typeCount[pType] == engQuantity and bManager:GetMaximumEngineers() >= (bManager:GetCurrentEngineerCount() + bManager:GetEngineersBuilding() + engQuantity) then
+        if typeCount[pType] == engQuantity and bManager.EngineerQuantity >= (bManager.CurrentEngineerCount + bManager:GetEngineersBuilding() + engQuantity) then
             return true
-        elseif bManager:GetMaximumEngineers() - (bManager:GetCurrentEngineerCount() + bManager:GetEngineersBuilding() + engQuantity) == 0 and typeCount[pType] >= engQuantity then
+        elseif bManager.EngineerQuantity - (bManager.CurrentEngineerCount + bManager:GetEngineersBuilding() + engQuantity) == 0 and typeCount[pType] >= engQuantity then
             return true
-        elseif bManager:GetMaximumEngineers() - (bManager:GetCurrentEngineerCount() + bManager:GetEngineersBuilding() + engQuantity) > 0 and engQuantity == 5 and typeCount[pType] >= 5 then
+        elseif bManager.EngineerQuantity - (bManager.CurrentEngineerCount + bManager:GetEngineersBuilding() + engQuantity) > 0 and engQuantity == 5 and typeCount[pType] >= 5 then
             return true
         end
     end
@@ -387,8 +387,8 @@ function HighestFactoryLevelType(aiBrain, level, baseName, type)
         catCheck = categories.NAVAL
     end
 
-    local t3FacList = AIUtils.GetOwnUnitsAroundPoint(aiBrain, categories.FACTORY * categories.TECH3 * catCheck, bManager:GetPosition(), bManager:GetRadius())
-    local t2FacList = AIUtils.GetOwnUnitsAroundPoint(aiBrain, categories.FACTORY * categories.TECH2 * catCheck, bManager:GetPosition(), bManager:GetRadius())
+    local t3FacList = AIUtils.GetOwnUnitsAroundPoint(aiBrain, categories.FACTORY * categories.TECH3 * catCheck, bManager:GetPosition(), bManager.Radius)
+    local t2FacList = AIUtils.GetOwnUnitsAroundPoint(aiBrain, categories.FACTORY * categories.TECH2 * catCheck, bManager:GetPosition(), bManager.Radius)
     if t3FacList and table.getn(t3FacList) > 0 then
         if level == 3 then
             return true

--- a/lua/editor/MiscBuildConditions.lua
+++ b/lua/editor/MiscBuildConditions.lua
@@ -59,7 +59,7 @@ end
 #
 ##############################################################################################################
 function IsAIBrainLayerPref(aiBrain, layerPref)
-    if layerPref == aiBrain:AIGetLayerPreference() then
+    if layerPref == aiBrain.LayerPref then
         return true
     end
     return false
@@ -279,7 +279,7 @@ end
 ##############################################################################################################
 function CheckAvailableGates(aiBrain, locType)
     local pos, rad
-    if aiBrain:PBMHasPlatoonList() then
+    if aiBrain.HasPlatoonList then
         for k,v in aiBrain.PBM.Locations do
             if v.LocationType == locType then
                 pos = v.Location
@@ -289,7 +289,7 @@ function CheckAvailableGates(aiBrain, locType)
         end
     elseif aiBrain.BuilderManagers[locType] then
         pos = aiBrain.BuilderManagers[locType].FactoryManager:GetLocationCoords()
-        rad = aiBrain.BuilderManagers[locType].FactoryManager:GetLocationRadius()
+        rad = aiBrain.BuilderManagers[locType].FactoryManager.Radius
     end
     if not pos then
         return false

--- a/lua/editor/SorianBuildConditions.lua
+++ b/lua/editor/SorianBuildConditions.lua
@@ -174,9 +174,9 @@ function EnemyToAllyRatioLessOrEqual(aiBrain, num)
     local enemies = 0
     local allies = 0
     for k,v in ArmyBrains do
-        if not v:IsDefeated() and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
+        if not v.Result == "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
             enemies = enemies + 1
-        elseif not v:IsDefeated() and not ArmyIsCivilian(v:GetArmyIndex()) and IsAlly(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
+        elseif not v.Result == "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsAlly(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
             allies = allies + 1
         end
     end
@@ -232,7 +232,7 @@ function ClosestEnemyLessThan(aiBrain, distance)
     local startX, startZ = aiBrain:GetArmyStartPos()
     local closest
     for k,v in ArmyBrains do
-        if not v:IsDefeated() and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
+        if not v.Result == "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
             local estartX, estartZ = v:GetArmyStartPos()
             local tempDistance = VDist2Sq(startX, startZ, estartX, estartZ)
             if not closest or tempDistance < closest then
@@ -251,7 +251,7 @@ function DamagedStructuresInArea(aiBrain, locationtype)
     if not engineerManager then
         return false
     end
-    local Structures = AIUtils.GetOwnUnitsAroundPoint(aiBrain, categories.STRUCTURE - (categories.TECH1 - categories.FACTORY), engineerManager:GetLocationCoords(), engineerManager:GetLocationRadius())
+    local Structures = AIUtils.GetOwnUnitsAroundPoint(aiBrain, categories.STRUCTURE - (categories.TECH1 - categories.FACTORY), engineerManager:GetLocationCoords(), engineerManager.Radius)
     for k,v in Structures do
         if not v.Dead and v:GetHealthPercent() < .8 then
         #LOG('*AI DEBUG: DamagedStructuresInArea return true')
@@ -362,7 +362,7 @@ function PoolThreatGreaterThanEnemyBase(aiBrain, locationType, ucat, ttype, utty
     end
     local StartX, StartZ = enemy:GetArmyStartPos()
     local position = engineerManager:GetLocationCoords()
-    local radius = engineerManager:GetLocationRadius()
+    local radius = engineerManager.Radius
 
     local enemyThreat = aiBrain:GetThreatAtPosition({StartX, 0, StartZ}, 1, true, ttype or 'Overall', enemyIndex)
     local Threat = pool:GetPlatoonThreat(uttype or 'Overall', ucat, position, radius)
@@ -438,7 +438,7 @@ function UnfinishedUnits(aiBrain, locationType, category)
     if not engineerManager then
         return false
     end
-    local unfinished = aiBrain:GetUnitsAroundPoint(category, engineerManager:GetLocationCoords(), engineerManager:GetLocationRadius(), 'Ally')
+    local unfinished = aiBrain:GetUnitsAroundPoint(category, engineerManager:GetLocationCoords(), engineerManager.Radius, 'Ally')
     for num, unit in unfinished do
         donePercent = unit:GetFractionComplete()
         if donePercent < 1 and SUtils.GetGuards(aiBrain, unit) < 1 then
@@ -460,7 +460,7 @@ function ShieldDamaged(aiBrain, locationType)
     if not engineerManager then
         return false
     end
-    local shields = aiBrain:GetUnitsAroundPoint(categories.STRUCTURE * categories.SHIELD, engineerManager:GetLocationCoords(), engineerManager:GetLocationRadius(), 'Ally')
+    local shields = aiBrain:GetUnitsAroundPoint(categories.STRUCTURE * categories.SHIELD, engineerManager:GetLocationCoords(), engineerManager.Radius, 'Ally')
     for num, unit in shields do
         if not unit.Dead and unit:ShieldIsOn() then
             shieldPercent = (unit.MyShield:GetHealth() / unit.MyShield:GetMaxHealth())
@@ -549,7 +549,7 @@ function HaveComparativeUnitsWithCategoryAndAllianceAtLocation(aiBrain, location
     if not engineerManager then
         return false
     end
-    local myUnits = table.getn(AIUtils.GetOwnUnitsAroundPoint(aiBrain, myCategory, engineerManager:GetLocationCoords(), engineerManager:GetLocationRadius()))
+    local myUnits = table.getn(AIUtils.GetOwnUnitsAroundPoint(aiBrain, myCategory, engineerManager:GetLocationCoords(), engineerManager.Radius))
     local numUnits = aiBrain:GetNumUnitsAroundPoint(eCategory, Vector(0,0,0), 100000, alliance)
     if alliance == 'Ally' then
         numUnits = numUnits - aiBrain:GetCurrentUnits(myCategory)
@@ -695,7 +695,7 @@ function EnemyInT3ArtilleryRange(aiBrain, locationtype, inrange)
         radius = 825 + offset
     end
     for k,v in ArmyBrains do
-        if not v:IsDefeated() and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
+        if not v.Result == "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
             local estartX, estartZ = v:GetArmyStartPos()
             if (VDist2Sq(start[1], start[3], estartX, estartZ) <= radius * radius) and inrange then
                 return true
@@ -723,7 +723,7 @@ function AIOutnumbered(aiBrain, bool)
     end
 
     for k,v in ArmyBrains do
-        if not v:IsDefeated() and aiBrain:GetArmyIndex() ~= v:GetArmyIndex() and not ArmyIsCivilian(v:GetArmyIndex()) then
+        if not v.Result == "defeat" and aiBrain:GetArmyIndex() ~= v:GetArmyIndex() and not ArmyIsCivilian(v:GetArmyIndex()) then
             local armyTeam = ScenarioInfo.ArmySetup[v.Name].Team
             #LOG('*AI DEBUG: '..v.Nickname..' is on team '..armyTeam)
             if v.CheatEnabled then

--- a/lua/editor/SorianInstantBuildConditions.lua
+++ b/lua/editor/SorianInstantBuildConditions.lua
@@ -558,7 +558,7 @@ function HavePoolUnitComparisonAtLocationExp(aiBrain, locationType, unitCount, u
         return false
     end
     local poolPlatoon = aiBrain:GetPlatoonUniquelyNamed('ArmyPool')
-    local numUnits = poolPlatoon:GetNumCategoryUnits(testCat, engineerManager:GetLocationCoords(), engineerManager:GetLocationRadius() * 2.5)
+    local numUnits = poolPlatoon:GetNumCategoryUnits(testCat, engineerManager:GetLocationCoords(), engineerManager.Radius * 2.5)
     return CompareBody(numUnits, unitCount, compareType)
 end
 

--- a/lua/editor/UnitCountBuildConditions.lua
+++ b/lua/editor/UnitCountBuildConditions.lua
@@ -444,7 +444,7 @@ function HaveAreaWithUnitsFewWalls(aiBrain, locationType, locationRadius, unitCo
         return false
     end
     local positions = {}
-    if aiBrain:PBMHasPlatoonList() then
+    if aiBrain.HasPlatoonList then
         for k,v in aiBrain.PBM.Locations do
             if v.LocationType ~= locationType and Utils.XZDistanceTwoVectors(pos, v.Location) <= locationRadius then
                 table.insert(positions, v.Location)
@@ -519,7 +519,7 @@ function HaveUnitComparisonAtLocation(aiBrain, locationType, unitCount, unitCate
         WARN('*AI WARNING: HaveUnitComparisonAtLocation - Invalid location - ' .. locationType)
         return false
     end
-    local numUnits = table.getn(AIUtils.GetOwnUnitsAroundPoint(aiBrain, testCat, engineerManager:GetLocationCoords(), engineerManager:GetLocationRadius()))
+    local numUnits = table.getn(AIUtils.GetOwnUnitsAroundPoint(aiBrain, testCat, engineerManager:GetLocationCoords(), engineerManager.Radius))
     return CompareBody(numUnits, unitCount, compareType)
 end
 
@@ -545,7 +545,7 @@ function HavePoolUnitComparisonAtLocation(aiBrain, locationType, unitCount, unit
         return false
     end
     local poolPlatoon = aiBrain:GetPlatoonUniquelyNamed('ArmyPool')
-    local numUnits = poolPlatoon:GetNumCategoryUnits(testCat, engineerManager:GetLocationCoords(), engineerManager:GetLocationRadius())
+    local numUnits = poolPlatoon:GetNumCategoryUnits(testCat, engineerManager:GetLocationCoords(), engineerManager.Radius)
     return CompareBody(numUnits, unitCount, compareType)
 end
 
@@ -1094,7 +1094,7 @@ function DamagedStructuresInArea(aiBrain, locationtype)
     if not engineerManager then
         return false
     end
-    local Structures = AIUtils.GetOwnUnitsAroundPoint(aiBrain, categories.STRUCTURE - (categories.TECH1 - categories.FACTORY), engineerManager:GetLocationCoords(), engineerManager:GetLocationRadius())
+    local Structures = AIUtils.GetOwnUnitsAroundPoint(aiBrain, categories.STRUCTURE - (categories.TECH1 - categories.FACTORY), engineerManager:GetLocationCoords(), engineerManager.Radius)
     for k,v in Structures do
         if not v.Dead and v:GetHealthPercent() < .8 then
         #LOG('*AI DEBUG: DamagedStructuresInArea return true')
@@ -1110,7 +1110,7 @@ function UnfinishedUnits(aiBrain, locationType, category)
     if not engineerManager then
         return false
     end
-    local unfinished = aiBrain:GetUnitsAroundPoint(category, engineerManager:GetLocationCoords(), engineerManager:GetLocationRadius(), 'Ally')
+    local unfinished = aiBrain:GetUnitsAroundPoint(category, engineerManager:GetLocationCoords(), engineerManager.Radius, 'Ally')
     for num, unit in unfinished do
         donePercent = unit:GetFractionComplete()
         if donePercent < 1 and GetGuards(aiBrain, unit) < 1 then

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -388,7 +388,7 @@ Platoon = Class(moho.platoon_methods) {
                 while not target do
 
                     --DUNCAN - Commented out
-                    --if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy():IsDefeated() then
+                    --if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy().Result == "defeat" then
                     --    aiBrain:PickEnemyLogic()
                     --end
                     --target = AIUtils.AIFindBrainTargetInRange(aiBrain, self, 'Attack', maxRadius, atkPri, aiBrain:GetCurrentEnemy())
@@ -1385,7 +1385,7 @@ Platoon = Class(moho.platoon_methods) {
         local reactionTime = aiBrain.BaseMonitor.PoolReactionTime
         while aiBrain:PlatoonExists(self) do
             local platoonUnits = self:GetPlatoonUnits()
-            if aiBrain:PBMHasPlatoonList() then
+            if aiBrain.HasPlatoonList then
                 for locNum, locData in aiBrain.PBM.Locations do
                     if not locData.DistressCall then
                         local distressLocation = aiBrain:BaseMonitorDistressLocation(locData.Location, aiBrain.BaseMonitor.PoolDistressRange, aiBrain.BaseMonitor.PoolDistressThreshold)
@@ -1432,7 +1432,7 @@ Platoon = Class(moho.platoon_methods) {
             for locName, locData in aiBrain.BuilderManagers do
                 if not locData.BaseSettings.DistressCall then
                     local position = locData.EngineerManager:GetLocationCoords()
-                    local radius = locData.EngineerManager:GetLocationRadius()
+                    local radius = locData.EngineerManager.Radius
                     local distressRange = locData.BaseSettings.DistressRange or aiBrain.BaseMonitor.PoolDistressRange
                     local distressLocation = aiBrain:BaseMonitorDistressLocation(position, distressRange, aiBrain.BaseMonitor.PoolDistressThreshold)
 
@@ -1741,7 +1741,7 @@ Platoon = Class(moho.platoon_methods) {
         --LOG('*AI DEBUG: Engineer Repairing')
         local aiBrain = self:GetBrain()
         local engineerManager = aiBrain.BuilderManagers[self.PlatoonData.LocationType].EngineerManager
-        local Structures = AIUtils.GetOwnUnitsAroundPoint(aiBrain, categories.STRUCTURE - (categories.TECH1 - categories.FACTORY), engineerManager:GetLocationCoords(), engineerManager:GetLocationRadius())
+        local Structures = AIUtils.GetOwnUnitsAroundPoint(aiBrain, categories.STRUCTURE - (categories.TECH1 - categories.FACTORY), engineerManager:GetLocationCoords(), engineerManager.Radius)
         for k,v in Structures do
             -- prevent repairing a unit while reclaim is in progress (see ReclaimStructuresAI)
             if not v.Dead and not v.ReclaimInProgress and v:GetHealthPercent() < .8 then
@@ -2609,7 +2609,7 @@ Platoon = Class(moho.platoon_methods) {
         local movingToScout = false
         while aiBrain:PlatoonExists(self) do
             if not target or target.Dead then
-                if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy():IsDefeated() then
+                if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy().Result == "defeat" then
                     aiBrain:PickEnemyLogic()
                 end
                 local mult = { 1,10,25 }
@@ -2865,7 +2865,7 @@ Platoon = Class(moho.platoon_methods) {
             end
 
             -- pick out the enemy
-            if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy():IsDefeated() then
+            if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy().Result == "defeat" then
                 aiBrain:PickEnemyLogic()
             end
 
@@ -3028,7 +3028,7 @@ Platoon = Class(moho.platoon_methods) {
             end
 
             -- pick out the enemy
-            if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy():IsDefeated() then
+            if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy().Result == "defeat" then
                 aiBrain:PickEnemyLogic()
             end
 
@@ -3973,7 +3973,7 @@ Platoon = Class(moho.platoon_methods) {
                 if not locData.BaseSettings.DistressCall then
                     local position = locData.EngineerManager:GetLocationCoords()
                     local retPos = AIUtils.RandomLocation(position[1],position[3])
-                    local radius = locData.EngineerManager:GetLocationRadius()
+                    local radius = locData.EngineerManager.Radius
                     local distressRange = locData.BaseSettings.DistressRange or aiBrain.BaseMonitor.PoolDistressRange
                     local distressLocation = aiBrain:BaseMonitorDistressLocation(position, distressRange, aiBrain.BaseMonitor.PoolDistressThreshold)
 
@@ -4178,7 +4178,7 @@ Platoon = Class(moho.platoon_methods) {
                 WaitSeconds(7)
                 target = false
                 while not target do
-                    --if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy():IsDefeated() then
+                    --if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy().Result == "defeat" then
                     --    aiBrain:PickEnemyLogic()
                     --end
 
@@ -4754,7 +4754,7 @@ Platoon = Class(moho.platoon_methods) {
             end
 
             -- pick out the enemy
-            if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy():IsDefeated() then
+            if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy().Result == "defeat" then
                 aiBrain:PickEnemyLogicSorian()
             end
 
@@ -5546,7 +5546,7 @@ Platoon = Class(moho.platoon_methods) {
             end
 
             -- pick out the enemy
-            if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy():IsDefeated() then
+            if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy().Result == "defeat" then
                 aiBrain:PickEnemyLogicSorian()
             end
 
@@ -5805,7 +5805,7 @@ Platoon = Class(moho.platoon_methods) {
                 end
             end
             if not target or target.Dead or not target:GetPosition() then
-                if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy():IsDefeated() then
+                if aiBrain:GetCurrentEnemy() and aiBrain:GetCurrentEnemy().Result == "defeat" then
                     aiBrain:PickEnemyLogicSorian()
                 end
                 --local mult = { 1,10,25 }
@@ -6468,7 +6468,7 @@ Platoon = Class(moho.platoon_methods) {
         -- if we're too close to a base, forget it
         if aiBrain.BuilderManagers then
             for baseName, base in aiBrain.BuilderManagers do
-                local baseRadius = base.FactoryManager:GetLocationRadius()
+                local baseRadius = base.FactoryManager.Radius
                 if VDist2Sq(platPos[1], platPos[3], base.Position[1], base.Position[3]) <= (baseRadius * baseRadius) + (3 * radiusSq) then
                     return
                 end
@@ -6544,7 +6544,7 @@ Platoon = Class(moho.platoon_methods) {
             end
         end
         for k,v in ArmyBrains do
-            if not v:IsDefeated() and not ArmyIsCivilian(v:GetArmyIndex()) and IsAlly(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
+            if not v.Result == "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsAlly(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
                 local startX, startZ = v:GetArmyStartPos()
                 if VDist2Sq(markerPos[1], markerPos[3], startX, startZ) < baseRadius * baseRadius then
                     return false

--- a/lua/sim/BuilderManager.lua
+++ b/lua/sim/BuilderManager.lua
@@ -68,8 +68,8 @@ BuilderManager = Class {
             local highest = 0
             local key, value
             for k, v in self.BuilderData[bType].Builders do
-                if v:GetPriority() > highest then
-                    highest = v:GetPriority()
+                if v.Priority > highest then
+                    highest = v.Priority
                     value = v
                     key = k
                 end
@@ -131,8 +131,8 @@ BuilderManager = Class {
     GetBuilderPriority = function(self, builderName)
         for _,bType in self.BuilderData do
             for _,builder in bType.Builders do
-                if builder:GetBuilderName() == builderName then
-                    return builder:GetPriority()
+                if builder.BuilderName == builderName then
+                    return builder.Priority
                 end
             end
         end
@@ -142,7 +142,7 @@ BuilderManager = Class {
     GetActivePriority = function(self, builderName)
         for _,bType in self.BuilderData do
             for _,builder in bType.Builders do
-                if builder:GetBuilderName() == builderName then
+                if builder.BuilderName == builderName then
                     return builder:GetActivePriority()
                 end
             end
@@ -153,7 +153,7 @@ BuilderManager = Class {
     SetBuilderPriority = function(self,builderName,priority,temporary,setbystrat)
         for _,bType in self.BuilderData do
             for _,builder in bType.Builders do
-                if builder:GetBuilderName() == builderName then
+                if builder.BuilderName == builderName then
                     builder:SetPriority(priority, temporary, setbystrat)
                     return
                 end
@@ -164,7 +164,7 @@ BuilderManager = Class {
     ResetBuilderPriority = function(self,builderName)
         for _,bType in self.BuilderData do
             for _,builder in bType.Builders do
-                if builder:GetBuilderName() == builderName then
+                if builder.BuilderName == builderName then
                     builder:ResetPriority()
                     return
                 end
@@ -220,7 +220,7 @@ BuilderManager = Class {
     GetBuilder = function(self, builderName)
         for _,bType in self.BuilderData do
             for _,builder in bType.Builders do
-                if builder:GetBuilderName() == builderName then
+                if builder.BuilderName == builderName then
                     return builder
                 end
             end
@@ -255,12 +255,12 @@ BuilderManager = Class {
         local found = false
         local possibleBuilders = {}
         for k,v in self.BuilderData[bType].Builders do
-            if v:GetPriority() >= 1 and self:BuilderParamCheck(v,params) and (not found or v:GetPriority() == found) and v:GetBuilderStatus() then
+            if v.Priority >= 1 and self:BuilderParamCheck(v,params) and (not found or v.Priority == found) and v:GetBuilderStatus() then
                 if not self:IsPlattonBuildDelayed(v.DelayEqualBuildPlattons) then
-                    found = v:GetPriority()
+                    found = v.Priority
                     table.insert(possibleBuilders, k)
                 end
-            elseif found and v:GetPriority() < found then
+            elseif found and v.Priority < found then
                 break
             end
         end

--- a/lua/sim/EngineerManager.lua
+++ b/lua/sim/EngineerManager.lua
@@ -696,10 +696,10 @@ EngineerManager = Class(BuilderManager) {
             unit.PlatoonHandle = hndl
 
             --if EntityCategoryContains(categories.COMMAND, unit) then
-            --    LOG('*AI DEBUG: ARMY '..self.Brain.Nickname..': Engineer Manager Forming - '..builder.BuilderName..' - Priority: '..builder:GetPriority())
+            --    LOG('*AI DEBUG: ARMY '..self.Brain.Nickname..': Engineer Manager Forming - '..builder.BuilderName..' - Priority: '..builder.Priority)
             --end
 
-            --LOG('*AI DEBUG: ARMY ', repr(self.Brain:GetArmyIndex()),': Engineer Manager Forming - ',repr(builder.BuilderName),' - Priority: ', builder:GetPriority())
+            --LOG('*AI DEBUG: ARMY ', repr(self.Brain:GetArmyIndex()),': Engineer Manager Forming - ',repr(builder.BuilderName),' - Priority: ', builder.Priority)
             hndl.PlanName = template[2]
 
             --If we have specific AI, fork that AI thread
@@ -732,8 +732,8 @@ EngineerManager = Class(BuilderManager) {
                 end
             end
 
-            hndl.Priority = builder:GetPriority()
-            hndl.BuilderName = builder:GetBuilderName()
+            hndl.Priority = builder.Priority
+            hndl.BuilderName = builder.BuilderName
 
             hndl:SetPlatoonData(builder:GetBuilderData(self.LocationType))
 

--- a/lua/sim/PlatoonFormManager.lua
+++ b/lua/sim/PlatoonFormManager.lua
@@ -102,7 +102,7 @@ PlatoonFormManager = Class(BuilderManager) {
     ManagerLoopBody = function(self,builder,bType)
         BuilderManager.ManagerLoopBody(self,builder,bType)
         # Try to form all builders that pass
-        if self.Brain.BuilderManagers[self.LocationType] and builder:GetPriority() >= 1 and builder:CheckInstanceCount() then
+        if self.Brain.BuilderManagers[self.LocationType] and builder.Priority >= 1 and builder:CheckInstanceCount() then
             local personality = self.Brain:GetPersonality()
             local poolPlatoon = self.Brain:GetPlatoonUniquelyNamed('ArmyPool')
             local template = self:GetPlatoonTemplate(builder:GetPlatoonTemplate())
@@ -155,8 +155,8 @@ PlatoonFormManager = Class(BuilderManager) {
                     end
                 end
 
-                hndl.Priority = builder:GetPriority()
-                hndl.BuilderName = builder:GetBuilderName()
+                hndl.Priority = builder.Priority
+                hndl.BuilderName = builder.BuilderName
 
                 hndl:SetPlatoonData(builder:GetBuilderData(self.LocationType))
 

--- a/lua/sim/StrategyManager.lua
+++ b/lua/sim/StrategyManager.lua
@@ -90,11 +90,11 @@ StrategyManager = Class(BuilderManager) {
     ManagerLoopBody = function(self,builder,bType)
         BuilderManager.ManagerLoopBody(self,builder,bType)
 
-        if builder:GetPriority() >= 70 and builder:GetBuilderStatus() and not builder:IsStrategyActive() then
-            #LOG('*AI DEBUG: '..self.Brain.Nickname..' '..SUtils.TimeConvert(GetGameTimeSeconds())..' Activating Strategy: '..builder.BuilderName..' Priority: '..builder:GetPriority())
+        if builder.Priority >= 70 and builder:GetBuilderStatus() and not builder:IsStrategyActive() then
+            #LOG('*AI DEBUG: '..self.Brain.Nickname..' '..SUtils.TimeConvert(GetGameTimeSeconds())..' Activating Strategy: '..builder.BuilderName..' Priority: '..builder.Priority)
             self:ExecuteChanges(builder)
-        elseif (builder:GetPriority() < 70 or not builder:GetBuilderStatus()) and builder:IsStrategyActive() then
-            #LOG('*AI DEBUG: '..self.Brain.Nickname..' '..SUtils.TimeConvert(GetGameTimeSeconds())..' Deactivating Strategy: '..builder.BuilderName..' Priority: '..builder:GetPriority())
+        elseif (builder.Priority < 70 or not builder:GetBuilderStatus()) and builder:IsStrategyActive() then
+            #LOG('*AI DEBUG: '..self.Brain.Nickname..' '..SUtils.TimeConvert(GetGameTimeSeconds())..' Deactivating Strategy: '..builder.BuilderName..' Priority: '..builder.Priority)
             self:UndoChanges(builder)
         end
     end,

--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -169,7 +169,7 @@ function ScoreThread()
             ArmyScore[index].resources.energyout.rate = brain:GetArmyStat("Economy_Output_Energy", 0.0).Value
             ArmyScore[index].resources.energyover = brain:GetArmyStat("Economy_AccumExcess_Energy", 0.0).Value
 
-            for unitId, stats in brain:GetUnitStats() do
+            for unitId, stats in brain.UnitStats do
                 if ArmyScore[index].blueprints[unitId] == nil then
                     ArmyScore[index].blueprints[unitId] = {}
                 end

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -688,7 +688,7 @@ local function disPauseFunc()
 end
 
 local function NukeBtnText(button)
-    if not currentSelection[1] or currentSelection[1]:IsDead() then return '' end
+    if not currentSelection[1] or currentSelection[1].Dead then return '' end
     if table.getsize(currentSelection) > 1 then
         button.buttonText:SetColor('fffff600')
         return '?'
@@ -704,7 +704,7 @@ local function NukeBtnText(button)
 end
 
 local function TacticalBtnText(button)
-    if not currentSelection[1] or currentSelection[1]:IsDead() then return '' end
+    if not currentSelection[1] or currentSelection[1].Dead then return '' end
     if table.getsize(currentSelection) > 1 then
         button.buttonText:SetColor('fffff600')
         return '?'
@@ -798,7 +798,7 @@ end
 
 function EnterOverchargeMode()
     local unit = currentSelection[1]
-    if not unit or unit:IsDead() or unit:IsOverchargePaused() then return end
+    if not unit or unit.Dead or unit:IsOverchargePaused() then return end
     local bp = unit:GetBlueprint()
     local weapon = FindOCWeapon(unit:GetBlueprint())
     if not weapon then return end
@@ -811,7 +811,7 @@ end
 
 local function OverchargeFrame(self, deltaTime)
     local unit = currentSelection[1]
-    if not unit or unit:IsDead() then return end
+    if not unit or unit.Dead then return end
     local weapon = FindOCWeapon(unit:GetBlueprint())
     if not weapon then
         self:SetNeedsFrameUpdate(false)

--- a/units/DEA0202/DEA0202_Script.lua
+++ b/units/DEA0202/DEA0202_Script.lua
@@ -106,7 +106,7 @@ DEA0202 = Class(TAirUnit) {
     MonitorWings = function(self)
         local airTargetRight
         local airTargetLeft
-        while self and not self:IsDead() do
+        while self and not self.Dead do
             WaitSeconds(1)
             local airTargetWeapon = self:GetWeaponByLabel('RightBeam')
             if airTargetWeapon then     

--- a/units/DRA0202/DRA0202_Script.lua
+++ b/units/DRA0202/DRA0202_Script.lua
@@ -100,7 +100,7 @@ DRA0202 = Class(CAirUnit) {
     
     MonitorWings = function(self)
         local airTarget
-        while self and not self:IsDead() do
+        while self and not self.Dead do
             WaitSeconds(1)
             local airTargetWeapon = self:GetWeaponByLabel('AntiAirMissiles')
             if airTargetWeapon then     

--- a/units/UEL0401/UEL0401_script.lua
+++ b/units/UEL0401/UEL0401_script.lua
@@ -86,7 +86,7 @@ UEL0401 = Class(TMobileFactoryUnit) {
             self.PrepareToBuildManipulator:SetRate(self.PrepareToBuildAnimRate)
             local bone = self.BuildAttachBone
             self:DetachAll(bone)
-            if not self.UnitBeingBuilt:IsDead() then
+            if not self.UnitBeingBuilt.Dead then
                 unitBuilding:AttachBoneTo(-2, self, bone)
                 local unitHeight = unitBuilding:GetBlueprint().SizeY
                 self.AttachmentSliderManip:SetGoal(0, unitHeight, 0)
@@ -110,7 +110,7 @@ UEL0401 = Class(TMobileFactoryUnit) {
     RollingOffState = State {
         Main = function(self)
             local unitBuilding = self.UnitBeingBuilt
-            if not unitBuilding:IsDead() then
+            if not unitBuilding.Dead then
                 unitBuilding:ShowBone(0, true)
             end
             WaitFor(self.PrepareToBuildManipulator)
@@ -124,7 +124,7 @@ UEL0401 = Class(TMobileFactoryUnit) {
             self.AttachmentSliderManip:SetGoal(0, -3, 17)
             WaitFor(self.AttachmentSliderManip)
 
-            if not unitBuilding:IsDead() then
+            if not unitBuilding.Dead then
                 unitBuilding:DetachFrom(true)
                 self:DetachAll(self.BuildAttachBone)
                 local  worldPos = self:CalculateWorldPositionFromRelative({0, 0, -15})

--- a/units/URL0402/URL0402_script.lua
+++ b/units/URL0402/URL0402_script.lua
@@ -105,7 +105,7 @@ URL0402 = Class(CWalkingLandUnit) {
     end,
 
     UnitLandAmbientEffectThread = function(self)
-        while not self:IsDead() do
+        while not self.Dead do
             local army = self:GetArmy()
 
             for kE, vE in self.AmbientLandExhaustEffects do

--- a/units/XEA3204/XEA3204_script.lua
+++ b/units/XEA3204/XEA3204_script.lua
@@ -21,7 +21,7 @@ XEA3204 = Class(TConstructionUnit) {
     end,
 
     OnKilled = function(self, instigator, type, overkillRatio)
-        if self.Parent and not self.Parent:IsDead() then
+        if self.Parent and not self.Parent.Dead then
             self.Parent:NotifyOfPodDeath(self.PodName)
             self.Parent = nil
         end
@@ -44,8 +44,8 @@ XEA3204 = Class(TConstructionUnit) {
     end,
 
     OnMotionHorzEventChange = function(self, new, old)
-        if self and not self:IsDead() then
-            if self.Parent and not self.Parent:IsDead() then
+        if self and not self.Dead then
+            if self.Parent and not self.Parent.Dead then
                 local myPosition = self:GetPosition()
                 local parentPosition = self.Parent:GetPosition(self.Parent.PodData[self.PodName].PodAttachpoint)
                 local distSq = VDist2Sq(myPosition[1], myPosition[3], parentPosition[1], parentPosition[3])

--- a/units/XSC9002/XSC9002_Script.lua
+++ b/units/XSC9002/XSC9002_Script.lua
@@ -26,7 +26,7 @@ XSC9002 = Class(SStructureUnit) {
 
     LandBlipThread = function(self)
         local position = self:GetPosition()
-        while not self:IsDead() do
+        while not self.Dead do
             -- Spawn land blips
             self.landChildUnit = CreateUnitHPR('XSC9010', self:GetArmy(), position[1], position[2], position[3], 0, 0, 0)
             self.landChildUnit.parentCrystal = self
@@ -40,7 +40,7 @@ XSC9002 = Class(SStructureUnit) {
 
     AirBlipThread = function(self)
         local position = self:GetPosition()
-        while not self:IsDead() do
+        while not self.Dead do
             -- Spawn air blips
             self.airChildUnit = CreateUnitHPR('XSC9011', self:GetArmy(), position[1], position[2], position[3], 0, 0, 0)
             self.airChildUnit.parentCrystal = self


### PR DESCRIPTION
Removed some functions like `:IsDead()` and used values directly (`.Dead`)

:IsDead() -> .Dead
:GetUnitStats() -> .UnitStats
:IsDefeated() -> .Result == "defeat"
:AIGetLayerPreference() -> .LayerPref
:PBMHasPlatoonList() -> .HasPlatoonList
:GetRadius() -> .Radius
:GetCurrentEngineerCount() -> .CurrentEngineerCount
:GetMaximumEngineers() -> .EngineerQuantity
:GetPriority() -> .Priority
:GetBuilderName() -> .BuilderName
:GetLocationRadius() -> .Radius
