### PR TITLE
In-game weapon tooltips fix

### DIFF
--- a/units/DEL0204/DEL0204_Script.lua
+++ b/units/DEL0204/DEL0204_Script.lua
@@ -1,0 +1,34 @@
+local TWalkingLandUnit = import('/lua/terranunits.lua').TWalkingLandUnit
+local TWeapons = import('/lua/terranweapons.lua')
+local TDFPlasmaCannonWeapon = TWeapons.TDFPlasmaCannonWeapon
+local TIFFragLauncherWeapon = TWeapons.TDFFragmentationGrenadeLauncherWeapon
+local EffectUtils = import('/lua/effectutilities.lua')
+local Effects = import('/lua/effecttemplates.lua')
+
+DEL0204 = Class(TWalkingLandUnit) 
+{
+    Weapons = {
+        GatlingCannon = Class(TDFPlasmaCannonWeapon) 
+        {
+            PlayFxWeaponPackSequence = function(self)
+                self.ExhaustEffects = EffectUtils.CreateBoneEffects( self.unit, 'Left_Arm_Barrel_Muzzle', self.unit:GetArmy(), Effects.WeaponSteam01 )
+                TDFPlasmaCannonWeapon.PlayFxWeaponPackSequence(self)
+            end,           
+            
+            PlayFxRackSalvoReloadSequence = function(self)
+                self.ExhaustEffects = EffectUtils.CreateBoneEffects( self.unit, 'Left_Arm_Barrel_Muzzle', self.unit:GetArmy(), Effects.WeaponSteam01 )
+                TDFPlasmaCannonWeapon.PlayFxRackSalvoChargeSequence(self)
+            end,
+        },
+        
+        Grenade = Class(TIFFragLauncherWeapon) {}
+    },
+
+    OnStopBeingBuilt = function(self,builder,layer)
+        TWalkingLandUnit.OnStopBeingBuilt(self,builder,layer)
+
+	self.Trash:Add(CreateRotator(self, 'Left_Arm_Barrel', 'z', nil, 270, 0, 0))
+    end,
+}
+
+TypeClass = DEL0204

