### PR TITLE
Fix Kennel lag and animation

### DIFF
--- a/lua/terranunits.lua
+++ b/lua/terranunits.lua
@@ -471,7 +471,7 @@ TPodTowerUnit = Class(TStructureUnit) {
 
     OnTransportAttach = function(self, bone, attachee)
         attachee:SetDoNotTarget(true)
-        self:PlayUnitSound('Load')
+        self:PlayUnitSound('Close')
         self:RequestRefreshUI()
         local PodPresent = 0
         for _, v in self.PodData or {} do
@@ -493,7 +493,7 @@ TPodTowerUnit = Class(TStructureUnit) {
 
     OnTransportDetach = function(self, bone, attachee)
         attachee:SetDoNotTarget(false)
-        self:PlayUnitSound('Unload')
+        self:PlayUnitSound('Open')
         self:RequestRefreshUI()
         if not self.OpeningAnimationStarted then
             self.OpeningAnimationStarted = true

--- a/units/XEA3204/XEA3204_script.lua
+++ b/units/XEA3204/XEA3204_script.lua
@@ -11,7 +11,6 @@ XEA3204 = Class(TConstructionUnit) {
     OnCreate = function(self)
         TConstructionUnit.OnCreate(self)
         self.docked = true
-        self.returning = false
     end,
 
     SetParent = function(self, parent, podName)
@@ -30,34 +29,14 @@ XEA3204 = Class(TConstructionUnit) {
 
     OnStartBuild = function(self, unitBeingBuilt, order)
         TConstructionUnit.OnStartBuild(self, unitBeingBuilt, order)
-        self.returning = false
     end,
 
     OnStopBuild = function(self, unitBuilding)
         TConstructionUnit.OnStopBuild(self, unitBuilding)
-        self.returning = true
     end,
 
     OnFailedToBuild = function(self)
         TConstructionUnit.OnFailedToBuild(self)
-        self.returning = true
-    end,
-
-    OnMotionHorzEventChange = function(self, new, old)
-        if self and not self.Dead then
-            if self.Parent and not self.Parent.Dead then
-                local myPosition = self:GetPosition()
-                local parentPosition = self.Parent:GetPosition(self.Parent.PodData[self.PodName].PodAttachpoint)
-                local distSq = VDist2Sq(myPosition[1], myPosition[3], parentPosition[1], parentPosition[3])
-                if self.docked and distSq > 0 and not self.returning then
-                    self.docked = false
-                    self.Parent:ForkThread(self.Parent.NotifyOfPodStartBuild)
-                elseif not self.docked and distSq < 1 and self.returning then
-                    self.docked = true
-                    self.Parent:ForkThread(self.Parent.NotifyOfPodStopBuild)
-                end
-            end
-        end
     end,
 
     -- Don't make wreckage


### PR DESCRIPTION
Old Issue; if you build more than 30 kennels and upgrade them at the same time, it was freezing the game for 2-3 seconds when new drones spawns.
The lag came from a table.deepcopy function that was making a deepcopy of the drone data.
The deepcopy was not only making a copy of the unit, it also did a copy of platoondata, Brain and all other tables that where only present by a pointer.

This was also triggering a error after several hours of playtime:
```
WARNING: Error running OnStopBuild script in Entity xeb0104 at 7c42e708: ...:\programdata\faforever\repo\fa\lua\system\utils.lua(91): stack overflow
         stack traceback:
         	...:\programdata\faforever\repo\fa\lua\system\utils.lua(91): in function `deepcopy'
         	...:\programdata\faforever\repo\fa\lua\system\utils.lua(102): in function `deepcopy'
```

Also fixed a minor issue with the door animation. They only opens if a real buildcommand was issued.
Selecting the drone and just let them start was not opening the doors.
Now doors stay open if the first drone is detached and will close if all drones return.

And last but not least i readded the door open and close sound.

Animation note:
The dooranimation is opening and closing the door in the same animation.
It takes 0.5 seconds to open the doors and 0.5 seconds to close the doors.
If we want the doors to stay open, we need to start the animation and stop it after 0.5 seconds.
That's why it needs a forked thread on animation open.