### PR TITLE
Optimize projectiles

### DIFF
--- a/lua/SeraphimProjectilesOpti.lua
+++ b/lua/SeraphimProjectilesOpti.lua
@@ -1,0 +1,52 @@
+------------------------------------------------------------
+--
+--  File     :  /cdimage/lua/seraphimprojectiles.lua
+--  Author(s):  Gordon Duclos, Greg Kohne, Matt Vainio, Aaron Lundquist
+--
+--  Summary  : Seraphim projectile base class definitions
+--
+--  Copyright � 2007 Gas Powered Games, Inc.  All rights reserved.
+------------------------------------------------------------
+
+--------------------------------------------------------------------------
+--  SERAPHIM PROJECTILES SCRIPTS
+--------------------------------------------------------------------------
+
+local EffectTemplate = import('/lua/EffectTemplates.lua')
+local DefaultProjectileFile = import('/lua/sim/defaultprojectiles.lua')
+local MultiPolyTrailProjectile = DefaultProjectileFile.MultiPolyTrailProjectileOpti
+
+SThunthoArtilleryShell = Class(MultiPolyTrailProjectile) {
+
+    FxImpactTrajectoryAligned = false,
+
+    FxImpactLand = EffectTemplate.SThunderStormCannonHit,
+    FxImpactNone = EffectTemplate.SThunderStormCannonHit,
+    FxImpactProjectile = false,
+    FxImpactProp = EffectTemplate.SThunderStormCannonHit,
+    FxImpactUnderWater = false,
+    FxImpactUnit = EffectTemplate.SThunderStormCannonHit,
+
+    FxTrails = EffectTemplate.SThunderStormCannonProjectileTrails,
+
+    PolyTrails = EffectTemplate.SThunderStormCannonProjectilePolyTrails,
+    PolyTrailOffset = false,
+}
+
+SThunthoArtilleryShell2 = Class(MultiPolyTrailProjectile) {
+
+    FxImpactTrajectoryAligned = false,
+
+    FxImpactLand = EffectTemplate.SThunderStormCannonLandHit,
+    FxImpactWater= EffectTemplate.SThunderStormCannonLandHit,
+    FxImpactNone = EffectTemplate.SThunderStormCannonHit,
+    FxImpactProjectile = false,
+    FxImpactProp = EffectTemplate.SThunderStormCannonHit,
+    FxImpactUnderWater = false,
+    FxImpactUnit = EffectTemplate.SThunderStormCannonUnitHit,
+
+    FxTrails = false,
+
+    PolyTrails = EffectTemplate.SThunderStormCannonProjectilePolyTrails,
+    PolyTrailOffset = false,
+}

--- a/lua/TerranProjectilesOpti.lua
+++ b/lua/TerranProjectilesOpti.lua
@@ -1,0 +1,62 @@
+------------------------------------------------------------
+--
+--  File     : /lua/terranprojectiles.lua
+--  Author(s): John Comes, Gordon Duclos, Matt Vainio
+--
+--  Summary  :
+--
+--  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+------------------------------------------------------------
+
+--------------------------------------------------------------------------
+--  TERRAN PROJECTILES SCRIPTS
+--------------------------------------------------------------------------
+
+local EffectTemplate = import('/lua/EffectTemplates.lua')
+local DefaultProjectileFile = import('/lua/sim/defaultprojectiles.lua')
+local SingleBeamProjectileOpti = DefaultProjectileFile.SingleBeamProjectileOpti
+
+
+-- upvalue for performance (globals)
+local CreateEmitterAtEntity = CreateEmitterAtEntity
+
+-- upvalue for performance (moho functions)
+local EmitterScaleEmitter = _G.moho.IEffect.ScaleEmitter 
+
+TMissileCruiseProjectile = Class(SingleBeamProjectileOpti) {
+
+    -- ??
+    DestroyOnImpact = false,
+
+    -- trail effects
+    FxTrails = EffectTemplate.TMissileExhaust02,
+    FxTrailOffset = -1,
+
+    -- beam effects (part of trail)
+    BeamName = '/effects/emitters/missile_munition_exhaust_beam_01_emit.bp',
+
+    -- impact effects
+    FxImpactUnit = EffectTemplate.TMissileHit01,
+    FxImpactLand = EffectTemplate.TMissileHit01,
+    FxImpactProp = EffectTemplate.TMissileHit01,
+    FxImpactUnderWater = false,
+
+    CreateImpactEffects = function(self, army, effectTable, effectScale)
+        -- store reference in memory once
+        local emit = false
+
+        -- only loop over an effectTable that exists
+        if effectTable then 
+            for k, v in effectTable do
+
+                -- create the emitter on ourselves
+                emit = CreateEmitterAtEntity(self, army, v)
+
+                -- no need to scale if it is just 1
+                if effectScale ~= 1 then
+                    EmitterScaleEmitter(emit, effectScale)
+                end
+            end
+        end
+    end,
+}

--- a/lua/seraphimprojectiles.lua
+++ b/lua/seraphimprojectiles.lua
@@ -5,7 +5,7 @@
 --
 --  Summary  : Seraphim projectile base class definitions
 --
---  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+--  Copyright ï¿½ 2007 Gas Powered Games, Inc.  All rights reserved.
 ------------------------------------------------------------
 
 --------------------------------------------------------------------------
@@ -1000,3 +1000,10 @@ SDFAireauProjectile = Class(MultiPolyTrailProjectile) { -- ythotha
         MultiPolyTrailProjectile.OnImpact(self, targetType, targetEntity)
     end,
 }
+
+-- Optimized versions -- 
+
+local SeraphimProjectilesOpti = import("/lua/SeraphimProjectilesOpti.lua")
+
+SThunthoArtilleryShellOpti = SeraphimProjectilesOpti.SThunthoArtilleryShell
+SThunthoArtilleryShell2Opti = SeraphimProjectilesOpti.SThunthoArtilleryShell2

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -500,3 +500,4 @@ local DefaultProjectilesOpti = import("/lua/sim/DefaultProjectilesOpti.lua")
 
 EmitterProjectileOpti = DefaultProjectilesOpti.EmitterProjectile
 SingleBeamProjectileOpti = DefaultProjectilesOpti.SingleBeamProjectile
+MultiPolyTrailProjectileOpti = DefaultProjectilesOpti.MultiPolyTrailProjectile

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -493,3 +493,10 @@ OverchargeProjectile = Class() {
         OCProjectiles[self.Army] = OCProjectiles[self.Army] + 1
     end,
 }
+
+-- Optimized default projectiles --
+
+local DefaultProjectilesOpti = import("/lua/sim/DefaultProjectilesOpti.lua")
+
+EmitterProjectileOpti = DefaultProjectilesOpti.EmitterProjectile
+SingleBeamProjectileOpti = DefaultProjectilesOpti.SingleBeamProjectile

--- a/lua/sim/DefaultProjectilesOpti.lua
+++ b/lua/sim/DefaultProjectilesOpti.lua
@@ -9,12 +9,48 @@
 local ProjectileOpti = import('/lua/sim/Projectile.lua').ProjectileOpti
 local ProjectileOnCreate = ProjectileOpti.OnCreate
 
--- upvalue for performance (globals)
+-- globals as upvalues for performance 
+local Damage = Damage
+local Random = Random
+local DamageRing = DamageRing
+local ForkThread = ForkThread
+local WaitSeconds = WaitSeconds
+local CreateTrail = CreateTrail
+local CreateEmitterOnEntity = CreateEmitterOnEntity
 local CreateBeamEmitterOnEntity = CreateBeamEmitterOnEntity
 
