### PR TITLE
Update initialisation files

### DIFF
--- a/init_faf.lua
+++ b/init_faf.lua
@@ -88,6 +88,7 @@ allowedAssetsScd = LowerHashTable(allowedAssetsScd)
 
 -- typical backwards compatible packages
 local allowedAssetsNxt = { }
+allowedAssetsNxt["kyros.nxt"] = true
 allowedAssetsNxt["texturepack.nxt"] = true
 allowedAssetsNxt["advanced strategic icons.nxt"] = true
 allowedAssetsNxt["advanced_strategic_icons.nxt"] = true
@@ -175,7 +176,9 @@ local function MountMapContent(dir)
         end
 
         -- do not load archives as maps
-        if StringSub(map, -4) == ".zip" or StringSub(map, -4) == ".scd"  or StringSub(map, -4) == ".rar" then
+        local extension = StringSub(map, -4)
+        if extension == ".zip" or extension == ".scd" or extension == ".rar" then
+            LOG("Prevented loading a map inside a zip / scd / rar file: " .. dir .. "/" .. map)
             continue 
         end
 
@@ -198,22 +201,22 @@ local function MountMapContent(dir)
 
         -- check if it has a scenario file
         if not scenarioFile then 
-            LOG("Map doesn't have a scenario file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no scenario file: " .. dir .. "/" .. map)
             continue 
         end
 
         if not scmapFile then 
-            LOG("Map doesn't have a scmap file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no scmap file: " .. dir .. "/" .. map)
             continue 
         end
 
         if not saveFile then 
-            LOG("Map doesn't have a save file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no save file: " .. dir .. "/" .. map)
             continue 
         end
 
         if not scriptFile then 
-            LOG("Map doesn't have a script file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no script file: " .. dir .. "/" .. map)
             continue 
         end
 
@@ -315,12 +318,14 @@ local function MountModContent(dir)
 
         -- do not load integrated mods
         if integratedMods[mod] then 
-            _ALERT("Blocked mod that is integrated: " .. mod )
+            LOG("Blocked mod that is integrated: " .. mod )
             continue 
         end 
 
         -- do not load archives as mods
-        if StringFind(mod, ".zip") or StringFind(mod, ".scd") or StringFind(mod, ".rar") then
+        local extension = StringSub(mod, -4)
+        if extension == ".zip" or extension == ".scd" or extension == ".rar" then
+            LOG("Prevented loading a mod inside a zip / scd / rar file: " .. dir .. "/" .. mod)
             continue 
         end
 
@@ -334,7 +339,7 @@ local function MountModContent(dir)
 
         -- check if it has a scenario file
         if not infoFile then 
-            _ALERT("Mod doesn't have an info file: " .. dir .. "/" .. mod)
+            LOG("Mod doesn't have an info file: " .. dir .. "/" .. mod)
             continue 
         end
 

--- a/init_faf.lua
+++ b/init_faf.lua
@@ -8,6 +8,10 @@
 -- imports fa_path to determine where it is installed
 dofile(InitFileDir .. '/../fa_path.lua')
 
+LOG("Client version: " .. tostring(ClientVersion))
+LOG("Game version: " .. tostring(GameVersion))
+LOG("Game type: " .. tostring(GameType))
+
 -- upvalued performance
 local dofile = dofile
 

--- a/init_faf.lua
+++ b/init_faf.lua
@@ -417,27 +417,18 @@ end
 
 -- END OF COPY --
 
--- -- minimum viable shader version - should be bumped to the next release version when we change the shaders
--- local minimumShaderVersion = 3729
+-- minimum viable shader version - should be bumped to the next release version when we change the shaders
+local minimumShaderVersion = 3729
 
--- -- look for unviable shaders and remove them
--- local shaderCache = SHGetFolderPath('LOCAL_APPDATA') .. 'Gas Powered Games/Supreme Commander Forged Alliance/cache'
--- for k, file in IoDir(shaderCache .. '/*') do
---     if file != '.' and file != '..' then 
---         local version = tonumber(string.sub(file, -4))
---         if not version or version < minimumShaderVersion then 
---             LOG("Force shader recompilation of: " .. file)
---             os.remove(shaderCache .. '/' .. file)
---         end
---     end
--- end
-
--- Clears out the shader cache as it takes a release to reset the shaders
--- This is a temporary solution until Nomads updated their shaders
+-- look for unviable shaders and remove them
 local shaderCache = SHGetFolderPath('LOCAL_APPDATA') .. 'Gas Powered Games/Supreme Commander Forged Alliance/cache'
 for k, file in IoDir(shaderCache .. '/*') do
     if file != '.' and file != '..' then 
-        os.remove(shaderCache .. '/' .. file)
+        local version = tonumber(string.sub(file, -4))
+        if not version or version < minimumShaderVersion then 
+            LOG("Force shader recompilation of: " .. file)
+            os.remove(shaderCache .. '/' .. file)
+        end
     end
 end
 

