### PR TITLE
ADD LODCutoff in Projectiles-3

### DIFF
--- a/projectiles/TDFGauss01/TDFGauss01_proj.bp
+++ b/projectiles/TDFGauss01/TDFGauss01_proj.bp
@@ -30,6 +30,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'TMeshGlow',
+                    LODCutoff = 90,
                 },
             },
         },

--- a/projectiles/TIFAntiMatterShells01/TIFAntiMatterShells01_proj.bp
+++ b/projectiles/TIFAntiMatterShells01/TIFAntiMatterShells01_proj.bp
@@ -31,6 +31,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'TMeshNoNormals',
+                    LODCutoff = 220,
                 },
             },
         },

--- a/projectiles/TIFHETacticalNuclearShell01/TIFHETacticalNuclearShell01_proj.bp
+++ b/projectiles/TIFHETacticalNuclearShell01/TIFHETacticalNuclearShell01_proj.bp
@@ -31,6 +31,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'TMeshNoNormals',
+                    LODCutoff = 380,
                 },
             },
         },

--- a/projectiles/TIFMissileCruise01/TIFMissileCruise01_proj.bp
+++ b/projectiles/TIFMissileCruise01/TIFMissileCruise01_proj.bp
@@ -38,6 +38,7 @@ ProjectileBlueprint {
             LODs = {
                 {
                     ShaderName = 'TMeshAlpha',
+                    LODCutoff = 230,
                 },
             },
         },

--- a/projectiles/TIFMissileCruise02/TIFMissileCruise02_proj.bp
+++ b/projectiles/TIFMissileCruise02/TIFMissileCruise02_proj.bp
@@ -40,6 +40,7 @@ ProjectileBlueprint {
                     AlbedoName = '/projectiles/TIFMissileCruise01/TIFMissileCruise01_albedo.dds',
                     MeshName = '/projectiles/TIFMissileCruise01/TIFMissileCruise01_lod0.scm',
                     ShaderName = 'TMeshGlow',
+                    LODCutoff = 230,
                 },
             },
         },

--- a/projectiles/TIFMissileCruise03/TIFMissileCruise03_proj.bp
+++ b/projectiles/TIFMissileCruise03/TIFMissileCruise03_proj.bp
@@ -40,6 +40,7 @@ ProjectileBlueprint {
                     AlbedoName = '/projectiles/TIFMissileCruise01/TIFMissileCruise01_albedo.dds',
                     MeshName = '/projectiles/TIFMissileCruise01/TIFMissileCruise01_lod0.scm',
                     ShaderName = 'TMeshAlpha',
+                    LODCutoff = 300,
                 },
             },
         },

--- a/projectiles/TIFMissileCruise05/TIFMissileCruise05_proj.bp
+++ b/projectiles/TIFMissileCruise05/TIFMissileCruise05_proj.bp
@@ -40,6 +40,7 @@ ProjectileBlueprint {
                     AlbedoName = '/projectiles/TIFMissileCruise01/TIFMissileCruise01_albedo.dds',
                     MeshName = '/projectiles/TIFMissileCruise01/TIFMissileCruise01_lod0.scm',
                     ShaderName = 'TMeshAlpha',
+                    LODCutoff = 300,
                 },
             },
         },

--- a/projectiles/TIFMissileCruiseCDR/TIFMissileCruiseCDR_proj.bp
+++ b/projectiles/TIFMissileCruiseCDR/TIFMissileCruiseCDR_proj.bp
@@ -37,6 +37,7 @@ ProjectileBlueprint {
                     AlbedoName = '/projectiles/tifmissilecruise01/tifmissilecruise01_albedo.dds',
                     MeshName = '/projectiles/tifmissilecruise01/tifmissilecruise01_lod0.scm',
                     ShaderName = 'TMeshAlpha',
+                    LODCutoff = 230,
                 },
             },
         },


### PR DESCRIPTION
ADD LODCutoff in Projectiles bp for bombs, missiles and torpedos : UEL0001, UEB2108, UES0304, UEL0111, XEL0306, UEL0201, UEB2302, UEB2401

The mainpart here is the lodcutoff add to shells that are used by all UEF tanks and ships.