### PR TITLE
Fix filtering insignificant units

### DIFF
--- a/lua/SimHooks.lua
+++ b/lua/SimHooks.lua
@@ -1,13 +1,14 @@
 
 -- upvalue for performance
 local EntityCategoryFilterDown = EntityCategoryFilterDown
-local CategoriesNoInsignificant = categories.ALLUNITS - categories.INSIGNIFICANTUNIT
+local CategoriesNoDummyUnits = categories.ALLUNITS - categories.DUMMYUNIT
 
 do
     local oldGetUnitsInRect = GetUnitsInRect
 
-    --- Retrieves all units in a rectangle, Excludes insignificant units, such as the Cybran Drone, by default.
+    --- Retrieves all units in a rectangle, Excludes dummy units, such as the Cybran Build Drone, by default.
     -- @param rectangle The rectangle to look for units in {x0, z0, x1, z1}.
+    -- @return nil if none found or a table.
     -- OR
     -- @param tlx Top left x coordinate.
     -- @param tlz Top left z coordinate.
@@ -26,7 +27,7 @@ do
 
         -- as it can return nil, check if we have any units
         if units then 
-            units = EntityCategoryFilterDown(CategoriesNoInsignificant, units)
+            units = EntityCategoryFilterDown(CategoriesNoDummyUnits, units)
         end
 
         return units

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -33,7 +33,7 @@ local Factions = import('/lua/factions.lua').GetFactions(true)
 -- upvalue for performance
 local BrainGetUnitsAroundPoint = moho.aibrain_methods.GetUnitsAroundPoint
 local BrainGetListOfUnits = moho.aibrain_methods.GetListOfUnits
