### PR TITLE
Add support for multiple upgrade animations

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -324,17 +324,19 @@ StructureUnit = Class(Unit) {
 
     UpgradingState = State {
         Main = function(self)
-            local bp = self.Blueprint.Display
             self:DestroyTarmac()
             self:PlayUnitSound('UpgradeStart')
             self:DisableDefaultToggleCaps()
-            if bp.AnimationUpgrade then
+
+            local animation = self:GetUpgradeAnimation(self.UnitBeingBuilt)
+            if animation then
+
                 local unitBuilding = self.UnitBeingBuilt
                 self.AnimatorUpgradeManip = CreateAnimator(self)
                 self.Trash:Add(self.AnimatorUpgradeManip)
                 local fractionOfComplete = 0
                 self:StartUpgradeEffects(unitBuilding)
-                self.AnimatorUpgradeManip:PlayAnim(bp.AnimationUpgrade, false):SetRate(0)
+                self.AnimatorUpgradeManip:PlayAnim(animation, false):SetRate(0)
 
                 while fractionOfComplete < 1 and not self.Dead do
                     fractionOfComplete = unitBuilding:GetFractionComplete()

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4268,6 +4268,15 @@ Unit = Class(moho.unit_methods) {
         end
     end,
 
+    --- Determines the upgrade animation to use. Allows you to manage units (by hooking) that can upgrade to
+    --- more than just one unit type, as an example tech 1 factories that can become HQs or
+    --- support factories.
+    ---@param self Unit A reference to the unit itself, automatically set when you use the ':' notation
+    ---@param unitBeingBuilt Unit A flag to determine whether our consumption should be active
+    GetUpgradeAnimation = function(self, unitBeingBuilt) 
+        return self.Blueprint.Display.AnimationUpgrade
+    end,
+
     --- Various callback-like functions
 
     -- Called when the C function unit.SetConsumptionActive is called

--- a/units/UAB0101/UAB0101_script.lua
+++ b/units/UAB0101/UAB0101_script.lua
@@ -10,14 +10,6 @@
 
 local ALandFactoryUnit = import('/lua/aeonunits.lua').ALandFactoryUnit
 
-UAB0101 = Class(ALandFactoryUnit) {
-    GetUpgradeAnimation = function(self, unitBeingBuilt) 
-        if unitBeingBuilt.BlueprintId == 'test001' then 
-            return self.Blueprint.Display.Animation1 
-        else
-            return self.Blueprint.Display.Animation2 
-        end 
-    end,
-}
+UAB0101 = Class(ALandFactoryUnit) {}
 
 TypeClass = UAB0101

--- a/units/UAB0101/UAB0101_script.lua
+++ b/units/UAB0101/UAB0101_script.lua
@@ -10,6 +10,14 @@
 
 local ALandFactoryUnit = import('/lua/aeonunits.lua').ALandFactoryUnit
 
-UAB0101 = Class(ALandFactoryUnit) {}
+UAB0101 = Class(ALandFactoryUnit) {
+    GetUpgradeAnimation = function(self, unitBeingBuilt) 
+        if unitBeingBuilt.BlueprintId == 'test001' then 
+            return self.Blueprint.Display.Animation1 
+        else
+            return self.Blueprint.Display.Animation2 
+        end 
+    end,
+}
 
 TypeClass = UAB0101


### PR DESCRIPTION
In particular relevant for tech 1 land factories that can either upgrade to an HQ or a support factory. These should have different upgrade animations.