### PR TITLE
Fix the tactical missile enhancements

### DIFF
--- a/lua/system/blueprints-weapons.lua
+++ b/lua/system/blueprints-weapons.lua
@@ -28,7 +28,6 @@ local function ProcessWeapon(unit, weapon)
     if weapon.DamageType == "DeathExplosion" or weapon.Label == "DeathWeapon" or weapon.Label == "DeathImpact" then 
         weapon.TargetCheckInterval = weaponTargetCheckUpperLimit
         weapon.AlwaysRecheckTarget = false 
-        -- weapon.ManualFire = true 
         weapon.TrackingRadius = 0.0
         return 
     end

--- a/lua/system/blueprints-weapons.lua
+++ b/lua/system/blueprints-weapons.lua
@@ -28,7 +28,7 @@ local function ProcessWeapon(unit, weapon)
     if weapon.DamageType == "DeathExplosion" or weapon.Label == "DeathWeapon" or weapon.Label == "DeathImpact" then 
         weapon.TargetCheckInterval = weaponTargetCheckUpperLimit
         weapon.AlwaysRecheckTarget = false 
-        weapon.ManualFire = true 
+        -- weapon.ManualFire = true 
         weapon.TrackingRadius = 0.0
         return 
     end


### PR DESCRIPTION
As reported [on the forums](https://forum.faforever.com/topic/4139/game-version-3738/6) there was an issue with the tactical missile enhancement. The fix was not turning the death weapon into a manual fire weapon. I don't understand why this fixes the issue - the death weapon and the tactical missile appear to be unrelated.

But here we are.