### PR TITLE
Chat settings window fixes & small improvements

### DIFF
--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -1459,9 +1459,16 @@ function CreateConfigWindow()
         index = index + 1
     end
 
+    local okBtn -- for reuse okBtn's.Onclick and for keeping buttons in logical order in the code flow (Apply + Reset | Ok + Cancel)
+    local applyBtn = UIUtil.CreateButtonStd(optionGroup, '/widgets02/small', '<LOC OPTIONS_0139>', 16)
+    LayoutHelpers.Below(applyBtn, optionGroup.options[index-1], 4)
+    LayoutHelpers.AtLeftIn(applyBtn, optionGroup)
+    applyBtn.OnClick = function(self) okBtn.OnClick(self, true) end -- re-use okBtn's click, but set noCloseDlg param
+
     local resetBtn = UIUtil.CreateButtonStd(optionGroup, '/widgets02/small', '<LOC _Reset>', 16)
     LayoutHelpers.Below(resetBtn, optionGroup.options[index-1], 4)
-    LayoutHelpers.AtHorizontalCenterIn(resetBtn, optionGroup)
+    LayoutHelpers.AtRightIn(resetBtn, optionGroup)
+    LayoutHelpers.ResetLeft(resetBtn)
     resetBtn.OnClick = function(self)
         for option, value in defOptions do
             for i, control in optionGroup.options do
@@ -1483,15 +1490,17 @@ function CreateConfigWindow()
         end
     end
 
-    local okBtn = UIUtil.CreateButtonStd(optionGroup, '/widgets02/small', '<LOC _Ok>', 16)
+    okBtn = UIUtil.CreateButtonStd(optionGroup, '/widgets02/small', '<LOC _Ok>', 16)
     LayoutHelpers.Below(okBtn, resetBtn, 4)
     LayoutHelpers.AtLeftIn(okBtn, optionGroup)
-    okBtn.OnClick = function(self)
+    okBtn.OnClick = function(self, noCloseDlg)
         ChatOptions = table.merged(ChatOptions, tempOptions)
         Prefs.SetToCurrentProfile("chatoptions", ChatOptions)
         GUI.bg:OnOptionsSet()
-        GUI.config:Destroy()
-        GUI.config = false
+        if (noCloseDlg or true) ~= true then -- preserve normal ok's behavior
+            GUI.config:Destroy()
+            GUI.config = false
+        end
     end
 
     local cancelBtn = UIUtil.CreateButtonStd(optionGroup, '/widgets02/small', '<LOC _Cancel>', 16)

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -1258,10 +1258,12 @@ function CreateConfigWindow()
         br = UIUtil.SkinnableFile('/game/panel/panel_brd_lr.dds'),
         borderColor = 'ff415055',
     }
-    GUI.config = Window(GetFrame(0), '<LOC chat_0008>Chat Options', nil, nil, nil, true, false, 'chat_config', nil, windowTextures)
+
+    local defPosition = Prefs.GetFromCurrentProfile('chat_config') or nil
+    GUI.config = Window(GetFrame(0), '<LOC chat_0008>Chat Options', nil, nil, nil, true, true, 'chat_config', defPosition, windowTextures)
     GUI.config.Depth:Set(GetFrame(0):GetTopmostDepth() + 1)
     Tooltip.AddButtonTooltip(GUI.config._closeBtn, 'chat_close')
-    LayoutHelpers.AnchorToTop(GUI.config, GetFrame(0), 0)
+    LayoutHelpers.AnchorToBottom(GUI.config, GetFrame(0), -700)
     LayoutHelpers.SetWidth(GUI.config, 300)
     LayoutHelpers.AtHorizontalCenterIn(GUI.config, GetFrame(0))
     LayoutHelpers.ResetRight(GUI.config)
@@ -1515,6 +1517,13 @@ function CreateConfigWindow()
 
 
     GUI.config.Bottom:Set(function() return okBtn.Bottom() + 5 end)
