### PR TITLE
Force shader compilation on development branches

### DIFF
--- a/init_fafbeta.lua
+++ b/init_fafbeta.lua
@@ -408,6 +408,12 @@ end
 
 -- END OF COPY --
 
+-- Clears out the shader cache as it takes a release to reset the shaders
+local shaderCache = SHGetFolderPath('LOCAL_APPDATA') .. 'Gas Powered Games/Supreme Commander Forged Alliance/cache'
+for k, file in IoDir(shaderCache .. '/*') do
+    os.remove(shaderCache .. '/' .. file)
+end
+
 -- typical FAF packages
 local allowedAssetsNxy = { }
 allowedAssetsNxy["effects.nx4"] = true

--- a/init_fafdevelop.lua
+++ b/init_fafdevelop.lua
@@ -408,6 +408,12 @@ end
 
 -- END OF COPY --
 
+-- Clears out the shader cache as it takes a release to reset the shaders
+local shaderCache = SHGetFolderPath('LOCAL_APPDATA') .. 'Gas Powered Games/Supreme Commander Forged Alliance/cache'
+for k, file in IoDir(shaderCache .. '/*') do
+    os.remove(shaderCache .. '/' .. file)
+end
+
 -- typical FAF packages
 local allowedAssetsNxy = { }
 allowedAssetsNxy["effects.nx5"] = true


### PR DESCRIPTION
Shader compilation is forced upon release, but not between development iterations. When hosting on a development branch (FAFBeta or FAFDevelop) then the shader cache is removed to force shader compilation. This prevents missing techniques when a shader has been updated.