### PR TITLE
Fix hard-crashes in /lua/DefaultCollisionBeams.lua

### DIFF
--- a/changelog-3724.md
+++ b/changelog-3724.md
@@ -9,6 +9,9 @@ Patch 3721 (19 September, 2021)
  - (#3442) Fix scathis packing animation time
  - (#3439) Fix Cybran drone visibility for other players than the owner
 
+### Stability
+ - (#3449) Fix significant hard-crash potential that patch 3721 introduced
+
 ### Performances
 
 ### AI
@@ -16,4 +19,4 @@ Patch 3721 (19 September, 2021)
 ### Other
 
 ### Contributors
- - Jip (#3442, #3439)
+ - Jip (#3442, #3439, #3449)

--- a/lua/defaultcollisionbeams.lua
+++ b/lua/defaultcollisionbeams.lua
@@ -5,7 +5,7 @@
 --
 --  Summary  :  Default definitions collision beams
 --
---  Copyright � 2005 Gas Powered Games, Inc.  All rights reserved.
+--  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 ------------------------------------------------------------
 
 local CollisionBeam = import('/lua/sim/CollisionBeam.lua').CollisionBeam

--- a/lua/defaultcollisionbeams.lua
+++ b/lua/defaultcollisionbeams.lua
@@ -5,7 +5,7 @@
 --
 --  Summary  :  Default definitions collision beams
 --
---  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--  Copyright ï¿½ 2005 Gas Powered Games, Inc.  All rights reserved.
 ------------------------------------------------------------
 
 local CollisionBeam = import('/lua/sim/CollisionBeam.lua').CollisionBeam
@@ -115,15 +115,17 @@ QuantumBeamGeneratorCollisionBeam = Class(SCCollisionBeam) { -- used by CZAR
         local CurrentPosition = self:GetPosition(1)
         local LastPosition = Vector(0,0,0)
         local skipCount = 1
-        local FriendlyFire = self.DamageData.DamageFriendly
+        -- local FriendlyFire = self.DamageData.DamageFriendly
         
         while true do
             if Util.GetDistanceBetweenTwoVectors( CurrentPosition, LastPosition ) > 0.25 or skipCount > 100 then
                 CreateSplat( CurrentPosition, Util.GetRandomFloat(0,2*math.pi), self.SplatTexture, size, size, 200, 150, army )
                 LastPosition = CurrentPosition
                 skipCount = 1
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+
+                -- commented due to hard-crash potential
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
             else
                 skipCount = skipCount + self.ScorchSplatDropTime
             end
@@ -186,15 +188,17 @@ MicrowaveLaserCollisionBeam01 = Class(SCCollisionBeam) { -- used by ML & cyb ACU
         local CurrentPosition = self:GetPosition(1)
         local LastPosition = Vector(0,0,0)
         local skipCount = 1
-        local FriendlyFire = self.DamageData.DamageFriendly
+        -- local FriendlyFire = self.DamageData.DamageFriendly
         
         while true do
             if Util.GetDistanceBetweenTwoVectors( CurrentPosition, LastPosition ) > 0.25 or skipCount > 100 then
                 CreateSplat( CurrentPosition, Util.GetRandomFloat(0,2*math.pi), self.SplatTexture, size, size, 200, 100, army )
                 LastPosition = CurrentPosition
                 skipCount = 1
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+
+                -- commented due to hard-crash potential
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
             else
                 skipCount = skipCount + self.ScorchSplatDropTime
             end
@@ -248,15 +252,17 @@ PhasonLaserCollisionBeam = Class(SCCollisionBeam) { -- used by GC
         local CurrentPosition = self:GetPosition(1)
         local LastPosition = Vector(0,0,0)
         local skipCount = 1
-        local FriendlyFire = self.DamageData.DamageFriendly
+        -- local FriendlyFire = self.DamageData.DamageFriendly
         
         while true do
             if Util.GetDistanceBetweenTwoVectors( CurrentPosition, LastPosition ) > 0.25 or skipCount > 100 then
                 CreateSplat( CurrentPosition, Util.GetRandomFloat(0,2*math.pi), self.SplatTexture, size, size, 200, 100, army )
                 LastPosition = CurrentPosition
                 skipCount = 1
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+
+                -- commented due to hard-crash potential
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
             else
                 skipCount = skipCount + self.ScorchSplatDropTime
             end
@@ -315,15 +321,17 @@ ExperimentalPhasonLaserCollisionBeam = Class(SCCollisionBeam) { -- unknown unit 
         local CurrentPosition = self:GetPosition(1)
         local LastPosition = Vector(0,0,0)
         local skipCount = 1
-        local FriendlyFire = self.DamageData.DamageFriendly
+        -- local FriendlyFire = self.DamageData.DamageFriendly
         
         while true do
             if Util.GetDistanceBetweenTwoVectors( CurrentPosition, LastPosition ) > 0.25 or skipCount > 100 then
                 CreateSplat( CurrentPosition, Util.GetRandomFloat(0,2*math.pi), self.SplatTexture, size, size, 100, 100, army )
                 LastPosition = CurrentPosition
                 skipCount = 1
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+
+                -- commented due to hard-crash potential
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
             else
                 skipCount = skipCount + self.ScorchSplatDropTime
             end
@@ -382,15 +390,17 @@ UnstablePhasonLaserCollisionBeam = Class(SCCollisionBeam) { -- ythota death ener
         local CurrentPosition = self:GetPosition(1)
         local LastPosition = Vector(0,0,0)
         local skipCount = 1
-        local FriendlyFire = self.DamageData.DamageFriendly
+        -- local FriendlyFire = self.DamageData.DamageFriendly
         
         while true do
             if Util.GetDistanceBetweenTwoVectors( CurrentPosition, LastPosition ) > 0.25 or skipCount > 100 then
                 CreateSplat( CurrentPosition, Util.GetRandomFloat(0,2*math.pi), self.SplatTexture, size, size, 250, 100, army )
                 LastPosition = CurrentPosition
                 skipCount = 1
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+
+                -- commented due to hard-crash potential
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
             else
                 skipCount = skipCount + self.ScorchSplatDropTime
             end
@@ -439,15 +449,17 @@ UltraChromaticBeamGeneratorCollisionBeam = Class(SCCollisionBeam) {
         local CurrentPosition = self:GetPosition(1)
         local LastPosition = Vector(0,0,0)
         local skipCount = 1
-        local FriendlyFire = self.DamageData.DamageFriendly
+        -- local FriendlyFire = self.DamageData.DamageFriendly
         
         while true do
             if Util.GetDistanceBetweenTwoVectors( CurrentPosition, LastPosition ) > 0.25 or skipCount > 100 then
                 CreateSplat( CurrentPosition, Util.GetRandomFloat(0,2*math.pi), self.SplatTexture, size, size, 70, 50, army )
                 LastPosition = CurrentPosition
                 skipCount = 1
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+
+                -- commented due to hard-crash potential
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
             else
                 skipCount = skipCount + self.ScorchSplatDropTime
             end
@@ -501,15 +513,17 @@ TDFHiroCollisionBeam = Class(CollisionBeam) { -- used by UEF battlecruser
         local CurrentPosition = self:GetPosition(1)
         local LastPosition = Vector(0,0,0)
         local skipCount = 1
-        local FriendlyFire = self.DamageData.DamageFriendly
+        -- local FriendlyFire = self.DamageData.DamageFriendly
         
         while true do
             if Util.GetDistanceBetweenTwoVectors( CurrentPosition, LastPosition ) > 0.25 or skipCount > 100 then
                 CreateSplat( CurrentPosition, Util.GetRandomFloat(0,2*math.pi), self.SplatTexture, size, size, 100, 70, army )
                 LastPosition = CurrentPosition
                 skipCount = 1
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+
+                -- commented due to hard-crash potential
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
             else
                 skipCount = skipCount + self.ScorchSplatDropTime
             end
@@ -576,15 +590,17 @@ OrbitalDeathLaserCollisionBeam = Class(SCCollisionBeam) { -- used by satellite
         local CurrentPosition = self:GetPosition(1)
         local LastPosition = Vector(0,0,0)
         local skipCount = 1
-        local FriendlyFire = self.DamageData.DamageFriendly
+        -- local FriendlyFire = self.DamageData.DamageFriendly
         
         while true do
             if Util.GetDistanceBetweenTwoVectors( CurrentPosition, LastPosition ) > 0.25 or skipCount > 100 then
                 CreateSplat( CurrentPosition, Util.GetRandomFloat(0,2*math.pi), self.SplatTexture, size, size, 250, 100, army )
                 LastPosition = CurrentPosition
                 skipCount = 1
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
-                DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+
+                -- commented due to hard-crash potential
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
+                -- DamageArea(self, CurrentPosition, size, 1, 'Force', FriendlyFire)
 
             else
                 skipCount = skipCount + self.ScorchSplatDropTime


### PR DESCRIPTION
This PR undo's some work done by #3200. According to KionX [in this topic](https://github.com/FAForever/fa/issues/2045#issuecomment-924858053) the cause of exceptions with the address `0x0050dfd8` originate from this file, in specific the functions that this PR comments out.

The issue with these hard-crashes is that they do happen, but they're hard to reproduce. I have not been able to reliably reproduce them myself as of yet, and therefore I can not test if this will solve the actual problem. 