### PR TITLE
Prevented unnecessary focus changes when cheats are enabled

### DIFF
--- a/lua/ui/game/gameresult.lua
+++ b/lua/ui/game/gameresult.lua
@@ -7,6 +7,8 @@
 
 local UIUtil = import('/lua/ui/uiutil.lua')
 
+local sessionInfo = SessionGetScenarioInfo()
+
 local OtherArmyResultStrings = {
     victory = '<LOC usersync_0001>%s wins!',
     defeat = '<LOC usersync_0002>%s has been defeated!',
@@ -42,7 +44,7 @@ function DoGameResult(armyIndex, result)
     local armies = GetArmiesTable().armiesTable
     announced[armyIndex] = true
 
-    if not SessionIsReplay() then
+    if (not SessionIsReplay()) and (sessionInfo.Options.CheatsEnabled ~= 'true') then
         SetFocusArmy(-1)
     end
 


### PR DESCRIPTION
When any player dies, the focus army switches to the observer. Prevented.