### PR TITLE
Hotfix for Seraphim T3 MAA

### DIFF
--- a/units/DSLK004/DSLK004_script.lua
+++ b/units/DSLK004/DSLK004_script.lua
@@ -67,8 +67,11 @@ local PhasonCollisionBeam = Class(SCCollisionBeam) {
 
     DoDamage = function(self, instigator, damageData, targetEntity)
 
+        -- fix me: beam weapons shouldn't be used. Instead, use a projectile based weapon that looks like a beam weapon.
         if self.TargetEntity then
-            targetEntity = self.TargetEntity
+            if EntityCategoryContains(categories.AIR, self.TargetEntity) then 
+                targetEntity = self.TargetEntity
+            end
         end
 
         local damage = damageData.DamageAmount or 0


### PR DESCRIPTION
This doesn't fix #3153 but at least it addresses it to land-based targets. The unit was doing damage to its target regardless of context. Beam weapons are inherently broken in this game - hitting an air unit is essentially impossible. Hence they 'fixed' it with this. 

Needs to be replaced with a projectile-based weapon, similar fix to the Rhino.