### PR TITLE
increase teamkill report wait time

### DIFF
--- a/lua/ui/dialogs/teamkill.lua
+++ b/lua/ui/dialogs/teamkill.lua
@@ -12,7 +12,7 @@ local TextArea = import('/lua/ui/controls/textarea.lua').TextArea
 
 local dialog = false
 local shouldReport = false
-local waitingTimeBeforeReport = 3;
+local waitingTimeBeforeReport = 10;
 
 function CreateDialog(teamkill)
     if dialog then


### PR DESCRIPTION
increases the time someone has to wait to create a teamkill report from 3 to 10 seconds
currently 9/10 reports are just people getting blown up by chain reactions eg by standing too close to t3 pgens of a teammate -> teammate dies -> pgens blow up -> user dies as well -> not a teamkill and just a massive waste of my time