### PR TITLE
Add lazy var evaluation for reclaim labels

### DIFF
--- a/lua/lazyvar.lua
+++ b/lua/lazyvar.lua
@@ -1,0 +1,115 @@
+--
+-- LazyVar module
+--
+
+
+local EvalContext = nil
+
+local LazyVarMetaTable = { }
+
+LazyVarMetaTable.__index = LazyVarMetaTable
+
+local WeakKeyMeta = { __mode = 'k' }
+
+-- Set this true to get tracebacks in error messages. It slows down lazyvars a lot,
+-- so don't use except when debugging.
+ExtendedErrorMessages = false
+
+function LazyVarMetaTable:__call()
+    if not self[1] then
+        if self.busy then
+            error("circular dependency in lazy evaluation for variable " .. (self.trace or ''), 2)
+        end
+        self.busy = true
+        local u
+        for u in self.uses do
+            u.used_by[self] = nil
+        end
+        self.uses = {}
+        local oldContext = EvalContext
+        EvalContext = self
+        local okay, value = pcall(self.compute)
+        EvalContext = oldContext
+        self.busy = nil
+        if okay then
+            self[1] = value
+        else
+            error("error evaluating lazy variable: " .. value .. "\nStack trace from definition: " .. (self.trace or '') .. '\n', 2)
+        end
+    end
+    if EvalContext then
+        EvalContext.uses[self] = true
+        self.used_by[EvalContext] = true
+    end
+    return self[1]
+end
+
+function LazyVarMetaTable:SetDirty(onDirtyList)
+    if self[1] then
+        if self.OnDirty then
+            table.insert(onDirtyList, self)
+        end
+        self[1] = nil
+        local u for u in self.used_by do 
+            u:SetDirty(onDirtyList)
+        end
+    end
+end 
+
+function LazyVarMetaTable:SetFunction(func)
+    local dirtyList = {}
+    self:SetDirty(dirtyList)
+    self.compute = func
+    if ExtendedErrorMessages then
+        self.trace = debug.traceback('set from:')
+    else
+        self.trace = '[Set lazyvar.ExtendedErrorMessages for extra trace info]'
+    end
+
+    for i,v in ipairs(dirtyList) do
+        v:OnDirty()
+    end
+end
+
+function LazyVarMetaTable:SetValue(value)
+    local dirtyList = {}
+    self:SetDirty(dirtyList)
+    self.compute = nil
+    self.trace = nil
+    self[1] = value
+    -- Now remove us from the used_by lists for any lazy vars we used to use.
+    for u in self.uses do
+        u.used_by[self] = nil
+    end
+    self.uses = {}
+    for i,v in ipairs(dirtyList) do
+        v:OnDirty()
+    end
+end
+
+function LazyVarMetaTable:Set(v)
+    if v == nil then
+        error("You are attempting to set a LazyVar's evaluation function to nil, don't do that!")    
+    end
+    if iscallable(v) then
+        self:SetFunction(v)
+    else
+        self:SetValue(v)
+    end
+end
+
+function LazyVarMetaTable:Destroy()
+    self.OnDirty = nil
+    self.compute = nil
+    self.value = nil
+end
+
+function Create(initial)
+    result = {&1&4}
+    setmetatable(result, LazyVarMetaTable)
+    result[1] = initial or 0
+    result.used_by = {}
+    setmetatable(result.used_by, WeakKeyMeta)
+    result.uses = {}
+    return result
+end

--- a/lua/lazyvar.lua
+++ b/lua/lazyvar.lua
@@ -13,7 +13,7 @@ local WeakKeyMeta = { __mode = 'k' }
 
 -- Set this true to get tracebacks in error messages. It slows down lazyvars a lot,
 -- so don't use except when debugging.
-ExtendedErrorMessages = false
+local ExtendedErrorMessages = false
 
 function LazyVarMetaTable:__call()
     if not self[1] then

