### PR TITLE
Loya add stun to the slow firing weapon 

### DIFF
--- a/units/URL0303/URL0303_unit.bp
+++ b/units/URL0303/URL0303_unit.bp
@@ -281,7 +281,7 @@ UnitBlueprint {
                     },
                     AppliedToTarget = true,
                     BuffType = 'STUN',
-                    Duration = 1,
+                    Duration = 1.5,
                     Radius = 0,
                     TargetAllow = 'TECH1,TECH2',
                     TargetDisallow = 'TECH3,EXPERIMENTAL,COMMAND,NAVAL,STRUCTURE',


### PR DESCRIPTION
Stuns up to t2, ignoring structures and navy. Allows to deal better with t2 which is the main threat during early t3 stage
