### PR TITLE
Fix Hives build effects

### DIFF
--- a/units/XRB0104/XRB0104_unit.bp
+++ b/units/XRB0104/XRB0104_unit.bp
@@ -161,6 +161,8 @@ UnitBlueprint {
             AimBone = 0,
             BuildEffectBones = {
                 'Attachpoint01',
+                'Attachpoint01',
+                'Attachpoint01',
             },
         },
         Category = 'Construction',

--- a/units/XRB0204/XRB0204_unit.bp
+++ b/units/XRB0204/XRB0204_unit.bp
@@ -163,6 +163,8 @@ UnitBlueprint {
             BuildEffectBones = {
                 'Attachpoint01',
                 'Attachpoint02',
+                'Attachpoint01',
+                'Attachpoint02',
             },
         },
 

--- a/units/XRB0304/XRB0304_unit.bp
+++ b/units/XRB0304/XRB0304_unit.bp
@@ -159,6 +159,9 @@ UnitBlueprint {
                 'Attachpoint01',
                 'Attachpoint02',
                 'Attachpoint03',
+                'Attachpoint01',
+                'Attachpoint02',
+                'Attachpoint03',
             },
         },
 


### PR DESCRIPTION
Since build bots are calculated from the build power, hives don't have
1/2/3 bots anymore but 3/4/6
One per 15 build power
Fixes #2715 