### PR TITLE
Fix icon loading

### DIFF
--- a/init_faf.lua
+++ b/init_faf.lua
@@ -219,6 +219,9 @@ mount_dir_with_whitelist(InitFileDir .. '\\..\\gamedata\\', '*.nx2', '/')
 -- load in any .nxt that matches the whitelist / blacklist in FA gamedata
 mount_dir_with_whitelist(fa_path .. '\\gamedata\\', '*.scd', '/')
 
+--load preferences into the game as well, letting us have much more control over their contents. This also includes cache and similar.
+mount_dir(SHGetFolderPath('LOCAL_APPDATA') .. 'Gas Powered Games\\Supreme Commander Forged Alliance', '/preferences')
+
 -- TODO: ?
 mount_dir(fa_path, '/')
 

--- a/init_faf.lua
+++ b/init_faf.lua
@@ -128,80 +128,98 @@ local function mount_dir_with_blacklist(dir, glob, mountpoint)
     table.foreach(sorted, function(k,v) mount_dir(v,'/') end)
 end
 
--- Begin map mounting section
--- This section mounts movies and sounds from maps, essential for custom missions and scripted maps
-local function mount_map_dir(dir, glob, mountpoint)
+--- A helper function that loads in additional content for maps.
+-- @param mountpoint The root folder to look for content in.
+local function mount_map_content(dir, glob, mountpoint)
     LOG('mounting maps from: '..dir)
     mount_contents(dir, mountpoint)
-    for _, map in io.dir(dir..glob) do
-        for _, folder in io.dir(dir..'\\'..map..'\\**') do
-            if folder == 'movies' then
-                LOG('Found map movies in: '..map)
-                mount_dir(dir..map..'\\movies', '/movies')
-            elseif folder == 'sounds' then
-                LOG('Found map sounds in: '..map)
-                mount_dir(dir..map..'\\sounds', '/sounds')
-            end
-        end
-    end
-end
 
--- Begin mod mounting section
--- This section mounts sounds and ui textures from the mods directory to allow mods to add custom sounds and textures to the game
-function mount_mod_content(MODFOLDER)
-    -- searching for mods inside the modfolder
-    for _,mod in io.dir(MODFOLDER..'\\*.*') do
-        -- do we have a true directory ?
-        if mod != '.' and mod != '..' then
-            -- searching for sounds inside mod folder
-            for _,folder in io.dir(MODFOLDER..'\\'..mod..'\\*.*') do
-                -- if we found a folder named sounds then mount it
+    -- look for all directories / maps at the mount point
+    for _, map in io.dir(dir..glob) do
+
+        -- make sure we're not retrieving the current / previous directory
+        if map != '.' and map != '..' then
+
+            -- look at each directory inside this map
+            for _, folder in io.dir(dir..'\\'..map..'\\**') do
+
+                -- if we found a directory named 'movies' then we mount its content
+                if folder == 'movies' then
+                    LOG('Found map movies in: '..map)
+                    mount_dir(dir..map..'\\movies', '/movies')
+                end
+
+                -- if we found a directory named 'sounds' then we mount its content
                 if folder == 'sounds' then
-                    LOG('Found mod sounds in: '..mod)
-                    mount_dir(MODFOLDER..'\\'..mod..'\\sounds', '/sounds')
-                -- mount ui textures if there are any
-                elseif folder == 'textures' then
-                    for _,folder in io.dir(MODFOLDER..'\\'..mod..'\\textures\\*.*') do
-                        if folder == 'ui' then
-                          LOG('Found mod icons in: '..mod)
-                          mount_dir(MODFOLDER..'\\'..mod..'\\textures\\ui', '/textures/ui')
-                          break
-                        end
-                    end
+                    LOG('Found map sounds in: '..map)
+                    mount_dir(dir..map..'\\sounds', '/sounds')
                 end
             end
         end
     end
 end
 
--- adds maps / mods to keep track of for the game
-local function load_vault(vault_path)
-	mount_map_dir(vault_path .. '\\maps\\', '**', '/maps')
-	mount_mod_content(vault_path .. '\\mods')
+--- A helper function that loads in additional content for mods.
+-- @param mountpoint The root folder to look for content in.
+function mount_mod_content(mountpoint)
+    -- get all directories / mods at the mount point
+    for _,mod in io.dir(mountpoint..'\\*.*') do
+        
+        -- make sure we're not retrieving the current / previous directory
+        if mod != '.' and mod != '..' then
 
