### PR TITLE
Feature/persist ferry

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -95,6 +95,7 @@ Callbacks.PersistFerry = function(data, units)
 
     -- function CreateUnit(blueprint, army, tx, ty, tz, qx, qy, qz, qw, [layer])
     local helper = CreateUnit('hel0001', units[1].Army, start[1], start[2], start[3], 1, 1, 1, 1, 'Air')
+
     TableInsert (units, helper)
     IssueClearCommands(units)
     for _, r in data.route do

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1515,6 +1515,7 @@ TransportBeaconUnit = Class(StructureUnit) {
         StructureUnit.OnCreate(self)
         self:SetCapturable(false)
         self:SetReclaimable(false)
+        self.CanBeKilled = false
     end,
 }
 

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -62,6 +62,8 @@ local startBehaviors = {}
 --- Behavior to run when exiting command mode. If f is a function, it is called as f(commandMode, modeData).
 local endBehaviors = {}
 
+local ferryRoute= {}
+
 --- Adds a starting behavior.
 -- @param behavior The behavior to add, called as behavior(commandMode, modeData).
 function AddStartBehavior(behavior)
@@ -359,6 +361,11 @@ function CapStructure(command)
     end
 end
 
+local function PersistFerryRoute() 
+    SimCallback({ Func = 'PersistFerry', Args = { route = ferryRoute} }, true)
+    ferryRoute = {}
+end
+
 -- cached category strings for performance
 local categoriesFactories = categories.STRUCTURE * categories.FACTORY
 local categoriesShields = categories.MOBILE * categories.SHIELD
@@ -474,6 +481,15 @@ function OnCommandIssued(command)
 
     -- used by spread attack to keep track of the orders of units
     import('/lua/spreadattack.lua').MakeShadowCopyOrders(command)
+
+    if command.CommandType == 'Ferry' then
+        local pos = command.Target.Position
+        table.insert(ferryRoute, {pos[1], pos[2], pos[3]})
+    end
+        
+    if not IsKeyDown('Shift') and table.getsize(ferryRoute) > 1 then
+        PersistFerryRoute()
+    end
 end
 
 --- ???
@@ -481,6 +497,10 @@ end
 function OnCommandModeBeat()
     if issuedOneCommand and not IsKeyDown('Shift') then
         EndCommandMode(true)
+    end
+
+    if not IsKeyDown('Shift') and table.getsize(ferryRoute) > 1 then
+        PersistFerryRoute()
     end
 end
 

--- a/units/HEL0001/HEL0001_script.lua
+++ b/units/HEL0001/HEL0001_script.lua
@@ -1,0 +1,13 @@
+HEL0001 = Class(moho.unit_methods) {
+    OnDamage = function(self, instigator, amount, vector, damageType)
+    end,
+
+    OnCreate = function(self)
+        self:SetCapturable(false)
+        self:SetReclaimable(false)
+        self:SetIsValidTarget(false)
+        self:SetCollisionShape('None')
+    end,
+}
+
+TypeClass = HEL0001

