### PR TITLE
Add the ability to force a weapon retarget on selected units through a hotkey

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -685,6 +685,7 @@ do
         -- make sure we have valid units with the correct command source
         units = SecureUnits(units)
         local tick = GetGameTick()
+        local rechecks = 0 
 
         -- reset their weapons
         for k, unit in units do
@@ -696,11 +697,21 @@ do
                     (tick - unit.RecheckTargetsOfWeaponsTick > 10)
                 ) 
             then
+                rechecks = rechecks + 1
                 unit.RecheckTargetsOfWeaponsTick = tick
                 for l = 1, unit.WeaponCount do
                     unit:GetWeapon(l):ResetTarget()
                 end
             end
+        end
+
+        if rechecks > 0 then 
+            if rechecks == 1 then 
+                print("1 weapon target recheck")
+            else 
+                print(string.format("%d weapon target rechecks", rechecks))
+            end
+
         end
     end
 end

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -676,6 +676,35 @@ do
     end
 end
 
+do
+    --- Allows the player to force a target recheck on the selected units
+    ---@param data table            # an empty table
+    ---@param units table<Unit>     # table of units
+    Callbacks.RecheckTargetsOfWeapons = function(data, units)
+
+        -- make sure we have valid units with the correct command source
+        units = SecureUnits(units)
+        local tick = GetGameTick()
+
+        -- reset their weapons
+        for k, unit in units do
+            if
+                -- unit should still exist
+                not unit:BeenDestroyed() and
+                (   -- do not allow players to spam this
+                    not unit.RecheckTargetsOfWeaponsTick or
+                    (tick - unit.RecheckTargetsOfWeaponsTick > 10)
+                ) 
+            then
+                unit.RecheckTargetsOfWeaponsTick = tick
+                for l = 1, unit.WeaponCount do
+                    unit:GetWeapon(l):ResetTarget()
+                end
+            end
+        end
+    end
+end
+
 Callbacks.MapResoureCheck = function(data)
     import("/lua/sim/MapUtilities.lua").MapResourceCheck()
 end

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -307,6 +307,8 @@ keyActions = {
         category = 'orders', order = 6,},
     ['toggle_weapon'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Weapon")',
         category = 'orders', order = 7,},
+    ['recheck_targets_of_weapons'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").RecheckTargetsOfWeapons()',
+        category = 'orders', order = 7,},
     ['toggle_jamming'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Jamming")',
         category = 'orders', order = 8,},
     ['toggle_intel'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Intel")',

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -453,4 +453,6 @@ keyDescriptions = {
     ['t3_support_land_factory'] = '<LOC key_desc_0385>build T3 Support Land Factory',
     ['t3_support_air_factory'] = '<LOC key_desc_0386>build T3 Support Air Factory',
     ['t3_support_naval_factory'] = '<LOC key_desc_0387>build T3 Support Naval Factory',
+
+    ['recheck_targets_of_weapons'] = 'Forces the weapons of units to recheck their targets',
 }

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -389,3 +389,7 @@ function SetWeaponPriorities(prioritiesString, name, exclusive)
 
     SimCallback({Func = 'WeaponPriorities', Args = {SelectedUnits = unitIds, prioritiesTable = priotable, name = name, exclusive = exclusive or false }})
 end
+
+function RecheckTargetsOfWeapons()
+    SimCallback({Func = 'RecheckTargetsOfWeapons', Args = { }}, true)
+end


### PR DESCRIPTION
As per #3857 weapons no longer retarget as usual. The average scenario does not require this, but especially at the start of the game there are moments where a weapon retargeting is critical. With this pull request we introduce the capability to force a weapon retarget.

As weapon retargeting is not cheap there is a cooldown of one second per unit at which it can retarget its weapons. To confirm to the player that it occurred a small print message is displayed on screen indication how many weapons are rechecking their targets.