### PR TITLE
remove frig sonar

### DIFF
--- a/units/UAS0103/UAS0103_unit.bp
+++ b/units/UAS0103/UAS0103_unit.bp
@@ -172,7 +172,7 @@ UnitBlueprint {
     },
     Intel = {
         RadarRadius = 80,
-        SonarRadius = 82,
+        SonarRadius = 16,
         VisionRadius = 32,
         WaterVisionRadius = 16,
     },

--- a/units/UES0103/UES0103_unit.bp
+++ b/units/UES0103/UES0103_unit.bp
@@ -200,7 +200,7 @@ UnitBlueprint {
         },
         JammerBlips = 5,
         RadarRadius = 80,
-        SonarRadius = 82,
+        SonarRadius = 16,
         VisionRadius = 32,
         WaterVisionRadius = 16,
     },

--- a/units/URS0103/URS0103_unit.bp
+++ b/units/URS0103/URS0103_unit.bp
@@ -183,7 +183,7 @@ UnitBlueprint {
     },
     Intel = {
         RadarRadius = 80,
-        SonarRadius = 82,
+        SonarRadius = 16,
         VisionRadius = 32,
         WaterVisionRadius = 16,
     },

--- a/units/XSS0103/XSS0103_unit.bp
+++ b/units/XSS0103/XSS0103_unit.bp
@@ -176,7 +176,7 @@ UnitBlueprint {
     },
     Intel = {
         RadarRadius = 80,
-        SonarRadius = 82,
+        SonarRadius = 16,
         VisionRadius = 32,
         WaterVisionRadius = 16,
     },


### PR DESCRIPTION
reduce it to water vision in order to make subs more prevalent.
Make it harder to spot them. You can notice your frig taking damage and rush in to spot them, subs can still kite a bit. Sending torp to kill them will be a bit harder (attack move would be preferable i guess).