### PR TITLE
ADD LODCutoff in Projectiles bp for AEON AA missiles and torpedos

### DIFF
--- a/projectiles/AAAZealotMissile01/AAAZealotMissile01_proj.bp
+++ b/projectiles/AAAZealotMissile01/AAAZealotMissile01_proj.bp
@@ -27,6 +27,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'TMeshAlpha',
+                    LODCutoff = 130,
                 },
             },
         },

--- a/projectiles/AAAZealotMissile02/AAAZealotMissile02_proj.bp
+++ b/projectiles/AAAZealotMissile02/AAAZealotMissile02_proj.bp
@@ -27,6 +27,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'TMeshAlpha',
+                    LODCutoff = 130,
                 },
             },
         },

--- a/projectiles/AANTorpedo01/AANTorpedo01_proj.bp
+++ b/projectiles/AANTorpedo01/AANTorpedo01_proj.bp
@@ -28,6 +28,7 @@ ProjectileBlueprint {
                     AlbedoName = '/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_albedo.dds',
                     MeshName = '/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_lod0.scm',
                     ShaderName = 'TMeshGlow',
+                    LODCutoff = 130,
                 },
             },
         },

--- a/projectiles/AANTorpedo02/AANTorpedo02_proj.bp
+++ b/projectiles/AANTorpedo02/AANTorpedo02_proj.bp
@@ -16,6 +16,7 @@ ProjectileBlueprint {
                     AlbedoName = '/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_albedo.dds',
                     MeshName = '/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_lod0.scm',
                     ShaderName = 'TMeshGlow',
+                    LODCutoff = 130,
                 },
             },
         },

--- a/projectiles/AANTorpedoClusterSplit01/AANTorpedoClusterSplit01_proj.bp
+++ b/projectiles/AANTorpedoClusterSplit01/AANTorpedoClusterSplit01_proj.bp
@@ -34,6 +34,7 @@ ProjectileBlueprint {
                     AlbedoName = '/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_albedo.dds',
                     MeshName = '/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_lod0.scm',
                     ShaderName = 'TMeshGlow',
+                    LODCutoff = 130,
                 },
             },
         },

--- a/projectiles/aaserpentine/AASerpentine_proj.bp
+++ b/projectiles/aaserpentine/AASerpentine_proj.bp
@@ -27,6 +27,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'TMeshAlpha',
+                    LODCutoff = 130,
                 },
             },
         },


### PR DESCRIPTION
ADD LODCutoff=130 in Projectiles bp for AEON AA missiles and torpedos : XAA0305, UAB2304, DALK003, UAB2109,  XAA0306

**Couldn't find the unit using AANTorpedo02_proj.bp**