### PR TITLE
Update AI threat values to suit new unit threat value generation.

### DIFF
--- a/lua/AI/AIBehaviors.lua
+++ b/lua/AI/AIBehaviors.lua
@@ -148,7 +148,7 @@ function CDROverCharge(aiBrain, cdr)
         local target
         local continueFighting = true
         local counter = 0
-        local cdrThreat = cdr:GetBlueprint().Defense.SurfaceThreatLevel or 75
+        local cdrThreat = cdr:GetBlueprint().Defense.SurfaceThreatLevel or 60
         local enemyThreat
         repeat
             overCharging = false
@@ -1780,7 +1780,7 @@ function CDROverChargeSorian(aiBrain, cdr)
         local target
         local continueFighting = true
         local counter = 0
-        local cdrThreat = cdr:GetBlueprint().Defense.SurfaceThreatLevel or 75
+        local cdrThreat = cdr:GetBlueprint().Defense.SurfaceThreatLevel or 60
         local enemyThreat
         repeat
             overCharging = false

--- a/lua/AI/AIBuilders/AIAirAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AIAirAttackBuilders.lua
@@ -31,7 +31,7 @@ function AirAttackCondition(aiBrain, locationType, targetNumber)
     local position = engineerManager:GetLocationCoords()
     local radius = engineerManager.Radius
 
-    local surfaceThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, position, radius)
+    local surfaceThreat = pool:GetPlatoonThreat('Surface', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, position, radius)
     local airThreat = pool:GetPlatoonThreat('AntiAir', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, position, radius)
     if (surfaceThreat + airThreat) > targetNumber then
         return true
@@ -889,8 +889,8 @@ BuilderGroup {
             MoveNext = 'GunshipHuntAI', 	#DUNCAN - was guardbase
             ThreatType = 'Economy', 		    # Type of threat to use for gauging attacks
             FindHighestThreat = false, 		# Don't find high threat targets
-            MaxThreatThreshold = 2900, 		# If threat is higher than this, do not attack
-            MinThreatThreshold = 1000, 		# If threat is lower than this, do not attack
+            MaxThreatThreshold = 140, 		# If threat is higher than this, do not attack
+            MinThreatThreshold = 50, 		# If threat is lower than this, do not attack
             AvoidBases = true,
             AvoidBasesRadius = 75,
             AggressiveMove = true,

--- a/lua/AI/AIBuilders/AIAirAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AIAirAttackBuilders.lua
@@ -32,7 +32,7 @@ function AirAttackCondition(aiBrain, locationType, targetNumber)
     local radius = engineerManager.Radius
 
     local surfaceThreat = pool:GetPlatoonThreat('Surface', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, position, radius)
-    local airThreat = pool:GetPlatoonThreat('AntiAir', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, position, radius)
+    local airThreat = pool:GetPlatoonThreat('Air', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, position, radius)
     if (surfaceThreat + airThreat) > targetNumber then
         return true
     end

--- a/lua/AI/AIBuilders/AILandAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AILandAttackBuilders.lua
@@ -32,7 +32,7 @@ function LandAttackCondition(aiBrain, locationType, targetNumber)
     local position = engineerManager:GetLocationCoords()
     local radius = engineerManager.Radius
 
-    local poolThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.LAND - categories.SCOUT - categories.ENGINEER, position, radius)
+    local poolThreat = pool:GetPlatoonThreat('Surface', categories.MOBILE * categories.LAND - categories.SCOUT - categories.ENGINEER, position, radius)
     if poolThreat > targetNumber then
         return true
     end
@@ -394,7 +394,7 @@ BuilderGroup {
         Priority = 600,
         BuilderConditions = {
             { UCBC, 'FactoryLessAtLocation', { 'LocationType', 1, 'FACTORY LAND TECH3' }},
-            { TBC, 'EnemyThreatGreaterThanValueAtBase', { 'LocationType', 10, 'Air' } },
+            { TBC, 'EnemyThreatGreaterThanValueAtBase', { 'LocationType', 15, 'Air' } },
             { UCBC, 'HaveUnitRatio', { 0.2, categories.LAND * categories.ANTIAIR, '<=', categories.LAND * categories.DIRECTFIRE}},
             { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.ANTIAIR * categories.LAND - categories.TECH1  } },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},
@@ -407,7 +407,7 @@ BuilderGroup {
         Priority = 850, #DUNCAN - was 500
         BuilderConditions = {
             { UCBC, 'FactoryLessAtLocation', { 'LocationType', 1, 'FACTORY LAND TECH3' }},
-            { TBC, 'EnemyThreatGreaterThanValueAtBase', { 'LocationType', 10, 'Air' } },
+            { TBC, 'EnemyThreatGreaterThanValueAtBase', { 'LocationType', 15, 'Air' } },
             { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.ANTIAIR * categories.LAND - categories.TECH1 } },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},
         },
