### PR TITLE
Fix Mercy being set to manual fire

### DIFF
--- a/units/DAA0206/DAA0206_unit.bp
+++ b/units/DAA0206/DAA0206_unit.bp
@@ -301,7 +301,6 @@ UnitBlueprint {
             TurretYawSpeed = 720,
             Turreted = true,
             WeaponCategory = 'Kamikaze',
-            ManualFire = true,
         },
         {
             AboveWaterTargetsOnly = true,


### PR DESCRIPTION
Removes a test statement that was part of #3857 , allowing the Mercy to do Mercy things again.