### PR TITLE
t1 scout attackmove range hotfix

### DIFF
--- a/units/UAL0101/UAL0101_unit.bp
+++ b/units/UAL0101/UAL0101_unit.bp
@@ -1,4 +1,7 @@
 UnitBlueprint {
+    AI = {
+        GuardScanRadius = 50, --RadarRadius
+    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'UAL',

--- a/units/UAL0101/UAL0101_unit.bp
+++ b/units/UAL0101/UAL0101_unit.bp
@@ -263,7 +263,7 @@ UnitBlueprint {
             },
             FiringTolerance = 2,
             Label = 'LaserTurret',
-            MaxRadius = 25,
+            MaxRadius = 30,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 25,

--- a/units/UEL0101/UEL0101_unit.bp
+++ b/units/UEL0101/UEL0101_unit.bp
@@ -1,4 +1,7 @@
 UnitBlueprint {
+    AI = {
+        GuardScanRadius = 45, --RadarRadius
+    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'UEL',

--- a/units/XSL0101/XSL0101_unit.bp
+++ b/units/XSL0101/XSL0101_unit.bp
@@ -1,5 +1,8 @@
 UnitBlueprint {
     ResolvePath = true,
+    AI = {
+        GuardScanRadius = 40, --RadarRadius
+    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'XSL',


### PR DESCRIPTION
Set a GuardScanRadius for t1 scouts with weapons so they don't run into enemy units but shoot from proper range.

Might be worth it to look into the code that auto-sets this to see why they aren't affected and if there are other units that might suffer from the same problem. I _might_ do it later.