### PR TITLE
Refactor effect utilities part 3

### DIFF
--- a/lua/EffectUtilities.lua
+++ b/lua/EffectUtilities.lua
@@ -230,8 +230,7 @@ local UnitBuildEffects = {
 }
 
 function CreateCybranFactoryBuildEffects(builder, unitBeingBuilt, BuildBones, BuildEffectsBag)
-
-    CreateCybranBuildBeams(builder, unitBeingBuilt, BuildBones.BuildEffectBones, BuildEffectsBag)
+    CreateCybranBuildBeamsOpti(builder, nil, unitBeingBuilt, BuildEffectsBag, false)
 
     for _, vB in BuildBones.BuildEffectBones do
         for _, vE in BuildEffects do

--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -530,7 +530,7 @@ CSonarUnit = Class(DefaultUnitsFile.SonarUnit) {}
 CSeaFactoryUnit = Class(SeaFactoryUnit) {
 
     StartBuildingEffects = function(self, unitBeingBuilt)
-        local thread = self:ForkThread(EffectUtil.CreateCybranBuildBeams, unitBeingBuilt, self.BuildEffectBones, self.BuildEffectsBag)
+        local thread = self:ForkThread(EffectUtil.CreateCybranBuildBeamsOpti, nil, unitBeingBuilt, self.BuildEffectsBag, false)
         unitBeingBuilt.Trash:Add(thread)
     end,
 

--- a/lua/defaultexplosions.lua
+++ b/lua/defaultexplosions.lua
@@ -19,13 +19,9 @@ local GetRandomOffset2 = util.GetRandomOffset2
 -- upvalue for performance
 local EfctUtil = import('EffectUtilities.lua')
 local ApplyWindDirection = EfctUtil.ApplyWindDirection
-local CreateEffects = EfctUtil.CreateEffects
-local CreateEffectsWithOffset = EfctUtil.CreateEffectsWithOffset
-local CreateEffectsWithRandomOffset = EfctUtil.CreateEffectsWithRandomOffset
-local CreateBoneEffects = EfctUtil.CreateBoneEffects
-local CreateBoneEffectsOffset = EfctUtil.CreateBoneEffectsOffset
-local CreateRandomEffects = EfctUtil.CreateRandomEffects
-local ScaleEmittersParam = EfctUtil.ScaleEmittersParam
+local CreateEffectsOpti = EfctUtil.CreateEffectsOpti
+local CreateBoneEffectsOpti = EfctUtil.CreateBoneEffectsOpti
+local CreateBoneEffectsOffsetOpti = EfctUtil.CreateBoneEffectsOffsetOpti
 
 local EffectTemplate = import('/lua/EffectTemplates.lua')
 local ExplosionSmall = EffectTemplate.ExplosionSmall
@@ -282,11 +278,11 @@ function CreateScalableUnitExplosion(unit, overKillRatio)
 
             -- create the emitters  
             if baseEffects then 
-                CreateEffects(unit, army, baseEffects)
+                CreateEffectsOpti(unit, army, baseEffects)
             end
 
             if environmentEffects then 
-                CreateEffects(unit, army, environmentEffects)       
+                CreateEffectsOpti(unit, army, environmentEffects)       
             end    
 
             -- create the flash
@@ -374,7 +370,7 @@ function CreateDefaultHitExplosion(obj, scale)
         )
         
         -- create the fire cloud
-        CreateEffects(obj, army, FireCloudMed01)
+        CreateEffectsOpti(obj, army, FireCloudMed01)
     end
 end
 
@@ -390,7 +386,7 @@ function CreateDefaultHitExplosionOffset(obj, scale, xOffset, yOffset, zOffset)
         return
     end
 
-    CreateBoneEffectsOffset(obj, -1, obj.Army, DefaultHitExplosion01, xOffset, yOffset, zOffset)
+    CreateBoneEffectsOffsetOpti(obj, -1, obj.Army, DefaultHitExplosion01, xOffset, yOffset, zOffset)
 end
 
 
@@ -401,7 +397,7 @@ end
 function CreateDefaultHitExplosionAtBone(obj, boneName, scale)
     local army = obj.Army
     CreateFlash(obj, boneName, scale * 0.5, army)
-    CreateBoneEffects(obj, boneName, army, FireCloudMed01)
+    CreateBoneEffectsOpti(obj, boneName, army, FireCloudMed01)
 end
 
 function CreateTimedStuctureUnitExplosion(obj)
