### PR TITLE
Check for dead status before killing beams

### DIFF
--- a/units/URL0402/URL0402_script.lua
+++ b/units/URL0402/URL0402_script.lua
@@ -125,13 +125,15 @@ URL0402 = Class(CWalkingLandUnit) {
         if self.AmbientExhaustEffectsBag then
             EffectUtil.CleanupEffectBag(self, 'AmbientExhaustEffectsBag')
         end
-        local wep = self:GetWeapon(1)
-        if wep.Beams then
-            if wep.Audio.BeamLoop and wep.Beams[1].Beam then
-                wep.Beams[1].Beam:SetAmbientSound(nil, nil)
-            end
-            for k, v in wep.Beams do
-                v.Beam:Disable()
+        if not self.Dead then
+            local wep = self:GetWeapon(1)
+            if wep.Beams then
+                if wep.Audio.BeamLoop and wep.Beams[1].Beam then
+                    wep.Beams[1].Beam:SetAmbientSound(nil, nil)
+                end
+                for k, v in wep.Beams do
+                    v.Beam:Disable()
+                end
             end
         end
         CWalkingLandUnit.OnKilled(self, inst, type, okr)

--- a/units/XES0307/XES0307_script.lua
+++ b/units/XES0307/XES0307_script.lua
@@ -42,31 +42,34 @@ UES0302 = Class(TSeaUnit) {
         },
     },
 
+
+
         OnKilled = function(self, instigator, type, overkillRatio)
-            local wep1 = self:GetWeaponByLabel('HiroCannonFront')
-            local bp1 = wep1:GetBlueprint()
-            if bp1.Audio.BeamStop then
-                wep1:PlaySound(bp1.Audio.BeamStop)
-            end
-            if bp1.Audio.BeamLoop and wep1.Beams[1].Beam then
-                wep1.Beams[1].Beam:SetAmbientSound(nil, nil)
-            end
-            for k, v in wep1.Beams do
-                v.Beam:Disable()
-            end
+            if not self.Dead then
+                local wep1 = self:GetWeaponByLabel('HiroCannonFront')
+                local bp1 = wep1:GetBlueprint()
+                if bp1.Audio.BeamStop then
+                    wep1:PlaySound(bp1.Audio.BeamStop)
+                end
+                if bp1.Audio.BeamLoop and wep1.Beams[1].Beam then
+                    wep1.Beams[1].Beam:SetAmbientSound(nil, nil)
+                end
+                for k, v in wep1.Beams do
+                    v.Beam:Disable()
+                end
 
-            local wep2 = self:GetWeaponByLabel('HiroCannonBack')
-            local bp2 = wep2:GetBlueprint()
-            if bp2.Audio.BeamStop then
-                wep2:PlaySound(bp2.Audio.BeamStop)
+                local wep2 = self:GetWeaponByLabel('HiroCannonBack')
+                local bp2 = wep2:GetBlueprint()
+                if bp2.Audio.BeamStop then
+                    wep2:PlaySound(bp2.Audio.BeamStop)
+                end
+                if bp2.Audio.BeamLoop and wep2.Beams[1].Beam then
+                    wep2.Beams[1].Beam:SetAmbientSound(nil, nil)
+                end
+                for k, v in wep2.Beams do
+                    v.Beam:Disable()
+                end
             end
-            if bp2.Audio.BeamLoop and wep2.Beams[1].Beam then
-                wep2.Beams[1].Beam:SetAmbientSound(nil, nil)
-            end
-            for k, v in wep2.Beams do
-                v.Beam:Disable()
-            end
-
             TSeaUnit.OnKilled(self, instigator, type, overkillRatio)
         end,
 }


### PR DESCRIPTION
so, if you called OnKilled on the ML and battlecruiser after they were
killed, then bad things happened since GetWeapon doesnt work on dead
units.

this removes the possibility of that happening.

done for clean code and mod support reasons.