### PR TITLE
Update consuption values on paused only when building

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -588,8 +588,10 @@ Unit = Class(moho.unit_methods) {
     end,
 
     OnPaused = function(self)
-        self:SetActiveConsumptionInactive()
-        self:StopUnitAmbientSound('ConstructLoop')
+        if self:IsUnitState('Building') or self:IsUnitState('Upgrading') or self:IsUnitState('Repairing') then
+            self:SetActiveConsumptionInactive()
+            self:StopUnitAmbientSound('ConstructLoop')
+        end
     end,
 
     OnUnpaused = function(self)


### PR DESCRIPTION
Fixes a bug where you could create a free resource by pausing a builder
after it built at least one 1 unit.