@@ -497,7 +493,7 @@ function _CreateScalableUnitExplosion(obj)
     end
 
     -- Create Generic emitter effects
-    CreateEffects(obj, army, EffectTable)
+    CreateEffectsOpti(obj, army, EffectTable)
 
     -- Create Light particle flash
     CreateFlash(obj, -1, scale, army)

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1643,7 +1643,7 @@ AirUnit = Class(MobileUnit) {
 
         if with == 'Water' then
             self:PlayUnitSound('AirUnitWaterImpact')
-            EffectUtil.CreateEffects(self, self.Army, EffectTemplate.DefaultProjectileWaterImpact)
+            EffectUtil.CreateEffectsOpti(self, self.Army, EffectTemplate.DefaultProjectileWaterImpact)
             self.shallSink = true
             self.colliderProj:Destroy()
             self.colliderProj = nil

--- a/units/DEL0204/DEL0204_Script.lua
+++ b/units/DEL0204/DEL0204_Script.lua
@@ -24,7 +24,7 @@ DEL0204 = Class(TWalkingLandUnit)
                 if self.SpinManip then
                     self.SpinManip:SetTargetSpeed(0)
                 end
-                self.ExhaustEffects = EffectUtils.CreateBoneEffects(self.unit, 'Left_Arm_Barrel_Muzzle', self.unit.Army, Effects.WeaponSteam01)
+                EffectUtils.CreateBoneEffectsOpti(self.unit, 'Left_Arm_Barrel_Muzzle', self.unit.Army, Effects.WeaponSteam01)
                 TDFPlasmaCannonWeapon.PlayFxWeaponPackSequence(self)
             end,
 
@@ -44,7 +44,7 @@ DEL0204 = Class(TWalkingLandUnit)
                 if self.SpinManip then
                     self.SpinManip:SetTargetSpeed(200)
                 end
-                self.ExhaustEffects = EffectUtils.CreateBoneEffects(self.unit, 'Left_Arm_Barrel_Muzzle', self.unit.Army, Effects.WeaponSteam01)
+                self.ExhaustEffects = EffectUtils.CreateBoneEffectsOpti(self.unit, 'Left_Arm_Barrel_Muzzle', self.unit.Army, Effects.WeaponSteam01)
                 TDFPlasmaCannonWeapon.PlayFxRackSalvoChargeSequence(self)
             end,
         },

