### PR TITLE
Potential swap and ready bugfixing

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5274,6 +5274,7 @@ local MessageHandlers = {
         Handle = function(data)
             gameInfo.PlayerOptions[data.OldSlot] = nil
             gameInfo.PlayerOptions[data.NewSlot] = PlayerData(data.Options)
+            gameInfo.PlayerOptions[data.NewSlot].Ready = false
             ClearSlotInfo(data.OldSlot)
             SetSlotInfo(data.NewSlot, gameInfo.PlayerOptions[data.NewSlot])
             UpdateFactionSelectorForPlayer(gameInfo.PlayerOptions[data.NewSlot])
@@ -6811,10 +6812,6 @@ function DoSlotSwap(slot1, slot2)
     player1.Ready = false 
     player2.Ready = false
 
-    -- unready players in GUI
-    GUI.slots[slot1].ready:SetCheck(false)
-    GUI.slots[slot2].ready:SetCheck(false)
-
     -- swap teams
     local team_bucket = player1.Team
     player1.Team = player2.Team
@@ -6835,6 +6832,8 @@ function DoSlotSwap(slot1, slot2)
     -- update faction selector
     UpdateFactionSelectorForPlayer(player1)
     UpdateFactionSelectorForPlayer(player2)
+
+    UpdateGame()
 end
 
 function KeepSameFactionOrRandom(slotFrom, slotTo, player)


### PR DESCRIPTION
Added UpdateGame to DoSlotSwap for the swapping bug (and removed the consequently superfluous ready set checks)
Made SlotMove set ready to false in the relevant playeroption for the ready bug
Tested doing 20ish swaps/moves in-lobby and launching a few times