### PR TITLE
Change army color order

### DIFF
--- a/lua/GameColors.lua
+++ b/lua/GameColors.lua
@@ -7,18 +7,18 @@ GameColors = {
     "FFe80a0a",      -- Cybran red
     "FF2929e1",      -- UEF blue
     "ff901427",      -- dark red
-    "ff66ffcc",      -- aqua
+    "ff9161ff",      -- purple
     "FFFF873E",      -- Nomads orange
-    "ff40bf40",      -- mid green
+    "ff66ffcc",      -- aqua
     "fffafa00",      -- new yellow
     "ffff88ff",      -- pink
     "ffff32ff",      -- new fuschia
-    "ff9161ff",      -- purple
     "FF5F01A7",      -- dark purple
     "ffa79602",      -- Sera golden
     "ffb76518",      -- new brown
     "FF2F4F4F",      -- olive (dark green)
     "ff2e8b57",      -- new green
+    "ff40bf40",      -- mid green
     "ff9fd802",      -- Order Green
     "ff616d7e",      -- grey
     "ffffffff",      -- white
@@ -29,18 +29,18 @@ GameColors = {
     "FFe80a0a",      -- Cybran red
     "FF2929e1",      -- UEF blue
     "ff901427",      -- dark red
-    "ff66ffcc",      -- aqua
+    "ff9161ff",      -- purple
     "FFFF873E",      -- Nomads orange
-    "ff40bf40",      -- mid green
+    "ff66ffcc",      -- aqua
     "fffafa00",      -- new yellow
     "ffff88ff",      -- pink
     "ffff32ff",      -- new fuschia
-    "ff9161ff",      -- purple
     "FF5F01A7",      -- dark purple
     "ffa79602",      -- Sera golden
     "ffb76518",      -- new brown
     "FF2F4F4F",      -- olive (dark green)
     "ff2e8b57",      -- new green
+    "ff40bf40",      -- mid green
     "ff9fd802",      -- Order Green
     "ff616d7e",      -- grey
     "ffffffff",      -- white

--- a/lua/GameColors.lua
+++ b/lua/GameColors.lua
@@ -5,45 +5,45 @@ GameColors = {
     ArmyColors = {
     "ff436eee",      -- new blue1
     "FFe80a0a",      -- Cybran red
-    "ff616d7e",      -- grey
-    "fffafa00",      -- new yellow
-    "FFFF873E",      -- Nomads orange
-    "ffffffff",      -- white
-    "ff9161ff",      -- purple
-    "ffff88ff",      -- pink
-    "ff2e8b57",      -- new green
     "FF2929e1",      -- UEF blue
-    "FF5F01A7",      -- dark purple
+    "ff901427",      -- dark red
+    "ff66ffcc",      -- aqua
+    "FFFF873E",      -- Nomads orange
+    "ff40bf40",      -- mid green
+    "fffafa00",      -- new yellow
+    "ffff88ff",      -- pink
     "ffff32ff",      -- new fuschia
+    "ff9161ff",      -- purple
+    "FF5F01A7",      -- dark purple
     "ffa79602",      -- Sera golden
     "ffb76518",      -- new brown
-    "ff901427",      -- dark red
     "FF2F4F4F",      -- olive (dark green)
-    "ff40bf40",      -- mid green
-    "ff66ffcc",      -- aqua
+    "ff2e8b57",      -- new green
     "ff9fd802",      -- Order Green
+    "ff616d7e",      -- grey
+    "ffffffff",      -- white
     },
 
     PlayerColors = {
     "ff436eee",      -- new blue1
     "FFe80a0a",      -- Cybran red
-    "ff616d7e",      -- grey
-    "fffafa00",      -- new yellow
-    "FFFF873E",      -- Nomads orange
-    "ffffffff",      -- white
-    "ff9161ff",      -- purple
-    "ffff88ff",      -- pink
-    "ff2e8b57",      -- new green
     "FF2929e1",      -- UEF blue
-    "FF5F01A7",      -- dark purple
+    "ff901427",      -- dark red
+    "ff66ffcc",      -- aqua
+    "FFFF873E",      -- Nomads orange
+    "ff40bf40",      -- mid green
+    "fffafa00",      -- new yellow
+    "ffff88ff",      -- pink
     "ffff32ff",      -- new fuschia
+    "ff9161ff",      -- purple
+    "FF5F01A7",      -- dark purple
     "ffa79602",      -- Sera golden
     "ffb76518",      -- new brown
-    "ff901427",      -- dark red
     "FF2F4F4F",      -- olive (dark green)
-    "ff40bf40",      -- mid green
-    "ff66ffcc",      -- aqua
+    "ff2e8b57",      -- new green
     "ff9fd802",      -- Order Green
+    "ff616d7e",      -- grey
+    "ffffffff",      -- white
     },
 
     TeamColorMode = {


### PR DESCRIPTION
We didn't really think about army colors in the team matchmakers, so they were pretty random. This new order creates team red vs.team blue for 2v2. For 4v4 we get a "warm" team against a "cold" team.
I ordered the rest of the colors in a way that somwhat similar colors are in order when picking them in the lobby. As I don't expect that we will make any 5v5+ matchmaker in the foreseeable future.