### PR TITLE
make selection of mobile exp/sonar under construction act as building

### DIFF
--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -116,6 +116,7 @@ UnitBlueprint {
         'OVERLAYMISC',
         'CANNOTUSEAIRSTAGING',
         'SNIPEMODE',
+        'LOWSELECTPRIO',
     },
     CollisionOffsetY = -1.5,
     Defense = {

--- a/units/UAL0401/UAL0401_unit.bp
+++ b/units/UAL0401/UAL0401_unit.bp
@@ -74,6 +74,7 @@ UnitBlueprint {
         'OVERLAYOMNI',
         'CQUEMOV', --"CQUEMOV" enables the selection and move commands during construction
         'SNIPEMODE',
+        'LOWSELECTPRIO',
     },
     CollisionOffsetY = 0.3,
     Defense = {

--- a/units/UAS0305/UAS0305_unit.bp
+++ b/units/UAS0305/UAS0305_unit.bp
@@ -32,6 +32,7 @@ UnitBlueprint {
         'SORTINTEL',
         'NAVAL', #added for shipwreck mod
         'CQUEMOV', --"CQUEMOV" enables the selection and move commands during construction
+        'LOWSELECTPRIO',
     },
     CollisionOffsetY = -0.25,
     Defense = {

--- a/units/UAS0401/UAS0401_unit.bp
+++ b/units/UAS0401/UAS0401_unit.bp
@@ -107,6 +107,7 @@ UnitBlueprint {
         'OVERLAYANTINAVY',
         'OVERLAYDIRECTFIRE',
         'SNIPEMODE',
+        'LOWSELECTPRIO',
     },
     CollisionOffsetY = -0.375,
     Defense = {

--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -134,6 +134,7 @@ UnitBlueprint {
         'OVERLAYMISC',
         'BUBBLESHIELDSPILLOVERCHECK',
         'SNIPEMODE',
+        'LOWSELECTPRIO',
     },
     CollisionOffsetZ = 0,
     Defense = {

--- a/units/UES0305/UES0305_unit.bp
+++ b/units/UES0305/UES0305_unit.bp
@@ -67,6 +67,7 @@ UnitBlueprint {
         'SORTINTEL',
         'NAVAL',
         'CQUEMOV', --"CQUEMOV" enables the selection and move commands during construction
+        'LOWSELECTPRIO',
     },
     CollisionOffsetY = -0.25,
     Defense = {

--- a/units/UES0401/UES0401_unit.bp
+++ b/units/UES0401/UES0401_unit.bp
@@ -107,6 +107,7 @@ UnitBlueprint {
         'OVERLAYANTINAVY',
         'OVERLAYMISC',
         'SNIPEMODE',
+        'LOWSELECTPRIO',
     },
     CollisionOffsetY = -0.375,
     CollisionOffsetZ = 0.5,

--- a/units/URA0401/URA0401_unit.bp
+++ b/units/URA0401/URA0401_unit.bp
@@ -112,6 +112,7 @@ UnitBlueprint {
         'CANNOTUSEAIRSTAGING',
         'CQUEMOV', --"CQUEMOV" enables the selection and move commands during construction
         'SNIPEMODE',
+        'LOWSELECTPRIO',
     },
     CollisionOffsetY = 0.9,
     Defense = {

--- a/units/URL0401/URL0401_unit.bp
+++ b/units/URL0401/URL0401_unit.bp
@@ -74,6 +74,7 @@
         'OVERLAYINDIRECTFIRE',
         'CQUEMOV', --"CQUEMOV" enables the selection and move commands during construction
         'SNIPEMODE',
+        'LOWSELECTPRIO',
     },
     Defense = {
         AirThreatLevel = 0,

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -92,6 +92,7 @@ UnitBlueprint {
         'OVERLAYINDIRECTFIRE',
         'CQUEMOV', --"CQUEMOV" enables the selection and move commands during construction
         'SNIPEMODE',
+        'LOWSELECTPRIO',
     },
     CollisionOffsetY = 0.9,
     Defense = {

--- a/units/URS0305/URS0305_unit.bp
+++ b/units/URS0305/URS0305_unit.bp
@@ -52,6 +52,7 @@ UnitBlueprint {
         'SORTINTEL',
         'NAVAL', #for shipwreck mod
         'CQUEMOV', --"CQUEMOV" enables the selection and move commands during construction
+        'LOWSELECTPRIO',
     },
     CollisionOffsetY = -0.25,
     Defense = {

--- a/units/XRL0403/XRL0403_unit.bp
+++ b/units/XRL0403/XRL0403_unit.bp
@@ -100,6 +100,7 @@ UnitBlueprint {
         'OVERLAYDIRECTFIRE',
         'CQUEMOV', --"CQUEMOV" enables the selection and move commands during construction
         'SNIPEMODE',
+        'LOWSELECTPRIO',
     },
     CollisionOffsetY = 2.1,
     CollisionOffsetZ = -0.6,

--- a/units/XSA0402/XSA0402_unit.bp
+++ b/units/XSA0402/XSA0402_unit.bp
@@ -120,6 +120,7 @@ UnitBlueprint {
         'DRAGBUILD',
         'CQUEMOV', --"CQUEMOV" enables the selection and move commands during construction
         'SNIPEMODE',
+        'LOWSELECTPRIO',
     },
     CollisionOffsetY = -1.5,
     Defense = {

--- a/units/XSB3202/XSB3202_unit.bp
+++ b/units/XSB3202/XSB3202_unit.bp
@@ -54,6 +54,7 @@ UnitBlueprint {
         'OVERLAYSONAR',
         'SORTINTEL',
         'CQUEMOV', --"CQUEMOV" enables the selection and move commands during construction
+        'LOWSELECTPRIO',
     },
     CollisionOffsetY = -0.25,
     Defense = {

--- a/units/XSL0401/XSL0401_unit.bp
+++ b/units/XSL0401/XSL0401_unit.bp
@@ -72,6 +72,7 @@ UnitBlueprint {
         'SHOWATTACKRETICLE',
         'CQUEMOV', --"CQUEMOV" enables the selection and move commands during construction
         'SNIPEMODE',
+        'LOWSELECTPRIO',
     },
     CollisionOffsetY = 0,
     CollisionOffsetZ = 0.6,


### PR DESCRIPTION
adding a cat that have been introduce with an exe update to reduce the priority of selection of mobile exp/sonars when being built.
i added the category only to mobile exp/sonar since T4 arties, para and novax doesn't have the selection issue.
This issue was brought when introducing CQUEMOV with exe patch to allow the selection of mobile exp/sonars under construction (in order to give rally point order for example) and to give attack order to pds (when their construction isn't yet finished)

worth noting : unfinished T4 building are selected over unfinished mobile exp/sonars, apart paragon that is selected last.