### PR TITLE
Overhaul stun logic to match the stun radius with the damage radius

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -452,7 +452,7 @@ Shield = Class(moho.shield_methods, Entity) {
     OnDamage = function(self, instigator, amount, vector, damageType)
 
         -- only applies to trees
-        if damageType == "TreeForce" or damageType == "TreeFire" then 
+        if damageType == "TreeForce" or damageType == "TreeFire" or damageType == 'Stun' then
             return 
         end
 

--- a/lua/sim/DefaultDamage.lua
+++ b/lua/sim/DefaultDamage.lua
@@ -8,24 +8,119 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
--- upvalue for performance
+-- scope as upvalue for performance
 local Damage = Damage 
 local DamageArea = DamageArea
 
--- cache for performance
+local Entity = import('/lua/sim/Entity.lua').Entity
+
+--- A cache of categories for stun allow / disallow strings
+local CategoriesCache = { }
+
+--- A dummy entity that is used to pass over stun parameters via stun instances
+---@class StunEntity
+---@field CategoriesAllowed Categories
+---@field CategoriesDisallowed Categories | boolean
+local StunEntity = Class(Entity) {
+
+    CategoriesAllowed = categories.ALLUNITS,
+    CategoriesDisallowed = false,
+
+    --- Defines the categories that we're allowed to stun, caching the parsing. Defaults to categories.ALLUNITS
+    ---@param self StunEntity       # Instance of StunEntity
+    ---@param cats string | nil     # String of categories, defaults to categories.ALLUNITS
+    SetAllowedCategories = function (self, cats)
+
+        -- if no categories given, we apply to all units
+        if not cats then
+            self.CategoriesDisallowed = categories.ALLUNITS
+            return
+        end
+
+        local cached = CategoriesCache[cats]
+        if cached then
+            self.CategoriesAllowed = cached
+        end
+
+        cached = ParseEntityCategory(cats)
+        CategoriesCache[cats] = cached
+        self.CategoriesAllowed = cached
+    end,
+
+    --- Defines the categories that we're allowed to stun, caching the parsing. Defaults to false
+    ---@param self StunEntity       # Instance of StunEntity
+    ---@param cats string | nil     # String of categories, defaults to false
+    SetDisallowedCategories = function (self, cats)
+
+        -- if no categories given, we do not exclude units
+        if not cats then
+            self.CategoriesDisallowed = false
+            return
+        end
+
+        local cached = CategoriesCache[cats]
+        if cached then
+            self.CategoriesDisallowed = cached
+        end
+
+        cached = ParseEntityCategory(cats)
+        CategoriesCache[cats] = cached
+        self.CategoriesDisallowed = cached
+    end,
+}
+
+--- Create an instance for each army
+local StunEntityInstances = { }
+for k, brain in ArmyBrains do 
+    StunEntityInstances[k] = StunEntity({ Army = brain:GetArmyIndex() })
+end
+
+--- Applies an area stun at the given location, caches the parsing of categories
+---@param position Vector           # Origin of the stun
+---@param duration number           # Duration of the stun, in seconds
+---@param radius number             # Radius of the stun, in oGrids
+---@param allowed string | nil      # String representation of allowed categories, nil allows all units
+---@param disallowed string | nil   # String representation of disallowed categories, nil disallows no units
+---@param army number               # Army where the stun damage originates from
+function ApplyAreaStun (position, duration, radius, allowed, disallowed, army)
+    StunEntityInstances[army]:SetAllowedCategories(allowed)
+    StunEntityInstances[army]:SetDisallowedCategories(disallowed)
+
+    DamageArea(StunEntityInstances[army], position, radius, 10 * duration, 'Stun', false)
+end
+
+--- Applies a single-target stun, caches the parsing of categories
+---@param target Unit               # Target to stun
+---@param duration number           # Duration of the stun, in seconds
+---@param allowed string | nil      # String representation of allowed categories, nil allows all units
+---@param disallowed string | nil   # String representation of disallowed categories, nil disallows no units
+---@param army number               # Army where the stun damage originates from
+function ApplyStun (target, duration, allowed, disallowed, army)
+    StunEntityInstances[army]:SetAllowedCategories(allowed)
+    StunEntityInstances[army]:SetDisallowedCategories(disallowed)
+
+    Damage(StunEntityInstances[army], target, 10 * duration, 'Stun')
+end
+
+-- scope as upvalue for performance
 local VectorCache = Vector(0, 0, 0)
-local MathFloor = math.floor 
-local CoroutineYield = coroutine.yield 
+local CoroutineYield = coroutine.yield
 
 local EntityBeenDestroyed = _G.moho.entity_methods.BeenDestroyed
 local EntityGetPositionXYZ = _G.moho.entity_methods.GetPositionXYZ
 
---- Performs damage over time on a unit.
+--- Applies damage over time on a single target
+---@param instigator Unit | Projectile | Weapon | Entity
+---@param unit Unit         # Unit to apply damage instances to
+---@param pulses number     # Number of damage instances
+---@param pulseTime number  # Time between damage instances
+---@param damage number     # Damage amount
+---@param damType string    # Damage type such as 'Normal' or 'Force'
+---@param friendly boolean  # Flag to indicate we can damage allied units
 function UnitDoTThread (instigator, unit, pulses, pulseTime, damage, damType, friendly)
 
     -- localize for performance
     local position = VectorCache
-    local DamageArea = DamageArea
     local CoroutineYield = CoroutineYield
 
     -- convert time to ticks
@@ -42,7 +137,15 @@ function UnitDoTThread (instigator, unit, pulses, pulseTime, damage, damType, fr
     end
 end
 
---- Performs damage over time in a given area.
+--- Applies damage over time in an area
+---@param instigator Unit | Projectile | Weapon | Entity
+---@param position Vector       # Location to apply damage instances at
+---@param pulses number         # Number of damage instances
+---@param pulseTime number      # Time between damage instances
+---@param radius number         # Damage radius
+---@param damage number         # Damage amount
+---@param damType string        # Damage type such as 'Normal' or 'Force'
+---@param friendly boolean      # Flag to indicate we can damage allied units
 function AreaDoTThread (instigator, position, pulses, pulseTime, radius, damage, damType, friendly)
 
     -- localize for performance
@@ -58,12 +161,13 @@ function AreaDoTThread (instigator, position, pulses, pulseTime, radius, damage,
     end
 end
 
--- Deprecated functionality -- 
-
 -- SCALABLE RADIUS AREA DOT
 -- - Allows for a scalable damage radius that begins with DamageStartRadius and ends
--- - with DamageEndRadius, interpolates between based on frequency and duration.
+-- - 
 
+--- Allows for a scalable damage radius that begins with DamageStartRadius and ends with DamageEndRadius, interpolates between based on frequency and duration.
+---@deprecated
+---@param entity any
 function ScalableRadiusAreaDoT(entity)
     local spec = entity.Spec.Data
 

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -589,8 +589,20 @@ Projectile = Class(moho.projectile_methods) {
         -- Check for buff
         if not TableEmpty(data.Buffs) then
 
-            -- Check for valid target
             for k, v in data.Buffs do
+
+                -- # new buff mechanics
+
+                if v.BuffType == 'STUN-ALT' then
+                    if v.Radius and v.Radius > 0 then
+                        DefaultDamage.ApplyAreaStun(self:GetPosition(), v.Duration, v.Radius, v.TargetAllow, v.TargetDisallow, self.Army)
+                    else
+                        DefaultDamage.ApplyStun(target, v.Duration, v.TargetAllow, v.TargetDisallow, self.Army)
+                    end
+                end
+
+                -- # old buff mechanics
+
                 if v.Add.OnImpact == true then
                     if v.AppliedToTarget ~= true or (v.Radius and v.Radius > 0) then
                         target = self:GetLauncher()

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -218,13 +218,13 @@ Prop = Class(moho.prop_methods) {
     OnDamage = function(self, instigator, amount, direction, damageType)
 
         -- only applies to trees
-        if damageType == "TreeForce" or damageType == "TreeFire" then 
+        if damageType == "TreeForce" or damageType == "TreeFire" or damageType == 'Stun' then
             return 
         end
 
         -- if we're immune then we're good
-        if not self.CanTakeDamage then 
-            return 
+        if not self.CanTakeDamage then
+            return
         end
 
         -- adjust our health

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1038,6 +1038,25 @@ Unit = Class(moho.unit_methods) {
             return 
         end
 
+        -- only applies to units
+        if damageType == 'Stun' then
+
+            -- don't stun air units
+            if self.Layer == 'Air' then
+                return
+            end
+
+            local allowed = instigator.CategoriesAllowed
+            if instigator.CategoriesDisallowed then
+                allowed = allowed - instigator.CategoriesDisallowed
+            end
+
+            -- do the stun if it is a fit
+            if EntityCategoryContains(allowed, self) then
+                self:SetStunned(0.1 * (amount or 10.0))
+            end
+        end
+
         if self.CanTakeDamage then
             self:DoOnDamagedCallbacks(instigator)
 

--- a/units/URL0103/URL0103_unit.bp
+++ b/units/URL0103/URL0103_unit.bp
@@ -204,30 +204,16 @@ UnitBlueprint {
                 },
             },
             BallisticArc = 'RULEUBA_HighArc',
+
             Buffs = {
                 {
-                    Add = {
-                        OnImpact = true,
-                    },
-                    AppliedToTarget = true,
-                    BuffType = 'STUN',
-                    Duration = 3,
-                    Radius = 2,
-                    TargetAllow = 'TECH1',
-            TargetDisallow = 'TECH2,WALL',  -- added for bug fix [162]
-                },
-                {
-                    Add = {
-                        OnImpact = true,
-                    },
-                    AppliedToTarget = true,
-                    BuffType = 'STUN',
+                    BuffType = 'STUN-ALT',
                     Duration = 2,
-                    Radius = 2.55,
-                    TargetAllow = 'TECH2',
-                    TargetDisallow = 'WALL',  -- added for bug fix [162]
+                    Radius = 2,
+                    TargetAllow = 'TECH1,TECH2'
                 },
             },
+
             CollideFriendly = false,
             Damage = 230, -- 195
             DamageFriendly = false,


### PR DESCRIPTION
As discussed in #4004 the stun radius does not match the damage radius. As a result we have #3478 and https://github.com/FAForever/fa/pull/3987 that try and fix this radius. But to no avail, as the query is fundamentally different:

- For damage the query is a sphere -> collision box intersection
- For stun the query was a sphere -> unit center intersection

As a result, the stun radius will always be off depending on the unit that you're applying the stun to. This pull request introduces a new damage type (coined 'Stun') that is ignored by entities except for units that the stun is applicable to. 