### PR TITLE
Optimize shield interactions

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -302,10 +302,10 @@ Shield = Class(moho.shield_methods, Entity) {
             end
         end
 
-        -- damage correction for overspill
+        -- damage correction for overspill, only apply to bubble shields
 
         local instigatorId = (instigator and instigator.EntityId) or false
-        if instigatorId then 
+        if self.ShieldType == "Bubble" and instigatorId then 
 
             -- check if source has applied damage this tick
             if self.DamageReductionTick[instigatorId] == tick then 

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -681,8 +681,10 @@ Shield = Class(moho.shield_methods, Entity) {
     OnState = State {
         Main = function(self)
 
-            -- inform 
-            self.RegenThreadState = "On"
+            -- unsuspend the regeneration thread
+            if self.RegenThreadSuspended then 
+                ResumeThread(self.RegenThread)
+            end
 
             if self.DamageRecharge then
                 self.Owner:SetMaintenanceConsumptionActive()
@@ -704,12 +706,6 @@ Shield = Class(moho.shield_methods, Entity) {
 
                 self:ChargingUp(0, self.ShieldEnergyDrainRechargeTime)
                 self.OnStateCharging = nil
-
-                -- If the shield has less than full health, allow the shield to begin regening
-                -- if self:GetHealth() < self:GetMaxHealth() and self.RegenRate > 0 then
-                --     self.RegenThread = ForkThread(self.RegenStartThread, self)
-                --     self.Owner.Trash:Add(self.RegenThread)
-                -- end
             end
             self.Owner:OnShieldEnabled()
 

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -374,8 +374,10 @@ Shield = Class(moho.shield_methods, Entity) {
         -- overspill damage checks
 
         if 
-            -- personal shields do not have overspill damage
+            -- prevent recursively applying overspill
             doOverspill 
+            -- personal shields do not have overspill damage
+            and self.ShieldType ~= "Personal"
             -- we consider damage without an instigator irrelevant, typically force events
             and IsEntity(instigator) 
             -- we consider damage that is 1 or lower irrelevant, typically force events

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -169,10 +169,10 @@ Shield = Class(moho.shield_methods, Entity) {
                     -- check if it is a different unti and that it has an active shield with a radius
                     -- larger than 0, as engine defaults shield table to 0
                     if      shieldOther 
+                        and shieldOther.ShieldType ~= "Personal"
                         and shieldOther:IsUp()
                         and shieldOther.Size
                         and shieldOther.Size > 0 
-                        and shieldOther.ShieldType ~= "Personal"
                         and self.Owner.EntityId ~= other.EntityId 
                     then 
 


### PR DESCRIPTION
On each hit against a shield a thread is de-allocated and then re-allocated: the regeneration thread. When dealing with units like a Mantis or a Janus this happens many times over per second. That is a bit of a waste! 

With this pull request we create one regeneration thread when the shield starts existing and suspend it accordingly. The ability to suspend a thread is not widely used in the code base. 