### PR TITLE
Fix for AI Base templates

### DIFF
--- a/lua/AI/AIAddBuilderTable.lua
+++ b/lua/AI/AIAddBuilderTable.lua
@@ -11,6 +11,8 @@ function AddGlobalBaseTemplate(aiBrain, locationType, baseBuilderName)
     if not BaseBuilderTemplates[baseBuilderName] then
         error('*AI ERROR: Invalid BaseBuilderTemplate: none found named - ' .. baseBuilderName)
     end
+    
+    --SPEW('*AI DEBUG: AddGlobalBaseTemplate(): Loading Base Template '..repr(baseBuilderName))
     for k,v in BaseBuilderTemplates[baseBuilderName].Builders do
         AddGlobalBuilderGroup(aiBrain, locationType, v)
     end

--- a/lua/AI/AIBaseTemplates/NavalExpansionLarge.lua
+++ b/lua/AI/AIBaseTemplates/NavalExpansionLarge.lua
@@ -80,6 +80,6 @@ BaseBuilderTemplate {
             return 100
         end
 
-        return 0
+        return 1
     end,
 }

--- a/lua/AI/AIBaseTemplates/NavalExpansionSmall.lua
+++ b/lua/AI/AIBaseTemplates/NavalExpansionSmall.lua
@@ -77,6 +77,6 @@ BaseBuilderTemplate {
             return 50
         end
 
-        return 0
+        return 1
     end,
 }

--- a/lua/AI/AIBaseTemplates/RushExpansionAirFull.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionAirFull.lua
@@ -141,6 +141,6 @@ BaseBuilderTemplate {
             return 10
         end
 
-        return 0
+        return 1
     end,
 }

--- a/lua/AI/AIBaseTemplates/RushExpansionAirSmall.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionAirSmall.lua
@@ -90,6 +90,6 @@ BaseBuilderTemplate {
             return 10
         end
 
-        return 0
+        return 1
     end,
 }

--- a/lua/AI/AIBaseTemplates/RushExpansionBalancedFull.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionBalancedFull.lua
@@ -145,6 +145,6 @@ BaseBuilderTemplate {
             return 25
         end
 
-        return 0
+        return 1
     end,
 }

--- a/lua/AI/AIBaseTemplates/RushExpansionBalancedSmall.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionBalancedSmall.lua
@@ -110,6 +110,6 @@ BaseBuilderTemplate {
             return 25
         end
 
-        return 0
+        return 1
     end,
 }

--- a/lua/AI/AIBaseTemplates/RushExpansionLandFull.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionLandFull.lua
@@ -145,6 +145,6 @@ BaseBuilderTemplate {
             return 100
         end
 
-        return 0
+        return 1
     end,
 }

--- a/lua/AI/AIBaseTemplates/RushExpansionLandSmall.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionLandSmall.lua
@@ -110,6 +110,6 @@ BaseBuilderTemplate {
             return 100
         end
 
-        return 0
+        return 1
     end,
 }

--- a/lua/AI/AIBaseTemplates/SorianExpansionAirFull.lua
+++ b/lua/AI/AIBaseTemplates/SorianExpansionAirFull.lua
@@ -142,7 +142,7 @@ BaseBuilderTemplate {
     },
     ExpansionFunction = function(aiBrain, location, markerType)
         if not aiBrain.Sorian then
-            return 0
+            return -1
         end
         if markerType != 'Start Location' and markerType != 'Expansion Area' then
             return 0

--- a/lua/AI/AIBaseTemplates/SorianExpansionBalancedFull.lua
+++ b/lua/AI/AIBaseTemplates/SorianExpansionBalancedFull.lua
@@ -141,7 +141,7 @@ BaseBuilderTemplate {
     },
     ExpansionFunction = function(aiBrain, location, markerType)
         if not aiBrain.Sorian then
-            return 0
+            return -1
         end
         if markerType != 'Start Location' and markerType != 'Expansion Area' then
             return 0

