### PR TITLE
Fix broken scaling of default position of the chat

### DIFF
--- a/lua/maui/window.lua
+++ b/lua/maui/window.lua
@@ -468,10 +468,18 @@ Window = Class(Group) {
                 self.Left:Set(math.max(math.min(location.right, parent.Right()) - oldWidth), parent.Left())
             end
         elseif defaultPosition then
-            self.Left:Set(LayoutHelpers.ScaleNumber(defaultPosition.Left))
-            self.Top:Set(LayoutHelpers.ScaleNumber(defaultPosition.Top))
-            self.Bottom:Set(LayoutHelpers.ScaleNumber(defaultPosition.Bottom))
-            self.Right:Set(LayoutHelpers.ScaleNumber(defaultPosition.Right))
+            -- Scale only if it's a number, else it's already scaled lazyvar
+            if type(defaultPosition.Left) == 'number' then
+                self.Left:Set(LayoutHelpers.ScaleNumber(defaultPosition.Left))
+                self.Top:Set(LayoutHelpers.ScaleNumber(defaultPosition.Top))
+                self.Bottom:Set(LayoutHelpers.ScaleNumber(defaultPosition.Bottom))
+                self.Right:Set(LayoutHelpers.ScaleNumber(defaultPosition.Right))
+            else
+                self.Left:Set(defaultPosition.Left)
+                self.Top:Set(defaultPosition.Top)
+                self.Bottom:Set(defaultPosition.Bottom)
+                self.Right:Set(defaultPosition.Right)
+            end
         end
     end,
     


### PR DESCRIPTION
Some windows have the default position by numbers and some by functions. Gotta cover both cases, once is saved in the game.prefs, it's always numbers.
Fixes #3051