### PR TITLE
Adjust dynamic threat computations

### DIFF
--- a/lua/system/blueprints-ai.lua
+++ b/lua/system/blueprints-ai.lua
@@ -77,7 +77,7 @@ end
 
 
 function SetUnitThreatValues(unitBPs)
-    
+
     -- localize for performance
     local TableFind = TableFind
     local TableGetn = TableGetn
@@ -103,6 +103,11 @@ function SetUnitThreatValues(unitBPs)
                 LOG(tostring(bp.BlueprintId) .. ": has no defense table in blueprint, skipped")
             end
 
+            continue 
+        end
+
+        -- not all units need dynamic threat calculations, such as the commanders
+        if bp.Defense.SkipDynamicThreatCalculations then 
             continue 
         end
 
@@ -136,10 +141,12 @@ function SetUnitThreatValues(unitBPs)
             -- Mass prod + 5% of health
             cache.EconomyThreatLevel = cache.EconomyThreatLevel + bp.Economy.ProductionPerSecondMass * 10 + (cache.HealthThreat + cache.PersonalShieldThreat) * 5
         end
+
         if bp.Economy.ProductionPerSecondEnergy then
             -- Energy prod + 1% of health
             cache.EconomyThreatLevel = cache.EconomyThreatLevel + bp.Economy.ProductionPerSecondEnergy * 0.1 + cache.HealthThreat + cache.PersonalShieldThreat
         end
+
         -- 0 off the personal health values if we alreaady used them
         if bp.Economy.ProductionPerSecondMass or bp.Economy.ProductionPerSecondEnergy then
             cache.HealthThreat = 0
@@ -166,6 +173,7 @@ function SetUnitThreatValues(unitBPs)
         if bp.Economy.StorageEnergy then
             cache.EconomyThreatLevel = cache.EconomyThreatLevel + bp.Economy.StorageEnergy * 0.001 + cache.HealthThreat + cache.PersonalShieldThreat
         end
+
         -- 0 off the personal health values if we alreaady used them
         if bp.Economy.StorageMass or bp.Economy.StorageEnergy then
             cache.HealthThreat = 0

--- a/lua/system/blueprints-ai.lua
+++ b/lua/system/blueprints-ai.lua
@@ -125,6 +125,7 @@ function SetUnitThreatValues(unitBPs)
         if bp.Defense.MaxHealth then
             cache.HealthThreat = bp.Defense.MaxHealth * 0.01
         end
+
         if bp.Defense.Shield then
             local shield = bp.Defense.Shield                                               -- ShieldProjectionRadius entirely only for the Pillar of Prominence
             local shieldarea = (shield.ShieldProjectionRadius or shield.ShieldSize or 0) * (shield.ShieldProjectionRadius or shield.ShieldSize or 0) * math.pi
@@ -147,7 +148,7 @@ function SetUnitThreatValues(unitBPs)
             cache.EconomyThreatLevel = cache.EconomyThreatLevel + bp.Economy.ProductionPerSecondEnergy * 0.1 + cache.HealthThreat + cache.PersonalShieldThreat
         end
 
-        -- 0 off the personal health values if we alreaady used them
+        -- remove health and shield because they're used
         if bp.Economy.ProductionPerSecondMass or bp.Economy.ProductionPerSecondEnergy then
             cache.HealthThreat = 0
             cache.PersonalShieldThreat = 0
@@ -174,7 +175,7 @@ function SetUnitThreatValues(unitBPs)
             cache.EconomyThreatLevel = cache.EconomyThreatLevel + bp.Economy.StorageEnergy * 0.001 + cache.HealthThreat + cache.PersonalShieldThreat
         end
 
-        -- 0 off the personal health values if we alreaady used them
+        -- remove health and shield because they're used
         if bp.Economy.StorageMass or bp.Economy.StorageEnergy then
             cache.HealthThreat = 0
             cache.PersonalShieldThreat = 0
@@ -194,47 +195,58 @@ function SetUnitThreatValues(unitBPs)
         if bp.Weapon then
             for i, weapon in bp.Weapon do
 
