### PR TITLE
Fix Tooltip for Experimental Transporter

### DIFF
--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -366,16 +366,11 @@ GetAbilityDesc = {
     end,]]
     ability_transport = function(bp)
         local text = LOC('<LOC uvd_Capacity>')
-        if bp.CategoriesHash.TECH1 then
-            return text..'≈6'
-        end
-        if bp.CategoriesHash.TECH2 then
-            return text..'≈12'
-        end
-        if bp.CategoriesHash.TECH3 then
-            return text..'≈28'
-        end
-        return ''
+        return bp.Transport and bp.Transport.Class1Capacity and text..bp.Transport.Class1Capacity
+            or bp.CategoriesHash.TECH1 and text..'≈6'
+            or bp.CategoriesHash.TECH2 and text..'≈12'
+            or bp.CategoriesHash.TECH3 and text..'≈28'
+            or ''
     end,
     ability_airstaging = function(bp)
         return LOCF('<LOC uvd_RepairRate>', bp.Transport.RepairRate)..', '

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -375,6 +375,9 @@ GetAbilityDesc = {
         if bp.CategoriesHash.TECH3 then
             return text..'≈28'
         end
+        if bp.CategoriesHash.EXPERIMENTAL then
+            return text..'≈28'
+        end
     end,
     ability_airstaging = function(bp)
         return LOCF('<LOC uvd_RepairRate>', bp.Transport.RepairRate)..', '

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -375,9 +375,7 @@ GetAbilityDesc = {
         if bp.CategoriesHash.TECH3 then
             return text..'≈28'
         end
-        if bp.CategoriesHash.EXPERIMENTAL then
-            return text..'≈28'
-        end
+        return ''
     end,
     ability_airstaging = function(bp)
         return LOCF('<LOC uvd_RepairRate>', bp.Transport.RepairRate)..', '

--- a/units/UAA0104/UAA0104_unit.bp
+++ b/units/UAA0104/UAA0104_unit.bp
@@ -258,6 +258,7 @@ UnitBlueprint {
         Class2AttachSize = 2,
         Class3AttachSize = 4,
         TransportClass = 10,
+        Class1Capacity = 12,
     },
     UseOOBTestZoom = 200,
     Veteran = {

--- a/units/UAA0107/UAA0107_unit.bp
+++ b/units/UAA0107/UAA0107_unit.bp
@@ -244,6 +244,7 @@ UnitBlueprint {
         Class2AttachSize = 2,
         Class3AttachSize = 4,
         TransportClass = 10,
+        Class1Capacity = 6,
     },
     UseOOBTestZoom = 200,
     Weapon = {

--- a/units/UEA0104/UEA0104_unit.bp
+++ b/units/UEA0104/UEA0104_unit.bp
@@ -282,6 +282,7 @@ UnitBlueprint {
         Class2AttachSize = 2,
         Class3AttachSize = 4,
         TransportClass = 10,
+        Class1Capacity = 14,
     },
     UseOOBTestZoom = 200,
     Veteran = {

--- a/units/UEA0107/UEA0107_unit.bp
+++ b/units/UEA0107/UEA0107_unit.bp
@@ -258,6 +258,7 @@ UnitBlueprint {
         Class2AttachSize = 2,
         Class3AttachSize = 4,
         TransportClass = 10,
+        Class1Capacity = 6,
     },
     UseOOBTestZoom = 200,
     Weapon = {

--- a/units/UEA0203/UEA0203_unit.bp
+++ b/units/UEA0203/UEA0203_unit.bp
@@ -266,6 +266,7 @@ UnitBlueprint {
         AirClass = true,
         ClassGenericUpTo = 2,
         TransportClass = 1,
+        Class1Capacity = 1,
     },
     Veteran = {
         Level1 = 6,

--- a/units/URA0104/URA0104_unit.bp
+++ b/units/URA0104/URA0104_unit.bp
@@ -273,6 +273,7 @@ UnitBlueprint {
         Class2AttachSize = 2,
         Class3AttachSize = 4,
         TransportClass = 10,
+        Class1Capacity = 10,
     },
     UseOOBTestZoom = 200,
     Veteran = {

--- a/units/URA0107/URA0107_unit.bp
+++ b/units/URA0107/URA0107_unit.bp
@@ -258,6 +258,7 @@ UnitBlueprint {
         Class2AttachSize = 2,
         Class3AttachSize = 4,
         TransportClass = 10,
+        Class1Capacity = 6,
     },
     UseOOBTestZoom = 200,
     Weapon = {

--- a/units/XEA0306/XEA0306_unit.bp
+++ b/units/XEA0306/XEA0306_unit.bp
@@ -318,6 +318,7 @@ UnitBlueprint {
         Class2AttachSize = 2,
         Class3AttachSize = 4,
         TransportClass = 10,
+        Class1Capacity = 28,
     },
     UseOOBTestZoom = 200,
     Veteran = {

--- a/units/XSA0104/XSA0104_unit.bp
+++ b/units/XSA0104/XSA0104_unit.bp
@@ -285,6 +285,7 @@ UnitBlueprint {
         Class2AttachSize = 2,
         Class3AttachSize = 4,
         TransportClass = 10,
+        Class1Capacity = 16,
     },
     UseOOBTestZoom = 200,
     Veteran = {

--- a/units/XSA0107/XSA0107_unit.bp
+++ b/units/XSA0107/XSA0107_unit.bp
@@ -269,6 +269,7 @@ UnitBlueprint {
         Class2AttachSize = 2,
         Class3AttachSize = 4,
         TransportClass = 10,
+        Class1Capacity = 8,
     },
     UseOOBTestZoom = 200,
     Weapon = {


### PR DESCRIPTION
Some mods provide Experimental Trasnporter and the ability function only checks for Tech1-3 units.
Experimental Transporters will trigger an error.

Also the description for transportcapacity only has estimated values so we need to add a helper variable.

---

Added Class1Capacity to all transporter blueprints to set the real transportcapacity

Unit ura0104 (Air Transport) Added missing transport capacity variable (Class1Capacity = 10,)
Unit xsa0104 (Air Transport) Added missing transport capacity variable (Class1Capacity = 16,)
Unit xsa0107 (Light Air Transport) Added missing transport capacity variable (Class1Capacity = 8,)
Unit ura0107 (Light Air Transport) Added missing transport capacity variable (Class1Capacity = 6,)
Unit xea0306 (Heavy Air Transport) Added missing transport capacity variable (Class1Capacity = 28,)
Unit uea0104 (Air Transport) Added missing transport capacity variable (Class1Capacity = 14,)
Unit uaa0104 (Air Transport) Added missing transport capacity variable (Class1Capacity = 12,)
Unit uaa0107 (Light Air Transport) Added missing transport capacity variable (Class1Capacity = 6,)
Unit uea0107 (Light Air Transport) Added missing transport capacity variable (Class1Capacity = 6,)
Unit uea0203 (Gunship) Added missing transport capacity variable (Class1Capacity = 1,)


