### PR TITLE
Fix the T1 Aeon Bomber Stun range

### DIFF
--- a/units/UAA0103/UAA0103_unit.bp
+++ b/units/UAA0103/UAA0103_unit.bp
@@ -284,7 +284,7 @@ UnitBlueprint {
                     AppliedToTarget = true,
                     BuffType = 'STUN',
                     Duration = 1.5,
-                    Radius = 4.55, -- this is the closest approximation in order to make the stun range the same as the DamageRadius (4)
+                    Radius = 4.55, -- this is the closest approximation in order to make the stun range the same as DamageRadius (4)
                     TargetAllow = 'ALLUNITS',
                     TargetDisallow = 'TECH3,EXPERIMENTAL,COMMAND,WALL',
                 },


### PR DESCRIPTION
This is the closest approximation in order to make the stun range the same as DamageRadius (4).