### PR TITLE
useful torpedo on amphibious unit

### DIFF
--- a/units/URL0203/URL0203_unit.bp
+++ b/units/URL0203/URL0203_unit.bp
@@ -362,7 +362,7 @@ UnitBlueprint {
             },
             BallisticArc = 'RULEUBA_None',
             CollideFriendly = false,
-            Damage = 22,
+            Damage = 15,
             DamageType = 'Normal',
             DisplayName = 'Meson Torpedo',
             FireTargetLayerCapsTable = {

--- a/units/URL0203/URL0203_unit.bp
+++ b/units/URL0203/URL0203_unit.bp
@@ -362,7 +362,7 @@ UnitBlueprint {
             },
             BallisticArc = 'RULEUBA_None',
             CollideFriendly = false,
-            Damage = 6,
+            Damage = 22,
             DamageType = 'Normal',
             DisplayName = 'Meson Torpedo',
             FireTargetLayerCapsTable = {

--- a/units/XRL0305/XRL0305_unit.bp
+++ b/units/XRL0305/XRL0305_unit.bp
@@ -313,7 +313,7 @@ UnitBlueprint {
             },
             BallisticArc = 'RULEUBA_None',
             CollideFriendly = false,
-            Damage = 4,
+            Damage = 64,
             DamageType = 'Normal',
             DisplayName = 'Nanite Torpedo Launcher',
             DoTPulses = 5,

--- a/units/XRL0305/XRL0305_unit.bp
+++ b/units/XRL0305/XRL0305_unit.bp
@@ -313,7 +313,7 @@ UnitBlueprint {
             },
             BallisticArc = 'RULEUBA_None',
             CollideFriendly = false,
-            Damage = 64,
+            Damage = 8,
             DamageType = 'Normal',
             DisplayName = 'Nanite Torpedo Launcher',
             DoTPulses = 5,

--- a/units/XSL0303/XSL0303_unit.bp
+++ b/units/XSL0303/XSL0303_unit.bp
@@ -507,7 +507,7 @@ UnitBlueprint {
             },
             BallisticArc = 'RULEUBA_None',
             CollideFriendly = false,
-            Damage = 10,
+            Damage = 42,
             DamageType = 'Normal',
             DisplayName = 'Uall Cavitation Torpedo Launcher',
             FireTargetLayerCapsTable = {

--- a/units/XSL0303/XSL0303_unit.bp
+++ b/units/XSL0303/XSL0303_unit.bp
@@ -507,7 +507,7 @@ UnitBlueprint {
             },
             BallisticArc = 'RULEUBA_None',
             CollideFriendly = false,
-            Damage = 42,
+            Damage = 30,
             DamageType = 'Normal',
             DisplayName = 'Uall Cavitation Torpedo Launcher',
             FireTargetLayerCapsTable = {


### PR DESCRIPTION
Making the torpedo worth not being a complete joke anymore.
ratio dps/mass : 0.15 for wagner; 0.1 for brick/othuums
comparison : 0.4 T1 subs, ~0.18 for destro (apart uef) but they also have good anti-torp, range and vision advantage; 0.4 T2 subs + they have antitorp, range/vision (possibly stealth) advantage