### PR TITLE
Fix shield ApplyDamage() function for ACU overcharge

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -178,7 +178,8 @@ Shield = Class(moho.shield_methods, Entity) {
     end,
 
     ApplyDamage = function(self, instigator, amount, vector, dmgType, doOverspill)
-        if dmgType == 'Overcharge' and instigator.EntityId then
+        -- check for UnitId, so we only check the ACU Overcharge damage and not shield overspill damage
+        if dmgType == 'Overcharge' and instigator.UnitId then
             local wep = instigator:GetWeaponByLabel('OverCharge')
             if self.StaticShield then -- fixed damage for static shields
                 amount = wep:GetBlueprint().Overcharge.structureDamage * 2

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -179,6 +179,8 @@ Shield = Class(moho.shield_methods, Entity) {
 
     ApplyDamage = function(self, instigator, amount, vector, dmgType, doOverspill)
         -- check for UnitId, so we only check the ACU Overcharge damage and not shield overspill damage
+        -- when UnitId is false and EntityId is true, then we got overspill from a shield that was impacted
+        -- by the splat damage of an ACU overcharge weapon.
         if dmgType == 'Overcharge' and instigator.UnitId then
             local wep = instigator:GetWeaponByLabel('OverCharge')
             if self.StaticShield then -- fixed damage for static shields


### PR DESCRIPTION
Function was checking for EntityId not UnitId.
This caused an error in executing instigator:GetWeaponByLabel()
while checking shields for a overcharge weapon.

This happens when UnitId is false and EntityId is true.
In this case we got overspill damage from a shield unit near the ACU that was impacted
by the splat damage of an ACU overcharge weapon.