### PR TITLE
Fixes ai detection and threat addition

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1545,52 +1545,7 @@ MobileUnit = Class(Unit) {
     end,
 
     OnKilled = function(self, instigator, type, overkillRatio)
-
-        -- only assign threat values when we have AIs that will make use of them.
-        if GameHasAIs then 
-            -- Add unit's threat to our influence map
-            local threat = 5
-            local decay = 0.1
-            local currentLayer = self.Layer
-            if instigator then
-                local unit = false
-                if IsUnit(instigator) then
-                    unit = instigator
-                elseif IsProjectile(instigator) or IsCollisionBeam(instigator) then
-                    unit = instigator.unit
-                end
-
-                if unit then
-                    local unitPos = unit:GetCachePosition()
-                    if EntityCategoryContains(categories.STRUCTURE, unit) then
-                        decay = 0.01
-                    end
-
-                    if unitPos then
-                        if currentLayer == 'Sub' then
-                            threat = self:GetAIBrain():GetThreatAtPosition(unitPos, 0, true, 'AntiSub')
-                        elseif currentLayer == 'Air' then
-                            threat = self:GetAIBrain():GetThreatAtPosition(unitPos, 0, true, 'AntiAir')
-                        else
-                            threat = self:GetAIBrain():GetThreatAtPosition(unitPos, 0, true, 'AntiSurface')
-                        end
-                        threat = threat / 2
-                    end
-                end
-            end
-
-            if currentLayer == 'Sub' then
-                self:GetAIBrain():AssignThreatAtPosition(self:GetPosition(), threat, decay * 10, 'AntiSub')
-            elseif currentLayer == 'Air' then
-                self:GetAIBrain():AssignThreatAtPosition(self:GetPosition(), threat, decay, 'AntiAir')
-            elseif currentLayer == 'Water' then
-                self:GetAIBrain():AssignThreatAtPosition(self:GetPosition(), threat, decay * 10, 'AntiSurface')
-            else
-                self:GetAIBrain():AssignThreatAtPosition(self:GetPosition(), threat, decay, 'AntiSurface')
-            end
-        end
-
-        -- This unit was in a transport
+        -- This unit was in a transport and should create a wreck on crash
         if self.killedInTransport then
             self.killedInTransport = false
         else

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -74,8 +74,13 @@ function SetupSession()
 
     ArmyBrains = {}
 
-    -- assume we have no AIs in the game
-    ScenarioInfo.GameHasAIs = false
+    -- if the AI replacement is on then there may be AIs, otherwise we check each brain
+    if ScenarioInfo.Options.AIReplacement == 'On' then 
+        ScenarioInfo.GameHasAIs = true 
+        SPEW("Game has AI replacement option enabled")
+    else 
+        ScenarioInfo.GameHasAIs = false 
+    end
 
     -- ScenarioInfo is a table filled in by the engine with fields from the _scenario.lua
     -- file we're using for this game. We use it to store additional global information
@@ -212,9 +217,13 @@ function OnCreateArmyBrain(index, brain, name, nickname)
         AddBuildRestriction(index, ScenarioInfo.BuildRestrictions)
     end
 
-    -- check if this brain is an AI, if so - then we can't skip some functionality!
-    if brain.Type == 'AI' then 
-        ScenarioInfo.GameHasAIs = true 
+    -- check if this brain is an active AI by checking its type and whether 
+    -- skirmish systems are setup (prevents detecting NEUTRAL_CIVILIAN or ARMY_17)
+    local brainType = brain.BrainType 
+    local brainSkirmishSystems = brain.SkirmishSystems 
+    if brainType == 'AI' and brainSkirmishSystems then 
+        ScenarioInfo.GameHasAIs = true
+        SPEW("Game has AIs in it: " .. brain.Name) 
     end
 end
 
@@ -226,7 +235,6 @@ end
 -- any units yet) and we're ready to start the game. It's responsible for setting up
 -- the initial units and any other gameplay state we need.
 function BeginSession()
-    LOG('BeginSession...')
     SPEW('Active mods in sim: ', repr(__active_mods))
 
     GameOverListeners = {}

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -236,7 +236,7 @@ function OnCreateArmyBrain(index, brain, name, nickname)
     local brainSkirmishSystems = brain.SkirmishSystems 
     if brainType == 'AI' and brainSkirmishSystems then 
         ScenarioInfo.GameHasAIs = true
-        SPEW("Game has AIs in it: " .. brain.Name) 
+        SPEW("Detected an AI with skirmish systems: " .. brain.Name .. ", enabling AI functionality") 
     end
 end
 

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -70,18 +70,31 @@ end
 --but before any armies are created.
 function SetupSession()
 
+    -- assume there are no AIs
+    ScenarioInfo.GameHasAIs = false
+
+    -- if the AI replacement is on then there may be AIs
+    if ScenarioInfo.Options.AIReplacement == 'On' then 
+        ScenarioInfo.GameHasAIs = true 
+        SPEW("Detected ai replacement option being enabled: enabling AI functionality")
+    end
+
+    -- if we're doing a campaign / special map then there may be AIs
+    if ScenarioInfo.type ~= 'skirmish' then 
+        ScenarioInfo.GameHasAIs = true 
+        SPEW("Detected a non-skirmish type map: enabling AI functionality")
+    end
+
+    -- if the map maker explicitly tells us
+    if ScenarioInfo.requiresAiFunctionality then 
+        ScenarioInfo.GameHasAIs = true 
+        SPEW("Detected the 'requiresAiFunctionality' field set by the map: enabling AI functionality")
+    end
+
     -- LOG('SetupSession: ', repr(ScenarioInfo))
 
     ArmyBrains = {}
-
-    -- if the AI replacement is on then there may be AIs, otherwise we check each brain
-    if ScenarioInfo.Options.AIReplacement == 'On' then 
-        ScenarioInfo.GameHasAIs = true 
-        SPEW("Game has AI replacement option enabled")
-    else 
-        ScenarioInfo.GameHasAIs = false 
-    end
-
+    
     -- ScenarioInfo is a table filled in by the engine with fields from the _scenario.lua
     -- file we're using for this game. We use it to store additional global information
     -- needed by our scenario.


### PR DESCRIPTION
This closes https://github.com/FAForever/fa/issues/3508 and removes threat additions when a mobile unit dies. This has been discussed with the AI devs and they are in favor.

 - [x] Toggle 'GameHasAIs' when we're in a campaign-like mission
 - [x] Allow a map to toggle 'GameHasAIs' to turn on functionality