### PR TITLE
ADD LODCutoff in Projectiles-2

### DIFF
--- a/projectiles/AAAZealotMissile01/AAAZealotMissile01_proj.bp
+++ b/projectiles/AAAZealotMissile01/AAAZealotMissile01_proj.bp
@@ -27,6 +27,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'TMeshAlpha',
+                    LODCutoff = 130,
                 },
             },
         },

--- a/projectiles/AAAZealotMissile02/AAAZealotMissile02_proj.bp
+++ b/projectiles/AAAZealotMissile02/AAAZealotMissile02_proj.bp
@@ -27,6 +27,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'TMeshAlpha',
+                    LODCutoff = 130,
                 },
             },
         },

--- a/projectiles/AANTorpedo01/AANTorpedo01_proj.bp
+++ b/projectiles/AANTorpedo01/AANTorpedo01_proj.bp
@@ -28,6 +28,7 @@ ProjectileBlueprint {
                     AlbedoName = '/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_albedo.dds',
                     MeshName = '/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_lod0.scm',
                     ShaderName = 'TMeshGlow',
+                    LODCutoff = 130,
                 },
             },
         },

--- a/projectiles/AANTorpedo02/AANTorpedo02_proj.bp
+++ b/projectiles/AANTorpedo02/AANTorpedo02_proj.bp
@@ -1,3 +1,5 @@
+--unused by faf
+
 ProjectileBlueprint {
     Categories = {
         'AEON',

--- a/projectiles/AANTorpedo02/AANTorpedo02_proj.bp
+++ b/projectiles/AANTorpedo02/AANTorpedo02_proj.bp
@@ -16,6 +16,7 @@ ProjectileBlueprint {
                     AlbedoName = '/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_albedo.dds',
                     MeshName = '/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_lod0.scm',
                     ShaderName = 'TMeshGlow',
+                    LODCutoff = 130,
                 },
             },
         },

--- a/projectiles/AANTorpedoClusterSplit01/AANTorpedoClusterSplit01_proj.bp
+++ b/projectiles/AANTorpedoClusterSplit01/AANTorpedoClusterSplit01_proj.bp
@@ -34,6 +34,7 @@ ProjectileBlueprint {
                     AlbedoName = '/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_albedo.dds',
                     MeshName = '/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_lod0.scm',
                     ShaderName = 'TMeshGlow',
+                    LODCutoff = 130,
                 },
             },
         },

--- a/projectiles/AIFBombGraviton01/AIFBombGraviton01_proj.bp
+++ b/projectiles/AIFBombGraviton01/AIFBombGraviton01_proj.bp
@@ -32,6 +32,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'TMeshAlpha',
+                     LODCutoff = 215,
                 },
             },
         },

--- a/projectiles/CIFMolecularResonanceShell01/CIFMolecularResonanceShell01_proj.bp
+++ b/projectiles/CIFMolecularResonanceShell01/CIFMolecularResonanceShell01_proj.bp
@@ -31,6 +31,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'TMeshNoNormals',
+                     LODCutoff = 130,
                 },
             },
         },

--- a/projectiles/CIFProtonBomb01/CIFProtonBomb01_proj.bp
+++ b/projectiles/CIFProtonBomb01/CIFProtonBomb01_proj.bp
@@ -33,6 +33,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'TMeshGlow',
+                     LODCutoff = 215,
                 },
             },
         },

--- a/projectiles/TAAMissileFlayer01/TAAMissileFlayer01_proj.bp
+++ b/projectiles/TAAMissileFlayer01/TAAMissileFlayer01_proj.bp
@@ -27,6 +27,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'NormalMappedAlpha',
+                     LODCutoff = 140,
                 },
             },
         },

--- a/projectiles/TANAnglerTorpedo01/TANAnglerTorpedo01_proj.bp
+++ b/projectiles/TANAnglerTorpedo01/TANAnglerTorpedo01_proj.bp
@@ -30,6 +30,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'TMeshGlow',
+                     LODCutoff = 140,
                 },
             },
         },

--- a/projectiles/aaserpentine/AASerpentine_proj.bp
+++ b/projectiles/aaserpentine/AASerpentine_proj.bp
@@ -27,6 +27,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'TMeshAlpha',
+                    LODCutoff = 130,
                 },
             },
         },


### PR DESCRIPTION
ADD LODCutoff in Projectiles bp for bombs, missiles and torpedos : UEB2304, UES0201, UAA0103, URB2303, URA0304

add "--unused by faf" in AANTorpedo02_proj.bp