### PR TITLE
TryCopyPose for unit without death animation as well

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1660,7 +1660,7 @@ Unit = Class(moho.unit_methods) {
 
         -- Attempt to copy our animation pose to the prop. Only works if
         -- the mesh and skeletons are the same, but will not produce an error if not.
-        if (layer ~= 'Air' and self.PlayDeathAnimation) or (layer == "Air" and halfBuilt) then
+        if layer ~= 'Air' or (layer == "Air" and halfBuilt) then
             TryCopyPose(self, prop, true)
         end
 


### PR DESCRIPTION
Fixes #2836

It was added
https://github.com/FAForever/fa/commit/0e1540799e7a69843cb61bc694fb3c230cd8af1e#diff-7d1c65a3fbe3fe1c1cf7016d8b83b162
but I see no explanation why.