### PR TITLE
Fix bugged acu button textoverlay labels when opening large map preview for second time

### DIFF
--- a/lua/ui/controls/acubutton.lua
+++ b/lua/ui/controls/acubutton.lua
@@ -99,13 +99,16 @@ ACUButton = Class(Group) {
 
         self.indicator = indicator
 
+        local textOverlay = Text(self)
+        textOverlay:SetFont(UIUtil.bodyFont, 20)
+        LayoutHelpers.AtCenterIn(textOverlay, self)
+        self.textOverlay = textOverlay
+
         self.OnHide = function(self, hidden)
             self.markerOverlay:SetHidden(hidden)
             self.marker:SetHidden(hidden)
             self.teamIndicator:SetHidden(hidden)
-            if self.textOverlay then
-                self.textOverlay:SetHidden(hidden)
-            end
+            self.textOverlay:SetHidden(hidden)
             return true
         end
     end,
@@ -182,20 +185,13 @@ ACUButton = Class(Group) {
     end,
 
     draw = function(self, color, text)
-        local textOverlay = Text(self)
-        textOverlay:SetFont(UIUtil.bodyFont, 20)
-        textOverlay:SetColor(color)
-        textOverlay:SetText(text)
-        LayoutHelpers.AtCenterIn(textOverlay, self)
-
-        self.textOverlay = textOverlay
+        self.textOverlay:SetColor(color)
+        self.textOverlay:SetText(text)
     end,
 
     RemoveTextOverlay = function(self)
-        if self.textOverlay then
-            self.textOverlay:Destroy()
-            self.textOverlay = nil
-        end
+        self.textOverlay:SetColor('00000000')
+        self.textOverlay:SetText('')
     end,
 
     -- Override for events...


### PR DESCRIPTION
When you open the large map preview in the lobby you can right click on the acu buttons to close spots.
When you open it the first time, you can right click and X appears to show that it slot is closed.
When you open it the second time or more, you can still remove X by right clicking it, but no more X will appear if you want to close something.

Weirdly when you hide and reopen the large map preview, the overlays all appear correctly.
But once you edit the correct X aren't shown.

This PR fixes this, so the X will always appear when you right click even on second or third try.

![image](https://user-images.githubusercontent.com/20644178/119268059-73d84d80-bbf1-11eb-85eb-4d7be925518d.png)
