### PR TITLE
Improve build effects logic

### DIFF
--- a/lua/EffectUtilities.lua
+++ b/lua/EffectUtilities.lua
@@ -82,6 +82,7 @@ function ScaleEmittersParam(Emitters, param, minRange, maxRange)
 end
 
 function CreateBuildCubeThread(unitBeingBuilt, builder, OnBeingBuiltEffectsBag)
+    unitBeingBuilt.BuildingCube = true
     local bp = unitBeingBuilt:GetBlueprint()
     local mul = 1.15
     local xPos, yPos, zPos = unpack(unitBeingBuilt:GetPosition())
@@ -148,6 +149,7 @@ function CreateBuildCubeThread(unitBeingBuilt, builder, OnBeingBuiltEffectsBag)
         lComplete = cComplete
         cComplete = unitBeingBuilt:GetFractionComplete()
     end
+    unitBeingBuilt.BuildingCube = nil
 end
 
 function CreateUEFUnitBeingBuiltEffects(builder, unitBeingBuilt, BuildEffectsBag)

--- a/lua/terranunits.lua
+++ b/lua/terranunits.lua
@@ -121,12 +121,11 @@ TConcreteStructureUnit = Class(ConcreteStructureUnit) {}
 --------------------------------------------------------------
 TConstructionUnit = Class(ConstructionUnit) {
     CreateBuildEffects = function(self, unitBeingBuilt, order)
-        local UpgradesFrom = unitBeingBuilt:GetBlueprint().General.UpgradesFrom
-        -- If we are assisting an upgrading unit, or repairing a unit, play seperate effects
-        if (order == 'Repair' and not unitBeingBuilt:IsBeingBuilt()) or (UpgradesFrom and UpgradesFrom  ~= 'none' and self:IsUnitState('Guarding'))then
-            EffectUtil.CreateDefaultBuildBeams(self, unitBeingBuilt, self.BuildEffectBones, self.BuildEffectsBag)
+        -- Different effect if we have building cube
+        if unitBeingBuilt.BuildingCube then
+            EffectUtil.CreateUEFBuildSliceBeams(self, unitBeingBuilt, self.BuildEffectBones, self.BuildEffectsBag)
         else
-            CreateUEFBuildSliceBeams(self, unitBeingBuilt, self.BuildEffectBones, self.BuildEffectsBag)
+            EffectUtil.CreateDefaultBuildBeams(self, unitBeingBuilt, self.BuildEffectBones, self.BuildEffectsBag)
         end
     end,
 

--- a/units/UEL0001/UEL0001_script.lua
+++ b/units/UEL0001/UEL0001_script.lua
@@ -68,12 +68,11 @@ UEL0001 = Class(ACUUnit) {
     end,
 
     CreateBuildEffects = function(self, unitBeingBuilt, order)
-        local UpgradesFrom = unitBeingBuilt:GetBlueprint().General.UpgradesFrom
-        -- If we are assisting an upgrading unit, or repairing a unit, play separate effects
-        if (order == 'Repair' and not unitBeingBuilt:IsBeingBuilt()) or (UpgradesFrom and UpgradesFrom ~= 'none' and self:IsUnitState('Guarding'))then
-            EffectUtil.CreateDefaultBuildBeams(self, unitBeingBuilt, self.BuildEffectBones, self.BuildEffectsBag)
-        else
+        -- Different effect if we have building cube
+        if unitBeingBuilt.BuildingCube then
             EffectUtil.CreateUEFCommanderBuildSliceBeams(self, unitBeingBuilt, self.BuildEffectBones, self.BuildEffectsBag)
+        else
+            EffectUtil.CreateDefaultBuildBeams(self, unitBeingBuilt, self.BuildEffectBones, self.BuildEffectsBag)
         end
     end,
 

--- a/units/UEL0301/UEL0301_script.lua
+++ b/units/UEL0301/UEL0301_script.lua
@@ -47,12 +47,11 @@ UEL0301 = Class(CommandUnit) {
     end,
 
     CreateBuildEffects = function(self, unitBeingBuilt, order)
-        local UpgradesFrom = unitBeingBuilt:GetBlueprint().General.UpgradesFrom
-        -- If we are assisting an upgrading unit, or repairing a unit, play separate effects
-        if (order == 'Repair' and not unitBeingBuilt:IsBeingBuilt()) or (UpgradesFrom and UpgradesFrom ~= 'none' and self:IsUnitState('Guarding'))then
-            EffectUtil.CreateDefaultBuildBeams(self, unitBeingBuilt, self.BuildEffectBones, self.BuildEffectsBag)
-        else
+        -- Different effect if we have building cube
+        if unitBeingBuilt.BuildingCube then
             EffectUtil.CreateUEFCommanderBuildSliceBeams(self, unitBeingBuilt, self.BuildEffectBones, self.BuildEffectsBag)
+        else
+            EffectUtil.CreateDefaultBuildBeams(self, unitBeingBuilt, self.BuildEffectBones, self.BuildEffectsBag)
         end
     end,
 


### PR DESCRIPTION
Changes logic of the UEF build beams.
This way it will never happen that we would have slice beams without the building cube.
It currently changes the effect for assisting factory producing units. From slices to default beam.
I believe it looks better, since those units don't have cube. And it's also more sim friendly beam, so I'll take it!