### PR TITLE
Remove inconsistency with spawning units through the cheat menu

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -399,13 +399,15 @@ Callbacks.BoxFormationSpawn = function(data)
     end
 
     local function RoundToSkirt(axe, val)
+        LOG(axe)
+        LOG(val)
         return unitbp.Physics.MotionType ~= 'RULEUMT_None'
         and val
         or math.floor(val) + (math.mod(FootprintSize(axe),2) == 1 and 0.5 or 0)
     end
 
-    local posX = math.floor(data.pos[1])
-    local posZ = math.floor(data.pos[3])
+    local posX = (data.pos[1])
+    local posZ = (data.pos[3])
     local offsetX = unitbp.SizeX or 1
     local offsetZ = unitbp.SizeZ or 1
 
@@ -419,6 +421,7 @@ Callbacks.BoxFormationSpawn = function(data)
     local startOffsetX = (squareX-1) * 0.5 * offsetX
     local startOffsetZ = (squareZ-1) * 0.5 * offsetZ
 
+    LOG("BoxFormationSpawn")
     for i = 1, data.count do
         local x = RoundToSkirt('x', posX - startOffsetX + math.mod(i,squareX) * offsetX)
         local z = RoundToSkirt('z', posZ - startOffsetZ + math.mod(math.floor(i/squareX), squareZ) * offsetZ)

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -399,8 +399,6 @@ Callbacks.BoxFormationSpawn = function(data)
     end
 
     local function RoundToSkirt(axe, val)
-        LOG(axe)
-        LOG(val)
         return unitbp.Physics.MotionType ~= 'RULEUMT_None'
         and val
         or math.floor(val) + (math.mod(FootprintSize(axe),2) == 1 and 0.5 or 0)
@@ -421,7 +419,6 @@ Callbacks.BoxFormationSpawn = function(data)
     local startOffsetX = (squareX-1) * 0.5 * offsetX
     local startOffsetZ = (squareZ-1) * 0.5 * offsetZ
 
