### PR TITLE
Add colors, reorder colors, add color order functionality, & fix lobby AI color bug

### DIFF
--- a/lua/GameColors.lua
+++ b/lua/GameColors.lua
@@ -15,7 +15,7 @@ GameColors = {
         "ff8e7cc3",      -- light purple
         "ff9161ff",      -- purple
         "FF5F01A7",      -- dark purple
-        "ff920092",      -- dark rich purple
+        "ff920092",      -- rich purple
         "ff901427",      -- dark red
         "ffff88ff",      -- pink
         "ffff32ff",      -- new fuschia
@@ -43,7 +43,7 @@ GameColors = {
         "ff8e7cc3",      -- light purple
         "ff9161ff",      -- purple
         "FF5F01A7",      -- dark purple
-        "ff920092",      -- dark rich purple
+        "ff920092",      -- rich purple
         "ff901427",      -- dark red
         "ffff88ff",      -- pink
         "ffff32ff",      -- new fuschia

--- a/lua/GameColors.lua
+++ b/lua/GameColors.lua
@@ -13,10 +13,12 @@ GameColors = {
         "ff1a9ba2",      -- dark cyan
         "ff6fa8dc",      -- sky blue
         "ff8e7cc3",      -- light purple
+        "ff9161ff",      -- purple
         "FF5F01A7",      -- dark purple
         "ff920092",      -- dark rich purple
         "ff901427",      -- dark red
         "ffff88ff",      -- pink
+        "ffff32ff",      -- new fuschia
         "FFe80a0a",      -- Cybran red
         "FFFF873E",      -- Nomads orange
         "ffb76518",      -- new brown
@@ -39,10 +41,12 @@ GameColors = {
         "ff1a9ba2",      -- dark cyan
         "ff6fa8dc",      -- sky blue
         "ff8e7cc3",      -- light purple
+        "ff9161ff",      -- purple
         "FF5F01A7",      -- dark purple
         "ff920092",      -- dark rich purple
         "ff901427",      -- dark red
         "ffff88ff",      -- pink
+        "ffff32ff",      -- new fuschia
         "FFe80a0a",      -- Cybran red
         "FFFF873E",      -- Nomads orange
         "ffb76518",      -- new brown

--- a/lua/GameColors.lua
+++ b/lua/GameColors.lua
@@ -1,49 +1,62 @@
+-- Default color order for TMM/etc is set in conjunction with these tables,
+-- and is specified in the local ColorOrder in lobby.lua.  So, if you change
+-- the colors/order in the ArnyColors and or PlayerColors tables, you should
+-- probably change the ColorOrder table in lobby.lua accordingly.
+
 GameColors = {
     CivilianArmyColor = "BurlyWood",
 
     -- Faction colours
     ArmyColors = {
-    "ff436eee",      -- new blue1
-    "FFe80a0a",      -- Cybran red
-    "FF2929e1",      -- UEF blue
-    "ff901427",      -- dark red
-    "ff9161ff",      -- purple
-    "FFFF873E",      -- Nomads orange
-    "ff66ffcc",      -- aqua
-    "fffafa00",      -- new yellow
-    "ffff88ff",      -- pink
-    "ffff32ff",      -- new fuschia
-    "FF5F01A7",      -- dark purple
-    "ffa79602",      -- Sera golden
-    "ffb76518",      -- new brown
-    "FF2F4F4F",      -- olive (dark green)
-    "ff2e8b57",      -- new green
-    "ff40bf40",      -- mid green
-    "ff9fd802",      -- Order Green
-    "ff616d7e",      -- grey
-    "ffffffff",      -- white
+        "FF2929e1",      -- UEF blue
+        "ff436eee",      -- new blue1
+        "ff1a9ba2",      -- dark cyan
+        "ff6fa8dc",      -- sky blue
+        "ff8e7cc3",      -- light purple
+        "FF5F01A7",      -- dark purple
+        "ff920092",      -- dark rich purple
+        "ff901427",      -- dark red
+        "ffff88ff",      -- pink
+        "FFe80a0a",      -- Cybran red
+        "FFFF873E",      -- Nomads orange
+        "ffb76518",      -- new brown
+        "ffa79602",      -- Sera golden
+        "FFD8B038",      -- golden brown
+        "fffafa00",      -- new yellow
+        "ffffffff",      -- white
+        "ff616d7e",      -- grey
+        "FF2F4F4F",      -- olive (dark green)
+        "ff1c6404",      -- dark green
+        "ff2e8b57",      -- new green
+        "ff40bf40",      -- mid green
+        "ff9fd802",      -- Order Green
+        "ff66ffcc",      -- aqua
     },
 
     PlayerColors = {
-    "ff436eee",      -- new blue1
-    "FFe80a0a",      -- Cybran red
-    "FF2929e1",      -- UEF blue
-    "ff901427",      -- dark red
-    "ff9161ff",      -- purple
-    "FFFF873E",      -- Nomads orange
-    "ff66ffcc",      -- aqua
-    "fffafa00",      -- new yellow
-    "ffff88ff",      -- pink
-    "ffff32ff",      -- new fuschia
-    "FF5F01A7",      -- dark purple
-    "ffa79602",      -- Sera golden
-    "ffb76518",      -- new brown
-    "FF2F4F4F",      -- olive (dark green)
-    "ff2e8b57",      -- new green
-    "ff40bf40",      -- mid green
-    "ff9fd802",      -- Order Green
-    "ff616d7e",      -- grey
-    "ffffffff",      -- white
+        "FF2929e1",      -- UEF blue
+        "ff436eee",      -- new blue1
+        "ff1a9ba2",      -- dark cyan
+        "ff6fa8dc",      -- sky blue
+        "ff8e7cc3",      -- light purple
+        "FF5F01A7",      -- dark purple
+        "ff920092",      -- dark rich purple
+        "ff901427",      -- dark red
+        "ffff88ff",      -- pink
+        "FFe80a0a",      -- Cybran red
+        "FFFF873E",      -- Nomads orange
+        "ffb76518",      -- new brown
+        "ffa79602",      -- Sera golden
+        "FFD8B038",      -- golden brown
+        "fffafa00",      -- new yellow
+        "ffffffff",      -- white
+        "ff616d7e",      -- grey
+        "FF2F4F4F",      -- olive (dark green)
+        "ff1c6404",      -- dark green
+        "ff2e8b57",      -- new green
+        "ff40bf40",      -- mid green
+        "ff9fd802",      -- Order Green
+        "ff66ffcc",      -- aqua
     },
 
     TeamColorMode = {

--- a/lua/GameColors.lua
+++ b/lua/GameColors.lua
@@ -1,8 +1,5 @@
--- Default color order for TMM/etc is set in conjunction with these tables,
--- and is specified in the local ColorOrder in lobby.lua.  So, if you change
--- the colors/order in the ArnyColors and or PlayerColors tables, you should
--- probably change the ColorOrder table in lobby.lua accordingly.
-
+--- Determines the available colors for players and the default color order for 
+-- matchmaking. See autolobby.lua and lobby.lua for more information.
 GameColors = {
 
     CivilianArmyColor = "BurlyWood",

--- a/lua/GameColors.lua
+++ b/lua/GameColors.lua
@@ -4,7 +4,12 @@
 -- probably change the ColorOrder table in lobby.lua accordingly.
 
 GameColors = {
+
     CivilianArmyColor = "BurlyWood",
+
+    -- Default color order used for lobbies/TMM if not otherwise specified. Tightly coupled 
+    -- with the ArmyColors and the PlayerColors tables.
+    DefaultColorOrder = {2, 12, 1, 9, 6, 13, 25, 17, 23, 11, 3, 16, 24, 18, 19, 14},
 
     -- Faction colours
     ArmyColors = {

--- a/lua/ui/lobby/autolobby.lua
+++ b/lua/ui/lobby/autolobby.lua
@@ -142,7 +142,7 @@ local function HostAddPlayer(senderId, playerInfo)
 
     playerInfo.PlayerName = lobbyComm:MakeValidPlayerName(playerInfo.OwnerID,playerInfo.PlayerName)
     -- TODO: Should colors be based on teams?
-    playerInfo.PlayerColor = lobby.ColorOrder[slot]
+    playerInfo.PlayerColor = gameColors.DefaultColorOrder[slot]
 
     gameInfo.PlayerOptions[slot] = playerInfo
 end

--- a/lua/ui/lobby/autolobby.lua
+++ b/lua/ui/lobby/autolobby.lua
@@ -19,7 +19,6 @@ local MenuCommon = import('/lua/ui/menus/menucommon.lua')
 local LobbyComm = import('/lua/ui/lobby/lobbyComm.lua')
 local gameColors = import('/lua/gameColors.lua').GameColors
 local utils = import('/lua/system/utils.lua')
-local lobby = import('/lua/ui/lobby/lobby.lua')
 
 
 

--- a/lua/ui/lobby/autolobby.lua
+++ b/lua/ui/lobby/autolobby.lua
@@ -19,6 +19,7 @@ local MenuCommon = import('/lua/ui/menus/menucommon.lua')
 local LobbyComm = import('/lua/ui/lobby/lobbyComm.lua')
 local gameColors = import('/lua/gameColors.lua').GameColors
 local utils = import('/lua/system/utils.lua')
+local lobby = import('/lua/ui/lobby/lobby.lua')
 
 
 
@@ -141,7 +142,7 @@ local function HostAddPlayer(senderId, playerInfo)
 
     playerInfo.PlayerName = lobbyComm:MakeValidPlayerName(playerInfo.OwnerID,playerInfo.PlayerName)
     -- TODO: Should colors be based on teams?
-    playerInfo.PlayerColor = slot
+    playerInfo.PlayerColor = lobby.ColorOrder[slot]
 
     gameInfo.PlayerOptions[slot] = playerInfo
 end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -54,9 +54,7 @@ local AIStrings = {}
 local AITooltips = {}
 
 
--- Default color order used for lobbies/TMM if not otherwise specified
--- Desired default order of the colors in the color tables in GameColors.lua for TMM/etc
-local ColorOrder = {2, 12, 1, 9, 6, 13, 25, 17, 23, 11, 3, 16, 24, 18, 19, 14}
+
 
 function GetAITypes()
     AIKeys = {}
@@ -86,6 +84,7 @@ local globalOpts = import('/lua/ui/lobby/lobbyOptions.lua').globalOpts
 local teamOpts = import('/lua/ui/lobby/lobbyOptions.lua').teamOptions
 local AIOpts = import('/lua/ui/lobby/lobbyOptions.lua').AIOpts
 local gameColors = import('/lua/gameColors.lua').GameColors
+
 local numOpenSlots = LobbyComm.maxPlayerSlots
 
 -- Add lobby options from AI mods
@@ -2441,11 +2440,11 @@ end
 
 function GetAvailableColor()
     for i = 1, LobbyComm.maxPlayerSlots do
-        if IsColorFree(ColorOrder[i]) then
-            return ColorOrder[i]
+        if IsColorFree(gameColors.DefaultColorOrder[i]) then
+            return gameColors.DefaultColorOrder[i]
         end
     end
-    LOG('Error: No available color found in ColorOrder.')
+    WARN('Error: No available colors found.')
 end
 
 --- This function is retarded.

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2440,11 +2440,12 @@ function OnModsChanged(simMods, UIMods, ignoreRefresh)
 end
 
 function GetAvailableColor()
-    for i = 1, 16 do
+    for i = 1, LobbyComm.maxPlayerSlots do
         if IsColorFree(ColorOrder[i]) then
             return ColorOrder[i]
         end
     end
+    LOG('Error: No available color found in ColorOrder.')
 end
 
 --- This function is retarded.

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -4202,7 +4202,7 @@ function AddChatText(text, playerID, scrollToBottom)
     local textColor = "AAAAAA"
     local nameFont = "Arial Gras"
     for id, player in gameInfo.PlayerOptions:pairs() do
-        if player.OwnerID == playerID then
+        if player.OwnerID == playerID and player.Human then
             textColor = nil
             nameColor = gameColors.PlayerColors[player.PlayerColor]
             if not chatPlayerColor then

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -56,7 +56,7 @@ local AITooltips = {}
 
 -- Default color order used for lobbies/TMM if not otherwise specified
 -- Desired default order of the colors in the color tables in GameColors.lua for TMM/etc
-local ColorOrder = {1, 10, 21, 7, 23, 15, 3, 9, 5, 8, 19, 16, 22, 12, 17, 13}
+local ColorOrder = {2, 12, 1, 9, 6, 13, 25, 17, 23, 11, 3, 16, 24, 18, 19, 14}
 
 function GetAITypes()
     AIKeys = {}


### PR DESCRIPTION
Adjusts which colors are available
Reorders available colors
Adds a ColorOrder local to lobby.lua that specifies the default color order for TMM/etc that gets used if color is not specified otherwise
Theoretically fixes TryAddPlayer's IsColorFree functionality, which theoretically used to give a false negative every time it was positive

Available Colors:
![image](https://user-images.githubusercontent.com/72904368/158696919-a5b0c42a-e8ca-4fac-9c78-6b74c1fdb385.png)

Default Color Order:
![image](https://user-images.githubusercontent.com/72904368/158696845-493051c8-0df3-4e8f-a220-183d5c1a683b.png)