### PR TITLE
Adding more restrictions to sim orders

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -258,11 +258,23 @@ function IsInvalidAssist(unit, target)
     end
 end
 
+-- This one is used for attack move button which was added in FAF.
+-- I think 90% of players use alt+RMB instead? So for now we exclude engies,
+-- but if some auto abuse will appear again, then better remove it completely.
 Callbacks.AttackMove = function(data, units)
-    if data.Clear then
-        IssueClearCommands(units)
+    units = SecureUnits(units)
+    local validatedUnits = {}
+
+    for k, unit in units do
+        if not unit:GetBlueprint().CategoriesHash.ENGINEER then
+            table.insert(validatedUnits, unit)
+        end
     end
-    IssueAggressiveMove(units, data.Target)
+
+    if data.Clear then
+        IssueClearCommands(validatedUnits)
+    end
+    IssueAggressiveMove(validatedUnits, data.Target)
 end
 
 --tells a unit to toggle its pointer


### PR DESCRIPTION
- dissalow sim attack-move for engies. Used by attack-move button, so not a big deal as most of the players use alt+RMB anyway.
- 10 sec delay between shift-g move orders.
- No delay for attack orders. I feel like it also can be abused in some way, so mb we should add 5 sec delay for attack too?

If you have better idea how to break ui mods such as auto attack-move engies, auto flanking, auto dodging etc., feel free to make another PR with it. (removing shift-g feature is not an option :)

