### PR TITLE
Update mapblacklist

### DIFF
--- a/etc/faf/mapblacklist.lua
+++ b/etc/faf/mapblacklist.lua
@@ -368,7 +368,6 @@ MapBlacklist = {
     ['denmark3.v0002'] = true,
     ['denmark3.v0003'] = true,
     ['depths v6'] = true,
-    ['desert arena.v0001'] = true,
     ['desert arena v2.v0002'] = true,
     ['desert conflict.v0001'] = true,
     ['desert fox.v0001'] = true,


### PR DESCRIPTION
Remove desert arena v1 from blacklist.
this version is the one played in tournament/ladder.
v2 is with hills which induce unbalance for long range units.
v3 is for FFA.