### PR TITLE
Fix a bug with Alliance of Heroes mod

### DIFF
--- a/lua/sim/Entity.lua
+++ b/lua/sim/Entity.lua
@@ -10,7 +10,9 @@
 -- administrator of the repository to discuss your changes before assuming
 -- that your changes will get merged in.
 
-local _c_CreateEntity = _c_CreateEntity 
+-- This file gets imported by UI mods sometimes, not sure why. But it prevents 
+-- us from scoping this as an upvalue
+-- local _c_CreateEntity = _c_CreateEntity 
 
 Entity = Class(moho.entity_methods) {
 


### PR DESCRIPTION
(https://github.com/FAForever/fa/pull/3824) introduced an upvalue that caused issues with some UI mods importing sim related files. One of those files was the Entity script. Removing the upvalue improves compatibility with unmaintained UI mods.