### PR TITLE
Improve shader recompilation logic

### DIFF
--- a/init_faf.lua
+++ b/init_faf.lua
@@ -408,6 +408,21 @@ end
 
 -- END OF COPY --
 
+-- minimum viable shader version - should be bumped to the next release version when we change the shaders
+local minimumShaderVersion = 3729
+
+-- look for unviable shaders and remove them
+local shaderCache = SHGetFolderPath('LOCAL_APPDATA') .. 'Gas Powered Games/Supreme Commander Forged Alliance/cache'
+for k, file in IoDir(shaderCache .. '/*') do
+    if file != '.' and file != '..' then 
+        local version = tonumber(string.sub(file, -4))
+        if not version or version < minimumShaderVersion then 
+            LOG("Force shader recompilation of: " .. file)
+            os.remove(shaderCache .. '/' .. file)
+        end
+    end
+end
+
 -- typical FAF packages
 local allowedAssetsNxy = { }
 allowedAssetsNxy["effects.nx2"] = true

--- a/init_faf.lua
+++ b/init_faf.lua
@@ -408,18 +408,27 @@ end
 
 -- END OF COPY --
 
--- minimum viable shader version - should be bumped to the next release version when we change the shaders
-local minimumShaderVersion = 3729
+-- -- minimum viable shader version - should be bumped to the next release version when we change the shaders
+-- local minimumShaderVersion = 3729
 
--- look for unviable shaders and remove them
+-- -- look for unviable shaders and remove them
+-- local shaderCache = SHGetFolderPath('LOCAL_APPDATA') .. 'Gas Powered Games/Supreme Commander Forged Alliance/cache'
+-- for k, file in IoDir(shaderCache .. '/*') do
+--     if file != '.' and file != '..' then 
+--         local version = tonumber(string.sub(file, -4))
+--         if not version or version < minimumShaderVersion then 
+--             LOG("Force shader recompilation of: " .. file)
+--             os.remove(shaderCache .. '/' .. file)
+--         end
+--     end
+-- end
+
+-- Clears out the shader cache as it takes a release to reset the shaders
+-- This is a temporary solution until Nomads updated their shaders
 local shaderCache = SHGetFolderPath('LOCAL_APPDATA') .. 'Gas Powered Games/Supreme Commander Forged Alliance/cache'
 for k, file in IoDir(shaderCache .. '/*') do
     if file != '.' and file != '..' then 
-        local version = tonumber(string.sub(file, -4))
-        if not version or version < minimumShaderVersion then 
-            LOG("Force shader recompilation of: " .. file)
-            os.remove(shaderCache .. '/' .. file)
-        end
+        os.remove(shaderCache .. '/' .. file)
     end
 end
 

--- a/init_fafbeta.lua
+++ b/init_fafbeta.lua
@@ -411,7 +411,9 @@ end
 -- Clears out the shader cache as it takes a release to reset the shaders
 local shaderCache = SHGetFolderPath('LOCAL_APPDATA') .. 'Gas Powered Games/Supreme Commander Forged Alliance/cache'
 for k, file in IoDir(shaderCache .. '/*') do
-    os.remove(shaderCache .. '/' .. file)
+    if file != '.' and file != '..' then 
+        os.remove(shaderCache .. '/' .. file)
+    end
 end
 
 -- typical FAF packages

--- a/init_fafdevelop.lua
+++ b/init_fafdevelop.lua
@@ -411,7 +411,9 @@ end
 -- Clears out the shader cache as it takes a release to reset the shaders
 local shaderCache = SHGetFolderPath('LOCAL_APPDATA') .. 'Gas Powered Games/Supreme Commander Forged Alliance/cache'
 for k, file in IoDir(shaderCache .. '/*') do
-    os.remove(shaderCache .. '/' .. file)
+    if file != '.' and file != '..' then 
+        os.remove(shaderCache .. '/' .. file)
+    end
 end
 
 -- typical FAF packages


### PR DESCRIPTION
When the shaders are changed they're not necessarily recompiled for all users. This is especially relevant when new techniques are introduced like in patch 3728. This introduces a 'minimum' version of the shader and any other version is removed.