### PR TITLE
AI-Patch -  Removing unused MassConsumption table and all child functions

### DIFF
--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -1233,58 +1233,11 @@ AIBrain = Class(moho.aibrain_methods) {
             PlatoonFormManager = PlatoonFormManager.CreatePlatoonFormManager(self, baseName, position, radius, useCenter),
             EngineerManager = EngineerManager.CreateEngineerManager(self, baseName, position, radius),
             StrategyManager = StratManager.CreateStrategyManager(self, baseName, position, radius),
-
-            -- Table to track consumption
-            MassConsumption = {
-                Resources = {Units = {}, Drain = 0, },
-                Units = {Units = {}, Drain = 0, },
-                Defenses = {Units = {}, Drain = 0, },
-                Upgrades = {Units = {}, Drain = 0, },
-                Engineers = {Units = {}, Drain = 0, },
-                TotalDrain = 0,
-            },
             BuilderHandles = {},
             Position = position,
             BaseType = Scenario.MasterChain._MASTERCHAIN_.Markers[baseName].type or 'MAIN',
         }
         self.NumBases = self.NumBases + 1
-    end,
-
-    AddConsumption = function(self, locationType, consumptionType, unit, unitBeingBuilt)
-        local consumptionData = self.BuilderManagers[locationType].MassConsumption
-        local bp = unitBeingBuilt:GetBlueprint()
-        local consumptionDrain = (unit:GetBuildRate() / bp.Economy.BuildTime) * bp.Economy.BuildCostMass
-
-        consumptionData[consumptionType].Drain = consumptionData[consumptionType].Drain + consumptionDrain
-        consumptionData.TotalDrain = consumptionData.TotalDrain + consumptionDrain
-
-        unit.ConsumptionData = {
-            ConsumptionType = consumptionType,
-            ConsumptionDrain = consumptionDrain,
-        }
-        table.insert(consumptionData[consumptionType].Units, unit)
-    end,
-
-    RemoveConsumption = function(self, locationType, unit)
-        local consumptionData = self.BuilderManagers[locationType].MassConsumption
-        local consumptionType = unit.ConsumptionData.ConsumptionType
-        if not consumptionType then
-            return
-        end
-
-        if not consumptionData[consumptionType] then
-            WARN('*AI WARNING: Invalid consumptionType - ' .. consumptionType)
-            return
-        end
-
-        for k, v in consumptionData[consumptionType].Units do
-            if v == unit then
-                consumptionData.TotalDrain = consumptionData.TotalDrain - unit.ConsumptionData.ConsumptionDrain
-                consumptionData[consumptionType].Drain = consumptionData[consumptionType].Drain - unit.ConsumptionData.ConsumptionDrain
-                consumptionData[consumptionType].Units[k] = nil
-                break
-            end
-        end
     end,
 
     GetEngineerManagerUnitsBeingBuilt = function(self, category)

