### PR TITLE
Seraphim Lightning tank is not aphmibious

### DIFF
--- a/units/DSLK004/DSLK004_unit.bp
+++ b/units/DSLK004/DSLK004_unit.bp
@@ -194,7 +194,7 @@ UnitBlueprint {
             LAYER_Orbit = false,
             LAYER_Seabed = false,
             LAYER_Sub = false,
-            LAYER_Water = true,
+            LAYER_Water = false,
         },
         DragCoefficient = 0.2,
         MaxAcceleration = 3.4,


### PR DESCRIPTION
Set the BuildOnLayerCaps for LAYER_Water to false from true. as it shows in the unit tooltip it is aquatic

- Found by Taunoob1

![image](https://user-images.githubusercontent.com/20344151/145853771-36b12583-4e94-42d6-a9e6-3e4f0badcd31.png)
