### PR TITLE
Fix Aurora missing first shot 

### DIFF
--- a/units/UAL0201/UAL0201_unit.bp
+++ b/units/UAL0201/UAL0201_unit.bp
@@ -244,7 +244,7 @@ UnitBlueprint {
                 Land = 'Land|Water|Seabed',
                 Water = 'Land|Water|Seabed',
             },
-            FiringTolerance = 0,
+            FiringTolerance = 2,
             Label = 'MainGun',
             MaxRadius = 26,
             MuzzleChargeDelay = 0.1,

--- a/units/UAL0201/UAL0201_unit.bp
+++ b/units/UAL0201/UAL0201_unit.bp
@@ -244,7 +244,7 @@ UnitBlueprint {
                 Land = 'Land|Water|Seabed',
                 Water = 'Land|Water|Seabed',
             },
-            FiringTolerance = 2,
+            FiringTolerance = 0,
             Label = 'MainGun',
             MaxRadius = 26,
             MuzzleChargeDelay = 0.1,

--- a/units/UAL0201/UAL0201_unit.bp
+++ b/units/UAL0201/UAL0201_unit.bp
@@ -294,6 +294,7 @@ UnitBlueprint {
             TurretYawRange = 10,
             TurretYawSpeed = 60,
             Turreted = true,
+            UseFiringSolutionInsteadOfAimBone = true,
             WeaponCategory = 'Direct Fire',
         },
     },


### PR DESCRIPTION
Auroras were firing their first shot before barrel could be fully aligned with their target, missing their first shot quite frequently. And with low fire rate and paper armor, that is a significant detriment to their effectiveness. This change forces Auroras to complete their aim before firing a shot.

Fixes issue:
https://github.com/FAForever/fa/issues/2924