### PR TITLE
Fix drones not being visible by recon

### DIFF
--- a/changelog-3724.md
+++ b/changelog-3724.md
@@ -1,0 +1,19 @@
+Patch 3721 (19 September, 2021)
+============================
+
+### Lobby
+
+### Gameplay
+
+### Bugs
+ - (#3442) Fix scathis packing animation time
+ - (#3439) Fix Cybran drone visibility for other players than the owner
+
+### Performances
+
+### AI
+
+### Other
+
+### Contributors
+ - Jip (#3442, #3439)

--- a/units/URA0001O/URA0001O_unit.bp
+++ b/units/URA0001O/URA0001O_unit.bp
@@ -38,6 +38,7 @@ UnitBlueprint {
         'INVULNERABLE',
         'UNSPAWNABLE',
         'UNSELECTABLE',
+        'VISIBLETORECON',
     },
     Display = {
         Mesh = {

--- a/units/URA0002O/URA0002O_unit.bp
+++ b/units/URA0002O/URA0002O_unit.bp
@@ -38,6 +38,7 @@ UnitBlueprint {
         'INVULNERABLE',
         'UNSPAWNABLE',
         'UNSELECTABLE',
+        'VISIBLETORECON',
     },
     Display = {
         Mesh = {

--- a/units/URA0003O/URA0003O_unit.bp
+++ b/units/URA0003O/URA0003O_unit.bp
@@ -38,6 +38,7 @@ UnitBlueprint {
         'INVULNERABLE',
         'UNSPAWNABLE',
         'UNSELECTABLE',
+        'VISIBLETORECON',
     },
     Display = {
         Mesh = {


### PR DESCRIPTION
Yes - silly mistake. Apparently that category is quite vital. Closes #3384 