### PR TITLE
Fix issues with extractors

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1064,24 +1064,6 @@ MassCollectionUnit = Class(StructureUnit) {
         adjacentUnit:RequestRefreshUI()
     end,
 
-    OnCreate = function(self)
-        StructureUnit.OnCreate(self)
-        local markers = ScenarioUtils.GetMarkers()
-        local unitPosition = self:GetPosition()
-
-        for _, v in pairs(markers) do
-            if v.type == 'MASS' then
-                local massPosition = v.position
-                if (massPosition[1] < unitPosition[1] + 1) and (massPosition[1] > unitPosition[1] - 1) and
-                    (massPosition[2] < unitPosition[2] + 1) and (massPosition[2] > unitPosition[2] - 1) and
-                    (massPosition[3] < unitPosition[3] + 1) and (massPosition[3] > unitPosition[3] - 1) then
-                    self:SetProductionPerSecondMass(self:GetProductionPerSecondMass() * (v.amount / 100))
-                    break
-                end
-            end
-        end
-    end,
-
     OnStopBeingBuilt = function(self, builder, layer)
         StructureUnit.OnStopBeingBuilt(self, builder, layer)
         self:SetMaintenanceConsumptionActive()

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -908,10 +908,12 @@ Unit = Class(moho.unit_methods) {
 
     OnProductionPaused = function(self)
         self:SetMaintenanceConsumptionInactive()
+        self:SetProductionActive(false)
     end,
 
     OnProductionUnpaused = function(self)
         self:SetMaintenanceConsumptionActive()
+        self:SetProductionActive(true)
     end,
 
     SetBuildTimeMultiplier = function(self, time_mult)


### PR DESCRIPTION
Fixes an issue reported by AlfaViTe#4489 on Discord where extractors would still produce mass even when they are paused. Removes some old TA-like code that caused an extractor to loop over all the markers of the map when it is created. This can easily be more than thousands of markers on AI-related maps.