### PR TITLE
fix mongoose hitbox

### DIFF
--- a/units/DEL0204/DEL0204_unit.bp
+++ b/units/DEL0204/DEL0204_unit.bp
@@ -194,7 +194,7 @@ UnitBlueprint {
     SelectionThickness = 0.62,
     SizeX = 0.7,
     SizeY = 1,
-    SizeZ = 0.4,
+    SizeZ = 1,
     StrategicIconName = 'icon_bot2_directfire',
     StrategicIconSortPriority = 115,
     Transport = {


### PR DESCRIPTION
tested so sera T2 pd and rhino can hit them.
SizeZ = 0.7 is enough for sera pd; but SizeZ = 1 is needed for rhino.