### PR TITLE
Hud Notifications leaks to the right view when split

### DIFF
--- a/lua/ui/notify/notifyoverlay.lua
+++ b/lua/ui/notify/notifyoverlay.lua
@@ -127,6 +127,12 @@ function createEnhancementOverlay(args)
         local worldView = import('/lua/ui/game/worldview.lua').viewLeft
         local pos = worldView:Project(overlay.pos)
 
+        if pos.x < 0 or pos.y < 0 or pos.x > worldView.Width() or pos.y > worldView:Height() then
+            self:Hide()
+        else
+            self:Show()
+        end
+
         LayoutHelpers.AtLeftTopIn(overlay, worldView, (pos.x - overlay.Width() / 2) / LayoutHelpers.GetPixelScaleFactor(), (pos.y - overlay.Height() / 2 + 1) / LayoutHelpers.GetPixelScaleFactor())
 
         local timeRemaining = math.ceil(overlay.eta - seconds)


### PR DESCRIPTION
Notifications about ACU upgrades are not staying inside its own view - se video before.
This PR fixing that.

Tested:
- windowed mode
- fullscreen mode single monitor
- fullscreen on dual monitors

Before:

https://user-images.githubusercontent.com/36369441/170982064-68c5e0fe-ce45-4f87-b817-934853d744a1.mp4


After:

https://user-images.githubusercontent.com/36369441/170982095-0ba7b681-917e-49d9-834f-d6101ec0d141.mp4


