### PR TITLE
fix error

### DIFF
--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -1082,10 +1082,10 @@ function GUI_OldMap(over)
     dialogContent.Width:Set(1000)
     dialogContent.Height:Set(100)
 
-    local Changelog = import('/lua/ui/lobby/changelog.lua')
+    local ChangelogData = import('/lua/ui/lobby/changelogData.lua')
     local OldMapPopup = Popup(GUI, dialogContent)
     OldMapPopup.OnClosed = function()
-        Prefs.SetToCurrentProfile('LobbyChangelog', Changelog.last_version)
+        Prefs.SetToCurrentProfile('LobbyChangelog', ChangelogData.last_version)
     end
 
     -- Title --


### PR DESCRIPTION
incorrectly named file changelog caused error in the lobby when trying to get rid of the warning related to obsolete maps

credits go to speed2 - thanks for fixing this 2 secs after the bug was reported to us