### PR TITLE
Fix damage of various projectiles after a split

### DIFF
--- a/projectiles/CIFMissileTactical01/CIFMissileTactical01_Script.lua
+++ b/projectiles/CIFMissileTactical01/CIFMissileTactical01_Script.lua
@@ -60,14 +60,6 @@ CIFMissileTactical01 = Class(CLOATacticalMissileProjectile) {
         return dist
     end,
     
-    PassDamageData = function(self, damageData)
-        CLOATacticalMissileProjectile.PassDamageData(self,damageData)
-        local launcherbp = self:GetLauncher():GetBlueprint()
-        self.ChildDamageData = table.copy(self.DamageData)
-        self.ChildDamageData.DamageAmount = launcherbp.SplitDamage.DamageAmount or 0
-        self.ChildDamageData.DamageRadius = launcherbp.SplitDamage.DamageRadius or 1
-    end,
-    
     OnImpact = function(self, targetType, targetEntity)       
         CreateLightParticle( self, -1, self.Army, 3, 7, 'glow_03', 'ramp_fire_11' )
             
@@ -88,6 +80,9 @@ CIFMissileTactical01 = Class(CLOATacticalMissileProjectile) {
             local angle = (2*math.pi) / self.NumChildMissiles
             local spreadMul = 1  -- Adjusts the width of the dispersal
 
+            self.DamageData.DamageAmount = self.Launcher.Blueprint.SplitDamage.DamageAmount
+            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageAmount
+
             -- Launch projectiles at semi-random angles away from split location
             for i = 0, (self.NumChildMissiles - 1) do
                 local xVec = vx + math.sin(i*angle) * spreadMul
@@ -96,7 +91,7 @@ CIFMissileTactical01 = Class(CLOATacticalMissileProjectile) {
                 local proj = self:CreateChildProjectile(ChildProjectileBP)
                 proj:SetVelocity(xVec,yVec,zVec)
                 proj:SetVelocity(velocity)
-                proj:PassDamageData(self.ChildDamageData)
+                proj:PassDamageData(self.DamageData)
             end
         end
         CLOATacticalMissileProjectile.OnDamage(self, instigator, amount, vector, damageType)

--- a/projectiles/CIFMissileTactical01/CIFMissileTactical01_Script.lua
+++ b/projectiles/CIFMissileTactical01/CIFMissileTactical01_Script.lua
@@ -81,7 +81,7 @@ CIFMissileTactical01 = Class(CLOATacticalMissileProjectile) {
             local spreadMul = 1  -- Adjusts the width of the dispersal
 
             self.DamageData.DamageAmount = self.Launcher.Blueprint.SplitDamage.DamageAmount
-            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageAmount
+            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageRadius
 
             -- Launch projectiles at semi-random angles away from split location
             for i = 0, (self.NumChildMissiles - 1) do

--- a/projectiles/CIFMissileTactical01/CIFMissileTactical01_Script.lua
+++ b/projectiles/CIFMissileTactical01/CIFMissileTactical01_Script.lua
@@ -80,8 +80,8 @@ CIFMissileTactical01 = Class(CLOATacticalMissileProjectile) {
             local angle = (2*math.pi) / self.NumChildMissiles
             local spreadMul = 1  -- Adjusts the width of the dispersal
 
-            self.DamageData.DamageAmount = self.Launcher.Blueprint.SplitDamage.DamageAmount
-            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageRadius
+            self.DamageData.DamageAmount = self.Launcher.Blueprint.SplitDamage.DamageAmount or 0
+            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageRadius or 1
 
             -- Launch projectiles at semi-random angles away from split location
             for i = 0, (self.NumChildMissiles - 1) do

--- a/projectiles/CIFMissileTactical02/CIFMissileTactical02_Script.lua
+++ b/projectiles/CIFMissileTactical02/CIFMissileTactical02_Script.lua
@@ -40,7 +40,7 @@ CIFMissileTactical02 = Class(CLOATacticalMissileProjectile) {
             local spreadMul = 0.5  -- Adjusts the width of the dispersal        
 
             self.DamageData.DamageAmount = self.Launcher.Blueprint.SplitDamage.DamageAmount
-            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageAmount
+            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageRadius
 
             -- Launch projectiles at semi-random angles away from split location
             for i = 0, (self.NumChildMissiles - 1) do

--- a/projectiles/CIFMissileTactical02/CIFMissileTactical02_Script.lua
+++ b/projectiles/CIFMissileTactical02/CIFMissileTactical02_Script.lua
@@ -19,14 +19,6 @@ CIFMissileTactical02 = Class(CLOATacticalMissileProjectile) {
         self:ForkThread( self.MovementThread )        
     end,
     
-    PassDamageData = function(self, damageData)
-        CLOATacticalMissileProjectile.PassDamageData(self,damageData)
-        local launcherbp = self:GetLauncher():GetBlueprint()  
-        self.ChildDamageData = table.copy(self.DamageData)
-        self.ChildDamageData.DamageAmount = launcherbp.SplitDamage.DamageAmount or 0
-        self.ChildDamageData.DamageRadius = launcherbp.SplitDamage.DamageRadius or 1   
-    end,    
-    
     OnImpact = function(self, targetType, targetEntity)
         CreateLightParticle( self, -1, self.Army, 3, 7, 'glow_03', 'ramp_fire_11' )
         
@@ -47,6 +39,9 @@ CIFMissileTactical02 = Class(CLOATacticalMissileProjectile) {
             local angle = (2*math.pi) / self.NumChildMissiles
             local spreadMul = 0.5  -- Adjusts the width of the dispersal        
 
+            self.DamageData.DamageAmount = self.Launcher.Blueprint.SplitDamage.DamageAmount
+            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageAmount
+
             -- Launch projectiles at semi-random angles away from split location
             for i = 0, (self.NumChildMissiles - 1) do
                 local xVec = vx + math.sin(i*angle) * spreadMul
@@ -55,7 +50,7 @@ CIFMissileTactical02 = Class(CLOATacticalMissileProjectile) {
                 local proj = self:CreateChildProjectile(ChildProjectileBP)
                 proj:SetVelocity(xVec,yVec,zVec)
                 proj:SetVelocity(velocity)
-                proj:PassDamageData(self.ChildDamageData)
+                proj:PassDamageData(self.DamageData)
             end
         end
         CLOATacticalMissileProjectile.OnDamage(self, instigator, amount, vector, damageType)

--- a/projectiles/CIFMissileTactical02/CIFMissileTactical02_Script.lua
+++ b/projectiles/CIFMissileTactical02/CIFMissileTactical02_Script.lua
@@ -39,8 +39,8 @@ CIFMissileTactical02 = Class(CLOATacticalMissileProjectile) {
             local angle = (2*math.pi) / self.NumChildMissiles
             local spreadMul = 0.5  -- Adjusts the width of the dispersal        
 
-            self.DamageData.DamageAmount = self.Launcher.Blueprint.SplitDamage.DamageAmount
-            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageRadius
+            self.DamageData.DamageAmount = self.Launcher.Blueprint.SplitDamage.DamageAmount or 0
+            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageRadius or 1
 
             -- Launch projectiles at semi-random angles away from split location
             for i = 0, (self.NumChildMissiles - 1) do

--- a/projectiles/CIFMissileTactical03/CIFMissileTactical03_Script.lua
+++ b/projectiles/CIFMissileTactical03/CIFMissileTactical03_Script.lua
@@ -38,8 +38,8 @@ CIFMissileTactical03 = Class(CLOATacticalMissileProjectile) {
             local angle = (2*math.pi) / self.NumChildMissiles
             local spreadMul = 0.5  -- Adjusts the width of the dispersal
 
-            self.DamageData.DamageAmount = self.Launcher.Blueprint.SplitDamage.DamageAmount
-            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageRadius
+            self.DamageData.DamageAmount = self.Launcher.Blueprint.SplitDamage.DamageAmount or 0
+            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageRadius or 1
 
             -- Launch projectiles at semi-random angles away from split location
             for i = 0, (self.NumChildMissiles - 1) do

--- a/projectiles/CIFMissileTactical03/CIFMissileTactical03_Script.lua
+++ b/projectiles/CIFMissileTactical03/CIFMissileTactical03_Script.lua
@@ -39,7 +39,7 @@ CIFMissileTactical03 = Class(CLOATacticalMissileProjectile) {
             local spreadMul = 0.5  -- Adjusts the width of the dispersal
 
             self.DamageData.DamageAmount = self.Launcher.Blueprint.SplitDamage.DamageAmount
-            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageAmount
+            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageRadius
 
             -- Launch projectiles at semi-random angles away from split location
             for i = 0, (self.NumChildMissiles - 1) do

--- a/projectiles/CIFMissileTactical03/CIFMissileTactical03_Script.lua
+++ b/projectiles/CIFMissileTactical03/CIFMissileTactical03_Script.lua
@@ -16,15 +16,7 @@ CIFMissileTactical03 = Class(CLOATacticalMissileProjectile) {
         self.Split = false
         self.MovementTurnLevel = 1
         self:ForkThread( self.MovementThread )
-    end,
-    
-    PassDamageData = function(self, damageData)
-        CLOATacticalMissileProjectile.PassDamageData(self,damageData)
-        local launcherbp = self:GetLauncher():GetBlueprint()
-        self.ChildDamageData = table.copy(self.DamageData)
-        self.ChildDamageData.DamageAmount = launcherbp.SplitDamage.DamageAmount or 0
-        self.ChildDamageData.DamageRadius = launcherbp.SplitDamage.DamageRadius or 1
-    end,    
+    end, 
     
     OnImpact = function(self, targetType, targetEntity)      
         CreateLightParticle( self, -1, self.Army, 3, 7, 'glow_03', 'ramp_fire_11' )
@@ -46,6 +38,9 @@ CIFMissileTactical03 = Class(CLOATacticalMissileProjectile) {
             local angle = (2*math.pi) / self.NumChildMissiles
             local spreadMul = 0.5  -- Adjusts the width of the dispersal
 
+            self.DamageData.DamageAmount = self.Launcher.Blueprint.SplitDamage.DamageAmount
+            self.DamageData.DamageRadius = self.Launcher.Blueprint.SplitDamage.DamageAmount
+
             -- Launch projectiles at semi-random angles away from split location
             for i = 0, (self.NumChildMissiles - 1) do
                 local xVec = vx + math.sin(i*angle) * spreadMul
@@ -54,7 +49,7 @@ CIFMissileTactical03 = Class(CLOATacticalMissileProjectile) {
                 local proj = self:CreateChildProjectile(ChildProjectileBP)
                 proj:SetVelocity(xVec,yVec,zVec)
                 proj:SetVelocity(velocity)
-                proj:PassDamageData(self.ChildDamageData)
+                proj:PassDamageData(self.DamageData)
             end
         end
         CLOATacticalMissileProjectile.OnDamage(self, instigator, amount, vector, damageType)


### PR DESCRIPTION
Closes #3902

In particular the child projectiles of Cybran missiles did no damage. 