### PR TITLE
Update antiair and antinavy categories-Cybran Experimentals

### DIFF
--- a/units/URA0401/URA0401_unit.bp
+++ b/units/URA0401/URA0401_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         'EXPERIMENTAL',
         'GROUNDATTACK',
         'NEEDMOBILEBUILD',
-        'ANTIAIR',
         'COUNTERINTELLIGENCE',
         'STEALTH',
         'VISIBLETORECON',

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -74,8 +74,6 @@ UnitBlueprint {
         'BOT',
         'DIRECTFIRE',
         'AMPHIBIOUS',
-        'ANTIAIR',
-        'ANTINAVY',
         'NEEDMOBILEBUILD',
         'INTELLIGENCE',
         'COUNTERINTELLIGENCE',

--- a/units/XRL0403/XRL0403_unit.bp
+++ b/units/XRL0403/XRL0403_unit.bp
@@ -84,8 +84,6 @@ UnitBlueprint {
         'FACTORY',
         'DIRECTFIRE',
         'AMPHIBIOUS',
-        'ANTIAIR',
-        'ANTINAVY',
         'SNIPER',
         'NEEDMOBILEBUILD',
         'SONAR',


### PR DESCRIPTION
Update so units use the overlayantiair and overlayantinavy variants for antiair and antinavy where it is very weak at that role
-Soul ripper, Monkeylord and Megalith