### PR TITLE
Remove collision shape from build bots and fallen trees

### DIFF
--- a/lua/proptree.lua
+++ b/lua/proptree.lua
@@ -120,6 +120,10 @@ Tree = Class(Prop) {
 
     --- Contains all the falling logic
     FallThread = function(self, dx, dy, dz, depth)
+
+        -- prevent collisions
+        self:SetCollisionShape('None')
+
         -- make it fall down
         local motor = self:FallDown()
         motor:Whack(dx, dy, dz, depth, true)

--- a/units/URA0001O/URA0001O_script.lua
+++ b/units/URA0001O/URA0001O_script.lua
@@ -9,20 +9,20 @@
 local CreateBuilderArmController = CreateBuilderArmController
 
 -- upvalued moho functions for performance
-local BuilderArmManipulator = _G.moho.BuilderArmManipulator 
-local BuilderArmManipulatorSetAimingArc = BuilderArmManipulator.SetAimingArc
-local BuilderArmManipulatorSetPrecedence = BuilderArmManipulator.SetPrecedence
-BuilderArmManipulator = nil 
+local BuilderArmManipulatorSetAimingArc = _G.moho.BuilderArmManipulator.SetAimingArc
+local BuilderArmManipulatorSetPrecedence = _G.moho.BuilderArmManipulator.SetPrecedence
 
 -- upvalued trashbag functions for performance
-local TrashBag = _G.TrashBag
-local TrashBagAdd = TrashBag.Add
+local TrashBagAdd = _G.TrashBag.Add
 
 local CBuildBotUnit = import('/lua/cybranunits.lua').CBuildBotUnit
 URA0001O = Class(CBuildBotUnit) { 
 
     OnCreate = function(self)
         CBuildBotUnit.OnCreate(self)
+
+        -- prevent collisions
+        self:SetCollisionShape('None')
 
         -- make the drone aim for the target
         local BuildArmManipulator = CreateBuilderArmController(self, 'URA0001' , 'URA0001', 0)

--- a/units/URA0002O/URA0002O_script.lua
+++ b/units/URA0002O/URA0002O_script.lua
@@ -9,20 +9,20 @@
 local CreateBuilderArmController = CreateBuilderArmController
 
 -- upvalued moho functions for performance
-local BuilderArmManipulator = _G.moho.BuilderArmManipulator 
-local BuilderArmManipulatorSetAimingArc = BuilderArmManipulator.SetAimingArc
-local BuilderArmManipulatorSetPrecedence = BuilderArmManipulator.SetPrecedence
-BuilderArmManipulator = nil 
+local BuilderArmManipulatorSetAimingArc = _G.moho.BuilderArmManipulator.SetAimingArc
+local BuilderArmManipulatorSetPrecedence = _G.moho.BuilderArmManipulator.SetPrecedence
 
 -- upvalued trashbag functions for performance
-local TrashBag = _G.TrashBag
-local TrashBagAdd = TrashBag.Add
+local TrashBagAdd = _G.TrashBag.Add
 
 local CBuildBotUnit = import('/lua/cybranunits.lua').CBuildBotUnit
 URA0002O = Class(CBuildBotUnit) { 
 
     OnCreate = function(self)
         CBuildBotUnit.OnCreate(self)
+
+        -- prevent collisions
+        self:SetCollisionShape('None')
 
         -- make the drone aim for the target
         local BuildArmManipulator = CreateBuilderArmController(self, 'URA0002' , 'URA0002', 0)

--- a/units/URA0003O/URA0003O_script.lua
+++ b/units/URA0003O/URA0003O_script.lua
@@ -9,28 +9,27 @@
 local CreateBuilderArmController = CreateBuilderArmController
 
 -- upvalued moho functions for performance
-local BuilderArmManipulator = _G.moho.BuilderArmManipulator 
-local BuilderArmManipulatorSetAimingArc = BuilderArmManipulator.SetAimingArc
-local BuilderArmManipulatorSetPrecedence = BuilderArmManipulator.SetPrecedence
+local BuilderArmManipulatorSetAimingArc = _G.moho.BuilderArmManipulator.SetAimingArc
+local BuilderArmManipulatorSetPrecedence = _G.moho.BuilderArmManipulator.SetPrecedence
 BuilderArmManipulator = nil 
 
 -- upvalued trashbag functions for performance
-local TrashBag = _G.TrashBag
-local TrashBagAdd = TrashBag.Add
+local TrashBagAdd = _G.TrashBag.Add
 
 local CBuildBotUnit = import('/lua/cybranunits.lua').CBuildBotUnit
-URA0003O = Class(CBuildBotUnit) { 
+URA0003O = Class(CBuildBotUnit) {
 
     OnCreate = function(self)
         CBuildBotUnit.OnCreate(self)
 
-        local trash = self.Trash
+        -- prevent collisions
+        self:SetCollisionShape('None')
 
         -- make the drone aim for the target
         local BuildArmManipulator = CreateBuilderArmController(self, 'URA0003' , 'URA0003', 0)
         BuilderArmManipulatorSetAimingArc(BuildArmManipulator, -180, 180, 360, -90, 90, 360)
         BuilderArmManipulatorSetPrecedence(BuildArmManipulator, 5)
-        TrashBagAdd(trash, BuildArmManipulator)
+        TrashBagAdd(self.Trash, BuildArmManipulator)
     end,
 
 }


### PR DESCRIPTION
Removes the collision shape of various entities that do not or no longer need it.

![image](https://user-images.githubusercontent.com/15778155/177029718-5d3bee86-9dd5-45c0-983f-a56148231928.png)
![image](https://user-images.githubusercontent.com/15778155/177029739-3f41a4e3-0a02-40fe-8681-7d2a2a72d07d.png)
_Props and drones without a collision shape_

![image](https://user-images.githubusercontent.com/15778155/177029816-0ec2f118-5b42-4987-9eb8-6d3f46f7fdf9.png)
![image](https://user-images.githubusercontent.com/15778155/177029836-ad9e4a21-0836-49ca-81fd-8771e551775c.png)
_Props and drones with a collision shape, note that the one of the drones is (really) small_

This was made possible due to an engine patch, see also the [changelog](https://github.com/FAForever/FA-Binary-Patches/blob/master/README.md) of the assembly repository.