### PR TITLE
Fixed Failed To Build in EngineerFailedToBuild Callbacks

### DIFF
--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -3513,17 +3513,19 @@ Platoon = Class(moho.platoon_methods) {
     EngineerFailedToBuild = function(unit, params)
         if not unit.PlatoonHandle then return end
         if not unit.PlatoonHandle.PlanName == 'EngineerBuildAI' then return end
+        if unit.UnitBeingBuiltBehavior then
+            if unit.ProcessBuild then
+                KillThread(unit.ProcessBuild)
+                unit.ProcessBuild = nil
+            end
+            return
+        end
         if unit.ProcessBuildDone and unit.ProcessBuild then
             KillThread(unit.ProcessBuild)
             unit.ProcessBuild = nil
         end
         if not unit.ProcessBuild then
             --LOG("*AI DEBUG: Failed to build" .. unit.Sync.id)
-            --Azraeel - Changed to False
-            --Within the Engine Code, this callback is completely busted there is no way to fix this.
-            --Instead Duncan decided in his wisdom to change this to way a build would not be repeated which 99% of the time fixed the issue.
-            --When True we would not attempt to repeat the job, When False would attempt to repeat the job again in case it had accidently failed.
-            --This as stated fixes the Engine Issue.
             unit.ProcessBuild = unit:ForkThread(unit.PlatoonHandle.ProcessBuildCommand, false) 
         end
     end,

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -3518,7 +3518,13 @@ Platoon = Class(moho.platoon_methods) {
             unit.ProcessBuild = nil
         end
         if not unit.ProcessBuild then
-            unit.ProcessBuild = unit:ForkThread(unit.PlatoonHandle.ProcessBuildCommand, true)  --DUNCAN - changed to true
+            --LOG("*AI DEBUG: Failed to build" .. unit.Sync.id)
+            --Azraeel - Changed to False
+            --Within the Engine Code, this callback is completely busted there is no way to fix this.
+            --Instead Duncan decided in his wisdom to change this to way a build would not be repeated which 99% of the time fixed the issue.
+            --When True we would not attempt to repeat the job, When False would attempt to repeat the job again in case it had accidently failed.
+            --This as stated fixes the Engine Issue.
+            unit.ProcessBuild = unit:ForkThread(unit.PlatoonHandle.ProcessBuildCommand, false) 
         end
     end,
 


### PR DESCRIPTION
Within the Engine Code, this callback is completely busted there is no way to fix this.
Instead Duncan decided in his wisdom to change this... to where the build would not be repeated, which 99% of the time fixed the issue.
When True we would not attempt to repeat the job, When False would attempt to repeat the job again in case it had accidentally failed.
This as stated fixes the Engine Issue.

I logged all processes and tested it.
ProcessbuildCommand Function
EngineerBuildAI Function
EngineerSetupCallbacks
WatchforNotBuilding

Attempted to fix with several fixes (help from Sprouto) none fixed said issue. Concluding that this relates back too callbacks and when logging callback Failed to Build, you will see it fail to build.
When changing said callback to false for it to try/attempt build again. 2nd Attempt works. 
Since how callbacks works are from engine we can not fix this and this is just a work around in reality but it does fix the issue in all my test when i was working on my AI Swarm.