--- a/lua/AI/AIBaseTemplates/SorianExpansionBalancedSmall.lua
+++ b/lua/AI/AIBaseTemplates/SorianExpansionBalancedSmall.lua
@@ -117,7 +117,7 @@ BaseBuilderTemplate {
     },
     ExpansionFunction = function(aiBrain, location, markerType)
         if not aiBrain.Sorian then
-            return 0
+            return -1
         end
         if markerType != 'Start Location' and markerType != 'Expansion Area' then
             return 0

--- a/lua/AI/AIBaseTemplates/SorianExpansionTurtleFull.lua
+++ b/lua/AI/AIBaseTemplates/SorianExpansionTurtleFull.lua
@@ -141,7 +141,7 @@ BaseBuilderTemplate {
     },
     ExpansionFunction = function(aiBrain, location, markerType)
         if not aiBrain.Sorian then
-            return 0
+            return -1
         end
         if markerType != 'Start Location' and markerType != 'Expansion Area' then
             return 0

--- a/lua/AI/AIBaseTemplates/SorianExpansionWaterFull.lua
+++ b/lua/AI/AIBaseTemplates/SorianExpansionWaterFull.lua
@@ -129,7 +129,7 @@ BaseBuilderTemplate {
     },
     ExpansionFunction = function(aiBrain, location, markerType)
         if not aiBrain.Sorian then
-            return 0
+            return -1
         end
         if markerType != 'Start Location' and markerType != 'Expansion Area' then
             return 0

--- a/lua/AI/AIBaseTemplates/SorianMainAir.lua
+++ b/lua/AI/AIBaseTemplates/SorianMainAir.lua
@@ -216,11 +216,11 @@ BaseBuilderTemplate {
         },
     },
     ExpansionFunction = function(aiBrain, location, markerType)
-        return 0
+        return -1
     end,
     FirstBaseFunction = function(aiBrain)
         if not aiBrain.Sorian then
-            return 0
+            return -1
         end
         local per = ScenarioInfo.ArmySetup[aiBrain.Name].AIPersonality
         if not per then

--- a/lua/AI/AIBaseTemplates/SorianMainBalanced.lua
+++ b/lua/AI/AIBaseTemplates/SorianMainBalanced.lua
@@ -219,11 +219,11 @@ BaseBuilderTemplate {
         },
     },
     ExpansionFunction = function(aiBrain, location, markerType)
-        return 0
+        return -1
     end,
     FirstBaseFunction = function(aiBrain)
         if not aiBrain.Sorian then
-            return 0
+            return -1
         end
         local per = ScenarioInfo.ArmySetup[aiBrain.Name].AIPersonality
         if not per then

--- a/lua/AI/AIBaseTemplates/SorianMainRush.lua
+++ b/lua/AI/AIBaseTemplates/SorianMainRush.lua
@@ -222,11 +222,11 @@ BaseBuilderTemplate {
         },
     },
     ExpansionFunction = function(aiBrain, location, markerType)
-        return 0
+        return -1
     end,
     FirstBaseFunction = function(aiBrain)
         if not aiBrain.Sorian then
-            return 0
+            return -1
         end
         local per = ScenarioInfo.ArmySetup[aiBrain.Name].AIPersonality
         if not per then

--- a/lua/AI/AIBaseTemplates/SorianMainTurtle.lua
+++ b/lua/AI/AIBaseTemplates/SorianMainTurtle.lua
@@ -218,11 +218,11 @@ BaseBuilderTemplate {
         },
     },
     ExpansionFunction = function(aiBrain, location, markerType)
-        return 0
+        return -1
     end,
     FirstBaseFunction = function(aiBrain)
         if not aiBrain.Sorian then
-            return 0
+            return -1
         end
         local per = ScenarioInfo.ArmySetup[aiBrain.Name].AIPersonality
         if not per then

--- a/lua/AI/AIBaseTemplates/SorianMainWater.lua
+++ b/lua/AI/AIBaseTemplates/SorianMainWater.lua
@@ -220,11 +220,11 @@ BaseBuilderTemplate {
         },
     },
     ExpansionFunction = function(aiBrain, location, markerType)
-        return 0
+        return -1
     end,
     FirstBaseFunction = function(aiBrain)
         if not aiBrain.Sorian then
