### PR TITLE
Fix Novax crashing other mods

### DIFF
--- a/lua/terranweapons.lua
+++ b/lua/terranweapons.lua
@@ -262,12 +262,4 @@ TOrbitalDeathLaserBeamWeapon = Class(DefaultBeamWeapon) {
         end
         DefaultBeamWeapon.PlayFxWeaponUnpackSequence(self)
     end,
-    
-    IdleState = State (DefaultProjectileWeapon.IdleState) {
-        Main = function(self)
-            DefaultProjectileWeapon.IdleState.Main(self)
-            --This is basically a copy of DefaultBeamWeapon.IdleState.Main without PlayFxBeamEnd() as we don't want satellite to stop firing when idle
-            --Beam will be turned off by DefaultBeamWeapon.BeamLifetimeThread later anyway.
-        end,
-    },
 }

--- a/units/XEA0002/XEA0002_unit.bp
+++ b/units/XEA0002/XEA0002_unit.bp
@@ -236,7 +236,7 @@ UnitBlueprint {
                 },
             },
             RackFireTogether = false,
-            RackRecoilDistance = 0,
+            RackRecoilDistance = -1,
             RackReloadTimeout = 0,
             RackSalvoChargeTime = 0,
             RackSalvoReloadTime = 0,


### PR DESCRIPTION
changing the script like that lead to mods that hook
defaultprojectileweapon to change something in there, have ambiguous
class definitions which is very difficult to fix if you dont know what
you are doing, and it locked out a bunch of modding opportunities. to
prevent this, there is a script free way of doing the same thing, with a
blueprint value.

what this really does is highlight the need to refactor the weapon
class. this only works because the Main function inside idle state waits
for the recoil manipulators, which lasts until the beam is destroyed via
the thread. its a complete mess really. but thats how all beam units
work.

there should be a proper blueprint value to end beam on retarget or not,
and the recoil should not stall the beam end sequence.