-local CategoriesNoInsignificant = categories.ALLUNITS - categories.INSIGNIFICANTUNIT
+local CategoriesDummyUnit = categories.DUMMYUNIT
 
 local observer = false
 local Points = {
@@ -4108,40 +4108,23 @@ AIBrain = Class(moho.aibrain_methods) {
         end
     end,
 
-    --- Retrieves all units that fit the criteria around some point.
+    --- Retrieves all units that fit the criteria around some point. Excludes dummy units.
     -- @param category The categories the units should fit.
     -- @param position The center point to start looking for units.
     -- @param radius The radius of the circle we look for units in.
     -- @param alliance The alliance status ('Ally', 'Enemy', 'Neutral') to those units.
-    -- @param excludeInsignificantUnits Whether or not we exclude insignificant units, defaults to true.
     -- @return nil if none found or a table.
-    GetUnitsAroundPoint = function(self, category, position, radius, alliance, excludeInsignificantUnits)
-        local units
+    GetUnitsAroundPoint = function(self, category, position, radius, alliance)
         if alliance then 
             -- call where we do care about alliance
-            units = BrainGetUnitsAroundPoint(self, category, position, radius, alliance)
+            return BrainGetUnitsAroundPoint(self, category - CategoriesDummyUnit, position, radius, alliance)
         else 
             -- call where we do not, which is different from providing nil (as there would be a fifth argument then)
-            units = BrainGetUnitsAroundPoint(self, category, position, radius)
+            return BrainGetUnitsAroundPoint(self, category - CategoriesDummyUnit, position, radius)
         end
-
-        -- as it can return nil, check if we have any units
-        if units then 
-            -- if it isn't set, we try and exclude them anyhow
-            if excludeInsignificantUnits == nil then 
-                excludeInsignificantUnits = true 
-            end
-
-            -- check if we want to exclude them
-            if excludeInsignificantUnits then 
-                units = EntityCategoryFilterDown(CategoriesNoInsignificant, units)
-            end
-        end
-
-        return units
     end,
 
-    --- Returns list of units by category.
+    --- Returns list of units by category. Excludes dummy units.
     -- @param category Unit's category, example: categories.TECH2 .
     -- @param needToBeIdle true/false Unit has to be idle (appears to be not functional).
     -- @param requireBuilt true/false defaults to false which excludes units that are NOT finished (appears to be not functional).
@@ -4151,6 +4134,6 @@ AIBrain = Class(moho.aibrain_methods) {
         requireBuilt = requireBuilt or false
 
         -- retrieve units, excluding insignificant units
-        return BrainGetListOfUnits(self, cats - categories.INSIGNIFICANTUNIT, needToBeIdle, requireBuilt)
+        return BrainGetListOfUnits(self, cats - CategoriesDummyUnit, needToBeIdle, requireBuilt)
     end,
 }

--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -5,7 +5,7 @@
 -- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 
-local InsignificantUnit = import('/lua/sim/unit.lua').InsignificantUnit
+local DummyUnit = import('/lua/sim/unit.lua').DummyUnit
 local DefaultUnitsFile = import('defaultunits.lua')
 local AirFactoryUnit = DefaultUnitsFile.AirFactoryUnit
 local AirStagingPlatformUnit = DefaultUnitsFile.AirStagingPlatformUnit
@@ -260,7 +260,7 @@ CConstructionTemplate = Class() {
 
 --- The build bot class for drones. It removes a lot of
 -- the basic functionality of a unit to save on performance.
-CBuildBotUnit = Class(InsignificantUnit) {
+CBuildBotUnit = Class(DummyUnit) {
 
     -- Keep track of the builder that made the bot
     SpawnedBy = false,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4522,9 +4522,9 @@ local UnitGetCurrentLayer = _G.moho.unit_methods.GetCurrentLayer
 local UnitGetUnitId = _G.moho.unit_methods.GetUnitId
 
 -- upvalued categories for performance
-local CategoriesInsignificant = categories.INSIGNIFICANTUNIT
+local CategoriesDummyUnit = categories.DUMMYUNIT
 
-InsignificantUnit = Class(moho.unit_methods) {
+DummyUnit = Class(moho.unit_methods) {
     -- the only things we need
     __init = function(self) end,
     __post_init = function(self) end,
@@ -4539,8 +4539,8 @@ InsignificantUnit = Class(moho.unit_methods) {
         self.Footprint = self.Blueprint.Footprint
 
         -- basic check if this insignificant unit is truely insignificant
-        if not EntityCategoryContains(CategoriesInsignificant, self) then 
-            WARN("Unit is insignificant but doesn't have the right categories set!")
+        if not EntityCategoryContains(CategoriesDummyUnit, self) then 
+            WARN("Unit " .. tostring(self.UnitId) .. " is a dummy unit but doesn't have the right categories set!")
 
             -- todo: add more info for dev
         end

--- a/units/URA0001O/URA0001O_unit.bp
+++ b/units/URA0001O/URA0001O_unit.bp
@@ -39,6 +39,7 @@ UnitBlueprint {
         'UNSPAWNABLE',
         'UNSELECTABLE',
         'INSIGNIFICANTUNIT',
+        'DUMMYUNIT',
         
         -- make it visible to recon at least
         'VISIBLETORECON',

--- a/units/URA0002O/URA0002O_unit.bp
+++ b/units/URA0002O/URA0002O_unit.bp
@@ -39,6 +39,7 @@ UnitBlueprint {
         'UNSPAWNABLE',
         'UNSELECTABLE',
         'INSIGNIFICANTUNIT',
+        'DUMMYUNIT',
         
         -- make it visible to recon at least
         'VISIBLETORECON',

--- a/units/URA0003O/URA0003O_unit.bp
+++ b/units/URA0003O/URA0003O_unit.bp
@@ -39,6 +39,7 @@ UnitBlueprint {
         'UNSPAWNABLE',
         'UNSELECTABLE',
         'INSIGNIFICANTUNIT',
+        'DUMMYUNIT',
         
         -- make it visible to recon at least
         'VISIBLETORECON',


### PR DESCRIPTION
We used the `categories.INSIGNIFICANTUNIT` categories to identify the new dummy units (that are no real unit - but just exist like the Cybran Build Drones). By doing so we also destroyed some mods that used this category before, like the anti teleporting towers.

To fix this we introduce a new category: `DUMMYUNIT`, that we use to filter out these units.