### PR TITLE
Mounting ui textures from mod directories

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -150,8 +150,8 @@ mount_map_dir(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supre
 mount_map_dir(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\maps\\', '**', '/maps')
 
 -- Begin mod mounting section
--- This section mounts sounds from the mods directory to allow mods to add custom sounds to the game
-function mount_mod_sounds(MODFOLDER)
+-- This section mounts sounds and ui textures from the mods directory to allow mods to add custom sounds and textures to the game
+function mount_mod_content(MODFOLDER)
     -- searching for mods inside the modfolder
     for _,mod in io.dir(MODFOLDER..'\\*.*') do
         -- do we have a true directory ?
@@ -162,16 +162,12 @@ function mount_mod_sounds(MODFOLDER)
                 if folder == 'sounds' then
                     LOG('Found mod sounds in: '..mod)
                     mount_dir(MODFOLDER..'\\'..mod..'\\sounds', '/sounds')
-                    break
-                end
-                -- This code mounts ui textures from mods as root, so things like strategic icons can be modified directly from the mod folders.
-                -- Workaround for dropping an .scd into gamedata folder, so mod installation can be fully automatic.
-                if folder == 'textures' then
+                -- mount ui textures if there are any
+                elseif folder == 'textures' then
                     for _,folder in io.dir(MODFOLDER..'\\'..mod..'\\textures\\*.*') do
                         if folder == 'ui' then
                           LOG('Found mod icons in: '..mod)
                           mount_dir(MODFOLDER..'\\'..mod..'\\textures\\ui', '/textures/ui')
-                          break
                         end
                     end
                 end
@@ -179,8 +175,8 @@ function mount_mod_sounds(MODFOLDER)
         end
     end
 end
-mount_mod_sounds(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
-mount_mod_sounds(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
+mount_mod_content(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
+mount_mod_content(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
 
 -- These are the classic supcom directories. They don't work with accents or other foreign characters in usernames
 mount_contents(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods', '/mods')

--- a/init.lua
+++ b/init.lua
@@ -171,6 +171,28 @@ end
 mount_mod_sounds(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
 mount_mod_sounds(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
 
+-- This code mounts ui textures from mods as root, so things like strategic icons can be modified directly from the mod folders.
+-- Workaround for dropping an .scd into gamedata folder, so mod installation can be fully automatic.
+local function mount_strategic_icons(MODFOLDER)
+    for _,mod in io.dir( MODFOLDER..'\\*.*') do
+        if mod != '.' and mod != '..' then
+            for _,folder in io.dir(MODFOLDER..'\\'..mod..'\\*.*') do
+                if folder == 'textures' then
+                    for _,folder in io.dir(MODFOLDER..'\\'..mod..'\\textures\\*.*') do
+                        if folder == 'ui' then
+                          LOG('Found mod icons in: '..mod)
+                          mount_dir(MODFOLDER..'\\'..mod..'\\textures\\ui', '/textures/ui')
+                          break
+                        end
+                    end
+                end
+            end
+        end
+    end
+end
+mount_strategic_icons(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
+mount_strategic_icons(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
+
 -- These are the classic supcom directories. They don't work with accents or other foreign characters in usernames
 mount_contents(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods', '/mods')
 mount_contents(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\maps', '/maps')

--- a/init.lua
+++ b/init.lua
@@ -164,19 +164,8 @@ function mount_mod_sounds(MODFOLDER)
                     mount_dir(MODFOLDER..'\\'..mod..'\\sounds', '/sounds')
                     break
                 end
-            end
-        end
-    end
-end
-mount_mod_sounds(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
-mount_mod_sounds(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
-
--- This code mounts ui textures from mods as root, so things like strategic icons can be modified directly from the mod folders.
--- Workaround for dropping an .scd into gamedata folder, so mod installation can be fully automatic.
-local function mount_strategic_icons(MODFOLDER)
-    for _,mod in io.dir( MODFOLDER..'\\*.*') do
-        if mod != '.' and mod != '..' then
-            for _,folder in io.dir(MODFOLDER..'\\'..mod..'\\*.*') do
+                -- This code mounts ui textures from mods as root, so things like strategic icons can be modified directly from the mod folders.
+                -- Workaround for dropping an .scd into gamedata folder, so mod installation can be fully automatic.
                 if folder == 'textures' then
                     for _,folder in io.dir(MODFOLDER..'\\'..mod..'\\textures\\*.*') do
                         if folder == 'ui' then
@@ -190,8 +179,8 @@ local function mount_strategic_icons(MODFOLDER)
         end
     end
 end
-mount_strategic_icons(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
-mount_strategic_icons(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
+mount_mod_sounds(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
+mount_mod_sounds(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
 
 -- These are the classic supcom directories. They don't work with accents or other foreign characters in usernames
 mount_contents(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods', '/mods')

--- a/init.lua
+++ b/init.lua
@@ -168,6 +168,7 @@ function mount_mod_content(MODFOLDER)
                         if folder == 'ui' then
                           LOG('Found mod icons in: '..mod)
                           mount_dir(MODFOLDER..'\\'..mod..'\\textures\\ui', '/textures/ui')
+                          break
                         end
                     end
                 end


### PR DESCRIPTION
Right now, mods cannot change some ui textures, as game is hardcoded to read them from "/textures/ui" directory. This particularily impacts ability to change or add strategic icons. The only way to do it is to pack them into an .scd and drop it into gamedata folder - which means installing mods from the mod vault requires additional manual step. This code change fixes that.

Reference to the forum post:
https://forums.faforever.com/viewtopic.php?f=45&t=18453#