--- a/units/DEL0204/DEL0204_unit.bp
+++ b/units/DEL0204/DEL0204_unit.bp
@@ -240,7 +240,7 @@ UnitBlueprint {
             NoPause = true,
             ProjectileId = '/projectiles/TDFPlasma02/TDFPlasma02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.15,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 15,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -252,13 +252,13 @@ UnitBlueprint {
             RackFireTogether = false,
             RackRecoilDistance = 0,
             RackReloadTimeout = 0,
-            RackSalvoChargeTime = 2,
+            RackSalvoChargeTime = 0,
             RackSalvoFiresAfterCharge = false,
-            RackSalvoReloadTime = 1,
+            RackSalvoReloadTime = 0,
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = 'UWRC_DirectFire',
-            RateOfFire = 1,
+            RateOfFire = 0.17,
             TargetCheckInterval = 0.25,
             TargetPriorities = {
                 'TECH3 MOBILE',
@@ -315,7 +315,7 @@ UnitBlueprint {
             MuzzleVelocityRandomness = 0.5,
             ProjectileId = '/projectiles/TDFFragmentationGrenade01/TDFFragmentationGrenade01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.3,
-            ProjectilesPerOnFire = 3,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/DRA0202/DRA0202_unit.bp
+++ b/units/DRA0202/DRA0202_unit.bp
@@ -369,7 +369,7 @@ UnitBlueprint {
             MuzzleVelocity = 30,#35
             ProjectileId = '/projectiles/CIFCorsairMissile01/CIFCorsairMissile01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.15,
-            ProjectilesPerOnFire = 6,
+            ProjectilesPerOnFire = 8,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -737,10 +737,11 @@ UnitBlueprint {
             Label = 'AAFizz01',
             MaxRadius = 44,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 20,
             ProjectileId = '/projectiles/AAAFizz01/AAAFizz01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -813,11 +814,12 @@ UnitBlueprint {
             Label = 'AAFizz02',
             MaxRadius = 44,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 20,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/AAAFizz01/AAAFizz01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UAB2109/UAB2109_unit.bp
+++ b/units/UAB2109/UAB2109_unit.bp
@@ -211,7 +211,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/AANTorpedo01/AANTorpedo01_proj.bp',
             ProjectileLifetime = 7,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UAB2205/UAB2205_unit.bp
+++ b/units/UAB2205/UAB2205_unit.bp
@@ -247,7 +247,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_proj.bp',
             ProjectileLifetime = 12,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UAL0104/UAL0104_unit.bp
+++ b/units/UAL0104/UAL0104_unit.bp
@@ -262,7 +262,7 @@ UnitBlueprint {
             MuzzleVelocity = 45,
             ProjectileId = '/projectiles/AAASonicPulse01/AAASonicPulse01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 3,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UAS0201/UAS0201_unit.bp
+++ b/units/UAS0201/UAS0201_unit.bp
@@ -386,6 +386,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/AANTorpedo01/AANTorpedo01_proj.bp',
             ProjectileLifetime = 7,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -434,6 +435,7 @@ UnitBlueprint {
             MuzzleVelocity = 80,
             ProjectileId = '/projectiles/AIMAntiTorpedo01/AIMAntiTorpedo01_proj.bp',
             ProjectileLifetime = 4,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UAS0202/UAS0202_unit.bp
+++ b/units/UAS0202/UAS0202_unit.bp
@@ -254,6 +254,7 @@ UnitBlueprint {
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 40,
             ProjectileId = '/projectiles/ADFQuantumCannon01/ADFQuantumCannon01_proj.bp',
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UAS0302/UAS0302_unit.bp
+++ b/units/UAS0302/UAS0302_unit.bp
@@ -520,6 +520,7 @@ UnitBlueprint {
             MuzzleVelocity = 15,
             ProjectileId = '/projectiles/AIMAntiMissile01/AIMAntiMissile01_proj.bp',
             ProjectileLifetime = 3,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UAS0401/UAS0401_unit.bp
+++ b/units/UAS0401/UAS0401_unit.bp
@@ -397,6 +397,7 @@ UnitBlueprint {
             NotExclusive = true,
             ProjectileId = '/projectiles/ADFOblivionCannon04/ADFOblivionCannon04_proj.bp',
             ProjectileLifetime = 10,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -465,6 +466,7 @@ UnitBlueprint {
             MuzzleVelocity = 20,
             ProjectileId = '/projectiles/AANDepthCharge02/AANDepthCharge02_proj.bp',
             ProjectileLifetime = 10,
+            ProjectilesPerOnFire = 6,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -524,10 +526,11 @@ UnitBlueprint {
             MaxRadius = 45,
             MinRadius = 15,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 80,
             ProjectileId = '/projectiles/AIMAntiTorpedo02/AIMAntiTorpedo02_proj.bp',
             ProjectileLifetime = 1.5,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UEA0103/UEA0103_unit.bp
+++ b/units/UEA0103/UEA0103_unit.bp
@@ -289,6 +289,7 @@ UnitBlueprint {
             MuzzleVelocity = 0,
             NeedToComputeBombDrop = true,
             ProjectileId = '/projectiles/TIFNapalmCarpetBomb01/TIFNapalmCarpetBomb01_proj.bp',
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UEA0104/UEA0104_unit.bp
+++ b/units/UEA0104/UEA0104_unit.bp
@@ -449,7 +449,7 @@ UnitBlueprint {
             MuzzleVelocity = 35,
             ProjectileId = '/projectiles/TAARailgun01/TAARailgun01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -523,7 +523,7 @@ UnitBlueprint {
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/TAARailgun01/TAARailgun01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UEB2109/UEB2109_unit.bp
+++ b/units/UEB2109/UEB2109_unit.bp
@@ -212,7 +212,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/TANAnglerTorpedo02/TANAnglerTorpedo02_proj.bp',
             ProjectileLifetime = 7,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UEB2205/UEB2205_unit.bp
+++ b/units/UEB2205/UEB2205_unit.bp
@@ -240,7 +240,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/TANAnglerTorpedo02/TANAnglerTorpedo02_proj.bp',
             ProjectileLifetime = 12,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UEL0103/UEL0103_unit.bp
+++ b/units/UEL0103/UEL0103_unit.bp
@@ -232,6 +232,7 @@ UnitBlueprint {
             MuzzleVelocity = 14,
             MuzzleVelocityReduceDistance = 28,
             ProjectileId = '/projectiles/TIFFragmentationSensorShell01/TIFFragmentationSensorShell01_proj.bp',
+            ProjectilesPerOnFire = 5,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UEL0111/UEL0111_unit.bp
+++ b/units/UEL0111/UEL0111_unit.bp
@@ -244,7 +244,7 @@ UnitBlueprint {
             MuzzleVelocity = 3,
             ProjectileId = '/projectiles/TIFMissileCruise03/TIFMissileCruise03_proj.bp',
             ProjectileLifetime = 20,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     HideMuzzle = true,

--- a/units/UEL0203/UEL0203_unit.bp
+++ b/units/UEL0203/UEL0203_unit.bp
@@ -321,11 +321,11 @@ UnitBlueprint {
             Label = 'Riotgun01',
             MaxRadius = 18,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 40,
             ProjectileId = '/projectiles/TDFRiot02/TDFRiot02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.15,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -953,11 +953,11 @@ UnitBlueprint {
             Label = 'RightAAGun',
             MaxRadius = 45,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 90,
             ProjectileId = '/projectiles/TAARailgun01/TAARailgun01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -1030,12 +1030,12 @@ UnitBlueprint {
             Label = 'LeftAAGun',
             MaxRadius = 45,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 90,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/TAARailgun01/TAARailgun01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -1101,10 +1101,11 @@ UnitBlueprint {
             Label = 'Torpedo',
             MaxRadius = 40,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 4,
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/TANAnglerTorpedo02/TANAnglerTorpedo02_proj.bp',
             ProjectileLifetime = 9,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UES0103/UES0103_unit.bp
+++ b/units/UES0103/UES0103_unit.bp
@@ -359,7 +359,7 @@ UnitBlueprint {
             MuzzleVelocity = 45,
             ProjectileId = '/projectiles/TAARailgun01/TAARailgun01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UES0201/UES0201_unit.bp
+++ b/units/UES0201/UES0201_unit.bp
@@ -287,7 +287,7 @@ UnitBlueprint {
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 30,
             ProjectileId = '/projectiles/TDFGauss01/TDFGauss01_proj.bp',
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -372,7 +372,7 @@ UnitBlueprint {
             MuzzleVelocity = 30,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/TDFGauss01/TDFGauss01_proj.bp',
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -448,7 +448,7 @@ UnitBlueprint {
             MuzzleVelocity = 60,
             ProjectileId = '/projectiles/TAARailgun01/TAARailgun01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -523,7 +523,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/TANAnglerTorpedo01/TANAnglerTorpedo01_proj.bp',
             ProjectileLifetime = 7,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -616,10 +616,11 @@ UnitBlueprint {
             MaxRadius = 30,
             MinRadius = 15,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/TIMAntiTorpedo01/TIMAntiTorpedo01_proj.bp',
             ProjectileLifetime = 3,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UES0202/UES0202_unit.bp
+++ b/units/UES0202/UES0202_unit.bp
@@ -287,6 +287,7 @@ UnitBlueprint {
             NotExclusive = true,
             ProjectileId = '/projectiles/TIFMissileCruise04/TIFMissileCruise04_proj.bp',
             ProjectileLifetime = 20,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -470,7 +471,7 @@ UnitBlueprint {
             MuzzleVelocity = 30,
             ProjectileId = '/projectiles/TAAMissileFlayer02/TAAMissileFlayer02_proj.bp',
             ProjectileLifetime = 4,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -542,6 +543,7 @@ UnitBlueprint {
             MuzzleVelocity = 100,
             ProjectileId = '/projectiles/TDPhalanx01/TDPhalanx01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.1,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UES0203/UES0203_unit.bp
+++ b/units/UES0203/UES0203_unit.bp
@@ -329,7 +329,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/TANAnglerTorpedo02/TANAnglerTorpedo02_proj.bp',
             ProjectileLifetime = 7,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UES0302/UES0302_unit.bp
+++ b/units/UES0302/UES0302_unit.bp
@@ -594,11 +594,11 @@ UnitBlueprint {
             Label = 'RightAAGun01',
             MaxRadius = 60,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 90,
             ProjectileId = '/projectiles/TAARailgun02/TAARailgun02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -669,12 +669,12 @@ UnitBlueprint {
             Label = 'RightAAGun01',
             MaxRadius = 60,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 90,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/TAARailgun02/TAARailgun02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -745,12 +745,12 @@ UnitBlueprint {
             Label = 'RightAAGun01',
             MaxRadius = 60,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 90,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/TAARailgun02/TAARailgun02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -821,12 +821,12 @@ UnitBlueprint {
             Label = 'RightAAGun01',
             MaxRadius = 60,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 90,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/TAARailgun02/TAARailgun02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -898,6 +898,7 @@ UnitBlueprint {
             MuzzleVelocity = 100,
             ProjectileId = '/projectiles/TDPhalanx01/TDPhalanx01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.1,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -962,6 +963,7 @@ UnitBlueprint {
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/TDPhalanx01/TDPhalanx01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.1,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UES0401/UES0401_unit.bp
+++ b/units/UES0401/UES0401_unit.bp
@@ -407,10 +407,11 @@ UnitBlueprint {
             Label = 'Torpedo01',
             MaxRadius = 80,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 4,
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/TANAnglerTorpedo02/TANAnglerTorpedo02_proj.bp',
             ProjectileLifetime = 9,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URA0103/URA0103_unit.bp
+++ b/units/URA0103/URA0103_unit.bp
@@ -302,6 +302,7 @@ UnitBlueprint {
             MuzzleVelocity = 0,
             NeedToComputeBombDrop = true,
             ProjectileId = '/projectiles/CIFNeutronClusterBomb01/CIFNeutronClusterBomb01_proj.bp',
+            ProjectilesPerOnFire = 6,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URA0304/URA0304_unit.bp
+++ b/units/URA0304/URA0304_unit.bp
@@ -382,11 +382,11 @@ UnitBlueprint {
             LeadTarget = true,
             MaxRadius = 44,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 45,
             ProjectileId = '/projectiles/CAAAutocannon01/CAAAutocannon01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -451,12 +451,12 @@ UnitBlueprint {
             LeadTarget = true,
             MaxRadius = 44,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 45,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/CAAAutocannon01/CAAAutocannon01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URA0401/URA0401_unit.bp
+++ b/units/URA0401/URA0401_unit.bp
@@ -593,11 +593,11 @@ UnitBlueprint {
             LeadTarget = true,
             MaxRadius = 30,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 30,
             ProjectileId = '/projectiles/CDFBolter03/CDFBolter03_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.15,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -663,12 +663,12 @@ UnitBlueprint {
             LeadTarget = true,
             MaxRadius = 30,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 30,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/CDFBolter03/CDFBolter03_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.15,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URB2109/URB2109_unit.bp
+++ b/units/URB2109/URB2109_unit.bp
@@ -210,7 +210,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/CANTorpedoNanite01/CANTorpedoNanite01_proj.bp',
             ProjectileLifetime = 7,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 3,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URB2205/URB2205_unit.bp
+++ b/units/URB2205/URB2205_unit.bp
@@ -229,7 +229,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/CANTorpedoNanite01/CANTorpedoNanite01_proj.bp',
             ProjectileLifetime = 12,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 3,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URB2301/URB2301_unit.bp
+++ b/units/URB2301/URB2301_unit.bp
@@ -199,11 +199,11 @@ UnitBlueprint {
             Label = 'MainGun',
             MaxRadius = 50,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 2,
+            MuzzleSalvoSize = 3,
             MuzzleVelocity = 100,
             ProjectileId = '/projectiles/CDFLaserHeavy02/CDFLaserHeavy02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.15,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 3,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URL0202/URL0202_unit.bp
+++ b/units/URL0202/URL0202_unit.bp
@@ -218,8 +218,8 @@ UnitBlueprint {
             LeadTarget = false,
             MaxRadius = 23,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
-            ProjectilesPerOnFire = 1,
+            MuzzleSalvoSize = 2,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URL0203/URL0203_unit.bp
+++ b/units/URL0203/URL0203_unit.bp
@@ -309,11 +309,11 @@ UnitBlueprint {
             LeadTarget = true,
             MaxRadius = 22,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 30,
             ProjectileId = '/projectiles/CDFBolter02/CDFBolter02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.15,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -733,11 +733,11 @@ UnitBlueprint {
             Label = 'Torpedo',
             MaxRadius = 45,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 4,
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/CANTorpedoMeson02/CANTorpedoMeson02_proj.bp',
             ProjectileLifetime = 9,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URS0103/URS0103_unit.bp
+++ b/units/URS0103/URS0103_unit.bp
@@ -333,11 +333,11 @@ UnitBlueprint {
             LeadTarget = true,
             MaxRadius = 48,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 45,
             ProjectileId = '/projectiles/CAAAutocannon01/CAAAutocannon01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URS0201/URS0201_unit.bp
+++ b/units/URS0201/URS0201_unit.bp
@@ -389,6 +389,7 @@ UnitBlueprint {
             MuzzleSalvoSize = 2,
             MuzzleVelocity = 30,
             ProjectileId = '/projectiles/CDFProtonCannon01/CDFProtonCannon01_proj.bp',
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -454,10 +455,11 @@ UnitBlueprint {
             LeadTarget = true,
             MaxRadius = 60,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 4,
             MuzzleVelocity = 60,
             ProjectileId = '/projectiles/CAAAutocannon02/CAAAutocannon02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -529,7 +531,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/CANTorpedoNanite02/CANTorpedoNanite02_proj.bp',
             ProjectileLifetime = 7,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -586,10 +588,11 @@ UnitBlueprint {
             MaxRadius = 30,
             MinRadius = 15,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/CIMAntiTorpedo01/CIMAntiTorpedo01_proj.bp',
             ProjectileLifetime = 3,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URS0202/URS0202_unit.bp
+++ b/units/URS0202/URS0202_unit.bp
@@ -303,10 +303,11 @@ UnitBlueprint {
             Label = 'ParticleGun',
             MaxRadius = 80,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 30,
             ProjectileId = '/projectiles/CDFProtonCannon02/CDFProtonCannon02_proj.bp',
             ProjectileLifetime = 2.6,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -369,6 +370,7 @@ UnitBlueprint {
             MuzzleSalvoSize = 1,
             PreferPrimaryWeaponTarget = true,
             ProjectileLifetimeUsesMultiplier = 1.15,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -512,6 +514,7 @@ UnitBlueprint {
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             NeedPrep = true,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -575,6 +578,7 @@ UnitBlueprint {
             MuzzleVelocity = 30,
             ProjectileId = '/projectiles/CAANanoDart02/CAANanoDart02_proj.bp',
             ProjectileLifetime = 5.5,
+            ProjectilesPerOnFire = 3,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URS0203/URS0203_unit.bp
+++ b/units/URS0203/URS0203_unit.bp
@@ -334,7 +334,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/CANTorpedoNanite01/CANTorpedoNanite01_proj.bp',
             ProjectileLifetime = 7,
-            ProjectilesPerOnFire = 2,
+            ProjectilesPerOnFire = 3,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URS0302/URS0302_unit.bp
+++ b/units/URS0302/URS0302_unit.bp
@@ -284,7 +284,7 @@ UnitBlueprint {
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 30,
             ProjectileId = '/projectiles/CDFProtonCannon03/CDFProtonCannon03_proj.bp',
-            ProjectilesPerOnFire = 3,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -373,7 +373,7 @@ UnitBlueprint {
             MuzzleVelocity = 30,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/CDFProtonCannon03/CDFProtonCannon03_proj.bp',
-            ProjectilesPerOnFire = 3,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -449,11 +449,11 @@ UnitBlueprint {
             LeadTarget = true,
             MaxRadius = 45,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 4,
             MuzzleVelocity = 90,
             ProjectileId = '/projectiles/CAAAutocannon01/CAAAutocannon01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -523,12 +523,12 @@ UnitBlueprint {
             LeadTarget = true,
             MaxRadius = 45,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 4,
             MuzzleVelocity = 90,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/CAAAutocannon01/CAAAutocannon01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -600,6 +600,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/CANTorpedoNanite01/CANTorpedoNanite01_proj.bp',
             ProjectileLifetime = 7,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -664,6 +665,7 @@ UnitBlueprint {
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             NeedPrep = true,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -725,6 +727,7 @@ UnitBlueprint {
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             NeedPrep = true,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/URS0304/URS0304_unit.bp
+++ b/units/URS0304/URS0304_unit.bp
@@ -433,11 +433,11 @@ UnitBlueprint {
             Label = 'Torpedo01',
             MaxRadius = 80,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/CANTorpedoNanite01/CANTorpedoNanite01_proj.bp',
             ProjectileLifetime = 7,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XAS0204/XAS0204_unit.bp
+++ b/units/XAS0204/XAS0204_unit.bp
@@ -326,6 +326,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/AANTorpedo01/AANTorpedo01_proj.bp',
             ProjectileLifetime = 7,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -388,10 +389,11 @@ UnitBlueprint {
             LeadTarget = false,
             MaxRadius = 32,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 80,
             ProjectileId = '/projectiles/AIMAntiTorpedo02/AIMAntiTorpedo02_proj.bp',
             ProjectileLifetime = 4,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XAS0306/XAS0306_unit.bp
+++ b/units/XAS0306/XAS0306_unit.bp
@@ -265,6 +265,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/AIFMissileSerpentine03/AIFMissileSerpentine03_proj.bp',
             ProjectileLifetime = 25,
+            ProjectilesPerOnFire = 5,
             RackBones = {
                 {
                     HideMuzzle = true,
@@ -344,6 +345,7 @@ UnitBlueprint {
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/AIFMissileSerpentine03/AIFMissileSerpentine03_proj.bp',
             ProjectileLifetime = 25,
+            ProjectilesPerOnFire = 5,
             RackBones = {
                 {
                     HideMuzzle = true,
@@ -414,6 +416,7 @@ UnitBlueprint {
             MuzzleVelocity = 80,
             ProjectileId = '/projectiles/AIMAntiTorpedo02/AIMAntiTorpedo02_proj.bp',
             ProjectileLifetime = 4,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -474,6 +477,7 @@ UnitBlueprint {
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/AIMAntiTorpedo02/AIMAntiTorpedo02_proj.bp',
             ProjectileLifetime = 4,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -534,6 +538,7 @@ UnitBlueprint {
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/AIMAntiTorpedo02/AIMAntiTorpedo02_proj.bp',
             ProjectileLifetime = 4,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -594,6 +599,7 @@ UnitBlueprint {
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/AIMAntiTorpedo02/AIMAntiTorpedo02_proj.bp',
             ProjectileLifetime = 4,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XEB2306/XEB2306_Script.lua
+++ b/units/XEB2306/XEB2306_Script.lua
@@ -1,0 +1,29 @@
+local TStructureUnit = import('/lua/terranunits.lua').TStructureUnit
+local TDFHeavyPlasmaCannonWeapon = import('/lua/terranweapons.lua').TDFHeavyPlasmaGatlingCannonWeapon
+
+local EffectUtils = import('/lua/effectutilities.lua')
+local Effects = import('/lua/effecttemplates.lua')
+
+XEB2306 = Class(TStructureUnit) {
+    Weapons = {
+        MainGun = Class(TDFHeavyPlasmaCannonWeapon) 
+        {       
+            PlayFxWeaponPackSequence = function(self)
+                self.ExhaustEffects = EffectUtils.CreateBoneEffects( self.unit, 'Exhaust', self.unit:GetArmy(), Effects.WeaponSteam01 )
+                TDFHeavyPlasmaCannonWeapon.PlayFxWeaponPackSequence(self)
+            end,
+            
+            PlayFxRackSalvoReloadSequence = function(self)
+                self.ExhaustEffects = EffectUtils.CreateBoneEffects( self.unit, 'Exhaust', self.unit:GetArmy(), Effects.WeaponSteam01 )
+                TDFHeavyPlasmaCannonWeapon.PlayFxRackSalvoChargeSequence(self)
+            end,    
+        }
+    },
+
+    OnStopBeingBuilt = function(self,builder,layer)
+        TStructureUnit.OnStopBeingBuilt(self,builder,layer)
+
+	self.Trash:Add(CreateRotator(self, 'Gun_Barrel', 'z', nil, 270, 0, 0))
+    end,
+}
+TypeClass = XEB2306

--- a/units/XEB2306/XEB2306_unit.bp
+++ b/units/XEB2306/XEB2306_unit.bp
@@ -209,7 +209,7 @@ UnitBlueprint {
             MuzzleVelocity = 32,
             ProjectileId = '/projectiles/TDFHeavyPlasmaGatlingCannon01/TDFHeavyPlasmaGatlingCannon01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.15,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 15,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -221,12 +221,12 @@ UnitBlueprint {
             RackFireTogether = false,
             RackRecoilDistance = 0,
             RackReloadTimeout = 10,
-            RackSalvoChargeTime = 2,
-            RackSalvoReloadTime = 3,
+            RackSalvoChargeTime = 0,
+            RackSalvoReloadTime = 0,
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = 'UWRC_DirectFire',
-            RateOfFire = 1,
+            RateOfFire = 0.1,
             TargetCheckInterval = 0.25,
             TargetPriorities = {
                 'MOBILE',

--- a/units/XES0102/XES0102_unit.bp
+++ b/units/XES0102/XES0102_unit.bp
@@ -241,6 +241,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/TANAnglerTorpedo02/TANAnglerTorpedo02_proj.bp',
             ProjectileLifetime = 7,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -304,10 +305,11 @@ UnitBlueprint {
             MaxRadius = 25,
             MinRadius = 10,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/TIMAntiTorpedo01/TIMAntiTorpedo01_proj.bp',
             ProjectileLifetime = 2.5,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XES0205/XES0205_unit.bp
+++ b/units/XES0205/XES0205_unit.bp
@@ -244,7 +244,7 @@ UnitBlueprint {
             Damage = 0,
             MaxRadius = 34,
             RangeCategory = 'UWRC_DirectFire',
-            WeaponCategory = 'Direct Fire Naval',
+            WeaponCategory = 'Fix',
         },
     },
 }

--- a/units/XES0307/XES0307_unit.bp
+++ b/units/XES0307/XES0307_unit.bp
@@ -280,8 +280,9 @@ UnitBlueprint {
             MaxRadius = 80,
             MuzzleChargeDelay = 0,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             NeedPrep = true,
+            ProjectilesPerOnFire = 18,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -355,8 +356,9 @@ UnitBlueprint {
             MaxRadius = 80,
             MuzzleChargeDelay = 0,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             NeedPrep = true,
+            ProjectilesPerOnFire = 18,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -425,7 +427,7 @@ UnitBlueprint {
             MuzzleVelocity = 8,
             ProjectileId = '/projectiles/TANAnglerTorpedo02/TANAnglerTorpedo02_proj.bp',
             ProjectileLifetime = 7,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -491,6 +493,7 @@ UnitBlueprint {
             MuzzleVelocity = 100,
             ProjectileId = '/projectiles/TDPhalanx01/TDPhalanx01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.1,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -551,10 +554,11 @@ UnitBlueprint {
             MaxRadius = 30,
             MinRadius = 10,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/TIMAntiTorpedo01/TIMAntiTorpedo01_proj.bp',
             ProjectileLifetime = 6,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XRB2308/XRB2308_unit.bp
+++ b/units/XRB2308/XRB2308_unit.bp
@@ -239,7 +239,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/CANKrilTorpedo01/CANKrilTorpedo01_proj.bp',
             ProjectileLifetime = 12,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 6,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XRL0403/XRL0403_unit.bp
+++ b/units/XRL0403/XRL0403_unit.bp
@@ -356,10 +356,11 @@ UnitBlueprint {
             MaxRadius = 64,
             MinRadius = 4,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 65,
             ProjectileId = '/projectiles/CDFProtonCannon05/CDFProtonCannon05_proj.bp',
             ProjectileLifetime = 0.9,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -443,11 +444,12 @@ UnitBlueprint {
             MaxRadius = 64,
             MinRadius = 4,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 65,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/CDFProtonCannon05/CDFProtonCannon05_proj.bp',
             ProjectileLifetime = 0.9,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -515,11 +517,11 @@ UnitBlueprint {
             Label = 'Torpedo01',
             MaxRadius = 64,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 4,
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/CANTorpedoNanite01/CANTorpedoNanite01_proj.bp',
             ProjectileLifetime = 7,
-            ProjectilesPerOnFire = 3,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -592,10 +594,11 @@ UnitBlueprint {
             Label = 'AntiTorpedo',
             MaxRadius = 25,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 6,
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/CIMAntiTorpedo02/CIMAntiTorpedo02_proj.bp',
             ProjectileLifetime = 3,
+            ProjectilesPerOnFire = 6,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -669,7 +672,7 @@ UnitBlueprint {
             MuzzleVelocity = 20,
             ProjectileId = '/projectiles/CAABurstCloud01/CAABurstCloud01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 2,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -745,7 +748,7 @@ UnitBlueprint {
             MuzzleVelocity = 14,
             MuzzleVelocityReduceDistance = 28,
             ProjectileId = '/projectiles/CIFBrackmanHackPegs01/CIFBrackmanHackPegs01_proj.bp',
-            ProjectilesPerOnFire = 5,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XRS0204/XRS0204_unit.bp
+++ b/units/XRS0204/XRS0204_unit.bp
@@ -337,7 +337,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/CANTorpedoNanite01/CANTorpedoNanite01_proj.bp',
             ProjectileLifetime = 7,
-            ProjectilesPerOnFire = 3,
+            ProjectilesPerOnFire = 6,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -396,10 +396,11 @@ UnitBlueprint {
             Label = 'AntiTorpedo01',
             MaxRadius = 25,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/CIMAntiTorpedo01/CIMAntiTorpedo01_proj.bp',
             ProjectileLifetime = 6,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XSA0104/XSA0104_unit.bp
+++ b/units/XSA0104/XSA0104_unit.bp
@@ -317,11 +317,11 @@ UnitBlueprint {
             Label = 'AALeft',
             MaxRadius = 20,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 60,
             ProjectileId = '/projectiles/SAAShleoAAGatlingGun04/SAAShleoAAGatlingGun04_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -391,12 +391,12 @@ UnitBlueprint {
             Label = 'AARight',
             MaxRadius = 20,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 60,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/SAAShleoAAGatlingGun04/SAAShleoAAGatlingGun04_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XSA0203/XSA0203_unit.bp
+++ b/units/XSA0203/XSA0203_unit.bp
@@ -273,7 +273,7 @@ UnitBlueprint {
             MuzzleVelocity = 40,
             ProjectileId = '/projectiles/SDFHeavyPhasicAutogun02/SDFHeavyPhasicAutogun02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.15,
-            ProjectilesPerOnFire = 4,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -338,7 +338,7 @@ UnitBlueprint {
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/SDFHeavyPhasicAutogun02/SDFHeavyPhasicAutogun02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.15,
-            ProjectilesPerOnFire = 4,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XSB2109/XSB2109_unit.bp
+++ b/units/XSB2109/XSB2109_unit.bp
@@ -226,7 +226,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/SANUallCavitationTorpedo03/SANUallCavitationTorpedo03_proj.bp',
             ProjectileLifetime = 7,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 3,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XSB2205/XSB2205_unit.bp
+++ b/units/XSB2205/XSB2205_unit.bp
@@ -251,7 +251,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/SANHeavyCavitationTorpedo02/SANHeavyCavitationTorpedo02_proj.bp',
             ProjectileLifetime = 12,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 3,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -321,6 +321,7 @@ UnitBlueprint {
             MuzzleVelocity = 80,
             ProjectileId = '/projectiles/SANAjelluAntiTorpedo01/SANAjelluAntiTorpedo01_proj.bp',
             ProjectileLifetime = 7,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XSB2301/XSB2301_unit.bp
+++ b/units/XSB2301/XSB2301_unit.bp
@@ -235,6 +235,7 @@ UnitBlueprint {
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             ProjectileLifetimeUsesMultiplier = 1.15,
+            ProjectilesPerOnFire = 9,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XSL0103/XSL0103_unit.bp
+++ b/units/XSL0103/XSL0103_unit.bp
@@ -304,6 +304,7 @@ UnitBlueprint {
             MuzzleVelocity = 14,
             MuzzleVelocityReduceDistance = 28,
             ProjectileId = '/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_proj.bp',
+            ProjectilesPerOnFire = 5,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XSS0103/XSS0103_unit.bp
+++ b/units/XSS0103/XSS0103_unit.bp
@@ -265,6 +265,7 @@ UnitBlueprint {
             MuzzleSalvoSize = 3,
             MuzzleVelocity = 30,
             ProjectileId = '/projectiles/SDFShieeihAutoCannon01/SDFShieeihAutoCannon01_proj.bp',
+            ProjectilesPerOnFire = 3,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -335,6 +336,7 @@ UnitBlueprint {
             MuzzleVelocity = 45,
             ProjectileId = '/projectiles/SAAShleoAAGatlingGun05/SAAShleoAAGatlingGun05_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XSS0201/XSS0201_unit.bp
+++ b/units/XSS0201/XSS0201_unit.bp
@@ -303,6 +303,7 @@ UnitBlueprint {
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             NeedPrep = true,
+            ProjectilesPerOnFire = 9,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -388,6 +389,7 @@ UnitBlueprint {
             MuzzleSalvoSize = 1,
             NeedPrep = true,
             PrefersPrimaryWeaponTarget = true,
+            ProjectilesPerOnFire = 9,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -456,6 +458,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/SANAnaitTorpedo01/SANAnaitTorpedo01_proj.bp',
             ProjectileLifetime = 7,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -514,6 +517,7 @@ UnitBlueprint {
             MuzzleVelocity = 80,
             ProjectileId = '/projectiles/SANAjelluAntiTorpedo01/SANAjelluAntiTorpedo01_proj.bp',
             ProjectileLifetime = 7,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XSS0202/XSS0202_unit.bp
+++ b/units/XSS0202/XSS0202_unit.bp
@@ -249,6 +249,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/SIFLaanseTacticalMissile02/SIFLaanseTacticalMissile02_proj.bp',
             ProjectileLifetime = 60,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -309,11 +310,11 @@ UnitBlueprint {
             Label = 'LeftAAGun',
             MaxRadius = 65,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 20,
             ProjectileId = '/projectiles/SAAOlarisAAArtillery04/SAAOlarisAAArtillery04_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -454,6 +455,7 @@ UnitBlueprint {
             MuzzleVelocity = 25,
             ProjectileId = '/projectiles/SIMAntiMissile02/SIMAntiMissile02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.1,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XSS0302/XSS0302_unit.bp
+++ b/units/XSS0302/XSS0302_unit.bp
@@ -529,6 +529,7 @@ UnitBlueprint {
             MuzzleVelocity = 25,
             ProjectileId = '/projectiles/SIMAntiMissile02/SIMAntiMissile02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.1,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -591,6 +592,7 @@ UnitBlueprint {
             MuzzleVelocity = 25,
             ProjectileId = '/projectiles/SIMAntiMissile02/SIMAntiMissile02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.1,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -652,10 +654,11 @@ UnitBlueprint {
             Label = 'AntiAirLeft',
             MaxRadius = 40,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 20,
             ProjectileId = '/projectiles/SAAOlarisAAArtillery05/SAAOlarisAAArtillery05_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -726,11 +729,12 @@ UnitBlueprint {
             Label = 'AntiAirRight',
             MaxRadius = 40,
             MuzzleSalvoDelay = 0,
-            MuzzleSalvoSize = 1,
+            MuzzleSalvoSize = 2,
             MuzzleVelocity = 20,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/SAAOlarisAAArtillery05/SAAOlarisAAArtillery05_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XSS0303/XSS0303_unit.bp
+++ b/units/XSS0303/XSS0303_unit.bp
@@ -287,6 +287,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/SIFLaanseTacticalMissile03/SIFLaanseTacticalMissile03_proj.bp',
             ProjectileLifetime = 60,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -339,6 +340,7 @@ UnitBlueprint {
             MuzzleVelocity = 90,
             ProjectileId = '/projectiles/SAALosaareAutoCannon03/SAALosaareAutoCannon03_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -410,6 +412,7 @@ UnitBlueprint {
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/SAALosaareAutoCannon03/SAALosaareAutoCannon03_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XSS0304/XSS0304_unit.bp
+++ b/units/XSS0304/XSS0304_unit.bp
@@ -319,6 +319,7 @@ UnitBlueprint {
             MuzzleVelocity = 5,
             ProjectileId = '/projectiles/SANUallCavitationTorpedo04/SANUallCavitationTorpedo04_proj.bp',
             ProjectileLifetime = 7,
+            ProjectilesPerOnFire = 4,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -378,6 +379,7 @@ UnitBlueprint {
             MuzzleVelocity = 80,
             ProjectileId = '/projectiles/SANAjelluAntiTorpedo01/SANAjelluAntiTorpedo01_proj.bp',
             ProjectileLifetime = 1.5,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -434,6 +436,7 @@ UnitBlueprint {
             MuzzleVelocity = 80,
             ProjectileId = '/projectiles/SANAjelluAntiTorpedo01/SANAjelluAntiTorpedo01_proj.bp',
             ProjectileLifetime = 1.5,
+            ProjectilesPerOnFire = 1,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -498,6 +501,7 @@ UnitBlueprint {
             MuzzleVelocity = 90,
             ProjectileId = '/projectiles/SAALosaareAutoCannon03/SAALosaareAutoCannon03_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.25,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/delk002/DELK002_script.lua
+++ b/units/delk002/DELK002_script.lua
@@ -10,7 +10,6 @@ local TLandUnit = import('/lua/terranunits.lua').TLandUnit
 local TWeapons = import('/lua/terranweapons.lua')
 local TDFPlasmaCannonWeapon = TWeapons.TDFPlasmaCannonWeapon
 local TAAPhalanxWeapon = import('/lua/kirvesweapons.lua').TAAPhalanxWeapon
-
 local EffectUtils = import('/lua/effectutilities.lua')
 local Effects = import('/lua/effecttemplates.lua')
 
@@ -19,52 +18,24 @@ DELK002 = Class(TLandUnit) {
         GatlingCannon = Class(TAAPhalanxWeapon)
         {
             PlayFxWeaponPackSequence = function(self)
-                if self.SpinManip1 then
-                    self.SpinManip1:SetTargetSpeed(0)
-                end
-                if self.SpinManip2 then
-                    self.SpinManip2:SetTargetSpeed(0)
-                end
                 self.ExhaustEffects = EffectUtils.CreateBoneEffects(self.unit, 'Left_Muzzle', self.unit:GetArmy(), Effects.WeaponSteam01)
                 self.ExhaustEffects = EffectUtils.CreateBoneEffects(self.unit, 'Right_Muzzle', self.unit:GetArmy(), Effects.WeaponSteam01)
                 TAAPhalanxWeapon.PlayFxWeaponPackSequence(self)
             end,
 
-            PlayFxRackSalvoChargeSequence = function(self)
-                if not self.SpinManip1 then
-                    self.SpinManip1 = CreateRotator(self.unit, 'Right_Barrel', 'z', nil, 360, 180, 60)
-                    self.unit.Trash:Add(self.SpinManip1)
-                end
-
-                if self.SpinManip1 then
-                    self.SpinManip1:SetTargetSpeed(500)
-                end
-                if not self.SpinManip2 then
-                    self.SpinManip2 = CreateRotator(self.unit, 'Left_Barrel', 'z', nil, 360, 180, 60)
-                    self.unit.Trash:Add(self.SpinManip2)
-                end
-
-                if self.SpinManip2 then
-                    self.SpinManip2:SetTargetSpeed(500)
-                end
-                TAAPhalanxWeapon.PlayFxRackSalvoChargeSequence(self)
-            end,
-
             PlayFxRackSalvoReloadSequence = function(self)
-                if self.SpinManip1 then
-                    self.SpinManip1:SetTargetSpeed(200)
-                end
-                if self.SpinManip2 then
-                    self.SpinManip2:SetTargetSpeed(200)
-                end
                 self.ExhaustEffects = EffectUtils.CreateBoneEffects(self.unit, 'Left_Muzzle', self.unit:GetArmy(), Effects.WeaponSteam01)
                 self.ExhaustEffects = EffectUtils.CreateBoneEffects(self.unit, 'Right_Muzzle', self.unit:GetArmy(), Effects.WeaponSteam01)
                 TAAPhalanxWeapon.PlayFxRackSalvoChargeSequence(self)
             end,
         },
-
     },
-
+	
+    OnStopBeingBuilt = function(self,builder,layer)
+        TLandUnit.OnStopBeingBuilt(self,builder,layer)
+		self.Trash:Add(CreateRotator(self, 'Left_Barrel', 'z', nil, 360, 0, 0))
+        self.Trash:Add(CreateRotator(self, 'Right_Barrel', 'z', nil, 360, 0, 0))
+    end,
 }
 
 TypeClass = DELK002

--- a/units/delk002/DELK002_unit.bp
+++ b/units/delk002/DELK002_unit.bp
@@ -276,7 +276,7 @@ UnitBlueprint {
             NoPause = true,
             ProjectileId = '/projectiles/AAPhalanx01/AAPhalanx01_proj.bp',
             ProjectileLifetime = 2,
-            ProjectilesPerOnFire = 1,
+            ProjectilesPerOnFire = 12,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -289,13 +289,13 @@ UnitBlueprint {
             RackFireTogether = true,
             RackRecoilDistance = 0,
             RackReloadTimeout = 0,
-            RackSalvoChargeTime = 1,
+            RackSalvoChargeTime = 0,
             RackSalvoFiresAfterCharge = false,
-            RackSalvoReloadTime = 4.5,
+            RackSalvoReloadTime = 0,
             RackSalvoSize = 1,
             RackSlavedToTurret = true,
             RangeCategory = 'UWRC_AntiAir',
-            RateOfFire = 1,
+            RateOfFire = 0.15,
             TargetCheckInterval = 0.25,
             TargetPriorities = {
                 'AIR MOBILE HIGHPRIAIR',

--- a/units/drlk001/DRLK001_unit.bp
+++ b/units/drlk001/DRLK001_unit.bp
@@ -249,6 +249,7 @@ UnitBlueprint {
             MuzzleVelocityReduceDistance = 30,
             ProjectileId = '/projectiles/CAANanoDartExGr/CAANanoDartExGr_proj.bp',
             ProjectileLifetime = 3,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {
@@ -422,6 +423,7 @@ UnitBlueprint {
             PreferPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/CAANanoDartEx/CAANanoDartEx_proj.bp',
             ProjectileLifetime = 8.0,
+            ProjectilesPerOnFire = 2,
             RackBones = {
                 {
                     MuzzleBones = {


### PR DESCRIPTION
![Screenshot](https://user-images.githubusercontent.com/58888496/70855407-a0e7e300-1eca-11ea-9dce-05e5c33cf93e.png)
Fixes broken in-game weapon tooltips for units by doing the following:
1) Removes merging entries for multiple weapon mounts of the same name, as multiplier indicating this was put in the wrong entry.
2) Makes beam weapons count all damage ticks correctly
3) Makes weapons that fire multiple projectiles per volley count them correctly
4) Added "Damage Radius" to all weapon tooltips. (DMG, Range, DPS, Range, Radius)
5) Added death weapons to weapon tooltips.

These changes have been implemented in Total Mayhem Lite mod as of writing and tested to be working and correct.