### PR TITLE
Reduce table creation with EventCallbacks

### DIFF
--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -142,7 +142,7 @@ NukeProjectile = Class(NullShell) {
 
     LauncherCallbacks = function(self)
         local launcher = self:GetLauncher()
-        if launcher and not launcher.Dead and launcher.EventCallbacks.ProjectileDamaged then
+        if launcher and not launcher.Dead and launcher.EventCallbacks and launcher.EventCallbacks.ProjectileDamaged then
             self.ProjectileDamaged = {}
             for k,v in launcher.EventCallbacks.ProjectileDamaged do
                 table.insert(self.ProjectileDamaged, v)

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -19,10 +19,12 @@ Prop = Class(moho.prop_methods, Entity) {
     end,
 
     OnCreate = function(self)
+        --[[
         self.EventCallbacks = {
             OnKilled = {},
             OnReclaimed = {},
         }
+        ]]
         Entity.OnCreate(self)
         self.Trash = TrashBag()
         local bp = self:GetBlueprint()
@@ -61,11 +63,15 @@ Prop = Class(moho.prop_methods, Entity) {
             error('*ERROR: Tried to add a callback type - ' .. type .. ' with a nil function')
             return
         end
+
+        if not self.EventCallbacks then self.EventCallbacks = {[type] = {}}
+        elseif not self.EventCallbacks[type] then self.EventCallbacks[type] = {} end
+
         table.insert(self.EventCallbacks[type], fn)
     end,
 
     DoPropCallbacks = function(self, type, param)
-        if self.EventCallbacks[type] then
+        if self.EventCallbacks and self.EventCallbacks[type] then
             for num, cb in self.EventCallbacks[type] do
                 cb(self, param)
             end
@@ -73,6 +79,7 @@ Prop = Class(moho.prop_methods, Entity) {
     end,
 
     RemoveCallback = function(self, fn)
+        if not self.EventCallbacks then return end
         for k, v in self.EventCallbacks do
             if type(v) == "table" then
                 for kcb, vcb in v do


### PR DESCRIPTION
Instead of creating 24 tables for every unit we create these when required

Could break some mod if they are manipulating / calling EventCallbacks table on a unit instead of using the AddUnitCallback etc 