### PR TITLE
Misc Performance Enhancements

### DIFF
--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -315,7 +315,8 @@ Weapon = Class(moho.weapon_methods) {
 
     end,
 
-    GetDamageTable = function(self)
+
+    GetDamageTableInternal = function(self)
         local weaponBlueprint = self:GetBlueprint()
         local damageTable = {}
         damageTable.InitialDamageAmount = weaponBlueprint.InitialDamage or 0
@@ -346,6 +347,12 @@ Weapon = Class(moho.weapon_methods) {
         return damageTable
     end,
 
+    damageTableCache = false,
+    GetDamageTable = function(self)
+        if not self.damageTableCache then self.damageTableCache = self:GetDamageTableInternal() end
+        return self.damageTableCache
+    end,
+    
     CreateProjectileForWeapon = function(self, bone)
         local proj = self:CreateProjectile(bone)
         local damageTable = self:GetDamageTable()
@@ -461,10 +468,12 @@ Weapon = Class(moho.weapon_methods) {
 
     AddDamageMod = function(self, dmgMod)
         self.DamageMod = self.DamageMod + dmgMod
+        self.damageTableCache = false
     end,
 
     AddDamageRadiusMod = function(self, dmgRadMod)
         self.DamageRadiusMod = self.DamageRadiusMod + (dmgRadMod or 0)
+        self.damageTableCache = false
     end,
 
     DoOnFireBuffs = function(self)
@@ -485,6 +494,7 @@ Weapon = Class(moho.weapon_methods) {
             -- Error
             error('ERROR: DisableBuff in weapon.lua does not have a buffname')
         end
+        self.damageTableCache = false
     end,
 
     ReEnableBuff = function(self, buffname)
@@ -494,6 +504,7 @@ Weapon = Class(moho.weapon_methods) {
             -- Error
             error('ERROR: ReEnableBuff in weapon.lua does not have a buffname')
         end
+        self.damageTableCache = false
     end,
 
     -- Method to mark weapon when parent unit gets loaded on to a transport unit

--- a/lua/system/class.lua
+++ b/lua/system/class.lua
@@ -330,22 +330,6 @@ function ChangeState(obj, newstate)
         newstate = obj[newstate]
     end
 
-    assert(getmetatable(newstate)==State)
-
-    local oldtype = getmetatable(obj)
-    if(getmetatable(oldtype)==Class) then
-        -- The object is an instance of a class which has not yet been assigned a state.
-        -- Make sure it's the same class this state is defined for.
-        assert(oldtype == newstate.__bases[1], "Tried to set a state, but the state wasn't defined on this object")
-    elseif(getmetatable(oldtype)==State) then
-        -- The object is an instance of a class that's already changed states.
-        -- Make sure it was defined in the same class we were.
-        assert(oldtype.__bases[1] == newstate.__bases[1], "Tried to changes states, but the new state wasn't defined on this object")
-    else
-        -- The object is not a class instance at all.
-        error("Attempted to change states on something other than a class instance")
-    end
-
     -- Ignore redundant state changes.
     if getmetatable(obj)==newstate then
         debug.traceback(nil, "Ignoring no-op state change...")


### PR DESCRIPTION
This PR contains 2 key changes
- Removing the asserts that happen on state changes (this happens ~8 times or something like that per weapon firing cycle)
- Caching the projectile data in the weapon (and correctly invalidating it) instead of recreating it on every shot

Both changes have been tested in my Simspeed++ mod for a few months now and have not caused any issue.

Getting good data on how much it helps is hard, for comparison for the sake of this PR I ran replay 11042968 at the max speed with and without those changes in it.
Without them it took 29min 30sec
With them it took 27min 30sec
Giving a roughly 7% speedup in a real game (a fairly short and casual ~1.2k setons)