### PR TITLE
Add unit tests for string utils

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: faforever/lua:v5.0-0
+    container: faforever/lua:v5.0-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -4,19 +4,34 @@
 -- * Summary    : Contains global functions for working with tables and strings
 -- ==========================================================================================
 
+
+-- upvalue globals for performance
+local type = type 
+local pcall = pcall 
+local unpack = unpack 
+local next = next
+
+-- local Random = Random
+
+-- upvalue table operations for performance
+local TableInsert = table.insert 
+local TableGetn = table.getn 
+local TableRemove = table.remove 
+local TableSort = table.sort
+
 --- RandomIter(table) returns a function that when called, returns a pseudo-random element of the supplied table.
 --- Each element of the table will be returned once. This is essentially for "shuffling" sets.
 function RandomIter(someSet)
     local keyList = {}
     for key, val in someSet do
-        table.insert(keyList, key)
+        TableInsert(keyList, key)
     end
 
     return function()
-        local size = table.getn(keyList)
+        local size = TableGetn(keyList)
 
         if size > 0 then
-            local key = table.remove(keyList, Random(1, size))
+            local key = TableRemove(keyList, Random(1, size))
             return key, someSet[key]
         else
             return
@@ -80,7 +95,7 @@ function table.removeByValue(t,val)
     if not t then return end -- prevent looping over nil table
     for k,v in t do
         if v == val then
-            table.remove(t,k)
+            TableRemove(t,k)
             return
         end
     end
@@ -170,11 +185,11 @@ function table.cat(t1, t2)
     if not t2 then return table.copy(t1) end
     local r = {}
     for i,v in t1 do
-        table.insert(r, v)
+        TableInsert(r, v)
     end
 
     for i,v in t2 do
-        table.insert(r, v)
+        TableInsert(r, v)
     end
 
     return r
@@ -185,10 +200,10 @@ end
 function table.concatenate(...)
     local ret = {}
 
-    for index = 1, table.getn(arg) do
+    for index = 1, TableGetn(arg) do
         if arg[index] then
             for k, v in arg[index] do
-                table.insert(ret, v)
+                TableInsert(ret, v)
             end
         end
     end
@@ -201,7 +216,7 @@ end
 --- but this avoids the need to copy the values in t1, saving some time.
 function table.destructiveCat(t1, t2)
     for k, v in t2 do
-        table.insert(t1, v)
+        TableInsert(t1, v)
     end
 end
 
@@ -210,7 +225,7 @@ end
 --- [comp] is an optional comparison function, defaulting to less-than.
 function table.sorted(t, comp)
     local r = table.copy(t)
-    table.sort(r, comp)
+    TableSort(r, comp)
     return r
 end
 
@@ -250,7 +265,7 @@ function table.keys(t, comp)
         r[n] = k -- faster than table.insert(r,k)
         n = n + 1
     end
-    if comp ~= false then table.sort(r, comp) end
+    if comp ~= false then TableSort(r, comp) end
     return r
 end
 
@@ -414,7 +429,7 @@ function table.shuffle(t)
     local r = {}
     for key, val in RandomIter(t) do
         if type(key) == 'number' then
-            table.insert(r, val)
+            TableInsert(r, val)
         else
             r[key] = val
         end
@@ -435,7 +450,7 @@ function table.binsert(t, value, cmp)
          end
       end
 
-      table.insert(t, mid + state, value)
+      TableInsert(t, mid + state, value)
       return mid + state
    end
 

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -544,7 +544,7 @@ end
 
 --- Returns true if the string starts with the specified value
 function StringStartsWith(stringToMatch, valueToSeek)
-    return string.sub(stringToMatch, 1, valueToSeek:len()) == valueToSeek
+    return stringToMatch:sub(1, valueToSeek:len()) == valueToSeek
 end
 
 --- Extracts a string between two specified strings
@@ -552,7 +552,7 @@ end
 function StringExtract(str, str1, str2, fromEnd)
     local pattern = str1 .. '(.*)' .. str2
     if fromEnd then pattern = '.*' .. pattern end
-    local i, ii, m = string.find(str, pattern)
+    local _, _, m = str:find(pattern)
     return m
 end
 
@@ -574,44 +574,51 @@ function StringPrepend(str, symbol)
     if not symbol then symbol = ' ' end
     return symbol .. str
 end
---- Splits a string with camel cast to a string with separate words
+
+--- Splits a string with camel case to a string with separate words
 --- e.g. StringSplitCamel('SupportCommanderUnit') -> 'Support Commander Unit'
 function StringSplitCamel(str)
