### PR TITLE
Scrollbars & Lobby small make-ups, widths, paddings

### DIFF
--- a/lua/ui/controls/combo.lua
+++ b/lua/ui/controls/combo.lua
@@ -203,7 +203,7 @@ Combo = Class(Group) {
         -- set the height of the list based on the number of items visible and the font metrics
         self._maxVisibleItems = maxVisibleItems
         self._visibleItems = LazyVar.Create()
-        self._list.Height:Set(function() return self._visibleItems() * (self._text.FontAscent() + self._text.FontDescent() + self._text.FontExternalLeading() + 1) end)
+        self._list.Height:Set(function() return self._visibleItems() * (self._text.FontAscent() + self._text.FontDescent() + self._text.FontExternalLeading()) end)
         self._dropdown.Height:Set(function() return self._list.Height() + ddum.Height() + ddlm.Height() end)
         self._visibleItems:Set(1)
 

--- a/lua/ui/controls/combo.lua
+++ b/lua/ui/controls/combo.lua
@@ -60,6 +60,12 @@ Combo = Class(Group) {
         self.mItemCue = itemCue or "UI_Tab_Click_01"
         self.EnableColor = EnableColor or true
 
+        -- sets the offsets to the auto-attached scrollbar
+        -- these are the better defaults for the FAF design
+        self._scrollbarOffsetRight = -22
+        self._scrollbarOffsetBottom = -6
+        self._scrollbarOffsetTop = -6
+
         bitmaps = bitmaps or defaultBitmaps
 
         pointSize = pointSize or 12
@@ -316,7 +322,7 @@ Combo = Class(Group) {
             self._scrollbar:Destroy()
         end
         if numItems > self._visibleItems() then
-            self._scrollbar = UIUtil.CreateVertScrollbarFor(self._list)
+            self._scrollbar = UIUtil.CreateVertScrollbarFor(self._list, self._scrollbarOffsetRight, nil, self._scrollbarOffsetBottom, self._scrollbarOffsetTop)
         end
 
         local realDefFinded = false
@@ -334,6 +340,13 @@ Combo = Class(Group) {
         end
 
         self:SetItem(defaultItemIndex)
+    end,
+
+    -- helper function to (re)set scrollbar offsets for dialogs or UI parts using Vanila design (Replays, Multiplayer LAN, etc)
+    SetScrollBarOffsets = function(self, offset_right, offset_bottom, offset_top)
+        self._scrollbarOffsetRight = offset_right or 0
+        self._scrollbarOffsetBottom = offset_bottom or 0
+        self._scrollbarOffsetTop = offset_top or 0
     end,
 
     ClearItems = function(self)

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -624,7 +624,8 @@ function ReallyCreateLobby(protocol, localPort, desiredPlayerName, localPlayerUI
                 GUI.chatEdit:AcquireFocus()
             end,
             nil, nil,
-            true
+            true,
+            {escapeButton = 2, enterButton = 1, worldCover = true}
         )
     end
     EscapeHandler.PushEscapeHandler(GUI.exitLobbyEscapeHandler)

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2738,7 +2738,7 @@ function CreateSlotsUI(makeLabel)
         newSlot:AddChild(numGamesText)
 
         -- Name
-        local nameLabel = Combo(newSlot, 14, 12, true, nil, "UI_Tab_Rollover_01", "UI_Tab_Click_01")
+        local nameLabel = Combo(newSlot, 14, 16, true, nil, "UI_Tab_Rollover_01", "UI_Tab_Click_01")
         newSlot.name = nameLabel
         nameLabel._text:SetFont('Arial Gras', 15)
         newSlot:AddChild(nameLabel)
@@ -3069,15 +3069,16 @@ function CreateUI(maxPlayers)
         LayoutHelpers.SetWidth(GUI.AIFillPanel, 278)
         UIUtil.SurroundWithBorder(GUI.AIFillPanel, '/scx_menu/lan-game-lobby/frame/')
         GUI.AIFillCombo = Combo.Combo(GUI.AIFillPanel, 14, 12, false, nil)
-        LayoutHelpers.AtLeftTopIn(GUI.AIFillCombo, GUI.AIFillPanel)
-        GUI.AIFillCombo.Width:Set(GUI.AIFillPanel.Width)
+        LayoutHelpers.AtHorizontalCenterIn(GUI.AIFillCombo, GUI.AIFillPanel)
+        LayoutHelpers.AtTopIn(GUI.AIFillCombo, GUI.AIFillPanel, 5)
+        GUI.AIFillCombo.Width:Set(function() return GUI.AIFillPanel.Width() - LayoutHelpers.ScaleNumber(15) end)
         GUI.AIFillCombo:AddItems(AIStrings)
         GUI.AIFillCombo:SetTitleText(LOC('<LOC lobui_0461>Choose AI for autofilling'))
         Tooltip.AddComboTooltip(GUI.AIFillCombo, AITooltips)
         GUI.AIFillButton = UIUtil.CreateButtonStd(GUI.AIFillCombo, '/BUTTON/medium/', LOC('<LOC lobui_0462>Fill Slots'), 12)
         LayoutHelpers.SetWidth(GUI.AIFillButton, 129)
         LayoutHelpers.SetHeight(GUI.AIFillButton, 30)
-        LayoutHelpers.AtLeftTopIn(GUI.AIFillButton, GUI.AIFillCombo, -10, 25)
+        LayoutHelpers.AtLeftTopIn(GUI.AIFillButton, GUI.AIFillCombo, -10, 20)
         GUI.AIClearButton = UIUtil.CreateButtonStd(GUI.AIFillButton, '/BUTTON/medium/', LOC('<LOC lobui_0463>Clear Slots'), 12)
         GUI.AIClearButton.Width:Set(GUI.AIFillButton.Width)
         GUI.AIClearButton.Height:Set(GUI.AIFillButton.Height)
@@ -3085,7 +3086,7 @@ function CreateUI(maxPlayers)
         GUI.TeamCountSelector = Combo.BitmapCombo(GUI.AIClearButton, teamIcons, 1, false, nil, "UI_Tab_Rollover_01", "UI_Tab_Click_01")
         LayoutHelpers.SetWidth(GUI.TeamCountSelector, 44)
         LayoutHelpers.AtTopIn(GUI.TeamCountSelector, GUI.AIClearButton, 5)
-        GUI.TeamCountSelector.Right:Set(GUI.AIFillPanel.Right)
+        GUI.TeamCountSelector.Right:Set(function() return GUI.AIFillPanel.Right() - LayoutHelpers.ScaleNumber(8) end)
         local tooltipText = {}
         tooltipText['text'] = '<LOC tooltipui0710>Teams Count'
         tooltipText['body'] = '<LOC tooltipui0711>On how many teams share players?'
@@ -3387,9 +3388,9 @@ function CreateUI(maxPlayers)
     local chatBG = Bitmap(GUI.chatPanel)
     GUI.chatBG = chatBG
     chatBG:SetSolidColor('FF212123')
-    LayoutHelpers.Below(chatBG, GUI.chatDisplay, 1)
-    LayoutHelpers.AtLeftIn(chatBG, GUI.chatDisplay, -5)
-    chatBG.Width:Set(GUI.chatPanel.Width() - LayoutHelpers.ScaleNumber(16))
+    LayoutHelpers.Below(chatBG, GUI.chatDisplay, 0)
+    LayoutHelpers.AtLeftIn(chatBG, GUI.chatDisplay, -2)
+    chatBG.Width:Set(GUI.chatPanel.Width)
     LayoutHelpers.SetHeight(chatBG, 24)
     
     -- Set up the chat edit buttons and functions
@@ -3731,7 +3732,7 @@ function CreateUI(maxPlayers)
     local initialState = Prefs.GetFromCurrentProfile("LobbyOpt_AutoTeams") or "none"
     GUI.autoTeams = ToggleButton(GUI.observerPanel, '/BUTTON/autoteam/', autoteamButtonStates, initialState)
 
-    LayoutHelpers.RightOf(GUI.autoTeams, GUI.randMap, -19)
+    LayoutHelpers.RightOf(GUI.autoTeams, GUI.randMap, LayoutHelpers.ScaleNumber(-19))
     if not isHost then
         GUI.autoTeams:Hide()
     else
@@ -3743,12 +3744,12 @@ function CreateUI(maxPlayers)
 
     -- CLOSE/OPEN EMPTY SLOTS BUTTON --
     GUI.closeEmptySlots = UIUtil.CreateButtonStd(GUI.observerPanel, '/BUTTON/closeslots/')
-    LayoutHelpers.AtLeftTopIn(GUI.closeEmptySlots, GUI.defaultOptions, -39, 47)
     Tooltip.AddButtonTooltip(GUI.closeEmptySlots, 'lob_close_empty_slots')
     if not isHost then
         GUI.closeEmptySlots:Hide()
-        LayoutHelpers.AtLeftTopIn(GUI.closeEmptySlots, GUI.defaultOptions, -40, 47)
+        LayoutHelpers.AtLeftTopIn(GUI.closeEmptySlots, GUI.defaultOptions, -40, 43)
     else
+        LayoutHelpers.AtLeftTopIn(GUI.closeEmptySlots, GUI.defaultOptions, -31, 43)
         GUI.closeEmptySlots.OnClick = function(self, modifiers)
             if lobbyComm:IsHost() then
                 if modifiers.Ctrl then
@@ -3787,7 +3788,7 @@ function CreateUI(maxPlayers)
 
     -- GO OBSERVER BUTTON --
     GUI.becomeObserver = UIUtil.CreateButtonStd(GUI.observerPanel, '/BUTTON/observer/')
-    LayoutHelpers.RightOf(GUI.becomeObserver, GUI.closeEmptySlots, -19)
+    LayoutHelpers.RightOf(GUI.becomeObserver, GUI.closeEmptySlots, -25)
     Tooltip.AddButtonTooltip(GUI.becomeObserver, 'lob_become_observer')
     GUI.becomeObserver.OnClick = function()
         if IsPlayer(localPlayerID) then
@@ -3807,7 +3808,7 @@ function CreateUI(maxPlayers)
 
     -- CPU BENCH BUTTON --
     GUI.rerunBenchmark = UIUtil.CreateButtonStd(GUI.observerPanel, '/BUTTON/cputest/', '', 11)
-    LayoutHelpers.RightOf(GUI.rerunBenchmark, GUI.becomeObserver, -19)
+    LayoutHelpers.RightOf(GUI.rerunBenchmark, GUI.becomeObserver, -25)
     Tooltip.AddButtonTooltip(GUI.rerunBenchmark,{text=LOC("<LOC lobui_0425>Run CPU Benchmark Test"), body=LOC("<LOC lobui_0426>Recalculates your CPU rating.")})
     GUI.rerunBenchmark.OnClick = function(self, modifiers)
         ForkThread(function() UpdateBenchmark(true) end)
@@ -3815,7 +3816,7 @@ function CreateUI(maxPlayers)
 
     -- Autobalance Button --
     GUI.PenguinAutoBalance = UIUtil.CreateButtonStd(GUI.observerPanel, '/BUTTON/autobalance/')
-    LayoutHelpers.RightOf(GUI.PenguinAutoBalance, GUI.becomeObserver, 59)
+    LayoutHelpers.RightOf(GUI.PenguinAutoBalance, GUI.rerunBenchmark, -25)
     Tooltip.AddButtonTooltip(GUI.PenguinAutoBalance, {text=LOC("<LOC lobui_0444>Autobalance"), body=LOC("<LOC lobui_0445>Automatically balance players into 2 equally sized teams")})
     if not isHost then
         GUI.PenguinAutoBalance:Hide()
@@ -4280,7 +4281,7 @@ end
 function setupChatEdit(chatPanel)
     GUI.chatEdit = Edit(chatPanel)
     LayoutHelpers.AtLeftTopIn(GUI.chatEdit, GUI.chatBG, 4, 3)
-    GUI.chatEdit.Width:Set(GUI.chatBG.Width() - LayoutHelpers.ScaleNumber(9))
+    GUI.chatEdit.Width:Set(GUI.chatBG.Width() - LayoutHelpers.ScaleNumber(4))
     LayoutHelpers.SetHeight(GUI.chatEdit, 22)
     GUI.chatEdit:SetFont(UIUtil.bodyFont, 16)
     GUI.chatEdit:SetForegroundColor(UIUtil.fontColor)
@@ -4288,7 +4289,7 @@ function setupChatEdit(chatPanel)
     GUI.chatEdit:SetDropShadow(true)
     GUI.chatEdit:AcquireFocus()
 
-    GUI.chatDisplayScroll = UIUtil.CreateLobbyVertScrollbar(chatPanel, -15, -2, 0)
+    GUI.chatDisplayScroll = UIUtil.CreateLobbyVertScrollbar(chatPanel, -15, 25, 0)
 
     GUI.chatEdit:SetMaxChars(200)
     GUI.chatEdit.OnCharPressed = function(self, charcode)

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3086,7 +3086,7 @@ function CreateUI(maxPlayers)
         GUI.TeamCountSelector = Combo.BitmapCombo(GUI.AIClearButton, teamIcons, 1, false, nil, "UI_Tab_Rollover_01", "UI_Tab_Click_01")
         LayoutHelpers.SetWidth(GUI.TeamCountSelector, 44)
         LayoutHelpers.AtTopIn(GUI.TeamCountSelector, GUI.AIClearButton, 5)
-        GUI.TeamCountSelector.Right:Set(function() return GUI.AIFillPanel.Right() - LayoutHelpers.ScaleNumber(8) end)
+        LayoutHelpers.AtRightIn(GUI.TeamCountSelector, GUI.AIFillPanel, 8)
         local tooltipText = {}
         tooltipText['text'] = '<LOC tooltipui0710>Teams Count'
         tooltipText['body'] = '<LOC tooltipui0711>On how many teams share players?'
@@ -3732,7 +3732,7 @@ function CreateUI(maxPlayers)
     local initialState = Prefs.GetFromCurrentProfile("LobbyOpt_AutoTeams") or "none"
     GUI.autoTeams = ToggleButton(GUI.observerPanel, '/BUTTON/autoteam/', autoteamButtonStates, initialState)
 
-    LayoutHelpers.RightOf(GUI.autoTeams, GUI.randMap, LayoutHelpers.ScaleNumber(-19))
+    LayoutHelpers.RightOf(GUI.autoTeams, GUI.randMap, -19)
     if not isHost then
         GUI.autoTeams:Hide()
     else


### PR DESCRIPTION
This PR does some make-ups to the UI - namely to the:
- scrollbars offsets (general change, Combo+Scrolling )
- scrollable combo last-item empty space
- some lobby UI elements repositioning
- improved [ESC] key behavior in the Lobby

## Scroll bars:
example of the impact - all auto-attached Scrollbars to the Combo elements are repositioned a bit.
Removed an "extra air" under the last Item
This change doesn't affects other (thin) scrollbars nor the some other Vanilla scrollbars (options, in-game chat etc.)

![scrollbar1](https://user-images.githubusercontent.com/36369441/171925809-84b6281b-2e7a-4f51-8644-3fd39a3bdd9e.gif)
![lobby2](https://user-images.githubusercontent.com/36369441/171925930-1b630db1-ad58-427f-ab56-6564d7bdd71f.gif)

Tested:
- tried to dig through all sections where this particular element is used, does look ok everywhere
- also the "original" remnants in UI, like Replays, load Save etc.


## Lobby UI elements:
![lobby1](https://user-images.githubusercontent.com/36369441/171926423-10a6a1b3-87eb-4b9e-bb9a-1f8a34f5396a.gif)


## Lobby Escape key improvements:
the change is that Esc key can dismiss "Lobby exit prompt" and by pressing Enter key exits lobby.
![lobbyESC](https://user-images.githubusercontent.com/36369441/171926571-4f2e3edb-c59b-428e-9168-18afc69f8068.gif)


