### PR TITLE
Load in the defaults of map options if an option is not set

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2018,6 +2018,7 @@ local function TryLaunch(skipNoObserversCheck)
         if scenarioInfo.options then 
             for _, option in scenarioInfo.options do 
                 if not gameInfo.GameOptions[option.key] then 
+                    LOG("Loading default map option: " .. tostring (option.key) .. " = " .. tostring (option.default))
                     gameInfo.GameOptions[option.key] = option.default
                 end
             end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2014,6 +2014,13 @@ local function TryLaunch(skipNoObserversCheck)
 
         scenarioInfo = MapUtil.LoadScenario(gameInfo.GameOptions.ScenarioFile)
 
+        -- load in the default map options if they are not set manually
+        for _, option in scenarioInfo.options do 
+            if not gameInfo.GameOptions[option.key] then 
+                gameInfo.GameOptions[option.key] = option.default
+            end
+        end
+
         if scenarioInfo.AdaptiveMap then
             gameInfo.GameOptions["SpawnMex"] = gameInfo.SpawnMex
         end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2015,9 +2015,11 @@ local function TryLaunch(skipNoObserversCheck)
         scenarioInfo = MapUtil.LoadScenario(gameInfo.GameOptions.ScenarioFile)
 
         -- load in the default map options if they are not set manually
-        for _, option in scenarioInfo.options do 
-            if not gameInfo.GameOptions[option.key] then 
-                gameInfo.GameOptions[option.key] = option.default
+        if scenarioInfo.options then 
+            for _, option in scenarioInfo.options do 
+                if not gameInfo.GameOptions[option.key] then 
+                    gameInfo.GameOptions[option.key] = option.default
+                end
             end
         end
 


### PR DESCRIPTION
This addresses issue #3136.

The default map options are being marked, but not loaded if not manually set. Added a small piece of code that on launch checks whether the map options are set, and if not, sends along the marked defaults.

Code such as:
``` lua
if (ScenarioInfo.Options.RainmakersMobileStealthFieldGens == nil) then
    ScenarioInfo.Options.RainmakersMobileStealthFieldGens = 2
    WARN("Options: RainmakersMobileStealthFieldGens is not set.");
end
```
Which checks whether a map option is set which resides in the <map-name>_options.lua file is therefore no longer required for FAF, it would still be required for Steam FA.