### PR TITLE
Adds exit button to endscreen

### DIFF
--- a/lua/ui/dialogs/hotstats.lua
+++ b/lua/ui/dialogs/hotstats.lua
@@ -1031,6 +1031,7 @@ function Set_graph(victory, showCampaign, operationVictoryTable, dialog, standar
             bar_btn:SetCheck(false)
             graph_btn:SetCheck(false)
             dual_btn:SetCheck(false)
+            exit_btn:SetCheck(false)
         end
     end
     -- main title
@@ -1052,6 +1053,7 @@ function Set_graph(victory, showCampaign, operationVictoryTable, dialog, standar
             standardBtn:SetCheck(false)
             graph_btn:SetCheck(false)
             dual_btn:SetCheck(false)
+            exit_btn:SetCheck(false)
         end
     end
     graph_btn = CreateDialogTabs(dialog, LOC("<LOC tooltipui0207>Graph"), "m")
@@ -1070,9 +1072,10 @@ function Set_graph(victory, showCampaign, operationVictoryTable, dialog, standar
             bar_btn:SetCheck(false)
             standardBtn:SetCheck(false)
             dual_btn:SetCheck(false)
+            exit_btn:SetCheck(false)
         end
     end
-    dual_btn = CreateDialogTabs(dialog, "Dual", "r")
+    dual_btn = CreateDialogTabs(dialog, "Dual", "m")
     LayoutHelpers.AtLeftIn(dual_btn, dialog, 467)
     dual_btn.Bottom:Set(dialog.Bottom() - 73)
     dual_btn:UseAlphaHitTest(false)
@@ -1089,8 +1092,35 @@ function Set_graph(victory, showCampaign, operationVictoryTable, dialog, standar
             bar_btn:SetCheck(false)
             standardBtn:SetCheck(false)
             graph_btn:SetCheck(false)
+            exit_btn:SetCheck(false)
         end
     end
+
+    if HasCommandLineArg("/gpgnet") then
+        exit_btn = CreateDialogTabs(dialog, LOC("<LOC _Exit_to_FAF>Exit to FAF"), "r")
+    else
+        exit_btn = CreateDialogTabs(dialog, LOC("<LOC _Continue>"), "r")
+    end
+    LayoutHelpers.AtLeftIn(exit_btn, dialog, 608)
+    exit_btn.Bottom:Set(dialog.Bottom() - 73)
+    exit_btn:UseAlphaHitTest(false)
+    exit_btn.Depth:Set(dialog.Depth() + 100)
+    exit_btn.OnClick = function(self)
+        if self:IsChecked() then
+            return
+        else
+            clean_view()
+            ConExecute("ren_Oblivion false")
+            if HasCommandLineArg("/gpgnet") then
+                -- Quit to desktop
+                import('/lua/ui/dialogs/eschandler.lua').SafeQuit()
+            else
+                -- Back to main menu
+                ExitGame()
+            end
+        end
+    end
+
     graph_btn:SetCheck(true)
     page_graph(dialog)
     -- create first graph


### PR DESCRIPTION
In case there is no data available at the endscreen, we have no exit button.

This PR will add one.
If the game was launched from FAF it will show "Exit to FAF".
If launched from desktop it will show "Continue".

![newexitbutton](https://user-images.githubusercontent.com/17804547/52372906-9d3d3180-2a59-11e9-8519-2af705063ec6.png)
