### PR TITLE
Fix torp bombers attack order + Solace buf

### DIFF
--- a/units/UAA0204/UAA0204_script.lua
+++ b/units/UAA0204/UAA0204_script.lua
@@ -20,6 +20,7 @@ UAA0204 = Class(AAirUnit) {
                         self:ChangeMaxRadius(100)
                         WaitTicks(1)
                         self:ChangeMaxRadius(self:GetBlueprint().MaxRadius)
+                        self:ResetTarget()
                     end)
                 end
                 AANDepthChargeBombWeapon.OnLostTarget(self)

--- a/units/UAA0204/UAA0204_script.lua
+++ b/units/UAA0204/UAA0204_script.lua
@@ -13,7 +13,18 @@ local AANDepthChargeBombWeapon = import('/lua/aeonweapons.lua').AANDepthChargeBo
 
 UAA0204 = Class(AAirUnit) {
     Weapons = {
-        Bomb = Class(AANDepthChargeBombWeapon) {},
+        Bomb = Class(AANDepthChargeBombWeapon) {
+            OnLostTarget = function(self)
+                if self.unit:GetTargetEntity().Dead then
+                    self:ForkThread(function()
+                        self:ChangeMaxRadius(100)
+                        WaitTicks(1)
+                        self:ChangeMaxRadius(self:GetBlueprint().MaxRadius)
+                    end)
+                end
+                AANDepthChargeBombWeapon.OnLostTarget(self)
+            end,
+        },
     },
 }
 

--- a/units/UAA0204/UAA0204_script.lua
+++ b/units/UAA0204/UAA0204_script.lua
@@ -1,0 +1,20 @@
+--****************************************************************************
+--**
+--**  File     :  /cdimage/units/UAA0204/UAA0204_script.lua
+--**  Author(s):  John Comes, David Tomandl, Jessica St. Croix
+--**
+--**  Summary  :  Aeon Torpedo Bomber Script
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
+
+local AAirUnit = import('/lua/aeonunits.lua').AAirUnit
+local AANDepthChargeBombWeapon = import('/lua/aeonweapons.lua').AANDepthChargeBombWeapon
+
+UAA0204 = Class(AAirUnit) {
+    Weapons = {
+        Bomb = Class(AANDepthChargeBombWeapon) {},
+    },
+}
+
+TypeClass = UAA0204

--- a/units/XAA0306/XAA0306_script.lua
+++ b/units/XAA0306/XAA0306_script.lua
@@ -27,6 +27,7 @@ XAA0306 = Class(AAirUnit) {
                     self:ChangeMaxRadius(100)
                     WaitTicks(1)
                     self:ChangeMaxRadius(self:GetBlueprint().MaxRadius)
+                    self:ResetTarget()
                 end)
             end,
         },

--- a/units/XAA0306/XAA0306_script.lua
+++ b/units/XAA0306/XAA0306_script.lua
@@ -14,7 +14,22 @@ local AANTorpedoCluster = import('/lua/aeonweapons.lua').AANTorpedoCluster
 
 XAA0306 = Class(AAirUnit) {
     Weapons = {
-        Bomb = Class(AANTorpedoCluster) {},
+        Bomb = Class(AANTorpedoCluster) {
+            OnLostTarget = function(self)
+                if self.unit:GetTargetEntity().Dead then
+                    self:ResetAttackOrder()
+                end
+                AANTorpedoCluster.OnLostTarget(self)
+            end,
+            
+            ResetAttackOrder = function(self)
+                self:ForkThread(function()
+                    self:ChangeMaxRadius(100)
+                    WaitTicks(1)
+                    self:ChangeMaxRadius(self:GetBlueprint().MaxRadius)
+                end)
+            end,
+        },
     },
 }
 

--- a/units/XAA0306/XAA0306_script.lua
+++ b/units/XAA0306/XAA0306_script.lua
@@ -1,0 +1,21 @@
+--****************************************************************************
+--**
+--**  File     :  /data/units/XAA0306/XAA0306_script.lua
+--**  Author(s):  Jessica St. Croix, Matt Vainio
+--**
+--**  Summary  :  Aeon Torpedo Cluster Bomber Script
+--**
+--**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
+
+local AAirUnit = import('/lua/aeonunits.lua').AAirUnit
+local AANTorpedoCluster = import('/lua/aeonweapons.lua').AANTorpedoCluster
+
+
+XAA0306 = Class(AAirUnit) {
+    Weapons = {
+        Bomb = Class(AANTorpedoCluster) {},
+    },
+}
+
+TypeClass = XAA0306

--- a/units/XSA0204/XSA0204_script.lua
+++ b/units/XSA0204/XSA0204_script.lua
@@ -14,7 +14,18 @@ local SANHeavyCavitationTorpedo = SeraphimWeapons.SANHeavyCavitationTorpedo
 
 XSA0204 = Class(SAirUnit) {
     Weapons = {
-        Bomb = Class(SANHeavyCavitationTorpedo) {},
+        Bomb = Class(SANHeavyCavitationTorpedo) {
+            OnLostTarget = function(self)
+                if self.unit:GetTargetEntity().Dead then
+                    self:ForkThread(function()
+                        self:ChangeMaxRadius(100)
+                        WaitTicks(1)
+                        self:ChangeMaxRadius(self:GetBlueprint().MaxRadius)
+                    end)
+                end
+                SANHeavyCavitationTorpedo.OnLostTarget(self)
+            end,
+        },
     },
 }
 TypeClass = XSA0204

--- a/units/XSA0204/XSA0204_script.lua
+++ b/units/XSA0204/XSA0204_script.lua
@@ -1,0 +1,20 @@
+--****************************************************************************
+--**
+--**  File     :  /main/data/Units/XSA0204/XSA0204_script.lua
+--**  Author(s):  Greg Kohne, Gordon Duclos
+--**
+--**  Summary  :  Seraphim Torpedo Bomber Script
+--**
+--**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
+
+local SAirUnit = import('/lua/seraphimunits.lua').SAirUnit
+local SeraphimWeapons = import('/lua/seraphimweapons.lua')
+local SANHeavyCavitationTorpedo = SeraphimWeapons.SANHeavyCavitationTorpedo
+
+XSA0204 = Class(SAirUnit) {
+    Weapons = {
+        Bomb = Class(SANHeavyCavitationTorpedo) {},
+    },
+}
+TypeClass = XSA0204

--- a/units/XSA0204/XSA0204_script.lua
+++ b/units/XSA0204/XSA0204_script.lua
@@ -21,6 +21,7 @@ XSA0204 = Class(SAirUnit) {
                         self:ChangeMaxRadius(100)
                         WaitTicks(1)
                         self:ChangeMaxRadius(self:GetBlueprint().MaxRadius)
+                        self:ResetTarget()
                     end)
                 end
                 SANHeavyCavitationTorpedo.OnLostTarget(self)


### PR DESCRIPTION
#3001 
~Only affects t2 and t3 aeon torps, other factions works fine.~ t2 and t3 aeon + t2 sera torps. Description is in commit message


Solace buff will be added later, I just need this fix for upcoming retargeting system.