+    if defPosition ~= nil then
+        GUI.config.Top:Set(defPosition.top)
+        GUI.config.Left:Set(defPosition.left)
+    else
+        GUI.config.Top:Set(function() return 90 end)
+    end
+    GUI.config:SetPositionLock(false) -- allow window to be draggable, didn't worked in Window() call
 end
 
 function CloseChatConfig()

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -1258,10 +1258,10 @@ function CreateConfigWindow()
         br = UIUtil.SkinnableFile('/game/panel/panel_brd_lr.dds'),
         borderColor = 'ff415055',
     }
-    GUI.config = Window(GetFrame(0), '<LOC chat_0008>Chat Options', nil, nil, nil, true, true, 'chat_config', nil, windowTextures)
+    GUI.config = Window(GetFrame(0), '<LOC chat_0008>Chat Options', nil, nil, nil, true, false, 'chat_config', nil, windowTextures)
     GUI.config.Depth:Set(GetFrame(0):GetTopmostDepth() + 1)
     Tooltip.AddButtonTooltip(GUI.config._closeBtn, 'chat_close')
-    LayoutHelpers.AnchorToBottom(GUI.config, GetFrame(0), -700)
+    LayoutHelpers.AnchorToTop(GUI.config, GetFrame(0), 0)
     LayoutHelpers.SetWidth(GUI.config, 300)
     LayoutHelpers.AtHorizontalCenterIn(GUI.config, GetFrame(0))
     LayoutHelpers.ResetRight(GUI.config)
@@ -1305,7 +1305,7 @@ function CreateConfigWindow()
                 {type = 'color', name = '<LOC _Links>', key = 'link_color', tooltip = 'chat_color'},
                 {type = 'color', name = '<LOC notify_0033>', key = 'notify_color', tooltip = 'chat_color'},
                 {type = 'splitter'},
-                {type = 'slider', name = '<LOC chat_0009>Chat Font Size', key = 'font_size', tooltip = 'chat_fontsize', min = 12, max = 18, inc = 2},
+                {type = 'slider', name = '<LOC chat_0009>Chat Font Size', key = 'font_size', tooltip = 'chat_fontsize', min = 12, max = 18, inc = 1},
                 {type = 'slider', name = '<LOC chat_0010>Window Fade Time', key = 'fade_time', tooltip = 'chat_fadetime', min = 5, max = 30, inc = 1},
                 {type = 'slider', name = '<LOC chat_0011>Window Alpha', key = 'win_alpha', tooltip = 'chat_alpha', min = 20, max = 100, inc = 1},
                 {type = 'splitter'},

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -248,7 +248,7 @@ function CreateChatLines()
             for i = curEntries + 1, neededEntries do
                 local index = i
                 GUI.chatLines[index] = CreateChatLine()
-                LayoutHelpers.Below(GUI.chatLines[index], GUI.chatLines[index-1], 2)
+                LayoutHelpers.Below(GUI.chatLines[index], GUI.chatLines[index-1], 0)
                 GUI.chatLines[index].Height:Set(function() return GUI.chatLines[index].name.Height() + 4 end)
                 GUI.chatLines[index].Right:Set(GUI.chatContainer.Right)
             end
@@ -281,7 +281,7 @@ function CreateChatLines()
             index = index + 1
             if not GUI.chatLines[index] then
                 GUI.chatLines[index] = CreateChatLine()
-                LayoutHelpers.Below(GUI.chatLines[index], GUI.chatLines[index-1], 2)
+                LayoutHelpers.Below(GUI.chatLines[index], GUI.chatLines[index-1], 0)
                 GUI.chatLines[index].Height:Set(function() return GUI.chatLines[index].name.Height() + 4 end)
                 GUI.chatLines[index].Right:Set(GUI.chatContainer.Right)
             end

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -1459,11 +1459,14 @@ function CreateConfigWindow()
         index = index + 1
     end
 
