### PR TITLE
Tweak mob shield attack move stop range

### DIFF
--- a/units/UAL0307/UAL0307_unit.bp
+++ b/units/UAL0307/UAL0307_unit.bp
@@ -1,4 +1,7 @@
 UnitBlueprint {
+    AI = {
+        GuardScanRadius = 28,
+    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'UAL',
@@ -258,7 +261,7 @@ UnitBlueprint {
                 Land = 'Land|Water',
                 Water = 'Land|Water',
             },
-            MaxRadius = 33,
+            MaxRadius = 26,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/UEL0307/UEL0307_unit.bp
+++ b/units/UEL0307/UEL0307_unit.bp
@@ -1,4 +1,7 @@
 UnitBlueprint {
+    AI = {
+        GuardScanRadius = 30,
+    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'UEL',
@@ -242,7 +245,7 @@ UnitBlueprint {
                 Land = 'Land|Water',
                 Water = 'Land|Water',
             },
-            MaxRadius = 33,
+            MaxRadius = 28,
             RackBones = {
                 {
                     MuzzleBones = {

--- a/units/XSL0307/XSL0307_unit.bp
+++ b/units/XSL0307/XSL0307_unit.bp
@@ -1,4 +1,7 @@
 UnitBlueprint {
+    AI = {
+        GuardScanRadius = 28,
+    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'XSL',
@@ -297,7 +300,7 @@ UnitBlueprint {
                 Land = 'Land|Water',
                 Water = 'Land|Water',
             },
-            MaxRadius = 38,
+            MaxRadius = 26,
             RackBones = {
                 {
                     MuzzleBones = {


### PR DESCRIPTION
Tweak shield GuardScanRadius and maxrange so they stop just behind the unit they are most likely to be partnered with instead of stopping short and not covering anything