@@ -441,7 +441,7 @@ BuilderGroup {
         BuilderType = 'Land',
         BuilderConditions = {
             { UCBC, 'FactoryGreaterAtLocation', { 'LocationType', 0, categories.LAND * categories.FACTORY * categories.TECH3 } },
-            { TBC, 'EnemyThreatGreaterThanValueAtBase', { 'LocationType', 5, 'AntiSurface' } },
+            { TBC, 'EnemyThreatGreaterThanValueAtBase', { 'LocationType', 10, 'AntiSurface' } },
             { UCBC, 'HaveUnitRatio', { 0.2, categories.LAND * categories.INDIRECTFIRE, '<=', categories.LAND * categories.DIRECTFIRE}},
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.6, 1.05 }},
@@ -494,7 +494,7 @@ BuilderGroup {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }}, #DUNCAN - was 0.6
             { UCBC, 'HaveUnitRatio', { 0.2, categories.LAND * categories.INDIRECTFIRE, '<=', categories.LAND * categories.DIRECTFIRE}},
-            { TBC, 'EnemyThreatGreaterThanValueAtBase', { 'LocationType', 5, 'AntiSurface' } },
+            { TBC, 'EnemyThreatGreaterThanValueAtBase', { 'LocationType', 10, 'AntiSurface' } },
         },
     },
     Builder {
@@ -613,7 +613,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, categories.MOBILE * categories.LAND - categories.ENGINEER - categories.TECH1 } },
-            { LandAttackCondition, { 'LocationType', 10 } },
+            { LandAttackCondition, { 'LocationType', 20 } },
         },
     },
     Builder {
@@ -649,7 +649,7 @@ BuilderGroup {
             },
         },
         BuilderConditions = {
-            { LandAttackCondition, { 'LocationType', 150 } },
+            { LandAttackCondition, { 'LocationType', 230 } },
         },
     },
 }
@@ -705,7 +705,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, categories.MOBILE * categories.LAND - categories.ENGINEER - categories.TECH1 } },
-            { LandAttackCondition, { 'LocationType', 10 } },
+            { LandAttackCondition, { 'LocationType', 20 } },
         },
     },
     Builder {
@@ -724,7 +724,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, categories.MOBILE * categories.LAND * categories.TECH3 - categories.ENGINEER} },
-            { LandAttackCondition, { 'LocationType', 50 } },
+            { LandAttackCondition, { 'LocationType', 70 } },
         },
     },
     Builder {
@@ -742,7 +742,7 @@ BuilderGroup {
             },
         },
         BuilderConditions = {
-            { LandAttackCondition, { 'LocationType', 150 } },
+            { LandAttackCondition, { 'LocationType', 230 } },
         },
     },
 }
@@ -763,7 +763,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, categories.MOBILE * categories.LAND - categories.ENGINEER - categories.TECH1 } },
-            { LandAttackCondition, { 'LocationType', 20 } },
+            { LandAttackCondition, { 'LocationType', 30 } },
         },
     },
     Builder {
@@ -779,7 +779,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, categories.MOBILE * categories.LAND * categories.TECH3 - categories.ENGINEER } },
-            { LandAttackCondition, { 'LocationType', 100 } },
+            { LandAttackCondition, { 'LocationType', 150 } },
         },
     },
     Builder {
@@ -794,7 +794,7 @@ BuilderGroup {
             UseFormation = 'AttackFormation',
         },
         BuilderConditions = {
-            { LandAttackCondition, { 'LocationType', 300 } },
+            { LandAttackCondition, { 'LocationType', 460 } },
         },
     },
 }
@@ -821,8 +821,8 @@ BuilderGroup {
             MoveNext = 'Threat',
             ThreatType = 'Economy', 		    # Type of threat to use for gauging attacks
             FindHighestThreat = false, 		# Don't find high threat targets
-            MaxThreatThreshold = 2900, 		# If threat is higher than this, do not attack
-            MinThreatThreshold = 1000, 		# If threat is lower than this, do not attack
+            MaxThreatThreshold = 140, 		# If threat is higher than this, do not attack
+            MinThreatThreshold = 50, 		# If threat is lower than this, do not attack
             AvoidBases = true,
             AvoidBasesRadius = 75,
             #UseFormation = 'AttackFormation',
@@ -851,7 +851,7 @@ BuilderGroup {
             ThreatType = 'Economy', 		    # Type of threat to use for gauging attacks
             FindHighestThreat = false, 		# Don't find high threat targets
             MaxThreatThreshold = 9999999, 	# If threat is higher than this, do not attack
-            MinThreatThreshold = 1000, 		# If threat is lower than this, do not attack
+            MinThreatThreshold = 50, 		# If threat is lower than this, do not attack
             AvoidBases = true,
             AvoidBasesRadius = 75,
             #UseFormation = 'AttackFormation',
@@ -973,7 +973,7 @@ BuilderGroup {
         BuilderConditions = {
             { MIBC, 'IsIsland', { false } }, #DUNCAN - added to stop units bunching on island maps
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, categories.MOBILE * categories.LAND - categories.ENGINEER - categories.TECH1 } },
-            { LandAttackCondition, { 'LocationType', 10 } },
+            { LandAttackCondition, { 'LocationType', 15 } },
         },
     },
 
@@ -995,7 +995,7 @@ BuilderGroup {
         BuilderConditions = {
             { MIBC, 'IsIsland', { false } }, #DUNCAN - added to stop units bunching on island maps
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, categories.MOBILE * categories.LAND - categories.ENGINEER - categories.TECH1 } },
-            { LandAttackCondition, { 'LocationType', 10 } },
+            { LandAttackCondition, { 'LocationType', 15 } },
         },
     },
 