-   return (str:gsub("[A-Z]", StringPrepend):gsub("^.", string.upper))
+    local first = str:sub(1, 1)
+    local split = first .. str:sub(2):gsub("[A-Z]", StringPrepend)
+    return split:gsub("^.", string.upper)
 end
 
 --- Reverses order of letters for specified string
---- e.g. StringCapitalize('abc123') --> 321cba
+--- e.g. StringReverse('abc123') --> 321cba
 function StringReverse(str)
     local tbl =  {}
-    str:gsub(".",function(c) table.insert(tbl,c) end)
+    str:gsub(".", function(c) table.insert(tbl,c) end)
     tbl = table.reverse(tbl)
     return table.concat(tbl)
 end
+
 --- Capitalizes each word in specified string
 --- e.g. StringCapitalize('hello supreme commander') --> Hello Supreme Commander
 function StringCapitalize(str)
     return string.gsub(" "..str, "%W%l", string.upper):sub(2)
 end
+
 --- Check if a given string starts with specified string
 function StringStarts(str, startString)
-   return string.sub(str, 1, string.len(startString)) == startString
+   return StringStartsWith(str, startString)
 end
+
 --- Check if a given string ends with specified string
 function StringEnds(str, endString)
-   return endString == '' or string.sub(str, -string.len(endString)) == endString
+   return endString == '' or str:sub(-endString:len()) == endString
 end
+
 --- Sorts two variables based on their numeric value or alpha order (strings)
 function Sort(itemA, itemB)
     if not itemA or not itemB then return 0 end
 
     if type(itemA) == "string" or
        type(itemB) == "string" then
-        if string.lower(itemA) == string.lower(itemB) then
+        if itemA:lower() == itemB:lower() then
             return 0
         else
             -- sort string using alpha order
-            return string.lower(itemA) < string.lower(itemB)
+            return itemA:lower() < itemB:lower()
         end
     else
        if math.abs(itemA - itemB) < 0.0001 then

--- a/run_lua_tests.sh
+++ b/run_lua_tests.sh
@@ -24,12 +24,13 @@ while read file; do
   (( files_checked++ ))
 done < <(find . -type d \( -path ./testmaps -o -path ./engine \) -prune -false -o -name '*.lua' -o -name '*.bp')
 
+echo "Checked $files_checked files"
+
 if [[ $had_error != 0 ]]; then
   echo "Syntax errors detected."
+  exit $had_error
 else
   echo "Syntax OK."
 fi
 
-echo "Checked $files_checked files"
-
-exit $had_error
+pushd tests && lua test_utils.lua && popd

