### PR TITLE
Layer optimizations 

### DIFF
--- a/engine/Sim/Unit.lua
+++ b/engine/Sim/Unit.lua
@@ -130,7 +130,9 @@ end
 function Unit:GetConsumptionPerSecondMass()
 end
 
---- Return the name of the layer the unit is currently in.
+--- Return the name of the layer the unit is currently in. This value is cached inside
+-- unit.Layer each time a layer changes (when OnLayerChanged is called) and the hierarchy
+-- is called accordingly (e.g., ends up in Unit.OnLayerChange).
 -- @return layer String, name of the layer, types: 'Air','Land', 'Orbital', 'Seabed', 'Sub', 'Water'.
 function Unit:GetCurrentLayer()
 end

--- a/lua/AI/AIBehaviors.lua
+++ b/lua/AI/AIBehaviors.lua
@@ -160,8 +160,8 @@ function CDROverCharge(aiBrain, cdr)
                     for k, v in priList do
                         target = plat:FindClosestUnit('Support', 'Enemy', true, v)
                         if target and Utilities.XZDistanceTwoVectors(cdrPos, target:GetPosition()) <= searchRadius then
-                            local cdrLayer = cdr:GetCurrentLayer()
-                            local targetLayer = target:GetCurrentLayer()
+                            local cdrLayer = cdr.Layer
+                            local targetLayer = target.Layer
                             if not (cdrLayer == 'Land' and (targetLayer == 'Air' or targetLayer == 'Sub' or targetLayer == 'Seabed')) and
                                not (cdrLayer == 'Seabed' and (targetLayer == 'Air' or targetLayer == 'Water')) then
                                 break
@@ -1790,8 +1790,8 @@ function CDROverChargeSorian(aiBrain, cdr)
                 for _, v in priList do
                     target = plat:FindClosestUnit('Support', 'Enemy', true, v)
                     if target and Utilities.XZDistanceTwoVectors(cdrPos, target:GetPosition()) < maxRadius then
-                        local cdrLayer = cdr:GetCurrentLayer()
-                        local targetLayer = target:GetCurrentLayer()
+                        local cdrLayer = cdr.Layer
+                        local targetLayer = target.Layer
                         if not (cdrLayer == 'Land' and (targetLayer == 'Air' or targetLayer == 'Sub' or targetLayer == 'Seabed')) and
                            not (cdrLayer == 'Seabed' and (targetLayer == 'Air' or targetLayer == 'Water')) then
                             break
@@ -2290,7 +2290,7 @@ CommanderOverrideCheckSorian = function(self)
     local aiBrain = self:GetBrain()
     local commanders = aiBrain:GetUnitsAroundPoint(categories.COMMAND, self:GetPlatoonPosition(), weaponRange, 'Enemy')
 
-    if table.empty(commanders) or commanders[1].Dead or commanders[1]:GetCurrentLayer() == 'Seabed' then
+    if table.empty(commanders) or commanders[1].Dead or commanders[1].Layer == 'Seabed' then
         return false
     end
 

--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -181,11 +181,11 @@ function OverrideKilled(self, instigator, type, overkillRatio)
     self.Dead = true
 
     local bp = self:GetBlueprint()
-    if self:GetCurrentLayer() == 'Water' and bp.Physics.MotionType == 'RULEUMT_Hover' then
+    if self.Layer == 'Water' and bp.Physics.MotionType == 'RULEUMT_Hover' then
         self:PlayUnitSound('HoverKilledOnWater')
     end
 
-    if self:GetCurrentLayer() == 'Land' and bp.Physics.MotionType == 'RULEUMT_AmphibiousFloating' then
+    if self.Layer == 'Land' and bp.Physics.MotionType == 'RULEUMT_AmphibiousFloating' then
         self:PlayUnitSound('AmphibiousFloatingKilledOnLand')
     else
         self:PlayUnitSound('Killed')

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -87,7 +87,7 @@ Callbacks.CapMex = function(data, units)
     local mex = GetEntityById(data.target)
     if not mex or not EntityCategoryContains(categories.MASSEXTRACTION * categories.STRUCTURE, mex) then return end
 
-    if mex:GetCurrentLayer() == 'Seabed' then return end
+    if mex.Layer == 'Seabed' then return end
 
     local pos = mex:GetPosition()
     local msid

