### PR TITLE
Optimized weapon prioritization by re-using single table

### DIFF
--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -470,7 +470,7 @@ Weapon = Class(moho.weapon_methods) {
                     count = count + 1
                 end
                 self:SetTargetingPriorities(priorityTable)
-                for i = 1, table.getn(priorityTable) do
+                for i = 1, count - 1 do
                     priorityTable[i] = nil
                 end
             end
@@ -483,7 +483,7 @@ Weapon = Class(moho.weapon_methods) {
                     count = count + 1
                 end
                 self:SetTargetingPriorities(priorityTable)
-                for i = 1, table.getn(priorityTable) do
+                for i = 1, count - 1 do
                     priorityTable[i] = nil
                 end
             else

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -479,7 +479,7 @@ Weapon = Class(moho.weapon_methods) {
                 local count = 1
                 local priorityTable = RecycledPriTable
                 for k, v in priTable do
-                    priorityTable[count] = ParseEntityCategory[v]
+                    priorityTable[count] = ParseEntityCategory(v)
                     count = count + 1
                 end
                 self:SetTargetingPriorities(priorityTable)

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -37,13 +37,6 @@ local function ParsePriorities()
     return finalPriorities
 end
 
-local function ClearRecycledPriTable()
-    local UnclearedRecycledPriTable = RecycledPriTable
-    for i = 1, table.getn(RecycledPriTable) do
-        UnclearedRecycledPriTable[i] = nil
-    end
-end
-
 Weapon = Class(moho.weapon_methods) {
     __init = function(self, unit)
         self.unit = unit
@@ -452,6 +445,7 @@ Weapon = Class(moho.weapon_methods) {
     end,
 
     SetWeaponPriorities = function(self, priTable)
+
         if not cachedPriorities then
             cachedPriorities = ParsePriorities()
         end
@@ -476,6 +470,9 @@ Weapon = Class(moho.weapon_methods) {
                     count = count + 1
                 end
                 self:SetTargetingPriorities(priorityTable)
+                for i = 1, table.getn(priorityTable) do
+                    priorityTable[i] = nil
+                end
             end
         else
             if type(priTable[1]) == 'string' then
@@ -486,11 +483,13 @@ Weapon = Class(moho.weapon_methods) {
                     count = count + 1
                 end
                 self:SetTargetingPriorities(priorityTable)
+                for i = 1, table.getn(priorityTable) do
+                    priorityTable[i] = nil
+                end
             else
                 self:SetTargetingPriorities(priTable)
             end
         end
-        ClearRecycledPriTable()
     end,
 
     WeaponUsesEnergy = function(self)

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -479,7 +479,7 @@ Weapon = Class(moho.weapon_methods) {
                 local count = 1
                 local priorityTable = RecycledPriTable
                 for k, v in priTable do
-                    priorityTable[count] = cachedPriorities[v]
+                    priorityTable[count] = ParseEntityCategory[v]
                     count = count + 1
                 end
                 self:SetTargetingPriorities(priorityTable)


### PR DESCRIPTION
For issue #3758 

Followed Approach 1 and added RecycledPriTable in the outer scope. This table is re-used and cleared each time SetWeaponPriorities() is run.

Followed the [table insertion benchmarks](https://github.com/FAForever/fa/blob/deploy/fafdevelop/lua/benchmarking/benchmarks/table-insert.lua) for inserting into the priority table as well.

I ran through a few bot matches just to make sure I didn't break the game, but I'm new to Lua and FAF so I may have missed something, please let me know if you spot any issues and I'll attempt to fix them 😁

Edit by Jip: closes #3758