-            return 0
+            return -1
         end
         local per = ScenarioInfo.ArmySetup[aiBrain.Name].AIPersonality
         if not per then

--- a/lua/AI/AIBaseTemplates/SorianNavalExpansionLarge.lua
+++ b/lua/AI/AIBaseTemplates/SorianNavalExpansionLarge.lua
@@ -87,7 +87,10 @@ BaseBuilderTemplate {
         },
     },
     ExpansionFunction = function(aiBrain, location, markerType)
-        if not aiBrain.Sorian or markerType != 'Naval Area' then
+        if not aiBrain.Sorian then
+            return -1
+        end
+        if markerType != 'Naval Area' then
             return 0
         end
 

--- a/lua/AI/AIBaseTemplates/SorianNavalExpansionSmall.lua
+++ b/lua/AI/AIBaseTemplates/SorianNavalExpansionSmall.lua
@@ -84,7 +84,10 @@ BaseBuilderTemplate {
         },
     },
     ExpansionFunction = function(aiBrain, location, markerType)
-        if not aiBrain.Sorian or markerType != 'Naval Area' then
+        if not aiBrain.Sorian then
+            return -1
+        end
+        if markerType != 'Naval Area' then
             return 0
         end
 

--- a/lua/AI/AIBaseTemplates/TechExpansion.lua
+++ b/lua/AI/AIBaseTemplates/TechExpansion.lua
@@ -152,6 +152,6 @@ BaseBuilderTemplate {
             return 10
         end
 
-        return 0
+        return 1
     end,
 }

--- a/lua/AI/AIBaseTemplates/TechExpansionSmall.lua
+++ b/lua/AI/AIBaseTemplates/TechExpansionSmall.lua
@@ -137,6 +137,6 @@ BaseBuilderTemplate {
             return 10
         end
 
-        return 0
+        return 1
     end,
 }

--- a/lua/AI/AIBaseTemplates/TurtleExpansion.lua
+++ b/lua/AI/AIBaseTemplates/TurtleExpansion.lua
@@ -144,10 +144,6 @@ BaseBuilderTemplate {
         },
     },
     ExpansionFunction = function(aiBrain, location, markerType)
-        if markerType != 'Start Location' then
-            return 0
-        end
-
         local personality = ScenarioInfo.ArmySetup[aiBrain.Name].AIPersonality
         if not(personality == 'adaptive' or personality == 'turtle') then
             return 0
@@ -165,6 +161,6 @@ BaseBuilderTemplate {
             return 10
         end
 
-        return 0
+        return 1
     end,
 }

