### PR TITLE
Dynamic LOD settings

### DIFF
--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -61,6 +61,8 @@ pcall = pcall
 doscript = doscript
 DiskFindFiles = DiskFindFiles
 
+doscript("/lua/system/blueprints-lod.lua")
+
 --- Load in the pre game data that is defined in the lobby through the preference file.
 local function LoadPreGameData()
 
@@ -867,6 +869,8 @@ function PostModBlueprints(all_bps)
     -- we do before releasing the blueprint values to the game as we want to catch all
     -- units, even those included by mods.
     FindCustomStrategicIcons(all_bps)
+
+    CalculateLODs(all_bps)
 end
 -----------------------------------------------------------------------------------------------
 --- Loads all blueprints with optional parameters

--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -870,6 +870,7 @@ function PostModBlueprints(all_bps)
     -- units, even those included by mods.
     FindCustomStrategicIcons(all_bps)
 
+    -- re-computes all the LODs of various entities to match the LOD with the size of the entity.
     CalculateLODs(all_bps)
 end
 -----------------------------------------------------------------------------------------------

--- a/lua/system/blueprints-lod.lua
+++ b/lua/system/blueprints-lod.lua
@@ -16,7 +16,7 @@ local function CalculateLODOfProp(prop)
     -- 5 -> ~ 750
     -- 6 -> ~ 820
     -- https://www.desmos.com/calculator/amw5fi5569 (1.5 * sqrt(100 * 500 * x))
-    local lod = 1.5 * MathSqrt(100 * 500 * weighted)
+    local lod = 1.45 * MathSqrt(100 * 500 * weighted)
     
     if prop.Display and prop.Display.Mesh and prop.Display.Mesh.LODs then
 

--- a/lua/system/blueprints-lod.lua
+++ b/lua/system/blueprints-lod.lua
@@ -1,0 +1,53 @@
+
+local MathSqrt = math.sqrt
+
+local LODFactors = {
+    [1] = { 1.0 },
+    [2] = { 0.3, 1.0 },
+    [3] = { 0.1, 0.3, 1.0 },
+    [4] = { 0.1, 0.3, 0.6, 1.0 },
+}
+
+local function CalculateLODOfProp(prop)
+    local sx = prop.SizeX or 1 
+    local sy = prop.SizeY or 1
+    local sz = prop.SizeZ or 1
+
+    -- give more emphasis to the x / z value as that is easier to see in the average camera angle
+    local weighted = 0.40 * sx + 0.2 * sy + 0.4 * sz 
+
+    -- https://www.desmos.com/calculator/amw5fi5569
+    -- 1 -> ~ 330
+    -- 2 -> ~ 470
+    -- 3 -> ~ 580
+    -- 4 -> ~ 670
+    -- 5 -> ~ 750
+    -- 6 -> ~ 820
+    local lod = 1.5 * MathSqrt(100 * 500 * weighted)
+    
+    if prop.Display and prop.Display.Mesh and prop.Display.Mesh.LODs then
+
+        local factors = LODFactors[table.getn(prop.Display.Mesh.LODs)]
+
+        -- find order of LODs 
+        for k = 1, table.getn(prop.Display.Mesh.LODs) do 
+            local data = prop.Display.Mesh.LODs[k]
+
+            -- if prop.ScriptClass and prop.ScriptClass == "TreeGroup" then 
+            --     LOG("Mapping ( " .. tostring(weighted) .. "): " .. tostring(data.LODCutoff) .. " -> " .. tostring(factors[k] * lod))
+            -- end
+
+            data.LODCutoff = factors[k] * lod 
+        end
+    end
+end
+
+local function CalculateLODsOfProps(props)
+    for k, prop in props do 
+        CalculateLODOfProp(prop)
+    end
+end
+
+function CalculateLODs(bps)
+    CalculateLODsOfProps(bps.Prop)
+end

