### PR TITLE
Mute all in-game music with /nomusic switch

### DIFF
--- a/lua/UserMusic.lua
+++ b/lua/UserMusic.lua
@@ -54,9 +54,10 @@ local PeaceCueIndex = 1
 local currentMusic = nil
 local battleWatch = nil
 local paused = GetVolume("Music") == 0
-
+local nomusicSwitchSet = HasCommandLineArg("/nomusic")
 
 function NotifyBattle()
+    if nomusicSwitchSet then return end -- nomusic set - save threading
     local tick = GameTick()
     local prevNotify = LastBattleNotify
     LastBattleNotify = tick
@@ -76,6 +77,7 @@ function NotifyBattle()
 end
 
 function StartBattleMusic()
+    if nomusicSwitchSet then return end -- nomusic set - save threading
     BattleStart = GameTick()
     PlayMusic(BattleCues[BattleCueIndex], 0) -- immediately
     BattleCueIndex = math.mod(BattleCueIndex,table.getn(BattleCues)) + 1
@@ -93,6 +95,7 @@ function StartBattleMusic()
 end
 
 function StartPeaceMusic()
+    if nomusicSwitchSet then return end -- nomusic set - save threading
     BattleStart = 0
     BattleEventCounter = 0
     LastBattleNotify = GameTick()

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -76,6 +76,7 @@ local savedMasterVol = false
 local savedFXVol = false
 local savedMusicVol = false
 local savedVOVol = false
+local nomusicSwitchSet = HasCommandLineArg("/nomusic")
 
 function PlayTestSound()
     local sound = Sound{ Bank = 'Interface', Cue = 'UI_Action_MouseDown' }
@@ -99,6 +100,66 @@ function PlayTestVoice()
     end
 end
 
+local function getMusicVolumeOption()
+
+    if not nomusicSwitchSet then
+
+        -- original option
+        return {
+            title = "<LOC OPTIONS_0027>Music Volume",
+            key = 'music_volume',
+            type = 'slider',
+            default = 100,
+
+            init = function()
+                savedMusicVol = GetVolume("Music")
+                SetMusicVolume(savedMusicVol)
+            end,
+
+            cancel = function()
+                if savedMusicVol then
+                    SetMusicVolume(savedMusicVol)
+                end
+            end,
+
+            set = function(key, value, startup)
+                SetMusicVolume(value / 100)
+                savedMusicVol = value / 100
+            end,
+            update = function(key, value)
+                SetMusicVolume(value / 100)
+            end,
+            custom = {
+                min = 0,
+                max = 100,
+                inc = 1,
+            },
+        }
+
+    else
+        
+        -- replaced option with an "disableable" type. It preserves the original value in config.
+        -- on empty profile it is defaulted to 100 as in original option
+        return {
+            title = "<LOC OPTIONS_0027>Music Volume",
+            key = 'music_volume',
+            type = 'toggle',
+            default = 100,
+            ignore = function(value)
+                return savedMusicVol
+            end,
+            set = function(key, value, startup)
+                savedMusicVol = value
+            end,
+            custom = {
+                states = {
+                    { text = "<LOC _Command_Line_Override>", key = 'overridden' },
+                },
+            },
+        }
+        
+    end
+end
 options = {
     gameplay = {
         title = "<LOC _Gameplay>",
@@ -1248,36 +1309,7 @@ options = {
                     inc = 1,
                 },
             },
-            {
-                title = "<LOC OPTIONS_0027>Music Volume",
-                key = 'music_volume',
-                type = 'slider',
-                default = 100,
-
-                init = function()
-                    savedMusicVol = GetVolume("Music")
-                    SetMusicVolume(savedMusicVol)
-                end,
-
-                cancel = function()
-                    if savedMusicVol then
-                        SetMusicVolume(savedMusicVol)
-                    end
-                end,
-
-                set = function(key,value,startup)
-                    SetMusicVolume(value / 100)
-                    savedMusicVol = value/100
-                end,
-                update = function(key,value)
-                    SetMusicVolume(value / 100)
-                end,
-                custom = {
-                    min = 0,
-                    max = 100,
-                    inc = 1,
-                },
-            },
+            getMusicVolumeOption(),
             {
                 title = "<LOC OPTIONS_0066>VO Volume",
                 key = 'vo_volume',

--- a/lua/ui/menus/main.lua
+++ b/lua/ui/menus/main.lua
@@ -218,7 +218,7 @@ function CreateUI()
 
     local musicHandle = false
     function StartMusic()
-        if not musicHandle then
+        if not musicHandle and not HasCommandLineArg("/nomusic") then
             musicHandle = PlaySound(Sound({Cue = "Main_Menu", Bank = "Music",}))
         end
     end


### PR DESCRIPTION
Although `/nomusic` can be found in binary.exe, seems it is ignored.
Both main menu and in-game music is now actually disabled with this PR, not just muted.
As this switch serves as an override, it does not reset the old `music_volume` value.
Also follows the pattern (Fig1) seen in the video settings (Fig2) if `/windowed` is used while the profile may be set to fullscreen. `Command Line Override` text is not new, therefore does not need new translation.

Tested on:
 - campaign
 - skirmish
 - populated profile
 - empty profile

Fig1:
![image](https://user-images.githubusercontent.com/36369441/170899071-11b14d6f-d25f-469e-955e-a5971e9809a8.png)

Fig2:
![image](https://user-images.githubusercontent.com/36369441/170899107-aec0e463-4013-482b-a1b5-b5d50b6f7b64.png)
