### PR TITLE
Fix wait on NukeAI to enable Aeon SML time to complete firing animation.

### DIFF
--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -448,7 +448,7 @@ Platoon = Class(moho.platoon_methods) {
                 nukePos = import('/lua/ai/aibehaviors.lua').GetHighestThreatClusterLocation(aiBrain, unit)
                 if nukePos then
                    IssueNuke({unit}, nukePos)
-                   WaitSeconds(10)
+                   WaitSeconds(12)
                    IssueClearCommands({unit})
                 end
                 WaitSeconds(1)
@@ -3785,7 +3785,7 @@ Platoon = Class(moho.platoon_methods) {
                 nukePos = import('/lua/ai/aibehaviors.lua').GetHighestThreatClusterLocation(aiBrain, unit)
                 if nukePos then
                     IssueNuke({unit}, nukePos)
-                    WaitSeconds(10)
+                    WaitSeconds(12)
                     IssueClearCommands({unit})
                 end
                 WaitSeconds(1)


### PR DESCRIPTION

Currently the Aeon Nuke launcher will never fire for an AI that is using this platoon function. Have corrected for the default AI and the Sorian AI NukeAI platoon function.
The default WaitSeconds time of 10 does not allow the Aeon SML enough time to complete its animation to fire a missile. This results in the default AI issuing a clear commands request and canceling the launch sequence. Increased to 12 seconds to allow time to launch missile. 

To test, spawn an Aeon T3 SML for the AI to pick up in its main base and validate missile is fired when completed.

This branch is for bugfixes, general improvements, and new features. If your change is designed to alter balance, please make 
sure your changes are rebased onto [development/balance] (https://github.com/FAForever/fa/tree/development/balance), and target that branch with your PR.