-                -- skip disabled weapons by default
+                -- skip weapons part of an enhancement
                 if weapon.EnabledByEnhancement then 
                     continue 
                 end
 
+                -- dps of weapon
+                local dps = CalculatedDPS(weapon)
+
+                -- multipliers to scale damage a bit
+                local econMult = 1
+                local surfaceMult = 0.1
+
+                -- determines if we apply dps to economic or anti surface threat
+                local blockedByArtilleryShield = weapon.ArtilleryShieldBlocks  
+
+                -- Anti air
                 if weapon.RangeCategory == 'UWRC_AntiAir' or weapon.TargetRestrictOnlyAllow == 'AIR' or StringFind(weapon.WeaponCategory or 'nope', 'Anti Air') then
-                    cache.AirThreatLevel = cache.AirThreatLevel + CalculatedDPS(weapon) / 10
+                    cache.AirThreatLevel = cache.AirThreatLevel + dps / 10
+
+                -- Anti submarine
                 elseif weapon.RangeCategory == 'UWRC_AntiNavy' or StringFind(weapon.WeaponCategory or 'nope', 'Anti Navy') then
                     if StringFind(weapon.WeaponCategory or 'nope', 'Bomb') or StringFind(weapon.Label or 'nope', 'Bomb') or weapon.NeedToComputeBombDrop or bp.Air.Winged then
                         cache.SubThreatLevel = cache.SubThreatLevel + CalculatedDamage(weapon) / 100
                     else
-                        cache.SubThreatLevel = cache.SubThreatLevel + CalculatedDPS(weapon) / 10
+                        cache.SubThreatLevel = cache.SubThreatLevel + dps / 10
                     end
+
+                -- Direct fire or artillery
                 elseif weapon.RangeCategory == 'UWRC_DirectFire' or StringFind(weapon.WeaponCategory or 'nope', 'Direct Fire')
                 or weapon.RangeCategory == 'UWRC_IndirectFire' or StringFind(weapon.WeaponCategory or 'nope', 'Artillery') then
-                    -- Range cutoff for artillery being considered eco and surface threat is 100
-                    local wepDPS = CalculatedDPS(weapon)
-                    local rangeCutoff = 50
-                    local econMult = 1
-                    local surfaceMult = 0.1
-                    if weapon.MinRadius and weapon.MinRadius >= rangeCutoff then
-                        cache.EconomyThreatLevel = cache.EconomyThreatLevel + wepDPS * econMult
-                    elseif weapon.MaxRadius and weapon.MaxRadius <= rangeCutoff then
-                        cache.SurfaceThreatLevel = cache.SurfaceThreatLevel + wepDPS * surfaceMult
-                    else
-                        local distr = (rangeCutoff - (weapon.MinRadius or 0)) / (weapon.MaxRadius - (weapon.MinRadius or 0))
-                        cache.EconomyThreatLevel = cache.EconomyThreatLevel + wepDPS * (1 - distr) * econMult
-                        cache.SurfaceThreatLevel = cache.SurfaceThreatLevel + wepDPS * distr * surfaceMult
+                    if blockedByArtilleryShield then 
+                        cache.EconomyThreatLevel = cache.EconomyThreatLevel + dps * econMult
+                    else 
+                        cache.SurfaceThreatLevel = cache.SurfaceThreatLevel + dps * surfaceMult
                     end
+
+                -- Bombers
                 elseif StringFind(weapon.WeaponCategory or 'nope', 'Bomb') or StringFind(weapon.Label or 'nope', 'Bomb') or weapon.NeedToComputeBombDrop then
                     cache.SurfaceThreatLevel = cache.SurfaceThreatLevel + CalculatedDamage(weapon) / 100
+
+                -- Death weapon
                 elseif StringFind(weapon.WeaponCategory or 'nope', 'Death') then
-                    cache.EconomyThreatLevel = MathFloor(cache.EconomyThreatLevel + CalculatedDPS(weapon) / 200)
+                    cache.EconomyThreatLevel = MathFloor(cache.EconomyThreatLevel + dps / 200)
+
+                -- Unknown weapon threat (mods)
                 else