-    local okBtn -- for reuse okBtn's.Onclick and for keeping buttons in logical order in the code flow (Apply + Reset | Ok + Cancel)
     local applyBtn = UIUtil.CreateButtonStd(optionGroup, '/widgets02/small', '<LOC OPTIONS_0139>', 16)
     LayoutHelpers.Below(applyBtn, optionGroup.options[index-1], 4)
     LayoutHelpers.AtLeftIn(applyBtn, optionGroup)
-    applyBtn.OnClick = function(self) okBtn.OnClick(self, true) end -- re-use okBtn's click, but set noCloseDlg param
+    applyBtn.OnClick = function(self)
+        ChatOptions = table.merged(ChatOptions, tempOptions)
+        Prefs.SetToCurrentProfile("chatoptions", ChatOptions)
+        GUI.bg:OnOptionsSet()
+    end
 
     local resetBtn = UIUtil.CreateButtonStd(optionGroup, '/widgets02/small', '<LOC _Reset>', 16)
     LayoutHelpers.Below(resetBtn, optionGroup.options[index-1], 4)
@@ -1490,17 +1493,15 @@ function CreateConfigWindow()
         end
     end
 
-    okBtn = UIUtil.CreateButtonStd(optionGroup, '/widgets02/small', '<LOC _Ok>', 16)
+    local okBtn = UIUtil.CreateButtonStd(optionGroup, '/widgets02/small', '<LOC _Ok>', 16)
     LayoutHelpers.Below(okBtn, resetBtn, 4)
     LayoutHelpers.AtLeftIn(okBtn, optionGroup)
-    okBtn.OnClick = function(self, noCloseDlg)
+    okBtn.OnClick = function(self)
         ChatOptions = table.merged(ChatOptions, tempOptions)
         Prefs.SetToCurrentProfile("chatoptions", ChatOptions)
         GUI.bg:OnOptionsSet()
-        if (noCloseDlg or true) ~= true then -- preserve normal ok's behavior
-            GUI.config:Destroy()
-            GUI.config = false
-        end
+        GUI.config:Destroy()
+        GUI.config = false
     end
 
     local cancelBtn = UIUtil.CreateButtonStd(optionGroup, '/widgets02/small', '<LOC _Cancel>', 16)

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -1521,7 +1521,7 @@ function CreateConfigWindow()
         GUI.config.Top:Set(defPosition.top)
         GUI.config.Left:Set(defPosition.left)
     else
-        GUI.config.Top:Set(function() return 90 end)
+        GUI.config.Top:Set(function() return LayoutHelpers.ScaleNumber(90) end)
     end
     GUI.config:SetPositionLock(false) -- allow window to be draggable, didn't worked in Window() call
 end


### PR DESCRIPTION
1) Chat settings window is not displayed correctly, when more than 6 players is in game (or so).
With higher number of the players, bottom part of the window is hidden and you can't save changes.

Before:
![image](https://user-images.githubusercontent.com/36369441/170117465-6a4c8a8b-7587-4465-afd4-230413fe1ffd.png)

After:
- you can also drag this window with mouse, which was not possible
- font size slider steps changed from 2 to 1, so you gain more precise font size

![image](https://user-images.githubusercontent.com/36369441/170118500-bccc16a5-ca61-4ea8-b11b-f1d4729317b2.png)


2) When you choose to "Show feed background" under the bare chat lines, there are an ugly paddings, which looks too "stripy": 
![image](https://user-images.githubusercontent.com/36369441/170120150-843fa130-b41a-4c69-b886-b25436495b95.png)

Before:
![image](https://user-images.githubusercontent.com/36369441/170117741-bf55874a-a5b8-47df-966c-c56b6bf1e04a.png)
After:
![image](https://user-images.githubusercontent.com/36369441/170117799-69c7990c-295a-4071-a4eb-cc5935d08bb4.png)


3) Added a QOL button "Apply", so when you trying to find a proper Font size and Alpha, you can use "Apply" button so see your settings without need to always re-open Settings window:
Fig1:
![image](https://user-images.githubusercontent.com/36369441/170118321-84f90436-8d75-40f8-943a-4b10676e67ce.png)

