### PR TITLE
Fix a typo in `blueprint-weapons.lua`

### DIFF
--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -801,8 +801,8 @@ function PostModBlueprints(all_bps)
     SetUnitThreatValues(all_bps.Unit)
     BlueprintLoaderUpdateProgress()
 
-    local ok, msg = pcall(ProcessWeapons, all_bps.Unit)
-    LOG(repr(msg))
+    ProcessWeapons(all_bps.Unit)
+    BlueprintLoaderUpdateProgress()
 
     -- re-computes all the LODs of various entities to match the LOD with the size of the entity.
     CalculateLODs(all_bps)

--- a/lua/system/blueprints-weapons.lua
+++ b/lua/system/blueprints-weapons.lua
@@ -133,6 +133,7 @@ local function ProcessWeapon(unit, weapon)
 
     weapon.TargetCheckInterval = 0.1 * math.floor(10 * weapon.TargetCheckInterval)
     weapon.TrackingRadius = 0.1 * math.floor(10 * weapon.TrackingRadius)
+    LOG(unit.BlueprintId)
 end
 
 function ProcessWeapons(units)
@@ -144,7 +145,7 @@ function ProcessWeapons(units)
     }
 
     for k, unit in units do 
-        if not unitsToSkip[StringLower(unit.Blueprint.BlueprintId)] then
+        if not unitsToSkip[StringLower(unit.Blueprint.BlueprintId or "")] then
             if unit.Weapon then 
                 for k, weapon in unit.Weapon do
                     if not weapon.DummyWeapon then

--- a/lua/system/blueprints-weapons.lua
+++ b/lua/system/blueprints-weapons.lua
@@ -133,7 +133,6 @@ local function ProcessWeapon(unit, weapon)
 
     weapon.TargetCheckInterval = 0.1 * math.floor(10 * weapon.TargetCheckInterval)
     weapon.TrackingRadius = 0.1 * math.floor(10 * weapon.TrackingRadius)
-    LOG(unit.BlueprintId)
 end
 
 function ProcessWeapons(units)


### PR DESCRIPTION
As introduced by #3989