### PR TITLE
T3 gs nerf

### DIFF
--- a/units/UEA0305/UEA0305_unit.bp
+++ b/units/UEA0305/UEA0305_unit.bp
@@ -215,8 +215,8 @@ UnitBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        BuildCostEnergy = 42000,
-        BuildCostMass = 1260,
+        BuildCostEnergy = 65000,
+        BuildCostMass = 1500,
         BuildTime = 6300,
         MaintenanceConsumptionPerSecondEnergy = 25,
     },

--- a/units/XRA0305/XRA0305_unit.bp
+++ b/units/XRA0305/XRA0305_unit.bp
@@ -192,8 +192,8 @@ UnitBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        BuildCostEnergy = 42000,
-        BuildCostMass = 1260,
+        BuildCostEnergy = 65000,
+        BuildCostMass = 1500,
         BuildTime = 6300,
         MaintenanceConsumptionPerSecondEnergy = 50,
     },


### PR DESCRIPTION
makes T3 gunship harder to rush. They nearly had same stat ratio as their T2 counter part. Need to lose efficiency for their beefiness.

mass cost : from 1260 to 1500
e cost : from 42000 to 65000