### PR TITLE
Optimize session armies and clients

### DIFF
--- a/lua/shared/observable.lua
+++ b/lua/shared/observable.lua
@@ -1,4 +1,7 @@
 
+-- implementation of the observable pattern as described on:
+--  - https://en.wikipedia.org/wiki/Observer_pattern
+
 -- upvalue for performance
 local TableInsert = table.insert
 

--- a/lua/shared/observable.lua
+++ b/lua/shared/observable.lua
@@ -2,11 +2,12 @@
 -- upvalue for performance
 local TableInsert = table.insert
 
-
 -- setup for a basic meta table
 local ObservableMeta = {}
 ObservableMeta.__index = ObservableMeta
 
+--- Adds an observer that is updated when the value is subject is set.
+-- @param callback A function that receives the value as its first argument.
 function ObservableMeta:AddObserver(callback)
     TableInsert(self.Listeners, callback)
 end

--- a/lua/shared/observable.lua
+++ b/lua/shared/observable.lua
@@ -1,0 +1,29 @@
+
+-- upvalue for performance
+local TableInsert = table.insert
+
+
+-- setup for a basic meta table
+local ObservableMeta = {}
+ObservableMeta.__index = ObservableMeta
+
+function ObservableMeta:AddObserver(callback)
+    TableInsert(self.Listeners, callback)
+end
+
+--- Sets the value of the subject and notifies all observers with the updated value.
+function ObservableMeta:Set(value)
+    for k, callback in self.Listeners do 
+        callback(value)
+    end
+end
+
+--- Constructs an observable as described by the observable pattern
+function Create()
+    local observable = {}
+    setmetatable(observable, ObservableMeta)
+
+    observable.Listeners = { }
+
+    return observable
+end

--- a/lua/ui/dialogs/disconnect.lua
+++ b/lua/ui/dialogs/disconnect.lua
@@ -14,10 +14,13 @@ local Group = import('/lua/maui/group.lua').Group
 local LazyVar = import('/lua/lazyvar.lua').Create
 local GameMain = import('/lua/ui/game/gamemain.lua')
 
+local SessionClients = import("/lua/ui/override/SessionClients.lua")
+
 local parent = false
 local myIndex = ''
 
 function DestroyDialog()
+    SessionClients.ResetInterval()
     if parent then
         parent:Destroy()
         parent = false
@@ -25,6 +28,7 @@ function DestroyDialog()
 end
 
 local function CreateDialog(clients)
+    SessionClients.FastInterval()
     import('/lua/ui/game/worldview.lua').UnlockInput()
     import('/lua/ui/game/gamemain.lua').KillWaitingDialog()
 

--- a/lua/ui/game/connectivity.lua
+++ b/lua/ui/game/connectivity.lua
@@ -12,6 +12,8 @@ local Group = import('/lua/maui/group.lua').Group
 local Bitmap = import('/lua/maui/bitmap.lua').Bitmap
 local GameMain = import('/lua/ui/game/gamemain.lua')
 
