### PR TITLE
Fix wreckage not taking damage

### DIFF
--- a/lua/wreckage.lua
+++ b/lua/wreckage.lua
@@ -52,14 +52,6 @@ Wreckage = Class(Prop) {
     end,
 
     OnDamage = function(self, instigator, amount, vector, damageType)
-        if not self.CanTakeDamage then 
-            return 
-        end
-
-        self.DoTakeDamage(self, instigator, amount, vector, damageType)
-    end,
-
-    DoTakeDamage = function(self, instigator, amount, vector, damageType)
         EntityAdjustHealth(self, instigator, -amount)
         local health = EntityGetHealth(self)
 

--- a/lua/wreckage.lua
+++ b/lua/wreckage.lua
@@ -49,9 +49,16 @@ Wreckage = Class(Prop) {
         -- # Set state
 
         self.IsWreckage = true
+        self.CanTakeDamage = true 
     end,
 
     OnDamage = function(self, instigator, amount, vector, damageType)
+        if self.CanTakeDamage then 
+            self.DoTakeDamage(self, instigator, amount, vector, damageType)
+        end
+    end,
+
+    DoTakeDamage = function(self, instigator, amount, vector, damageType)
         EntityAdjustHealth(self, instigator, -amount)
         local health = EntityGetHealth(self)
 


### PR DESCRIPTION
Props were changed in #3714 to improve performance, a mistake slipped in that accidentally makes wrecks immune to damage. In particular, a wreck no longer calls the base class. The value `CanTakeDamage` was set in the base class. Wrecks now just always take damage.