### PR TITLE
Aeon torp def

### DIFF
--- a/projectiles/AIMAntiTorpedo01/AIMAntiTorpedo01_proj.bp
+++ b/projectiles/AIMAntiTorpedo01/AIMAntiTorpedo01_proj.bp
@@ -31,8 +31,8 @@ ProjectileBlueprint {
     Physics = {
         Acceleration = 30,
         DestroyOnWater = false,
-        MaxSpeed = 20,
-
+        InitialSpeed = 120,
+        MaxSpeed = 30,
         # this is a workaround for tracking projectiles not intercepting correctly.  Original value: true
         StayUnderwater = true,
         TrackTarget = true,

--- a/projectiles/AIMAntiTorpedo01/AIMAntiTorpedo01_script.lua
+++ b/projectiles/AIMAntiTorpedo01/AIMAntiTorpedo01_script.lua
@@ -3,6 +3,11 @@
 #
 local QuasarAntiTorpedoChargeSubProjectile = import('/lua/aeonprojectiles.lua').ATorpedoSubProjectile
 
-AIMAntiTorpedo01 = Class(QuasarAntiTorpedoChargeSubProjectile) {}
+AIMAntiTorpedo01 = Class(QuasarAntiTorpedoChargeSubProjectile) {
+    OnLostTarget = function(self)
+        self:SetAcceleration(-3.6)
+        self:SetLifetime(0.5)
+    end,
+}
 
 TypeClass = AIMAntiTorpedo01


### PR DESCRIPTION
Copy values from sera torp defence to aeon torp defence used by frigate and destroyer.

Currently Beacon and Exodus torp defence is unable to intercept incomming projectiles and calculates impact point after the targetted unit. This change makes torp defence a little more reliable at defending nearest units. Just like sera torp defence or Vesper. Although doesn't solve the problem entirely.

Adds cosmetic behaviour from sera torp defence. When target is lost the projectile loses its speed and dies.

https://youtu.be/kvvDlgi49mY