### PR TITLE
Optimize hover effects

### DIFF
--- a/effects/emitters/aeon_groundFX_emit.bp
+++ b/effects/emitters/aeon_groundFX_emit.bp
@@ -1,9 +1,9 @@
 EmitterBlueprint {
-	BlueprintId = 'seraphim_groundFX',
+	BlueprintId = 'aeon_groundFX',
 	Lifetime = -1.00,
 	Repeattime = 10.00,
 	TextureFramecount = 1.00,
-	Blendmode = 3.00,
+	Blendmode = 0.00,
 	LocalVelocity = false,
 	LocalAcceleration = false,
 	Gravity = false,
@@ -23,8 +23,8 @@ EmitterBlueprint {
 	LowFidelity = false,
 	MedFidelity = true,
 	HighFidelity = true,
-	Texture = [[/textures/particles/ser_plasma05.dds]],
-	RampTexture = [[/textures/particles/ramp_blue_16.dds]],
+	Texture = [[/textures/particles/glow_alpha_03.dds]],
+	RampTexture = [[/textures/particles/ramp_white_07.dds]],
 	XDirectionCurve = {
 		XRange = 10.00,
 		Keys = {
@@ -46,13 +46,13 @@ EmitterBlueprint {
 	EmitRateCurve = {
 		XRange = 10.00,
 		Keys = {
-			{ x=5.000,y=2.000,z=0.000 },
+			{ x=5.000,y=3.000,z=0.000 },
 		},
 	},
 	LifetimeCurve = {
 		XRange = 10.00,
 		Keys = {
-			{ x=5.000,y=2.000,z=1.000 },
+			{ x=5.000,y=1.000,z=1.000 },
 		},
 	},
 	VelocityCurve = {
@@ -100,7 +100,7 @@ EmitterBlueprint {
 	YPosCurve = {
 		XRange = 10.00,
 		Keys = {
-			{ x=5.000,y=0.100,z=0.100 },
+			{ x=5.000,y=0.000,z=0.000 },
 		},
 	},
 	ZPosCurve = {
@@ -112,13 +112,13 @@ EmitterBlueprint {
 	StartSizeCurve = {
 		XRange = 10.00,
 		Keys = {
-			{ x=5.000,y=0.200,z=0.000 },
+			{ x=5.000,y=0.500,z=0.000 },
 		},
 	},
 	EndSizeCurve = {
 		XRange = 10.00,
 		Keys = {
-			{ x=4.182,y=1.000,z=0.000 },
+			{ x=4.182,y=0.800,z=0.000 },
 		},
 	},
 	InitialRotationCurve = {

--- a/effects/emitters/aeon_groundFX_emit.bp
+++ b/effects/emitters/aeon_groundFX_emit.bp
@@ -10,7 +10,7 @@ EmitterBlueprint {
 	AlignRotation = false,
 	AlignToBone = false,
 	Flat = true,
-	LODCutoff = 100.00,
+	LODCutoff = 80.00,
 	EmitIfVisible = true,
 	CatchupEmit = true,
 	CreateIfVisible = false,

--- a/effects/emitters/aeon_t1eng_groundfx01_emit.bp
+++ b/effects/emitters/aeon_t1eng_groundfx01_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'aeon_t1eng_groundfx01',
+	Lifetime = -0.50,
+	Repeattime = 0.50,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 200.00,
+	EmitIfVisible = true,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/quantum_generator_add_03.dds]],
+	RampTexture = [[/textures/particles/ramp_white_03.dds]],
+	XDirectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.035 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.011,y=-0.048,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.101,y=0.000,z=0.035 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.000,y=8.698,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=3.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=6.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.094,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.101,y=0.000,z=0.100 },
+		},
+	},
+	YPosCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.094,y=0.150,z=0.250 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.000,y=0.000,z=0.100 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.049,y=0.100,z=0.100 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.108,y=1.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/aeon_t1eng_groundfx01_emit.bp
+++ b/effects/emitters/aeon_t1eng_groundfx01_emit.bp
@@ -20,7 +20,7 @@ EmitterBlueprint {
 	InterpolateEmission = true,
 	TextureStripcount = 1.00,
 	SortOrder = 0.00,
-	LowFidelity = true,
+	LowFidelity = false,
 	MedFidelity = true,
 	HighFidelity = true,
 	Texture = [[/textures/particles/quantum_generator_add_03.dds]],

--- a/effects/emitters/aeon_t1eng_groundfx01_emit.bp
+++ b/effects/emitters/aeon_t1eng_groundfx01_emit.bp
@@ -1,16 +1,16 @@
 EmitterBlueprint {
 	BlueprintId = 'aeon_t1eng_groundfx01',
-	Lifetime = -0.50,
-	Repeattime = 0.50,
+	Lifetime = -0.80,
+	Repeattime = 0.80,
 	TextureFramecount = 1.00,
 	Blendmode = 3.00,
-	LocalVelocity = true,
+	LocalVelocity = false,
 	LocalAcceleration = false,
 	Gravity = false,
 	AlignRotation = true,
 	AlignToBone = false,
 	Flat = false,
-	LODCutoff = 200.00,
+	LODCutoff = 80.00,
 	EmitIfVisible = true,
 	CatchupEmit = true,
 	CreateIfVisible = false,
@@ -46,7 +46,7 @@ EmitterBlueprint {
 	EmitRateCurve = {
 		XRange = 0.20,
 		Keys = {
-			{ x=0.000,y=8.698,z=0.000 },
+			{ x=0.000,y=4.0,z=0.000 },
 		},
 	},
 	LifetimeCurve = {
@@ -58,7 +58,7 @@ EmitterBlueprint {
 	VelocityCurve = {
 		XRange = 0.20,
 		Keys = {
-			{ x=0.100,y=6.000,z=0.000 },
+			{ x=0.100,y=1.000,z=0.000 },
 		},
 	},
 	XAccelCurve = {
@@ -100,7 +100,7 @@ EmitterBlueprint {
 	YPosCurve = {
 		XRange = 0.20,
 		Keys = {
-			{ x=0.094,y=0.150,z=0.250 },
+			{ x=0.094,y=-0.100,z=0.250 },
 		},
 	},
 	ZPosCurve = {

--- a/effects/emitters/aeon_t2eng_groundfx01_emit.bp
+++ b/effects/emitters/aeon_t2eng_groundfx01_emit.bp
@@ -20,7 +20,7 @@ EmitterBlueprint {
 	InterpolateEmission = true,
 	TextureStripcount = 1.00,
 	SortOrder = 0.00,
-	LowFidelity = true,
+	LowFidelity = false,
 	MedFidelity = true,
 	HighFidelity = true,
 	Texture = [[/textures/particles/quantum_generator_add_03.dds]],

--- a/effects/emitters/aeon_t2eng_groundfx01_emit.bp
+++ b/effects/emitters/aeon_t2eng_groundfx01_emit.bp
@@ -1,7 +1,7 @@
 EmitterBlueprint {
 	BlueprintId = 'aeon_t2eng_groundfx01',
-	Lifetime = -0.20,
-	Repeattime = 0.20,
+	Lifetime = -0.80,
+	Repeattime = 0.80,
 	TextureFramecount = 1.00,
 	Blendmode = 3.00,
 	LocalVelocity = true,
@@ -10,7 +10,7 @@ EmitterBlueprint {
 	AlignRotation = true,
 	AlignToBone = false,
 	Flat = false,
-	LODCutoff = 200.00,
+	LODCutoff = 80.00,
 	EmitIfVisible = true,
 	CatchupEmit = true,
 	CreateIfVisible = false,
@@ -46,7 +46,7 @@ EmitterBlueprint {
 	EmitRateCurve = {
 		XRange = 0.20,
 		Keys = {
-			{ x=0.000,y=8.698,z=0.000 },
+			{ x=0.000,y=4.000,z=0.000 },
 		},
 	},
 	LifetimeCurve = {
@@ -58,7 +58,7 @@ EmitterBlueprint {
 	VelocityCurve = {
 		XRange = 0.20,
 		Keys = {
-			{ x=0.100,y=6.000,z=0.000 },
+			{ x=0.100,y=1.000,z=0.000 },
 		},
 	},
 	XAccelCurve = {
@@ -100,7 +100,7 @@ EmitterBlueprint {
 	YPosCurve = {
 		XRange = 0.20,
 		Keys = {
-			{ x=0.094,y=0.150,z=0.250 },
+			{ x=0.094,y=-0.100,z=0.250 },
 		},
 	},
 	ZPosCurve = {

--- a/effects/emitters/aeon_t2eng_groundfx01_emit.bp
+++ b/effects/emitters/aeon_t2eng_groundfx01_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'aeon_t2eng_groundfx01',
+	Lifetime = -0.20,
+	Repeattime = 0.20,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 200.00,
+	EmitIfVisible = true,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/quantum_generator_add_03.dds]],
+	RampTexture = [[/textures/particles/ramp_white_03.dds]],
+	XDirectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.035 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.011,y=-0.048,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.101,y=0.000,z=0.035 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.000,y=8.698,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=3.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=6.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.094,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.101,y=0.300,z=0.100 },
+		},
+	},
+	YPosCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.094,y=0.150,z=0.250 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.000,y=0.000,z=0.100 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.049,y=0.100,z=0.100 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.108,y=1.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/aeon_t2eng_groundfx02_emit.bp
+++ b/effects/emitters/aeon_t2eng_groundfx02_emit.bp
@@ -1,7 +1,7 @@
 EmitterBlueprint {
 	BlueprintId = 'aeon_t2eng_groundfx02',
-	Lifetime = -0.20,
-	Repeattime = 0.20,
+	Lifetime = -0.80,
+	Repeattime = 0.80,
 	TextureFramecount = 1.00,
 	Blendmode = 3.00,
 	LocalVelocity = true,
@@ -10,7 +10,7 @@ EmitterBlueprint {
 	AlignRotation = true,
 	AlignToBone = false,
 	Flat = false,
-	LODCutoff = 200.00,
+	LODCutoff = 80.00,
 	EmitIfVisible = true,
 	CatchupEmit = true,
 	CreateIfVisible = false,
@@ -46,7 +46,7 @@ EmitterBlueprint {
 	EmitRateCurve = {
 		XRange = 0.20,
 		Keys = {
-			{ x=0.000,y=8.698,z=0.000 },
+			{ x=0.000,y=4.000,z=0.000 },
 		},
 	},
 	LifetimeCurve = {
@@ -58,7 +58,7 @@ EmitterBlueprint {
 	VelocityCurve = {
 		XRange = 0.20,
 		Keys = {
-			{ x=0.100,y=6.000,z=0.000 },
+			{ x=0.100,y=1.000,z=0.000 },
 		},
 	},
 	XAccelCurve = {
@@ -100,7 +100,7 @@ EmitterBlueprint {
 	YPosCurve = {
 		XRange = 0.20,
 		Keys = {
-			{ x=0.094,y=0.150,z=0.250 },
+			{ x=0.094,y=-0.100,z=0.250 },
 		},
 	},
 	ZPosCurve = {

--- a/effects/emitters/aeon_t2eng_groundfx02_emit.bp
+++ b/effects/emitters/aeon_t2eng_groundfx02_emit.bp
@@ -20,7 +20,7 @@ EmitterBlueprint {
 	InterpolateEmission = true,
 	TextureStripcount = 1.00,
 	SortOrder = 0.00,
-	LowFidelity = true,
+	LowFidelity = false,
 	MedFidelity = true,
 	HighFidelity = true,
 	Texture = [[/textures/particles/quantum_generator_add_03.dds]],

--- a/effects/emitters/aeon_t2eng_groundfx02_emit.bp
+++ b/effects/emitters/aeon_t2eng_groundfx02_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'aeon_t2eng_groundfx02',
+	Lifetime = -0.20,
+	Repeattime = 0.20,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 200.00,
+	EmitIfVisible = true,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/quantum_generator_add_03.dds]],
+	RampTexture = [[/textures/particles/ramp_white_03.dds]],
+	XDirectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.035 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.011,y=-0.048,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.035 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.000,y=8.698,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=3.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=6.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.094,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.101,y=-0.300,z=0.100 },
+		},
+	},
+	YPosCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.094,y=0.150,z=0.250 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.000,y=0.000,z=0.100 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.049,y=0.100,z=0.100 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.108,y=1.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_adjacency_node_01_emit.bp
+++ b/effects/emitters/seraphim_adjacency_node_01_emit.bp
@@ -20,7 +20,7 @@ EmitterBlueprint {
 	InterpolateEmission = true,
 	TextureStripcount = 1.00,
 	SortOrder = 0.00,
-	LowFidelity = true,
+	LowFidelity = false,
 	MedFidelity = true,
 	HighFidelity = true,
 	Texture = [[/textures/particles/blast_cloud_01.dds]],

--- a/effects/emitters/seraphim_adjacency_node_01_emit.bp
+++ b/effects/emitters/seraphim_adjacency_node_01_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_adjacency_node_01',
+	Lifetime = -1.00,
+	Repeattime = 100.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = true,
+	LODCutoff = 100.00,
+	EmitIfVisible = true,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/blast_cloud_01.dds]],
+	RampTexture = [[/textures/particles/ramp_white_02.dds]],
+	XDirectionCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.000,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=51.715,y=0.000,z=0.400 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=0.000,y=0.500,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=52.243,y=30.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.790,y=0.040,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=51.187,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.000,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=52.902,y=0.000,z=0.000 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.923,y=0.300,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.000,y=0.000,z=0.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=36.412,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 100.00,
+		Keys = {
+			{ x=50.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_groundFX_02_emit.bp
+++ b/effects/emitters/seraphim_groundFX_02_emit.bp
@@ -46,13 +46,13 @@ EmitterBlueprint {
 	EmitRateCurve = {
 		XRange = 10.00,
 		Keys = {
-			{ x=5.000,y=5.000,z=0.000 },
+			{ x=5.000,y=2.000,z=0.000 },
 		},
 	},
 	LifetimeCurve = {
 		XRange = 10.00,
 		Keys = {
-			{ x=5.000,y=1.500,z=1.000 },
+			{ x=5.000,y=2.000,z=1.000 },
 		},
 	},
 	VelocityCurve = {

--- a/effects/emitters/seraphim_groundFX_02_emit.bp
+++ b/effects/emitters/seraphim_groundFX_02_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_groundFX_02',
+	Lifetime = -1.00,
+	Repeattime = 10.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 100.00,
+	EmitIfVisible = true,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = false,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/smoke.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_16.dds]],
+	XDirectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.500,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=5.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=1.500,z=1.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.400 },
+		},
+	},
+	YPosCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.100,z=0.100 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.400 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.200,z=0.000 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=4.182,y=0.400,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_groundFX_03_emit.bp
+++ b/effects/emitters/seraphim_groundFX_03_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_groundFX_03',
+	Lifetime = -1.00,
+	Repeattime = 10.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = true,
+	LODCutoff = 100.00,
+	EmitIfVisible = true,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = false,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ring_09.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_26.dds]],
+	XDirectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.700,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=5.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=1.500,z=1.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=-0.500,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.800,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=2.691,y=0.400,z=0.000 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=2.652,y=0.200,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_groundFX_03_emit.bp
+++ b/effects/emitters/seraphim_groundFX_03_emit.bp
@@ -46,13 +46,13 @@ EmitterBlueprint {
 	EmitRateCurve = {
 		XRange = 10.00,
 		Keys = {
-			{ x=5.000,y=5.000,z=0.000 },
+			{ x=5.000,y=2.000,z=0.000 },
 		},
 	},
 	LifetimeCurve = {
 		XRange = 10.00,
 		Keys = {
-			{ x=5.000,y=1.500,z=1.000 },
+			{ x=5.000,y=2.000,z=1.000 },
 		},
 	},
 	VelocityCurve = {

--- a/effects/emitters/seraphim_groundFX_04_emit.bp
+++ b/effects/emitters/seraphim_groundFX_04_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_groundFX_04',
+	Lifetime = -1.00,
+	Repeattime = 10.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = true,
+	LODCutoff = 100.00,
+	EmitIfVisible = true,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = false,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ring_11.dds]],
+	RampTexture = [[/textures/particles/ramp_white_29.dds]],
+	XDirectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.500,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=5.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=1.500,z=1.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.100,z=0.100 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.350,z=0.000 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=4.182,y=1.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=3.008,y=0.950,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/seraphim_groundFX_04_emit.bp
+++ b/effects/emitters/seraphim_groundFX_04_emit.bp
@@ -46,13 +46,13 @@ EmitterBlueprint {
 	EmitRateCurve = {
 		XRange = 10.00,
 		Keys = {
-			{ x=5.000,y=5.000,z=0.000 },
+			{ x=5.000,y=2.000,z=0.000 },
 		},
 	},
 	LifetimeCurve = {
 		XRange = 10.00,
 		Keys = {
-			{ x=5.000,y=1.500,z=1.000 },
+			{ x=5.000,y=2.000,z=1.000 },
 		},
 	},
 	VelocityCurve = {

--- a/effects/emitters/seraphim_groundFX_emit.bp
+++ b/effects/emitters/seraphim_groundFX_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'seraphim_groundFX',
+	Lifetime = -1.00,
+	Repeattime = 10.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = true,
+	LODCutoff = 100.00,
+	EmitIfVisible = true,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = false,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = [[/textures/particles/ser_plasma05.dds]],
+	RampTexture = [[/textures/particles/ramp_blue_16.dds]],
+	XDirectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.500,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=5.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=1.500,z=1.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.100,z=0.100 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.200,z=0.000 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=4.182,y=1.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 10.00,
+		Keys = {
+			{ x=5.000,y=0.000,z=0.000 },
+		},
+	},
+}
+


### PR DESCRIPTION
Optimizes the hover effects used by units. In particular Aeon engineers can easily take 2% - 4$ of the sim time just by having their effects being rendered on screen.

The following results are with 150 units of each, comparing the difference between zoomed in (all rendering their effects) and zoomed out (no effects rendered).

```
`aeon_groundfx_emit -> AeonGroundFX01` done marginal gains -0.3/0.5 ms
Used by: DAL0310, ual0101, ual0201, ual0205, ual0307, xal0203 

`aeon_t1eng_groundfx01_emit -> AeonGroundFXT1Engineer` done -2/2.5 ms
Used by: UAL0105, UAL0309

`aeon_t2eng_groundfx01_emit -> AeonGroundFXT2Engineer` done -2/2.5 ms
`aeon_t2eng_groundfx02_emit -> AeonGroundFXT2Engineer` done -2/2.5 ms
Used by: UAL0208

`seraphim_groundFX_emit -> SeraphimGroundFX01` done marginal gains -0.3/0.5 ms
`seraphim_groundFX_02_emit -> SeraphimGroundFX01` done marginal gains -0.3/0.5 ms
Used by: XSL0103, XSL0105, XSL0205, XSL0208, XSL0307, XSL0309

`seraphim_groundFX_03_emit -> SeraphimGroundFX02` done marginal gains -0.3/0.5 ms
`seraphim_groundFX_04_emit -> SeraphimGroundFX02` done marginal gains -0.3/0.5 ms
Used by: XSL0305
```

With thanks to Madmax for his work on this PR.