### PR TITLE
Fix backwards compatibility of blueprints.lua

### DIFF
--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -397,10 +397,12 @@ function ExtractBuildMeshBlueprint(bp)
     local FactionName = bp.General.FactionName
     local isSubCommander = false 
 
-    for k, v in bp.Categories do 
-        if v == 'SUBCOMMANDER' then 
-            isSubCommander = true 
-            break 
+    if bp.Categories then 
+        for k, v in bp.Categories do 
+            if v == 'SUBCOMMANDER' then 
+                isSubCommander = true 
+                break 
+            end
         end
     end
 


### PR DESCRIPTION
Introduces a guard in case a blueprint doesn't have categories.