### PR TITLE
fix ArmyBrain result not equal to defeat bug in Sorian AI logic

### DIFF
--- a/lua/AI/AIBuilders/SorianStrategyBuilders.lua
+++ b/lua/AI/AIBuilders/SorianStrategyBuilders.lua
@@ -867,9 +867,9 @@ BuilderGroup {
             local enemies = 0
             local allies = 0
             for k,v in ArmyBrains do
-                if not v.Result == "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
+                if v.Result ~= "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
                     enemies = enemies + 1
-                elseif not v.Result == "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsAlly(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
+                elseif v.Result ~= "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsAlly(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
                     allies = allies + 1
                 end
             end

--- a/lua/editor/SorianBuildConditions.lua
+++ b/lua/editor/SorianBuildConditions.lua
@@ -174,9 +174,9 @@ function EnemyToAllyRatioLessOrEqual(aiBrain, num)
     local enemies = 0
     local allies = 0
     for k,v in ArmyBrains do
-        if not v.Result == "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
+        if v.Result ~= "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
             enemies = enemies + 1
-        elseif not v.Result == "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsAlly(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
+        elseif v.Result ~= "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsAlly(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
             allies = allies + 1
         end
     end
@@ -237,7 +237,7 @@ function ClosestEnemyLessThan(aiBrain, distance)
     local startX, startZ = aiBrain:GetArmyStartPos()
     local closest
     for k,v in ArmyBrains do
-        if not v.Result == "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
+        if v.Result ~= "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
             local estartX, estartZ = v:GetArmyStartPos()
             local tempDistance = VDist2Sq(startX, startZ, estartX, estartZ)
             if not closest or tempDistance < closest then
@@ -699,7 +699,7 @@ function EnemyInT3ArtilleryRange(aiBrain, locationtype, inrange)
         radius = 825 + offset
     end
     for k,v in ArmyBrains do
-        if not v.Result == "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
+        if v.Result ~= "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsEnemy(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
             local estartX, estartZ = v:GetArmyStartPos()
             if (VDist2Sq(start[1], start[3], estartX, estartZ) <= radius * radius) and inrange then
                 return true
@@ -727,7 +727,7 @@ function AIOutnumbered(aiBrain, bool)
     end
 
     for k,v in ArmyBrains do
-        if not v.Result == "defeat" and aiBrain:GetArmyIndex() ~= v:GetArmyIndex() and not ArmyIsCivilian(v:GetArmyIndex()) then
+        if v.Result ~= "defeat" and aiBrain:GetArmyIndex() ~= v:GetArmyIndex() and not ArmyIsCivilian(v:GetArmyIndex()) then
             local armyTeam = ScenarioInfo.ArmySetup[v.Name].Team
             #LOG('*AI DEBUG: '..v.Nickname..' is on team '..armyTeam)
             if v.CheatEnabled then

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -6534,7 +6534,7 @@ Platoon = Class(moho.platoon_methods) {
             end
         end
         for k,v in ArmyBrains do
-            if not v.Result == "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsAlly(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
+            if v.Result ~= "defeat" and not ArmyIsCivilian(v:GetArmyIndex()) and IsAlly(v:GetArmyIndex(), aiBrain:GetArmyIndex()) then
                 local startX, startZ = v:GetArmyStartPos()
                 if VDist2Sq(markerPos[1], markerPos[3], startX, startZ) < baseRadius * baseRadius then
                     return false


### PR DESCRIPTION
resubmission of previous PR that had some unwanted extra code.

When SorianAI was migrated to faf an error was made in the if statements related to the game status Result. The original code used if not v:IsDefeated then, when it was migrated to faf the following was used.
if not v.Result == "Defeat" then
This never returns true.
I have corrected it to
if v.Result ~= "Defeat" then
across the instances within the sorian builder/strategy conditions and one of its platoon function.

Impacted AI Logic.
Platoon Functions. 
AvoidBasesSorian. Impacts AI's ability to detect if they are avoiding bases correctly.

BuildConditions.
AIOutnumbered. Calculating players vs AI strength.
EnemyToAllyRatioLessOrEqual. Calculating enemies vs allies.
ClosestEnemyLessThan. Allows the sorian rush AI to use the ACU in early game.
EnemyInT3ArtilleryRange. Allows the AI to build T3 arty when it knows the enemy is in range of its mainbase.

Strategy.
SorianSmallMapRush. Don't personally know the impact on these or if the sorian strategy manager is enabled. But it wouldn't trigger without this fix.

If you want to validate the above you can simply test it in lua with the following, only the second if will return true.

```
v = {}
v.Result = nil

if not v.Result == "Defeat" then
    print('not result is true')
end

if v.Result ~= "Defeat" then
    print('~= result is true')
end
```