--- a/lua/AI/AIBuilders/AINavalBuilders.lua
+++ b/lua/AI/AIBuilders/AINavalBuilders.lua
@@ -33,6 +33,7 @@ BuilderGroup {
         Priority = 922,
         InstanceCount = 1,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             #DUNCAN - Added to limit expansions
             { UCBC, 'NavalBaseCount', { '<', 1 } },
             { UCBC, 'NavalAreaNeedsEngineer', { 'LocationType', 250, -1000, 10, 1, 'AntiSurface' } },
@@ -71,6 +72,7 @@ BuilderGroup {
         Priority = 0, #DUNCAN - was 922
         InstanceCount = 1,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             #DUNCAN - Added to limit expansions
             { UCBC, 'NavalBaseCount', { '<', 1 } },
             { UCBC, 'NavalAreaNeedsEngineer', { 'LocationType', 250, -1000, 10, 1, 'AntiSurface' } },
@@ -104,6 +106,7 @@ BuilderGroup {
         Priority = 0, #DUNCAN - was 922
         InstanceCount = 1,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             #DUNCAN - Added to limit expansions
             { UCBC, 'NavalBaseCount', { '<', 1 } },
             { UCBC, 'NavalAreaNeedsEngineer', { 'LocationType', 250, -1000, 10, 1, 'AntiSurface' } },
@@ -144,6 +147,7 @@ BuilderGroup {
         Priority = 985,
         InstanceCount = 1,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             #DUNCAN - Added to limit expansions
             { UCBC, 'NavalBaseCount', { '<', 1 } },
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, 'FACTORY NAVAL' } },
@@ -186,6 +190,7 @@ BuilderGroup {
         Priority = 850,
         InstanceCount = 1,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             #DUNCAN - Added to limit expansions
             { UCBC, 'NavalBaseCount', { '<', 2 } },
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, 'FACTORY NAVAL'}},
@@ -225,6 +230,7 @@ BuilderGroup {
         Priority = 0, #DUNCAN - was 850
         InstanceCount = 1,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             #DUNCAN - Added to limit expansions
             { UCBC, 'NavalBaseCount', { '<', 2 } },
             { MIBC, 'MapGreaterThan', { 512, 512 }},
@@ -259,6 +265,7 @@ BuilderGroup {
         Priority =  0, #DUNCAN - was 850
         InstanceCount = 1,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             #DUNCAN - Added to limit expansions
             { UCBC, 'NavalBaseCount', { '<', 2 } },
             { MIBC, 'MapGreaterThan', { 512, 512 }},
@@ -297,8 +304,7 @@ BuilderGroup {
         PlatoonTemplate = 'EngineerBuilder',
         Priority = 850,
         BuilderConditions = {
-            #{ UCBC, 'HaveGreaterThanUnitsWithCategory', { 2, 'MOBILE NAVAL'}},
-            #{ UCBC, 'EngineerLessAtLocation', { 'LocationType', 1, 'ENGINEER TECH2, ENGINEER TECH3' } },
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Sea' } },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.2 }},
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
@@ -320,7 +326,7 @@ BuilderGroup {
         PlatoonTemplate = 'T2EngineerBuilder',
         Priority = 850,
         BuilderConditions = {
-            #{ UCBC, 'EngineerLessAtLocation', { 'LocationType', 1, 'ENGINEER TECH3' } },
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Sea' } },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.2 }},
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
@@ -342,6 +348,7 @@ BuilderGroup {
         PlatoonTemplate = 'T3EngineerBuilder',
         Priority = 850,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Sea' } },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.2 }},
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },

--- a/lua/AI/AIBuilders/SorianNavalBuilders.lua
+++ b/lua/AI/AIBuilders/SorianNavalBuilders.lua
@@ -34,6 +34,7 @@ BuilderGroup {
         Priority = 985,
         InstanceCount = 1,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             { UCBC, 'NavalAreaNeedsEngineer', { 'LocationType', 600, -1000, 10, 1, 'AntiSurface' } },
             { UCBC, 'HaveLessThanUnitsWithCategory', { 1, 'FACTORY NAVAL TECH2, FACTORY NAVAL TECH3'}},
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, 'FACTORY NAVAL TECH2, FACTORY NAVAL TECH3' } },
@@ -71,6 +72,7 @@ BuilderGroup {
         Priority = 922,
         InstanceCount = 1,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             { UCBC, 'NavalAreaNeedsEngineer', { 'LocationType', 600, -1000, 10, 1, 'AntiSurface' } },
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, 'FACTORY NAVAL'}},
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, 'FACTORY NAVAL TECH2, FACTORY NAVAL TECH3' } },
@@ -108,6 +110,7 @@ BuilderGroup {
         Priority = 922,
         InstanceCount = 1,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             { UCBC, 'NavalAreaNeedsEngineer', { 'LocationType', 600, -1000, 10, 1, 'AntiSurface' } },
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, 'FACTORY NAVAL TECH2, FACTORY NAVAL TECH3' } },
             { SIBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.1 }},
@@ -144,6 +147,7 @@ BuilderGroup {
         Priority = 922,
         InstanceCount = 1,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             { UCBC, 'NavalAreaNeedsEngineer', { 'LocationType', 600, -1000, 10, 1, 'AntiSurface' } },
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, 'FACTORY NAVAL TECH2, FACTORY NAVAL TECH3' } },
             { SIBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.1 }},
