### PR TITLE
Add self.Army to drones for when AOE damage tries to hit it

### DIFF
--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -311,6 +311,9 @@ CBuildBotUnit = Class(AirUnit) {
     OnCreate = function(self)
         -- prevent drone from consuming anything and remove collision shape
         UnitSetConsumptionActive(self, false)
+
+        -- store the army in case AOE damage tries to hit the drone
+        self.Army = self:GetArmy()
     end,
 
     -- short-cut when being destroyed


### PR DESCRIPTION
A hotfix for fixing AOE damage not working properly on the build drones. See replay:
 - https://replay.faforever.com/15185545

At around minute 04:00 - poor mid player.