--- a/tests/lust.lua
+++ b/tests/lust.lua
@@ -1,0 +1,236 @@
+-- lust v0.1.0 - Lua test framework
+-- https://github.com/bjornbytes/lust
+-- MIT LICENSE
+-- Modified by Askaholic for lua 5.0
+
+-- Useful for better test output
+require "../lua/system/repr.lua"
+
+local lust = {}
+lust.level = 0
+lust.passes = 0
+lust.errors = 0
+lust.befores = {}
+lust.afters = {}
+
+local red = string.char(27) .. '[31m'
+local green = string.char(27) .. '[32m'
+local normal = string.char(27) .. '[0m'
+local function indent(level) return string.rep('\t', level or lust.level) end
+
+function lust.finish()
+  if lust.errors ~= 0 then
+    os.exit(-1)
+  end
+end
+
+function lust.describe(name, fn)
+  print(indent() .. name)
+  lust.level = lust.level + 1
+  fn()
+  lust.befores[lust.level] = {}
+  lust.afters[lust.level] = {}
+  lust.level = lust.level - 1
+end
+
+function lust.it(name, fn)
+  for level = 1, lust.level do
+    if lust.befores[level] then
+      for i = 1, table.getn(lust.befores[level]) do
+        lust.befores[level][i](name)
+      end
+    end
+  end
+
+  local success, err = pcall(fn)
+  if success then lust.passes = lust.passes + 1
+  else lust.errors = lust.errors + 1 end
+  local color = success and green or red
+  local label = success and 'PASS' or 'FAIL'
+  print(indent() .. color .. label .. normal .. ' ' .. name)
+  if err then
+    print(indent(lust.level + 1) .. red .. err .. normal)
+  end
+
+  for level = 1, lust.level do
+    if lust.afters[level] then
+      for i = 1, table.getn(lust.afters[level]) do
+        lust.afters[level][i](name)
+      end
+    end
+  end
+end
+
+function lust.before(fn)
+  lust.befores[lust.level] = lust.befores[lust.level] or {}
+  table.insert(lust.befores[lust.level], fn)
+end
+
+function lust.after(fn)
+  lust.afters[lust.level] = lust.afters[lust.level] or {}
+  table.insert(lust.afters[lust.level], fn)
+end
+
+-- Assertions
+local function isa(v, x)
+  if type(x) == 'string' then
+    return type(v) == x,
+      'expected ' .. repr(v) .. ' to be a ' .. x,
+      'expected ' .. repr(v) .. ' to not be a ' .. x
+  elseif type(x) == 'table' then
+    if type(v) ~= 'table' then
+      return false,
+        'expected ' .. repr(v) .. ' to be a ' .. repr(x),
+        'expected ' .. repr(v) .. ' to not be a ' .. repr(x)
+    end
+
+    local seen = {}
+    local meta = v
+    while meta and not seen[meta] do
+      if meta == x then return true end
+      seen[meta] = true
+      meta = getmetatable(meta) and getmetatable(meta).__index
+    end
+
+    return false,
+      'expected ' .. repr(v) .. ' to be a ' .. repr(x),
+      'expected ' .. repr(v) .. ' to not be a ' .. repr(x)
+  end
+
+  error('invalid type ' .. repr(x))
+end
+
+local function has(t, x)
+  for k, v in pairs(t) do
+    if v == x then return true end
+  end
+  return false
+end
+
+local function strict_eq(t1, t2)
+  if type(t1) ~= type(t2) then return false end
+  if type(t1) ~= 'table' then return t1 == t2 end
+  for k, _ in pairs(t1) do
+    if not strict_eq(t1[k], t2[k]) then return false end
+  end
+  for k, _ in pairs(t2) do
+    if not strict_eq(t2[k], t1[k]) then return false end
+  end
+  return true
+end
+
+local paths = {
+  [''] = { 'to', 'to_not' },
+  to = { 'have', 'equal', 'be', 'exist', 'fail' },
+  to_not = { 'have', 'equal', 'be', 'exist', 'fail', chain = function(a) a.negate = not a.negate end },
+  a = { test = isa },
+  an = { test = isa },
+  be = { 'a', 'an', 'truthy',
+    test = function(v, x)
+      return v == x,
+        'expected ' .. repr(v) .. ' and ' .. repr(x) .. ' to be equal',
+        'expected ' .. repr(v) .. ' and ' .. repr(x) .. ' to not be equal'
+    end
+  },
+  exist = {
+    test = function(v)
+      return v ~= nil,
+        'expected ' .. repr(v) .. ' to exist',
+        'expected ' .. repr(v) .. ' to not exist'
+    end
+  },
+  truthy = {
+    test = function(v)
+      return v,
+        'expected ' .. repr(v) .. ' to be truthy',
+        'expected ' .. repr(v) .. ' to not be truthy'
+    end
+  },
+  equal = {
+    test = function(v, x)
+      return strict_eq(v, x),
+        'expected ' .. repr(v) .. ' and ' .. repr(x) .. ' to be exactly equal',
+        'expected ' .. repr(v) .. ' and ' .. repr(x) .. ' to not be exactly equal'
+    end
+  },
+  have = {
+    test = function(v, x)
+      if type(v) ~= 'table' then
+        error('expected ' .. repr(v) .. ' to be a table')
+      end
+
+      return has(v, x),
+        'expected ' .. repr(v) .. ' to contain ' .. repr(x),
+        'expected ' .. repr(v) .. ' to not contain ' .. repr(x)
+    end
+  },
+  fail = {
+    test = function(v)
+      return not pcall(v),
+        'expected ' .. repr(v) .. ' to fail',
+        'expected ' .. repr(v) .. ' to not fail'
+    end
+  }
+}
+
+function lust.expect(v)
+  local assertion = {}
+  assertion.val = v
+  assertion.action = ''
+  assertion.negate = false
+
+  setmetatable(assertion, {
+    __index = function(t, k)
+      if has(paths[rawget(t, 'action')], k) then
+        rawset(t, 'action', k)
+        local chain = paths[rawget(t, 'action')].chain
+        if chain then chain(t) end
+        return t
+      end
+      return rawget(t, k)
+    end,
+    __call = function(t, ...)
+      if paths[t.action].test then
+        local res, err, nerr = paths[t.action].test(t.val, unpack(arg))
+        if assertion.negate then
+          res = not res
+          err = nerr or err
+        end
+        if not res then
+          error(err or 'unknown failure', 2)
+        end
+      end
+    end
+  })
+
+  return assertion
+end
+
+function lust.spy(target, name, run)
+  local spy = {}
+  local subject
+
+  local function capture(...)
+    table.insert(spy, arg)
+    return subject(unpack(arg))
+  end
+
+  if type(target) == 'table' then
+    subject = target[name]
+    target[name] = capture
+  else
+    run = name
+    subject = target or function() end
+  end
+
+  setmetatable(spy, {__call = function(_, ...) return capture(unpack(arg)) end})
+
+  if run then run() end
+
+  return spy
+end
+
+lust.test = lust.it
+lust.paths = paths
+
+return lust

