### PR TITLE
Paragon adjustments

### DIFF
--- a/units/XAB1401/XAB1401_unit.bp
+++ b/units/XAB1401/XAB1401_unit.bp
@@ -154,6 +154,7 @@ UnitBlueprint {
         BuildTime = 325000,
         MaxEnergy = 1000000,
         MaxMass = 10000,
+        StorageEnergy = 100000,
         RebuildBonusIds = {
             'xab1401',
         },


### PR DESCRIPTION
Gives Paragon 100k E storage to avoid stalls when sudden changes in player's E consumption occur.