### PR TITLE
Fix Novax Background Icon

### DIFF
--- a/units/XEB2402/XEB2402_unit.bp
+++ b/units/XEB2402/XEB2402_unit.bp
@@ -171,7 +171,7 @@ UnitBlueprint {
         },
         ConstructionBar = true,
         FactionName = 'UEF',
-        Icon = 'land',
+        Icon = 'air',
         SelectionPriority = 5,
         TechLevel = 'RULEUTL_Basic',
         UnitName = '<LOC xeb2402_name>Novax Center',


### PR DESCRIPTION
The Novax has "land" as background icon but sould have "air" like air-factories.

