### PR TITLE
UnitBeingBuilt is only SET by defaultunits.lua

### DIFF
--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -216,7 +216,6 @@ Platoon = Class(moho.platoon_methods) {
             v.AssistSet = nil
             v.AssistPlatoon = nil
             v.UnitBeingAssist = nil
-            v.UnitBeingBuilt = nil
             v.ReclaimInProgress = nil
             v.CaptureInProgress = nil
             if v:IsPaused() then


### PR DESCRIPTION
UnitBeingBuilt is only SET by defaultunits.lua - OnStartBuild() and OnStopBuild()
All other files only READ from this value.

So setting it in AI function is the wrong place.

I can remember to put this line in there for debug reasons.
We don't need it any more :)