### PR TITLE
Re-introduce input delay when there is one or fewer players

### DIFF
--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -287,14 +287,6 @@ function CreateUI(isReplay)
         import('/lua/ui/game/economy.lua').ToggleEconPanel(false)
         import('/lua/ui/game/avatars.lua').ToggleAvatars(false)
         AddBeatFunction(UiBeat)
-    else
-        -- check if we should reduce network delay / lag
-        local clients = GetSessionClients()
-        if table.getsize(clients) <= 1 then
-            if not HasCommandLineArg("/RunWithTheWind") then 
-                ConExecute('net_lag 0')
-            end
-        end
     end
 
     if options.gui_render_enemy_lifebars == 1 or options.gui_render_custom_names == 0 then


### PR DESCRIPTION
Reverts https://github.com/FAForever/fa/commit/cfe4dab93011cdb428d2dba864e67287e80e50eb that removes the input delay of 500ms when someone is playing alone. It also reverts #3653, that tried to tackle this issue.

It introduces a significant penalty on the simulation, causes a wide range of stuttering and introducing the 11'th tick, slowing down the game even though the simulation is at +0. It also breaks the `wld_RunWithTheWind` command.

This behavior was captured with the Benchmark map where there is only one player. The benchmark map could easily be 40 to 50 seconds (on a scale of 180 seconds) faster. A few data points:
 - 120.6 revised 74.6
 - 155.9 seconds (revised time: 91.9422 seconds ) 
 
The impact is most notable when you speed up the game. But it is also notable when the game is running at +0. It shows itself as the 'hidden 11th tick' that slows down the game, even though there is nothing going on. I'm not sure why this is - I assume the desync check happens significantly more often. It has to be something that is quite expensive.

I'd argue that co-op maps, AI players that tend to play alone and AI-vs-AI game will experience a game that can easily be described as 'twice as smooth' .