--- a/units/HEL0001/HEL0001_script.lua
+++ b/units/HEL0001/HEL0001_script.lua
@@ -7,6 +7,7 @@ HEL0001 = Class(moho.unit_methods) {
         self:SetReclaimable(false)
         self:SetIsValidTarget(false)
         self:SetCollisionShape('None')
+        self.CanBeKilled = false
 
         ForkThread(self.KillHelperWhenIdle, self)
     end,

--- a/units/HEL0001/HEL0001_script.lua
+++ b/units/HEL0001/HEL0001_script.lua
@@ -7,7 +7,19 @@ HEL0001 = Class(moho.unit_methods) {
         self:SetReclaimable(false)
         self:SetIsValidTarget(false)
         self:SetCollisionShape('None')
+
+        ForkThread(self.KillHelperWhenIdle, self)
     end,
+    
+    -- The ferry helper unit is destroyed when command queue is empty (happens when beacon is destroyed with shift-ctrl right click)
+    KillHelperWhenIdle = function(self)
+        repeat 
+            WaitSeconds(1)
+            cmds = self:GetCommandQueue()
+        until table.empty(cmds)
+        
+        self:Destroy()
+    end
 }
 
 TypeClass = HEL0001

--- a/units/HEL0001/HEL0001_unit.bp
+++ b/units/HEL0001/HEL0001_unit.bp
@@ -1,0 +1,79 @@
+UnitBlueprint {
+    AI = {
+        --BeaconName = 'UAB5102'
+    },
+    Categories = {
+        'UNTARGETABLE',
+        'TRANSPORTATION',
+    },
+    Defense = {
+        AirThreatLevel = 0,
+        ArmorType = 'Normal',
+        EconomyThreatLevel = 0,
+        Health = 1,
+        MaxHealth = 1,
+        RegenRate = 0,
+        SubThreatLevel = 0,
+        SurfaceThreatLevel = 0,
+    },
+    Description = 'Ferry helper',
+    Economy = {
+        BuildCostEnergy = 0,
+        BuildCostMass = 0,
+        BuildRate = 0,
+        BuildTime = 0,
+        BuildableCategory = {
+        },
+        ConsumptionPerSecondEnergy = 0,
+        ConsumptionPerSecondMass = 0,
+        MaxBuildDistance = 0,
+    },
+    Footprint = {
+        MaxSlope = 0,
+        SizeX = 0,
+        SizeZ = 0,
+    },
+    General = {
+        CapCost = 0,
+        Category = 'Transport',
+        Classification = 'RULEUC_MiscSupport',
+        CommandCaps = {
+            RULEUCC_Attack = false,
+            RULEUCC_CallTransport = true,
+            RULEUCC_Capture = false,
+            RULEUCC_Ferry = true,
+            RULEUCC_Guard = false,
+            RULEUCC_Move = false,
+            RULEUCC_Nuke = false,
+            RULEUCC_Patrol = false,
+            RULEUCC_Reclaim = false,
+            RULEUCC_Repair = false,
+            RULEUCC_RetaliateToggle = false,
+            RULEUCC_Stop = false,
+            RULEUCC_Transport = true,
+        },
+    },
+    Intel = {
+        VisionRadius = 0,
+    },
+    Interface = {
+        HelpText = 'Ferry helper',
+    },
+    LifeBarRender = false,
+    Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
+        MotionType = 'RULEUMT_None',
+    },
+    SelectionThickness = 0,
+    SizeX = 0,
+    SizeY = 0,
+    SizeZ = 0,
+    StrategicIconSortPriority = 0,
+}

--- a/units/HEL0001/HEL0001_unit.bp
+++ b/units/HEL0001/HEL0001_unit.bp
@@ -3,8 +3,9 @@ UnitBlueprint {
         --BeaconName = 'UAB5102'
     },
     Categories = {
+        'DUMMYUNIT',
         'UNTARGETABLE',
-        'TRANSPORTATION',
+        'TRANSPORTATION'
     },
     Defense = {
         AirThreatLevel = 0,

--- a/units/HEL0001/HEL0001_unit.bp
+++ b/units/HEL0001/HEL0001_unit.bp
@@ -76,4 +76,11 @@ UnitBlueprint {
     SizeY = 0,
     SizeZ = 0,
     StrategicIconSortPriority = 0,
+    Transport = {
+        AirClass = true,
+        Class2AttachSize = 0,
+        Class3AttachSize = 0,
+        Class1Capacity = 0,
+        TransportClass = 1,
+    },
 }


### PR DESCRIPTION
Persistent ferry routes, #3631

I resurrected an old branch I had on persistent ferry routes. Half of the work (simcallbacks, helper unit) was already merged years ago. The dummy unit wasn't destroyed correctly then but I fixed that now.

Needs to be tested, especially with multiple routes in same ferry route. Unfortunately we cannot access command queue on the UI side

