### PR TITLE
Introduce .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,6 +2,7 @@
 
 # Changes all lines in lobby.lua
 b5ad96a044b34f12b1c95121c4b49297fc0d243d
+27d8e201037bbf0b78a631e3baa42ce22c007dd0
 
 # Changes all line endings to LF
 76f8ac36b322bae6c0145e9da7b56e3e5dabb1ca

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,7 +1,7 @@
 # https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
 
 # Changes all lines in lobby.lua
-27d8e201037bbf0b78a631e3baa42ce22c007dd0
+b5ad96a044b34f12b1c95121c4b49297fc0d243d
 
 # Changes all line endings to LF
 76f8ac36b322bae6c0145e9da7b56e3e5dabb1ca

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -5,3 +5,6 @@
 
 # Changes all line endings to LF
 76f8ac36b322bae6c0145e9da7b56e3e5dabb1ca
+
+# Global white space cleanup
+16d5cfebac6ddd19a3a9496b810beb9a1a73d950

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view
+
+# Changes all lines in lobby.lua
+27d8e201037bbf0b78a631e3baa42ce22c007dd0
+
+# Changes all line endings to LF
+76f8ac36b322bae6c0145e9da7b56e3e5dabb1ca

--- a/config
+++ b/config
@@ -1,0 +1,1 @@
+blame.ignorerevsfile=.git-blame-ignore-revs

--- a/config
+++ b/config
@@ -1,1 +1,0 @@
-blame.ignorerevsfile=.git-blame-ignore-revs


### PR DESCRIPTION
Allows us to ignore various large commits when using the blame view.

