### PR TITLE
Speedup of score sync

### DIFF
--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -3,9 +3,13 @@ scoreInterval = 1
 resourcesInterval = 0.1
 alliesScore = true
 
-local scoreData = {current={}, historical={}}
-local scoreOption = ScenarioInfo.Options.Score or "no"
-local ArmyScore = {}
+local Victory = import('/lua/victory.lua')
+local ScoreHistory = {}
+local BpStatsToCollect = {}
+local ScoreEnabled = (ScenarioInfo.Options.Score or 'no') == 'no'
+local SentOnVictory = false
+local IsObserver = false
+
 
 -- Some of these values pre-existed and are used in other places, that's why their naming is not consistent
 local categoriesToCollect = {
@@ -23,27 +27,59 @@ local categoriesToCollect = {
     transportation=categories.TRANSPORTATION
 }
 
+local armyStatsToCollect = {
+    ['general.mass']                  = 'Economy_Stored_Mass',
+    ['general.energy']                = 'Economy_Stored_Energy',
 
-function UpdateScoreData(newData)
-    scoreData.current = table.deepcopy(newData)
+    ['general.currentunits.count']    = 'UnitCap_Current',
+    ['general.currentcap.count']      = 'UnitCap_MaxCap',
+    ['general.kills.count']           = 'Enemies_Killed',
+    ['general.kills.mass']            = 'Enemies_MassValue_Destroyed',
+    ['general.kills.energy']          = 'Enemies_EnergyValue_Destroyed',
+    ['general.kills.commander']       = 'Enemies_Commander_Destroyed',
+
+    ['general.built.count']           = 'Units_History',
+    ['general.built.mass']            = 'Units_MassValue_Built',
+    ['general.built.energy']          = 'Units_EnergyValue_Built',
+    ['general.lost.count']            = 'Units_Killed',
+    ['general.lost.mass']             = 'Units_MassValue_Lost',
+    ['general.lost.energy']           = 'Units_EnergyValue_Lost',
+
+    ['damage.total.dealt']            = 'DamageStats_TotalDamageDealt',
+    ['damage.total.received']         = 'DamageStats_TotalDamageReceived',
+    ['damage.units.dealt']            = 'Units_TotalDamageDealt',
+    ['damage.units.received']         = 'Units_TotalDamageReceived',
+
+    ['resources.massin.rate']         = 'Economy_Income_Mass',
+    ['resources.massin.total']        = 'Economy_TotalProduced_Mass',
+    ['resources.massout.rate']        = 'Economy_Output_Mass',
+    ['resources.massout.total']       = 'Economy_TotalConsumed_Mass',
+    ['resources.massover.total']      = 'Economy_AccumExcess_Mass',
+    ['resources.massreclaim.total']   = 'Economy_Reclaimed_Mass',
+    ['resources.energyin.total']      = 'Economy_TotalProduced_Energy',
+    ['resources.energyin.rate']       = 'Economy_Input_Energy',
+    ['resources.energyout.total']     = 'Economy_TotalConsumed_Energy',
+    ['resources.energyout.rate']      = 'Economy_Output_Energy',
+    ['resources.energyover.total']    = 'Economy_AccumExcess_Energy',
+    ['resources.energyreclaim.total'] = 'Economy_Reclaimed_Energy',
+}
+
+for categoryName, category in categoriesToCollect do
+    for k, v in {kills='Enemies_Killed', built='Units_History', lost='Units_Killed'} do
+        BpStatsToCollect[string.format("blueprints.%s.%s", categoryName, k)] = {name=v, category=category}
+    end
 end
 
 function CalculateBrainScore(brain)
-    local commanderKills = brain:GetArmyStat("Enemies_Commanders_Destroyed",0).Value
-    local massSpent = brain:GetArmyStat("Economy_TotalConsumed_Mass",0.0).Value
-    local massProduced = brain:GetArmyStat("Economy_TotalProduced_Mass",0.0).Value -- not currently being used
-    local energySpent = brain:GetArmyStat("Economy_TotalConsumed_Energy",0.0).Value
-    local energyProduced = brain:GetArmyStat("Economy_TotalProduced_Energy",0.0).Value -- not currently being used
-    local massValueDestroyed = brain:GetArmyStat("Enemies_MassValue_Destroyed",0.0).Value
-    local massValueLost = brain:GetArmyStat("Units_MassValue_Lost",0.0).Value
-    local energyValueDestroyed = brain:GetArmyStat("Enemies_EnergyValue_Destroyed",0.0).Value
-    local energyValueLost = brain:GetArmyStat("Units_EnergyValue_Lost",0.0).Value
+    local commanderKills = brain:GetArmyStat("Enemies_Commanders_Destroyed", 0).Value
+    local massSpent = brain:GetArmyStat("Economy_TotalConsumed_Mass", 0).Value
+    local energySpent = brain:GetArmyStat("Economy_TotalConsumed_Energy", 0).Value
+    local massValueDestroyed = brain:GetArmyStat("Enemies_MassValue_Destroyed", 0).Value
+    local massValueLost = brain:GetArmyStat("Units_MassValue_Lost", 0).Value
+    local energyValueDestroyed = brain:GetArmyStat("Enemies_EnergyValue_Destroyed", 0).Value
+    local energyValueLost = brain:GetArmyStat("Units_EnergyValue_Lost", 0).Value
 
-    -- helper variables to make equation more clear
-    local excessMassProduced = massProduced - massSpent -- not currently being used
-    local excessEnergyProduced = energyProduced - energySpent -- not currently being used
     local energyValueCoefficient = 20
-    local commanderKillBonus = commanderKills + 1 -- not currently being used
 
     -- score components calculated
     local resourceProduction = ((massSpent) + (energySpent / energyValueCoefficient)) / 2
@@ -58,230 +94,233 @@ function CalculateBrainScore(brain)
     return score
 end
 
-function ScoreHistoryThread()
-    while true do
-        WaitSeconds(historyInterval)
-        table.insert(scoreData.historical, table.deepcopy(scoreData.current))
+function CalculateAllScores(armyScore)
+    for army, score in armyScore do
+        if score['general.score'] == -1 then
+            score['general.score'] = CalculateBrainScore(ArmyBrains[army])
+        end
+    end
+end
+
+local lastHistoryValues = {}
+function StoreScoreInHistory(armyScore, second)
+    local lastValues = lastHistoryValues
+    for army, score in armyScore do
+        local brain = ArmyBrains[army]
+
+        for key, value in score do
+            if not ScoreHistory[key] then
+                ScoreHistory[key] = {}
+            end
+
+            if not ScoreHistory[key][army] then
+                ScoreHistory[key][army] = {}
+            end
+
+            if not lastValues[key] then
+                lastValues[key] = {}
+            end
+
+            if key == 'general.score' and value == -1 then
+                value = CalculateBrainScore(brain)
+            end
+
+            if lastValues[key][army] ~= value then
+                ScoreHistory[key][army][second] = value
+                lastValues[key][army] = value
+            end
+        end
     end
 end
 
 function ScoreThread()
+    local armyScore = {}
+
     for index, brain in ArmyBrains do
-        ArmyScore[index] = {
-            faction = 0,
-            name = '',
-            type = '',
-            general = {
-                score = 0,
-                mass = 0,
-                lastReclaimedMass = 0,
-                lastReclaimedEnergy = 0,
-                energy = 0,
-                kills = {
-                    count = 0,
-                    mass = 0,
-                    energy = 0
-                },
-                built = {
-                    count = 0,
-                    mass = 0,
-                    energy = 0
-                },
-                lost = {
-                    count = 0,
-                    mass = 0,
-                    energy = 0
-                },
-                currentunits = {
-                    count = 0
-                },
-                currentcap = {
-                    count = 0
-                }
-            },
-
-            blueprints = {
-                -- filled dynamically below
-            },
-
-            units = {
-                -- filled dynamically below
-            },
-
-            resources = {
-                massin = {
-                    total = 0,
-                    rate = 0
-                },
-                massout = {
-                    total = 0,
-                    rate = 0
-                },
-                energyin = {
-                    total = 0,
-                    rate = 0
-                },
-                energyout = {
-                    total = 0,
-                    rate = 0
-                },
-                massover = {
-                    total = 0,
-                    rate = 0
-                },
-                energyover = {
-                    total = 0,
-                    rate = 0
-                },
-                storage = {
-                    storedMass = 0,
-                    storedEnergy = 0,
-                    maxMass = 0,
-                    maxEnergy = 0,
-                },
-                MassReclaimRate = 0,
-                EnergyReclaimRate = 0
-            }
-        }
-
-        for categoryName, category in categoriesToCollect do
-            ArmyScore[index].units[categoryName] = {
-                kills = 0,
-                built = 0,
-                lost = 0
+        if not ArmyIsCivilian(index) then
+            armyScore[index] = {
+                faction = brain:GetFactionIndex(),
+                name = brain.Nickname,
+                type = brain.BrainType,
             }
         end
     end
 
-    ForkThread(ScoreDisplayResourcesThread)
-
+    local SCORE_WAIT = math.max(0.1, scoreInterval - table.getsize(armyScore) * 0.1)
+    local last_tick = {}
+    local nextHistorySecond = 0
+    
     while true do
-        local updInterval = scoreInterval / table.getsize(ArmyBrains)
-        for index, brain in ArmyBrains do
-            ArmyScore[index].faction = brain:GetFactionIndex()
-            ArmyScore[index].name = brain.Nickname
-            ArmyScore[index].type = brain.BrainType
-            ArmyScore[index].general.score = CalculateBrainScore(brain)
+        local calcScore = ScoreEnabled or IsObserver
 
-            ArmyScore[index].general.mass = brain:GetArmyStat("Economy_TotalProduced_Mass", 0.0).Value
-            ArmyScore[index].general.energy = brain:GetArmyStat("Economy_TotalProduced_Energy", 0.0).Value
-            ArmyScore[index].general.currentunits.count = brain:GetArmyStat("UnitCap_Current", 0.0).Value
-            ArmyScore[index].general.currentcap.count = brain:GetArmyStat("UnitCap_MaxCap", 0.0).Value
-
-            ArmyScore[index].general.kills.count = brain:GetArmyStat("Enemies_Killed", 0.0).Value
-            ArmyScore[index].general.kills.mass = brain:GetArmyStat("Enemies_MassValue_Destroyed", 0.0).Value
-            ArmyScore[index].general.kills.energy = brain:GetArmyStat("Enemies_EnergyValue_Destroyed", 0.0).Value
-
-            ArmyScore[index].general.built.count = brain:GetArmyStat("Units_History", 0.0).Value
-            ArmyScore[index].general.built.mass = brain:GetArmyStat("Units_MassValue_Built", 0.0).Value
-            ArmyScore[index].general.built.energy = brain:GetArmyStat("Units_EnergyValue_Built", 0.0).Value
-            ArmyScore[index].general.lost.count = brain:GetArmyStat("Units_Killed", 0.0).Value
-            ArmyScore[index].general.lost.mass = brain:GetArmyStat("Units_MassValue_Lost", 0.0).Value
-            ArmyScore[index].general.lost.energy = brain:GetArmyStat("Units_EnergyValue_Lost", 0.0).Value
-
-            ArmyScore[index].resources.massin.total = brain:GetArmyStat("Economy_TotalProduced_Mass", 0.0).Value
-            ArmyScore[index].resources.massout.total = brain:GetArmyStat("Economy_TotalConsumed_Mass", 0.0).Value
-            ArmyScore[index].resources.massout.rate = brain:GetArmyStat("Economy_Output_Mass", 0.0).Value
-            ArmyScore[index].resources.massover.total = brain:GetArmyStat("Economy_AccumExcess_Mass", 0.0).Value
-
-            ArmyScore[index].resources.energyin.total = brain:GetArmyStat("Economy_TotalProduced_Energy", 0.0).Value
-            ArmyScore[index].resources.energyout.total = brain:GetArmyStat("Economy_TotalConsumed_Energy", 0.0).Value
-            ArmyScore[index].resources.energyout.rate = brain:GetArmyStat("Economy_Output_Energy", 0.0).Value
-            ArmyScore[index].resources.energyover.total = brain:GetArmyStat("Economy_AccumExcess_Energy", 0.0).Value
-
-            ArmyScore[index].resources.storage.storedMass = brain:GetEconomyStored('MASS')
-            ArmyScore[index].resources.storage.storedEnergy = brain:GetEconomyStored('ENERGY')
-
-            ArmyScore[index].resources.storage.maxMass = brain:GetArmyStat("Economy_MaxStorage_Mass", 0.0).Value
-            ArmyScore[index].resources.storage.maxEnergy = brain:GetArmyStat("Economy_MaxStorage_Energy", 0.0).Value
-
-            for unitId, stats in brain.UnitStats do
-                if ArmyScore[index].blueprints[unitId] == nil then
-                    ArmyScore[index].blueprints[unitId] = {}
-                end
-
-                for statName, value in stats do
-                    ArmyScore[index].blueprints[unitId][statName] = value
-                end
+        for army, t in armyScore do
+            local brain = ArmyBrains[army]
+            if brain:IsDefeated() then continue end
+            
+            local tick = GetGameTick()
+            
+            if calcScore then
+                t['general.score'] = CalculateBrainScore(brain)
+            else
+                t['general.score'] = -1
             end
 
-            for categoryName, category in categoriesToCollect do
-                ArmyScore[index].units[categoryName]['kills'] = brain:GetBlueprintStat("Enemies_Killed", category)
-                ArmyScore[index].units[categoryName]['built'] = brain:GetBlueprintStat("Units_History", category)
-                ArmyScore[index].units[categoryName]['lost'] = brain:GetBlueprintStat("Units_Killed", category)
+            local lastReclaimMass = t['general.massreclaim.total'] or 0
+            local lastReclaimEnergy = t['general.energyreclaim.total'] or 0
+
+            for k, s in armyStatsToCollect do
+                t[k] = brain:GetArmyStat(s, 0).Value
             end
 
-            WaitSeconds(updInterval)
+            local tick_diff = tick - (last_tick[army] or 0)
+            local reclaimRate
+
+            -- Subtract reclaim from mass income
+            reclaimRate = (t['resources.massreclaim.total'] - lastReclaimMass) / tick_diff
+            t['resources.massin.rate'] = t['resources.massin.rate'] - reclaimRate
+            t['resources.massover.rate'] = t['resources.massin.rate'] - t['resources.massout.rate']
+            t['resources.massreclaim.rate'] = reclaimRate
+
+            -- Subtract reclaim from energy income
+            reclaimRate = (t['resources.energyreclaim.total'] - lastReclaimEnergy) / tick_diff
+            t['resources.energyin.rate'] = t['resources.energyin.rate'] - reclaimRate
+            t['resources.energyover.rate'] = t['resources.energyin.rate'] - t['resources.energyout.rate']
+            t['resources.energyreclaim.rate'] = reclaimRate
+
+            last_tick[army] = tick
+
+            WaitSeconds(0.1)
         end
 
-        UpdateScoreData(ArmyScore)
-        SyncScores()
+        local currentSecond = GetGameTick() / 10
+        if nextHistorySecond <= currentSecond then
+            StoreScoreInHistory(armyScore, nextHistorySecond)
+            nextHistorySecond = nextHistorySecond + historyInterval
+        end
+
+        SyncScores(armyScore)
+        WaitSeconds(SCORE_WAIT)
     end
 end
 
-function ScoreDisplayResourcesThread()
-    -- For certain stats, we need to do this every tick. We can't for all because it is quite heavy CPU
-    -- We don't need to sync every tick though, just make sure the number is right
-    while true do
-        for index, brain in ArmyBrains do
-            local reclaimedMass = brain:GetArmyStat("Economy_Reclaimed_Mass", 0.0).Value
-            local massReclaimRate = reclaimedMass - ArmyScore[index].general.lastReclaimedMass
-            ArmyScore[index].resources.MassReclaimRate = massReclaimRate
-            ArmyScore[index].resources.massin.rate = brain:GetArmyStat("Economy_Income_Mass", 0.0).Value - massReclaimRate
-            ArmyScore[index].general.lastReclaimedMass = reclaimedMass
-            ArmyScore[index].resources.massover.rate = ArmyScore[index].resources.massin.rate - ArmyScore[index].resources.massout.rate + ArmyScore[index].resources.MassReclaimRate
-
-            local reclaimedEnergy = brain:GetArmyStat("Economy_Reclaimed_Energy", 0.0).Value
-            local energyReclaimRate = reclaimedEnergy - ArmyScore[index].general.lastReclaimedEnergy
-            ArmyScore[index].resources.EnergyReclaimRate = energyReclaimRate
-            ArmyScore[index].resources.energyin.rate = brain:GetArmyStat("Economy_Income_Energy", 0.0).Value - energyReclaimRate
-            ArmyScore[index].general.lastReclaimedEnergy = reclaimedEnergy
-            ArmyScore[index].resources.energyover.rate = ArmyScore[index].resources.energyin.rate - ArmyScore[index].resources.energyout.rate + ArmyScore[index].resources.EnergyReclaimRate
-        end
-        WaitSeconds(resourcesInterval)
-    end
-end
-
-local observer = false
-function SyncScores()
+function SyncScores(armyScore)
     local myArmyIndex = GetFocusArmy()
-    observer = myArmyIndex == -1
 
-    local victory = import('/lua/victory.lua')
-    if observer or victory.gameOver or SessionIsReplay() then
-        Sync.FullScoreSync = true
-        Sync.ScoreAccum = scoreData
-        Sync.Score = scoreData.current
-
-        -- We don't want to report full scores to server unless game over
-        if victory.gameOver then
-            Sync.StatsToSend = Sync.Score
-        end
+    IsObserver = IsObserver or myArmyIndex == -1 or SessionIsReplay()
+    if IsObserver or Victory.gameOver then
+        SyncFullScore(armyScore)
     else
-        for index, brain in ArmyBrains do
-            if brain.Result and not brain.StatsSent then
-                Sync.StatsToSend = table.deepcopy(scoreData.current)
-                brain.StatsSent = true
-            end
+        SyncCurrentScore(armyScore)
+    end
+end
 
-            if (myArmyIndex == index) or (alliesScore and IsAlly(myArmyIndex, index)) then
-                Sync.Score[index] = ArmyScore[index]
-            else
-                Sync.Score[index] = {}
-                Sync.Score[index].general = {}
-            end
+function SyncCurrentScore(armyScore)
+    local myArmyIndex = GetFocusArmy()
+    local scoreEnabled = ScoreEnabled
+    Sync.Score = {}
 
-            if scoreOption ~= 'no' then
-                Sync.Score[index].general.score = ArmyScore[index].general.score
-            else
-                Sync.Score[index].general.score = -1
+    for index, score in armyScore do
+        local brain = ArmyBrains[index]
+        if brain.Result and not brain.StatsSent then
+            SyncStats(armyScore)
+            brain.StatsSent = true
+        end
+
+        local syncScore
+        if (myArmyIndex == index) or (alliesScore and IsAlly(myArmyIndex, index) and not ArmyIsCivilian(index)) then
+            syncScore = score
+        else 
+            syncScore = {}
+        end
+
+        if not scoreEnabled then
+            syncScore['general.score'] = -1
+        else
+            syncScore['general.score'] = score['general.score']
+        end
+
+        Sync.Score[index] = syncScore
+    end
+end
+
+function SyncFullScore(armyScore)
+    -- We don't want to report full stats / history to server unless game over
+    if Victory.gameOver and not SentOnVictory then
+        CalculateAllScores(armyScore)
+        SyncStats(armyScore)
+        SyncHistory()
+        SentOnVictory = true
+    end
+
+    Sync.FullScoreSync = true
+    Sync.Score = armyScore
+end
+
+function SyncStats(armyScore)
+    local sendStats = {}
+
+    for index, score in armyScore do
+        local brain = ArmyBrains[index]
+        local t = {}
+
+        for unitId, stats in brain.UnitStats do
+            for statName, value in stats do
+                t[string.format("units.%s.%s", unitId, statName)] = value
             end
         end
 
+        for k, stat in BpStatsToCollect do
+            t[k] = brain:GetBlueprintStat(stat.name, stat.category)
+        end
+
+        sendStats[index] = t
     end
+
+    Sync.StatsToSend = sendStats
+end
+
+function SyncHistory()
+    local jsonOptions = {keyorder={}}
+    local lastSecond = math.round(GetGameTick() / 10)
+    local i
+
+    for i=0, lastSecond, historyInterval do
+        table.insert(jsonOptions.keyorder, i)
+    end
+
+    -- Rebuild history to old format so hotstats doesn't break
+    local finalHistory = {}
+    local currentValues = {}
+    for i=0, lastSecond, historyInterval do
+        local history = {}
+        for k, armies in ScoreHistory do
+            for army, values in armies do
+                local value
+
+                if not history[army] then
+                    history[army] = {}
+                end
+
+                if not currentValues[army] then
+                    currentValues[army] = {}
+                end
+
+                if values[i] ~= nil then
+                    currentValues[army][k] = values[i]
+                end
+
+                history[army][k] = currentValues[army][k]
+            end
+        end
+
+        table.insert(finalHistory, history)
+    end
+
+    Sync.ScoreHistory = finalHistory
+    --local json = import('/lua/system/dkson.lua').json.encode(ScoreHistory, jsonOptions)
+    --SPEW(json)
 end
 
 function init()
     ForkThread(ScoreThread)
-    ForkThread(ScoreHistoryThread)
 end

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -524,6 +524,43 @@ function table.unique(t)
     return unique
 end
 
+-- flatten nested keys of a table into dot notation
+function table.flatten(t, ret, index)
+    if type(t) ~= 'table' then
+        ret[index] = t
+        return
+    end
+
+    ret = ret or {}
+    for k, v in t do
+        table.flatten(v, ret, index and (index .. '.' .. k) or k)
+    end
+
+    return ret
+end
+
+-- inflate a table with dot-notation into a multi-dimension table
+function table.inflate(t)
+    if type(t) ~= 'table' then return t end
+    local nested, curr = {}, nil
+
+    for k, v in pairs(t) do
+        local last_t, last_key
+
+        curr = nested
+        for key in string.gfind(k, '([^.]+)') do
+            key = tonumber(key) or key
+            curr[key] = curr[key] or {}
+            last_key, last_t = key, curr
+            curr = curr[key]
+        end
+
+        last_t[last_key] = table.inflate(v)
+    end
+
+    return nested
+end
+
 --- Returns items as a single string, separated by the delimiter
 function StringJoin(items, delimiter)
     local str = "";

--- a/lua/ui/game/scoreaccum.lua
+++ b/lua/ui/game/scoreaccum.lua
@@ -5,112 +5,6 @@
 --*
 --* Copyright © :005 Gas Powered Games, Inc.  All rights reserved.
 --*****************************************************************************
-
--- this table collects score info from the sync table and stores it for later use
--- it keeps both historical data (controled by the interval) and current tick data
--- typically it's used for the post game score screen, but could be used during the game as well
-
---[[
-TABLE FORMAT
-
-scoreData {
-    current {
-        playerIndex {
-            general {
-                score,
-                mass,
-                energy,
-                kills {
-                    count,
-                    mass,
-                    energy,
-                }
-                built {
-                    count,
-                    mass,
-                    energy,
-                }
-                lost {
-                    count,
-                    mass,
-                    energy,
-                }
-            },
-            units {
-                cdr {
-                    kills,
-                    built,
-                    lost,
-                },
-                land {
-                    kills,
-                    built,
-                    lost,
-                },
-                air {
-                    kills,
-                    built,
-                    lost,
-                },
-                naval {
-                    kills,
-                    built,
-                    lost,
-                },
-                structures {
-                    kills,
-                    built,
-                    lost,
-                },
-                experimental {
-                    kills,
-                    built,
-                    lost,
-                },
-                ... and more for specific units
-            },
-            resources {
-                massin {
-                    total,
-                    rate,
-                },
-                massout {
-                    total,
-                    rate,
-                },
-                massover {
-                    total,
-                    rate,
-                },
-                energyin {
-                    total,
-                    rate,
-                },
-                energyout {
-                    total,
-                    rate,
-                },
-                energyover {
-                    total,
-                    rate,
-                },
-            },
-        }
-        ... for each player
-    },
-    historical {
-        [interval1] {
-            same data as in current
-        },
-        [interval2] {
-        },
-        ... for each time interval
-    },
-}
-
---]]
-
--- global score data can be read from directly
 scoreData = {}
 scoreData.current = {}
 scoreData.historical = {}
@@ -120,13 +14,17 @@ fullSyncOccured = false
 -- score interval determines how often the historical data gets updated, this is in seconds
 scoreInterval = 10 -- FIXME: this should be synced from sim side
 
-function UpdateScoreData(newData)
+function UpdateScoreData(score)
     if fullSyncOccured == false then
-        scoreData.current = table.deepcopy(newData)
+        scoreData.current = score
     end
 end
 
-function OnFullSync(accumData)
-    scoreData = accumData
+function OnFullSync(score)
+    scoreData.current = score
     fullSyncOccured = true
+end
+
+function UpdateScoreHistory(history) 
+    scoreData.historical = history
 end

--- a/schook/lua/UserSync.lua
+++ b/schook/lua/UserSync.lua
@@ -30,7 +30,7 @@ OnSync = function()
     end
 
     if Sync.ObjectiveTimer then
-        if Sync.ObjectiveTimer != false then
+        if Sync.ObjectiveTimer ~= false then
             import('/lua/ui/game/timer.lua').SetTimer(Sync.ObjectiveTimer)
         else
             import('/lua/ui/game/timer.lua').ResetTimer()
@@ -83,19 +83,23 @@ OnSync = function()
     end
 
     if not table.empty(Sync.Score) then
-        import('/lua/ui/game/score.lua').currentScores = Sync.Score
-        if not Sync.FullScoreSync then
-            import('/lua/ui/game/scoreaccum.lua').UpdateScoreData(Sync.Score)
+        local score = table.inflate(Sync.Score)
+        import('/lua/ui/game/score.lua').currentScores = score
+
+        if Sync.FullScoreSync then
+            import('/lua/ui/game/scoreaccum.lua').OnFullSync(score)
+        else
+            import('/lua/ui/game/scoreaccum.lua').UpdateScoreData(score)
         end
     end
 
-    if Sync.FullScoreSync then
-        if not table.empty(Sync.ScoreAccum) then
-            import('/lua/ui/game/scoreaccum.lua').OnFullSync(Sync.ScoreAccum)
-        end
+    if not table.empty(Sync.ScoreHistory) then
+        local history = table.inflate(Sync.ScoreHistory)
+       
+        import('/lua/ui/game/scoreaccum.lua').scoreData.historical = history
     end
 
-    if not import("/lua/ui/dialogs/eschandler.lua").isExiting then
+    if not table.empty(Sync.GameResult) and not import("/lua/ui/dialogs/eschandler.lua").isExiting then
         for _, gameResult in Sync.GameResult do
             local armyIndex, result = unpack(gameResult)
             LOG(string.format('Sending game result: %i %s', armyIndex, result))
@@ -105,8 +109,9 @@ OnSync = function()
     end
 
     if Sync.StatsToSend then
-        local json = import('/lua/system/dkson.lua').json.encode({ stats = Sync.StatsToSend })
-        LOG('Sending stats: '..json)
+        local inflated = table.inflate(Sync.StatsToSend)
+        local json = import('/lua/system/dkson.lua').json.encode({ stats = inflated })
+        SPEW('Sending stats: '..json)
         GpgNetSend('JsonStats', json)
         Sync.StatsToSend = nil
     end
@@ -121,7 +126,7 @@ OnSync = function()
         end
     end
 
-    if Sync.Paused != PreviousSync.Paused then
+    if Sync.Paused ~= PreviousSync.Paused then
         import("/lua/ui/game/gamemain.lua").OnPause(Sync.Paused);
     end
 
@@ -146,7 +151,7 @@ OnSync = function()
         local isare = LOC('<LOC cheating_fragment_0000>is')
         local srcs = SessionGetCommandSourceNames()
         for k,v in ipairs(Sync.Cheaters) do
-            if names != '' then
+            if names ~= '' then
                 names = names .. ', '
                 isare = LOC('<LOC cheating_fragment_0001>are')
             end
@@ -221,7 +226,7 @@ OnSync = function()
         import('/lua/ui/game/objectives2.lua').RemovePingGroups(Sync.RemovePingGroups)
     end
 
-    if Sync.SetAlliedVictory != nil then
+    if Sync.SetAlliedVictory ~= nil then
         import('/lua/ui/game/diplomacy.lua').SetAlliedVictory(Sync.SetAlliedVictory)
     end
 
@@ -269,7 +274,7 @@ OnSync = function()
         import('/lua/ui/game/gamemain.lua').IsSavedGame = true
     end
 
-    if Sync.ChangeCameraZoom != nil then
+    if Sync.ChangeCameraZoom ~= nil then
         import('/lua/ui/game/gamemain.lua').SimChangeCameraZoom(Sync.ChangeCameraZoom)
     end
 end


### PR DESCRIPTION
**Experiment: DO NOT MERGE, untested**

* Do not calculate score / history for civilian
* Do not calculate stats for dead players
* Only store delta changes in history table
* Do not sync everything in ArmyScore (unit bp stats etc), only store this in history
* Reduce number of tables by flattening structure
* Reduce number of score threads running

@KionX Take a look at this and see if this speeds up game / replays