### PR TITLE
ChatArea refactor

### DIFF
--- a/lua/ui/lobby/chatarea.lua
+++ b/lua/ui/lobby/chatarea.lua
@@ -65,9 +65,11 @@ ChatArea = Class(Group) {
             }
             table.insert(self.ChatHistory, entry)
         end
+        local name = authorName
         if authorName == nil then
             authorName = ''
         else
+
             authorName = '[' .. authorName .. '] '
         end
         messageText = messageText or ''
@@ -86,7 +88,8 @@ ChatArea = Class(Group) {
                 table.insert(self.ChatLines, {
                     author = {
                         text = authorName,
-                        style = authorStyle
+                        style = authorStyle,
+                        name = name
                     },
                     message = {
                         text = strText,
@@ -132,15 +135,18 @@ ChatArea = Class(Group) {
         line:DisableHitTest()
 
         line.author = UIUtil.CreateText(line, '', self.Style.fontSize(), self.Style.author.fontFamily())
+        
         LayoutHelpers.AtLeftTopIn(line.author, line)
         line.message = UIUtil.CreateText(line, '', self.Style.fontSize(), self.Style.message.fontFamily())
         LayoutHelpers.RightOf(line.message, line.author)
 
         line.Render = function(control, message, author)
             if author then
+                control.author.name = author.name
                 control.author:SetText(author.text)
                 control.author:SetColor(author.style.fontColor)
             else
+                control.author.name = nil
                 control.author:SetText('')
             end
             if message then
@@ -150,6 +156,12 @@ ChatArea = Class(Group) {
                 control.message:SetText('')
             end
         end
+        line.author.HandleEvent = function(control, event)
+            if event.Type == 'ButtonPress' and line.author.name then
+                self.Parent.edit:SetText('/w '.. line.author.name..' ')
+            end
+        end
+        line.author:EnableHitTest()
         return line
     end,
 

--- a/lua/ui/lobby/chatarea.lua
+++ b/lua/ui/lobby/chatarea.lua
@@ -3,15 +3,15 @@ local Text = import('/lua/maui/text.lua')
 local UIUtil = import('/lua/ui/uiutil.lua')
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 local Prefs = import('/lua/user/prefs.lua')
+local LazyVar = import('/lua/lazyvar.lua')
 
 local defaultStyle = {
-    -- storing style values in a flat table for easy access
-    fontColor = 'FFFFFFFF', -- #FFFFFFFF
-    fontFamily = UIUtil.bodyFont,
-    fontSize = tonumber(Prefs.GetFromCurrentProfile('LobbyChatFontSize')) or 14,
+    fontColor = LazyVar.Create('FFFFFFFF'), -- #FFFFFFFF
+    fontFamily = LazyVar.Create(UIUtil.bodyFont),
+    fontSize = LazyVar.Create(tonumber(Prefs.GetFromCurrentProfile('LobbyChatFontSize')) or 14),
 
     shadow = false,
-    lineSpacing = 1, -- don't use higher values because chat looks strange with small fonts
+    lineSpacing = 1,
     padding = {
         left = 0,
         top = 3,
@@ -20,48 +20,23 @@ local defaultStyle = {
     }
 }
 
---- Represents a control that keep tracks and displays chat messages and their author's names
 ChatArea = Class(Group) {
 
     __init = function(self, parent, width, height)
         Group.__init(self, parent)
-
-        -- initializing some tables for managing and storing chat lines that will display messages
-
-        -- this table stores lines that are represented using multiple UI Group classes.
-        -- Each line can have multiple TextFields and each TextField can have its own style
-        -- All chat lines are indexed by the order in which they were created - so older messages are first
-        self.ChatLines = {} -- for example:
-        -- ChatLines = {
-        --   { TextFields = { { text = "Mike" }, { text = "Hi Dave, How are you?" } } },
-        --   { TextFields = { { text = "Dave" }, { text = "I'm fine, how are you" } } }
-        -- }
-
-        -- this table stores all messages added to the ChatArea and the ReflowLines() will use this table
-        -- to re-create and layout ChatLines if size of the ChatArea is changed or if fontSize is changed in lobby
-        -- The chat history is indexed by the order in which they were added - so older messages are first
-        self.ChatHistory = {} -- for example:
-        -- ChatHistory = {
-        --   { authorName = "Mike", messageText = "Hi Dave, How are you?" },
-        --   { authorName = "Dave", messageText = "I'm fine, how are you?" },
-        -- }
-
-        -- specifies whether or not to save new messages in chat history
-        self.ChatHistoryActive = true
-
-        self.Style = defaultStyle
+        self.ChatHistory = {} 
         self.Parent = parent
+        self.Style = defaultStyle
 
-        -- iInitial width and height are necessary to dodge partial-initialization/re-flow weirdness.
+     
         self.Width:Set(width)
         self.Height:Set(height)
 
-        -- re-flow chat lines when the width is changed.
-        self.Width.OnDirty = function()
+        self.Width.OnDirty = function(lazyvar)
             LOG('chatArea dirty Width')
             self:ReflowLines()
         end
-        self.Height.OnDirty = function()
+        self.Height.OnDirty = function(lazyvar)
             LOG('chatArea dirty Height')
             self:ReflowLines()
         end
@@ -69,189 +44,134 @@ ChatArea = Class(Group) {
         LayoutHelpers.AtLeftTopIn(self, parent, 0, 0)
     end,
 
-    --- posts a new chat message and its author name using optional styling tables
     PostMessage = function(self, messageText, authorName, messageStyle, authorStyle)
 
-        -- WARNING
-        -- The author style must be _roughly_ the same in font size and weight than the text style.
-        -- Too different values might break the text wrapping, because the Text.Wrap method doesn't take style as a parameter.
+        messageStyle = table.merged(defaultStyle, messageStyle or {})
+        authorStyle = table.merged(defaultStyle, authorStyle or {})
 
-        -- ensure we have a style for the message text
-        if messageStyle == nil then
-            messageStyle = defaultStyle
-        else
-            -- ensure message style has all required values otherwise use values of default style
-            for k, v in pairs(defaultStyle) do
-                messageStyle[k] = messageStyle[k] or defaultStyle[k]
-            end
-        end
-
-        -- ensure we have a style for the author name
-        if authorStyle == nil then
-            authorStyle = table.deepcopy(defaultStyle)
-            authorStyle.fontFamily = "Arial Gras"
-        else
-            -- ensure author style has all required values otherwise use values of default style
-            for k, v in pairs(defaultStyle) do
-                authorStyle[k] = authorStyle[k] or defaultStyle[k]
-            end
-        end
-        -- avoid waste horizontal space
         authorStyle.padding.left = 0
         authorStyle.padding.right = 0
 
-        -- always use bolder font for the Author name
-
-        -- keep track of chat history by storing messages and their authors
-        if self.ChatHistoryActive then
-            local entry = {
-                authorName = authorName,
-                authorStyle = authorStyle,
-                messageText = messageText,
-                messageStyle = messageStyle
-            }
-            table.insert(self.ChatHistory, entry)
-        end
-
-        -- If no author provided, we're simply going to skip it. Else we're going to style it
         if authorName == nil then
             authorName = ''
         else
             authorName = '[' .. authorName .. '] '
         end
         messageText = messageText or ''
-        
+
         local chatText = authorName .. messageText
-        -- This custom advance function will take care of font size and other style parameters
         local customAdvanceFunction = function(chatText)
             return self.AdvanceFunction(self, chatText, messageStyle)
         end
 
-        -- wrap message text and its author into multiple lines based on control's width
         local wrapLines = Text.WrapText(chatText, self.Width() - self.Style.padding.left - self.Style.padding.right,
             customAdvanceFunction)
 
-        -- group wrapped text in to lines and text fields
         for i = 1, table.getn(wrapLines) do
             if (i == 1 and string.len(authorName) > 0) then
                 local strText = string.sub(wrapLines[i], string.len(authorName))
+                table.insert(self.ChatHistory, {
+                    author = {
+                        text = authorName,
+                        style = authorStyle
+                    },
+                    message = {
+                        text = strText,
+                        style = messageStyle
+                    }
+                })
 
-                self:AppendText(authorName, authorStyle, true)
-                self:AppendText(strText, messageStyle, false, 2)
             else
-                self:AppendText(wrapLines[i], messageStyle, true)
+                table.insert(self.ChatHistory, {
+                    message = {
+                        text = wrapLines[i],
+                        style = messageStyle
+                    }
+                })
             end
         end
         self:ShowLines(self.Parent.top, self.Parent.bottom)
     end,
 
-    --- appends text field to existing line or on a new line
-    AppendText = function(self, str, style, useNewLine)
-        -- make sure we always append text to an existing line
-        local line = nil
-        if useNewLine or table.empty(self.ChatLines) then
-            line = self:CreateLine(style.fontSize + self.Style.lineSpacing)
-        else
-            line = self.lastLine -- getting the last/current line
+    CreateLines = function(self)
+        local linesGroup = Group(self)
+        LayoutHelpers.FillParent(linesGroup, self)
+        linesGroup.Lines = {}
+        local index = 1
+        linesGroup.Lines[index] = self:CreateLine(linesGroup)
+        local previous = linesGroup.Lines[index]
+        LayoutHelpers.AtLeftTopIn(previous, linesGroup, 2)
+        while previous.Bottom() < linesGroup.Bottom() do
+            index = index + 1
+            linesGroup.Lines[index] = self:CreateLine(linesGroup)
+            LayoutHelpers.Below(linesGroup.Lines[index], previous)
+            previous = linesGroup.Lines[index]
         end
-
-        local textField = UIUtil.CreateText(line, str, style.fontSize, style.fontFamily)
-        textField:SetColor(style.fontColor)
-        textField:DisableHitTest()
-        textField.style = style
-        textField.useNewLine = useNewLine
-        -- position text field at the start of current line or at the end
-        if useNewLine or table.empty(line.TextFields) then
-            LayoutHelpers.AtLeftTopIn(textField, line, style.padding.left, 0)
-        else
-            LayoutHelpers.RightOf(textField, line.lastTextField, -5)
-        end
-        -- keep track of text fields added to the current line
-        table.insert(line.TextFields, textField)
-        line.lastTextField = textField
+        self.linesGroup = linesGroup
     end,
 
-    --- create a new line and arranges its layout position based on line's index
-    CreateLine = function(self, lineHeight)
-
-        local line = Group(self)
-
-        line.Height:Set(lineHeight)
-        line.Width:Set(self.Width)
+    CreateLine = function(self, parent)
+        local line = Group(parent)
+        line.Height:Set(self.Style.lineSpacing + self.Style.fontSize())
+        line.Width:Set(parent.Width)
         line:DisableHitTest()
-        line.index = table.getsize(self.ChatLines) + 1
-        -- creating a table that will store all text fields that belong to this line
-        line.TextFields = {}
 
-        -- layout the new line based on its index
-        if line.index == 1 then
-            LayoutHelpers.AtLeftTopIn(line, self, 0, self.Style.padding.top)
-        else
-            -- putting the line below previous line
-            line.previous = self.ChatLines[line.index - 1]
-            line.Left:Set(function()
-                return self.Left()
-            end)
-            LayoutHelpers.Below(line, line.previous)
+        line.author = UIUtil.CreateText(line, '', self.Style.fontSize(), self.Style.fontFamily())
+        LayoutHelpers.AtLeftTopIn(line.author, line, 2)
+        line.message = UIUtil.CreateText(line, '', self.Style.fontSize(), self.Style.fontFamily())
+        LayoutHelpers.RightOf(line.message, line.author)
+
+        line.Render = function(control, message, author)
+            if author then
+                control.author:SetText(author.text)
+                control.author:SetColor(author.style.fontColor)
+            else
+                control.author:SetText('')
+            end
+            if message then
+                control.message:SetText(message.text)
+                control.message:SetColor(message.style.fontColor)
+            else
+                control.message:SetText('')
+            end
         end
-        -- store the new line so we can destroy all lines later
-        table.insert(self.ChatLines, line)
-
-        -- keep track of the last line so we do not need to search for it
-        self.lastLine = line
         return line
     end,
 
-    --- shows lines between specified indexes and hides all other lines
     ShowLines = function(self, topIndex, bottomIndex)
+        if IsDestroyed(self.linesGroup) then
+            self:CreateLines()
+        end
+        bottomIndex = bottomIndex or table.getn(self.ChatHistory)
         local visibleIndex = 1
-        for _, line in ipairs(self.ChatLines) do
-            if visibleIndex < topIndex or visibleIndex >= bottomIndex then
-                line:Hide() -- hide lines outside top and bottom index
+        for id = topIndex, bottomIndex do
+            local entry = self.ChatHistory[id]
+            if entry then
+                self.linesGroup.Lines[visibleIndex]:Render(entry.message, entry.author)
             else
-                line:Show() -- show lines between top and bottom index
-                local i = visibleIndex
-                local c = line
-                -- calculate top position of a line based on its visible index
-                line.Top:Set(function()
-                    return self.Top() + ((i - topIndex) * (c.Height() + 2))
-                end)
+                self.linesGroup.Lines[visibleIndex]:Render()
             end
             visibleIndex = visibleIndex + 1
         end
     end,
 
-    --- clears existing chat history and its UI representation
     ClearHistory = function(self)
         self:ClearLines()
         self.ChatHistory = {}
     end,
 
-    --- clears existing chat lines by destroying and dereferencing its UI elements
     ClearLines = function(self)
-        -- LOG('chatArea ClearLines')
-        for l, line in self.ChatLines or {} do
-            for t, textField in line.TextFields or {} do
-                textField:OnDestroy()
-                textField = nil
-            end
-            line:Destroy()
-            line = nil
+        if not IsDestroyed(self.linesGroup) then
+            self.linesGroup:ApplyFunction(function(control)
+                control:Destroy()
+            end)
+            self.linesGroup = nil
         end
-        self.ChatLines = {}
-        self.lastLine = nil
     end,
 
-    --- recreates the old lines with the newly-wrapped chat messages
     ReflowLines = function(self)
         self:ClearLines()
-
-        -- temporary deactivate Chat history while re-creating chat lines
-        self.ChatHistoryActive = false
-        for _, chat in self.ChatHistory or {} do
-            self:PostMessage(chat.messageText, chat.authorName, chat.messageStyle, chat.authorStyle)
-        end
-        self.ChatHistoryActive = true
+        self:CreateLines()
     end,
 
     --- sets font family and/or font size in all chat messages
@@ -261,43 +181,27 @@ ChatArea = Class(Group) {
         local hasFontFamily = type(fontFamily) == 'string'
         local hasFontSize = type(fontSize) == 'number'
 
-        if self.fontSize == fontSize and self.fontFamily == fontFamily then
-            return -- skip if the font did not changed
-        else
-            self.fontSize = fontSize
-            self.fontFamily = fontFamily
+        if hasFontFamily then
+            self.Style.fontFamily:Set(fontFamily)
         end
-        -- updating styles of authors and messages
-        for _, chat in self.ChatHistory or {} do
-            if hasFontFamily then
-                chat.authorStyle.fontFamily = fontFamily
-                chat.messageStyle.fontFamily = fontFamily
-            end
-            if hasFontSize then
-                chat.authorStyle.fontSize = fontSize
-                chat.messageStyle.fontSize = fontSize
-            end
+        if hasFontSize then
+            self.Style.fontSize:Set(fontSize)
+            self:ReflowLines()
         end
-        -- recreate chat lines with new font family and font size
-        self:ReflowLines()
     end,
 
-    --- gets the width of text field that would displayed the string passed as argument
     AdvanceFunction = function(self, str, strStyle)
-        -- Creates a dummy text to measure width
         local dummy = Text.Text(self.Parent)
         dummy:Hide()
-        dummy:SetFont(strStyle.fontFamily, strStyle.fontSize)
+        dummy:SetFont(strStyle.fontFamily(), strStyle.fontSize())
         dummy:SetText(str)
         local width = dummy:Width()
         dummy:Destroy()
         return width
     end,
 
-    --- destroys safely all current chat lines and chat history
     OnDestroy = function(self)
         self:ClearLines()
-        self.ChatLines = nil
         self.ChatHistory = nil
         Group.OnDestroy(self)
     end

--- a/lua/ui/lobby/chatarea.lua
+++ b/lua/ui/lobby/chatarea.lua
@@ -122,7 +122,7 @@ ChatArea = Class(Group) {
         while previous.Bottom() + previous.Height()  < linesGroup.Bottom() do
             index = index + 1
             linesGroup.Lines[index] = self:CreateLine(linesGroup)
-            LayoutHelpers.Below(linesGroup.Lines[index], previous)
+            LayoutHelpers.Below(linesGroup.Lines[index], previous, 2)
             previous = linesGroup.Lines[index]
         end
         self.linesGroup = linesGroup

--- a/lua/ui/lobby/chatarea.lua
+++ b/lua/ui/lobby/chatarea.lua
@@ -157,8 +157,8 @@ ChatArea = Class(Group) {
             end
         end
         line.author.HandleEvent = function(control, event)
-            if event.Type == 'ButtonPress' and line.author.name then
-                self.Parent.edit:SetText('/w '.. line.author.name..' ')
+            if event.Type == 'ButtonPress' and control.name then
+                self.Parent.edit:SetText('/w '.. control.name..' ')
             end
         end
         line.author:EnableHitTest()

--- a/lua/ui/lobby/chatarea.lua
+++ b/lua/ui/lobby/chatarea.lua
@@ -6,10 +6,15 @@ local Prefs = import('/lua/user/prefs.lua')
 local LazyVar = import('/lua/lazyvar.lua')
 
 local defaultStyle = {
-    fontColor = LazyVar.Create('FFFFFFFF'), -- #FFFFFFFF
-    fontFamily = LazyVar.Create(UIUtil.bodyFont),
+    message = {
+        fontColor = LazyVar.Create('FFFFFFFF'),
+        fontFamily = LazyVar.Create(UIUtil.bodyFont),
+    },
+    author = {
+        fontColor = LazyVar.Create('FFFFFFFF'),
+        fontFamily = LazyVar.Create("Arial Gras"),
+    },
     fontSize = LazyVar.Create(tonumber(Prefs.GetFromCurrentProfile('LobbyChatFontSize')) or 14),
-
     shadow = false,
     lineSpacing = 1,
     padding = {
@@ -48,11 +53,8 @@ ChatArea = Class(Group) {
 
     PostMessage = function(self, messageText, authorName, messageStyle, authorStyle)
 
-        messageStyle = table.merged(defaultStyle, messageStyle or {})
-        authorStyle = table.merged(defaultStyle, authorStyle or {})
-
-        authorStyle.padding.left = 0
-        authorStyle.padding.right = 0
+        messageStyle = table.merged(defaultStyle.message, messageStyle or {})
+        authorStyle = table.merged(defaultStyle.author, authorStyle or {})
 
         if self.ChatHistoryActive then
             local entry = {
@@ -113,7 +115,7 @@ ChatArea = Class(Group) {
         local index = 1
         linesGroup.Lines[index] = self:CreateLine(linesGroup)
         local previous = linesGroup.Lines[index]
-        LayoutHelpers.AtLeftTopIn(previous, linesGroup, 2)
+        LayoutHelpers.AtLeftTopIn(previous, linesGroup, self.Style.padding.left)
         while previous.Bottom() + previous.Height()  < linesGroup.Bottom() do
             index = index + 1
             linesGroup.Lines[index] = self:CreateLine(linesGroup)
@@ -129,9 +131,9 @@ ChatArea = Class(Group) {
         line.Width:Set(parent.Width)
         line:DisableHitTest()
 
-        line.author = UIUtil.CreateText(line, '', self.Style.fontSize(), self.Style.fontFamily())
-        LayoutHelpers.AtLeftTopIn(line.author, line, 2)
-        line.message = UIUtil.CreateText(line, '', self.Style.fontSize(), self.Style.fontFamily())
+        line.author = UIUtil.CreateText(line, '', self.Style.fontSize(), self.Style.author.fontFamily())
+        LayoutHelpers.AtLeftTopIn(line.author, line)
+        line.message = UIUtil.CreateText(line, '', self.Style.fontSize(), self.Style.message.fontFamily())
         LayoutHelpers.RightOf(line.message, line.author)
 
         line.Render = function(control, message, author)
@@ -206,7 +208,7 @@ ChatArea = Class(Group) {
         local hasFontSize = type(fontSize) == 'number'
 
         if hasFontFamily then
-            self.Style.fontFamily:Set(fontFamily)
+            self.Style.message.fontFamily:Set(fontFamily)
         end
         if hasFontSize then
             self.Style.fontSize:Set(fontSize)
@@ -217,7 +219,7 @@ ChatArea = Class(Group) {
     AdvanceFunction = function(self, str, strStyle)
         local dummy = Text.Text(self.Parent)
         dummy:Hide()
-        dummy:SetFont(strStyle.fontFamily(), strStyle.fontSize())
+        dummy:SetFont(strStyle.fontFamily(), self.Style.fontSize())
         dummy:SetText(str)
         local width = dummy:Width()
         dummy:Destroy()

--- a/lua/ui/lobby/chatarea.lua
+++ b/lua/ui/lobby/chatarea.lua
@@ -146,6 +146,7 @@ ChatArea = Class(Group){
                 self:AppendText(wrapLines[i], messageStyle, true)
             end
         end
+        self:ShowLines(self.Parent.top, self.Parent.bottom)
     end,
 
     --- appends text field to existing line or on a new line
@@ -286,7 +287,7 @@ ChatArea = Class(Group){
     --- gets the width of text field that would displayed the string passed as argument
     AdvanceFunction = function(self, str, strStyle)
         -- Creates a dummy text to measure width
-        dummy = Text.Text(self.Parent)
+        local dummy = Text.Text(self.Parent)
         dummy:Hide()
         dummy:SetFont(strStyle.fontFamily, strStyle.fontSize)
         dummy:SetText(str)

--- a/lua/ui/lobby/chatarea.lua
+++ b/lua/ui/lobby/chatarea.lua
@@ -4,8 +4,24 @@ local UIUtil = import('/lua/ui/uiutil.lua')
 local LayoutHelpers = import('/lua/maui/layouthelpers.lua')
 local Prefs = import('/lua/user/prefs.lua')
 
+local defaultStyle = {
+    -- storing style values in a flat table for easy access
+    fontColor = 'FFFFFFFF', -- #FFFFFFFF
+    fontFamily = UIUtil.bodyFont,
+    fontSize = tonumber(Prefs.GetFromCurrentProfile('LobbyChatFontSize')) or 14,
+
+    shadow = false,
+    lineSpacing = 1, -- don't use higher values because chat looks strange with small fonts
+    padding = {
+        left = 0,
+        top = 3,
+        right = 3,
+        bottom = 3
+    }
+}
+
 --- Represents a control that keep tracks and displays chat messages and their author's names
-ChatArea = Class(Group){
+ChatArea = Class(Group) {
 
     __init = function(self, parent, width, height)
         Group.__init(self, parent)
@@ -19,7 +35,7 @@ ChatArea = Class(Group){
         -- ChatLines = {
         --   { TextFields = { { text = "Mike" }, { text = "Hi Dave, How are you?" } } },
         --   { TextFields = { { text = "Dave" }, { text = "I'm fine, how are you" } } }
-        --}
+        -- }
 
         -- this table stores all messages added to the ChatArea and the ReflowLines() will use this table
         -- to re-create and layout ChatLines if size of the ChatArea is changed or if fontSize is changed in lobby
@@ -28,12 +44,12 @@ ChatArea = Class(Group){
         -- ChatHistory = {
         --   { authorName = "Mike", messageText = "Hi Dave, How are you?" },
         --   { authorName = "Dave", messageText = "I'm fine, how are you?" },
-        --}
+        -- }
 
         -- specifies whether or not to save new messages in chat history
         self.ChatHistoryActive = true
 
-        self.Style = self:GetDefaultStyle()
+        self.Style = defaultStyle
         self.Parent = parent
 
         -- iInitial width and height are necessary to dodge partial-initialization/re-flow weirdness.
@@ -53,19 +69,6 @@ ChatArea = Class(Group){
         LayoutHelpers.AtLeftTopIn(self, parent, 0, 0)
     end,
 
-    GetDefaultStyle = function(self)
-        return {
-            -- storing style values in a flat table for easy access
-            fontColor = 'FFFFFFFF', --#FFFFFFFF
-            fontFamily = UIUtil.bodyFont,
-            fontSize = tonumber(Prefs.GetFromCurrentProfile('LobbyChatFontSize')) or 14,
-
-            shadow = false,
-            lineSpacing = 1, -- don't use higher values because chat looks strange with small fonts
-            padding = { left = 0, top = 3, right = 3, bottom = 3 },
-        }
-    end,
-
     --- posts a new chat message and its author name using optional styling tables
     PostMessage = function(self, messageText, authorName, messageStyle, authorStyle)
 
@@ -73,29 +76,24 @@ ChatArea = Class(Group){
         -- The author style must be _roughly_ the same in font size and weight than the text style.
         -- Too different values might break the text wrapping, because the Text.Wrap method doesn't take style as a parameter.
 
-        local defaultStyle = self:GetDefaultStyle()
         -- ensure we have a style for the message text
         if messageStyle == nil then
-           messageStyle = self:GetDefaultStyle()
+            messageStyle = defaultStyle
         else
             -- ensure message style has all required values otherwise use values of default style
-            for k,v in pairs(defaultStyle) do
-                if messageStyle[k] == nil then
-                   messageStyle[k] = defaultStyle[k]
-                end
+            for k, v in pairs(defaultStyle) do
+                messageStyle[k] = messageStyle[k] or defaultStyle[k]
             end
         end
 
         -- ensure we have a style for the author name
         if authorStyle == nil then
-            authorStyle = self:GetDefaultStyle()
+            authorStyle = table.deepcopy(defaultStyle)
             authorStyle.fontFamily = "Arial Gras"
         else
             -- ensure author style has all required values otherwise use values of default style
-            for k,v in pairs(defaultStyle) do
-                if authorStyle[k] == nil then
-                   authorStyle[k] = defaultStyle[k]
-                end
+            for k, v in pairs(defaultStyle) do
+                authorStyle[k] = authorStyle[k] or defaultStyle[k]
             end
         end
         -- avoid waste horizontal space
@@ -106,33 +104,31 @@ ChatArea = Class(Group){
 
         -- keep track of chat history by storing messages and their authors
         if self.ChatHistoryActive then
-            local entry = {}
-            entry.authorName = authorName
-            entry.authorStyle = authorStyle
-            entry.messageText = messageText
-            entry.messageStyle = messageStyle
+            local entry = {
+                authorName = authorName,
+                authorStyle = authorStyle,
+                messageText = messageText,
+                messageStyle = messageStyle
+            }
             table.insert(self.ChatHistory, entry)
         end
 
         -- If no author provided, we're simply going to skip it. Else we're going to style it
         if authorName == nil then
-           authorName = ''
+            authorName = ''
         else
-            authorName = '['..authorName..'] '
+            authorName = '[' .. authorName .. '] '
         end
-        if messageText == nil then
-           messageText = ''
-        end
-
-        local chatText = authorName..messageText
+        messageText = messageText or ''
+        
+        local chatText = authorName .. messageText
         -- This custom advance function will take care of font size and other style parameters
         local customAdvanceFunction = function(chatText)
             return self.AdvanceFunction(self, chatText, messageStyle)
         end
 
         -- wrap message text and its author into multiple lines based on control's width
-        local wrapLines = Text.WrapText(chatText,
-            self.Width() - self.Style.padding.left - self.Style.padding.right,
+        local wrapLines = Text.WrapText(chatText, self.Width() - self.Style.padding.left - self.Style.padding.right,
             customAdvanceFunction)
 
         -- group wrapped text in to lines and text fields
@@ -156,7 +152,7 @@ ChatArea = Class(Group){
         if useNewLine or table.empty(self.ChatLines) then
             line = self:CreateLine(style.fontSize + self.Style.lineSpacing)
         else
-            line = self.lastLine  -- getting the last/current line
+            line = self.lastLine -- getting the last/current line
         end
 
         local textField = UIUtil.CreateText(line, str, style.fontSize, style.fontFamily)
@@ -183,18 +179,20 @@ ChatArea = Class(Group){
         line.Height:Set(lineHeight)
         line.Width:Set(self.Width)
         line:DisableHitTest()
-        line.index = table.getsize(self.ChatLines)+ 1
+        line.index = table.getsize(self.ChatLines) + 1
         -- creating a table that will store all text fields that belong to this line
         line.TextFields = {}
 
         -- layout the new line based on its index
         if line.index == 1 then
-           LayoutHelpers.AtLeftTopIn(line, self, 0, self.Style.padding.top)
+            LayoutHelpers.AtLeftTopIn(line, self, 0, self.Style.padding.top)
         else
-           -- putting the line below previous line
-           line.previous = self.ChatLines[line.index - 1]
-           line.Left:Set(function() return self.Left() end)
-           LayoutHelpers.Below(line, line.previous)
+            -- putting the line below previous line
+            line.previous = self.ChatLines[line.index - 1]
+            line.Left:Set(function()
+                return self.Left()
+            end)
+            LayoutHelpers.Below(line, line.previous)
         end
         -- store the new line so we can destroy all lines later
         table.insert(self.ChatLines, line)
@@ -215,7 +213,9 @@ ChatArea = Class(Group){
                 local i = visibleIndex
                 local c = line
                 -- calculate top position of a line based on its visible index
-                line.Top:Set(function() return self.Top() + ((i - topIndex) * (c.Height() + 2)) end)
+                line.Top:Set(function()
+                    return self.Top() + ((i - topIndex) * (c.Height() + 2))
+                end)
             end
             visibleIndex = visibleIndex + 1
         end
@@ -229,7 +229,7 @@ ChatArea = Class(Group){
 
     --- clears existing chat lines by destroying and dereferencing its UI elements
     ClearLines = function(self)
-       -- LOG('chatArea ClearLines')
+        -- LOG('chatArea ClearLines')
         for l, line in self.ChatLines or {} do
             for t, textField in line.TextFields or {} do
                 textField:OnDestroy()
@@ -249,8 +249,7 @@ ChatArea = Class(Group){
         -- temporary deactivate Chat history while re-creating chat lines
         self.ChatHistoryActive = false
         for _, chat in self.ChatHistory or {} do
-            self:PostMessage(chat.messageText, chat.authorName,
-                               chat.messageStyle, chat.authorStyle)
+            self:PostMessage(chat.messageText, chat.authorName, chat.messageStyle, chat.authorStyle)
         end
         self.ChatHistoryActive = true
     end,
@@ -262,9 +261,8 @@ ChatArea = Class(Group){
         local hasFontFamily = type(fontFamily) == 'string'
         local hasFontSize = type(fontSize) == 'number'
 
-        if self.fontSize == fontSize and
-           self.fontFamily == fontFamily then
-           return -- skip if the font did not changed
+        if self.fontSize == fontSize and self.fontFamily == fontFamily then
+            return -- skip if the font did not changed
         else
             self.fontSize = fontSize
             self.fontFamily = fontFamily
@@ -302,5 +300,5 @@ ChatArea = Class(Group){
         self.ChatLines = nil
         self.ChatHistory = nil
         Group.OnDestroy(self)
-    end,
+    end
 }

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3287,11 +3287,11 @@ function CreateUI(maxPlayers)
 
     -- this function get index of 1st line on the last scroll page (when scroll all the way down)
     GUI.chatPanel.GetScrollLastPage = function(self)
-        return table.getn(GUI.chatDisplay.ChatHistory) - self.linesPerScrollPage
+        return table.getn(GUI.chatDisplay.ChatLines) - self.linesPerScrollPage
     end
     -- this function gets scrolling max range and current range
     GUI.chatPanel.GetScrollValues = function(self, axis)
-        local max = table.getsize(GUI.chatDisplay.ChatHistory)
+        local max = table.getsize(GUI.chatDisplay.ChatLines)
         local bottom = math.min(self.top + self.linesPerScrollPage, max)
         return 1, max, self.top, bottom
     end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3957,6 +3957,7 @@ function setupChatEdit(chatPanel)
             end
         end
     end
+    chatPanel.edit = GUI.chatEdit
 end
 
 function RefreshOptionDisplayData(scenarioInfo)

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3287,12 +3287,12 @@ function CreateUI(maxPlayers)
 
     -- this function get index of 1st line on the last scroll page (when scroll all the way down)
     GUI.chatPanel.GetScrollLastPage = function(self)
-        return table.getsize(GUI.chatDisplay.ChatLines) - self.linesPerScrollPage
+        return table.getn(GUI.chatDisplay.ChatHistory) - self.linesPerScrollPage
     end
     -- this function gets scrolling max range and current range
     GUI.chatPanel.GetScrollValues = function(self, axis)
-        local max = table.getsize(GUI.chatDisplay.ChatLines)
-        local bottom = math.min(self.top + self.linesPerScrollPage - 1, max)
+        local max = table.getsize(GUI.chatDisplay.ChatHistory)
+        local bottom = math.min(self.top + self.linesPerScrollPage, max)
         return 1, max, self.top, bottom
     end
     -- this function controls how many lines to scroll when clicking on up/down arrows of the scrollbar
@@ -3308,7 +3308,7 @@ function CreateUI(maxPlayers)
         top = math.floor(top)
         if top == self.top then return end
         local delta = self:GetScrollLastPage()
-        self.top = math.max( math.min(delta + 1, top), 1)
+        self.top = math.max( math.min(delta, top), 1)
         self.bottom = self.top + self.linesPerScrollPage
         GUI.chatDisplay:ShowLines(self.top, self.bottom)
         if self.top >= delta + 1 then


### PR DESCRIPTION
Most of lobby issues come from chat: in some cases a lots of messages can cause lobby bug or even crash and here is why. 
Every message you receive creates a control. More messages = more controls = more usage of memory and, most importantly, when you Alt-Tab each LazyVar calculates its position on frame, which are 6 times more than controls...