### PR TITLE
Capping feature adjustment nr 2000

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -293,16 +293,23 @@ Callbacks.CapStructure = function(data, units)
         local structures = GetUnitsInRect(rect)
         structures = EntityCategoryFilterDown(categories.STRUCTURE + categories.EXPERIMENTAL, structures)
 
+        -- determine offset to enlarge unit skirt to include structure we're trying to use to cap
+        -- this is a hard-coded fix to make walls work
+        local offset = 1
+        if skirtSize == 1 then 
+            offset = 0.5 
+        end
+
         -- replace unit -> skirt to prevent allocating a new table
         for k, unit in structures do 
             local blueprint = unit:GetBlueprint()
             local px, py, pz = unit:GetPositionXYZ()
             local sx, sz = 0.5 * blueprint.Physics.SkirtSizeX, 0.5 * blueprint.Physics.SkirtSizeZ
             local rect = { 
-                px - sx - 1, -- top left
-                pz - sz - 1, -- top left
-                px + sx + 1, -- bottom right
-                pz + sz + 1  -- bottom right
+                px - sx - offset, -- top left
+                pz - sz - offset, -- top left
+                px + sx + offset, -- bottom right
+                pz + sz + offset  -- bottom right
             }
 
             structures[k] = rect

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -268,7 +268,6 @@ Callbacks.CapStructure = function(data, units)
     end
 
     -- compute / retrieve information for capping
-    local brain = builders[1]:GetAIBrain()
     local blueprintID = ConstructBlueprintID(faction, data.id)
     local blueprint = structure:GetBlueprint()
     local skirtSize = blueprint.Physics.SkirtSizeX
@@ -288,6 +287,7 @@ Callbacks.CapStructure = function(data, units)
         local x2 = cx + (skirtSize + 10)
         local z2 = cz + (skirtSize + 10)
         local rect = Rect(x1, z1, x2, z2)
+
         -- find all units that may prevent us from building
         local structures = GetUnitsInRect(rect)
         structures = EntityCategoryFilterDown(categories.STRUCTURE + categories.EXPERIMENTAL, structures)
@@ -303,7 +303,7 @@ Callbacks.CapStructure = function(data, units)
                 px + sx + 0.5 * skirtSize, -- bottom right
                 pz + sz + 0.5 * skirtSize  -- bottom right
             }
-            
+
             structures[k] = rect
         end
 
@@ -318,7 +318,7 @@ Callbacks.CapStructure = function(data, units)
             buildLocation[3] = cz + location[2]
             buildLocation[2] = GetSurfaceHeight(buildLocation[1], buildLocation[3])
 
-            -- check all skirts manually
+            -- check all skirts manually as brain:CanBuildStructureAt(...) is unreliable when structures have been upgraded
             local freeToBuild = true
             for k, skirt in skirts do 
                 if buildLocation[1] > skirt[1] and buildLocation[1] < skirt[3] then 

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -198,6 +198,7 @@ end
 Callbacks.CapStructure = function(data, units)
 
     -- check if we have a structure
