### PR TITLE
Experiment with torpedoes

### DIFF
--- a/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_proj.bp
+++ b/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_proj.bp
@@ -43,11 +43,10 @@ ProjectileBlueprint {
         DestroyOnWater = false,
         InitialSpeed = 14,
         Lifetime = 20,
-        UseGravity = false,
         MaxSpeed = 14,
         StayUnderwater = true,
-        TrackTarget = true,
+        TrackTarget = false,
         TurnRate = 230,
-        VelocityAlign = false,
+        VelocityAlign = true,
     },
 }

--- a/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_proj.bp
+++ b/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_proj.bp
@@ -43,10 +43,11 @@ ProjectileBlueprint {
         DestroyOnWater = false,
         InitialSpeed = 14,
         Lifetime = 20,
+        UseGravity = false,
         MaxSpeed = 14,
         StayUnderwater = true,
         TrackTarget = true,
         TurnRate = 230,
-        VelocityAlign = true,
+        VelocityAlign = false,
     },
 }

--- a/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_script.lua
+++ b/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_script.lua
@@ -1,0 +1,27 @@
+#
+# Terran Torpedo Bomb
+#
+local TTorpedoShipProjectile = import('/lua/terranprojectiles.lua').TTorpedoShipProjectile
+
+TANAnglerTorpedo06 = Class(TTorpedoShipProjectile) 
+{
+
+    OnEnterWater = function(self)
+        #TTorpedoShipProjectile.OnEnterWater(self)
+        self:SetCollisionShape('Sphere', 0, 0, 0, 1.0)
+        local army = self:GetArmy()
+
+        for k, v in self.FxEnterWater do #splash
+            CreateEmitterAtEntity(self,army,v)
+        end
+        self:TrackTarget(true)
+        self:StayUnderwater(true)
+        self:SetTurnRate(240)
+        self:SetMaxSpeed(18)
+        #self:SetVelocity(0)
+        #self:ForkThread(self.MovementThread)
+    end,
+
+}
+
+TypeClass = TANAnglerTorpedo06

--- a/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_script.lua
+++ b/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_script.lua
@@ -1,25 +1,25 @@
-#
-# Terran Torpedo Bomb
-#
+--
+-- Terran Torpedo Bomb
+--
 local TTorpedoShipProjectile = import('/lua/terranprojectiles.lua').TTorpedoShipProjectile
 
 TANAnglerTorpedo06 = Class(TTorpedoShipProjectile) 
 {
 
     OnEnterWater = function(self)
-        #TTorpedoShipProjectile.OnEnterWater(self)
+        --TTorpedoShipProjectile.OnEnterWater(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 1.0)
         local army = self:GetArmy()
 
-        for k, v in self.FxEnterWater do #splash
+        for k, v in self.FxEnterWater do --splash
             CreateEmitterAtEntity(self,army,v)
         end
         self:TrackTarget(true)
         self:StayUnderwater(true)
         self:SetTurnRate(240)
         self:SetMaxSpeed(18)
-        #self:SetVelocity(0)
-        #self:ForkThread(self.MovementThread)
+        --self:SetVelocity(0)
+        --self:ForkThread(self.MovementThread)
     end,
 
 }

--- a/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_script.lua
+++ b/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_script.lua
@@ -10,19 +10,9 @@ TANAnglerTorpedo06 = Class(TTorpedoShipProjectile)
         TTorpedoShipProjectile.OnCreate(self, inWater)
         
         -- change it up a bit but keep same magnitude
-        -- self:SetVelocity(vx, vy - 0.1, vz)
-        -- self:SetScaleVelocity(m)
-        -- local launcher = self:GetLauncher()
-        -- local vx, vy, vz = launcher:GetVelocity()
-        -- self:SetVelocity(vx, vy - 1, vz)
-
-        -- don't track the target while we're in the air
-        -- self:TrackTarget(false)
-
-        -- local meta = getmetatable(self)
-        -- for k, v in meta do
-        --     LOG(k)
-        -- end
+        local launcher = self:GetLauncher()
+        local vx, vy, vz = launcher:GetVelocity()
+        self:SetVelocity(vx, vy - 1, vz)
     end,
 
     OnEnterWater = function(self)

--- a/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_script.lua
+++ b/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_script.lua
@@ -8,14 +8,20 @@ TANAnglerTorpedo06 = Class(TTorpedoShipProjectile)
 
     OnCreate = function(self, inWater)
         TTorpedoShipProjectile.OnCreate(self, inWater)
-        
-        -- change it up a bit but keep same magnitude
+
+        -- make them point towards the water
         local launcher = self:GetLauncher()
         local vx, vy, vz = launcher:GetVelocity()
-        self:SetVelocity(vx, vy - 1, vz)
+        self:SetVelocity(vx, vy - 0.05, vz)
     end,
 
     OnEnterWater = function(self)
+
+        if self.DropBehavior then 
+            KillThread(self.DropBehavior)
+            self.DropBehavior = false 
+        end
+
         -- set a collision shape to make them easier to hit for defenses
         -- can't be too big (e.g., 1.0) because then torpedo bombers are worthless in shallow water
         self:SetCollisionShape('Sphere', 0, 0, 0, 0.5)

