### PR TITLE
Disable mesh rendering for minimap

### DIFF
--- a/lua/ui/game/minimap.lua
+++ b/lua/ui/game/minimap.lua
@@ -181,6 +181,9 @@ function CreateMinimap(parent)
     controls.displayGroup.ClientGroup:DisableHitTest()
     controls.miniMap:EnableHitTest()
     CommonLogic()
+    if Prefs.GetFromCurrentProfile('disableMinimapMesh') ~= false then
+        ConExecute("cam_DefaultMiniLOD 0")
+    end
 end
 
 function ToggleMinimap()

--- a/lua/ui/game/multifunction.lua
+++ b/lua/ui/game/multifunction.lua
@@ -456,6 +456,24 @@ function CreateMapDropout(parent)
                 Borders.SplitMapGroup(splitOnCheck)
             end
             LayoutHelpers.Below(group.toggles[3], group.toggles[2])
+        elseif camName == 'MiniMap' then
+            local disableMinimapMesh = Prefs.GetFromCurrentProfile('disableMinimapMesh')
+            local wording = 'Disable meshes'
+            group.toggles[3] = CreateToggleItem(group, wording)
+            if disableMinimapMesh == false then
+                group.toggles[3]:SetCheck(false)
+            end
+            group.toggles[3].OnCheck = function(self, checked)
+                if checked then
+                    Prefs.SetToCurrentProfile('disableMinimapMesh', true)
+                    ConExecute("cam_DefaultMiniLOD 0")
+                else
+                    Prefs.SetToCurrentProfile('disableMinimapMesh', false)
+                    ConExecute("cam_DefaultMiniLOD 1.8")
+                end
+            end
+            Tooltip.AddCheckboxTooltip(group.toggles[3], "minimap_mesh")
+            LayoutHelpers.Below(group.toggles[3], group.toggles[2])
         end
 
         LayoutHelpers.AtLeftTopIn(group.toggles[1], group, 0, 20)

--- a/lua/ui/help/tooltips.lua
+++ b/lua/ui/help/tooltips.lua
@@ -2043,6 +2043,9 @@ Tooltips = {
         title = "<LOC tooltipui0629>Save Template",
         description = "<LOC tooltipui0630>Creates construction template by saving units/structures and their position",
     },
+    minimap_mesh = {
+        description = "<LOC tooltipui0720>Disables mesh rendering for minimap. Greatly improves performance",
+    },
 
     -- **********************
     -- ** GazUI

--- a/lua/ui/help/tooltips.lua
+++ b/lua/ui/help/tooltips.lua
@@ -2044,7 +2044,7 @@ Tooltips = {
         description = "<LOC tooltipui0630>Creates construction template by saving units/structures and their position",
     },
     minimap_mesh = {
-        description = "<LOC tooltipui0720>Disables mesh rendering for minimap. Greatly improves performance",
+        description = "<LOC tooltipui0720>Disables the rendering of meshes of units and props on the minimap to reduce the burden on the rendering thread. Can potentially improve your framerate.",
     },
 
     -- **********************


### PR DESCRIPTION
I'm currently working on ability to change LOD modifiers for different type of objects via console and one thing that bothered me is why mesh renderer code that makes LOD calculations for visible objects is called so often, as if there are thousands objects in view, even though I'm zoomed in and there is 1 unit and a few props on the screen.

The answer is simple - minimap. Why bother adding simplified renderer for minimap, if you can just copy-paste main camera implementation and apply fancy cartographic view on it :+1: And things become even more dramatic if you accidentally zoom in and minimap starts to  render all these props and units.

Anyway, with this engine patch https://github.com/FAForever/FA-Binary-Patches/pull/7 `cam_DefaultMiniLOD 0` command will disable minimap mesh renderer completely. As a result minimap becomes an actual minimap, stops eating your fps and shows only 2 things that you expect from it: the map itself and unit icons. The option is added to minimap settings and it's ON by default:
![Screenshot_9](https://user-images.githubusercontent.com/36897892/154838604-a06bee91-7271-46ac-bf4c-87c4496103f5.png)

Exe for testing:
https://mega.nz/file/QYI3gCyJ#JVUH0BHUFEPG_arlgPE0PMyR9yvRuptxXk1_EbogAY8

