### PR TITLE
Fix GetUnitsInRect hook for insignificant units

### DIFF
--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -460,8 +460,14 @@ end
 function GetUnitById(id)
 end
 
---- Return a table with units inside the given rectangle.
--- @param rectangle Map area created by function Rect(x0, z0, x1, z1).
+--- Retrieves all units in a rectangle, Excludes insignificant units, such as the Cybran Drone, by default.
+-- @param rectangle The rectangle to look for units in {x0, z0, x1, z1}.
+-- OR
+-- @param tlx Top left x coordinate.
+-- @param tlz Top left z coordinate.
+-- @param brx Bottom right x coordinate.
+-- @param brz Bottom right z coordinate.
+-- @return nil if none found or a table.
 function GetUnitsInRect(rectangle)
 end
 

--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -2071,8 +2071,10 @@ function GenerateOffMapAreas()
 end
 
 function AntiOffMapMainThread()
+
     WaitTicks(11)
     GenerateOffMapAreas()
+    local WaitTicks = coroutine.yield
     local OffMapAreas = {}
     local UnitsThatAreOffMap = {}
 
@@ -2090,7 +2092,10 @@ function AntiOffMapMainThread()
                     end
                 else
             end
+            WaitTicks(11)
         end
+
+        WaitTicks(11)
         local NumberOfUnitsOffMap = table.getn(NewUnitsThatAreOffMap)
         for index, NewUnitThatIsOffMap in NewUnitsThatAreOffMap do
             if not NewUnitThatIsOffMap.IAmOffMap then
@@ -2107,7 +2112,7 @@ function AntiOffMapMainThread()
                 end
             end
         end
-        WaitSeconds(1)
+
         NewUnitsThatAreOffMap = nil
     end
 end

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -298,10 +298,9 @@ Callbacks.CapStructure = function(data, units)
         local z1 = cz - (skirtSize + 10)
         local x2 = cx + (skirtSize + 10)
         local z2 = cz + (skirtSize + 10)
-        local rect = Rect(x1, z1, x2, z2)
 
         -- find all units that may prevent us from building
-        local structures = GetUnitsInRect(rect)
+        local structures = GetUnitsInRect(x1, z1, x2, z2)
         structures = EntityCategoryFilterDown(categories.STRUCTURE + categories.EXPERIMENTAL, structures)
 
         -- determine offset to enlarge unit skirt to include structure we're trying to use to cap

--- a/lua/SimHooks.lua
+++ b/lua/SimHooks.lua
@@ -18,7 +18,7 @@ do
 
         -- try and retrieve units
         local units 
-        if tlz then 
+        if brx then 
             units = oldGetUnitsInRect(rtlx, tlz, brx, brz)
         else
             units = oldGetUnitsInRect(rtlx)

--- a/lua/SimHooks.lua
+++ b/lua/SimHooks.lua
@@ -18,11 +18,9 @@ do
 
         -- try and retrieve units
         local units 
-        if tlz then 
-            LOG("Numbers!")
+        if brx then 
             units = oldGetUnitsInRect(rtlx, tlz, brx, brz)
         else
-            LOG("rectangle!")
             units = oldGetUnitsInRect(rtlx)
         end
 

--- a/lua/SimHooks.lua
+++ b/lua/SimHooks.lua
@@ -14,10 +14,17 @@ do
     -- @param brx Bottom right x coordinate.
     -- @param brz Bottom right z coordinate.
     -- @return nil if none found or a table.
-    _G.GetUnitsInRect = function(...)
+    _G.GetUnitsInRect = function(rtlx, tlz, brx, brz)
 
-        -- retrieve the units 
-        local units = oldGetUnitsInRect(unpack(arg))
+        -- try and retrieve units
+        local units 
+        if tlz then 
+            LOG("Numbers!")
+            units = oldGetUnitsInRect(rtlx, tlz, brx, brz)
+        else
+            LOG("rectangle!")
+            units = oldGetUnitsInRect(rtlx)
+        end
 
         -- as it can return nil, check if we have any units
         if units then 

--- a/lua/SimHooks.lua
+++ b/lua/SimHooks.lua
@@ -18,7 +18,7 @@ do
 
         -- try and retrieve units
         local units 
-        if brx then 
+        if tlz then 
             units = oldGetUnitsInRect(rtlx, tlz, brx, brz)
         else
             units = oldGetUnitsInRect(rtlx)

