### PR TITLE
Add allies resources balance to scoreboard

### DIFF
--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -128,6 +128,8 @@ function ScoreThread()
                     total = 0,
                     rate = 0                
                 },
+                StoredMass = 0,
+                StoredEnergy = 0,
                 MassReclaimRate = 0,
                 EnergyReclaimRate = 0
             }
@@ -176,6 +178,9 @@ function ScoreThread()
             ArmyScore[index].resources.energyout.total = brain:GetArmyStat("Economy_TotalConsumed_Energy", 0.0).Value
             ArmyScore[index].resources.energyout.rate = brain:GetArmyStat("Economy_Output_Energy", 0.0).Value
             ArmyScore[index].resources.energyover.total = brain:GetArmyStat("Economy_AccumExcess_Energy", 0.0).Value
+            
+            ArmyScore[index].resources.StoredMass = brain:GetEconomyStored('MASS')
+            ArmyScore[index].resources.StoredEnergy = brain:GetEconomyStored('ENERGY')
 
             for unitId, stats in brain.UnitStats do
                 if ArmyScore[index].blueprints[unitId] == nil then

--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -122,14 +122,18 @@ function ScoreThread()
                 },
                 massover = {
                     total = 0,
-                    rate = 0                
+                    rate = 0
                 },
                 energyover = {
                     total = 0,
-                    rate = 0                
+                    rate = 0
                 },
-                StoredMass = 0,
-                StoredEnergy = 0,
+                storage = {
+                    storedMass = 0,
+                    storedEnergy = 0,
+                    maxMass = 0,
+                    maxEnergy = 0,
+                },
                 MassReclaimRate = 0,
                 EnergyReclaimRate = 0
             }
@@ -178,9 +182,21 @@ function ScoreThread()
             ArmyScore[index].resources.energyout.total = brain:GetArmyStat("Economy_TotalConsumed_Energy", 0.0).Value
             ArmyScore[index].resources.energyout.rate = brain:GetArmyStat("Economy_Output_Energy", 0.0).Value
             ArmyScore[index].resources.energyover.total = brain:GetArmyStat("Economy_AccumExcess_Energy", 0.0).Value
-            
-            ArmyScore[index].resources.StoredMass = brain:GetEconomyStored('MASS')
-            ArmyScore[index].resources.StoredEnergy = brain:GetEconomyStored('ENERGY')
+
+            ArmyScore[index].resources.storage.storedMass = brain:GetEconomyStored('MASS')
+            ArmyScore[index].resources.storage.storedEnergy = brain:GetEconomyStored('ENERGY')
+            local MassRatio = brain:GetEconomyStoredRatio('MASS')
+            if MassRatio ~= 0 then
+                ArmyScore[index].resources.storage.maxMass = ArmyScore[index].resources.storage.storedMass / MassRatio
+            else
+                ArmyScore[index].resources.storage.maxMass = 0
+            end
+            local EnergyRatio = brain:GetEconomyStoredRatio('ENERGY')
+            if EnergyRatio ~= 0 then
+                ArmyScore[index].resources.storage.maxEnergy = ArmyScore[index].resources.storage.storedEnergy / EnergyRatio
+            else
+                ArmyScore[index].resources.storage.maxEnergy = 0
+            end
 
             for unitId, stats in brain.UnitStats do
                 if ArmyScore[index].blueprints[unitId] == nil then
@@ -217,14 +233,14 @@ function ScoreDisplayResourcesThread()
             ArmyScore[index].resources.MassReclaimRate = massReclaimRate
             ArmyScore[index].resources.massin.rate = brain:GetArmyStat("Economy_Income_Mass", 0.0).Value - massReclaimRate
             ArmyScore[index].general.lastReclaimedMass = reclaimedMass
-            ArmyScore[index].resources.massover.rate = ((ArmyScore[index].resources.massin.rate - ArmyScore[index].resources.massout.rate) + ArmyScore[index].resources.MassReclaimRate) * 10
+            ArmyScore[index].resources.massover.rate = ArmyScore[index].resources.massin.rate - ArmyScore[index].resources.massout.rate + ArmyScore[index].resources.MassReclaimRate
 
             local reclaimedEnergy = brain:GetArmyStat("Economy_Reclaimed_Energy", 0.0).Value
             local energyReclaimRate = reclaimedEnergy - ArmyScore[index].general.lastReclaimedEnergy
             ArmyScore[index].resources.EnergyReclaimRate = energyReclaimRate
             ArmyScore[index].resources.energyin.rate = brain:GetArmyStat("Economy_Income_Energy", 0.0).Value - energyReclaimRate
             ArmyScore[index].general.lastReclaimedEnergy = reclaimedEnergy
-            ArmyScore[index].resources.energyover.rate = ((ArmyScore[index].resources.energyin.rate - ArmyScore[index].resources.energyout.rate) + ArmyScore[index].resources.EnergyReclaimRate) * 10
+            ArmyScore[index].resources.energyover.rate = ArmyScore[index].resources.energyin.rate - ArmyScore[index].resources.energyout.rate + ArmyScore[index].resources.EnergyReclaimRate
         end
         WaitSeconds(0.1)
     end

