### PR TITLE
Hotfix explosions

### DIFF
--- a/lua/defaultexplosions.lua
+++ b/lua/defaultexplosions.lua
@@ -189,6 +189,10 @@ function CreateScalableUnitExplosion(unit, overKillRatio)
             local sy = blueprint.SizeY or 1 
             local sz = blueprint.SizeZ or 1 
 
+            LOG(sx)
+            LOG(sy)
+            LOG(sz)
+
             -- cache stats 
             local army = unit.Army
             local boundingXZRadius = 0.25 * (sx + sz)
@@ -201,6 +205,8 @@ function CreateScalableUnitExplosion(unit, overKillRatio)
             local environmentEffects = false 
             local shakeTimeModifier = 0
             local shakeMaxMul = 1
+
+            LOG(boundingXZRadius)
 
             if layer == 'Land' then
                 -- determine land effects
@@ -250,7 +256,7 @@ function CreateScalableUnitExplosion(unit, overKillRatio)
                 -- determine air effects
                 if boundingXZRadius < 1.1 then
                     baseEffects = ExplosionSmallAir
-                elseif boundingXZRadius > 3 then
+                elseif boundingXZRadius > 7 then
                     -- large units cause camera to shake
                     baseEffects = ExplosionLarge
                     ShakeTimeModifier = 1.0
@@ -260,9 +266,9 @@ function CreateScalableUnitExplosion(unit, overKillRatio)
                 end
             elseif layer == 'Water' then
                 -- determine water effects
-                if boundingXZRadius < 1 then
+                if boundingXZRadius < 2 then
                     baseEffects = ExplosionSmallWater
-                elseif boundingXZRadius > 3 then
+                elseif boundingXZRadius > 3.6 then
                     -- large units cause camera to shake
                     baseEffects = ExplosionMediumWater
                     ShakeTimeModifier = 1.0
@@ -272,7 +278,7 @@ function CreateScalableUnitExplosion(unit, overKillRatio)
                 end
 
                 -- environment effects
-                if boundingXZRadius < 0.5 then
+                if boundingXZRadius < 1.0 then
                     environmentEffects = Splashy
                 end
             end

--- a/lua/defaultexplosions.lua
+++ b/lua/defaultexplosions.lua
@@ -619,15 +619,15 @@ function CreateDebrisProjectiles(obj, volume, dimensions)
     -- for backwards compatibility
     local sx, sy, sz = unpack(dimensions)
 
-        -- determine blueprint value
-        local bp = false 
-        if volume < 0.2 then
-            bp = '/effects/entities/DebrisMisc09/DebrisMisc09_proj.bp'
-        elseif volume < 2.0 then
-            bp = '/effects/entities/DebrisMisc04/DebrisMisc04_proj.bp'
-        else 
-            bp = '/effects/entities/DebrisMisc010/DebrisMisc010_proj.bp'
-        end
+    -- determine blueprint value
+    local bp = false 
+    if volume < 0.2 then
+        bp = '/effects/entities/DebrisMisc09/DebrisMisc09_proj.bp'
+    elseif volume < 2.0 then
+        bp = '/effects/entities/DebrisMisc04/DebrisMisc04_proj.bp'
+    else 
+        bp = '/effects/entities/DebrisMisc010/DebrisMisc010_proj.bp'
+    end
 
     -- get number of projectiles
     local amount = MathMin(Random(1 + (volume * 25), (volume * 50)) , 100)
@@ -647,7 +647,7 @@ function CreateDebrisProjectiles(obj, volume, dimensions)
         local zdir = 10 * ((1 - r1) * sz - (sz * 0.5))
 
         -- create debris projectile
-        EntityCreateProjectile(unit, bp, xpos, xpos, zpos, xdir, ydir + 4.5, zdir)
+        EntityCreateProjectile(obj, bp, xpos, xpos, zpos, xdir, ydir + 4.5, zdir)
     end
 end
 

--- a/lua/defaultexplosions.lua
+++ b/lua/defaultexplosions.lua
@@ -147,8 +147,8 @@ end
 function QuatFromRotation(rotation, x, y, z)
     local angleRot, qw, qx, qy, qz, angle
     angle = 0.00872664625 * rotation
-    angleRot = math.sin(angle)
-    qw = math.cos(angle)
+    angleRot = MathSin(angle)
+    qw = MathCos(angle)
     qx = x * angleRot
     qy = y * angleRot
     qz = z * angleRot
@@ -188,7 +188,7 @@ function CreateScalableUnitExplosion(unit, overKillRatio)
             local sx = blueprint.SizeX or 1 
             local sy = blueprint.SizeY or 1 
             local sz = blueprint.SizeZ or 1 
-            
+
             -- cache stats 
             local army = unit.Army
             local boundingXZRadius = 0.25 * (sx + sz)

--- a/lua/defaultexplosions.lua
+++ b/lua/defaultexplosions.lua
@@ -188,11 +188,7 @@ function CreateScalableUnitExplosion(unit, overKillRatio)
             local sx = blueprint.SizeX or 1 
             local sy = blueprint.SizeY or 1 
             local sz = blueprint.SizeZ or 1 
-
-            LOG(sx)
-            LOG(sy)
-            LOG(sz)
-
+            
             -- cache stats 
             local army = unit.Army
             local boundingXZRadius = 0.25 * (sx + sz)
@@ -205,8 +201,6 @@ function CreateScalableUnitExplosion(unit, overKillRatio)
             local environmentEffects = false 
             local shakeTimeModifier = 0
             local shakeMaxMul = 1
-
-            LOG(boundingXZRadius)
 
             if layer == 'Land' then
                 -- determine land effects


### PR DESCRIPTION
A small hotfix:
 - A typo in variable name that prevents the Galactic Colossus and Ythotha to spawn their wrecks.
 - A quick tweak magic values that determine what unit should receive what type of explosion