### PR TITLE
Add option to hide resource markers on preview

### DIFF
--- a/lua/ui/controls/resmappreview.lua
+++ b/lua/ui/controls/resmappreview.lua
@@ -214,7 +214,7 @@ ResourceMapPreview = Class(Group) {
             local slot = inSlot
 
             -- Create an ACUButton for each start position.
-            local marker = ACUButton(self.mapPreview, not self.buttonsDisabled)
+            local marker = ACUButton(self.mapPreview, not self.buttonsDisabled and not scenarioInfo.hidePreviewMarkers)
             local markerWidth = xOffset + ((pos[1] / mWidth) * self.size * xFactor) - (marker.Width() / 2)
             local markerHeight = yOffset + ((pos[2] / mHeight) * self.size * yFactor) - (marker.Height() / 2)
             LayoutHelpers.AtLeftTopIn(marker, self.mapPreview, markerWidth, markerHeight)

--- a/lua/ui/controls/resmappreview.lua
+++ b/lua/ui/controls/resmappreview.lua
@@ -152,7 +152,11 @@ ResourceMapPreview = Class(Group) {
                         if v.Position then
                             local marker = self.wreckageIconPool:Get()
                             table.insert(wreckagemarkers, marker)
-                            marker:Show()
+                            if scenarioInfo.hidePreviewMarkers then
+                                marker:Hide()
+                            else
+                                marker:Show()
+                            end
 
                             -- Yes, these ones have a capital Position, but the others have a lowercase.
                             LayoutHelpers.AtLeftTopIn(marker, self.mapPreview,
@@ -170,7 +174,11 @@ ResourceMapPreview = Class(Group) {
         local masses = {}
         for i = 1, table.getn(massmarkers) do
             masses[i] = self.massIconPool:Get()
-            masses[i]:Show()
+            if scenarioInfo.hidePreviewMarkers then
+                masses[i]:Hide()
+            else
+                masses[i]:Show()
+            end
 
             LayoutHelpers.AtLeftTopIn(masses[i], self.mapPreview,
                 xOffset + (massmarkers[i].position[1] / mWidth) * (self.size * xFactor)  - halfMassIconSize,
@@ -183,7 +191,11 @@ ResourceMapPreview = Class(Group) {
         local halfHydroIconSize = self.hydroIconSize / 2
         for i = 1, table.getn(hydromarkers) do
             hydros[i] = self.hydroIconPool:Get()
-            hydros[i]:Show()
+            if scenarioInfo.hidePreviewMarkers then
+                hydros[i]:Hide()
+            else
+                hydros[i]:Show()
+            end
 
             LayoutHelpers.AtLeftTopIn(hydros[i], self.mapPreview,
                 xOffset + (hydromarkers[i].position[1] / mWidth) * (self.size * xFactor)  - halfHydroIconSize,
@@ -213,6 +225,11 @@ ResourceMapPreview = Class(Group) {
             -- Create Labels above markers to show rating of player or AI names
             self.ratingLabel[slot] = UIUtil.CreateText(self.mapPreview, '', 10, 'Arial Gras', true)
             LayoutHelpers.CenteredAbove(self.ratingLabel[slot], marker, 5)
+
+            if scenarioInfo.hidePreviewMarkers then
+                marker:Hide()
+                self.ratingLabel[slot]:Hide()
+            end
 
             startPositions[slot] = marker
         end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2504,7 +2504,7 @@ function CreateSlotsUI(makeLabel)
 
             local associatedMarker = GUI.mapView.startPositions[curRow]
             if event.Type == 'MouseEnter' then
-                if gameInfo.GameOptions['TeamSpawn'] == 'fixed' and gameInfo.scenarioInfo.hidePreviewMarkers then
+                if gameInfo.GameOptions['TeamSpawn'] == 'fixed' and associatedMarker:IsEnabled() then
                     associatedMarker.indicator:Play()
                 end
             elseif event.Type == 'MouseExit' then

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2504,7 +2504,7 @@ function CreateSlotsUI(makeLabel)
 
             local associatedMarker = GUI.mapView.startPositions[curRow]
             if event.Type == 'MouseEnter' then
-                if gameInfo.GameOptions['TeamSpawn'] == 'fixed' then
+                if gameInfo.GameOptions['TeamSpawn'] == 'fixed' and gameInfo.scenarioInfo.hidePreviewMarkers then
                     associatedMarker.indicator:Play()
                 end
             elseif event.Type == 'MouseExit' then


### PR DESCRIPTION
Fixes #3186 

This change adds an option to not spawn the resource and spawn markers in the spawn preview. It introduces a boolean variable hidePreviewMarkers in the scenarioInfo of a map that is used to determine whether or not the preview should include markers.

This allows the determination to be made on a map by map basis.