### PR TITLE
fix T3 uef gs jammer ring

### DIFF
--- a/units/UEA0305/UEA0305_unit.bp
+++ b/units/UEA0305/UEA0305_unit.bp
@@ -96,6 +96,7 @@ UnitBlueprint {
         'RECLAIMABLE',
         'OVERLAYANTIAIR',
         'OVERLAYDIRECTFIRE',
+        'OVERLAYCOUNTERINTEL',
     },
     CollisionOffsetZ = 0,
     Defense = {

--- a/units/XRA0305/XRA0305_unit.bp
+++ b/units/XRA0305/XRA0305_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         'RECLAIMABLE',
         'COUNTERINTELLIGENCE',
         'OVERLAYANTIAIR',
-        'OVERLAYCOUNTERINTEL',
         'OVERLAYDIRECTFIRE',
     },
     CollisionOffsetZ = 0,


### PR DESCRIPTION
- add 'OVERLAYCOUNTERINTEL' to uef t3 gs
- remove 'OVERLAYCOUNTERINTEL' from cybran t3 gs

fix #2861