### PR TITLE
Platoon movement

### DIFF
--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -615,9 +615,9 @@ end
 -- @param tblUnits Table containing units.
 -- @param position Table with position {x, y, z}.
 -- @param formation Formation to use, 'AttackFormation', 'GrowthFormation'.
--- @param number Unknown TODO.
+-- @param degrees The orientation the platoon should take when it reaches the position. South is 0 degrees, east is 90 degrees, etc.
 -- @return Returns the issued command.
-function IssueFormAggressiveMove(tblUnits, position, formation, number)
+function IssueFormAggressiveMove(tblUnits, position, formation, degrees)
 end
 
 --- Orders group of units to attack the target unit.
@@ -625,18 +625,18 @@ end
 -- @param tblUnits Table containing units.
 -- @param target Unit to attack.
 -- @param formation Formation to use, 'AttackFormation', 'GrowthFormation'.
--- @param number Unknown TODO.
+-- @param degrees The orientation the platoon should take when it reaches the position. South is 0 degrees, east is 90 degrees, etc.
 -- @return Returns the issued command.
-function IssueFormAttack(tblUnits, target, formation, number)
+function IssueFormAttack(tblUnits, target, formation, degrees)
 end
 
 --- Oders group of units to move in formation to target position.
 -- @param tblUnits Table containing units.
 -- @param position Table with position {x, y, z}.
 -- @param formation Formation to use, 'AttackFormation', 'GrowthFormation'.
--- @param number Unknown TODO.
+-- @param degrees The orientation the platoon should take when it reaches the position. South is 0 degrees, east is 90 degrees, etc.
 -- @return Returns the issued command.
-function IssueFormMove(tblUnits, position, formation, number)
+function IssueFormMove(tblUnits, position, formation, degrees)
 end
 
 --- Oders group of units to patrol in formation on target position.
@@ -644,9 +644,9 @@ end
 -- @param tblUnits Table containing units.
 -- @param position Table with position {x, y, z}.
 -- @param formation Formation to use, 'AttackFormation', 'GrowthFormation'.
--- @param number Unknown TODO.
+-- @param degrees The orientation the platoon should take when it reaches the position. South is 0 degrees, east is 90 degrees, etc.
 -- @return Returns the issued command.
-function IssueFormPatrol(tblUnits, position, formation, number)
+function IssueFormPatrol(tblUnits, position, formation, degrees)
 end
 
 --- Orders group of unit to assist the target unit.

--- a/lua/ScenarioPlatoonAI.lua
+++ b/lua/ScenarioPlatoonAI.lua
@@ -2,7 +2,7 @@
 -- File     :  /lua/ai/ScenarioPlatoonAI.lua
 -- Author(s):  Drew Staltman
 -- Summary  :  Houses a number of AI threads that are used in operations
--- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright ï¿½ 2005 Gas Powered Games, Inc.  All rights reserved.
 ------------------------------------------------------------------------
 
 local Utilities = import('/lua/utilities.lua')

--- a/lua/ScenarioPlatoonAI.lua
+++ b/lua/ScenarioPlatoonAI.lua
@@ -2,11 +2,7 @@
 -- File     :  /lua/ai/ScenarioPlatoonAI.lua
 -- Author(s):  Drew Staltman
 -- Summary  :  Houses a number of AI threads that are used in operations
-<<<<<<< HEAD
--- Copyright � 2005 Gas Powered Games, Inc.  All rights reserved.
-=======
 -- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
