### PR TITLE
Fix release 3732 09

### DIFF
--- a/lua/EffectUtilitiesUEF.lua
+++ b/lua/EffectUtilitiesUEF.lua
@@ -297,7 +297,7 @@ function CreateBuildCubeThread(
     CoroutineYield(BuildCubeDelay)
 
     -- always check if we're still there after waiting
-    if unitBeingBuilt.Dead then
+    if EntityBeenDestroyed(unitBeingBuilt) then
         return
     end
 

--- a/lua/EffectUtilitiesUEF.lua
+++ b/lua/EffectUtilitiesUEF.lua
@@ -276,7 +276,7 @@ function CreateBuildCubeThread(
     CoroutineYield(BuildCubeGlowDuration)
 
     -- always check if we're still there after waiting
-    if unitBeingBuilt.Dead then
+    if EntityBeenDestroyed(unitBeingBuilt) then
         return
     end
 

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -69,8 +69,10 @@ local function TransferUnitsOwnershipDelayedWeapons (weapon)
         local delay = 1 / bp.RateOfFire
         WaitSeconds(delay)
 
-        -- enable the weapon again
-        weapon:SetEnabled(true)
+        -- enable the weapon again if it still exists
+        if not weapon:BeenDestroyed() then 
+            weapon:SetEnabled(true)
+        end
     end
 end
 

--- a/lua/maui/cursor.lua
+++ b/lua/maui/cursor.lua
@@ -3,8 +3,6 @@
 -- SetDefaultTexture(filename, hotspotX, hotspotY)
 -- Reset() -- re-applies default texture
 
-LOG("Cursor being made!")
-
 Cursor = Class(moho.cursor_methods) {
     __init = function(self, defaultTexture, defaultHotspotX, defaultHotspotY)
         _c_CreateCursor(self, nil)

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -34,6 +34,7 @@ local TableAssimilate = table.assimilate
 local Warp = Warp
 local IsEntity = IsEntity
 local IsUnit = IsUnit
+local IsAlly = IsAlly
 local IsEnemy = IsEnemy
 local Random = Random
 local GetGameTick = GetGameTick
@@ -645,6 +646,19 @@ Shield = Class(moho.shield_methods, Entity) {
         return IsEnemy(self.Army, other.Army)
     end,
 
+    --- Called when a unit collides with a collision beam to check if the collision is valid
+    -- @param self The unit we're checking the collision for
+    -- @param firingWeapon The weapon the beam originates from that we're checking the collision with
+    OnCollisionCheckWeapon = function(self, firingWeapon)
+
+        -- if we're allied, check if we allow that type of collision
+        if self.Army == firingWeapon.Army or IsAlly(self.Army, firingWeapon.Army) then
+            return firingWeapon.Blueprint.CollideFriendly
+        end
+
+        return true
+    end,
+
     TurnOn = function(self)
         ChangeState(self, self.OnState)
     end,
@@ -903,32 +917,7 @@ Shield = Class(moho.shield_methods, Entity) {
         end,
     },
 
-    OnCollisionCheckWeapon = function(self, firingWeapon)
 
-        if not DeprecatedWarnings.OnCollisionCheckWeapon then 
-            DeprecatedWarnings.OnCollisionCheckWeapon = true 
-            WARN("OnCollisionCheckWeapon is deprecated.")
-            WARN(debug.tracestack())
-        end
-
-        local weaponBP = firingWeapon:GetBlueprint()
-        local collide = weaponBP.CollideFriendly
-        if collide == false then
-            if not (IsEnemy(self.Army, firingWeapon.unit.Army)) then
-                return false
-            end
-        end
-        -- Check DNC list
-        if weaponBP.DoNotCollideList then
-            for _, v in pairs(weaponBP.DoNotCollideList) do
-                if EntityCategoryContains(ParseEntityCategory(v), self) then
-                    return false
-                end
-            end
-        end
-
-        return true
-    end,
 
     GetCachePosition = function(self)
 

--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -208,19 +208,8 @@ DefaultProjectileWeapon = Class(Weapon) {
 
     -- Played when a muzzle is fired. Mostly used for muzzle flashes
     PlayFxMuzzleSequence = function(self, muzzle)
-
-        local ok, msg = pcall (
-            function()
-                for k, v in self.FxMuzzleFlash do
-                    CreateAttachedEmitter(self.unit, muzzle, self.Army, v):ScaleEmitter(self.FxMuzzleFlashScale)
-                end
-            end
-        )
-
-        if not ok then 
-            WARN(msg)
-            LOG(self.Blueprint.BlueprintId)
-            LOG(self.unit.Blueprint.BlueprintId)
+        for k, v in self.FxMuzzleFlash do
+            CreateAttachedEmitter(self.unit, muzzle, self.Army, v):ScaleEmitter(self.FxMuzzleFlashScale)
         end
     end,
 

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -36,29 +36,6 @@ local function ParsePriorities()
     return finalPriorities
 end
 
---- A collection of functions that are most often called. Is not in any specific order.
--- These functions should be cached during OnCreate to improve the access pattern. See also
--- the benchmark about metatables.
--- local FunctionsToCache = { 
---     "GetDamageTable"
-
---   , "OnStartTracking"
---   , "OnStopTracking"
---   , "OnGotTarget"
---   , "OnLostTarget"
-
---   , "PlayWeaponSound"
---   , "PlayWeaponAmbientSound"
---   , "StopWeaponAmbientSound"
-
---   , "ForkThread"
-
---   , "OnMotionHorzEventChange"
-
---   , "DoOnFireBuffs"
---   , "CreateProjectileForWeapon"
--- }
-
 Weapon = Class(moho.weapon_methods) {
     __init = function(self, unit)
         self.unit = unit

--- a/units/XRL0302/XRL0302_Script.lua
+++ b/units/XRL0302/XRL0302_Script.lua
@@ -13,9 +13,6 @@ local Weapon = import('/lua/sim/Weapon.lua').Weapon
 
 --- A unique death weapon for the Fire Beetle
 local DeathWeaponKamikaze = Class(Weapon) {
-
-
-
     OnFire = function(self)
         -- do regular death weapon of unit if we didn't already
         if not self.unit.Dead then 
@@ -136,14 +133,6 @@ XRL0302 = Class(CWalkingLandUnit) {
             end
 
             WaitSeconds(3)
-        end
-    end,
-
-    --- Called when the unit dies - if it dies to some instigator then the suicide weapon is activated.
-    OnKilled = function(self, instigator, type, overkillRatio)
-        CWalkingLandUnit.OnKilled(self, instigator, type, overkillRatio)
-        if instigator then
-            self:GetWeaponByLabel('Suicide'):FireWeapon()
         end
     end,
     


### PR DESCRIPTION
Removes lonely LOG statements and fixes the following issues:

```
WARNING: Error running lua script: ...gramdata\faforever\gamedata\lua.nx5\lua\simutils.lua(73): Game object has been destroyed
         stack traceback:
             [C]: in function `SetEnabled'
             ...gramdata\faforever\gamedata\lua.nx5\lua\simutils.lua(73): in function <...gramdata\faforever\gamedata\lua.nx5\lua\simutils.lua:65>
```
As part of #3696, always check if it has not been destroyed after a wait.

```
WARNING: Failed to create emitter as you passed in an invalid blueprint name /effects/emitters/antiair_muzzle_fire_01_emit.bp.
WARNING: ...aforever\gamedata\lua.nx5\lua\sim\defaultweapons.lua(215): attempt to call method `ScaleEmitter' (a nil value)
WARNING: stack traceback:
WARNING:         ...aforever\gamedata\lua.nx5\lua\sim\defaultweapons.lua(215): in function <...aforever\gamedata\lua.nx5\lua\sim\defaultweapons.lua:213>
WARNING:         [C]: in function `pcall'
WARNING:         ...aforever\gamedata\lua.nx5\lua\sim\defaultweapons.lua(212): in function `PlayFxMuzzleSequence'
WARNING:         ...aforever\gamedata\lua.nx5\lua\sim\defaultweapons.lua(674): in function <...aforever\gamedata\lua.nx5\lua\sim\defaultweapons.lua:607>
```
As part of https://github.com/FAForever/fa/pull/3710, not sure why or how that got introduced. I suspect it is part of some testing code that never got cleaned up.

```
WARNING: Error running lua script: ...aforever\gamedata\lua.nx5\lua\effectutilitiesuef.lua(305): Game object has been destroyed
         stack traceback:
             [C]: ?
             ...aforever\gamedata\lua.nx5\lua\effectutilitiesuef.lua(305): in function <...aforever\gamedata\lua.nx5\lua\effectutilitiesuef.lua:255>
```

As part of #3701 , replacing the .Dead check with Entity.BeenDestroyed as apparently the c-object van be destroyed before the call is made. Sprouto warned us of this 😄 

```
WARNING: Error running OnKilled script in Entity xrl0302 at 1fbc7108: ...upreme commander\fa\units\xrl0302\xrl0302_script.lua(143): attempt to call method `FireWeapon' (a nil value)
         stack traceback:
         	...upreme commander\fa\units\xrl0302\xrl0302_script.lua(143): in function <...upreme commander\fa\units\xrl0302\xrl0302_script.lua:140>
         	[C]: in function `Kill'
         	...\jip\documents\supreme commander\fa\lua\sim\unit.lua(1122): in function `DoTakeDamage'
         	...\jip\documents\supreme commander\fa\lua\sim\unit.lua(1078): in function <...\jip\documents\supreme commander\fa\lua\sim\unit.lua:1064>
         	[C]: in function `DamageArea'
         	...ments\supreme commander\fa\lua\sim\collisionbeam.lua(104): in function `DoDamage'
         	...ments\supreme commander\fa\lua\sim\collisionbeam.lua(278): in function `OnImpact'
         	...s\supreme commander\fa\lua\defaultcollisionbeams.lua(240): in function <...s\supreme commander\fa\lua\defaultcollisionbeams.lua:231>
```
Fixes an issue with the beetle where its weapon is triggered twice, causing the second to fail.

