### PR TITLE
Update strings_db.lua for T3 Mass Fabs and Engineering Drones

### DIFF
--- a/loc/US/strings_db.lua
+++ b/loc/US/strings_db.lua
@@ -1540,7 +1540,7 @@ Unit_Description_0094="Generates 500 Energy per second. Construct next to other 
 Unit_Description_0095="Extracts 6 mass per second. Must be constructed on mass deposits. Construct structures next to mass extractor for adjacency bonus. Can be upgraded."
 Unit_Description_0096="Generates 2500 energy per second. Construct next to other energy consuming structures for adjacency bonus."
 Unit_Description_0097="Generates 18 mass per second. Must be constructed on mass deposits. Construct structures next to mass extractor for adjacency bonus."
-Unit_Description_0098="Creates 12 mass per second using 3500 energy per second. Construct next to other energy consuming structures for adjacency bonus."
+Unit_Description_0098="Creates 12 mass per second using 1500 energy per second. Construct next to other energy consuming structures for adjacency bonus."
 
 -- UEF -- Engineers
 Unit_Description_0076="Tech 1 amphibious construction, repair, capture and reclamation unit."
@@ -1549,8 +1549,8 @@ Unit_Description_0078="Tech 3 amphibious construction, repair, capture and recla
 Unit_Description_0315="Tech 2 Fast-moving amphibious construction, repair, capture and reclamation unit armed with a Riot Gun, radar and radar jamming. Can only build offensive buildings, no economy."
 Unit_Description_0446="Houses one flying Drone which automatically assists or repairs any unit with its operational radius. Can be ordered to fly around and reclaim, but cannot initiate construction."
 Unit_Description_0453="Houses two flying Drones, each of which automatically assists or repairs any unit with its operational radius. Can be ordered to fly around and reclaim, but cannot initiate construction."
-Unit_Description_0458="Flying Drone which can assists, repairs, and reclaim any unit. Can be ordered to initiate construction of T1 structures. It's vulnerable to any air fighters or anti-air units"
-Unit_Description_0459="Flying Drone which can assists, repairs, and reclaim any unit. Can be ordered to initiate construction of T3 structures. It's vulnerable to any air fighters or anti-air units"
+Unit_Description_0458="Flying Drone which can assist, repairs, and reclaim any unit. Can be ordered to initiate construction of T1 structures. It's vulnerable to any air fighters or anti-air units"
+Unit_Description_0459="Flying Drone which can assist, repairs, and reclaim any unit. Can be ordered to initiate construction of T3 structures. It's vulnerable to any air fighters or anti-air units"
 
 -- UEF -- Factories HQ
 Unit_Description_0079="Constructs Tech 1 Land units. Upgradeable to T2 Factory HQ which allows you to upgrade other T1 factories to T2 support factories for a much cheaper cost."
@@ -1703,7 +1703,7 @@ Unit_Description_0211="Generates 500 Energy per second. Construct next to other 
 Unit_Description_0212="Extracts 6 mass per second. Must be constructed on mass deposits. Construct structures next to mass extractor for adjacency bonus. Can be upgraded."
 Unit_Description_0213="Generates 2500 energy per second. Construct next to other energy consuming structures for adjacency bonus."
 Unit_Description_0214="Generates 18 mass per second. Must be constructed on mass deposits. Construct structures next to mass extractor for adjacency bonus."
-Unit_Description_0215="Creates 12 mass per second using 3500 energy per second. Construct next to other energy consuming structures for adjacency bonus."
+Unit_Description_0215="Creates 12 mass per second using 1500 energy per second. Construct next to other energy consuming structures for adjacency bonus."
 
 -- CYBRAN -- Engineers
 Unit_Description_0193="Tech 1 amphibious construction, repair, capture and reclamation unit."
@@ -1860,7 +1860,7 @@ Unit_Description_0291="Generates 500 Energy per second. Construct next to other 
 Unit_Description_0292="Extracts 6 mass per second. Must be constructed on mass deposits. Construct structures next to mass extractor for adjacency bonus. Can be upgraded."
 Unit_Description_0293="Generates 2500 energy per second. Construct next to other energy consuming structures for adjacency bonus."
 Unit_Description_0294="Generates 18 mass per second. Must be constructed on mass deposits. Construct structures next to mass extractor for adjacency bonus."
-Unit_Description_0295="Creates 12 mass per second using 3500 energy per second. Construct next to other energy consuming structures for adjacency bonus."
+Unit_Description_0295="Creates 12 mass per second using 1500 energy per second. Construct next to other energy consuming structures for adjacency bonus."
 Unit_Description_0336="Generates an adaptive economy of up to 10000 mass per second and 1000000 energy per second. When killed the reactor core destabilizes in a fully-fledged nuclear explosion."
 
 -- AEON -- Engineers
@@ -2004,7 +2004,7 @@ Unit_Description_0406="Generates 500 Energy per second. Construct next to other 
 Unit_Description_0407="Extracts 6 mass per second. Must be constructed on mass deposits. Construct structures next to mass extractor for adjacency bonus. Can be upgraded."
 Unit_Description_0408="Generates 2500 energy per second. Construct next to other energy consuming structures for adjacency bonus."
 Unit_Description_0409="Generates 18 mass per second. Must be constructed on mass deposits. Construct structures next to mass extractor for adjacency bonus."
-Unit_Description_0410="Creates 12 mass per second using 3500 energy per second. Construct next to other energy consuming structures for adjacency bonus."
+Unit_Description_0410="Creates 12 mass per second using 1500 energy per second. Construct next to other energy consuming structures for adjacency bonus."
 
 -- SERAPHIM -- Engineers
 Unit_Description_0387="Tech 1 amphibious construction, Repair, Capture and Reclamation unit."


### PR DESCRIPTION
Changed T3 Mass Fabricator description for all 4 races from "3500" to "1500" to match its in-game Yield.

Changed "assists" to "assist" for the Engineering drones to make grammatical sense.

This branch is for bugfixes, general improvements, and new features. If your change is designed to alter balance, please make 
sure your changes are rebased onto [development/balance] (https://github.com/FAForever/fa/tree/development/balance), and target that branch with your PR.