### PR TITLE
Temporarily disables weapons of a unit when gifted

### DIFF
--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -56,6 +56,23 @@ function KillSharedUnits(owner)
     end
 end
 
+local function TransferUnitsOwnershipComparator (a, b) 
+    a = a.Blueprint or a:GetBlueprint()
+    b = b.Blueprint or b:GetBlueprint()
+    return a.Economy.BuildCostMass > b.Economy.BuildCostMass 
+end
+
+local function TransferUnitsOwnershipDelayedWeapons (weapon)
+    -- compute delay
+    local bp = weapon:GetBlueprint()
+    local delay = 1 / bp.RateOfFire
+    WaitSeconds(delay)
+
+    -- enable the weapon again
+    weapon:SetEnabled(true)
+    LOG("Enabled: " .. bp.Label)
+end
+
 function TransferUnitsOwnership(units, ToArmyIndex, captured)
     local toBrain = GetArmyBrain(ToArmyIndex)
     if not toBrain or toBrain:IsDefeated() or not units or table.empty(units) then
@@ -72,7 +89,7 @@ function TransferUnitsOwnership(units, ToArmyIndex, captured)
     units = EntityCategoryFilterDown(categories.ALLUNITS - categories.INSIGNIFICANTUNIT, units)
 
     -- gift most valuable units first
-    table.sort(units, function (a, b) return a:GetBlueprint().Economy.BuildCostMass > b:GetBlueprint().Economy.BuildCostMass end)
+    table.sort(units, TransferUnitsOwnershipComparator)
 
     local newUnits = {}
     local upUnits = {}
@@ -249,6 +266,17 @@ function TransferUnitsOwnership(units, ToArmyIndex, captured)
 
         if upgradeKennels[1] then
             ForkThread(UpgradeTransferredKennels, upgradeKennels)
+        end
+    end
+
+    -- add delay on turning on each weapon 
+    for k, unit in newUnits do 
+        
+        -- disable all weapons, enable with a delay
+        for k = 1, unit.WeaponCount do 
+            local weapon = unit:GetWeapon(k)
+            weapon:SetEnabled(false)
+            weapon:ForkThread(TransferUnitsOwnershipDelayedWeapons)
         end
     end
 

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -70,7 +70,6 @@ local function TransferUnitsOwnershipDelayedWeapons (weapon)
 
     -- enable the weapon again
     weapon:SetEnabled(true)
-    LOG("Enabled: " .. bp.Label)
 end
 
 function TransferUnitsOwnership(units, ToArmyIndex, captured)


### PR DESCRIPTION
The weapon cooldowns of units are reset when it is gifted. This pull requests disables the weapons in question. They're enabled after their 'reload time' has passed. 