--- a/lua/SimHooks.lua
+++ b/lua/SimHooks.lua
@@ -7,25 +7,21 @@ do
     local oldGetUnitsInRect = GetUnitsInRect
 
     --- Retrieves all units in a rectangle, Excludes insignificant units, such as the Cybran Drone, by default.
-    -- @param rectangle The rectangle to look for units in.
-    -- @param excludeInsignificantUnits Whether or not we exclude insignificant units, defaults to true. 
+    -- @param rectangle The rectangle to look for units in {x0, z0, x1, z1}.
+    -- OR
+    -- @param tlx Top left x coordinate.
+    -- @param tlz Top left z coordinate.
+    -- @param brx Bottom right x coordinate.
+    -- @param brz Bottom right z coordinate.
     -- @return nil if none found or a table.
-    _G.GetUnitsInRect = function(rectangle, excludeInsignificantUnits)
+    _G.GetUnitsInRect = function(...)
 
         -- retrieve the units 
-        local units = oldGetUnitsInRect(rectangle)
+        local units = oldGetUnitsInRect(unpack(arg))
 
         -- as it can return nil, check if we have any units
         if units then 
-            -- if it isn't set, we try and exclude them anyhow
-            if excludeInsignificantUnits == nil then 
-                excludeInsignificantUnits = true 
-            end
-
-            -- check if we want to exclude them
-            if excludeInsignificantUnits then 
-                units = EntityCategoryFilterDown(CategoriesNoInsignificant, units)
-            end
+            units = EntityCategoryFilterDown(CategoriesNoInsignificant, units)
         end
 
         return units

--- a/lua/utilities.lua
+++ b/lua/utilities.lua
@@ -26,7 +26,7 @@ function CanBuildInSpot(originUnit, unitId, pos)
     local z2 = pos.z + zDiff
 
     -- Find all the units in that rectangle
-    local units = GetUnitsInRect(Rect(x1, z1, x2, z2))
+    local units = GetUnitsInRect(x1, z1, x2, z2)
 
     -- Filter it down to structures and experimentals only
     units = EntityCategoryFilterDown(categories.STRUCTURE + categories.EXPERIMENTAL, units)
@@ -65,7 +65,7 @@ function GetEnemyUnitsInSphere(unit, position, radius)
     local x2 = position.x + radius
     local y2 = position.y + radius
     local z2 = position.z + radius
-    local UnitsinRec = GetUnitsInRect(Rect(x1, z1, x2, z2))
+    local UnitsinRec = GetUnitsInRect(x1, z1, x2, z2)
 
     -- Check for empty rectangle
     if not UnitsinRec then
@@ -91,7 +91,7 @@ function GetTrueEnemyUnitsInSphere(unit, position, radius, categories)
     local x2 = position.x + radius
     local y2 = position.y + radius
     local z2 = position.z + radius
-    local UnitsinRec = GetUnitsInRect(Rect(x1, z1, x2, z2))
+    local UnitsinRec = GetUnitsInRect(x1, z1, x2, z2)
 
     -- Check for empty rectangle
     if not UnitsinRec then

--- a/units/XRB0204/XRB0204_script.lua
+++ b/units/XRB0204/XRB0204_script.lua
@@ -16,7 +16,7 @@ XRB0204 = Class(CConstructionStructureUnit) {
         -- We might be being rebuild by the slightly bugtacular SCU REBUILDER behaviour, in which
         -- case we want to show all our bones anyway.
         local upos = self:GetPosition()
-        local candidates = GetUnitsInRect(Rect(upos[1], upos[3], upos[1], upos[3]))
+        local candidates = GetUnitsInRect(upos[1], upos[3], upos[1], upos[3])
         for k, v in candidates do
             if target == v:GetBlueprint().BlueprintId then
                 self:HideBone('xrb0304', true)

--- a/units/XRB0304/XRB0304_script.lua
+++ b/units/XRB0304/XRB0304_script.lua
@@ -16,7 +16,7 @@ XRB0304 = Class(CConstructionStructureUnit) {
         -- We might be being rebuild by the slightly bugtacular SCU REBUILDER behaviour, in which
         -- case we want to show all our bones anyway.
         local upos = self:GetPosition()
-        local candidates = GetUnitsInRect(Rect(upos[1], upos[3], upos[1], upos[3]))
+        local candidates = GetUnitsInRect(upos[1], upos[3], upos[1], upos[3])
         for k, v in candidates do
             if target == v:GetBlueprint().BlueprintId then
                 self:HideBone('xrb0304', true)


### PR DESCRIPTION
Apparently the function GetUnitsInRect can have a rectangle (table) as an argument but also the four elements that make up the table as separate arguments.