--- a/units/DELK002/DELK002_script.lua
+++ b/units/DELK002/DELK002_script.lua
@@ -25,8 +25,8 @@ DELK002 = Class(TLandUnit) {
                 if self.SpinManip2 then
                     self.SpinManip2:SetTargetSpeed(0)
                 end
-                self.ExhaustEffects = EffectUtils.CreateBoneEffects(self.unit, 'Left_Muzzle', self.unit.Army, Effects.WeaponSteam01)
-                self.ExhaustEffects = EffectUtils.CreateBoneEffects(self.unit, 'Right_Muzzle', self.unit.Army, Effects.WeaponSteam01)
+                EffectUtils.CreateBoneEffectsOpti(self.unit, 'Left_Muzzle', self.unit.Army, Effects.WeaponSteam01)
+                EffectUtils.CreateBoneEffectsOpti(self.unit, 'Right_Muzzle', self.unit.Army, Effects.WeaponSteam01)
                 TAAPhalanxWeapon.PlayFxWeaponPackSequence(self)
             end,
 
@@ -57,8 +57,8 @@ DELK002 = Class(TLandUnit) {
                 if self.SpinManip2 then
                     self.SpinManip2:SetTargetSpeed(200)
                 end
-                self.ExhaustEffects = EffectUtils.CreateBoneEffects(self.unit, 'Left_Muzzle', self.unit.Army, Effects.WeaponSteam01)
-                self.ExhaustEffects = EffectUtils.CreateBoneEffects(self.unit, 'Right_Muzzle', self.unit.Army, Effects.WeaponSteam01)
+                EffectUtils.CreateBoneEffectsOpti(self.unit, 'Left_Muzzle', self.unit.Army, Effects.WeaponSteam01)
+                EffectUtils.CreateBoneEffectsOpti(self.unit, 'Right_Muzzle', self.unit.Army, Effects.WeaponSteam01)
                 TAAPhalanxWeapon.PlayFxRackSalvoChargeSequence(self)
             end,
         },

--- a/units/URA0001/URA0001_script.lua
+++ b/units/URA0001/URA0001_script.lua
@@ -56,7 +56,7 @@ URA0001 = Class(CAirUnit) {
     OnImpact = function(self, with)
         if with == 'Water' then
             self:PlayUnitSound('AirUnitWaterImpact')
-            EffectUtil.CreateEffects(self, self.Army, EffectTemplate.DefaultProjectileWaterImpact)
+            EffectUtil.CreateEffectsOpti(self, self.Army, EffectTemplate.DefaultProjectileWaterImpact)
         end
 
         self:ForkThread(self.DeathThread, self.OverKillRatio)

--- a/units/URA0001/URA0001_script.lua
+++ b/units/URA0001/URA0001_script.lua
@@ -5,7 +5,7 @@
 -- Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 local CAirUnit = import('/lua/cybranunits.lua').CAirUnit
-local CreateCybranBuildBeams = import('/lua/EffectUtilities.lua').CreateCybranBuildBeams
+local CreateCybranBuildBeamsOpti = import('/lua/EffectUtilities.lua').CreateCybranBuildBeamsOpti
 local EffectUtil = import('/lua/EffectUtilities.lua')
 local EffectTemplate = import('/lua/EffectTemplates.lua')
 
@@ -36,7 +36,7 @@ URA0001 = Class(CAirUnit) {
     CreateBuildEffects = function(self, unitBeingBuilt, order)
         self.BuildEffectsBag:Add(AttachBeamEntityToEntity(self, 'Muzzle_03', self, 'Muzzle_01', self.Army, '/effects/emitters/build_beam_02_emit.bp'))
         self.BuildEffectsBag:Add(AttachBeamEntityToEntity(self, 'Muzzle_03', self, 'Muzzle_02', self.Army, '/effects/emitters/build_beam_02_emit.bp'))
-        CreateCybranBuildBeams(self, unitBeingBuilt, {'Muzzle_03',}, self.BuildEffectsBag)
+        CreateCybranBuildBeamsOpti(self, nil, unitBeingBuilt, self.BuildEffectsBag, false)
     end,
 
     OnStartCapture = function(self, target)
@@ -56,7 +56,7 @@ URA0001 = Class(CAirUnit) {
     OnImpact = function(self, with)
         if with == 'Water' then
             self:PlayUnitSound('AirUnitWaterImpact')
-            EffectUtil.CreateEffectsOpti(self, self.Army, EffectTemplate.DefaultProjectileWaterImpact)
+            EffectUtil.CreateEffects(self, self.Army, EffectTemplate.DefaultProjectileWaterImpact)
         end
 
         self:ForkThread(self.DeathThread, self.OverKillRatio)

--- a/units/XEB2306/XEB2306_Script.lua
+++ b/units/XEB2306/XEB2306_Script.lua
@@ -21,7 +21,7 @@ XEB2306 = Class(TStructureUnit) {
                 if self.SpinManip then
                     self.SpinManip:SetTargetSpeed(0)
                 end
-                self.ExhaustEffects = EffectUtils.CreateBoneEffects(self.unit, 'Exhaust', self.unit.Army, Effects.WeaponSteam01)
+				EffectUtils.CreateBoneEffectsOpti(self.unit, 'Exhaust', self.unit.Army, Effects.WeaponSteam01)
                 TDFHeavyPlasmaCannonWeapon.PlayFxWeaponPackSequence(self)
             end,
 
@@ -41,7 +41,7 @@ XEB2306 = Class(TStructureUnit) {
                 if self.SpinManip then
                     self.SpinManip:SetTargetSpeed(200)
                 end
-                self.ExhaustEffects = EffectUtils.CreateBoneEffects(self.unit, 'Exhaust', self.unit.Army, Effects.WeaponSteam01)
+                EffectUtils.CreateBoneEffectsOpti(self.unit, 'Exhaust', self.unit.Army, Effects.WeaponSteam01)
                 TDFHeavyPlasmaCannonWeapon.PlayFxRackSalvoChargeSequence(self)
             end,    
         }


### PR DESCRIPTION
Replaces all references to the old unoptimized effect utility functions to the optimized ones.
This PR changes `DEL0204`, `DELK002`, and `XEB2306` to no longer store their weapon effects into `ExhaustEffects`, since those units weren't actually taking care of them.
This needs [part 1](https://github.com/FAForever/fa/pull/3995) to work!