### PR TITLE
Buff BT and E cost of Loya & Titan

### DIFF
--- a/units/UEL0303/UEL0303_unit.bp
+++ b/units/UEL0303/UEL0303_unit.bp
@@ -144,9 +144,9 @@ UnitBlueprint {
         UniformScale = 0.7,
     },
     Economy = {
-        BuildCostEnergy = 5400,
+        BuildCostEnergy = 5250,
         BuildCostMass = 480,
-        BuildTime = 2400,
+        BuildTime = 2160,
         MaintenanceConsumptionPerSecondEnergy = 25,
         TeleportEnergyMod = 0.15,
         TeleportMassMod = 1,

--- a/units/URL0303/URL0303_unit.bp
+++ b/units/URL0303/URL0303_unit.bp
@@ -144,9 +144,9 @@ UnitBlueprint {
         UniformScale = 0.15,
     },
     Economy = {
-        BuildCostEnergy = 5400,
+        BuildCostEnergy = 5250,
         BuildCostMass = 480,
-        BuildTime = 2400,
+        BuildTime = 2160,
         TeleportEnergyMod = 0.15,
         TeleportMassMod = 1,
         TeleportTimeMod = 0.01,


### PR DESCRIPTION
Bring the E cost in line with Percy/Brick.
Buff the BT/mass from 5 -> 4.5 (Brick & Percy have 3.75)