->>>>>>> 2acb9e2fde7072a42d457403b24efa36077f4f64
 ------------------------------------------------------------------------
 
 local Utilities = import('/lua/utilities.lua')

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -6620,26 +6620,29 @@ Platoon = Class(moho.platoon_methods) {
     IssuePatrolAlongRoute = function(self, path)
 
         -- check for optional / default values
-        local first = 1 
-        local last = table.getn(path)
         local formation = self.PlatoonData.UseFormation or 'NoFormation'
+
+        -- check if the parameters are correct
+        if not path or not (type(path) == 'table') then
+            error("IssuePatrolAlongRoute: The path is not a table. For paths with only one node, use { node } as the path.")
+            return { }
+        end
+
+        if table.empty(path) then
+            error("IssuePatrolAlongRoute: The path is empty.");
+            return { } 
+        end
 
         -- keep track of all the commands we issued
         local commands = { }
-
-        -- check if we have a path, if no path we can return immediately
-        if first > last then
-            return commands
-        end
 
         -- we have no formation, further computations are not required. We use this
         -- shortcut because calling IssueFormPatrol() with no formation causes them
         -- to not move at all.
         if formation == 'NoFormation' then 
             local units = self:GetPlatoonUnits()
-            for k = first, last do 
-                local point = path[k]
-                local command = IssuePatrol(units, point)
+            for k, node in path do
+                local command = IssuePatrol(units, node)
                 table.insert(commands, command)
             end
 
@@ -6649,7 +6652,7 @@ Platoon = Class(moho.platoon_methods) {
         -- check if we have a path of tables, instead to a path of vectors. A lot of the functionality provided by
         -- this library generates lists of tables instead of lists of vectors. Functionality in this file requires
         -- a list of vectors. Convert it if neccesary.
-        if not path[first].x then 
+        if not path[1].x then 
             local oldPath = path
             path = {}
             for k, node in oldPath do
@@ -6658,19 +6661,20 @@ Platoon = Class(moho.platoon_methods) {
         end
 
         -- store locally for better performance
+        local count = table.getn(path)
         local GetAngleCCW = Utilities.GetAngleCCW
         local GetDirectionVector = Utilities.GetDirectionVector
 
         -- pre-compute the angles
         local angles = { }
-        for k = first, last do 
+        for k = 1, count do 
     
             local curr = path[k - 1]
             local next = path[k]
     
-            -- if we're trying to look before the first node of the path, use the platoons current position instead
-            if k - 1 < first then 
-                curr = path[last]
+            -- if we're trying to look before the first node of the path, use the last node instead
+            if k - 1 < 1 then 
+                curr = path[count]
             end
 
             -- base orientation when the angle is 0 for the function IssueFormMove
@@ -6682,7 +6686,8 @@ Platoon = Class(moho.platoon_methods) {
 
         -- move over the path in formation
         local units = self:GetPlatoonUnits()
-        for k = first, last do 
+
+        for k = 1, count do 
             local point = path[k]
             local angle = angles[k]
             local command = IssueFormPatrol(units, point, formation, angle)
@@ -6699,17 +6704,21 @@ Platoon = Class(moho.platoon_methods) {
     -- @return Table of commands.
     IssueAggressiveMoveAlongRoute = function(self, path)
         -- check for optional / default values
-        local first = 1 
-        local last = table.getn(path)
         local formation = self.PlatoonData.UseFormation or 'NoFormation'
+
+        -- check if the parameters are correct
+        if not path or not (type(path) == 'table') then
+            error("IssueAggressiveMoveAlongRoute: The path is not a table. For paths with only one node, use { node } as the path.")
+            return { }
+        end
+
+        if table.empty(path) then
+            error("IssueAggressiveMoveAlongRoute: The path is empty.");
+            return { } 
+        end
 
         -- keep track of all the commands we issued
         local commands = { }
-
-        -- check if we have a path, if there is no path we can return immediately
-        if first > last then
-            return commands
-        end
 
         -- we have no formation, further computations are not required. We use this
         -- shortcut because calling IssueFormAggressiveMove() with no formation causes 
@@ -6717,9 +6726,9 @@ Platoon = Class(moho.platoon_methods) {
         if formation == 'NoFormation' then 
             -- store the commands / orders
             local units = self:GetPlatoonUnits()
-            for k = first, last do 
-                local point = path[k]
-                local command = IssueAggressiveMove(units, point)
+
+            for k, node in path do
+                local command = IssueAggressiveMove(units, node)
                 table.insert(commands, command)
             end
 
@@ -6729,7 +6738,7 @@ Platoon = Class(moho.platoon_methods) {
         -- check if we have a path of tables, instead of a path of vectors. A lot of the functionality provided by
         -- this library generates lists of tables instead of lists of vectors. Functionality in this file requires
         -- a list of vectors. Convert it if neccesary.
-        if not path[first].x then 
+        if not path[1].x then 
             local oldPath = path
             path = {}
             for k, node in oldPath do
@@ -6738,18 +6747,19 @@ Platoon = Class(moho.platoon_methods) {
         end
 
         -- store locally for better performance
+        local count = table.getn(path)
         local GetAngleCCW = Utilities.GetAngleCCW
         local GetDirectionVector = Utilities.GetDirectionVector
 
         -- pre-compute the angles
         local angles = { }
-        for k = first, last do 
+        for k = 1, count do 
     
             local curr = path[k - 1]
             local next = path[k]
     
             -- if we're trying to look before the first node of the path, use the platoons current position instead
-            if k - 1 < first then 
+            if k - 1 < 1 then 
                 local pos = self:GetPlatoonPosition()
                 curr = Vector(pos[1], pos[2], pos[3])
             end
@@ -6763,7 +6773,8 @@ Platoon = Class(moho.platoon_methods) {
 
         -- move over the path, store the commands
         local units = self:GetPlatoonUnits()
-        for k = first, last do 
+
+        for k = fi1rst, count do 
             local point = path[k]
             local angle = angles[k]
             local command = IssueFormAggressiveMove(units, point, formation, angle)
@@ -6780,17 +6791,21 @@ Platoon = Class(moho.platoon_methods) {
     -- @return Table of commands.
     IssueMoveAlongRoute = function(self, path)
         -- check for optional / default values
-        local first = 1 
-        local last = table.getn(path)
         local formation = self.PlatoonData.UseFormation or 'NoFormation'
+        
+        -- check if the parameters are correct
+        if not path or not (type(path) == 'table') then
+            error("IssueMoveAlongRoute: The path is not a table. For paths with only one node, use { node } as the path.")
+            return { }
+        end
+
+        if table.empty(path) then
+            error("IssueMoveAlongRoute: The path is empty.");
+            return { } 
+        end
 
         -- keep track of all the commands we issued
         local commands = { }
-        
-        -- check if we have a path, if there is no path we can return immediately
-        if first > last then
-            return { }
-        end
 
         -- we have no formation, further computations are not required. We use this
         -- shortcut because calling IssueFormMove() with no formation causes them 
@@ -6798,9 +6813,8 @@ Platoon = Class(moho.platoon_methods) {
         if formation == 'NoFormation' then 
             -- store the commands / orders
             local units = self:GetPlatoonUnits()
-            for k = first, last do 
-                local point = path[k]
-                local command = IssueMove(units, point)
+            for k, node in path do
+                local command = IssueMove(units, node)
                 table.insert(commands, command)
             end
 
@@ -6810,7 +6824,7 @@ Platoon = Class(moho.platoon_methods) {
         -- check if we have a path of tables, instead of a path of vectors. A lot of the functionality provided by
         -- this library generates lists of tables instead of lists of vectors. Functionality in this file requires
         -- a list of vectors. Convert it if neccesary.
-        if not path[first].x then 
+        if not path[1].x then 
             local oldPath = path
             path = {}
             for k, node in oldPath do
@@ -6819,18 +6833,19 @@ Platoon = Class(moho.platoon_methods) {
         end
 
         -- store locally for better performance
+        local count = table.getn(path)
         local GetAngleCCW = Utilities.GetAngleCCW
         local GetDirectionVector = Utilities.GetDirectionVector
 
         -- pre-compute the angles
         local angles = { }
-        for k = first, last do 
+        for k = 1, count do 
     
             local curr = path[k - 1]
             local next = path[k]
     
             -- if we're trying to look before the first node of the path, use the platoons current position instead
-            if k - 1 < first then 
+            if k - 1 < 1 then 
                 local pos = self:GetPlatoonPosition()
                 curr = Vector(pos[1], pos[2], pos[3])
             end
@@ -6844,7 +6859,8 @@ Platoon = Class(moho.platoon_methods) {
 
         -- move over the path, store the commands
         local units = self:GetPlatoonUnits()
-        for k = first, last do 
+
+        for k = 1, count do 
             local point = path[k]
             local angle = angles[k]
             local command = IssueFormMove(units, point, formation, angle)

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -6623,68 +6623,68 @@ Platoon = Class(moho.platoon_methods) {
 
         -- defaults
         first = first or 1 
-        last = last or table.getn(path);
-        local formation = self.PlatoonData.UseFormation or 'NoFormation';
+        last = last or table.getn(path)
+        local formation = self.PlatoonData.UseFormation or 'NoFormation'
 
         -- check if we have a formation, IssueFormMove doesn't work if the formation argument is 'NoFormation'.
         if formation == 'NoFormation' then 
-            WARN('MovePathOrientedByFuture: No platoon formation provided, defaulting to GrowthFormation.');
-            formation = 'GrowthFormation';
+            WARN('MovePathOrientedByFuture: No platoon formation provided, defaulting to GrowthFormation.')
+            formation = 'GrowthFormation'
         end
 
         -- check if we have a path, if no path we can return immediately
         if first == last then
-            return;
+            return
         end
 
         -- if we only have one node to cross we cannot determine the next orientation we need
         if last - first < 2 then 
-            MovePathOrientedByPast(self, path, first, last);
-            return;
+            MovePathOrientedByPast(self, path, first, last)
+            return
         end
 
         -- check if we have a path of tables, instead to a path of vectors. A lot of the functionality provided by
         -- this library generates lists of tables instead of lists of vectors. Functionality in this file requires
         -- a list of vectors. Convert it if neccesary.
         if not path[first].x then 
-            local oldPath = path;
-            path = {};
+            local oldPath = path
+            path = {}
             for k, node in oldPath do
-                table.insert(path, Vector(node[1], node[2], node[3]));
+                table.insert(path, Vector(node[1], node[2], node[3]))
             end
         end
 
         -- pre-compute the angles
-        local angles = { };
+        local angles = { }
         for k = first, last, 1 do 
     
-            local curr = path[k];
-            local next = path[k + 1];
+            local curr = path[k]
+            local next = path[k + 1]
     
             -- if we're trying to look beyond the last node of the path, look at the last two nodes instead
             if k + 1 > last then 
-                curr = path[k - 1];
-                next = path[k];
+                curr = path[k - 1]
+                next = path[k]
             end
 
             -- base orientation when the angle is 0 for the function IssueFormMove
             local base = Vector( 0, 0, 1 )
-            local direction = Utilities.GetDirectionVector(next, curr);
-            local angle = Utilities.GetFull2DAngle(base, direction);
-            angles[k] = angle;
+            local direction = Utilities.GetDirectionVector(next, curr)
+            local angle = Utilities.GetAngleCCW(base, direction)
+            angles[k] = angle
         end
 
         -- move over the path, store the commands
-        local commands = { };
-        local units = self:GetPlatoonUnits();
+        local commands = { }
+        local units = self:GetPlatoonUnits()
         for k = first, last, 1 do 
-            local point = path[k];
-            local angle = angles[k];
-            local command = IssueFormMove(units, point, formation, angle);
-            table.insert(commands, command);
+            local point = path[k]
+            local angle = angles[k]
+            local command = IssueFormMove(units, point, formation, angle)
+            table.insert(commands, command)
         end
 
-        return commands;
+        return commands
     end,
 
     --- Moves the platoon along the path, orientating at each node to match the line from the previous node to the current node.
@@ -6697,62 +6697,62 @@ Platoon = Class(moho.platoon_methods) {
 
         -- defaults
         first = first or 1 
-        last = last or table.getn(path);
-        local formation = self.PlatoonData.UseFormation or 'NoFormation';
+        last = last or table.getn(path)
+        local formation = self.PlatoonData.UseFormation or 'NoFormation'
 
         -- check if we have a formation, IssueFormMove doesn't work if the formation argument is 'NoFormation'.
         if formation == 'NoFormation' then 
-            WARN('MovePathOrientedByPast: No platoon formation provided, defaulting to GrowthFormation.');
-            formation = 'GrowthFormation';
+            WARN('MovePathOrientedByPast: No platoon formation provided, defaulting to GrowthFormation.')
+            formation = 'GrowthFormation'
         end
 
         -- check if we have a path, if no path we can return immediately
         if first == last then
-            return;
+            return
         end
 
         -- check if we have a path of tables, instead to a path of vectors. A lot of the functionality provided by
         -- this library generates lists of tables instead of lists of vectors. Functionality in this file requires
         -- a list of vectors. Convert it if neccesary.
         if not path[first].x then 
-            local oldPath = path;
-            path = {};
+            local oldPath = path
+            path = {}
             for k, node in oldPath do
-                table.insert(path, Vector(node[1], node[2], node[3]));
+                table.insert(path, Vector(node[1], node[2], node[3]))
             end
         end
 
         -- pre-compute the angles
-        local angles = { };
+        local angles = { }
         for k = first, last, 1 do 
     
-            local curr = path[k - 1];
-            local next = path[k];
+            local curr = path[k - 1]
+            local next = path[k]
     
             -- if we're trying to look before the first node of the path, use the platoons current position instead
             if k - 1 < first then 
-                local pos = self:GetPlatoonPosition();
-                curr = Vector(pos[1], pos[2], pos[3]);
+                local pos = self:GetPlatoonPosition()
+                curr = Vector(pos[1], pos[2], pos[3])
             end
 
             -- base orientation when the angle is 0 for the function IssueFormMove
             local base = Vector( 0, 0, 1 )
-            local direction = Utilities.GetDirectionVector(next, curr);
-            local angle = Utilities.GetFull2DAngle(base, direction);
-            angles[k] = angle;
+            local direction = Utilities.GetDirectionVector(next, curr)
+            local angle = Utilities.GetAngleCCW(base, direction)
+            angles[k] = angle
         end
 
         -- move over the path, store the commands
-        local commands = { };
-        local units = self:GetPlatoonUnits();
+        local commands = { }
+        local units = self:GetPlatoonUnits()
         for k = first, last, 1 do 
-            local point = path[k];
-            local angle = angles[k];
-            local command = IssueFormMove(units, point, formation, angle);
-            table.insert(commands, command);
+            local point = path[k]
+            local angle = angles[k]
+            local command = IssueFormMove(units, point, formation, angle)
+            table.insert(commands, command)
         end
 
-        return commands;
+        return commands
     end,
     
 }

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -6680,7 +6680,8 @@ Platoon = Class(moho.platoon_methods) {
     end,
 
     
-    --- Issues a command to the platoon along the path, orientating at each node to match the line from the previous node to the current node.
+    --- Issues a command to the platoon along the path, orientating at each node to match the line from the previous 
+    -- node to the current node. Do not use this function directly, use IssueAggressiveMovePath or IssueMovePath instead.
     -- @param self The platoon itself.
     -- @param command Commands with parameters (units, position, formation, degrees) such as IssueFormMove or IssueFormMoveAggressive.
     -- @param path A table of positions, preferably of type Vector. Converted otherwise.
@@ -6704,7 +6705,7 @@ Platoon = Class(moho.platoon_methods) {
             return
         end
 
-        -- check if we have a path of tables, instead to a path of vectors. A lot of the functionality provided by
+        -- check if we have a path of tables, instead of a path of vectors. A lot of the functionality provided by
         -- this library generates lists of tables instead of lists of vectors. Functionality in this file requires
         -- a list of vectors. Convert it if neccesary.
         if not path[first].x then 
@@ -6728,7 +6729,7 @@ Platoon = Class(moho.platoon_methods) {
                 curr = Vector(pos[1], pos[2], pos[3])
             end
 
-            -- base orientation when the angle is 0 for the function IssueFormMove
+            -- base orientation when the angle is 0
             local base = Vector( 0, 0, 1 )
             local direction = Utilities.GetDirectionVector(next, curr)
             local angle = Utilities.GetAngleCCW(base, direction)
@@ -6755,7 +6756,7 @@ Platoon = Class(moho.platoon_methods) {
     -- @param last The index of the last node of the path, is by default the length of the path.
     -- @return Table of commands.
     IssueAggressiveMovePath = function (self, path, first, last) 
-        return self:IssueCommandPath(IssueFormAggressiveMove, path, first, last);
+        return self:IssueCommandPath(IssueFormAggressiveMove, path, first, last)
     end,
 
     --- Moves the platoon along the path, orientating at each node to match the line from the previous node to the current node.
@@ -6765,7 +6766,7 @@ Platoon = Class(moho.platoon_methods) {
     -- @param last The index of the last node of the path, is by default the length of the path.
     -- @return Table of commands.
     IssueMovePath = function (self, path, first, last) 
-        return self:IssueCommandPath(IssueFormMove, path, first, last);
+        return self:IssueCommandPath(IssueFormMove, path, first, last)
     end,
     
 }

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -6615,19 +6615,14 @@ Platoon = Class(moho.platoon_methods) {
     --- Patrols the platoon along the path, orientating at each node to match the line from the previous node to the current node.
     -- @param self The platoon itself.
     -- @param path A table of positions, preferably of type Vector. Converted otherwise.
-    -- @param opts A table of optional values, containing:
-    --        opts.First the index of the first node the path
-    --        opts.Last the index of the last node of the path
-    --        opts.UseFormation the formation to use for the platoon, overrides the formation of the squads
+    -- @param self.PlatoonData.UseFormation The formation to apply, such as GrowthFormation, AttackFormation or NoFormation.
     -- @return Table of commands.
-    IssuePatrolAlongRoute = function(self, path, opts)
-        -- check for optional / default values
-        local first = opts.First or 1 
-        local last = opts.Last or table.getn(path)
-        local formation = opts.UseFormation or self.PlatoonData.UseFormation or 'NoFormation'
+    IssuePatrolAlongRoute = function(self, path)
 
-        -- This is done elsewhere too after checking for self.PlatoonData.UseFormation. Should we do this here?
-        -- self:SetPlatoonFormationOverride(formation) 
+        -- check for optional / default values
+        local first = 1 
+        local last = table.getn(path)
+        local formation = self.PlatoonData.UseFormation or 'NoFormation'
 
         -- keep track of all the commands we issued
         local commands = { }
@@ -6637,7 +6632,9 @@ Platoon = Class(moho.platoon_methods) {
             return commands
         end
 
-        -- we have no formation, further computations are not required
+        -- we have no formation, further computations are not required. We use this
+        -- shortcut because calling IssueFormPatrol() with no formation causes them
+        -- to not move at all.
         if formation == 'NoFormation' then 
             local units = self:GetPlatoonUnits()
             for k = first, last do 
@@ -6660,6 +6657,10 @@ Platoon = Class(moho.platoon_methods) {
             end
         end
 
+        -- store locally for better performance
+        local GetAngleCCW = Utilities.GetAngleCCW
+        local GetDirectionVector = Utilities.GetDirectionVector
+
         -- pre-compute the angles
         local angles = { }
         for k = first, last do 
@@ -6674,8 +6675,8 @@ Platoon = Class(moho.platoon_methods) {
 
             -- base orientation when the angle is 0 for the function IssueFormMove
             local base = Vector( 0, 0, 1 )
-            local direction = Utilities.GetDirectionVector(next, curr)
-            local angle = Utilities.GetAngleCCW(base, direction)
+            local direction = GetDirectionVector(next, curr)
+            local angle = GetAngleCCW(base, direction)
             angles[k] = angle
         end
 
@@ -6694,19 +6695,13 @@ Platoon = Class(moho.platoon_methods) {
     --- Aggressive-moves the platoon along the path, orientating at each node to match the line from the previous node to the current node.
     -- @param self The platoon itself.
     -- @param path A table of positions, preferably of type Vector. Converted otherwise.
-    -- @param opts A table of optional values, containing:
-    --        opts.First the index of the first node the path
-    --        opts.Last the index of the last node of the path
-    --        opts.UseFormation the formation to use for the platoon, overrides the formation of the squads
+    -- @param self.PlatoonData.UseFormation The formation to apply, such as GrowthFormation, AttackFormation or NoFormation.
     -- @return Table of commands.
-    IssueAggressiveMoveAlongRoute = function(self, path, opts)
+    IssueAggressiveMoveAlongRoute = function(self, path)
         -- check for optional / default values
-        local first = opts.First or 1 
-        local last = opts.Last or table.getn(path)
-        local formation = opts.UseFormation or self.PlatoonData.UseFormation or 'NoFormation'
-
-        -- This is done elsewhere too after checking for self.PlatoonData.UseFormation. Should we do this here?
-        -- self:SetPlatoonFormationOverride(formation) 
+        local first = 1 
+        local last = table.getn(path)
+        local formation = self.PlatoonData.UseFormation or 'NoFormation'
 
         -- keep track of all the commands we issued
         local commands = { }
@@ -6716,7 +6711,9 @@ Platoon = Class(moho.platoon_methods) {
             return commands
         end
 
-        -- we have no formation, further computations are not required
+        -- we have no formation, further computations are not required. We use this
+        -- shortcut because calling IssueFormAggressiveMove() with no formation causes 
+        -- them to not move at all.
         if formation == 'NoFormation' then 
             -- store the commands / orders
             local units = self:GetPlatoonUnits()
@@ -6740,6 +6737,10 @@ Platoon = Class(moho.platoon_methods) {
             end
         end
 
+        -- store locally for better performance
+        local GetAngleCCW = Utilities.GetAngleCCW
+        local GetDirectionVector = Utilities.GetDirectionVector
+
         -- pre-compute the angles
         local angles = { }
         for k = first, last do 
@@ -6755,8 +6756,8 @@ Platoon = Class(moho.platoon_methods) {
 
             -- base orientation when the angle is 0
             local base = Vector( 0, 0, 1 )
-            local direction = Utilities.GetDirectionVector(next, curr)
-            local angle = Utilities.GetAngleCCW(base, direction)
+            local direction = GetDirectionVector(next, curr)
+            local angle = GetAngleCCW(base, direction)
             angles[k] = angle
         end
 
@@ -6775,19 +6776,13 @@ Platoon = Class(moho.platoon_methods) {
     --- Moves the platoon along the path, orientating at each node to match the line from the previous node to the current node.
     -- @param self The platoon itself.
     -- @param path A table of positions, preferably of type Vector. Converted otherwise.
-    -- @param opts A table of optional values, containing:
-    --        opts.First the index of the first node the path
-    --        opts.Last the index of the last node of the path
-    --        opts.UseFormation the formation to use for the platoon, overrides the formation of the squads
+    -- @param self.PlatoonData.UseFormation The formation to apply, such as GrowthFormation, AttackFormation or NoFormation.
     -- @return Table of commands.
-    IssueMoveAlongRoute = function(self, path, opts)
+    IssueMoveAlongRoute = function(self, path)
         -- check for optional / default values
-        local first = opts.First or 1 
-        local last = opts.Last or table.getn(path)
-        local formation = opts.UseFormation or self.PlatoonData.UseFormation or 'NoFormation'
-
-        -- This is done elsewhere too after checking for self.PlatoonData.UseFormation. Should we do this here?
-        -- self:SetPlatoonFormationOverride(formation) 
+        local first = 1 
+        local last = table.getn(path)
+        local formation = self.PlatoonData.UseFormation or 'NoFormation'
 
         -- keep track of all the commands we issued
         local commands = { }
@@ -6797,7 +6792,9 @@ Platoon = Class(moho.platoon_methods) {
             return { }
         end
 
-        -- we have no formation, further computations are not required
+        -- we have no formation, further computations are not required. We use this
+        -- shortcut because calling IssueFormMove() with no formation causes them 
+        -- to not move at all.
         if formation == 'NoFormation' then 
             -- store the commands / orders
             local units = self:GetPlatoonUnits()
@@ -6821,6 +6818,10 @@ Platoon = Class(moho.platoon_methods) {
             end
         end
 
+        -- store locally for better performance
+        local GetAngleCCW = Utilities.GetAngleCCW
+        local GetDirectionVector = Utilities.GetDirectionVector
+
         -- pre-compute the angles
         local angles = { }
         for k = first, last do 
@@ -6836,8 +6837,8 @@ Platoon = Class(moho.platoon_methods) {
 
             -- base orientation when the angle is 0
             local base = Vector( 0, 0, 1 )
-            local direction = Utilities.GetDirectionVector(next, curr)
-            local angle = Utilities.GetAngleCCW(base, direction)
+            local direction = GetDirectionVector(next, curr)
+            local angle = GetAngleCCW(base, direction)
             angles[k] = angle
         end
 

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -6617,10 +6617,10 @@ Platoon = Class(moho.platoon_methods) {
     -- @param path A table of positions, preferably of type Vector. Converted otherwise.
     -- @param self.PlatoonData.UseFormation The formation to apply, such as GrowthFormation, AttackFormation or NoFormation.
     -- @return Table of commands.
-    IssuePatrolAlongRoute = function(self, path)
+    IssuePatrolAlongRoute = function(self, path, formation)
 
         -- check for optional / default values
-        local formation = self.PlatoonData.UseFormation or 'NoFormation'
+        local formation = formation or self.PlatoonData.UseFormation or 'NoFormation'
 
         -- check if the parameters are correct
         if not path or not (type(path) == 'table') then
@@ -6702,9 +6702,9 @@ Platoon = Class(moho.platoon_methods) {
     -- @param path A table of positions, preferably of type Vector. Converted otherwise.
     -- @param self.PlatoonData.UseFormation The formation to apply, such as GrowthFormation, AttackFormation or NoFormation.
     -- @return Table of commands.
-    IssueAggressiveMoveAlongRoute = function(self, path)
+    IssueAggressiveMoveAlongRoute = function(self, path, formation)
         -- check for optional / default values
-        local formation = self.PlatoonData.UseFormation or 'NoFormation'
+        local formation = formation or self.PlatoonData.UseFormation or 'NoFormation'
 
         -- check if the parameters are correct
         if not path or not (type(path) == 'table') then
@@ -6789,9 +6789,9 @@ Platoon = Class(moho.platoon_methods) {
     -- @param path A table of positions, preferably of type Vector. Converted otherwise.
     -- @param self.PlatoonData.UseFormation The formation to apply, such as GrowthFormation, AttackFormation or NoFormation.
     -- @return Table of commands.
-    IssueMoveAlongRoute = function(self, path)
+    IssueMoveAlongRoute = function(self, path, formation)
         -- check for optional / default values
-        local formation = self.PlatoonData.UseFormation or 'NoFormation'
+        local formation = formation or self.PlatoonData.UseFormation or 'NoFormation'
         
         -- check if the parameters are correct
         if not path or not (type(path) == 'table') then

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -40,9 +40,9 @@ Platoon = Class(moho.platoon_methods) {
         self.CreationTime = GetGameTimeSeconds()
     end,
 
-SetPlatoonData = function(self, dataTable)
-    self.PlatoonData = table.deepcopy(dataTable)
-end,
+    SetPlatoonData = function(self, dataTable)
+        self.PlatoonData = table.deepcopy(dataTable)
+    end,
 
     SetPartOfAttackForce = function(self)
         if not self.PlatoonData then

--- a/lua/utilities.lua
+++ b/lua/utilities.lua
@@ -224,22 +224,22 @@ end
 -- is computed in a counter clockwise direction: if the base is to the south ({0, 0, 1}) then the direction to the east ({1, 0, 0}) is 90 degrees.
 -- @param base The base direction from which the angle will be computed in a counter clockwise fashion.
 -- @param direction The direction from which we want to compute the angle given a base.
-function GetFull2DAngle(base, direction) 
+function GetAngleCCW(base, direction) 
 
-    local bn = NormalizeVector(base);
-    local dn = NormalizeVector(direction);
+    local bn = NormalizeVector(base)
+    local dn = NormalizeVector(direction)
 
     -- compute the orthogonal vector to determine if we need to take the inverse
     local ort = { bn[3], 0, -bn[1] }
 
     -- compute the radians, correct it accordingly
-    local rads = math.acos(bn[1] * dn[1] + bn[3] * dn[3]);
+    local rads = math.acos(bn[1] * dn[1] + bn[3] * dn[3])
     if ort[1] * dn[1] + ort[3] * dn[3] < 0 then 
-        rads = 2 * math.pi - rads;
+        rads = 2 * math.pi - rads
     end
 
     -- convert to degrees
-    return (180 / math.pi) * rads;
+    return (180 / math.pi) * rads
 end
 
 function UserConRequest(string)

--- a/lua/utilities.lua
+++ b/lua/utilities.lua
@@ -220,6 +220,28 @@ function GetAngleInBetween(v1, v2)
     return math.acos(dotp) * (360 / (math.pi * 2))
 end
 
+--- Computes the full angle between the two vectors in two dimensions: the y dimension is not taken into account. Angle 
+-- is computed in a counter clockwise direction: if the base is to the south ({0, 0, 1}) then the direction to the east ({1, 0, 0}) is 90 degrees.
+-- @param base The base direction from which the angle will be computed in a counter clockwise fashion.
+-- @param direction The direction from which we want to compute the angle given a base.
+function GetFull2DAngle(base, direction) 
+
+    local bn = NormalizeVector(base);
+    local dn = NormalizeVector(direction);
+
+    -- compute the orthogonal vector to determine if we need to take the inverse
+    local ort = { bn[3], 0, -bn[1] }
+
+    -- compute the radians, correct it accordingly
+    local rads = math.acos(bn[1] * dn[1] + bn[3] * dn[3]);
+    if ort[1] * dn[1] + ort[3] * dn[3] < 0 then 
+        rads = 2 * math.pi - rads;
+    end
+
+    -- convert to degrees
+    return (180 / math.pi) * rads;
+end
+
 function UserConRequest(string)
     if not Sync.UserConRequests then
         Sync.UserConRequests = {}


### PR DESCRIPTION
Introducing an alternative approach to move platoons around. The current approach forces the platoon to orient to the south at the end of every move order.  The new approach either aligns them to the line between the current and next node (...ByFuture) or between the current and past node (...ByPast).

To showcase, see the following video:
https://www.youtube.com/watch?v=e4LH9oaKwTQ

The video becomes especially interesting about 30 seconds in, when the platoons are moving to the north.

From the outer to the inner line:
 - (new) platoon:MovePathOrientedByFuture(...)
 - (new) platoon:MovePathOrientedByPast(...)
 - (old) platoon:MoveToLocation(...)
 - (old) platoon:Patrol(...)

Especially platoon:MovePathOrientedByPast(...) (2nd from the outer one) is promising: it appears to be very smooth and is able to keep up with one of the older approaches that has a lower total distance. They finish at the same time.

I intend to make similar functions for:
 - IssueFormAggressiveMove(...)
 - IssueFormAttack(...)
 - IssueFormPatrol(...)

Waiting for feedback on the coding style, naming and / or the taken approach before I continue.