### PR TITLE
Do not include (air) structures into footprint adjustments

### DIFF
--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -118,7 +118,7 @@ local function PostProcessUnit(unit)
     -- value used by formations to determine the distance between other air units. Note
     -- that the value must be of type unsigned integer!
 
-    if isAir and not isExperimental then 
+    if isAir and not (isExperimental or isStructure) then 
         unit.Footprint = unit.Footprint or { }
         if isBomber then 
             unit.Footprint.SizeX = 4


### PR DESCRIPTION
Fix for #3892 , where air factories have a significant offset.

![image](https://user-images.githubusercontent.com/15778155/170884249-1aabea58-0180-4525-ad7a-f05125edeff8.png)
