### PR TITLE
Feature/sanitize guard scan radius

### DIFF
--- a/units/UAA0102/UAA0102_unit.bp
+++ b/units/UAA0102/UAA0102_unit.bp
@@ -1,6 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 75,
+        GuardScanRadius = 45,
     },
     Air = {
         AutoLandTime = 1,

--- a/units/UAA0102/UAA0102_unit.bp
+++ b/units/UAA0102/UAA0102_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 75,
-        GuardScanRadius = 45,
+        GuardScanRadius = 45,       -- 150% of range
     },
     Air = {
         AutoLandTime = 1,

--- a/units/UAA0303/UAA0303_unit.bp
+++ b/units/UAA0303/UAA0303_unit.bp
@@ -1,6 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 125,
+        GuardScanRadius = 45,
     },
     Air = {
         AutoLandTime = 1,

--- a/units/UAA0303/UAA0303_unit.bp
+++ b/units/UAA0303/UAA0303_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 125,
-        GuardScanRadius = 45,
+        GuardScanRadius = 45,       -- 150% of range
     },
     Air = {
         AutoLandTime = 1,

--- a/units/UEA0102/UEA0102_unit.bp
+++ b/units/UEA0102/UEA0102_unit.bp
@@ -1,6 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 75,
+        GuardScanRadius = 45,
     },
     Air = {
         AutoLandTime = 1,

--- a/units/UEA0102/UEA0102_unit.bp
+++ b/units/UEA0102/UEA0102_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 75,
-        GuardScanRadius = 45,
+        GuardScanRadius = 45,       -- match with ASF
     },
     Air = {
         AutoLandTime = 1,

--- a/units/UEA0303/UEA0303_unit.bp
+++ b/units/UEA0303/UEA0303_unit.bp
@@ -1,6 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 125,
+        GuardScanRadius = 45,
     },
     Air = {
         AutoLandTime = 1,

--- a/units/UEA0303/UEA0303_unit.bp
+++ b/units/UEA0303/UEA0303_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 125,
-        GuardScanRadius = 45,
+        GuardScanRadius = 45,       -- 150% of range
     },
     Air = {
         AutoLandTime = 1,

--- a/units/URA0102/URA0102_unit.bp
+++ b/units/URA0102/URA0102_unit.bp
@@ -1,6 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 75,
+        GuardScanRadius = 45,
     },
     Air = {
         AutoLandTime = 1,

--- a/units/URA0102/URA0102_unit.bp
+++ b/units/URA0102/URA0102_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 75,
-        GuardScanRadius = 45,
+        GuardScanRadius = 45,       -- match with ASF
     },
     Air = {
         AutoLandTime = 1,

--- a/units/URA0303/URA0303_unit.bp
+++ b/units/URA0303/URA0303_unit.bp
@@ -1,6 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 125,
+        GuardScanRadius = 45,
     },
     Air = {
         AutoLandTime = 1,

--- a/units/URA0303/URA0303_unit.bp
+++ b/units/URA0303/URA0303_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 125,
-        GuardScanRadius = 45,
+        GuardScanRadius = 45,       -- 150% of range
     },
     Air = {
         AutoLandTime = 1,

--- a/units/XSA0102/XSA0102_unit.bp
+++ b/units/XSA0102/XSA0102_unit.bp
@@ -1,6 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 75,
+        GuardScanRadius = 45,
     },
     Air = {
         AutoLandTime = 1,

--- a/units/XSA0102/XSA0102_unit.bp
+++ b/units/XSA0102/XSA0102_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 75,
-        GuardScanRadius = 45,
+        GuardScanRadius = 45,       -- match with ASF
     },
     Air = {
         AutoLandTime = 1,

--- a/units/XSA0303/XSA0303_unit.bp
+++ b/units/XSA0303/XSA0303_unit.bp
@@ -1,6 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 125,
+        GuardScanRadius = 45,
     },
     Air = {
         AutoLandTime = 1,

--- a/units/XSA0303/XSA0303_unit.bp
+++ b/units/XSA0303/XSA0303_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         GuardReturnRadius = 125,
-        GuardScanRadius = 45,
+        GuardScanRadius = 45,       -- 150% of range
     },
     Air = {
         AutoLandTime = 1,


### PR DESCRIPTION
Increases the guard scan radius of t1 and t3 interceptors to 150% of their range. As per the executable deployment, the guard scan radius is not applied when it is not used. The current values allow them to still engage enemies while on patrol, without being a liability to performance.