### PR TITLE
Remove rocking behavior calls

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -381,11 +381,10 @@ StructureUnit = Class(Unit) {
             Unit.OnFailedToBuild(self)
             self:EnableDefaultToggleCaps()
 
-            if self.AnimatorUpgradeManip then self.AnimatorUpgradeManip:Destroy() end
-
-            if self:GetCurrentLayer() == 'Water' then
-                self:StartRocking()
+            if self.AnimatorUpgradeManip then 
+                self.AnimatorUpgradeManip:Destroy() 
             end
+            
             self:PlayUnitSound('UpgradeFailed')
             self:PlayActiveAnimation()
             self:CreateTarmac(true, true, true, self.TarmacBag.Orientation, self.TarmacBag.CurrentBP)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4249,13 +4249,19 @@ Unit = Class(moho.unit_methods) {
             KillThread(self.StartRockThread)
             self.StartRockThread = nil
 
-            self.StopRockThread = self:ForkThread(self.EndRockingThread)
+            local bp = self:GetBlueprint().Display
+            local speed = bp.MaxRockSpeed
+
+            self.StopRockThread = self:ForkThread(self.EndRockingThread, speed)
         end
     end,
 
     --- Rocking thread to move a unit when it is on the water.
     RockingThread = function(self, speed)
-        self.RockManip = CreateRotator(self, 0, 'z', nil, 0, (speed or 1.5) / 5, (speed or 1.5) * 3 / 5)
+        -- default value
+        speed = speed or 1.5
+
+        self.RockManip = CreateRotator(self, 0, 'z', nil, 0, speed * 0.2, speed * 0.6)
         self.Trash:Add(self.RockManip)
         self.RockManip:SetPrecedence(0)
 
@@ -4275,11 +4281,14 @@ Unit = Class(moho.unit_methods) {
 
     --- Stopping of the rocking thread, allowing it to gracefully end instead of suddenly
     -- warping to the original position.
-    EndRockingThread = function(self)
-        local bp = self:GetBlueprint().Display
+    EndRockingThread = function(self, speed)
         if self.RockManip then
+
+            -- default value
+            speed = speed or 1.5
+
             self.RockManip:SetGoal(0)
-            self.RockManip:SetSpeed((bp.MaxRockSpeed or 1.5) / 4)
+            self.RockManip:SetSpeed(speed / 4)
             WaitFor(self.RockManip)
 
             if self.RockManip then

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4253,7 +4253,7 @@ Unit = Class(moho.unit_methods) {
 
                 if self.Dead then break end -- Abort if the unit died
 
-                self.RockManip:SetTargetSpeed(- bp.MaxRockSpeed or 1.5)
+                self.RockManip:SetTargetSpeed(- (bp.MaxRockSpeed or 1.5)) 
                 WaitFor(self.RockManip)
 
                 if self.Dead then break end -- Abort if the unit died

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4227,20 +4227,16 @@ Unit = Class(moho.unit_methods) {
     --- Allows the unit to rock from side to side. Useful when the unit is on water. Is not used
     -- in practice, nor by this repository or by any of the commonly played mod packs.
     StartRocking = function(self)
-        if bypassDeprecation then 
-            KillThread(self.StopRockThread)
-            self.StartRockThread = self:ForkThread(self.RockingThread)
-        end
+        KillThread(self.StopRockThread)
+        self.StartRockThread = self:ForkThread(self.RockingThread)
     end,
 
     --- Stops the unit to rock from side to side. Useful when the unit is on water. Is not used
     -- in practice, nor by this repository or by any of the commonly played mod packs.
     StopRocking = function(self)
-        if bypassDeprecation then 
-            if self.StartRockThread then
-                KillThread(self.StartRockThread)
-                self.StopRockThread = self:ForkThread(self.EndRockingThread)
-            end
+        if self.StartRockThread then
+            KillThread(self.StartRockThread)
+            self.StopRockThread = self:ForkThread(self.EndRockingThread)
         end
     end,
 

--- a/lua/terranunits.lua
+++ b/lua/terranunits.lua
@@ -673,9 +673,6 @@ TPodTowerUnit = Class(TStructureUnit) {
             TStructureUnit.OnFailedToBuild(self)
             self:EnableDefaultToggleCaps()
             self.AnimatorUpgradeManip:Destroy()
-            if self:GetCurrentLayer() == 'Water' then
-                self:StartRocking()
-            end
             self:PlayUnitSound('UpgradeFailed')
             self:PlayActiveAnimation()
             self:CreateTarmac(true, true, true, self.TarmacBag.Orientation, self.TarmacBag.CurrentBP)


### PR DESCRIPTION
All calls to starting / stopping the rocking behavior are removed. If you're wondering what it is - it wasn't used in practice. It requires blueprint values set that aren't set by any blueprint, both of the base game files (including those that are not part of the repository) and common mods. 

Removing the call on its own is good - but preventing _a lot_ of threads from being made is better. To give an idea, each time StartRocking is called a thread is made. Each time StopRocking is called, if a thread was made, a new thread is made to stop the previous one. In a game of 4 AIx fighting these functions were called 2030 times to start rocking and introduce a thread and 2580 times to kill the start thread and start a new thread to stop rocking. This was over a timespan of 13 minutes, which means (2030 + 2580) / 780 = 5.9 threads a second. If you take into account that almost no thread spawns the first 5 minutes because there are no units on the water then we get (2030 + 2580) / 480 = 9.6 threads a second. That is almost one thread a tick, for just four AIs in a game that is 13 minutes long.

And all of that - for nothing!

There is one mod that calls the rocking behaviors: Jaggeds_Infrastructure_Pack. I suspect it is because the original files (where the author looked at) made similar calls. There are no mods that define the right values in their blueprint files, hence there would be no actual rocking even though a call was made.

I've looked at the following mods, highlighted some that I think are important:
#2x Resources,Storage,BuildRate,BuildRange
**#Marlos mods compilation**
additionalCameraStuff
Advanced target priorities
AdvancedShieldsV4Fixed
AI-Swarm
AI-Uveso
AllFactionsFixed
AllFactions_FAF_BO_Nomads
All_Faction_Quantum_Gate
Big boom
**BlackOpsFAF-ACUs
BlackOpsFAF-EXUnits
BlackOpsFAF-Unleashed
BrewLAN
BrewLAN_Units**
CinematicsMod
Commanders_x4 BlackOps
Compat_GilbotCore+BlackOpsACU
Cybran UnBalanced
dear-windowing
DilliDalli
Hard FFA (ACUS spawn in T2 transport in center)
Improved Close-up Camera
Jaggeds_Infrastructure_Pack
kazbek-replay-ui
Low Commander Upgrades Costs Tweaked
Low Commander Upgrades Costs Tweaked 2
Music_PhilCrofts
No Friendly Fire
NuclearRepulsorShields
Oof
Personal Phantomz Blackops Balance Patch
PxModAlphaV6
rks_explosions
RNGAI
SACUAI
simspeed++
Sorian Edit
StorageRich_x10Fixed
SupremeScoreBoard
T1 UNIT HEALTH X2
Unholy Alliance - BlackOps ACUs
x2 Build Range