### PR TITLE
Fix unfinished units transfer in fullshare games

### DIFF
--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -338,6 +338,7 @@ function TransferUnfinishedUnitsAfterDeath(units, armies)
     local failedToTransfer = {}
     local failedToTransferCounter = 0
     local modifiedWrecks = {}
+    local modifiedUnits = {}
     local createWreckIfTransferFailed = {}
     
     for _, unit in EntityCategoryFilterDown(categories.EXPERIMENTAL + categories.TECH3 * categories.STRUCTURE * categories.ARTILLERY, units) do
@@ -395,6 +396,10 @@ function TransferUnfinishedUnitsAfterDeath(units, armies)
                     end
                 end       
                
+                for _,u in GetUnitsInRect(unit:GetSkirtRect()) do --same as for wrecks
+                    u:SetCollisionShape('None')
+                    table.insert(modifiedUnits, u)
+                end 
                 
                 if progress > 0.5 then --if transfer failed, we have to create wreck manually. progress should be more than 50%
                     createWreckIfTransferFailed[ID] = true    
@@ -480,6 +485,8 @@ function TransferUnfinishedUnitsAfterDeath(units, armies)
         end   
     end
     
+    local createWreckage = import('/lua/wreckage.lua').CreateWreckage
+    
     for ID,_ in createWreckIfTransferFailed do --create 50% wreck. Copied from Unit:CreateWreckageProp()
         local data = failedToTransfer[ID]
         local bp = data.Bp
@@ -489,7 +496,7 @@ function TransferUnfinishedUnitsAfterDeath(units, armies)
         local energy = 0
         local time = (bp.Wreckage.ReclaimTimeMultiplier or 1) * 2
         
-        local wreck = Wreckage.CreateWreckage(bp, pos, orientation, mass, energy, time)    
+        local wreck = createWreckage(bp, pos, orientation, mass, energy, time)    
     end
     
     for key, wreck in modifiedWrecks do --revert wrecks collision shape. Copied from Prop.lua SetPropCollision()
@@ -508,6 +515,12 @@ function TransferUnfinishedUnitsAfterDeath(units, armies)
             wreck:SetCollisionShape(shape, centerx, centery + sizey, centerz, sizex, sizey, sizez)
         end
     end
+    
+    for _, u in modifiedUnits do
+        if not u:BeenDestroyed() then
+            u:RevertCollisionShape()
+        end   
+    end    
 end
 
 function GiveUnitsToPlayer(data, units)


### PR DESCRIPTION
I just forgot to import createWreckage() function, so in some situations transfer stops and all units stay in dead army. Also added check for units which interfere construction.