### PR TITLE
Create adjacency effects only once

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -559,7 +559,7 @@ StructureUnit = Class(Unit) {
                 return
             end
         end
-        self:ForkThread(EffectUtil.CreateAdjacencyBeams, adjacentUnit, self.AdjacencyBeamsBag)
+        EffectUtil.CreateAdjacencyBeams(self, adjacentUnit, self.AdjacencyBeamsBag)
     end,
 
     DestroyAdjacentEffects = function(self, adjacentUnit)


### PR DESCRIPTION
`CreateAdjacentEffect` is called twice, since there are always 2 building adjacent to each other. But the check if the adjacency beams are already created doesnt work, since the function CreateAdjacencyBeams is threaded and runs twice at the same time. Since there is no waiting inside it, it's safe to not thread it, which fixes the check for duplicates.

In the end you get only one set of effects per 2 adjacent units instead of two (they overlapped most of the time, so they were just brighter)