### PR TITLE
Rotate towards enemy logic redo

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -31,6 +31,7 @@ DummyUnit = Class(Unit) {
     end,
 }
 
+-- compute once and store as upvalue for performance
 local StructureUnitRotateTowardsEnemiesLand = categories.STRUCTURE + categories.LAND + categories.NAVAL
 local StructureUnitRotateTowardsEnemiesArtillery = categories.ARTILLERY * (categories.TECH3 + categories.EXPERIMENTAL)
 local StructureUnitOnStartBeingBuiltRotateBuildings = categories.STRUCTURE * (categories.DIRECTFIRE + categories.INDIRECTFIRE) * (categories.DEFENSE + categories.ARTILLERY)
@@ -120,7 +121,6 @@ StructureUnit = Class(Unit) {
 
         -- some buildings can only take 90 degree angles
         if EntityCategoryContains(StructureUnitRotateTowardsEnemiesArtillery, self) then
-            LOG("THIS GUY!")
             degrees = math.floor((degrees + 45) / 90) * 90
         end
 


### PR DESCRIPTION
The original function first gathers all the units in radius, sorts them and then chooses the unit with the most threat. That is O(n) space and O(n * lg(n)) computation time, where _n_ is the number of units found. Since we're only interested in the unit with the most threat we can store it in O(1) space and run it in O(n) complexity.

It doesn't happen often that this function runs on a large amount of units - but when building artillery pieces it can happily sort all hostile units on the map and that may cause a stutter.