### PR TITLE
Allow transports to define the number of slots in the blueprint

### DIFF
--- a/lua/ScenarioPlatoonAI.lua
+++ b/lua/ScenarioPlatoonAI.lua
@@ -2212,6 +2212,8 @@ function GetNumTransportSlots(unit)
         Medium = 0,
         Small = 0,
     }
+
+    -- compute count based on bones
     for i = 1, unit:GetBoneCount() do
         if unit:GetBoneName(i) ~= nil then
             if string.find(unit:GetBoneName(i), 'Attachpoint_Lrg') then
@@ -2223,6 +2225,17 @@ function GetNumTransportSlots(unit)
             end
         end
     end
+
+    -- retrieve number of slots set by blueprint, if it is set
+    local largeSlotsByBlueprint = unit.Blueprint.Transport.SlotsLarge or bones.Large 
+    local mediumSlotsByBlueprint = unit.Blueprint.Transport.SlotsMedium or bones.Medium 
+    local smallSlotsByBlueprint = unit.Blueprint.Transport.SlotsSmall or bones.Small 
+
+    -- take the minimum of the two
+    bones.Large = math.min(bones.Large, largeSlotsByBlueprint)
+    bones.Medium = math.min(bones.Medium, mediumSlotsByBlueprint)
+    bones.Small = math.min(bones.Small, smallSlotsByBlueprint)
+
     return bones
 end
 

--- a/units/UAA0104/UAA0104_unit.bp
+++ b/units/UAA0104/UAA0104_unit.bp
@@ -190,8 +190,8 @@ UnitBlueprint {
     },
     Footprint = {
         MaxSlope = 0.25,
-        SizeX = 8,
-        SizeZ = 8,
+        SizeX = 2,
+        SizeZ = 6,
     },
     General = {
         Category = 'Transport',

--- a/units/UAA0107/UAA0107_unit.bp
+++ b/units/UAA0107/UAA0107_unit.bp
@@ -175,7 +175,7 @@ UnitBlueprint {
     },
     Footprint = {
         MaxSlope = 0.25,
-        SizeX = 4,
+        SizeX = 1,
         SizeZ = 4,
     },
     General = {

--- a/units/UEA0104/UEA0104_unit.bp
+++ b/units/UEA0104/UEA0104_unit.bp
@@ -214,8 +214,8 @@ UnitBlueprint {
     },
     Footprint = {
         MaxSlope = 0.25,
-        SizeX = 8,
-        SizeZ = 8,
+        SizeX = 2,
+        SizeZ = 6,
     },
     General = {
         Category = 'Transport',

--- a/units/UEA0107/UEA0107_unit.bp
+++ b/units/UEA0107/UEA0107_unit.bp
@@ -1,4 +1,4 @@
-FUnitBlueprint {
+UnitBlueprint {
     AI = {
         BeaconName = 'UEB5102',
         TargetBones = {

--- a/units/UEA0107/UEA0107_unit.bp
+++ b/units/UEA0107/UEA0107_unit.bp
@@ -1,4 +1,4 @@
-UnitBlueprint {
+FUnitBlueprint {
     AI = {
         BeaconName = 'UEB5102',
         TargetBones = {
@@ -190,7 +190,7 @@ UnitBlueprint {
     },
     Footprint = {
         MaxSlope = 0.25,
-        SizeX = 4,
+        SizeX = 1,
         SizeZ = 4,
     },
     General = {

--- a/units/URA0104/URA0104_unit.bp
+++ b/units/URA0104/URA0104_unit.bp
@@ -208,8 +208,8 @@ UnitBlueprint {
     },
     Footprint = {
         MaxSlope = 0.25,
-        SizeX = 8,
-        SizeZ = 8,
+        SizeX = 1,
+        SizeZ = 6,
     },
     General = {
         Category = 'Transport',

--- a/units/URA0104/URA0104_unit.bp
+++ b/units/URA0104/URA0104_unit.bp
@@ -208,7 +208,7 @@ UnitBlueprint {
     },
     Footprint = {
         MaxSlope = 0.25,
-        SizeX = 1,
+        SizeX = 2,
         SizeZ = 6,
     },
     General = {

--- a/units/URA0107/URA0107_unit.bp
+++ b/units/URA0107/URA0107_unit.bp
@@ -193,7 +193,7 @@ UnitBlueprint {
     },
     Footprint = {
         MaxSlope = 0.25,
-        SizeX = 4,
+        SizeX = 1,
         SizeZ = 4,
     },
     General = {

--- a/units/XEA0306/XEA0306_unit.bp
+++ b/units/XEA0306/XEA0306_unit.bp
@@ -319,6 +319,8 @@ UnitBlueprint {
         Class3AttachSize = 4,
         TransportClass = 10,
         Class1Capacity = 28,
+
+        SlotsLarge = 6,
     },
     UseOOBTestZoom = 200,
     Veteran = {

--- a/units/XEA0306/XEA0306_unit.bp
+++ b/units/XEA0306/XEA0306_unit.bp
@@ -241,8 +241,8 @@ UnitBlueprint {
     },
     Footprint = {
         MaxSlope = 0.25,
-        SizeX = 10,
-        SizeZ = 10,
+        SizeX = 4,
+        SizeZ = 8,
     },
     General = {
         Category = 'Transport',

--- a/units/XEA0306/XEA0306_unit.bp
+++ b/units/XEA0306/XEA0306_unit.bp
@@ -320,6 +320,7 @@ UnitBlueprint {
         TransportClass = 10,
         Class1Capacity = 28,
 
+        SlotsMedium = 12,
         SlotsLarge = 6,
     },
     UseOOBTestZoom = 200,

--- a/units/XSA0104/XSA0104_unit.bp
+++ b/units/XSA0104/XSA0104_unit.bp
@@ -217,8 +217,8 @@ UnitBlueprint {
     },
     Footprint = {
         MaxSlope = 0.25,
-        SizeX = 8,
-        SizeZ = 8,
+        SizeX = 3,
+        SizeZ = 5,
     },
     General = {
         Category = 'Transport',

--- a/units/XSA0107/XSA0107_unit.bp
+++ b/units/XSA0107/XSA0107_unit.bp
@@ -201,7 +201,7 @@ UnitBlueprint {
     },
     Footprint = {
         MaxSlope = 0.25,
-        SizeX = 4,
+        SizeX = 1,
         SizeZ = 4,
     },
     General = {


### PR DESCRIPTION
Fixes the continental for AIs as it thought the continental could carry 12 tech 3 units instead of 6.