### PR TITLE
Improve performance of unit sound interactions

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -4,6 +4,7 @@
 -- Summary  :  Default definitions of units
 -- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
+local Entity = import('/lua/sim/Entity.lua').Entity
 local Unit = import('/lua/sim/Unit.lua').Unit
 local explosion = import('defaultexplosions.lua')
 local EffectUtil = import('EffectUtilities.lua')
@@ -1667,6 +1668,49 @@ SubUnit = Class(MobileUnit) {
     -- DESTRUCTION PARAMS
     ShowUnitDestructionDebris = false,
     DeathThreadDestructionWaitTime = 0,
+
+    OnCreate = function(self, spec)
+        MobileUnit.OnCreate(self, spec)
+
+        -- submarines do not make a sound by default, we want them to make sound so we use an entity as source instead
+        self.SoundEntity = Entity()
+        self.Trash:Add(self.SoundEntity)
+        Warp(self.SoundEntity, self:GetPosition())
+        self.SoundEntity:AttachTo(self,-1)
+    end,
+
+    --- Plays a sound using the unit as a source. Returns true if successful, false otherwise
+    -- @param self A unit
+    -- @param sound A string identifier that represents the sound to be played.
+    PlayUnitSound = function(self, sound)
+        local audio = self.Audio[sound]
+        if not audio then 
+            return false
+        end
+
+        self.SoundEntity:PlaySound(audio)
+        return true
+    end,
+
+    --- Plays an ambient sound using the unit as a source. Returns true if successful, false otherwise
+    -- @param self A unit
+    -- @param sound A string identifier that represents the ambient sound to be played.
+    PlayUnitAmbientSound = function(self, sound)
+        local audio = self.Audio[sound]
+        if not audio then 
+            return false
+        end
+
+        self.SoundEntity:SetAmbientSound(audio, nil)
+        return true 
+    end,
+
+    --- Stops playing the ambient sound that is currently being played.
+    -- @param self A unit
+    StopUnitAmbientSound = function(self, sound)
+        self.SoundEntity:SetAmbientSound(nil, nil)
+        return true
+    end,
 }
 
 -- AIR UNITS

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1678,39 +1678,6 @@ SubUnit = Class(MobileUnit) {
         Warp(self.SoundEntity, self:GetPosition())
         self.SoundEntity:AttachTo(self,-1)
     end,
-
-    --- Plays a sound using the unit as a source. Returns true if successful, false otherwise
-    -- @param self A unit
-    -- @param sound A string identifier that represents the sound to be played.
-    PlayUnitSound = function(self, sound)
-        local audio = self.Audio[sound]
-        if not audio then 
-            return false
-        end
-
-        self.SoundEntity:PlaySound(audio)
-        return true
-    end,
-
-    --- Plays an ambient sound using the unit as a source. Returns true if successful, false otherwise
-    -- @param self A unit
-    -- @param sound A string identifier that represents the ambient sound to be played.
-    PlayUnitAmbientSound = function(self, sound)
-        local audio = self.Audio[sound]
-        if not audio then 
-            return false
-        end
-
-        self.SoundEntity:SetAmbientSound(audio, nil)
-        return true 
-    end,
-
-    --- Stops playing the ambient sound that is currently being played.
-    -- @param self A unit
-    StopUnitAmbientSound = function(self, sound)
-        self.SoundEntity:SetAmbientSound(nil, nil)
-        return true
-    end,
 }
 
 -- AIR UNITS

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -44,7 +44,7 @@ for k, bp in __blueprints do
     end
 end
 
