### PR TITLE
Increasing t2 arty minimum range

### DIFF
--- a/units/UAB2303/UAB2303_unit.bp
+++ b/units/UAB2303/UAB2303_unit.bp
@@ -209,7 +209,7 @@ UnitBlueprint {
             FiringTolerance = 1,
             Label = 'MainGun',
             MaxRadius = 128,
-            MinRadius = 5,
+            MinRadius = 50,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 26.13,

--- a/units/UEB2303/UEB2303_unit.bp
+++ b/units/UEB2303/UEB2303_unit.bp
@@ -216,7 +216,7 @@ UnitBlueprint {
             FiringTolerance = 1,
             Label = 'MainGun',
             MaxRadius = 128,
-            MinRadius = 5,
+            MinRadius = 50,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 26.13,

--- a/units/URB2303/URB2303_unit.bp
+++ b/units/URB2303/URB2303_unit.bp
@@ -203,7 +203,7 @@ UnitBlueprint {
             FiringTolerance = 1,
             Label = 'MainGun',
             MaxRadius = 128,
-            MinRadius = 5,
+            MinRadius = 50,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 26.13,

--- a/units/XSB2303/XSB2303_unit.bp
+++ b/units/XSB2303/XSB2303_unit.bp
@@ -242,7 +242,7 @@ UnitBlueprint {
             FiringTolerance = 1,
             Label = 'MainGun',
             MaxRadius = 128,
-            MinRadius = 5,
+            MinRadius = 50,
             MuzzleChargeDelay = 1,
             MuzzleSalvoChargeDelay = 0,
             MuzzleSalvoDelay = 0,


### PR DESCRIPTION
Making t2 arties a little less good and making sure they are used for their original purpose: Long range shelling. Min range = t2 pd max range
All t2 arties: Min range: 5 > 50