### PR TITLE
improved T3 air crash

### DIFF
--- a/units/UAA0302/UAA0302_unit.bp
+++ b/units/UAA0302/UAA0302_unit.bp
@@ -244,9 +244,9 @@ UnitBlueprint {
     Weapon = {
         {
             AboveWaterTargetsOnly = true,
-            Damage = 100,
+            Damage = 150,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/UAA0303/UAA0303_unit.bp
+++ b/units/UAA0303/UAA0303_unit.bp
@@ -341,7 +341,7 @@ UnitBlueprint {
             AboveWaterTargetsOnly = true,
             Damage = 200,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/UAA0304/UAA0304_unit.bp
+++ b/units/UAA0304/UAA0304_unit.bp
@@ -328,7 +328,7 @@ UnitBlueprint {
             AboveWaterTargetsOnly = true,
             Damage = 500,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/UEA0302/UEA0302_unit.bp
+++ b/units/UEA0302/UEA0302_unit.bp
@@ -252,9 +252,9 @@ UnitBlueprint {
     Weapon = {
         {
             AboveWaterTargetsOnly = true,
-            Damage = 100,
+            Damage = 150,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/UEA0303/UEA0303_unit.bp
+++ b/units/UEA0303/UEA0303_unit.bp
@@ -417,7 +417,7 @@ UnitBlueprint {
             AboveWaterTargetsOnly = true,
             Damage = 200,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/UEA0304/UEA0304_unit.bp
+++ b/units/UEA0304/UEA0304_unit.bp
@@ -488,7 +488,7 @@ UnitBlueprint {
             AboveWaterTargetsOnly = true,
             Damage = 500,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/UEA0305/UEA0305_unit.bp
+++ b/units/UEA0305/UEA0305_unit.bp
@@ -467,7 +467,7 @@ UnitBlueprint {
             AboveWaterTargetsOnly = true,
             Damage = 300,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/URA0302/URA0302_unit.bp
+++ b/units/URA0302/URA0302_unit.bp
@@ -255,9 +255,9 @@ UnitBlueprint {
     },
     Weapon = {
         {
-            Damage = 100,
+            Damage = 150,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/URA0303/URA0303_unit.bp
+++ b/units/URA0303/URA0303_unit.bp
@@ -421,7 +421,7 @@ UnitBlueprint {
             AboveWaterTargetsOnly = true,
             Damage = 200,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/URA0304/URA0304_unit.bp
+++ b/units/URA0304/URA0304_unit.bp
@@ -501,7 +501,7 @@ UnitBlueprint {
             AboveWaterTargetsOnly = true,
             Damage = 500,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/XAA0305/XAA0305_unit.bp
+++ b/units/XAA0305/XAA0305_unit.bp
@@ -451,9 +451,9 @@ UnitBlueprint {
         },
         {
             AboveWaterTargetsOnly = true,
-            Damage = 100,
+            Damage = 300,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/XAA0306/XAA0306_unit.bp
+++ b/units/XAA0306/XAA0306_unit.bp
@@ -347,9 +347,9 @@ UnitBlueprint {
         },
         {
             AboveWaterTargetsOnly = true,
-            Damage = 150,
+            Damage = 400,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/XEA0306/XEA0306_unit.bp
+++ b/units/XEA0306/XEA0306_unit.bp
@@ -877,9 +877,9 @@ UnitBlueprint {
         },
         {
             AboveWaterTargetsOnly = true,
-            Damage = 25,
+            Damage = 500,
             DamageFriendly = true,
-            DamageRadius = 3,
+            DamageRadius = 4,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/XRA0305/XRA0305_unit.bp
+++ b/units/XRA0305/XRA0305_unit.bp
@@ -442,9 +442,9 @@ UnitBlueprint {
         },
         {
             AboveWaterTargetsOnly = true,
-            Damage = 100,
+            Damage = 300,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/XSA0302/XSA0302_unit.bp
+++ b/units/XSA0302/XSA0302_unit.bp
@@ -245,9 +245,9 @@ UnitBlueprint {
     Weapon = {
         {
             AboveWaterTargetsOnly = true,
-            Damage = 100,
+            Damage = 150,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/XSA0303/XSA0303_unit.bp
+++ b/units/XSA0303/XSA0303_unit.bp
@@ -344,7 +344,7 @@ UnitBlueprint {
         {
             Damage = 200,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,

--- a/units/XSA0304/XSA0304_unit.bp
+++ b/units/XSA0304/XSA0304_unit.bp
@@ -347,7 +347,7 @@ UnitBlueprint {
         {
             Damage = 500,
             DamageFriendly = true,
-            DamageRadius = 1,
+            DamageRadius = 2,
             DamageType = 'Normal',
             DisplayName = 'Air Crash',
             DummyWeapon = true,


### PR DESCRIPTION
T3 scout from 100 to 150 damage and 1 aoe to 2 aoe
ASF stay at 200 damage and get from 1 to 2 aoe
strat stay at 500 damage and get from 1 aoe to 2 aoe
uef T3 gunship stay at 300 damage and get from 1 aoe to 2 aoe
cybran T3 gunship / resto get from 100 to 300 aoe and get from 1 aoe to 2 aoe
solace get from 150 damage to 400 damage, and get from 1 aoe to 2 aoe
T3 transport get from 25 damage to 500 damage, and from 3 aoe to 4 aoe