### PR TITLE
Issue/#3087 Result reporting on 'Exit to Windows` fix

### DIFF
--- a/lua/ui/dialogs/eschandler.lua
+++ b/lua/ui/dialogs/eschandler.lua
@@ -11,14 +11,11 @@ local Prefs = import('/lua/user/prefs.lua')
 local Utils = import('/lua/system/utils.lua')
 
 local quickDialog = false
--- Used to skip result reporting when we exit the game early
-isExiting = false
 
 -- Terminate the game in a vaguely graceful fashion. This may or may not reduce the amount of times
 -- sudden quits lead to players having to wait for a timeout.
 function SafeQuit()
     if SessionIsActive() and not SessionIsReplay() then
-        isExiting = true
         ForkThread(function ()
             ConExecute('ren_oblivion true')
             ConExecute('ren_ui false')

--- a/schook/lua/UserSync.lua
+++ b/schook/lua/UserSync.lua
@@ -95,11 +95,13 @@ OnSync = function()
         end
     end
 
-    for _, gameResult in Sync.GameResult do
-        local armyIndex, result = unpack(gameResult)
-        LOG(string.format('Sending game result: %i %s', armyIndex, result))
-        GpgNetSend('GameResult', armyIndex, result)
-        import('/lua/ui/game/gameresult.lua').DoGameResult(armyIndex, result)
+    if not Sync.RequestingExit then
+        for _, gameResult in Sync.GameResult do
+            local armyIndex, result = unpack(gameResult)
+            LOG(string.format('Sending game result: %i %s', armyIndex, result))
+            GpgNetSend('GameResult', armyIndex, result)
+            import('/lua/ui/game/gameresult.lua').DoGameResult(armyIndex, result)
+        end
     end
 
     if Sync.StatsToSend then

--- a/schook/lua/UserSync.lua
+++ b/schook/lua/UserSync.lua
@@ -95,13 +95,11 @@ OnSync = function()
         end
     end
 
-    if not import("/lua/ui/dialogs/eschandler.lua").isExiting then
-        for _, gameResult in Sync.GameResult do
-            local armyIndex, result = unpack(gameResult)
-            LOG(string.format('Sending game result: %i %s', armyIndex, result))
-            GpgNetSend('GameResult', armyIndex, result)
-            import('/lua/ui/game/gameresult.lua').DoGameResult(armyIndex, result)
-        end
+    for _, gameResult in Sync.GameResult do
+        local armyIndex, result = unpack(gameResult)
+        LOG(string.format('Sending game result: %i %s', armyIndex, result))
+        GpgNetSend('GameResult', armyIndex, result)
+        import('/lua/ui/game/gameresult.lua').DoGameResult(armyIndex, result)
     end
 
     if Sync.StatsToSend then


### PR DESCRIPTION
New idea, use existing `RequestingExit` property of the Sync table to selectively ignore results. I found this property after tracing what happens when a user clicks the "Score" button, as this turns out to be another way of causing the false results. I suspect it can happen whenever the simulation is stopped early, which probably causes the engine to set all players to "defeated" for a brief moment before exiting. However, I am also hoping that this same code will also be setting the `RequestingExit` property at the same time, and that we can use this to ignore results. 

Still needs to be tested.

Hopefully fixes #3087.