--- a/tests/test_utils.lua
+++ b/tests/test_utils.lua
@@ -1,0 +1,81 @@
+-- Test framework
+local lust = require "lust"
+
+-- Functions are imported to the global scope...
+require "../lua/system/utils.lua"
+
+lust.describe("test utils", function()
+  lust.describe("string", function()
+    lust.it("StringSplit empty", function()
+      lust.expect(StringSplit("")).to.equal({})
+    end)
+
+    lust.it("StringSplit default", function()
+      lust.expect(StringSplit("Hello:World")).to.equal({"Hello", "World"})
+      lust.expect(StringSplit("Hello:foo:World"))
+        .to.equal({"Hello", "foo", "World"})
+    end)
+
+    lust.it("StringSplit separator", function()
+      lust.expect(StringSplit("Hello World", " "))
+        .to.equal({"Hello", "World"})
+      lust.expect(StringSplit("Hello foo World", " "))
+        .to.equal({"Hello", "foo", "World"})
+      lust.expect(StringSplit("Hello |foo| World", "|"))
+        .to.equal({"Hello ", "foo", " World"})
+    end)
+
+    lust.it("StringStartsWith", function()
+      lust.expect(StringStartsWith("Hello, World", "Hello")).to.equal(true)
+    end)
+
+    lust.it("StringExtract", function()
+      lust.expect(StringExtract("/path/name_end.lua", "/", "_end", true))
+        .to.equal("name")
+    end)
+
+    lust.it("StringComma", function()
+      lust.expect(StringComma(100)).to.equal("100")
+      lust.expect(StringComma(1000)).to.equal("1,000")
+      lust.expect(StringComma(10000)).to.equal("10,000")
+      -- Maybe not desired, but included for documentation purposes
+      lust.expect(StringComma(100000)).to.equal("1e+05")
+      lust.expect(StringComma(1000000)).to.equal("1e+06")
+    end)
+
+    lust.it("StringPrepend", function()
+      lust.expect(StringPrepend("foo")).to.equal(" foo")
+      lust.expect(StringPrepend("foo", "bar")).to.equal("barfoo")
+    end)
+
+    lust.it("StringSplitCamel", function()
+      lust.expect(StringSplitCamel("SupportCommanderUnit"))
+        .to.equal("Support Commander Unit")
+      lust.expect(StringSplitCamel("supportCommanderUnit"))
+        .to.equal("Support Commander Unit")
+    end)
+
+    lust.it("StringReverse", function()
+      lust.expect(StringReverse("abc123")).to.equal("321cba")
+    end)
+
+    lust.it("StringCapitalize", function()
+      lust.expect(StringCapitalize("hello supreme commander"))
+        .to.equal("Hello Supreme Commander")
+    end)
+
+    lust.it("StringStarts", function()
+      lust.expect(StringStarts("Hello, World", "Hello")).to.equal(true)
+      lust.expect(StringStarts("Hello, World", "World")).to.equal(false)
+    end)
+
+    lust.it("StringEnds", function()
+      lust.expect(StringEnds("Hello, World", "Hello")).to.equal(false)
+      lust.expect(StringEnds("Hello, World", "World")).to.equal(true)
+    end)
+
+  end)
+end)
+
+-- Make sure to call finish so that any errors will fail the CI!
+lust.finish()


### PR DESCRIPTION
I found a single file test framework that was pretty easy to convert to lua 5.0 syntax. With the help of the `repr` function it gives fairly useful test output on failures too. I had to change all of the `str:foo` calls to `string.foo(str)` because by default in lua 5.0 you must invoke them like that. But, I see the `str:foo` all over the codebase so I feel like GPG must have added it to SupCom (which means I'll need to add it to faflua and then probably revert all those changes in this PR).

Here's an example of what the console output looks like:
![image](https://user-images.githubusercontent.com/17941539/133026865-f02d425e-09e4-494e-b272-2fd56fe3598c.png)