@@ -186,6 +190,7 @@ BuilderGroup {
         Priority = 922,
         InstanceCount = 1,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             { UCBC, 'NavalAreaNeedsEngineer', { 'LocationType', 600, -1000, 10, 1, 'AntiSurface' } },
             { SIBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.1 }},
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
@@ -221,6 +226,7 @@ BuilderGroup {
         Priority = 922,
         InstanceCount = 1,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             { UCBC, 'NavalAreaNeedsEngineer', { 'LocationType', 600, -1000, 10, 1, 'AntiSurface' } },
             { SIBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.1 }},
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
@@ -256,6 +262,7 @@ BuilderGroup {
         Priority = 922,
         InstanceCount = 1,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             { UCBC, 'NavalAreaNeedsEngineer', { 'LocationType', 600, -1000, 10, 1, 'AntiSurface' } },
             { SIBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.1 }},
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
@@ -295,6 +302,7 @@ BuilderGroup {
         PlatoonTemplate = 'EngineerBuilderSorian',
         Priority = 905,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             { UCBC, 'EngineerLessAtLocation', { 'LocationType', 1, 'ENGINEER TECH2, ENGINEER TECH3' } },
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Sea' } },
             { SIBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.1 }},
@@ -317,6 +325,7 @@ BuilderGroup {
         PlatoonTemplate = 'T2EngineerBuilderSorian',
         Priority = 905,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             { UCBC, 'EngineerLessAtLocation', { 'LocationType', 1, 'ENGINEER TECH3' } },
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Sea' } },
             { SIBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.1 }},
@@ -339,6 +348,7 @@ BuilderGroup {
         PlatoonTemplate = 'T3EngineerBuilderSorian',
         Priority = 905,
         BuilderConditions = {
+            { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Sea' } },
             { SIBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.1 }},
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },

--- a/lua/AI/aibuildstructures.lua
+++ b/lua/AI/aibuildstructures.lua
@@ -456,7 +456,9 @@ function AINewExpansionBase(aiBrain, baseName, position, builder, constructionDa
         for templateName, baseData in BaseBuilderTemplates do
             local baseValue = baseData.ExpansionFunction(aiBrain, position, constructionData.NearMarkerType)
             table.insert(baseValues, { Base = templateName, Value = baseValue })
+            --SPEW('*AI DEBUG: AINewExpansionBase(): Scann next Base. baseValue= ' .. repr(baseValue) .. ' ('..repr(templateName)..')')
             if not highPri or baseValue > highPri then
+                --SPEW('*AI DEBUG: AINewExpansionBase(): Possible next Base. baseValue= ' .. repr(baseValue) .. ' ('..repr(templateName)..')')
                 highPri = baseValue
             end
         end
@@ -468,6 +470,7 @@ function AINewExpansionBase(aiBrain, baseName, position, builder, constructionDa
                 table.insert(validNames, v.Base)
             end
         end
+        --SPEW('*AI DEBUG: AINewExpansionBase(): validNames for Expansions ' .. repr(validNames))
         local pick = validNames[ Random(1, table.getn(validNames)) ]
 
         # Error if no pick
@@ -476,7 +479,7 @@ function AINewExpansionBase(aiBrain, baseName, position, builder, constructionDa
         end
 
         # Setup base
-        #LOG('*AI DEBUG: ARMY ' .. aiBrain:GetArmyIndex() .. ': Expanding using - ' .. pick .. ' at location ' .. baseName)
+        --SPEW('*AI DEBUG: AINewExpansionBase(): ARMY ' .. aiBrain:GetArmyIndex() .. ': Expanding using - ' .. pick .. ' at location ' .. baseName)
         import('/lua/ai/AIAddBuilderTable.lua').AddGlobalBaseTemplate(aiBrain, baseName, pick)
 
         # If air base switch to building an air factory rather than land


### PR DESCRIPTION
`Fix for AI Base templates:`

GPG AI Tech had no expansion template for `Expansion Areas` or `Large Expansion Areas`.
(It's now using the existing expansion template for all expansions)

Also fixed an issue where the GPG AI was using a sorian expansion template.
(changed expansion function return value to -1 for sorian templates)

Left some (inactive) debug lines for other AI developers ^^
(only way to see the actual used expansion template)

---
`Added check for naval expansions:`

Added new buildcondition to all naval expansion builders to respect naval expansion count from game options