### PR TITLE
Fix overcharge indicator and add shared code

### DIFF
--- a/changelog-3724.md
+++ b/changelog-3724.md
@@ -11,6 +11,7 @@ Patch 3724 (04th October, 2021)
  - (#3457) Fix Cybran drone being interactable and other small issues (with thanks to Archsimkat)
  - (#3453) Fix units being gifted to the same player causing a soft-crash for the shared army mod (co-op campaign)
  - (#3468) Revert changes to sending the results of games
+ - (#3471) Fix overcharge mouse indicator to use the right damage calculations
 
 ### Stability
  - (#3436) Prevent fetching blueprints for potential entities with no blueprints
@@ -22,7 +23,7 @@ Patch 3724 (04th October, 2021)
  - (#3385) Add support for custom game options being set by the server (for 3v3 / 4v4 TMM)
 
 ### Contributors
- - Jip (#3442, #3439, #3449, #3458, #3457, #3460, #3450, #3467, #3468)
+ - Jip (#3442, #3439, #3449, #3458, #3457, #3460, #3450, #3467, #3468, #3471)
  - KionX (#3449)
  - Crotalus (#3436)
  - Balthazar (#3450)

--- a/lua/shared/overcharge.lua
+++ b/lua/shared/overcharge.lua
@@ -1,4 +1,8 @@
 
+-- All functions in this file (inside /lua/shared) should be:
+-- - pure: they should only use the arguments provided, do not touch any global state.
+-- - sim / ui proof: they should work for both sim code and ui code.
+
 --- Formula to compute the damage of an overcharge.
 EnergyAsDamage = function(energy)
     return 0.25 * energy

--- a/lua/shared/overcharge.lua
+++ b/lua/shared/overcharge.lua
@@ -1,0 +1,10 @@
+
+--- Formula to compute the damage of an overcharge.
+EnergyAsDamage = function(energy)
+    return 0.25 * energy
+end
+
+--- Formula to compute the energy drain of an overcharge.
+DamageAsEnergy = function(damage)
+    return 4 * damage
+end

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -442,7 +442,7 @@ OverchargeProjectile = Class() {
                     energyLimit = energyLimit / OCProjectiles[self.Army]
                 end
 
-                local energyLimitDamage = OverchargeShared.EnergyAsDamage(energyLimit)
+                local energyLimitDamage = self:EnergyAsDamage(energyLimit)
 
                 -- Find max available damage
                 damage = math.min(data.maxDamage, energyLimitDamage)
@@ -482,7 +482,7 @@ OverchargeProjectile = Class() {
         end
 
         -- Turn the final damage into energy
-        local drain = OverchargeShared.DamageAsEnergy(damage)
+        local drain = self:DamageAsEnergy(damage)
 
         --LOG('Drain is ' .. drain)
         --LOG('Damage is ' .. damage)
@@ -504,15 +504,12 @@ OverchargeProjectile = Class() {
         end
     end,
 
-    -- y = 3000e^(0.000095(x+15500))-10090 = old values
-    -- y = 4x = new values
-    -- https://www.desmos.com/calculator/ap0kazbdp0
     DamageAsEnergy = function(self, damage)
-        return damage * 4
+        return OverchargeShared.DamageAsEnergy(damage)
     end,
 
     EnergyAsDamage = function(self, energy)
-        return energy / 4
+        return OverchargeShared.EnergyAsDamage(energy)
     end,
 
     UnitsDetection = function(self, targetType, targetEntity)

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -9,6 +9,10 @@ local DummyProjectile = import('/lua/sim/Projectile.lua').DummyProjectile
 local UnitsInSphere = import('/lua/utilities.lua').GetTrueEnemyUnitsInSphere
 local GetDistanceBetweenTwoEntities = import('/lua/utilities.lua').GetDistanceBetweenTwoEntities
 local OCProjectiles = {}
+
+-- shared between sim and ui
+local OverchargeShared = import('/lua/shared/overcharge.lua')
+
 -----------------------------------------------------------------
 -- Null Shell
 -----------------------------------------------------------------
@@ -438,7 +442,7 @@ OverchargeProjectile = Class() {
                     energyLimit = energyLimit / OCProjectiles[self.Army]
                 end
 
-                local energyLimitDamage = self:EnergyAsDamage(energyLimit)
+                local energyLimitDamage = OverchargeShared.EnergyAsDamage(energyLimit)
 
                 -- Find max available damage
                 damage = math.min(data.maxDamage, energyLimitDamage)
@@ -478,7 +482,7 @@ OverchargeProjectile = Class() {
         end
 
         -- Turn the final damage into energy
-        local drain = self:DamageAsEnergy(damage)
+        local drain = OverchargeShared.DamageAsEnergy(damage)
 
         --LOG('Drain is ' .. drain)
         --LOG('Damage is ' .. damage)

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -27,6 +27,9 @@ local updateThread = nil
 local unitHP = {}
 controls = import('/lua/ui/controls.lua').Get()
 
+-- shared between sim and ui
+local OverchargeShared = import('/lua/shared/overcharge.lua')
+
 function OverchargeCanKill()
     if unitHP[1] and unitHP.blueprintId then
         local selected = GetSelectedUnits()
@@ -53,8 +56,7 @@ function OverchargeCanKill()
 
             if bp then
                 local targetCategories = __blueprints[unitHP.blueprintId].CategoriesHash
-                -- this one is from DefaultProjectiles.lua OverchargeProjectile EnergyAsDamage()
-                local damage = (math.log((GetEconomyTotals().stored.ENERGY * bp.energyMult + 9700) / 3000) / 0.000095) - 15500
+                local damage = OverchargeShared.EnergyAsDamage(GetEconomyTotals().stored.ENERGY)
 
                 if damage > bp.maxDamage then
                     damage = bp.maxDamage


### PR DESCRIPTION
The latter is to fix issues like the former in the future. The original authors copied the code over, and then when the change was made the coupling was not clear and therefore it got left with the old damage calculations.