### PR TITLE
Revert the changes made to how game results are send

### DIFF
--- a/changelog-3724.md
+++ b/changelog-3724.md
@@ -1,8 +1,5 @@
-Patch 3721 (19 September, 2021)
+Patch 3724 (04th October, 2021)
 ============================
-
-### Lobby
-
 ### Gameplay
  - (#3450) An alternative approach to loading in custom strategic icons
  - (#3458) Fix UEF Triad and UEF Destroyer projectile on impact animation
@@ -12,22 +9,22 @@ Patch 3721 (19 September, 2021)
  - (#3439) Fix Cybran drone visibility for other players than the owner
  - (#3450) Fix UI textures being overridden by mods that are not enabled
  - (#3457) Fix Cybran drone being interactable and other small issues (with thanks to Archsimkat)
- - (#3453) Fix units being gifted to the same player causing a crash for the shared army mod (co-op campaign)
+ - (#3453) Fix units being gifted to the same player causing a soft-crash for the shared army mod (co-op campaign)
+ - (#3468) Revert changes to sending the results of games
 
 ### Stability
  - (#3436) Prevent fetching blueprints for potential entities with no blueprints
  - (#3449) Fix significant hard-crash potential that patch 3721 introduced
  - (#3460) Fix potential soft-crash when gifting units upon death (with thanks to FemtoZetta)
 
-### Performances
-
-### AI
-
 ### Other
+ - (#3385) Add support for custom game options being set by the server (for 3v3 / 4v4 TMM)
 
 ### Contributors
- - Jip (#3442, #3439, #3449, #3458, #3457, #3460, #3450)
+ - Jip (#3442, #3439, #3449, #3458, #3457, #3460, #3450, #3468)
  - KionX (#3449)
  - Crotalus (#3436)
  - Balthazar (#3450)
  - speed2 (#3453)
+ - Askaholic (#3385)
+ - BlackYps (#3385)

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -1,3 +1,4 @@
+
 -- The global sync table is copied from the sim layer every time the main and sim threads are
 -- synchronized on the sim beat (which is like a tick but happens even when the game is paused)
 Sync = {}


### PR DESCRIPTION
And here we are - this PR is a direct result of https://github.com/FAForever/fa/pull/3275 where changes were made to how games are reported to the server. And it intents to close https://github.com/FAForever/fa/issues/3459 .

Before that there were several PRs that changed the reporting (#3032, #3115, #3152, #3166) as a result of a [discussion on Zulip](https://faforever.zulipchat.com/#narrow/stream/203478-general/topic/DrawBug) and those got into the previous patch (https://github.com/FAForever/fa/releases/tag/3715) and that was considered stable with the exception of one particular draw bug.

I've been trying to re-produce the errors that people [have been reporting](https://forum.faforever.com/topic/2656/game-was-not-reted-reason-unknow-result) [on the forums](https://forum.faforever.com/topic/2596/rating-system-is-not-rating-certain-games-although-it-should/20) and sadly, out of maybe 30 local tests I've been able to re-produce it once and I'm not even certain anymore if I wasn't dreaming.

Therefore I'm reverting the only changes that were made to how the score was send over - hoping that we get back to the same state as before.