### PR TITLE
Fix potential nil on transfer

### DIFF
--- a/changelog-3724.md
+++ b/changelog-3724.md
@@ -9,11 +9,12 @@ Patch 3721 (19 September, 2021)
 ### Bugs
  - (#3442) Fix scathis packing animation time
  - (#3439) Fix Cybran drone visibility for other players than the owner
- - (#3457) Fix Cybran drone being interactable and other small issues
+ - (#3457) Fix Cybran drone being interactable and other small issues (with thanks to Archsimkat)
 
 ### Stability
  - (#3436) Prevent fetching blueprints for potential entities with no blueprints
  - (#3449) Fix significant hard-crash potential that patch 3721 introduced
+ - (#3460) Fix potential soft-crash when gifting units upon death (with thanks to FemtoZetta)
 
 ### Performances
 
@@ -22,5 +23,5 @@ Patch 3721 (19 September, 2021)
 ### Other
 
 ### Contributors
- - Jip (#3442, #3439, #3449, #3458, #3457)
+ - Jip (#3442, #3439, #3449, #3458, #3457, #3460)
  - Crotalus (#3436)

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -379,16 +379,22 @@ function TransferUnfinishedUnitsAfterDeath(units, armies)
                 failedToTransfer[ID].Orientation = unit:GetOrientation()
 
 
-                for _, reclaim in GetReclaimablesInRect(unit:GetSkirtRect()) do --wrecks can prevent drone from starting construction
-                    if reclaim.IsWreckage then
-                        reclaim:SetCollisionShape('None') --so we set collision shape 'None'
-                        table.insert(modifiedWrecks, reclaim) --and save wrecks to revert our changes later
+                local wrecks = GetReclaimablesInRect(unit:GetSkirtRect())
+                if wrecks then 
+                    for _, reclaim in wrecks do --wrecks can prevent drone from starting construction
+                        if reclaim.IsWreckage then
+                            reclaim:SetCollisionShape('None') --so we set collision shape 'None'
+                            table.insert(modifiedWrecks, reclaim) --and save wrecks to revert our changes later
+                        end
                     end
                 end
 
-                for _,u in GetUnitsInRect(unit:GetSkirtRect()) do --same as for wrecks
-                    u:SetCollisionShape('None')
-                    table.insert(modifiedUnits, u)
+                local units = GetUnitsInRect(unit:GetSkirtRect())
+                if units then 
+                    for _,u in units do --same as for wrecks
+                        u:SetCollisionShape('None')
+                        table.insert(modifiedUnits, u)
+                    end
                 end
 
                 if progress > 0.5 then --if transfer failed, we have to create wreck manually. progress should be more than 50%

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -378,20 +378,23 @@ function TransferUnfinishedUnitsAfterDeath(units, armies)
                 failedToTransfer[ID].DefaultProgress = math.floor(progress * 1000)
                 failedToTransfer[ID].Orientation = unit:GetOrientation()
 
-
-                local wrecks = GetReclaimablesInRect(unit:GetSkirtRect())
+                -- wrecks can prevent drone from starting construction
+                local wrecks = GetReclaimablesInRect(unit:GetSkirtRect()) -- returns nil instead of empty table when empty
                 if wrecks then 
-                    for _, reclaim in wrecks do --wrecks can prevent drone from starting construction
+                    for _, reclaim in wrecks do 
                         if reclaim.IsWreckage then
-                            reclaim:SetCollisionShape('None') --so we set collision shape 'None'
-                            table.insert(modifiedWrecks, reclaim) --and save wrecks to revert our changes later
+                            -- collision shape to none to prevent it from blocking, keep track to revert later
+                            reclaim:SetCollisionShape('None')
+                            table.insert(modifiedWrecks, reclaim)
                         end
                     end
                 end
 
-                local units = GetUnitsInRect(unit:GetSkirtRect())
+                -- units can prevent drone from starting construction
+                local units = GetUnitsInRect(unit:GetSkirtRect()) -- returns nil instead of empty table when empty
                 if units then 
-                    for _,u in units do --same as for wrecks
+                    for _,u in units do
+                        -- collision shape to none to prevent it from blocking, keep track to revert later
                         u:SetCollisionShape('None')
                         table.insert(modifiedUnits, u)
                     end

--- a/units/UEL0401/UEL0401_script.lua
+++ b/units/UEL0401/UEL0401_script.lua
@@ -2,7 +2,7 @@
 -- File     :  /cdimage/units/UEL0401/UEL0401_script.lua
 -- Author(s):  John Comes, David Tomandl, Gordon Duclos
 -- Summary  :  UEF Mobile Factory Script
--- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+-- Copyright Â© 2005 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
 local TMobileFactoryUnit = import('/lua/terranunits.lua').TMobileFactoryUnit

--- a/units/UES0103/UES0103_script.lua
+++ b/units/UES0103/UES0103_script.lua
@@ -5,7 +5,7 @@
 --#**
 --#**  Summary  :  UEF Frigate Script
 --#**
---#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--#**  Copyright ï¿½ 2005 Gas Powered Games, Inc.  All rights reserved.
 --#****************************************************************************
 local TSeaUnit = import('/lua/terranunits.lua').TSeaUnit
 local TAALinkedRailgun = import('/lua/terranweapons.lua').TAALinkedRailgun

--- a/units/UES0103/UES0103_script.lua
+++ b/units/UES0103/UES0103_script.lua
@@ -5,7 +5,7 @@
 --#**
 --#**  Summary  :  UEF Frigate Script
 --#**
---#**  Copyright � 2005 Gas Powered Games, Inc.  All rights reserved.
+--#**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --#****************************************************************************
 local TSeaUnit = import('/lua/terranunits.lua').TSeaUnit
 local TAALinkedRailgun = import('/lua/terranweapons.lua').TAALinkedRailgun


### PR DESCRIPTION
Both `GetReclaimablesInRect` and `GetUnitsInRect` return nil if nothing is found, instead of an empty table. This can happen, as it did during [this replay](https://replay.faforever.com/15419462) at around 35:00 to LilMiss.

![image](https://user-images.githubusercontent.com/15778155/135523526-7f5b1540-be14-409b-ac53-1ae83036847e.png)
