### PR TITLE
github and close button are now reversed

### DIFF
--- a/lua/ui/lobby/changelog.lua
+++ b/lua/ui/lobby/changelog.lua
@@ -88,7 +88,7 @@ function CreateUI(parent, showPatch)
 
     -- Close button
     local CloseButton = UIUtil.CreateButtonWithDropshadow(dialogContent, '/BUTTON/medium/', '<LOC _Close>Close')
-    LayoutHelpers.AtLeftIn(CloseButton, dialogContent)
+    LayoutHelpers.AtRightIn(GithubButton, dialogContent)
     LayoutHelpers.AtBottomIn(CloseButton, dialogContent, 10)
     CloseButton.OnClick = function()
         changelogPopup:Close()
@@ -96,7 +96,7 @@ function CreateUI(parent, showPatch)
 
     -- Link to the changelog on github
     local GithubButton = UIUtil.CreateButtonWithDropshadow(dialogContent, '/BUTTON/medium/', "Github")
-    LayoutHelpers.AtRightIn(GithubButton, dialogContent)
+    LayoutHelpers.AtLeftIn(CloseButton, dialogContent)
     LayoutHelpers.AtBottomIn(GithubButton, dialogContent, 10)
     GithubButton.OnClick = function()
         OpenURL('http://github.com/FAForever/fa/blob/develop/changelog.md')

--- a/lua/ui/lobby/changelog.lua
+++ b/lua/ui/lobby/changelog.lua
@@ -88,7 +88,7 @@ function CreateUI(parent, showPatch)
 
     -- Close button
     local CloseButton = UIUtil.CreateButtonWithDropshadow(dialogContent, '/BUTTON/medium/', '<LOC _Close>Close')
-    LayoutHelpers.AtRightIn(GithubButton, dialogContent)
+    LayoutHelpers.AtRightIn(CloseButton, dialogContent)
     LayoutHelpers.AtBottomIn(CloseButton, dialogContent, 10)
     CloseButton.OnClick = function()
         changelogPopup:Close()
@@ -96,7 +96,7 @@ function CreateUI(parent, showPatch)
 
     -- Link to the changelog on github
     local GithubButton = UIUtil.CreateButtonWithDropshadow(dialogContent, '/BUTTON/medium/', "Github")
-    LayoutHelpers.AtLeftIn(CloseButton, dialogContent)
+    LayoutHelpers.AtLeftIn(GithubButton, dialogContent)
     LayoutHelpers.AtBottomIn(GithubButton, dialogContent, 10)
     GithubButton.OnClick = function()
         OpenURL('http://github.com/FAForever/fa/blob/develop/changelog.md')


### PR DESCRIPTION
Every UI in the world ptus the "OK" button in a dialog box (or Close) in the bottom right corner.
https://www.google.fr/search?safe=off&tbm=isch&source=hp&biw=1910&bih=961&ei=J-MxXPbcLrKPlwTkmoL4DA&q=dialog+box&oq=dialog+box&gs_l=img.3..0j0i30l9.324.1065..1144...0.0..0.103.702.8j1......0....1..gws-wiz-img.....0..0i10.Icb9MVit33M#imgrc=1n5ta9JZZ2UPKM:
"More details" buttons and all should be on the other side of the window, or at the left of such button.
I keep pressing the wrong button by reflex when I want to close the window and I think that means the window isn't very intuitive to use.

This branch is for bugfixes, general improvements, and new features. If your change is designed to alter balance, please make 
sure your changes are rebased onto [development/balance] (https://github.com/FAForever/fa/tree/development/balance), and target that branch with your PR.