### PR TITLE
adjust beetle trigger radius

### DIFF
--- a/units/XRL0302/XRL0302_unit.bp
+++ b/units/XRL0302/XRL0302_unit.bp
@@ -229,7 +229,7 @@ UnitBlueprint {
             },
             FiringTolerance = 180,
             Label = 'Suicide',
-            MaxRadius = 2,
+            MaxRadius = 3,
             TargetCheckInterval = 999999,
             TargetPriorities = {
                 'MOBILE',
@@ -260,7 +260,7 @@ UnitBlueprint {
             FiringTolerance = 2,
             IgnoreIfDisabled = true,
             Label = 'DeathWeapon',
-            MaxRadius = 2,
+            MaxRadius = 3,
             MuzzleVelocity = 0,
             ProjectileId = '/projectiles/CIFEMP01/CIFEMP01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.15,


### PR DESCRIPTION
low trigger radius resurfaces the issue of https://github.com/FAForever/fa/issues/109

Adjust it to be slightly bigger, the only problematic unit I found with this radius is fatboy, which is a lesser evil than having bad behavior vs every other unit