### PR TITLE
SingleRangeOverlay cleanup

### DIFF
--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -339,8 +339,6 @@ keyActions = {
         category = 'selection', order = 22,},
     ['toggle_selectedinfo'] = {action = 'UI_Lua import("/lua/keymap/selectedinfo.lua").ToggleOn()',
         category = 'ui', order = 23,},
-    ['toggle_selectedrings'] = {action = 'UI_Lua import("/lua/keymap/selectedinfo.lua").ToggleOverlayOn()',
-        category = 'ui', order = 24,},
     ['toggle_cloakjammingstealth'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleCloakJammingStealthScript()',
         category = 'orders', order = 25,},
     ['toggle_intelshield'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleIntelShieldScript()',

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -337,8 +337,6 @@ keyActions = {
         category = 'selection', order = 21,},
     ['select_next_naval_factory'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").GetNextNavalFactory()',
         category = 'selection', order = 22,},
-    ['toggle_selectedinfo'] = {action = 'UI_Lua import("/lua/keymap/selectedinfo.lua").ToggleOn()',
-        category = 'ui', order = 23,},
     ['toggle_cloakjammingstealth'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleCloakJammingStealthScript()',
         category = 'orders', order = 25,},
     ['toggle_intelshield'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleIntelShieldScript()',

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -244,7 +244,6 @@ keyDescriptions = {
     ['select_next_air_factory'] = '<LOC key_desc_0208>Select next air factory',
     ['select_next_naval_factory'] = '<LOC key_desc_0209>Select next naval factory',
     ['toggle_selectedinfo'] = '<LOC key_desc_0210>Toggle single unit selected info',
-    ['toggle_selectedrings'] = '<LOC key_desc_0211>Toggle single unit selected rings',
     ['toggle_cloakjammingstealth'] = '<LOC key_desc_0212>Toggle all counter-intelligence abilities',
     ['toggle_intelshield'] = '<LOC key_desc_0213>Toggle intel and shield',
     ['toggle_mdf_panel'] = '<LOC key_desc_0214>Toggle MFD panel',

--- a/lua/keymap/selectedinfo.lua
+++ b/lua/keymap/selectedinfo.lua
@@ -9,12 +9,6 @@ local selectionOverlay = {
         Tooltip = "overlay_selection",
 }
 
-SelectedInfoOn = true
-
-if options.gui_enhanced_unitview == 0 then
-   SelectedInfoOn = false
-end
-
 function GetUnitRolloverInfo(unit)
     local info = {}
 
@@ -57,13 +51,5 @@ function GetUnitRolloverInfo(unit)
     info.armyIndex = unit:GetArmy() - 1
 
     return info
-end
-
-function ToggleOn()
-   if SelectedInfoOn then
-      SelectedInfoOn = false
-   else
-      SelectedInfoOn = true
-   end
 end
 

--- a/lua/keymap/selectedinfo.lua
+++ b/lua/keymap/selectedinfo.lua
@@ -10,14 +10,9 @@ local selectionOverlay = {
 }
 
 SelectedInfoOn = true
-SelectedOverlayOn = true
 
 if options.gui_enhanced_unitview == 0 then
    SelectedInfoOn = false
-end
-
-if options.gui_enhanced_unitrings == 0 then
-   SelectedOverlayOn = false
 end
 
 function GetUnitRolloverInfo(unit)
@@ -72,28 +67,3 @@ function ToggleOn()
    end
 end
 
-function ToggleOverlayOn()
-   if SelectedOverlayOn then
-      SelectedOverlayOn = false
-      DeactivateSingleRangeOverlay()
-   else
-      SelectedOverlayOn = true
-      local selUnits = GetSelectedUnits()
-      if selUnits and table.getn(selUnits) == 1 then
-         ActivateSingleRangeOverlay()
-      end
-   end
-end
-
-function ActivateSingleRangeOverlay()
-   ConExecute('range_RenderSelected true')
-end
-
-function DeactivateSingleRangeOverlay()
-   local info = selectionOverlay
-   local pref = Prefs.GetFromCurrentProfile(info.Pref)
-   if pref == nil then
-      pref = true
-   end
-   ConExecute(info.Pref..' '..tostring(pref))
-end

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -550,19 +550,6 @@ options = {
             },
 
             {
-                title = "<LOC OPTIONS_0235>Single Unit Selected Rings",
-                key = 'gui_enhanced_unitrings',
-                type = 'toggle',
-                default = 0,
-                custom = {
-                    states = {
-                        {text = "<LOC _Off>", key = 0 },
-                        {text = "<LOC _On>", key = 1 },
-                    },
-                },
-            },
-
-            {
                 title = "<LOC OPTIONS_0236>Zoom Pop Distance",
                 key = 'gui_zoom_pop_distance',
                 type = 'slider',

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -553,12 +553,6 @@ function OnSelectionChanged(oldSelection, newSelection, added, removed)
     if newSelection then
         local n = table.getn(newSelection)
 
-        if n == 1 and import("/lua/keymap/selectedinfo.lua").SelectedOverlayOn then
-            import("/lua/keymap/selectedinfo.lua").ActivateSingleRangeOverlay()
-        else
-            import("/lua/keymap/selectedinfo.lua").DeactivateSingleRangeOverlay()
-        end
-
         -- if something died in selection, restore command mode
         if n > 0 and table.getsize(removed) > 0 and table.getsize(added) == 0 then
             local CM = import('/lua/ui/game/commandmode.lua')


### PR DESCRIPTION
This code was added to fix issue #94 or at least to make it less harmful. But code logic is broken and doesn't work as intended.

Also idea is bad overall, cause if you have 'global' rings disabled and this code works as intended, then you can't see any rings for multiple selected units at all.

And it's 2020 after all, gpus are good enough to handle range rings in most cases + we did some optimisations in engine.

-----------------Testing-------------------
As I said, the code logic is broken and removing this code won't affect anything. Some basic tests: select units with `Selection rings on` then with `Selection rings off` and things like that.