### PR TITLE
priority rework adjustments

### DIFF
--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -928,11 +928,7 @@ UnitBlueprint {
             RateOfFire = 1,
             TargetCheckInterval = 0.5,
             TargetPriorities = {
-                'MOBILE BOMB',
-                'MOBILE EXPERIMENTAL',
-                'MOBILE TECH3',
-                'MOBILE TECH2',
-                'MOBILE TECH1',
+                'MOBILE',
                 'COMMAND',
                 '(STRUCTURE * DEFENSE - ANTIMISSILE)',
                 '(ALLUNITS - SPECIALLOWPRI)',
@@ -1015,7 +1011,6 @@ UnitBlueprint {
             TargetCheckInterval = 0.1,
             TargetPriorities = {
                 'MOBILE EXPERIMENTAL',
-                'MOBILE BOMB',
                 'MOBILE TECH3',
                 'MOBILE TECH2',
                 '(STRUCTURE * DEFENSE - ANTIMISSILE)',
@@ -1101,7 +1096,6 @@ UnitBlueprint {
             TargetCheckInterval = 0.1,
             TargetPriorities = {
                 'MOBILE EXPERIMENTAL',
-                'MOBILE BOMB',
                 'MOBILE TECH3',
                 'MOBILE TECH2',
                 '(STRUCTURE * DEFENSE - ANTIMISSILE)',

--- a/units/UAS0203/UAS0203_unit.bp
+++ b/units/UAS0203/UAS0203_unit.bp
@@ -362,8 +362,8 @@ UnitBlueprint {
             SlavedToBodyArcRange = 10,
             TargetCheckInterval = 2,
             TargetPriorities = {
-                'TECH2 LIGHTBOAT',
                 'SUBMERSIBLE',
+                'TECH2 LIGHTBOAT',
                 '(STRUCTURE * DEFENSE - ANTIAIR)',
                 '(TECH2 * MOBILE * NAVAL - CRUISER)',
                 'ANTINAVY',

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -997,11 +997,7 @@ UnitBlueprint {
             SlavedToBody = false,
             TargetCheckInterval = 0.5,
             TargetPriorities = {
-                'MOBILE BOMB',
-                'MOBILE EXPERIMENTAL',
-                'MOBILE TECH3',
-                'MOBILE TECH2',
-                'MOBILE TECH1',
+                'MOBILE',
                 'COMMAND',
                 '(STRUCTURE * DEFENSE - ANTIMISSILE)',
                 '(ALLUNITS - SPECIALLOWPRI)',
@@ -1084,7 +1080,6 @@ UnitBlueprint {
             TargetCheckInterval = 0.1,
             TargetPriorities = {
                 'MOBILE EXPERIMENTAL',
-                'MOBILE BOMB',
                 'MOBILE TECH3',
                 'MOBILE TECH2',
                 '(STRUCTURE * DEFENSE - ANTIMISSILE)',
@@ -1170,7 +1165,6 @@ UnitBlueprint {
             TargetCheckInterval = 0.1,
             TargetPriorities = {
                 'MOBILE EXPERIMENTAL',
-                'MOBILE BOMB',
                 'MOBILE TECH3',
                 'MOBILE TECH2',
                 '(STRUCTURE * DEFENSE - ANTIMISSILE)',

--- a/units/UES0202/UES0202_unit.bp
+++ b/units/UES0202/UES0202_unit.bp
@@ -350,10 +350,10 @@ UnitBlueprint {
             RenderFireClock = true,
             TargetCheckInterval = 5,
             TargetPriorities = {
+                'NAVAL MOBILE',
                 'TECH3 STRUCTURE',
                 'TECH2 STRUCTURE',
                 'TECH1 STRUCTURE',
-                'NAVAL MOBILE',
                 '(ALLUNITS - SPECIALLOWPRI)',
             },
             TargetRestrictDisallow = 'UNTARGETABLE',

--- a/units/UES0203/UES0203_unit.bp
+++ b/units/UES0203/UES0203_unit.bp
@@ -358,8 +358,8 @@ UnitBlueprint {
             SlavedToBodyArcRange = 10,
             TargetCheckInterval = 2,
             TargetPriorities = {
-                'TECH2 LIGHTBOAT',
                 'SUBMERSIBLE',
+                'TECH2 LIGHTBOAT',
                 '(STRUCTURE * DEFENSE - ANTIAIR)',
                 '(TECH2 * MOBILE * NAVAL - CRUISER)',
                 'ANTINAVY',

--- a/units/UES0401/UES0401_unit.bp
+++ b/units/UES0401/UES0401_unit.bp
@@ -437,8 +437,8 @@ UnitBlueprint {
             SlavedToBodyArcRange = 35,
             TargetCheckInterval = 1,
             TargetPriorities = {
-                'TECH2 LIGHTBOAT',
                 'SUBMERSIBLE',
+                'TECH2 LIGHTBOAT',
                 '(STRUCTURE * DEFENSE - ANTIAIR)',
                 '(TECH2 * MOBILE * NAVAL - CRUISER)',
                 'ANTINAVY',

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -872,11 +872,7 @@ UnitBlueprint {
             RateOfFire = 1,
             TargetCheckInterval = 0.5,
             TargetPriorities = {
-                'MOBILE BOMB',
-                'MOBILE EXPERIMENTAL',
-                'MOBILE TECH3',
-                'MOBILE TECH2',
-                'MOBILE TECH1',
+                'MOBILE',
                 'COMMAND',
                 '(STRUCTURE * DEFENSE - ANTIMISSILE)',
                 '(ALLUNITS - SPECIALLOWPRI)',
@@ -962,7 +958,6 @@ UnitBlueprint {
             TargetCheckInterval = 0.1,
             TargetPriorities = {
                 'MOBILE EXPERIMENTAL',
-                'MOBILE BOMB',
                 'MOBILE TECH3',
                 'MOBILE TECH2',
                 'MOBILE TECH1',
@@ -1049,7 +1044,6 @@ UnitBlueprint {
             TargetCheckInterval = 0.1,
             TargetPriorities = {
                 'MOBILE EXPERIMENTAL',
-                'MOBILE BOMB',
                 'MOBILE TECH3',
                 'MOBILE TECH2',
                 '(STRUCTURE * DEFENSE - ANTIMISSILE)',
@@ -1184,7 +1178,6 @@ UnitBlueprint {
             TargetPriorities = {
                 'COMMAND',
                 'MOBILE EXPERIMENTAL',
-                'MOBILE BOMB',
                 'MOBILE TECH3',
                 'MOBILE TECH2',
                 '(STRUCTURE * DEFENSE - ANTIMISSILE)',

--- a/units/URS0203/URS0203_unit.bp
+++ b/units/URS0203/URS0203_unit.bp
@@ -358,8 +358,8 @@ UnitBlueprint {
             SlavedToBodyArcRange = 10,
             TargetCheckInterval = 1.5,
             TargetPriorities = {
-                'TECH2 LIGHTBOAT',
                 'SUBMERSIBLE',
+                'TECH2 LIGHTBOAT',
                 '(STRUCTURE * DEFENSE - ANTIAIR)',
                 '(TECH2 * MOBILE * NAVAL - CRUISER)',
                 'ANTINAVY',

--- a/units/XAS0204/XAS0204_unit.bp
+++ b/units/XAS0204/XAS0204_unit.bp
@@ -349,8 +349,8 @@ UnitBlueprint {
             SlavedToBodyArcRange = 10,
             TargetCheckInterval = 2,
             TargetPriorities = {
-                'TECH2 LIGHTBOAT',
                 'SUBMERSIBLE',
+                'TECH2 LIGHTBOAT',
                 '(STRUCTURE * DEFENSE - ANTIAIR)',
                 '(TECH2 * MOBILE * NAVAL - CRUISER)',
                 'ANTINAVY',

--- a/units/XRB2308/XRB2308_unit.bp
+++ b/units/XRB2308/XRB2308_unit.bp
@@ -265,8 +265,8 @@ UnitBlueprint {
             RateOfFire = 0.25,
             TargetCheckInterval = 0.25,
             TargetPriorities = {
-                'LIGHTBOAT TECH2', -- cooper
                 'SUBMERSIBLE',
+                'LIGHTBOAT TECH2',
                 '(STRUCTURE * DEFENSE - ANTIMISSILE - ANTIAIR)',
                 '(TECH2 * MOBILE * NAVAL - CRUISER)',
                 'MOBILE ANTINAVY',

--- a/units/XRS0204/XRS0204_unit.bp
+++ b/units/XRS0204/XRS0204_unit.bp
@@ -362,8 +362,8 @@ UnitBlueprint {
             SlavedToBodyArcRange = 10,
             TargetCheckInterval = 0.4,
             TargetPriorities = {
-                'TECH2 LIGHTBOAT',
                 'SUBMERSIBLE',
+                'TECH2 LIGHTBOAT',
                 '(STRUCTURE * DEFENSE - ANTIAIR)',
                 '(TECH2 * MOBILE * NAVAL - CRUISER)',
                 'ANTINAVY',

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -963,11 +963,7 @@ UnitBlueprint {
             RateOfFire = 1,
             TargetCheckInterval = 0.5,
             TargetPriorities = {
-                'MOBILE BOMB',
-                'MOBILE EXPERIMENTAL',
-                'MOBILE TECH3',
-                'MOBILE TECH2',
-                'MOBILE TECH1',
+                'MOBILE',
                 'COMMAND',
                 '(STRUCTURE * DEFENSE - ANTIMISSILE)',
                 '(ALLUNITS - SPECIALLOWPRI)',
@@ -1051,7 +1047,6 @@ UnitBlueprint {
             TargetCheckInterval = 0.1,
             TargetPriorities = {
                 'MOBILE EXPERIMENTAL',
-                'MOBILE BOMB',
                 'MOBILE TECH3',
                 'MOBILE TECH2',
                 '(STRUCTURE * DEFENSE - ANTIMISSILE)',
@@ -1138,7 +1133,6 @@ UnitBlueprint {
             TargetCheckInterval = 0.1,
             TargetPriorities = {
                 'MOBILE EXPERIMENTAL',
-                'MOBILE BOMB',
                 'MOBILE TECH3',
                 'MOBILE TECH2',
                 '(STRUCTURE * DEFENSE - ANTIMISSILE)',

--- a/units/XSS0202/XSS0202_unit.bp
+++ b/units/XSS0202/XSS0202_unit.bp
@@ -270,10 +270,10 @@ UnitBlueprint {
             RenderFireClock = true,
             TargetCheckInterval = 2,
             TargetPriorities = {
+                'NAVAL MOBILE',
                 'TECH3 STRUCTURE',
                 'TECH2 STRUCTURE',
                 'TECH1 STRUCTURE',
-                'NAVAL MOBILE',
                 '(ALLUNITS - SPECIALLOWPRI)',
             },
             TargetRestrictDisallow = 'UNTARGETABLE',

--- a/units/XSS0203/XSS0203_unit.bp
+++ b/units/XSS0203/XSS0203_unit.bp
@@ -349,8 +349,8 @@ UnitBlueprint {
             SlavedToBodyArcRange = 10,
             TargetCheckInterval = 1.5,
             TargetPriorities = {
-                'TECH2 LIGHTBOAT',
                 'SUBMERSIBLE',
+                'TECH2 LIGHTBOAT',
                 '(STRUCTURE * DEFENSE - ANTIAIR)',
                 '(TECH2 * MOBILE * NAVAL - CRUISER)',
                 'ANTINAVY',

--- a/units/XSS0304/XSS0304_unit.bp
+++ b/units/XSS0304/XSS0304_unit.bp
@@ -343,8 +343,8 @@ UnitBlueprint {
             SlavedToBodyArcRange = 10,
             TargetCheckInterval = 0.5,
             TargetPriorities = {
-                'TECH2 LIGHTBOAT',
                 'SUBMERSIBLE',
+                'TECH2 LIGHTBOAT',
                 '(STRUCTURE * DEFENSE - ANTIAIR)',
                 '(TECH2 * MOBILE * NAVAL - CRUISER)',
                 'ANTINAVY',


### PR DESCRIPTION
- Revert ACUs to their previous "loose" targeting of mobile units with no preference
- Cruisers now target navy before structures again
- Subs target other subs before coopers
