### PR TITLE
Increase the BT of Fobo

### DIFF
--- a/units/XSL0103/XSL0103_unit.bp
+++ b/units/XSL0103/XSL0103_unit.bp
@@ -192,7 +192,7 @@ UnitBlueprint {
     Economy = {
         BuildCostEnergy = 180,
         BuildCostMass = 54,
-        BuildTime = 180,
+        BuildTime = 270,
         TeleportEnergyMod = 0.15,
         TeleportMassMod = 1,
         TeleportTimeMod = 0.01,


### PR DESCRIPTION
Increase the BT of Fobo to 270 to bring it in line with other t1 units and the BT/mass cost ratio for t1 units.