--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -217,14 +217,14 @@ function ScoreDisplayResourcesThread()
             ArmyScore[index].resources.MassReclaimRate = massReclaimRate
             ArmyScore[index].resources.massin.rate = brain:GetArmyStat("Economy_Income_Mass", 0.0).Value - massReclaimRate
             ArmyScore[index].general.lastReclaimedMass = reclaimedMass
-            ArmyScore[index].resources.massover.rate = ((ArmyScore[index].resources.massin.rate - ArmyScore[index].resources.massout.rate) + ArmyScore[index].resources.MassReclaimRate)
+            ArmyScore[index].resources.massover.rate = ((ArmyScore[index].resources.massin.rate - ArmyScore[index].resources.massout.rate) + ArmyScore[index].resources.MassReclaimRate) * 10
 
             local reclaimedEnergy = brain:GetArmyStat("Economy_Reclaimed_Energy", 0.0).Value
             local energyReclaimRate = reclaimedEnergy - ArmyScore[index].general.lastReclaimedEnergy
             ArmyScore[index].resources.EnergyReclaimRate = energyReclaimRate
             ArmyScore[index].resources.energyin.rate = brain:GetArmyStat("Economy_Income_Energy", 0.0).Value - energyReclaimRate
             ArmyScore[index].general.lastReclaimedEnergy = reclaimedEnergy
-            ArmyScore[index].resources.energyover.rate = ((ArmyScore[index].resources.energyin.rate - ArmyScore[index].resources.energyout.rate) + ArmyScore[index].resources.EnergyReclaimRate)
+            ArmyScore[index].resources.energyover.rate = ((ArmyScore[index].resources.energyin.rate - ArmyScore[index].resources.energyout.rate) + ArmyScore[index].resources.EnergyReclaimRate) * 10
         end
         WaitSeconds(0.1)
     end

--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -120,8 +120,16 @@ function ScoreThread()
                     total = 0,
                     rate = 0
                 },
-                massover = 0,
-                energyover = 0
+                massover = {
+                    total = 0,
+                    rate = 0                
+                },
+                energyover = {
+                    total = 0,
+                    rate = 0                
+                },
+                MassReclaimRate = 0,
+                EnergyReclaimRate = 0
             }
         }
 
@@ -162,12 +170,12 @@ function ScoreThread()
             ArmyScore[index].resources.massin.total = brain:GetArmyStat("Economy_TotalProduced_Mass", 0.0).Value
             ArmyScore[index].resources.massout.total = brain:GetArmyStat("Economy_TotalConsumed_Mass", 0.0).Value
             ArmyScore[index].resources.massout.rate = brain:GetArmyStat("Economy_Output_Mass", 0.0).Value
-            ArmyScore[index].resources.massover = brain:GetArmyStat("Economy_AccumExcess_Mass", 0.0).Value
+            ArmyScore[index].resources.massover.total = brain:GetArmyStat("Economy_AccumExcess_Mass", 0.0).Value
 
             ArmyScore[index].resources.energyin.total = brain:GetArmyStat("Economy_TotalProduced_Energy", 0.0).Value
             ArmyScore[index].resources.energyout.total = brain:GetArmyStat("Economy_TotalConsumed_Energy", 0.0).Value
             ArmyScore[index].resources.energyout.rate = brain:GetArmyStat("Economy_Output_Energy", 0.0).Value
-            ArmyScore[index].resources.energyover = brain:GetArmyStat("Economy_AccumExcess_Energy", 0.0).Value
+            ArmyScore[index].resources.energyover.total = brain:GetArmyStat("Economy_AccumExcess_Energy", 0.0).Value
 
             for unitId, stats in brain.UnitStats do
                 if ArmyScore[index].blueprints[unitId] == nil then
@@ -201,13 +209,17 @@ function ScoreDisplayResourcesThread()
         for index, brain in ArmyBrains do
             local reclaimedMass = brain:GetArmyStat("Economy_Reclaimed_Mass", 0.0).Value
             local massReclaimRate = reclaimedMass - ArmyScore[index].general.lastReclaimedMass
+            ArmyScore[index].resources.MassReclaimRate = massReclaimRate
             ArmyScore[index].resources.massin.rate = brain:GetArmyStat("Economy_Income_Mass", 0.0).Value - massReclaimRate
             ArmyScore[index].general.lastReclaimedMass = reclaimedMass
+            ArmyScore[index].resources.massover.rate = ((ArmyScore[index].resources.massin.rate - ArmyScore[index].resources.massout.rate) + ArmyScore[index].resources.MassReclaimRate)
 
             local reclaimedEnergy = brain:GetArmyStat("Economy_Reclaimed_Energy", 0.0).Value
             local energyReclaimRate = reclaimedEnergy - ArmyScore[index].general.lastReclaimedEnergy
+            ArmyScore[index].resources.EnergyReclaimRate = energyReclaimRate
             ArmyScore[index].resources.energyin.rate = brain:GetArmyStat("Economy_Income_Energy", 0.0).Value - energyReclaimRate
             ArmyScore[index].general.lastReclaimedEnergy = reclaimedEnergy
+            ArmyScore[index].resources.energyover.rate = ((ArmyScore[index].resources.energyin.rate - ArmyScore[index].resources.energyout.rate) + ArmyScore[index].resources.EnergyReclaimRate)
         end
         WaitSeconds(0.1)
     end