-                    cache.UnknownWeaponThreat = cache.UnknownWeaponThreat + CalculatedDPS(weapon)
+                    cache.UnknownWeaponThreat = cache.UnknownWeaponThreat + dps
                     if ReportIssues then 
                         LOG(" * WARNING: Unknown weapon type on: " .. id .. " with the weapon label: " .. (weapon.Label or "nil") )
                     end
                     bp.Warnings = (bp.Warnings or 0) + 1
                 end
-                -- LOG(id .. " - " .. LOC(bp.General.UnitName or bp.Description) .. ' --  ' .. (weapon.DisplayName or '<Unnamed weapon>') .. ' ' .. weapon.RangeCategory .. " DPS: " .. CalculatedDPS(weapon))
             end
         end
 

--- a/lua/system/blueprints-ai.lua
+++ b/lua/system/blueprints-ai.lua
@@ -68,8 +68,8 @@ local function CalculatedDPS(weapon)
     elseif weapon.BeamLifetime and weapon.BeamLifetime > 0 then
         -- Uncontinuous beam. Interval from start to next start.
         DamageInterval = DamageInterval + weapon.BeamLifetime
-        -- Damage is calculated as a single glob
-        Damage = Damage * (weapon.BeamLifetime / (0.1 + (weapon.BeamCollisionDelay or 0)))
+        -- Damage is calculated as a single glob, beam weapons are typically underappreciated
+        Damage = 1.5 * Damage * (weapon.BeamLifetime / (0.1 + (weapon.BeamCollisionDelay or 0)))
     end
 
     return Damage * (1 / DamageInterval) or 0

--- a/lua/system/blueprints-ai.lua
+++ b/lua/system/blueprints-ai.lua
@@ -69,7 +69,7 @@ local function CalculatedDPS(weapon)
         -- Uncontinuous beam. Interval from start to next start.
         DamageInterval = DamageInterval + weapon.BeamLifetime
         -- Damage is calculated as a single glob, beam weapons are typically underappreciated
-        Damage = 1.5 * Damage * (weapon.BeamLifetime / (0.1 + (weapon.BeamCollisionDelay or 0)))
+        Damage = Damage * (weapon.BeamLifetime / (0.1 + (weapon.BeamCollisionDelay or 0)))
     end
 
     return Damage * (1 / DamageInterval) or 0

--- a/units/DAL0310/DAL0310_unit.bp
+++ b/units/DAL0310/DAL0310_unit.bp
@@ -55,6 +55,7 @@ UnitBlueprint {
     },
     CollisionOffsetZ = 0.1,
     Defense = {
+        SkipDynamicThreatCalculations = true,
         AirThreatLevel = 0,
         ArmorType = 'Normal',
         EconomyThreatLevel = 0,

--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -148,6 +148,7 @@ UnitBlueprint {
         'SNIPEMODE',
     },
     Defense = {
+        SkipDynamicThreatCalculations = true,
         AirThreatLevel = 0,
         ArmorType = 'Commander',
         EconomyThreatLevel = 5,

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -154,6 +154,7 @@ UnitBlueprint {
         'SNIPEMODE',
     },
     Defense = {
+        SkipDynamicThreatCalculations = true,
         AirThreatLevel = 0,
         ArmorType = 'Commander',
         EconomyThreatLevel = 5,

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -150,6 +150,7 @@ UnitBlueprint {
         'SNIPEMODE',
     },
     Defense = {
+        SkipDynamicThreatCalculations = true,
         AirThreatLevel = 0,
         ArmorType = 'Commander',
         EconomyThreatLevel = 5,

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -169,6 +169,7 @@ UnitBlueprint {
     },
     CollisionOffsetZ = 0.2,
     Defense = {
+        SkipDynamicThreatCalculations = true,
         AirThreatLevel = 0,
         ArmorType = 'Commander',
         EconomyThreatLevel = 5,


### PR DESCRIPTION
Introduces a flag to allow a unit to skip the dynamic threat computations, used by the armored command units. Only weapons that can be blocked by an artillery shield produce economic threat.