### PR TITLE
Set rebuild progress based on ratio of mass to max possible wreckage mass

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2500,8 +2500,8 @@ Unit = Class(moho.unit_methods) {
             for _, p in props do
                 local pos = p.CachePosition
                 if p.IsWreckage and p.AssociatedBP == bpid and upos[1] == pos[1] and upos[3] == pos[3] then
-                    local bp = unit:GetBlueprint();
-                    local MaxMassReclaim = bp.Economy.BuildCostMass * (bp.Wreckage.MassMult or 0);
+                    local bp = unit:GetBlueprint()
+                    local MaxMassReclaim = bp.Economy.BuildCostMass * (bp.Wreckage.MassMult or 0)
                     local progress = (p.ReclaimLeft * p.MaxMassReclaim) / MaxMassReclaim * 0.5
                     -- Set health according to how much is left of the wreck
                     unit:SetHealth(self, unit:GetMaxHealth() * progress)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2501,10 +2501,12 @@ Unit = Class(moho.unit_methods) {
                 local pos = p.CachePosition
                 if p.IsWreckage and p.AssociatedBP == bpid and upos[1] == pos[1] and upos[3] == pos[3] then
                     local bp = unit:GetBlueprint()
-                    local MaxMassReclaim = bp.Economy.BuildCostMass * (bp.Wreckage.MassMult or 0)
-                    local progress = (p.ReclaimLeft * p.MaxMassReclaim) / MaxMassReclaim * 0.5
-                    -- Set health according to how much is left of the wreck
-                    unit:SetHealth(self, unit:GetMaxHealth() * progress)
+                    local UnitMaxMassReclaim = bp.Economy.BuildCostMass * (bp.Wreckage.MassMult or 0)
+                    if UnitMaxMassReclaim and UnitMaxMassReclaim > 0 then
+                        local progress = (p.ReclaimLeft * p.MaxMassReclaim) / UnitMaxMassReclaim * 0.5
+                        -- Set health according to how much is left of the wreck
+                        unit:SetHealth(self, unit:GetMaxHealth() * progress)
+                    end
 
                     -- Clear up wreck after rebuild bonus applied if engine won't
                     if not unit.EngineIsDeletingWreck then

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2500,7 +2500,9 @@ Unit = Class(moho.unit_methods) {
             for _, p in props do
                 local pos = p.CachePosition
                 if p.IsWreckage and p.AssociatedBP == bpid and upos[1] == pos[1] and upos[3] == pos[3] then
-                    local progress = p:GetFractionComplete() * 0.5
+                    local bp = unit:GetBlueprint();
+                    local MaxMassReclaim = bp.Economy.BuildCostMass * (bp.Wreckage.MassMult or 0);
+                    local progress = (p.ReclaimLeft * p.MaxMassReclaim) / MaxMassReclaim * 0.5
                     -- Set health according to how much is left of the wreck
                     unit:SetHealth(self, unit:GetMaxHealth() * progress)
 


### PR DESCRIPTION
Fixes #3095 

This sets the rebuild progress from a wreck proportionally to the amount of mass left in the wreck compared to the buildCost*wreckageMult.

This has to retrieve the unit blueprint first to calculate the max wreckage mass for the unit. This could be avoided if overkill damaged the wreck rather than just changing the initial mass value.

Additionally this sets the maximum rebuild progress after ctrl king a building to 45% from 50% due to the difference in intial reclaim left vs the buildCost*wreckageMult.