### PR TITLE
Expand disconnection dialog

### DIFF
--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -109,6 +109,7 @@ function OnSync()
     end
 
     if Sync.LobbyOptions then 
+        LOG(repr(Sync.LobbyOptions))
         import('/lua/ui/game/gamemain.lua').LobbyOptions = table.deepcopy(Sync.LobbyOptions)
     end
 end

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -107,4 +107,8 @@ function OnSync()
     if Sync.GameEnded then
         GpgNetSend('GameEnded')
     end
+
+    if Sync.LobbyOptions then 
+        import('/lua/ui/game/gamemain.lua').LobbyOptions = table.deepcopy(Sync.LobbyOptions)
+    end
 end

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -109,7 +109,6 @@ function OnSync()
     end
 
     if Sync.LobbyOptions then 
-        LOG(repr(Sync.LobbyOptions))
         import('/lua/ui/game/gamemain.lua').LobbyOptions = table.deepcopy(Sync.LobbyOptions)
     end
 end

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -253,6 +253,9 @@ end
 function BeginSession()
     SPEW('Active mods in sim: ', repr(__active_mods))
 
+    -- pass options to the UI
+    Sync.LobbyOptions = ScenarioInfo.Options
+
     GameOverListeners = {}
     ForkThread(function()
         while not IsGameOver() do

--- a/lua/ui/dialogs/disconnect.lua
+++ b/lua/ui/dialogs/disconnect.lua
@@ -12,6 +12,7 @@ local Button = import('/lua/maui/button.lua').Button
 local Bitmap = import('/lua/maui/bitmap.lua').Bitmap
 local Group = import('/lua/maui/group.lua').Group
 local LazyVar = import('/lua/lazyvar.lua').Create
+local GameMain = import('/lua/ui/game/gamemain.lua')
 
 local parent = false
 local myIndex = ''
@@ -31,7 +32,7 @@ local function CreateDialog(clients)
     DestroyDialog()
 
     parent = Group(GetFrame(0), "diconnectDialogParentGroup")
-    parent.Depth:Set(GetFrame(0):GetTopmostDepth() + 10)
+    parent.Depth:Set(GetFrame(0):GetTopmostDepth() + 1)
     parent:SetNeedsFrameUpdate(true)
     parent.time = 0
 
@@ -96,10 +97,11 @@ local function CreateDialog(clients)
         slot.eject:Disable() -- Disable all temporarily so they can't be misclicked, then unlock a few seconds later
     end
 
+    local disconnectionDelay = GameMain.LobbyOptions.DisconnectionDelay or 90
     local canEject = false
-    local canEjectTime = 90
+    local canEjectTime = disconnectionDelay
     local forceEject = false
-    local forceEjectTime = 180
+    local forceEjectTime = math.max(disconnectionDelay * 2, 90)
 
     parent.OnFrame = function(self, delta)
         self.time = self.time + delta

--- a/lua/ui/dialogs/disconnect.lua
+++ b/lua/ui/dialogs/disconnect.lua
@@ -97,7 +97,8 @@ local function CreateDialog(clients)
         slot.eject:Disable() -- Disable all temporarily so they can't be misclicked, then unlock a few seconds later
     end
 
-    local disconnectionDelay = GameMain.LobbyOptions.DisconnectionDelay or 90
+    -- retrieve disconnection delay and reduce it by five (that is how long it takes for the window to show)
+    local disconnectionDelay = (GameMain.LobbyOptions.DisconnectionDelay - 5) or 85
     local canEject = false
     local canEjectTime = disconnectionDelay
     local forceEject = false

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -57,6 +57,8 @@ end
 gameUIHidden = false
 PostScoreVideo = false
 IsSavedGame = false
+
+-- lobby options as set by the host in the lobby
 LobbyOptions = false
 
 OriginalFocusArmy = -1

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -58,9 +58,10 @@ gameUIHidden = false
 PostScoreVideo = false
 IsSavedGame = false
 
--- lobby options as set by the host in the lobby
+-- Lobby options as set by the host in the lobby
 LobbyOptions = false
 
+-- The focus army as set at the start of the game. Allows us to detect whether someone was originally an observer or a player
 OriginalFocusArmy = -1
 
 function KillWaitingDialog()

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -57,6 +57,7 @@ end
 gameUIHidden = false
 PostScoreVideo = false
 IsSavedGame = false
+lobbyOptions = false
 
 OriginalFocusArmy = -1
 

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -57,7 +57,7 @@ end
 gameUIHidden = false
 PostScoreVideo = false
 IsSavedGame = false
-lobbyOptions = false
+LobbyOptions = false
 
 OriginalFocusArmy = -1
 

--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -234,6 +234,30 @@ globalOpts = {
         },
     },
     {
+        default = 3,
+        label = "Disconnection delay",
+        help = "Sets the disconnect delay when a player has trouble connecting.",
+        key = 'DisconnectionDelay',
+        mponly = true,
+        values = {
+            {
+                text = "Tournament",
+                help = "The eject delay is set to 10 seconds and after 90 seconds the player is ejected automatically.",
+                key = 10,
+            },
+            {
+                text = "Quick",
+                help = "The eject delay is set to 30 seconds and after 90 seconds the player is ejected automatically.",
+                key = 30,
+            },
+            {
+                text = "Regular",
+                help = "The eject delay is set to 90 seconds and after 180 seconds the player is ejected automatically.",
+                key = 90,
+            },
+        },
+    },
+    {
         default = 1,
         label = "<LOC lobui_0258>Game Speed",
         help = "<LOC lobui_0259>Set the game speed",


### PR DESCRIPTION
Ensures that the exit dialog is always on top of the disconnection dialog and the disconnection dialog waiting time can be set by the host in the lobby.