### PR TITLE
T1 Land Scout Rework

### DIFF
--- a/units/UAL0101/UAL0101_unit.bp
+++ b/units/UAL0101/UAL0101_unit.bp
@@ -1,6 +1,4 @@
 UnitBlueprint {
-    AI = {
-    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'UAL',

--- a/units/UAL0101/UAL0101_unit.bp
+++ b/units/UAL0101/UAL0101_unit.bp
@@ -1,6 +1,5 @@
 UnitBlueprint {
     AI = {
-        GuardScanRadius = 50, --RadarRadius
     },
     Audio = {
         AmbientMove = Sound {

--- a/units/UAL0101/UAL0101_unit.bp
+++ b/units/UAL0101/UAL0101_unit.bp
@@ -1,4 +1,7 @@
 UnitBlueprint {
+    AI = {
+        GuardScanRadius = 33, -- Weapon range so that the scout doesn't suicide when attack moved into T1 tanks including Aurora
+    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'UAL',
@@ -205,7 +208,7 @@ UnitBlueprint {
         DragCoefficient = 0.2,
         Elevation = 0.25,
         MaxAcceleration = 5,
-        MaxBrake = 5,
+        MaxBrake = 10,
         MaxSpeed = 5,
         MaxSpeedReverse = 3,
         MaxSteerForce = 1000,
@@ -260,7 +263,7 @@ UnitBlueprint {
             },
             FiringTolerance = 2,
             Label = 'LaserTurret',
-            MaxRadius = 30,
+            MaxRadius = 33,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 25,

--- a/units/UEL0101/UEL0101_unit.bp
+++ b/units/UEL0101/UEL0101_unit.bp
@@ -1,6 +1,5 @@
 UnitBlueprint {
     AI = {
-        GuardScanRadius = 45, --RadarRadius
     },
     Audio = {
         AmbientMove = Sound {

--- a/units/UEL0101/UEL0101_unit.bp
+++ b/units/UEL0101/UEL0101_unit.bp
@@ -1,4 +1,7 @@
 UnitBlueprint {
+    AI = {
+        GuardScanRadius = 26, -- Weapon range so that the scout doesn't suicide when attack moved into T1 tanks that are not Aurora
+    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'UEL',
@@ -169,7 +172,7 @@ UnitBlueprint {
         },
         DragCoefficient = 0.2,
         MaxAcceleration = 4.5,
-        MaxBrake = 4.5,
+        MaxBrake = 9,
         MaxSpeed = 4.5,
         MaxSpeedReverse = 4.5,
         MaxSteerForce = 1000,
@@ -221,7 +224,7 @@ UnitBlueprint {
             },
             FiringTolerance = 2,
             Label = 'MainGun',
-            MaxRadius = 25,
+            MaxRadius = 26,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 25,

--- a/units/UEL0101/UEL0101_unit.bp
+++ b/units/UEL0101/UEL0101_unit.bp
@@ -1,6 +1,4 @@
 UnitBlueprint {
-    AI = {
-    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'UEL',

--- a/units/URL0101/URL0101_unit.bp
+++ b/units/URL0101/URL0101_unit.bp
@@ -1,6 +1,4 @@
 UnitBlueprint {
-    AI = {
-    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'URL',
@@ -109,7 +107,7 @@ UnitBlueprint {
         BuildCostEnergy = 80,
         BuildCostMass = 8,
         BuildTime = 80,
-        MaintenanceConsumptionPerSecondEnergy = 5,
+        MaintenanceConsumptionPerSecondEnergy = 1,
         TeleportEnergyMod = 0.15,
         TeleportMassMod = 1,
         TeleportTimeMod = 0.01,
@@ -193,7 +191,7 @@ UnitBlueprint {
                 Land = 'Land|Water',
                 Water = 'Land|Water',
             },
-            MaxRadius = 19,
+            MaxRadius = 20,
             RateOfFire = 0.1,
             ReTargetOnMiss = false,
             TargetCheckInterval = 0.1,

--- a/units/URL0101/URL0101_unit.bp
+++ b/units/URL0101/URL0101_unit.bp
@@ -1,8 +1,5 @@
 UnitBlueprint {
     AI = {
-        GuardScanRadius = 27, --MaxRadius of the dummy gun instead of 
-        -- the radar range because no point to aggro on units outside the
-        -- shooting range as the gun isn't real
     },
     Audio = {
         AmbientMove = Sound {
@@ -196,7 +193,7 @@ UnitBlueprint {
                 Land = 'Land|Water',
                 Water = 'Land|Water',
             },
-            MaxRadius = 25, -- Tweaked so it stops a bit behind mantis using GuardScanRadius
+            MaxRadius = 19,
             RateOfFire = 0.1,
             ReTargetOnMiss = false,
             TargetCheckInterval = 0.1,

--- a/units/URL0101/URL0101_unit.bp
+++ b/units/URL0101/URL0101_unit.bp
@@ -1,4 +1,7 @@
 UnitBlueprint {
+    AI = {
+        GuardScanRadius = 26, -- Dummy Weapon range so that the scout doesn't suicide when attack moved into T1 tanks that are not Aurora
+    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'URL',
@@ -162,7 +165,7 @@ UnitBlueprint {
         },
         DragCoefficient = 0.2,
         MaxAcceleration = 4.8,
-        MaxBrake = 4.8,
+        MaxBrake = 9.6,
         MaxSpeed = 4.8,
         MaxSpeedReverse = 0,
         MaxSteerForce = 10,
@@ -191,7 +194,7 @@ UnitBlueprint {
                 Land = 'Land|Water',
                 Water = 'Land|Water',
             },
-            MaxRadius = 20,
+            MaxRadius = 26,
             RateOfFire = 0.1,
             ReTargetOnMiss = false,
             TargetCheckInterval = 0.1,

--- a/units/XSL0101/XSL0101_unit.bp
+++ b/units/XSL0101/XSL0101_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     ResolvePath = true,
     AI = {
-        GuardScanRadius = 40, --RadarRadius
+        GuardScanRadius = 26, -- Same as other T1 scouts (UEF & Cybran), this scout will suicide into T1 tanks because it's weapon range is too small and changing it would have too big of an impact on the gameplay
     },
     Audio = {
         AmbientMove = Sound {


### PR DESCRIPTION
Remove the GuardScanRadius to prevent the scouts from agro'ing onto units and buildings from very far away, now they will trigger based on their weapon's maxRadius which is still much larger then their tank counterparts which should prevent them from suiciding too often when attack moved while removing the great annoyance of your scouts getting stuck if they are attack moved or assisted.

