### PR TITLE
Fix damage over time instances

### DIFF
--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -114,9 +114,9 @@ Projectile = Class(moho.projectile_methods, Entity) {
         self.CollideFriendly = self.DamageData.CollideFriendly
     end,
 
-    DoDamage = function(self, instigator, DamageData, targetEntity, position)
+    DoDamage = function(self, instigator, DamageData, targetEntity)
 
-        position = position or self:GetPosition()
+        local position = self:GetPosition()
 
         local damage = DamageData.DamageAmount
         if damage and damage > 0 then
@@ -381,7 +381,7 @@ Projectile = Class(moho.projectile_methods, Entity) {
         local bp = self.Blueprint 
 
         -- do the projectile damage
-        self:DoDamage(instigator, damageData, targetEntity, vc)
+        self:DoDamage(instigator, damageData, targetEntity)
 
         -- compute whether we should spawn additional effects for this 
         -- projectile, there's always a 10% chance or if we're far away from 


### PR DESCRIPTION
An invariant was broken in an eager attempt to improve the performance of the game . 

With #3718 we introduced the use of cached vectors (a table that represents a position, that we re-use the memory location of). The idea of a cached vector is that it prevents the typical 'allocate table, use table, de-allocate table' pattern. One invariant of it is that you can not assume that the same value holds after a wait or fork statement. In other words:

```lua
-- somewhere in outer scope
local VectorCached = Vector()

-- somewhere in a function in the same file
local vc = VectorCached
vc[1], vc[2], vc[3] = unit:GetPositionXYZ()

-- (...)

WaitSeconds(...)

-- Invariant broken, we can't be sure that the same content is still in vc at this point, as it is used across instances
DamageArea(..., vc, ...)
```

And that is exactly what we did in 3718. In turn, all projectiles that use `AreaDoTThread` would have their damage applied _somewhere else on the map_ depending on the instance that used the cached vector right before the next pulse is applied. 