### PR TITLE
Add guard surrounding expand / contract functions of scoreboard

### DIFF
--- a/lua/ui/game/score.lua
+++ b/lua/ui/game/score.lua
@@ -42,6 +42,8 @@ local resModeSwitch = {}
 local DisplayResMode = 0
 local DisplayStorage = 0
 
+local created = false 
+
 function armyGroupHeight()
     local height = 0
     for _, line in controls.armyLines do
@@ -51,6 +53,8 @@ function armyGroupHeight()
 end
 
 function CreateScoreUI(parent)
+    created = true
+    LOG("I WAS MADE!")
     savedParent = GetFrame(0)
 
     controls.bg = Group(savedParent)
@@ -821,33 +825,37 @@ function ToggleScoreControl(state)
 end
 
 function Expand()
-    if needExpand then
-        controls.bg:Show()
-        controls.collapseArrow:Show()
-        local sound = Sound({Cue = "UI_Score_Window_Open", Bank = "Interface",})
-        PlaySound(sound)
-        needExpand = false
-    else
-        controls.collapseArrow:Show()
+    if created then 
+        if needExpand then
+            controls.bg:Show()
+            controls.collapseArrow:Show()
+            local sound = Sound({Cue = "UI_Score_Window_Open", Bank = "Interface",})
+            PlaySound(sound)
+            needExpand = false
+        else
+            controls.collapseArrow:Show()
+        end
     end
 end
 
 function Contract()
-    if controls.bg then
-        if not controls.bg:IsHidden() then
-            local sound = Sound({Cue = "UI_Score_Window_Close", Bank = "Interface",})
-            PlaySound(sound)
-            controls.bg:Hide()
-            controls.collapseArrow:Hide()
-            if Prefs.GetFromCurrentProfile("scoreoverlay") ~= false then
-                needExpand = true
+    if created then 
+        if controls.bg then
+            if not controls.bg:IsHidden() then
+                local sound = Sound({Cue = "UI_Score_Window_Close", Bank = "Interface",})
+                PlaySound(sound)
+                controls.bg:Hide()
+                controls.collapseArrow:Hide()
+                if Prefs.GetFromCurrentProfile("scoreoverlay") ~= false then
+                    needExpand = true
+                end
+            else
+                needExpand = false
+                controls.collapseArrow:Hide()
             end
         else
-            needExpand = false
-            controls.collapseArrow:Hide()
+            contractOnCreate = true
         end
-    else
-        contractOnCreate = true
     end
 end
 

--- a/lua/ui/game/score.lua
+++ b/lua/ui/game/score.lua
@@ -54,7 +54,6 @@ end
 
 function CreateScoreUI(parent)
     created = true
-    LOG("I WAS MADE!")
     savedParent = GetFrame(0)
 
     controls.bg = Group(savedParent)


### PR DESCRIPTION
Closes #3935 

An error sneaked in for co-op where the usual scoreboard doesn't exist. As a consequence all of the UI bogs down for co-op.