### PR TITLE
Update units consumption values only if building something

### DIFF
--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -417,6 +417,20 @@ CConstructionStructureUnit = Class(CStructureUnit) {
         CStructureUnit.OnUnpaused(self)
     end,
 
+    OnProductionPaused = function(self)
+        if self:IsUnitState('Building') then
+            self:SetMaintenanceConsumptionInactive()
+        end
+        self:SetProductionActive(false)
+    end,
+
+    OnProductionUnpaused = function(self)
+        if self:IsUnitState('Building') then
+            self:SetMaintenanceConsumptionActive()
+        end
+        self:SetProductionActive(true)
+    end,
+
     StartBuildingEffects = function(self, unitBeingBuilt, order)
         CStructureUnit.StartBuildingEffects(self, unitBeingBuilt, order)
     end,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -935,7 +935,7 @@ Unit = Class(moho.unit_methods) {
         local units = {}
         -- We need to check all the units assisting.
         for _, v in self:GetGuards() do
-            if not v.Dead then
+            if not v.Dead and (v:IsUnitState('Building') or v:IsUnitState('Repairing')) then
                 table.insert(units, v)
             end
         end


### PR DESCRIPTION
Untested, might have side effects of breaking up something else. Up to the testers to find out all possible combinations of building and assisting.