### PR TITLE
Don't set the center background Tiled in the popout window

### DIFF
--- a/lua/ui/controls/ninepatch.lua
+++ b/lua/ui/controls/ninepatch.lua
@@ -13,8 +13,6 @@ NinePatch = Class(Group) {
             self.center.Left:Set(self.Left)
             self.center.Bottom:Set(self.Bottom)
             self.center.Right:Set(self.Right)
-
-            self.center:SetTiled(true)
         end
 
         self.tl = Bitmap(self, topLeft)


### PR DESCRIPTION
Fixes #2996

With the trial and error I found out this line causing the most problems. If you test it (described in the linked issue) you get much better performance. Changelog not causing any load anymore. Going into map selection is still more expensive, but if you go to unit restrictions, you get no lag anymore.

The thing is I don't know what SetTiled(true) does, can someone tell me?