--- a/lua/AI/AIBuilders/AISeaAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AISeaAttackBuilders.lua
@@ -34,7 +34,7 @@ function SeaAttackCondition(aiBrain, locationType, targetNumber)
     local position = engineerManager:GetLocationCoords()
     local radius = engineerManager.Radius
 
-    local surfaceThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.NAVAL, position, radius)
+    local surfaceThreat = pool:GetPlatoonThreat('Surface', categories.MOBILE * categories.NAVAL, position, radius)
     local subThreat = pool:GetPlatoonThreat('AntiSub', categories.MOBILE * categories.NAVAL, position, radius)
     if (surfaceThreat + subThreat) > targetNumber then
         return true

--- a/lua/AI/AIBuilders/AISeaAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AISeaAttackBuilders.lua
@@ -35,7 +35,7 @@ function SeaAttackCondition(aiBrain, locationType, targetNumber)
     local radius = engineerManager.Radius
 
     local surfaceThreat = pool:GetPlatoonThreat('Surface', categories.MOBILE * categories.NAVAL, position, radius)
-    local subThreat = pool:GetPlatoonThreat('AntiSub', categories.MOBILE * categories.NAVAL, position, radius)
+    local subThreat = pool:GetPlatoonThreat('Sub', categories.MOBILE * categories.NAVAL, position, radius)
     if (surfaceThreat + subThreat) > targetNumber then
         return true
     end

--- a/lua/AI/AIBuilders/SorianAirAttackBuilders.lua
+++ b/lua/AI/AIBuilders/SorianAirAttackBuilders.lua
@@ -43,7 +43,7 @@ function AirAttackCondition(aiBrain, locationType, targetNumber)
     local radius = engineerManager.Radius
 
     --local surfaceThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.AIR - categories.EXPERIMENTAL - categories.SCOUT - categories.INTELLIGENCE, position, radius)
-    local surfaceThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.AIR - categories.EXPERIMENTAL - categories.SCOUT - categories.INTELLIGENCE)
+    local surfaceThreat = pool:GetPlatoonThreat('Surface', categories.MOBILE * categories.AIR - categories.EXPERIMENTAL - categories.SCOUT - categories.INTELLIGENCE)
     local airThreat = 0 #pool:GetPlatoonThreat('AntiAir', categories.MOBILE * categories.AIR - categories.EXPERIMENTAL - categories.SCOUT - categories.INTELLIGENCE, position, radius)
     if (surfaceThreat + airThreat) >= targetNumber then
         return true
