### PR TITLE
Mute the Main Menu ambient sound with /nomovie switch on cmdline

### DIFF
--- a/lua/ui/menus/main.lua
+++ b/lua/ui/menus/main.lua
@@ -214,7 +214,10 @@ function CreateUI()
     end
 
     -- music
-    local ambientSoundHandle = PlaySound(Sound({Cue = "AMB_Menu_Loop", Bank = "AmbientTest",}))
+    local ambientSoundHandle = false
+    if not HasCommandLineArg("/nomovie") then
+        ambientSoundHandle = PlaySound(Sound({Cue = "AMB_Menu_Loop", Bank = "AmbientTest",}))
+    end
 
     local musicHandle = false
     function StartMusic()


### PR DESCRIPTION
This should be normally controlled with this switch, since ambient sounds were meant
to provide sound for the background movie, which - when this switch is used - is turned off anyway.

This switch is not normally used by players (i believe), since it removes the radio relations
from "HQ" during Campaign as well.

This is rather a QOL for dev.
