### PR TITLE
possible fix of a bug with secondary display

### DIFF
--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -1428,6 +1428,7 @@ function OnClickHandler(button, modifiers)
                 DecreaseBuildCountInQueue(unitIndex, count)
             end
         end
+        RefreshUI()
     elseif item.type == 'unitstack' then
         if modifiers.Left then
             SelectUnits(item.units)

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -1557,8 +1557,8 @@ function OnClickHandler(button, modifiers)
         elseif modifiers.Right then
             DecreaseBuildCountInQueue(item.position, count)
         end
+        RefreshUI()
     end
-    RefreshUI()
 end
 
 local warningtext = false


### PR DESCRIPTION
 - the template removal window pops up again
 - the unit highlights in transports work again
 - the factory queue on hover works too