### PR TITLE
Economy bar red warning texture fix

### DIFF
--- a/lua/ui/game/economy.lua
+++ b/lua/ui/game/economy.lua
@@ -168,6 +168,7 @@ function CommonLogic()
             group.expense:SetHidden(hidden)
             group.reclaimDelta:SetHidden(hidden)
             group.reclaimTotal:SetHidden(hidden)
+            group.warningBG:SetHidden(hidden)
 
             return true
         end


### PR DESCRIPTION
Fixed red underlying warning texture which stayed visible after UI_ToggleGamePanels.

Before:

https://user-images.githubusercontent.com/36369441/170463095-46859726-4352-495b-8a55-057431ec18cb.mp4



After:


https://user-images.githubusercontent.com/36369441/170462573-32a86846-97b6-4e56-86c6-d23246def421.mp4


