### PR TITLE
Increase engineer build distance by 1 per level

### DIFF
--- a/units/UAL0105/UAL0105_unit.bp
+++ b/units/UAL0105/UAL0105_unit.bp
@@ -200,6 +200,7 @@ UnitBlueprint {
         BuildableCategory = {
             'BUILTBYTIER1ENGINEER AEON',
         },
+        MaxBuildDistance = 5,
         NeedToFaceTargetToBuild = false,
         SacrificeEnergyMult = 0.6,
         SacrificeMassMult = 0.6,

--- a/units/UAL0208/UAL0208_unit.bp
+++ b/units/UAL0208/UAL0208_unit.bp
@@ -198,6 +198,7 @@ UnitBlueprint {
         BuildableCategory = {
             'BUILTBYTIER2ENGINEER AEON',
         },
+        MaxBuildDistance = 6,
         SacrificeEnergyMult = 0.6,
         SacrificeMassMult = 0.6,
         StorageEnergy = 0,

--- a/units/UAL0309/UAL0309_unit.bp
+++ b/units/UAL0309/UAL0309_unit.bp
@@ -197,6 +197,7 @@ UnitBlueprint {
         BuildableCategory = {
             'BUILTBYTIER3ENGINEER AEON',
         },
+        MaxBuildDistance = 7,
         SacrificeEnergyMult = 0.6,
         SacrificeMassMult = 0.6,
         StorageEnergy = 0,

--- a/units/UEL0208/UEL0208_unit.bp
+++ b/units/UEL0208/UEL0208_unit.bp
@@ -203,6 +203,7 @@ UnitBlueprint {
         BuildableCategory = {
             'BUILTBYTIER2ENGINEER UEF',
         },
+        MaxBuildDistance = 6,
         StorageEnergy = 0,
         StorageMass = 20,
         TeleportEnergyMod = 0.15,

--- a/units/UEL0309/UEL0309_unit.bp
+++ b/units/UEL0309/UEL0309_unit.bp
@@ -202,6 +202,7 @@ UnitBlueprint {
         BuildableCategory = {
             'BUILTBYTIER3ENGINEER UEF',
         },
+        MaxBuildDistance = 7,
         StorageEnergy = 0,
         StorageMass = 40,
         TeleportEnergyMod = 0.15,

--- a/units/URL0105/URL0105_unit.bp
+++ b/units/URL0105/URL0105_unit.bp
@@ -190,6 +190,7 @@ UnitBlueprint {
         BuildableCategory = {
             'BUILTBYTIER1ENGINEER CYBRAN',
         },
+        MaxBuildDistance = 5,
         StorageEnergy = 0,
         StorageMass = 10,
         TeleportEnergyMod = 0.15,

--- a/units/URL0208/URL0208_unit.bp
+++ b/units/URL0208/URL0208_unit.bp
@@ -190,6 +190,7 @@ UnitBlueprint {
         BuildableCategory = {
             'BUILTBYTIER2ENGINEER CYBRAN',
         },
+        MaxBuildDistance = 6,
         StorageEnergy = 0,
         StorageMass = 20,
         TeleportEnergyMod = 0.15,

--- a/units/URL0309/URL0309_unit.bp
+++ b/units/URL0309/URL0309_unit.bp
@@ -189,6 +189,7 @@ UnitBlueprint {
         BuildableCategory = {
             'BUILTBYTIER3ENGINEER CYBRAN',
         },
+        MaxBuildDistance = 7,
         StorageEnergy = 0,
         StorageMass = 40,
         TeleportEnergyMod = 0.15,

--- a/units/XSL0105/XSL0105_unit.bp
+++ b/units/XSL0105/XSL0105_unit.bp
@@ -222,6 +222,7 @@ UnitBlueprint {
         BuildableCategory = {
             'BUILTBYTIER1ENGINEER SERAPHIM',
         },
+        MaxBuildDistance = 5,
         NeedToFaceTargetToBuild = false, -- changed to make it build faster
         StorageEnergy = 0,
         StorageMass = 10,

--- a/units/XSL0208/XSL0208_unit.bp
+++ b/units/XSL0208/XSL0208_unit.bp
@@ -221,6 +221,7 @@ UnitBlueprint {
         BuildableCategory = {
             'BUILTBYTIER2ENGINEER SERAPHIM',
         },
+        MaxBuildDistance = 6,
         NeedToFaceTargetToBuild = false,  -- changed to make faster building like otehr engineers
         StorageEnergy = 0,
         StorageMass = 20,

--- a/units/XSL0309/XSL0309_unit.bp
+++ b/units/XSL0309/XSL0309_unit.bp
@@ -225,6 +225,7 @@ UnitBlueprint {
         BuildableCategory = {
             'BUILTBYTIER3ENGINEER SERAPHIM',
         },
+        MaxBuildDistance = 7,
         NeedToFaceTargetToBuild = false,
         StorageEnergy = 0,
         StorageMass = 40,


### PR DESCRIPTION
Should help some with annoying pathfinding shit when building bases with lots of 5x5 buildings.

Would have to be approved by balance team so feel free to close this PR if declined

T1 build range is still 5 (was the default if not set)