### PR TITLE
Refactor layouthelpers

### DIFF
--- a/lua/maui/layouthelpers.lua
+++ b/lua/maui/layouthelpers.lua
@@ -6,12 +6,13 @@
 --* Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --*****************************************************************************
 
--- Percentage versus offset
--- Percentages are specified as a float, with 0.00 to 1.00 the normal ranges
--- Percentages can change spacing when dimension is expended.
+-- Percentage versus offset:
 --
--- Offsets are specified in pixels for the "base art" size. If the art is
--- scaled (ie large UI mode) this factor will keep the layout correct
+-- Percentages are specified as a float, with 0.00 to 1.00 as the normal ranges
+-- Percentages can change spacing when dimension is expanded.
+--
+-- Offsets are specified in pixels for the "base art" size. If the UI is
+-- scaled (e.g. large UI mode) the pixel scale factor will keep the layout correct.
 
 
 local MathFloor = math.floor
@@ -23,21 +24,22 @@ local Prefs = import('/lua/user/prefs.lua')
 -- Note that if you add a new layout helper function that uses offsets, you need
 -- to scale the offset with this factor or your layout may get funky when the
 -- art is changed
+---@type number
 local pixelScaleFactor = Prefs.GetFromCurrentProfile('options').ui_scale or 1
 
---- Set new scale factor for absolute offset in layout functions
+--- Sets new pixel scale factor for fixed offset in layout functions
 ---@param newFactor number
 function SetPixelScaleFactor(newFactor)
     pixelScaleFactor = newFactor
 end
 
---- Get scale factor for absolute offset in layout functions
+--- Gets pixel scale factor for fixed offset in layout functions
 ---@return number pixelScaleFactor
 function GetPixelScaleFactor()
     return pixelScaleFactor
 end
 
---- Set absolute width of a control
+--- Sets fixed width of a control, scaled by the pixel scale factor
 ---@param control Control
 ---@param width? number no change if nil
 function SetWidth(control, width)
@@ -46,7 +48,7 @@ function SetWidth(control, width)
     end
 end
 
---- Set absolute height of a control
+--- Sets fixed height of a control, scaled by the pixel scale factor
 ---@param control Control
 ---@param height? number no change if nil
 function SetHeight(control, height)
@@ -55,7 +57,7 @@ function SetHeight(control, height)
     end
 end
 
---- Set absolute dimensions of a control
+--- Sets fixed dimensions of a control, scaled by the pixel scale factor
 ---@param control Control
 ---@param width? number no change if nil
 ---@param height? number no change if nil
@@ -65,7 +67,7 @@ function SetDimensions(control, width, height)
 end
 
 
---- Set the depth of a control higher than a parent
+--- Sets depth of a control to be above a parent
 ---@param control Control
 ---@param parent Control
 ---@param depth? integer defaults to 1
@@ -77,7 +79,7 @@ function DepthOverParent(control, parent, depth)
     end
 end
 
---- Set the depth of a control lower than a parent
+--- Sets depth of a control to be below a parent
 ---@param control Control
 ---@param parent Control
 ---@param depth? integer defaults to 1
@@ -89,7 +91,7 @@ function DepthUnderParent(control, parent, depth)
     end
 end
 
---- Scales a control according to the globally set pixel ratio
+--- Scales a control's dimensions by the pixel scale factor
 ---@param control Control
 function Scale(control)
     SetDimensions(control, control.Width(), control.Height())
@@ -110,204 +112,201 @@ function InvScaleNumber(scaledNumber)
 end
 
 
+-- Single positioning functions
 
--- Anchor functions lock the appropriate side of a control to the side of another control
+-- Anchor functions lock the appropriate edge of a control to the edge of another control
 
---- Anchors a control to the left of a parent, with optional padding
+--- Anchors a control's right edge to the left edge of a parent, with optional padding
 ---@param control Control
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
 function AnchorToLeft(control, parent, padding)
     if padding and padding ~= 0 then
-        control.Right:SetFunction(function() return parent.Left() - MathFloor(padding * pixelScaleFactor) end)
+        control.Right:SetFunction(function() return MathFloor(parent.Left() - padding * pixelScaleFactor) end)
     else
         -- We shouldn't need to let the child refer to the parent if the parent is already laid out
-        -- however, this does change functionallity of the layout, so I've left them commented out for now
-        control.Right:SetFunction(function() return parent.Left() end)
+        -- however, this does change functionallity of the layout, so I've had to refrain
         --control.Right:SetFunction(parent.Left)
+        control.Right:SetFunction(function() return parent.Left() end)
     end
 end
 
---- Anchors a control to the top of a parent, with optional padding
+--- Anchors a control's bottom edge to the top edge of a parent, with optional padding
 ---@param control Control
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
 function AnchorToTop(control, parent, padding)
     if padding and padding ~= 0 then
-        control.Bottom:SetFunction(function() return parent.Top() - MathFloor(padding * pixelScaleFactor) end)
+        control.Bottom:SetFunction(function() return MathFloor(parent.Top() - padding * pixelScaleFactor) end)
     else
         control.Bottom:SetFunction(function() return parent.Top() end)
-        --control.Bottom:SetFunction(parent.Top)
     end
 end
 
---- Anchors a control to the right of a parent, with optional padding
+--- Anchors a control's left edge to the right edge of a parent, with optional padding
 ---@param control Control
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
 function AnchorToRight(control, parent, padding)
     if padding and padding ~= 0 then
-        control.Left:SetFunction(function() return parent.Right() + MathFloor(padding * pixelScaleFactor) end)
+        control.Left:SetFunction(function() return MathFloor(parent.Right() + padding * pixelScaleFactor) end)
     else
         control.Left:SetFunction(function() return parent.Right() end)
-        --control.Left:SetFunction(parent.Right)
     end
 end
 
---- Anchors a control to the bottom of a parent, with optional padding
+--- Anchors a control's top edge to the bottom edge of a parent, with optional padding
 ---@param control Control
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
 function AnchorToBottom(control, parent, padding)
     if padding and padding ~= 0 then
-        control.Top:SetFunction(function() return parent.Bottom() + MathFloor(padding * pixelScaleFactor) end)
+        control.Top:SetFunction(function() return MathFloor(parent.Bottom() + padding * pixelScaleFactor) end)
     else
         control.Top:SetFunction(function() return parent.Bottom() end)
-        --control.Top:SetFunction(parent.Bottom)
     end
 end
 
 -- These functions will set the controls position to be placed relative to
--- its parents dimensions. 
--- note that the offset is in the opposite direction as placement, to position 
--- the controls further inside the parent
+-- its parents dimensions.
+-- Note that the offset is in the opposite direction as placement, to position
+-- the controls further inside the parent.
 
 -- These are generally most useful for elements that don't change size, they can also be
 -- used for controls that stretch to match parent.
 
---- Centers a control horizontally on a parent, with optional right offset
+--- Centers a control horizontally on a parent, with optional rightward offset.
+--- This sets the control's left edge.
 ---@param control Control
 ---@param parent Control
----@param leftOffset? number
+---@param leftOffset? number Offset of control's left edge in the rightward direction, scaled by the pixel scale factor. Defaults to 0.
 function AtHorizontalCenterIn(control, parent, leftOffset)
     if leftOffset then
         control.Left:SetFunction(function()
-            return parent.Left() + MathFloor(((parent.Width() - control.Width()) / 2) + (leftOffset * pixelScaleFactor))
+            return MathFloor(parent.Left() + (parent.Width() - control.Width()) / 2 + leftOffset * pixelScaleFactor)
         end)
     else
         control.Left:SetFunction(function()
-            return parent.Left() + MathFloor((parent.Width() - control.Width()) / 2)
+            return MathFloor(parent.Left() + (parent.Width() - control.Width()) / 2)
         end)
     end
 end
 
---- Centers a control vertically on a parent, with optional down offset
+--- Centers a control vertically on a parent, with optional downward offset.
+--- This sets the control's top edge.
 ---@param control Control
 ---@param parent Control
----@param topOffset? number
+---@param topOffset? number Offset of the control's top edge in the downward direction, scaled by the pixel scale factor. Defaults to 0.
 function AtVerticalCenterIn(control, parent, topOffset)
     if topOffset then
         control.Top:SetFunction(function()
-            return parent.Top() + MathFloor(((parent.Height() - control.Height()) / 2) + (topOffset * pixelScaleFactor))
+            return MathFloor(parent.Top() + (parent.Height() - control.Height()) / 2 + topOffset * pixelScaleFactor)
         end)
     else
         control.Top:SetFunction(function()
-            return parent.Top() + MathFloor((parent.Height() - control.Height()) / 2)
+            return MathFloor(parent.Top() + (parent.Height() - control.Height()) / 2)
         end)
     end
 end
 
---- Places a control inside the left edge of a parent, with optional right offset
+--- Places a control's left edge inside of a parent's, with optional rightward offset
 ---@param control Control
 ---@param parent Control
----@param leftOffset? number
+---@param leftOffset? number Offset of the control's left edge in the rightward direction, scaled by the pixel scale factor. Defaults to 0.
 function AtLeftIn(control, parent, leftOffset)
     if leftOffset and leftOffset ~= 0 then
-        control.Left:SetFunction(function() return parent.Left() + MathFloor(leftOffset * pixelScaleFactor) end)
+        control.Left:SetFunction(function() return MathFloor(parent.Left() + leftOffset * pixelScaleFactor) end)
     else
         control.Left:SetFunction(function() return parent.Left() end)
-        --control.Left:SetFunction(parent.Left)
     end
 end
 
---- Places a control inside the top edge of a parent, with optional down offset
+--- Places a control's top edge inside of a parent's, with optional downward offset
 ---@param control Control
 ---@param parent Control
----@param topOffset? number
+---@param topOffset? number Offset of the control's top edge in the downward direction, scaled by the pixel scale factor. Defaults to 0.
 function AtTopIn(control, parent, topOffset)
     if topOffset and topOffset ~= 0 then
-        control.Top:SetFunction(function() return parent.Top() + MathFloor(topOffset * pixelScaleFactor) end)
+        control.Top:SetFunction(function() return MathFloor(parent.Top() + topOffset * pixelScaleFactor) end)
     else
         control.Top:SetFunction(function() return parent.Top() end)
-        --control.Top:SetFunction(parent.Top)
     end
 end
 
---- Places a control inside the right edge of a parent, with optional left offset
+--- Places a control's right edge inside of a parent's, with optional leftward offset
 ---@param control Control
 ---@param parent Control
----@param rightOffset? number
+---@param rightOffset? number Offset of the control's right edge in the leftward direction, scaled by the pixel scale factor. Defaults to 0.
 function AtRightIn(control, parent, rightOffset)
     if rightOffset and rightOffset ~= 0 then
-        control.Right:SetFunction(function() return parent.Right() - MathFloor(rightOffset * pixelScaleFactor) end)
+        control.Right:SetFunction(function() return MathFloor(parent.Right() - rightOffset * pixelScaleFactor) end)
     else
         control.Right:SetFunction(function() return parent.Right() end)
-        --control.Right:SetFunction(parent.Right)
     end
 end
 
---- Places a control inside the bottom edge of a parent, with optional up offset
+--- Places a control's bottom edge inside of a parent's, with optional upward offset
 ---@param control Control
 ---@param parent Control
----@param bottomOffset? number
+---@param bottomOffset? number Offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor. Defaults to 0.
 function AtBottomIn(control, parent, bottomOffset)
     if bottomOffset and bottomOffset ~= 0 then
-        control.Bottom:SetFunction(function() return parent.Bottom() - MathFloor(bottomOffset * pixelScaleFactor) end)
+        control.Bottom:SetFunction(function() return MathFloor(parent.Bottom() - bottomOffset * pixelScaleFactor) end)
     else
         control.Bottom:SetFunction(function() return parent.Bottom() end)
-        --control.Bottom:SetFunction(parent.Bottom)
     end
 end
 
 -- These functions use percentages to place the item rather than offsets so they will
 -- stay proportially spaced when the parent resizes
 
---- Places the control's left at a percentage along the width of a parent, with 0.00 at the parent's left
+--- Places the control's left edge at a percentage along the width of a parent,
+--- with 0.00 at the parent's left edge
 ---@param control Control
 ---@param parent Control
----@param leftPercent? number
+---@param leftPercent? number defaults to 0.00 (all the way to left)
 function FromLeftIn(control, parent, leftPercent)
     if leftPercent and leftPercent ~= 0 then
-        control.Left:SetFunction(function() return parent.Left() + MathFloor(leftPercent * parent.Width()) end)
+        control.Left:SetFunction(function() return MathFloor(parent.Left() + leftPercent * parent.Width()) end)
     else
         control.Left:SetFunction(function() return parent.Left() end)
-        --control.Left:SetFunction(parent.Left)
     end
 end
 
---- Places the control's top at a percentage along the height of a parent, with 0.00 at the parent's top
+--- Places the control's top edge at a percentage along the height of a parent,
+--- with 0.00 at the parent's top edge
 ---@param control Control
 ---@param parent Control
----@param topPercent? number
+---@param topPercent? number defaults to 0.00 (all the way at the top)
 function FromTopIn(control, parent, topPercent)
     if topPercent and topPercent ~= 0 then
-        control.Top:SetFunction(function() return parent.Top() + MathFloor(topPercent * parent.Height()) end)
+        control.Top:SetFunction(function() return MathFloor(parent.Top() + topPercent * parent.Height()) end)
     else
         control.Top:SetFunction(function() return parent.Top() end)
-        --control.Top:SetFunction(parent.Top)
     end
 end
 
---- Places the control's right at a percentage along the width of a parent, with 0.00 at the parent's right
+--- Places the control's right edge at a percentage along the width of a parent,
+--- with 0.00 at the parent's right edge
 ---@param control Control
 ---@param parent Control
----@param rightPercent? number
+---@param rightPercent? number defaults to 0.00 (all the way right)
 function FromRightIn(control, parent, rightPercent)
     if rightPercent and rightPercent ~= 0 then
-        control.Right:SetFunction(function() return parent.Right() - MathFloor(rightPercent * parent.Width()) end)
+        control.Right:SetFunction(function() return MathFloor(parent.Right() - rightPercent * parent.Width()) end)
     else
         control.Right:SetFunction(function() return parent.Right() end)
-        --control.Right:SetFunction(parent.Right)
     end
 end
 
---- Places the control's top at a percentage along the height of a parent, with 0.00 at the parent's bottom
+--- Places the control's bottom edge at a percentage along the height of a parent,
+--- with 0.00 at the parent's bottom edge
 ---@param control Control
 ---@param parent Control
----@param bottomPercent? number
+---@param bottomPercent? number defaults to 0.00 (all the way at the bottom)
 function FromBottomIn(control, parent, bottomPercent)
     if bottomPercent and bottomPercent ~= 0 then
-        control.Bottom:SetFunction(function() return parent.Bottom() - MathFloor(bottomPercent * parent.Height()) end)
+        control.Bottom:SetFunction(function() return MathFloor(parent.Bottom() - bottomPercent * parent.Height()) end)
     else
         control.Bottom:SetFunction(function() return parent.Bottom() end)
         --control.Bottom:SetFunction(parent.Bottom)
@@ -316,43 +315,43 @@ end
 
 -- These functions reset a control to be calculated from the others
 
---- Resets a control's left to be calculated from its right and width  
---- **Make sure `Right` and `Width` are defined!!!**
+--- Resets a control's left edge to be calculated from its right edge and width.  
+--- Make sure `control:Right` and `control:Width` are not reset.
 ---@param control Control
 function ResetLeft(control)
     control.Left:SetFunction(function() return control.Right() - control.Width() end)
 end
 
---- Resets a control's top to be calculated from its bottom and height  
---- **Make sure `Bottom` and `Height` are defined!!!**
+--- Resets a control's top edge to be calculated from its bottom edge and height.  
+--- Make sure `control:Bottom` and `control:Height` are not reset.
 ---@param control Control
 function ResetTop(control)
     control.Top:SetFunction(function() return control.Bottom() - control.Height() end)
 end
 
---- Resets a control's left to be calculated from its right and width  
---- **Make sure `Left` and `Width` are defined!!!**
+--- Resets a control's right edge to be calculated from its left edge and width.  
+--- Make sure `control:Left` and `control:Width` are not reset.
 ---@param control Control
 function ResetRight(control)
     control.Right:SetFunction(function() return control.Left() + control.Width() end)
 end
 
---- Resets a control's bottom to be calculated from its top and height  
---- **Make sure `Top` and `Height` are Defined!!!**
+--- Resets a control's bottom edge to be calculated from its top edge and height.  
+--- Make sure `control:Top` and `control:Height` are not reset.
 ---@param control Control
 function ResetBottom(control)
     control.Bottom:SetFunction(function() return control.Top() + control.Height() end)
 end
 
---- Resets a control's width to be calculated from its right and left  
---- **Make sure `Right` and `Left` are defined!!!**
+--- Resets a control's width to be calculated from its left and right edges.  
+--- Make sure `control:Left` and `control:Right` are not reset.
 ---@param control Control
 function ResetWidth(control)
     control.Width:SetFunction(function() return control.Right() - control.Left() end)
 end
 
---- Resets a control's height to be calculated from its top and bottom  
---- **Make sure `Bottom` and `Top` are defined!!!**
+--- Resets a control's height to be calculated from its top and bottom edges.  
+--- Make sure `control:Top` and `control:Bottom` are not reset.
 ---@param control Control
 function ResetHeight(control)
     control.Height:SetFunction(function() return control.Bottom() - control.Top() end)
@@ -363,47 +362,53 @@ end
 --* Composite Functions
 --**********
 
---- Places a control in the center of a parent, with optional offsets
+--- Places a control in the center of a parent, with optional offsets.
+--- This sets the control's left and top edges.  
+--- Note the argument order.
 ---@param control Control
 ---@param parent Control
----@param topOffset? number offset of top edge (offset in down direction)
----@param leftOffset? number offset of left edge (offset in right direction)
+---@param topOffset? number offset of top edge in downward direction, scaled by the pixel scale factor
+---@param leftOffset? number offset of left edge in rightward direction, scaled by the pixel scale factor
 function AtCenterIn(control, parent, topOffset, leftOffset)
     AtHorizontalCenterIn(control, parent, leftOffset)
     AtVerticalCenterIn(control, parent, topOffset)
 end
 
---- Lock right edge of a control to left of a parent, centered vertically
+--- Lock right edge of a control to left edge of a parent, centered vertically.
+--- This sets the control's right and top edges.
 ---@param control Control
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 function CenteredLeftOf(control, parent, padding)
     AnchorToLeft(control, parent, padding)
     AtVerticalCenterIn(control, parent)
 end
 
---- Lock bottom edge of a control to top of a parent, centered horizontally
+--- Lock bottom edge of a control to top edge of a parent, centered horizontally.
+--- This sets the control's left and bottom edges.
 ---@param control Control
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 function CenteredAbove(control, parent, padding)
     AtHorizontalCenterIn(control, parent)
     AnchorToTop(control, parent, padding)
 end
 
---- Lock top left of a control to right of a parent, centered vertically
+--- Lock left edge of a control to right edge of a parent, centered vertically.
+--- This sets the control's left and top edges.
 ---@param control Control
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 function CenteredRightOf(control, parent, padding)
     AnchorToRight(control, parent, padding)
     AtVerticalCenterIn(control, parent)
 end
 
---- Lock top left of a control to bottom left of a parent, centered horizontally
+--- Lock top edge of a control to bottom edge of a parent, centered horizontally.
+--- This sets the control's left and top edges.
 ---@param control Control
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 function CenteredBelow(control, parent, padding)
     AtHorizontalCenterIn(control, parent)
     AnchorToBottom(control, parent, padding)
