### PR TITLE
Sera ACU regen field rework

### DIFF
--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -367,6 +367,14 @@ function BuffCalculate(unit, buffName, affectType, initialVal, initialBool)
     local multsTotal = 0 -- Used only for regen buffs
     local bool = initialBool or false
     local floor = 0
+    local ceil = 0
+    -- Dynamic ceilings with fallback values for sera regen field
+    local ceilings = {
+        TECH1 = 10,
+        TECH2 = 15,
+        TECH3 = 25,
+        TECH4 = 40
+    }
 
     if not unit.Buffs.Affects[affectType] then return initialVal, bool end
 
@@ -378,6 +386,21 @@ function BuffCalculate(unit, buffName, affectType, initialVal, initialBool)
         if v.Floor then
             floor = v.Floor
         end
+
+        if v.CeilT1 then
+            ceilings['TECH1'] = v.CeilT1
+        end
+        if v.CeilT2 then
+            ceilings['TECH2'] = v.CeilT2
+        end
+        if v.CeilT3 then
+            ceilings['TECH3'] = v.CeilT3
+        end
+        if v.CeilT4 then
+            ceilings['TECH4'] = v.CeilT4
+        end
+
+        ceil = ceilings[unit.techCategory]
 
         if v.Mult then
             if affectType == 'Regen' then
@@ -391,7 +414,7 @@ function BuffCalculate(unit, buffName, affectType, initialVal, initialBool)
                 if v.Mult ~= 1 then
                     local maxHealth = unit:GetBlueprint().Defense.MaxHealth
                     for i=1,v.Count do
-                        multsTotal = multsTotal + math.min((v.Mult * maxHealth), v.Ceil or 999999)
+                        multsTotal = multsTotal + math.min((v.Mult * maxHealth), ceil)
                     end
                 end
             else

