### PR TITLE
Do not apply buffs to insignificant units

### DIFF
--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -29,7 +29,14 @@
 --Function to apply a buff to a unit.
 --This function is a fire-and-forget.  Apply this and it'll be applied over time if there is a duration.
 function ApplyBuff(unit, buffName, instigator)
+
+    -- do not buff dead units
     if unit.Dead then
+        return
+    end
+
+    -- do not buff insignificant / dummy units
+    if EntityCategoryContains(categories.INSIGNIFICANTUNIT, unit) then 
         return
     end
 


### PR DESCRIPTION
Closes https://github.com/FAForever/fa/issues/3429 where buffs were applied to the drones whom do not have a buff table anymore. As they are insignificant they shouldn't be able to take on buffs anyhow.