### PR TITLE
Adjust BT and costs of T1 Land scouts

### DIFF
--- a/units/UAL0101/UAL0101_unit.bp
+++ b/units/UAL0101/UAL0101_unit.bp
@@ -154,9 +154,9 @@ UnitBlueprint {
         UniformScale = 0.08,
     },
     Economy = {
-        BuildCostEnergy = 40,
+        BuildCostEnergy = 80,
         BuildCostMass = 8,
-        BuildTime = 80,
+        BuildTime = 40,
         TeleportEnergyMod = 0.15,
         TeleportMassMod = 1,
         TeleportTimeMod = 0.01,

--- a/units/UAL0101/UAL0101_unit.bp
+++ b/units/UAL0101/UAL0101_unit.bp
@@ -154,9 +154,9 @@ UnitBlueprint {
         UniformScale = 0.08,
     },
     Economy = {
-        BuildCostEnergy = 80,
+        BuildCostEnergy = 60,
         BuildCostMass = 8,
-        BuildTime = 40,
+        BuildTime = 60,
         TeleportEnergyMod = 0.15,
         TeleportMassMod = 1,
         TeleportTimeMod = 0.01,

--- a/units/UEL0101/UEL0101_unit.bp
+++ b/units/UEL0101/UEL0101_unit.bp
@@ -119,8 +119,8 @@ UnitBlueprint {
     },
     Economy = {
         BuildCostEnergy = 80,
-        BuildCostMass = 8,
-        BuildTime = 40,
+        BuildCostMass = 12,
+        BuildTime = 60,
         MinBuildTime = 100,
         TeleportEnergyMod = 0.15,
         TeleportMassMod = 1,

--- a/units/UEL0101/UEL0101_unit.bp
+++ b/units/UEL0101/UEL0101_unit.bp
@@ -119,8 +119,8 @@ UnitBlueprint {
     },
     Economy = {
         BuildCostEnergy = 80,
-        BuildCostMass = 12,
-        BuildTime = 80,
+        BuildCostMass = 8,
+        BuildTime = 40,
         MinBuildTime = 100,
         TeleportEnergyMod = 0.15,
         TeleportMassMod = 1,

--- a/units/URL0101/URL0101_unit.bp
+++ b/units/URL0101/URL0101_unit.bp
@@ -107,9 +107,9 @@ UnitBlueprint {
         UniformScale = 0.027,
     },
     Economy = {
-        BuildCostEnergy = 80,
+        BuildCostEnergy = 40,
         BuildCostMass = 8,
-        BuildTime = 80,
+        BuildTime = 40,
         MaintenanceConsumptionPerSecondEnergy = 1,
         TeleportEnergyMod = 0.15,
         TeleportMassMod = 1,

--- a/units/URL0101/URL0101_unit.bp
+++ b/units/URL0101/URL0101_unit.bp
@@ -107,9 +107,9 @@ UnitBlueprint {
         UniformScale = 0.027,
     },
     Economy = {
-        BuildCostEnergy = 40,
+        BuildCostEnergy = 60,
         BuildCostMass = 8,
-        BuildTime = 40,
+        BuildTime = 60,
         MaintenanceConsumptionPerSecondEnergy = 1,
         TeleportEnergyMod = 0.15,
         TeleportMassMod = 1,


### PR DESCRIPTION
80 -> 60 BT for UEF, Aeon, and Cybran.
Adjust the E cost slightly
