### PR TITLE
Always define the selected unit in UI

### DIFF
--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -543,9 +543,9 @@ options = {
 
             {
                 title = "<LOC OPTIONS_0246>Show Factory Queue on Hover",
-                key = 'gui_queue_on_hover_01',
+                key = 'gui_queue_on_hover_02',
                 type = 'toggle',
-                default = 1,
+                default = 'only-obs',
                 custom = {
                     states = {
                         {text = "<LOC _Off>Off", key = 'off' },

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -40,6 +40,28 @@ Each tab has:
 
 the optionsOrder table is just an array of keys in to the option table, and their order will determine what
 order the tabs show in the dialog
+
+Note the behavior of the default value:
+ - map / mod / lobby options: the index of the value we're interested in
+ - game options: the key of the value that we're interested in
+
+As an example:
+
+{
+    title = "<LOC OPTIONS_0212>Accept Build Templates",
+    key = 'accept_build_templates',
+    type = 'toggle',
+    default = 'yes',                                    <-------- This is set to the actual value (instead of 1, which would be the index)
+    set = function(key,value,startup)
+    end,
+    custom = {
+        states = {
+            {text = "<LOC _On>", key = 'yes' },         <-------- That is defined here as key
+            {text = "<LOC _Off>", key = 'no' },
+        },
+    },
+},
+
 --]]
 
 optionsOrder = {

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -532,12 +532,12 @@ function UpdateWindow(info)
 
         -- # Build queue upon hovering of unit
 
-        local always = Prefs.GetFromCurrentProfile('options.gui_queue_on_hover_01') == 'always'
+        local always = Prefs.GetFromCurrentProfile('options.gui_queue_on_hover_02') == 'always'
         local isObserver = GameMain.OriginalFocusArmy == -1 or GetFocusArmy() == -1
-        local whenObserving = Prefs.GetFromCurrentProfile('options.gui_queue_on_hover_01') == 'only-obs'
+        local whenObserving = Prefs.GetFromCurrentProfile('options.gui_queue_on_hover_02') == 'only-obs'
 
         if always or (whenObserving and isObserver) then 
-            if info.userUnit ~= nil and EntityCategoryContains(UpdateWindowShowQueueOfUnit, info.userUnit) and info.userUnit ~= selectedUnit then
+            if (info.userUnit ~= nil) and EntityCategoryContains(UpdateWindowShowQueueOfUnit, info.userUnit) and (info.userUnit ~= selectedUnit) then
 
                 -- find the main factory we're using the queue of
                 local mainFactory
@@ -791,7 +791,7 @@ function CreateUI()
 
     controls.bg.OnFrame = function(self, delta)
         local info = GetRolloverInfo()
-        if not info and selectedUnit then
+        if not info and selectedUnit and options.gui_enhanced_unitview ~= 0 then
             info = GetUnitRolloverInfo(selectedUnit)
         end
 
@@ -820,10 +820,7 @@ function CreateUI()
 end
 
 function OnSelection(units)
-    if options.gui_enhanced_unitview == 0 then
-        return
-    end
-
+    -- set if we have one unit selected, useful for state management for information to show
     if units and table.getn(units) == 1 then
         selectedUnit = units[1]
     else

--- a/lua/ui/help/tooltips.lua
+++ b/lua/ui/help/tooltips.lua
@@ -2056,7 +2056,7 @@ Tooltips = {
         title = '<LOC OPTIONS_0231>Draggable Build Queue',
         description = '<LOC OPTIONS_0258>Allows factory build queues to be reordered with drag and drop.',
     },
-    options_gui_queue_on_hover_01 = {
+    options_gui_queue_on_hover_02 = {
         title = '<LOC OPTIONS_0246>Show Factory Queue on Hover',
         description = '<LOC OPTIONS_0249>Shows Factory queue above unit description when hover over unit with mouse.',
     },


### PR DESCRIPTION
This ensures the selected unit is always set if there is just one. Originally it was only used by one feature, but these days more features depend on it. It also fixes the default value being set properly (to 'only-obs').