### PR TITLE
Allow Hive to upgrade immediately

### DIFF
--- a/engine/User.lua
+++ b/engine/User.lua
@@ -926,10 +926,11 @@ end
 function SetVolume(category,  volume)
 end
 
---- SimCallback(callback[,bool]): Execute a lua function in sim
+--- SimCallback(identifier, bool) 
+-- Performs a callback with the given identifier from /lua/sim/simcallbacks.lua. Optionally appends the unit selection to the arguments
 -- @param callback Table of { Func :: String, Args :: Table } where Func represents the callback functions and Args additional data
 -- @param addUnitSelection Toggles appending the unit selection to the callback
-function SimCallback(callback, addUnitSelection)
+function SimCallback(identifier, addUnitSelection)
 end
 
 ---

--- a/engine/User.lua
+++ b/engine/User.lua
@@ -926,9 +926,10 @@ end
 function SetVolume(category,  volume)
 end
 
----
---  SimCallback(callback[,bool]): Execute a lua function in sim
-function SimCallback(callback[, bool])
+--- SimCallback(callback[,bool]): Execute a lua function in sim
+-- @param callback Table of { Func :: String, Args :: Table } where Func represents the callback functions and Args additional data
+-- @param addUnitSelection Toggles appending the unit selection to the callback
+function SimCallback(callback, addUnitSelection)
 end
 
 ---

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -588,3 +588,73 @@ end
 Callbacks.ToggleDebugMarkersByType = function (data, units)
     import("/lua/sim/markerutilities.lua").ToggleDebugMarkersByType(data.Type)
 end
+
+-- upvalue for performance
+local EntityCategoryFilterDown = EntityCategoryFilterDown
+local IssueClearCommands = IssueClearCommands
+local IssueUpgrade = IssueUpgrade
+
+local cxrb0104 = categories.xrb0104
+local cxrb0204 = categories.xrb0204
+
+--- Force hives in the selection to upgrade immediately
+-- @param data A table { UpgradeTo :: String } that tells us what we want to upgrade to
+-- @param units A table of the selected units
+Callbacks.UpgradeHive = function(data, units)
+
+    -- make sure we have valid units
+    units = SecureUnits(units)
+
+    -- find t1 / t2 hives
+    local xrb0104 = EntityCategoryFilterDown(cxrb0104, units)
+    local xrb0204 = EntityCategoryFilterDown(cxrb0204, units)
+
+    -- upgrade tech 1 hives
+    if xrb0104[1] then 
+
+        -- oof for performance, but this doesn't get run that often
+        local notUpgradingh = 1
+        local notUpgrading = { }
+        
+        local upgradingh = 1 
+        local upgrading = { }
+
+        -- split between upgrading / and not upgrading hives for different behavior
+        for k, unit in xrb0104 do 
+            if not unit:IsUnitState('Upgrading') then 
+                notUpgrading[notUpgradingh] = unit 
+                notUpgradingh = notUpgradingh + 1
+            else 
+                upgrading[upgradingh] = unit 
+                upgradingh = upgradingh + 1
+            end
+        end
+
+        -- always clear things out
+        IssueClearCommands(notUpgrading)
+
+        -- upgrading to t2 from t1
+        if data.UpgradeTo == "xrb0204" then 
+            IssueUpgrade( notUpgrading, "xrb0204")
+        
+        -- upgrading to t3 from t1
+        elseif data.UpgradeTo == "xrb0304" then 
+            IssueUpgrade( notUpgrading, "xrb0204")
+            IssueUpgrade( xrb0104, "xrb0304")
+        end
+    end
+
+    -- upgrade tech 2 hives
+    if xrb0204[1] then 
+
+        -- always clear things out
+        if data.ClearCommands then 
+            IssueClearCommands(xrb0204)
+        end
+
+        -- upgrading to t3 form t1
+        if data.UpgradeTo == "xrb0304" then 
+            IssueUpgrade( xrb0204, "xrb0304")
+        end
+    end
+end

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -589,72 +589,74 @@ Callbacks.ToggleDebugMarkersByType = function (data, units)
     import("/lua/sim/markerutilities.lua").ToggleDebugMarkersByType(data.Type)
 end
 
--- upvalue for performance
-local EntityCategoryFilterDown = EntityCategoryFilterDown
-local IssueClearCommands = IssueClearCommands
-local IssueUpgrade = IssueUpgrade
+do
+    -- upvalue for performance
+    local EntityCategoryFilterDown = EntityCategoryFilterDown
+    local IssueClearCommands = IssueClearCommands
+    local IssueUpgrade = IssueUpgrade
 
-local cxrb0104 = categories.xrb0104
-local cxrb0204 = categories.xrb0204
+    local cxrb0104 = categories.xrb0104
+    local cxrb0204 = categories.xrb0204
 
---- Forces hives in the selection to upgrade immediately
--- @param data A table { UpgradeTo :: String } that tells us what we want to upgrade to, should be 'xrb0204' or 'xrb0304'
--- @param units A table of the selected units
-Callbacks.ImmediateHiveUpgrade = function(data, units)
+    --- Forces hives in the selection to upgrade immediately
+    -- @param data A table { UpgradeTo :: String } that tells us what we want to upgrade to, should be 'xrb0204' or 'xrb0304'
+    -- @param units A table of the selected units
+    Callbacks.ImmediateHiveUpgrade = function(data, units)
 
-    -- make sure we have valid units
-    units = SecureUnits(units)
+        -- make sure we have valid units
+        units = SecureUnits(units)
 
