### PR TITLE
Add Quality of Performance 2022 to mod blacklist

### DIFF
--- a/init_faf.lua
+++ b/init_faf.lua
@@ -65,6 +65,7 @@ integratedMods = LowerHashTable(integratedMods)
 -- mods that are deprecated, based on folder name
 local deprecatedMods = { }
 deprecatedMods["simspeed++"] = true
+deprecatedMods["#quality of performance 2022"] = true
 deprecatedMods = LowerHashTable(deprecatedMods)
 
 -- typical FA packages

--- a/init_fafbeta.lua
+++ b/init_fafbeta.lua
@@ -65,6 +65,7 @@ integratedMods = LowerHashTable(integratedMods)
 -- mods that are deprecated, based on folder name
 local deprecatedMods = { }
 deprecatedMods["simspeed++"] = true
+deprecatedMods["#quality of performance 2022"] = true
 deprecatedMods = LowerHashTable(deprecatedMods)
 
 -- typical FA packages

--- a/init_fafdevelop.lua
+++ b/init_fafdevelop.lua
@@ -65,6 +65,7 @@ integratedMods = LowerHashTable(integratedMods)
 -- mods that are deprecated, based on folder name
 local deprecatedMods = { }
 deprecatedMods["simspeed++"] = true
+deprecatedMods["#quality of performance 2022"] = true
 deprecatedMods = LowerHashTable(deprecatedMods)
 
 -- typical FA packages

--- a/init_shared.lua
+++ b/init_shared.lua
@@ -65,6 +65,7 @@ integratedMods = LowerHashTable(integratedMods)
 -- mods that are deprecated, based on folder name
 local deprecatedMods = { }
 deprecatedMods["simspeed++"] = true
+deprecatedMods["#quality of performance 2022"] = true
 deprecatedMods = LowerHashTable(deprecatedMods)
 
 -- typical FA packages


### PR DESCRIPTION
It conflicts with the optimalisations already applied to the game and it introduces a free resource producing unit to only the Cybran faction. It is marked as a cheat mod because of that.