### PR TITLE
Optimize Trashbag

### DIFF
--- a/lua/system/trashbag.lua
+++ b/lua/system/trashbag.lua
@@ -1,0 +1,39 @@
+local getn = table.getn
+
+#
+# TrashBag is a class to help manage objects that need destruction. You add objects to it with Add().
+# When TrashBag:Destroy() is called, it calls Destroy() in turn on all its contained objects.
+#
+# If an object in a TrashBag is destroyed through other means, it automatically disappears from the TrashBag.
+# This doesn't necessarily happen instantly, so it's possible in this case that Destroy() will be called twice.
+# So Destroy() should always be idempotent.
+#
+TrashBag = Class {
+
+    __mode = 'v',
+
+    #
+    # Add an object to the TrashBag.
+    #
+    Add = function(self, obj)
+        if obj == nil then return end
+
+        assert(obj.Destroy, 'Attempted to add an object with no Destroy() method to a TrashBag')
+
+        local i = getn(self)+1
+        self[i] = obj
+    end,
+
+    #
+    # Call Destroy() for all objects in this bag.
+    #
+    Destroy = function(self)
+        # loop over all values in self. ipairs() won't work correctly because we may have holes in our ordering.
+        for i,v in self do
+            if type(i)=='number' then
+                self[i]:Destroy()
+                self[i] = nil
+            end
+        end
+    end
+}

--- a/lua/system/trashbag.lua
+++ b/lua/system/trashbag.lua
@@ -28,7 +28,7 @@ TrashBag = Class {
     __mode = 'v',
 
     -- Keep track of the number of elements in the trash bag
-    Count = 1,
+    Next = 1,
 
     --- Add an entity to the trash bag.
     Add = function(self, entity)
@@ -49,8 +49,8 @@ TrashBag = Class {
         -- counter is updated _after_ the table has been set, this is faster because the table
         -- operation depends on the counter value and doesn't have to wait for it in this case.
 
-        self[self.Count] = entity
-        self.Count = self.Count + 1
+        self[self.Next] = entity
+        self.Next = self.Next + 1
     end,
 
     --- Destroy all (remaining) entities in the trash bag.
@@ -63,7 +63,7 @@ TrashBag = Class {
         -- end
 
         -- Check if values are still relevant
-        for k = 1, self.Count - 1 do 
+        for k = 1, self.Next - 1 do 
             if self[k] then 
                 self[k]:Destroy()
                 self[k] = nil


### PR DESCRIPTION
It is now optimized according to the loops benchmark - instead of using table.getn we keep a separate counter. The trashbag is not
used often (primarily during initialization) but it does have a significant difference overall. There is commented blocks of code that you can uncomment to trace where invalid calls to the class are made - makes them easier to track down and clean up.