### PR TITLE
Synchronization init files

### DIFF
--- a/init_faf.lua
+++ b/init_faf.lua
@@ -177,7 +177,7 @@ end
 -- adds maps / mods to keep track of for the game
 local function load_vault(vault_path)
 	mount_map_dir(vault_path .. '\\maps\\', '**', '/maps')
-	mount_mod_sounds(vault_path .. '\\mods')
+	mount_mod_content(vault_path .. '\\mods')
 
 	mount_contents(vault_path .. '\\mods', '/mods')
 	mount_contents(vault_path .. '\\maps', '/maps')

--- a/init_faf.lua
+++ b/init_faf.lua
@@ -1,6 +1,8 @@
---  this imports a path file that is written by Forged Alliance Forever right before it starts the game.
+-- This imports a path file that is written by Forged Alliance Forever right before it starts the game.
 dofile(InitFileDir .. '\\..\\fa_path.lua')
+
 path = {}
+
 blacklist = {
     "00_BigMap.scd",
     "00_BigMapLEM.scd",
@@ -17,8 +19,8 @@ blacklist = {
     "lobby.nxt",
     "faforever.nxt"
 }
-whitelist =
-{
+
+whitelist = {
     "effects.nx2",
     "env.nx2",
     "etc.nx2",
@@ -26,7 +28,6 @@ whitelist =
     "lua.nx2",
     "meshes.nx2",
     "mods.nx2",
-    "modules.nx2",
     "projectiles.nx2",
     "schook.nx2",
     "textures.nx2",
@@ -62,8 +63,9 @@ whitelist =
 }
 
 local function mount_dir(dir, mountpoint)
-    table.insert(path, { dir = dir, mountpoint = mountpoint } )
+    table.insert(path, { dir = dir, mountpoint = mountpoint })
 end
+
 local function mount_contents(dir, mountpoint)
     LOG('checking ' .. dir)
     for _,entry in io.dir(dir .. '\\*') do
@@ -145,10 +147,10 @@ local function mount_map_dir(dir, glob, mountpoint)
 end
 
 -- Begin mod mounting section
--- This section mounts sounds from the mods directory to allow mods to add custom sounds to the game
-function mount_mod_sounds(MODFOLDER)
+-- This section mounts sounds and ui textures from the mods directory to allow mods to add custom sounds and textures to the game
+function mount_mod_content(MODFOLDER)
     -- searching for mods inside the modfolder
-    for _,mod in io.dir( MODFOLDER..'\\*.*') do
+    for _,mod in io.dir(MODFOLDER..'\\*.*') do
         -- do we have a true directory ?
         if mod != '.' and mod != '..' then
             -- searching for sounds inside mod folder
@@ -157,7 +159,15 @@ function mount_mod_sounds(MODFOLDER)
                 if folder == 'sounds' then
                     LOG('Found mod sounds in: '..mod)
                     mount_dir(MODFOLDER..'\\'..mod..'\\sounds', '/sounds')
-                    break
+                -- mount ui textures if there are any
+                elseif folder == 'textures' then
+                    for _,folder in io.dir(MODFOLDER..'\\'..mod..'\\textures\\*.*') do
+                        if folder == 'ui' then
+                          LOG('Found mod icons in: '..mod)
+                          mount_dir(MODFOLDER..'\\'..mod..'\\textures\\ui', '/textures/ui')
+                          break
+                        end
+                    end
                 end
             end
         end
@@ -189,7 +199,7 @@ load_vault(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme 
 
 mount_dir_with_whitelist(InitFileDir .. '\\..\\gamedata\\', '*.nxt', '/')
 mount_dir_with_whitelist(InitFileDir .. '\\..\\gamedata\\', '*.nx2', '/')
- 
+
 -- these are using the newly generated path from the dofile() statement at the beginning of this script
 mount_dir_with_whitelist(fa_path .. '\\gamedata\\', '*.scd', '/')
 mount_dir(fa_path, '/')
@@ -197,7 +207,7 @@ mount_dir(fa_path, '/')
 hook = {
     '/schook'
 }
- 
+
 protocols = {
     'http',
     'https',

--- a/init_fafdevelop.lua
+++ b/init_fafdevelop.lua
@@ -177,7 +177,7 @@ end
 -- adds maps / mods to keep track of for the game
 local function load_vault(vault_path)
 	mount_map_dir(vault_path .. '\\maps\\', '**', '/maps')
-	mount_mod_sounds(vault_path .. '\\mods')
+	mount_mod_content(vault_path .. '\\mods')
 
 	mount_contents(vault_path .. '\\mods', '/mods')
 	mount_contents(vault_path .. '\\maps', '/maps')

--- a/init_fafdevelop.lua
+++ b/init_fafdevelop.lua
@@ -198,7 +198,7 @@ load_vault(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Comm
 load_vault(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance')
 
 mount_dir_with_whitelist(InitFileDir .. '\\..\\gamedata\\', '*.nxt', '/')
-mount_dir_with_whitelist(InitFileDir .. '\\..\\gamedata\\', '*.nx2', '/')
+mount_dir_with_whitelist(InitFileDir .. '\\..\\gamedata\\', '*.nx5', '/')
 
 -- these are using the newly generated path from the dofile() statement at the beginning of this script
 mount_dir_with_whitelist(fa_path .. '\\gamedata\\', '*.scd', '/')

--- a/init_fafdevelop.lua
+++ b/init_fafdevelop.lua
@@ -32,7 +32,6 @@ whitelist = {
     "schook.nx5",
     "textures.nx5",
     "units.nx5",
-    "props.nx5",
     "murderparty.nxt",
     "labwars.nxt",
     "units.scd",
@@ -146,8 +145,6 @@ local function mount_map_dir(dir, glob, mountpoint)
         end
     end
 end
-mount_map_dir(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\maps\\', '**', '/maps')
-mount_map_dir(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\maps\\', '**', '/maps')
 
 -- Begin mod mounting section
 -- This section mounts sounds and ui textures from the mods directory to allow mods to add custom sounds and textures to the game
@@ -176,25 +173,36 @@ function mount_mod_content(MODFOLDER)
         end
     end
 end
-mount_mod_content(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
-mount_mod_content(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods')
 
--- These are the classic supcom directories. They don't work with accents or other foreign characters in usernames
-mount_contents(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods', '/mods')
-mount_contents(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\maps', '/maps')
+-- adds maps / mods to keep track of for the game
+local function load_vault(vault_path)
+	mount_map_dir(vault_path .. '\\maps\\', '**', '/maps')
+	mount_mod_sounds(vault_path .. '\\mods')
 
--- These are the local FAF directories. The My Games ones are only there for people with usernames that don't work in the uppder ones.
-mount_contents(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\mods', '/mods')
-mount_contents(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance\\maps', '/maps')
+	mount_contents(vault_path .. '\\mods', '/mods')
+	mount_contents(vault_path .. '\\maps', '/maps')
+end
+
+-- load in custom vault location first so that it takes precendence
+if custom_vault_path then
+	LOG('Loading custom vault path' .. custom_vault_path)
+	load_vault(custom_vault_path)
+else
+    LOG("No custom vault path defined.")
+end
+
+-- load in files from backup vault location
+load_vault(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance')
+
+-- load in files from default vault location
+load_vault(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance')
+
 mount_dir_with_whitelist(InitFileDir .. '\\..\\gamedata\\', '*.nxt', '/')
-mount_dir_with_whitelist(InitFileDir .. '\\..\\gamedata\\', '*.nx5', '/')
+mount_dir_with_whitelist(InitFileDir .. '\\..\\gamedata\\', '*.nx2', '/')
 
--- These are using the newly generated path from the dofile() statement at the beginning of this script
+-- these are using the newly generated path from the dofile() statement at the beginning of this script
 mount_dir_with_whitelist(fa_path .. '\\gamedata\\', '*.scd', '/')
 mount_dir(fa_path, '/')
-
---load preferences into the game as well, letting us have much more control over their contents. This also includes cache and similar.
-mount_dir(SHGetFolderPath('LOCAL_APPDATA') .. 'Gas Powered Games\\Supreme Commander Forged Alliance', '/preferences')
 
 hook = {
     '/schook'


### PR DESCRIPTION
Also modules.nx was removed because
https://github.com/FAForever/fa/search?q=modules&type=commits

We should do something about the copy-paste.
I suggest putting the general part in init_common.lua
The problem is only with patches...