--- a/init_faf.lua
+++ b/init_faf.lua
@@ -426,7 +426,7 @@ for k, file in IoDir(shaderCache .. '/*') do
     if file != '.' and file != '..' then 
         local version = tonumber(string.sub(file, -4))
         if not version or version < minimumShaderVersion then 
-            LOG("Force shader recompilation of: " .. file)
+            LOG("Removed incompatible shader: " .. file)
             os.remove(shaderCache .. '/' .. file)
         end
     end

--- a/init_fafbeta.lua
+++ b/init_fafbeta.lua
@@ -8,6 +8,10 @@
 -- imports fa_path to determine where it is installed
 dofile(InitFileDir .. '/../fa_path.lua')
 
+LOG("Client version: " .. tostring(ClientVersion))
+LOG("Game version: " .. tostring(GameVersion))
+LOG("Game type: " .. tostring(GameType))
+
 -- upvalued performance
 local dofile = dofile
 

--- a/init_fafbeta.lua
+++ b/init_fafbeta.lua
@@ -176,7 +176,9 @@ local function MountMapContent(dir)
         end
 
         -- do not load archives as maps
-        if StringSub(map, -4) == ".zip" or StringSub(map, -4) == ".scd"  or StringSub(map, -4) == ".rar" then
+        local extension = StringSub(map, -4)
+        if extension == ".zip" or extension == ".scd" or extension == ".rar" then
+            LOG("Prevented loading a map inside a zip / scd / rar file: " .. dir .. "/" .. map)
             continue 
         end
 
@@ -199,22 +201,22 @@ local function MountMapContent(dir)
 
         -- check if it has a scenario file
         if not scenarioFile then 
-            LOG("Map doesn't have a scenario file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no scenario file: " .. dir .. "/" .. map)
             continue 
         end
 
         if not scmapFile then 
-            LOG("Map doesn't have a scmap file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no scmap file: " .. dir .. "/" .. map)
             continue 
         end
 
         if not saveFile then 
-            LOG("Map doesn't have a save file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no save file: " .. dir .. "/" .. map)
             continue 
         end
 
         if not scriptFile then 
-            LOG("Map doesn't have a script file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no script file: " .. dir .. "/" .. map)
             continue 
         end
 
@@ -316,12 +318,14 @@ local function MountModContent(dir)
 
         -- do not load integrated mods
         if integratedMods[mod] then 
-            _ALERT("Blocked mod that is integrated: " .. mod )
+            LOG("Blocked mod that is integrated: " .. mod )
             continue 
         end 
 
         -- do not load archives as mods
-        if StringFind(mod, ".zip") or StringFind(mod, ".scd") or StringFind(mod, ".rar") then
+        local extension = StringSub(mod, -4)
+        if extension == ".zip" or extension == ".scd" or extension == ".rar" then
+            LOG("Prevented loading a mod inside a zip / scd / rar file: " .. dir .. "/" .. mod)
             continue 
         end
 
@@ -335,7 +339,7 @@ local function MountModContent(dir)
 
         -- check if it has a scenario file
         if not infoFile then 
-            _ALERT("Mod doesn't have an info file: " .. dir .. "/" .. mod)
+            LOG("Mod doesn't have an info file: " .. dir .. "/" .. mod)
             continue 
         end
 

--- a/init_fafdevelop.lua
+++ b/init_fafdevelop.lua
@@ -8,6 +8,10 @@
 -- imports fa_path to determine where it is installed
 dofile(InitFileDir .. '/../fa_path.lua')
 
+LOG("Client version: " .. tostring(ClientVersion))
+LOG("Game version: " .. tostring(GameVersion))
+LOG("Game type: " .. tostring(GameType))
+
 -- upvalued performance
 local dofile = dofile
 

--- a/init_fafdevelop.lua
+++ b/init_fafdevelop.lua
@@ -176,7 +176,9 @@ local function MountMapContent(dir)
         end
 
         -- do not load archives as maps
-        if StringSub(map, -4) == ".zip" or StringSub(map, -4) == ".scd"  or StringSub(map, -4) == ".rar" then
+        local extension = StringSub(map, -4)
+        if extension == ".zip" or extension == ".scd" or extension == ".rar" then
+            LOG("Prevented loading a map inside a zip / scd / rar file: " .. dir .. "/" .. map)
             continue 
         end
 
@@ -199,22 +201,22 @@ local function MountMapContent(dir)
 
         -- check if it has a scenario file
         if not scenarioFile then 
-            LOG("Map doesn't have a scenario file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no scenario file: " .. dir .. "/" .. map)
             continue 
         end
 
         if not scmapFile then 
-            LOG("Map doesn't have a scmap file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no scmap file: " .. dir .. "/" .. map)
             continue 
         end
 
         if not saveFile then 
