### PR TITLE
Better available color list update functionality

### DIFF
--- a/lua/ui/controls/combo.lua
+++ b/lua/ui/controls/combo.lua
@@ -656,8 +656,10 @@ BitmapCombo = Class(Group) {
         -- prev will be last control here
         self.ddm.Bottom:Set(prev.Bottom)
 
-        self._dropdown:Hide()
-        self._ddhidden = true
+        if self._dropdown:IsHidden() then
+            self._dropdown:Hide()
+            self._ddhidden = true
+        end
     end,
 
     SetBitmap = function(self, bmp, name)

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -542,7 +542,6 @@ local function DoSlotBehavior(slot, key, name)
         else
             HostUtils.RemoveAI(slot)
         end
-        Check_Availaible_Color()
     else
         -- We're adding an AI of some sort.
         if lobbyComm:IsHost() then
@@ -1232,6 +1231,7 @@ function ClearSlotInfo(slotIndex)
     UpdateSlotBackground(slotIndex)
     ShowGameQuality()
     RefreshMapPositionForAllControls(slotIndex)
+    Check_Availaible_Color()
     refreshObserverList()
 end
 
@@ -3113,14 +3113,12 @@ function CreateUI(maxPlayers)
           else
             AssignAutoTeams()
           end
-          Check_Availaible_Color()
         end
         GUI.AIClearButton.OnClick = function()
           for i = 1, table.getn(ChangedSlots) do
             HostUtils.RemoveAI(ChangedSlots[i])
           end
           ChangedSlots = {}
-          Check_Availaible_Color()
         end
         GUI.TeamCountSelector.OnClick = function(Self, Index, Text)
           local OccupiedSlots = 0


### PR DESCRIPTION
This makes the in-lobby color list able to update without "closing."

Fixes the problem of the available color list "closing" (being destroyed and recreated, with the new one set to hidden) when the available color list is updated.  Now, when a BitmapCombo is changed via ChangeBitmapArray, the new one is not hidden if the old one was not hidden.
Also simplifies where Check_Availaible_Color is called and makes it get called when a player switches to observer (the available color list was previously not triggered to update by this action).