### PR TITLE
Fix trampling damage of units

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -3316,7 +3316,7 @@ Unit = Class(moho.unit_methods) {
 
     OnAnimCollision = function(self, bone, x, y, z)
         local layer = self.Layer
-        local movementEffects = self.MovementEffects and self.MovementEffects[layer] and self.MovementEffectsExist.Footfall
+        local movementEffects = self.MovementEffects and self.MovementEffects[layer] and self.MovementEffects[layer].Footfall
 
         if movementEffects then
             local effects = {}


### PR DESCRIPTION
A typo slipped into #3587 and in turn no trampling damage was applied - this pull requests fixes that typo. 

Edit: With thanks to @Dragun123 for spotting the mistake.