### PR TITLE
GetReclaimCosts() - Grab blueprints after we know it's a unit

### DIFF
--- a/changelog-3724.md
+++ b/changelog-3724.md
@@ -8,7 +8,9 @@ Patch 3721 (19 September, 2021)
 ### Bugs
  - (#3442) Fix scathis packing animation time
  - (#3439) Fix Cybran drone visibility for other players than the owner
-
+ 
+### Stability
+ - (#3436) Prevent fetching blueprints for potential entities with no blueprints
 ### Performances
 
 ### AI
@@ -17,3 +19,4 @@ Patch 3721 (19 September, 2021)
 
 ### Contributors
  - Jip (#3442, #3439)
+ - Crotalus (#3436)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -3638,9 +3638,9 @@ Unit = Class(moho.unit_methods) {
     -- Return the total time in seconds, cost in energy, and cost in mass to reclaim the given target from 100%.
     -- The energy and mass costs will normally be negative, to indicate that you gain mass/energy back.
     GetReclaimCosts = function(self, target_entity)
-        local bp = self:GetBlueprint()
-        local target_bp = target_entity:GetBlueprint()
         if IsUnit(target_entity) then
+            local bp = self:GetBlueprint()
+            local target_bp = target_entity:GetBlueprint()
             local mtime = target_bp.Economy.BuildCostEnergy / self:GetBuildRate()
             local etime = target_bp.Economy.BuildCostMass / self:GetBuildRate()
             local time = mtime


### PR DESCRIPTION
As a safeguard only get blueprints after we're sure it's a unit and actually need to use blueprint values.

See comment here about GetBlueprint() on a shield bubble entity crashes the game.
https://github.com/FAForever/fa/issues/2045#issuecomment-922841853
