### PR TITLE
Fix attack animation of the Monkey Lord

### DIFF
--- a/lua/cybranweapons.lua
+++ b/lua/cybranweapons.lua
@@ -81,7 +81,7 @@ CDFHeavyMicrowaveLaserGenerator = Class(DefaultBeamWeapon) {
         end
 
         -- set their respective properties when firing
-        self.RotatorManip:SetTargetSpeed(400)
+        self.RotatorManip:SetTargetSpeed(500)
         self.RotatorManip:SetAccel(200)
 
         DefaultBeamWeapon.PlayFxBeamStart(self, muzzle)


### PR DESCRIPTION
The rotation of the laser weapon stutters when firing. It stops stuttering when the Monkey Lord stops firing. Apparently a slider doesn't work well with other sources of animation - its effect was minor (pushing back the gun very slightly) and removing it made the attack animation smooth again.

