### PR TITLE
Add an 80% option for low resolution screens

### DIFF
--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -305,6 +305,7 @@ options = {
                 default = 1.0,
                 custom = {
                     states = {
+                        {text = "80%", key = 0.8,},
                         {text = "100%", key = 1.0,},
                         {text = "125%", key = 1.25,},
                         {text = "150%", key = 1.5,},


### PR DESCRIPTION
Adds an additional option to UI scaling for monitors with very low resolutions. Otherwise just the scoreboard may take up half of the screen.