### PR TITLE
Store the layer for compatibility with how we work with layers

### DIFF
--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -260,7 +260,7 @@ CBuildBotUnit = Class(AirUnit) {
     -- do not perform the logic of these functions                      
     OnMotionHorzEventChange = function(self, new, old) end,                     -- called a million times, keep it simple
     OnMotionVertEventChange = function(self, new, old) end,                 
-    OnLayerChange = function(self, new, old) end,
+    OnLayerChange = function(self, new, old) self.Layer = new end,
 
     CreateBuildEffects = function(self, unitBeingBuilt, order) end,             -- do not make build effects (engineer / builder takes care of that)
     StartBuildingEffects = function(self, built, order) end,


### PR DESCRIPTION
Ensures the self.Layer value is also set for drones. In practice, it prevents the stun buff from being applied.