### PR TITLE
 [Issue#1260] Ythotha fix destroy

### DIFF
--- a/units/XSL0401/XSL0401_Script.lua
+++ b/units/XSL0401/XSL0401_Script.lua
@@ -23,6 +23,32 @@ XSL0401 = Class(SWalkingLandUnit) {
         '/effects/emitters/seraphim_othuy_spawn_04_emit.bp',
     },
 
+    SpawnElectroStorm = function(self)
+        local army = self:GetArmy()
+        local position = self:GetPosition()
+        local spawnEffects = self.SpawnEffects
+        
+        -- Spawn the Energy Being
+        local spiritUnit = CreateUnitHPR('XSL0402', army, position[1], position[2], position[3], 0, 0, 0)
+        -- Create effects for spawning of energy being
+        for k, v in spawnEffects do
+            CreateAttachedEmitter(spiritUnit, -1, army, v)
+        end
+    end,
+
+    OnReclaimed = function(self, entity)
+        --save before destroy
+        local army = self:GetArmy()
+
+        SWalkingLandUnit.OnReclaimed(self, entity)
+
+        if army == entity:GetArmy() or IsAlly(army,entity:GetArmy()) then  -- for reclaim from self player (defuse)
+            return
+        end
+        -- Spawn the Energy Being
+        self:SpawnElectroStorm()
+    end,
+
     Weapons = {
         EyeWeapon = Class(SDFExperimentalPhasonProj) {},
         LeftArm = Class(SDFAireauWeapon) {},
@@ -111,25 +137,14 @@ XSL0401 = Class(SWalkingLandUnit) {
             end
         end
 
+        if self:GetFractionComplete() == 1 then
+            self:SpawnElectroStorm()
+        end
+
         self:PlayUnitSound('Destroyed')
         self:Destroy()
     end,
 
-    OnDestroy = function(self)
-        SWalkingLandUnit.OnDestroy(self)
-
-        -- Don't make the energy being if not built, or if this is a unit transfer
-        if self:GetFractionComplete() ~= 1 or self.IsBeingTransferred then return end
-
-        -- Spawn the Energy Being
-        local position = self:GetPosition()
-        local spiritUnit = CreateUnitHPR('XSL0402', self:GetArmy(), position[1], position[2], position[3], 0, 0, 0)
-
-        -- Create effects for spawning of energy being
-        for k, v in self.SpawnEffects do
-            CreateAttachedEmitter(spiritUnit, -1, self:GetArmy(), v)
-        end
-    end,
 }
 
 TypeClass = XSL0401


### PR DESCRIPTION
[Issue#1260](https://github.com/FAForever/fa/issues/1260) Ythotha fix destroy
Refactored code in fa/units/XSL0401/XSL0401_Script.lua
Changed:
1. Move lightning spawn from OnDestroy to OnReclaimed
2. Spawn lightning in DeathThread as original
3. Add defuse lightning from owner by reclaim
4. Call Unit:Destroy() not spawn lightning [as wanila]

This commits add lightning after reclaim Ythotha unit by any army (not owner). But it work more correctly then this [commit 1449dc5a3450b4cb497d20439969f0736ff6c784](https://github.com/FAForever/fa/commit/1449dc5a3450b4cb497d20439969f0736ff6c784) without using duct tape [IsBeingTransferred](https://github.com/FAForever/fa/commit/810ffcc30af98701374bd2588fbdc61d911a605b#diff-978e442e90e99e5cab1d4e27bd351351). Also not spawn lightning on Unit:Destroy() how it should be