### PR TITLE
Fix/cybran acu

### DIFF
--- a/units/URL0001/URL0001_script.lua
+++ b/units/URL0001/URL0001_script.lua
@@ -411,23 +411,6 @@ URL0001 = Class(ACUUnit, CCommandUnit) {
         end
     end,
 
-    -- Death
-    OnKilled = function(self, instigator, type, overkillRatio)
-        local bp
-        for k, v in self:GetBlueprint().Buffs do
-            if v.Add.OnDeath then
-                bp = v
-            end
-        end
-        -- If we could find a blueprint with v.Add.OnDeath, then add the buff
-        if bp ~= nil then
-            -- Apply Buff
-            self:AddBuff(bp)
-        end
-        -- Otherwise, we should finish killing the unit
-        ACUUnit.OnKilled(self, instigator, type, overkillRatio)
-    end,
-
     OnLayerChange = function(self, new, old)
         ACUUnit.OnLayerChange(self, new, old)
         if self:GetWeaponByLabel('DummyWeapon') == nil then return end

--- a/units/URL0301/URL0301_script.lua
+++ b/units/URL0301/URL0301_script.lua
@@ -196,23 +196,6 @@ URL0301 = Class(CCommandUnit) {
         end
     end,
 
-    -- Death
-    OnKilled = function(self, instigator, type, overkillRatio)
-        local bp
-        for k, v in self:GetBlueprint().Buffs do
-            if v.Add.OnDeath then
-                bp = v
-            end
-        end
-        -- If we could find a blueprint with v.Add.OnDeath, then add the buff
-        if bp ~= nil then
-            -- Apply Buff
-            self:AddBuff(bp)
-        end
-        -- Otherwise, we should finish killing the unit
-        CCommandUnit.OnKilled(self, instigator, type, overkillRatio)
-    end,
-
     IntelEffects = {
         Cloak = {
             {


### PR DESCRIPTION
Closes #4010 , there was some legacy code that expected the buffs table to be set. That code was previously used to make the (S)ACU stun when destroyed.