### PR TITLE
Supreme Props: Added missing fix

### DIFF
--- a/env/Swamp/Props/Rocks/boulder01_prop.bp
+++ b/env/Swamp/Props/Rocks/boulder01_prop.bp
@@ -19,7 +19,7 @@ PropBlueprint {
         UniformScale = 0.015,
     },
     Economy = {
-        ReclaimEnergyMax = 10,
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 15,
         ReclaimTime = 5,
     },


### PR DESCRIPTION
I missed one fix in the Supreme Props integration. The 10 energy of the boulder/rock should be removed. The value should be 0 like all the other rocks.

See here: https://user-images.githubusercontent.com/28671151/57193683-2e7b5180-6f3e-11e9-9e24-cf2af24384e7.png