-	mount_contents(vault_path .. '\\mods', '/mods')
-	mount_contents(vault_path .. '\\maps', '/maps')
+            -- look at each directory inside this mod
+            for _, folder in io.dir(mountpoint..'\\'..mod..'\\*.*') do
+                
+                -- if we found a directory named 'sounds' then we mount its content
+                if folder == 'sounds' then
+                    LOG('Found mod sounds in: '..mod)
+                    mount_dir(mountpoint..'\\'..mod..'\\sounds', '/sounds')
+                end
+
+                -- if we found a directory named 'custom-strategic-icons' then we mount its content
+                if folder == 'custom-strategic-icons' then
+                    LOG('Found mod icons in: '..mod)
+                    mount_dir(mountpoint..'\\'..mod..'\\custom-strategic-icons', '/custom-strategic-icons')
+                end
+            end
+        end
+    end
 end
 
--- load in custom vault location first so that it takes precendence
+--- A helper function to load in all maps and mods on a given location.
+-- @param path The root folder for the maps and mods
+local function load_content(path)
+    -- load in additional things, like sounds and 
+	mount_map_content(path .. '\\maps\\', '**', '/maps')
+	mount_mod_content(path .. '\\mods')
+
+	mount_contents(path .. '\\mods', '/mods')
+	mount_contents(path .. '\\maps', '/maps')
+end
+
+-- load maps / mods from custom vault location, if set by client
 if custom_vault_path then
 	LOG('Loading custom vault path' .. custom_vault_path)
-	load_vault(custom_vault_path)
+	load_content(custom_vault_path)
 else
     LOG("No custom vault path defined.")
 end
 
--- load in files from backup vault location
-load_vault(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance')
+-- load maps / mods from backup vault location location
+load_content(InitFileDir .. '\\..\\user\\My Games\\Gas Powered Games\\Supreme Commander Forged Alliance')
 
--- load in files from default vault location
-load_vault(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance')
+-- load maps / mods from my documents vault location
+load_content(SHGetFolderPath('PERSONAL') .. 'My Games\\Gas Powered Games\\Supreme Commander Forged Alliance')
 
+-- load in any .nxt that matches the whitelist / blacklist in FAF gamedata
 mount_dir_with_whitelist(InitFileDir .. '\\..\\gamedata\\', '*.nxt', '/')
 mount_dir_with_whitelist(InitFileDir .. '\\..\\gamedata\\', '*.nx2', '/')
 
--- these are using the newly generated path from the dofile() statement at the beginning of this script
+-- load in any .nxt that matches the whitelist / blacklist in FA gamedata
 mount_dir_with_whitelist(fa_path .. '\\gamedata\\', '*.scd', '/')
+
+-- TODO: ?
 mount_dir(fa_path, '/')
 
 hook = {

--- a/init_faf.lua
+++ b/init_faf.lua
@@ -219,7 +219,8 @@ mount_dir_with_whitelist(InitFileDir .. '\\..\\gamedata\\', '*.nx2', '/')
 -- load in any .nxt that matches the whitelist / blacklist in FA gamedata
 mount_dir_with_whitelist(fa_path .. '\\gamedata\\', '*.scd', '/')
 
---load preferences into the game as well, letting us have much more control over their contents. This also includes cache and similar.
+-- TODO: should we limit this?
+-- load preferences into the game as well, letting us have much more control over their contents. This also includes cache and similar.
 mount_dir(SHGetFolderPath('LOCAL_APPDATA') .. 'Gas Powered Games\\Supreme Commander Forged Alliance', '/preferences')
 
 -- TODO: ?


### PR DESCRIPTION
This branch will try to fix the icon loading procedure that was added during the 3721 patch. It is very broken from many perspectives, including:
 - It loads in textures regardless of whether the mod is active.
 - It loads in _all_ ui textures, regardless of whether they're icons.

These two combined can result in strange behavior, such as inactive mods interfering with the base game. An example as reported by FtGr is the following:
![image](https://user-images.githubusercontent.com/15778155/134799761-9daa0182-322b-4fdb-87e5-008d054b72b2.png)
![image](https://user-images.githubusercontent.com/15778155/134799767-6596f9e8-7919-4355-a0a3-a3ed3dd43d4c.png)

These are probably defined in some mod on his system. They're override the default icons on the UI.