### PR TITLE
Prefetch loading in lobby to lower time spent in loading screen

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2148,6 +2148,11 @@ local function UpdateGame()
             GUI.mapView:SetScenario(scenarioInfo)
             ShowMapPositions(GUI.mapView, scenarioInfo)
             ConfigureMapListeners(GUI.mapView, scenarioInfo)
+
+            -- prefetch the session to make loading screen shorter
+            local mods = Mods.GetGameMods(gameInfo.GameMods)
+            PrefetchSession(scenarioInfo.map, mods, true)
+
         else
             AlertHostMapMissing()
             GUI.mapView:Clear()


### PR DESCRIPTION
Allows prefetching of all assets (including mod blueprints) up to the point where 'BeginSession' is called. No mod or map code is actually being run during prefetching. Lowers the loading time significantly, especially for slower computers.

Inspired by LOUD.

Tested with and passed with flying colors:
 - AI-Uveso
 - All Blackops mods
 - Dilli Dalli AI
 - SSB

To test it, make sure to have the Moholog open while in the lobby. You can do so by having /showlog as a program argument. You can see that when you change mods / maps, the loading already happens. Where as previously, that only happened during loading.