### PR TITLE
Death damage fix

### DIFF
--- a/lua/maui/button.lua
+++ b/lua/maui/button.lua
@@ -81,8 +81,8 @@ Button = Class(Bitmap) {
                 if self.mMouseOver then
                     self:SetTexture(self.mHighlight)
                     self:OnRolloverEvent('exit')
-                    self:Play()
                     self:OnClick(event.Modifiers)
+                    self:Play()
                 end
             end
             dragger.OnCancel = function(dragger)

--- a/units/UAL0401/UAL0401_Script.lua
+++ b/units/UAL0401/UAL0401_Script.lua
@@ -58,16 +58,19 @@ UAL0401 = Class(AWalkingLandUnit) {
             WaitFor(self.DeathAnimManip)
         end
 
-        local bp = self:GetBlueprint()
-        local position = self:GetPosition()
-        local qx, qy, qz, qw = unpack(self:GetOrientation())
-        local a = math.atan2(2.0 * (qx * qz + qw * qy), qw * qw + qx * qx - qz * qz - qy * qy)
-        for i, numWeapons in bp.Weapon do
-            if bp.Weapon[i].Label == 'CollossusDeath' then
-                position[3] = position[3]+5*math.cos(a)
-                position[1] = position[1]+5*math.sin(a)
-                DamageArea(self, position, bp.Weapon[i].DamageRadius, bp.Weapon[i].Damage, bp.Weapon[i].DamageType, bp.Weapon[i].DamageFriendly)
-                break
+        -- only apply death damage when the unit is finished building
+        if self:GetFractionComplete() == 1 then 
+            local bp = self:GetBlueprint()
+            local position = self:GetPosition()
+            local qx, qy, qz, qw = unpack(self:GetOrientation())
+            local a = math.atan2(2.0 * (qx * qz + qw * qy), qw * qw + qx * qx - qz * qz - qy * qy)
+            for i, numWeapons in bp.Weapon do
+                if bp.Weapon[i].Label == 'CollossusDeath' then
+                    position[3] = position[3]+5*math.cos(a)
+                    position[1] = position[1]+5*math.sin(a)
+                    DamageArea(self, position, bp.Weapon[i].DamageRadius, bp.Weapon[i].Damage, bp.Weapon[i].DamageType, bp.Weapon[i].DamageFriendly)
+                    break
+                end
             end
         end
 

--- a/units/URL0402/URL0402_script.lua
+++ b/units/URL0402/URL0402_script.lua
@@ -236,18 +236,22 @@ URL0402 = Class(CWalkingLandUnit) {
         local x, y, z = unpack(self:GetPosition())
         z = z + 3
 
-        local bp = self:GetBlueprint()
-        local position = self:GetPosition()
-        local qx, qy, qz, qw = unpack(self:GetOrientation())
-        local a = math.atan2(2.0 * (qx * qz + qw * qy), qw * qw + qx * qx - qz * qz - qy * qy)
-        for i, numWeapons in bp.Weapon do
-            if bp.Weapon[i].Label == 'SpiderDeath' then
-                position[3] = position[3]+3*math.cos(a)
-                position[1] = position[1]+3*math.sin(a)
-                DamageArea(self, position, bp.Weapon[i].DamageRadius, bp.Weapon[i].Damage, bp.Weapon[i].DamageType, bp.Weapon[i].DamageFriendly)
-                break
+        -- only apply death damage when the unit is finished building
+        if self:GetFractionComplete() == 1 then 
+            local bp = self:GetBlueprint()
+            local position = self:GetPosition()
+            local qx, qy, qz, qw = unpack(self:GetOrientation())
+            local a = math.atan2(2.0 * (qx * qz + qw * qy), qw * qw + qx * qx - qz * qz - qy * qy)
+            for i, numWeapons in bp.Weapon do
+                if bp.Weapon[i].Label == 'SpiderDeath' then
+                    position[3] = position[3]+3*math.cos(a)
+                    position[1] = position[1]+3*math.sin(a)
+                    DamageArea(self, position, bp.Weapon[i].DamageRadius, bp.Weapon[i].Damage, bp.Weapon[i].DamageType, bp.Weapon[i].DamageFriendly)
+                    break
+                end
             end
         end
+
         DamageRing(self, {x, y,z}, 0.1, 3, 1, 'Force', true)
         WaitSeconds(0.5)
         CreateDeathExplosion(self, 'Center_Turret', 2)

--- a/units/XRL0403/XRL0403_script.lua
+++ b/units/XRL0403/XRL0403_script.lua
@@ -180,16 +180,19 @@ XRL0403 = Class(CWalkingLandUnit) {
         WaitSeconds(0.4)
         self:CreateDeathExplosionDustRing()
         
-        local bp = self:GetBlueprint()
-        local position = self:GetPosition()
-        local qx, qy, qz, qw = unpack(self:GetOrientation())
-        local a = math.atan2(2.0 * (qx * qz + qw * qy), qw * qw + qx * qx - qz * qz - qy * qy)
-        for i, numWeapons in bp.Weapon do
-            if(bp.Weapon[i].Label == 'MegalithDeath') then
-                position[3] = position[3]+2.5*math.cos(a)
-                position[1] = position[1]+2.5*math.sin(a)
-                DamageArea(self, position, bp.Weapon[i].DamageRadius, bp.Weapon[i].Damage, bp.Weapon[i].DamageType, bp.Weapon[i].DamageFriendly)
-                break
+        -- only apply death damage when the unit is finished building
+        if self:GetFractionComplete() == 1 then 
+            local bp = self:GetBlueprint()
+            local position = self:GetPosition()
+            local qx, qy, qz, qw = unpack(self:GetOrientation())
+            local a = math.atan2(2.0 * (qx * qz + qw * qy), qw * qw + qx * qx - qz * qz - qy * qy)
+            for i, numWeapons in bp.Weapon do
+                if(bp.Weapon[i].Label == 'MegalithDeath') then
+                    position[3] = position[3]+2.5*math.cos(a)
+                    position[1] = position[1]+2.5*math.sin(a)
+                    DamageArea(self, position, bp.Weapon[i].DamageRadius, bp.Weapon[i].Damage, bp.Weapon[i].DamageType, bp.Weapon[i].DamageFriendly)
+                    break
+                end
             end
         end
         

--- a/units/XSL0401/XSL0401_Script.lua
+++ b/units/XSL0401/XSL0401_Script.lua
@@ -2,7 +2,7 @@
 -- File     :  /data/units/XSL0401/XSL0401_script.lua
 -- Author(s):  Jessica St. Croix, Dru Staltman, Aaron Lundquist
 -- Summary  :  Seraphim Experimental Assault Bot
--- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright ï¿½ 2007 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local SWalkingLandUnit = import('/lua/seraphimunits.lua').SWalkingLandUnit
@@ -131,6 +131,7 @@ XSL0401 = Class(SWalkingLandUnit) {
             end
         end
 
+        -- only spawn storm when the unit is finished building
         if self:GetFractionComplete() == 1 then
             self:SpawnElectroStorm()
         end

--- a/units/XSL0401/XSL0401_Script.lua
+++ b/units/XSL0401/XSL0401_Script.lua
@@ -98,13 +98,7 @@ XSL0401 = Class(SWalkingLandUnit) {
             WaitTicks(Random(1, 4))
         end
 
-        local bp = self:GetBlueprint()
-        for i, numWeapons in bp.Weapon do
-            if bp.Weapon[i].Label == 'CollossusDeath' then
-                DamageArea(self, self:GetPosition(), bp.Weapon[i].DamageRadius, bp.Weapon[i].Damage, bp.Weapon[i].DamageType, bp.Weapon[i].DamageFriendly)
-                break
-            end
-        end
+
         WaitSeconds(3.5)
         explosion.CreateDefaultHitExplosionAtBone(self, 'Torso', 5.0)
 
@@ -131,8 +125,17 @@ XSL0401 = Class(SWalkingLandUnit) {
             end
         end
 
-        -- only spawn storm when the unit is finished building
+        -- only spawn storm and do damage when the unit is finished building
         if self:GetFractionComplete() == 1 then
+
+            local bp = self:GetBlueprint()
+            for i, numWeapons in bp.Weapon do
+                if bp.Weapon[i].Label == 'CollossusDeath' then
+                    DamageArea(self, self:GetPosition(), bp.Weapon[i].DamageRadius, bp.Weapon[i].Damage, bp.Weapon[i].DamageType, bp.Weapon[i].DamageFriendly)
+                    break
+                end
+            end
+
             self:SpawnElectroStorm()
         end
 


### PR DESCRIPTION
Fixes the following bug:
 - https://youtu.be/7JlFxlfGQOc

Currently the damage animations (e.g., the explosions) are still happening. Maybe those shouldn't happen at all when the unit dies under construction? It would simplify the check as a whole: do not run the death thread at all if the unit isn't finished building.