### PR TITLE
ASF rebalance

### DIFF
--- a/units/UAA0302/UAA0302_unit.bp
+++ b/units/UAA0302/UAA0302_unit.bp
@@ -15,7 +15,7 @@ UnitBlueprint {
         KTurn = 1,
         KTurnDamping = 1.5,
         LiftFactor = 7,
-        MaxAirspeed = 30,
+        MaxAirspeed = 27,
         MinAirspeed = 25,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.1,

--- a/units/UAA0303/UAA0303_unit.bp
+++ b/units/UAA0303/UAA0303_unit.bp
@@ -21,7 +21,7 @@ UnitBlueprint {
         KTurn = 1.5,
         KTurnDamping = 2.3,
         LiftFactor = 7,
-        MaxAirspeed = 25,
+        MaxAirspeed = 22,
         MinAirspeed = 8,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.02,
@@ -185,7 +185,7 @@ UnitBlueprint {
     Economy = {
         BuildCostEnergy = 40000,
         BuildCostMass = 350,
-        BuildTime = 3000,
+        BuildTime = 4000,
     },
     Footprint = {
         MaxSlope = 0.25,

--- a/units/UEA0302/UEA0302_unit.bp
+++ b/units/UEA0302/UEA0302_unit.bp
@@ -15,7 +15,7 @@ UnitBlueprint {
         KTurn = 1,
         KTurnDamping = 1.5,
         LiftFactor = 7,
-        MaxAirspeed = 30,
+        MaxAirspeed = 27,
         MinAirspeed = 25,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.1,

--- a/units/UEA0303/UEA0303_unit.bp
+++ b/units/UEA0303/UEA0303_unit.bp
@@ -21,7 +21,7 @@ UnitBlueprint {
         KTurn = 1.5,
         KTurnDamping = 2.3,
         LiftFactor = 7,
-        MaxAirspeed = 25,
+        MaxAirspeed = 22,
         MinAirspeed = 8,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.03,
@@ -190,7 +190,7 @@ UnitBlueprint {
     Economy = {
         BuildCostEnergy = 40000,
         BuildCostMass = 350,
-        BuildTime = 3000,
+        BuildTime = 4000,
     },
     Footprint = {
         MaxSlope = 0.25,

--- a/units/URA0302/URA0302_unit.bp
+++ b/units/URA0302/URA0302_unit.bp
@@ -15,7 +15,7 @@ UnitBlueprint {
         KTurn = 1,
         KTurnDamping = 1.5,
         LiftFactor = 7,
-        MaxAirspeed = 30,
+        MaxAirspeed = 27,
         MinAirspeed = 25,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.1,

--- a/units/URA0303/URA0303_unit.bp
+++ b/units/URA0303/URA0303_unit.bp
@@ -21,7 +21,7 @@ UnitBlueprint {
         KTurn = 1.5,
         KTurnDamping = 2.3,
         LiftFactor = 7,
-        MaxAirspeed = 25,
+        MaxAirspeed = 22,
         MinAirspeed = 8,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.03,
@@ -185,7 +185,7 @@ UnitBlueprint {
     Economy = {
         BuildCostEnergy = 40000,
         BuildCostMass = 350,
-        BuildTime = 3000,
+        BuildTime = 4000,
         MaintenanceConsumptionPerSecondEnergy = 25,
     },
     Footprint = {

--- a/units/XSA0302/XSA0302_unit.bp
+++ b/units/XSA0302/XSA0302_unit.bp
@@ -15,7 +15,7 @@ UnitBlueprint {
         KTurn = 1,
         KTurnDamping = 1.5,
         LiftFactor = 7,
-        MaxAirspeed = 30,
+        MaxAirspeed = 27,
         MinAirspeed = 25,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.1,

--- a/units/XSA0303/XSA0303_unit.bp
+++ b/units/XSA0303/XSA0303_unit.bp
@@ -21,7 +21,7 @@ UnitBlueprint {
         KTurn = 1.5,
         KTurnDamping = 2.3,
         LiftFactor = 7,
-        MaxAirspeed = 25,
+        MaxAirspeed = 22,
         MinAirspeed = 8,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.02,
@@ -185,7 +185,7 @@ UnitBlueprint {
     Economy = {
         BuildCostEnergy = 40000,
         BuildCostMass = 350,
-        BuildTime = 3000,
+        BuildTime = 4000,
     },
     Footprint = {
         MaxSlope = 0.25,


### PR DESCRIPTION
- to reduce the need of ASF spam
- to make droping a bit more prevalente even if T3 air is in the game
- to make air exp less easy to snipe
- some speed tweaking might be needed for T3 scout/strat, although ASF still have 5 more speed than strat.