### PR TITLE
Remove deprecation warnings

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -906,37 +906,36 @@ Shield = Class(moho.shield_methods, Entity) {
 
         Main = function(self)
 
-            if not DeprecatedWarnings.DamageRechargeState then 
-                DeprecatedWarnings.DamageRechargeState = true 
-                WARN("DamageRechargeState is deprecated: use shield.RechargeState instead.")
-                WARN("Unit type of owner: " .. self.Owner.UnitId)
-            end
+            -- if not DeprecatedWarnings.DamageRechargeState then 
+            --     DeprecatedWarnings.DamageRechargeState = true 
+            --     SPEW("DamageRechargeState is deprecated: use shield.RechargeState instead.")
+            --     SPEW("Unit type of owner: " .. self.Owner.UnitId)
+            --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+            -- end
 
             -- back to the regular onstate
             ChangeState(self, self.RechargeState)
         end,
     },
 
-
-
     GetCachePosition = function(self)
 
-        if not DeprecatedWarnings.GetCachePosition then 
-            DeprecatedWarnings.GetCachePosition = true 
-            WARN("GetCachePosition is deprecated: use shield:GetPosition() or shield:GetPositionXYZ() instead.")
-            WARN("Source: " .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.GetCachePosition then 
+        --     DeprecatedWarnings.GetCachePosition = true 
+        --     SPEW("GetCachePosition is deprecated: use shield:GetPosition() or shield:GetPositionXYZ() instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         return self:GetPosition()
     end,
 
     SetRechargeTime = function(self, rechargeTime, energyRechargeTime)
 
-        if not DeprecatedWarnings.SetRechargeTime then 
-            DeprecatedWarnings.SetRechargeTime = true 
-            WARN("SetRechargeTime is deprecated: set the values shield.ShieldRechargeTime and shield.ShieldEnergyDrainRechargeTime instead.")
-            WARN("Source: " .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.SetRechargeTime then 
+        --     DeprecatedWarnings.SetRechargeTime = true 
+        --     SPEW("SetRechargeTime is deprecated: set the values shield.ShieldRechargeTime and shield.ShieldEnergyDrainRechargeTime instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         self.ShieldRechargeTime = rechargeTime
         self.ShieldEnergyDrainRechargeTime = energyRechargeTime
@@ -944,55 +943,55 @@ Shield = Class(moho.shield_methods, Entity) {
 
     SetVerticalOffset = function(self, offset)
 
-        if not DeprecatedWarnings.SetVerticalOffset then 
-            DeprecatedWarnings.SetVerticalOffset = true 
-            WARN("SetVerticalOffset is deprecated: set the value shield.ShieldVerticalOffset instead.")
-            WARN("Source: " .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.SetVerticalOffset then 
+        --     DeprecatedWarnings.SetVerticalOffset = true 
+        --     SPEW("SetVerticalOffset is deprecated: set the value shield.ShieldVerticalOffset instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         self.ShieldVerticalOffset = offset
     end,
 
     SetSize = function(self, size)
 
-        if not DeprecatedWarnings.SetSize then 
-            DeprecatedWarnings.SetSize = true 
-            WARN("SetSize is deprecated: set the value shield.Size instead.")
-            WARN("Source: " .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.SetSize then 
+        --     DeprecatedWarnings.SetSize = true 
+        --     SPEW("SetSize is deprecated: set the value shield.Size instead.")
+        --     SPEW("Source: " .. repr(debug.traceback()))
+        -- end
 
         self.Size = size
     end,
 
     SetShieldRegenRate = function(self, rate)
 
-        if not DeprecatedWarnings.SetShieldRegenRate then 
-            DeprecatedWarnings.SetShieldRegenRate = true 
-            WARN("SetShieldRegenRate is deprecated: set the value shield.RegenRate instead.")
-            WARN("Source: " .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.SetShieldRegenRate then 
+        --     DeprecatedWarnings.SetShieldRegenRate = true 
+        --     SPEW("SetShieldRegenRate is deprecated: set the value shield.RegenRate instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         self.RegenRate = rate
     end,
 
     SetShieldRegenStartTime = function(self, time)
 
-        if not DeprecatedWarnings.SetShieldRegenStartTime then 
-            DeprecatedWarnings.SetShieldRegenStartTime = true 
-            WARN("SetShieldRegenStartTime is deprecated: set the value shield.RegenStartTime instead.")
-            WARN("Source: " .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.SetShieldRegenStartTime then 
+        --     DeprecatedWarnings.SetShieldRegenStartTime = true 
+        --     SPEW("SetShieldRegenStartTime is deprecated: set the value shield.RegenStartTime instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         self.RegenStartTime = time
     end,
 
     SetType = function(self, type)
 
-        if not DeprecatedWarnings.ShieldType then 
-            DeprecatedWarnings.ShieldType = true 
-            WARN("ShieldType is deprecated: set the value shield.ShieldType instead.")
-            WARN("Source: " .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.ShieldType then 
+        --     DeprecatedWarnings.ShieldType = true 
+        --     SPEW("ShieldType is deprecated: set the value shield.ShieldType instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         self.ShieldType = type
     end,

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -3,6 +3,7 @@ local Entity = import('/lua/sim/Entity.lua').Entity
 local PlayReclaimEndEffects = import('/lua/EffectUtilities.lua').PlayReclaimEndEffects
 
 local DeprecatedWarnings = { }
+
 local minimumLabelMass = 10
 
 -- upvalue globals for performance
@@ -438,11 +439,11 @@ Prop = Class(moho.prop_methods, Entity) {
     -- This should never be called - use the actual value.
     GetCachePosition = function(self)
 
-        if not DeprecatedWarnings.GetCachePosition then 
-            DeprecatedWarnings.GetCachePosition = true 
-            WARN("GetCachePosition is deprecated: use self.CachePosition instead")
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.GetCachePosition then 
+        --     DeprecatedWarnings.GetCachePosition = true 
+        --     SPEW("GetCachePosition is deprecated: use self.CachePosition instead")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         return self.CachePosition
     end,
@@ -450,11 +451,11 @@ Prop = Class(moho.prop_methods, Entity) {
     -- This should never be called - use the actual value. When set to false the prop can't take damage.
     SetCanTakeDamage = function(self, val)
 
-        if not DeprecatedWarnings.SetCanTakeDamage then 
-            DeprecatedWarnings.SetCanTakeDamage = true 
-            WARN("SetCanTakeDamage is deprecated: set self.CanTakeDamage instead")
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.SetCanTakeDamage then 
+        --     DeprecatedWarnings.SetCanTakeDamage = true 
+        --     SPEW("SetCanTakeDamage is deprecated: set self.CanTakeDamage instead")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         self.CanTakeDamage = val
     end,
@@ -462,11 +463,11 @@ Prop = Class(moho.prop_methods, Entity) {
     -- This should never be called - use the actual value. When set to false the prop can't be killed.
     SetCanBeKilled = function(self, val)
 
-        if not DeprecatedWarnings.SetCanBeKilled then 
-            DeprecatedWarnings.SetCanBeKilled = true 
-            WARN("SetCanBeKilled is deprecated: set self.SetCanBeKilled instead")
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.SetCanBeKilled then 
+        --     DeprecatedWarnings.SetCanBeKilled = true 
+        --     SPEW("SetCanBeKilled is deprecated: set self.SetCanBeKilled instead")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         self.CanBeKilled = val
     end,
@@ -474,11 +475,11 @@ Prop = Class(moho.prop_methods, Entity) {
     -- This should never be called - use the actual value. Retrieves whether the prop can be killed.
     CheckCanBeKilled = function(self, other)
 
-        if not DeprecatedWarnings.CheckCanBeKilled then 
-            DeprecatedWarnings.CheckCanBeKilled = true 
-            WARN("CheckCanBeKilled is deprecated: use self.CheckCanBeKilled instead")
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.CheckCanBeKilled then 
+        --     DeprecatedWarnings.CheckCanBeKilled = true 
+        --     SPEW("CheckCanBeKilled is deprecated: use self.CheckCanBeKilled instead")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         return self.CanBeKilled
     end,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4354,9 +4354,8 @@ Unit = Class(moho.unit_methods) {
 
         if not DeprecatedWarnings.AddOnHorizontalStartMoveCallback then 
             DeprecatedWarnings.AddOnHorizontalStartMoveCallback = true 
-            WARN("AddOnHorizontalStartMoveCallback is deprecated.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
+            WARN("AddOnHorizontalStartMoveCallback is deprecated and no longer functional. There is no alternative.")
+            WARN("Stacktrace: " .. repr(debug.traceback()))
         end
 
     end,
@@ -4365,12 +4364,11 @@ Unit = Class(moho.unit_methods) {
     -- in practice, nor by this repository or by any of the commonly played mod packs.
     StartRocking = function(self)
 
-        if not DeprecatedWarnings.StartRocking then 
-            DeprecatedWarnings.StartRocking = true 
-            WARN("StartRocking is deprecated.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.StartRocking then 
+        --     DeprecatedWarnings.StartRocking = true 
+        --     SPEW("StartRocking is deprecated.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         local bp = self.Blueprint.Display
         local speed = bp.MaxRockSpeed
@@ -4390,12 +4388,11 @@ Unit = Class(moho.unit_methods) {
     -- in practice, nor by this repository or by any of the commonly played mod packs.
     StopRocking = function(self)
 
-        if not DeprecatedWarnings.StopRocking then 
-            DeprecatedWarnings.StopRocking = true 
-            WARN("StopRocking is deprecated.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.StopRocking then 
+        --     DeprecatedWarnings.StopRocking = true 
+        --     SPEW("StopRocking is deprecated.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         if self.StartRockThread then
             -- clear it so that GC can take it
@@ -4412,12 +4409,11 @@ Unit = Class(moho.unit_methods) {
     --- Rocking thread to move a unit when it is on the water.
     RockingThread = function(self, speed)
 
-        if not DeprecatedWarnings.RockingThread then 
-            DeprecatedWarnings.RockingThread = true 
-            WARN("RockingThread is deprecated.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.RockingThread then 
+        --     DeprecatedWarnings.RockingThread = true 
+        --     SPEW("RockingThread is deprecated.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         -- default value
         speed = speed or 1.5
@@ -4444,12 +4440,11 @@ Unit = Class(moho.unit_methods) {
     -- warping to the original position.
     EndRockingThread = function(self, speed)
 
-        if not DeprecatedWarnings.EndRockingThread then 
-            DeprecatedWarnings.EndRockingThread = true 
-            WARN("EndRockingThread is deprecated.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.EndRockingThread then 
+        --     DeprecatedWarnings.EndRockingThread = true 
+        --     SPEW("EndRockingThread is deprecated.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         if self.RockManip then
 
@@ -4468,12 +4463,11 @@ Unit = Class(moho.unit_methods) {
     end,
 
     updateBuildRestrictions = function(self)
-        if not DeprecatedWarnings.updateBuildRestrictions then 
-            WARN("updateBuildRestrictions is deprecated. Call unit.UpdateBuildRestrictions instead.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-            DeprecatedWarnings.updateBuildRestrictions = true 
-        end
+        -- if not DeprecatedWarnings.updateBuildRestrictions then 
+        --     SPEW("updateBuildRestrictions is deprecated. Call unit.UpdateBuildRestrictions instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        --     DeprecatedWarnings.updateBuildRestrictions = true 
+        -- end
 
         -- call the old function
         self.UpdateBuildRestrictions(self)
@@ -4482,110 +4476,99 @@ Unit = Class(moho.unit_methods) {
     FindHQType = function(aiBrain, category)
         if not DeprecatedWarnings.FindHQType then 
             DeprecatedWarnings.FindHQType = true 
-            WARN("FindHQType is deprecated since PR #3319.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
+            WARN("FindHQType is deprecated and is no longer functional. There is no alternative.")
+            WARN("Stacktrace: " .. repr(debug.traceback()))
         end
     end,
 
     SetDead = function(self)
-        if not DeprecatedWarnings.SetDead then 
-            DeprecatedWarnings.SetDead = true 
-            WARN("SetDead is deprecated: use unit.Dead = true instead.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.SetDead then 
+        --     DeprecatedWarnings.SetDead = true 
+        --     SPEW("SetDead is deprecated: use unit.Dead = true instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
         self.Dead = true
     end,
 
     IsDead = function(self)
-        if not DeprecatedWarnings.IsDead then 
-            DeprecatedWarnings.IsDead = true 
-            WARN("IsDead is deprecated: use unit.Dead instead.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.IsDead then 
+        --     DeprecatedWarnings.IsDead = true 
+        --     SPEW("IsDead is deprecated: use unit.Dead instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         return self.Dead
     end,
 
     GetCachePosition = function(self)
-        if not DeprecatedWarnings.GetCachePosition then 
-            DeprecatedWarnings.GetCachePosition = true 
-            WARN("GetCachePosition is deprecated: use unit:GetPosition() instead.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.GetCachePosition then 
+        --     DeprecatedWarnings.GetCachePosition = true 
+        --     SPEW("GetCachePosition is deprecated: use unit:GetPosition() instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
         return self:GetPosition()
     end,
     
     GetFootPrintSize = function(self)
-        if not DeprecatedWarnings.GetFootPrintSize then 
-            DeprecatedWarnings.GetFootPrintSize = true 
-            WARN("GetFootPrintSize is deprecated: use unit.FootPrintSize instead.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.GetFootPrintSize then 
+        --     DeprecatedWarnings.GetFootPrintSize = true 
+        --     SPEW("GetFootPrintSize is deprecated: use unit.FootPrintSize instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
         return self.FootPrintSize
     end,
     
     GetUnitSizes = function(self)
-        if not DeprecatedWarnings.GetUnitSizes then 
-            DeprecatedWarnings.GetUnitSizes = true 
-            WARN("GetUnitSizes is deprecated: use unit.Size.SizeX, unit.Size.SizeY, unit.Size.SizeZ instead.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.GetUnitSizes then 
+        --     DeprecatedWarnings.GetUnitSizes = true 
+        --     SPEW("GetUnitSizes is deprecated: use unit.Size.SizeX, unit.Size.SizeY, unit.Size.SizeZ instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
         return self.Size.SizeX, self.Size.SizeY, self.Size.SizeZ
     end,
 
     SetCanTakeDamage = function(self, val)
-        if not DeprecatedWarnings.SetCanTakeDamage then 
-            DeprecatedWarnings.SetCanTakeDamage = true 
-            WARN("SetCanTakeDamage is deprecated: use unit.CanTakeDamage = val instead.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.SetCanTakeDamage then 
+        --     DeprecatedWarnings.SetCanTakeDamage = true 
+        --     SPEW("SetCanTakeDamage is deprecated: use unit.CanTakeDamage = val instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
         self.CanTakeDamage = val
     end,
 
     CheckCanTakeDamage = function(self)
-        if not DeprecatedWarnings.CheckCanTakeDamage then 
-            DeprecatedWarnings.CheckCanTakeDamage = true 
-            WARN("CheckCanTakeDamage is deprecated: use unit.CanTakeDamage instead.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.CheckCanTakeDamage then 
+        --     DeprecatedWarnings.CheckCanTakeDamage = true 
+        --     SPEW("CheckCanTakeDamage is deprecated: use unit.CanTakeDamage instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
         return self.CanTakeDamage
     end,
 
     CheckCanBeKilled = function(self, other)
-        if not DeprecatedWarnings.CheckCanBeKilled then 
-            DeprecatedWarnings.CheckCanBeKilled = true 
-            WARN("CheckCanBeKilled is deprecated: use unit.CanBeKilled instead.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.CheckCanBeKilled then 
+        --     DeprecatedWarnings.CheckCanBeKilled = true 
+        --     SPEW("CheckCanBeKilled is deprecated: use unit.CanBeKilled instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
         return self.CanBeKilled
     end,
     
     SetCanBeKilled = function(self, val)
-        if not DeprecatedWarnings.SetCanBeKilled then 
-            DeprecatedWarnings.SetCanBeKilled = true 
-            WARN("SetCanBeKilled is deprecated: use unit.CanBeKilled = val instead.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.SetCanBeKilled then 
+        --     DeprecatedWarnings.SetCanBeKilled = true 
+        --     SPEW("SetCanBeKilled is deprecated: use unit.CanBeKilled = val instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
         self.CanBeKilled = val
     end,
 
     GetUnitBeingBuilt = function(self)
-        if not DeprecatedWarnings.GetUnitBeingBuilt then
-            DeprecatedWarnings.GetUnitBeingBuilt = true
-            WARN("GetUnitBeingBuilt is deprecated: use unit.UnitBeingBuilt instead.")
-            WARN("Source: " .. repr(debug.getinfo(2)))
-            WARN("Stacktrace:" .. repr(debug.traceback()))
-        end
+        -- if not DeprecatedWarnings.GetUnitBeingBuilt then
+        --     DeprecatedWarnings.GetUnitBeingBuilt = true
+        --     SPEW("GetUnitBeingBuilt is deprecated: use unit.UnitBeingBuilt instead.")
+        --     SPEW("Stacktrace: " .. repr(debug.traceback()))
+        -- end
 
         return self.UnitBeingBuilt
     end,


### PR DESCRIPTION
Removes the deprecation warnings as it confused mod and map makers. It will come back in an alternative format that makes them easier to toggle on / off for the game developers.