### PR TITLE
increase performance of table.empty and math.round

### DIFF
--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -405,7 +405,7 @@ end
 
 --- table.empty(t) returns true iff t has no keys/values.
 function table.empty(t)
-    return table.getsize(t) == 0
+    return next(t) == nil
 end
 
 --- table.shuffle(t) returns a shuffled table
@@ -623,12 +623,13 @@ function Sort(itemA, itemB)
 end
 
 -- Rounds a number to specified double precision
-function math.round(num, idp)
+function math.round(num,idp)
     if not idp then
         return math.floor(num+.5)
-    else
-        return tonumber(string.format("%." .. (idp or 0) .. "f", num))
     end
+
+    idp = 10^idp
+    return math.floor(num*idp+.5)/idp
 end
 
 --- Clamps numeric value to specified Min and Max range

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -628,7 +628,7 @@ function math.round(num,idp)
         return math.floor(num+.5)
     end
 
-    idp = 10^idp
+    idp = math.pow(10,idp)
     return math.floor(num*idp+.5)/idp
 end
 


### PR DESCRIPTION
I discovered that many functions in this file are are implemented in a very inefficient way. These two were just the easiest to fix, which is why I took a few seconds of my time to do so.

The new `table.empty` no longer needs to iterate over the whole table to know whether it's empty. It's therefore O(1) as opposed to O(n).
The new `math.round` no longer converts the value to a string and back again. It also supports using negative values to round to the nearest digit on the left side of the decimal point, as opposed to only allowing positive values to round to sub-decimal values.

Quick performance comparison of math.round
```
old round 5,000,000 iterations:	4.74 sec
new round 5,000,000 iterations:	0.628 sec
```