### PR TITLE
Fix bp parsing and annotation types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,9 +18,13 @@
     "Lua.workspace.ignoreDir": [
         ".vscode",
         "loc",
+        "*.bp"
     ],
     "[lua]": {
         "editor.wordBasedSuggestions": false,
+    },
+    "files.associations": {
+        "*.bp": "lua"
     },
     "Lua.completion.requireSeparator": "/",
     "Lua.diagnostics.enable": true,

--- a/engine/BlueprintCategories.lua
+++ b/engine/BlueprintCategories.lua
@@ -2,7 +2,7 @@
 ---@declare-global
 
 --- dummy value just so we have something to assign the categories to
----@alias CategorieType userdata
+---@class CategorieType: userdata
 ---@type CategorieType
 local categoryValue
 

--- a/engine/Sim/Entity.lua
+++ b/engine/Sim/Entity.lua
@@ -2,8 +2,8 @@
 ---@class moho.entity_methods
 local Entity = {}
 
----@alias Army number
----@alias EntityId string
+---@class Army: number
+---@class EntityId: string
 
 ---
 --  Entity:AddManualScroller(scrollSpeed1, scrollSpeed2)

--- a/engine/Sim/Entity.lua
+++ b/engine/Sim/Entity.lua
@@ -3,7 +3,7 @@
 local Entity = {}
 
 ---@alias Army number
----@alias EntityId number
+---@alias EntityId string
 
 ---
 --  Entity:AddManualScroller(scrollSpeed1, scrollSpeed2)

--- a/engine/Sim/Unit.lua
+++ b/engine/Sim/Unit.lua
@@ -2,7 +2,7 @@
 ---@class moho.unit_methods : moho.entity_methods
 local Unit = {}
 
----@alias UnitId number
+---@alias UnitId string
 
 --- Add a command cap to a unit.
 --- Also adds a button to the UI, or enables it, for the unit to use the new command.

--- a/engine/Sim/Unit.lua
+++ b/engine/Sim/Unit.lua
@@ -2,7 +2,7 @@
 ---@class moho.unit_methods : moho.entity_methods
 local Unit = {}
 
----@alias UnitId string
+---@class UnitId: string
 
 --- Add a command cap to a unit.
 --- Also adds a button to the UI, or enables it, for the unit to use the new command.


### PR DESCRIPTION
Currently annotations for EntityId and UnitId treate them as numbers when in reality they are strings, this fixes that.

This also changes settings so that `.bp` files should be treated as `lua` files (the file association setting). however it tells the extension not to parse them for references and diagnostics unless that file is opened in the editor (the ignoreDir setting)