--- a/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_script.lua
+++ b/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_script.lua
@@ -6,6 +6,25 @@ local TTorpedoShipProjectile = import('/lua/terranprojectiles.lua').TTorpedoShip
 TANAnglerTorpedo06 = Class(TTorpedoShipProjectile) 
 {
 
+    OnCreate = function(self, inWater)
+        TTorpedoShipProjectile.OnCreate(self, inWater)
+        
+        -- change it up a bit but keep same magnitude
+        -- self:SetVelocity(vx, vy - 0.1, vz)
+        -- self:SetScaleVelocity(m)
+        -- local launcher = self:GetLauncher()
+        -- local vx, vy, vz = launcher:GetVelocity()
+        -- self:SetVelocity(vx, vy - 1, vz)
+
+        -- don't track the target while we're in the air
+        -- self:TrackTarget(false)
+
+        -- local meta = getmetatable(self)
+        -- for k, v in meta do
+        --     LOG(k)
+        -- end
+    end,
+
     OnEnterWater = function(self)
         -- set a collision shape to make them easier to hit for defenses
         -- can't be too big (e.g., 1.0) because then torpedo bombers are worthless in shallow water
@@ -45,7 +64,6 @@ TANAnglerTorpedo06 = Class(TTorpedoShipProjectile)
         self:SetTurnRate(80)
         WaitSeconds(0.25)
     end,
-
 }
 
 TypeClass = TANAnglerTorpedo06

--- a/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_script.lua
+++ b/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_script.lua
@@ -9,18 +9,13 @@ TANAnglerTorpedo06 = Class(TTorpedoShipProjectile)
     OnCreate = function(self, inWater)
         TTorpedoShipProjectile.OnCreate(self, inWater)
 
-        -- make them point towards the water
+        -- inherit velocity of bomber and point towards the water
         local launcher = self:GetLauncher()
         local vx, vy, vz = launcher:GetVelocity()
-        self:SetVelocity(vx, vy - 0.05, vz)
+        self:SetVelocity(vx, vy - 0.1, vz)
     end,
 
     OnEnterWater = function(self)
-
-        if self.DropBehavior then 
-            KillThread(self.DropBehavior)
-            self.DropBehavior = false 
-        end
 
         -- set a collision shape to make them easier to hit for defenses
         -- can't be too big (e.g., 1.0) because then torpedo bombers are worthless in shallow water

--- a/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_script.lua
+++ b/projectiles/TANAnglerTorpedo06/TANAnglerTorpedo06_script.lua
@@ -7,19 +7,43 @@ TANAnglerTorpedo06 = Class(TTorpedoShipProjectile)
 {
 
     OnEnterWater = function(self)
-        --TTorpedoShipProjectile.OnEnterWater(self)
-        self:SetCollisionShape('Sphere', 0, 0, 0, 1.0)
+        -- set a collision shape to make them easier to hit for defenses
+        -- can't be too big (e.g., 1.0) because then torpedo bombers are worthless in shallow water
+        self:SetCollisionShape('Sphere', 0, 0, 0, 0.5)
+        
+        -- splash!!
         local army = self:GetArmy()
-
-        for k, v in self.FxEnterWater do --splash
+        for k, v in self.FxEnterWater do
             CreateEmitterAtEntity(self,army,v)
         end
+
+        -- set properties of the torpedo once it is underwater
         self:TrackTarget(true)
         self:StayUnderwater(true)
         self:SetTurnRate(240)
+
+        -- set the magnitude of the velocity to something tiny to really make that water
+        -- impact slow it down. We need this to prevent torpedo's striking the bottom
+        -- of a shallow pond, like in setons
+        self:SetVelocity(0.01)
         self:SetMaxSpeed(18)
-        --self:SetVelocity(0)
-        --self:ForkThread(self.MovementThread)
+        self:ForkThread(self.MovementThread)
+    end,
+
+    MovementThread = function(self)
+        -- gradually increase acceleration, but make them less flexible
+        self:SetAcceleration(2)
+        self:SetTurnRate(200)
+        WaitSeconds(0.25)
+        self:SetAcceleration(4)
+        self:SetTurnRate(160)
+        WaitSeconds(0.25)
+        self:SetAcceleration(6)
+        self:SetTurnRate(120)
+        WaitSeconds(0.25)
+        self:SetAcceleration(8)
+        self:SetTurnRate(80)
+        WaitSeconds(0.25)
     end,
 
 }


### PR DESCRIPTION
This is likely a balance related PR than a develop related one. 

![image](https://user-images.githubusercontent.com/15778155/147508279-b7e8caf3-d520-443e-affa-dc6719098496.png)
_old behavior_

I noticed that there are two issues with torpedo bombers:
 - Projectiles aim at their target while not being in the water
 - Projectiles essentially fly towards their target, unless that target is considerably deep (aka, a unit on the ocean floor)
 - Because the projectiles fly, torpedo defenses do not trigger

![image](https://user-images.githubusercontent.com/15778155/147507790-861afe28-595d-428a-b3d0-17cf38a6232c.png)
_new behavior_

In this PR I change this to:
 - Projectiles take the velocity of the bomber, but with a slightly increased y velocity
 - Projectiles do not aim until they are in the water
 - Projectiles slow down on impact with the water surface (essentially to a velocity of 0.1), this ensures that they do not immediately drop into the floor of a shallow pond
 - Torpedo defenses work properly, in fact the Aeon frigate is now quite rigid against the UEF torpedo bomber because the first torpedo is always intercepted.

I personally think the new behavior is how it should be. People complained that it would make it impossible to hit things in say the pond of Seton's. Tweaking the projectiles slightly allows you to still hit things (al though not as reliable as some torpedoes drop on land now, but that makes sense :) ). It also allows torpedo defenses to be relevant when torpedo bombers try and strike your fleet. For example, you may want to take out the UEF torpedo boats _before_ you aim for the cruisers.

Note that this PR now only applies to the UEF torpedo bomber.