-    LOG("BoxFormationSpawn")
     for i = 1, data.count do
         local x = RoundToSkirt('x', posX - startOffsetX + math.mod(i,squareX) * offsetX)
         local z = RoundToSkirt('z', posZ - startOffsetZ + math.mod(math.floor(i/squareX), squareZ) * offsetZ)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1325,9 +1325,11 @@ Unit = Class(moho.unit_methods) {
         ArmyBrains[self.Army]:AddUnitStat(unitKilled.UnitId, "kills", 1)
     end,
 
-    CalculateVeterancyLevel = function(self, massKilled)
-        -- Limit the veterancy gain from one kill to one level worth
-        massKilled = math.min(massKilled, self.Sync.myValue or self.Sync.manualVeterancy[self.Sync.VeteranLevel + 1])
+    CalculateVeterancyLevel = function(self, massKilled, noLimit)
+        if not noLimit then 
+            -- Limit the veterancy gain from one kill to one level worth
+            massKilled = math.min(massKilled, self.Sync.myValue or self.Sync.manualVeterancy[self.Sync.VeteranLevel + 1])
+        end
 
         -- Total up the mass the unit has killed overall, and store it
         self.Sync.totalMassKilled = math.floor(self.Sync.totalMassKilled + massKilled)
@@ -1387,9 +1389,9 @@ Unit = Class(moho.unit_methods) {
         if not self.gainsVeterancy then return end
 
         if self.Sync.myValue then
-            self:CalculateVeterancyLevel(self.Sync.myValue * veteranLevel)
+            self:CalculateVeterancyLevel(self.Sync.myValue * veteranLevel, true)
         else
-            self:CalculateVeterancyLevel(self.Sync.manualVeterancy[veteranLevel])
+            self:CalculateVeterancyLevel(self.Sync.manualVeterancy[veteranLevel], true)
         end
     end,
 

--- a/lua/ui/dialogs/createunit.lua
+++ b/lua/ui/dialogs/createunit.lua
@@ -687,6 +687,8 @@ function CreateDialog(x, y)
 
     local function spreadSpawn(id, count, vet)
 
+        -- store selection so that units do not go of and try to build the unit we're 
+        -- cheating in, is reset in EndCommandMode of '/lua/ui/game/commandmode.lua'
         local selection = GetSelectedUnits()
         SelectUnits(nil);
 

--- a/lua/ui/dialogs/createunit.lua
+++ b/lua/ui/dialogs/createunit.lua
@@ -686,43 +686,36 @@ function CreateDialog(x, y)
     if SpawnThread then KillThread(SpawnThread) end
 
     local function spreadSpawn(id, count, vet)
-        count = tonumber(count:GetText()) or 1
-        vet = tonumber(vet:GetText()) or 0
-        local ori = (tonumber(orientation:GetText()) or 0) / 57.295779513
 
-        import('/lua/ui/game/commandmode.lua').StartCommandMode("build", { name = id })
-        local function callbackargs() return {
-            Func = 'BoxFormationSpawn',
-            Args = {
+        -- enables command mode for spawning units
+        import('/lua/ui/game/commandmode.lua').StartCommandMode(
+            "build", 
+            { 
+                -- default information required
+                name = id, 
+
+                -- inform this is part of a cheat
+                cheat = true, 
+
+                -- information for spawning
                 bpId = id,
-                count = count,
+                count = tonumber(count:GetText()) or 1,
+                vet = tonumber(vet:GetText()) or 0,
+                yaw = (tonumber(orientation:GetText()) or 0) / 57.295779513,
                 army = currentArmy,
-                pos = GetMouseWorldPos(),
-                veterancy = vet,
-                yaw = ori,
             }
-        } end
+        )
 
+        -- options for user to exit the spawn mode
         local function IsCancelKeyDown() return IsKeyDown('ESCAPE') or IsKeyDown(2) end
 
         WaitSeconds(0.15)
-        local shift
+
+        -- check if user wants to exit
         while not dialog do
-            if IsCancelKeyDown() then break end
-            if IsKeyDown(1) then
-                while IsKeyDown(1) do -- do on release
-                    if IsCancelKeyDown() then return end
-                    WaitSeconds(0.01)
-                end
-                SimCallback(callbackargs(), true)
-                if IsKeyDown('SHIFT') then
-                    shift = true
-                else
-                    break
-                end
-            end
-            if shift and not IsKeyDown('SHIFT') then
-               break
+            if IsCancelKeyDown() then 
+                import('/lua/ui/game/commandmode.lua').EndCommandMode(true)
+                break 
             end
             WaitSeconds(0.1)
         end

--- a/lua/ui/dialogs/createunit.lua
+++ b/lua/ui/dialogs/createunit.lua
@@ -687,6 +687,9 @@ function CreateDialog(x, y)
 
     local function spreadSpawn(id, count, vet)
 
+        local selection = GetSelectedUnits()
+        SelectUnits(nil);
+
         -- enables command mode for spawning units
         import('/lua/ui/game/commandmode.lua').StartCommandMode(
             "build", 
@@ -703,6 +706,7 @@ function CreateDialog(x, y)
                 vet = tonumber(vet:GetText()) or 0,
                 yaw = (tonumber(orientation:GetText()) or 0) / 57.295779513,
                 army = currentArmy,
+                selection = selection,
             }
         )
 

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -359,6 +359,28 @@ function CapStructure(command)
     end
 end
 
+--- Creates a callback to spawn a unit triggered by the cheat menu.
+-- @param command Command that contains the position of the click
+-- @param data A shallow copy of the modeData to make the function pure data-wise
+local function CheatSpawn(command, data)
+    SimCallback({
+        Func = 'BoxFormationSpawn',
+        Args = {
+            bpId = data.bpId,
+            count = data.count,
+            army = data.army,
+            pos = command.Target.Position,
+            veterancy = data.vet,
+            yaw = data.yaw,
+        }
+    }, true)
+
+    -- if we hold shift then we get to place another unit!
+    if not IsKeyDown('Shift') then 
+        EndCommandMode(true)
+    end
+end
+
 -- cached category strings for performance
 local categoriesFactories = categories.STRUCTURE * categories.FACTORY
 local categoriesShields = categories.MOBILE * categories.SHIELD
@@ -367,6 +389,12 @@ local categoriesStructure = categories.STRUCTURE
 --- Called by the engine when a new command has been issued by the player.
 -- @param command Information surrounding the command that has been issued, such as its CommandType or its Target.
 function OnCommandIssued(command)
+
+    -- part of the cheat menu
+    if modeData.cheat and command.CommandType == "BuildMobile" and (not command.Units[1]) then
+        CheatSpawn(command, modeData)
+        return
+    end
 
     -- unknown when set, do not understand when this applies yet. In other words: ???
     if not command.Clear then

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -396,7 +396,7 @@ local categoriesStructure = categories.STRUCTURE
 function OnCommandIssued(command)
 
     -- part of the cheat menu
-    if modeData.cheat and command.CommandType == "BuildMobile" then
+    if modeData.cheat and command.CommandType == "BuildMobile" and (not command.Units[1]) then
         CheatSpawn(command, modeData)
         command.Units = { }
         return false

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -112,6 +112,11 @@ function EndCommandMode(isCancel)
         return
     end
 
+    -- regain selection if we were cheating in units
+    if modeData.cheat and modeData.selection then 
+        SelectUnits(modeData.selection)
+    end
+
     -- add information to modeData for end behavior
     modeData.isCancel = isCancel or false
 
@@ -393,7 +398,8 @@ function OnCommandIssued(command)
     -- part of the cheat menu
     if modeData.cheat and command.CommandType == "BuildMobile" then
         CheatSpawn(command, modeData)
-        return
+        command.Units = { }
+        return false
     end
 
     -- unknown when set, do not understand when this applies yet. In other words: ???

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -391,7 +391,7 @@ local categoriesStructure = categories.STRUCTURE
 function OnCommandIssued(command)
 
     -- part of the cheat menu
-    if modeData.cheat and command.CommandType == "BuildMobile" and (not command.Units[1]) then
+    if modeData.cheat and command.CommandType == "BuildMobile" then
         CheatSpawn(command, modeData)
         return
     end


### PR DESCRIPTION
The previous implementation checked every 0.1 seconds if the mouse was pressed - if it was, then a callback would trigger. In practice however there can be the case that a mouse click is shorter than 0.1 seconds, effectively missing a click. As an example in the logs:

![image](https://user-images.githubusercontent.com/15778155/152139084-40099391-424a-47d9-a70d-3c2ac2bc2383.png)

The command issues are triggered at the same moment we click. But the spawn function is not called sometimes. 

The new implementation uses the build mode introduced by Balthazar as a callback mechanism - the build preview is issuing a command and we make use of that. In turn, no clicks are missed while retaining the current functionality.

Closes #3655 .