### PR TITLE
Update the shield bar more often

### DIFF
--- a/lua/defaultantiprojectile.lua
+++ b/lua/defaultantiprojectile.lua
@@ -81,7 +81,6 @@ MissileRedirect = Class(Entity) {
         -- Return true to process this collision, false to ignore it.
         WaitingState = State {
             OnCollisionCheck = function(self, other)
-                LOG("OnCollisionCheck")
                 if EntityCategoryContains(categories.MISSILE, other) and not EntityCategoryContains(categories.STRATEGIC, other) and
                    other ~= self.EnemyProj and IsEnemy(self.Army, other.Army) then
                     self.Enemy = other:GetLauncher()

--- a/lua/defaultantiprojectile.lua
+++ b/lua/defaultantiprojectile.lua
@@ -81,6 +81,7 @@ MissileRedirect = Class(Entity) {
         -- Return true to process this collision, false to ignore it.
         WaitingState = State {
             OnCollisionCheck = function(self, other)
+                LOG("OnCollisionCheck")
                 if EntityCategoryContains(categories.MISSILE, other) and not EntityCategoryContains(categories.STRATEGIC, other) and
                    other ~= self.EnemyProj and IsEnemy(self.Army, other.Army) then
                     self.Enemy = other:GetLauncher()

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -503,9 +503,6 @@ Shield = Class(moho.shield_methods, Entity) {
             -- take some damage
             EntityAdjustHealth(self, instigator, -absorbed)
 
-            -- adjust shield bar
-            self:UpdateShieldRatio(-1)
-
             -- check to spawn impact effect
             local r = Random(1, self.Size)
             if  dmgType ~= "ShieldSpill"

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -282,7 +282,7 @@ Shield = Class(moho.shield_methods, Entity) {
                 -- if not, yield for the difference in ticks
                 end
 
-                -- adjust shield bar
+                -- adjust shield bar as we may be assisted
                 self:UpdateShieldRatio(-1)
             end
 

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -279,12 +279,13 @@ Shield = Class(moho.shield_methods, Entity) {
 
                     -- adjust health, rate is in seconds 
                     EntityAdjustHealth(self, self.Owner, 0.1 * self.RegenRate)
+                    health = health + 0.1 * self.RegenRate
 
                 -- if not, yield for the difference in ticks
                 end
 
                 -- adjust shield bar as we may be assisted
-                self:UpdateShieldRatio((health + 0.1 * self.RegenRate) / maxHealth)
+                self:UpdateShieldRatio(health / maxHealth)
             end
 
             -- wait till next tick

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -260,6 +260,10 @@ Shield = Class(moho.shield_methods, Entity) {
                 -- we're not recharged
                 or  not self.Recharged
             then 
+                -- adjust shield bar one last time
+                self:UpdateShieldRatio(-1)
+
+                -- suspend ourselves and wait
                 self.RegenThreadSuspended = true 
                 SuspendCurrentThread()
                 self.RegenThreadSuspended = false
@@ -275,13 +279,11 @@ Shield = Class(moho.shield_methods, Entity) {
                     -- adjust health, rate is in seconds 
                     EntityAdjustHealth(self, self.Owner, 0.1 * self.RegenRate)
 
-                    -- adjust shield bar
-                    self:UpdateShieldRatio(-1)
-
                 -- if not, yield for the difference in ticks
-                else 
-                    CoroutineYield(self.RegenThreadStartTick - tick )
                 end
+
+                -- adjust shield bar
+                self:UpdateShieldRatio(-1)
             end
 
             -- wait till next tick

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -248,20 +248,21 @@ Shield = Class(moho.shield_methods, Entity) {
             local fromSuspension = false
             local tick = GetGameTick()
             local health = EntityGetHealth(self)
+            local maxHealth = EntityGetMaxHealth(self)
 
             -- check if we need to suspend ourself
             if 
                 -- we're at zero health or lower
                     health <= 0 
                 -- we're full health
-                or  health == EntityGetMaxHealth(self) 
+                or  health == maxHealth
                 -- we're not enabled
                 or  not self.Enabled 
                 -- we're not recharged
                 or  not self.Recharged
             then 
                 -- adjust shield bar one last time
-                self:UpdateShieldRatio(-1)
+                self:UpdateShieldRatio(health / maxHealth)
 
                 -- suspend ourselves and wait
                 self.RegenThreadSuspended = true 
@@ -283,7 +284,7 @@ Shield = Class(moho.shield_methods, Entity) {
                 end
 
                 -- adjust shield bar as we may be assisted
-                self:UpdateShieldRatio(-1)
+                self:UpdateShieldRatio((health + 0.1 * self.RegenRate) / maxHealth)
             end
 
             -- wait till next tick

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -279,7 +279,6 @@ Shield = Class(moho.shield_methods, Entity) {
 
                     -- adjust health, rate is in seconds 
                     EntityAdjustHealth(self, self.Owner, 0.1 * self.RegenRate)
-                    health = health + 0.1 * self.RegenRate
 
                 -- if not, yield for the difference in ticks
                 end


### PR DESCRIPTION
Fixes an issue introduced by #3699 . The shield bar (the blue bar below the shield) was not being updated often enough. In turn, the shield bar was not always in sync with the actual health of the shield. This was most notable when the shield is being assisted, right after it took damage and when it was done healing (when being assisted). 

This was purely a visual glitch, the shield was being healed and it was in fact full health 😄 .