### PR TITLE
Fix consumption bug

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2450,6 +2450,18 @@ CommandUnit = Class(WalkingLandUnit) {
         self.UnitBeingTeleported = nil
         self.TeleportThread = nil
     end,
+
+    OnWorkBegin = function(self, work)
+        if WalkingLandUnit.OnWorkBegin(self, work) then 
+
+            -- Prevent consumption bug where two enhancements in a row prevents assisting units from
+            -- updating their consumption costs based on the new build rate values.
+            self:UpdateAssistersConsumption()
+
+            -- Inform EnhanceTask that enhancement is not restricted
+            return true
+        end
+    end,
 }
 
 ACUUnit = Class(CommandUnit) {

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -3008,6 +3008,7 @@ Unit = Class(moho.unit_methods) {
             return false
         end
 
+
         self.WorkItem = tempEnhanceBp
         self.WorkItemBuildCostEnergy = tempEnhanceBp.BuildCostEnergy
         self.WorkItemBuildCostMass = tempEnhanceBp.BuildCostEnergy


### PR DESCRIPTION
Closes #3592 . All engineers in the area have to update their consumption computations when an (S)ACU starts an enhancement.