--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -80,7 +80,7 @@ CConstructionUnit = Class(ConstructionUnit){
     OnStopBeingBuilt = function(self, builder, layer)
         ConstructionUnit.OnStopBeingBuilt(self, builder, layer)
         -- If created with F2 on land, then play the transform anim.
-        if self:GetCurrentLayer() == 'Water' then
+        if self.Layer == 'Water' then
             self.TerrainLayerTransitionThread = self:ForkThread(self.TransformThread, true)
         end
     end,
@@ -375,7 +375,7 @@ CConstructionStructureUnit = Class(CStructureUnit) {
         CStructureUnit.OnStopBeingBuilt(self, builder, layer)
 
         -- If created with F2 on land, then play the transform anim.
-        if self:GetCurrentLayer() == 'Water' then
+        if self.Layer == 'Water' then
             self.TerrainLayerTransitionThread = self:ForkThread(self.TransformThread, true)
         end
     end,

--- a/lua/defaultexplosions.lua
+++ b/lua/defaultexplosions.lua
@@ -110,7 +110,7 @@ function MakeExplosionEntitySpec(unit, overKillRatio)
         BoundingXYZRadius = GetAverageBoundingXYZRadius(unit),
         OverKillRatio = overKillRatio,
         Volume = GetUnitVolume(unit),
-        Layer = unit:GetCurrentLayer(),
+        Layer = unit.Layer,
     }
 end
 
@@ -269,7 +269,7 @@ function CreateWreckageEffects(obj, prop)
     if IsUnit(obj) then
         local scale = GetAverageBoundingXYZRadius(obj)
         local emitters = {}
-        local layer = obj:GetCurrentLayer()
+        local layer = obj.Layer
 
         if scale < 0.5 then -- SMALL UNITS
             emitters = CreateRandomEffects(prop, obj.Army, EffectTemplate.DefaultWreckageEffectsSml01, 1)

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -51,7 +51,7 @@ StructureUnit = Class(Unit) {
         Unit.OnCreate(self)
         self.WeaponMod = {}
         self.FxBlinkingLightsBag = {}
-        if self:GetCurrentLayer() == 'Land' and self:GetBlueprint().Physics.FlattenSkirt then
+        if self.Layer == 'Land' and self:GetBlueprint().Physics.FlattenSkirt then
             self:FlattenSkirt()
         end
     end,
@@ -165,7 +165,7 @@ StructureUnit = Class(Unit) {
     end,
 
     CreateTarmac = function(self, albedo, normal, glow, orientation, specTarmac, lifeTime)
-        if self:GetCurrentLayer() ~= 'Land' then return end
+        if self.Layer ~= 'Land' then return end
         local tarmac
         local bp = self:GetBlueprint().Display.Tarmacs
         if not specTarmac then
@@ -1398,7 +1398,7 @@ RadarJammerUnit = Class(StructureUnit) {
         StructureUnit.OnIntelEnabled(self)
         if self.IntelEffects and not self.IntelFxOn then
             self.IntelEffectsBag = {}
-            self.CreateTerrainTypeEffects(self, self.IntelEffects, 'FXIdle', self:GetCurrentLayer(), nil, self.IntelEffectsBag)
+            self.CreateTerrainTypeEffects(self, self.IntelEffects, 'FXIdle', self.Layer, nil, self.IntelEffectsBag)
             self.IntelFxOn = true
         end
     end,
@@ -1425,7 +1425,7 @@ SonarUnit = Class(StructureUnit) {
     end,
 
     TimedIdleSonarEffects = function(self)
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         local pos = self:GetPosition()
 
         if self.TimedSonarTTIdleEffects then
@@ -1545,7 +1545,7 @@ MobileUnit = Class(Unit) {
         -- Add unit's threat to our influence map
         local threat = 5
         local decay = 0.1
-        local currentLayer = self:GetCurrentLayer()
+        local currentLayer = self.Layer
         if instigator then
             local unit = false
             if IsUnit(instigator) then
@@ -1817,7 +1817,7 @@ AirUnit = Class(MobileUnit) {
     end,
 
     ShallSink = function(self)
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         local shallSink = (
             self.shallSink or -- Only the case when a bounced plane hits water. Overrides the fact that the layer is 'Air'
             ((layer == 'Water' or layer == 'Sub') and  -- In a layer for which sinking is meaningful
@@ -1843,7 +1843,7 @@ AirUnit = Class(MobileUnit) {
 
         -- Additional stupidity: An idle transport, bot loaded and unloaded, counts as 'Land' layer so it would die with the wreck hovering.
         -- It also wouldn't call this code, and hence the cargo destruction. Awful!
-        if self:GetFractionComplete() == 1 and (self:GetCurrentLayer() == 'Air' or EntityCategoryContains(categories.TRANSPORTATION, self)) then
+        if self:GetFractionComplete() == 1 and (self.Layer == 'Air' or EntityCategoryContains(categories.TRANSPORTATION, self)) then
             self.CreateUnitAirDestructionEffects(self, 1.0)
             self:DestroyTopSpeedEffects()
             self:DestroyBeamExhaust()
@@ -2222,7 +2222,10 @@ HoverLandUnit = Class(MobileUnit) {}
 
 SlowHoverLandUnit = Class(HoverLandUnit) {
     OnLayerChange = function(self, new, old)
+
+        -- call base class to make sure self.layer is set
         HoverLandUnit.OnLayerChange(self, new, old)
+
         -- Slow these units down when they transition from land to water
         -- The mult is applied twice thanks to an engine bug, so careful when adjusting it
         -- Newspeed = oldspeed * mult * mult
@@ -2241,6 +2244,10 @@ AmphibiousLandUnit = Class(MobileUnit) {}
 
 SlowAmphibiousLandUnit = Class(AmphibiousLandUnit) {
     OnLayerChange = function(self, new, old)
+
+        -- call base class to make sure self.layer is set
+        HoverLandUnit.OnLayerChange(self, new, old)
+
         local mult = self:GetBlueprint().Physics.WaterSpeedMultiplier
         if new == 'Seabed'  then
             self:SetSpeedMult(mult)

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -641,7 +641,7 @@ Platoon = Class(moho.platoon_methods) {
                     WaitSeconds(5)
 
                     if self.PlatoonData.EngineerGuardTimeLimit and guardTime >= self.PlatoonData.EngineerGuardTimeLimit
-                    or (not unitToGuard.Dead and unitToGuard:GetCurrentLayer() == 'Seabed' and self.MovementLayer == 'Land') then
+                    or (not unitToGuard.Dead and unitToGuard.Layer == 'Seabed' and self.MovementLayer == 'Land') then
                         break
                     end
                 end
@@ -705,7 +705,7 @@ Platoon = Class(moho.platoon_methods) {
                 WaitSeconds(5)
 
                 if self.PlatoonData.GuardTimeLimit and guardTime >= self.PlatoonData.GuardTimeLimit
-                or (not unitToGuard.Dead and unitToGuard:GetCurrentLayer() == 'Seabed' and self.MovementLayer == 'Land') then
+                or (not unitToGuard.Dead and unitToGuard.Layer == 'Seabed' and self.MovementLayer == 'Land') then
                     break
                 end
             end
@@ -2895,7 +2895,7 @@ Platoon = Class(moho.platoon_methods) {
                 continue
             end
 
-            if v:GetCurrentLayer() != 'Sub' then
+            if v.Layer != 'Sub' then
                 continue
             end
 
@@ -4744,7 +4744,7 @@ Platoon = Class(moho.platoon_methods) {
                 continue
             end
 
-            if v:GetCurrentLayer() == 'Sub' then
+            if v.Layer == 'Sub' then
                 continue
             end
 
@@ -4954,7 +4954,7 @@ Platoon = Class(moho.platoon_methods) {
                 end
 
                 if self.PlatoonData.T4GuardTimeLimit and guardTime >= self.PlatoonData.T4GuardTimeLimit
-                or (not unitToGuard.Dead and unitToGuard:GetCurrentLayer() == 'Seabed' and self.MovementLayer == 'Land') then
+                or (not unitToGuard.Dead and unitToGuard.Layer == 'Seabed' and self.MovementLayer == 'Land') then
                     break
                 end
             end
@@ -5324,7 +5324,7 @@ Platoon = Class(moho.platoon_methods) {
                 continue
             end
 
-            if v:GetCurrentLayer() == 'Sub' then
+            if v.Layer == 'Sub' then
                 continue
             end
 

--- a/lua/seraphimunits.lua
+++ b/lua/seraphimunits.lua
@@ -651,7 +651,7 @@ SEnergyBallUnit = Class(SHoverLandUnit) {
     DeathState = State {
         Main = function(self)
             self:SetCanBeKilled(true)
-            if self:GetCurrentLayer() == 'Water' then
+            if self.Layer == 'Water' then
                 self:PlayUnitSound('HoverKilledOnWater')
             end
             self:PlayUnitSound('Destroyed')

--- a/lua/seraphimweapons.lua
+++ b/lua/seraphimweapons.lua
@@ -106,7 +106,7 @@ SDFThauCannon = Class(DefaultProjectileWeapon) {
         DefaultProjectileWeapon.PlayFxMuzzleSequence(self, muzzle)
         local pos = self.unit:GetPosition()
         local TerrainType = GetTerrainType(pos.x,pos.z)
-        local effectTable = TerrainType.FXOther[self.unit:GetCurrentLayer()][self.FxMuzzleTerrainTypeName]
+        local effectTable = TerrainType.FXOther[self.unit.Layer][self.FxMuzzleTerrainTypeName]
         if effectTable ~= nil then
             local army = self.unit.Army
             for k, v in effectTable do

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -492,7 +492,7 @@ function CreateWreckageUnit(unit)
 	local isExperimental = bp.CategoriesHash.EXPERIMENTAL
 	local isNaval = bp.CategoriesHash.NAVAL
 
-	local layer = unit:GetCurrentLayer()
+	local layer = unit.Layer
 	local unitPos = unit:GetPosition()
 	local deep = (GetSurfaceHeight(unitPos[1],unitPos[3]) - GetTerrainHeight(unitPos[1],unitPos[3]))
 	local deathAnim = bp.Display['AnimationDeath']

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -155,6 +155,10 @@ Unit = Class(moho.unit_methods) {
 
     OnCreate = function(self)
         Entity.OnCreate(self)
+
+        -- cache commonly used values from the engine
+        -- self.Layer = self:GetCurrentLayer() -- Not required: ironically OnLayerChange is called _before_ OnCreate is called!
+
         -- Turn off land bones if this unit has them.
         self:HideLandBones()
 
@@ -1153,7 +1157,7 @@ Unit = Class(moho.unit_methods) {
 
     -- On killed: this function plays when the unit takes a mortal hit. Plays death effects and spawns wreckage, dependant on overkill
     OnKilled = function(self, instigator, type, overkillRatio)
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         self.Dead = true
 
         -- Units killed while being invisible because they're teleporting should show when they're killed
@@ -1595,7 +1599,7 @@ Unit = Class(moho.unit_methods) {
         local energy = bp.Economy.BuildCostEnergy * (bp.Wreckage.EnergyMult or 0)
         local time = (bp.Wreckage.ReclaimTimeMultiplier or 1)
         local pos = self:GetPosition()
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
 
         -- Reduce the mass value of submerged wrecks
         if layer == 'Water' or layer == 'Sub' then
@@ -1758,7 +1762,7 @@ Unit = Class(moho.unit_methods) {
     end,
 
     ShallSink = function(self)
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         local shallSink = (
             (layer == 'Water' or layer == 'Sub') and  -- In a layer for which sinking is meaningful
             not EntityCategoryContains(categories.STRUCTURE, self)  -- Exclude structures
@@ -1969,7 +1973,7 @@ Unit = Class(moho.unit_methods) {
 
     HideLandBones = function(self)
         -- Hide the bones for buildings built on land
-        if self.LandBuiltHiddenBones and self:GetCurrentLayer() == 'Land' then
+        if self.LandBuiltHiddenBones and self.Layer == 'Land' then
             for _, v in self.LandBuiltHiddenBones do
                 if self:IsValidBone(v) then
                     self:HideBone(v, true)
@@ -2172,7 +2176,7 @@ Unit = Class(moho.unit_methods) {
         self:EnableUnitIntel('NotInitialized', nil)
         self:ForkThread(self.StopBeingBuiltEffects, builder, layer)
 
-        if self:GetCurrentLayer() == 'Water' then
+        if self.Layer == 'Water' then
             local surfaceAnim = bp.Display.AnimationSurface
             if not self.SurfaceAnimator and surfaceAnim then
                 self.SurfaceAnimator = CreateAnimator(self)
@@ -3063,6 +3067,15 @@ Unit = Class(moho.unit_methods) {
     -- LAYER EVENTS
     -------------------------------------------------------------------------------------------
     OnLayerChange = function(self, new, old)
+
+        -- This function is called when:
+        -- - A unit changes layer (heh)
+        -- - For all units part of a transport, when the transport changes layer (e.g., land units can become 'Air')
+        -- - When a jet lands, it changes to land (from Air)
+
+        -- Store latest layer for performance, preventing .Layer engine calls.
+        self.Layer = new 
+
         -- Bail out early if dead. The engine calls this function AFTER entity:Destroy() has killed
         -- the C object. Any functions down this line which expect a live C object (self:CreateAnimator())
         -- for example, will throw an error.
@@ -3109,7 +3122,7 @@ Unit = Class(moho.unit_methods) {
         if self.Dead then
             return
         end
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
 
         if old == 'Stopped' or (old == 'Stopping' and (new == 'Cruise' or new == 'TopSpeed')) then
             -- Try the specialised sound, fall back to the general one.
@@ -3184,7 +3197,7 @@ Unit = Class(moho.unit_methods) {
         end
 
         -- Surfacing and sinking, landing and take off idle effects
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         if (new == 'Up' and old == 'Bottom') or (new == 'Down' and old == 'Top') then
             self:DestroyIdleEffects()
 
@@ -3231,7 +3244,7 @@ Unit = Class(moho.unit_methods) {
     end,
 
     OnAnimCollision = function(self, bone, x, y, z)
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         local bpTable = self:GetBlueprint().Display.MovementEffects
 
         if bpTable[layer].Footfall then
@@ -3301,7 +3314,7 @@ Unit = Class(moho.unit_methods) {
             self:DestroyTopSpeedEffects()
         end
 
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         local bpMTable = self:GetBlueprint().Display.MovementEffects
         if new == 'TopSpeed' and self.HasFuel then
             if bpMTable[layer].Contrails and self.ContrailEffects then
@@ -3379,7 +3392,7 @@ Unit = Class(moho.unit_methods) {
             end
 
             if not vTypeGroup.Bones or (vTypeGroup.Bones and (table.empty(vTypeGroup.Bones))) then
-                WARN('*WARNING: No effect bones defined for layer group ', repr(self.UnitId), ', Add these to a table in Display.[EffectGroup].', self:GetCurrentLayer(), '.Effects {Bones ={}} in unit blueprint.')
+                WARN('*WARNING: No effect bones defined for layer group ', repr(self.UnitId), ', Add these to a table in Display.[EffectGroup].', self.Layer, '.Effects {Bones ={}} in unit blueprint.')
             else
                 for kb, vBone in vTypeGroup.Bones do
                     for ke, vEffect in effects do
@@ -3397,7 +3410,7 @@ Unit = Class(moho.unit_methods) {
     end,
 
     CreateIdleEffects = function(self)
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         local bpTable = self:GetBlueprint().Display.IdleEffects
         if bpTable[layer] and bpTable[layer].Effects then
             self:CreateTerrainTypeEffects(bpTable[layer].Effects, 'FXIdle',  layer, nil, self.IdleEffectsBag)
@@ -3405,7 +3418,7 @@ Unit = Class(moho.unit_methods) {
     end,
 
     CreateMovementEffects = function(self, EffectsBag, TypeSuffix, TerrainType)
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         local bpTable = self:GetBlueprint().Display.MovementEffects
 
         if bpTable[layer] then
@@ -3443,7 +3456,7 @@ Unit = Class(moho.unit_methods) {
     end,
 
     CreateMotionChangeEffects = function(self, new, old)
-        local key = self:GetCurrentLayer()..old..new
+        local key = self.Layer..old..new
         local bpTable = self:GetBlueprint().Display.MotionChangeEffects[key]
 
         if bpTable then
@@ -3456,7 +3469,7 @@ Unit = Class(moho.unit_methods) {
 
         -- Clean up any camera shake going on.
         local bpTable = self:GetBlueprint().Display.MovementEffects
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         if self.CamShakeT1 then
             KillThread(self.CamShakeT1)
 
@@ -3897,7 +3910,7 @@ Unit = Class(moho.unit_methods) {
 
             -- Exclude things currently flying around
             for _, target in targets or {} do
-                if target:GetCurrentLayer() ~= 'Air' then
+                if target.Layer ~= 'Air' then
                     target:SetStunned(buffTable.Duration or 1)
                 end
             end

--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -122,7 +122,7 @@ DefaultProjectileWeapon = Class(Weapon) {
         if bp.Flare then
             proj:AddFlare(bp.Flare)
         end
-        if self.unit:GetCurrentLayer() == 'Water' and bp.Audio.FireUnderWater then
+        if self.unit.Layer == 'Water' and bp.Audio.FireUnderWater then
             self:PlaySound(bp.Audio.FireUnderWater)
         elseif bp.Audio.Fire then
             self:PlaySound(bp.Audio.Fire)
@@ -1121,7 +1121,7 @@ DefaultBeamWeapon = Class(DefaultProjectileWeapon) {
         end
 
         local bp = self:GetBlueprint()
-        if self.unit:GetCurrentLayer() == 'Water' and bp.Audio.FireUnderWater then
+        if self.unit.Layer == 'Water' and bp.Audio.FireUnderWater then
             self:PlaySound(bp.Audio.FireUnderWater)
         elseif bp.Audio.Fire then
             self:PlaySound(bp.Audio.Fire)

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -45,7 +45,7 @@ Weapon = Class(moho.weapon_methods) {
         if not self.unit.Trash then
             self.unit.Trash = TrashBag()
         end
-        self:SetValidTargetsForCurrentLayer(self.unit:GetCurrentLayer())
+        self:SetValidTargetsForCurrentLayer(self.unit.Layer)
         local bp = self:GetBlueprint()
         if bp.Turreted == true then
             self:SetupTurret()

--- a/projectiles/CIFArtilleryProton02/CIFArtilleryProton02_script.lua
+++ b/projectiles/CIFArtilleryProton02/CIFArtilleryProton02_script.lua
@@ -11,6 +11,7 @@ CIFArtilleryProton02 = Class(CArtilleryProtonProjectile) {
     FxUnitHitScale = 1.1,
     
     OnImpact = function(self, targetType, targetEntity)
+        local army = self.Army
         local pos = self:GetPosition()
         local radius = self.DamageData.DamageRadius
         local FriendlyFire = self.DamageData.DamageFriendly

--- a/units/UAL0307/UAL0307_script.lua
+++ b/units/UAL0307/UAL0307_script.lua
@@ -81,7 +81,7 @@ UAL0307 = Class(AShieldHoverLandUnit) {
 
             if not self:GetGuardedUnit() then
                 self.PointerEnabled = true
-                self.TargetPointer:SetFireTargetLayerCaps(self.TargetLayerCaps[self:GetCurrentLayer()]) --this resets the stop feature - note that its reset on layer change!
+                self.TargetPointer:SetFireTargetLayerCaps(self.TargetLayerCaps[self.Layer]) --this resets the stop feature - note that its reset on layer change!
             end
         end
     end,

--- a/units/UAS0305/UAS0305_script.lua
+++ b/units/UAS0305/UAS0305_script.lua
@@ -5,7 +5,7 @@
 --#**
 --#**  Summary  :  Aeon T3 Sonar
 --#**
---#**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+--#**  Copyright ï¿½ 2006 Gas Powered Games, Inc.  All rights reserved.
 --#****************************************************************************
 local ASeaUnit = import('/lua/aeonunits.lua').ASeaUnit
 local AIFQuasarAntiTorpedoWeapon = import('/lua/aeonweapons.lua').AIFQuasarAntiTorpedoWeapon
@@ -30,7 +30,7 @@ UAS0305 = Class(ASeaUnit) {
     end,
 
     TimedIdleSonarEffects = function(self)
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         local pos = self:GetPosition()
 
         if self.TimedSonarTTIdleEffects then

--- a/units/UAS0401/UAS0401_script.lua
+++ b/units/UAS0401/UAS0401_script.lua
@@ -165,7 +165,7 @@ UAS0401 = Class(ASeaUnit) {
             self:Destroy()
         end)
 
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         self:DestroyIdleEffects()
         if layer == 'Water' or layer == 'Seabed' or layer == 'Sub' then
             self.SinkExplosionThread = self:ForkThread(self.ExplosionThread)

--- a/units/UEB1102/UEB1102_script.lua
+++ b/units/UEB1102/UEB1102_script.lua
@@ -5,7 +5,7 @@
 --
 --  Summary  :  UEF Hydrocarbon Power Plant Script
 --
---  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--  Copyright ï¿½ 2005 Gas Powered Games, Inc.  All rights reserved.
 ----------------------------------------------------------------------------
 
 local TEnergyCreationUnit = import('/lua/terranunits.lua').TEnergyCreationUnit
@@ -35,10 +35,10 @@ UEB1102 = Class(TEnergyCreationUnit) {
             local effects = {}
             local bones = {}
             local scale = 1
-            if self:GetCurrentLayer() == 'Land' then
+            if self.Layer == 'Land' then
                 effects = self.AirEffects
                 bones = self.AirEffectsBones
-            elseif self:GetCurrentLayer() == 'Seabed' then
+            elseif self.Layer == 'Seabed' then
                 effects = self.WaterEffects
                 bones = self.WaterEffectsBones
                 scale = 3

--- a/units/UEL0301/UEL0301_script.lua
+++ b/units/UEL0301/UEL0301_script.lua
@@ -179,7 +179,7 @@ UEL0301 = Class(CommandUnit) {
         if self.RadarJammerEnh and self:IsIntelEnabled('Jammer') then
             if self.IntelEffects then
                 self.IntelEffectsBag = {}
-                self.CreateTerrainTypeEffects(self, self.IntelEffects, 'FXIdle',  self:GetCurrentLayer(), nil, self.IntelEffectsBag)
+                self.CreateTerrainTypeEffects(self, self.IntelEffects, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
             end
             self:SetEnergyMaintenanceConsumptionOverride(self:GetBlueprint().Enhancements['RadarJammer'].MaintenanceConsumptionPerSecondEnergy or 0)
             self:SetMaintenanceConsumptionActive()

--- a/units/UEL0307/UEL0307_script.lua
+++ b/units/UEL0307/UEL0307_script.lua
@@ -111,7 +111,7 @@ UEL0307 = Class(TShieldLandUnit) {
             -- if not gooner, check whether we need to enable our weapon to keep reasonable distance
             if not self:GetGuardedUnit() then
                 self.PointerEnabled = true
-                self.TargetPointer:SetFireTargetLayerCaps(self.TargetLayerCaps[self:GetCurrentLayer()]) --this resets the stop feature - note that its reset on layer change!
+                self.TargetPointer:SetFireTargetLayerCaps(self.TargetLayerCaps[self.Layer]) --this resets the stop feature - note that its reset on layer change!
             end
         end
     end,

--- a/units/UES0305/UES0305_script.lua
+++ b/units/UES0305/UES0305_script.lua
@@ -5,7 +5,7 @@
 --#**
 --#**  Summary  :  UEF T3 Mobile Sonar
 --#**
---#**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
+--#**  Copyright ï¿½ 2006 Gas Powered Games, Inc.  All rights reserved.
 --#****************************************************************************
 local TSeaUnit = import('/lua/terranunits.lua').TSeaUnit
 local TANTorpedoAngler = import('/lua/terranweapons.lua').TANTorpedoAngler
@@ -36,7 +36,7 @@ UES0305 = Class(TSeaUnit) {
     end,
 
     TimedIdleSonarEffects = function(self)
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         local pos = self:GetPosition()
 
         if self.TimedSonarTTIdleEffects then

--- a/units/UES0401/UES0401_script.lua
+++ b/units/UES0401/UES0401_script.lua
@@ -41,7 +41,7 @@ UES0401 = Class(AircraftCarrier) {
             self.Trash:Add(v)
         end
 
-        if self:GetCurrentLayer() == 'Water' then
+        if self.Layer == 'Water' then
             self:PlayAllOpenAnims(true)
         end
     end,

--- a/units/URB1102/URB1102_script.lua
+++ b/units/URB1102/URB1102_script.lua
@@ -5,7 +5,7 @@
 --#**
 --#**  Summary  :  Cybran Hydrocarbon Power Plant Script
 --#**
---#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--#**  Copyright ï¿½ 2005 Gas Powered Games, Inc.  All rights reserved.
 --#****************************************************************************
 local CEnergyCreationUnit = import('/lua/cybranunits.lua').CEnergyCreationUnit
 
@@ -33,10 +33,10 @@ URB1102 = Class(CEnergyCreationUnit) {
                 self:PlaySound(myBlueprint.Audio.Activate)
             end
 
-            if self:GetCurrentLayer() == 'Land' then
+            if self.Layer == 'Land' then
                 effects = self.AirEffects
                 bones = self.AirEffectsBones
-            elseif self:GetCurrentLayer() == 'Seabed' then
+            elseif self.Layer == 'Seabed' then
                 effects = self.WaterEffects
                 bones = self.WaterEffectsBones
                 scale = 2

--- a/units/URL0001/URL0001_script.lua
+++ b/units/URL0001/URL0001_script.lua
@@ -256,7 +256,7 @@ URL0001 = Class(ACUUnit, CCommandUnit) {
             oc:ChangeMaxRadius(bp.NewMaxRadius or 30)
             local aoc = self:GetWeaponByLabel('AutoOverCharge')
             aoc:ChangeMaxRadius(bp.NewMaxRadius or 30)
-            if not (self:GetCurrentLayer() == 'Seabed' and self:HasEnhancement('NaniteTorpedoTube')) then
+            if not (self.Layer == 'Seabed' and self:HasEnhancement('NaniteTorpedoTube')) then
                 self:GetWeaponByLabel('DummyWeapon'):ChangeMaxRadius(self.normalRange)
             end
         elseif enh == 'CoolingUpgradeRemove' then
@@ -271,7 +271,7 @@ URL0001 = Class(ACUUnit, CCommandUnit) {
                     self:GetWeaponByLabel('OverCharge'):ChangeMaxRadius(v.MaxRadius or 22)
                     self:GetWeaponByLabel('AutoOverCharge'):ChangeMaxRadius(v.MaxRadius or 22)
                     self.normalRange = v.MaxRadius or 22
-                    if not (self:GetCurrentLayer() == 'Seabed' and self:HasEnhancement('NaniteTorpedoTube')) then
+                    if not (self.Layer == 'Seabed' and self:HasEnhancement('NaniteTorpedoTube')) then
                         self:GetWeaponByLabel('DummyWeapon'):ChangeMaxRadius(self.normalRange)
                     end
                     break
@@ -286,7 +286,7 @@ URL0001 = Class(ACUUnit, CCommandUnit) {
             self:SetWeaponEnabledByLabel('Torpedo', true)
             self:SetIntelRadius('Sonar', bp.NewSonarRadius or 60)
             self:EnableUnitIntel('Enhancement', 'Sonar')
-            if self:GetCurrentLayer() == 'Seabed' then
+            if self.Layer == 'Seabed' then
                 self:GetWeaponByLabel('DummyWeapon'):ChangeMaxRadius(self.torpRange)
             end
         elseif enh == 'NaniteTorpedoTubeRemove' then
@@ -294,7 +294,7 @@ URL0001 = Class(ACUUnit, CCommandUnit) {
             self:SetWeaponEnabledByLabel('Torpedo', false)
             self:SetIntelRadius('Sonar', bpIntel.SonarRadius or 26)
             self:DisableUnitIntel('Enhancement', 'Sonar')
-            if self:GetCurrentLayer() == 'Seabed' then
+            if self.Layer == 'Seabed' then
                 self:GetWeaponByLabel('DummyWeapon'):ChangeMaxRadius(self.normalRange)
             end
         end
@@ -353,14 +353,14 @@ URL0001 = Class(ACUUnit, CCommandUnit) {
             self:SetMaintenanceConsumptionActive()
             if not self.IntelEffectsBag then
                 self.IntelEffectsBag = {}
-                self.CreateTerrainTypeEffects(self, self.IntelEffects.Cloak, 'FXIdle',  self:GetCurrentLayer(), nil, self.IntelEffectsBag)
+                self.CreateTerrainTypeEffects(self, self.IntelEffects.Cloak, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
             end
         elseif self.StealthEnh and self:IsIntelEnabled('RadarStealth') and self:IsIntelEnabled('SonarStealth') then
             self:SetEnergyMaintenanceConsumptionOverride(self:GetBlueprint().Enhancements['StealthGenerator'].MaintenanceConsumptionPerSecondEnergy or 0)
             self:SetMaintenanceConsumptionActive()
             if not self.IntelEffectsBag then
                 self.IntelEffectsBag = {}
-                self.CreateTerrainTypeEffects(self, self.IntelEffects.Field, 'FXIdle',  self:GetCurrentLayer(), nil, self.IntelEffectsBag)
+                self.CreateTerrainTypeEffects(self, self.IntelEffects.Field, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
             end
         end
     end,

--- a/units/URL0203/URL0203_script.lua
+++ b/units/URL0203/URL0203_script.lua
@@ -23,13 +23,13 @@ URL0203 = Class(CLandUnit, SlowAmphibious) {
     OnStopBeingBuilt = function(self, builder, layer)
         CLandUnit.OnStopBeingBuilt(self,builder,layer)
         # If created with F2 on land, then play the transform anim.
-        if(self:GetCurrentLayer() == 'Land') then
+        if(self.Layer == 'Land') then
 			# Enable Land weapons
 	        self:SetWeaponEnabledByLabel('Rocket', true)
 	        self:SetWeaponEnabledByLabel('Bolter', true)
 			# Disable Torpedo
 	        self:SetWeaponEnabledByLabel('Torpedo', false)
-        elseif (self:GetCurrentLayer() == 'Seabed') then
+        elseif (self.Layer == 'Seabed') then
 			# Disable Land Weapons
 	        self:SetWeaponEnabledByLabel('Rocket', false)
 	        self:SetWeaponEnabledByLabel('Bolter', false)

--- a/units/URL0301/URL0301_script.lua
+++ b/units/URL0301/URL0301_script.lua
@@ -267,14 +267,14 @@ URL0301 = Class(CCommandUnit) {
             self:SetMaintenanceConsumptionActive()
             if not self.IntelEffectsBag then
                 self.IntelEffectsBag = {}
-                self.CreateTerrainTypeEffects(self, self.IntelEffects.Cloak, 'FXIdle',  self:GetCurrentLayer(), nil, self.IntelEffectsBag)
+                self.CreateTerrainTypeEffects(self, self.IntelEffects.Cloak, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
             end
         elseif self.StealthEnh and self:IsIntelEnabled('RadarStealth') and self:IsIntelEnabled('SonarStealth') then
             self:SetEnergyMaintenanceConsumptionOverride(self:GetBlueprint().Enhancements['StealthGenerator'].MaintenanceConsumptionPerSecondEnergy or 0)
             self:SetMaintenanceConsumptionActive()
             if not self.IntelEffectsBag then
                 self.IntelEffectsBag = {}
-                self.CreateTerrainTypeEffects(self, self.IntelEffects.Field, 'FXIdle',  self:GetCurrentLayer(), nil, self.IntelEffectsBag)
+                self.CreateTerrainTypeEffects(self, self.IntelEffects.Field, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
             end
         end
     end,

--- a/units/URL0306/URL0306_Script.lua
+++ b/units/URL0306/URL0306_Script.lua
@@ -53,7 +53,7 @@ URL0306 = Class(CRadarJammerUnit) {
             WaitSeconds(1)
             if not self:GetGuardedUnit() then
                 self.PointerEnabled = true
-                self.TargetPointer:SetFireTargetLayerCaps(self.TargetLayerCaps[self:GetCurrentLayer()]) --this resets the stop feature - note that its reset on layer change!
+                self.TargetPointer:SetFireTargetLayerCaps(self.TargetLayerCaps[self.Layer]) --this resets the stop feature - note that its reset on layer change!
             end
         end
     end,

--- a/units/URL0402/URL0402_script.lua
+++ b/units/URL0402/URL0402_script.lua
@@ -42,7 +42,7 @@ URL0402 = Class(CWalkingLandUnit) {
 
     OnStopBeingBuilt = function(self, builder, layer)
         CWalkingLandUnit.OnStopBeingBuilt(self, builder, layer)
-        self:CreateUnitAmbientEffect(self:GetCurrentLayer())
+        self:CreateUnitAmbientEffect(self.Layer)
         if self.AnimationManipulator then
             self:SetUnSelectable(true)
             self.AnimationManipulator:SetRate(1)

--- a/units/URS0201/URS0201_script.lua
+++ b/units/URS0201/URS0201_script.lua
@@ -112,7 +112,7 @@ URS0201 = Class(CSeaUnit) {
     OnKilled = function(self, instigator, type, overkillRatio)
         self.Trash:Destroy()
         self.Trash = TrashBag()
-        if self:GetCurrentLayer() ~= 'Water' and not self.IsWaiting then
+        if self.Layer ~= 'Water' and not self.IsWaiting then
             self:GetBlueprint().Display.AnimationDeath = self:GetBlueprint().Display.LandAnimationDeath
         else
             self:GetBlueprint().Display.AnimationDeath = self:GetBlueprint().Display.WaterAnimationDeath
@@ -122,7 +122,7 @@ URS0201 = Class(CSeaUnit) {
     end,
 
      DeathThread = function(self, overkillRatio)
-        if self:GetCurrentLayer() ~= 'Water' and not self.IsWaiting then
+        if self.Layer ~= 'Water' and not self.IsWaiting then
             self:PlayUnitSound('Destroyed')
             if self.PlayDestructionEffects then
                 self:CreateDestructionEffects(self, overkillRatio)
@@ -160,7 +160,7 @@ URS0201 = Class(CSeaUnit) {
     OnStopBeingBuilt = function(self, builder, layer)
         CSeaUnit.OnStopBeingBuilt(self, builder, layer)
 
-        if self:GetAIBrain().BrainType == 'Human' and self:GetCurrentLayer() ~= 'Land' then
+        if self:GetAIBrain().BrainType == 'Human' and self.Layer ~= 'Land' then
             self:SetScriptBit('RULEUTC_WeaponToggle', true)
         end
     end,
@@ -169,7 +169,7 @@ URS0201 = Class(CSeaUnit) {
     OnScriptBitSet = function(self, bit)
         CSeaUnit.OnScriptBitSet(self, bit)
         if bit == 1 then
-            if self:GetCurrentLayer() ~= 'Land' then
+            if self.Layer ~= 'Land' then
                 self:GetStat("h1_SetSalemAmph", 0)
             else
                 self:SetScriptBit('RULEUTC_WeaponToggle', false)

--- a/units/URS0305/URS0305_script.lua
+++ b/units/URS0305/URS0305_script.lua
@@ -5,7 +5,7 @@
 --#**
 --#**  Summary  :  Cybran Long Range Sonar Script
 --#**
---#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--#**  Copyright ï¿½ 2005 Gas Powered Games, Inc.  All rights reserved.
 --#****************************************************************************
 local CSeaUnit = import('/lua/cybranunits.lua').CSeaUnit
 
@@ -31,7 +31,7 @@ URB3302 = Class(CSeaUnit) {
     end,
 
     TimedIdleSonarEffects = function(self)
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         local pos = self:GetPosition()
 
         if self.TimedSonarTTIdleEffects then

--- a/units/XRL0302/XRL0302_Script.lua
+++ b/units/XRL0302/XRL0302_Script.lua
@@ -54,7 +54,7 @@ XRL0302 = Class(CWalkingLandUnit) {
 
         self.EffectsBag = {}
         self.AmbientExhaustEffectsBag = {}
-        self.CreateTerrainTypeEffects(self, self.IntelEffects.Cloak, 'FXIdle',  self:GetCurrentLayer(), nil, self.EffectsBag)
+        self.CreateTerrainTypeEffects(self, self.IntelEffects.Cloak, 'FXIdle',  self.Layer, nil, self.EffectsBag)
         self.PeriodicFXThread = self:ForkThread(self.EmitPeriodicEffects)
     end,
 

--- a/units/XSB1102/XSB1102_script.lua
+++ b/units/XSB1102/XSB1102_script.lua
@@ -5,7 +5,7 @@
 --#**
 --#**  Summary  :  Seraphim Hydrocarbon Power Plant Script
 --#**
---#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+--#**  Copyright ï¿½ 2007 Gas Powered Games, Inc.  All rights reserved.
 --#****************************************************************************
 local SEnergyCreationUnit = import('/lua/seraphimunits.lua').SEnergyCreationUnit
 XSB1102 = Class(SEnergyCreationUnit) {
@@ -23,10 +23,10 @@ XSB1102 = Class(SEnergyCreationUnit) {
         local bones = {}
         local scale = 0.75
 
-        if self:GetCurrentLayer() == 'Land' then
+        if self.Layer == 'Land' then
             effects = self.AirEffects
             bones = self.AirEffectsBones
-        elseif self:GetCurrentLayer() == 'Seabed' then
+        elseif self.Layer == 'Seabed' then
             effects = self.WaterEffects
             bones = self.WaterEffectsBones
             scale = 3

--- a/units/XSB3202/XSB3202_script.lua
+++ b/units/XSB3202/XSB3202_script.lua
@@ -50,7 +50,7 @@ XSB3202 = Class(SSubUnit) {
     
     
     TimedIdleSonarEffects = function( self )
-        local layer = self:GetCurrentLayer()
+        local layer = self.Layer
         local pos = self:GetPosition()
         if self.TimedSonarTTIdleEffects then
             while not self:IsDead() do

--- a/units/XSL0307/XSL0307_script.lua
+++ b/units/XSL0307/XSL0307_script.lua
@@ -71,7 +71,7 @@ XSL0307 = Class(SShieldHoverLandUnit) {
 
             if not self:GetGuardedUnit() then
                 self.PointerEnabled = true
-                self.TargetPointer:SetFireTargetLayerCaps(self.TargetLayerCaps[self:GetCurrentLayer()]) --this resets the stop feature - note that its reset on layer change!
+                self.TargetPointer:SetFireTargetLayerCaps(self.TargetLayerCaps[self.Layer]) --this resets the stop feature - note that its reset on layer change!
             end
         end
     end,


### PR DESCRIPTION
Optimizes the access to the current layer of a unit. Instead of performing an engine call the layer is stored when it is changed inside the unit. All current code in the repository will reference this value instead of performing the engine call.

This does not break compatibility because mods will still perform the engine call.