### PR TITLE
Fix seraphim support commander build effect

### DIFF
--- a/units/XSL0301/XSL0301_script.lua
+++ b/units/XSL0301/XSL0301_script.lua
@@ -43,7 +43,7 @@ XSL0301 = Class(CommandUnit) {
 
     StartBeingBuiltEffects = function(self, builder, layer)
         CommandUnit.StartBeingBuiltEffects(self, builder, layer)
-        self:ForkThread( EffectUtil.CreateSeraphimBuildThread, builder, self.OnBeingBuiltEffectsBag, 1 )
+        self:ForkThread( EffectUtil.CreateSeraphimBuildThread, builder, self.OnBeingBuiltEffectsBag, 2 )
     end,
 
     CreateBuildEffects = function(self, unitBeingBuilt, order)

--- a/units/XSL0301/XSL0301_script.lua
+++ b/units/XSL0301/XSL0301_script.lua
@@ -41,6 +41,11 @@ XSL0301 = Class(CommandUnit) {
         self:GetWeaponByLabel('AutoOverCharge').NeedsUpgrade = true
     end,
 
+    StartBeingBuiltEffects = function(self, builder, layer)
+        CommandUnit.StartBeingBuiltEffects(self, builder, layer)
+        self:ForkThread( EffectUtil.CreateSeraphimBuildThread, builder, self.OnBeingBuiltEffectsBag, 1 )
+    end,
+
     CreateBuildEffects = function(self, unitBeingBuilt, order)
         EffectUtil.CreateSeraphimUnitEngineerBuildingEffects(self, unitBeingBuilt, self.BuildEffectBones, self.BuildEffectsBag)
     end,


### PR DESCRIPTION
Adds the default build effect to the construction of the Seraphim support commanders. This effect is used on all the other Seraphim units and buildings.

![image](https://user-images.githubusercontent.com/15778155/161014841-b5726197-21cb-48a5-85d5-ab433ea095b1.png)