### PR TITLE
Allow for ambiguous states

### DIFF
--- a/lua/system/class.lua
+++ b/lua/system/class.lua
@@ -33,9 +33,20 @@
 -- - state
 -- - class 
 
+--- look up hierarchy to help determine the relationships between classes. 
+
+-- function: 1E0F3E00 (OnDestroy, id = 1) = { base instance }
+-- function: 1F45AA80 (OnGotTarget, id = 1) = { base instance }
+-- function: 1F3902D8 (OnCreate, id = 1) = { function: 1F37B500 (OnCreate, id = 1) }
+-- function: 1F40F0E0 (OnKilled, id = 1) = { function: 1F3D3EE0 (OnKilled, id = 1) }
+-- function: 1DE7E1C0 (BuilderParamCheck, id = 1) = { base instance }
+
+-- It allows us to track a function back to the base instance.
+local Hierarchy = { }
+
 --- Debug utilities
 
-local debug = false 
+local enableDebugging = false 
 
 local HierarchyDebugLookup = { }
 local HierarchyDebugLookupCFunctions = { }
@@ -51,9 +62,9 @@ local function PrintHierarchy()
         if HierarchyDebugLookupCFunctions[key] then 
             return "base instance (cfunction)"
         elseif HierarchyDebugLookup[key] then 
-            return tostring(key) .. " (" .. tostring(HierarchyDebugLookup[key].func)  .. ", id = " .. tostring(HierarchyDebugLookup[key].identity) .. ")"
+            return tostring(key) .. " (" .. tostring(HierarchyDebugLookup[key].func)  .. ", id = " .. tostring(HierarchyDebugLookup[key].identity) .. ", type = " .. tostring(HierarchyDebugLookup[key].type) .. ")"
         else 
-            return "base instance (lua function)"
+            return "base instance (lua function or table)"
         end
     end
 
@@ -79,6 +90,7 @@ local unpack = unpack
 local getmetatable = getmetatable
 local setmetatable = setmetatable
 
+local TableInsert = table.insert
 local TableEmpty = table.empty 
 local TableGetn = table.getn 
 
@@ -128,6 +140,7 @@ function State(...)
         local state = ConstructClass(nil, arg[1] )
         state.__State = true 
         state.__StateIdentifier = StateIdentifier
+        state.__StateInheritance = { }
         StateIdentifier = StateIdentifier + 1
         return state 
 
@@ -138,6 +151,13 @@ function State(...)
             local state = ConstructClass(bases, specs)
             state.__State = true 
             state.__StateIdentifier = StateIdentifier
+            state.__StateInheritance = { }
+            for k , v in bases do 
+                TableInsert(state.__StateInheritance, v.__StateIdentifier) 
+                for k, other in v.__StateInheritance do 
+                    TableInsert(state.__StateInheritance, other) 
+                end
+            end
             StateIdentifier = StateIdentifier + 1
             return state 
         end
@@ -178,18 +198,6 @@ function Class(...)
     end
 end
 
---- look up hierarchy to help determine the relationships between classes. Can be printed using 'PrintHierarchy' 
--- defined in the debug module. An example output is:
-
--- function: 1E0F3E00 (OnDestroy, id = 1) = { base instance }
--- function: 1F45AA80 (OnGotTarget, id = 1) = { base instance }
--- function: 1F3902D8 (OnCreate, id = 1) = { function: 1F37B500 (OnCreate, id = 1) }
--- function: 1F40F0E0 (OnKilled, id = 1) = { function: 1F3D3EE0 (OnKilled, id = 1) }
--- function: 1DE7E1C0 (BuilderParamCheck, id = 1) = { base instance }
-
--- It allows us to track a function back to the base instance.
-local Hierarchy = { }
-
 --- Computes the hierarchy chain of a function: determine the path from the current function back to 
 -- the base instance. Note that this assumes that the base is always called, which is not always the case.
 local ChainStack = { }
@@ -224,7 +232,7 @@ local function ComputeHierarchyChain(a, cache)
         end
     end
 
-    if debug then 
+    if enableDebugging then 
         LOG("Chain for: " .. tostring(a) .. " (" .. tostring(HierarchyDebugLookup[a].func)  .. ", id = " .. tostring(HierarchyDebugLookup[a].identity) .. ")")
         for k, v in cache do 
             LOG(tostring(k) .. ": " .. tostring(v))
@@ -237,20 +245,28 @@ local function CheckHierarchy(a, b)
 
     local c = ChainCache
 
-    -- populate the hierarchy chains
-    ComputeHierarchyChain(a, c)
+    -- cfunctions, functions and regular tables
+    if not a.__State then 
 
