### PR TITLE
Fix missing normals on lava/trees

### DIFF
--- a/env/Lava/Props/Trees/LV_Dead01_s1_prop.bp
+++ b/env/Lava/Props/Trees/LV_Dead01_s1_prop.bp
@@ -33,13 +33,13 @@ PropBlueprint {
                 {
                     AlbedoName = 'LV_Dead01_s1_albedo.dds',
                     LODCutoff = 60,
-                    NormalsName = 'LV_Dead01_s1_normalsTS.dds',
+                    NormalsName = 'Dead01_s1_normalsTS.dds',
                     ShaderName = 'TMeshAlpha',
                 },
                 {
                     AlbedoName = 'LV_Dead01_s1_albedo.dds',
                     LODCutoff = 200,
-                    NormalsName = 'LV_Dead01_s1_normalsTS.dds',
+                    NormalsName = 'Dead01_s1_normalsTS.dds',
                     ShaderName = 'TMeshAlpha',
                 },
                 {

--- a/env/Lava/Props/Trees/XDead01_s1_prop.bp
+++ b/env/Lava/Props/Trees/XDead01_s1_prop.bp
@@ -33,13 +33,13 @@ PropBlueprint {
                 {
                     AlbedoName = 'XDead01_s1_albedo.dds',
                     LODCutoff = 60,
-                    NormalsName = 'XDead01_s1_normalsTS.dds',
+                    NormalsName = 'Dead01_s1_normalsTS.dds',
                     ShaderName = 'TMeshAlpha',
                 },
                 {
                     AlbedoName = 'XDead01_s1_albedo.dds',
                     LODCutoff = 200,
-                    NormalsName = 'XDead01_s1_normalsTS.dds',
+                    NormalsName = 'Dead01_s1_normalsTS.dds',
                     ShaderName = 'TMeshAlpha',
                 },
                 {

--- a/env/Lava/Props/Trees/xDead01_s2_prop.bp
+++ b/env/Lava/Props/Trees/xDead01_s2_prop.bp
@@ -33,13 +33,13 @@ PropBlueprint {
                 {
                     AlbedoName = 'xDead01_s1_albedo.dds',
                     LODCutoff = 60,
-                    NormalsName = 'xDead01_s1_normalsTS.dds',
+                    NormalsName = 'Dead01_s1_normalsTS.dds',
                     ShaderName = 'TMeshAlpha',
                 },
                 {
                     AlbedoName = 'xDead01_s1_albedo.dds',
                     LODCutoff = 200,
-                    NormalsName = 'xDead01_s1_normalsTS.dds',
+                    NormalsName = 'Dead01_s1_normalsTS.dds',
                     ShaderName = 'TMeshAlpha',
                 },
                 {

--- a/env/Lava/Props/Trees/xDead01_s3_prop.bp
+++ b/env/Lava/Props/Trees/xDead01_s3_prop.bp
@@ -33,13 +33,13 @@ PropBlueprint {
                 {
                     AlbedoName = 'xDead01_s1_albedo.dds',
                     LODCutoff = 60,
-                    NormalsName = 'xDead01_s1_normalsTS.dds',
+                    NormalsName = 'Dead01_s1_normalsTS.dds',
                     ShaderName = 'TMeshAlpha',
                 },
                 {
                     AlbedoName = 'xDead01_s1_albedo.dds',
                     LODCutoff = 200,
-                    NormalsName = 'xDead01_s1_normalsTS.dds',
+                    NormalsName = 'Dead01_s1_normalsTS.dds',
                     ShaderName = 'TMeshAlpha',
                 },
                 {


### PR DESCRIPTION
With the missing normals:
![image](https://user-images.githubusercontent.com/15778155/130042069-17075f1f-bbfa-4050-83dc-13a4e1cb1d00.png)

Without the missing normals:
![image](https://user-images.githubusercontent.com/15778155/130042096-ca561be0-86cb-4850-bad1-afd3deb060ca.png)

This PR closes https://github.com/FAForever/fa/issues/2258 - as badbowi suggested there is no visual difference except for missing out on a few warnings in the log.