+    -- if army is not set then the structure is not 'our' structure (e.g., we're trying to cap an allied or hostile extractor)
     local structure = GetEntityById(data.target)
     if (not structure) or (not structure.Army) then return end 
 
@@ -224,7 +225,7 @@ Callbacks.CapStructure = function(data, units)
     -- determine of all units in selection what they can build
     for _, unit in units do
         -- make sure we're allowed to mess with this unit, if not we exclude
-        if OkayToMessWithArmy(unit.Army) then 
+        if unit.Army and OkayToMessWithArmy(unit.Army) then 
             -- compute blueprint id
             local faction = unit.factionCategory
             local blueprintID = ConstructBlueprintID(faction, data.id)

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -39,7 +39,7 @@ local IssueFerry = IssueFerry
 
 -- upvalue categories for performance
 local CategoriesTransportation = categories.TRANSPORTATION
-local CategoriesEngineer = categories.ENGINEER
+local CategoriesEngineer = categories.ENGINEER - categories.INSIGNIFICANTUNIT
 
 --- Used to warn users (mainly developers) once for invalid use of functionality 
 local Warnings = { }

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -297,7 +297,13 @@ Callbacks.CapStructure = function(data, units)
             local blueprint = unit:GetBlueprint()
             local px, py, pz = unit:GetPositionXYZ()
             local sx, sz = 0.5 * blueprint.Physics.SkirtSizeX, 0.5 * blueprint.Physics.SkirtSizeZ
-            local rect = { px - sx, pz - sz, px + sx, pz + sz }
+            local rect = { 
+                px - sx - 0.5 * skirtSize, -- top left
+                pz - sz - 0.5 * skirtSize, -- top left
+                px + sx + 0.5 * skirtSize, -- bottom right
+                pz + sz + 0.5 * skirtSize  -- bottom right
+            }
+            
             structures[k] = rect
         end
 

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -299,10 +299,10 @@ Callbacks.CapStructure = function(data, units)
             local px, py, pz = unit:GetPositionXYZ()
             local sx, sz = 0.5 * blueprint.Physics.SkirtSizeX, 0.5 * blueprint.Physics.SkirtSizeZ
             local rect = { 
-                px - sx - 0.5 * skirtSize, -- top left
-                pz - sz - 0.5 * skirtSize, -- top left
-                px + sx + 0.5 * skirtSize, -- bottom right
-                pz + sz + 0.5 * skirtSize  -- bottom right
+                px - sx - 1, -- top left
+                pz - sz - 1, -- top left
+                px + sx + 1, -- bottom right
+                pz + sz + 1  -- bottom right
             }
 
             structures[k] = rect

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -246,7 +246,7 @@ function CapStructure(command)
             end
 
         -- if we have a t3 fabricator, create storages around it
-        elseif structure:IsInCategory('MASSFABRICATION') and isTech3 and isDoubleTapped then 
+        elseif structure:IsInCategory('MASSFABRICATION') and isTech3 then 
             SimCallback({Func = 'CapStructure', Args = {target = command.Target.EntityId, layer = 1, id = "b1106" }}, true)
 
             -- reset state
@@ -255,7 +255,7 @@ function CapStructure(command)
             pStructure2 = nil
 
         -- if we have a t2 artillery, create t1 pgens around it
-        elseif structure:IsInCategory('ARTILLERY') and isTech2 and isDoubleTapped then 
+        elseif structure:IsInCategory('ARTILLERY') and isTech2 then 
             SimCallback({Func = 'CapStructure', Args = {target = command.Target.EntityId, layer = 1, id =  "b1101" }}, true)
 
             -- reset state
@@ -264,7 +264,7 @@ function CapStructure(command)
             pStructure2 = nil
 
         -- if we have a radar, create t1 pgens around it
-        elseif ((structure:IsInCategory('RADAR') and (isTech2 or (isTech1 and isUpgrading))) or structure:IsInCategory('OMNI')) and isDoubleTapped then 
+        elseif structure:IsInCategory('RADAR') and ((isTech1 and isUpgrading and isDoubleTapped) or isTech2 or structure:IsInCategory('OMNI'))  then 
             SimCallback({Func = 'CapStructure', Args = {target = command.Target.EntityId, layer = 1, id =  "b1101" }}, true)
 
             -- reset state

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -223,7 +223,7 @@ function CapStructure(command)
 
             -- check what type of buildings we'd like to make
             local buildStorages = (isTech1 and isUpgrading and isDoubleTapped) or isTech2 or isTech3
-            local buildFabs = (isTech2 and isUpgrading and isDoubleTapped) or (isTech3 and isDoubleTapped)
+            local buildFabs = (isTech2 and isUpgrading and isTripleTapped) or (isTech3 and isDoubleTapped)
 
             if buildStorages then 
                 SimCallback({Func = 'CapStructure', Args = {target = command.Target.EntityId, layer = 1, id = "b1106" }}, true)

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -216,14 +216,14 @@ function CapStructure(command)
     local isTech3 = structure:IsInCategory('TECH3')
 
     -- are we a structure and are we holding shift?
-    if structure:IsInCategory('STRUCTURE') and IsKeyDown('Shift') and isDoubleTapped then 
+    if structure:IsInCategory('STRUCTURE') and IsKeyDown('Shift') then 
 
         -- try and create storages and / or fabricators around it
         if structure:IsInCategory('MASSEXTRACTION') then 
 
             -- check what type of buildings we'd like to make
-            local buildStorages = (isTech1 and isUpgrading) or isTech2 or isTech3
-            local buildFabs = (isTech2 and isUpgrading and isTripleTapped) or (isTech3 and isTripleTapped)
+            local buildStorages = (isTech1 and isUpgrading and isDoubleTapped) or isTech2 or isTech3
+            local buildFabs = (isTech2 and isUpgrading and isDoubleTapped) or (isTech3 and isDoubleTapped)
 
             if buildStorages then 
                 SimCallback({Func = 'CapStructure', Args = {target = command.Target.EntityId, layer = 1, id = "b1106" }}, true)
@@ -246,7 +246,7 @@ function CapStructure(command)
             end
 
         -- if we have a t3 fabricator, create storages around it
-        elseif structure:IsInCategory('MASSFABRICATION') and isTech3 then 
+        elseif structure:IsInCategory('MASSFABRICATION') and isTech3 and isDoubleTapped then 
             SimCallback({Func = 'CapStructure', Args = {target = command.Target.EntityId, layer = 1, id = "b1106" }}, true)
 
             -- reset state
@@ -255,7 +255,7 @@ function CapStructure(command)
             pStructure2 = nil
 
         -- if we have a t2 artillery, create t1 pgens around it
-        elseif structure:IsInCategory('ARTILLERY') and isTech2 then 
+        elseif structure:IsInCategory('ARTILLERY') and isTech2 and isDoubleTapped then 
             SimCallback({Func = 'CapStructure', Args = {target = command.Target.EntityId, layer = 1, id =  "b1101" }}, true)
 
             -- reset state
@@ -264,7 +264,7 @@ function CapStructure(command)
             pStructure2 = nil
 
         -- if we have a radar, create t1 pgens around it
-        elseif ((structure:IsInCategory('RADAR') and (isTech2 or (isTech1 and isUpgrading))) or structure:IsInCategory('OMNI')) then 
+        elseif ((structure:IsInCategory('RADAR') and (isTech2 or (isTech1 and isUpgrading))) or structure:IsInCategory('OMNI')) and isDoubleTapped then 
             SimCallback({Func = 'CapStructure', Args = {target = command.Target.EntityId, layer = 1, id =  "b1101" }}, true)
 
             -- reset state


### PR DESCRIPTION
This changes the capping behavior to:
  - 2 clicks + shift to mass storage an upgrading t1 (or t2) extractor
  - 1 click (+ shift) to mass storage a (finished) t2 / t3 extractor
  - 3 clicks + shift to mass fab cap an upgrading t2 extractor
  - 2 clicks + shift to mass fab cap a t3 extractor
  - 1 clicks + shift to mass storage a t3 fabricator
  - 1 clicks + shift to pgen an artillery
  - 2 clicks + shift to pgen an upgrading t1 radar
  - 1 clicks + shift to pgen an radar, t2 radar or t3 radar
  - 1 click + shift to wall a t1 pd
  
  General rule of thumb:
   - Typical: shift + 1 click
   - Upgrading: shift + 2 click
   - Dangerous: shift + (regular click count + 1)
  
Also closes #3513 