### PR TITLE
increase energy drain of T3 sonar

### DIFF
--- a/units/UAS0305/UAS0305_unit.bp
+++ b/units/UAS0305/UAS0305_unit.bp
@@ -102,9 +102,9 @@ UnitBlueprint {
     },
     Economy = {
         BuildCostEnergy = 12000,
-        BuildCostMass = 1000,#400
+        BuildCostMass = 1000,
         BuildTime = 750,
-        MaintenanceConsumptionPerSecondEnergy = 250,#100
+        MaintenanceConsumptionPerSecondEnergy = 500,
     },
     Footprint = {
         MinWaterDepth = 1.5,

--- a/units/UES0305/UES0305_unit.bp
+++ b/units/UES0305/UES0305_unit.bp
@@ -130,9 +130,9 @@ UnitBlueprint {
     },
     Economy = {
         BuildCostEnergy = 12000,
-        BuildCostMass = 1000,#400
+        BuildCostMass = 1000,
         BuildTime = 750,
-        MaintenanceConsumptionPerSecondEnergy = 250,#100
+        MaintenanceConsumptionPerSecondEnergy = 500,
     },
     Footprint = {
         MinWaterDepth = 1.5,

--- a/units/URS0305/URS0305_unit.bp
+++ b/units/URS0305/URS0305_unit.bp
@@ -124,9 +124,9 @@ UnitBlueprint {
     },
     Economy = {
         BuildCostEnergy = 14400,
-        BuildCostMass = 1200,#480
+        BuildCostMass = 1200,
         BuildTime = 900,
-        MaintenanceConsumptionPerSecondEnergy = 400,#250
+        MaintenanceConsumptionPerSecondEnergy = 700,
     },
     Footprint = {
         MinWaterDepth = 1.5,


### PR DESCRIPTION
T3 sonar is very cheap, and can even get supported on T1 pgen. Forcing player to get at least a T2 pgen should be the very least we can do.

also might promote the use of T2 sonar a little bit more (for the transition period).