### PR TITLE
Hook Brain.GetListOfUnits to exclude insignificant units

### DIFF
--- a/engine/Sim/CAiBrain.lua
+++ b/engine/Sim/CAiBrain.lua
@@ -266,8 +266,8 @@ end
 
 --- Returns list of units by category.
 -- @param category Unit's category, example: categories.TECH2 .
--- @param needToBeIdle true/false Unit has to be idle.
--- @param requireBuilt true/false defaults to false which excludes units that are NOT finished.
+-- @param needToBeIdle true/false Unit has to be idle (appears to be not functional).
+-- @param requireBuilt true/false defaults to false which excludes units that are NOT finished (appears to be not functional).
 -- @return tblUnits Table containing units.
 function CAiBrain:GetListOfUnits(category,  needToBeIdle,  requireBuilt)
 end

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -4146,11 +4146,11 @@ AIBrain = Class(moho.aibrain_methods) {
     -- @param needToBeIdle true/false Unit has to be idle.
     -- @param requireBuilt true/false defaults to false which excludes units that are NOT finished.
     -- @return tblUnits Table containing units.
-    GetListOfUnits = function(self, categories, needToBeIdle, requireBuilt)
+    GetListOfUnits = function(self, cats, needToBeIdle, requireBuilt)
         -- defaults to false, prevent sending nil
-        requireBuilt = requireBuilt or false 
+        requireBuilt = requireBuilt or false
 
         -- retrieve units, excluding insignificant units
-        return BrainGetListOfUnits(self, categories - categories.INSIGNIFICANTUNIT, needToBeIdle, requireBuilt)
+        return BrainGetListOfUnits(self, cats - categories.INSIGNIFICANTUNIT, needToBeIdle, requireBuilt)
     end,
 }

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -4139,7 +4139,7 @@ AIBrain = Class(moho.aibrain_methods) {
         end
 
         return units
-    end
+    end,
 
     --- Returns list of units by category.
     -- @param category Unit's category, example: categories.TECH2 .
@@ -4152,5 +4152,5 @@ AIBrain = Class(moho.aibrain_methods) {
 
         -- retrieve units, excluding insignificant units
         return BrainGetListOfUnits(self, categories - categories.INSIGNIFICANTUNIT, needToBeIdle, requireBuilt)
-    end
+    end,
 }

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -4143,8 +4143,8 @@ AIBrain = Class(moho.aibrain_methods) {
 
     --- Returns list of units by category.
     -- @param category Unit's category, example: categories.TECH2 .
-    -- @param needToBeIdle true/false Unit has to be idle.
-    -- @param requireBuilt true/false defaults to false which excludes units that are NOT finished.
+    -- @param needToBeIdle true/false Unit has to be idle (appears to be not functional).
+    -- @param requireBuilt true/false defaults to false which excludes units that are NOT finished (appears to be not functional).
     -- @return tblUnits Table containing units.
     GetListOfUnits = function(self, cats, needToBeIdle, requireBuilt)
         -- defaults to false, prevent sending nil

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -32,6 +32,7 @@ local Factions = import('/lua/factions.lua').GetFactions(true)
 
 -- upvalue for performance
 local BrainGetUnitsAroundPoint = moho.aibrain_methods.GetUnitsAroundPoint
+local BrainGetListOfUnits = moho.aibrain_methods.GetListOfUnits
 local CategoriesNoInsignificant = categories.ALLUNITS - categories.INSIGNIFICANTUNIT
 
 local observer = false
@@ -4140,4 +4141,16 @@ AIBrain = Class(moho.aibrain_methods) {
         return units
     end
 
+    --- Returns list of units by category.
+    -- @param category Unit's category, example: categories.TECH2 .
+    -- @param needToBeIdle true/false Unit has to be idle.
+    -- @param requireBuilt true/false defaults to false which excludes units that are NOT finished.
+    -- @return tblUnits Table containing units.
+    GetListOfUnits = function(self, categories, needToBeIdle, requireBuilt)
+        -- defaults to false, prevent sending nil
+        requireBuilt = requireBuilt or false 
+
+        -- retrieve units, excluding insignificant units
+        return BrainGetListOfUnits(self, categories - categories.INSIGNIFICANTUNIT, needToBeIdle, requireBuilt)
+    end
 }


### PR DESCRIPTION
```
warning: Error running lua script: ...faforever\gamedata\lua.nx2\lua\scenarioframework.lua(1984): attempt to call method `SetCanBeKilled' (a nil value)
         stack traceback:
         	...faforever\gamedata\lua.nx2\lua\scenarioframework.lua(1984): in function `UnflagUnkillable'
         	...amdata\faforever\gamedata\lua.nx2\lua\cinematics.lua(76): in function `SetInvincible'
         	...ce\maps\x1ca_coop_001.v0026\x1ca_coop_001_script.lua(1312): in function <...ce\maps\x1ca_coop_001.v0026\x1ca_coop_001_script.lua:1256>
```

Related to #3441 .