### PR TITLE
update harb rateoffire to accurately represent behaviour

### DIFF
--- a/units/UAL0303/UAL0303_unit.bp
+++ b/units/UAL0303/UAL0303_unit.bp
@@ -296,7 +296,7 @@ UnitBlueprint {
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = 'UWRC_DirectFire',
-            RateOfFire = 1.85,
+            RateOfFire = 2,
             TargetCheckInterval = 0.6,
             TargetPriorities = {
                 'TECH3 MOBILE',


### PR DESCRIPTION
1.85 -> 2

These numbers are functionally the same because the game works in ticks which are 1/10 of a second but a rof of 2 requires no rounding.