### PR TITLE
AI Color Fixing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,8 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
If an AI exists in a lobby slot, and that AI is replaced with another AI (ie: an Easy AI is changed to an Adaptive AI), this PR makes it so the new AI gets the same color as the old AI that was in that slot. (as opposed to getting the next available color instead)