### PR TITLE
Add flags for mods

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -17,7 +17,7 @@
 --  - RolledFromFactory: flag that allows us to skip the first attachment check
 
 -- Current shield flags for mods:
---  - SkipAttachmentCheck: flag that allows us to skip all attachment checks 
+--  - SkipAttachmentCheck: flag that allows us to skip all attachment checks, as an example when the unit is attached to a transport
 
 -- Current shield states:
 -- - OnState

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -107,7 +107,7 @@ local DEFAULT_OPTIONS = {
     ShieldRegenRate = 1,
     ShieldRegenStartTime = 5,
     PassOverkillDamage = false,
-    SkipAttachmentCheck = false,
+    -- SkipAttachmentCheck = false, -- defaults to nil, same as false
 }
 
 -- scan blueprints for the largest shield radius
@@ -157,7 +157,7 @@ Shield = Class(moho.shield_methods, Entity) {
         self.PassOverkillDamage = spec.PassOverkillDamage
         self.ImpactMeshBp = spec.ImpactMesh
         self.SkipAttachmentCheck = spec.SkipAttachmentCheck
-        
+
         if spec.ImpactEffects ~= '' then
             self.ImpactEffects = EffectTemplate[spec.ImpactEffects]
         else

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -107,6 +107,7 @@ local DEFAULT_OPTIONS = {
     ShieldRegenRate = 1,
     ShieldRegenStartTime = 5,
     PassOverkillDamage = false,
+    SkipAttachmentCheck = false,
 }
 
 -- scan blueprints for the largest shield radius
@@ -155,6 +156,8 @@ Shield = Class(moho.shield_methods, Entity) {
         self.RegenStartTime = spec.ShieldRegenStartTime
         self.PassOverkillDamage = spec.PassOverkillDamage
         self.ImpactMeshBp = spec.ImpactMesh
+        self.SkipAttachmentCheck = spec.SkipAttachmentCheck
+        
         if spec.ImpactEffects ~= '' then
             self.ImpactEffects = EffectTemplate[spec.ImpactEffects]
         else
@@ -752,7 +755,7 @@ Shield = Class(moho.shield_methods, Entity) {
             self.Owner:SetMaintenanceConsumptionActive()
 
             -- if we're attached to a transport then our shield should be off
-            if UnitIsUnitState(self.Owner, 'Attached') and self.RolledFromFactory then
+            if (not self.SkipAttachmentCheck) and (UnitIsUnitState(self.Owner, 'Attached') and self.RolledFromFactory) then
                 ChangeState(self, self.OffState)
 
             -- if we're still out of energy, go wait for that to fix itself

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -8,7 +8,7 @@
 -- Legacy shield flags:
 --  - _IsUp: determines whether the shield is up
 
--- Current shield flags:
+-- Shield flags:
 --  - Enabled: flag that indicates the shield is enabled or not (via the toggle of the user)
 --  - Recharged : flag that indicates whether the shield is recharged
 --  - DepletedByEnergy: flag that indicates the shield is drained of energy and needs to recharge
@@ -16,10 +16,10 @@
 --  - NoEnergyToSustain: flag that indicates the shield does not have sufficient energy to recharge
 --  - RolledFromFactory: flag that allows us to skip the first attachment check
 
--- Current shield flags for mods:
+-- Shield flags for mods:
 --  - SkipAttachmentCheck: flag that allows us to skip all attachment checks, as an example when the unit is attached to a transport
 
--- Current shield states:
+-- Shield states:
 -- - OnState
 -- - OffState
 -- - RechargeState

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -16,6 +16,9 @@
 --  - NoEnergyToSustain: flag that indicates the shield does not have sufficient energy to recharge
 --  - RolledFromFactory: flag that allows us to skip the first attachment check
 
+-- Current shield flags for mods:
+--  - SkipAttachmentCheck: flag that allows us to skip all attachment checks 
+
 -- Current shield states:
 -- - OnState
 -- - OffState
@@ -107,6 +110,8 @@ local DEFAULT_OPTIONS = {
     ShieldRegenRate = 1,
     ShieldRegenStartTime = 5,
     PassOverkillDamage = false,
+
+    -- flags for mods
     -- SkipAttachmentCheck = false, -- defaults to nil, same as false
 }
 

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -272,7 +272,7 @@ function BuffAffectUnit(unit, buffName, instigator, afterRemove)
             unit:SetAccMult(val)
             unit:SetTurnMult(val)
         elseif atype == 'Stun' and not afterRemove then
-            if unit.ImmuneToStun then 
+            if not unit.ImmuneToStun then 
                 unit:SetStunned(buffDef.Duration or 1, instigator)
                 if unit.Anims then
                     for k, manip in unit.Anims do

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -272,10 +272,12 @@ function BuffAffectUnit(unit, buffName, instigator, afterRemove)
             unit:SetAccMult(val)
             unit:SetTurnMult(val)
         elseif atype == 'Stun' and not afterRemove then
-            unit:SetStunned(buffDef.Duration or 1, instigator)
-            if unit.Anims then
-                for k, manip in unit.Anims do
-                    manip:SetRate(0)
+            if unit.ImmuneToStun then 
+                unit:SetStunned(buffDef.Duration or 1, instigator)
+                if unit.Anims then
+                    for k, manip in unit.Anims do
+                        manip:SetRate(0)
+                    end
                 end
             end
         elseif atype == 'WeaponsEnable' then

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4280,7 +4280,6 @@ Unit = Class(moho.unit_methods) {
     end,
 
     SetStunned = function(self, duration)
-        LOG(self.ImmuneToStun)
         if not self.ImmuneToStun then 
             cUnit.SetStunned(self, duration)
         end

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2230,6 +2230,7 @@ Unit = Class(moho.unit_methods) {
         -- }
         -- ... Which we must carefully ignore.
         local bpShield = bp.Defense.Shield
+        bpShield.SkipAttachmentCheck = true 
         if bpShield.ShieldSize ~= 0 then
             self:CreateShield(bpShield)
         end

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -113,6 +113,7 @@ local function PopulateBlueprintCache(entity, blueprint)
     SharedTypeCache[blueprint.BlueprintId] = cache 
 end
 
+local cUnit = moho.unit_methods
 Unit = Class(moho.unit_methods) {
 
     Cache = false,
@@ -4275,6 +4276,13 @@ Unit = Class(moho.unit_methods) {
                 local message = {source = source or unitType, trigger = trigger, category = category, id = id, army = self.Army}
                 table.insert(Sync.EnhanceMessage, message)
             end
+        end
+    end,
+
+    SetStunned = function(self, duration)
+        LOG(self.ImmuneToStun)
+        if not self.ImmuneToStun then 
+            cUnit.SetStunned(self, duration)
         end
     end,
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2230,7 +2230,6 @@ Unit = Class(moho.unit_methods) {
         -- }
         -- ... Which we must carefully ignore.
         local bpShield = bp.Defense.Shield
-        bpShield.SkipAttachmentCheck = true 
         if bpShield.ShieldSize ~= 0 then
             self:CreateShield(bpShield)
         end
@@ -4220,8 +4219,12 @@ Unit = Class(moho.unit_methods) {
     OnAttachedToTransport = function(self, transport, bone)
         self:MarkWeaponsOnTransport(true)
         if self:ShieldIsOn() or self.MyShield.Charging then
-            self:DisableShield()
+            if not self.MyShield.SkipAttachmentCheck then 
+                self:DisableShield()
+            end
+
             self:DisableDefaultToggleCaps()
+
         end
         self:DoUnitCallbacks('OnAttachedToTransport', transport, bone)
     end,


### PR DESCRIPTION
Introduces two flags that can be used by mods:
 - `unit.ImmuneToStun`: Prevents the unit from being stunned
 - `shield.SkipAttachmentCheck`: Prevents the shield from turning off when attached or not turning on when attached