### PR TITLE
Fix building effect playing twice for command units

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2184,16 +2184,8 @@ CommandUnit = Class(WalkingLandUnit) {
         WalkingLandUnit.OnStartBuild(self, unitBeingBuilt, order)
         self.UnitBeingBuilt = unitBeingBuilt
 
-        local bp = self:GetBlueprint()
-        local isUpgrade = order == 'Upgrade'
-        local showEffects = not isUpgrade or bp.Display.ShowBuildEffectsDuringUpgrade
-
-        if not isUpgrade then
+        if order ~= 'Upgrade' then
             self.BuildingUnit = true
-        end
-
-        if showEffects then
-            self:StartBuildingEffects(unitBeingBuilt, order)
         end
 
         -- Check if we're about to try and build something we shouldn't. This can only happen due to


### PR DESCRIPTION
StartBuildingEffects is called from Unit.OnStartBuild so this was
actually calling it second time.
In game it was almost not noticable, since the the effect was just
brighter since there were 2 same emitters on top of each other doing the
same thing.