### PR TITLE
Fix error when pausing/unpausing factory

### DIFF
--- a/lua/aeonunits.lua
+++ b/lua/aeonunits.lua
@@ -52,7 +52,7 @@ AFactoryUnit = Class(FactoryUnit) {
    
     OnPaused = function(self)
         -- When factory is paused take some action
-        if self:IsUnitState('Building') then
+        if self:IsUnitState('Building') and self.unitBeingBuilt ~= nil then
             self:StopUnitAmbientSound('ConstructLoop')
             StructureUnit.StopBuildingEffects(self, self.UnitBeingBuilt)
             self:StartBuildFx(self:GetFocusUnit())
@@ -62,7 +62,7 @@ AFactoryUnit = Class(FactoryUnit) {
 
     OnUnpaused = function(self)
         FactoryUnit.OnUnpaused(self)
-        if self:IsUnitState('Building') then
+        if self:IsUnitState('Building') and self.unitBeingBuilt ~= nil then
             StructureUnit.StopBuildingEffects(self, self.UnitBeingBuilt)
             self:StartBuildFx(self:GetFocusUnit())
         end

--- a/lua/aeonunits.lua
+++ b/lua/aeonunits.lua
@@ -52,7 +52,7 @@ AFactoryUnit = Class(FactoryUnit) {
    
     OnPaused = function(self)
         -- When factory is paused take some action
-        if self:IsUnitState('Building') and self.unitBeingBuilt ~= nil then
+        if self:IsUnitState('Building') and self.unitBeingBuilt then
             self:StopUnitAmbientSound('ConstructLoop')
             StructureUnit.StopBuildingEffects(self, self.UnitBeingBuilt)
             self:StartBuildFx(self:GetFocusUnit())
@@ -62,7 +62,7 @@ AFactoryUnit = Class(FactoryUnit) {
 
     OnUnpaused = function(self)
         FactoryUnit.OnUnpaused(self)
-        if self:IsUnitState('Building') and self.unitBeingBuilt ~= nil then
+        if self:IsUnitState('Building') and self.unitBeingBuilt then
             StructureUnit.StopBuildingEffects(self, self.UnitBeingBuilt)
             self:StartBuildFx(self:GetFocusUnit())
         end

--- a/lua/seraphimunits.lua
+++ b/lua/seraphimunits.lua
@@ -52,7 +52,7 @@ SFactoryUnit = Class(FactoryUnit) {
     
     OnPaused = function(self)
         -- When factory is paused take some action
-        if self:IsUnitState('Building') then
+        if self:IsUnitState('Building') and self.unitBeingBuilt ~= nil then
             self:StopUnitAmbientSound('ConstructLoop')
             StructureUnit.StopBuildingEffects(self, self.UnitBeingBuilt)
             self:StartBuildFx(self:GetFocusUnit())
@@ -62,7 +62,7 @@ SFactoryUnit = Class(FactoryUnit) {
 
     OnUnpaused = function(self)
         FactoryUnit.OnUnpaused(self)
-        if self:IsUnitState('Building') then
+        if self:IsUnitState('Building') and self.unitBeingBuilt ~= nil then
             self:StartBuildFxUnpause(self:GetFocusUnit())
         end
     end,

--- a/lua/seraphimunits.lua
+++ b/lua/seraphimunits.lua
@@ -52,7 +52,7 @@ SFactoryUnit = Class(FactoryUnit) {
     
     OnPaused = function(self)
         -- When factory is paused take some action
-        if self:IsUnitState('Building') and self.unitBeingBuilt ~= nil then
+        if self:IsUnitState('Building') and self.unitBeingBuilt then
             self:StopUnitAmbientSound('ConstructLoop')
             StructureUnit.StopBuildingEffects(self, self.UnitBeingBuilt)
             self:StartBuildFx(self:GetFocusUnit())
@@ -62,7 +62,7 @@ SFactoryUnit = Class(FactoryUnit) {
 
     OnUnpaused = function(self)
         FactoryUnit.OnUnpaused(self)
-        if self:IsUnitState('Building') and self.unitBeingBuilt ~= nil then
+        if self:IsUnitState('Building') and self.unitBeingBuilt then
             self:StartBuildFxUnpause(self:GetFocusUnit())
         end
     end,


### PR DESCRIPTION
happened when unit inside sera/aeon factories died and then we pause/unpause

![image](https://user-images.githubusercontent.com/11618427/75118201-4c09db00-5678-11ea-9a9d-11373daf2a4c.png)

logs : 
`WARNING: Error running OnPaused script in Entity uab0201 at 22247308: c:\programdata\faforever\repo\fa\lua\aeonunits.lua(50): attempt to call method 'Add' (a nil value)
         stack traceback:
            c:\programdata\faforever\repo\fa\lua\aeonunits.lua(50): in function 'StartBuildFx'
            c:\programdata\faforever\repo\fa\lua\aeonunits.lua(153): in function 'StartBuildFx'
            c:\programdata\faforever\repo\fa\lua\aeonunits.lua(58): in function 'OnPaused'
            c:\programdata\faforever\repo\fa\lua\aeonunits.lua(157): in function <c:\programdata\faforever\repo\fa\lua\aeonunits.lua:156>
            [C]: in function 'SetPaused'`

`WARNING: Error running OnUnpaused script in Entity uab0201 at 22247308: c:\programdata\faforever\repo\fa\lua\aeonunits.lua(50): attempt to call method 'Add' (a nil value)
         stack traceback:
            c:\programdata\faforever\repo\fa\lua\aeonunits.lua(50): in function 'StartBuildFx'
            c:\programdata\faforever\repo\fa\lua\aeonunits.lua(153): in function 'StartBuildFx'
            c:\programdata\faforever\repo\fa\lua\aeonunits.lua(67): in function 'OnUnpaused'
            c:\programdata\faforever\repo\fa\lua\aeonunits.lua(161): in function <c:\programdata\faforever\repo\fa\lua\aeonunits.lua:160>
            [C]: in function 'SetPaused'`

`WARNING: Error running OnPaused script in Entity xsb0102 at 177e6808: ...\programdata\faforever\repo\fa\lua\seraphimunits.lua(44): attempt to call method 'Add' (a nil value)`