+local SessionClients = import("/lua/ui/override/SessionClients.lua")
+
 local GUI = {
     slots = {},
     bgTop = false,
@@ -95,6 +97,8 @@ function CreateUI()
     local _,isSession = UIUtil.GetNetworkBool()
     if not isSession then return end
 
+    SessionClients.FastInterval()
+
     GUI.group = Bitmap(GetFrame(0), UIUtil.UIFile('/scx_menu/panel-brd/panel_brd_m.dds'))
     GUI.group.Depth:Set(GetFrame(0):GetTopmostDepth() + 10)
 
@@ -176,6 +180,9 @@ function CreateUI()
 end
 
 function CloseWindow()
+
+    SessionClients.ResetInterval()
+
     if updateThread then
         KillThread(updateThread)
         updateThread = nil

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -143,6 +143,10 @@ end
 
 function CreateUI(isReplay)
 
+    -- override some UI globals
+    import("/lua/ui/override/ArmiesTable.lua").Setup()
+    import("/lua/ui/override/SessionClients.lua").Setup()
+
     -- ensure logger is turned off for the average user
     if not GetPreference('debug.enable_debug_facilities') then
         SetPreference('Options.Log', {

--- a/lua/ui/override/ArmiesTable.lua
+++ b/lua/ui/override/ArmiesTable.lua
@@ -1,12 +1,10 @@
 
-local Observable = import('/lua/shared/observable.lua')
-
 -- keep a reference to the actual function
 local GlobalGetArmiesTable = _G.GetArmiesTable
 
 --- Allows UI elements to be updated when the cache is updated by adding a callback via Observable:AddObserver()
 local Cached = GlobalGetArmiesTable()
-Observable = Observable.Create()
+Observable = import('/lua/shared/observable.lua').Create()
 Observable:Set(Cached)
 
 --- Interval for when we update the cache

--- a/lua/ui/override/ArmiesTable.lua
+++ b/lua/ui/override/ArmiesTable.lua
@@ -2,7 +2,7 @@
 local Observable = import('/lua/shared/observable.lua')
 
 -- keep a reference to the actual function
-local GlobalGetArmiesTable = _G.GetArmiesTables
+local GlobalGetArmiesTable = _G.GetArmiesTable
 
 --- Allows UI elements to be updated when the cache is updated by adding a callback via Observable:AddObserver()
 local Cached = GlobalGetArmiesTable()
@@ -10,7 +10,7 @@ Observable = Observable.Create()
 Observable:Set(Cached)
 
 --- Interval for when we update the cache
-local TickInterval = 0.5
+local TickInterval = 2.0
 
 --- A counter that keeps track of how often the interval was increased,
 -- allows us to keep track of when we really want to reset it. As an example,
@@ -23,7 +23,13 @@ local HandleToTickThread = false
 --- A simple tick thread that updates the cache
 local function TickThread()
     while true do 
-        WaitSeconds(TickInterval)
+        -- allows us to be more responsive on tick interval changes
+        WaitSeconds(0.5 * TickInterval)
+        WaitSeconds(0.5 * TickInterval)
+        WaitSeconds(0.5 * TickInterval)
+        WaitSeconds(0.5 * TickInterval)
+
+        -- update the cache and inform observers
         Cached = GlobalGetArmiesTable()
         Observable:Set(Cached)
     end
@@ -40,7 +46,8 @@ function Setup()
 end
 
 --- Override global function to return our cache
-_G.GetArmiesTables = function()
+_G.GetArmiesTable = function()
+    LOG("Returning cache of GetArmiesTable:" .. tostring(Cached))
     return Cached
 end
 
@@ -55,10 +62,10 @@ function FastInterval()
     TickInterval = 0.025
 end
 
---- Resets the interval to every 0.5 seconds or a framerate of 2.
+--- Resets the interval to every 2.0 seconds or a framerate of 0.5.
 function ResetInterval()
     TickIntervalResetCounter = TickIntervalResetCounter - 1
     if TickIntervalResetCounter == 0 then 
-        TickInterval = 0.5
+        TickInterval = 2.0
     end
 end

--- a/lua/ui/override/ArmiesTable.lua
+++ b/lua/ui/override/ArmiesTable.lua
@@ -1,0 +1,64 @@
+
+local Observable = import('/lua/shared/observable.lua')
+
+-- keep a reference to the actual function
+local GlobalGetArmiesTable = _G.GetArmiesTables
+
+--- Allows UI elements to be updated when the cache is updated by adding a callback via Observable:AddObserver()
+local Cached = GlobalGetArmiesTable()
+Observable = Observable.Create()
+Observable:Set(Cached)
+
+--- Interval for when we update the cache
+local TickInterval = 0.5
+
+--- A counter that keeps track of how often the interval was increased,
+-- allows us to keep track of when we really want to reset it. As an example,
+-- when FastInterval() is called again before ResetInterval() is.
+local TickIntervalResetCounter = 0
+
+--- Handle to the tick thread that updates the cache
+local HandleToTickThread = false 
+
+--- A simple tick thread that updates the cache
+local function TickThread()
+    while true do 
+        WaitSeconds(TickInterval)
+        Cached = GlobalGetArmiesTable()
+        Observable:Set(Cached)
+    end
+end
+
+--- Starts the tick thread to update the cache, should be called only once
+function Setup()
+    if not HandleToTickThread then 
+        HandleToTickThread = ForkThread(TickThread)
+    else 
+        WARN("Tried to start a second tick thread for updating the cache of GetArmiesTable:")
+        LOG(repr(debug.getinfo(2)))
+    end
+end
+
+--- Override global function to return our cache
+_G.GetArmiesTables = function()
+    return Cached
+end
+
+--- A getter to return the check interval
+function GetInterval()
+    return TickInterval
+end
+
+--- Increases the check interval to every 0.025 seconds or a framerate of 40.
+function FastInterval()
+    TickIntervalResetCounter = TickIntervalResetCounter + 1
+    TickInterval = 0.025
+end
+
+--- Resets the interval to every 0.5 seconds or a framerate of 2.
+function ResetInterval()
+    TickIntervalResetCounter = TickIntervalResetCounter - 1
+    if TickIntervalResetCounter == 0 then 
+        TickInterval = 0.5
+    end
+end

--- a/lua/ui/override/ArmiesTable.lua
+++ b/lua/ui/override/ArmiesTable.lua
@@ -47,7 +47,6 @@ end
 
 --- Override global function to return our cache
 _G.GetArmiesTable = function()
-    LOG("Returning cache of GetArmiesTable:" .. tostring(Cached))
     return Cached
 end
 

--- a/lua/ui/override/SessionClients.lua
+++ b/lua/ui/override/SessionClients.lua
@@ -1,12 +1,10 @@
 
-local Observable = import('/lua/shared/observable.lua')
-
 -- keep a reference to the actual function
 local GlobalGetSessionClients = _G.GetSessionClients
 
 --- Allows UI elements to be updated when the cache is updated by adding a callback via Observable:AddObserver()
 local Cached = GlobalGetSessionClients()
-Observable = Observable.Create()
+Observable = import('/lua/shared/observable.lua').Create()
 Observable:Set(Cached)
 
 --- Interval for when we update the cache

--- a/lua/ui/override/SessionClients.lua
+++ b/lua/ui/override/SessionClients.lua
@@ -47,7 +47,6 @@ end
 
 --- Override global function to return our cache
 _G.GetSessionClients = function()
-    LOG("Returning cache of GetSessionClients:" .. tostring(Cached))
     return Cached
 end
 

--- a/lua/ui/override/SessionClients.lua
+++ b/lua/ui/override/SessionClients.lua
@@ -1,0 +1,64 @@
+
+local Observable = import('/lua/shared/observable.lua')
+
+-- keep a reference to the actual function
+local GlobalGetSessionClients = _G.GetSessionClients
+
+--- Allows UI elements to be updated when the cache is updated by adding a callback via Observable:AddObserver()
+local Cached = GlobalGetSessionClients()
+Observable = Observable.Create()
+Observable:Set(Cached)
+
+--- Interval for when we update the cache
+local TickInterval = 0.5
+
+--- A counter that keeps track of how often the interval was increased,
+-- allows us to keep track of when we really want to reset it. As an example,
+-- when FastInterval() is called again before ResetInterval() is.
+local TickIntervalResetCounter = 0
+
+--- Handle to the tick thread that updates the cache
+local HandleToTickThread = false 
+
+--- A simple tick thread that updates the cache
+local function TickThread()
+    while true do 
+        WaitSeconds(TickInterval)
+        Cached = GlobalGetSessionClients()
+        Observable:Set(Cached)
+    end
+end
+
+--- Starts the tick thread to update the cache, should be called only once
+function Setup()
+    if not HandleToTickThread then 
+        HandleToTickThread = ForkThread(TickThread)
+    else 
+        WARN("Tried to start a second tick thread for updating the cache of GetSessionClients:")
+        LOG(repr(debug.getinfo(2)))
+    end
+end
+
+--- Override global function to return our cache
+_G.GetSessionClients = function()
+    return Cached
+end
+
+--- A getter to return the check interval
+function GetInterval()
+    return TickInterval
+end
+
+--- Increases the check interval to every 0.025 seconds or a framerate of 40.
+function FastInterval()
+    TickIntervalResetCounter = TickIntervalResetCounter + 1
+    TickInterval = 0.025
+end
+
+--- Resets the interval to every 0.5 seconds or a framerate of 2.
+function ResetInterval()
+    TickIntervalResetCounter = TickIntervalResetCounter - 1
+    if TickIntervalResetCounter == 0 then 
+        TickInterval = 0.5
+    end
+end

--- a/lua/ui/override/SessionClients.lua
+++ b/lua/ui/override/SessionClients.lua
@@ -10,7 +10,7 @@ Observable = Observable.Create()
 Observable:Set(Cached)
 
 --- Interval for when we update the cache
-local TickInterval = 0.5
+local TickInterval = 2.0
 
 --- A counter that keeps track of how often the interval was increased,
 -- allows us to keep track of when we really want to reset it. As an example,
@@ -23,7 +23,13 @@ local HandleToTickThread = false
 --- A simple tick thread that updates the cache
 local function TickThread()
     while true do 
-        WaitSeconds(TickInterval)
+        -- allows us to be more responsive on tick interval changes
+        WaitSeconds(0.5 * TickInterval)
+        WaitSeconds(0.5 * TickInterval)
+        WaitSeconds(0.5 * TickInterval)
+        WaitSeconds(0.5 * TickInterval)
+
+        -- update the cache and inform observers
         Cached = GlobalGetSessionClients()
         Observable:Set(Cached)
     end
@@ -41,6 +47,7 @@ end
 
 --- Override global function to return our cache
 _G.GetSessionClients = function()
+    LOG("Returning cache of GetSessionClients:" .. tostring(Cached))
     return Cached
 end
 
@@ -55,10 +62,10 @@ function FastInterval()
     TickInterval = 0.025
 end
 
---- Resets the interval to every 0.5 seconds or a framerate of 2.
+--- Resets the interval to every 2.0 seconds or a framerate of 0.5.
 function ResetInterval()
     TickIntervalResetCounter = TickIntervalResetCounter - 1
     if TickIntervalResetCounter == 0 then 
-        TickInterval = 0.5
+        TickInterval = 2.0
     end
 end

--- a/lua/ui/override/readme.md
+++ b/lua/ui/override/readme.md
@@ -1,0 +1,111 @@
+
+# Override
+
+This folder contains overrides to various UI globals as they are inefficient with their current implementation. A
+
+# Memory argument
+
+s an example say we have the function `GetSessionClients`. It returns a table in a similar format to:
+
+```lua
+{
+  {
+    authorizedCommandSources={ 1 },
+    connected=true,
+    ejectedBy={ },
+    local=true,
+    name="Jip",
+    ping=0,
+    quiet=0,
+    uid="0"
+  }
+}
+```
+
+The table grows linearly with the number of players. Rough indications of the amount of memory this consumes per call:
+ - 1 table pointer:         40 bytes
+ - 1 table pointer:         40 bytes per player
+   - 8 hash table entries:      8x 40 bytes per player
+   - 2 table pointers:          2x 40 bytes per player
+   - 1 index table entry:       1x 16 bytes per player
+
+Therefore a call is expensive. A unique table is returned regardles of the Lua state. As an example, when we do:
+
+```lua
+LOG(GetSessionClients())
+LOG(GetSessionClients())
+LOG(GetSessionClients())
+```
+
+Then the output is:
+
+```yaml
+table: 11E9C488
+table: 11E9C370
+table: 11E9C870
+```
+
+And these are unique, as the memory adres they point to are unique too. That shows us that, even when we're on the same frame, it returns a new table because the memory address of the tables are unique. Therefore we cache it and provide an interface for the UI to be updated when the clients are updated.
+
+# Functions that we Override
+
+Due to the memory argument:
+ - GetArmiesTable
+ - GetSessionClients
+
+# Sources
+
+The number of bytes per entry is based on this article:
+ - https://wowwiki-archive.fandom.com/wiki/Lua_object_memory_sizes
+
+And a quote of the relevant section in case the link is no longer available:
+
+Tables behave in different ways depending on how much data is put in them, and the style of indexing used. A new, empty table will consume 40 bytes. As indexes are added, the table will allocate space for new indexes at an exponential rate. For example:
+
+```lua
+local t = {}  -- 40 bytes
+t[1] = true   -- alloc 1 index
+t[2] = true   -- alloc 1 index
+t[3] = true   -- alloc 2 indexes
+t[4] = true
+t[5] = true   -- alloc 4 indexes
+...
+```
+
+If a table is indexed by sequential integers, each index will take 16 bytes (not including any memory allocated for the value). If the becomes a hash, the index size will jump to 40 bytes each. Lua is "smart" and will allocate at the 16 byte rate as much as it can. If the int sequence is broken, the new values will allocate at the 40 byte rate. For example:
+
+```lua
+local t = {}  -- 40 bytes
+t[1] = true   -- 16 bytes
+t[2] = true   -- 16 bytes
+t[3] = true   -- 32 bytes
+t[4] = true
+t[8] = true   -- 40 bytes
+t[9] = true   -- 40 bytes
+t[10] = true  -- 80 bytes
+t["x"] = true
+t["y"] = true -- 160 bytes
+...
+```
+
+Note that sequential-int and hash allocation can be intermixed. Lua will continue to allocate at the 16-byte rate as long as it possibly can.
+
+```lua
+local t = {}  -- 40 bytes
+t[1] = true   -- 16 bytes
+t["1"] = true -- 40 bytes
+t[2] = true   -- 16 bytes
+t["2"] = true -- 40 bytes
+t[3] = true   -- 32 bytes
+t["3"] = true -- 80 bytes
+```
+
+Erasing values from a table will not deallocate space used for indexes. Thus, tables don't "shrink back" when erased. However, if a value is written into the table on a new index, the table will deallocate back to fit it's new data. This is not delayed until a GC step, but rather an immediate effect. To erase and shrink a table, one can use:
+
+```lua
+for i,v in pairs(t) do t[i] = nil end
+t.reset = 1
+t.reset = nil
+```
+
+It should be noted that erasing a table is generally more expensive than collecting the table during GC. One may wish to simply allocate a new empty table.

--- a/lua/ui/uimain.lua
+++ b/lua/ui/uimain.lua
@@ -1,0 +1,264 @@
+--*****************************************************************************
+--* File: lua/modules/ui/uimain.lua
+--* Author: Chris Blackwell
+--* Summary: The entry point for UI scripting
+--*
+--* Copyright � 2005 Gas Powered Games, Inc.  All rights reserved.
+--*****************************************************************************
+
+local UIUtil = import('uiutil.lua')
+local UIFile = UIUtil.UIFile
+local Prefs = import('/lua/user/prefs.lua')
+local Text = import('/lua/maui/text.lua').Text
+local OnlineProvider = import('/lua/multiplayer/onlineprovider.lua')
+local CampaignManager = import('/lua/ui/campaign/campaignmanager.lua')
+
+local console = false
+local alreadySetup = false
+
+--* Initialize the UI states, this is always called on startup
+function SetupUI()
+    
+    -- SetCursor needs to happen anytime this function is called because we
+    -- could be switching lua states.
+    local c = UIUtil.CreateCursor()
+    SetCursor( c )
+
+    -- the rest of this function only needs to run once to set up the globals, so 
+    -- don't do it again if not needed
+    if alreadySetup then return end
+    alreadySetup = true
+
+    UIUtil.currentLayout = Prefs.GetFromCurrentProfile('layout') or 'bottom'
+    local skin = Prefs.GetFromCurrentProfile('skin')
+    UIUtil.SetCurrentSkin(skin or 'uef')    -- default skin to start
+
+    UIUtil.consoleDepth = 5000000 -- no UI element should depth higher than this!
+end
+
+-- THE FOLLOWING FUNCTIONS SHOULD NOT BE CALLED FROM LUA CODE
+-- THEY ARE CALLED FROM THE ENGINE AND EXPECT A DIFFERENT LUA STATE
+function StartSplashScreen()
+    console = false
+    import('/lua/ui/splash/splash.lua').CreateUI()
+end
+
+function StartFrontEndUI()
+    console = false
+    
+    -- make sure cheat keys are disabled if needed
+    if not DebugFacilitiesEnabled() then
+        local keyMap = import('/lua/keymap/defaultKeyMap.lua')
+        IN_RemoveKeyMapTable(keyMap.debugKeyMap)                
+    end    
+    
+    -- if there is an auto continue state, then launch op immediately
+    if GetFrontEndData('NextOpBriefing') then
+        CampaignManager.LaunchBriefing(GetFrontEndData('NextOpBriefing'))
+    else
+        import('/lua/ui/menus/main.lua').CreateUI()
+    end
+    if GetNumRootFrames() > 1 then
+        import('/lua/ui/game/multihead.lua').ShowLogoInHead1()
+    end
+end
+
+
+--Used by command line to host a game
+function StartHostLobbyUI(protocol, port, playerName, gameName, mapName, natTraversalProvider)
+    LOG("Command line hostlobby")
+    local lobby = import('/lua/ui/lobby/lobby.lua')
+    lobby.CreateLobby(protocol, port, playerName, nil, natTraversalProvider, GetFrame(0), StartFrontEndUI)
+    lobby.HostGame(gameName, mapName, false)
+end
+
+--Used by command line to join a game
+function StartJoinLobbyUI(protocol, address, playerName, natTraversalProvider)
+    local lobby = import('/lua/ui/lobby/lobby.lua')
+    local port = 0
+    lobby.CreateLobby(protocol, port, playerName, nil, natTraversalProvider, GetFrame(0), StartFrontEndUI)
+    lobby.JoinGame(address, false)
+end
+
+function StartGameUI()
+    console = false
+    import('/lua/ui/game/gamemain.lua').CreateWldUIProvider()
+end
+-- END SHOULD NOT BE CALLED FROM LUA CODE
+
+-- toggle the console window (create if needed)
+function ToggleConsole()
+    if console then
+        if console:IsHidden() then
+            console:Show()
+        else
+            console:Hide()
+        end
+    else
+        console = import('/lua/ui/dialogs/console.lua').CreateDialog()
+        console:Show()
+    end
+end
+
+--* The following scripts are alternate entry points to the UI from the engine
+--* Typically these are dialog popup type calls
+
+-- context sensitive exit dialog
+function ShowEscapeDialog(yesNoOnly)
+    import('/lua/ui/dialogs/eschandler.lua').HandleEsc(yesNoOnly)
+end
+
+-- when escape is pressed and it's not captured by any controls, this defines the behvaior of what should occur
+local escapeHandler = nil
+
+function SetEscapeHandler(handler)
+    escapeHandler = handler
+end
+
+-- called by the engine when escape is pressed but there's no specific handler for it
+function EscapeHandler()
+    if not WorldIsLoading() and (import('/lua/ui/game/gamemain.lua').supressExitDialog != true) then
+        if escapeHandler then
+            escapeHandler()
+        else
+            import('/lua/ui/dialogs/eschandler.lua').HandleEsc()
+        end
+    end
+end
+
+-- network disconnection/boot dialog
+local prevDisconnectModule
+function UpdateDisconnectDialog()
+    local module = import('/lua/ui/dialogs/disconnect.lua')
+    if prevDisconnectModule and prevDisconnectModule != module then
+        pcall(prevDisconnectModule.DestroyDialog)
+    end
+    prevDisconnectModule = module
+    module.Update()
+end
+
+function NoteGameSpeedChanged(clientIndex, newSpeed)
+    local clients = GetSessionClients()
+    local client = clients[clientIndex]
+    -- Note: this string has an Engine loc tag because it was
+    -- originally in the engine.  If we were not already past the loc
+    -- deadline, I'd change to to be some UI loc tag.  But we are, so
+    -- I'm not going to change it and risk the wrath of the producers.
+    print(LOCF("<LOC Engine0006>%s: adjusting game speed to %+d", client.name, newSpeed))
+    import('/lua/ui/game/score.lua').NoteGameSpeedChanged(newSpeed)
+end
+
+function NoteGameOver()
+    SetFocusArmy(-1)
+    if not import('/lua/ui/dialogs/score.lua').scoreScreenActive then
+        GetCursor():Show()
+    end
+    if SessionIsReplay() then
+        --local scoreDlg = import('/lua/ui/dialogs/score.lua').dialog
+        --import('/lua/ui/game/gameresult.lua').OnReplayEnd()
+        import('/lua/ui/game/score.lua').ArmyAnnounce(1, '<LOC _Replay_over>Replay over.')
+    else
+        import('/lua/ui/game/score.lua').ArmyAnnounce(1, '<LOC _Game_over>Game over.')
+    end
+end
+
+local mouseClickFuncs = {}
+
+function OnMouseButtonPress(event)
+    if mouseClickFuncs and table.getsize(mouseClickFuncs) > 0 then
+        for _, func in mouseClickFuncs do
+            func(event)
+        end
+    end
+end
+
+function AddOnMouseClickedFunc(func)
+    table.insert(mouseClickFuncs, func)
+end
+
+function RemoveOnMouseClickedFunc(func)
+    local i = 1
+    local found = false
+    while mouseClickFuncs[i] do
+        if mouseClickFuncs[i] == func then
+            found = true
+            break
+        end
+        i = i + 1
+    end
+    if found then
+        table.remove(mouseClickFuncs, i)
+    end
+end
+
+-- network desync info
+function ShowDesyncDialog(beatNumber, strings)
+    import('/lua/ui/dialogs/desync.lua').UpdateDialog(beatNumber, strings)
+end
+
+--* The following functions are invoked by the engine to show some text at a certain location
+--TODO keep a table of cursor texts to have multiple available?
+local cursorText = false
+
+function StartCursorText(x, y, text, color, time, flash)
+    if cursorText and cursorText._inTimer then return end -- if cursor text has a time, don't stomp it
+    if cursorText then cursorText:Destroy() end
+    cursorText = Text(GetFrame(0))
+    cursorText:SetText(LOC(text))
+    cursorText:SetColor(color)
+    cursorText:SetFont(UIUtil.bodyFont, 18)
+    cursorText:SetDropShadow(true)
+    cursorText.Left:Set(x + 16)
+    cursorText.Top:Set(y)
+
+    cursorText:SetNeedsFrameUpdate(true)
+
+    cursorText.OnFrame = function(self, elapsedTime)
+        if flash then
+            if not cursorText._flashTime then
+                cursorText._flashTime = 0
+            else
+                cursorText._flashTime = cursorText._flashTime + elapsedTime
+            end
+            if cursorText._flashTime > 0.25 then -- 1/4 second flashes
+                cursorText:SetHidden(not cursorText:IsHidden())
+                cursorText._flashTime = 0
+            end
+        end
+
+        if not cursorText._time then
+            cursorText._time = 0
+        else
+            cursorText._time = cursorText._time + elapsedTime
+        end
+        if time > 0 then
+            cursorText._inTimer = true
+            if time < (cursorText._time) then
+                cursorText:Destroy()
+                cursorText = nil
+            end
+        end
+    end
+end
+
+function StopCursorText()
+    if cursorText and cursorText._inTimer then return end -- if cursor text has a time, don't stomp it
+    if cursorText then cursorText:Destroy() end
+end
+
+function IncreaseGameSpeed()
+    if not WorldIsLoading() and (import('/lua/ui/game/gamemain.lua').supressExitDialog != true) then
+        ConExecute('WLD_IncreaseSimRate')
+    end    
+end
+
+function DecreaseGameSpeed()
+    if not WorldIsLoading() and (import('/lua/ui/game/gamemain.lua').supressExitDialog != true) then
+        ConExecute('WLD_DecreaseSimRate')
+    end    
+end
+
+function OnApplicationResize(head, width, height)
+    -- resize can cause odd ui behavior in construction manager, so just deselect after a resize
+    SelectUnits(nil)
+end

--- a/lua/ui/uimain.lua
+++ b/lua/ui/uimain.lua
@@ -18,7 +18,7 @@ local alreadySetup = false
 
 --* Initialize the UI states, this is always called on startup
 function SetupUI()
-    
+
     -- SetCursor needs to happen anytime this function is called because we
     -- could be switching lua states.
     local c = UIUtil.CreateCursor()


### PR DESCRIPTION
Caches result of GetSessionClients and GetArmiesTable. These are often called (as much as at least once per frame). Each call returns a unique result. Each unique result needs to be populated. And tables are expensive memory-wise. 

By default the cache is refreshed every two seconds. A faster interval is available: then the cache is refreshed every 0.025 seconds. As an example, GetSessionClients needs a faster interval when the connectivity / disconnection dialogue is open.