### PR TITLE
Remove large preview when map markers hidden

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5118,6 +5118,11 @@ end
 
 -- Perform one-time setup of the large map preview
 function CreateBigPreview(parent)
+    local scenarioInfo = MapUtil.LoadScenario(gameInfo.GameOptions.ScenarioFile)
+    if scenarioInfo.hidePreviewMarkers then
+        return
+    end
+
     if LrgMap then
         LrgMap.isHidden = false
         RefreshLargeMap()


### PR DESCRIPTION
This removes the ability to see the large preview when map markers are hidden as otherwise the map markers are visible on the large preview when it is opened a second time