### PR TITLE
Fix wreckages causing an error when full share triggers

### DIFF
--- a/lua/sim/DefaultDamage.lua
+++ b/lua/sim/DefaultDamage.lua
@@ -17,6 +17,9 @@ local VectorCache = Vector(0, 0, 0)
 local MathFloor = math.floor 
 local CoroutineYield = coroutine.yield 
 
+local EntityBeenDestroyed = _G.moho.entity_methods.BeenDestroyed
+local EntityGetPositionXYZ = _G.moho.entity_methods.GetPositionXYZ
+
 --- Performs damage over time on a unit.
 function UnitDoTThread (instigator, unit, pulses, pulseTime, damage, damType, friendly)
 
@@ -29,8 +32,8 @@ function UnitDoTThread (instigator, unit, pulses, pulseTime, damage, damType, fr
     pulseTime = 10 * pulseTime + 1
 
     for i = 1, pulses do
-        if unit and not unit.Dead then
-            position[1], position[2], position[3] = unit:GetPositionXYZ()
+        if unit and not EntityBeenDestroyed(unit) then
+            position[1], position[2], position[3] = EntityGetPositionXYZ(unit)
             Damage(instigator, position, unit, damage, damType )
         else
             break

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -298,6 +298,18 @@ Prop = Class(moho.prop_methods, Entity) {
     -- @param sizez The length of the box.
     -- @param radius The radius of the sphere.
     SetPropCollision = function(self, shape, centerx, centery, centerz, sizex, sizey, sizez, radius)
+
+        -- only store this for wreckages, it is used to restore the collision box when armies are shared 
+        -- upon death, see '/lua/simutils.lua' and then the function TransferUnfinishedUnitsAfterDeath.
+        self.CollisionRadius = radius
+        self.CollisionSizeX = sizex
+        self.CollisionSizeY = sizey
+        self.CollisionSizeZ = sizez
+        self.CollisionCenterX = centerx
+        self.CollisionCenterY = centery
+        self.CollisionCenterZ = centerz
+        self.CollisionShape = shape
+
         if radius and shape == 'Sphere' then
             EntitySetCollisionShape(self, shape, centerx, centery, centerz, radius)
         else


### PR DESCRIPTION
Fixes an issue when DOT damage is applied and an issue with wreckages when full share is enabled.

```
WARNING: Error running lua script: ...faforever\gamedata\lua.nx5\lua\sim\defaultdamage.lua(33): Game object has been destroyed
         stack traceback:
         	[C]: in function `GetPositionXYZ'
         	...faforever\gamedata\lua.nx5\lua\sim\defaultdamage.lua(33): in function <...faforever\gamedata\lua.nx5\lua\sim\defaultdamage.lua:21
```

