### PR TITLE
Optimized unitcount for VictoryConditions.

### DIFF
--- a/lua/victory.lua
+++ b/lua/victory.lua
@@ -6,15 +6,14 @@ local victoryCategories = {
     eradication=categories.ALLUNITS - categories.WALL,
 }
 
-function CountCurrentUnits(brain,categoryCheck)
+function AllUnitsInCategoryDead(brain,categoryCheck)
     local ListOfUnits = brain:GetListOfUnits(categoryCheck, false)
-    local count = 0
-    for index,unit in ListOfUnits do
-        if unit.CanBeKilled and not unit.Dead then
-            count = count + 1
+    for index, unit in ListOfUnits do
+        if unit.CanBeKilled and not unit.Dead and unit:GetFractionComplete() == 1 then
+            return false
         end
     end
-    return count
+    return true
 end
 
 function CheckVictory(scenarioInfo)
@@ -30,7 +29,7 @@ function CheckVictory(scenarioInfo)
         local stillAlive = {}
         for _, brain in ArmyBrains do
             if not brain:IsDefeated() and not ArmyIsCivilian(brain:GetArmyIndex()) then
-                if CountCurrentUnits(brain,categoryCheck) == 0 then
+                if AllUnitsInCategoryDead(brain,categoryCheck) then
                     brain:OnDefeat()
                 else
                     table.insert(stillAlive, brain)


### PR DESCRIPTION
Uncompleted units will no longer count for end game conditions.

Also we don't really need to know how many units are alive, we only need to know if at least 1 unit is not dead.
So i renamed the function CountCurrentUnits to AllUnitsInCategoryDead.
The function is now returning true or false instead of a unitcount.

This way we only need to find the first unit and break the search loop, instead of looping over all units.