--- a/lua/system/blueprints-lod.lua
+++ b/lua/system/blueprints-lod.lua
@@ -1,6 +1,8 @@
 
 local MathSqrt = math.sqrt
 
+--- Calculates the LODs of a single prop
+-- @param props Prop to compute the LODs for
 local function CalculateLODOfProp(prop)
     local sx = prop.SizeX or 1 
     local sy = prop.SizeY or 1
@@ -43,12 +45,16 @@ local function CalculateLODOfProp(prop)
     end
 end
 
+--- Calculates the LODs of a list of props
+-- @param props List of props to tweak the LODs for
 local function CalculateLODsOfProps(props)
     for k, prop in props do 
         CalculateLODOfProp(prop)
     end
 end
 
+--- Calculates the LODs of all entities
+-- @param bps All available blueprints
 function CalculateLODs(bps)
     CalculateLODsOfProps(bps.Prop)
 end

--- a/lua/system/blueprints-lod.lua
+++ b/lua/system/blueprints-lod.lua
@@ -1,13 +1,6 @@
 
 local MathSqrt = math.sqrt
 
-local LODFactors = {
-    [1] = { 1.0 },
-    [2] = { 0.3, 1.0 },
-    [3] = { 0.1, 0.3, 1.0 },
-    [4] = { 0.1, 0.3, 0.6, 1.0 },
-}
-
 local function CalculateLODOfProp(prop)
     local sx = prop.SizeX or 1 
     local sy = prop.SizeY or 1
@@ -16,28 +9,36 @@ local function CalculateLODOfProp(prop)
     -- give more emphasis to the x / z value as that is easier to see in the average camera angle
     local weighted = 0.40 * sx + 0.2 * sy + 0.4 * sz 
 
-    -- https://www.desmos.com/calculator/amw5fi5569
     -- 1 -> ~ 330
     -- 2 -> ~ 470
     -- 3 -> ~ 580
     -- 4 -> ~ 670
     -- 5 -> ~ 750
     -- 6 -> ~ 820
+    -- https://www.desmos.com/calculator/amw5fi5569 (1.5 * sqrt(100 * 500 * x))
     local lod = 1.5 * MathSqrt(100 * 500 * weighted)
     
     if prop.Display and prop.Display.Mesh and prop.Display.Mesh.LODs then
 
-        local factors = LODFactors[table.getn(prop.Display.Mesh.LODs)]
+        -- used for scaling the LODs
+        local n = table.getn(prop.Display.Mesh.LODs)
 
-        -- find order of LODs 
+        -- read LODs in order
         for k = 1, table.getn(prop.Display.Mesh.LODs) do 
             local data = prop.Display.Mesh.LODs[k]
 
+            -- 1/1 -> 1/1
+            -- 1/2 -> 1/4
+            -- 1/3 -> 1/9
+            -- 1/4 -> 1/16
+            -- https://www.desmos.com/calculator/keue6viu3b (x * x)
+            local factor = (k / n) * (k / n)
+
             -- if prop.ScriptClass and prop.ScriptClass == "TreeGroup" then 
-            --     LOG("Mapping ( " .. tostring(weighted) .. "): " .. tostring(data.LODCutoff) .. " -> " .. tostring(factors[k] * lod))
+            --     LOG("Mapping ( " .. tostring(weighted) .. "): " .. tostring(data.LODCutoff) .. " -> " .. tostring(factor * lod))
             -- end
 
-            data.LODCutoff = factors[k] * lod 
+            data.LODCutoff = factor * lod + 10
         end
     end
 end


### PR DESCRIPTION
Some of the LOD values are out of balance. This can cause sudden framerate drops. This pull request scales the LOD of entities according to their size. A small entity occupies less screen space, therefore it is less detailed and can do with a lower LOD. The same (but reversed) logic can be used for a large entity.

This pull request is a result of a discussion with Strogo about [this video](https://youtu.be/dAqlgrOjy2Q).