### PR TITLE
Changed collision size of sonars to make them easier to hit

### DIFF
--- a/units/UAB3102/UAB3102_unit.bp
+++ b/units/UAB3102/UAB3102_unit.bp
@@ -180,7 +180,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.4,
     SelectionThickness = 1,
     SizeX = 0.6,
-    SizeY = 0.5,
+    SizeY = 0.6,
     SizeZ = 0.6,
     StrategicIconName = 'icon_structure1_intel',
     StrategicIconSortPriority = 64,

--- a/units/UAB3202/UAB3202_unit.bp
+++ b/units/UAB3202/UAB3202_unit.bp
@@ -179,7 +179,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.55,
     SelectionThickness = 0.7,
     SizeX = 0.5,
-    SizeY = 0.5,
+    SizeY = 0.6,
     SizeZ = 0.5,
     StrategicIconName = 'icon_structure2_intel',
     StrategicIconSortPriority = 230,

--- a/units/URB3102/URB3102_unit.bp
+++ b/units/URB3102/URB3102_unit.bp
@@ -174,7 +174,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.4,
     SelectionThickness = 1,
     SizeX = 0.5,
-    SizeY = 0.5,
+    SizeY = 0.6,
     SizeZ = 0.5,
     StrategicIconName = 'icon_structure1_intel',
     StrategicIconSortPriority = 235,

--- a/units/URB3202/URB3202_unit.bp
+++ b/units/URB3202/URB3202_unit.bp
@@ -174,7 +174,7 @@ UnitBlueprint {
     SelectionSizeZ = 0.45,
     SelectionThickness = 0.88,
     SizeX = 0.5,
-    SizeY = 0.5,
+    SizeY = 0.6,
     SizeZ = 0.5,
     StrategicIconName = 'icon_structure2_intel',
     StrategicIconSortPriority = 230,


### PR DESCRIPTION
Especially relevant when firing with low-arc units such as the riptide and the aurora. Fixes issue #3326. Tested on all sonars, also tested submarines being able to hit them or not. All should be good.