### PR TITLE
Make yolo a little smoother

### DIFF
--- a/units/XSB2401/XSB2401_unit.bp
+++ b/units/XSB2401/XSB2401_unit.bp
@@ -331,7 +331,7 @@ UnitBlueprint {
             TurretYawSpeed = 0,
             Turreted = false,
             WeaponCategory = 'Missile',
-            WeaponRepackTimeout = 32.5,
+            WeaponRepackTimeout = 20,
             WeaponUnpackAnimation = '/units/uab2305/uab2305_alaunchsequence.sca',
             WeaponUnpackAnimationRate = 10,
             WeaponUnpacks = true,


### PR DESCRIPTION
https://forum.faforever.com/topic/523/aeon-shield-animation related
WeaponRepackTimeout 32.5 -> 20

it still shits the bed hard when you drag the order around as its shooting, seemingly locking it forever, something to look into in the future
