### PR TITLE
rebalance T3 sonar stealth

### DIFF
--- a/units/URS0305/URS0305_unit.bp
+++ b/units/URS0305/URS0305_unit.bp
@@ -168,10 +168,10 @@ UnitBlueprint {
         UpgradesFrom = 'urb3202',
     },
     Intel = {
-        RadarStealthFieldRadius = 45,
+        RadarStealthFieldRadius = 70,
         ShowIntelOnSelect = true,
         SonarRadius = 450,
-        SonarStealthFieldRadius = 90,
+        SonarStealthFieldRadius = 70,
         VisionRadius = 32,
         WaterVisionRadius = 24,
     },


### PR DESCRIPTION
- nerf sonar stealth from 90 to 70
- buff radar stealth from 45 to 70

get the same range for both stealth, so it makes sense ui wise when displaying the stealth range.