### PR TITLE
Remove curated maps button

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3087,13 +3087,15 @@ function CreateUI(maxPlayers)
     end
 
     -- curated Maps
-    GUI.curatedmapsButton = UIUtil.CreateButtonWithDropshadow(GUI.panel, '/Button/medium/', "<LOC lobui_0433>Curated Maps")
-    Tooltip.AddButtonTooltip(GUI.curatedmapsButton, 'lob_curated_maps')
-    LayoutHelpers.AtBottomIn(GUI.curatedmapsButton, GUI.optionsPanel, -51)
-    LayoutHelpers.AtHorizontalCenterIn(GUI.curatedmapsButton, GUI.optionsPanel, -55)
-    GUI.curatedmapsButton.OnClick = function()
-        OpenURL('http://forum.faforever.com/topic/347')
-    end
+    -- GUI.curatedmapsButton = UIUtil.CreateButtonWithDropshadow(GUI.panel, '/Button/medium/', "<LOC lobui_0433>Curated Maps")
+    -- Tooltip.AddButtonTooltip(GUI.curatedmapsButton, 'lob_curated_maps')
+    -- LayoutHelpers.AtBottomIn(GUI.curatedmapsButton, GUI.optionsPanel, -51)
+    -- LayoutHelpers.AtHorizontalCenterIn(GUI.curatedmapsButton, GUI.optionsPanel, -55)
+    -- GUI.curatedmapsButton.OnClick = function()
+    --     OpenURL('http://forum.faforever.com/topic/347')
+    -- end
+
+    -- GUI.curatedmapsButton:Disable()
 
     -- A buton that, for the host, is "game options", but for everyone else shows a ready-only mod
     -- manager.


### PR DESCRIPTION
Closes https://github.com/FAForever/fa/issues/3474.

The curator map button is removed until an alternative is available on the new wiki.