--- a/lua/sim/EngineerManager.lua
+++ b/lua/sim/EngineerManager.lua
@@ -327,14 +327,6 @@ EngineerManager = Class(BuilderManager) {
                         end
                         import('/lua/ScenarioTriggers.lua').CreateUnitBuiltTrigger(unitConstructionFinished, unit, categories.ALLUNITS)
 
-                        local unitConstructionStarted = function(unit, unitBeingBuilt)
-                                                    local aiBrain = unit:GetAIBrain()
-                                                    local engManager = aiBrain.BuilderManagers[unit.BuilderManagerData.LocationType].EngineerManager
-                                                    if engManager then
-                                                        engManager:UnitConstructionStarted(unit, unitBeingBuilt)
-                                                    end
-                        end
-                        import('/lua/ScenarioTriggers.lua').CreateStartBuildTrigger(unitConstructionStarted, unit, categories.ALLUNITS)
                     end
                 end
 
@@ -547,8 +539,6 @@ EngineerManager = Class(BuilderManager) {
                 break
             end
         end
-
-        self.Brain:RemoveConsumption(self.LocationType, unit)
     end,
 
     ReassignUnit = function(self, unit)
@@ -579,28 +569,6 @@ EngineerManager = Class(BuilderManager) {
         end
     end,
 
-    UnitConstructionStarted = function(self, unit, unitBeingBuilt)
-        if EntityCategoryContains(categories.FACTORY, unitBeingBuilt) then
-            self:AddConsumption(unit, 'Upgrades', unitBeingBuilt)
-        elseif EntityCategoryContains(categories.EXPERIMENTAL + categories.MOBILE, unitBeingBuilt) then
-            self:AddConsumption(unit, 'Units', unitBeingBuilt)
-        elseif EntityCategoryContains(categories.MASSEXTRACTION + categories.MASSFABRICATION + categories.ENERGYPRODUCTION, unitBeingBuilt) then
-            self:AddConsumption(unit, 'Resources', unitBeingBuilt)
-        elseif EntityCategoryContains(categories.DEFENSE, unitBeingBuilt) then
-            self:AddConsumption(unit, 'Defenses', unitBeingBuilt)
-        elseif EntityCategoryContains(categories.ENGINEER, unitBeingBuilt) then
-            self:AddConsumption(unit, 'Engineers', unitBeingBuilt)
-        elseif EntityCategoryContains(categories.STRUCTURE, unitBeingBuilt) then
-            self:AddConsumption(unit, 'Upgrades', unitBeingBuilt)
-        else
-            WARN('*AI DEBUG: Unknown consumption type for UnitId - ' .. unitBeingBuilt.UnitId)
-        end
-    end,
-
-    AddConsumption = function(self, unit, consumptionType, unitBeingBuilt)
-        self.Brain:AddConsumption(self.LocationType, consumptionType, unit, unitBeingBuilt)
-    end,
-
     UnitConstructionFinished = function(self, unit, finishedUnit)
         if EntityCategoryContains(categories.FACTORY * categories.STRUCTURE, finishedUnit) and finishedUnit:GetAIBrain():GetArmyIndex() == self.Brain:GetArmyIndex() then
             self.Brain.BuilderManagers[self.LocationType].FactoryManager:AddFactory(finishedUnit)
@@ -620,7 +588,6 @@ EngineerManager = Class(BuilderManager) {
                 end
             end
         end
-        self.Brain:RemoveConsumption(self.LocationType, unit)
     end,
 
     AssignTimeout = function(self, builderName)

--- a/lua/sim/FactoryBuilderManager.lua
+++ b/lua/sim/FactoryBuilderManager.lua
@@ -217,11 +217,6 @@ FactoryBuilderManager = Class(BuilderManager) {
                                         end
                 import('/lua/ScenarioTriggers.lua').CreateUnitCapturedTrigger(nil, factoryNewlyCaptured, v)
 
-                local factoryWorkStart = function(factory, unitBeingBuilt)
-                                            factory.BuilderManagerData.FactoryBuildManager:UnitConstructionStarted(factory, unitBeingBuilt)
-                                        end
-                import('/lua/ScenarioTriggers.lua').CreateStartBuildTrigger(factoryWorkStart, v, categories.ALLUNITS)
-
                 local factoryWorkFinish = function(v, finishedUnit)
                                             -- Call function on builder manager; let it handle the finish of work
                                             self:FactoryFinishBuilding(v, finishedUnit)
@@ -254,7 +249,6 @@ FactoryBuilderManager = Class(BuilderManager) {
             end
         end
         self.LocationActive = false
-        self.Brain:RemoveConsumption(self.LocationType, factory)
     end,
 
     DelayBuildOrder = function(self,factory,bType,time)
@@ -398,36 +392,12 @@ FactoryBuilderManager = Class(BuilderManager) {
         end
     end,
 
-    UnitConstructionStarted = function(self, factory, unitBeingBuilt)
-        if EntityCategoryContains(categories.FACTORY, unitBeingBuilt) then
-            self:AddConsumption(factory, 'Upgrades', unitBeingBuilt)
-        elseif EntityCategoryContains(categories.EXPERIMENTAL + categories.MOBILE, unitBeingBuilt) then
-            self:AddConsumption(factory, 'Units', unitBeingBuilt)
-        elseif EntityCategoryContains(categories.MASSEXTRACTION + categories.MASSFABRICATION + categories.ENERGYPRODUCTION, unitBeingBuilt) then
-            self:AddConsumption(factory, 'Resources', unitBeingBuilt)
-        elseif EntityCategoryContains(categories.DEFENSE, unitBeingBuilt) then
-            self:AddConsumption(factory, 'Defenses', unitBeingBuilt)
-        elseif EntityCategoryContains(categories.ENGINEER, unitBeingBuilt) then
-            self:AddConsumption(factory, 'Engineers', unitBeingBuilt)
-        elseif EntityCategoryContains(categories.STRUCTURE, unitBeingBuilt) then
-            self:AddConsumption(factory, 'Upgrades', unitBeingBuilt)
-        else
-            WARN('*AI DEBUG: Unknown consumption type for UnitId - ' .. unitBeingBuilt.UnitId)
-        end
-    end,
-
-    AddConsumption = function(self, factory, consumptionType, unitBeingBuilt)
-        self.Brain:AddConsumption(self.LocationType, consumptionType, factory, unitBeingBuilt)
-    end,
-
     FactoryFinishBuilding = function(self,factory,finishedUnit)
         if EntityCategoryContains(categories.ENGINEER, finishedUnit) then
             self.Brain.BuilderManagers[self.LocationType].EngineerManager:AddUnit(finishedUnit)
         elseif EntityCategoryContains(categories.FACTORY, finishedUnit) then
             self:AddFactory(finishedUnit)
         end
-        self.Brain:RemoveConsumption(self.LocationType, factory)
-
         self:AssignBuildOrder(factory, factory.BuilderManagerData.BuilderType)
     end,
 


### PR DESCRIPTION
The Table and all child functions are not in use,
and we don't need to track energy/mass consumption in LUA for the AI.

We can get the data from every unit direcly with
Unit:GetConsumptionPerSecondMass()
Unit:GetConsumptionPerSecondEnergy()
