### PR TITLE
Remove empty functions

### DIFF
--- a/lua/cybranweapons.lua
+++ b/lua/cybranweapons.lua
@@ -416,10 +416,6 @@ CAMZapperWeapon03 = Class(DefaultBeamWeapon) {
     end,
 
     IdleState = State (DefaultBeamWeapon.IdleState) {
-        Main = function(self)
-            DefaultBeamWeapon.IdleState.Main(self)
-        end,
-
         OnGotTarget = function(self)
             DefaultBeamWeapon.IdleState.OnGotTarget(self)
             self.SphereEffectEntity:SetMesh(self.SphereEffectActiveMesh)

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1444,18 +1444,6 @@ MobileUnit = Class(Unit) {
         end
     end,
 
-    StopBeingBuiltEffects = function(self, builder, layer)
-        Unit.StopBeingBuiltEffects(self, builder, layer)
-    end,
-
-    StartBuildingEffects = function(self, unitBeingBuilt, order)
-        Unit.StartBuildingEffects(self, unitBeingBuilt, order)
-    end,
-
-    StopBuildingEffects = function(self, unitBeingBuilt)
-        Unit.StopBuildingEffects(self, unitBeingBuilt)
-    end,
-
     CreateReclaimEffects = function(self, target)
         EffectUtil.PlayReclaimEffects(self, target, self.BuildEffectBones or {0, }, self.ReclaimEffectsBag)
     end,


### PR DESCRIPTION
Removed all of the truly empty functions I could find.
There are so many more methods that restore a parent's parent behavior, or that does its own version of multiple inheritance; those are beyond the scope of this PR.
Files I checked: everything in `/lua/` and `/lua/sim/`