### PR TITLE
In-Lobby AutoBalance Improvements

### DIFF
--- a/loc/US/strings_db.lua
+++ b/loc/US/strings_db.lua
@@ -7611,6 +7611,7 @@ lobui_0442="From %s"
 lobui_0443="To %s"
 lobui_0444 = "Autobalance"
 lobui_0445 = "Automatically balance players into 2 equally sized teams"
+lobui_0446 = "Enabled fixed spawn locations"
 
 lobui_0450="CPU"
 lobui_0451="Ping"

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3992,7 +3992,7 @@ function CreateUI(maxPlayers)
             end
 
             -- if the teams were not set properly, set them properly
-            if table.getn(sortedTeam1Slots) < teamSize or table.getn(sortedTeam2Slots) < teamSize or (manualTeams and (numPlayersTeam1 != teamSize or numPlayersTeam2 != teamSize)) then
+            if (not manualTeams and (table.getn(sortedTeam1Slots) < teamSize or table.getn(sortedTeam2Slots) < teamSize)) or (manualTeams and (numPlayersTeam1 != teamSize or numPlayersTeam2 != teamSize)) then
                 -- set AutoTeams to none (so, they can be set by slot by this function)
                 gameInfo.GameOptions.AutoTeams = 'none'
                 local counter = 0

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3848,12 +3848,15 @@ function CreateUI(maxPlayers)
         GUI.PenguinAutoBalance.OnClick = function()
 
             -- set spawns to fixed
-            gameInfo.GameOptions.TeamSpawn = 'fixed'
-            -- tell everyone else to set spawns to fixed
-            lobbyComm:BroadcastData {
-                Type = 'GameOptions',
-                Options = {['TeamSpawn'] = 'fixed'}
-            }
+            if gameInfo.GameOptions.TeamSpawn ~= 'fixed' then
+                gameInfo.GameOptions.TeamSpawn = 'fixed'
+                -- tell everyone else to set spawns to fixed
+                lobbyComm:BroadcastData {
+                    Type = 'GameOptions',
+                    Options = {['TeamSpawn'] = 'fixed'}
+                }
+                AddChatText(LOC("<LOC lobui_0446>Enabled fixed spawn locations"))
+            end
 
             -- a table of the target mean, target deviation, and the lowest logged imbalance value
             local goalValue = {0, 0, 99999}

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3827,11 +3827,15 @@ function CreateUI(maxPlayers)
         GUI.PenguinAutoBalance:Hide()
     else
         -- What this does: it balances all occupied slots into two teams with equal numbers of
-        -- players.  If half of the occupied slots are set to team 1 and half to team 2, then
-        -- it balances the players while keeping the team-slot matches.  If the teams are not
-        -- set that way, they are changed automatically to be alternating team 1 and team 2.
+        -- players.  If teams are set manually and half of the occupied slots are set to team 1
+        -- and half to team 2, then it balances the players while keeping the team-slot matches.
+        -- If the teams are set manually, but there is an uneven number of players on teams 1
+        -- and 2, then players' teams are changed automatically to be alternating team 1 and team 2.
         -- If there are an odd number of occupied slots, the last one is set to team - (no team)
-        -- and the others are balanced without it.
+        -- and the others are balanced without it.  Alternatively, if teams are not set manually,
+        -- players will be balanced into the slowest available slot numbers on their teams.
+        -- If there is an odd number of players in that case, the last player will be made an
+        -- observer if human or removed if AI.
 
         -- How it balances: this function checks every possible balance combination for making 
         -- the two teams (while keeping their player counts equal to half the number of occupied
@@ -3862,6 +3866,8 @@ function CreateUI(maxPlayers)
             local goalValue = {0, 0, 99999}
 
             local playerCount = 0
+            -- a table of the highest occupied slot's slot number, that slot's player's order number
+            -- in the playerRatings table, and a booleon of whether or not that player is human
             local lastSlot = {0, 0, false}
             local playerRatings = {}
             -- get rating data for each player
@@ -3991,8 +3997,13 @@ function CreateUI(maxPlayers)
                 manualTeams = true
             end
 
-            -- if the teams were not set properly, set them properly
-            if (not manualTeams and (table.getn(sortedTeam1Slots) < teamSize or table.getn(sortedTeam2Slots) < teamSize)) or (manualTeams and (numPlayersTeam1 != teamSize or numPlayersTeam2 != teamSize)) then
+            -- If the teams were not set properly, set them properly.
+            -- When teams are set manually, they are not set properly if the number of 
+            -- players on either team does not equal the team size.  
+            -- When teams are not set manually, they are not set properly if the number
+            -- of slots on either team is less than the team size.
+            if (manualTeams and (numPlayersTeam1 != teamSize or numPlayersTeam2 != teamSize))
+             or (not manualTeams and (table.getn(sortedTeam1Slots) < teamSize or table.getn(sortedTeam2Slots) < teamSize)) then
                 -- set AutoTeams to none (so, they can be set by slot by this function)
                 gameInfo.GameOptions.AutoTeams = 'none'
                 local counter = 0

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3847,6 +3847,14 @@ function CreateUI(maxPlayers)
         -- Automatically balance an even number of non-observer players into 2 teams in the lobby
         GUI.PenguinAutoBalance.OnClick = function()
 
+            -- set spawns to fixed
+            gameInfo.GameOptions.TeamSpawn = 'fixed'
+            -- tell everyone else to set spawns to fixed
+            lobbyComm:BroadcastData {
+                Type = 'GameOptions',
+                Options = {['TeamSpawn'] = 'fixed'}
+            }
+
             -- a table of the target mean, target deviation, and the lowest logged imbalance value
             local goalValue = {0, 0, 99999}
 
@@ -3866,6 +3874,7 @@ function CreateUI(maxPlayers)
 
             -- if there are fewer than 2 players, there is no need to balance
             if playerCount < 2 then
+                UpdateGame()
                 return
             end
 


### PR DESCRIPTION
Adds AutoBalance button functionality of automatically setting spawns to fixed if that's not already the case
Adds AutoBalance button functionality for odd vs even, top vs bottom, and left vs right AutoTeams configurations (rather than forcing manual and using the previously occupied slots) - slots are used in numerical order, only skipping closed slots and slots necessary to skip to keep team size equal (if any)