### PR TITLE
Corrects text display if video doesn't play

### DIFF
--- a/lua/ui/game/missiontext.lua
+++ b/lua/ui/game/missiontext.lua
@@ -91,6 +91,15 @@ function PlayMFDMovie(movie, text)
         controls.subtitles = CreateSubtitles(controls.movieBrackets, text[1])
         
         controls.movieBrackets.movie.OnFinished = function(self)
+            if (not controls.movieBrackets.movie:IsLoaded()) and (self.loadCheck == nil) then
+                ForkThread(
+                function(self, duration, onFinished)
+                    WaitSeconds(duration)
+                    onFinished(self)
+                end, self, GetMovieDuration(movie[1]), controls.movieBrackets.movie.OnFinished)
+                self.loadCheck = true
+                return
+            end
             controls.movieBrackets.panel:SetNeedsFrameUpdate(true)
             controls.movieBrackets.panel.sound = PlaySound(Sound{Bank='Interface', Cue=prefix[movie[4]].cue..'_Out'})
             controls.subtitles:Contract()


### PR DESCRIPTION
To reproduce the problem, delete the movies folder and launch the scenario.

As a consequence of this fix if video dialogue is broken, text dialogue is show.
It not adds desyncs and not eliminate them.
![Broken dialogue video](https://user-images.githubusercontent.com/5648030/69011164-6cdfd780-0989-11ea-80c3-6eda0f1d6181.png)

History:
The game only plays unpacked videos.
Videos from gamedata are found but not played. The sound also does not play.
Problem in any SC1 scenario. For example Joust.
After switching to Win 10 and reinstalling FAF, the problem disappeared.