@@ -411,41 +416,41 @@ end
 
 -- Set to a corner inside the parent
 
---- Places top left corner of a control inside of a parent's
+--- Places top left corner of a control inside of a parent's, with optional offsets
 ---@param control Control
 ---@param parent Control
----@param leftOffset? number
----@param topOffset? number
+---@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
+---@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
 function AtLeftTopIn(control, parent, leftOffset, topOffset)
     AtLeftIn(control, parent, leftOffset)
     AtTopIn(control, parent, topOffset)
 end
 
---- Places top right corner of a control inside of a parent's
+--- Places top right corner of a control inside of a parent's, with optional offsets
 ---@param control Control
 ---@param parent Control
----@param rightOffset? number
----@param topOffset? number
+---@param rightOffset? number offset of the control's right edge in the leftward direction, scaled by the pixel scale factor
+---@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
 function AtRightTopIn(control, parent, rightOffset, topOffset)
     AtRightIn(control, parent, rightOffset)
     AtTopIn(control, parent, topOffset)
 end
 
---- Places bottom left corner of a control inside of a parent's
+--- Places bottom left corner of a control inside of a parent's, with optional offsets
 ---@param control Control
 ---@param parent Control
----@param leftOffset? number
----@param bottomOffset? number
+---@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
+---@param bottomOffset? number offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor
 function AtLeftBottomIn(control, parent, leftOffset, bottomOffset)
     AtLeftIn(control, parent, leftOffset)
     AtBottomIn(control, parent, bottomOffset)
 end
 
---- Places bottom right corner of a control inside of its parent's
+--- Places bottom right corner of a control inside of its parent's, with optional offsets
 ---@param control Control
 ---@param parent Control
----@param rightOffset? number
----@param bottomOffset? number
+---@param rightOffset? number offset of the control's right edge in the leftward direction, scaled by the pixel scale factor
+---@param bottomOffset? number offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor
 function AtRightBottomIn(control, parent, rightOffset, bottomOffset)
     AtRightIn(control, parent, rightOffset)
     AtBottomIn(control, parent, bottomOffset)
@@ -456,7 +461,7 @@ end
 --- Lock top right of a control to top left of a parent
 ---@param control Control
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 function LeftOf(control, parent, padding)
     AnchorToLeft(control, parent, padding)
     AtTopIn(control, parent)
@@ -465,7 +470,7 @@ end
 --- Lock top left of a control to top right of a parent
 ---@param control Control
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 function RightOf(control, parent, padding)
     AnchorToRight(control, parent, padding)
     AtTopIn(control, parent)
@@ -474,7 +479,7 @@ end
 --- Lock bottom left of a control to top left of a parent
 ---@param control Control
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 function Above(control, parent, padding)
     AtLeftIn(control, parent)
     AnchorToTop(control, parent, padding)
@@ -483,18 +488,19 @@ end
 --- Lock top left of a control to bottom left of a parent
 ---@param control Control
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 function Below(control, parent, padding)
     AtLeftIn(control, parent)
     AnchorToBottom(control, parent, padding)
 end
 
 
--- These functions will place the control and resize in a specified location within the parent
--- note that the offset version is more useful than hard coding the location
+-- These functions will place the control and resize in a specified location within the parent.
+-- Note that the offset version is more useful than hard coding the location
 -- as it will take advantage of the pixel scale factor
 
---- Sets all sides of a control to be a certain amount inside of a parent
+--- Sets all edges of a control to be a certain amount inside of a parent.
+--- Offsets are optional and scaled by the pixel scale factor.
 ---@param control Control
 ---@param parent Control
 ---@param left? number
@@ -508,7 +514,8 @@ function OffsetIn(control, parent, left, top, right, bottom)
     AtBottomIn(control, parent, bottom)
 end
 
---- Sets all sides of a control to be a certain percentage inside of a parent
+--- Sets all edges of a control to be a certain percentage inside of a parent.
+--- Percentages are optional.
 ---@param control Control
 ---@param parent Control
 ---@param left? number
@@ -524,8 +531,8 @@ end
 
 -- These functions will stretch the control to fill the parent and provide an optional border
 
---- Sets a control to fill a parent
---- Note this function copies the parent's side functions, it does not refer
+--- Sets a control to fill a parent.
+--- Note that this function copies the parent's edges (it does not refer) so they must be set first.
 ---@param control Control
 ---@param parent Control
 function FillParent(control, parent)
@@ -535,7 +542,7 @@ function FillParent(control, parent)
     control.Right:SetFunction(parent.Right)
 end
 
---- Sets a control to fill a parent's with fixed padding
+--- Sets a control to fill a parent's with fixed padding on all edges
 ---@param control Control
 ---@param parent Control
 ---@param offset? number
@@ -543,7 +550,7 @@ function FillParentFixedBorder(control, parent, offset)
     OffsetIn(control, parent, offset, offset, offset, offset)
 end
 
---- Sets a control to fill a parent's with percent padding
+--- Sets a control to fill a parent's with percent padding on all edges
 ---@param control Control
 ---@param parent Control
 ---@param percent? number
@@ -551,8 +558,7 @@ function FillParentRelativeBorder(control, parent, percent)
     PercentIn(control, parent, percent, percent, percent, percent)
 end
 
---- Sets a control to fill a parent while preversing its width and height ratio
---- Fill the parent control while preserving the aspect ratio of the item
+--- Sets a control's edges to fill a parent while preserving its width-to-height ratio
 ---@param control Control
 ---@param parent Control
 function FillParentPreserveAspectRatio(control, parent)
@@ -565,22 +571,22 @@ function FillParentPreserveAspectRatio(control, parent)
     end
 
     control.Top:SetFunction(function()
-        return MathFloor(parent.Top() + ((parent.Height() - (control.Height() * GetRatio(control, parent))) / 2))
+        return MathFloor(parent.Top() + (parent.Height() - control.Height() * GetRatio(control, parent)) / 2)
     end)
     control.Bottom:SetFunction(function()
-        return MathFloor(parent.Bottom() - ((parent.Height() - (control.Height() * GetRatio(control, parent))) / 2))
+        return MathFloor(parent.Bottom() - (parent.Height() - control.Height() * GetRatio(control, parent)) / 2)
     end)
     control.Left:SetFunction(function()
-        return MathFloor(parent.Left() + ((parent.Width() - (control.Width() * GetRatio(control, parent))) / 2))
+        return MathFloor(parent.Left() + (parent.Width() - control.Width() * GetRatio(control, parent)) / 2)
     end)
     control.Right:SetFunction(function()
-        return MathFloor(parent.Right() - ((parent.Width() - (control.Width() * GetRatio(control, parent))) / 2))
+        return MathFloor(parent.Right() - (parent.Width() - control.Width() * GetRatio(control, parent)) / 2)
     end)
 end
 
---- Reset to the default layout functions  
---- You should call control:ResetLayout() instead unless you cannot rely on overriden behavior  
---- **Remember to redefine two horizontal and two vertical properties to avoid circular dependencies!**
+--- Reset all edges and dimensions to the default layout functions.  
+--- You should call `control:ResetLayout()` instead unless you cannot rely on overriden behavior.  
+--- Remember to redefine two horizontal and two vertical properties to avoid circular dependencies.
 ---@param control Control
 function Reset(control)
     ResetLeft(control)
@@ -600,7 +606,8 @@ end
 --     {control_name_2 = {left = 0, top = 0, width = 100, height = 100,},
 -- }
 
---- Sets a control to be positioned to a parent using a layout table
+--- Sets a control's top and left edges to be positioned to a parent using a layout table.  
+--- Note the argument order.
 ---@param control Control
 ---@param parent Control
 ---@param fileName LazyVar|function Full path and filename of the layout file. Must be a lazy var or function that returns the filename.
@@ -629,7 +636,7 @@ function RelativeTo(control, parent, fileName, controlName, parentName, topOffse
     end)
 end
 
---- Sets a control's left to be positioned to a parent using a layout table
+--- Sets a control's left edge to be positioned to a parent using a layout table
 ---@param control Control
 ---@param parent Control
 ---@param fileName LazyVar|function Full path and filename of the layout file. Must be a lazy var or function that returns the filename.
@@ -645,11 +652,11 @@ function LeftRelativeTo(control, parent, fileName, controlName, parentName)
     end
     control.Left:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return MathFloor(parent.Left() + (layoutTable[controlName].left - layoutTable[parentName].left))
+        return MathFloor(parent.Left() + layoutTable[controlName].left - layoutTable[parentName].left)
     end)
 end
 
---- Sets a control's top to be positioned to a parent using a layout table
+--- Sets a control's top edge to be positioned to a parent using a layout table
 ---@param control Control
 ---@param parent Control
 ---@param fileName LazyVar|function Full path and filename of the layout file. Must be a lazy var or function that returns the filename.
@@ -665,11 +672,11 @@ function TopRelativeTo(control, parent, fileName, controlName, parentName)
     end
     control.Top:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return MathFloor(parent.Top() + (layoutTable[controlName].top - layoutTable[parentName].top))
+        return MathFloor(parent.Top() + layoutTable[controlName].top - layoutTable[parentName].top)
     end)
 end
 
---- Sets a control's right to be positioned to a parent using a layout table
+--- Sets a control's right edge to be positioned to a parent using a layout table
 ---@param control Control
 ---@param parent Control
 ---@param fileName LazyVar|function Full path and filename of the layout file. Must be a lazy var or function that returns the filename.
@@ -691,7 +698,7 @@ function RightRelativeTo(control, parent, fileName, controlName, parentName)
     end)
 end
 
---- Sets a control's bottom to be positioned to a parent using a layout table
+--- Sets a control's bottom edge to be positioned to a parent using a layout table
 ---@param control Control
 ---@param parent Control
 ---@param fileName LazyVar|function Full path and filename of the layout file. Must be a lazy var or function that returns the filename.
@@ -774,7 +781,7 @@ function LayouterMetaTable:Hide()
 end
 
 --- Sets the color of the control
----@param color string hexcolor
+---@param color string color as a hexcode
 ---@return Layouter
 function LayouterMetaTable:Color(color)
     if self.c.SetSolidColor then
@@ -838,33 +845,34 @@ function LayouterMetaTable:Alpha(alpha, forChildren)
 end
 
 -- Raw setting
+---@alias lazyvarType function|number
 
---- Sets the left side of the control
----@param left function|number
+--- Sets the left edge of the control
+---@param left lazyvarType
 ---@return Layouter
 function LayouterMetaTable:Left(left)
     self.c.Left:Set(left)
     return self
 end
 
---- Sets the top side of the control
----@param top function|number
+--- Sets the top edge of the control
+---@param top lazyvarType
 ---@return Layouter
 function LayouterMetaTable:Top(top)
     self.c.Top:Set(top)
     return self
 end
 
---- Sets the right side of the control
----@param right function|number
+--- Sets the right edge of the control
+---@param right lazyvarType
 ---@return Layouter
 function LayouterMetaTable:Right(right)
     self.c.Right:Set(right)
     return self
 end
 
---- Sets the bottom side of the control
----@param bottom function|number
+--- Sets the bottom edge of the control
+---@param bottom lazyvarType
 ---@return Layouter
 function LayouterMetaTable:Bottom(bottom)
     self.c.Bottom:Set(bottom)
@@ -872,7 +880,7 @@ function LayouterMetaTable:Bottom(bottom)
 end
 
 --- Sets the width of the control
----@param width function|number #width will be scaled by the pixel factor
+---@param width lazyvarType #if a number, width will be scaled by the pixel factor
 ---@return Layouter
 function LayouterMetaTable:Width(width)
     if iscallable(width) then
@@ -884,7 +892,7 @@ function LayouterMetaTable:Width(width)
 end
 
 --- Sets the height of the control
----@param height function|number #height will be scaled by the pixel factor
+---@param height lazyvarType #if a number, height will be scaled by the pixel factor
 ---@return Layouter
 function LayouterMetaTable:Height(height)
     if iscallable(height) then
@@ -898,7 +906,7 @@ end
 
 -- Depth
 
---- Sets the depth of the control higher than a parent
+--- Sets depth of the control to be above a parent
 ---@param parent Control
 ---@param depth? integer defaults to 1
 ---@return Layouter
@@ -908,7 +916,7 @@ function LayouterMetaTable:Over(parent, depth)
 end
 
 
---- Sets the depth of the control lower than a parent
+--- Sets depth of the control to be below a parent
 ---@param parent Control
 ---@param depth? integer defaults to 1
 ---@return Layouter
@@ -923,36 +931,36 @@ end
 
 -- Anchors
 
---- Anchors the control to the left of a parent, with optional padding
+--- Anchors the control's right edge to the left edge of a parent, with optional padding
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
 ---@return Layouter
 function LayouterMetaTable:AnchorToLeft(parent, padding)
     AnchorToLeft(self.c, parent, padding)
     return self
 end
 
---- Anchors a control to the top of a parent, with optional offset
+--- Anchors the control's bottom edge to the top edge of a parent, with optional padding
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
 ---@return Layouter
 function LayouterMetaTable:AnchorToTop(parent, padding)
     AnchorToTop(self.c, parent, padding)
     return self
 end
 
---- Anchors a control to the right of a parent, with optional offset
+--- Anchors the control's left edge to the right edge of a parent, with optional padding
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
 ---@return Layouter
 function LayouterMetaTable:AnchorToRight(parent, padding)
     AnchorToRight(self.c, parent, padding)
     return self
 end
 
---- Anchors a control to the bottom of a parent, with optional offset
+--- Anchors the control's top edge to the bottom edge of a parent, with optional padding
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
 ---@return Layouter
 function LayouterMetaTable:AnchorToBottom(parent, padding)
     AnchorToBottom(self.c, parent, padding)
@@ -961,19 +969,21 @@ end
 
 -- Centered
 
---- Centers a control horizontally on a parent, with an optional offset
+--- Centers the control horizontally on a parent, with optional rightward offset.
+--- This sets the control's left edge.
 ---@param parent Control
----@param leftOffset? number in right direction
+---@param leftOffset? number Offset of control's left edge in the rightward direction, scaled by the pixel scale factor. Defaults to 0.
 ---@return Layouter
 function LayouterMetaTable:AtHorizontalCenterIn(parent, leftOffset)
     AtHorizontalCenterIn(self.c, parent, leftOffset)
     return self
 end
 
---- Centers a control vertically on a parent, with an optional offset
+--- Centers the control vertically on a parent, with optional downward offset.
+--- This sets the control's top edge.
 ---@param control Control
 ---@param parent Control
----@param topOffset? number in down direction
+---@param topOffset? number Offset of the control's top edge in the downward direction, scaled by the pixel scale factor. Defaults to 0.
 ---@return Layouter
 function LayouterMetaTable:AtVerticalCenterIn(parent, topOffset)
     AtVerticalCenterIn(self.c, parent, topOffset)
@@ -982,36 +992,36 @@ end
 
 -- Inside
 
---- Places the control inside the left border of a parent, with optional right offset
+--- Places the control's left edge inside of a parent's, with optional rightward offset
 ---@param parent Control
----@param leftOffset? number
+---@param leftOffset? number Offset of the control's left edge in the rightward direction, scaled by the pixel scale factor. Defaults to 0.
 ---@return Layouter
 function LayouterMetaTable:AtLeftIn(parent, leftOffset)
     AtLeftIn(self.c, parent, leftOffset)
     return self
 end
 
---- Places the control inside the top border of a parent, with optional down offset
+--- Places the control's top edge inside of a parent's, with optional downward offset
 ---@param parent Control
----@param topOffset? number
+---@param topOffset? number Offset of the control's top edge in the downward direction, scaled by the pixel scale factor. Defaults to 0.
 ---@return Layouter
 function LayouterMetaTable:AtTopIn(parent, topOffset)
     AtTopIn(self.c, parent, topOffset)
     return self
 end
 
---- Places the control inside the right border of a parent, with optional left offset
+--- Places the control's right edge inside of a parent's, with optional leftward offset
 ---@param parent Control
----@param rightOffset? number
+---@param rightOffset? number Offset of the control's right edge in the leftward direction, scaled by the pixel scale factor. Defaults to 0.
 ---@return Layouter
 function LayouterMetaTable:AtRightIn(parent, rightOffset)
     AtRightIn(self.c, parent, rightOffset)
     return self
 end
 
---- Places the control inside the bottom border of a parent, with optional up offset
+--- Places the control's bottom edge inside of a parent's, with optional upward offset
 ---@param parent Control
----@param bottomOffset? number
+---@param bottomOffset? number Offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor. Defaults to 0.
 ---@return Layouter
 function LayouterMetaTable:AtBottomIn(parent, bottomOffset)
     AtBottomIn(self.c, parent, bottomOffset)
@@ -1020,48 +1030,48 @@ end
 
 -- Resets
 
---- Resets the control's left to be calculated from its right and width  
---- **Make sure `Right` and `Width` are defined!!!**
+--- Resets the control's left edge to be calculated from its right edge and width.  
+--- Make sure `control:Right` and `control:Width` are not reset.
 ---@return Layouter
 function LayouterMetaTable:ResetLeft()
     ResetLeft(self.c)
     return self
 end
 
---- Resets the control's top to be calculated from its bottom and height  
---- **Make sure `Bottom` and `Height` are defined!!!**
+--- Resets the control's top edge to be calculated from its bottom edge and height.  
+--- Make sure `control:Bottom` and `control:Height` are not reset.
 ---@return Layouter
 function LayouterMetaTable:ResetTop()
     ResetTop(self.c)
     return self
 end
 
---- Resets the control's right to be calculated from its right and width  
---- **Make sure `Left` and `Width` are defined!!!**
+--- Resets the control's right edge to be calculated from its left edge and width.  
+--- Make sure `control:Left` and `control:Width` are not reset.
 ---@return Layouter
 function LayouterMetaTable:ResetRight()
     ResetRight(self.c)
     return self
 end
 
---- Resets the control's bottom to be calculated from its top and height  
---- **Make sure `Top` and `Height` are Defined!!!**
+--- Resets the control's bottom edge to be calculated from its top edge and height.  
+--- Make sure `control:Top` and `control:Height` are not reset.
 ---@return Layouter
 function LayouterMetaTable:ResetBottom()
     ResetBottom(self.c)
     return self
 end
 
---- Resets the control's width to be calculated from its right and left  
---- **Make sure `Right` and `Left` are defined!!!**
+--- Resets the control's width to be calculated from its left and right edges.  
+--- Make sure `control:Left` and `control:Right` are not reset.
 ---@return Layouter
 function LayouterMetaTable:ResetWidth()
     ResetWidth(self.c)
     return self
 end
 
---- Resets the control's height to be calculated from its top and bottom  
---- **Make sure `Bottom` and `Top` are defined!!!**
+--- Resets the control's height to be calculated from its top and bottom edges.  
+--- Make sure `control:Top` and `control:Bottom` are not reset.
 ---@return Layouter
 function LayouterMetaTable:ResetHeight()
     ResetHeight(self.c)
@@ -1074,61 +1084,67 @@ end
 
 --- Surround positioning
 
---- Lock right of the control to left of a parent, centered vertically
+--- Lock right edge of the control to the left edge of a parent, centered vertically.
+--- This sets the control's right and top edges.
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 ---@return Layouter
 function LayouterMetaTable:CenteredLeftOf(parent, padding)
     CenteredLeftOf(self.c, parent, padding)
     return self
 end
 
