### PR TITLE
Add new optimal / mirrored spawn

### DIFF
--- a/loc/US/strings_db.lua
+++ b/loc/US/strings_db.lua
@@ -7177,6 +7177,8 @@ lobui_0778="Optimal balance (Revealed)"
 lobui_0779="Teams will be optimally balanced, labeled random start locations"
 lobui_0780="Flexible balance (Revealed)"
 lobui_0781="Teams will be balanced with up to 5%% tolerance of best setup to make it a bit unpredictable, labeled random start locations"
+lobui_0782="Optimal balance (Mirrored / Revealed)"
+lobui_0783="Teams will be optimally balanced, mirrored start locations"
 
 aisettings_0001="AIx Cheat Multiplier"
 aisettings_0002="Set the cheat multiplier for the cheating AIs."

--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -45,6 +45,11 @@ teamOptions =
                 key = 'balanced_reveal',
             },
             {
+                text = "<LOC lobui_0782>Optimal balance mirrored (Revealed)",
+                help = "<LOC lobui_0783>Teams will be optimally balanced with mirrored positions, labeled random start locations",
+                key = 'balanced_reveal_mirrored',
+            },
+            {
                 text = "<LOC lobui_0780>Flexible balance (Revealed)",
                 help = "<LOC lobui_0781>Teams will be balanced with up to 5%% tolerance of best setup to make it a bit unpredictable, labeled random start locations",
                 key = 'balanced_flex_reveal',


### PR DESCRIPTION
New optimal, mirrored option

For example, if you're ranked `#1` in your team you will be against the guy ranked `#1`  in the opposite spot.

Won't work on maps where spots aren't in logical order, I'm too lazy to start calculate mirrors by looking at left / right / top bottom option  + the x,y positions on the map

Needs testing