### PR TITLE
remove player color that is to close to civilian one

### DIFF
--- a/lua/GameColors.lua
+++ b/lua/GameColors.lua
@@ -15,7 +15,6 @@ GameColors = {
     "FF2929e1",      -- UEF blue
     "FF5F01A7",      -- dark purple
     "ffff32ff",      -- new fuschia
-    "ffffbf80",      -- lt orange
     "ffa79602",      -- Sera golden
     "ffb76518",      -- new brown
     "ff901427",      -- dark red
@@ -38,7 +37,6 @@ GameColors = {
     "FF2929e1",      -- UEF blue
     "FF5F01A7",      -- dark purple
     "ffff32ff",      -- new fuschia
-    "ffffbf80",      -- lt orange
     "ffa79602",      -- Sera golden
     "ffb76518",      -- new brown
     "ff901427",      -- dark red


### PR DESCRIPTION
… other colour

You can see the new colour on the right here : 
(img)https://i.imgur.com/P1iCPY0.jpg
I put it with the nearest colours available (light blue, grey, blue) and it visually conflicts with none.