-            LOG("Map doesn't have a save file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no save file: " .. dir .. "/" .. map)
             continue 
         end
 
         if not scriptFile then 
-            LOG("Map doesn't have a script file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no script file: " .. dir .. "/" .. map)
             continue 
         end
 
@@ -316,12 +318,14 @@ local function MountModContent(dir)
 
         -- do not load integrated mods
         if integratedMods[mod] then 
-            _ALERT("Blocked mod that is integrated: " .. mod )
+            LOG("Blocked mod that is integrated: " .. mod )
             continue 
         end 
 
         -- do not load archives as mods
-        if StringFind(mod, ".zip") or StringFind(mod, ".scd") or StringFind(mod, ".rar") then
+        local extension = StringSub(mod, -4)
+        if extension == ".zip" or extension == ".scd" or extension == ".rar" then
+            LOG("Prevented loading a mod inside a zip / scd / rar file: " .. dir .. "/" .. mod)
             continue 
         end
 
@@ -335,7 +339,7 @@ local function MountModContent(dir)
 
         -- check if it has a scenario file
         if not infoFile then 
-            _ALERT("Mod doesn't have an info file: " .. dir .. "/" .. mod)
+            LOG("Mod doesn't have an info file: " .. dir .. "/" .. mod)
             continue 
         end
 
@@ -434,7 +438,7 @@ allowedAssetsNxy = LowerHashTable(allowedAssetsNxy)
 
 -- load maps / mods from custom vault location, if set by client
 if custom_vault_path then
-	LOG('Loading custom vault path' .. custom_vault_path)
+	LOG('Loading custom vault path: ' .. custom_vault_path)
 	LoadVaultContent(custom_vault_path)
 else
     LOG("No custom vault path defined: loading from backup locations. You should update your client to 2021/10/+.")

--- a/init_shared.lua
+++ b/init_shared.lua
@@ -8,6 +8,10 @@
 -- imports fa_path to determine where it is installed
 dofile(InitFileDir .. '/../fa_path.lua')
 
+LOG("Client version: " .. tostring(ClientVersion))
+LOG("Game version: " .. tostring(GameVersion))
+LOG("Game type: " .. tostring(GameType))
+
 -- upvalued performance
 local dofile = dofile
 

--- a/init_shared.lua
+++ b/init_shared.lua
@@ -176,7 +176,9 @@ local function MountMapContent(dir)
         end
 
         -- do not load archives as maps
-        if StringSub(map, -4) == ".zip" or StringSub(map, -4) == ".scd"  or StringSub(map, -4) == ".rar" then
+        local extension = StringSub(map, -4)
+        if extension == ".zip" or extension == ".scd" or extension == ".rar" then
+            LOG("Prevented loading a map inside a zip / scd / rar file: " .. dir .. "/" .. map)
             continue 
         end
 
@@ -199,22 +201,22 @@ local function MountMapContent(dir)
 
         -- check if it has a scenario file
         if not scenarioFile then 
-            LOG("Map doesn't have a scenario file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no scenario file: " .. dir .. "/" .. map)
             continue 
         end
 
         if not scmapFile then 
-            LOG("Map doesn't have a scmap file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no scmap file: " .. dir .. "/" .. map)
             continue 
         end
 
         if not saveFile then 
-            LOG("Map doesn't have a save file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no save file: " .. dir .. "/" .. map)
             continue 
         end
 
         if not scriptFile then 
-            LOG("Map doesn't have a script file: " .. dir .. "/" .. map)
+            LOG("Prevented loading a map with no script file: " .. dir .. "/" .. map)
             continue 
         end
 
@@ -316,12 +318,14 @@ local function MountModContent(dir)
 
         -- do not load integrated mods
         if integratedMods[mod] then 
-            _ALERT("Blocked mod that is integrated: " .. mod )
+            LOG("Blocked mod that is integrated: " .. mod )
             continue 
         end 
 
         -- do not load archives as mods
-        if StringFind(mod, ".zip") or StringFind(mod, ".scd") or StringFind(mod, ".rar") then
+        local extension = StringSub(mod, -4)
+        if extension == ".zip" or extension == ".scd" or extension == ".rar" then
+            LOG("Prevented loading a mod inside a zip / scd / rar file: " .. dir .. "/" .. mod)
             continue 
         end
 
@@ -335,7 +339,7 @@ local function MountModContent(dir)
 
         -- check if it has a scenario file
         if not infoFile then 
-            _ALERT("Mod doesn't have an info file: " .. dir .. "/" .. mod)
+            LOG("Mod doesn't have an info file: " .. dir .. "/" .. mod)
             continue 
         end
 


### PR DESCRIPTION
Includes the `kyros.scd` to `init_faf.lua` and proper checks the extension of maps / mods instead of triggering on the the existence of the `.rar` pattern somewhere in its name.