--- cache categories computation for overspill calculations
+-- cache categories computations
 local CategoriesOverspill = (categories.SHIELD * categories.DEFENSE) + categories.BUBBLESHIELDSPILLOVERCHECK
 
 Shield = Class(moho.shield_methods, Entity) {

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -10,7 +10,10 @@ local EffectTemplate = import('/lua/EffectTemplates.lua')
 local Util = import('utilities.lua')
 
 local VectorCached = Vector(0, 0, 0)
+
+-- upvalue for performance
 local MathSqrt = math.sqrt
+local IsEnemy = IsEnemy
 
 
 -- Default values for a shield specification table (to be passed to native code)

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -543,10 +543,10 @@ Shield = Class(moho.shield_methods, Entity) {
         end
 
         -- cache categories of projectile for performance
-        local otherCategories = other.BlueprintCache.HashedCats
+        local otherHashedCats = other.BlueprintCache.HashedCats
 
         -- special behavior for projectiles attached to planes
-        if otherCategories['SHIELDCOLLIDE'] then
+        if otherHashedCats['SHIELDCOLLIDE'] then
             if other.ShieldImpacted then
                 return false
             else
@@ -558,7 +558,7 @@ Shield = Class(moho.shield_methods, Entity) {
         end
 
         -- special behavior for projectiles that represent strategic missiles
-        if otherCategories['STRATEGIC'] and otherCategories['MISSILE'] then
+        if otherHashedCats['STRATEGIC'] and otherHashedCats['MISSILE'] then
             return false
         end
 

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -532,9 +532,9 @@ Shield = Class(moho.shield_methods, Entity) {
         ChangeState(self, self.DeadState)
     end,
 
-    -- Return true to process this collision, false to ignore it.
-    -- @param self Shield we're checking the collision for
-    -- @param other Projectile that we're checking the collision with
+    --- Called when a shield collides with a projectile to check if the collision is valid
+    -- @param self The shield we're checking the collision for
+    -- @param other The projectile we're checking the collision with
     OnCollisionCheck = function(self, other)
 
         -- neutral projectiles never collide
@@ -543,7 +543,7 @@ Shield = Class(moho.shield_methods, Entity) {
         end
 
         -- cache categories of projectile for performance
-        local otherCategories = other.BlueprintCache.Categories 
+        local otherCategories = other.BlueprintCache.HashedCats
 
         -- special behavior for projectiles attached to planes
         if otherCategories['SHIELDCOLLIDE'] then

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -25,6 +25,9 @@ local function PopulateProjectileCache(projectile, blueprint)
     SPEW("Populated meta cache for projectile: " .. tostring(blueprint.BlueprintId))
 end
 
+-- cache categories computations
+local CategoriesDoNotCollide = categories.TORPEDO + categories.MISSILE + categories.DIRECTFIRE
+
 Projectile = Class(moho.projectile_methods, Entity) {
 
     BlueprintCache = false,
@@ -176,8 +179,7 @@ Projectile = Class(moho.projectile_methods, Entity) {
         -- By default, anything hitting us should know about it so we return true.
         if self.Army == other.Army then return false end
 
-        local dnc_cats = categories.TORPEDO + categories.MISSILE + categories.DIRECTFIRE
-        if EntityCategoryContains(dnc_cats, self) and EntityCategoryContains(dnc_cats, other) then
+        if EntityCategoryContains(CategoriesDoNotCollide, self) and EntityCategoryContains(CategoriesDoNotCollide, other) then
             return false
         end
 

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -186,20 +186,14 @@ Projectile = Class(moho.projectile_methods, Entity) {
     -- @param self The projectile we're checking the collision for
     -- @param other The projectile we're checking the collision with
     OnCollisionCheck = function(self, other)
-        LOG("OnCollisionCheck")
 
         -- If we return false the thing hitting us has no idea that it came into contact with us.
         -- By default, anything hitting us should know about it so we return true.
         if self.Army == other.Army then return false end
 
-
-        LOG(repr(other:GetBlueprint().BlueprintId))
-
         if EntityCategoryContains(CategoriesDoNotCollide, self) and EntityCategoryContains(CategoriesDoNotCollide, other) then
             return false
         end
-
-
 
         if other:GetBlueprint().Physics.HitAssignedTarget and other:GetTrackingTarget() ~= self then
             return false

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -10,7 +10,7 @@ local Explosion = import('/lua/defaultexplosions.lua')
 local DefaultDamage = import('/lua/sim/defaultdamage.lua')
 local Flare = import('/lua/defaultantiprojectile.lua').Flare
 
-local function PopulateBlueprintCache(projectile, blueprint)
+local function PopulateBlueprintCache(entity, blueprint)
 
     -- populate the cache
     local cache = { }
@@ -27,7 +27,7 @@ local function PopulateBlueprintCache(projectile, blueprint)
     cache.CollideFriendlyShield = blueprint.Physics.CollideFriendlyShield
 
     -- store the result
-    local meta = getmetatable(projectile)
+    local meta = getmetatable(entity)
     meta.BlueprintCache = cache
 
     SPEW("Populated blueprint cache for projectile: " .. tostring(blueprint.BlueprintId))

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -187,9 +187,10 @@ Projectile = Class(moho.projectile_methods, Entity) {
     -- @param other The projectile we're checking the collision with
     OnCollisionCheck = function(self, other)
 
-        -- If we return false the thing hitting us has no idea that it came into contact with us.
-        -- By default, anything hitting us should know about it so we return true.
-        if self.Army == other.Army then return false end
+        -- bail out immediately
+        if self.Army == other.Army then 
+            return false 
+        end
 
         if EntityCategoryContains(CategoriesDoNotCollide, self) and EntityCategoryContains(CategoriesDoNotCollide, other) then
             return false

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -37,8 +37,6 @@ Projectile = Class(moho.projectile_methods, Entity) {
         self.DamageData.CollideFriendly = DamageData.CollideFriendly
         self.DamageData.DoTTime = DamageData.DoTTime
         self.DamageData.DoTPulses = DamageData.DoTPulses
-        self.DamageData.MetaImpactAmount = DamageData.MetaImpactAmount
-        self.DamageData.MetaImpactRadius = DamageData.MetaImpactRadius
         self.DamageData.Buffs = DamageData.Buffs
         self.DamageData.ArtilleryShieldBlocks = DamageData.ArtilleryShieldBlocks
         self.DamageData.InitialDamageAmount = DamageData.InitialDamageAmount
@@ -154,9 +152,7 @@ Projectile = Class(moho.projectile_methods, Entity) {
             DamageRadius = nil,
             DamageAmount = nil,
             DamageType = nil,
-            DamageFriendly = nil,
-            MetaImpactAmount = nil,
-            MetaImpactRadius = nil,
+            DamageFriendly = nil
         }
 
         self.Army = self:GetArmy()
@@ -249,14 +245,6 @@ Projectile = Class(moho.projectile_methods, Entity) {
         self:Destroy()
     end,
 
-    DoMetaImpact = function(self, damageData)
-        if damageData.MetaImpactRadius and damageData.MetaImpactAmount then
-            local pos = self:GetPosition()
-            pos[2] = GetSurfaceHeight(pos[1], pos[3])
-            MetaImpact(self, pos, damageData.MetaImpactRadius, damageData.MetaImpactAmount)
-        end
-    end,
-
     CreateImpactEffects = function(self, army, EffectTable, EffectScale)
         local emit = nil
         for _, v in EffectTable do
@@ -327,9 +315,6 @@ Projectile = Class(moho.projectile_methods, Entity) {
 
         -- Do Damage
         self:DoDamage(instigator, damageData, targetEntity)
-
-        -- Meta-Impact
-        self:DoMetaImpact(damageData)
 
         -- Buffs (Stun, etc)
         self:DoUnitImpactBuffs(targetEntity)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -199,6 +199,7 @@ Unit = Class(moho.unit_methods) {
 
         -- copy reference from meta table to inner table
         self.BlueprintCache = self.BlueprintCache
+        self.SoundEntity = self
 
         -- cache commonly used values from the engine
         -- self.Layer = self:GetCurrentLayer() -- Not required: ironically OnLayerChange is called _before_ OnCreate is called!
@@ -3822,7 +3823,7 @@ Unit = Class(moho.unit_methods) {
             return false
         end
 
-        self:PlaySound(audio)
+        self.SoundEntity:PlaySound(audio)
         return true
     end,
 
@@ -3835,14 +3836,14 @@ Unit = Class(moho.unit_methods) {
             return false
         end
 
-        self:SetAmbientSound(audio, nil)
+        self.SoundEntity:SetAmbientSound(audio, nil)
         return true 
     end,
 
     --- Stops playing the ambient sound that is currently being played.
     -- @param self A unit
     StopUnitAmbientSound = function(self)
-        self:SetAmbientSound(nil, nil)
+        self.SoundEntity:SetAmbientSound(nil, nil)
         return true
     end,
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -3809,62 +3809,41 @@ Unit = Class(moho.unit_methods) {
         end
     end,
 
-    GetSoundEntity = function(self, type)
-        -- these may not be initialised yet
-        self.Sounds = self.Sounds or { }
-        self.SoundEntities = self.SoundEntities or { }
+    -------------------------------------------------------------------------------------------
+    -- Sound
+    -------------------------------------------------------------------------------------------
 
-        local entity = self.Sounds[type]
-        if not self.Sounds[type] then
-            if self.SoundEntities[1] then
-                entity = table.remove(self.SoundEntities, 1)
-            else
-                entity = Entity()
-                Warp(entity, self:GetPosition())
-                entity:AttachTo(self, -1)
-                self.Trash:Add(entity)
-            end
-            self.Sounds[type] = entity
-        end
-
-        return self.Sounds[type]
-    end,
-
+    --- Plays a sound using the unit as a source. Returns true if successful, false otherwise
+    -- @param self A unit
+    -- @param sound A string identifier that represents the sound to be played.
     PlayUnitSound = function(self, sound)
         local audio = self.Audio[sound]
         if not audio then 
-            return 
+            return false
         end
 
-        self:GetSoundEntity('UnitSound'):PlaySound(audio)
-
+        self:PlaySound(audio)
         return true
     end,
 
+    --- Plays an ambient sound using the unit as a source. Returns true if successful, false otherwise
+    -- @param self A unit
+    -- @param sound A string identifier that represents the ambient sound to be played.
     PlayUnitAmbientSound = function(self, sound)
         local audio = self.Audio[sound]
         if not audio then 
-            return 
+            return false
         end
 
-        self:GetSoundEntity('Ambient' .. sound):SetAmbientSound(audio, nil)
+        self:SetAmbientSound(audio, nil)
+        return true 
     end,
 
-    StopUnitAmbientSound = function(self, sound)
-        -- these may not be initialised yet
-        self.Sounds = self.Sounds or { }
-        self.SoundEntities = self.SoundEntities or { }
-
-        if not self.Audio[sound] then return end
-
-        local type = 'Ambient' .. sound
-        local entity = self:GetSoundEntity(type)
-        if entity and not entity:BeenDestroyed() then
-            self.Sounds[type] = nil
-            entity:SetAmbientSound(nil, nil)
-            self.SoundEntities = self.SoundEntities
-            table.insert(self.SoundEntities, entity)
-        end
+    --- Stops playing the ambient sound that is currently being played.
+    -- @param self A unit
+    StopUnitAmbientSound = function(self)
+        self:SetAmbientSound(nil, nil)
+        return true
     end,
 
     -------------------------------------------------------------------------------------------

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -32,9 +32,11 @@ local DeprecatedWarnings = { }
 -- allows us to skip ai-specific functionality
 local GameHasAIs = ScenarioInfo.GameHasAIs
 
--- Localised category operations for performance
+-- cached categories for performance
 local UpdateAssistersConsumptionCats = categories.REPAIR - categories.INSIGNIFICANTUNIT     -- anything that repairs but insignificant things, such as drones
 
+-- upvalues for performance
+local IsAlly = IsAlly
 
 -- Localised global functions for speed. ~10% for single references, ~30% for double (eg table.insert)
 
@@ -1556,10 +1558,8 @@ Unit = Class(moho.unit_methods) {
         end
 
         -- if we're allied, check if we allow allied collisions
-        if other.BlueprintCache.HashedCats['PROJECTILE'] then
-            if IsAlly(self.Army, other.Army) then
-                return other.CollideFriendly
-            end
+        if self.Army == other.Army or IsAlly(self.Army, other.Army) then
+            return other.CollideFriendly
         end
 
         -- check for exclusions from projectile perspective

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -84,6 +84,8 @@ local function PopulateBlueprintCache(projectile, blueprint)
     cache.DoNotCollideCatsCount = table.getn(blueprint.DoNotCollideList or { })
     cache.HashedDoNotCollideCats = table.hash(blueprint.DoNotCollideList)
 
+    cache.Audio = blueprint.Audio
+
     -- store the result
     local meta = getmetatable(projectile)
     meta.BlueprintCache = cache
@@ -199,6 +201,11 @@ Unit = Class(moho.unit_methods) {
 
         -- copy reference from meta table to inner table
         self.BlueprintCache = self.BlueprintCache
+
+        -- copy frequently used values from cache to reduce table look ups
+        self.Audio = self.BlueprintCache.Audio
+
+        -- the entity that produces sound, by default ourself
         self.SoundEntity = self
 
         -- cache commonly used values from the engine

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1556,7 +1556,7 @@ Unit = Class(moho.unit_methods) {
         end
 
         -- if we're allied, check if we allow allied collisions
-        if other.BlueprintCache.Categories['PROJECTILE'] then
+        if other.BlueprintCache.HashedCats['PROJECTILE'] then
             if IsAlly(self.Army, other.Army) then
                 return other.CollideFriendly
             end


### PR DESCRIPTION
According to commit https://github.com/FAForever/fa/commit/dfb363dcdc6685bdf4daf8f94178a7da2b06ae8f the sound of submarine units do not work. The solution introduced is applied to all units and allocates a handful of entities per unit. These allocations are expensive!

By default, units try to play the sound themselves. For submarine units we introduce one entity that plays all the sounds of the submarine. This appears to work fine - note that sound is important, but during the late accurate sound is by far less critical than having a high performing simulation.