### PR TITLE
Resourcebar visibility fix

### DIFF
--- a/lua/ui/game/economy.lua
+++ b/lua/ui/game/economy.lua
@@ -168,6 +168,7 @@ function CommonLogic()
             group.expense:SetHidden(hidden)
             group.reclaimDelta:SetHidden(hidden)
             group.reclaimTotal:SetHidden(hidden)
+            group.warningBG:SetHidden(hidden)
 
             return true
         end

--- a/lua/ui/game/economy.lua
+++ b/lua/ui/game/economy.lua
@@ -168,9 +168,8 @@ function CommonLogic()
             group.expense:SetHidden(hidden)
             group.reclaimDelta:SetHidden(hidden)
             group.reclaimTotal:SetHidden(hidden)
-            group.warningBG:SetHidden(hidden)
 
-            return true
+            return false
         end
 
         Tooltip.AddControlTooltip(group.reclaimDelta, prefix..'_reclaim_display')


### PR DESCRIPTION
It is working now. Tested both on fresh profile and the normal one. Sorry ;)

Fixed red underlying warning texture which stayed visible after UI_ToggleGamePanels.

Before:
https://user-images.githubusercontent.com/36369441/170463095-46859726-4352-495b-8a55-057431ec18cb.mp4

After:
https://user-images.githubusercontent.com/36369441/170462573-32a86846-97b6-4e56-86c6-d23246def421.mp4
