### PR TITLE
fix BaseMonitorPlatoonDistress function from creating infinite table …

### DIFF
--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -2828,7 +2828,7 @@ AIBrain = Class(moho.aibrain_methods) {
         local found = false
         for k, v in self.BaseMonitor.PlatoonDistressTable do
             -- If already calling for help, don't add another distress call
-            if table.equal(v.Platoon, platoon) then
+            if v.Platoon == platoon then
                 found = true
                 break
             end

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -2920,7 +2920,7 @@ AIBrain = Class(moho.aibrain_methods) {
             for k, v in self.BaseMonitor.PlatoonDistressTable do
                 if self:PlatoonExists(v.Platoon) then
                     local platPos = v.Platoon:GetPlatoonPosition()
-                    local tempDist = Utilities.XZDistanceTwoVectors(platPos)
+                    local tempDist = Utilities.XZDistanceTwoVectors(position, platPos)
 
                     -- Platoon too far away to help
                     if tempDist > radius then
@@ -2928,7 +2928,7 @@ AIBrain = Class(moho.aibrain_methods) {
                     end
 
                     -- Area not scary enough
-                    if v.Threat < theshold then
+                    if v.Threat < threshold then
                         continue
                     end
 

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -2828,14 +2828,15 @@ AIBrain = Class(moho.aibrain_methods) {
         local found = false
         for k, v in self.BaseMonitor.PlatoonDistressTable do
             -- If already calling for help, don't add another distress call
-            if v.Platoon == platoon then
-                continue
+            if table.equal(v.Platoon, platoon) then
+                found = true
+                break
             end
-
+        end
+        if not found then
             -- Add platoon to list desiring aid
             table.insert(self.BaseMonitor.PlatoonDistressTable, {Platoon = platoon, Threat = threat})
         end
-
         -- Create the distress call if it doesn't exist
         if not self.BaseMonitor.PlatoonDistressThread then
             self.BaseMonitor.PlatoonDistressThread = self:ForkThread(self.BaseMonitorPlatoonDistressThread)


### PR DESCRIPTION
This is a fix to the default AI function BaseMonitorPlatoonDistress.
It corrects an edge case crash that can happen when platoons are using the 'PlatoonCallForHelpAI' addon plan.

By default if 2 or more platoons are under distress the function will only check if one is under distress and then add the next even if it is already within the table. Should 2 or more platoon remain under distress for a prolonged period this causes the table size to exponentially increase in size until the game eventually starts lagging and crashes due to the table size. In logging I saw the table size go into the tens of thousands within a 3 minute period once the issue started happening.