### PR TITLE
Fix the build animation of the fatboy and atlantis

### DIFF
--- a/lua/EffectUtilitiesUEF.lua
+++ b/lua/EffectUtilitiesUEF.lua
@@ -306,7 +306,11 @@ function CreateBuildCubeThread(
 
     -- update internal state
     UnitShowBone(unitBeingBuilt, 0, true)
-    unitBeingBuilt:HideLandBones() -- we can't upvalue this, it is a Lua function
+    if unitBeingBuilt.HideLandBones then 
+        -- non-structure units that use this setup do not have the land bones function
+        -- we can't upvalue this, it is a Lua function
+        unitBeingBuilt:HideLandBones() 
+    end
     unitBeingBuilt.BeingBuiltShowBoneTriggered = true
 
     local lComplete = UnitGetFractionComplete(unitBeingBuilt)


### PR DESCRIPTION
```
Error running lua script: ...aforever\gamedata\lua.nx5\lua\effectutilitiesuef.lua(309): attempt to call method `HideLandBones' (a nil value)
         stack traceback:
             ...aforever\gamedata\lua.nx5\lua\effectutilitiesuef.lua(309): in function <...aforever\gamedata\lua.nx5\lua\effectutilitiesuef.lua:254>
```