@@ -216,7 +228,7 @@ end
 local observer = false
 function SyncScores()
     local my_army_index = GetFocusArmy()
-    observer = observer or my_army_index == -1
+    observer = my_army_index == -1
 
     local victory = import('/lua/victory.lua')
     if observer or victory.gameOver then
@@ -235,14 +247,11 @@ function SyncScores()
                 brain.StatsSent = true
             end
 
-            Sync.Score[index] = {}
-            Sync.Score[index].general = {}
-
-            if my_army_index == index then
-                Sync.Score[index].general.currentunits = {}
-                Sync.Score[index].general.currentunits.count = ArmyScore[index].general.currentunits.count
-                Sync.Score[index].general.currentcap = {}
-                Sync.Score[index].general.currentcap.count = ArmyScore[index].general.currentcap.count
+            if IsAlly(my_army_index,brain:GetArmyIndex()) then
+                Sync.Score[index] = ArmyScore[index]
+            else
+                Sync.Score[index] = {}
+                Sync.Score[index].general = {}
             end
 
             if scoreOption ~= 'no' then

--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -66,6 +66,8 @@ function ScoreThread()
     for index, brain in ArmyBrains do
         ArmyScore[index] = {
             faction = 0,
+            name = '',
+            type = '',
             general = {
                 score = 0,
                 mass = 0,

--- a/lua/ui/dialogs/hotstats.lua
+++ b/lua/ui/dialogs/hotstats.lua
@@ -33,10 +33,10 @@ local info_dialog = {
     {name="<LOC SCORE_0085>Total Losses", path={"general","lost","count"},key=7},
     {name="<LOC SCORE_0086>Energy Rate", path={"resources","energyin","rate",fac_mul=10},key=59},
     {name="<LOC SCORE_0087>Total Energy Spent", path={"resources","energyout","total"},key=9},
-    {name="<LOC SCORE_0088>Total Energy Wasted", path={"resources","energyover",false},key=10},
+    {name="<LOC SCORE_0088>Total Energy Wasted", path={"resources","energyover","total"},key=10},
     {name="<LOC SCORE_0089>Mass Rate", path={"resources","massin","rate",fac_mul=10},key=59},
     {name="<LOC SCORE_0090>Total Mass Spent", path={"resources","massout","total"},key=12},
-    {name="<LOC SCORE_0091>Total Mass Wasted", path={"resources","massover",false},key=13},
+    {name="<LOC SCORE_0091>Total Mass Wasted", path={"resources","massover","total"},key=13},
     {name="<LOC SCORE_0092>Air Units Built", path={"units","air","built"},key=14},
     {name="<LOC SCORE_0093>Air Units Killed", path={"units","air","kills"},key=15},
     {name="<LOC SCORE_0094>Air Units Lost", path={"units","air","lost"},key=16},
@@ -91,10 +91,10 @@ local histo={
     main_histo={
         [1]={name="mass",icon=mySkinnableFile("/textures/ui/common/game/unit-build-over-panel/mass.dds"),label1="mass",link="mass_histo",Tooltip="<LOC SCORE_0005>Mass",
             data={{name="mass incombe",icon="",path={"resources","massin","total"},color="green",Tooltip="<LOC SCORE_0072>Mass earned during the game."},
-            {name="mass wasted",icon=mySkinnableFile("/textures/ui/common/game/icons/icon-trash-lg_btn_up.png"),path={"resources","massover",false},color="2e6405",Tooltip="<LOC SCORE_0071>Mass wasted during the game."} }},
+            {name="mass wasted",icon=mySkinnableFile("/textures/ui/common/game/icons/icon-trash-lg_btn_up.png"),path={"resources","massover","total"},color="2e6405",Tooltip="<LOC SCORE_0071>Mass wasted during the game."} }},
         [2]={name="energy",icon=mySkinnableFile("/textures/ui/common/game/unit-build-over-panel/energy.dds"),label1="energy",link="energy_histo",Tooltip="<LOC SCORE_0006>Energy",
             data={{name="energy incombe",icon="",path={"resources","energyin","total"},color="orange",Tooltip="<LOC SCORE_0075>Energy earned during the game."},
-            {name="energy wasted",icon=mySkinnableFile("/textures/ui/common/game/icons/icon-trash-lg_btn_up.png"),path={"resources","energyover",false},color="c77d1e",Tooltip="<LOC SCORE_0074>Energy wasted during the game."} }},
+            {name="energy wasted",icon=mySkinnableFile("/textures/ui/common/game/icons/icon-trash-lg_btn_up.png"),path={"resources","energyover","total"},color="c77d1e",Tooltip="<LOC SCORE_0074>Energy wasted during the game."} }},
         [3]={name="units built",icon=mySkinnableFile("/textures/ui/common/game/unit_view_icons/build.dds"),label1="built",label2="",link="built_histo",Tooltip="<LOC SCORE_0078>Total units/structures built during the game.",
             data={{name="air unit",icon=UIUtil.UIFile("/textures/ui/icons_strategic/fighter_generic.dds"),path={"units","air","built"},color="39b0be",Tooltip="<LOC SCORE_0069>Air units."},
             {name="land unit",icon=UIUtil.UIFile("/textures/ui/icons_strategic/land_generic.dds"),path={"units","land","built"},color="64421a",Tooltip="<LOC SCORE_0068>Land units."},
@@ -116,7 +116,7 @@ local histo={
         [2]={name="mass",icon=UIUtil.UIFile("/hotstats/score/mass-out-icon.dds"),label1="out",label2="",Tooltip="<LOC SCORE_0073>Mass used during the game.",link="main_histo",
             data={{name="mass out",icon="",path={"resources","massout","total"},color="5fdc5c",Tooltip="<LOC SCORE_0073>Mass used during the game."} }},
         [3]={name="mass",icon=UIUtil.UIFile("/hotstats/score/mass-waste-icon.dds"),label1="wasted",label2="",Tooltip="<LOC SCORE_0071>Mass wasted during the game.",link="main_histo",
-            data={{name="mass wasted",icon=mySkinnableFile("/textures/ui/common/game/icons/icon-trash-lg_btn_up.png"),path={"resources","massover",false},color="2e6405",Tooltip="<LOC SCORE_0071>Mass wasted during the game."} }}
+            data={{name="mass wasted",icon=mySkinnableFile("/textures/ui/common/game/icons/icon-trash-lg_btn_up.png"),path={"resources","massover","total"},color="2e6405",Tooltip="<LOC SCORE_0071>Mass wasted during the game."} }}
     },
     energy_histo={
         [1]={name="energy",icon=UIUtil.UIFile("/hotstats/score/energy-in-icon.dds"),label1="in",label2="",Tooltip="<LOC SCORE_0075>Energy earned during the game.",link="main_histo",
@@ -124,7 +124,7 @@ local histo={
         [2]={name="energy",icon=UIUtil.UIFile("/hotstats/score/energy-out-icon.dds"),label1="out",label2="",Tooltip="<LOC SCORE_0076>Energy used during the game.",link="main_histo",
             data={{name="energy out",icon="",path={"resources","energyout","total"},color="dcb05c",Tooltip="<LOC SCORE_0076>Energy used during the game."} }},
         [3]={name="energy",icon=UIUtil.UIFile("/hotstats/score/energy-waste-icon.dds"),label1="wasted",label2="",Tooltip="<LOC SCORE_0074>Energy wasted during the game.",link="main_histo",
-            data={{name="energy wasted",icon=mySkinnableFile("/textures/ui/common/game/icons/icon-trash-lg_btn_up.png"),path={"resources","energyover",false},color="c77d1e",Tooltip="<LOC SCORE_0074>Energy wasted during the game."} }}
+            data={{name="energy wasted",icon=mySkinnableFile("/textures/ui/common/game/icons/icon-trash-lg_btn_up.png"),path={"resources","energyover","total"},color="c77d1e",Tooltip="<LOC SCORE_0074>Energy wasted during the game."} }}
     },
     built_histo={
         [1]={name="units built",icon=UIUtil.UIFile("/hotstats/score/fighter-icon.dds"),label1="air",label2="",Tooltip="<LOC SCORE_0069>Air units.",link="main_histo",

--- a/lua/ui/game/layouts/score_mini.lua
+++ b/lua/ui/game/layouts/score_mini.lua
@@ -81,6 +81,8 @@ function SetLayout()
     controls.timeIcon.Width:Set(function() return controls.timeIcon.BitmapWidth() * .8 end)
     controls.unitIcon.Height:Set(function() return controls.unitIcon.BitmapHeight() * .9 end)
     controls.unitIcon.Width:Set(function() return controls.unitIcon.BitmapWidth() * .9 end)
+    local avatarGroup = import('/lua/ui/game/avatars.lua').controls.avatarGroup
+    avatarGroup.Top:Set(function() return controls.bgBottom.Bottom() + 4 end)
 
     LayoutArmyLines()
 end

--- a/lua/ui/game/layouts/score_mini.lua
+++ b/lua/ui/game/layouts/score_mini.lua
@@ -66,7 +66,7 @@ function SetLayout()
         for _, line in controls.armyLines do
             totHeight = totHeight + line.Height()
         end
-        return math.max(totHeight, 50)
+        return totHeight
     end)
 
     LayoutHelpers.AtLeftTopIn(controls.timeIcon, controls.bgTop, 10, 6)
@@ -81,10 +81,6 @@ function SetLayout()
     controls.timeIcon.Width:Set(function() return controls.timeIcon.BitmapWidth() * .8 end)
     controls.unitIcon.Height:Set(function() return controls.unitIcon.BitmapHeight() * .9 end)
     controls.unitIcon.Width:Set(function() return controls.unitIcon.BitmapWidth() * .9 end)
-    if not SessionIsReplay() then
-        local avatarGroup = import('/lua/ui/game/avatars.lua').controls.avatarGroup
-        avatarGroup.Top:Set(function() return controls.bgBottom.Bottom() + 4 end)
-    end
 
     LayoutArmyLines()
 end
@@ -101,4 +97,3 @@ function LayoutArmyLines()
         end
     end
 end
-    

--- a/lua/ui/game/score.lua
+++ b/lua/ui/game/score.lua
@@ -294,8 +294,8 @@ function SetupPlayerLines()
                 self.bg:SetSolidColor('ff777777')
             elseif event.Type == 'MouseExit' then
                 self.bg:SetSolidColor('00000000')
-            elseif (event.Type == 'ButtonPress') and (not event.Modifiers.Shift) and (not event.Modifiers.Ctrl) and (sessionInfo.Options.CheatsEnabled) then
-                ConExecute('SetFocusArmy '..tostring(self.armyID-1))
+            elseif (event.Type == 'ButtonPress') and (not event.Modifiers.Shift) and (not event.Modifiers.Ctrl) then
+                ConExecute('SetFocusArmy '..tostring(self.armyID - 1))
             end
         end
 

--- a/lua/ui/game/score.lua
+++ b/lua/ui/game/score.lua
@@ -111,11 +111,11 @@ function CreateScoreUI(parent)
 end
 
 function fmtnum(ns)
-    if (ns < 1000) then         -- 0 to 999
+    if (math.abs(ns) < 1000) then         -- 0 to 999
         return string.format("%01.0f", ns)
-    elseif (ns < 10000) then   -- 1.0K to 9.9K
+    elseif (math.abs(ns) < 10000) then   -- 1.0K to 9.9K
         return string.format("%01.1fk", ns / 1000)
-    elseif (ns < 1000000) then -- 10K to 999K
+    elseif (math.abs(ns) < 1000000) then -- 10K to 999K
         return string.format("%01.0fk", ns / 1000)
     else                       -- 1.0M to ....
         return string.format("%01.1fm", ns / 1000000)
@@ -134,43 +134,44 @@ function SetupPlayerLines()
         local group = Group(controls.bgStretch)
         local sw = 42
 
-        if armyIndex ~= 0 and SessionIsReplay() then
-            group.faction = Bitmap(group)
-            if armyIndex ~= 0 then
-                group.faction:SetTexture(UIUtil.UIFile(UIUtil.GetFactionIcon(data.faction)))
-            else
-                group.faction:SetTexture(UIUtil.UIFile('/widgets/faction-icons-alpha_bmp/observer_ico.dds'))
-            end
-            group.faction.Height:Set(14)
-            group.faction.Width:Set(14)
-            group.faction:DisableHitTest()
-            LayoutHelpers.AtLeftTopIn(group.faction, group, -4)
+        group.faction = Bitmap(group)
+        if armyIndex ~= 0 then
+            group.faction:SetTexture(UIUtil.UIFile(UIUtil.GetFactionIcon(data.faction)))
+        else
+            group.faction:SetTexture(UIUtil.UIFile('/widgets/faction-icons-alpha_bmp/observer_ico.dds'))
+        end
+        group.faction.Height:Set(14)
+        group.faction.Width:Set(14)
+        group.faction:DisableHitTest()
+        LayoutHelpers.AtLeftTopIn(group.faction, group, -4)
 
-            group.color = Bitmap(group.faction)
-            group.color:SetSolidColor(data.color)
-            group.color.Depth:Set(function() return group.faction.Depth() - 1 end)
-            group.color:DisableHitTest()
-            LayoutHelpers.FillParent(group.color, group.faction)
+        group.color = Bitmap(group.faction)
+        group.color:SetSolidColor(data.color)
+        group.color.Depth:Set(function() return group.faction.Depth() - 1 end)
+        group.color:DisableHitTest()
+        LayoutHelpers.FillParent(group.color, group.faction)
 
-            group.name = UIUtil.CreateText(group, data.nickname, 12, UIUtil.bodyFont)
-            group.name:DisableHitTest()
-            LayoutHelpers.AtLeftIn(group.name, group, 12)
-            LayoutHelpers.AtVerticalCenterIn(group.name, group)
-            group.name:SetColor('ffffffff')
+        group.name = UIUtil.CreateText(group, data.nickname, 12, UIUtil.bodyFont)
+        group.name:DisableHitTest()
+        LayoutHelpers.AtLeftIn(group.name, group, 12)
+        LayoutHelpers.AtVerticalCenterIn(group.name, group)
+        group.name:SetColor('ffffffff')
 
-            group.score = UIUtil.CreateText(group, '', 12, UIUtil.bodyFont)
-            group.score:DisableHitTest()
-            LayoutHelpers.AtRightIn(group.score, group, sw * 2)
-            LayoutHelpers.AtVerticalCenterIn(group.score, group)
-            group.score:SetColor('ffffffff')
+        group.score = UIUtil.CreateText(group, '', 12, UIUtil.bodyFont)
+        group.score:DisableHitTest()
+        LayoutHelpers.AtRightIn(group.score, group, sw * 2)
+        LayoutHelpers.AtVerticalCenterIn(group.score, group)
+        group.score:SetColor('ffffffff')
 
-            group.name.Right:Set(group.score.Left)
-            group.name:SetClipToWidth(true)
+        group.name.Right:Set(group.score.Left)
+        group.name:SetClipToWidth(true)
 
+        if armyIndex ~= 0 then
             group.mass = Bitmap(group)
             group.mass:SetTexture(UIUtil.UIFile('/game/build-ui/icon-mass_bmp.dds'))
             LayoutHelpers.AtRightIn(group.mass, group, sw * 1)
             LayoutHelpers.AtVerticalCenterIn(group.mass, group)
+            group.mass:DisableHitTest()
             group.mass.Height:Set(14)
             group.mass.Width:Set(14)
 
@@ -184,6 +185,7 @@ function SetupPlayerLines()
             group.energy:SetTexture(UIUtil.UIFile('/game/build-ui/icon-energy_bmp.dds'))
             LayoutHelpers.AtRightIn(group.energy, group, sw * 0)
             LayoutHelpers.AtVerticalCenterIn(group.energy, group)
+            group.energy:DisableHitTest()
             group.energy.Height:Set(14)
             group.energy.Width:Set(14)
 
@@ -192,39 +194,8 @@ function SetupPlayerLines()
             LayoutHelpers.AtRightIn(group.energy_in, group, sw * 0+14)
             LayoutHelpers.AtVerticalCenterIn(group.energy_in, group)
             group.energy_in:SetColor('fff7c70f')
-        else
-            group.faction = Bitmap(group)
-            if armyIndex ~= 0 then
-                group.faction:SetTexture(UIUtil.UIFile(UIUtil.GetFactionIcon(data.faction)))
-            else
-                group.faction:SetTexture(UIUtil.UIFile('/widgets/faction-icons-alpha_bmp/observer_ico.dds'))
-            end
-            group.faction.Height:Set(14)
-            group.faction.Width:Set(14)
-            group.faction:DisableHitTest()
-            LayoutHelpers.AtLeftTopIn(group.faction, group)
-
-            group.color = Bitmap(group.faction)
-            group.color:SetSolidColor(data.color)
-            group.color.Depth:Set(function() return group.faction.Depth() - 1 end)
-            group.color:DisableHitTest()
-            LayoutHelpers.FillParent(group.color, group.faction)
-
-            group.name = UIUtil.CreateText(group, data.nickname, 12, UIUtil.bodyFont)
-            group.name:DisableHitTest()
-             LayoutHelpers.AtLeftIn(group.name, group, 16)
-            LayoutHelpers.AtVerticalCenterIn(group.name, group)
-            group.name:SetColor('ffffffff')
-
-            group.score = UIUtil.CreateText(group, '', 12, UIUtil.bodyFont)
-            group.score:DisableHitTest()
-            LayoutHelpers.AtRightIn(group.score, group)
-            LayoutHelpers.AtVerticalCenterIn(group.score, group)
-            group.score:SetColor('ffffffff')
-
-            group.name.Right:Set(group.score.Left)
-            group.name:SetClipToWidth(true)
         end
+
         group.Height:Set(group.faction.Height)
         group.Width:Set(262)
         group.armyID = armyIndex
@@ -261,6 +232,7 @@ function SetupPlayerLines()
         controls.armyLines[index] = CreateArmyLine(armyData, armyIndex)
         index = index + 1
     end
+
     if SessionIsReplay() then
         observerLine = CreateArmyLine({color = 'ffffffff', nickname = LOC("<LOC score_0003>Observer")}, 0)
         observerLine.name.Top:Set(observerLine.Top)
@@ -370,6 +342,7 @@ function SetupPlayerLines()
     --if tonumber(replayID) > 0 then mapData.mapname = mapData.mapname .. ', ID: ' .. replayID end
     controls.armyLines[index] = CreateMapNameLine(mapData, 0)
 end
+
 function _OnBeat()
     local s = string.format("%s (%+d / %+d)", GetGameTime(), gameSpeed, GetSimRate())
     if sessionInfo.Options.Quality then
@@ -390,16 +363,24 @@ function _OnBeat()
             issuedNoRushWarning = true
         end
     end
+
     local armiesInfo = GetArmiesTable().armiesTable
     if currentScores then
         for index, scoreData in currentScores do
             for _, line in controls.armyLines do
                 if line.armyID == index then
                     if line.OOG then break end
-                    if SessionIsReplay() then
-                        if scoreData.resources.massin.rate then
-                            line.mass_in:SetText(fmtnum(scoreData.resources.massin.rate * 10))
-                            line.energy_in:SetText(fmtnum(scoreData.resources.energyin.rate * 10))
+                    if not GetFocusArmy() == -1 then
+                        if not IsAlly(GetFocusArmy(),line.armyID) then
+                            line.mass_in:SetText('')
+                            line.energy_in:SetText('')
+                        end
+                    end
+                    
+                    if not armiesInfo[index].outOfGame then
+                        if scoreData.resources.massover.rate then
+                            line.mass_in:SetText(fmtnum(scoreData.resources.massover.rate * 10))
+                            line.energy_in:SetText(fmtnum(scoreData.resources.energyover.rate * 10))
                         end
                     end
                     if scoreData.general.score == -1 then
@@ -433,10 +414,8 @@ function _OnBeat()
                         line.color:SetSolidColor('ff000000')
                         line.name:SetColor('ffa0a0a0')
                         line.score:SetColor('ffa0a0a0')
-                        if SessionIsReplay() then
-                            line.mass_in:SetColor('ffa0a0a0')
-                            line.energy_in:SetColor('ffa0a0a0')
-                        end
+                        line.mass_in:SetColor('ffa0a0a0')
+                        line.energy_in:SetColor('ffa0a0a0')
                     end
                     break
                 end

--- a/lua/ui/game/score.lua
+++ b/lua/ui/game/score.lua
@@ -538,9 +538,11 @@ function _OnBeat()
                 end
             end
         end
-        table.sort(controls.armyLines, function(a,b)
-            return a.scoreNumber > b.scoreNumber
-        end)
+        if sessionInfo.Options.Score == 'yes' then
+            table.sort(controls.armyLines, function(a,b)
+                return a.scoreNumber > b.scoreNumber
+            end)
+        end
         import(UIUtil.GetLayoutFilename('score')).LayoutArmyLines()
         local line = {}
         for index, data in controls.armyLines do
@@ -555,17 +557,22 @@ function _OnBeat()
 
     local cur = GetFocusArmy()
     if prevArmy ~= cur then
-        for _, data in controls.armyLines do
-            if data.armyID == prevArmy then
-                data.name:SetColor('ffffffff')
-                data.score:SetColor('ffffffff')
-                data.name:SetFont(UIUtil.bodyFont, 12)
-                data.score:SetFont(UIUtil.bodyFont, 12)
-            elseif data.armyID == cur then
-                data.name:SetColor('ffff7f00')
-                data.score:SetColor('ffff7f00')
-                data.name:SetFont('Arial Bold', 12)
-                data.score:SetFont('Arial Bold', 12)
+        for _, line in controls.armyLines do
+            if line.armyID == prevArmy then
+                if line.OOG then
+                    line.name:SetColor('ffa0a0a0')
+                    line.score:SetColor('ffa0a0a0')
+                else
+                    line.name:SetColor('ffffffff')
+                    line.score:SetColor('ffffffff')
+                end
+                line.name:SetFont(UIUtil.bodyFont, 12)
+                line.score:SetFont(UIUtil.bodyFont, 12)
+            elseif line.armyID == cur then
+                line.name:SetColor('ffff7f00')
+                line.score:SetColor('ffff7f00')
+                line.name:SetFont('Arial Bold', 12)
+                line.score:SetFont('Arial Bold', 12)
             end
         end
         if observerLine then

--- a/lua/ui/game/score.lua
+++ b/lua/ui/game/score.lua
@@ -370,7 +370,7 @@ function _OnBeat()
             for _, line in controls.armyLines do
                 if line.armyID == index then
                     if line.OOG then break end
-                    if not GetFocusArmy() == -1 then
+                    if GetFocusArmy() ~= -1 then
                         if not IsAlly(GetFocusArmy(),line.armyID) then
                             line.mass_in:SetText('')
                             line.energy_in:SetText('')

--- a/lua/ui/game/score.lua
+++ b/lua/ui/game/score.lua
@@ -177,16 +177,30 @@ function SetupPlayerLines()
             group.mass.HandleEvent = function(self, event)
                 if event.Type == 'MouseEnter' then
                     if MassEnergyStoredCache[group.armyID].Mass then
-                        group.mass_in:SetText(fmtnum(MassEnergyStoredCache[group.armyID].Mass) or '')
+                        group.mass_in:SetText(fmtnum(MassEnergyStoredCache[group.armyID].Mass))
                     end
+                elseif event.Type == 'MouseExit' then
+                    if MassEnergyStoredCache[group.armyID].Massover then
+                        group.mass_in:SetText(fmtnum(MassEnergyStoredCache[group.armyID].Massover))
+                    end                    
                 end
             end
 
             group.mass_in = UIUtil.CreateText(group, '', 12, UIUtil.bodyFont)
-            group.mass_in:DisableHitTest()
             LayoutHelpers.AtRightIn(group.mass_in, group, sw * 1+14)
             LayoutHelpers.AtVerticalCenterIn(group.mass_in, group)
             group.mass_in:SetColor('ffb7e75f')
+            group.mass_in.HandleEvent = function(self, event)
+                if event.Type == 'MouseEnter' then
+                    if MassEnergyStoredCache[group.armyID].Mass then
+                        group.mass_in:SetText(fmtnum(MassEnergyStoredCache[group.armyID].Mass))
+                    end
+                elseif event.Type == 'MouseExit' then
+                    if MassEnergyStoredCache[group.armyID].Massover then
+                        group.mass_in:SetText(fmtnum(MassEnergyStoredCache[group.armyID].Massover))
+                    end                    
+                end
+            end
 
             group.energy = Bitmap(group)
             group.energy:SetTexture(UIUtil.UIFile('/game/build-ui/icon-energy_bmp.dds'))
@@ -197,16 +211,30 @@ function SetupPlayerLines()
             group.energy.HandleEvent = function(self, event)
                 if event.Type == 'MouseEnter' then
                     if MassEnergyStoredCache[group.armyID].Energy then
-                        group.energy_in:SetText(fmtnum(MassEnergyStoredCache[group.armyID].Energy) or '')
+                        group.energy_in:SetText(fmtnum(MassEnergyStoredCache[group.armyID].Energy))
                     end
+                elseif event.Type == 'MouseExit' then
+                    if MassEnergyStoredCache[group.armyID].Energyover then
+                        group.energy_in:SetText(fmtnum(MassEnergyStoredCache[group.armyID].Energyover))
+                    end 
                 end
             end
 
             group.energy_in = UIUtil.CreateText(group, '', 12, UIUtil.bodyFont)
-            group.energy_in:DisableHitTest()
             LayoutHelpers.AtRightIn(group.energy_in, group, sw * 0+14)
             LayoutHelpers.AtVerticalCenterIn(group.energy_in, group)
             group.energy_in:SetColor('fff7c70f')
+            group.energy_in.HandleEvent = function(self, event)
+                if event.Type == 'MouseEnter' then
+                    if MassEnergyStoredCache[group.armyID].Energy then
+                        group.energy_in:SetText(fmtnum(MassEnergyStoredCache[group.armyID].Energy))
+                    end
+                elseif event.Type == 'MouseExit' then
+                    if MassEnergyStoredCache[group.armyID].Energyover then
+                        group.energy_in:SetText(fmtnum(MassEnergyStoredCache[group.armyID].Energyover))
+                    end 
+                end
+            end
         end
 
         group.Height:Set(group.faction.Height)
@@ -384,7 +412,8 @@ function _OnBeat()
             for _, line in controls.armyLines do
                 if line.armyID == index then
                     if line.OOG then break end
-                    MassEnergyStoredCache[line.armyID] = {Mass = scoreData.resources.StoredMass, Energy = scoreData.resources.StoredEnergy}
+                    MassEnergyStoredCache[line.armyID] = {Massover = scoreData.resources.massover.rate, Mass = scoreData.resources.StoredMass,
+                                                          Energyover = scoreData.resources.energyover.rate, Energy = scoreData.resources.StoredEnergy}
                     if GetFocusArmy() ~= -1 then
                         if not IsAlly(GetFocusArmy(),line.armyID) then
                             line.mass_in:SetText('')
@@ -392,11 +421,9 @@ function _OnBeat()
                         end
                     end
                     
-                    if not armiesInfo[index].outOfGame then
-                        if scoreData.resources.massover.rate then
-                            line.mass_in:SetText(fmtnum(scoreData.resources.massover.rate * 10))
-                            line.energy_in:SetText(fmtnum(scoreData.resources.energyover.rate * 10))
-                        end
+                    if scoreData.resources.massover.rate then
+                        line.mass_in:SetText(fmtnum(scoreData.resources.massover.rate))
+                        line.energy_in:SetText(fmtnum(scoreData.resources.energyover.rate))
                     end
                     if scoreData.general.score == -1 then
                         line.score:SetText(LOC("<LOC _Playing>Playing"))

--- a/lua/ui/game/score.lua
+++ b/lua/ui/game/score.lua
@@ -37,6 +37,7 @@ local issuedNoRushWarning = false
 local gameSpeed = 0
 local needExpand = false
 local contractOnCreate = false
+local MassEnergyStoredCache = {}
 function CreateScoreUI(parent)
     savedParent = GetFrame(0)
 
@@ -171,9 +172,15 @@ function SetupPlayerLines()
             group.mass:SetTexture(UIUtil.UIFile('/game/build-ui/icon-mass_bmp.dds'))
             LayoutHelpers.AtRightIn(group.mass, group, sw * 1)
             LayoutHelpers.AtVerticalCenterIn(group.mass, group)
-            group.mass:DisableHitTest()
             group.mass.Height:Set(14)
             group.mass.Width:Set(14)
+            group.mass.HandleEvent = function(self, event)
+                if event.Type == 'MouseEnter' then
+                    if MassEnergyStoredCache[group.armyID].Mass then
+                        group.mass_in:SetText(fmtnum(MassEnergyStoredCache[group.armyID].Mass) or '')
+                    end
+                end
+            end
 
             group.mass_in = UIUtil.CreateText(group, '', 12, UIUtil.bodyFont)
             group.mass_in:DisableHitTest()
@@ -185,9 +192,15 @@ function SetupPlayerLines()
             group.energy:SetTexture(UIUtil.UIFile('/game/build-ui/icon-energy_bmp.dds'))
             LayoutHelpers.AtRightIn(group.energy, group, sw * 0)
             LayoutHelpers.AtVerticalCenterIn(group.energy, group)
-            group.energy:DisableHitTest()
             group.energy.Height:Set(14)
             group.energy.Width:Set(14)
+            group.energy.HandleEvent = function(self, event)
+                if event.Type == 'MouseEnter' then
+                    if MassEnergyStoredCache[group.armyID].Energy then
+                        group.energy_in:SetText(fmtnum(MassEnergyStoredCache[group.armyID].Energy) or '')
+                    end
+                end
+            end
 
             group.energy_in = UIUtil.CreateText(group, '', 12, UIUtil.bodyFont)
             group.energy_in:DisableHitTest()
@@ -366,10 +379,12 @@ function _OnBeat()
 
     local armiesInfo = GetArmiesTable().armiesTable
     if currentScores then
+        MassEnergyStoredCache = {}
         for index, scoreData in currentScores do
             for _, line in controls.armyLines do
                 if line.armyID == index then
                     if line.OOG then break end
+                    MassEnergyStoredCache[line.armyID] = {Mass = scoreData.resources.StoredMass, Energy = scoreData.resources.StoredEnergy}
                     if GetFocusArmy() ~= -1 then
                         if not IsAlly(GetFocusArmy(),line.armyID) then
                             line.mass_in:SetText('')


### PR DESCRIPTION
Present three mode display resources.
Switch button located below energy icons.
I - Income (default), B - Balance, S - Storage

Transferring mass, energy, units on click with Shift and
request him with Ctrl.

Add display map size and replay ID.
Fixed formatted negative values displayed resources.