### PR TITLE
Fix inconsistent lods

### DIFF
--- a/lua/system/blueprints-lod.lua
+++ b/lua/system/blueprints-lod.lua
@@ -10,6 +10,9 @@ local function CalculateLODOfProp(prop)
 
     -- give more emphasis to the x / z value as that is easier to see in the average camera angle
     local weighted = 0.40 * sx + 0.2 * sy + 0.4 * sz 
+    if prop.ScriptClass == 'Tree' or prop.ScriptClass == 'TreeGroup' then 
+        weighted = 4 
+    end
 
     -- 1 -> ~ 330
     -- 2 -> ~ 470
@@ -49,6 +52,7 @@ end
 -- @param props List of props to tweak the LODs for
 local function CalculateLODsOfProps(props)
     for k, prop in props do 
+        LOG(k)
         CalculateLODOfProp(prop)
     end
 end

--- a/lua/system/blueprints-lod.lua
+++ b/lua/system/blueprints-lod.lua
@@ -11,7 +11,7 @@ local function CalculateLODOfProp(prop)
     -- give more emphasis to the x / z value as that is easier to see in the average camera angle
     local weighted = 0.40 * sx + 0.2 * sy + 0.4 * sz 
     if prop.ScriptClass == 'Tree' or prop.ScriptClass == 'TreeGroup' then 
-        weighted = 4 
+        weighted = 3 
     end
 
     -- 1 -> ~ 330

--- a/lua/system/blueprints-lod.lua
+++ b/lua/system/blueprints-lod.lua
@@ -52,7 +52,6 @@ end
 -- @param props List of props to tweak the LODs for
 local function CalculateLODsOfProps(props)
     for k, prop in props do 
-        LOG(k)
         CalculateLODOfProp(prop)
     end
 end

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -164,22 +164,29 @@ function CreateUI(isReplay)
     ConExecute('d3d_WindowsCursor on')  
 
     -- enable experimental graphics
-    if      Prefs.GetFromCurrentProfile('options.fidelity') == 2 
+    if      Prefs.GetFromCurrentProfile('options.fidelity') >= 2 
         and Prefs.GetFromCurrentProfile('options.experimental_graphics') == 1 then 
 
-        LOG("Experimental graphics enabled, use at your own risk: ")
+        ForkThread(
+            function() 
 
-        if Prefs.GetFromCurrentProfile('options.level_of_detail') == 2 then 
-            -- allow meshes and effects to be seen from further away
-            ConExecute("cam_SetLOD WorldCamera 0.6")
-        end
+                WaitSeconds(1.0)
 
-        if Prefs.GetFromCurrentProfile('options.shadow_quality') == 3 then 
+                LOG("Experimental graphics enabled, use at your own risk: ")
 
-            -- improve shadow LOD and resolution
-            ConExecute("ren_ShadowLOD 1024")
-            ConExecute("ren_ShadowSize 2048")
-        end
+                if Prefs.GetFromCurrentProfile('options.level_of_detail') == 2 then 
+                    -- allow meshes and effects to be seen from further away
+                    ConExecute("cam_SetLOD WorldCamera 0.7")
+                end
+
+                if Prefs.GetFromCurrentProfile('options.shadow_quality') == 3 then 
+
+                    -- improve shadow LOD and resolution
+                    ConExecute("ren_ShadowLOD 1024")
+                    ConExecute("ren_ShadowSize 2048")
+                end
+            end
+        )
     end
 
     -- keep track of the original focus army


### PR DESCRIPTION
Tree groups could disappear when broken due to #3662. Now all trees share the same LOD, regardless whether they are an individual tree or a tree group.