### PR TITLE
Update defaultunits.lua

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1986,7 +1986,7 @@ ConstructionUnit = Class(MobileUnit) {
         self.UnitBeingBuilt = unitBeingBuilt
         self.UnitBuildOrder = order
         self.BuildingUnit = true
-        if (unitBeingBuilt.UnitId or unitBeingBuilt:GetUnitId) == self:GetBlueprint().General.UpgradesTo and order == 'Upgrade' then
+        if (unitBeingBuilt.UnitId or unitBeingBuilt:GetUnitId()) == self:GetBlueprint().General.UpgradesTo and order == 'Upgrade' then
             self.Upgrading = true
             self.BuildingUnit = false
         end
@@ -2384,7 +2384,7 @@ ACUUnit = Class(CommandUnit) {
 
     OnStopBeingBuilt = function(self, builder, layer)
         CommandUnit.OnStopBeingBuilt(self, builder, layer)
-        ArmyBrains[self.Army]:SetUnitStat(self.UnitId or self:GetUnitId, "lowest_health", self:GetHealth())
+        ArmyBrains[self.Army]:SetUnitStat(self.UnitId or self:GetUnitId(), "lowest_health", self:GetHealth())
         self.WeaponEnabled = {}
     end,
     
@@ -2401,8 +2401,8 @@ ACUUnit = Class(CommandUnit) {
             aiBrain:OnPlayCommanderUnderAttackVO()
         end
 
-        if self:GetHealth() < ArmyBrains[self.Army]:GetUnitStat(self.UnitId or self:GetUnitId, "lowest_health") then
-            ArmyBrains[self.Army]:SetUnitStat(self.UnitId or self:GetUnitId, "lowest_health", self:GetHealth())
+        if self:GetHealth() < ArmyBrains[self.Army]:GetUnitStat(self.UnitId or self:GetUnitId(), "lowest_health") then
+            ArmyBrains[self.Army]:SetUnitStat(self.UnitId or self:GetUnitId(), "lowest_health", self:GetHealth())
         end
     end,
 

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -180,7 +180,7 @@ StructureUnit = Class(Unit) {
 
         -- Players and AI can build buildings outside of their faction. Get the *building's* faction to determine the correct tarrain-specific tarmac
         local factionTable = {e = 1, a = 2, r = 3, s = 4}
-        local faction  = factionTable[string.sub(self.UnitId, 2, 2)]
+        local faction  = factionTable[string.sub(self.UnitId or self:GetUnitId(), 2, 2)]
         if albedo and tarmac.Albedo then
             local albedo2 = tarmac.Albedo2
             if albedo2 then
@@ -367,15 +367,15 @@ StructureUnit = Class(Unit) {
         if FactionName == 'UEF' then
             self:HideBone(0, true)
             self.BeingBuiltShowBoneTriggered = false
-            if bp.General.UpgradesFrom ~= builder.UnitId then
+            if bp.General.UpgradesFrom ~= (builder.UnitId or builder:GetUnitId()) then
                 self:ForkThread(EffectUtil.CreateBuildCubeThread, builder, self.OnBeingBuiltEffectsBag)
             end
         elseif FactionName == 'Aeon' then
-            if bp.General.UpgradesFrom ~= builder.UnitId then
+            if bp.General.UpgradesFrom ~= (builder.UnitId or builder:GetUnitId()) then
                 self:ForkThread(EffectUtil.CreateAeonBuildBaseThread, builder, self.OnBeingBuiltEffectsBag)
             end
         elseif FactionName == 'Seraphim' then
-            if bp.General.UpgradesFrom ~= builder.UnitId then
+            if bp.General.UpgradesFrom ~= (builder.UnitId or builder:GetUnitId()) then
                 self:ForkThread(EffectUtil.CreateSeraphimBuildBaseThread, builder, self.OnBeingBuiltEffectsBag)
             end
         end
@@ -1695,7 +1695,7 @@ AirUnit = Class(MobileUnit) {
 
         -- Damage the area we hit. For damage, use the value which may have been adjusted by a shield impact
         if not self.deathWep or not self.DeathCrashDamage then -- Bail if stuff is missing
-            WARN('defaultunits.lua OnImpact: did not find a deathWep on the plane! Is the weapon defined in the blueprint? ' .. self.UnitId)
+            WARN('defaultunits.lua OnImpact: did not find a deathWep on the plane! Is the weapon defined in the blueprint? ' .. (self.UnitId or self:GetUnitId()))
         elseif self.DeathCrashDamage > 0 then -- It was completely absorbed by a shield!
             local deathWep = self.deathWep -- Use a local copy for speed and easy reading
             DamageArea(self, self:GetPosition(), deathWep.DamageRadius, self.DeathCrashDamage, deathWep.DamageType, deathWep.DamageFriendly)
@@ -1986,7 +1986,7 @@ ConstructionUnit = Class(MobileUnit) {
         self.UnitBeingBuilt = unitBeingBuilt
         self.UnitBuildOrder = order
         self.BuildingUnit = true
-        if unitBeingBuilt.UnitId == self:GetBlueprint().General.UpgradesTo and order == 'Upgrade' then
+        if (unitBeingBuilt.UnitId or unitBeingBuilt:GetUnitId) == self:GetBlueprint().General.UpgradesTo and order == 'Upgrade' then
             self.Upgrading = true
             self.BuildingUnit = false
         end
@@ -2384,7 +2384,7 @@ ACUUnit = Class(CommandUnit) {
 
     OnStopBeingBuilt = function(self, builder, layer)
         CommandUnit.OnStopBeingBuilt(self, builder, layer)
-        ArmyBrains[self.Army]:SetUnitStat(self.UnitId, "lowest_health", self:GetHealth())
+        ArmyBrains[self.Army]:SetUnitStat(self.UnitId or self:GetUnitId, "lowest_health", self:GetHealth())
         self.WeaponEnabled = {}
     end,
     
@@ -2401,8 +2401,8 @@ ACUUnit = Class(CommandUnit) {
             aiBrain:OnPlayCommanderUnderAttackVO()
         end
 
-        if self:GetHealth() < ArmyBrains[self.Army]:GetUnitStat(self.UnitId, "lowest_health") then
-            ArmyBrains[self.Army]:SetUnitStat(self.UnitId, "lowest_health", self:GetHealth())
+        if self:GetHealth() < ArmyBrains[self.Army]:GetUnitStat(self.UnitId or self:GetUnitId, "lowest_health") then
+            ArmyBrains[self.Army]:SetUnitStat(self.UnitId or self:GetUnitId, "lowest_health", self:GetHealth())
         end
     end,
 


### PR DESCRIPTION
It is entirely possible that a unit doesn't have self.UnitId defined, and it costs nothing to have a fallback.

This is specifically to fix a compatibility issues with BrewLAN walls, but it's entirely possible that other mod units will try to use those scripts and cause an error by not having self.UnitId defined. There's no reason to not fallback to self:GetUnitId when self.UnitId is nil.

This branch is for bugfixes, general improvements, and new features. If your change is designed to alter balance, please make 
sure your changes are rebased onto [development/balance] (https://github.com/FAForever/fa/tree/development/balance), and target that branch with your PR.