### PR TITLE
Integrate nvidia fix

### DIFF
--- a/init_faf.lua
+++ b/init_faf.lua
@@ -55,6 +55,7 @@ end
 
 -- mods that have been integrated, based on folder name 
 local integratedMods = { }
+integratedMods["nvidia fix"] = true
 integratedMods = LowerHashTable(integratedMods)
 
 -- typical FA packages

--- a/init_fafbeta.lua
+++ b/init_fafbeta.lua
@@ -55,6 +55,7 @@ end
 
 -- mods that have been integrated, based on folder name 
 local integratedMods = { }
+integratedMods["nvidia fix"] = true
 integratedMods = LowerHashTable(integratedMods)
 
 -- typical FA packages

--- a/init_fafdevelop.lua
+++ b/init_fafdevelop.lua
@@ -55,6 +55,7 @@ end
 
 -- mods that have been integrated, based on folder name 
 local integratedMods = { }
+integratedMods["nvidia fix"] = true
 integratedMods = LowerHashTable(integratedMods)
 
 -- typical FA packages

--- a/init_shared.lua
+++ b/init_shared.lua
@@ -55,6 +55,7 @@ end
 
 -- mods that have been integrated, based on folder name 
 local integratedMods = { }
+integratedMods["nvidia fix"] = true
 integratedMods = LowerHashTable(integratedMods)
 
 -- typical FA packages

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -137,6 +137,9 @@ end
 
 function CreateUI(isReplay)
 
+    -- prevents the nvidia stuttering bug with their more recent drivers
+    ConExecute('d3d_WindowsCursor on')  
+
     -- keep track of the original focus army
     import("/lua/ui/game/ping.lua").OriginalFocusArmy = GetFocusArmy()
 


### PR DESCRIPTION
The nvidia fix mod as found in the vault will be applied by default. It prevents stuttering with the recent drivers of Nvidia.