### PR TITLE
Fixed Seraphim Rambo SACU buildmode keys

### DIFF
--- a/lua/ui/game/buildmodedata.lua
+++ b/lua/ui/game/buildmodedata.lua
@@ -1095,7 +1095,7 @@ buildModeKeys = {
         [4] = SeraphimT4Eng,
     },
     -- subcommander - rambo preset
-    ['xsl0301'] = {
+    ['xsl0301_Rambo'] = {
         [1] = SeraphimT1Eng,
         [2] = SeraphimT2Eng,
         [3] = SeraphimT3Eng,


### PR DESCRIPTION
When using the Seraphim SACU in buildmode, the hotkeys are not working.

The unit was already present in buildmodedata.lua, but a (most likely) copy/paste error in the unit-name prevented it from working.