### PR TITLE
Air scout nerf

### DIFF
--- a/units/UAA0101/UAA0101_unit.bp
+++ b/units/UAA0101/UAA0101_unit.bp
@@ -19,7 +19,7 @@ UnitBlueprint {
         MinAirspeed = 17,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.1,
-        TurnSpeed = 0.8,
+        TurnSpeed = 0.6,
         Winged = true,
     },
     Audio = {

--- a/units/UAA0302/UAA0302_unit.bp
+++ b/units/UAA0302/UAA0302_unit.bp
@@ -15,11 +15,11 @@ UnitBlueprint {
         KTurn = 1,
         KTurnDamping = 1.5,
         LiftFactor = 7,
-        MaxAirspeed = 30,
+        MaxAirspeed = 28,
         MinAirspeed = 25,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.1,
-        TurnSpeed = 0.8,
+        TurnSpeed = 0.6,
         Winged = true,
     },
     Audio = {

--- a/units/UEA0101/UEA0101_unit.bp
+++ b/units/UEA0101/UEA0101_unit.bp
@@ -19,7 +19,7 @@ UnitBlueprint {
         MinAirspeed = 17,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.1,
-        TurnSpeed = 0.8,
+        TurnSpeed = 0.6,
         Winged = true,
     },
     Audio = {

--- a/units/UEA0302/UEA0302_unit.bp
+++ b/units/UEA0302/UEA0302_unit.bp
@@ -15,11 +15,11 @@ UnitBlueprint {
         KTurn = 1,
         KTurnDamping = 1.5,
         LiftFactor = 7,
-        MaxAirspeed = 30,
+        MaxAirspeed = 28,
         MinAirspeed = 25,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.1,
-        TurnSpeed = 1,
+        TurnSpeed = 0.6,
         Winged = true,
     },
     Audio = {

--- a/units/URA0101/URA0101_unit.bp
+++ b/units/URA0101/URA0101_unit.bp
@@ -19,7 +19,7 @@ UnitBlueprint {
         MinAirspeed = 17,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.1,
-        TurnSpeed = 0.8,
+        TurnSpeed = 0.6,
         Winged = true,
     },
     Audio = {

--- a/units/URA0302/URA0302_unit.bp
+++ b/units/URA0302/URA0302_unit.bp
@@ -15,11 +15,11 @@ UnitBlueprint {
         KTurn = 1,
         KTurnDamping = 1.5,
         LiftFactor = 7,
-        MaxAirspeed = 30,
+        MaxAirspeed = 28,
         MinAirspeed = 25,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.1,
-        TurnSpeed = 0.8,
+        TurnSpeed = 0.6,
         Winged = true,
     },
     Audio = {

--- a/units/XSA0101/XSA0101_unit.bp
+++ b/units/XSA0101/XSA0101_unit.bp
@@ -19,7 +19,7 @@ UnitBlueprint {
         MinAirspeed = 17,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.1,
-        TurnSpeed = 0.8,
+        TurnSpeed = 0.6,
         Winged = true,
     },
     Audio = {

--- a/units/XSA0302/XSA0302_unit.bp
+++ b/units/XSA0302/XSA0302_unit.bp
@@ -15,11 +15,11 @@ UnitBlueprint {
         KTurn = 1,
         KTurnDamping = 1.5,
         LiftFactor = 7,
-        MaxAirspeed = 30,
+        MaxAirspeed = 28,
         MinAirspeed = 25,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.1,
-        TurnSpeed = 0.8,
+        TurnSpeed = 0.6,
         Winged = true,
     },
     Audio = {


### PR DESCRIPTION
T3 air scout : 
- speed nerf from 28 to 25
- turnspeed nerf from 0.8 to 0.6

T1 air scout : 
- turnspeed nerf from 0.8 to 0.6