---- Lock bottom of the control to top left of a parent, centered horizontally
+--- Lock bottom edge of the control to the top edge of a parent, centered horizontally.
+--- This sets the control's left and bottom edges.
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 ---@return Layouter
 function LayouterMetaTable:CenteredAbove(parent, padding)
     CenteredAbove(self.c, parent, padding)
     return self
 end
 
---- Lock left of the control to right of a parent, centered vertically
+--- Lock left edge of the control to the right edge of a parent, centered vertically.
+--- This sets the control's left and top edges.
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 ---@return Layouter
 function LayouterMetaTable:CenteredRightOf(parent, padding)
     CenteredRightOf(self.c, parent, padding)
     return self
 end
 
---- Lock top of the control to bottom left of parent, centered horizontally
+--- Lock top edge of the control to the bottom edge of parent, centered horizontally.
+--- This sets the controls's left and top edges.
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 ---@return Layouter
 function LayouterMetaTable:CenteredBelow(parent, padding)
     CenteredBelow(self.c, parent, padding)
     return self
 end
 
-
 -- Inside positioning
--- note that the inside-edge layouts don't have a function counterpart like
--- the inside-corner layouts do
+-- Note that the inside-edge layouts don't have a function counterpart like
+-- the inside-corner layouts do.
 
---- Places the control in the center of the parent, with optional offsets
+--- Places the control in the center of the parent, with optional offsets.
+--- This sets the control's left and top edges.  
+--- Note the argument order.
 ---@param parent Control
----@param topOffset? number offset of top edge (offset in down direction)
----@param leftOffset? number offset of left edge (offset in right direction)
+---@param topOffset? number offset of top edge in downward direction, scaled by the pixel scale factor
+---@param leftOffset? number offset of left edge in rightward direction, scaled by the pixel scale factor
 ---@return Layouter
 function LayouterMetaTable:AtCenterIn(parent, topOffset, leftOffset)
     AtCenterIn(self.c, parent, topOffset, leftOffset)
     return self
 end
 
---- Places left edge of the control vertically centered inside of a parent's
+--- Places left edge of the control vertically centered inside of a parent's, with optional offsets.
+--- This sets the control's left and top edges.
 ---@param parent Control
----@param leftOffset? number
----@param topOffset? number
+---@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
+---@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
 ---@return Layouter
 function LayouterMetaTable:AtLeftCenterIn(parent, leftOffset, topOffset)
     AtLeftIn(self.c, parent, leftOffset)
@@ -1136,20 +1152,22 @@ function LayouterMetaTable:AtLeftCenterIn(parent, leftOffset, topOffset)
     return self
 end
 
---- Places top left corner of the control inside of a parent's
+--- Places top left corner of the control inside of a parent's, with optional offsets
 ---@param parent Control
----@param leftOffset? number
----@param topOffset? number
+---@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
+---@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
 ---@return Layouter
 function LayouterMetaTable:AtLeftTopIn(parent, leftOffset, topOffset)
     AtLeftTopIn(self.c, parent, leftOffset, topOffset)
     return self
 end
 
---- Places top edge of the control horizontally centered inside of a parent's
+--- Places top edge of the control horizontally centered inside of a parent's, with optional offsets.
+--- Sets the control's left and top edges.  
+--- Note the argument order.
 ---@param parent Control
----@param topOffset? number
----@param leftOffset? number
+---@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
+---@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
 ---@return Layouter
 function LayouterMetaTable:AtTopCenterIn(parent, topOffset, leftOffset)
     AtTopIn(self.c, parent, topOffset)
@@ -1157,20 +1175,21 @@ function LayouterMetaTable:AtTopCenterIn(parent, topOffset, leftOffset)
     return self
 end
 
---- Places top right corner of the control inside of its parent's
+--- Places top right corner of the control inside of its parent's, with optional offsets
 ---@param parent Control
----@param rightOffset? number
----@param topOffset? number
+---@param rightOffset? number offset of the control's right edge in the leftward direction, scaled by the pixel scale factor
+---@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
 ---@return Layouter
 function LayouterMetaTable:AtRightTopIn(parent, rightOffset, topOffset)
     AtRightTopIn(self.c, parent, rightOffset, topOffset)
     return self
 end
 
---- Places right edge of the control vertically centered inside of a parent's
+--- Places right edge of the control vertically centered inside of a parent's, with optional offsets.
+--- Sets the control's right and top edges.
 ---@param parent Control
----@param rightOffset? number
----@param topOffset? number
+---@param rightOffset? number offset of the control's right edge in the leftward direction, scaled by the pixel scale factor
+---@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
 ---@return Layouter
 function LayouterMetaTable:AtRightCenterIn(parent, rightOffset, topOffset)
     AtRightIn(self.c, parent, rightOffset)
@@ -1178,20 +1197,22 @@ function LayouterMetaTable:AtRightCenterIn(parent, rightOffset, topOffset)
     return self
 end
 
---- Places bottom right corner of the control inside of a parent's
+--- Places bottom right corner of the control inside of a parent's, with optional offsets
 ---@param parent Control
----@param rightOffset? number
----@param bottomOffset? number
+---@param rightOffset? number offset of the control's right edge in the leftward direction, scaled by the pixel scale factor
+---@param bottomOffset? number offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor
 ---@return Layouter
 function LayouterMetaTable:AtRightBottomIn(parent, rightOffset, bottomOffset)
     AtRightBottomIn(self.c, parent, rightOffset, bottomOffset)
     return self
 end
 
---- Places bottom edge of the control horizontally centered inside of a parent's
+--- Places bottom edge of the control horizontally centered inside of a parent's, with optional offsets.
+--- Sets the control's left and bottom edges.  
+--- Note the argument order.
 ---@param parent Control
----@param leftOffset? number
----@param bottomOffset? number
+---@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
+---@param bottomOffset? number offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor
 ---@return Layouter
 function LayouterMetaTable:AtBottomCenterIn(parent, bottomOffset, leftOffset)
     AtBottomIn(self.c, parent, bottomOffset)
@@ -1199,50 +1220,48 @@ function LayouterMetaTable:AtBottomCenterIn(parent, bottomOffset, leftOffset)
     return self
 end
 
---- Places bottom left corner of the control inside of a parent's
+--- Places bottom left corner of the control inside of a parent's, with optional offsets
 ---@param parent Control
----@param leftOffset? number
----@param bottomOffset? number
+---@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
+---@param bottomOffset? number offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor
 ---@return Layouter
 function LayouterMetaTable:AtLeftBottomIn(parent, leftOffset, bottomOffset)
     AtLeftBottomIn(self.c, parent, leftOffset, bottomOffset)
     return self
 end
 
-
 -- Out-of positioning
 
---- Lock top right of the control to top left of a parent
+--- Lock top right of the control to the top left of a parent
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 ---@return Layouter
 function LayouterMetaTable:LeftOf(parent, padding)
     LeftOf(self.c, parent, padding)
     return self
 end
 
---- Lock top left of the control to top right of a parent
+--- Lock top left of the control to the top right of a parent
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 ---@return Layouter
 function LayouterMetaTable:RightOf(parent, padding)
     RightOf(self.c, parent, padding)
     return self
 end
 
---- Lock bottom left of the control to top left of a parent
+--- Lock bottom left of the control to the top left of a parent
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 ---@return Layouter
 function LayouterMetaTable:Above(parent, padding)
     Above(self.c, parent, padding)
     return self
 end
 
-
---- Lock top left of the control to bottom left of a parent
+--- Lock top left of the control to the bottom left of a parent
 ---@param parent Control
----@param padding? number fixed padding between control and parent
+---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
 ---@return Layouter
 function LayouterMetaTable:Below(parent, padding)
     Below(self.c, parent, padding)
@@ -1251,8 +1270,8 @@ end
 
 -- Fill parent
 
---- Sets control to fill a parent  
---- Note this function copies the parent's edge functions, it does not refer
+--- Sets the control to fill a parent.
+--- Note that this function copies the parent's edges (it does not refer) so they must be set first.
 ---@param parent Control
 ---@return Layouter
 function LayouterMetaTable:Fill(parent)
@@ -1260,7 +1279,7 @@ function LayouterMetaTable:Fill(parent)
     return self
 end
 
---- Sets control to fill a parent's with fixed padding
+--- Sets the control to fill a parent's with fixed padding
 ---@param parent Control
 ---@param offset? number
 ---@return Layouter
@@ -1270,8 +1289,8 @@ function LayouterMetaTable:FillFixedBorder(parent, offset)
 end
 
 
--- Calculates control's Properties to determine its layout completion and returns it  
--- remember, if parent has incomplete layout it will warn you anyway
+-- Calculates the control's Properties to determine its layout completion and returns it.  
+-- Remember, if parent has incomplete layout it will warn you anyway.
 ---@return Control
 function LayouterMetaTable:End()
     if not pcall(self.c.Top) or not pcall(self.c.Bottom) or not pcall(self.c.Height) then
@@ -1287,9 +1306,11 @@ function LayouterMetaTable:End()
     return self.c
 end
 
+
 function LayouterMetaTable:__newindex(key, value)
     error("attempt to set new index for a Layouter object")
 end
+
 
 --- Returns a layouter for a control
 ---@param control Control

--- a/lua/maui/layouthelpers.lua
+++ b/lua/maui/layouthelpers.lua
@@ -51,7 +51,7 @@ end
 ---@param width? number no change if nil
 function SetWidth(control, width)
     if width then
-        control.Width:Set(MapFloor(width * pixelScaleFactor))
+        control.Width:SetValue(MapFloor(width * pixelScaleFactor))
     end
 end
 
@@ -60,11 +60,11 @@ end
 ---@param height? number no change if nil
 function SetHeight(control, height)
     if height then
-        control.Height:Set(MapFloor(height * pixelScaleFactor))
+        control.Height:SetValue(MapFloor(height * pixelScaleFactor))
     end
 end
 
---- Set the depth of a control higher than the parent
+--- Set the depth of a control higher than a parent
 ---@param control Control
 ---@param parent Control
 ---@param depth? integer defaults to 1
@@ -73,7 +73,7 @@ function DepthOverParent(control, parent, depth)
     control.Depth:SetFunction(function() return parent.Depth() + depth end)
 end
 
---- Set the depth of a control lower than the parent
+--- Set the depth of a control lower than a parent
 ---@param control Control
 ---@param parent Control
 ---@param depth? integer defaults to 1
@@ -106,52 +106,54 @@ end
 
 -- Anchor functions lock the appropriate side of a control to the side of another control
 
---- Anchors a control to the left of a parent, with optional offset
+--- Anchors a control to the left of a parent, with optional padding
 ---@param control Control
 ---@param parent Control
----@param leftOffset? number
-function AnchorToLeft(control, parent, leftOffset)
-    if leftOffset and leftOffset ~= 0 then
-        control.Right:SetFunction(function() return parent.Left() - MapFloor(leftOffset * pixelScaleFactor) end)
+---@param padding? number fixed padding between control and parent
+function AnchorToLeft(control, parent, padding)
+    if padding and padding ~= 0 then
+        control.Right:SetFunction(function() return parent.Left() - MapFloor(padding * pixelScaleFactor) end)
     else
+        -- We shouldn't need to let the child refer to the parent if the parent is already laid out
+        -- however, this does change functionallity of the layout, so I've left them commented out for now
         control.Right:SetFunction(function() return parent.Left() end)
         --control.Right:SetFunction(parent.Left)
     end
 end
 
---- Anchors a control to the top of a parent, with optional offset
+--- Anchors a control to the top of a parent, with optional padding
 ---@param control Control
 ---@param parent Control
----@param upOffset? number
-function AnchorToTop(control, parent, upOffset)
-    if upOffset and upOffset ~= 0 then
-        control.Bottom:SetFunction(function() return parent.Top() - MapFloor(upOffset * pixelScaleFactor) end)
+---@param padding? number fixed padding between control and parent
+function AnchorToTop(control, parent, padding)
+    if padding and padding ~= 0 then
+        control.Bottom:SetFunction(function() return parent.Top() - MapFloor(padding * pixelScaleFactor) end)
     else
         control.Bottom:SetFunction(function() return parent.Top() end)
         --control.Bottom:SetFunction(parent.Top)
     end
 end
 
---- Anchors a control to the right of a parent, with optional offset
+--- Anchors a control to the right of a parent, with optional padding
 ---@param control Control
 ---@param parent Control
----@param rightOffset? number
-function AnchorToRight(control, parent, rightOffset)
-    if rightOffset and rightOffset ~= 0 then
-        control.Left:SetFunction(function() return parent.Right() + MapFloor(rightOffset * pixelScaleFactor) end)
+---@param padding? number fixed padding between control and parent
+function AnchorToRight(control, parent, padding)
+    if padding and padding ~= 0 then
+        control.Left:SetFunction(function() return parent.Right() + MapFloor(padding * pixelScaleFactor) end)
     else
         control.Left:SetFunction(function() return parent.Right() end)
         --control.Left:SetFunction(parent.Right)
     end
 end
 
---- Anchors a control to the bottom of a parent, with optional offset
+--- Anchors a control to the bottom of a parent, with optional padding
 ---@param control Control
 ---@param parent Control
----@param downOffset? number
-function AnchorToBottom(control, parent, downOffset)
-    if downOffset and downOffset ~= 0 then
-        control.Top:SetFunction(function() return parent.Bottom() + MapFloor(downOffset * pixelScaleFactor) end)
+---@param padding? number fixed padding between control and parent
+function AnchorToBottom(control, parent, padding)
+    if padding and padding ~= 0 then
+        control.Top:SetFunction(function() return parent.Bottom() + MapFloor(padding * pixelScaleFactor) end)
     else
         control.Top:SetFunction(function() return parent.Bottom() end)
         --control.Top:SetFunction(parent.Bottom)
@@ -166,14 +168,14 @@ end
 -- These are generally most useful for elements that don't change size, they can also be
 -- used for controls that stretch to match parent.
 
---- Centers a control horizontally on a parent, with an optional offset
+--- Centers a control horizontally on a parent, with optional right offset
 ---@param control Control
 ---@param parent Control
