### PR TITLE
Add support for custom map Props

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -193,6 +193,8 @@ mount_dir_with_whitelist(InitFileDir .. '\\..\\gamedata\\', '*.nx5', '/')
 mount_dir_with_whitelist(fa_path .. '\\gamedata\\', '*.scd', '/')
 mount_dir(fa_path, '/')
 
+--load preferences into the game as well, letting us have much more control over their contents. This also includes cache and similar.
+mount_dir(SHGetFolderPath('LOCAL_APPDATA') .. 'Gas Powered Games\\Supreme Commander Forged Alliance', '/preferences')
 
 hook = {
     '/schook'

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -51,6 +51,10 @@ AIKeys = {}
 AIStrings = {}
 AITooltips = {}
 
+--This is a special table that allows us to pass data to blueprints.lua, before the rest of the game is loaded.
+-- do not use this for anything that doesnt do blueprint modding, use GameOptions for that instead, which will load it into sim.
+PreGameData = {}
+
 local IsSyncReplayServer = false
 
 local AddUnicodeCharToEditText = import('/lua/UTF.lua').AddUnicodeCharToEditText
@@ -2039,7 +2043,9 @@ local function TryLaunch(skipNoObserversCheck)
         SetWindowedLobby(false)
 
         SavePresetToName(LAST_GAME_PRESET_NAME)
-
+        
+        PreGameData.CurrentMapDir = Dirname(gameInfo.GameOptions.ScenarioFile)
+        SetPreference('PreGameData',PreGameData)
         lobbyComm:LaunchGame(gameInfo)
     end
 


### PR DESCRIPTION
This requires a change to the init file. running this without the init
file should result in no changes - nothing breaks but no new features.

This adds support for custom props, and more to maps, and allows passing
arbitrary data to blueprints.lua, which is insanely useful and has been
a limitation for a long time.

Currently this is only used to load the custom content in the current
map, but mods and maps could do loads of stuff with it. Such as:
1. adding mod settings to turn off/on changes
2. adding map settings for optional features, and props.
3.mods can edit the logic by hooking modblueprints, and so can have
total control over which parts of themselves get loaded.

a note on security - this might sound like it creates a hole but it
doesnt let you break anything that couldnt be broken before:
game preferences is arbitrarily readable from UI already,
no writing functionality that wasnt there before has been added.
any non-deterministic change in blueprints.lua results in desyncs, just
like before