### PR TITLE
Fix issues with the Fire Beetle and trashbag management

### DIFF
--- a/lua/EffectUtilities.lua
+++ b/lua/EffectUtilities.lua
@@ -731,11 +731,26 @@ function CreateEnhancementUnitAmbient(unit, bone, TrashBag)
     end
 end
 
-function CleanupEffectBag(self, EffectBag)
-    for _, v in self[EffectBag] do
-        v:Destroy()
+local TableEmpty = table.empty 
+
+function CleanupEffectBag(self, identifier)
+
+    local bag = self[identifier]
+
+    -- old 'bag' where it is just a table
+    if TableEmpty(getmetatable(bag)) then 
+        for k, v in bag do 
+            if v.Destroy then 
+                v:Destroy()
+            end
+            
+            bag[k] = nil 
+        end
+
+    -- new 'bag' that is a trashbag
+    else 
+        bag:Destroy()
     end
-    self[EffectBag] = {}
 end
 
 function SeraphimRiftIn(unit)

--- a/lua/selfdestruct.lua
+++ b/lua/selfdestruct.lua
@@ -1,21 +1,83 @@
 
 local GetEntityById = GetEntityById
 local OkayToMessWithArmy = OkayToMessWithArmy
+local StartCountdown = StartCountdown
+local CancelCountdown = CancelCountdown
+local ForkThread = ForkThread
+local KillThread = KillThread
+
+local TableInsert = table.insert
+
+
+-- prevent magic numbers
+local countdownDuration = 5
 
 function ToggleSelfDestruct(data)
-    -- Suppress self destruct in tutorial missions as they screw up the mission end
+    -- suppress self destruct in tutorial missions as they screw up the mission end
     if ScenarioInfo.tutorial and ScenarioInfo.tutorial == true then
         return
     end
 
+    -- do not allow observers to use this
     if data.owner ~= -1 then
 
-        -- find and take them out
-        for _, unitId in data.units do
-            local unit = GetEntityById(unitId)
-            if OkayToMessWithArmy(unit.Army) then
-                if not (unit.Dead or unit:BeenDestroyed()) then 
-                    unit:Kill()
+        -- just take them all out
+        if data.noDelay then 
+            for _, unitId in data.units do
+                local unit = GetEntityById(unitId)
+                if OkayToMessWithArmy(unit.Army) then
+                    if not (unit.Dead or unit:BeenDestroyed()) then 
+                        unit:Kill()
+                    end
+                end
+            end
+
+        -- wait a few seconds, then destroy
+        else 
+
+            -- gather units
+            local unitEntities = { }
+            for _, unitId in data.units do
+                local unit = GetEntityById(unitId)
+                if OkayToMessWithArmy(unit.Army) then
+                    TableInsert(unitEntities, unit)
+                end
+            end
+
+            -- if one is in the process of being destroyed, remove all destruction threads
+            local togglingOff = false
+            for _, unit in unitEntities do
+                if unit.SelfDestructThread then
+                    togglingOff = true
+                    KillThread(unit.SelfDestructThread)
+                    unit.SelfDestructThread = false
+                    CancelCountdown(unit.EntityId)                          -- as defined in SymSync.lua
+                end
+            end
+
+            -- if none are in the process of being destroyed, destroy them after a delay
+            if not togglingOff then
+                for _, unit in unitEntities do
+
+                    -- allows fire beetle to be destroyed immediately
+                    if unit.Blueprint.General.InstantDeathOnSelfDestruct then 
+                        unit:Kill()
+
+                    -- destroy everything else after five seconds
+                    else 
+                        StartCountdown(unit.EntityId, countdownDuration)    -- as defined in SymSync.lua
+                        unit.SelfDestructThread = ForkThread(
+                            function(unit)
+                                WaitSeconds(countdownDuration)
+                                if unit:BeenDestroyed() then 
+                                    return 
+                                end
+
+                                unit:Kill()
+                            end,
+                            unit 
+                        )
+                    end
                 end
             end
         end

--- a/lua/selfdestruct.lua
+++ b/lua/selfdestruct.lua
@@ -1,3 +1,7 @@
+
+local GetEntityById = GetEntityById
+local OkayToMessWithArmy = OkayToMessWithArmy
+
 function ToggleSelfDestruct(data)
     -- Suppress self destruct in tutorial missions as they screw up the mission end
     if ScenarioInfo.tutorial and ScenarioInfo.tutorial == true then