--- a/lua/ui/game/reclaim.lua
+++ b/lua/ui/game/reclaim.lua
@@ -139,6 +139,8 @@ local RootLabel = Class(Group) {
 
         if update then 
 
+            -- LOG("update")
+
             -- keep track of current zoom / position
             self.OldCameraZoom = zoom 
             self.OldCameraPosition = position
@@ -147,34 +149,73 @@ local RootLabel = Class(Group) {
             local pixelFactor = LayoutHelpers.GetPixelScaleFactor()
 
             -- for each displayed label: project and position it
+            local view = self.View
+            -- local width = view:Width()
+            -- local height = view:Height()
+
+            local project = self.View.Project 
+            local label, projected, px, py
+            local left, top, width, height
+            local element
+
+            -- local DummyVector2 = Vector2(0, 0)
+            -- local topLeft, topRight, bottomLeft, bottomRight 
+
+            -- DummyVector2[1] = 0 
+            -- DummyVector2[2] = 0
+            -- topLeft = UnProject(view, DummyVector2)
+
+            -- DummyVector2[1] = width 
+            -- DummyVector2[2] = 0
+            -- topRight = UnProject(view, DummyVector2)
+
+            -- DummyVector2[1] = 0 
+            -- DummyVector2[2] = height
+            -- bottomLeft = UnProject(view, DummyVector2)
+
+            -- DummyVector2[1] = width 
+            -- DummyVector2[2] = height
+            -- bottomRight = UnProject(view, DummyVector2)
+
+            -- LOG("topLeft: " .. repr(topLeft))
+            -- LOG("topRight: " .. repr(topRight))
+            -- LOG("bottomLeft: " .. repr(bottomLeft))
+            -- LOG("bottomRight: " .. repr(bottomRight))
+            -- LOG("GetMouseScreenPos: " .. repr(GetMouseScreenPos()))
+            -- LOG("GetMouseWorldPos: " .. repr(GetMouseWorldPos()))
+
             for k = 1, MaxLabels do 
-                local label = LabelPool[k]
+                label = LabelPool[k]
                 if label and label.Displayed then 
-                    local projected = self.View:Project(label.Position)
 
-                    if k == 1 then 
-                        label.mass.Left.Debug = true 
-                    end
+                    -- determine projected position: this introduces a ton of small blocks!
+                    projected = project(view, label.Position)
+                    px = projected[1]
+                    py = projected[2]
 
-                    local left = pixelFactor * (projected.x - 12)
-                    local top = pixelFactor * (projected.y - 13)
-                    local width = pixelFactor * 14 
-                    local height = pixelFactor * 14 
+                    -- determine position and size of bitmap
+                    left = pixelFactor * (px - 12)
+                    top = pixelFactor * (py - 13)
+                    width = pixelFactor * 14 
+                    height = pixelFactor * 14 
 
-                    label.mass.Left:SetValue(left)
-                    label.mass.Top:SetValue(top)
-                    label.mass.Right:SetValue(left + width)
-                    label.mass.Bottom:SetValue(top + height)
+                    element = label.mass
+                    element.Left[1] = (left)
+                    element.Top[1] = (top)
+                    element.Right[1] = (left + width)
+                    element.Bottom[1] = (top + height)
 
-                    local left = pixelFactor * (projected.x + 4)
-                    local top = pixelFactor * (projected.y - 13)
-                    local width = pixelFactor * 25 
-                    local height = pixelFactor * 25 
+                    -- determine position and size of text
+                    left = pixelFactor * (px + 4)
+                    top = pixelFactor * (py - 13)
+                    width = pixelFactor * 25 
+                    height = pixelFactor * 25 
 
-                    label.text.Left:SetValue(left)
-                    label.text.Top:SetValue(top)
-                    label.text.Right:SetValue(left + width)
-                    label.text.Bottom:SetValue(top + height)
+                    element = label.text
+                    element.Left[1] = (left)
+                    element.Top[1] = (top)
+                    element.Right[1] = (left + width)
+                    element.Bottom[1] = (top + height)
                 end
             end
         end
@@ -189,6 +230,8 @@ local Label = Class(Group) {
         -- default values
         self.Top:SetValue(0)
         self.Left:SetValue(0)
+        self.Right:SetValue(25)
+        self.Bottom:SetValue(25)
         self.Width:SetValue(25)
         self.Height:SetValue(25)
     end,
@@ -207,6 +250,7 @@ function CreateReclaimLabel(root)
     label.mass:SetTexture(UIUtil.UIFile('/game/build-ui/icon-mass_bmp.dds'))
     label.mass.Left:SetValue(0)
     label.mass.Top:SetValue(0)
+
     label.mass.Width:SetValue(pixelScaleFactor * 14)
     label.mass.Height:SetValue(pixelScaleFactor * 14)
 


### PR DESCRIPTION
This is an experimental branch with regard to reclaim labels - it will be embedded into #3534 .

I noticed that these labels were not using lazy evaluation, and instead re-creating functions and closures each frame to update their positions. On this branch they use lazy evaluation. This works like a charm because now the labels are only updated during movement and not during each individual frame. This has a significant performance boost: just rendering the 1000 labels is not an issue. But, updating them (even through lazy evaluation) the memory usage just spikes (~10 mb per second) and then it stutters because the garbage collector kicks in. 

@Crotalus You mentioned using lazy evaluation as a way to speed up the performance of the UI. Do you have any idea what causes the massive memory usage?

Steps to reproduce:
 - Turn on `ShowStats` in the console
 - Open up `Heap` and `Frame` 
 - Start the map `Forest Nothing`
 - Zoom out after starting, then press CTRL + SHIFT to show reclaim
 - Watch framerate drop when moving, but stable when not moving and check logs to see how often things are updated

I have no idea where the memory is being used for. At least when merging with the other PR the performance will be steady when the camera is not moving at all.

And another question: how does the lazy evaluation work internally? I found the file in the base game, but it isn't quite as informative.