### PR TITLE
Add New Patchnotes Button

### DIFF
--- a/loc/US/strings_db.lua
+++ b/loc/US/strings_db.lua
@@ -7566,6 +7566,7 @@ lobui_0430="Country not found. Please contact the development team on the forums
 lobui_0431="Close - spawn mex"
 lobui_0432="Closed - spawn mex"
 lobui_0433="Curated Maps"
+lobui_1000="Patchnotes"
 tooltipui0360 = "Set how quickly the Game runs"
 
 sorian_0001="AI: Sorian"

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3030,15 +3030,15 @@ function CreateUI(maxPlayers)
     GUI.gameVersionText:SetColor('677983')
     GUI.gameVersionText:SetDropShadow(true)
     LayoutHelpers.AtLeftTopIn(GUI.gameVersionText, GUI.panel, 70, 3)
-    GUI.gameVersionText.HandleEvent = function (self, event)
-        if event.Type == 'MouseEnter' then
-            self:SetColor('ffffff')
-        elseif event.Type == 'MouseExit' then
-            self:SetColor('677983')
-        elseif event.Type == 'ButtonPress' then
-            Changelog.Changelog(GUI)
-        end
-    end
+    --GUI.gameVersionText.HandleEvent = function (self, event)
+    --    if event.Type == 'MouseEnter' then
+    --        self:SetColor('ffffff')
+    --    elseif event.Type == 'MouseExit' then
+    --        self:SetColor('677983')
+    --    elseif event.Type == 'ButtonPress' then
+    --        Changelog.Changelog(GUI)
+    --    end
+    --end
 
     -- Player Slots
     GUI.playerPanel = Group(GUI.panel, "playerPanel")
@@ -3209,6 +3209,16 @@ function CreateUI(maxPlayers)
         GUI.OptionContainer.ScrollSetTop(GUI.OptionContainer, 'Vert', 0)
         Prefs.SetToCurrentProfile('LobbyHideDefaultOptions', tostring(checked))
     end
+
+    -- Patchnotes Button
+    GUI.patchnotesButton = UIUtil.CreateButtonWithDropshadow(GUI.panel, '/Button/medium/', "<LOC lobui_1000>Patchnotes")
+    Tooltip.AddButtonTooltip(GUI.patchnotesButton, 'lob_patchnotes')
+    LayoutHelpers.AtBottomIn(GUI.patchnotesButton, GUI.optionsPanel, -51)
+    LayoutHelpers.AtHorizontalCenterIn(GUI.patchnotesButton, GUI.optionsPanel, -55)
+    GUI.patchnotesButton.OnClick = function(self, event)
+        Changelog.Changelog(GUI)
+    end
+
 
     -- curated Maps
     -- GUI.curatedmapsButton = UIUtil.CreateButtonWithDropshadow(GUI.panel, '/Button/medium/', "<LOC lobui_0433>Curated Maps")


### PR DESCRIPTION
Add a new patchnotes button next to where the options/mod manager button is and link to the new patchnotes screen.
![image](https://user-images.githubusercontent.com/20344151/167177813-df1905b0-eac0-456e-9543-5a7e7f8a86cb.png)

And removed the ability to access the patchnotes from the Game Patch X text
![image](https://user-images.githubusercontent.com/20344151/167177961-6b6249f3-03f4-426d-abbe-2d25cb5ca179.png)