@@ -5,73 +9,14 @@ function ToggleSelfDestruct(data)
     end
 
     if data.owner ~= -1 then
-        local unitEntities = {}
+
+        -- find and take them out
         for _, unitId in data.units do
             local unit = GetEntityById(unitId)
             if OkayToMessWithArmy(unit.Army) then
-                table.insert(unitEntities, unit)
-            end
-        end
-        if not table.empty(unitEntities) then
-            if data.noDelay then -- Kill these units instantly
-                for _, unit in unitEntities do
-                    if unit:BeenDestroyed() or unit.Dead then return end
-
-                    FireSelfdestructWeapons(unit)
-                    unit.SelfDestructed = true
+                if not (unit.Dead or unit:BeenDestroyed()) then 
                     unit:Kill()
                 end
-            else
-                local togglingOff = false
-                for _, unit in unitEntities do -- Rescue anything in the process of dying, and skip the next bit
-                    if unit.SelfDestructThread then
-                        togglingOff = true
-                        KillThread(unit.SelfDestructThread)
-                        unit.SelfDestructThread = false
-                        CancelCountdown(unit.EntityId)
-                    end
-                end
-
-                if not togglingOff then
-                    for _, unitEnt in unitEntities do
-                        local unit = unitEnt
-
-                        -- Unit and weapon bp flags can be used to control behaviour on SelfDestruct
-                        -- Instant kill if InstantDeathOnSelfDestruct = true variable set in units general table
-                        -- Fires weapons with FireOnSelfDestruct = true in units weapon table
-                        local bp = unit:GetBlueprint()
-                        if bp.General.InstantDeathOnSelfDestruct then
-                            FireSelfdestructWeapons(unit)
-                            unit.SelfDestructed = true
-                            unit:Kill()
-                        else
-                            -- Regular self destruct cycle
-                            StartCountdown(unit.EntityId)
-                            unit.SelfDestructThread = ForkThread(function()
-                                WaitSeconds(5)
-                                if unit:BeenDestroyed() then return end
-                                FireSelfdestructWeapons(unit)
-                                unit.SelfDestructed = true
-                                unit:Kill()
-                            end)
-                        end
-                    end
-                end
-            end
-        end
-    end
-end
-
-function FireSelfdestructWeapons(unit)
-    local wepCount = unit:GetWeaponCount()
-    for i = 1, wepCount do
-        local wep = unit:GetWeapon(i)
-        local wepBP = wep:GetBlueprint()
-        if wepBP.FireOnSelfDestruct then
-            if wep.Fire then
-                wep.Fire()
-            else
-                wep.OnFire(wep)
             end
         end
     end

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1491,7 +1491,6 @@ Unit = Class(moho.unit_methods) {
                 else
                     self:ForkThread(self.DeathWeaponDamageThread, v.DamageRadius, v.Damage, v.DamageType, v.DamageFriendly)
                 end
-                break
             end
         end
     end,

--- a/lua/system/trashbag.lua
+++ b/lua/system/trashbag.lua
@@ -25,6 +25,7 @@
 -- for a given effect.
 
 local TableGetn = table.getn 
+local TableEmpty = table.empty
 
 TrashBag = Class {
 
@@ -33,10 +34,6 @@ TrashBag = Class {
     -- http://lua-users.org/wiki/GarbageCollectionTutorial
     -- http://lua-users.org/wiki/WeakTablesTutorial
     __mode = 'v',
-
-    -- Signifies the largest index used by this trashbag,  
-    -- used during cleaning to ensure we destroy all values
-    LargestIndex = 0,
 
     --- Add an entity to the trash bag.
     Add = function(self, entity)
@@ -53,12 +50,7 @@ TrashBag = Class {
         --     return 
         -- end
 
-        local index = TableGetn(self) + 1
-        self[index] = entity
-
-        if index > self.LargestIndex then 
-            self.LargestIndex = index 
-        end
+        self[TableGetn(self) + 1] = entity
     end,
 
     --- Destroy all (remaining) entities in the trash bag.
@@ -71,18 +63,16 @@ TrashBag = Class {
         -- end
 
         -- Remove any value still in the trashbag
-        for k = 1, self.LargestIndex do 
+        for k, v in self do
             if self[k] then 
                 self[k]:Destroy()
                 self[k] = nil
             end
         end 
-
-        self.LargestIndex = 0
     end,
     
     -- Check if the trashbag is empty. True if empty, false otherwise
     Empty = function(self)
-        return TableGetn(self) == 0
+        return TableEmpty(self)
     end
 }

--- a/lua/ui/game/confirmunitdestroy.lua
+++ b/lua/ui/game/confirmunitdestroy.lua
@@ -21,7 +21,7 @@ function ConfirmUnitDestruction(instant)
             for _, unit in units do
                 table.insert(unitIds, unit:GetEntityId())
             end
-            SimCallback({Func = 'ToggleSelfDestruct', Args = {units = unitIds, owner = GetFocusArmy(), noDelay = instant}})
+            SimCallback({Func = 'ToggleSelfDestruct', Args = {units = unitIds, owner = GetFocusArmy(), noDelay = instant}}, true)
         end
     end
 end

--- a/lua/ui/game/confirmunitdestroy.lua
+++ b/lua/ui/game/confirmunitdestroy.lua
@@ -11,17 +11,21 @@ local controls = {}
 local countdownThreads = {}
 
 function ConfirmUnitDestruction(instant)
-    if import('/lua/ui/campaign/campaignmanager.lua').campaignMode
-    and not table.empty(EntityCategoryFilterDown(categories.COMMAND, GetSelectedUnits())) then
+
+    -- get selected units
+    local units = GetSelectedUnits()
+
+    if  
+        -- if we're in campaign mode
+        import('/lua/ui/campaign/campaignmanager.lua').campaignMode  
+
+        -- and we're trying to self destruct a command unit
+        and not table.empty(EntityCategoryFilterDown(categories.COMMAND, units)) 
+    then
+        -- don't allow that, as it would end the operation
         CreateAnnouncement('<LOC confirm_0001>You cannot self destruct during an operation!')
     else
-        local units = GetSelectedUnits()
-        if units then
-            local unitIds = {}
-            for _, unit in units do
-                table.insert(unitIds, unit:GetEntityId())
-            end
-            SimCallback({Func = 'ToggleSelfDestruct', Args = {units = unitIds, owner = GetFocusArmy(), noDelay = instant}}, true)
-        end
+        -- do the callback accordingly
+        SimCallback({Func = 'ToggleSelfDestruct', Args = { owner = GetFocusArmy(), noDelay = instant }}, true)
     end
 end

--- a/units/XRL0302/XRL0302_Script.lua
+++ b/units/XRL0302/XRL0302_Script.lua
@@ -156,12 +156,8 @@ XRL0302 = Class(CWalkingLandUnit) {
         CWalkingLandUnit.DoDeathWeapon(self)
 
         -- clean up some effects
-        if self.EffectsBagXRL then
-            self.EffectsBagXRL:Destroy()
-        end
-        if self.AmbientExhaustEffectsBagXRL then
-            self.AmbientExhaustEffectsBagXRL:Destroy()
-        end
+        self.EffectsBagXRL:Destroy()
+        self.AmbientExhaustEffectsBagXRL:Destroy()
 
         -- stop the periodice effects
         self.PeriodicFXThread:Destroy()

--- a/units/XRL0302/XRL0302_Script.lua
+++ b/units/XRL0302/XRL0302_Script.lua
@@ -14,9 +14,27 @@ local Weapon = import('/lua/sim/Weapon.lua').Weapon
 --- A unique death weapon for the Fire Beetle
 local DeathWeaponKamikaze = Class(Weapon) {
 
-    FxDeath = EffectTemplate.CMobileKamikazeBombExplosion,
+
 
     OnFire = function(self)
+        -- do regular death weapon of unit if we didn't already
+        if not self.unit.Dead then 
+            self.unit:Kill()
+        end
+    end,
+}
+
+--- A unique death weapon for the Fire Beetle
+local DeathWeaponEMP = Class(Weapon) {
+
+    FxDeath = EffectTemplate.CMobileKamikazeBombExplosion,
+
+    OnCreate = function(self)
+        Weapon.OnCreate(self)
+        self:SetWeaponEnabled(false)
+    end,
+
+    Fire = function(self)
 
         -- get information
         local blueprint = self:GetBlueprint()
@@ -39,29 +57,10 @@ local DeathWeaponKamikaze = Class(Weapon) {
             CreateDecal( position, rotation, 'scorch_010_albedo', '', 'Albedo', 11, 11, 250, 120, army)
         end
 
-        -- do regular death weapon of unit if we didn't already
-        if not self.unit.Dead then 
-            self.unit:DoDeathWeapon()
-        end
-
-        -- do damage
+        -- do the damage
         DamageArea(self.unit, position, blueprint.DamageRadius, blueprint.Damage, blueprint.DamageType or 'Normal', blueprint.DamageFriendly or false)
         self.unit:PlayUnitSound('Destroyed')
         self.unit:Destroy()
-    end,
-}
-
---- A unique death weapon for the Fire Beetle
-local DeathWeaponEMP = Class(Weapon) {
-    OnCreate = function(self)
-        Weapon.OnCreate(self)
-        self:SetWeaponEnabled(false)
-    end,
-
-    Fire = function(self)
-        local blueprint = self:GetBlueprint()
-        DamageArea(self.unit, self.unit:GetPosition(), blueprint.DamageRadius,
-                   blueprint.Damage, blueprint.DamageType, blueprint.DamageFriendly)
     end,
 }
 

--- a/units/XRL0302/XRL0302_Script.lua
+++ b/units/XRL0302/XRL0302_Script.lua
@@ -96,8 +96,8 @@ XRL0302 = Class(CWalkingLandUnit) {
     OnCreate = function(self)
         CWalkingLandUnit.OnCreate(self)
 
-        self.EffectsBag = {}
-        self.AmbientExhaustEffectsBag = {}
+        self.EffectsBagXRL = TrashBag()
+        self.AmbientExhaustEffectsBagXRL = TrashBag()
         self.CreateTerrainTypeEffects(self, self.IntelEffects.Cloak, 'FXIdle',  self.Layer, nil, self.EffectsBag)
         self.PeriodicFXThread = self:ForkThread(self.EmitPeriodicEffects)
     end,
@@ -157,13 +157,11 @@ XRL0302 = Class(CWalkingLandUnit) {
         CWalkingLandUnit.DoDeathWeapon(self)
 
         -- clean up some effects
-        if self.EffectsBag then
-            EffectUtil.CleanupEffectBag(self, 'EffectsBag')
-            self.EffectsBag = nil
+        if self.EffectsBagXRL then
+            self.EffectsBagXRL:Destroy()
         end
-        if self.AmbientExhaustEffectsBag then
-            EffectUtil.CleanupEffectBag(self, 'AmbientExhaustEffectsBag')
-            self.AmbientExhaustEffectsBag = nil
+        if self.AmbientExhaustEffectsBagXRL then
+            self.AmbientExhaustEffectsBagXRL:Destroy()
         end
 
         -- stop the periodice effects

--- a/units/XRL0302/XRL0302_unit.bp
+++ b/units/XRL0302/XRL0302_unit.bp
@@ -245,7 +245,7 @@ UnitBlueprint {
             Accurate = true,
             BallisticArc = 'RULEUBA_None',
             CollideFriendly = false,
-            Damage = 1,
+            Damage = 1100,
             DamageFriendly = false,
             DamageRadius = 6.5,
             DamageType = 'EMP',

--- a/units/XRL0302/XRL0302_unit.bp
+++ b/units/XRL0302/XRL0302_unit.bp
@@ -217,7 +217,7 @@ UnitBlueprint {
         {            
             AboveWaterTargetsOnly = true,
             CollideFriendly = false,
-            Damage = 1100,
+            Damage = 1,
             DamageFriendly = false,
             DamageRadius = 6.5,
             DamageType = 'FireBeetleExplosion',


### PR DESCRIPTION
Allows the `CleanupEffectBag` function of `effectutilities.lua` to work with both regular tables and trashbags. Revamps the self destruct that was doing a lot of additional logic - I have no idea why as the default flow of code when a unit is destroyed triggers all of that too.