### PR TITLE
Fafdevelop hotfix 1

### DIFF
--- a/lua/EffectUtilities.lua
+++ b/lua/EffectUtilities.lua
@@ -335,7 +335,6 @@ function CreateDefaultBuildBeams(builder, unitBeingBuilt, BuildEffectBones, Buil
 end
 
 function CreateAeonBuildBaseThread(unitBeingBuilt, builder, EffectsBag)
-    LOG("Called: CreateAeonBuildBaseThread")
     local bp = unitBeingBuilt:GetBlueprint()
     local x, y, z = unpack(unitBeingBuilt:GetPosition())
     local mul = 0.5

--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -320,7 +320,10 @@ CBuildBotUnit = Class(AirUnit) {
     OnDestroy = function(self) 
         self.Dead = true 
         self.Trash:Destroy()
-        self.SpawnedBy.BuildBotsNext = self.SpawnedBy.BuildBotsNext - 1
+        
+        if self.SpawnedBy then 
+            self.SpawnedBy.BuildBotsNext = self.SpawnedBy.BuildBotsNext - 1
+        end
     end,
 
     Kill = function(self)

--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -141,16 +141,20 @@ CConstructionTemplate = Class() {
 
     --- When making build effects, try and make the bots.
     CreateBuildEffects = function(self, unitBeingBuilt, order, stationary)
+        -- check if the unit still exists, this can happen when: 
+        -- pause during construction, constructing unit dies, unpause
+        if unitBeingBuilt then 
 
-        -- Prevent an AI from (ab)using the bots for other purposes than building
-        local builderArmy = self.Army
-        local unitBeingBuiltArmy = unitBeingBuilt.Army
-        if builderArmy == unitBeingBuiltArmy or ArmyBrains[builderArmy].BrainType == "Human" then
-            SpawnBuildBotsOpti(self)
-            if stationary then 
-                CreateCybranEngineerBuildEffectsOpti(self, self.BuildEffectBones, self.BuildBots, self.BuildBotTotal, self.BuildEffectsBag)
+            -- Prevent an AI from (ab)using the bots for other purposes than building
+            local builderArmy = self.Army
+            local unitBeingBuiltArmy = unitBeingBuilt.Army
+            if builderArmy == unitBeingBuiltArmy or ArmyBrains[builderArmy].BrainType == "Human" then
+                SpawnBuildBotsOpti(self)
+                if stationary then 
+                    CreateCybranEngineerBuildEffectsOpti(self, self.BuildEffectBones, self.BuildBots, self.BuildBotTotal, self.BuildEffectsBag)
+                end
+                CreateCybranBuildBeamsOpti(self, self.BuildBots, unitBeingBuilt, self.BuildEffectsBag, stationary)
             end
-            CreateCybranBuildBeamsOpti(self, self.BuildBots, unitBeingBuilt, self.BuildEffectsBag, stationary)
         end
     end,
 
@@ -320,7 +324,7 @@ CBuildBotUnit = Class(AirUnit) {
     OnDestroy = function(self) 
         self.Dead = true 
         self.Trash:Destroy()
-        
+
         if self.SpawnedBy then 
             self.SpawnedBy.BuildBotsNext = self.SpawnedBy.BuildBotsNext - 1
         end
@@ -741,9 +745,13 @@ CConstructionStructureUnit = Class(CStructureUnit, CConstructionTemplate) {
 
     OnUnpaused = function(self)
         CStructureUnit.OnUnpaused(self)
-        CStructureUnit.StartBuildingEffects(self, self.UnitBeingBuilt, self.UnitBuildOrder)
 
-        self.AnimationManipulator:SetRate(1)
+        -- make sure the unit is still there
+        local unitBeingBuilt = self.UnitBeingBuilt
+        if unitBeingBuilt then 
+            CStructureUnit.StartBuildingEffects(self, unitBeingBuilt, self.UnitBuildOrder)
+            self.AnimationManipulator:SetRate(1)
+        end
     end,
 
     CreateBuildEffects = function(self, unitBeingBuilt, order)

--- a/units/URB1104/URB1104_script.lua
+++ b/units/URB1104/URB1104_script.lua
@@ -22,12 +22,16 @@ URB1104 = Class(CMassFabricationUnit) {
     
     OnProductionUnpaused = function(self)
         CMassFabricationUnit.OnProductionUnpaused(self)
-        self.Rotator:SetTargetSpeed(150)
+        if self.Rotator then 
+            self.Rotator:SetTargetSpeed(150)
+        end
     end,
     
     OnProductionPaused = function(self)
         CMassFabricationUnit.OnProductionPaused(self)
-        self.Rotator:SetTargetSpeed(0)
+        if self.Rotator then 
+            self.Rotator:SetTargetSpeed(0)
+        end
     end,
 }
 

--- a/units/URB1104/URB1104_script.lua
+++ b/units/URB1104/URB1104_script.lua
@@ -1,0 +1,34 @@
+#****************************************************************************
+#**
+#**  File     :  /cdimage/units/URB1104/URB1104_script.lua
+#**  Author(s):  Jessica St. Croix, David Tomandl
+#**
+#**  Summary  :  Cybran Mass Fabricator
+#**
+#**  Copyright � 2005 Gas Powered Games, Inc.  All rights reserved.
+#****************************************************************************
+local CMassFabricationUnit = import('/lua/cybranunits.lua').CMassFabricationUnit
+
+URB1104 = Class(CMassFabricationUnit) {
+    DestructionPartsLowToss = {'Blade',},
+
+    OnStopBeingBuilt = function(self,builder,layer)
+        CMassFabricationUnit.OnStopBeingBuilt(self,builder,layer)
+        self.Rotator = CreateRotator(self, 'Blade', 'z')
+        self.Trash:Add(self.Rotator)
+        self.Rotator:SetAccel(40)
+        self.Rotator:SetTargetSpeed(150)
+    end,
+    
+    OnProductionUnpaused = function(self)
+        CMassFabricationUnit.OnProductionUnpaused(self)
+        self.Rotator:SetTargetSpeed(150)
+    end,
+    
+    OnProductionPaused = function(self)
+        CMassFabricationUnit.OnProductionPaused(self)
+        self.Rotator:SetTargetSpeed(0)
+    end,
+}
+
+TypeClass = URB1104


### PR DESCRIPTION
Contains a few fixes:
 - Removed a LOG that should not have been merged
 - Prevent a mass fabricator from crashing its script (no idea why, has to do with eco manager)
 - Prevent drones from trying to update the engineer / hive when it got gifted
 - Prevent hives from thinking the unit they're building still exists when unpausing, when in reality it died to a mantis (or a bomber, of course)