-    -- if the head of chain b is part of ca, then ca is longer
-    if c[b] then 
-        return a
+        -- populate the hierarchy chains
+        ComputeHierarchyChain(a, c)
+
+        -- if the head of chain b is part of ca, then ca is longer
+        if c[b] then 
+            return a
+        end
+
+        ComputeHierarchyChain(b, c)
+
+        -- if the head of chain a is part of cb, then cb is longer
+        if c[a] then 
+            return b
+        end 
+
+    -- states that do something different
+    else 
+
     end
-
-    ComputeHierarchyChain(b, c)
-
-    -- if the head of chain a is part of cb, then cb is longer
-    if c[a] then 
-        return b
-    end 
 
     -- not part of a hierarchy
     return false
@@ -294,16 +310,22 @@ function ConstructClass(bases, specs)
         -- keep track of hierarchy chains
         for ks, s in specs do 
             local t = type(s)
-            if t == "function" or t == "cfunction" then 
+            if t == "function" or t == "cfunction" or t == "table" then 
                 for kb, base in bases do 
                     -- we're trying to override something here
                     if base[ks] ~= nil then 
-
                         -- keep track of the names and give them some unique identifier
-                        if debug then 
+                        if enableDebugging then 
                             HierarchyDebugLookupCount[ks] = HierarchyDebugLookupCount[ks] or 0
                             HierarchyDebugLookupCount[ks] = HierarchyDebugLookupCount[ks] + 1
-                            HierarchyDebugLookup[s] = { func = ks, identity = HierarchyDebugLookupCount[ks] }  
+
+                            -- allow us to track states specifically
+                            local ts = t 
+                            if t == "table" and s.__State then 
+                                ts = "state"
+                            end
+
+                            HierarchyDebugLookup[s] = { func = ks, identity = HierarchyDebugLookupCount[ks], type = ts }  
                         end
 
                         -- link to or create a table
@@ -321,7 +343,6 @@ function ConstructClass(bases, specs)
         -- check for collisions 
         for k, base in bases do 
             for l, element in base do 
-                -- todo, refine this a bit
                 if not exclusions[l] then 
                     -- first time we've seen this key, keep track of it
                     if seen[l] == nil then 
@@ -334,22 +355,42 @@ function ConstructClass(bases, specs)
                     -- we've got two elements with the same key but different values, but our specs has a function to define the behavior: we're good
                     elseif specs[l] ~= nil then
                         -- do nothing
+                    else
+                        local t = type(element)
 
-                    -- we've got two elements with the same key but different values, check if they're not secretly a state with matching identifiers
-                    elseif type(element) == "table" and (seen[l].__StateIdentifier == element.__StateIdentifier) then
-                        -- do nothing 
+                        -- we've got two elements with the same key but different values that are states, check if their state identifiers match
+                        if t == "table" and element.__State and (element.__StateIdentifier == seen[l].__StateIdentifier) then
+                            -- do nothing, it is the same state
 
-                    else 
-                        -- check if one is part of the hierarchy of the other
-                        local hierarchy = CheckHierarchy(seen[l], element)
-                        if hierarchy then 
-                            class[l] = hierarchy 
-                            seen[l] = hierarchy 
+                        -- the following two statements are TECHNICALLY wrong, and should be fixed by manually determining the state
 
-                        -- we've got two elements with the same key but they're not part of each others hierarchy chain: ambigious!
-                        else    
-                            error("Class initialisation: field '" .. tostring(l).. "' is ambigious between the bases. They use the same field for different values. You need to create a field in the specifications that defines the behavior.")
-                            LOG(repr(debug.traceback()))
+                        -- we've got two elements with the same key but different values that are states - oh no!
+                        elseif t == "table" and element.__State and (element.__StateIdentifier < seen[l].__StateIdentifier) then 
+                            WARN("Ambigious state with identifier: " .. tostring(l) .. ", behavior is unpredictable. Solution is to choose the desired state of the basis in the specifications - this needs to be done by the author of the mod.")
+                            WARN(debug.traceback())
+
+                            -- do nothing
+                        
+                        -- we've got two elements with the same key but different values that are states - oh no!
+                        elseif t == "table" and element.__State and (element.__StateIdentifier > seen[l].__StateIdentifier) then 
+                            WARN("Ambigious state with identifier: " .. tostring(l) .. ", behavior is unpredictable. Solution is to choose the desired state of the basis in the specifications - this needs to be done by the author of the mod.")                           
+                            WARN(debug.traceback())
+
+                            -- switch them up, use the state made last
+                            class[l] = element 
+                            seen[l] = element 
+
+                        else 
+                            -- check if one is part of the hierarchy of the other
+                            local hierarchy = CheckHierarchy(seen[l], element)
+                            if hierarchy then 
+                                class[l] = hierarchy 
+                                seen[l] = hierarchy 
+
+                            -- we've got two elements with the same key but they're not part of each others hierarchy chain: ambigious!
+                            else    
+                                error("Class initialisation: field '" .. tostring(l).. "' is ambigious between the bases. They use the same field for different values. You need to create a field in the specifications that defines the behavior.")
+                            end
                         end
                     end
                 end
