### PR TITLE
Fix Aeon and UEF build animations

### DIFF
--- a/lua/EffectUtilitiesAeon.lua
+++ b/lua/EffectUtilitiesAeon.lua
@@ -231,7 +231,7 @@ function CreateAeonFactoryBuildingEffects(builder, unitBeingBuilt, buildEffectBo
 
         local sx = unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
         local sz = unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
-        local sy = unitBeingBuilt.Blueprint.Physics.MeshExtentsY or unitBeingBuilt.Blueprint.Footprint.SizeY or (sx + sz)
+        local sy = unitBeingBuilt.Blueprint.Physics.MeshExtentsY or math.min(sx, sz)
 
         -- -- Create pool of mercury
 
@@ -445,7 +445,7 @@ function CreateAeonCZARBuildingEffects(unitBeingBuilt)
 
     local sx = 0.6 * unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
     local sz = 0.6 * unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
-    local sy = 1.5 * unitBeingBuilt.Blueprint.Physics.MeshExtentsY or unitBeingBuilt.Blueprint.Footprint.SizeY or (sx + sz)
+    local sy = 1.5 * unitBeingBuilt.Blueprint.Physics.MeshExtentsY or math.min(sx, sz)
 
     -- -- Create generic build effects
 
@@ -515,7 +515,7 @@ function CreateAeonTempestBuildingEffects(unitBeingBuilt)
 
     local sx = 0.55 * unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
     local sz = 0.55 * unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
-    local sy = 3 * unitBeingBuilt.Blueprint.Physics.MeshExtentsY or unitBeingBuilt.Blueprint.Footprint.SizeY or (sx + sz)
+    local sy = 3 * unitBeingBuilt.Blueprint.Physics.MeshExtentsY or math.min(sx, sz)
 
     -- -- Create effects of build animation
 
@@ -621,7 +621,7 @@ function CreateAeonParagonBuildingEffects(unitBeingBuilt)
 
     local sx = 1 * unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
     local sz = 1 * unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
-    local sy = 2 * unitBeingBuilt.Blueprint.Physics.MeshExtentsY or unitBeingBuilt.Blueprint.Footprint.SizeY or (sx + sz)
+    local sy = 2 * unitBeingBuilt.Blueprint.Physics.MeshExtentsY or math.min(sx, sz)
 
     -- -- Create effects of build animation
 

--- a/lua/EffectUtilitiesUEF.lua
+++ b/lua/EffectUtilitiesUEF.lua
@@ -269,9 +269,6 @@ function CreateBuildCubeThread(
     local bx = unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
     local bz = unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
     local by = unitBeingBuilt.Blueprint.Physics.MeshExtentsY or math.min(bx, bz)
-    LOG(bx)
-    LOG(bz)
-    LOG(by)
 
     -- create a quick glow effect
     local proj = EntityCreateProjectile(unitBeingBuilt, '/effects/Entities/UEFBuildEffect/UEFBuildEffect02_proj.bp', 0, 0, 0, nil, nil, nil)

--- a/lua/EffectUtilitiesUEF.lua
+++ b/lua/EffectUtilitiesUEF.lua
@@ -136,7 +136,7 @@ function CreateUEFBuildSliceBeams(
     -- Determine beam positioning on build cube, this should match sizes of CreateBuildCubeThread
     local ox = unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
     local oz = unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
-    local oy = unitBeingBuilt.Blueprint.Physics.MeshExtentsY or unitBeingBuilt.Blueprint.Footprint.SizeY or (ox + oz)
+    local oy = unitBeingBuilt.Blueprint.Physics.MeshExtentsY or math.min(ox, oz)
 
     ox = ox * 0.5
     oz = oz * 0.5
@@ -268,7 +268,10 @@ function CreateBuildCubeThread(
 
     local bx = unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
     local bz = unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
-    local by = unitBeingBuilt.Blueprint.Physics.MeshExtentsY or unitBeingBuilt.Blueprint.Footprint.SizeY or (bx + bz)
+    local by = unitBeingBuilt.Blueprint.Physics.MeshExtentsY or math.min(bx, bz)
+    LOG(bx)
+    LOG(bz)
+    LOG(by)
 
     -- create a quick glow effect
     local proj = EntityCreateProjectile(unitBeingBuilt, '/effects/Entities/UEFBuildEffect/UEFBuildEffect02_proj.bp', 0, 0, 0, nil, nil, nil)
@@ -422,7 +425,7 @@ function CreateUEFCommanderBuildSliceBeams(
     -- Determine beam positioning on build cube, this should match sizes of CreateBuildCubeThread
     local ox = unitBeingBuilt.Blueprint.Physics.MeshExtentsX or unitBeingBuilt.Blueprint.Footprint.SizeX
     local oz = unitBeingBuilt.Blueprint.Physics.MeshExtentsZ or unitBeingBuilt.Blueprint.Footprint.SizeZ
-    local oy = unitBeingBuilt.Blueprint.Physics.MeshExtentsY or unitBeingBuilt.Blueprint.Footprint.SizeY or (ox + oz)
+    local oy = unitBeingBuilt.Blueprint.Physics.MeshExtentsY or math.min(ox, oz)
 
     ox = ox * 0.5
     oz = oz * 0.5


### PR DESCRIPTION
Closes #3929

Fixes an incorrect replacement done by #3875 to reduce the memory impact of the game.