### PR TITLE
Use saved EntityId from the unit

### DIFF
--- a/lua/AI/OpAI/BaseManager.lua
+++ b/lua/AI/OpAI/BaseManager.lua
@@ -435,9 +435,8 @@ BaseManager = Class {
     end,
 
     RemoveConstructionEngineer = function(self, unit)
-        local entId = unit:GetEntityId()
         for k, v in self.ConstructionEngineers do
-            if v:GetEntityId() == entId then
+            if v.EntityId == unit.EntityId then
                 table.remove(self.ConstructionEngineers, k)
                 break
             end
@@ -476,9 +475,8 @@ BaseManager = Class {
             return false
         end
 
-        local entId = unit:GetEntityId()
         for k, v in self.ConstructionEngineers do
-            if v:GetEntityId() == entId then
+            if v.EntityId == unit.EntityId then
                 return true
             end
         end

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -235,7 +235,7 @@ Callbacks.ValidateAssist = function(data, units)
 end
 
 function IsInvalidAssist(unit, target)
-    if target and target:GetEntityId() == unit:GetEntityId() then
+    if target and target.EntityId == unit.EntityId then
         return true
     elseif not target or not target:GetGuardedUnit() then
         return false

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -344,8 +344,7 @@ function TransferUnfinishedUnitsAfterDeath(units, armies)
     for _, unit in EntityCategoryFilterDown(categories.EXPERIMENTAL + categories.TECH3 * categories.STRUCTURE * categories.ARTILLERY, units) do
         --This transfer is pretty complex, so we do it only for really important units (EXPs and t3 arty). 
         if unit:IsBeingBuilt() then
-            local entityID = unit:GetEntityId()
-            unfinishedUnits[entityID] = unit
+            unfinishedUnits[unit.EntityId] = unit
             noUnits = nil --have to store units using entityID and not table.insert
         end
     end

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -1749,7 +1749,7 @@ AIBrain = Class(moho.aibrain_methods) {
         for _, v in factories do
             if not v.Dead and not (v:IsUnitState('Building') or v:IsUnitState('Upgrading')) then
                 local guarded = v:GetGuardedUnit()
-                if not guarded or guarded:GetEntityId() ~= primary:GetEntityId() then
+                if not guarded or guarded.EntityId ~= primary.EntityId then
                     IssueClearCommands({v})
                     IssueFactoryAssist({v}, primary)
                 end

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -436,7 +436,7 @@ StructureUnit = Class(Unit) {
         if scus[1] then
             for _, u in scus do
                 u:SetFocusEntity(self)
-                self.Repairers[u:GetEntityId()] = u
+                self.Repairers[u.EntityId] = u
             end
         end
 
@@ -568,7 +568,7 @@ StructureUnit = Class(Unit) {
         end
 
         for k, v in self.AdjacencyBeamsBag do
-            if v.Unit:GetEntityId() == adjacentUnit:GetEntityId() then
+            if v.Unit.EntityId == adjacentUnit.EntityId then
                 return
             end
         end

--- a/lua/overspill.lua
+++ b/lua/overspill.lua
@@ -78,7 +78,7 @@ function DoOverspill(source, instigator, amount, dmgType, dmgMod)
         return
     end
     if source:IsUp() then
-        local instigatorId = instigator:GetEntityId()
+        local instigatorId = instigator.EntityId
         RegisterDamage(source:GetEntityId(), instigatorId, amount)
         local doDamage = function()
             WaitTicks(1)

--- a/lua/selfdestruct.lua
+++ b/lua/selfdestruct.lua
@@ -28,8 +28,7 @@ function ToggleSelfDestruct(data)
                         togglingOff = true
                         KillThread(unit.SelfDestructThread)
                         unit.SelfDestructThread = false
-                        local entityId = unit:GetEntityId()
-                        CancelCountdown(entityId)
+                        CancelCountdown(unit.EntityId)
                     end
                 end
 
@@ -47,8 +46,7 @@ function ToggleSelfDestruct(data)
                             unit:Kill()
                         else
                             -- Regular self destruct cycle
-                            local entityId = unit:GetEntityId()
-                            StartCountdown(entityId)
+                            StartCountdown(unit.EntityId)
                             unit.SelfDestructThread = ForkThread(function()
                                 WaitSeconds(5)
                                 if unit:BeenDestroyed() then return end

--- a/lua/sim/CalcBallisticAcceleration.lua
+++ b/lua/sim/CalcBallisticAcceleration.lua
@@ -11,7 +11,7 @@ CalculateBallisticAcceleration = function(weapon, projectile)
     local acc = 4.75
     local launcher = projectile:GetLauncher()
     if not launcher then return acc end
-    local id = launcher:GetEntityId()
+    local id = launcher.EntityId
 
     -- Get projectile position and velocity
     -- velocity needs to multiplied by 10 due to being returned /tick instead of /s

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -530,13 +530,10 @@ Weapon = Class(moho.weapon_methods) {
         end
         local bp = self:GetBlueprint().EnabledByEnhancement
         if bp then
-            local id = self.unit:GetEntityId()
-            if SimUnitEnhancements[id] then
-                for k, v in SimUnitEnhancements[id] do
-                    if v == bp then
-                        self:SetEnabled(enable)
-                        return
-                    end
+            for k, v in SimUnitEnhancements[self.unit.EntityId] or {} do
+                if v == bp then
+                    self:SetEnabled(enable)
+                    return
                 end
             end
             -- Enhancement needed but doesn't have it, don't allow weapon to be enabled.

--- a/lua/terranweapons.lua
+++ b/lua/terranweapons.lua
@@ -213,8 +213,7 @@ TIFCarpetBombWeapon = Class(DefaultProjectileWeapon) {
     CreateProjectileAtMuzzle = function(self, muzzle)
         -- Adapt this function to keep the correct target lock during carpet bombing
         local BallisticsList = import('/lua/sim/CalcBallisticAcceleration.lua').bomb_data
-        local id = self.unit:GetEntityId()
-        local data = BallisticsList[id]
+        local data = BallisticsList[self.unit.EntityId]
         if data and data.usestore and data.targetpos then -- We are repeating, and have lost our original target
             self:SetTargetGround(data.targetpos)
         end

--- a/schook/lua/SimSync.lua
+++ b/schook/lua/SimSync.lua
@@ -30,7 +30,7 @@ SimUnitEnhancements = {}
 
 function AddUnitEnhancement(unit, enhancement, slot)
     if not slot then return end
-    local id = unit:GetEntityId()
+    local id = unit.EntityId
     SimUnitEnhancements[id] = SimUnitEnhancements[id] or {}
     SimUnitEnhancements[id][slot] = enhancement
     SyncUnitEnhancements()
@@ -38,7 +38,7 @@ end
 
 function RemoveUnitEnhancement(unit, enhancement)
     if not unit or unit.Dead then return end
-    local id = unit:GetEntityId()
+    local id = unit.EntityId
     local slots = SimUnitEnhancements[id]
     if not slots then return end
     local key = nil
@@ -58,7 +58,7 @@ function RemoveUnitEnhancement(unit, enhancement)
 end
 
 function RemoveAllUnitEnhancements(unit)
-    local id = unit:GetEntityId()
+    local id = unit.EntityId
     if not SimUnitEnhancements[id] then return end
     SimUnitEnhancements[id] = nil
     SyncUnitEnhancements()


### PR DESCRIPTION
EntityId is saved in the unit on creation, so this is faster than
calling an engine function. Works only in sim on unit entities.