### PR TITLE
Fixed getting game/replay id from /savereplay cmd argument

### DIFF
--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -1090,9 +1090,12 @@ function GetReplayId()
     if HasCommandLineArg("/syncreplay") and HasCommandLineArg("/gpgnet") and GetFrontEndData('syncreplayid') ~= nil and GetFrontEndData('syncreplayid') ~= 0 then
         id = GetFrontEndData('syncreplayid')
     elseif HasCommandLineArg("/savereplay") then
+        -- /savereplay format is gpgnet://local_ip:port/replay_id/USERNAME.SCFAreplay
+        -- see https://github.com/FAForever/downlords-faf-client/blob/b819997b2c4964ae6e6801d5d2eecd232bca5688/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java#L192
         local url = GetCommandLineArg("/savereplay", 1)[1]
-        local lastpos = string.find(url, "/", 20)
-        id = string.sub(url, 20, lastpos-1)
+        local fistpos = string.find(url, "/", 10) + 1
+        local lastpos = string.find(url, "/", fistpos) - 1
+        id = string.sub(url, fistpos, lastpos)
     elseif HasCommandLineArg("/replayid") then
         id =  GetCommandLineArg("/replayid", 1)[1]
     end


### PR DESCRIPTION
This is the port of fixes https://github.com/FA-mods/SupremeScoreBoard/pull/20.

Previously `/savereplay` cmd arg had a format of `gpgnet://localhost/uid/username.SCFAreplay`, but in https://github.com/FAForever/downlords-faf-client/commit/1ae6c7e936305f0336ecb9c324e9fc0560b843c3#diff-3d47503b30b47f5a259049a2e45e1eb555b502bd1f9cc68c936394a0d8fc6f1fR192 it has been changed to `gpgnet://localIp:localReplayPort/uid/username.SCFAreplay`, what leads a bug when in the `ID` text in score board instead of replayid there is local replay port ("magic number" `20` in `string.find(url, "/", 20)` and `string.sub(url, 20, lastpos-1)` is for length of `gpgnet://localhost/`) ¯\_(ツ)_/¯

This PR fixes this bug.