### PR TITLE
Whitelist Kyro's lobby

### DIFF
--- a/init_fafbeta.lua
+++ b/init_fafbeta.lua
@@ -88,6 +88,7 @@ allowedAssetsScd = LowerHashTable(allowedAssetsScd)
 
 -- typical backwards compatible packages
 local allowedAssetsNxt = { }
+allowedAssetsNxt["kyros.nxt"] = true
 allowedAssetsNxt["texturepack.nxt"] = true
 allowedAssetsNxt["advanced strategic icons.nxt"] = true
 allowedAssetsNxt["advanced_strategic_icons.nxt"] = true

--- a/init_fafdevelop.lua
+++ b/init_fafdevelop.lua
@@ -88,6 +88,7 @@ allowedAssetsScd = LowerHashTable(allowedAssetsScd)
 
 -- typical backwards compatible packages
 local allowedAssetsNxt = { }
+allowedAssetsNxt["kyros.nxt"] = true
 allowedAssetsNxt["texturepack.nxt"] = true
 allowedAssetsNxt["advanced strategic icons.nxt"] = true
 allowedAssetsNxt["advanced_strategic_icons.nxt"] = true

--- a/init_shared.lua
+++ b/init_shared.lua
@@ -88,6 +88,7 @@ allowedAssetsScd = LowerHashTable(allowedAssetsScd)
 
 -- typical backwards compatible packages
 local allowedAssetsNxt = { }
+allowedAssetsNxt["kyros.nxt"] = true
 allowedAssetsNxt["texturepack.nxt"] = true
 allowedAssetsNxt["advanced strategic icons.nxt"] = true
 allowedAssetsNxt["advanced_strategic_icons.nxt"] = true


### PR DESCRIPTION
Adds a separate exception for Kyro's lobby to the initialization files. In particular, a file named `kyros.nxt` is accepted.

I was not aware that many people were using this. Note that this doesn't mean that we officially support it - if the game breaks then there is nothing we can / will do about that.