-    -- find t1 / t2 hives
-    local xrb0104 = EntityCategoryFilterDown(cxrb0104, units)
-    local xrb0204 = EntityCategoryFilterDown(cxrb0204, units)
+        -- find t1 / t2 hives
+        local xrb0104 = EntityCategoryFilterDown(cxrb0104, units)
+        local xrb0204 = EntityCategoryFilterDown(cxrb0204, units)
 
-    -- upgrade tech 1 hives
-    if xrb0104[1] then 
+        -- upgrade tech 1 hives
+        if xrb0104[1] then 
 
-        -- oof for performance, but this doesn't get run that often
-        local notUpgradingh = 1
-        local notUpgrading = { }
-        
-        local upgradingh = 1 
-        local upgrading = { }
+            -- oof for performance, but this doesn't get run that often
+            local notUpgradingh = 1
+            local notUpgrading = { }
+            
+            local upgradingh = 1 
+            local upgrading = { }
 
-        -- split between upgrading / and not upgrading hives for different behavior
-        for k, unit in xrb0104 do 
-            if not unit:IsUnitState('Upgrading') then 
-                notUpgrading[notUpgradingh] = unit 
-                notUpgradingh = notUpgradingh + 1
-            else 
-                upgrading[upgradingh] = unit 
-                upgradingh = upgradingh + 1
+            -- split between upgrading / and not upgrading hives for different behavior
+            for k, unit in xrb0104 do 
+                if not unit:IsUnitState('Upgrading') then 
+                    notUpgrading[notUpgradingh] = unit 
+                    notUpgradingh = notUpgradingh + 1
+                else 
+                    upgrading[upgradingh] = unit 
+                    upgradingh = upgradingh + 1
+                end
+            end
+
+            -- always clear things out
+            IssueClearCommands(notUpgrading)
+
+            -- upgrading to t2 from t1
+            if data.UpgradeTo == "xrb0204" then 
+                IssueUpgrade( notUpgrading, "xrb0204")
+            
+            -- upgrading to t3 from t1
+            elseif data.UpgradeTo == "xrb0304" then 
+                IssueUpgrade( notUpgrading, "xrb0204")
+                IssueUpgrade( xrb0104, "xrb0304")
             end
         end
 
-        -- always clear things out
-        IssueClearCommands(notUpgrading)
+        -- upgrade tech 2 hives
+        if xrb0204[1] then 
 
-        -- upgrading to t2 from t1
-        if data.UpgradeTo == "xrb0204" then 
-            IssueUpgrade( notUpgrading, "xrb0204")
-        
-        -- upgrading to t3 from t1
-        elseif data.UpgradeTo == "xrb0304" then 
-            IssueUpgrade( notUpgrading, "xrb0204")
-            IssueUpgrade( xrb0104, "xrb0304")
-        end
-    end
+            -- always clear things out
+            if data.ClearCommands then 
+                IssueClearCommands(xrb0204)
+            end
 
-    -- upgrade tech 2 hives
-    if xrb0204[1] then 
-
-        -- always clear things out
-        if data.ClearCommands then 
-            IssueClearCommands(xrb0204)
-        end
-
-        -- upgrading to t3 form t1
-        if data.UpgradeTo == "xrb0304" then 
-            IssueUpgrade( xrb0204, "xrb0304")
+            -- upgrading to t3 form t1
+            if data.UpgradeTo == "xrb0304" then 
+                IssueUpgrade( xrb0204, "xrb0304")
+            end
         end
     end
 end

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -597,10 +597,10 @@ local IssueUpgrade = IssueUpgrade
 local cxrb0104 = categories.xrb0104
 local cxrb0204 = categories.xrb0204
 
---- Force hives in the selection to upgrade immediately
--- @param data A table { UpgradeTo :: String } that tells us what we want to upgrade to
+--- Forces hives in the selection to upgrade immediately
+-- @param data A table { UpgradeTo :: String } that tells us what we want to upgrade to, should be 'xrb0204' or 'xrb0304'
 -- @param units A table of the selected units
-Callbacks.UpgradeHive = function(data, units)
+Callbacks.ImmediateHiveUpgrade = function(data, units)
 
     -- make sure we have valid units
     units = SecureUnits(units)

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -395,6 +395,13 @@ local categoriesStructure = categories.STRUCTURE
 -- @param command Information surrounding the command that has been issued, such as its CommandType or its Target.
 function OnCommandIssued(command)
 
+    -- if we're trying to upgrade hives then this allows us to force the upgrade to happen immediately
+    if command.CommandType == "Upgrade" and (command.Blueprint == "xrb0204" or command.Blueprint == "xrb0304") then 
+        if not IsKeyDown('Shift') then 
+            SimCallback({ Func = 'UpgradeHive', Args = { UpgradeTo = command.Blueprint } }, true )
+        end
+    end
+        
     -- part of the cheat menu
     if modeData.cheat and command.CommandType == "BuildMobile" and (not command.Units[1]) then
         CheatSpawn(command, modeData)

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -398,7 +398,7 @@ function OnCommandIssued(command)
     -- if we're trying to upgrade hives then this allows us to force the upgrade to happen immediately
     if command.CommandType == "Upgrade" and (command.Blueprint == "xrb0204" or command.Blueprint == "xrb0304") then 
         if not IsKeyDown('Shift') then 
-            SimCallback({ Func = 'UpgradeHive', Args = { UpgradeTo = command.Blueprint } }, true )
+            SimCallback({ Func = 'ImmediateHiveUpgrade', Args = { UpgradeTo = command.Blueprint } }, true )
         end
     end
         


### PR DESCRIPTION
Allows the hive to upgrade immediately when you are not holding shift.

Worked with @Tagada14  on this pull request as a study session.