--- a/units/XSL0001/XSL0001_script.lua
+++ b/units/XSL0001/XSL0001_script.lua
@@ -111,7 +111,10 @@ XSL0001 = Class(ACUUnit) {
                             Add = 0,
                             Mult = bp.RegenPerSecond,
                             Floor = bp.RegenFloor,
-                            Ceil = bp.RegenCeiling,
+                            CeilT1 = bp.RegenCeilingT1,
+                            CeilT2 = bp.RegenCeilingT2,
+                            CeilT3 = bp.RegenCeilingT3,
+                            CeilT4 = bp.RegenCeilingT4,
                         },
                     },
                 }

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -392,13 +392,16 @@ UnitBlueprint {
             Radius = 35,
             MaxHealthFactor = 1.2,
             RegenFloor = 15,
-            RegenCeiling = 200,
+            RegenCeilingT1 = 20,
+            RegenCeilingT2 = 50,
+            RegenCeilingT3 = 120,
+            RegenCeilingT4 = 240,
             RegenPerSecond = 0.01111111111,
-            Slot = 'RCH',
+            Slot = 'LCH',
             UnitCategory = 'BUILTBYTIER3FACTORY, BUILTBYQUANTUMGATE, NEEDMOBILEBUILD',
             UpgradeEffectBones = {
-                'Right_Upgrade',
-                'Right_Turret_Muzzle',
+                'Left_Upgrade',
+                'Left_Turret_Muzzle',
             },
             UpgradeUnitAmbientBones = {
                 'Body',
@@ -415,7 +418,7 @@ UnitBlueprint {
                 'AdvancedRegenAura',
                 'AdvancedRegenAuraRemove',
             },
-            Slot = 'RCH',
+            Slot = 'LCH',
         },
         BlastAttack = {
             AdditionalDamage = 620,
@@ -604,16 +607,19 @@ UnitBlueprint {
             Radius = 30,
             MaxHealthFactor = 1.1,
             RegenFloor = 3,
-            RegenCeiling = 15,
+            RegenCeilingT1 = 10,
+            RegenCeilingT2 = 15,
+            RegenCeilingT3 = 25,
+            RegenCeilingT4 = 40,
             RegenPerSecond = 0.02,
             ShowBones = {
-                'Right_Upgrade',
+                'Left_Upgrade',
             },
-            Slot = 'RCH',
+            Slot = 'LCH',
             UnitCategory = 'BUILTBYTIER3FACTORY, BUILTBYQUANTUMGATE, NEEDMOBILEBUILD',
             UpgradeEffectBones = {
-                'Right_Upgrade',
-                'Right_Turret_Muzzle',
+                'Left_Upgrade',
+                'Left_Turret_Muzzle',
             },
             UpgradeUnitAmbientBones = {
                 'Body',
@@ -624,7 +630,7 @@ UnitBlueprint {
             BuildCostMass = 1,
             BuildTime = 0.1,
             HideBones = {
-                'Right_Upgrade',
+                'Left_Upgrade',
             },
             Icon = 'nrf',
             Name = '<LOC enhancements_0126>Remove Restoration Field',
@@ -633,7 +639,7 @@ UnitBlueprint {
                 'RegenAura',
                 'RegenAuraRemove',
             },
-            Slot = 'RCH',
+            Slot = 'LCH',
         },
         ResourceAllocation = {
             BuildCostEnergy = 175000,
@@ -644,9 +650,13 @@ UnitBlueprint {
             ProductionPerSecondEnergy = 2000,
             ProductionPerSecondMass = 16,
             ShowBones = {
-                'Back_Upgrade',
+                'Right_Upgrade',
             },
-            Slot = 'Back',
+            Slot = 'RCH',
+            UpgradeEffectBones = {
+                'Right_Upgrade',
+                'Right_Turret_Muzzle',
+            },
             UpgradeUnitAmbientBones = {
                 'Body',
             },
@@ -661,9 +671,13 @@ UnitBlueprint {
             ProductionPerSecondEnergy = 4000,
             ProductionPerSecondMass = 32,
             ShowBones = {
-                'Back_Upgrade',
+                'Right_Upgrade',
             },
-            Slot = 'Back',
+            Slot = 'RCH',
+            UpgradeEffectBones = {
+                'Right_Upgrade',
+                'Right_Turret_Muzzle',
+            },
             UpgradeUnitAmbientBones = {
                 'Body',
             },
@@ -673,7 +687,7 @@ UnitBlueprint {
             BuildCostMass = 1,
             BuildTime = 0.1,
             HideBones = {
-                'Back_Upgrade',
+                'Right_Upgrade',
             },
             Icon = 'eras',
             Name = '<LOC enhancements_0012>Remove Advanced Allocation System',
@@ -683,14 +697,14 @@ UnitBlueprint {
                 'ResourceAllocationAdvanced',
                 'ResourceAllocationAdvancedRemove',
             },
-            Slot = 'Back',
+            Slot = 'RCH',
         },
         ResourceAllocationRemove = {
             BuildCostEnergy = 1,
             BuildCostMass = 1,
             BuildTime = 0.1,
             HideBones = {
-                'Back_Upgrade',
+                'Right_Upgrade',
             },
             Icon = 'ras',
             Name = '<LOC enhancements_0013>Remove Resource Allocation System',
@@ -699,7 +713,7 @@ UnitBlueprint {
                 'ResourceAllocation',
                 'ResourceAllocationRemove',
             },
-            Slot = 'Back',
+            Slot = 'RCH',
         },
         Slots = {
             Back = {


### PR DESCRIPTION
As per call changed the slots of regen field and ras around (I know there is an open PR for it but it seems to be missing a few lines of upgrade VFX code.)
Rebalanced to have a regen ceiling based on a tech level as opposed to a shared one.
Regen field ceilings:
* T1 - 10
* T2 - 15
* T3 - 25
* T4 - 40

Advanced regen field ceilings:
* T1 - 20
* T2 - 50
* T3 - 120
* T4 - 240