### PR TITLE
Allow trashbag to be re-used

### DIFF
--- a/lua/system/trashbag.lua
+++ b/lua/system/trashbag.lua
@@ -69,5 +69,8 @@ TrashBag = Class {
                 self[k] = nil
             end
         end 
+
+        -- allow us to be re-used, useful for effects
+        self.Next = 1
     end
 }


### PR DESCRIPTION
This allows a trashbag to be re-used after it is 'destroyed'. Useful for effects that come and go. Allows us to replace [these tables](https://github.com/FAForever/fa/blob/deploy/fafdevelop/lua/sim/Unit.lua#L192) for example. They are currently 'destroyed' through [this function](https://github.com/FAForever/fa/blob/deploy/fafdevelop/lua/EffectUtilities.lua#L1338) which is silly at best 😄 : 
 - A new table is allocated, that starts fresh. This means the first few entries will trigger reconstructions.
 - The old table is de-allocated, which is a shame because we're going to use another table for the same task.