### PR TITLE
Fix Ingame CPU Benchmark

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5228,20 +5228,15 @@ local BenchTime
 --  CPU Benchmarking Functions
 --------------------------------------------------
 function CPUBenchmark()
+    -- Uveso: Actual we are checking more or less RAM speed not CPU speed
     --This function gives the CPU some busy work to do.
     --CPU score is determined by how quickly the work is completed.
     local totalTime = 0
     local lastTime
     local currTime
     local countTime = 0
-    --Make everything a local variable
-    --This is necessary because we don't want LUA searching through the globals as part of the benchmark
-    local h
-    local i
-    local j
-    local k
-    local l
-    local m
+    local TABLE1 = 'ABC123.-/'
+    local TABLE2 = {}
     for h = 1, 48, 1 do
         -- If the need for the benchmark no longer exists, abort it now.
         if not lobbyComm then
@@ -5250,21 +5245,7 @@ function CPUBenchmark()
 
         lastTime = GetSystemTimeSeconds()
         for i = 1.0, 25.0, 0.0008 do
-            --This instruction set should cover most LUA operators
-            j = i + i   --Addition
-            k = i * i   --Multiplication
-            l = k / j   --Division
-            m = j - i   --Subtraction
-            j = i ^ 4   --Power
-            l = -i      --Negation
-            m = {'One', 'Two', 'Three'} --Create Table
-            table.insert(m, 'Four')     --Insert Table Value
-            table.remove(m, 1)          --Remove Table Value
-            l = table.getn(m)           --Get Table Length
-            k = i < j   --Less Than
-            k = i == j  --Equality
-            k = i <= j  --Less Than or Equal to
-            k = not k
+            TABLE2[tostring(i)] = TABLE1
         end
         currTime = GetSystemTimeSeconds()
         totalTime = totalTime + currTime - lastTime

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5228,24 +5228,45 @@ local BenchTime
 --  CPU Benchmarking Functions
 --------------------------------------------------
 function CPUBenchmark()
-    -- Uveso: Actual we are checking more or less RAM speed not CPU speed
     --This function gives the CPU some busy work to do.
     --CPU score is determined by how quickly the work is completed.
     local totalTime = 0
     local lastTime
     local currTime
     local countTime = 0
-    local TABLE1 = 'ABC123.-/'
-    local TABLE2 = {}
-    for h = 1, 48, 1 do
+    --Make everything a local variable
+    --This is necessary because we don't want LUA searching through the globals as part of the benchmark
+    local TableInsert = table.insert
+    local TableRemove = table.remove
+    local h
+    local i
+    local j
+    local k
+    local l
+    local m
+    local n = {}
+    for h = 1, 24, 1 do
         -- If the need for the benchmark no longer exists, abort it now.
         if not lobbyComm then
             return
         end
 
         lastTime = GetSystemTimeSeconds()
-        for i = 1.0, 25.0, 0.0008 do
-            TABLE2[tostring(i)] = TABLE1
+        for i = 1.0, 30.4, 0.0008 do
+           --This instruction set should cover most LUA operators
+            j = i + i   --Addition
+            k = i * i   --Multiplication
+            l = k / j   --Division
+            m = j - i   --Subtraction
+            j = i ^ 4   --Power
+            l = -i      --Negation
+            m = {'1234567890', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', true} --Create Table
+            TableInsert(m, '1234567890')     --Insert Table Value
+            k = i < j   --Less Than
+            k = i == j  --Equality
+            k = i <= j  --Less Than or Equal to
+            k = not k
+            n[tostring(i)] = m
         end
         currTime = GetSystemTimeSeconds()
         totalTime = totalTime + currTime - lastTime
@@ -5253,7 +5274,7 @@ function CPUBenchmark()
         if totalTime > countTime then
             --This is necessary in order to make this 'thread' yield so other things can be done.
             countTime = totalTime + .125
-            WaitSeconds(0)
+            coroutine.yield(1)
         end
     end
     BenchTime = math.ceil(totalTime * 100)


### PR DESCRIPTION
Benchmark is now testing RAM speed, not CPU calculating speed.

Benchmarks: (lower = better)
old= old CPU benchmark
new= new RAM benchmark
             
old: 144 new: 98 - netjaxx ( i7-6700K DDR4 )
old: 156 new: 144 - Uveso ( i7-4790K DDR3 )
old: 184 new: 115 - Moby ( Ryzen 5 DDR4 )
old: 327 new: 325 - Lionheart ( Q8400 DDR2 )
![Bench1](https://user-images.githubusercontent.com/17804547/112846500-69dd1700-90a6-11eb-98a2-761cb9a5d93a.png)

Ingame gamespeed multiplayer: (higher = better)
+7 netjaxx ( i7-6700K DDR4 ) CPU is slower than i7-4790 but RAM is DDR4
+6 Moby ( Ryzen 5 DDR4 ) slightly faster than i7-4790K Also because of DDR4
+6 Uveso ( i7-4790K DDR3 )
+3 Lionheart ( Q8400 DDR2 ) Old Intel Core 2 Quad
![Bench2](https://user-images.githubusercontent.com/17804547/112846530-71042500-90a6-11eb-944b-58f05efd4faf.png)