----@param rightOffset? number
-function AtHorizontalCenterIn(control, parent, rightOffset)
-    if rightOffset then
+---@param leftOffset? number
+function AtHorizontalCenterIn(control, parent, leftOffset)
+    if leftOffset then
         control.Left:SetFunction(function()
-            return parent.Left() + MapFloor(((parent.Width() - control.Width()) / 2) + (rightOffset * pixelScaleFactor))
+            return parent.Left() + MapFloor(((parent.Width() - control.Width()) / 2) + (leftOffset * pixelScaleFactor))
         end)
     else
         control.Left:SetFunction(function()
@@ -182,14 +184,14 @@ function AtHorizontalCenterIn(control, parent, rightOffset)
     end
 end
 
---- Centers a control vertically on a parent, with an optional offset
+--- Centers a control vertically on a parent, with optional down offset
 ---@param control Control
 ---@param parent Control
----@param downOffset? number
-function AtVerticalCenterIn(control, parent, downOffset)
-    if downOffset then
+---@param topOffset? number
+function AtVerticalCenterIn(control, parent, topOffset)
+    if topOffset then
         control.Top:SetFunction(function()
-            return parent.Top() + MapFloor(((parent.Height() - control.Height()) / 2) + (downOffset * pixelScaleFactor))
+            return parent.Top() + MapFloor(((parent.Height() - control.Height()) / 2) + (topOffset * pixelScaleFactor))
         end)
     else
         control.Top:SetFunction(function()
@@ -198,54 +200,52 @@ function AtVerticalCenterIn(control, parent, downOffset)
     end
 end
 
---- Places a control inside the left border of a parent, with optional offset
+--- Places a control inside the left edge of a parent, with optional right offset
 ---@param control Control
 ---@param parent Control
----@param rightOffset? number
-function AtLeftIn(control, parent, rightOffset)
-    if rightOffset and rightOffset ~= 0 then
-        control.Left:SetFunction(function() return parent.Left() + MapFloor(rightOffset * pixelScaleFactor) end)
+---@param leftOffset? number
+function AtLeftIn(control, parent, leftOffset)
+    if leftOffset and leftOffset ~= 0 then
+        control.Left:SetFunction(function() return parent.Left() + MapFloor(leftOffset * pixelScaleFactor) end)
     else
-        -- We shouldn't need to let the child refer to the parent if the parent is already laid out
-        -- however, this does change functionallity of the layout, so I've left them commented out for now
         control.Left:SetFunction(function() return parent.Left() end)
         --control.Left:SetFunction(parent.Left)
     end
 end
 
---- Places a control inside the top border of a parent, with optional offset
+--- Places a control inside the top edge of a parent, with optional down offset
 ---@param control Control
 ---@param parent Control
----@param downOffset? number
-function AtTopIn(control, parent, downOffset)
-    if downOffset and downOffset ~= 0 then
-        control.Top:SetFunction(function() return parent.Top() + MapFloor(downOffset * pixelScaleFactor) end)
+---@param topOffset? number
+function AtTopIn(control, parent, topOffset)
+    if topOffset and topOffset ~= 0 then
+        control.Top:SetFunction(function() return parent.Top() + MapFloor(topOffset * pixelScaleFactor) end)
     else
         control.Top:SetFunction(function() return parent.Top() end)
         --control.Top:SetFunction(parent.Top)
     end
 end
 
---- Places a control inside the right border of a parent, with optional offset
+--- Places a control inside the right edge of a parent, with optional left offset
 ---@param control Control
 ---@param parent Control
----@param leftOffset? number
-function AtRightIn(control, parent, leftOffset)
-    if leftOffset and leftOffset ~= 0 then
-        control.Right:SetFunction(function() return parent.Right() - MapFloor(leftOffset * pixelScaleFactor) end)
+---@param rightOffset? number
+function AtRightIn(control, parent, rightOffset)
+    if rightOffset and rightOffset ~= 0 then
+        control.Right:SetFunction(function() return parent.Right() - MapFloor(rightOffset * pixelScaleFactor) end)
     else
         control.Right:SetFunction(function() return parent.Right() end)
         --control.Right:SetFunction(parent.Right)
     end
 end
 
---- Places a control inside the bottom border of a parent, with optional offset
+--- Places a control inside the bottom edge of a parent, with optional up offset
 ---@param control Control
 ---@param parent Control
----@param upOffset? number
-function AtBottomIn(control, parent, upOffset)
-    if upOffset and upOffset ~= 0 then
-        control.Bottom:SetFunction(function() return parent.Bottom() - MapFloor(upOffset * pixelScaleFactor) end)
+---@param bottomOffset? number
+function AtBottomIn(control, parent, bottomOffset)
+    if bottomOffset and bottomOffset ~= 0 then
+        control.Bottom:SetFunction(function() return parent.Bottom() - MapFloor(bottomOffset * pixelScaleFactor) end)
     else
         control.Bottom:SetFunction(function() return parent.Bottom() end)
         --control.Bottom:SetFunction(parent.Bottom)
@@ -258,10 +258,10 @@ end
 --- Places the control's left at a percentage along the width of a parent, with 0.00 at the parent's left
 ---@param control Control
 ---@param parent Control
----@param rightPercent? number
-function FromLeftIn(control, parent, rightPercent)
-    if rightPercent and rightPercent ~= 0 then
-        control.Left:SetFunction(function() return parent.Left() + MapFloor(rightPercent * parent.Width()) end)
+---@param leftPercent? number
+function FromLeftIn(control, parent, leftPercent)
+    if leftPercent and leftPercent ~= 0 then
+        control.Left:SetFunction(function() return parent.Left() + MapFloor(leftPercent * parent.Width()) end)
     else
         control.Left:SetFunction(function() return parent.Left() end)
         --control.Left:SetFunction(parent.Left)
@@ -271,22 +271,23 @@ end
 --- Places the control's top at a percentage along the height of a parent, with 0.00 at the parent's top
 ---@param control Control
 ---@param parent Control
----@param downPercent? number
-function FromTopIn(control, parent, downPercent)
-    if downPercent and downPercent ~= 0 then
-        control.Top:SetFunction(function() return parent.Top() + MapFloor(downPercent * parent.Height()) end)
+---@param topPercent? number
+function FromTopIn(control, parent, topPercent)
+    if topPercent and topPercent ~= 0 then
+        control.Top:SetFunction(function() return parent.Top() + MapFloor(topPercent * parent.Height()) end)
     else
         control.Top:SetFunction(function() return parent.Top() end)
+        --control.Top:SetFunction(parent.Top)
     end
 end
 
 --- Places the control's right at a percentage along the width of a parent, with 0.00 at the parent's right
 ---@param control Control
 ---@param parent Control
----@param leftPercent? number
-function FromRightIn(control, parent, leftPercent)
-    if leftPercent and leftPercent ~= 0 then
-        control.Right:SetFunction(function() return parent.Right() - MapFloor(leftPercent * parent.Width()) end)
+---@param rightPercent? number
+function FromRightIn(control, parent, rightPercent)
+    if rightPercent and rightPercent ~= 0 then
+        control.Right:SetFunction(function() return parent.Right() - MapFloor(rightPercent * parent.Width()) end)
     else
         control.Right:SetFunction(function() return parent.Right() end)
         --control.Right:SetFunction(parent.Right)
@@ -296,10 +297,10 @@ end
 --- Places the control's top at a percentage along the height of a parent, with 0.00 at the parent's bottom
 ---@param control Control
 ---@param parent Control
----@param upPercent? number
-function FromBottomIn(control, parent, upPercent)
-    if upPercent and upPercent ~= 0 then
-        control.Bottom:SetFunction(function() return parent.Bottom() - MapFloor(upPercent * parent.Height()) end)
+---@param bottomPercent? number
+function FromBottomIn(control, parent, bottomPercent)
+    if bottomPercent and bottomPercent ~= 0 then
+        control.Bottom:SetFunction(function() return parent.Bottom() - MapFloor(bottomPercent * parent.Height()) end)
     else
         control.Bottom:SetFunction(function() return parent.Bottom() end)
         --control.Bottom:SetFunction(parent.Bottom)
@@ -350,69 +351,69 @@ function ResetHeight(control)
 end
 
 
---**************************************
---*      Composite Functions           *
---**************************************
+--**********
+--* Composite Functions
+--**********
 
---- Places a control in the center of the parent, with optional offsets
+--- Places a control in the center of a parent, with optional offsets
 ---@param control Control
 ---@param parent Control
----@param downOffset? number
----@param rightOffset? number
-function AtCenterIn(control, parent, downOffset, rightOffset)
-    AtHorizontalCenterIn(control, parent, rightOffset)
-    AtVerticalCenterIn(control, parent, downOffset)
+---@param topOffset? number offset of top edge (offset in down direction)
+---@param leftOffset? number offset of left edge (offset in right direction)
+function AtCenterIn(control, parent, topOffset, leftOffset)
+    AtHorizontalCenterIn(control, parent, leftOffset)
+    AtVerticalCenterIn(control, parent, topOffset)
 end
 
---- Lock top right of control to left of parent, centered vertically to the parent
+--- Lock right edge of a control to left of a parent, centered vertically
 ---@param control Control
 ---@param parent Control
----@param leftOffset? number 
-function CenteredLeftOf(control, parent, leftOffset)
-    AnchorToLeft(control, parent, leftOffset)
+---@param padding? number fixed padding between control and parent
+function CenteredLeftOf(control, parent, padding)
+    AnchorToLeft(control, parent, padding)
     AtVerticalCenterIn(control, parent)
 end
 
---- Lock bottom left of control to top left of parent, centered horizontally to the parent
+--- Lock bottom edge of a control to top of a parent, centered horizontally
 ---@param control Control
 ---@param parent Control
----@param upOffset? number 
-function CenteredAbove(control, parent, upOffset)
+---@param padding? number fixed padding between control and parent
+function CenteredAbove(control, parent, padding)
     AtHorizontalCenterIn(control, parent)
-    AnchorToTop(control, parent, upOffset)
+    AnchorToTop(control, parent, padding)
 end
 
---- Lock top left of control to right of parent, centered vertically to the parent
+--- Lock top left of a control to right of a parent, centered vertically
 ---@param control Control
 ---@param parent Control
----@param rightOffset? number 
-function CenteredRightOf(control, parent, rightOffset)
-    AnchorToRight(control, parent, rightOffset)
+---@param padding? number fixed padding between control and parent
+function CenteredRightOf(control, parent, padding)
+    AnchorToRight(control, parent, padding)
     AtVerticalCenterIn(control, parent)
 end
 
---- Lock top left of control to bottom left of parent, centered horizontally to the parent
+--- Lock top left of a control to bottom left of a parent, centered horizontally
 ---@param control Control
 ---@param parent Control
----@param downOffset? number 
-function CenteredBelow(control, parent, downOffset)
+---@param padding? number fixed padding between control and parent
+function CenteredBelow(control, parent, padding)
     AtHorizontalCenterIn(control, parent)
-    AnchorToBottom(control, parent, downOffset)
+    AnchorToBottom(control, parent, padding)
 end
 
 -- Set to a corner inside the parent
 
---- Places top left corner of a control inside of its parent's
+--- Places top left corner of a control inside of a parent's
 ---@param control Control
 ---@param parent Control
----@param rightOffset? number
----@param downOffset? number
-function AtLeftTopIn(control, parent, rightOffset, downOffset)
-    AtLeftIn(control, parent, rightOffset)
-    AtTopIn(control, parent, downOffset)
+---@param leftOffset? number
+---@param topOffset? number
+function AtLeftTopIn(control, parent, leftOffset, topOffset)
+    AtLeftIn(control, parent, leftOffset)
+    AtTopIn(control, parent, topOffset)
 end
 
---- Places top right corner of a control inside of its parent's
+--- Places top right corner of a control inside of a parent's
 ---@param control Control
 ---@param parent Control
 ---@param rightOffset? number
@@ -422,7 +423,7 @@ function AtRightTopIn(control, parent, rightOffset, topOffset)
     AtTopIn(control, parent, topOffset)
 end
 
---- Places bottom left corner of a control inside of its parent's
+--- Places bottom left corner of a control inside of a parent's
 ---@param control Control
 ---@param parent Control
 ---@param leftOffset? number
@@ -444,40 +445,40 @@ end
 
 -- These functions will set the controls position relative to another, usually a sibling
 
---- Lock top right of control to top left of parent
+--- Lock top right of a control to top left of a parent
 ---@param control Control
 ---@param parent Control
----@param leftOffset? number
-function LeftOf(control, parent, leftOffset)
-    AnchorToLeft(control, parent, leftOffset)
+---@param padding? number fixed padding between control and parent
+function LeftOf(control, parent, padding)
+    AnchorToLeft(control, parent, padding)
     AtTopIn(control, parent)
 end
 
---- Lock top left of control to top right of parent
+--- Lock top left of a control to top right of a parent
 ---@param control Control
 ---@param parent Control
----@param rightOffset? number
-function RightOf(control, parent, rightOffset)
-    AnchorToRight(control, parent, rightOffset)
+---@param padding? number fixed padding between control and parent
+function RightOf(control, parent, padding)
+    AnchorToRight(control, parent, padding)
     AtTopIn(control, parent)
 end
 
---- Lock bottom left of control to top left of parent
+--- Lock bottom left of a control to top left of a parent
 ---@param control Control
 ---@param parent Control
----@param topOffset? number
-function Above(control, parent, topOffset)
+---@param padding? number fixed padding between control and parent
+function Above(control, parent, padding)
     AtLeftIn(control, parent)
-    AnchorToTop(control, parent, topOffset)
+    AnchorToTop(control, parent, padding)
 end
 
---- Lock top left of control to bottom left of parent
+--- Lock top left of a control to bottom left of a parent
 ---@param control Control
 ---@param parent Control
----@param bottomOffset? number
-function Below(control, parent, bottomOffset)
+---@param padding? number fixed padding between control and parent
+function Below(control, parent, padding)
     AtLeftIn(control, parent)
-    AnchorToBottom(control, parent, bottomOffset)
+    AnchorToBottom(control, parent, padding)
 end
 
 
@@ -569,7 +570,8 @@ function FillParentPreserveAspectRatio(control, parent)
     end)
 end
 
---- Reset to the default layout functions  
+--- Reset to the default layout functions
+--- You should call control:ResetLayout() instead unless you cannot rely on overriden behavior
 --- **Remember to redefine two horizontal and two vertical properties to avoid circular dependencies!**
 ---@param control Control
 function Reset(control)
@@ -727,26 +729,45 @@ end
 --*********  Layouter  *************
 --**********************************
 
+---@class Layouter : moho.aibrain_methods
+---@field c Control
 local LayouterMetaTable = {}
 LayouterMetaTable.__index = LayouterMetaTable
 
+
+-- Get control
+---@return Control c
+function LayouterMetaTable:Get()
+    return self.c
+end
+
 -- Controls' mostly used methods
 
+--- Sets the name of the control
+---@param debugName string
+---@return Layouter
 function LayouterMetaTable:Name(debugName)
     self.c:SetName(debugName)
     return self
 end
 
+--- Disables the control
+---@return Layouter
 function LayouterMetaTable:Disable()
     self.c:Disable()
     return self
 end
 
+--- Hides the control
+---@return Layouter
 function LayouterMetaTable:Hide()
     self.c:Hide()
     return self
 end
 
+--- Sets the color of the control
+---@param color string hexcolor
+---@return Layouter
 function LayouterMetaTable:Color(color)
     if self.c.SetSolidColor then
         self.c:SetSolidColor(color)
@@ -758,58 +779,93 @@ function LayouterMetaTable:Color(color)
     return self
 end
 
-function LayouterMetaTable:DropShadow(bool)
-    self.c:SetDropShadow(bool)
+--- Sets if the control has a drop shadow
+---@param hasShadow boolean
+---@return Layouter
+function LayouterMetaTable:DropShadow(hasShadow)
+    self.c:SetDropShadow(hasShadow)
     return self
 end
 
+--- Sets the control's texture
+---@param texture string resource location
+---@param border? Border
+---@return Layouter
 function LayouterMetaTable:Texture(texture, border)
     self.c:SetTexture(texture, border)
     return self
 end
 
-function LayouterMetaTable:EnableHitTest(recursive)
-    self.c:EnableHitTest(recursive)
+--- Enables the control's hit test
+---@param isRecursive boolean
+---@return Layouter
+function LayouterMetaTable:EnableHitTest(isRecursive)
+    self.c:EnableHitTest(isRecursive)
     return self
 end
 
-function LayouterMetaTable:DisableHitTest(recursive)
-    self.c:DisableHitTest(recursive)
+--- Disables the control's hit test
+---@param isRecursive boolean
+---@return Layouter
+function LayouterMetaTable:DisableHitTest(isRecursive)
+    self.c:DisableHitTest(isRecursive)
     return self
 end
 
-function LayouterMetaTable:NeedsFrameUpdate(bool)
-    self.c:SetNeedsFrameUpdate(bool)
+--- Sets if the control needs a frame update
+---@param needsUpdate boolean
+---@return Layouter
+function LayouterMetaTable:NeedsFrameUpdate(needsUpdate)
+    self.c:SetNeedsFrameUpdate(needsUpdate)
     return self
 end
 
-function LayouterMetaTable:Alpha(alpha, children)
-    self.c:SetAlpha(alpha, children)
+--- Sets the alpha of the control
+---@param alpha number
+---@param forChildren boolean
+---@return Layouter
+function LayouterMetaTable:Alpha(alpha, forChildren)
+    self.c:SetAlpha(alpha, forChildren)
     return self
 end
 
 -- Raw setting
 
+--- Sets the left side of the control
+---@param left function|number
+---@return Layouter
 function LayouterMetaTable:Left(left)
     self.c.Left:Set(left)
     return self
 end
 
-function LayouterMetaTable:Right(right)
-    self.c.Right:Set(right)
-    return self
-end
-
+--- Sets the top side of the control
+---@param top function|number
+---@return Layouter
 function LayouterMetaTable:Top(top)
     self.c.Top:Set(top)
     return self
 end
 
+--- Sets the right side of the control
+---@param right function|number
+---@return Layouter
+function LayouterMetaTable:Right(right)
+    self.c.Right:Set(right)
+    return self
+end
+
+--- Sets the bottom side of the control
+---@param bottom function|number
+---@return Layouter
 function LayouterMetaTable:Bottom(bottom)
     self.c.Bottom:Set(bottom)
     return self
 end
 
+--- Sets the width of the control
+---@param width function|number #width will be scaled
+---@return Layouter
 function LayouterMetaTable:Width(width)
     if iscallable(width) then
         self.c.Width:SetFunction(width)
@@ -819,6 +875,9 @@ function LayouterMetaTable:Width(width)
     return self
 end
 
+--- Sets the height of the control
+---@param height function|number #height will be scaled
+---@return Layouter
 function LayouterMetaTable:Height(height)
     if iscallable(height) then
         self.c.Height:SetFunction(height)
@@ -828,249 +887,388 @@ function LayouterMetaTable:Height(height)
     return self
 end
 
--- Fill parent
-
-function LayouterMetaTable:Fill(parent)
-    FillParent(self.c, parent)
-    return self
-end
-
-function LayouterMetaTable:FillFixedBorder(parent, offset)
-    FillParentFixedBorder(self.c, parent, offset)
-    return self
-end
-
--- Double-based positioning
-
-function LayouterMetaTable:AtLeftTopIn(parent, leftOffset, topOffset)
-    AtLeftTopIn(self.c, parent, leftOffset, topOffset)
-    return self
-end
-
-function LayouterMetaTable:AtRightBottomIn(parent, rightOffset, bottomOffset)
-    AtRightBottomIn(self.c, parent, rightOffset, bottomOffset)
-    return self
-end
-
-function LayouterMetaTable:AtLeftBottomIn(parent, leftOffset, bottomOffset)
-    AtLeftBottomIn(self.c, parent, leftOffset, bottomOffset)
-    return self
-end
-
-function LayouterMetaTable:AtRightTopIn(parent, rightOffset, topOffset)
-    AtRightTopIn(self.c, parent, rightOffset, topOffset)
-    return self
-end
-
--- Centered out of parent
-
-function LayouterMetaTable:CenteredLeftOf(parent, offset)
-    CenteredLeftOf(self.c, parent, offset)
-    return self
-end
-
-function LayouterMetaTable:CenteredRightOf(parent, offset)
-    CenteredRightOf(self.c, parent, offset)
-    return self
-end
-
-function LayouterMetaTable:CenteredAbove(parent, offset)
-    CenteredAbove(self.c, parent, offset)
-    return self
-end
-
-function LayouterMetaTable:CenteredBelow(parent, offset)
-    CenteredBelow(self.c, parent, offset)
-    return self
-end
-
--- Centered
-
-function LayouterMetaTable:AtHorizontalCenterIn(parent, offset)
-    AtHorizontalCenterIn(self.c, parent, offset)
-    return self
-end
-
-function LayouterMetaTable:AtVerticalCenterIn(parent, offset)
-    AtVerticalCenterIn(self.c, parent, offset)
-    return self
-end
-
-function LayouterMetaTable:AtCenterIn(parent, vertOffset, horzOffset)
-    AtCenterIn(self.c, parent, vertOffset, horzOffset)
-    return self
-end
-
--- Single-in positioning
-
-function LayouterMetaTable:AtLeftIn(parent, offset)
-    AtLeftIn(self.c, parent, offset)
-    return self
-end
-
-function LayouterMetaTable:AtRightIn(parent, offset)
-    AtRightIn(self.c, parent, offset)
-    return self
-end
-
-function LayouterMetaTable:AtTopIn(parent, offset)
-    AtTopIn(self.c, parent, offset)
-    return self
-end
-
-function LayouterMetaTable:AtBottomIn(parent, offset)
-    AtBottomIn(self.c, parent, offset)
-    return self
-end
-
--- Center-in positioning
-
-function LayouterMetaTable:AtLeftCenterIn(parent, offset, verticalOffset)
-    AtLeftIn(self.c, parent, offset)
-    AtVerticalCenterIn(self.c, parent, verticalOffset)
-    return self
-end
-
-function LayouterMetaTable:AtRightCenterIn(parent, offset, verticalOffset)
-    AtRightIn(self.c, parent, offset)
-    AtVerticalCenterIn(self.c, parent, verticalOffset)
-    return self
-end
-
-function LayouterMetaTable:AtTopCenterIn(parent, offset, horizonalOffset)
-    AtTopIn(self.c, parent, offset)
-    AtHorizontalCenterIn(self.c, parent, horizonalOffset)
-    return self
-end
-
-function LayouterMetaTable:AtBottomCenterIn(parent, offset, horizonalOffset)
-    AtBottomIn(self.c, parent, offset)
-    AtHorizontalCenterIn(self.c, parent, horizonalOffset)
-    return self
-end
-
--- Center-in positioning
-
-function LayouterMetaTable:AtLeftCenterIn(parent, offset, verticalOffset)
-    AtLeftIn(self.c, parent, offset)
-    AtVerticalCenterIn(self.c, parent, verticalOffset)
-    return self
-end
-
-function LayouterMetaTable:AtRightCenterIn(parent, offset, verticalOffset)
-    AtRightIn(self.c, parent, offset)
-    AtVerticalCenterIn(self.c, parent, verticalOffset)
-    return self
-end
-
-function LayouterMetaTable:AtTopCenterIn(parent, offset, horizonalOffset)
-    AtTopIn(self.c, parent, offset)
-    AtHorizontalCenterIn(self.c, parent, horizonalOffset)
-    return self
-end
-
-function LayouterMetaTable:AtBottomCenterIn(parent, offset, horizonalOffset)
-    AtBottomIn(self.c, parent, offset)
-    AtHorizontalCenterIn(self.c, parent, horizonalOffset)
-    return self
-end
-
--- Out-of positioning
-
-function LayouterMetaTable:Below(parent, offset)
-    Below(self.c, parent, offset)
-    return self
-end
-
-function LayouterMetaTable:Above(parent, offset)
-    Above(self.c, parent, offset)
-    return self
-end
-
-function LayouterMetaTable:RightOf(parent, offset)
-    RightOf(self.c, parent, offset)
-    return self
-end
-
-function LayouterMetaTable:LeftOf(parent, offset)
-    LeftOf(self.c, parent, offset)
-    return self
-end
 
 -- Depth
 
+--- Sets the depth of the control higher than a parent
+---@param parent Control
+---@param depth? integer defaults to 1
+---@return Layouter
 function LayouterMetaTable:Over(parent, depth)
     DepthOverParent(self.c, parent, depth)
     return self
 end
 
+
+--- Sets the depth of the control lower than a parent
+---@param parent Control
+---@param depth? integer defaults to 1
+---@return Layouter
 function LayouterMetaTable:Under(parent, depth)
     DepthUnderParent(self.c, parent, depth)
     return self
 end
 
--- Anchor
 
-function LayouterMetaTable:AnchorToTop(parent, offset)
-    AnchorToTop(self.c, parent, offset)
+
+-- Single positioning methods
+
+-- Anchors
+
+--- Anchors the control to the left of a parent, with optional padding
+---@param parent Control
+---@param padding? number fixed padding between control and parent
+---@return Layouter
+function LayouterMetaTable:AnchorToLeft(parent, padding)
+    AnchorToLeft(self.c, parent, padding)
     return self
 end
 
-function LayouterMetaTable:AnchorToLeft(parent, offset)
-    AnchorToLeft(self.c, parent, offset)
+--- Anchors a control to the top of a parent, with optional offset
+---@param parent Control
+---@param padding? number fixed padding between control and parent
+---@return Layouter
+function LayouterMetaTable:AnchorToTop(parent, padding)
+    AnchorToTop(self.c, parent, padding)
     return self
 end
 
-function LayouterMetaTable:AnchorToRight(parent, offset)
-    AnchorToRight(self.c, parent, offset)
+--- Anchors a control to the right of a parent, with optional offset
+---@param parent Control
+---@param padding? number fixed padding between control and parent
+---@return Layouter
+function LayouterMetaTable:AnchorToRight(parent, padding)
+    AnchorToRight(self.c, parent, padding)
     return self
 end
 
-function LayouterMetaTable:AnchorToBottom(parent, offset)
-    AnchorToBottom(self.c, parent, offset)
+--- Anchors a control to the bottom of a parent, with optional offset
+---@param parent Control
+---@param padding? number fixed padding between control and parent
+---@return Layouter
+function LayouterMetaTable:AnchorToBottom(parent, padding)
+    AnchorToBottom(self.c, parent, padding)
     return self
 end
 
+-- Centered
 
--- Resets control's properties to default
+--- Centers a control horizontally on a parent, with an optional offset
+---@param parent Control
+---@param leftOffset? number in right direction
+---@return Layouter
+function LayouterMetaTable:AtHorizontalCenterIn(parent, leftOffset)
+    AtHorizontalCenterIn(self.c, parent, leftOffset)
+    return self
+end
 
+--- Centers a control vertically on a parent, with an optional offset
+---@param control Control
+---@param parent Control
+---@param topOffset? number in down direction
+---@return Layouter
+function LayouterMetaTable:AtVerticalCenterIn(parent, topOffset)
+    AtVerticalCenterIn(self.c, parent, topOffset)
+    return self
+end
+
+-- Inside
+
+--- Places the control inside the left border of a parent, with optional right offset
+---@param parent Control
+---@param leftOffset? number
+---@return Layouter
+function LayouterMetaTable:AtLeftIn(parent, leftOffset)
+    AtLeftIn(self.c, parent, leftOffset)
+    return self
+end
+
+--- Places the control inside the top border of a parent, with optional down offset
+---@param parent Control
+---@param topOffset? number
+---@return Layouter
+function LayouterMetaTable:AtTopIn(parent, topOffset)
+    AtTopIn(self.c, parent, topOffset)
+    return self
+end
+
+--- Places the control inside the right border of a parent, with optional left offset
+---@param parent Control
+---@param rightOffset? number
+---@return Layouter
+function LayouterMetaTable:AtRightIn(parent, rightOffset)
+    AtRightIn(self.c, parent, rightOffset)
+    return self
+end
+
+--- Places the control inside the bottom border of a parent, with optional up offset
+---@param parent Control
+---@param bottomOffset? number
+---@return Layouter
+function LayouterMetaTable:AtBottomIn(parent, bottomOffset)
+    AtBottomIn(self.c, parent, bottomOffset)
+    return self
+end
+
+-- Resets
+
+--- Resets the control's left to be calculated from its right and width
+--- *Make sure Right and Width are defined!!!*
+---@return Layouter
 function LayouterMetaTable:ResetLeft()
     ResetLeft(self.c)
     return self
 end
 
+--- Resets the control's top to be calculated from its bottom and height
+--- **Make sure Bottom and Height are defined!!!**
+---@return Layouter
 function LayouterMetaTable:ResetTop()
     ResetTop(self.c)
     return self
 end
 
+--- Resets the control's right to be calculated from its right and width
+--- **Make sure Left and Width are defined!!!**
+---@return Layouter
 function LayouterMetaTable:ResetRight()
     ResetRight(self.c)
     return self
 end
 
+--- Resets the control's bottom to be calculated from its top and height
+--- **Make sure Top and Height are Defined!!!**
+---@return Layouter
 function LayouterMetaTable:ResetBottom()
     ResetBottom(self.c)
     return self
 end
 
+--- Resets the control's width to be calculated from its right and left
+--- **Make sure Right and Left are defined!!!**
+---@return Layouter
 function LayouterMetaTable:ResetWidth()
     ResetWidth(self.c)
     return self
 end
 
+--- Resets the control's height to be calculated from its top and bottom
+--- **Make sure Bottom and Top are defined!!!**
+---@return Layouter
 function LayouterMetaTable:ResetHeight()
     ResetHeight(self.c)
     return self
 end
 
--- Get control
-function LayouterMetaTable:Get()
-    return self.c
+--**********
+--* Composite positioning
+--**********
+
+--- Surround positioning
+
+--- Lock right of the control to left of a parent, centered vertically
+---@param parent Control
+---@param padding? number fixed padding between control and parent
+---@return Layouter
+function LayouterMetaTable:CenteredLeftOf(parent, padding)
+    CenteredLeftOf(self.c, parent, padding)
+    return self
 end
+
+--- Lock bottom of the control to top left of a parent, centered horizontally
+---@param parent Control
+---@param padding? number fixed padding between control and parent
+---@return Layouter
+function LayouterMetaTable:CenteredAbove(parent, padding)
+    CenteredAbove(self.c, parent, padding)
+    return self
+end
+
+--- Lock left of the control to right of a parent, centered vertically
+---@param parent Control
+---@param padding? number fixed padding between control and parent
+---@return Layouter
+function LayouterMetaTable:CenteredRightOf(parent, padding)
+    CenteredRightOf(self.c, parent, padding)
+    return self
+end
+
+--- Lock top of the control to bottom left of parent, centered horizontally
+---@param parent Control
+---@param padding? number fixed padding between control and parent
+---@return Layouter
+function LayouterMetaTable:CenteredBelow(parent, padding)
+    CenteredBelow(self.c, parent, padding)
+    return self
+end
+
+
+-- Inside positioning
+-- note that the inside-edge layouts don't have a function counterpart like
+-- the inside-corner layouts do
+
+--- Places the control in the center of the parent, with optional offsets
+---@param parent Control
+---@param topOffset? number offset of top edge (offset in down direction)
+---@param leftOffset? number offset of left edge (offset in right direction)
+---@return Layouter
+function LayouterMetaTable:AtCenterIn(parent, topOffset, leftOffset)
+    AtCenterIn(self.c, parent, topOffset, leftOffset)
+    return self
+end
+
+--- Places left edge of the control vertically centered inside of a parent's
+---@param parent Control
+---@param leftOffset? number
+---@param topOffset? number
+---@return Layouter
+function LayouterMetaTable:AtLeftCenterIn(parent, leftOffset, topOffset)
+    AtLeftIn(self.c, parent, leftOffset)
+    AtVerticalCenterIn(self.c, parent, topOffset)
+    return self
+end
+
+--- Places top left corner of the control inside of a parent's
+---@param parent Control
+---@param leftOffset? number
+---@param topOffset? number
+---@return Layouter
+function LayouterMetaTable:AtLeftTopIn(parent, leftOffset, topOffset)
+    AtLeftTopIn(self.c, parent, leftOffset, topOffset)
+    return self
+end
+
+--- Places top edge of the control horizontally centered inside of a parent's
+---@param parent Control
+---@param topOffset? number
+---@param leftOffset? number
+---@return Layouter
+function LayouterMetaTable:AtTopCenterIn(parent, topOffset, leftOffset)
+    AtTopIn(self.c, parent, topOffset)
+    AtHorizontalCenterIn(self.c, parent, leftOffset)
+    return self
+end
+
+--- Places top right corner of the control inside of its parent's
+---@param parent Control
+---@param rightOffset? number
+---@param topOffset? number
+---@return Layouter
+function LayouterMetaTable:AtRightTopIn(parent, rightOffset, topOffset)
+    AtRightTopIn(self.c, parent, rightOffset, topOffset)
+    return self
+end
+
+--- Places right edge of the control vertically centered inside of a parent's
+---@param parent Control
+---@param rightOffset? number
+---@param topOffset? number
+---@return Layouter
+function LayouterMetaTable:AtRightCenterIn(parent, rightOffset, topOffset)
+    AtRightIn(self.c, parent, rightOffset)
+    AtVerticalCenterIn(self.c, parent, topOffset)
+    return self
+end
+
+--- Places bottom right corner of the control inside of a parent's
+---@param parent Control
+---@param rightOffset? number
+---@param bottomOffset? number
+---@return Layouter
+function LayouterMetaTable:AtRightBottomIn(parent, rightOffset, bottomOffset)
+    AtRightBottomIn(self.c, parent, rightOffset, bottomOffset)
+    return self
+end
+
+--- Places bottom edge of the control horizontally centered inside of a parent's
+---@param parent Control
+---@param leftOffset? number
+---@param bottomOffset? number
+---@return Layouter
+function LayouterMetaTable:AtBottomCenterIn(parent, bottomOffset, leftOffset)
+    AtBottomIn(self.c, parent, bottomOffset)
+    AtHorizontalCenterIn(self.c, parent, leftOffset)
+    return self
+end
+
+--- Places bottom left corner of the control inside of a parent's
+---@param parent Control
+---@param leftOffset? number
+---@param bottomOffset? number
+---@return Layouter
+function LayouterMetaTable:AtLeftBottomIn(parent, leftOffset, bottomOffset)
+    AtLeftBottomIn(self.c, parent, leftOffset, bottomOffset)
+    return self
+end
+
+
+-- Out-of positioning
+
+--- Lock top right of the control to top left of a parent
+---@param control Control
+---@param parent Control
+---@param padding? number fixed padding between control and parent
+---@return Layouter
+function LayouterMetaTable:LeftOf(parent, padding)
+    LeftOf(self.c, parent, padding)
+    return self
+end
+
+--- Lock top left of the control to top right of a parent
+---@param control Control
+---@param parent Control
+---@param padding? number fixed padding between control and parent
+---@return Layouter
+function LayouterMetaTable:RightOf(parent, padding)
+    RightOf(self.c, parent, padding)
+    return self
+end
+
+--- Lock bottom left of the control to top left of a parent
+---@param control Control
+---@param parent Control
+---@param padding? number fixed padding between control and parent
+---@return Layouter
+function LayouterMetaTable:Above(parent, padding)
+    Above(self.c, parent, padding)
+    return self
+end
+
+
+--- Lock top left of the control to bottom left of a parent
+---@param control Control
+---@param parent Control
+---@param padding? number fixed padding between control and parent
+---@return Layouter
+function LayouterMetaTable:Below(parent, padding)
+    Below(self.c, parent, padding)
+    return self
+end
+
+-- Fill parent
+
+--- Sets control to fill a parent
+--- Note this function copies the parent's side functions, it does not refer
+---@param parent Control
+---@return Layouter
+function LayouterMetaTable:Fill(parent)
+    FillParent(self.c, parent)
+    return self
+end
+
+--- Sets control to fill a parent's with fixed padding
+---@param parent Control
+---@param offset? number
+---@return Layouter
+function LayouterMetaTable:FillFixedBorder(parent, offset)
+    FillParentFixedBorder(self.c, parent, offset)
+    return self
+end
+
 
 -- Calculates control's Properties to determine its layout completion and returns it
 -- remember, if parent has incomplete layout it will warn you anyway
+---@return Control
 function LayouterMetaTable:End()
     if not pcall(self.c.Top) or not pcall(self.c.Bottom) or not pcall(self.c.Height) then
         WARN(string.format("Incorrect layout for \"%s\" Top-Height-Bottom", self.c:GetName()))
@@ -1091,7 +1289,7 @@ end
 
 --- Returns a layouter for a control
 ---@param control Control
----@return table #layouter
+---@return Layouter
 function LayoutFor(control)
     local result = {
         c = control
@@ -1107,7 +1305,7 @@ setmetatable(layouter, LayouterMetaTable)
 
 --- Use if you don't cache layouter object
 ---@param control Control
----@return table #cached layouter
+---@return Layouter #cached layouter
 function ReusedLayoutFor(control)
     layouter.c = control or false
     return layouter

--- a/lua/maui/layouthelpers.lua
+++ b/lua/maui/layouthelpers.lua
@@ -6,20 +6,21 @@
 --* Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --*****************************************************************************
 
---* Percentage versus offset
---* Percentages are specified as a float, with 0.00 to 1.00 the normal ranges
---* Percentages can change spacing when dimension is expended.
---*
---* Offsets are specified in pixels for the "base art" size. If the art is
---* scaled (ie large UI mode) this factor will keep the layout correct
+-- Percentage versus offset
+-- Percentages are specified as a float, with 0.00 to 1.00 the normal ranges
+-- Percentages can change spacing when dimension is expended.
+--
+-- Offsets are specified in pixels for the "base art" size. If the art is
+-- scaled (ie large UI mode) this factor will keep the layout correct
 
---* Store and set the current pixel scale multiplier. This will be used when the
---* artwork is scaled up or down so that offsets scale up and down appropriately.
---* Note that if you add a new layout helper function that uses offsets, you need
---* to scale the offset with this factor or your layout may get funky when the
---* art is changed
+-- Store and set the current pixel scale multiplier. This will be used when the
+-- artwork is scaled up or down so that offsets scale up and down appropriately.
+-- Note that if you add a new layout helper function that uses offsets, you need
+-- to scale the offset with this factor or your layout may get funky when the
+-- art is changed
 local Prefs = import('/lua/user/prefs.lua')
 local pixelScaleFactor = Prefs.GetFromCurrentProfile('options').ui_scale or 1
+local floor = math.floor
 
 function SetPixelScaleFactor(newFactor)
     pixelScaleFactor = newFactor
@@ -29,132 +30,130 @@ function GetPixelScaleFactor()
     return pixelScaleFactor
 end
 
---* These functions will set the controls position to be placed relative to
---* its parents dimensions. They are generally most useful for elements that
---* don't change size, they can also be used for controls that stretch
---* to match parent.
+-- These functions will set the controls position to be placed relative to
+-- its parents dimensions. They are generally most useful for elements that
+-- don't change size, they can also be used for controls that stretch
+-- to match parent.
 
 function AtCenterIn(control, parent, vertOffset, horzOffset)
     vertOffset = vertOffset or 0
     horzOffset = horzOffset or 0
-    control.Left:Set(
-        function()
-            return math.floor(parent.Left() + (((parent.Width() / 2) - (control.Width() / 2)) + (horzOffset * pixelScaleFactor)))
-        end)
-    control.Top:Set(
-        function()
-            return math.floor(parent.Top() + (((parent.Height() / 2) - (control.Height() / 2)) + (vertOffset * pixelScaleFactor)))
-        end)
+    control.Left:SetFunction(function()
+        return floor(parent.Left() + ((parent.Width() - control.Width()) / 2) + (horzOffset * pixelScaleFactor))
+    end)
+    control.Top:SetFunction(function()
+        return floor(parent.Top() + ((parent.Height() - control.Height()) / 2) + (vertOffset * pixelScaleFactor))
+    end)
 end
 
 function AtHorizontalCenterIn(control, parent, offset)
     offset = offset or 0
-    control.Left:Set(
-        function()
-            return math.floor(parent.Left() + (((parent.Width() / 2) - (control.Width() / 2)) + (offset * pixelScaleFactor)))
-        end)
+    control.Left:SetFunction(function()
+        return floor(parent.Left() + ((parent.Width() - control.Width()) / 2) + (offset * pixelScaleFactor))
+    end)
 end
 
 function AtVerticalCenterIn(control, parent, offset)
     offset = offset or 0
-    control.Top:Set(
-        function()
-            return math.floor(parent.Top() + (((parent.Height() / 2) - (control.Height() / 2)) + (offset * pixelScaleFactor)))
-        end)
+    control.Top:SetFunction(function()
+        return floor(parent.Top() + ((parent.Height() - control.Height()) / 2) + (offset * pixelScaleFactor))
+    end)
 end
 
 function AtLeftIn(control, parent, offset)
     offset = offset or 0
-    control.Left:Set(function() return math.floor(parent.Left() + (offset * pixelScaleFactor)) end)
+    control.Left:SetFunction(function() return floor(parent.Left() + (offset * pixelScaleFactor)) end)
 end
 
 function AtRightIn(control, parent, offset)
     offset = offset or 0
-    control.Right:Set(function() return math.floor(parent.Right() - (offset * pixelScaleFactor)) end)
+    control.Right:SetFunction(function() return floor(parent.Right() - (offset * pixelScaleFactor)) end)
 end
 
 function AtBottomIn(control, parent, offset)
     offset = offset or 0
-    control.Bottom:Set(function() return math.floor(parent.Bottom() - (offset * pixelScaleFactor)) end)
+    control.Bottom:SetFunction(function() return floor(parent.Bottom() - (offset * pixelScaleFactor)) end)
 end
 
 function AtTopIn(control, parent, offset)
     offset = offset or 0
-    control.Top:Set(function() return math.floor(parent.Top() + (offset * pixelScaleFactor)) end)
+    control.Top:SetFunction(function() return floor(parent.Top() + (offset * pixelScaleFactor)) end)
 end
 
 function AtLeftTopIn(control, parent, leftOffset, topOffset)
     leftOffset = leftOffset or 0
     topOffset = topOffset or 0
-    control.Left:Set(function() return math.floor(parent.Left() + (leftOffset * pixelScaleFactor)) end)
-    control.Top:Set(function() return math.floor(parent.Top() + (topOffset * pixelScaleFactor)) end)
+    control.Left:SetFunction(function() return floor(parent.Left() + (leftOffset * pixelScaleFactor)) end)
+    control.Top:SetFunction(function() return floor(parent.Top() + (topOffset * pixelScaleFactor)) end)
 end
 
 function AtRightTopIn(control, parent, rightOffset, topOffset)
     rightOffset = rightOffset or 0
     topOffset = topOffset or 0
-    control.Right:Set(function() return math.floor(parent.Right() - (rightOffset * pixelScaleFactor)) end)
-    control.Top:Set(function() return math.floor(parent.Top() + (topOffset * pixelScaleFactor)) end)
+    control.Right:SetFunction(function() return floor(parent.Right() - (rightOffset * pixelScaleFactor)) end)
+    control.Top:SetFunction(function() return floor(parent.Top() + (topOffset * pixelScaleFactor)) end)
 end
 
 function AtLeftBottomIn(control, parent, leftOffset, bottomOffset)
     leftOffset = leftOffset or 0
     bottomOffset = bottomOffset or 0
-    control.Left:Set(function() return math.floor(parent.Left() + (leftOffset * pixelScaleFactor)) end)
-    control.Bottom:Set(function() return math.floor(parent.Bottom() - (bottomOffset * pixelScaleFactor)) end)
+    control.Left:SetFunction(function() return floor(parent.Left() + (leftOffset * pixelScaleFactor)) end)
+    control.Bottom:SetFunction(function() return floor(parent.Bottom() - (bottomOffset * pixelScaleFactor)) end)
 end
 
 function AtRightBottomIn(control, parent, rightOffset, bottomOffset)
     rightOffset = rightOffset or 0
     bottomOffset = bottomOffset or 0
-    control.Right:Set(function() return math.floor(parent.Right() - (rightOffset * pixelScaleFactor)) end)
-    control.Bottom:Set(function() return math.floor(parent.Bottom() - (bottomOffset * pixelScaleFactor)) end)
+    control.Right:SetFunction(function() return floor(parent.Right() - (rightOffset * pixelScaleFactor)) end)
+    control.Bottom:SetFunction(function() return floor(parent.Bottom() - (bottomOffset * pixelScaleFactor)) end)
 end
 
---* these functions use percentages to place the item rather than offsets so they will
---* stay proportially spaced when the parent resizes
+-- These functions use percentages to place the item rather than offsets so they will
+-- stay proportially spaced when the parent resizes
+
 function FromLeftIn(control, parent, percent)
     percent = percent or 0.00
-    control.Left:Set(function() return math.floor(parent.Left() + (parent.Width() * percent)) end)
+    control.Left:SetFunction(function() return floor(parent.Left() + (parent.Width() * percent)) end)
 end
 
 function FromTopIn(control, parent, percent)
     percent = percent or 0.00
-    control.Top:Set( function() return math.floor(parent.Top() + (parent.Height() * percent)) end)
+    control.Top:SetFunction( function() return floor(parent.Top() + (parent.Height() * percent)) end)
 end
 
 function FromRightIn(control, parent, percent)
     percent = percent or 0.00
-    control.Right:Set(function() return math.floor(parent.Right() - (parent.Width() * percent)) end)
+    control.Right:SetFunction(function() return floor(parent.Right() - (parent.Width() * percent)) end)
 end
 
 function FromBottomIn(control, parent, percent)
     percent = percent or 0.00
-    control.Bottom:Set( function() return math.floor(parent.Bottom() - (parent.Height() * percent)) end)
+    control.Bottom:SetFunction( function() return floor(parent.Bottom() - (parent.Height() * percent)) end)
 end
 
---* these functions will stretch the control to fill the parent and provide an optional border
+-- These functions will stretch the control to fill the parent and provide an optional border
+
 function FillParent(control, parent)
-    control.Top:Set(parent.Top)
-    control.Left:Set(parent.Left)
-    control.Bottom:Set(parent.Bottom)
-    control.Right:Set(parent.Right)
+    control.Top:SetFunction(parent.Top)
+    control.Left:SetFunction(parent.Left)
+    control.Bottom:SetFunction(parent.Bottom)
+    control.Right:SetFunction(parent.Right)
 end
 
 function FillParentRelativeBorder(control, parent, percent)
     percent = percent or 0.00
-    control.Top:Set(function() return math.floor(parent.Top() + (parent.Height() * percent)) end)
-    control.Left:Set(function() return math.floor(parent.Left() + (parent.Width() * percent)) end)
-    control.Bottom:Set(function() return math.floor(parent.Bottom() - (parent.Height() * percent)) end)
-    control.Right:Set(function() return math.floor(parent.Right() - (parent.Width() * percent)) end)
+    control.Top:SetFunction(function() return floor(parent.Top() + (parent.Height() * percent)) end)
+    control.Left:SetFunction(function() return floor(parent.Left() + (parent.Width() * percent)) end)
+    control.Bottom:SetFunction(function() return floor(parent.Bottom() - (parent.Height() * percent)) end)
+    control.Right:SetFunction(function() return floor(parent.Right() - (parent.Width() * percent)) end)
 end
 
 function FillParentFixedBorder(control, parent, offset)
     offset = offset or 0
-    control.Top:Set(function() return math.floor(parent.Top() + (offset * pixelScaleFactor)) end)
-    control.Left:Set(function() return math.floor(parent.Left() + (offset * pixelScaleFactor)) end)
-    control.Bottom:Set(function() return math.floor(parent.Bottom() - (offset * pixelScaleFactor)) end)
-    control.Right:Set(function() return math.floor(parent.Right() - (offset * pixelScaleFactor)) end)
+    control.Top:SetFunction(function() return floor(parent.Top() + (offset * pixelScaleFactor)) end)
+    control.Left:SetFunction(function() return floor(parent.Left() + (offset * pixelScaleFactor)) end)
+    control.Bottom:SetFunction(function() return floor(parent.Bottom() - (offset * pixelScaleFactor)) end)
+    control.Right:SetFunction(function() return floor(parent.Right() - (offset * pixelScaleFactor)) end)
 end
 
 -- Fill the parent control while preserving the aspect ratio of the item
@@ -167,33 +166,34 @@ function FillParentPreserveAspectRatio(control, parent)
         return ratio
     end
 
-    control.Top:Set(function() return
-        math.floor(parent.Top() + ((parent.Height() - (control.Height() * GetRatio(control, parent))) / 2))
+    control.Top:SetFunction(function()
+        return floor(parent.Top() + ((parent.Height() - (control.Height() * GetRatio(control, parent))) / 2))
     end)
-    control.Bottom:Set(function()
-        return math.floor(parent.Bottom() - ((parent.Height() - (control.Height() * GetRatio(control, parent))) / 2))
+    control.Bottom:SetFunction(function()
+        return floor(parent.Bottom() - ((parent.Height() - (control.Height() * GetRatio(control, parent))) / 2))
     end)
-    control.Left:Set(function()
-        return math.floor(parent.Left() + ((parent.Width() - (control.Width() * GetRatio(control, parent))) / 2))
+    control.Left:SetFunction(function()
+        return floor(parent.Left() + ((parent.Width() - (control.Width() * GetRatio(control, parent))) / 2))
     end)
-    control.Right:Set(function()
-        return math.floor(parent.Right() - ((parent.Width() - (control.Width() * GetRatio(control, parent))) / 2))
+    control.Right:SetFunction(function()
+        return floor(parent.Right() - ((parent.Width() - (control.Width() * GetRatio(control, parent))) / 2))
     end)
 end
 
---* these functions will place the control and resize in a specified location within the parent
---* note that the offset version is more useful than hard coding the location
---* as it will take advantage of the pixel scale factor
+-- These functions will place the control and resize in a specified location within the parent
+-- note that the offset version is more useful than hard coding the location
+-- as it will take advantage of the pixel scale factor
+
 function PercentIn(control, parent, left, top, right, bottom)
     left = left or 0.00
     top = top or 0.00
     right = right or 0.00
     bottom = bottom or 0.00
 
-    control.Left:Set(function() return math.floor(parent.Left() + (left * parent.Width())) end)
-    control.Top:Set(function() return math.floor(parent.Top() + (top * parent.Height())) end)
-    control.Right:Set(function() return math.floor(parent.Right() - (right * parent.Width())) end)
-    control.Bottom:Set(function() return math.floor(parent.Bottom() - (bottom * parent.Height())) end)
+    control.Left:SetFunction(function() return floor(parent.Left() + (left * parent.Width())) end)
+    control.Top:SetFunction(function() return floor(parent.Top() + (top * parent.Height())) end)
+    control.Right:SetFunction(function() return floor(parent.Right() - (right * parent.Width())) end)
+    control.Bottom:SetFunction(function() return floor(parent.Bottom() - (bottom * parent.Height())) end)
 end
 
 function OffsetIn(control, parent, left, top, right, bottom)
@@ -202,127 +202,128 @@ function OffsetIn(control, parent, left, top, right, bottom)
     right = right or 0
     bottom = bottom or 0
 
-    control.Left:Set(function() return math.floor(parent.Left() + (left * pixelScaleFactor)) end)
-    control.Top:Set(function() return math.floor(parent.Top() + (top * pixelScaleFactor)) end)
-    control.Right:Set(function() return math.floor(parent.Right() - (right * pixelScaleFactor)) end)
-    control.Bottom:Set(function() return math.floor(parent.Bottom() - (bottom * pixelScaleFactor)) end)
+    control.Left:SetFunction(function() return floor(parent.Left() + (left * pixelScaleFactor)) end)
+    control.Top:SetFunction(function() return floor(parent.Top() + (top * pixelScaleFactor)) end)
+    control.Right:SetFunction(function() return floor(parent.Right() - (right * pixelScaleFactor)) end)
+    control.Bottom:SetFunction(function() return floor(parent.Bottom() - (bottom * pixelScaleFactor)) end)
 end
 
---* these functions will set the controls position relative to a sibling
+-- These functions will set the controls position relative to a sibling
 
---* lock right top of control to left top of parent
+-- Lock right top of control to left top of parent
 function LeftOf(control, parent, offset)
     offset = offset or 0
-    control.Right:Set(function() return math.floor(parent.Left() - (offset * pixelScaleFactor)) end)
-    control.Top:Set(parent.Top)
+    control.Right:SetFunction(function() return floor(parent.Left() - (offset * pixelScaleFactor)) end)
+    control.Top:SetFunction(parent.Top)
 end
 
---* lock left top of control to right top of parent
+-- Lock left top of control to right top of parent
 function RightOf(control, parent, offset)
     offset = offset or 0
-    control.Left:Set(function() return math.floor(parent.Right() + (offset * pixelScaleFactor)) end)
-    control.Top:Set(parent.Top)
+    control.Left:SetFunction(function() return floor(parent.Right() + (offset * pixelScaleFactor)) end)
+    control.Top:SetFunction(parent.Top)
 end
 
---* lock right top of control to left of parent, cenetered vertically to the parent
+-- Lock right top of control to left of parent, centered vertically to the parent
 function CenteredLeftOf(control, parent, offset)
     offset = offset or 0
-    control.Right:Set(function() return math.floor(parent.Left() - (offset * pixelScaleFactor)) end)
-    control.Top:Set(function() return math.floor(parent.Top() + ((parent.Height() / 2) - (control.Height() / 2))) end)
+    control.Right:SetFunction(function() return floor(parent.Left() - (offset * pixelScaleFactor)) end)
+    control.Top:SetFunction(function() return floor(parent.Top() + ((parent.Height() - control.Height()) / 2)) end)
 end
 
---* lock left top of control to right of parent, centered vertically to the parent
+-- Lock left top of control to right of parent, centered vertically to the parent
 function CenteredRightOf(control, parent, offset)
     offset = offset or 0
-    control.Left:Set(function() return math.floor(parent.Right() + (offset * pixelScaleFactor)) end)
-    control.Top:Set(function() return math.floor(parent.Top() + ((parent.Height() / 2) - (control.Height() / 2))) end)
+    control.Left:SetFunction(function() return floor(parent.Right() + (offset * pixelScaleFactor)) end)
+    control.Top:SetFunction(function() return floor(parent.Top() + ((parent.Height() - control.Height()) / 2)) end)
 end
 
---* lock bottom left of control to top left of parent
+-- Lock bottom left of control to top left of parent
 function Above(control, parent, offset)
     offset = offset or 0
-    control.Left:Set(parent.Left)
-    control.Bottom:Set(function() return parent.Top() - (offset * pixelScaleFactor) end)
+    control.Left:SetFunction(parent.Left)
+    control.Bottom:SetFunction(function() return parent.Top() - (offset * pixelScaleFactor) end)
 end
 
---* lock top left of control to bottom left of parent
+-- Lock top left of control to bottom left of parent
 function Below(control, parent, offset)
     offset = offset or 0
-    control.Left:Set(parent.Left)
-    control.Top:Set(function() return math.floor(parent.Bottom() + (offset * pixelScaleFactor)) end)
+    control.Left:SetFunction(parent.Left)
+    control.Top:SetFunction(function() return floor(parent.Bottom() + (offset * pixelScaleFactor)) end)
 end
 
---* lock bottom left of control to top left of parent, centered horizontally to the parent
+-- Lock bottom left of control to top left of parent, centered horizontally to the parent
 function CenteredAbove(control, parent, offset)
     offset = offset or 0
-    control.Left:Set(function() return math.floor(parent.Left() + ((parent.Width() / 2) - (control.Width() / 2))) end)
-    control.Bottom:Set(function() return math.floor(parent.Top() - (offset * pixelScaleFactor)) end)
+    control.Left:SetFunction(function() return floor(parent.Left() + ((parent.Width() - control.Width()) / 2)) end)
+    control.Bottom:SetFunction(function() return floor(parent.Top() - (offset * pixelScaleFactor)) end)
 end
 
---* lock top left of control to bottom left of parent, centered horizontally to the parent
+-- Lock top left of control to bottom left of parent, centered horizontally to the parent
 function CenteredBelow(control, parent, offset)
     offset = offset or 0
-    control.Left:Set(function() return math.floor(parent.Left() + ((parent.Width() / 2) - (control.Width() / 2))) end)
-    control.Top:Set(function() return math.floor(parent.Bottom() + (offset * pixelScaleFactor)) end)
+    control.Left:SetFunction(function() return floor(parent.Left() + ((parent.Width() - control.Width()) / 2)) end)
+    control.Top:SetFunction(function() return floor(parent.Bottom() + (offset * pixelScaleFactor)) end)
 end
 
--- anchor functions lock the appropriate side of a control to the side of another control
--- lock top of control to parent bottom
+-- Anchor functions lock the appropriate side of a control to the side of another control
+
+-- Lock top of control to parent bottom
 function AnchorToTop(control, parent, offset)
     offset = offset or 0
-    control.Bottom:Set(function() return math.floor(parent.Top() - (offset * pixelScaleFactor)) end)
+    control.Bottom:SetFunction(function() return floor(parent.Top() - (offset * pixelScaleFactor)) end)
 end
 
--- lock bottom of control parent top
+-- Lock bottom of control parent top
 function AnchorToBottom(control, parent, offset)
     offset = offset or 0
-    control.Top:Set(function() return math.floor(parent.Bottom() + (offset * pixelScaleFactor)) end)
+    control.Top:SetFunction(function() return floor(parent.Bottom() + (offset * pixelScaleFactor)) end)
 end
 
--- lock left of control to parent right
+-- Lock left of control to parent right
 function AnchorToRight(control, parent, offset)
     offset = offset or 0
-    control.Left:Set(function() return math.floor(parent.Right() + (offset * pixelScaleFactor)) end)
+    control.Left:SetFunction(function() return floor(parent.Right() + (offset * pixelScaleFactor)) end)
 end
 
--- lock right of control to parent left
+-- Lock right of control to parent left
 function AnchorToLeft(control, parent, offset)
     offset = offset or 0
-    control.Right:Set(function() return math.floor(parent.Left() - (offset * pixelScaleFactor)) end)
+    control.Right:SetFunction(function() return floor(parent.Left() - (offset * pixelScaleFactor)) end)
 end
 
---* Reset to the default layout functions
+-- Reset to the default layout functions
 function Reset(control)
-    control.Left:Set(function() return control.Right() - control.Width() end)
-    control.Top:Set(function() return control.Bottom() - control.Height() end)
-    control.Right:Set(function() return control.Left() + control.Width() end)
-    control.Bottom:Set(function() return control.Top() + control.Height() end)
-    control.Width:Set(function() return control.Right() - control.Left() end)
-    control.Height:Set(function() return control.Bottom() - control.Top() end)
+    control.Left:SetFunction(function() return control.Right() - control.Width() end)
+    control.Top:SetFunction(function() return control.Bottom() - control.Height() end)
+    control.Right:SetFunction(function() return control.Left() + control.Width() end)
+    control.Bottom:SetFunction(function() return control.Top() + control.Height() end)
+    control.Width:SetFunction(function() return control.Right() - control.Left() end)
+    control.Height:SetFunction(function() return control.Bottom() - control.Top() end)
 end
 
 function ResetLeft(control)
-    control.Left:Set(function() return control.Right() - control.Width() end)
+    control.Left:SetFunction(function() return control.Right() - control.Width() end)
 end
 
 function ResetTop(control)
-    control.Top:Set(function() return control.Bottom() - control.Height() end)
+    control.Top:SetFunction(function() return control.Bottom() - control.Height() end)
 end
 
 function ResetRight(control)
-    control.Right:Set(function() return control.Left() + control.Width() end)
+    control.Right:SetFunction(function() return control.Left() + control.Width() end)
 end
 
 function ResetBottom(control)
-    control.Bottom:Set(function() return control.Top() + control.Height() end)
+    control.Bottom:SetFunction(function() return control.Top() + control.Height() end)
 end
 
 function ResetWidth(control)
-    control.Width:Set(function() return control.Right() - control.Left() end)
+    control.Width:SetFunction(function() return control.Right() - control.Left() end)
 end
 
 function ResetHeight(control)
-    control.Height:Set(function() return control.Bottom() - control.Top() end)
+    control.Height:SetFunction(function() return control.Bottom() - control.Top() end)
 end
 
 --[[
@@ -351,14 +352,16 @@ function RelativeTo(control, parent, fileName, controlName, parentName, topOffse
     if not layoutTable[parentName] then
         WARN("Parent not found in layout table: " .. parentName)
     end
-    control.Left:Set(function()
+    topOffset = topOffset or 0
+    leftOffset = leftOffset or 0
+    control.Top:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return math.floor(parent.Left() + ((layoutTable[controlName].left - layoutTable[parentName].left) * pixelScaleFactor + ((leftOffset or 0) * pixelScaleFactor)))
+        return floor(parent.Top() + ((layoutTable[controlName].top - layoutTable[parentName].top) * pixelScaleFactor + (topOffset * pixelScaleFactor)))
     end)
-
-    control.Top:Set(function()
+    
+    control.Left:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return math.floor(parent.Top() + ((layoutTable[controlName].top - layoutTable[parentName].top) * pixelScaleFactor + ((topOffset or 0) * pixelScaleFactor)))
+        return floor(parent.Left() + ((layoutTable[controlName].left - layoutTable[parentName].left) * pixelScaleFactor + (leftOffset * pixelScaleFactor)))
     end)
 end
 
@@ -371,9 +374,9 @@ function LeftRelativeTo(control, parent, fileName, controlName, parentName)
     if not layoutTable[parentName] then
         WARN("Parent not found in layout table: " .. parentName)
     end
-    control.Left:Set(function()
+    control.Left:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return math.floor(parent.Left() + (layoutTable[controlName].left - layoutTable[parentName].left))
+        return floor(parent.Left() + (layoutTable[controlName].left - layoutTable[parentName].left))
     end)
 end
 
@@ -385,9 +388,9 @@ function TopRelativeTo(control, parent, fileName, controlName, parentName)
     if not layoutTable[parentName] then
         WARN("Parent not found in layout table: " .. parentName)
     end
-    control.Top:Set(function()
+    control.Top:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return math.floor(parent.Top() + (layoutTable[controlName].top - layoutTable[parentName].top))
+        return floor(parent.Top() + (layoutTable[controlName].top - layoutTable[parentName].top))
     end)
 end
 
@@ -399,9 +402,11 @@ function RightRelativeTo(control, parent, fileName, controlName, parentName)
     if not layoutTable[parentName] then
         WARN("Parent not found in layout table: " .. parentName)
     end
-    control.Right:Set(function()
+    control.Right:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return math.floor(parent.Right() - ((layoutTable[parentName].left + layoutTable[parentName].width) - (layoutTable[controlName].left + layoutTable[controlName].width)))
+        local layoutParent = layoutTable[parentName]
+        local layoutControl = layoutTable[controlName]
+        return floor(parent.Right() - ((layoutParent.left + layoutParent.width) - (layoutControl.left + layoutControl.width)))
     end)
 end
 
@@ -413,9 +418,11 @@ function BottomRelativeTo(control, parent, fileName, controlName, parentName)
     if not layoutTable[parentName] then
         WARN("Parent not found in layout table: " .. parentName)
     end
-    control.Bottom:Set(function()
+    control.Bottom:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return math.floor(parent.Bottom() - ((layoutTable[parentName].top + layoutTable[parentName].height) - (layoutTable[controlName].top + layoutTable[controlName].height)))
+        local layoutParent = layoutTable[parentName]
+        local layoutControl = layoutTable[controlName]
+        return floor(parent.Bottom() - ((layoutParent.top + layoutParent.height) - (layoutControl.top + layoutControl.height)))
     end)
 end
 
@@ -424,17 +431,17 @@ function DimensionsRelativeTo(control, fileName, controlName)
     if not layoutTable[controlName] then
         WARN("Control not found in layout table: " .. controlName)
     end
-    control.Width:Set(function()
+    control.Width:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return math.floor(layoutTable[controlName].width * pixelScaleFactor)
+        return floor(layoutTable[controlName].width * pixelScaleFactor)
     end)
-    control.Height:Set(function()
+    control.Height:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return math.floor(layoutTable[controlName].height * pixelScaleFactor)
+        return floor(layoutTable[controlName].height * pixelScaleFactor)
     end)
 end
 
---* set the dimensions
+-- Set the dimensions
 function SetDimensions(control, width, height)
     SetWidth(control, width)
     SetHeight(control, height)
@@ -442,25 +449,25 @@ end
 
 function SetWidth(control, width)
     if width then
-        control.Width:Set(math.floor(width * pixelScaleFactor))
+        control.Width:SetValue(floor(width * pixelScaleFactor))
     end
 end
 
 function SetHeight(control, height)
     if height then
-        control.Height:Set(math.floor(height * pixelScaleFactor))
+        control.Height:SetValue(floor(height * pixelScaleFactor))
     end
 end
 
---* set the depth relative to the parent
+-- Set the depth relative to the parent
 function DepthOverParent(control, parent, depth)
     depth = depth or 1
-    control.Depth:Set(function() return parent.Depth() + depth end)
+    control.Depth:SetFunction(function() return parent.Depth() + depth end)
 end
 
 function DepthUnderParent(control, parent, depth)
     depth = depth or 1
-    control.Depth:Set(function() return parent.Depth() - depth end)
+    control.Depth:SetFunction(function() return parent.Depth() - depth end)
 end
 
 -- Scale according to the globally set ratio
@@ -469,11 +476,11 @@ function Scale(control)
 end
 
 function ScaleNumber(number)
-    return math.floor(number * pixelScaleFactor)
+    return floor(number * pixelScaleFactor)
 end
 
 function InvScaleNumber(number)
-    return math.floor(number * (1 / pixelScaleFactor))
+    return floor(number / pixelScaleFactor)
 end
 
 --**********************************

--- a/lua/maui/layouthelpers.lua
+++ b/lua/maui/layouthelpers.lua
@@ -309,42 +309,43 @@ end
 
 -- These functions reset a control to be calculated from the others
 
---- Resets a control's left to be calculated from its right and width
---- *Make sure Right and Width are defined!!!*
+--- Resets a control's left to be calculated from its right and width  
+--- **Make sure `Right` and `Width` are defined!!!**
 ---@param control Control 
 function ResetLeft(control)
     control.Left:SetFunction(function() return control.Right() - control.Width() end)
 end
 
---- Resets a control's top to be calculated from its bottom and height
---- **Make sure Bottom and Height are defined!!!**
+--- Resets a control's top to be calculated from its bottom and height  
+--- **Make sure `Bottom` and `Height` are defined!!!**
 ---@param control Control
 function ResetTop(control)
     control.Top:SetFunction(function() return control.Bottom() - control.Height() end)
 end
 
---- Resets a control's left to be calculated from its right and width
----@param control Control make sure Left and Width are defined!!!
+--- Resets a control's left to be calculated from its right and width  
+--- **Make sure `Left` and `Width` are defined!!!**
+---@param control Control
 function ResetRight(control)
     control.Right:SetFunction(function() return control.Left() + control.Width() end)
 end
 
---- Resets a control's bottom to be calculated from its top and height
---- **Make sure Top and Height are Defined!!!**
+--- Resets a control's bottom to be calculated from its top and height  
+--- **Make sure `Top` and `Height` are Defined!!!**
 ---@param control Control
 function ResetBottom(control)
     control.Bottom:SetFunction(function() return control.Top() + control.Height() end)
 end
 
---- Resets a control's width to be calculated from its right and left
---- **Make sure Right and Left are defined!!!**
+--- Resets a control's width to be calculated from its right and left  
+--- **Make sure `Right` and `Left` are defined!!!**
 ---@param control Control
 function ResetWidth(control)
     control.Width:SetFunction(function() return control.Right() - control.Left() end)
 end
 
---- Resets a control's height to be calculated from its top and bottom
---- **Make sure Bottom and Top are defined!!!**
+--- Resets a control's height to be calculated from its top and bottom  
+--- **Make sure `Bottom` and `Top` are defined!!!**
 ---@param control Control
 function ResetHeight(control)
     control.Height:SetFunction(function() return control.Bottom() - control.Top() end)
@@ -570,8 +571,8 @@ function FillParentPreserveAspectRatio(control, parent)
     end)
 end
 
---- Reset to the default layout functions
---- You should call control:ResetLayout() instead unless you cannot rely on overriden behavior
+--- Reset to the default layout functions  
+--- You should call control:ResetLayout() instead unless you cannot rely on overriden behavior  
 --- **Remember to redefine two horizontal and two vertical properties to avoid circular dependencies!**
 ---@param control Control
 function Reset(control)
@@ -595,7 +596,7 @@ end
 --- Sets a control to be positioned to a parent using a layout table
 ---@param control Control
 ---@param parent Control
----@param fileName string full path and filename of the layout file. Must be a lazy var or function that returns the file name
+---@param fileName string Full path and filename of the layout file. Must be a lazy var or function that returns the filename.
 ---@param controlName string name (table key) of the control to be positioned
 ---@param parentName string name (table key) of the control to be positioned relative to
 ---@param topOffset? number
@@ -624,7 +625,7 @@ end
 --- Sets a control's left to be positioned to a parent using a layout table
 ---@param control Control
 ---@param parent Control
----@param fileName string full path and filename of the layout file. must be a lazy var or function that returns the file name
+---@param fileName string Full path and filename of the layout file. Must be a lazy var or function that returns the filename.
 ---@param controlName string name (table key) of the control to be positioned
 ---@param parentName string name (table key) of the control to be positioned relative to
 function LeftRelativeTo(control, parent, fileName, controlName, parentName)
@@ -644,7 +645,7 @@ end
 --- Sets a control's top to be positioned to a parent using a layout table
 ---@param control Control
 ---@param parent Control
----@param fileName string full path and filename of the layout file. must be a lazy var or function that returns the file name
+---@param fileName string Full path and filename of the layout file. Must be a lazy var or function that returns the filename.
 ---@param controlName string name (table key) of the control to be positioned
 ---@param parentName string name (table key) of the control to be positioned relative to
 function TopRelativeTo(control, parent, fileName, controlName, parentName)
@@ -662,11 +663,11 @@ function TopRelativeTo(control, parent, fileName, controlName, parentName)
 end
 
 --- Sets a control's right to be positioned to a parent using a layout table
----@param control Control the control to position
----@param parent Control the control that the above is positioned relative to
----@param fileName string the full path and filename of the layout file. must be a lazy var or function that returns the file name
----@param controlName string the name( table key) of the control to be positioned
----@param parentName string the name (table key) of the control to be positioned relative to
+---@param control Control
+---@param parent Control
+---@param fileName string Full path and filename of the layout file. Must be a lazy var or function that returns the filename.
+---@param controlName string name (table key) of the control to be positioned
+---@param parentName string name (table key) of the control to be positioned relative to
 function RightRelativeTo(control, parent, fileName, controlName, parentName)
     local layoutTable = import(fileName()).layout
     if not layoutTable[controlName] then
@@ -686,7 +687,7 @@ end
 --- Sets a control's bottom to be positioned to a parent using a layout table
 ---@param control Control
 ---@param parent Control
----@param fileName string full path and filename of the layout file. must be a lazy var or function that returns the file name
+---@param fileName string Full path and filename of the layout file. Must be a lazy var or function that returns the filename.
 ---@param controlName string name (table key) of the control to be positioned
 ---@param parentName string name (table key) of the control to be positioned relative to
 function BottomRelativeTo(control, parent, fileName, controlName, parentName)
@@ -707,7 +708,7 @@ end
 
 --- Sets a control's dimensions using a layout table
 ---@param control Control
----@param fileName string full path and filename of the layout file. must be a lazy var or function that returns the file name
+---@param fileName string Full path and filename of the layout file. Must be a lazy var or function that returns the filename.
 ---@param controlName string name (table key) of the control to be positioned
 function DimensionsRelativeTo(control, fileName, controlName)
     local layoutTable = import(fileName()).layout
@@ -864,7 +865,7 @@ function LayouterMetaTable:Bottom(bottom)
 end
 
 --- Sets the width of the control
----@param width function|number #width will be scaled
+---@param width function|number #width will be scaled by the pixel factor
 ---@return Layouter
 function LayouterMetaTable:Width(width)
     if iscallable(width) then
@@ -876,7 +877,7 @@ function LayouterMetaTable:Width(width)
 end
 
 --- Sets the height of the control
----@param height function|number #height will be scaled
+---@param height function|number #height will be scaled by the pixel factor
 ---@return Layouter
 function LayouterMetaTable:Height(height)
     if iscallable(height) then
@@ -1012,48 +1013,48 @@ end
 
 -- Resets
 
---- Resets the control's left to be calculated from its right and width
---- *Make sure Right and Width are defined!!!*
+--- Resets the control's left to be calculated from its right and width  
+--- **Make sure `Right` and `Width` are defined!!!**
 ---@return Layouter
 function LayouterMetaTable:ResetLeft()
     ResetLeft(self.c)
     return self
 end
 
---- Resets the control's top to be calculated from its bottom and height
---- **Make sure Bottom and Height are defined!!!**
+--- Resets the control's top to be calculated from its bottom and height  
+--- **Make sure `Bottom` and `Height` are defined!!!**
 ---@return Layouter
 function LayouterMetaTable:ResetTop()
     ResetTop(self.c)
     return self
 end
 
---- Resets the control's right to be calculated from its right and width
---- **Make sure Left and Width are defined!!!**
+--- Resets the control's right to be calculated from its right and width  
+--- **Make sure `Left` and `Width` are defined!!!**
 ---@return Layouter
 function LayouterMetaTable:ResetRight()
     ResetRight(self.c)
     return self
 end
 
---- Resets the control's bottom to be calculated from its top and height
---- **Make sure Top and Height are Defined!!!**
+--- Resets the control's bottom to be calculated from its top and height  
+--- **Make sure `Top` and `Height` are Defined!!!**
 ---@return Layouter
 function LayouterMetaTable:ResetBottom()
     ResetBottom(self.c)
     return self
 end
 
---- Resets the control's width to be calculated from its right and left
---- **Make sure Right and Left are defined!!!**
+--- Resets the control's width to be calculated from its right and left  
+--- **Make sure `Right` and `Left` are defined!!!**
 ---@return Layouter
 function LayouterMetaTable:ResetWidth()
     ResetWidth(self.c)
     return self
 end
 
---- Resets the control's height to be calculated from its top and bottom
---- **Make sure Bottom and Top are defined!!!**
+--- Resets the control's height to be calculated from its top and bottom  
+--- **Make sure `Bottom` and `Top` are defined!!!**
 ---@return Layouter
 function LayouterMetaTable:ResetHeight()
     ResetHeight(self.c)
@@ -1243,8 +1244,8 @@ end
 
 -- Fill parent
 
---- Sets control to fill a parent
---- Note this function copies the parent's side functions, it does not refer
+--- Sets control to fill a parent  
+--- Note this function copies the parent's edge functions, it does not refer
 ---@param parent Control
 ---@return Layouter
 function LayouterMetaTable:Fill(parent)
@@ -1262,7 +1263,7 @@ function LayouterMetaTable:FillFixedBorder(parent, offset)
 end
 
 
--- Calculates control's Properties to determine its layout completion and returns it
+-- Calculates control's Properties to determine its layout completion and returns it  
 -- remember, if parent has incomplete layout it will warn you anyway
 ---@return Control
 function LayouterMetaTable:End()

--- a/lua/maui/layouthelpers.lua
+++ b/lua/maui/layouthelpers.lua
@@ -449,13 +449,13 @@ end
 
 function SetWidth(control, width)
     if width then
-        control.Width:SetValue(floor(width * pixelScaleFactor))
+        control.Width:Set(floor(width * pixelScaleFactor))
     end
 end
 
 function SetHeight(control, height)
     if height then
-        control.Height:SetValue(floor(height * pixelScaleFactor))
+        control.Height:Set(floor(height * pixelScaleFactor))
     end
 end
 

--- a/lua/maui/layouthelpers.lua
+++ b/lua/maui/layouthelpers.lua
@@ -81,105 +81,105 @@ end
 -- to match parent.
 
 function AtHorizontalCenterIn(control, parent, offset)
-	if offset then
-		control.Left:SetFunction(function()
-			return parent.Left() + floor(((parent.Width() - control.Width()) / 2) + (offset * pixelScaleFactor))
-		end)
-	else
-		control.Left:SetFunction(function()
-			return parent.Left() + floor((parent.Width() - control.Width()) / 2)
-		end)
-	end
+    if offset then
+        control.Left:SetFunction(function()
+            return parent.Left() + floor(((parent.Width() - control.Width()) / 2) + (offset * pixelScaleFactor))
+        end)
+    else
+        control.Left:SetFunction(function()
+            return parent.Left() + floor((parent.Width() - control.Width()) / 2)
+        end)
+    end
 end
 
 function AtVerticalCenterIn(control, parent, offset)
     if offset then
-		control.Top:SetFunction(function()
-			return parent.Top() + floor(((parent.Height() - control.Height()) / 2) + (offset * pixelScaleFactor))
-		end)
-	else
-		control.Top:SetFunction(function()
-			return parent.Top() + floor((parent.Height() - control.Height()) / 2)
-		end)
-	end
+        control.Top:SetFunction(function()
+            return parent.Top() + floor(((parent.Height() - control.Height()) / 2) + (offset * pixelScaleFactor))
+        end)
+    else
+        control.Top:SetFunction(function()
+            return parent.Top() + floor((parent.Height() - control.Height()) / 2)
+        end)
+    end
 end
 
 -- These functions place a controls inside a parent
 
 function AtLeftIn(control, parent, offset)
     if offset and offset ~= 0 then
-		control.Left:SetFunction(function() return parent.Left() + floor(offset * pixelScaleFactor) end)
-	else
-		-- We shouldn't need to let the child refer to the parent if the parent is already laid out
-		-- however, this does change functionallity of the layout, so I've left them commented out for now
-		control.Left:SetFunction(function() return parent.Left() end)
-		--control.Left:SetFunction(parent.Left)
-	end
+        control.Left:SetFunction(function() return parent.Left() + floor(offset * pixelScaleFactor) end)
+    else
+        -- We shouldn't need to let the child refer to the parent if the parent is already laid out
+        -- however, this does change functionallity of the layout, so I've left them commented out for now
+        control.Left:SetFunction(function() return parent.Left() end)
+        --control.Left:SetFunction(parent.Left)
+    end
 end
 
 function AtTopIn(control, parent, offset)
     if offset and offset ~= 0 then
-		control.Top:SetFunction(function() return parent.Top() + floor(offset * pixelScaleFactor) end)
-	else
-		control.Top:SetFunction(function() return parent.Top() end)
-		--control.Top:SetFunction(parent.Top)
-	end
+        control.Top:SetFunction(function() return parent.Top() + floor(offset * pixelScaleFactor) end)
+    else
+        control.Top:SetFunction(function() return parent.Top() end)
+        --control.Top:SetFunction(parent.Top)
+    end
 end
 
 function AtRightIn(control, parent, offset)
     if offset and offset ~= 0 then
-		control.Right:SetFunction(function() return parent.Right() - floor(offset * pixelScaleFactor) end)
-	else
-		control.Right:SetFunction(function() return parent.Right() end)
-		--control.Right:SetFunction(parent.Right)
-	end
+        control.Right:SetFunction(function() return parent.Right() - floor(offset * pixelScaleFactor) end)
+    else
+        control.Right:SetFunction(function() return parent.Right() end)
+        --control.Right:SetFunction(parent.Right)
+    end
 end
 
 function AtBottomIn(control, parent, offset)
-	if offset and offset ~= 0 then
-		control.Bottom:SetFunction(function() return parent.Bottom() - floor(offset * pixelScaleFactor) end)
-	else
-		control.Bottom:SetFunction(function() return parent.Bottom() end)
-		--control.Bottom:SetFunction(parent.Bottom)
-	end
+    if offset and offset ~= 0 then
+        control.Bottom:SetFunction(function() return parent.Bottom() - floor(offset * pixelScaleFactor) end)
+    else
+        control.Bottom:SetFunction(function() return parent.Bottom() end)
+        --control.Bottom:SetFunction(parent.Bottom)
+    end
 end
 
 -- Anchor functions lock the appropriate side of a control to the side of another control
 
 function AnchorToLeft(control, parent, offset)
     if offset and offset ~= 0 then
-		control.Right:SetFunction(function() return parent.Left() - floor(offset * pixelScaleFactor) end)
-	else
-		control.Right:SetFunction(function() return parent.Left() end)
-		--control.Right:SetFunction(parent.Left)
-	end
+        control.Right:SetFunction(function() return parent.Left() - floor(offset * pixelScaleFactor) end)
+    else
+        control.Right:SetFunction(function() return parent.Left() end)
+        --control.Right:SetFunction(parent.Left)
+    end
 end
 
 function AnchorToTop(control, parent, offset)
     if offset and offset ~= 0 then
-		control.Bottom:SetFunction(function() return parent.Top() - floor(offset * pixelScaleFactor) end)
-	else
-		control.Bottom:SetFunction(function() return parent.Top() end)
-		--control.Bottom:SetFunction(parent.Top)
-	end
+        control.Bottom:SetFunction(function() return parent.Top() - floor(offset * pixelScaleFactor) end)
+    else
+        control.Bottom:SetFunction(function() return parent.Top() end)
+        --control.Bottom:SetFunction(parent.Top)
+    end
 end
 
 function AnchorToRight(control, parent, offset)
-	if offset and offset ~= 0 then
-		control.Left:SetFunction(function() return parent.Right() + floor(offset * pixelScaleFactor) end)
-	else
-		control.Left:SetFunction(function() return parent.Right() end)
-		--control.Left:SetFunction(parent.Right)
-	end
+    if offset and offset ~= 0 then
+        control.Left:SetFunction(function() return parent.Right() + floor(offset * pixelScaleFactor) end)
+    else
+        control.Left:SetFunction(function() return parent.Right() end)
+        --control.Left:SetFunction(parent.Right)
+    end
 end
 
 function AnchorToBottom(control, parent, offset)
     if offset and offset ~= 0 then
-		control.Top:SetFunction(function() return parent.Bottom() + floor(offset * pixelScaleFactor) end)
-	else
-		control.Top:SetFunction(function() return parent.Bottom() end)
-		--control.Top:SetFunction(parent.Bottom)
-	end
+        control.Top:SetFunction(function() return parent.Bottom() + floor(offset * pixelScaleFactor) end)
+    else
+        control.Top:SetFunction(function() return parent.Bottom() end)
+        --control.Top:SetFunction(parent.Bottom)
+    end
 end
 
 -- These functions use percentages to place the item rather than offsets so they will
@@ -187,37 +187,37 @@ end
 
 function FromLeftIn(control, parent, percent)
     if percent and percent ~= 0 then
-		control.Left:SetFunction(function() return parent.Left() + floor(percent * parent.Width()) end)
-	else
-		control.Left:SetFunction(function() return parent.Left() end)
-		--control.Left:SetFunction(parent.Left)
-	end
+        control.Left:SetFunction(function() return parent.Left() + floor(percent * parent.Width()) end)
+    else
+        control.Left:SetFunction(function() return parent.Left() end)
+        --control.Left:SetFunction(parent.Left)
+    end
 end
 
 function FromTopIn(control, parent, percent)
     if percent and percent ~= 0 then
-		control.Top:SetFunction(function() return parent.Top() + floor(percent * parent.Height()) end)
-	else
-		control.Top:SetFunction(function() return parent.Top() end)
-	end
+        control.Top:SetFunction(function() return parent.Top() + floor(percent * parent.Height()) end)
+    else
+        control.Top:SetFunction(function() return parent.Top() end)
+    end
 end
 
 function FromRightIn(control, parent, percent)
     if percent and percent ~= 0 then
-		control.Right:SetFunction(function() return parent.Right() - floor(percent * parent.Width()) end)
-	else
-		control.Right:SetFunction(function() return parent.Right() end)
-		--control.Right:SetFunction(parent.Right)
-	end
+        control.Right:SetFunction(function() return parent.Right() - floor(percent * parent.Width()) end)
+    else
+        control.Right:SetFunction(function() return parent.Right() end)
+        --control.Right:SetFunction(parent.Right)
+    end
 end
 
 function FromBottomIn(control, parent, percent)
     if percent and percent ~= 0 then
-		control.Bottom:SetFunction(function() return parent.Bottom() - floor(percent * parent.Height()) end)
-	else
-		control.Bottom:SetFunction(function() return parent.Bottom() end)
-		--control.Bottom:SetFunction(parent.Bottom)
-	end
+        control.Bottom:SetFunction(function() return parent.Bottom() - floor(percent * parent.Height()) end)
+    else
+        control.Bottom:SetFunction(function() return parent.Bottom() end)
+        --control.Bottom:SetFunction(parent.Bottom)
+    end
 end
 
 -- These functions reset a control to be calculated from the others
@@ -258,7 +258,7 @@ end
 
 -- Lock right top of control to left of parent, centered vertically to the parent
 function CenteredLeftOf(control, parent, offset)
-	AnchorToLeft(control, parent, offset)
+    AnchorToLeft(control, parent, offset)
     AtVerticalCenterIn(control, parent)
 end
 
@@ -270,7 +270,7 @@ end
 
 -- Lock left top of control to right of parent, centered vertically to the parent
 function CenteredRightOf(control, parent, offset)
-	AnchorToRight(control, parent, offset)
+    AnchorToRight(control, parent, offset)
     AtVerticalCenterIn(control, parent)
 end
 
@@ -307,12 +307,12 @@ end
 -- Lock right top of control to left top of parent
 function LeftOf(control, parent, offset)
     AnchorToLeft(control, parent, offset)
-	AtTopIn(control, parent)
+    AtTopIn(control, parent)
 end
 
 -- Lock bottom left of control to top left of parent
 function Above(control, parent, offset)
-	AtLeftIn(control, parent)
+    AtLeftIn(control, parent)
     AnchorToTop(control, parent, offset)
 end
 
@@ -324,7 +324,7 @@ end
 
 -- Lock top left of control to bottom left of parent
 function Below(control, parent, offset)
-	AtLeftIn(control, parent)
+    AtLeftIn(control, parent)
     AnchorToBottom(control, parent, offset)
 end
 
@@ -343,9 +343,9 @@ end
 
 function PercentIn(control, parent, left, top, right, bottom)
     FromLeftIn(control, parent, left)
-	FromTopIn(control, parent, top)
-	FromRightIn(control, parent, right)
-	FromBottomIn(control, parent, bottom)
+    FromTopIn(control, parent, top)
+    FromRightIn(control, parent, right)
+    FromBottomIn(control, parent, bottom)
 end
 
 -- These functions will stretch the control to fill the parent and provide an optional border
@@ -391,12 +391,12 @@ end
 
 -- Reset to the default layout functions
 function Reset(control)
-	ResetLeft(control)
-	ResetTop(control)
-	ResetRight(control)
-	ResetBottom(control)
-	ResetWidth(control)
-	ResetHeight(control)
+    ResetLeft(control)
+    ResetTop(control)
+    ResetRight(control)
+    ResetBottom(control)
+    ResetWidth(control)
+    ResetHeight(control)
 end
 
 --[[

--- a/lua/maui/layouthelpers.lua
+++ b/lua/maui/layouthelpers.lua
@@ -14,8 +14,8 @@
 -- scaled (ie large UI mode) this factor will keep the layout correct
 
 
-local MapFloor = math.floor
-local MapCeil = math.ceil
+local MathFloor = math.floor
+local MathCeil = math.ceil
 
 -- Store and set the current pixel scale multiplier. This will be used when the
 -- artwork is scaled up or down so that offsets scale up and down appropriately.
@@ -51,7 +51,7 @@ end
 ---@param width? number no change if nil
 function SetWidth(control, width)
     if width then
-        control.Width:SetValue(MapFloor(width * pixelScaleFactor))
+        control.Width:SetValue(MathFloor(width * pixelScaleFactor))
     end
 end
 
@@ -60,7 +60,7 @@ end
 ---@param height? number no change if nil
 function SetHeight(control, height)
     if height then
-        control.Height:SetValue(MapFloor(height * pixelScaleFactor))
+        control.Height:SetValue(MathFloor(height * pixelScaleFactor))
     end
 end
 
@@ -92,7 +92,7 @@ end
 ---@param number number
 ---@return number scaledNumber
 function ScaleNumber(number)
-    return MapFloor(number * pixelScaleFactor)
+    return MathFloor(number * pixelScaleFactor)
 end
 
 --- Unscales a number by the pixel scale factor
@@ -112,7 +112,7 @@ end
 ---@param padding? number fixed padding between control and parent
 function AnchorToLeft(control, parent, padding)
     if padding and padding ~= 0 then
-        control.Right:SetFunction(function() return parent.Left() - MapFloor(padding * pixelScaleFactor) end)
+        control.Right:SetFunction(function() return parent.Left() - MathFloor(padding * pixelScaleFactor) end)
     else
         -- We shouldn't need to let the child refer to the parent if the parent is already laid out
         -- however, this does change functionallity of the layout, so I've left them commented out for now
@@ -127,7 +127,7 @@ end
 ---@param padding? number fixed padding between control and parent
 function AnchorToTop(control, parent, padding)
     if padding and padding ~= 0 then
-        control.Bottom:SetFunction(function() return parent.Top() - MapFloor(padding * pixelScaleFactor) end)
+        control.Bottom:SetFunction(function() return parent.Top() - MathFloor(padding * pixelScaleFactor) end)
     else
         control.Bottom:SetFunction(function() return parent.Top() end)
         --control.Bottom:SetFunction(parent.Top)
@@ -140,7 +140,7 @@ end
 ---@param padding? number fixed padding between control and parent
 function AnchorToRight(control, parent, padding)
     if padding and padding ~= 0 then
-        control.Left:SetFunction(function() return parent.Right() + MapFloor(padding * pixelScaleFactor) end)
+        control.Left:SetFunction(function() return parent.Right() + MathFloor(padding * pixelScaleFactor) end)
     else
         control.Left:SetFunction(function() return parent.Right() end)
         --control.Left:SetFunction(parent.Right)
@@ -153,7 +153,7 @@ end
 ---@param padding? number fixed padding between control and parent
 function AnchorToBottom(control, parent, padding)
     if padding and padding ~= 0 then
-        control.Top:SetFunction(function() return parent.Bottom() + MapFloor(padding * pixelScaleFactor) end)
+        control.Top:SetFunction(function() return parent.Bottom() + MathFloor(padding * pixelScaleFactor) end)
     else
         control.Top:SetFunction(function() return parent.Bottom() end)
         --control.Top:SetFunction(parent.Bottom)
@@ -175,11 +175,11 @@ end
 function AtHorizontalCenterIn(control, parent, leftOffset)
     if leftOffset then
         control.Left:SetFunction(function()
-            return parent.Left() + MapFloor(((parent.Width() - control.Width()) / 2) + (leftOffset * pixelScaleFactor))
+            return parent.Left() + MathFloor(((parent.Width() - control.Width()) / 2) + (leftOffset * pixelScaleFactor))
         end)
     else
         control.Left:SetFunction(function()
-            return parent.Left() + MapFloor((parent.Width() - control.Width()) / 2)
+            return parent.Left() + MathFloor((parent.Width() - control.Width()) / 2)
         end)
     end
 end
@@ -191,11 +191,11 @@ end
 function AtVerticalCenterIn(control, parent, topOffset)
     if topOffset then
         control.Top:SetFunction(function()
-            return parent.Top() + MapFloor(((parent.Height() - control.Height()) / 2) + (topOffset * pixelScaleFactor))
+            return parent.Top() + MathFloor(((parent.Height() - control.Height()) / 2) + (topOffset * pixelScaleFactor))
         end)
     else
         control.Top:SetFunction(function()
-            return parent.Top() + MapFloor((parent.Height() - control.Height()) / 2)
+            return parent.Top() + MathFloor((parent.Height() - control.Height()) / 2)
         end)
     end
 end
@@ -206,7 +206,7 @@ end
 ---@param leftOffset? number
 function AtLeftIn(control, parent, leftOffset)
     if leftOffset and leftOffset ~= 0 then
-        control.Left:SetFunction(function() return parent.Left() + MapFloor(leftOffset * pixelScaleFactor) end)
+        control.Left:SetFunction(function() return parent.Left() + MathFloor(leftOffset * pixelScaleFactor) end)
     else
         control.Left:SetFunction(function() return parent.Left() end)
         --control.Left:SetFunction(parent.Left)
@@ -219,7 +219,7 @@ end
 ---@param topOffset? number
 function AtTopIn(control, parent, topOffset)
     if topOffset and topOffset ~= 0 then
-        control.Top:SetFunction(function() return parent.Top() + MapFloor(topOffset * pixelScaleFactor) end)
+        control.Top:SetFunction(function() return parent.Top() + MathFloor(topOffset * pixelScaleFactor) end)
     else
         control.Top:SetFunction(function() return parent.Top() end)
         --control.Top:SetFunction(parent.Top)
@@ -232,7 +232,7 @@ end
 ---@param rightOffset? number
 function AtRightIn(control, parent, rightOffset)
     if rightOffset and rightOffset ~= 0 then
-        control.Right:SetFunction(function() return parent.Right() - MapFloor(rightOffset * pixelScaleFactor) end)
+        control.Right:SetFunction(function() return parent.Right() - MathFloor(rightOffset * pixelScaleFactor) end)
     else
         control.Right:SetFunction(function() return parent.Right() end)
         --control.Right:SetFunction(parent.Right)
@@ -245,7 +245,7 @@ end
 ---@param bottomOffset? number
 function AtBottomIn(control, parent, bottomOffset)
     if bottomOffset and bottomOffset ~= 0 then
-        control.Bottom:SetFunction(function() return parent.Bottom() - MapFloor(bottomOffset * pixelScaleFactor) end)
+        control.Bottom:SetFunction(function() return parent.Bottom() - MathFloor(bottomOffset * pixelScaleFactor) end)
     else
         control.Bottom:SetFunction(function() return parent.Bottom() end)
         --control.Bottom:SetFunction(parent.Bottom)
@@ -261,7 +261,7 @@ end
 ---@param leftPercent? number
 function FromLeftIn(control, parent, leftPercent)
     if leftPercent and leftPercent ~= 0 then
-        control.Left:SetFunction(function() return parent.Left() + MapFloor(leftPercent * parent.Width()) end)
+        control.Left:SetFunction(function() return parent.Left() + MathFloor(leftPercent * parent.Width()) end)
     else
         control.Left:SetFunction(function() return parent.Left() end)
         --control.Left:SetFunction(parent.Left)
@@ -274,7 +274,7 @@ end
 ---@param topPercent? number
 function FromTopIn(control, parent, topPercent)
     if topPercent and topPercent ~= 0 then
-        control.Top:SetFunction(function() return parent.Top() + MapFloor(topPercent * parent.Height()) end)
+        control.Top:SetFunction(function() return parent.Top() + MathFloor(topPercent * parent.Height()) end)
     else
         control.Top:SetFunction(function() return parent.Top() end)
         --control.Top:SetFunction(parent.Top)
@@ -287,7 +287,7 @@ end
 ---@param rightPercent? number
 function FromRightIn(control, parent, rightPercent)
     if rightPercent and rightPercent ~= 0 then
-        control.Right:SetFunction(function() return parent.Right() - MapFloor(rightPercent * parent.Width()) end)
+        control.Right:SetFunction(function() return parent.Right() - MathFloor(rightPercent * parent.Width()) end)
     else
         control.Right:SetFunction(function() return parent.Right() end)
         --control.Right:SetFunction(parent.Right)
@@ -300,7 +300,7 @@ end
 ---@param bottomPercent? number
 function FromBottomIn(control, parent, bottomPercent)
     if bottomPercent and bottomPercent ~= 0 then
-        control.Bottom:SetFunction(function() return parent.Bottom() - MapFloor(bottomPercent * parent.Height()) end)
+        control.Bottom:SetFunction(function() return parent.Bottom() - MathFloor(bottomPercent * parent.Height()) end)
     else
         control.Bottom:SetFunction(function() return parent.Bottom() end)
         --control.Bottom:SetFunction(parent.Bottom)
@@ -557,16 +557,16 @@ function FillParentPreserveAspectRatio(control, parent)
     end
 
     control.Top:SetFunction(function()
-        return MapFloor(parent.Top() + ((parent.Height() - (control.Height() * GetRatio(control, parent))) / 2))
+        return MathFloor(parent.Top() + ((parent.Height() - (control.Height() * GetRatio(control, parent))) / 2))
     end)
     control.Bottom:SetFunction(function()
-        return MapFloor(parent.Bottom() - ((parent.Height() - (control.Height() * GetRatio(control, parent))) / 2))
+        return MathFloor(parent.Bottom() - ((parent.Height() - (control.Height() * GetRatio(control, parent))) / 2))
     end)
     control.Left:SetFunction(function()
-        return MapFloor(parent.Left() + ((parent.Width() - (control.Width() * GetRatio(control, parent))) / 2))
+        return MathFloor(parent.Left() + ((parent.Width() - (control.Width() * GetRatio(control, parent))) / 2))
     end)
     control.Right:SetFunction(function()
-        return MapFloor(parent.Right() - ((parent.Width() - (control.Width() * GetRatio(control, parent))) / 2))
+        return MathFloor(parent.Right() - ((parent.Width() - (control.Width() * GetRatio(control, parent))) / 2))
     end)
 end
 
@@ -612,12 +612,12 @@ function RelativeTo(control, parent, fileName, controlName, parentName, topOffse
     leftOffset = leftOffset or 0
     control.Top:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return MapFloor(parent.Top() + ((layoutTable[controlName].top - layoutTable[parentName].top) * pixelScaleFactor + (topOffset * pixelScaleFactor)))
+        return MathFloor(parent.Top() + ((layoutTable[controlName].top - layoutTable[parentName].top) * pixelScaleFactor + (topOffset * pixelScaleFactor)))
     end)
     
     control.Left:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return MapFloor(parent.Left() + ((layoutTable[controlName].left - layoutTable[parentName].left) * pixelScaleFactor + (leftOffset * pixelScaleFactor)))
+        return MathFloor(parent.Left() + ((layoutTable[controlName].left - layoutTable[parentName].left) * pixelScaleFactor + (leftOffset * pixelScaleFactor)))
     end)
 end
 
@@ -637,7 +637,7 @@ function LeftRelativeTo(control, parent, fileName, controlName, parentName)
     end
     control.Left:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return MapFloor(parent.Left() + (layoutTable[controlName].left - layoutTable[parentName].left))
+        return MathFloor(parent.Left() + (layoutTable[controlName].left - layoutTable[parentName].left))
     end)
 end
 
@@ -657,7 +657,7 @@ function TopRelativeTo(control, parent, fileName, controlName, parentName)
     end
     control.Top:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return MapFloor(parent.Top() + (layoutTable[controlName].top - layoutTable[parentName].top))
+        return MathFloor(parent.Top() + (layoutTable[controlName].top - layoutTable[parentName].top))
     end)
 end
 
@@ -679,7 +679,7 @@ function RightRelativeTo(control, parent, fileName, controlName, parentName)
         local layoutTable = import(fileName()).layout
         local layoutParent = layoutTable[parentName]
         local layoutControl = layoutTable[controlName]
-        return MapFloor(parent.Right() - ((layoutParent.left + layoutParent.width) - (layoutControl.left + layoutControl.width)))
+        return MathFloor(parent.Right() - ((layoutParent.left + layoutParent.width) - (layoutControl.left + layoutControl.width)))
     end)
 end
 
@@ -701,7 +701,7 @@ function BottomRelativeTo(control, parent, fileName, controlName, parentName)
         local layoutTable = import(fileName()).layout
         local layoutParent = layoutTable[parentName]
         local layoutControl = layoutTable[controlName]
-        return MapFloor(parent.Bottom() - ((layoutParent.top + layoutParent.height) - (layoutControl.top + layoutControl.height)))
+        return MathFloor(parent.Bottom() - ((layoutParent.top + layoutParent.height) - (layoutControl.top + layoutControl.height)))
     end)
 end
 
@@ -716,11 +716,11 @@ function DimensionsRelativeTo(control, fileName, controlName)
     end
     control.Width:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return MapFloor(layoutTable[controlName].width * pixelScaleFactor)
+        return MathFloor(layoutTable[controlName].width * pixelScaleFactor)
     end)
     control.Height:SetFunction(function()
         local layoutTable = import(fileName()).layout
-        return MapFloor(layoutTable[controlName].height * pixelScaleFactor)
+        return MathFloor(layoutTable[controlName].height * pixelScaleFactor)
     end)
 end
 
@@ -1205,7 +1205,6 @@ end
 -- Out-of positioning
 
 --- Lock top right of the control to top left of a parent
----@param control Control
 ---@param parent Control
 ---@param padding? number fixed padding between control and parent
 ---@return Layouter
@@ -1215,7 +1214,6 @@ function LayouterMetaTable:LeftOf(parent, padding)
 end
 
 --- Lock top left of the control to top right of a parent
----@param control Control
 ---@param parent Control
 ---@param padding? number fixed padding between control and parent
 ---@return Layouter
@@ -1225,7 +1223,6 @@ function LayouterMetaTable:RightOf(parent, padding)
 end
 
 --- Lock bottom left of the control to top left of a parent
----@param control Control
 ---@param parent Control
 ---@param padding? number fixed padding between control and parent
 ---@return Layouter
@@ -1236,7 +1233,6 @@ end
 
 
 --- Lock top left of the control to bottom left of a parent
----@param control Control
 ---@param parent Control
 ---@param padding? number fixed padding between control and parent
 ---@return Layouter


### PR DESCRIPTION
Refactor layouthelpers, as proposed in [issue#3762](https://github.com/FAForever/fa/issues/3762#issue-1193077875). Mostly just the things requested there, but comprehensively:
- Standardized comments
- Upvalued math.floor
- Replaced Set with SetFunction where appropriate
- Removed double divide by 2 in centering functions
- Moved optional argument checking into parent functions
- Reused tablelayouts in RightRelativeTo and BottomRelativeTo functions (though if the cost of setting extra local variables is more expensive than the table lookup, let me know)
- Removed redundant multiplication in InvScaleNumber

There's a lot a extra parentheses in here--I just left them because it doesn't matter, but I'd be interested to know if we have a style guideline for that.