### PR TITLE
Reduce memory impact

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,5 +7,6 @@ b5ad96a044b34f12b1c95121c4b49297fc0d243d
 # Changes all line endings to LF
 76f8ac36b322bae6c0145e9da7b56e3e5dabb1ca
 
-# Global white space cleanup
+# white space cleanups
 16d5cfebac6ddd19a3a9496b810beb9a1a73d950
+ce65d77916260cb29d021a036d484e84bd38eabd

--- a/lua/EffectUtilitiesAeon.lua
+++ b/lua/EffectUtilitiesAeon.lua
@@ -82,7 +82,7 @@ local function SharedBuildThread(pool, unitBeingBuilt, unitBeingBuiltTrash, unit
     if EntityCategoryContains(CategoriesHover, unitBeingBuilt) then 
 
         -- set elevation offset
-        offset = unitBeingBuilt.Elevation or 0
+        offset = unitBeingBuilt.Blueprint.Elevation or 0
 
         -- create a slider
         slider = CreateSlider(unitBeingBuilt, 0)
@@ -132,7 +132,7 @@ local function SharedBuildThread(pool, unitBeingBuilt, unitBeingBuiltTrash, unit
     end
 
     -- set correct shader of unitBeingBuilt so that it happens instantly after finishing
-    unitBeingBuilt:SetMesh(unitBeingBuilt.MeshBlueprint, true)
+    unitBeingBuilt:SetMesh(unitBeingBuilt.Blueprint.Display.MeshBlueprint, true)
 end
 
 --- The build animation for Aeon buildings in general.
@@ -153,12 +153,12 @@ function CreateAeonBuildBaseThread(unitBeingBuilt, builder, effectsBag)
 
     local effect = false
     local army = unitBeingBuilt.Army
-    local orientation = EntityGetOrientation(unitBeingBuilt)
     local unitBeingBuiltTrash = unitBeingBuilt.Trash
     local unitOnStopBeingBuiltTrash = unitBeingBuilt.OnBeingBuiltEffectsBag
-    local sx = unitBeingBuilt.BuildExtentsX
-    local sz = unitBeingBuilt.BuildExtentsZ
-    local sy = unitBeingBuilt.BuildExtentsY or (sx + sz)
+    local bp = unitBeingBuilt.Blueprint
+    local sx = bp.Physics.MeshExtentsX or bp.Footprint.SizeX
+    local sz = bp.Physics.MeshExtentsZ or bp.Footprint.SizeZ
+    local sy = bp.Physics.MeshExtentsY or bp.Footprint.SizeYX or (sx + sz)
 
     -- # Create pool of mercury
 
@@ -166,7 +166,7 @@ function CreateAeonBuildBaseThread(unitBeingBuilt, builder, effectsBag)
     TrashBagAdd(unitBeingBuiltTrash, pool)
     TrashBagAdd(unitOnStopBeingBuiltTrash, pool)
 
-    EntitySetOrientation(pool, orientation, true)
+    EntitySetOrientation(pool, EntityGetOrientation(unitBeingBuilt), true)
     ProjectileSetScale(pool, sx, sy * 1.5, sz)
 
     -- # Create effects
@@ -229,9 +229,9 @@ function CreateAeonFactoryBuildingEffects(builder, unitBeingBuilt, buildEffectBo
         local unitBeingBuiltTrash = unitBeingBuilt.Trash
         local unitOnStopBeingBuiltTrash = unitBeingBuilt.OnBeingBuiltEffectsBag
 
-        local sx = unitBeingBuilt.BuildExtentsX
-        local sz = unitBeingBuilt.BuildExtentsZ
-        local sy = unitBeingBuilt.BuildExtentsY or (sx + sz)
+        local sx = unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
+        local sz = unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
+        local sy = unitBeingBuilt.Blueprint.Physics.MeshExtentsY or unitBeingBuilt.Blueprint.Footprint.SizeY or (sx + sz)
 
         -- # Create pool of mercury
 
@@ -443,9 +443,9 @@ function CreateAeonCZARBuildingEffects(unitBeingBuilt)
     local onFinishedTrash = unitBeingBuilt.OnBeingBuiltEffectsBag
     local orientation = EntityGetOrientation(unitBeingBuilt)
 
-    local sx = 0.6 * unitBeingBuilt.BuildExtentsX
-    local sz = 0.6 * unitBeingBuilt.BuildExtentsZ
-    local sy = 1.5 * (unitBeingBuilt.BuildExtentsY or (sx + sz))
+    local sx = 0.6 * unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
+    local sz = 0.6 * unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
+    local sy = 1.5 * unitBeingBuilt.Blueprint.Physics.MeshExtentsY or unitBeingBuilt.Blueprint.Footprint.SizeY or (sx + sz)
 
     -- # Create generic build effects
 
@@ -513,9 +513,9 @@ function CreateAeonTempestBuildingEffects(unitBeingBuilt)
     local onFinishedTrash = unitBeingBuilt.OnBeingBuiltEffectsBag
     local orientation = EntityGetOrientation(unitBeingBuilt)
 
-    local sx = 0.55 * unitBeingBuilt.BuildExtentsX
-    local sz = 0.55 * unitBeingBuilt.BuildExtentsZ
-    local sy = 3 * unitBeingBuilt.BuildExtentsY or (sx + sz)
+    local sx = 0.55 * unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
+    local sz = 0.55 * unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
+    local sy = 3 * unitBeingBuilt.Blueprint.Physics.MeshExtentsY or unitBeingBuilt.Blueprint.Footprint.SizeY or (sx + sz)
 
     -- # Create effects of build animation
 
@@ -619,9 +619,9 @@ function CreateAeonParagonBuildingEffects(unitBeingBuilt)
     local onFinishedTrash = unitBeingBuilt.OnBeingBuiltEffectsBag
     local orientation = EntityGetOrientation(unitBeingBuilt)
 
-    local sx = 1 * unitBeingBuilt.BuildExtentsX
-    local sz = 1 * unitBeingBuilt.BuildExtentsZ
-    local sy = 2 * unitBeingBuilt.BuildExtentsY or (sx + sz)
+    local sx = 1 * unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
+    local sz = 1 * unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
+    local sy = 2 * unitBeingBuilt.Blueprint.Physics.MeshExtentsY or unitBeingBuilt.Blueprint.Footprint.SizeY or (sx + sz)
 
     -- # Create effects of build animation
 

--- a/lua/EffectUtilitiesSeraphim.lua
+++ b/lua/EffectUtilitiesSeraphim.lua
@@ -72,12 +72,15 @@ function CreateSeraphimFactoryBuildingEffects(builder, unitBeingBuilt, effectBon
 
     local effect = false
     local army = builder.Army
-    local sy = unitBeingBuilt.BuildExtentsY or (unitBeingBuilt.BuildExtentsX + unitBeingBuilt.BuildExtentsZ) or 1
+    local bp = unitBeingBuilt.Blueprint
+    local sx = bp.Physics.MeshExtentsX or bp.Footprint.SizeX
+    local sz = bp.Physics.MeshExtentsZ or bp.Footprint.SizeZ
+    local sy = bp.Physics.MeshExtentsY or bp.Footprint.SizeYX or (sx + sz)
 
     -- do not apply offsets for subs and air units
     local offset = 0
     if unitBeingBuilt.Cache.HashedCats["HOVER"] then
-        offset = unitBeingBuilt.Elevation or 0
+        offset = bp.Elevation or 0
     end
 
     -- # Create effects for each build bone
@@ -166,7 +169,10 @@ function CreateSeraphimBuildThread(unitBeingBuilt, builder, effectsBag, scaleFac
     -- determine a sane LOD cutoff for the size of the unit
     local lods = unitBeingBuilt.Blueprint.Display.Mesh.LODs
     local count = TableGetn(lods)
-    local LODCutoff = 0.9 * lods[count].LODCutoff or (90 * MathMax(unitBeingBuilt.BuildExtentsX, unitBeingBuilt.BuildExtentsZ))
+
+    local sx = unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
+    local sz = unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
+    local LODCutoff = 0.9 * lods[count].LODCutoff or (90 * MathMax(sx, sz))
 
     -- smaller inner, dark-purple effect
     for _, vEffect in BuildEffectsEmitters do
@@ -193,7 +199,7 @@ function CreateSeraphimBuildThread(unitBeingBuilt, builder, effectsBag, scaleFac
     -- # Scale effects until the unit is finished
 
     -- only naval factories are not square, use the Z axis to get largest axis
-    local unitScaleMetric = unitBeingBuilt.BuildExtentsZ * 0.75
+    local unitScaleMetric = 0.75 * sz
     local complete = UnitGetFractionComplete(unitBeingBuilt)
     while not unitBeingBuilt.Dead and complete < 1.0 do
 

--- a/lua/EffectUtilitiesUEF.lua
+++ b/lua/EffectUtilitiesUEF.lua
@@ -134,9 +134,9 @@ function CreateUEFBuildSliceBeams(
     end
 
     -- Determine beam positioning on build cube, this should match sizes of CreateBuildCubeThread
-    local ox = unitBeingBuilt.BuildExtentsX
-    local oz = unitBeingBuilt.BuildExtentsZ
-    local oy = unitBeingBuilt.BuildExtentsY
+    local ox = unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
+    local oz = unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
+    local oy = unitBeingBuilt.Blueprint.Physics.MeshExtentsY or unitBeingBuilt.Blueprint.Footprint.SizeY or (ox + oz)
 
     ox = ox * 0.5
     oz = oz * 0.5
@@ -266,9 +266,9 @@ function CreateBuildCubeThread(
     local px, py, pz = EntityGetPositionXYZ(unitBeingBuilt)
     py = py + (unitBeingBuilt.Blueprint.Physics.MeshExtentsOffsetY or 0)
 
-    local bx = unitBeingBuilt.BuildExtentsX
-    local by = unitBeingBuilt.BuildExtentsY
-    local bz = unitBeingBuilt.BuildExtentsZ
+    local bx = unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
+    local bz = unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
+    local by = unitBeingBuilt.Blueprint.Physics.MeshExtentsY or unitBeingBuilt.Blueprint.Footprint.SizeY or (bx + bz)
 
     -- create a quick glow effect
     local proj = EntityCreateProjectile(unitBeingBuilt, '/effects/Entities/UEFBuildEffect/UEFBuildEffect02_proj.bp', 0, 0, 0, nil, nil, nil)
@@ -420,9 +420,9 @@ function CreateUEFCommanderBuildSliceBeams(
     end
 
     -- Determine beam positioning on build cube, this should match sizes of CreateBuildCubeThread
-    local ox = unitBeingBuilt.BuildExtentsX
-    local oz = unitBeingBuilt.BuildExtentsZ
-    local oy = unitBeingBuilt.BuildExtentsY
+    local ox = unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
+    local oz = unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
+    local oy = unitBeingBuilt.Blueprint.Physics.MeshExtentsY or unitBeingBuilt.Blueprint.Footprint.SizeY or (ox + oz)
 
     ox = ox * 0.5
     oz = oz * 0.5

--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -411,7 +411,7 @@ CConstructionUnit = Class(ConstructionUnit, CConstructionTemplate){
     end,
 
     LayerChangeTrigger = function(self, new, old)
-        if self.AnimationWater then
+        if self.Blueprint.Display.AnimationWater then
             if self.TerrainLayerTransitionThread then
                 self.TerrainLayerTransitionThread:Destroy()
                 self.TerrainLayerTransitionThread = nil
@@ -429,7 +429,7 @@ CConstructionUnit = Class(ConstructionUnit, CConstructionTemplate){
         end
 
         if water then
-            self.TransformManipulator:PlayAnim(self.AnimationWater)
+            self.TransformManipulator:PlayAnim(self.Blueprint.Display.AnimationWater)
             self.TransformManipulator:SetRate(1)
             self.TransformManipulator:SetPrecedence(0)
         else

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -37,7 +37,7 @@ StructureUnit = Class(Unit) {
     OnCreate = function(self)
         Unit.OnCreate(self)
         self:HideLandBones()
-        self.WeaponMod = {}
+        self.AdjacentUnits = {}
         self.FxBlinkingLightsBag = {}
         if self.Layer == 'Land' and self.Blueprint.Physics.FlattenSkirt then
             self:FlattenSkirt()

--- a/lua/proptree.lua
+++ b/lua/proptree.lua
@@ -39,15 +39,6 @@ local EffectSetEmitterCurveParam = EffectMethods.SetEmitterCurveParam
 
 Tree = Class(Prop) {
 
-    --- Initialize the tree
-    OnCreate = function (self, spec)
-        Prop.OnCreate(self, spec)
-        self.NoBurn = false
-        self.Burning = false 
-        self.Fallen = false
-        self.Dead = false 
-    end,
-
     OnDestroy = function(self)
         Prop.OnDestroy(self)
 
@@ -77,7 +68,6 @@ Tree = Class(Prop) {
     --- When damaged in some fashion - note that the tree can only be destroyed by disintegrating 
     -- damage and that the base class is not called accordingly.
     OnDamage = function(self, instigator, amount, direction, type)
-
         if not self.Dead then 
 
             local canFall = not self.Fallen 

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -44,11 +44,7 @@ local StringGsub = string.gsub
 -- upvalue table functions for performance
 local TableInsert = table.insert
 
-Prop = Class(moho.prop_methods, Entity) {
-
-    -- override the functions provided in the Entity class: we don't need an additional c-object!
-    __init = false,
-    __post_init = false,
+Prop = Class(moho.prop_methods) {
 
     OnCreate = function(self)
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -181,71 +181,69 @@ Unit = Class(moho.unit_methods) {
         }
 
         self.EventCallbacks = {
-            OnKilled = {},
-            OnUnitBuilt = {},
-            OnStartBuild = {},
-            OnReclaimed = {},
-            OnStartReclaim = {},
-            OnStopReclaim = {},
-            OnStopBeingBuilt = {},
-            OnCaptured = {},
-            OnCapturedNewUnit = {},
-            OnDamaged = {},
-            OnStartCapture = {},
-            OnStopCapture = {},
-            OnFailedCapture = {},
-            OnStartBeingCaptured = {},
-            OnStopBeingCaptured = {},
-            OnFailedBeingCaptured = {},
-            OnFailedToBuild = {},
-            OnVeteran = {},
-            OnGiven = {},
-            ProjectileDamaged = {},
-            SpecialToggleEnableFunction = false,
-            SpecialToggleDisableFunction = false,
-            OnAttachedToTransport = {}, -- Returns self, transport, bone
-            OnDetachedFromTransport = {}, -- Returns self, transport, bone
+            -- OnKilled = {},
+            -- OnUnitBuilt = {},
+            -- OnStartBuild = {},
+            -- OnReclaimed = {},
+            -- OnStartReclaim = {},
+            -- OnStopReclaim = {},
+            -- OnStopBeingBuilt = {},
+            -- OnCaptured = {},
+            -- OnCapturedNewUnit = {},
+            -- OnDamaged = {},
+            -- OnStartCapture = {},
+            -- OnStopCapture = {},
+            -- OnFailedCapture = {},
+            -- OnStartBeingCaptured = {},
+            -- OnStopBeingCaptured = {},
+            -- OnFailedBeingCaptured = {},
+            -- OnFailedToBuild = {},
+            -- OnVeteran = {},
+            -- OnGiven = {},
+            -- ProjectileDamaged = {},
+            -- SpecialToggleEnableFunction = false,
+            -- SpecialToggleDisableFunction = false,
+            -- OnAttachedToTransport = {}, -- Returns self, transport, bone
+            -- OnDetachedFromTransport = {}, -- Returns self, transport, bone
         }
     end,
 
     OnCreate = function(self)
-        local blueprint = self:GetBlueprint()
+        local bp = self:GetBlueprint()
 
         -- populate blueprint cache if we haven't done that yet
-        if not SharedTypeCache[blueprint.BlueprintId] then 
-            PopulateBlueprintCache(self, blueprint)
+        if not SharedTypeCache[bp.BlueprintId] then 
+            PopulateBlueprintCache(self, bp)
         end
 
         -- copy reference from meta table to inner table
-        self.Cache = SharedTypeCache[blueprint.BlueprintId]
+        self.Cache = SharedTypeCache[bp.BlueprintId]
 
         -- cache often accessed values into inner table
-        self.UnitId = self:GetUnitId()
-        self.Brain = self:GetAIBrain()
-        self.Blueprint = blueprint
+        self.Blueprint = bp
         self.FootPrintSize = math.max(self.Blueprint.Footprint.SizeX, self.Blueprint.Footprint.SizeZ)
-        self.Audio = self.Cache.Audio
+        self.techCategory = bp.TechCategory
+        self.layerCategory = bp.LayerCategory
+        self.factionCategory = bp.FactionCategory
+        self.MovementEffects = bp.Display.MovementEffects
+        self.Audio = bp.Audio
 
-        -- cache unique values into inner table
+        -- cache engine calls
         self.EntityId = self:GetEntityId()
         self.Army = self:GetArmy()
-        self.Layer = self:GetCurrentLayer()
+        self.UnitId = self:GetUnitId()
+        self.Brain = self:GetAIBrain()
 
         -- the entity that produces sound, by default ourself
         self.SoundEntity = self
 
-        local bp = self.Blueprint
 
-        -- cache commonly used values from the engine
-        -- self.Layer = self:GetCurrentLayer() -- Not required: ironically OnLayerChange is called _before_ OnCreate is called!
 
         -- Store size information for performance
         self.Footprint = { SizeX = bp.Footprint.SizeX, SizeZ = bp.Footprint.SizeZ }
-        self.FootPrintSize = math.max(self.Footprint.SizeX, self.Footprint.SizeZ)
         self.SkirtOffset = { OffsetX = bp.Physics.SkirtOffsetX, OffsetZ = bp.Physics.SkirtOffsetZ }
         self.SkirtSize = { SizeX = bp.Physics.SkirtSizeX, SizeZ = bp.Physics.SkirtSizeZ }
         self.Size = { SizeX = bp.SizeX, SizeY = bp.SizeY, SizeZ = bp.SizeZ }
-        self.CollisionOffsetY = bp.CollisionOffsetY
 
         -- Set number of effects per damage depending on its volume
         local x, y, z = self.Size.SizeX, self.Size.SizeY, self.Size.SizeZ
@@ -286,25 +284,10 @@ Unit = Class(moho.unit_methods) {
         self.UpgradeEffectsBag = TrashBag()
         self.TeleportFxBag = TrashBag()
 
-        -- Store targets and attackers for proper Stealth management
-        self.Targets = {}
-        self.WeaponTargets = {}
-        self.WeaponAttackers = {}
-
         -- Set up veterancy
         self.xp = 0
         self.Instigators = {}
         self.totalDamageTaken = 0
-
-        self.debris_Vector = Vector(0, 0, 0)
-
-        -- Store build information for performance
-        self.BuildExtentsX = bp.Physics.MeshExtentsX or bp.Footprint.SizeX
-        self.BuildExtentsZ = bp.Physics.MeshExtentsZ or bp.Footprint.SizeZ
-        self.BuildExtentsY = bp.Physics.MeshExtentsY or math.max(self.BuildExtentsX, self.BuildExtentsZ)
-        self.Elevation = bp.Physics.Elevation
-        self.MeshBlueprint = bp.Display.MeshBlueprint
-        self.MeshBuildBlueprint = bp.Display.MeshBuildBlueprint
 
         -- Store weapon information for performance
         self.WeaponCount = self:GetWeaponCount() or 0
@@ -314,18 +297,6 @@ Unit = Class(moho.unit_methods) {
             self.WeaponInstances[weapon.Label] = weapon
             self.WeaponInstances[k] = weapon
         end
-
-        -- Store animations for performance
-        self.AnimationWater = bp.Display.AnimationWater
-
-        -- Store common accessed information for performance
-        self.Audio = bp.Audio
-        self.Brain = self:GetAIBrain()
-        self.UnitId = self:GetUnitId()
-        self.techCategory = bp.TechCategory
-        self.layerCategory = bp.LayerCategory
-        self.factionCategory = bp.FactionCategory
-        self.MovementEffects = bp.Display.MovementEffects
 
         -- Define Economic modifications
         local bpEcon = bp.Economy
@@ -343,8 +314,7 @@ Unit = Class(moho.unit_methods) {
             Affects = {},
         }
 
-        local bpVision = bp.Intel.VisionRadius
-        self:SetIntelRadius('Vision', bpVision or 0)
+        self:SetIntelRadius('Vision', bp.Intel.VisionRadius or 0)
 
         self.CanTakeDamage = true
         self.CanBeKilled = true
@@ -358,23 +328,13 @@ Unit = Class(moho.unit_methods) {
         self.MaintenanceConsumption = false
         self.ActiveConsumption = false
         self.ProductionEnabled = true
-        self.EnergyModifier = 0
-        self.MassModifier = 0
-
-        -- Cheating
-        if self:GetAIBrain().CheatEnabled then
-            AIUtils.ApplyCheatBuffs(self)
-        end
-
-        self.Dead = false
-
-        -- Ensure transport slots are available
-        self.attachmentBone = nil
-
-        -- Set up Adjacency container
-        self.AdjacentUnits = {}
 
         self.Repairers = {}
+
+        -- Cheating
+        if self.Brain.CheatEnabled then
+            AIUtils.ApplyCheatBuffs(self)
+        end
     end,
 
     -------------------------------------------------------------------------------------------
@@ -393,6 +353,7 @@ Unit = Class(moho.unit_methods) {
     end,
 
     GetRandomOffset = function(self, scalar)
+        local bp = self.blueprint
         local size = self.Size
         local sx, sy, sz = size.SizeX, size.SizeY, size.SizeZ
         local heading = self:GetHeading()
@@ -402,7 +363,7 @@ Unit = Class(moho.unit_methods) {
         sz = sz * scalar
 
         local rx = Random() * sx - (sx * 0.5)
-        local y  = Random() * sy + (self.CollisionOffsetY or 0)
+        local y  = Random() * sy + (bp.CollisionOffsetY or 0)
         local rz = Random() * sz - (sz * 0.5)
 
         local cosh = math.cos(heading)
@@ -1018,8 +979,8 @@ Unit = Class(moho.unit_methods) {
             local mai_mass = myBlueprint.Economy.MaintenanceConsumptionPerSecondMass or 0
 
             -- Apply economic bonuses
-            mai_energy = mai_energy * (100 + self.EnergyModifier) * (self.EnergyMaintAdjMod or 1) * 0.01
-            mai_mass = mai_mass * (100 + self.MassModifier) * (self.MassMaintAdjMod or 1) * 0.01
+            mai_energy = mai_energy * (100 + (self.EnergyModifier or 0)) * (self.EnergyMaintAdjMod or 1) * 0.01
+            mai_mass = mai_mass * (100 + (self.MassModifier or 0)) * (self.MassMaintAdjMod or 1) * 0.01
 
             energy_rate = energy_rate + mai_energy
             mass_rate = mass_rate + mai_mass
@@ -3748,10 +3709,7 @@ Unit = Class(moho.unit_methods) {
     -- UNIT CALLBACKS
     -------------------------------------------------------------------------------------------
     AddUnitCallback = function(self, fn, type)
-        if not fn then
-            error('*ERROR: Tried to add a callback type - ' .. type .. ' with a nil function')
-            return
-        end
+        self.EventCallbacks[type] = self.EventCallbacks[type] or { }
         table.insert(self.EventCallbacks[type], fn)
     end,
 
@@ -3768,10 +3726,6 @@ Unit = Class(moho.unit_methods) {
     end,
 
     AddOnCapturedCallback = function(self, cbOldUnit, cbNewUnit)
-        if not cbOldUnit and not cbNewUnit then
-            error('*ERROR: Tried to add an OnCaptured callback without any functions', 2)
-            return
-        end
         if cbOldUnit then
             self:AddUnitCallback(cbOldUnit, 'OnCaptured')
         end
@@ -3795,13 +3749,16 @@ Unit = Class(moho.unit_methods) {
     end,
 
     AddOnUnitBuiltCallback = function(self, fn, category)
+        self.EventCallbacks.OnUnitBuilt = self.EventCallbacks.OnUnitBuilt or { }
         table.insert(self.EventCallbacks['OnUnitBuilt'], {category=category, cb=fn})
     end,
 
     DoOnUnitBuiltCallbacks = function(self, unit)
-        for _, v in self.EventCallbacks['OnUnitBuilt'] or {} do
-            if unit and not unit.Dead and EntityCategoryContains(v.category, unit) then
-                v.cb(self, unit)
+        if self.EventCallbacks.OnUnitBuilt then 
+            for _, v in self.EventCallbacks.OnUnitBuilt do
+                if unit and not unit.Dead and EntityCategoryContains(v.category, unit) then
+                    v.cb(self, unit)
+                end
             end
         end
     end,
@@ -3819,12 +3776,9 @@ Unit = Class(moho.unit_methods) {
     end,
 
     AddOnDamagedCallback = function(self, fn, amount, repeatNum)
-        if not fn then
-            error('*ERROR: Tried to add an OnDamaged callback with a nil function')
-            return
-        end
         local num = amount or -1
         repeatNum = repeatNum or 1
+        self.EventCallbacks.OnDamaged = self.EventCallbacks.OnDamaged or { }
         table.insert(self.EventCallbacks.OnDamaged, {Func = fn, Amount=num, Called=0, Repeat = repeatNum})
     end,
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -216,6 +216,61 @@ Unit = Class(moho.unit_methods) {
             PopulateBlueprintCache(self, bp)
         end
 
+
+
+local ok, msg = pcall(
+    function()
+
+        if true then 
+            return 
+        end
+
+        local lookUp = { }
+
+        -- keep the duplicate values in a table that has a weak reference to the value, e.g. if this
+        -- is the only reference then they can get dropped.
+        local duplicates = { }
+        setmetatable(duplicates, { __mode = "v" })
+
+        -- construct a lookup table, keep track of the duplicates
+        for k, other in __blueprints do 
+            if type(k) == 'string' then 
+                table.insert(duplicates, other)
+            else
+                lookUp[other.BlueprintId] = k
+            end
+        end
+
+        -- do a shallow copy from the one used by entity:GetBlueprint() to the more user friendly version
+        for hash, id in lookUp do 
+            if __blueprints[hash].BlueprintId == __blueprints[id].BlueprintId then 
+                __blueprints[hash] = __blueprints[id]
+            else 
+                LOG(string.format("Error: %s doesn't match %i", hash, id))
+            end
+        end
+
+        -- sanity check
+        LOG(table.getn(duplicates))         -- one less because blueprints start at [0]
+        LOG(table.getsize(__blueprints))
+        LOG(table.getsize(lookUp))
+
+        -- check if they get dropped, this should happen in a second or two. But they never do :sad:
+        self.Trash:Add(ForkThread(
+            function()
+                while true do 
+                    WaitSeconds(1.0)
+                    LOG(table.getn(duplicates))
+                end
+            end
+        ))
+    end
+)
+
+reprol(msg)
+
+
+
         -- copy reference from meta table to inner table
         self.Cache = SharedTypeCache[bp.BlueprintId]
 

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -399,3 +399,9 @@ function AIModTemplatesPreloader()
         end
     end
 end
+
+LOG("Sim init: check if they are the same")
+LOG(__blueprints[__blueprints[1].BlueprintId])
+LOG(__blueprints[1])
+LOG(table.getsize(__blueprints))
+

--- a/lua/terranunits.lua
+++ b/lua/terranunits.lua
@@ -131,7 +131,7 @@ TConstructionUnit = Class(ConstructionUnit) {
     end,
 
     LayerChangeTrigger = function(self, new, old)
-        if self.AnimationWater then
+        if self.Blueprint.Display.AnimationWater then
             if self.TerrainLayerTransitionThread then
                 self.TerrainLayerTransitionThread:Destroy()
                 self.TerrainLayerTransitionThread = nil
@@ -149,7 +149,7 @@ TConstructionUnit = Class(ConstructionUnit) {
         end
 
         if water then
-            self.TransformManipulator:PlayAnim(self.AnimationWater)
+            self.TransformManipulator:PlayAnim(self.Blueprint.Display.AnimationWater)
             self.TransformManipulator:SetRate(1)
             self.TransformManipulator:SetPrecedence(0)
         else

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -66,3 +66,8 @@ local oldEntityCategoryFilterOut = EntityCategoryFilterOut
 function EntityCategoryFilterOut(categories, units)
     return oldEntityCategoryFilterOut(categories, units or {})
 end
+
+LOG("User init: check if they are the same")
+LOG(__blueprints[__blueprints[1].BlueprintId])
+LOG(__blueprints[1])
+LOG(table.getsize(__blueprints))


### PR DESCRIPTION
From the GPG era, over the years on FAF and throughout the last year of FAF we've been consistently adding fields to units. As it turns out, these fields are expensive: each field takes up 20 bytes of information. In this pull request we carefully look at tables that come in large quantities (units, projectiles, props, weapons) and carefully evaluate if a field should exist or not.