### PR TITLE
Issue/#3031 Don't send results after initiating a `SafeQuit`.

### DIFF
--- a/lua/ui/dialogs/eschandler.lua
+++ b/lua/ui/dialogs/eschandler.lua
@@ -11,11 +11,14 @@ local Prefs = import('/lua/user/prefs.lua')
 local Utils = import('/lua/system/utils.lua')
 
 local quickDialog = false
+-- Used to skip result reporting when we exit the game early
+isExiting = false
 
 -- Terminate the game in a vaguely graceful fashion. This may or may not reduce the amount of times
 -- sudden quits lead to players having to wait for a timeout.
 function SafeQuit()
     if SessionIsActive() and not SessionIsReplay() then
+        isExiting = true
         ForkThread(function ()
             ConExecute('ren_oblivion true')
             ConExecute('ren_ui false')

--- a/schook/lua/UserSync.lua
+++ b/schook/lua/UserSync.lua
@@ -96,7 +96,7 @@ OnSync = function()
     end
 
     if not import("/lua/ui/dialogs/eschandler.lua").isExiting then
-        for k,gameResult in Sync.GameResult do
+        for _, gameResult in Sync.GameResult do
             local armyIndex, result = unpack(gameResult)
             LOG(string.format('Sending game result: %i %s', armyIndex, result))
             GpgNetSend('GameResult', armyIndex, result)

--- a/schook/lua/UserSync.lua
+++ b/schook/lua/UserSync.lua
@@ -95,11 +95,13 @@ OnSync = function()
         end
     end
 
-    for k,gameResult in Sync.GameResult do
-        local armyIndex, result = unpack(gameResult)
-        LOG(string.format('Sending game result: %i %s', armyIndex, result))
-        GpgNetSend('GameResult', armyIndex, result)
-        import('/lua/ui/game/gameresult.lua').DoGameResult(armyIndex, result)
+    if not import("/lua/ui/dialogs/eschandler.lua").isExiting then
+        for k,gameResult in Sync.GameResult do
+            local armyIndex, result = unpack(gameResult)
+            LOG(string.format('Sending game result: %i %s', armyIndex, result))
+            GpgNetSend('GameResult', armyIndex, result)
+            import('/lua/ui/game/gameresult.lua').DoGameResult(armyIndex, result)
+        end
     end
 
     if Sync.StatsToSend then


### PR DESCRIPTION
Fixes #3031.

Works like a charm. If our instance of FA closes via `Exit to FAF` then that will be picked up by the other players in the game and our `defeat` result will be reported appropriately, but we won't be spamming bogus `defeat` results for the other remaining players.