### PR TITLE
Fix the seraphim quantum gate skirts

### DIFF
--- a/units/XSB0304/XSB0304_unit.bp
+++ b/units/XSB0304/XSB0304_unit.bp
@@ -259,19 +259,24 @@ UnitBlueprint {
         MotionType = 'RULEUMT_None',
         OccupyRects = {
             -- offsetX offsetZ  sizeX sizeZ, offset from center of unit
+            -3.0,
+            1.5,
+            1,
+            1.0,
+
+            2.5,
+            1.5,
+            1,
+            1.0,
+
+            -0.0,
             -3.5,
-            0.9,
+            1.5,
             0.5,
-            2,
 
-            3,
-            0.9,
+            -0.25,
+            -2.5,
             0.5,
-            2,
-
-            -1.5,
-            -3,
-            3,
             0.5,
         },
         RaisedPlatforms = {


### PR DESCRIPTION
Closes #3514 .

![image](https://user-images.githubusercontent.com/15778155/140639587-a6bc0bd3-6398-42c6-a2d4-543e4b5f444c.png)

![image](https://user-images.githubusercontent.com/15778155/140639622-a94a6dfd-01a0-4ec4-a45b-bbe0c6edaff5.png)

Idea was to consider the 'hover pads' (Halo - thanks) as unpathable.