### PR TITLE
Improve weapon state when owner dies

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1195,9 +1195,9 @@ Unit = Class(moho.unit_methods) {
         local layer = self.Layer
         self.Dead = true
 
-        -- destroy all weapon effects
+        -- Clear out any remaining projectiles
         for k = 1, self.WeaponCount do 
-            self.WeaponInstances[k].Trash:Destroy();
+            self.WeaponInstances[k]:ClearProjectileTrash();
         end
 
         -- Units killed while being invisible because they're teleporting should show when they're killed
@@ -1977,6 +1977,7 @@ Unit = Class(moho.unit_methods) {
             v:Destroy()
         end
 
+        -- destroy remaining trash of weapon
         for k = 1, self.WeaponCount do 
             self.WeaponInstances[k].Trash:Destroy();
         end
@@ -1984,6 +1985,12 @@ Unit = Class(moho.unit_methods) {
 
     OnDestroy = function(self)
         self.Dead = true
+
+        -- clear out all manipulators, at this point the wreck has been made
+        for k = 1, self.WeaponCount do 
+            self.WeaponInstances[k]:ClearProjectileTrash();
+            self.WeaponInstances[k]:ClearManipulatorTrash();
+        end
 
         if self:GetFractionComplete() < 1 then
             self:SendNotifyMessage('cancelled')

--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -285,7 +285,7 @@ DefaultProjectileWeapon = Class(Weapon) {
             self.UnpackAnimator = CreateAnimator(self.unit)
             self.UnpackAnimator:PlayAnim(bp.WeaponUnpackAnimation):SetRate(0)
             self.UnpackAnimator:SetPrecedence(bp.WeaponUnpackAnimatorPrecedence or 0)
-            self.Trash:Add(self.UnpackAnimator)
+            self.TrashManipulators:Add(self.UnpackAnimator)
         end
         if self.UnpackAnimator then
             self.UnpackAnimator:SetRate(bp.WeaponUnpackAnimationRate)
@@ -318,14 +318,14 @@ DefaultProjectileWeapon = Class(Weapon) {
             tmpSldr:SetPrecedence(11)
             tmpSldr:SetGoal(0, 0, bp.RackRecoilDistance)
             tmpSldr:SetSpeed(-1)
-            self.Trash:Add(tmpSldr)
+            self.TrashManipulators:Add(tmpSldr)
             if v.TelescopeBone then
                 tmpSldr = CreateSlider(self.unit, v.TelescopeBone)
                 table.insert(self.RecoilManipulators, tmpSldr)
                 tmpSldr:SetPrecedence(11)
                 tmpSldr:SetGoal(0, 0, v.TelescopeRecoilDistance or bp.RackRecoilDistance)
                 tmpSldr:SetSpeed(-1)
-                self.Trash:Add(tmpSldr)
+                self.TrashManipulators:Add(tmpSldr)
             end
         end
         self:ForkThread(self.PlayRackRecoilReturn, rackList)
@@ -1096,7 +1096,7 @@ DefaultBeamWeapon = Class(DefaultProjectileWeapon) {
                 }
                 local beamTable = {Beam = beam, Muzzle = mv, Destroyables = {}}
                 table.insert(self.Beams, beamTable)
-                self.Trash:Add(beam)
+                self.TrashProjectiles:Add(beam)
                 beam:SetParentWeapon(self)
                 beam:Disable()
             end
@@ -1143,7 +1143,7 @@ DefaultBeamWeapon = Class(DefaultProjectileWeapon) {
 
         if beam:IsEnabled() then return end
         beam:Enable()
-        self.Trash:Add(beam)
+        self.TrashProjectiles:Add(beam)
 
         -- Deal with continuous and non-continuous beams
         if bp.BeamLifetime > 0 then

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -82,7 +82,10 @@ Weapon = Class(moho.weapon_methods) {
         self.EnergyDrainPerSecond = bp.EnergyDrainPerSecond
 
         -- cache information of unit, weapons get created before unit.OnCreate is called
-        self.Trash = TrashBag();
+        self.Trash = TrashBag()
+        self.TrashProjectiles = TrashBag()
+        self.TrashManipulators = TrashBag()
+
         self.Brain = self.unit:GetAIBrain()
         self.Army = self.unit:GetArmy()
 
@@ -161,22 +164,22 @@ Weapon = Class(moho.weapon_methods) {
                     self.AimControl:SetResetPoseTime(9999999)
                 end
                 self:SetFireControl('Right')
-                self.Trash:Add(self.AimControl)
-                self.Trash:Add(self.AimRight)
-                self.Trash:Add(self.AimLeft)
+                self.TrashManipulators:Add(self.AimControl)
+                self.TrashManipulators:Add(self.AimRight)
+                self.TrashManipulators:Add(self.AimLeft)
             else
                 self.AimControl = CreateAimController(self, 'Default', yawBone, pitchBone, muzzleBone)
                 if EntityCategoryContains(categories.STRUCTURE, self.unit) then
                     self.AimControl:SetResetPoseTime(9999999)
                 end
-                self.Trash:Add(self.AimControl)
+                self.TrashManipulators:Add(self.AimControl)
                 self.AimControl:SetPrecedence(precedence)
                 if bp.RackSlavedToTurret and not table.empty(bp.RackBones) then
                     for k, v in bp.RackBones do
                         if v.RackBone ~= pitchBone then
                             local slaver = CreateSlaver(self.unit, v.RackBone, pitchBone)
                             slaver:SetPrecedence(precedence-1)
-                            self.Trash:Add(slaver)
+                            self.TrashManipulators:Add(slaver)
                         end
                     end
                 end
@@ -447,7 +450,18 @@ Weapon = Class(moho.weapon_methods) {
         end
     end,
 
+
     OnDestroy = function(self)
+    end,
+
+    --- Clears out the trash of projectiles, such as beams. Called by the owning unit
+    ClearProjectileTrash = function(self)
+        self.TrashProjectiles:Destroy()
+    end,
+
+    --- Clears out the manipulators. Called by the owning unit
+    ClearManipulatorTrash = function(self)
+        self.TrashManipulators:Destroy()
     end,
 
     SetWeaponPriorities = function(self, priTable)


### PR DESCRIPTION
Solves two open issues with weaponry:
 - The weapon manipulators were removed of a unit before the wreck was made. All weapons switched back to their default orientation when the unit dies. This looks bad. The wreck then copies the default location.
 - Trash of weapons were not removed properly. This could leave potential lingering beams when units die. This is no longer the case.