### PR TITLE
Blacklist old nomads version

### DIFF
--- a/etc/faf/blacklist.lua
+++ b/etc/faf/blacklist.lua
@@ -22,7 +22,8 @@ Blacklist = {
     ['xxxx-NetLag-Experimental-v3'] = HARMFUL,
 
 -- Broken --
-
+    --Old Nomads version thats not featured, and doesnt show up in the mod list
+    ['50423624-1e83-4fc2-85b3-nomadsv00074'] = BROKEN,
 -- Obselete --
 
     -- XINNONY TRY FIX CORRECT DISCONNECT


### PR DESCRIPTION
this is rather annoying since people keep trying to use it, and its
completely messed up. This doesnt even show up in the mods list ingame!
its been hidden in the mod vault but whoever still has it might still
think its a great idea to try and use it.