### PR TITLE
Medusa stun radius fix

### DIFF
--- a/units/URL0103/URL0103_unit.bp
+++ b/units/URL0103/URL0103_unit.bp
@@ -221,7 +221,7 @@ UnitBlueprint {
                     AppliedToTarget = true,
                     BuffType = 'STUN',
                     Duration = 3,
-                    Radius = 2.3,
+                    Radius = 2,
                     TargetAllow = 'TECH1',
             TargetDisallow = 'TECH2,WALL',  -- added for bug fix [162]
                 },

--- a/units/URL0103/URL0103_unit.bp
+++ b/units/URL0103/URL0103_unit.bp
@@ -221,7 +221,7 @@ UnitBlueprint {
                     AppliedToTarget = true,
                     BuffType = 'STUN',
                     Duration = 3,
-                    Radius = 2,
+                    Radius = 2.3,
                     TargetAllow = 'TECH1',
             TargetDisallow = 'TECH2,WALL',  -- added for bug fix [162]
                 },
@@ -232,7 +232,7 @@ UnitBlueprint {
                     AppliedToTarget = true,
                     BuffType = 'STUN',
                     Duration = 2,
-                    Radius = 2,
+                    Radius = 2.55,
                     TargetAllow = 'TECH2',
                     TargetDisallow = 'WALL',  -- added for bug fix [162]
                 },
@@ -250,7 +250,7 @@ UnitBlueprint {
             FiringTolerance = 1,
             Label = 'MainGun',
             MaxRadius = 30,
-            MinRadius = 5,
+            MinRadius = 1,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 14,

--- a/units/URL0103/URL0103_unit.bp
+++ b/units/URL0103/URL0103_unit.bp
@@ -250,7 +250,7 @@ UnitBlueprint {
             FiringTolerance = 1,
             Label = 'MainGun',
             MaxRadius = 30,
-            MinRadius = 1,
+            MinRadius = 5,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 14,


### PR DESCRIPTION
Medusa often times damage units without stunning them. This changes the stun radius to more closely fit the damage radius.