--- upvalue for performance (moho)
-local EmitterScaleEmitter = _G.moho.IEffect.ScaleEmitter
-local EmitterOffsetEmitter = _G.moho.IEffect.OffsetEmitter
+local TableGetN = table.getn
+
+-- math functions as upvalues for performance
+local MathFloor = _G.math.floor
+local MathMin = _G.math.min
+local MathMax = _G.math.max 
+
+-- moho functions as upvalue for performance
+local EntityMethods = _G.moho.entity_methods
+local EntityGetPosition = EntityMethods.GetPosition
+local EntityGetHealth = EntityMethods.GetHealth
+local EntityPlaySound = EntityMethods.PlaySound
+local EntityBeenDestroyed = EntityMethods.BeenDestroyed
+local EntityCreateProjectile = EntityMethods.CreateProjectile
+local EntitySetAmbientSound = EntityMethods.SetAmbientSound
+
+local ProjectileMethods = _G.moho.projectile_methods
+local ProjectileSetAcceleration = ProjectileMethods.SetAcceleration
+local ProjectileStayUnderwater = ProjectileMethods.StayUnderwater
+local ProjectileSetTurnRate = ProjectileMethods.SetTurnRate
+
+local ProjectileTrackTarget = ProjectileMethods.TrackTarget
+local ProjectileSetDestroyOnWater = ProjectileMethods.SetDestroyOnWater
+local ProjectileGetCurrentTargetPosition = ProjectileMethods.GetCurrentTargetPosition
+local ProjectileSetCollisionShape = ProjectileMethods.SetCollisionShape
+local ProjectileSetCollision = ProjectileMethods.SetCollision
+
+local EmitterMethods = _G.moho.IEffect
+local EmitterScaleEmitter = EmitterMethods.ScaleEmitter
+local EmitterOffsetEmitter = EmitterMethods.OffsetEmitter
+
+local TrashAdd = TrashBag.Add
 
 EmitterProjectile = Class(ProjectileOpti) {
 
@@ -72,6 +108,53 @@ SingleBeamProjectile = Class(EmitterProjectile) {
 
         if beamName then
             CreateBeamEmitterOnEntity(self, -1, army, beamName)
+        end
+    end,
+}
+
+MultiPolyTrailProjectile = Class(EmitterProjectile) {
+
+    PolyTrails = { '/effects/emitters/test_missile_trail_emit.bp' },
+    PolyTrailOffset = false,
+    RandomPolyTrails = 0,   -- Count of how many are selected randomly for PolyTrail table
+
+    FxTrails = false,
+
+    OnCreate = function(self)
+        EmitterProjectileOnCreate(self)
+
+        -- see if we have trails
+        local polyTrails = self.PolyTrails
+        if polyTrails then
+
+            -- information that is used in both branches
+            local emit = false
+            local army = self.Army
+            local randomPolyTrails = self.RandomPolyTrails
+            local polyTrailOffset = self.PolyTrailOffset
+            local NumPolyTrails = TableGetN(self.PolyTrails)
+
+            -- choose random trail
+            if randomPolyTrails ~= 0 then
+                local index = 0
+                for i = 1, randomPolyTrails do
+                    index = Random(1, NumPolyTrails)
+                    emit = CreateTrail(self, -1, army, polyTrails[index])
+
+                    if polyTrailOffset then 
+                        EmitterOffsetEmitter(emit, 0, 0, polyTrailOffset[index])
+                    end
+                end
+            -- choose fixed trail
+            else
+                for i = 1, NumPolyTrails do
+                    emit = CreateTrail(self, -1, army, polyTrails[i])
+
+                    if polyTrailOffset then 
+                        EmitterOffsetEmitter(emit, 0, 0, polyTrailOffset[i])
+                    end
+                end
+            end
         end
     end,
 }

--- a/lua/sim/DefaultProjectilesOpti.lua
+++ b/lua/sim/DefaultProjectilesOpti.lua
@@ -1,0 +1,77 @@
+-----------------------------------------------------------------
+-- File     : /lua/defaultprojectiles.lua
+-- Author(s): John Comes, Gordon Duclos
+-- Summary  : Script for default projectiles
+-- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+-----------------------------------------------------------------
+
+-- get original projectile and upvalue often called base functions
+local ProjectileOpti = import('/lua/sim/Projectile.lua').ProjectileOpti
+local ProjectileOnCreate = ProjectileOpti.OnCreate
+
+-- upvalue for performance (globals)
+local CreateBeamEmitterOnEntity = CreateBeamEmitterOnEntity
+
+-- upvalue for performance (moho)
+local EmitterScaleEmitter = _G.moho.IEffect.ScaleEmitter
+local EmitterOffsetEmitter = _G.moho.IEffect.OffsetEmitter
+
+EmitterProjectile = Class(ProjectileOpti) {
+
+    -- typical trail emitters
+    FxTrailScale = 1,
+    FxTrailOffset = 0,
+    FxTrails = { '/effects/emitters/missile_munition_trail_01_emit.bp', },
+
+    OnCreate = function(self)
+        ProjectileOnCreate(self)
+
+        -- make sure there is at least one effect in it 
+        local fxTrails = self.FxTrails
+        if fxTrails[1] then 
+
+            -- sequential / cached table look ups are faster
+            local emit = false
+            local army = self.Army
+            local fxTrailScale = self.FxTrailScale
+            local fxTrailOffset = self.FxTrailOffset
+            for i in fxTrails do
+                emit = CreateEmitterOnEntity(self, army, fxTrails[i])
+
+                -- only scale if it matters
+                if fxTrailScale != 1 then 
+                    EmitterScaleEmitter(emit, fxTrailScale)
+                end
+
+                -- only apply offset if it matters
+                if fxTrailOffset != 0 then 
+                    EmitterOffsetEmitter(emit, 0, 0, fxTrailOffset)
+                end
+            end
+        end
+    end,
+}
+
+-- upvalue often called base functions
+local EmitterProjectileOnCreate = EmitterProjectile.OnCreate
+
+SingleBeamProjectile = Class(EmitterProjectile) {
+
+    -- beam of the projectile (typically part of trail)
+    BeamName = '/effects/emitters/default_beam_01_emit.bp',
+
+    -- do not allocate these
+    FxTrails = false,
+
+    OnCreate = function(self)
+        EmitterProjectileOnCreate(self)
+
+        -- sequential / cached table look ups are faster
+        local army = self.Army 
+        local beamName = self.BeamName 
+
+        if beamName then
+            CreateBeamEmitterOnEntity(self, -1, army, beamName)
+        end
+    end,
+}

--- a/lua/sim/MissileManager.lua
+++ b/lua/sim/MissileManager.lua
@@ -1,0 +1,91 @@
+
+-- import 'dem things
+local TMissileCruiseProjectileOpti = import('/lua/terranprojectiles.lua').TMissileCruiseProjectileOpti
+
+-- upvalue for performance (globals)
+local VDist2 = VDist2
+local ForkThread = ForkThread
+local WaitTicks = coroutine.yield
+local setmetatable = setmetatable
+
+-- upvalue for performance (math functions)
+local MathPi = math.pi
+
+-- upvalue for performance (moho functions)
+local EntityBeenDestroyed = _G.moho.entity_methods.BeenDestroyed
+local EntityGetPosition = _G.moho.entity_methods.GetPosition
+local EntityGetPositionXYZ = _G.moho.entity_methods.GetPositionXYZ
+local EntitySetCollisionShape = _G.moho.entity_methods.SetCollisionShape
+
+local ProjectileSetTurnRate = _G.moho.projectile_methods.SetTurnRate
+local ProjectileGetCurrentTargetPosition = _G.moho.projectile_methods.GetCurrentTargetPosition
+
+-- functions to hook missiles in
+AddMissile2Ticks = false
+-- AddMissile4Ticks = false 
+-- AddMissile8Ticks = false 
+-- AddMissile10Ticks = false
+
+do 
+    -- keeps track of the missiles in various stages
+    local Stage1 = { }
+    local Stage2 = { }
+
+    local Stage1Next = 1
+    local Stage2Next = 1
+
+    -- tells the garbage collector it doesn't have to wait for us
+    local Weak = { __mode = "v" }
+    setmetatable(Stage1, Weak)
+    setmetatable(Stage2, Weak)
+
+    -- provide implementation of the function above
+    AddMissile2Ticks = function(missile)
+        Stage1[Stage1Next] = missile 
+        Stage1Next = Stage1Next + 1
+    end
+
+    -- run the behavior
+    ForkThread(
+        function()
+            while true do 
+
+                -- adjust missiles that reached stage 2
+                for k = 1, Stage2Next - 1 do 
+        
+                    -- get the missile and check if it is still valid
+                    local missile = Stage2[k]
+                    if not missile or EntityBeenDestroyed(missile) then 
+                        continue 
+                    end
+        
+                    -- compute distance
+                    local tpos = ProjectileGetCurrentTargetPosition(missile)
+                    local px, _, pz = EntityGetPositionXYZ(missile)
+                    local dist = VDist2(px, pz, tpos[1], tpos[3])
+        
+                    -- compute multiplier
+                    local multiplier = 200 / dist
+                    if multiplier < 1.0 then 
+                        multiplier = 1.0
+                    end
+        
+                    -- set turn rate accordingly
+                    ProjectileSetTurnRate(missile, multiplier * 10)
+                end
+        
+                -- switch them up
+                local temp = Stage2
+                Stage2 = Stage1 
+                Stage1 = temp 
+        
+                -- switch them up
+                Stage2Next = Stage1Next
+                Stage1Next = 1
+        
+                -- wait a bit
+                WaitTicks(2)
+            end
+        end
+    )
+end

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -372,9 +372,9 @@ Projectile = Class(moho.projectile_methods, Entity) {
         local TerrainEffects = self:GetTerrainEffects(targetType, bp.Display.ImpactEffects.Type)
         self:CreateImpactEffects(self.Army, ImpactEffects, ImpactEffectScale)
         self:CreateTerrainEffects(self.Army, TerrainEffects, bp.Display.ImpactEffects.Scale or 1)
-        LOG(targetType)
-        LOG(bp.Display.ImpactEffects.Type)
-        LOG(repr(TerrainEffects))
+        -- LOG(targetType)
+        -- LOG(bp.Display.ImpactEffects.Type)
+        -- LOG(repr(TerrainEffects))
 
         local timeout = bp.Physics.ImpactTimeout
         if timeout and targetType == 'Terrain' then

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -372,6 +372,9 @@ Projectile = Class(moho.projectile_methods, Entity) {
         local TerrainEffects = self:GetTerrainEffects(targetType, bp.Display.ImpactEffects.Type)
         self:CreateImpactEffects(self.Army, ImpactEffects, ImpactEffectScale)
         self:CreateTerrainEffects(self.Army, TerrainEffects, bp.Display.ImpactEffects.Scale or 1)
+        LOG(targetType)
+        LOG(bp.Display.ImpactEffects.Type)
+        LOG(repr(TerrainEffects))
 
         local timeout = bp.Physics.ImpactTimeout
         if timeout and targetType == 'Terrain' then
@@ -485,3 +488,7 @@ Projectile = Class(moho.projectile_methods, Entity) {
         end
     end,
 }
+
+-- Optimized projectile --
+
+ProjectileOpti = import("/lua/sim/ProjectileOpti.lua").Projectile

--- a/lua/sim/ProjectileOpti.lua
+++ b/lua/sim/ProjectileOpti.lua
@@ -1,0 +1,554 @@
+------------------------------------------------------------------
+--  File     :  /lua/sim/Projectile.lua
+--  Author(s):  John Comes, Gordon Duclos
+--  Summary  :  Base Projectile Definition
+--  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+------------------------------------------------------------------
+
+local Entity = import('/lua/sim/Entity.lua').Entity
+local Explosion = import('/lua/defaultexplosions.lua')
+local DefaultDamage = import('/lua/sim/defaultdamage.lua')
+local Flare = import('/lua/defaultantiprojectile.lua').Flare
+
+-- upvalued globals for performance
+local Damage = _G.Damage
+local DamageArea = _G.DamageArea
+
+local TrashBag = _G.TrashBag
+local TrashBagAdd = _G.TrashBag.Add 
+local TrashBagDestroy = _G.TrashBag.Destroy
+
+local ForkThread = _G.ForkThread
+local GetTerrainType = _G.GetTerrainType
+local GetSurfaceHeight = _G.GetSurfaceHeight
+
+local EntityCategoryContains = EntityCategoryContains
+local CreateEmitterAtBone = CreateEmitterAtBone
+local CreateEmitterAtEntity = CreateEmitterAtEntity
+
+-- upvalued moho functions for performance
+
+local EntityMethods = _G.moho.entity_methods
+local EntityGetBlueprint = EntityMethods.GetBlueprint
+local EntityGetArmy = EntityMethods.GetArmy
+local EntityDestroy = EntityMethods.Destroy
+local EntityPlaySound = EntityMethods.PlaySound
+local EntityGetHealth = EntityMethods.GetHealth
+local EntitySetHealth = EntityMethods.SetHealth
+local EntityAdjustHealth = EntityMethods.AdjustHealth
+local EntitySetMaxHealth = EntityMethods.SetMaxHealth
+local EntitySetAmbientSound = EntityMethods.SetAmbientSound
+local EntityGetPositionXYZ = EntityMethods.GetPositionXYZ
+local EntityGetPosition = EntityMethods.GetPosition
+
+local ProjectileMethods = _G.moho.projectile_methods
+local ProjectileGetLauncher = ProjectileMethods.GetLauncher
+local ProjectileSetNewTargetGround = ProjectileMethods.SetNewTargetGround
+local ProjectileGetCurrentTargetPosition = ProjectileMethods.GetCurrentTargetPosition
+local ProjectileGetTrackingTarget = ProjectileMethods.GetTrackingTarget
+local ProjectileSetLifetime = ProjectileMethods.SetLifetime
+
+local EmitterMethods = _G.moho.IEffect
+local EmitterScaleEmitter = EmitterMethods.ScaleEmitter
+local EmitterOffsetEmitter = EmitterMethods.OffsetEmitter
+
+-- upvalued read-only values
+local DoNotCollideCategories = categories.TORPEDO + categories.MISSILE + categories.DIRECTFIRE
+local OnImpactDestroyCategories = categories.ANTIMISSILE * categories.ALLPROJECTILES
+local DefaultTerrainTypeFxImpact = GetTerrainType(-1, -1).FXImpact
+
+Projectile = Class(moho.projectile_methods, Entity) {
+
+    -- data initialisation --
+
+    -- FxImpactAirUnit = false,
+    -- FxImpactLand = false,
+    -- FxImpactNone = false,
+    -- FxImpactProp = false,
+    -- FxImpactShield = false,
+    -- FxImpactWater = false,
+    -- FxImpactUnderWater = false,
+    -- FxImpactUnit = false,
+    -- FxImpactProjectile = false,
+    -- FxImpactProjectileUnderWater = false,
+    -- FxOnKilled = false,
+
+    -- FxAirUnitHitScale = 1,
+    -- FxLandHitScale = 1,
+    -- FxNoneHitScale = 1,
+    -- FxPropHitScale = 1,
+    -- FxProjectileHitScale = 1,
+    -- FxProjectileUnderWaterHitScale = 1,
+    -- FxShieldHitScale = 1,
+    -- FxUnderWaterHitScale = 0.25,
+    -- FxUnitHitScale = 1,
+    -- FxWaterHitScale = 1,
+    -- FxOnKilledScale = 1,
+
+    -- this is always false
+    -- FxImpactLandScorch = false,
+    -- FxImpactLandScorchScale = 1.0,
+
+    DestroyOnImpact = true,
+    FxImpactTrajectoryAligned = true,
+
+    --- Passes the damage data as a shallow copy.
+    PassDamageData = function(self, DamageData)
+        -- shallow copy (copy reference)
+        self.DamageData = DamageData
+    end,
+
+    --- Passes the data as a deep copy.
+    DeepDamageData = function(self, DamageData)
+        -- deep copy (copy values)
+
+        -- cache for performance
+        local selfDamageData = self.DamageData
+
+        -- loop over table and get all values
+        for k, data in Damagedata do 
+            selfDamageData[k] = data
+        end
+    end,
+
+    --- Performs damage.
+    DoDamage = function(self, instigator, DamageData, targetEntity)
+        local damage = DamageData.DamageAmount
+        if damage and damage > 0 then
+            local radius = DamageData.DamageRadius
+            if radius and radius > 0 then
+                if not DamageData.DoTTime or DamageData.DoTTime <= 0 then
+                    DamageArea(instigator, self:GetPosition(), radius, damage, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
+                else
+                    -- DoT damage - check for initial damage
+                    local initialDmg = DamageData.InitialDamageAmount or 0
+                    if initialDmg > 0 then
+                        if radius > 0 then
+                            DamageArea(instigator, self:GetPosition(), radius, initialDmg, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
+                        elseif targetEntity then
+                            Damage(instigator, self:GetPosition(), targetEntity, initialDmg, DamageData.DamageType)
+                        end
+                    end
+
+                    ForkThread(DefaultDamage.AreaDoTThread, instigator, self:GetPosition(), DamageData.DoTPulses or 1, (DamageData.DoTTime / (DamageData.DoTPulses or 1)), radius, damage, DamageData.DamageType, DamageData.DamageFriendly)
+                end
+            -- ONLY DO DAMAGE IF THERE IS DAMAGE DATA.  SOME PROJECTILE DO NOT DO DAMAGE WHEN THEY IMPACT.
+            elseif DamageData.DamageAmount and targetEntity then
+                if not DamageData.DoTTime or DamageData.DoTTime <= 0 then
+                    Damage(instigator, self:GetPosition(), targetEntity, DamageData.DamageAmount, DamageData.DamageType)
+                else
+                    -- DoT damage - check for initial damage
+                    local initialDmg = DamageData.InitialDamageAmount or 0
+                    if initialDmg > 0 then
+                        if radius > 0 then
+                            DamageArea(instigator, self:GetPosition(), radius, initialDmg, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
+                        elseif targetEntity then
+                            Damage(instigator, self:GetPosition(), targetEntity, initialDmg, DamageData.DamageType)
+                        end
+                    end
+
+                    ForkThread(DefaultDamage.UnitDoTThread, instigator, targetEntity, DamageData.DoTPulses or 1, (DamageData.DoTTime / (DamageData.DoTPulses or 1)), damage, DamageData.DamageType, DamageData.DamageFriendly)
+                end
+            end
+        end
+        if self.InnerRing and self.OuterRing then
+            local pos = self:GetPosition()
+            self.InnerRing:DoNukeDamage(self.Launcher, pos, self.Brain, self.Army, DamageData.DamageType or 'Nuke')
+            self.OuterRing:DoNukeDamage(self.Launcher, pos, self.Brain, self.Army, DamageData.DamageType or 'Nuke')
+        end
+    end,
+
+    -- Do not call the base class __init and __post_init, we already have a c++ object
+    __init = function(self, spec)
+    end,
+
+    __post_init = function(self, spec)
+    end,
+
+    OnCreate = function(self, inWater)
+        -- retrieve the blueprint
+        local blueprint = EntityGetBlueprint(self)
+
+        -- cache some engine related information
+        self.Trash = TrashBag()
+        self.Army = EntityGetArmy(self)
+        self.Launcher = ProjectileGetLauncher(self)
+        self.Blueprint = blueprint -- questionable according to KionX
+        
+        -- this data is typically part of a shallow copy
+        -- self.DamageData = false
+
+        -- set health of projectile and cache max health
+        local health = blueprint.Defense.MaxHealth or 1
+        self.MaxHealth = health
+        EntitySetMaxHealth(self, health)
+        EntitySetHealth(self, self, health)
+
+        -- adjust for surface height 
+        if blueprint.Physics.TrackTargetGround and blueprint.Physics.TrackTargetGround == true then
+            local pos = ProjectileGetCurrentTargetPosition(self)
+            pos[2] = GetSurfaceHeight(pos[1], pos[3])
+            ProjectileSetNewTargetGround(self, pos)
+        end
+    end,
+
+    OnCollisionCheck = function(self, other)
+
+        -- prevent colliding to ourselves
+        if self.Army == other.Army then return false end
+
+        -- standard do not collide categories
+        if EntityCategoryContains(DoNotCollideCategories, self) and EntityCategoryContains(DoNotCollideCategories, other) then
+            return false
+        end
+
+        if other:GetBlueprint().Physics.HitAssignedTarget and other:GetTrackingTarget() ~= self then
+            return false
+        end
+
+        local dnc
+        for _, p in {{self, other}, {other, self}} do
+            dnc = p[1]:GetBlueprint().DoNotCollideList
+            if dnc then
+                for _, v in dnc do
+                    if EntityCategoryContains(ParseEntityCategory(v), p[2]) then
+                        return false
+                    end
+                end
+            end
+        end
+
+        return true
+    end,
+
+    OnDamage = function(self, instigator, amount, vector, damageType)
+        -- only perform damage logic if we can sustain any damage
+        if self.MaxHealth > 1 then
+            self.DoTakeDamage(self, instigator, amount, vector, damageType)
+        -- otherwise just get rid of ourselves :(
+        else
+            self.OnKilled(self, instigator, damageType)
+        end
+    end,
+
+    OnDestroy = function(self)
+        -- Not all projectiles inherit the OnCreate we made here. An example is
+        -- the UEF dummy projectile for build animations. Hence the if statement.
+        local trash = self.Trash 
+        if trash then 
+            TrashBagDestroy(self.Trash)
+        end
+    end,
+
+    DoTakeDamage = function(self, instigator, amount, vector, damageType)
+
+        -- check for valid projectile
+        if not self or EntityBeenDestroyed(self) then
+            return
+        end
+
+        -- adjust health accordingly
+        EntityAdjustHealth(self, instigator, -amount)
+        local health = EntityGetHealth(self)
+
+        -- if we're a gooner
+        if health <= 0 then
+            -- hold up, reclaimable?
+            if damageType == 'Reclaimed' then
+                self:Destroy()
+            -- create impact effects through OnKilled
+            else
+                self:OnKilled(instigator, damageType, 0)
+            end
+        end
+    end,
+
+    --- Called when the projectile is killed in a typical fashion
+    OnKilled = function(self, instigator, type, overkillRatio)
+        self.CreateImpactEffects(self, self.Army, self.FxOnKilled, self.FxOnKilledScale)
+        EntityDestroy(self)
+    end,
+
+    --- TODO: What is this?
+    DoMetaImpact = function(self, damageData)
+        if damageData.MetaImpactRadius and damageData.MetaImpactAmount then
+            local pos = EntityGetPosition(self)
+            pos[2] = GetSurfaceHeight(pos[1], pos[3])
+            MetaImpact(self, pos, damageData.MetaImpactRadius, damageData.MetaImpactAmount)
+        end
+    end,
+
+    --- Creates the impact effects such as explosions when it a jet flies into the projectile
+    CreateImpactEffects = function(self, army, effectTable, effectScale)
+
+        -- keep on stack for performance
+        local emit = false
+        effectScale = effectScale or 1
+
+        -- check if table exists, can be set to false
+        if effectTable then 
+
+            local fxImpactTrajectoryAligned = self.FxImpactTrajectoryAligned
+
+            for _, v in effectTable do
+
+                -- create emitter accordingly
+                if fxImpactTrajectoryAligned then
+                    emit = CreateEmitterAtBone(self, -2, army, v)
+                else
+                    emit = CreateEmitterAtEntity(self, army, v)
+                end
+
+                -- scale if applicable
+                if effectScale != 1 then
+                    EmitterScaleEmitter(emit, effectScale)
+                end
+            end
+        end
+    end,
+
+    --- Creates terrain effects such as a water splash
+    CreateTerrainEffects = function(self, army, effectTable, effectScale)
+        -- keep on stack for performance
+        local emit = false
+        effectScale = effectScale or 1
+
+        -- check if table exists, can be set to false
+        if effectTable then 
+            for _, v in effectTable do
+
+                -- create emitter and scale accordingly
+                emit = CreateEmitterAtBone(self, -2, army, v)
+                if effectScale != 1 then
+                    EmitterScaleEmitter(emit, effectScale)
+                end
+            end
+        end
+    end,
+
+    --- Get the terrain effects depending on terrain type and impact type
+    GetTerrainEffects = function(self, targetType, impactEffectType)
+        -- default value
+        impactEffectType = impactEffectType or 'Default'
+
+        -- get x / z position
+        local x, y, z = EntityGetPositionXYZ(self)
+    
+        -- get terrain at that location and try and get some effects
+        local terrainTypeFxImpact = GetTerrainType(x, z).FXImpact
+        return terrainTypeFxImpact[targetType][impactEffectType] or DefaultTerrainTypeFxImpact[targetType][impactEffectType] or { }
+    end,
+
+    --- Check if the firing weapon has its own do-not-collide list
+    -- TODO: parsing in live code
+    OnCollisionCheckWeapon = function(self, firingWeapon)
+        if not firingWeapon.CollideFriendly and self.Army == firingWeapon.unit.Army then
+            return false
+        end
+
+        -- If this unit category is on the weapon's do-not-collide list, skip!
+        local weaponBP = firingWeapon:GetBlueprint()
+        if weaponBP.DoNotCollideList then
+            for k, v in pairs(weaponBP.DoNotCollideList) do
+                if EntityCategoryContains(ParseEntityCategory(v), self) then
+                    return false
+                end
+            end
+        end
+        return true
+    end,
+
+    -- Create some cool explosions when we get destroyed
+    OnImpact = function(self, targetType, targetEntity)
+        -- put values on stack for performance
+        local army = self.Army
+        local blueprint = self.Blueprint
+        local damageData = self.DamageData
+        local instigator = self.Launcher or self -- use launcher for army if available
+
+        local ImpactEffects = false
+        local ImpactEffectScale = 1
+
+        -- Do Damage
+        self.DoDamage(self, instigator, damageData, targetEntity)
+
+        -- Meta-Impact
+        self.DoMetaImpact(self, damageData)
+
+        -- Buffs (Stun, etc)
+        self.DoUnitImpactBuffs(self, targetEntity)
+
+        -- try and play specific sound file, or generic as fallback
+        local blueprintAudio = self.Blueprint.Audio
+        local snd = blueprintAudio['Impact' .. targetType]
+        if snd then
+            EntityPlaySound(self, snd)
+            -- Generic Impact Sound
+        elseif blueprintAudio.Impact then
+            EntityPlaySound(self, blueprintAudio.Impact)
+        end
+
+        -- Possible targetType values are:
+        --  'Unit', 'Terrain', 'Water', 'Air', 'Prop'
+        --  'Shield', 'UnitAir', 'UnderWater', 'UnitUnderwater'
+        --  'Projectile', 'ProjectileUnderWater
+
+        if targetType == 'Water' then
+            ImpactEffects = self.FxImpactWater
+            ImpactEffectScale = self.FxWaterHitScale
+        elseif targetType == 'Terrain' then
+            ImpactEffects = self.FxImpactLand
+            ImpactEffectScale = self.FxLandHitScale
+        elseif targetType == 'Shield' then
+            ImpactEffects = self.FxImpactShield
+            ImpactEffectScale = self.FxShieldHitScale
+        elseif targetType == 'Unit' then
+            ImpactEffects = self.FxImpactUnit
+            ImpactEffectScale = self.FxUnitHitScale
+        elseif targetType == 'UnitAir' then
+            ImpactEffects = self.FxImpactAirUnit
+            ImpactEffectScale = self.FxAirUnitHitScale
+        elseif targetType == 'Air' then
+            ImpactEffects = self.FxImpactNone
+            ImpactEffectScale = self.FxNoneHitScale
+        elseif targetType == 'Projectile' then
+            ImpactEffects = self.FxImpactProjectile
+            ImpactEffectScale = self.FxProjectileHitScale
+        elseif targetType == 'ProjectileUnderwater' then
+            ImpactEffects = self.FxImpactProjectileUnderWater
+            ImpactEffectScale = self.FxProjectileUnderWaterHitScale
+        elseif targetType == 'Prop' then
+            ImpactEffects = self.FxImpactProp
+            ImpactEffectScale = self.FxPropHitScale
+        elseif targetType == 'Underwater' or targetType == 'UnitUnderwater' then
+            ImpactEffects = self.FxImpactUnderWater
+            ImpactEffectScale = self.FxUnderWaterHitScale or 0.25
+        else
+            LOG('*ERROR: Projectile:OnImpact(): UNKNOWN TARGET TYPE ', repr(targetType))
+        end
+
+        -- check if they were set and use default values otherwise
+        ImpactEffects = ImpactEffects or false
+        ImpactEffectScale = ImpactEffectScale or self.FxScale or 1
+
+        local BlueprintDisplayImpactEffects = blueprint.Display.ImpactEffects
+        local TerrainEffects = self.GetTerrainEffects(self, targetType, BlueprintDisplayImpactEffects.Type)
+        self.CreateImpactEffects(self, army, ImpactEffects, ImpactEffectScale)
+        self.CreateTerrainEffects(self, army, TerrainEffects, BlueprintDisplayImpactEffects.Scale or 1)
+
+        local timeout = blueprint.Physics.ImpactTimeout
+        if timeout and targetType == 'Terrain' then
+            TrashBagAdd(self.Trash, ForkThread(self.ImpactTimeoutThread, self, timeout))
+        else
+            self.OnImpactDestroy(self, targetType, targetEntity)
+        end
+    end,
+
+    --- What to do when we're destroyed on impact
+    OnImpactDestroy = function(self, targetType, targetEntity)
+        local destroyOnImpact = self.DestroyOnImpact
+        if destroyOnImpact or not targetEntity or
+            (not destroyOnImpact and targetEntity and (not EntityCategoryContains(OnImpactDestroyCategories, targetEntity))) then
+            EntityDestroy(self)
+        end
+    end,
+
+    --- An impact delay for the dramatic effects
+    ImpactTimeoutThread = function(self, seconds)
+        WaitTicks(seconds * 10 + 1) -- add one for coroutine.yield offset
+        EntityDestroy(self)
+    end,
+
+    -- When this projectile impacts with the target, do any buffs that have been passed to it.
+    DoUnitImpactBuffs = function(self, target)
+        local data = self.DamageData
+        -- Check for buff
+        if data.Buffs then
+            -- Check for valid target
+            for k, v in data.Buffs do
+                if v.Add.OnImpact == true then
+                    if v.AppliedToTarget ~= true or (v.Radius and v.Radius > 0) then
+                        target = self.Launcher
+                    end
+                    -- Check for target validity
+                    if target and IsUnit(target) then
+                        if v.Radius and v.Radius > 0 then
+                            -- This is a radius buff
+                            -- get the position of the projectile
+                            target:AddBuff(v, self:GetPosition())
+                        else
+                            -- This is a single target buff
+                            target:AddBuff(v)
+                        end
+                    end
+                end
+            end
+        end
+    end,
+
+    -- this should never be called - use the actual function.
+    GetCachePosition = function(self)
+        return self:GetPosition()
+    end,
+
+    -- this should never be called - use the actual value.
+    GetCollideFriendly = function(self)
+        return self.CollideFriendly
+    end,
+
+    -- this should never be called - use the actual value.
+    PassData = function(self, data)
+        self.Data = data
+    end,
+
+    OnExitWater = function(self)
+        -- no projectile blueprint has this value set
+        -- local snd = self.Blueprint.Audio.ExitWater
+        -- if snd then
+        --     self:PlaySound(snd)
+        -- end
+    end,
+
+    OnEnterWater = function(self)
+        local snd = self.Blueprint.Audio['EnterWater']
+        if snd then
+            self:PlaySound(snd)
+        end
+    end,
+
+    AddFlare = function(self, tbl)
+        if not tbl then return end
+        if not tbl.Radius then return end
+        self.MyFlare = Flare {
+            Owner = self,
+            Radius = tbl.Radius or 5,
+            Category = tbl.Category or 'MISSILE',  -- We pass the category bp value along so that it actually has a function.
+        }
+        if tbl.Stack == true then -- Secondary flare hitboxes, one above, one below (Aeon TMD)
+            self.MyUpperFlare = Flare {
+                Owner = self,
+                Radius = tbl.Radius,
+                OffsetMult = tbl.OffsetMult,
+                Category = tbl.Category or 'MISSILE',
+            }
+            self.MyLowerFlare = Flare {
+                Owner = self,
+                Radius = tbl.Radius,
+                OffsetMult = -tbl.OffsetMult,
+                Category = tbl.Category or 'MISSILE',
+            }
+            TrashBagAdd(self.Trash, self.MyUpperFlare)
+            TrashBagAdd(self.Trash, self.MyLowerFlare)
+        end
+
+        TrashBagAdd(self.Trash, self.MyFlare)
+    end,
+
+    OnLostTarget = function(self)
+        local bp = self.Blueprint.Physics
+        if bp.TrackTarget then
+            local time = bp.OnLostTargetLifetime or 0.5
+            ProjectileSetLifetime(self, time)
+        end
+    end,
+}

--- a/lua/sim/ProjectileOpti.lua
+++ b/lua/sim/ProjectileOpti.lua
@@ -37,9 +37,8 @@ local EntityGetHealth = EntityMethods.GetHealth
 local EntitySetHealth = EntityMethods.SetHealth
 local EntityAdjustHealth = EntityMethods.AdjustHealth
 local EntitySetMaxHealth = EntityMethods.SetMaxHealth
-local EntitySetAmbientSound = EntityMethods.SetAmbientSound
-local EntityGetPositionXYZ = EntityMethods.GetPositionXYZ
 local EntityGetPosition = EntityMethods.GetPosition
+local EntityGetPositionXYZ = EntityMethods.GetPositionXYZ
 
 local ProjectileMethods = _G.moho.projectile_methods
 local ProjectileGetLauncher = ProjectileMethods.GetLauncher
@@ -85,7 +84,7 @@ Projectile = Class(moho.projectile_methods, Entity) {
     -- FxWaterHitScale = 1,
     -- FxOnKilledScale = 1,
 
-    -- this is always false
+    -- this is always false: legacy code from SC1
     -- FxImpactLandScorch = false,
     -- FxImpactLandScorchScale = 1.0,
 
@@ -118,32 +117,32 @@ Projectile = Class(moho.projectile_methods, Entity) {
             local radius = DamageData.DamageRadius
             if radius and radius > 0 then
                 if not DamageData.DoTTime or DamageData.DoTTime <= 0 then
-                    DamageArea(instigator, self:GetPosition(), radius, damage, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
+                    DamageArea(instigator, EntityGetPosition(self), radius, damage, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
                 else
                     -- DoT damage - check for initial damage
                     local initialDmg = DamageData.InitialDamageAmount or 0
                     if initialDmg > 0 then
                         if radius > 0 then
-                            DamageArea(instigator, self:GetPosition(), radius, initialDmg, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
+                            DamageArea(instigator, EntityGetPosition(self), radius, initialDmg, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
                         elseif targetEntity then
-                            Damage(instigator, self:GetPosition(), targetEntity, initialDmg, DamageData.DamageType)
+                            Damage(instigator, EntityGetPosition(self), targetEntity, initialDmg, DamageData.DamageType)
                         end
                     end
 
-                    ForkThread(DefaultDamage.AreaDoTThread, instigator, self:GetPosition(), DamageData.DoTPulses or 1, (DamageData.DoTTime / (DamageData.DoTPulses or 1)), radius, damage, DamageData.DamageType, DamageData.DamageFriendly)
+                    ForkThread(DefaultDamage.AreaDoTThread, instigator, EntityGetPosition(self), DamageData.DoTPulses or 1, (DamageData.DoTTime / (DamageData.DoTPulses or 1)), radius, damage, DamageData.DamageType, DamageData.DamageFriendly)
                 end
             -- ONLY DO DAMAGE IF THERE IS DAMAGE DATA.  SOME PROJECTILE DO NOT DO DAMAGE WHEN THEY IMPACT.
             elseif DamageData.DamageAmount and targetEntity then
                 if not DamageData.DoTTime or DamageData.DoTTime <= 0 then
-                    Damage(instigator, self:GetPosition(), targetEntity, DamageData.DamageAmount, DamageData.DamageType)
+                    Damage(instigator, EntityGetPosition(self), targetEntity, DamageData.DamageAmount, DamageData.DamageType)
                 else
                     -- DoT damage - check for initial damage
                     local initialDmg = DamageData.InitialDamageAmount or 0
                     if initialDmg > 0 then
                         if radius > 0 then
-                            DamageArea(instigator, self:GetPosition(), radius, initialDmg, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
+                            DamageArea(instigator, EntityGetPosition(self), radius, initialDmg, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
                         elseif targetEntity then
-                            Damage(instigator, self:GetPosition(), targetEntity, initialDmg, DamageData.DamageType)
+                            Damage(instigator, EntityGetPosition(self), targetEntity, initialDmg, DamageData.DamageType)
                         end
                     end
 
@@ -152,7 +151,7 @@ Projectile = Class(moho.projectile_methods, Entity) {
             end
         end
         if self.InnerRing and self.OuterRing then
-            local pos = self:GetPosition()
+            local pos = EntityGetPosition(self)
             self.InnerRing:DoNukeDamage(self.Launcher, pos, self.Brain, self.Army, DamageData.DamageType or 'Nuke')
             self.OuterRing:DoNukeDamage(self.Launcher, pos, self.Brain, self.Army, DamageData.DamageType or 'Nuke')
         end

--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -1333,3 +1333,6 @@ SCUDeathWeapon = Class(BareBonesWeapon) {
         myProjectile:PassDamageData(self:GetDamageTable())
     end,
 }
+
+-- Tactical missile threads --
+

--- a/lua/terranprojectiles.lua
+++ b/lua/terranprojectiles.lua
@@ -892,3 +892,8 @@ THiroLaser = Class(SinglePolyTrailProjectile) {
 }
 
 
+-- Optimized projectiles --
+
+local TerranProjectilesOpti = import("/lua/TerranProjectilesOpti.lua")
+
+TMissileCruiseProjectileOpti = TerranProjectilesOpti.TMissileCruiseProjectile

--- a/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_script.lua
+++ b/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_script.lua
@@ -8,10 +8,8 @@
 --**  Copyright � 2007 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-local SThunderStormCannonProjectileSplitFx = import('/lua/EffectTemplates.lua').SThunderStormCannonProjectileSplitFx
 local SThunthoArtilleryShell = import('/lua/seraphimprojectiles.lua').SThunthoArtilleryShellOpti
-local RandomFloat = import('/lua/utilities.lua').GetRandomFloat
-local VizMarker = import('/lua/sim/VizMarker.lua').VizMarker
+local SThunderStormCannonProjectileSplitFx = import('/lua/EffectTemplates.lua').SThunderStormCannonProjectileSplitFx
 
 -- globals as upvalues for performance 
 local Random = Random
@@ -34,22 +32,23 @@ local ProjectileCreateChildProjectile = ProjectileMethods.CreateChildProjectile
 
 SIFThunthoArtilleryShell01 = Class(SThunthoArtilleryShell) {
                
-    OnImpact = function(self, TargetType, TargetEntity) 
+    OnImpact = function(self, targetType, targetEntity) 
         
+        -- cache for performance
         local army = self.Army
         local bp = self.Blueprint.Physics
         local bpFragments = bp.Fragments
         local bpFragmentId = bp.FragmentId
         local damageData = self.DamageData
-        local FxFragEffect = SThunderStormCannonProjectileSplitFx
+        local fxFragEffect = SThunderStormCannonProjectileSplitFx
               
         -- split effects
-        for k, v in FxFragEffect do
+        for k, v in fxFragEffect do
             CreateEmitterAtEntity( self, army, v )
         end     
 
         -- Randomization of the spread
-        local angle = (2 * 3.141592) / bpFragments
+        local angle = 6.28 / bpFragments
         local angleInitial = Random() * angle
         local angleVariation = angle * 0.8 -- Adjusts angle variance spread     
 
@@ -60,13 +59,14 @@ SIFThunthoArtilleryShell01 = Class(SThunthoArtilleryShell) {
         local zVec = 0
 
         -- Launch projectiles at semi-random angles away from split location
+        local proj = false
         for i = 1, bpFragments do
-            xVec = vx + (MathSin(angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation))) * 0.15 -- spreadMul
-            zVec = vz + (MathCos(angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation))) * 0.15 -- spreadMul 
-            local proj = ProjectileCreateChildProjectile(self, bpFragmentId)
+            xVec = vx + 0.15 * (MathSin(angleInitial + (i * angle) + 2 * Random() * angleVariation - angleVariation))  -- spreadMul
+            zVec = vz + 0.15 * (MathCos(angleInitial + (i * angle) + 2 * Random() * angleVariation - angleVariation))  -- spreadMul
+            proj = ProjectileCreateChildProjectile(self, bpFragmentId)
             ProjectileSetVelocity(proj, xVec, yVec, zVec)
             ProjectileSetVelocity(proj, 18) -- velocity
-            proj.PassDamageData(proj, damageData)                        
+            proj.DamageData = damageData
         end
         
         EntityDestroy(self)

--- a/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_script.lua
+++ b/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_script.lua
@@ -1,64 +1,75 @@
-#****************************************************************************
-#**
-#**  File     :  /data/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_script.lua
-#**  Author(s):  Gordon Duclos, Aaron Lundquist
-#**
-#**  Summary  :  Thuntho Artillery Shell Projectile script, XSL0103
-#**
-#**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
-#****************************************************************************
+--****************************************************************************
+--**
+--**  File     :  /data/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_script.lua
+--**  Author(s):  Gordon Duclos, Aaron Lundquist
+--**
+--**  Summary  :  Thuntho Artillery Shell Projectile script, XSL0103
+--**
+--**  Copyright ï¿½ 2007 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
 
-local EffectTemplate = import('/lua/EffectTemplates.lua')
-local SThunthoArtilleryShell = import('/lua/seraphimprojectiles.lua').SThunthoArtilleryShell
+local SThunderStormCannonProjectileSplitFx = import('/lua/EffectTemplates.lua').SThunderStormCannonProjectileSplitFx
+local SThunthoArtilleryShell = import('/lua/seraphimprojectiles.lua').SThunthoArtilleryShellOpti
 local RandomFloat = import('/lua/utilities.lua').GetRandomFloat
 local VizMarker = import('/lua/sim/VizMarker.lua').VizMarker
+
+-- globals as upvalues for performance 
+local Random = Random
+local CreateEmitterAtEntity = CreateEmitterAtEntity
+
+-- math functions as upvalues for performance
+local MathSin = _G.math.sin
+local MathCos = _G.math.cos 
+
+-- moho functions as upvalue for performance
+local EntityMethods = _G.moho.entity_methods
+local EntityDestroy = EntityMethods.Destroy
+
+local ProjectileMethods = _G.moho.projectile_methods
+local ProjectileGetVelocity = ProjectileMethods.GetVelocity
+local ProjectileSetVelocity = ProjectileMethods.SetVelocity
+local ProjectileCreateChildProjectile = ProjectileMethods.CreateChildProjectile
+
+-- attach for CTRL + SHIFT F replacement
 
 SIFThunthoArtilleryShell01 = Class(SThunthoArtilleryShell) {
                
     OnImpact = function(self, TargetType, TargetEntity) 
         
-        local FxFragEffect = EffectTemplate.SThunderStormCannonProjectileSplitFx 
-        local bp = self:GetBlueprint().Physics
+        local army = self.Army
+        local bp = self.Blueprint.Physics
+        local bpFragments = bp.Fragments
+        local bpFragmentId = bp.FragmentId
+        local damageData = self.DamageData
+        local FxFragEffect = SThunderStormCannonProjectileSplitFx
               
-        ### Split effects
+        -- split effects
         for k, v in FxFragEffect do
-            CreateEmitterAtEntity( self, self:GetArmy(), v )
-        end
-        
-        local vx, vy, vz = self:GetVelocity()
-        local velocity = 18
-    
-		# One initial projectile following same directional path as the original
-        #self:CreateChildProjectile(bp.FragmentId):SetVelocity(vx, vy, vz):SetVelocity(velocity):PassDamageData(self.DamageData)
-   		
-		# Create several other projectiles in a dispersal pattern
-        local numProjectiles = bp.Fragments
-        
-        local angle = (2 * math.pi) / numProjectiles
-        local angleInitial = RandomFloat( 0, angle )
-        
-        # Randomization of the spread
-        local angleVariation = angle * 0.8 # Adjusts angle variance spread
-        local spreadMul = 0.15 # Adjusts the width of the dispersal        
-        
-        --vy= -0.8
-        
+            CreateEmitterAtEntity( self, army, v )
+        end     
+
+        -- Randomization of the spread
+        local angle = (2 * 3.141592) / bpFragments
+        local angleInitial = Random() * angle
+        local angleVariation = angle * 0.8 -- Adjusts angle variance spread     
+
+        local vx, vy, vz = ProjectileGetVelocity(self)
+
         local xVec = 0
         local yVec = vy
         local zVec = 0
-     
 
-        # Launch projectiles at semi-random angles away from split location
-        for i = 0, numProjectiles - 1 do
-            xVec = vx + (math.sin(angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation))) * spreadMul
-            zVec = vz + (math.cos(angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation))) * spreadMul 
-            local proj = self:CreateChildProjectile(bp.FragmentId)
-            proj:SetVelocity(xVec,yVec,zVec)
-            proj:SetVelocity(velocity)
-            proj:PassDamageData(self.DamageData)                        
+        -- Launch projectiles at semi-random angles away from split location
+        for i = 1, bpFragments do
+            xVec = vx + (MathSin(angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation))) * 0.15 -- spreadMul
+            zVec = vz + (MathCos(angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation))) * 0.15 -- spreadMul 
+            local proj = ProjectileCreateChildProjectile(self, bpFragmentId)
+            ProjectileSetVelocity(proj, xVec, yVec, zVec)
+            ProjectileSetVelocity(proj, 18) -- velocity
+            proj.PassDamageData(proj, damageData)                        
         end
         
-        self:Destroy()
+        EntityDestroy(self)
     end
 }
 

--- a/projectiles/SIFThunthoArtilleryShell02/SIFThunthoArtilleryShell02_script.lua
+++ b/projectiles/SIFThunthoArtilleryShell02/SIFThunthoArtilleryShell02_script.lua
@@ -24,21 +24,19 @@ local EntityGetPosition = EntityMethods.GetPosition
 
 SIFThunthoArtilleryShell02 = Class(SThunthoArtilleryShell2) {
     OnImpact = function(self, targetType, targetEntity)
-        local pos = EntityGetPosition(self)
-
         local army = self.Army
         local data = self.DamageData
         local radius = data.DamageRadius
         local FriendlyFire = data.DamageFriendly
+        local pos = EntityGetPosition(self)
         
         DamageArea( self, pos, radius, 1, 'Force', FriendlyFire )
         DamageArea( self, pos, radius, 1, 'Force', FriendlyFire )
         
         data.DamageAmount = data.DamageAmount - 2
         
-        if targetType ~= 'Shield' and targetType ~= 'Water' and targetType ~= 'Air' and targetType ~= 'UnitAir' and targetType ~= 'Projectile' then
-            local rotation = Random() * 2 * 3.141592
-            CreateDecal(pos, rotation, 'crater_radial01_albedo', '', 'Albedo', radius-1, radius-1, 100, 10, army)
+        if targetType == 'Terrain' then
+            CreateDecal(pos, Random() * 6.28, 'crater_radial01_albedo', '', 'Albedo', radius-1, radius-1, 100, 10, army)
         end
         
         SThunthoArtilleryShell2.OnImpact(self, targetType, targetEntity)

--- a/projectiles/SIFThunthoArtilleryShell02/SIFThunthoArtilleryShell02_script.lua
+++ b/projectiles/SIFThunthoArtilleryShell02/SIFThunthoArtilleryShell02_script.lua
@@ -6,26 +6,38 @@
 --  Summary  :  Thuntho Artillery Shell Projectile script
 --              Seraphim T1 Artillery : XSL0103
 --
---  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
+--  Copyright ï¿½ 2007 Gas Powered Games, Inc.  All rights reserved.
 ------------------------------------------------------------
-local SThunthoArtilleryShell2 = import('/lua/seraphimprojectiles.lua').SThunthoArtilleryShell2
+
+local RandomFloat = import('/lua/utilities.lua').GetRandomFloat
+local SThunthoArtilleryShell2 = import('/lua/seraphimprojectiles.lua').SThunthoArtilleryShell2Opti
+
+-- globals as upvalues for performance 
+local DamageArea = DamageArea
+local CreateDecal = CreateDecal
+
+-- moho functions as upvalue for performance
+local EntityMethods = _G.moho.entity_methods
+local EntityGetPosition = EntityMethods.GetPosition
+
+-- attach for CTRL + SHIFT F replacement
 
 SIFThunthoArtilleryShell02 = Class(SThunthoArtilleryShell2) {
     OnImpact = function(self, targetType, targetEntity)
-        local pos = self:GetPosition()
-        local radius = self.DamageData.DamageRadius
-        local FriendlyFire = self.DamageData.DamageFriendly
+        local pos = EntityGetPosition(self)
+
+        local army = self.Army
+        local data = self.DamageData
+        local radius = data.DamageRadius
+        local FriendlyFire = data.DamageFriendly
         
         DamageArea( self, pos, radius, 1, 'Force', FriendlyFire )
         DamageArea( self, pos, radius, 1, 'Force', FriendlyFire )
         
-        self.DamageData.DamageAmount = self.DamageData.DamageAmount - 2
+        data.DamageAmount = data.DamageAmount - 2
         
         if targetType ~= 'Shield' and targetType ~= 'Water' and targetType ~= 'Air' and targetType ~= 'UnitAir' and targetType ~= 'Projectile' then
-            local RandomFloat = import('/lua/utilities.lua').GetRandomFloat
-            local rotation = RandomFloat(0,2*math.pi)
-            local army = self.Army
-            
+            local rotation = Random() * 2 * 3.141592
             CreateDecal(pos, rotation, 'crater_radial01_albedo', '', 'Albedo', radius-1, radius-1, 100, 10, army)
         end
         

--- a/projectiles/TIFMissileCruise04/TIFMissileCruise04_Script.lua
+++ b/projectiles/TIFMissileCruise04/TIFMissileCruise04_Script.lua
@@ -3,11 +3,12 @@
 --
 
 local TMissileCruiseProjectileOpti = import('/lua/terranprojectiles.lua').TMissileCruiseProjectileOpti
-local Explosion = import('/lua/defaultexplosions.lua')
+local MissileManager = import('/lua/sim/MissileManager.lua')
+local AddMissile2Ticks = MissileManager.AddMissile2Ticks
 
 -- upvalue for performance (globals)
-local ForkThread = ForkThread
-local WaitTicks = coroutine.yield
+local DamageArea = DamageArea
+local CreateDecal = CreateDecal
 
 -- upvalue for performance (math functions)
 local MathPi = math.pi
@@ -15,72 +16,7 @@ local MathPi = math.pi
 -- upvalue for performance (moho functions)
 local EntityBeenDestroyed = _G.moho.entity_methods.BeenDestroyed
 local EntityGetPosition = _G.moho.entity_methods.GetPosition
-local EntityGetPositionXYZ = _G.moho.entity_methods.GetPositionXYZ
 local EntitySetCollisionShape = _G.moho.entity_methods.SetCollisionShape
-
-local ProjectileSetTurnRate = _G.moho.projectile_methods.SetTurnRate
-local ProjectileGetCurrentTargetPosition = _G.moho.projectile_methods.GetCurrentTargetPosition
-
--- stores all references to missiles that need to be adjusted 
-local MissilesT1 = { }
-local MissilesT2 = { }
-local MissilesT3 = { }
-
--- make garbage collector pick up projectiles as it sees fit
-local Weak = { __mode = "v" }
-setmetatable(MissilesT1, Weak)
-setmetatable(MissilesT2, Weak)
-setmetatable(MissilesT3, Weak)
-
-local MissileT1Next = 1
-local MissileT2Next = 1
-local MissileT3Next = 1
-
--- a thread that runs over all missiles in a continious loop and kicks them out again
-ForkThread(
-    function()
-
-        while true do 
-
-            for k = 1, MissileT3Next - 1 do 
-
-                -- get the missile and check if it is still valid
-                local missile = MissilesT3[k]
-                if not missile or EntityBeenDestroyed(missile) then 
-                    continue 
-                end
-
-                -- compute distance
-                local tpos = ProjectileGetCurrentTargetPosition(missile)
-                local px, _, pz = EntityGetPositionXYZ(missile)
-                local dist = VDist2(px, pz, tpos[1], tpos[3])
-
-                -- compute multiplier
-                local multiplier = 200 / dist
-                if multiplier < 1.0 then 
-                    multiplier = 1.0
-                end
-
-                -- set turn rate accordingly
-                ProjectileSetTurnRate(missile, multiplier * 10)
-            end
-
-            -- switch them up
-            local temp = MissilesT3
-            MissilesT3 = MissilesT2 
-            MissilesT2 = MissilesT1 
-            MissilesT1 = temp
-
-            -- switch them up
-            MissileT3Next = MissileT2Next
-            MissileT2Next = MissileT1Next
-            MissileT1Next = 1 
-
-            -- wait a bit
-            WaitTicks(3)
-        end
-    end
-)
 
 TIFMissileCruise04 = Class(TMissileCruiseProjectileOpti) {
 
@@ -91,8 +27,7 @@ TIFMissileCruise04 = Class(TMissileCruiseProjectileOpti) {
         EntitySetCollisionShape(self, 'Sphere', 0, 0, 0, 2.0)
 
         -- queue us up for changing the turn rate
-        MissilesT1[MissileT1Next] = self
-        MissileT1Next = MissileT1Next + 1
+        AddMissile2Ticks(self)
     end,    
     
     OnImpact = function(self, targetType, targetEntity)

--- a/projectiles/TIFMissileCruise04/TIFMissileCruise04_Script.lua
+++ b/projectiles/TIFMissileCruise04/TIFMissileCruise04_Script.lua
@@ -2,15 +2,18 @@
 -- Terran Land-Based Cruise Missile : UES0202 (UEF cruiser)
 --
 
-local TMissileCruiseProjectile = import('/lua/terranprojectiles.lua').TMissileCruiseProjectile
+local TMissileCruiseProjectileOpti = import('/lua/terranprojectiles.lua').TMissileCruiseProjectileOpti
 local Explosion = import('/lua/defaultexplosions.lua')
 
-
+-- upvalue for performance (globals)
 local ForkThread = ForkThread
 local WaitTicks = coroutine.yield
 
+-- upvalue for performance (math functions)
 local MathPi = math.pi
 
+-- upvalue for performance (moho functions)
+local EntityBeenDestroyed = _G.moho.entity_methods.BeenDestroyed
 local EntityGetPosition = _G.moho.entity_methods.GetPosition
 local EntityGetPositionXYZ = _G.moho.entity_methods.GetPositionXYZ
 local EntitySetCollisionShape = _G.moho.entity_methods.SetCollisionShape
@@ -18,47 +21,81 @@ local EntitySetCollisionShape = _G.moho.entity_methods.SetCollisionShape
 local ProjectileSetTurnRate = _G.moho.projectile_methods.SetTurnRate
 local ProjectileGetCurrentTargetPosition = _G.moho.projectile_methods.GetCurrentTargetPosition
 
-local function arc(projectile)
+-- stores all references to missiles that need to be adjusted 
+local MissilesT1 = { }
+local MissilesT2 = { }
+local MissilesT3 = { }
 
-    -- compute distance
-    local tpos = ProjectileGetCurrentTargetPosition(projectile)
-    local px, _, pz = EntityGetPositionXYZ(projectile)
-    local dist = VDist2(px, pz, tpos[1], tpos[3])
+-- make garbage collector pick up projectiles as it sees fit
+local Weak = { __mode = "v" }
+setmetatable(MissilesT1, Weak)
+setmetatable(MissilesT2, Weak)
+setmetatable(MissilesT3, Weak)
 
-    -- compute multiplier
-    local multiplier = 200 / dist
-    if multiplier < 1.0 then 
-        multiplier = 1.0
+local MissileT1Next = 1
+local MissileT2Next = 1
+local MissileT3Next = 1
+
+-- a thread that runs over all missiles in a continious loop and kicks them out again
+ForkThread(
+    function()
+
+        while true do 
+
+            for k = 1, MissileT3Next - 1 do 
+
+                -- get the missile and check if it is still valid
+                local missile = MissilesT3[k]
+                if not missile or EntityBeenDestroyed(missile) then 
+                    continue 
+                end
+
+                -- compute distance
+                local tpos = ProjectileGetCurrentTargetPosition(missile)
+                local px, _, pz = EntityGetPositionXYZ(missile)
+                local dist = VDist2(px, pz, tpos[1], tpos[3])
+
+                -- compute multiplier
+                local multiplier = 200 / dist
+                if multiplier < 1.0 then 
+                    multiplier = 1.0
+                end
+
+                -- set turn rate accordingly
+                ProjectileSetTurnRate(missile, multiplier * 10)
+            end
+
+            -- switch them up
+            local temp = MissilesT3
+            MissilesT3 = MissilesT2 
+            MissilesT2 = MissilesT1 
+            MissilesT1 = temp
+
+            -- switch them up
+            MissileT3Next = MissileT2Next
+            MissileT2Next = MissileT1Next
+            MissileT1Next = 1 
+
+            -- wait a bit
+            WaitTicks(3)
+        end
     end
+)
 
-    -- set turn rate accordingly
-    ProjectileSetTurnRate(projectile, 0) 
-    WaitTicks(6)
-    ProjectileSetTurnRate(projectile, multiplier * 10)
-end
+TIFMissileCruise04 = Class(TMissileCruiseProjectileOpti) {
 
-TIFMissileCruise04 = Class(TMissileCruiseProjectile) {
-
-    FxAirUnitHitScale = 1.5,
-    FxLandHitScale = 1.5,
-    FxNoneHitScale = 1.5,
-    FxPropHitScale = 1.5,
-    FxProjectileHitScale = 1.5,
-    FxProjectileUnderWaterHitScale = 1.5,
-    FxShieldHitScale = 1.5,
-    FxUnderWaterHitScale = 1.5,
-    FxUnitHitScale = 1.5,
-    FxWaterHitScale = 1.5,
-    FxOnKilledScale = 1.5,
+    FxScale = 1.5,
 
     OnCreate = function(self)
-        TMissileCruiseProjectile.OnCreate(self)
+        TMissileCruiseProjectileOpti.OnCreate(self)
         EntitySetCollisionShape(self, 'Sphere', 0, 0, 0, 2.0)
-        ForkThread(arc, self)
+
+        -- queue us up for changing the turn rate
+        MissilesT1[MissileT1Next] = self
+        MissileT1Next = MissileT1Next + 1
     end,    
     
     OnImpact = function(self, targetType, targetEntity)
-
         -- retrieve for damage and decal
         local damageData = self.DamageData
         local radius = damageData.DamageRadius
@@ -76,7 +113,7 @@ TIFMissileCruise04 = Class(TMissileCruiseProjectile) {
         if targetType == 'Shield' or targetType == 'Water' or targetType == 'Air' or targetType == 'UnitAir' or targetType == 'Projectile' then
 
             -- perform typical logic
-            TMissileCruiseProjectile.OnImpact(self, targetType, targetEntity)
+            TMissileCruiseProjectileOpti.OnImpact(self, targetType, targetEntity)
 
             -- get out of here
             return
@@ -97,7 +134,7 @@ TIFMissileCruise04 = Class(TMissileCruiseProjectile) {
         )
 
         -- perform typical logic
-        TMissileCruiseProjectile.OnImpact(self, targetType, targetEntity)
+        TMissileCruiseProjectileOpti.OnImpact(self, targetType, targetEntity)
     end,
 }
 TypeClass = TIFMissileCruise04

--- a/projectiles/TIFMissileCruise04/TIFMissileCruise04_proj.bp
+++ b/projectiles/TIFMissileCruise04/TIFMissileCruise04_proj.bp
@@ -1,0 +1,62 @@
+ProjectileBlueprint {
+    Audio = {
+        Impact = Sound {
+            Bank = 'Impacts',
+            Cue = 'UEF_Expl_Med_Impact',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+        ImpactTerrain = Sound {
+            Bank = 'Impacts',
+            Cue = 'Impact_Land_Gen_UEF',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+        ImpactWater = Sound {
+            Bank = 'Impacts',
+            Cue = 'Impact_Water_Splash_UEF',
+            LodCutoff = 'Weapon_LodCutoff',
+        },
+    },
+    Categories = {
+        'UEF',
+        'PROJECTILE',
+        'INDIRECTFIRE',
+        'TACTICAL',
+        'MISSILE',
+        'NOSPLASHDAMAGE',
+    },
+    Defense = {
+        Health = 2,
+        MaxHealth = 2,
+    },
+    Display = {
+        CameraFollowTimeout = 2,
+        CameraFollowsProjectile = true,
+        ImpactEffects = {
+            Type = 'Medium01',
+        },
+        MeshBlueprint = '/projectiles/tifmissilecruise01/tifmissilecruise01_mesh.bp',
+        StrategicIconSize = 2,
+        UniformScale = 0.15,
+    },
+    General = {
+        Category = 'Missile',
+        Faction = 'UEF',
+    },
+    Interface = {
+        HelpText = 0,
+    },
+    Physics = {
+        Acceleration = 3,
+        DestroyOnWater = true,
+        InitialSpeed = 3,
+        LifeTime = 30,
+        MaxSpeed = 12,
+        RotationalVelocity = 0,
+        RotationalVelocityRange = 0,
+        TrackTarget = true,
+        TrackTargetGround = true,
+        TurnRate = 0,
+        UseGravity = false,
+        VelocityAlign = true,
+    },
+}

--- a/units/UES0202/UES0202_script.lua
+++ b/units/UES0202/UES0202_script.lua
@@ -1,0 +1,101 @@
+#****************************************************************************
+#**
+#**  File     :  /cdimage/units/UES0202/UES0202_script.lua
+#**  Author(s):  John Comes, David Tomandl, Jessica St. Croix
+#**
+#**  Summary  :  UEF Cruiser Script
+#**
+#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+local EffectTemplate = import('/lua/EffectTemplates.lua')
+local TSeaUnit = import('/lua/terranunits.lua').TSeaUnit
+local WeaponFile = import('/lua/terranweapons.lua')
+local TSAMLauncher = WeaponFile.TSAMLauncher
+local TDFGaussCannonWeapon = WeaponFile.TDFGaussCannonWeapon
+local TAMPhalanxWeapon = WeaponFile.TAMPhalanxWeapon
+local TIFCruiseMissileLauncher = WeaponFile.TIFCruiseMissileLauncher
+
+UES0202 = Class(TSeaUnit) {
+    DestructionTicks = 200,
+
+    Weapons = {
+        FrontTurret01 = Class(TDFGaussCannonWeapon) {},
+        BackTurret02 = Class(TSAMLauncher) {
+            FxMuzzleFlash = EffectTemplate.TAAMissileLaunchNoBackSmoke,
+        },
+        PhalanxGun01 = Class(TAMPhalanxWeapon) {
+            PlayFxWeaponUnpackSequence = function(self)
+                if not self.SpinManip then 
+                    self.SpinManip = CreateRotator(self.unit, 'Center_Turret_Barrel', 'z', nil, 270, 180, 60)
+                    self.SpinManip:SetPrecedence(10)
+                    self.unit.Trash:Add(self.SpinManip)
+                end
+                if self.SpinManip then
+                    self.SpinManip:SetTargetSpeed(270)
+                end
+                TAMPhalanxWeapon.PlayFxWeaponUnpackSequence(self)
+            end,
+
+            PlayFxWeaponPackSequence = function(self)
+                if self.SpinManip then
+                    self.SpinManip:SetTargetSpeed(0)
+                end
+                TAMPhalanxWeapon.PlayFxWeaponPackSequence(self)
+            end,
+        },
+        
+        CruiseMissile = Class(TIFCruiseMissileLauncher) {
+                CurrentRack = 1,
+                
+                #taken out because all this waiting causes broken rate of fire clock issues
+                --PlayFxMuzzleSequence = function(self, muzzle)
+                    --local bp = self:GetBlueprint()
+                    --self.Rotator = CreateRotator(self.unit, bp.RackBones[self.CurrentRack].RackBone, 'y', nil, 90, 90, 90)
+                    --muzzle = bp.RackBones[self.CurrentRack].MuzzleBones[1]
+                    --self.Rotator:SetGoal(90)
+                    --TIFCruiseMissileLauncher.PlayFxMuzzleSequence(self, muzzle)
+                    --WaitFor(self.Rotator)
+                    --WaitSeconds(1)
+                --end,
+                
+                CreateProjectileAtMuzzle = function(self, muzzle)
+                    muzzle = self:GetBlueprint().RackBones[self.CurrentRack].MuzzleBones[1]
+                    if self.CurrentRack >= 8 then
+                        self.CurrentRack = 1
+                    else
+                        self.CurrentRack = self.CurrentRack + 1
+                    end
+                    TIFCruiseMissileLauncher.CreateProjectileAtMuzzle(self, muzzle)
+                end,
+                
+                #taken out because all this waiting causes broken rate of fire clock issues
+                --PlayFxRackReloadSequence = function(self)
+                    --WaitSeconds(1)
+                    --self.Rotator:SetGoal(0)
+                    --WaitFor(self.Rotator)
+                    --self.Rotator:Destroy()
+                    --self.Rotator = nil
+                --end,
+            },
+    },
+
+    RadarThread = function(self)
+        local spinner = CreateRotator(self, 'Spinner04', 'x', nil, 0, 30, -45)
+        while true do
+            WaitFor(spinner)
+            spinner:SetTargetSpeed(-45)
+            WaitFor(spinner)
+            spinner:SetTargetSpeed(45)
+        end
+    end,
+
+    OnStopBeingBuilt = function(self, builder,layer)
+        TSeaUnit.OnStopBeingBuilt(self, builder,layer)
+        self:ForkThread(self.RadarThread)
+        self.Trash:Add(CreateRotator(self, 'Spinner01', 'y', nil, 45, 0, 0))
+        self.Trash:Add(CreateRotator(self, 'Spinner03', 'y', nil, -30, 0, 0))
+    end,
+
+}
+
+TypeClass = UES0202


### PR DESCRIPTION
This PR is an example of the performance / stability increase we can get when we optimize projectiles according to the benchmarks. Up to this point the following units / projectiles are properly optimized:
 - Zthuee (T1 Seraphim Mobile Artillery)

When having 400 Zthuee idling we spent 3 ms / tick on both branches. When we let them ground fire, the results are:
 - Current default FAF branch: 11 / 13 ms -> 8 / 10 ms for firing
 - This branch: 8  / 9 ms -> 5 / 6 ms for firing

Disclaimer: _make sure you are _completely_ zoomed out when checking the performance of the sim. The amount of effects Zthuee spawn do effect the sim and the results if they get rendered._

This shows that there is a significant gain to be had for applying the benchmark optimizations to projectiles in general. This include:
 - No empty and / or unnecessary table allocations
 - [Upvalue moho functions](https://github.com/FAForever/fa/blob/deploy/fafdevelop/lua/benchmarking/benchmarks/function-origin.lua)
 - [Pre-allocating table elements](https://github.com/FAForever/fa/blob/deploy/fafdevelop/lua/benchmarking/benchmarks/table-hash.lua)
 - [Inlining of functions](https://github.com/FAForever/fa/blob/deploy/fafdevelop/lua/benchmarking/benchmarks/function-inlining.lua)

I intent this PR to also form a basis for a discussion as to whether creating a second, optimized hierarchy can allow us to increase the performance of the game without breaking mod compatibility. The structure makes a copy of each file part of the hierarchy with 'Opti'  attached. As an example for the `SIFThunthoArtilleryShell01_script.lua` projectile script:
 - `SIFThunthoArtilleryShell01_script`: inherits `SeraphimProjectilesOpti.SThunthoArtilleryShell`
 - `SThunthoArtilleryShell`: inherits `DefaultProjectilesOpti.MultiPolyTrailProjectile`
 - `MultiPolyTrailProjectile`: inherits `DefaultProjectilesOpti.EmitterProjectile`
 - `EmitterProjectile`: inherits `ProjectileOpti.Projectile`

The original hierarchy is still completely intact and untouched. The file just inherits from a different, more optimized base class. And the same applies for that parent, and the ancestor, and the grand ancestors - etc. Essentially creating a new, optimized hierarchy next to the existing hierarchy.

The question is: if we'd apply this to weapons and units too (creating a 2nd, optimized hierarchy) - up to what extent would this break mods?
 - Mods that create new units?
 - Mods that adjust existing units through soft-hooking functions?
 - Mods that adjusts existing units through blueprint merging?

Note that we're not creating a 2nd unit / weapon / projectile: these change the classes they inherit from instead. This is to ensure the unit name / blueprint value does not change and so that we do not get duplicated units.

One situation where I can expect something to break is when a mod tries to soft-hook an existing unit. But I'm not sure how common this is - any idea of mods that would do this?