### PR TITLE
Fix shield warning

### DIFF
--- a/lua/overspill.lua
+++ b/lua/overspill.lua
@@ -87,7 +87,7 @@ function DoOverspill(source, instigator, amount, dmgType, dmgMod)
                 local targetId = v.EntityId
                 if v:IsUp() and not DidTakeDamageAlready(targetId, instigatorId, amount) then
                     local direction = Util.GetDirectionVector(source.Owner:GetCachePosition(), v.Owner:GetCachePosition())
-                    v:ApplyDamage(source, (amount * dmgMod), direction, dmgType, false)
+                    v:ApplyDamage(instigator, (amount * dmgMod), direction, dmgType, false)
                     RegisterDamage(targetId, instigatorId, amount)
                 end
             end

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -425,7 +425,7 @@ OverchargeProjectile = Class() {
                 OCProjectiles[self.Army] = OCProjectiles[self.Army] - 1
                 launcher.EconDrain = nil
                 -- if oc depletes a mobile shield it kills the generator, vet counted, no wreck left
-                if targetCats.DIESTOOCDEPLETINGSHIELD and not targetEntity.MyShield:IsUp() then
+                if targetCats.DIESTOOCDEPLETINGSHIELD and (IsDestroyed(targetEntity.MyShield) or (not targetEntity.MyShield:IsUp())) then
                     targetEntity:Kill(launcher, 'Overcharge', 2)
                     launcher:OnKilledUnit(targetEntity, targetEntity:GetVeterancyValue())
                 end

--- a/units/UAL0307/UAL0307_script.lua
+++ b/units/UAL0307/UAL0307_script.lua
@@ -5,7 +5,7 @@
 --**
 --**  Summary  :  Aeon Mobile Shield Generator Script
 --**
---**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--**  Copyright ï¿½ 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
 local AShieldHoverLandUnit = import('/lua/aeonunits.lua').AShieldHoverLandUnit
@@ -73,6 +73,12 @@ UAL0307 = Class(AShieldHoverLandUnit) {
     --sadly i couldnt find some way of doing this without a thread. dont know where to check if its still assisting other than this.
         while self.PointerEnabled == false do
             WaitSeconds(1)
+
+            -- break if we're a gooner
+            if IsDestroyed(self) then 
+                break 
+            end
+
             if not self:GetGuardedUnit() then
                 self.PointerEnabled = true
                 self.TargetPointer:SetFireTargetLayerCaps(self.TargetLayerCaps[self:GetCurrentLayer()]) --this resets the stop feature - note that its reset on layer change!

--- a/units/UAL0307/UAL0307_script.lua
+++ b/units/UAL0307/UAL0307_script.lua
@@ -75,7 +75,7 @@ UAL0307 = Class(AShieldHoverLandUnit) {
             WaitSeconds(1)
 
             -- break if we're a gooner
-            if IsDestroyed(self) then 
+            if IsDestroyed(self) or IsDestroyed(self.TargetPointer) then 
                 break 
             end
 

--- a/units/UEL0307/UEL0307_script.lua
+++ b/units/UEL0307/UEL0307_script.lua
@@ -5,7 +5,7 @@
 --**
 --**  Summary  :  UEF Mobile Shield Generator Script
 --**
---**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--**  Copyright ï¿½ 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
 local TShieldLandUnit = import('/lua/terranunits.lua').TShieldLandUnit
@@ -98,8 +98,14 @@ UEL0307 = Class(TShieldLandUnit) {
     end,
         
     PointerRestart = function(self)
-    --sadly i couldnt find some way of doing this without a thread. dont know where to check if its still assisting other than this.
-        while self.PointerEnabled == false do
+        --sadly i couldnt find some way of doing this without a thread. dont know where to check if its still assisting other than this.
+        while not self.PointerEnabled do
+
+            -- break if we're a gooner
+            if self:BeenDestroyed() then 
+                break 
+            end
+
             WaitSeconds(1)
             if not self:GetGuardedUnit() then
                 self.PointerEnabled = true

--- a/units/UEL0307/UEL0307_script.lua
+++ b/units/UEL0307/UEL0307_script.lua
@@ -104,7 +104,7 @@ UEL0307 = Class(TShieldLandUnit) {
             WaitSeconds(1)
 
             -- break if we're a gooner
-            if IsDestroyed(self) then 
+            if IsDestroyed(self) or IsDestroyed(self.TargetPointer) then 
                 break 
             end
 

--- a/units/UEL0307/UEL0307_script.lua
+++ b/units/UEL0307/UEL0307_script.lua
@@ -101,12 +101,14 @@ UEL0307 = Class(TShieldLandUnit) {
         --sadly i couldnt find some way of doing this without a thread. dont know where to check if its still assisting other than this.
         while not self.PointerEnabled do
 
+            WaitSeconds(1)
+
             -- break if we're a gooner
-            if self:BeenDestroyed() then 
+            if IsDestroyed(self) then 
                 break 
             end
 
-            WaitSeconds(1)
+            -- if not gooner, check whether we need to enable our weapon to keep reasonable distance
             if not self:GetGuardedUnit() then
                 self.PointerEnabled = true
                 self.TargetPointer:SetFireTargetLayerCaps(self.TargetLayerCaps[self:GetCurrentLayer()]) --this resets the stop feature - note that its reset on layer change!

--- a/units/XSL0307/XSL0307_script.lua
+++ b/units/XSL0307/XSL0307_script.lua
@@ -4,7 +4,7 @@
 --**
 --**  Summary  :  Seraphim Mobile Shield Generator Script
 --**
---**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--**  Copyright ï¿½ 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
 local SShieldHoverLandUnit = import('/lua/seraphimunits.lua').SShieldHoverLandUnit
@@ -63,6 +63,12 @@ XSL0307 = Class(SShieldHoverLandUnit) {
     --sadly i couldnt find some way of doing this without a thread. dont know where to check if its still assisting other than this.
         while self.PointerEnabled == false do
             WaitSeconds(1)
+
+            -- break if we're a gooner
+            if IsDestroyed(self) then 
+                break 
+            end
+
             if not self:GetGuardedUnit() then
                 self.PointerEnabled = true
                 self.TargetPointer:SetFireTargetLayerCaps(self.TargetLayerCaps[self:GetCurrentLayer()]) --this resets the stop feature - note that its reset on layer change!

--- a/units/XSL0307/XSL0307_script.lua
+++ b/units/XSL0307/XSL0307_script.lua
@@ -65,7 +65,7 @@ XSL0307 = Class(SShieldHoverLandUnit) {
             WaitSeconds(1)
 
             -- break if we're a gooner
-            if IsDestroyed(self) then 
+            if IsDestroyed(self) or IsDestroyed(self.TargetPointer) then 
                 break 
             end
 


### PR DESCRIPTION
Fixes #3315 

Also fixes the following error:
```
WARNING: Error running lua script: ...rs\jip\documents\supreme commander\fa\lua\shield.lua(188): attempt to call method `GetWeaponByLabel' (a nil value)
         stack traceback:
         	...rs\jip\documents\supreme commander\fa\lua\shield.lua(188): in function `ApplyDamage'
         	...jip\documents\supreme commander\fa\lua\overspill.lua(90): in function <...jip\documents\supreme commander\fa\lua\overspill.lua:83>
```
         	
Which is caused by the overspill function passing in the wrong table to the instigator parameter (source instead of instigator). Not sure if this has impact on other areas of the code - in my own testing I couldn't find any issues. I tried shooting with a commander that has enough storage for full overcharge at a few shields, behavior appears to be normal and no errors.
