### PR TITLE
Enable transport rates to be set vs blueprint

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4050,23 +4050,27 @@ Unit = Class(moho.unit_methods) {
     end,
 
     TransportAnimationThread = function(self, rate)
-        local bp = self:GetBlueprint().Display.TransportAnimation
+        local bp = self:GetBlueprint().Display
+        local animbp
+        rate = rate or 1
 
-        if rate and rate < 0 and self:GetBlueprint().Display.TransportDropAnimation then
-            bp = self:GetBlueprint().Display.TransportDropAnimation
-            rate = -rate
+        if rate < 0 and bp.TransportDropAnimation then
+            animbp = bp.TransportDropAnimation
+            rate = bp.TransportDropAnimationSpeed or -rate
+        else
+            animbp = bp.TransportAnimation
+            rate = bp.TransportAnimationSpeed or rate
         end
 
         WaitSeconds(.5)
-        if bp then
-            local animBlock = self:ChooseAnimBlock(bp)
+        if animbp then
+            local animBlock = self:ChooseAnimBlock(animbp)
             if animBlock.Animation then
                 if not self.TransAnimation then
                     self.TransAnimation = CreateAnimator(self)
                     self.Trash:Add(self.TransAnimation)
                 end
                 self.TransAnimation:PlayAnim(animBlock.Animation)
-                rate = rate or 1
                 self.TransAnimation:SetRate(rate)
                 WaitFor(self.TransAnimation)
             end


### PR DESCRIPTION
pretty much what it says on the tin. This allows blueprints to have
TransportAnimationSpeed and TransportDropAnimationSpeed which can
configure the rates at which the animations play. If they are missing,
the code assumes default behavior, so its backwards compatible.

this is for mod support reasons.