### PR TITLE
Change SelectionPriority of UEF Drones (kennel ones)

### DIFF
--- a/units/XEA3204/XEA3204_unit.bp
+++ b/units/XEA3204/XEA3204_unit.bp
@@ -176,7 +176,7 @@ UnitBlueprint {
                 helpText = 'drone_station',
             },
         },
-        SelectionPriority = 6,
+        SelectionPriority = 3,
         TechLevel = 'RULEUTL_Basic',
         UnitName = '<LOC xea3204_name>C-D2 "Rover-2"',
         UnitWeight = 1,


### PR DESCRIPTION
Selection Priority 6 -> 3 (same as engies)
It still gets selected after engies (no idea why)
