### PR TITLE
Fix units lose veterancy after transfer

### DIFF
--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -87,6 +87,7 @@ function TransferUnitsOwnership(units, ToArmyIndex)
         local numNukes = unit:GetNukeSiloAmmoCount()  -- looks like one of these 2 works for SMDs also
         local numTacMsl = unit:GetTacticalSiloAmmoCount()
         local massKilled = unit.Sync.totalMassKilled
+        local massKilledTrue = unit.Sync.totalMassKilledTrue
         local unitHealth = unit:GetHealth()
         local shieldIsOn = false
         local ShieldHealth = 0
@@ -137,7 +138,7 @@ function TransferUnitsOwnership(units, ToArmyIndex)
 
         -- A F T E R
         if massKilled and massKilled > 0 then
-            unit:CalculateVeterancyLevelAfterTransfer(massKilled)
+            unit:CalculateVeterancyLevelAfterTransfer(massKilled, massKilledTrue)
         end
         if enh and table.getn(enh) > 0 then
             for k, v in enh do

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -137,7 +137,7 @@ function TransferUnitsOwnership(units, ToArmyIndex)
 
         -- A F T E R
         if massKilled and massKilled > 0 then
-            unit:CalculateVeterancyLevel(massKilled)
+            unit:CalculateVeterancyLevelAfterTransfer(massKilled)
         end
         if enh and table.getn(enh) > 0 then
             for k, v in enh do

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1376,8 +1376,9 @@ Unit = Class(moho.unit_methods) {
         self:SetVeteranLevel(self.Sync.VeteranLevel)
     end,
     
-    CalculateVeterancyLevelAfterTransfer = function(self, massKilled)
+    CalculateVeterancyLevelAfterTransfer = function(self, massKilled, massKilledTrue)
         self.Sync.totalMassKilled = math.floor(massKilled)
+        self.Sync.totalMassKilledTrue = math.floor(massKilledTrue)
         
         local newVetLevel = math.min(math.floor(self.Sync.totalMassKilled / self.Sync.myValue), 5)
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1358,8 +1358,6 @@ Unit = Class(moho.unit_methods) {
     end,
 
     CalculateVeterancyLevel = function(self, massKilled)
-        local bp = self:GetBlueprint()
-
         -- Limit the veterancy gain from one kill to one level worth
         massKilled = math.min(massKilled, self.Sync.myValue)
 
@@ -1375,6 +1373,17 @@ Unit = Class(moho.unit_methods) {
         -- Update our recorded veterancy level
         self.Sync.VeteranLevel = newVetLevel
 
+        self:SetVeteranLevel(self.Sync.VeteranLevel)
+    end,
+    
+    CalculateVeterancyLevelAfterTransfer = function(self, massKilled)
+        self.Sync.totalMassKilled = math.floor(massKilled)
+        
+        local newVetLevel = math.min(math.floor(self.Sync.totalMassKilled / self.Sync.myValue), 5)
+
+        if newVetLevel == self.Sync.VeteranLevel then return end
+
+        self.Sync.VeteranLevel = newVetLevel
         self:SetVeteranLevel(self.Sync.VeteranLevel)
     end,
 

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -409,6 +409,7 @@ function UpdateWindow(info)
                 if currentLevel < 5 then
                     controls.vetBar:Show()
                     controls.vetBar:SetValue(progress)
+                    controls.vetTitle:SetText('Veterancy')
 
                     local nextLevel = myValue * (currentLevel + 1)
                     local text


### PR DESCRIPTION
vet 2,3,4,5 units become vet 1 after transfer because of this code
```
-- Limit the veterancy gain from one kill to one level worth
    massKilled = math.min(massKilled, self.Sync.myValue)
```
now there is separate function for transferred units.

Also added massKilledTrue value (which is used by "Mass killed" feature) to the transfer process, so now it will be displayed for transferred unit too. And fixed little UI bug (If you select full veted unit and after that select smth else, then "Mass killed" text won't change to "Veterancy")

