### PR TITLE
Play unit death animations only for completed units

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1246,7 +1246,7 @@ Unit = Class(moho.unit_methods) {
             self:PlayUnitSound('Killed')
         end
 
-        if self.PlayDeathAnimation and self:GetFractionComplete() > 0.5 then
+        if self.PlayDeathAnimation and self:GetFractionComplete() == 1 then
             self:ForkThread(self.PlayAnimationThread, 'AnimationDeath')
             self.DisallowCollisions = true
         end


### PR DESCRIPTION
Fixes #2399
This bug isnt affecting only Mega, but all experimental units. depending on the animation, the unit could behave weirdly. Mega the most, since it has to first stand on the legs when completed and the death animation counts with this.

Anyway, others are affected as well, so I think the animation should be played only for units that are actually completed.

As usually test properly please.