### PR TITLE
Optimize Zthuee projectiles (amongst other projectile things)

### DIFF
--- a/engine/Sim/Projectile.lua
+++ b/engine/Sim/Projectile.lua
@@ -18,6 +18,7 @@ end
 
 ---
 --  Projectile:CreateChildProjectile(blueprint)
+-- Internally calls import to find the projectile
 function Projectile:CreateChildProjectile(blueprint)
 end
 

--- a/lua/proptree.lua
+++ b/lua/proptree.lua
@@ -84,11 +84,10 @@ Tree = Class(Prop) {
             local canBurn = (not self.Burning) and (not self.NoBurn)
 
             if type == 'Disintegrate' or type == "Reclaimed" then 
-                LOG("Desintegrated!")
                 -- we just got obliterated
                 EntityDestroy(self)
 
-            elseif type == 'Force' then
+            elseif type == 'Force' or type == "KnockTree" then
                 if canFall then 
                     -- change internal state
                     self.NoBurn = true

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -242,12 +242,13 @@ MultiPolyTrailProjectile = Class(EmitterProjectile) {
 
         if self.PolyTrails then
             local effect
+            local army = self.Army 
             if self.RandomPolyTrails ~= 0 then
                 local index
                 local NumPolyTrails = TableGetn(self.PolyTrails)
                 for i = 1, self.RandomPolyTrails do
                     index = Random(1, NumPolyTrails)
-                    effect = CreateTrail(self, -1, self.Army, self.PolyTrails[index])
+                    effect = CreateTrail(self, -1, army, self.PolyTrails[index])
 
                     -- only do these engine calls when they matter
                     if self.PolyTrailOffset[index] ~= 0 then 
@@ -256,7 +257,7 @@ MultiPolyTrailProjectile = Class(EmitterProjectile) {
                 end
             else
                 for i = 1, NumPolyTrails do
-                    effect = CreateTrail(self, -1, self.Army, self.PolyTrails[i])
+                    effect = CreateTrail(self, -1, army, self.PolyTrails[i])
 
                     -- only do these engine calls when they matter
                     if self.PolyTrailOffset[i] ~= 0 then 
@@ -324,7 +325,7 @@ OnWaterEntryEmitterProjectile = Class(Projectile) {
         Projectile.OnCreate(self, inWater)
 
         if inWater then
-            
+
             local effect 
             local army = self.Army 
 

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -4,6 +4,7 @@
 -- Summary  : Script for default projectiles
 -- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
+
 local Projectile = import('/lua/sim/Projectile.lua').Projectile
 local DummyProjectile = import('/lua/sim/Projectile.lua').DummyProjectile
 local UnitsInSphere = import('/lua/utilities.lua').GetTrueEnemyUnitsInSphere
@@ -243,9 +244,10 @@ MultiPolyTrailProjectile = Class(EmitterProjectile) {
         if self.PolyTrails then
             local effect
             local army = self.Army 
+            local NumPolyTrails = TableGetn(self.PolyTrails)
+
             if self.RandomPolyTrails ~= 0 then
                 local index
-                local NumPolyTrails = TableGetn(self.PolyTrails)
                 for i = 1, self.RandomPolyTrails do
                     index = Random(1, NumPolyTrails)
                     effect = CreateTrail(self, -1, army, self.PolyTrails[index])

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -21,6 +21,10 @@ NullShell = Class(Projectile) {}
 -----------------------------------------------------------------
 -- PROJECTILE WITH ATTACHED EFFECT EMITTERS
 -----------------------------------------------------------------
+
+-- upvalue for performance
+local CreateEmitterOnEntity = CreateEmitterOnEntity
+
 EmitterProjectile = Class(Projectile) {
     FxTrails = {'/effects/emitters/missile_munition_trail_01_emit.bp',},
     FxTrailScale = 1,
@@ -193,6 +197,12 @@ SinglePolyTrailProjectile = Class(EmitterProjectile) {
     end,
 }
 
+-- upvalue for performance
+local TableGetn = table.getn
+local MathFloor = math.floor 
+local Random = Random
+local CreateTrail = CreateTrail
+
 MultiPolyTrailProjectile = Class(EmitterProjectile) {
 
     PolyTrails = {'/effects/emitters/test_missile_trail_emit.bp'},
@@ -203,12 +213,12 @@ MultiPolyTrailProjectile = Class(EmitterProjectile) {
     OnCreate = function(self)
         EmitterProjectile.OnCreate(self)
         if self.PolyTrails then
-            local NumPolyTrails = table.getn(self.PolyTrails)
+            local NumPolyTrails = TableGetn(self.PolyTrails)
 
             if self.RandomPolyTrails ~= 0 then
                 local index = nil
                 for i = 1, self.RandomPolyTrails do
-                    index = math.floor(Random(1, NumPolyTrails))
+                    index = MathFloor(Random(1, NumPolyTrails))
                     CreateTrail(self, -1, self.Army, self.PolyTrails[index]):OffsetEmitter(0, 0, self.PolyTrailOffset[index])
                 end
             else

--- a/lua/sim/Profiler.lua
+++ b/lua/sim/Profiler.lua
@@ -19,7 +19,7 @@ local thread = false
 --- Data that we send over to the UI
 local data = CreateEmptyProfilerTable()
 
-local lastImport = ""
+local traces = { }
 
 --- Toggles the profiler on / off
 function ToggleProfiler(army, forceEnable)
@@ -105,12 +105,14 @@ function ToggleProfiler(army, forceEnable)
                     scope = "other"
                 end
 
-                if name == "import" then 
+                if name == "lambda" then 
                     local trace = repr(debug.traceback())
-                    if lastImport ~= trace then 
-                        lastImport = trace 
-                        LOG(trace)
+                    if not traces[trace] or traces[trace] == 500 then
+                        traces[trace] = traces[trace] or 0  
+                        LOG(tostring(traces[trace]) .. ": " .. trace)
                     end
+                    
+                    traces[trace] = traces[trace] + 1
                 end
 
                 -- keep track 

--- a/lua/sim/Profiler.lua
+++ b/lua/sim/Profiler.lua
@@ -19,6 +19,8 @@ local thread = false
 --- Data that we send over to the UI
 local data = CreateEmptyProfilerTable()
 
+local lastImport = ""
+
 --- Toggles the profiler on / off
 function ToggleProfiler(army, forceEnable)
 
@@ -101,6 +103,14 @@ function ToggleProfiler(army, forceEnable)
                 -- prevent an empty scope
                 if scope == "" then 
                     scope = "other"
+                end
+
+                if name == "import" then 
+                    local trace = repr(debug.traceback())
+                    if lastImport ~= trace then 
+                        lastImport = trace 
+                        LOG(trace)
+                    end
                 end
 
                 -- keep track 

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -13,6 +13,7 @@ local Flare = import('/lua/defaultantiprojectile.lua').Flare
 local VectorCached = Vector(0, 0, 0)
 
 -- upvalue for performance
+local EntityGetBlueprint = _G.moho.entity_methods.GetBlueprint
 local EntityGetArmy = _G.moho.entity_methods.GetArmy
 local EntitySetMaxHealth = _G.moho.entity_methods.SetMaxHealth
 local EntitySetHealth = _G.moho.entity_methods.SetHealth
@@ -172,7 +173,7 @@ Projectile = Class(moho.projectile_methods, Entity) {
 
         -- populate blueprint cache if we haven't done that yet
         if not self.Cache then 
-            local bp = self:GetBlueprint()
+            local bp = EntityGetBlueprint(self)
             PopulateBlueprintCache(self, bp)
         end
 
@@ -562,17 +563,16 @@ DummyProjectile = Class(moho.projectile_methods, Entity) {
     __init = false,
     __post_init = false,
 
-    OnCreate = function(self, inWater) 
-
-        local bp = self:GetBlueprint()
+    OnCreate = function(self, inWater)
 
         -- populate blueprint cache if we haven't done that yet
         if not self.Cache then 
-            PopulateBlueprintCache(self, bp)
+            PopulateBlueprintCache(self, EntityGetBlueprint(self))
         end
 
         -- copy reference from meta table to inner table
         self.Cache = self.Cache
+        self.Blueprint = self.Cache.Blueprint
 
         -- expected to be cached by all projectiles
         self.Army = self:GetArmy()

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -10,6 +10,30 @@ local Explosion = import('/lua/defaultexplosions.lua')
 local DefaultDamage = import('/lua/sim/defaultdamage.lua')
 local Flare = import('/lua/defaultantiprojectile.lua').Flare
 
+local VectorCached = Vector(0, 0, 0)
+
+-- upvalue for performance
+local EntityGetArmy = _G.moho.entity_methods.GetArmy
+local EntitySetMaxHealth = _G.moho.entity_methods.SetMaxHealth
+local EntitySetHealth = _G.moho.entity_methods.SetHealth
+local EntityGetPositionXYZ = _G.moho.entity_methods.GetPositionXYZ
+local EntityDestroy = _G.moho.entity_methods.Destroy
+
+local ProjectileGetLauncher = _G.moho.projectile_methods.GetLauncher
+
+local TrashBag = TrashBag
+
+local TableEmpty = table.empty
+
+local EntityCategoryContains = EntityCategoryContains
+local CreateEmitterAtBone = CreateEmitterAtBone
+local CreateEmitterAtEntity = CreateEmitterAtEntity
+local GetTerrainType = GetTerrainType
+local DefaultTerrainType = GetTerrainType(-1, -1)
+
+local OnImpactDestroyCategories = categories.ANTIMISSILE * categories.ALLPROJECTILES
+
+
 local function PopulateBlueprintCache(entity, blueprint)
 
     -- populate the cache
@@ -41,6 +65,7 @@ Projectile = Class(moho.projectile_methods, Entity) {
     Cache = false,
 
     PassDamageData = function(self, DamageData)
+        self.DamageData = { }
         self.DamageData.DamageRadius = DamageData.DamageRadius
         self.DamageData.DamageAmount = DamageData.DamageAmount
         self.DamageData.DamageType = DamageData.DamageType
@@ -54,38 +79,41 @@ Projectile = Class(moho.projectile_methods, Entity) {
         self.CollideFriendly = self.DamageData.CollideFriendly
     end,
 
-    DoDamage = function(self, instigator, DamageData, targetEntity)
+    DoDamage = function(self, instigator, DamageData, targetEntity, position)
+
+        position = position or self:GetPosition()
+
         local damage = DamageData.DamageAmount
         if damage and damage > 0 then
             local radius = DamageData.DamageRadius
             if radius and radius > 0 then
                 if not DamageData.DoTTime or DamageData.DoTTime <= 0 then
-                    DamageArea(instigator, self:GetPosition(), radius, damage, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
+                    DamageArea(instigator, position, radius, damage, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
                 else
                     -- DoT damage - check for initial damage
                     local initialDmg = DamageData.InitialDamageAmount or 0
                     if initialDmg > 0 then
                         if radius > 0 then
-                            DamageArea(instigator, self:GetPosition(), radius, initialDmg, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
+                            DamageArea(instigator, position, radius, initialDmg, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
                         elseif targetEntity then
-                            Damage(instigator, self:GetPosition(), targetEntity, initialDmg, DamageData.DamageType)
+                            Damage(instigator, position, targetEntity, initialDmg, DamageData.DamageType)
                         end
                     end
 
-                    ForkThread(DefaultDamage.AreaDoTThread, instigator, self:GetPosition(), DamageData.DoTPulses or 1, (DamageData.DoTTime / (DamageData.DoTPulses or 1)), radius, damage, DamageData.DamageType, DamageData.DamageFriendly)
+                    ForkThread(DefaultDamage.AreaDoTThread, instigator, position, DamageData.DoTPulses or 1, (DamageData.DoTTime / (DamageData.DoTPulses or 1)), radius, damage, DamageData.DamageType, DamageData.DamageFriendly)
                 end
             -- ONLY DO DAMAGE IF THERE IS DAMAGE DATA.  SOME PROJECTILE DO NOT DO DAMAGE WHEN THEY IMPACT.
             elseif DamageData.DamageAmount and targetEntity then
                 if not DamageData.DoTTime or DamageData.DoTTime <= 0 then
-                    Damage(instigator, self:GetPosition(), targetEntity, DamageData.DamageAmount, DamageData.DamageType)
+                    Damage(instigator, position, targetEntity, DamageData.DamageAmount, DamageData.DamageType)
                 else
                     -- DoT damage - check for initial damage
                     local initialDmg = DamageData.InitialDamageAmount or 0
                     if initialDmg > 0 then
                         if radius > 0 then
-                            DamageArea(instigator, self:GetPosition(), radius, initialDmg, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
+                            DamageArea(instigator, position, radius, initialDmg, DamageData.DamageType, DamageData.DamageFriendly, DamageData.DamageSelf or false)
                         elseif targetEntity then
-                            Damage(instigator, self:GetPosition(), targetEntity, initialDmg, DamageData.DamageType)
+                            Damage(instigator, position, targetEntity, initialDmg, DamageData.DamageType)
                         end
                     end
 
@@ -94,18 +122,14 @@ Projectile = Class(moho.projectile_methods, Entity) {
             end
         end
         if self.InnerRing and self.OuterRing then
-            local pos = self:GetPosition()
-            self.InnerRing:DoNukeDamage(self.Launcher, pos, self.Brain, self.Army, DamageData.DamageType or 'Nuke')
-            self.OuterRing:DoNukeDamage(self.Launcher, pos, self.Brain, self.Army, DamageData.DamageType or 'Nuke')
+            self.InnerRing:DoNukeDamage(self.Launcher, position, self.Brain, self.Army, DamageData.DamageType or 'Nuke')
+            self.OuterRing:DoNukeDamage(self.Launcher, position, self.Brain, self.Army, DamageData.DamageType or 'Nuke')
         end
     end,
 
     -- Do not call the base class __init and __post_init, we already have a c++ object
-    __init = function(self, spec)
-    end,
-
-    __post_init = function(self, spec)
-    end,
+    __init = false,
+    __post_init = false,
 
     DestroyOnImpact = true,
     FxImpactTrajectoryAligned = true,
@@ -134,9 +158,6 @@ Projectile = Class(moho.projectile_methods, Entity) {
     FxWaterHitScale = 1,
     FxOnKilledScale = 1,
 
-    FxImpactLandScorch = false,
-    FxImpactLandScorchScale = 1.0,
-
     ForkThread = function(self, fn, ...)
         if fn then
             local thread = ForkThread(fn, self, unpack(arg))
@@ -158,24 +179,22 @@ Projectile = Class(moho.projectile_methods, Entity) {
         -- copy reference from meta table to inner table
         self.Cache = self.Cache
         self.Blueprint = self.Cache.Blueprint 
-
-        self.DamageData = {
-            DamageRadius = nil,
-            DamageAmount = nil,
-            DamageType = nil,
-            DamageFriendly = nil
-        }
-
-        self.Army = self:GetArmy()
+        self.Army = EntityGetArmy(self)
         self.Trash = TrashBag()
-        self:SetMaxHealth(self.Blueprint.Defense.MaxHealth or 1)
-        self:SetHealth(self, self:GetMaxHealth())
+
+        -- set some health
+        local health = self.Blueprint.Defense.MaxHealth or 1
+        EntitySetMaxHealth(self, health)
+        EntitySetHealth(self, self, health)
+
+        -- only used by strategic missiles
         local snd = self.Blueprint.Audio.ExistLoop
         if snd then
             self:SetAmbientSound(snd, nil)
         end
 
-        if self.Blueprint.Physics.TrackTargetGround and self.Blueprint.Physics.TrackTargetGround == true then
+        -- only used by tactical missiles
+        if self.Blueprint.Physics.TrackTargetGround then
             local pos = self:GetCurrentTargetPosition()
             pos[2] = GetSurfaceHeight(pos[1], pos[3])
             self:SetNewTargetGround(pos)
@@ -268,7 +287,8 @@ Projectile = Class(moho.projectile_methods, Entity) {
             else
                 emit = CreateEmitterAtEntity(self, army, v)
             end
-            if emit and EffectScale ~= 1 then
+
+            if EffectScale ~= 1 then
                 emit:ScaleEmitter(EffectScale or 1)
             end
         end
@@ -284,35 +304,41 @@ Projectile = Class(moho.projectile_methods, Entity) {
         end
     end,
 
-    GetTerrainEffects = function(self, TargetType, ImpactEffectType)
-        local pos = self:GetPosition()
-        local TerrainType = nil
+    GetTerrainEffects = function(self, TargetType, ImpactEffectType, position)
 
+        local position = position or self:GetPosition()
+
+        local TerrainType = nil
         if ImpactEffectType then
-            TerrainType = GetTerrainType(pos.x, pos.z)
+            TerrainType = GetTerrainType(position.x, position.z)
             if TerrainType.FXImpact[TargetType][ImpactEffectType] == nil then
-                TerrainType = GetTerrainType(-1, -1)
+                TerrainType = DefaultTerrainType
             end
         else
-            TerrainType = GetTerrainType(-1, -1)
+            TerrainType = DefaultTerrainType
             ImpactEffectType = 'Default'
         end
 
-        return TerrainType.FXImpact[TargetType][ImpactEffectType] or {}
+        return TerrainType.FXImpact[TargetType][ImpactEffectType] or false
     end,
 
     -- Create some cool explosions when we get destroyed
     OnImpact = function(self, targetType, targetEntity)
         -- Try to use the launcher as instigator first. If its been deleted, use ourselves (this
         -- projectile is still associated with an army)
-        local instigator = self:GetLauncher()
+        local instigator = ProjectileGetLauncher(self)
         if instigator == nil then
             instigator = self
         end
+
+        -- localize information for performance
+        local vc = VectorCached 
+        vc[1], vc[2], vc[3] = EntityGetPositionXYZ(self)
         local damageData = self.DamageData
 
         -- Do Damage
-        self:DoDamage(instigator, damageData, targetEntity)
+
+        self:DoDamage(instigator, damageData, targetEntity, vc)
 
         -- Buffs (Stun, etc)
         self:DoUnitImpactBuffs(targetEntity)
@@ -329,9 +355,9 @@ Projectile = Class(moho.projectile_methods, Entity) {
         --  'UnitUnderwater'
         --  'Projectile'
         --  'ProjectileUnderWater
-        local ImpactEffects = {}
+        local ImpactEffects = false
         local ImpactEffectScale = 1
-        local bp = self:GetBlueprint()
+        local bp = self.Blueprint 
         local bpAud = bp.Audio
 
         -- Sounds for all other impacts, ie: Impact<TargetTypeName>
@@ -344,24 +370,22 @@ Projectile = Class(moho.projectile_methods, Entity) {
         end
 
         -- ImpactEffects
-        if targetType == 'Water' then
+
+        if targetType == 'Terrain' then
+            ImpactEffects = self.FxImpactLand
+            ImpactEffectScale = self.FxLandHitScale
+        elseif targetType == 'Water' then
             ImpactEffects = self.FxImpactWater
             ImpactEffectScale = self.FxWaterHitScale
-        elseif targetType == 'Underwater' or targetType == 'UnitUnderwater' then
-            ImpactEffects = self.FxImpactUnderWater
-            ImpactEffectScale = self.FxUnderWaterHitScale
         elseif targetType == 'Unit' then
             ImpactEffects = self.FxImpactUnit
             ImpactEffectScale = self.FxUnitHitScale
         elseif targetType == 'UnitAir' then
             ImpactEffects = self.FxImpactAirUnit
             ImpactEffectScale = self.FxAirUnitHitScale
-        elseif targetType == 'Terrain' then
-            ImpactEffects = self.FxImpactLand
-            ImpactEffectScale = self.FxLandHitScale
-            if self.FxImpactLandScorch then
-                Explosion.CreateRandomScorchSplatAtObject(self, self.FxImpactLandScorchScale, 150, 20, self.Army)
-            end
+        elseif targetType == 'Shield' then
+            ImpactEffects = self.FxImpactShield
+            ImpactEffectScale = self.FxShieldHitScale
         elseif targetType == 'Air' then
             ImpactEffects = self.FxImpactNone
             ImpactEffectScale = self.FxNoneHitScale
@@ -371,20 +395,28 @@ Projectile = Class(moho.projectile_methods, Entity) {
         elseif targetType == 'ProjectileUnderwater' then
             ImpactEffects = self.FxImpactProjectileUnderWater
             ImpactEffectScale = self.FxProjectileUnderWaterHitScale
+        elseif targetType == 'Underwater' or targetType == 'UnitUnderwater' then
+            ImpactEffects = self.FxImpactUnderWater
+            ImpactEffectScale = self.FxUnderWaterHitScale
         elseif targetType == 'Prop' then
             ImpactEffects = self.FxImpactProp
             ImpactEffectScale = self.FxPropHitScale
-        elseif targetType == 'Shield' then
-            ImpactEffects = self.FxImpactShield
-            ImpactEffectScale = self.FxShieldHitScale
         else
             LOG('*ERROR: Projectile:OnImpact(): UNKNOWN TARGET TYPE ', repr(targetType))
         end
 
-        local TerrainEffects = self:GetTerrainEffects(targetType, bp.Display.ImpactEffects.Type)
-        self:CreateImpactEffects(self.Army, ImpactEffects, ImpactEffectScale)
-        self:CreateTerrainEffects(self.Army, TerrainEffects, bp.Display.ImpactEffects.Scale or 1)
+        ImpactEffects = ImpactEffects or { }
 
+        -- impact effects
+        self:CreateImpactEffects(self.Army, ImpactEffects, ImpactEffectScale)
+
+        -- terrain effects
+        local TerrainEffects = self:GetTerrainEffects(targetType, bp.Display.ImpactEffects.Type, vc)
+        if TerrainEffects then 
+            self:CreateTerrainEffects(self.Army, TerrainEffects, bp.Display.ImpactEffects.Scale or 1)
+        end
+
+        -- some time out value
         local timeout = bp.Physics.ImpactTimeout
         if timeout and targetType == 'Terrain' then
             self:ForkThread(self.ImpactTimeoutThread, timeout)
@@ -394,9 +426,11 @@ Projectile = Class(moho.projectile_methods, Entity) {
     end,
 
     OnImpactDestroy = function(self, targetType, targetEntity)
-        if self.DestroyOnImpact or not targetEntity or
-            (not self.DestroyOnImpact and targetEntity and not EntityCategoryContains(categories.ANTIMISSILE * categories.ALLPROJECTILES, targetEntity)) then
-            self:Destroy()
+        if  self.DestroyOnImpact or 
+            (not targetEntity) or
+            (not EntityCategoryContains(OnImpactDestroyCategories, targetEntity))
+        then
+            EntityDestroy(self)
         end
     end,
 
@@ -408,8 +442,10 @@ Projectile = Class(moho.projectile_methods, Entity) {
     -- When this projectile impacts with the target, do any buffs that have been passed to it.
     DoUnitImpactBuffs = function(self, target)
         local data = self.DamageData
+
         -- Check for buff
-        if data.Buffs then
+        if not TableEmpty(data.Buffs) then
+
             -- Check for valid target
             for k, v in data.Buffs do
                 if v.Add.OnImpact == true then
@@ -523,9 +559,9 @@ Projectile = Class(moho.projectile_methods, Entity) {
 DummyProjectile = Class(moho.projectile_methods, Entity) {
 
     Cache = false,
+    __init = false,
+    __post_init = false,
 
-    __init = function(self, spec) end,
-    __post_init = function(self, spec) end,
     OnCreate = function(self, inWater) 
 
         local bp = self:GetBlueprint()

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1031,14 +1031,16 @@ Unit = Class(moho.unit_methods) {
     -------------------------------------------------------------------------------------------
 
     OnDamage = function(self, instigator, amount, vector, damageType)
-        if self.CanTakeDamage then
-            self:DoOnDamagedCallbacks(instigator)
+        if damageType ~= "KnockTree" then 
+            if self.CanTakeDamage then
+                self:DoOnDamagedCallbacks(instigator)
 
-            -- Pass damage to an active personal shield, as personal shields no longer have collisions
-            if self:GetShieldType() == 'Personal' and self:ShieldIsOn() and not self.MyShield.Charging then
-                self.MyShield:ApplyDamage(instigator, amount, vector, damageType)
-            else
-                self:DoTakeDamage(instigator, amount, vector, damageType)
+                -- Pass damage to an active personal shield, as personal shields no longer have collisions
+                if self:GetShieldType() == 'Personal' and self:ShieldIsOn() and not self.MyShield.Charging then
+                    self.MyShield:ApplyDamage(instigator, amount, vector, damageType)
+                else
+                    self:DoTakeDamage(instigator, amount, vector, damageType)
+                end
             end
         end
     end,

--- a/lua/system/import.lua
+++ b/lua/system/import.lua
@@ -36,20 +36,19 @@ local StringSub = string.sub
 -- these values can be adjusted by hooking into this file
 local informDevOfLoad = false
 
--- local once = true
-
 --- The global import function used to keep track of modules.
 -- @param name The path to the module to load.
 function import(name)
 
-    -- if once then 
-    --     once = false
-    --     LOG(repr(debug.listcode(import)))
-    -- end
-
-    -- caching: if it exists then we return the previous version
-    name = StringLower(name)
+    -- attempt to find the module without lowering the string
     local existing = upModules[name]
+    if existing then
+        return existing
+    end
+
+    -- try again after lowering the string
+    name = StringLower(name)
+    existing = upModules[name]
     if existing then
         return existing
     end

--- a/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_script.lua
+++ b/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_script.lua
@@ -46,7 +46,7 @@ SIFThunthoArtilleryShell01 = Class(SThunthoArtilleryShell) {
     end,
 
     OnImpact = function(self, TargetType, TargetEntity) 
-    
+        LOG("OnImpact!")
         local Random = Random
 
         -- the split fx

--- a/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_script.lua
+++ b/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_script.lua
@@ -46,8 +46,6 @@ SIFThunthoArtilleryShell01 = Class(SThunthoArtilleryShell) {
     end,
 
     OnImpact = function(self, TargetType, TargetEntity) 
-        LOG("OnImpact!")
-        local Random = Random
 
         -- the split fx
         CreateEmitterAtEntity( self, self.Army, SThunderStormCannonProjectileSplitFx[1])

--- a/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_script.lua
+++ b/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_script.lua
@@ -27,23 +27,7 @@ local ProjectileCreateChildProjectile = _G.moho.projectile_methods.CreateChildPr
 local ProjectileSetVelocity = _G.moho.projectile_methods.SetVelocity
 local ProjectileGetVelocity = _G.moho.projectile_methods.GetVelocity
 
-local ProjectileOnCreate = import('/lua/sim/Projectile.lua').Projectile.OnCreate
-
 SIFThunthoArtilleryShell01 = Class(SThunthoArtilleryShell) {
-               
-    OnCreate = function(self, spec)
-        ProjectileOnCreate(self, spec)
-
-        -- create the fx for trails
-        for i in self.FxTrails do
-            CreateEmitterOnEntity(self, self.Army, self.FxTrails[i])
-        end
-
-        -- create an actual trail
-        for i in self.PolyTrails do
-            CreateTrail(self, -1, self.Army, self.PolyTrails[i])
-        end
-    end,
 
     OnImpact = function(self, TargetType, TargetEntity) 
 

--- a/projectiles/SIFThunthoArtilleryShell02/SIFThunthoArtilleryShell02_script.lua
+++ b/projectiles/SIFThunthoArtilleryShell02/SIFThunthoArtilleryShell02_script.lua
@@ -12,6 +12,7 @@
 local VectorCached = Vector(0, 0, 0)
 
 local Random = Random 
+local DamageArea = DamageArea
 local CreateDecal = CreateDecal
 local CreateTrail = CreateTrail
 

--- a/projectiles/SIFThunthoArtilleryShell02/SIFThunthoArtilleryShell02_script.lua
+++ b/projectiles/SIFThunthoArtilleryShell02/SIFThunthoArtilleryShell02_script.lua
@@ -19,18 +19,8 @@ local CreateTrail = CreateTrail
 local EntityGetPositionXYZ = _G.moho.entity_methods.GetPositionXYZ
 
 local SThunthoArtilleryShell2 = import('/lua/seraphimprojectiles.lua').SThunthoArtilleryShell2
-local ProjectileOnCreate = import('/lua/sim/Projectile.lua').Projectile.OnCreate
 
 SIFThunthoArtilleryShell02 = Class(SThunthoArtilleryShell2) {
-
-    OnCreate = function(self, spec)
-        ProjectileOnCreate(self, spec)
-
-        -- create an actual trail
-        for i in self.PolyTrails do
-            CreateTrail(self, -1, self.Army, self.PolyTrails[i])
-        end
-    end,
 
     OnImpact = function(self, targetType, targetEntity)
         SThunthoArtilleryShell2.OnImpact(self, targetType, targetEntity)


### PR DESCRIPTION
Our benchmark is 400 Zthuee firing at once on the map White Fire. The map has no civilians. All functionality of the original projectile is still there, just faster. A base line is the same scenario, but without the Zthuee firing.

On the FAF branch: `12 - 14 ms` with a base line of `3 ms`
![here-is-gif-15-faf](https://user-images.githubusercontent.com/15778155/160083873-09dda77e-42cb-4867-b72f-5a2fa2572da5.gif)

This pull request: `9 - 12 ms` with a base line of `3 ms`
![here-is-gif-15-develop](https://user-images.githubusercontent.com/15778155/160083889-9fcc912f-79c6-4a69-89eb-9f308a460065.gif)

This pull request, without decals: `9 - 10.5 ms` with a base line of `3 ms`
![here-is-gif-15-develop-no-decals](https://user-images.githubusercontent.com/15778155/160083895-9e989399-b6fd-41ac-9271-ea2a4c0a7810.gif)

If we'd reduce the base lines:
 - FAF branch: `9 - 11 ms` for firing
 - This pull request: `6 - 9 ms` for firing
 - This pull request, without decals: `6 - 7.5 ms` when firing
 
Therefore we can safely assume that there's at least a 20% performance improvement. Some of these changes apply to all projectiles.