@@ -1129,7 +1129,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             #{ UCBC, 'PoolGreaterAtLocation', { 'LocationType', 2, 'AIR MOBILE BOMBER' } },
-            { AirAttackCondition, { 'LocationType', 4 } },
+            { AirAttackCondition, { 'LocationType', 6 } },
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, 'AIR MOBILE TECH2, MOBILE AIR TECH3' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
@@ -1162,7 +1162,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             #{ UCBC, 'PoolGreaterAtLocation', { 'LocationType', 2, 'AIR MOBILE BOMBER' } },
-            { AirAttackCondition, { 'LocationType', 4 } },
+            { AirAttackCondition, { 'LocationType', 6 } },
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, 'AIR MOBILE TECH2, MOBILE AIR TECH3' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
@@ -1196,7 +1196,7 @@ BuilderGroup {
         BuilderConditions = {
             { UCBC, 'HaveUnitsWithCategoryAndAlliance', { false, 4, categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, 'Enemy'}},
             #{ UCBC, 'PoolGreaterAtLocation', { 'LocationType', 2, 'AIR MOBILE BOMBER' } },
-            { AirAttackCondition, { 'LocationType', 4 } },
+            { AirAttackCondition, { 'LocationType', 6 } },
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, 'AIR MOBILE TECH2, MOBILE AIR TECH3' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
@@ -1229,7 +1229,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             #{ UCBC, 'PoolGreaterAtLocation', { 'LocationType', 2, 'AIR MOBILE BOMBER' } },
-            { AirAttackCondition, { 'LocationType', 4 } },
+            { AirAttackCondition, { 'LocationType', 6 } },
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, 'AIR MOBILE TECH2, MOBILE AIR TECH3' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
@@ -1244,7 +1244,7 @@ BuilderGroup {
         BuilderType = 'Any',
         BuilderConditions = {
             #{ UCBC, 'PoolGreaterAtLocation', { 'LocationType', 2, 'AIR MOBILE GROUNDATTACK' } },
-            { AirAttackCondition, { 'LocationType', 4 } },
+            { AirAttackCondition, { 'LocationType', 6 } },
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, 'AIR MOBILE TECH2, AIR MOBILE TECH3' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
@@ -1292,7 +1292,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             #{ UCBC, 'PoolGreaterAtLocation', { 'LocationType', 3, 'AIR MOBILE BOMBER' } },
-            { AirAttackCondition, { 'LocationType', 12 } },
+            { AirAttackCondition, { 'LocationType', 20 } },
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, 'AIR MOBILE TECH3' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
@@ -1325,7 +1325,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             #{ UCBC, 'PoolGreaterAtLocation', { 'LocationType', 3, 'AIR MOBILE BOMBER' } },
-            { AirAttackCondition, { 'LocationType', 12 } },
+            { AirAttackCondition, { 'LocationType', 20 } },
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, 'AIR MOBILE TECH3' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
@@ -1360,7 +1360,7 @@ BuilderGroup {
         BuilderConditions = {
             { UCBC, 'HaveUnitsWithCategoryAndAlliance', { false, 4, categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, 'Enemy'}},
             #{ UCBC, 'PoolGreaterAtLocation', { 'LocationType', 3, 'AIR MOBILE BOMBER' } },
-            { AirAttackCondition, { 'LocationType', 12 } },
+            { AirAttackCondition, { 'LocationType', 20 } },
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, 'AIR MOBILE TECH3' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
@@ -1393,7 +1393,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             #{ UCBC, 'PoolGreaterAtLocation', { 'LocationType', 3, 'AIR MOBILE BOMBER' } },
-            { AirAttackCondition, { 'LocationType', 12 } },
+            { AirAttackCondition, { 'LocationType', 20 } },
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, 'AIR MOBILE TECH3' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
@@ -1661,7 +1661,7 @@ BuilderGroup {
             },
         },
         BuilderConditions = {
-            { SBC, 'PoolThreatGreaterThanEnemyBase', {'LocationType', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, 'AntiAir', 'AntiSurface', 1}},
+            { SBC, 'PoolThreatGreaterThanEnemyBase', {'LocationType', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, 'AntiAir', 'Surface', 1}},
             { UCBC, 'FactoryGreaterAtLocation', { 'LocationType', 0, 'FACTORY TECH2 AIR, FACTORY TECH3 AIR' }},
             { UCBC, 'PoolGreaterAtLocation', { 'LocationType', 5, 'AIR MOBILE BOMBER TECH2, AIR MOBILE BOMBER TECH3' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
@@ -1698,7 +1698,7 @@ BuilderGroup {
             },
         },
         BuilderConditions = {
-            { SBC, 'PoolThreatGreaterThanEnemyBase', {'LocationType', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, 'AntiAir', 'AntiSurface', 1}},
+            { SBC, 'PoolThreatGreaterThanEnemyBase', {'LocationType', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, 'AntiAir', 'Surface', 1}},
             { UCBC, 'FactoryLessAtLocation', { 'LocationType', 1, 'FACTORY TECH2 AIR, FACTORY TECH3 AIR' }},
             { UCBC, 'PoolGreaterAtLocation', { 'LocationType', 3, 'AIR MOBILE BOMBER TECH1' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
@@ -1736,7 +1736,7 @@ BuilderGroup {
             },
         },
         BuilderConditions = {
-            { SBC, 'PoolThreatGreaterThanEnemyBase', {'LocationType', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, 'AntiAir', 'AntiSurface', 1}},
+            { SBC, 'PoolThreatGreaterThanEnemyBase', {'LocationType', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, 'AntiAir', 'Surface', 1}},
             { UCBC, 'FactoryGreaterAtLocation', { 'LocationType', 0, 'FACTORY TECH2 AIR, FACTORY TECH3 AIR' }},
             { UCBC, 'PoolGreaterAtLocation', { 'LocationType', 5, 'AIR MOBILE GROUNDATTACK TECH2, AIR MOBILE GROUNDATTACK TECH3' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
@@ -1773,7 +1773,7 @@ BuilderGroup {
             },
         },
         BuilderConditions = {
-            { SBC, 'PoolThreatGreaterThanEnemyBase', {'LocationType', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, 'AntiAir', 'AntiSurface', 1}},
+            { SBC, 'PoolThreatGreaterThanEnemyBase', {'LocationType', categories.MOBILE * categories.AIR - categories.SCOUT - categories.INTELLIGENCE, 'AntiAir', 'Surface', 1}},
             { UCBC, 'FactoryLessAtLocation', { 'LocationType', 1, 'FACTORY TECH2 AIR, FACTORY TECH3 AIR' }},
             { UCBC, 'PoolGreaterAtLocation', { 'LocationType', 3, 'AIR MOBILE GROUNDATTACK TECH1' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
@@ -1792,7 +1792,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             #{ UCBC, 'PoolGreaterAtLocation', { 'LocationType', 2, 'AIR MOBILE BOMBER' } },
-            { AirAttackCondition, { 'LocationType', 4 } },
+            { AirAttackCondition, { 'LocationType', 6 } },
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, 'AIR MOBILE TECH2, MOBILE AIR TECH3' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
             { SIBC, 'AIThreatExists', { 100 } },
@@ -1811,7 +1811,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             #{ UCBC, 'PoolGreaterAtLocation', { 'LocationType', 2, 'AIR MOBILE BOMBER' } },
-            { AirAttackCondition, { 'LocationType', 12 } },
+            { AirAttackCondition, { 'LocationType', 20 } },
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, 'AIR MOBILE TECH3' } },
             { SBC, 'NoRushTimeCheck', { 0 }},
             { SIBC, 'AIThreatExists', { 100 } },
@@ -1920,8 +1920,8 @@ BuilderGroup {
             MoveNext = 'Guard Base',
             ThreatType = 'Economy', 		    # Type of threat to use for gauging attacks
             FindHighestThreat = false, 		# Don't find high threat targets
-            MaxThreatThreshold = 2900, 		# If threat is higher than this, do not attack
-            MinThreatThreshold = 1000, 		# If threat is lower than this, do not attack
+            MaxThreatThreshold = 140, 		# If threat is higher than this, do not attack
+            MinThreatThreshold = 50, 		# If threat is lower than this, do not attack
             AvoidBases = true,
             AvoidBasesRadius = 75,
             AggressiveMove = true,

--- a/lua/AI/AIBuilders/SorianAirAttackBuilders.lua
+++ b/lua/AI/AIBuilders/SorianAirAttackBuilders.lua
@@ -44,7 +44,7 @@ function AirAttackCondition(aiBrain, locationType, targetNumber)
 
     --local surfaceThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.AIR - categories.EXPERIMENTAL - categories.SCOUT - categories.INTELLIGENCE, position, radius)
     local surfaceThreat = pool:GetPlatoonThreat('Surface', categories.MOBILE * categories.AIR - categories.EXPERIMENTAL - categories.SCOUT - categories.INTELLIGENCE)
-    local airThreat = 0 #pool:GetPlatoonThreat('AntiAir', categories.MOBILE * categories.AIR - categories.EXPERIMENTAL - categories.SCOUT - categories.INTELLIGENCE, position, radius)
+    local airThreat = 0 #pool:GetPlatoonThreat('Air', categories.MOBILE * categories.AIR - categories.EXPERIMENTAL - categories.SCOUT - categories.INTELLIGENCE, position, radius)
     if (surfaceThreat + airThreat) >= targetNumber then
         return true
     elseif UC.UnitCapCheckGreater(aiBrain, .95) then

--- a/lua/AI/AIBuilders/SorianExperimentalBuilders.lua
+++ b/lua/AI/AIBuilders/SorianExperimentalBuilders.lua
@@ -51,7 +51,7 @@ function T4LandAttackCondition(aiBrain, locationType, targetNumber)
     local radius = engineerManager.Radius
 
     --local surThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.LAND * categories.EXPERIMENTAL, position, radius * 2.5)
-    local surThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.LAND * categories.EXPERIMENTAL)
+    local surThreat = pool:GetPlatoonThreat('Surface', categories.MOBILE * categories.LAND * categories.EXPERIMENTAL)
     if surThreat >= targetNumber * .6 then
         return true
     --elseif UC.UnitCapCheckGreater(aiBrain, .99) then
@@ -82,7 +82,7 @@ function T4AirAttackCondition(aiBrain, locationType, targetNumber)
     local position = engineerManager:GetLocationCoords()
     local radius = engineerManager.Radius
 
-    local surThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.AIR * categories.EXPERIMENTAL, position, radius * 2.5)
+    local surThreat = pool:GetPlatoonThreat('Surface', categories.MOBILE * categories.AIR * categories.EXPERIMENTAL, position, radius * 2.5)
     if surThreat > targetNumber * .6 then
         return true
     --elseif UC.UnitCapCheckGreater(aiBrain, .99) then
@@ -449,7 +449,7 @@ BuilderGroup {
         BuilderConditions = {
             #{ SIBC, 'HaveLessThanUnitsWithCategory', { 3, 'EXPERIMENTAL MOBILE LAND, EXPERIMENTAL MOBILE AIR'}},
             #{ UCBC, 'FactoryGreaterAtLocation', { 'LocationType', 1, 'FACTORY TECH1, FACTORY TECH2' } },
-            { T4LandAttackCondition, { 'LocationType', 250 } },
+            { T4LandAttackCondition, { 'LocationType', 350 } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
         BuilderData = {
@@ -632,7 +632,7 @@ BuilderGroup {
         BuilderConditions = {
             #{ SIBC, 'HaveLessThanUnitsWithCategory', { 3, 'EXPERIMENTAL MOBILE LAND, EXPERIMENTAL MOBILE AIR'}},
             #{ UCBC, 'FactoryGreaterAtLocation', { 'LocationType', 1, 'FACTORY TECH1, FACTORY TECH2' } },
-            { T4AirAttackCondition, { 'LocationType', 250 } },
+            { T4AirAttackCondition, { 'LocationType', 350 } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
         BuilderData = {

--- a/lua/AI/AIBuilders/SorianLandAttackBuilders.lua
+++ b/lua/AI/AIBuilders/SorianLandAttackBuilders.lua
@@ -46,7 +46,7 @@ function LandAttackCondition(aiBrain, locationType, targetNumber)
 
     --local surThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.LAND - categories.EXPERIMENTAL - categories.SCOUT - categories.ENGINEER, position, radius)
     local surThreat = pool:GetPlatoonThreat('Surface', categories.MOBILE * categories.LAND - categories.EXPERIMENTAL - categories.SCOUT - categories.ENGINEER)
-    local airThreat = 0 #pool:GetPlatoonThreat('AntiAir', categories.MOBILE * categories.LAND - categories.EXPERIMENTAL - categories.SCOUT - categories.ENGINEER, position, radius)
+    local airThreat = 0 #pool:GetPlatoonThreat('Air', categories.MOBILE * categories.LAND - categories.EXPERIMENTAL - categories.SCOUT - categories.ENGINEER, position, radius)
     local adjustForTime = 1 + (math.floor(GetGameTimeSeconds()/60) * .01)
     --LOG("*AI DEBUG: Pool Threat: "..surThreat.." adjustment: "..adjustForTime.." Enemy Threat: "..targetNumber)
     if (surThreat + airThreat) >= targetNumber and targetNumber > 0 then
@@ -244,7 +244,7 @@ BuilderGroup {
         PlatoonAddBehaviors = { 'AirLandToggleSorian' },
         Priority = 900,
         BuilderConditions = {
-            { TBC, 'HaveLessThreatThanNearby', { 'LocationType', 'AntiAir', 'Air' } },
+            { TBC, 'HaveLessThreatThanNearby', { 'LocationType', 'Air', 'Air' } },
             { UCBC, 'FactoryGreaterAtLocation', { 'LocationType', 0, categories.LAND * categories.FACTORY * categories.TECH1 } },
             { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, 'LAND ANTIAIR MOBILE' } },
             { UCBC, 'FactoryLessAtLocation', { 'LocationType', 1, 'FACTORY TECH2, FACTORY TECH3' }},
@@ -513,7 +513,7 @@ BuilderGroup {
         Priority = 900,
         BuilderConditions = {
             #{ TBC, 'EnemyThreatGreaterThanValueAtBase', { 'LocationType', 10, 'Air' } },
-            { TBC, 'HaveLessThreatThanNearby', { 'LocationType', 'AntiAir', 'Air' } },
+            { TBC, 'HaveLessThreatThanNearby', { 'LocationType', 'Air', 'Air' } },
             { UCBC, 'FactoryLessAtLocation', { 'LocationType', 1, 'FACTORY TECH3' }},
             { UCBC, 'FactoryGreaterAtLocation', { 'LocationType', 0, categories.LAND * categories.FACTORY * categories.TECH2 } },
             { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, 'LAND ANTIAIR MOBILE' } },
@@ -584,7 +584,7 @@ BuilderGroup {
             { SBC, 'NoRushTimeCheck', { 600 }},
             { UCBC, 'HaveUnitRatio', { 0.15, categories.LAND * categories.ANTIAIR * categories.MOBILE, '<=', categories.LAND * categories.DIRECTFIRE * categories.MOBILE}},
             { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, 'LAND ANTIAIR MOBILE' } },
-            #{ TBC, 'HaveLessThreatThanNearby', { 'LocationType', 'AntiAir', 'Air' } },
+            #{ TBC, 'HaveLessThreatThanNearby', { 'LocationType', 'Air', 'Air' } },
         },
         BuilderType = 'Land',
     },
@@ -655,7 +655,7 @@ BuilderGroup {
             { IBC, 'BrainNotLowPowerMode', {} },
             { UCBC, 'FactoryGreaterAtLocation', { 'LocationType', 0, categories.LAND * categories.FACTORY * categories.TECH3 } },
             { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, 'LAND ANTIAIR MOBILE' } },
-            { TBC, 'HaveLessThreatThanNearby', { 'LocationType', 'AntiAir', 'Air' } },
+            { TBC, 'HaveLessThreatThanNearby', { 'LocationType', 'Air', 'Air' } },
             { SIBC, 'GreaterThanEconEfficiencyOverTime', { 0.65, 1.05 }},
             { SBC, 'NoRushTimeCheck', { 600 }},
         },

--- a/lua/AI/AIBuilders/SorianLandAttackBuilders.lua
+++ b/lua/AI/AIBuilders/SorianLandAttackBuilders.lua
@@ -45,7 +45,7 @@ function LandAttackCondition(aiBrain, locationType, targetNumber)
     local radius = engineerManager.Radius
 
     --local surThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.LAND - categories.EXPERIMENTAL - categories.SCOUT - categories.ENGINEER, position, radius)
-    local surThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.LAND - categories.EXPERIMENTAL - categories.SCOUT - categories.ENGINEER)
+    local surThreat = pool:GetPlatoonThreat('Surface', categories.MOBILE * categories.LAND - categories.EXPERIMENTAL - categories.SCOUT - categories.ENGINEER)
     local airThreat = 0 #pool:GetPlatoonThreat('AntiAir', categories.MOBILE * categories.LAND - categories.EXPERIMENTAL - categories.SCOUT - categories.ENGINEER, position, radius)
     local adjustForTime = 1 + (math.floor(GetGameTimeSeconds()/60) * .01)
     --LOG("*AI DEBUG: Pool Threat: "..surThreat.." adjustment: "..adjustForTime.." Enemy Threat: "..targetNumber)
@@ -838,7 +838,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, categories.MOBILE * categories.LAND - categories.ENGINEER - categories.TECH1 } },
-            { LandAttackCondition, { 'LocationType', 10 } },
+            { LandAttackCondition, { 'LocationType', 20 } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
     },
@@ -864,7 +864,7 @@ BuilderGroup {
         BuilderConditions = {
             { UCBC, 'PoolGreaterAtLocation', { 'LocationType', 0, categories.MOBILE * categories.LAND * categories.TECH2 - categories.ENGINEER} },
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, categories.MOBILE * categories.LAND * categories.TECH3 - categories.ENGINEER} },
-            { LandAttackCondition, { 'LocationType', 50 } },
+            { LandAttackCondition, { 'LocationType', 70 } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
     },
@@ -890,7 +890,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             { UCBC, 'PoolGreaterAtLocation', { 'LocationType', 0, categories.MOBILE * categories.LAND * categories.TECH3 - categories.ENGINEER} },
-            { LandAttackCondition, { 'LocationType', 150 } },
+            { LandAttackCondition, { 'LocationType', 230 } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
     },
@@ -911,7 +911,7 @@ BuilderGroup {
         Priority = 950,
         BuilderConditions = {
                 { SBC, 'LessThanGameTime', { 600 } },
-                { LandAttackCondition, { 'LocationType', 10 } },
+                { LandAttackCondition, { 'LocationType', 20 } },
                 { SBC, 'NoRushTimeCheck', { 0 }},
                 { SBC, 'MapGreaterThan', { 500, 500 }},
                 #{ UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.TECH2 * categories.MOBILE * categories.LAND - categories.ENGINEER } },
@@ -924,8 +924,8 @@ BuilderGroup {
             MoveNext = 'Threat',
             ThreatType = 'Economy', 		    # Type of threat to use for gauging attacks
             FindHighestThreat = false, 		# Don't find high threat targets
-            MaxThreatThreshold = 2900, 		# If threat is higher than this, do not attack
-            MinThreatThreshold = 1000, 		# If threat is lower than this, do not attack
+            MaxThreatThreshold = 140, 		# If threat is higher than this, do not attack
+            MinThreatThreshold = 50, 		# If threat is lower than this, do not attack
             AvoidBases = true,
             AvoidBasesRadius = 75,
             UseFormation = 'AttackFormation',
@@ -946,7 +946,7 @@ BuilderGroup {
         Priority = 950,
         BuilderConditions = {
                 { SBC, 'GreaterThanGameTime', { 600 } },
-                { LandAttackCondition, { 'LocationType', 50 } },
+                { LandAttackCondition, { 'LocationType', 70 } },
                 { SBC, 'NoRushTimeCheck', { 0 }},
                 { SBC, 'MapGreaterThan', { 500, 500 }},
                 #{ UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.TECH2 * categories.MOBILE * categories.LAND - categories.ENGINEER } },
@@ -960,7 +960,7 @@ BuilderGroup {
             ThreatType = 'Economy', 		    # Type of threat to use for gauging attacks
             FindHighestThreat = false, 		# Don't find high threat targets
             MaxThreatThreshold = 9999999, 	# If threat is higher than this, do not attack
-            MinThreatThreshold = 1000, 		# If threat is lower than this, do not attack
+            MinThreatThreshold = 50, 		# If threat is lower than this, do not attack
             AvoidBases = true,
             AvoidBasesRadius = 75,
             UseFormation = 'AttackFormation',
@@ -1047,7 +1047,7 @@ BuilderGroup {
         BuilderConditions = {
                 #{ UCBC, 'ExpansionAreaNeedsEngineer', { 'LocationType', 350, -1000, 0, 2, 'StructuresNotMex' } },
                 { SBC, 'GreaterThanGameTime', { 720 } },
-                { LandAttackCondition, { 'LocationType', 50 } },
+                { LandAttackCondition, { 'LocationType', 70 } },
                 { SBC, 'MapLessThan', { 1000, 1000 }},
                 { SBC, 'NoRushTimeCheck', { 0 }},
                 #{ UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.TECH2 * categories.MOBILE * categories.LAND - categories.ENGINEER } },
@@ -1108,11 +1108,11 @@ BuilderGroup {
         PlatoonAddBehaviors = { 'AirLandToggleSorian' },
         Priority = 1400,
         BuilderConditions = {
-            { SBC, 'PoolThreatGreaterThanEnemyBase', {'LocationType', categories.MOBILE * categories.LAND - categories.SCOUT - categories.ENGINEER, 'AntiSurface', 'AntiSurface', 1}},
+            { SBC, 'PoolThreatGreaterThanEnemyBase', {'LocationType', categories.MOBILE * categories.LAND - categories.SCOUT - categories.ENGINEER, 'AntiSurface', 'Surface', 1}},
             { UCBC, 'FactoryGreaterAtLocation', { 'LocationType', 0, 'FACTORY TECH2 LAND, FACTORY TECH3 LAND' }},
             { SBC, 'GreaterThanGameTime', { 720 } },
             { SBC, 'NoRushTimeCheck', { 0 }},
-            { LandAttackCondition, { 'LocationType', 50 } },
+            { LandAttackCondition, { 'LocationType', 70 } },
         },
         BuilderData = {
             ThreatSupport = 75,
@@ -1152,11 +1152,11 @@ BuilderGroup {
         PlatoonAddBehaviors = { 'AirLandToggleSorian' },
         Priority = 1400,
         BuilderConditions = {
-            { SBC, 'PoolThreatGreaterThanEnemyBase', {'LocationType', categories.MOBILE * categories.LAND - categories.SCOUT - categories.ENGINEER, 'AntiSurface', 'AntiSurface', 1}},
+            { SBC, 'PoolThreatGreaterThanEnemyBase', {'LocationType', categories.MOBILE * categories.LAND - categories.SCOUT - categories.ENGINEER, 'AntiSurface', 'Surface', 1}},
             { UCBC, 'FactoryLessAtLocation', { 'LocationType', 1, 'FACTORY TECH2 LAND, FACTORY TECH3 LAND' }},
             { SBC, 'GreaterThanGameTime', { 720 } },
             { SBC, 'NoRushTimeCheck', { 0 }},
-            { LandAttackCondition, { 'LocationType', 10 } },
+            { LandAttackCondition, { 'LocationType', 20 } },
         },
         BuilderData = {
             ThreatSupport = 75,
@@ -1276,7 +1276,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, categories.MOBILE * categories.LAND - categories.ENGINEER - categories.TECH1 } },
-            { LandAttackCondition, { 'LocationType', 10 } },
+            { LandAttackCondition, { 'LocationType', 15 } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
     },
@@ -1304,7 +1304,7 @@ BuilderGroup {
         BuilderConditions = {
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, categories.MOBILE * categories.LAND - categories.ENGINEER - categories.TECH1 - categories.TECH2 } },
             { SBC, 'MapLessThan', { 1000, 1000 }},
-            { LandAttackCondition, { 'LocationType', 50 } },
+            { LandAttackCondition, { 'LocationType', 70 } },
             { SBC, 'NoRushTimeCheck', { 0 }},
         },
     },

--- a/lua/AI/AIBuilders/SorianSeaAttackBuilders.lua
+++ b/lua/AI/AIBuilders/SorianSeaAttackBuilders.lua
@@ -46,7 +46,7 @@ function SeaAttackCondition(aiBrain, locationType, targetNumber)
     --local surfaceThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.NAVAL, position, radius)
     --local subThreat = pool:GetPlatoonThreat('AntiSub', categories.MOBILE * categories.NAVAL, position, radius)
     local surfaceThreat = pool:GetPlatoonThreat('Surface', categories.MOBILE * categories.NAVAL)
-    local subThreat = pool:GetPlatoonThreat('AntiSub', categories.MOBILE * categories.NAVAL)
+    local subThreat = pool:GetPlatoonThreat('Sub', categories.MOBILE * categories.NAVAL)
     if (surfaceThreat + subThreat) >= targetNumber then
         return true
     elseif UC.UnitCapCheckGreater(aiBrain, .95) then

--- a/lua/AI/AIBuilders/SorianSeaAttackBuilders.lua
+++ b/lua/AI/AIBuilders/SorianSeaAttackBuilders.lua
@@ -45,7 +45,7 @@ function SeaAttackCondition(aiBrain, locationType, targetNumber)
 
     --local surfaceThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.NAVAL, position, radius)
     --local subThreat = pool:GetPlatoonThreat('AntiSub', categories.MOBILE * categories.NAVAL, position, radius)
-    local surfaceThreat = pool:GetPlatoonThreat('AntiSurface', categories.MOBILE * categories.NAVAL)
+    local surfaceThreat = pool:GetPlatoonThreat('Surface', categories.MOBILE * categories.NAVAL)
     local subThreat = pool:GetPlatoonThreat('AntiSub', categories.MOBILE * categories.NAVAL)
     if (surfaceThreat + subThreat) >= targetNumber then
         return true

--- a/lua/AI/AIBuilders/SorianStrategyPlatoonBuilders.lua
+++ b/lua/AI/AIBuilders/SorianStrategyPlatoonBuilders.lua
@@ -307,7 +307,7 @@ BuilderGroup {
             { UCBC, 'PoolGreaterAtLocation', { 'LocationType', 5, categories.TECH1 * categories.LAND * categories.MOBILE * categories.DIRECTFIRE * categories.BOT - categories.SCOUT - categories.ENGINEER - categories.EXPERIMENTAL} },
         },
         BuilderData = {
-            ThreatSupport = 75,
+            ThreatSupport = 60,
             PrioritizedCategories = {
                 'ENERGYPRODUCTION DRAGBUILD',
                 'HYDROCARBON',


### PR DESCRIPTION
Final ACU value needed. 
Correct error in CalculatePlatoonThreat and CalculatePlatoonThreatAroundPosition usage where it was checking for 'AntiSurface' rather than 'Surface' so it was getting 'Overall' instead. These two functions look at the bp's so antisurface is not present. Same for AntiAir (should be Air) and AntiSub (should be Sub)

For the function fix, based on testing done I believe the internal engine is performing a string search on the defense table of the blueprint for each unit looking for the values.
Below is an example from in game.

info: Platoon Threat values
info: Surface 8
info: AntiAir 11
info: Air 3
info: AntiSurface 11
info: Overall 11

This platoon had 4 x T1 Tanks (2 surface threat each) and 1x T1 Mobile AA (3 air threat each)

The following code was used.
 LOG('Platoon Threat values')
 LOG('Surface '..self:GetPlatoonThreat('Surface', categories.ALLUNITS))
 LOG('AntiAir '..self:GetPlatoonThreat('AntiAir', categories.ALLUNITS))
 LOG('Air '..self:GetPlatoonThreat('Air', categories.ALLUNITS))
 LOG('AntiSurface '..self:GetPlatoonThreat('AntiSurface', categories.ALLUNITS))
 LOG('Overall '..self:GetPlatoonThreat('Overall', categories.ALLUNITS))

You can see in the results that AntiAir and AntiSurface both returned the Overall threat of the platoon instead of the actual values.