@@ -499,7 +540,7 @@ function ConvertCClassToLuaSimplifiedClass(cclass)
         cclass[k] = val 
 
         -- allow us to print it out
-        if debug then 
+        if enableDebugging then 
             HierarchyDebugLookupCFunctions[val] = true
         end
     end

--- a/lua/system/class.lua
+++ b/lua/system/class.lua
@@ -366,14 +366,14 @@ function ConstructClass(bases, specs)
 
                         -- we've got two elements with the same key but different values that are states - oh no!
                         elseif t == "table" and element.__State and (element.__StateIdentifier < seen[l].__StateIdentifier) then 
-                            WARN("Ambigious state with identifier: " .. tostring(l) .. ", behavior is unpredictable. Solution is to choose the desired state of the basis in the specifications - this needs to be done by the author of the mod.")
+                            WARN("ambiguous state with identifier: " .. tostring(l) .. ", behavior is unpredictable. Solution is to choose the desired state of the basis in the specifications - this needs to be done by the author of the mod.")
                             WARN(debug.traceback())
 
                             -- do nothing
                         
                         -- we've got two elements with the same key but different values that are states - oh no!
                         elseif t == "table" and element.__State and (element.__StateIdentifier > seen[l].__StateIdentifier) then 
-                            WARN("Ambigious state with identifier: " .. tostring(l) .. ", behavior is unpredictable. Solution is to choose the desired state of the basis in the specifications - this needs to be done by the author of the mod.")                           
+                            WARN("ambiguous state with identifier: " .. tostring(l) .. ", behavior is unpredictable. Solution is to choose the desired state of the basis in the specifications - this needs to be done by the author of the mod.")                           
                             WARN(debug.traceback())
 
                             -- switch them up, use the state made last

--- a/lua/system/class.lua
+++ b/lua/system/class.lua
@@ -140,7 +140,6 @@ function State(...)
         local state = ConstructClass(nil, arg[1] )
         state.__State = true 
         state.__StateIdentifier = StateIdentifier
-        state.__StateInheritance = { }
         StateIdentifier = StateIdentifier + 1
         return state 
 
@@ -151,13 +150,6 @@ function State(...)
             local state = ConstructClass(bases, specs)
             state.__State = true 
             state.__StateIdentifier = StateIdentifier
-            state.__StateInheritance = { }
-            for k , v in bases do 
-                TableInsert(state.__StateInheritance, v.__StateIdentifier) 
-                for k, other in v.__StateInheritance do 
-                    TableInsert(state.__StateInheritance, other) 
-                end
-            end
             StateIdentifier = StateIdentifier + 1
             return state 
         end

--- a/lua/system/class.lua
+++ b/lua/system/class.lua
@@ -237,28 +237,20 @@ local function CheckHierarchy(a, b)
 
     local c = ChainCache
 
-    -- cfunctions, functions and regular tables
-    if not a.__State then 
+    -- populate the hierarchy chains
+    ComputeHierarchyChain(a, c)
 
-        -- populate the hierarchy chains
-        ComputeHierarchyChain(a, c)
-
-        -- if the head of chain b is part of ca, then ca is longer
-        if c[b] then 
-            return a
-        end
-
-        ComputeHierarchyChain(b, c)
-
-        -- if the head of chain a is part of cb, then cb is longer
-        if c[a] then 
-            return b
-        end 
-
-    -- states that do something different
-    else 
-
+    -- if the head of chain b is part of ca, then ca is longer
+    if c[b] then 
+        return a
     end
+
+    ComputeHierarchyChain(b, c)
+
+    -- if the head of chain a is part of cb, then cb is longer
+    if c[a] then 
+        return b
+    end 
 
     -- not part of a hierarchy
     return false


### PR DESCRIPTION
Allows for ambiguous states. In contradiction to classes, a state doesn't typically inherit from another state. Instead, it just directly overwrites the previous state. As an example:

```lua
    -- of StructureUnit class
    IdleState = State {
        Main = function(self)
        end,
    },

    -- of FactoryUnit class
    IdleState = State {
        Main = function(self)
            self:SetBusy(false)
            self:SetBlockCommandQueue(false)
            self:DestroyBuildRotator()
        end,
    },
```

There is no base defined. Therefore anything we do is based on assumptions. And as we can't assume anything when mods are in play we can only make an educated guess.

Luckily, this appears to only happen with the `RKs Explosions` mod - at least what I've heard of. It is because of this pattern, that uses the example of earlier:

```
local oldFactoryUnit = FactoryUnit
FactoryUnit = Class(StructureUnit, oldFactoryUnit) { }
```