### PR TITLE
Fix projectile-related issues

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -646,8 +646,8 @@ Shield = Class(moho.shield_methods, Entity) {
         return IsEnemy(self.Army, other.Army)
     end,
 
-    --- Called when a unit collides with a collision beam to check if the collision is valid
-    -- @param self The unit we're checking the collision for
+    --- Called when a shield collides with a collision beam to check if the collision is valid
+    -- @param self The shield we're checking the collision for
     -- @param firingWeapon The weapon the beam originates from that we're checking the collision with
     OnCollisionCheckWeapon = function(self, firingWeapon)
 

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -637,7 +637,7 @@ Shield = Class(moho.shield_methods, Entity) {
         end
 
         -- special behavior for projectiles that represent strategic missiles
-        local otherHashedCats = other.BlueprintCache.HashedCats
+        local otherHashedCats = other.Cache.HashedCats
         if otherHashedCats['STRATEGIC'] and otherHashedCats['MISSILE'] then
             return false
         end

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -349,8 +349,8 @@ Projectile = Class(moho.projectile_methods, Entity) {
         return true
     end,
 
-    --- Called when a unit collides with a collision beam to check if the collision is valid
-    -- @param self The unit we're checking the collision for
+    --- Called when a projectile collides with a collision beam to check if the collision is valid
+    -- @param self The projectile we're checking the collision for
     -- @param firingWeapon The weapon the beam originates from that we're checking the collision with
     OnCollisionCheckWeapon = function(self, firingWeapon)
 

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -204,17 +204,7 @@ Projectile = Class(moho.projectile_methods, Entity) {
                     -- check for initial damage
                     local initialDmg = DamageData.InitialDamageAmount or 0
                     if initialDmg > 0 then
-                        if radius > 0 then      -- isn't this always false at this point?
-                            DamageArea(
-                                instigator, 
-                                cachedPosition, 
-                                radius, 
-                                initialDmg, 
-                                DamageData.DamageType, 
-                                DamageData.DamageFriendly, 
-                                DamageData.DamageSelf or false
-                            )
-                        elseif targetEntity then
+                        if targetEntity then
                             Damage(
                                 instigator, 
                                 cachedPosition, 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1498,6 +1498,7 @@ Unit = Class(moho.unit_methods) {
     --- Called when a unit collides with a projectile to check if the collision is valid
     -- @param self The unit we're checking the collision for
     -- @param other The projectile we're checking the collision with
+    -- @param firingWeapon The weapon that the projectile originates from
     OnCollisionCheck = function(self, other, firingWeapon)
 
         -- bail out immediately


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15778155/164181648-df2ed2f3-c245-41c5-bc5a-a1565a61e0d2.png)

Fixes the issue where collision beams can destroy projectiles other than tactical missiles and strategic missiles. Re-applies some table reductions removed by #3794 , but this time correct and with more documentation.