### PR TITLE
Re-implement game results

### DIFF
--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -37,7 +37,7 @@ function EndOperation(_success, _allPrimary, _allSecondary, _allBonus)
         _opData = import(opFile)
     end
 
-    import('/lua/victory.lua').CallEndGame() -- We need this here to populate the score screen
+    import('/lua/sim/matchstate.lua').CallEndGame() -- We need this here to populate the score screen
 
     ForkThread(function()
         WaitSeconds(3) -- Wait for the stats to be synced

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -380,7 +380,9 @@ function OnSync()
 
     -- Game <-> server communications
 
-    -- Adjusting the behavior of this part of the sync is strictly forbidden
+    -- Adjusting the behavior of this part of the sync is strictly forbidden and is considered
+    -- game manipulation and / or rating manipulation. See also the in-game rules:
+    -- - https://www.faforever.com/rules
 
     if not SessionIsReplay() then
 

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -210,12 +210,6 @@ function OnSync()
         import('/lua/ui/game/score.lua').currentScores = Sync.Score
     end
 
-    if not table.empty(Sync.ScoreAccum) then
-        import('/lua/ui/dialogs/hotstats.lua').scoreData = Sync.ScoreAccum
-    end
-
-
-
     if Sync.PausedBy then
         if not PreviousSync.PausedBy then
             import('/lua/ui/game/gamemain.lua').OnPause(Sync.PausedBy, Sync.TimeoutsRemaining)
@@ -376,6 +370,11 @@ function OnSync()
 
     if Sync.ChangeCameraZoom != nil then
         import('/lua/ui/game/gamemain.lua').SimChangeCameraZoom(Sync.ChangeCameraZoom)
+    end
+
+    if not table.empty(Sync.ScoreAccum) then
+        LOG("Score data received!")
+        import('/lua/ui/dialogs/hotstats.lua').scoreData = Sync.ScoreAccum
     end
 
     -- Game <-> server communications

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -384,13 +384,19 @@ function OnSync()
     -- game manipulation and / or rating manipulation. See also the in-game rules:
     -- - https://www.faforever.com/rules
 
+    --- Processes game results to adjust UI capabilities
+    for _, gameResult in Sync.GameResult do
+        local armyIndex, result = unpack(gameResult)
+        import('/lua/ui/game/gameresult.lua').DoGameResult(armyIndex, result)
+    end
+
     if not SessionIsReplay() then
 
         --- Sends the defeat / victory / draw game results over to the server
         for _, gameResult in Sync.GameResult do
             local armyIndex, result = unpack(gameResult)
+            SPEW(string.format("(%s) Sending game result: %s %s", tostring(GameTick()), armyIndex, result))
             GpgNetSend('GameResult', armyIndex, result)
-            import('/lua/ui/game/gameresult.lua').DoGameResult(armyIndex, result)
         end
 
         --- Sends the (unit) statistics over to the server
@@ -401,7 +407,7 @@ function OnSync()
         end
 
         --- Sends potential team kill events to the server
-        if Sync.Teamkill and not SessionIsReplay() then
+        if Sync.Teamkill then
             local armies, clients = GetArmiesTable().armiesTable, GetSessionClients()
             local victim, instigator = Sync.Teamkill.victim, Sync.Teamkill.instigator
             local data = {time=Sync.Teamkill.killTime, victim={}, instigator={}}

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -104,28 +104,6 @@ function OnSync()
         UpdateReclaim(Sync.Reclaim)
     end
 
-    if Sync.Teamkill and not SessionIsReplay() then
-        local armies, clients = GetArmiesTable().armiesTable, GetSessionClients()
-        local victim, instigator = Sync.Teamkill.victim, Sync.Teamkill.instigator
-        local data = {time=Sync.Teamkill.killTime, victim={}, instigator={}}
-
-        for k, army in {victim=victim, instigator=instigator} do
-            data[k].name = armies[army] and armies[army].nickname or "-"
-            data[k].id = clients[army] and clients[army].uid or 0
-        end
-
-        GpgNetSend('TeamkillHappened', data.time, data.victim.id, data.victim.name,  data.instigator.id, data.instigator.name)
-        WARN(string.format("TEAMKILL: %s KILLED BY %s, TIME: %s", data.victim.name, data.instigator.name, data.time))
-
-        if GetFocusArmy() == victim then
-            import('/lua/ui/dialogs/teamkill.lua').CreateDialog(data)
-        end
-    end
-
-    if Sync.EnforceRating then
-        GpgNetSend('EnforceRating')
-    end
-
     if Sync.EnhanceMessage and not table.empty(Sync.EnhanceMessage) then
         for _, messageTable in Sync.EnhanceMessage do
             sendEnhancementMessage(messageTable)
@@ -138,10 +116,6 @@ function OnSync()
 
     if Sync.StartPositions then
         import('/lua/ui/game/worldview.lua').MarkStartPositions(Sync.StartPositions)
-    end
-
-    if Sync.GameEnded then
-        GpgNetSend('GameEnded')
     end
 
     if Sync.LobbyOptions then 
@@ -241,27 +215,6 @@ function OnSync()
     end
 
 
-    for _, gameResult in Sync.GameResult do
-        local armyIndex, result = unpack(gameResult)
-
-        -- Only send defeat results if the player has not been defeated yet
-        if not hasSeenResult or not utils.StringStartsWith(result, "defeat") then
-            LOG(string.format('Sending game result: %i %s', armyIndex, result))
-            GpgNetSend('GameResult', armyIndex, result)
-            import('/lua/ui/game/gameresult.lua').DoGameResult(armyIndex, result)
-
-            if armyIndex == GetFocusArmy() then
-                hasSeenResult = true
-            end
-        end
-    end
-
-    if Sync.StatsToSend then
-        local json = import('/lua/system/dkson.lua').json.encode({ stats = Sync.StatsToSend })
-        LOG('Sending stats: '..json)
-        GpgNetSend('JsonStats', json)
-        Sync.StatsToSend = nil
-    end
 
     if Sync.PausedBy then
         if not PreviousSync.PausedBy then
@@ -423,5 +376,55 @@ function OnSync()
 
     if Sync.ChangeCameraZoom != nil then
         import('/lua/ui/game/gamemain.lua').SimChangeCameraZoom(Sync.ChangeCameraZoom)
+    end
+
+    -- Game <-> server communications
+
+    -- Adjusting the behavior of this part of the sync is strictly forbidden
+
+    if not SessionIsReplay() then
+
+        --- Sends the defeat / victory / draw game results over to the server
+        for _, gameResult in Sync.GameResult do
+            local armyIndex, result = unpack(gameResult)
+            GpgNetSend('GameResult', armyIndex, result)
+            import('/lua/ui/game/gameresult.lua').DoGameResult(armyIndex, result)
+        end
+
+        --- Sends the (unit) statistics over to the server
+        if Sync.StatsToSend then
+            local json = import('/lua/system/dkson.lua').json.encode({ stats = Sync.StatsToSend })
+            GpgNetSend('JsonStats', json)
+            Sync.StatsToSend = nil
+        end
+
+        --- Sends potential team kill events to the server
+        if Sync.Teamkill and not SessionIsReplay() then
+            local armies, clients = GetArmiesTable().armiesTable, GetSessionClients()
+            local victim, instigator = Sync.Teamkill.victim, Sync.Teamkill.instigator
+            local data = {time=Sync.Teamkill.killTime, victim={}, instigator={}}
+
+            for k, army in {victim=victim, instigator=instigator} do
+                data[k].name = armies[army] and armies[army].nickname or "-"
+                data[k].id = clients[army] and clients[army].uid or 0
+            end
+
+            GpgNetSend('TeamkillHappened', data.time, data.victim.id, data.victim.name,  data.instigator.id, data.instigator.name)
+            WARN(string.format("TEAMKILL: %s KILLED BY %s, TIME: %s", data.victim.name, data.instigator.name, data.time))
+
+            if GetFocusArmy() == victim then
+                import('/lua/ui/dialogs/teamkill.lua').CreateDialog(data)
+            end
+        end
+
+        --- Informs the server to enforce the rating of the game
+        if Sync.EnforceRating then
+            GpgNetSend('EnforceRating')
+        end
+
+        --- Informs the server that the game has ended
+        if Sync.GameEnded then
+            GpgNetSend('GameEnded')
+        end
     end
 end

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -86,11 +86,11 @@ local CoroutineYield = coroutine.yield
 ---@field EnergyExcessThread thread
 ---@field IntelData table<string, number>|nil
 ---@field targetoveride boolean
----@field BrainState BrainState
+---@field Status BrainState
 AIBrain = Class(moho.aibrain_methods) {
 
     -- The state of the brain in the match
-    BrainState = 'InProgress',
+    Status = 'InProgress',
 
     --- HUMAN BRAIN FUNCTIONS HANDLED HERE
     ---@param self AIBrain
@@ -747,7 +747,7 @@ AIBrain = Class(moho.aibrain_methods) {
 
     ---@param self AIBrain
     OnDefeat = function(self)
-        self.BrainState = 'Defeat'
+        self.Status = 'Defeat'
 
         import('/lua/SimUtils.lua').UpdateUnitCap(self:GetArmyIndex())
         import('/lua/SimPing.lua').OnArmyDefeat(self:GetArmyIndex())
@@ -997,17 +997,17 @@ AIBrain = Class(moho.aibrain_methods) {
 
     ---@param self AIBrain
     OnVictory = function(self)
-        self.BrainState = 'Victory'
+        self.Status = 'Victory'
     end,
 
     ---@param self AIBrain
     OnDraw = function(self)
-        self.BrainState = 'Draw'
+        self.Status = 'Draw'
     end,
 
     ---@param self AIBrain
     IsDefeated = function(self)
-        return self.BrainState == "Defeat"
+        return self.Status == "Defeat"
     end,
 
     ---@param self AIBrain

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -749,8 +749,6 @@ AIBrain = Class(moho.aibrain_methods) {
     OnDefeat = function(self)
         self.BrainState = 'Defeat'
 
-        SetArmyOutOfGame(self:GetArmyIndex())
-
         import('/lua/SimUtils.lua').UpdateUnitCap(self:GetArmyIndex())
         import('/lua/SimPing.lua').OnArmyDefeat(self:GetArmyIndex())
 

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2477,10 +2477,6 @@ ACUUnit = Class(CommandUnit) {
             if IsAlly(self.Army, instigator.Army) and not ((type == 'DeathExplosion' or type == 'Nuke' or type == 'Deathnuke') and not instigator.SelfDestructed) then
                 WARN('Teamkill detected')
                 Sync.Teamkill = {killTime = GetGameTimeSeconds(), instigator = instigator.Army, victim = self.Army}
-            else
-                ForkThread(function()
-                    instigatorBrain:ReportScore()
-                end)
             end
         end
         ArmyBrains[self.Army].CommanderKilledBy = (instigator or self).Army

--- a/lua/sim/MatchState.lua
+++ b/lua/sim/MatchState.lua
@@ -30,7 +30,7 @@ local function CollectDefeatedBrains(aliveBrains, condition, delay)
         if criticalUnits then
             -- critical units found, make sure they all exist properly
             local oneCriticalUnitAlive = false
-            for k, unit in criticalUnits do
+            for _, unit in criticalUnits do
                 if (not IsDestroyed(unit)) and (unit:GetFractionComplete() == 1) then
                     oneCriticalUnitAlive = true
                     break
@@ -90,7 +90,7 @@ local function MatchStateThread()
 
     -- consider all non-civilian brains to be alive and kicking
     local aliveBrains = { }
-    for k, brain in ArmyBrains do
+    for _, brain in ArmyBrains do
         local index = brain:GetArmyIndex()
         if not ArmyIsCivilian(index) then
             aliveBrains[index] = brain
@@ -126,7 +126,7 @@ local function MatchStateThread()
                 brain:OnDefeat()
 
                 -- communicate to the server that this brain has been defeated
-                table.insert(Sync.GameResult, { k, string.format("%s %i", 'defeat', -10) })
+                table.insert(Sync.GameResult, { k, "defeat -10" })
 
                 -- stop considering it a brain that is still alive
                 aliveBrains[k] = nil
@@ -139,7 +139,7 @@ local function MatchStateThread()
 
             -- check for draw
             local draw = true
-            for k, brain in aliveBrains do
+            for _, brain in aliveBrains do
                 draw = draw and brain.OfferingDraw
             end
 
@@ -153,7 +153,7 @@ local function MatchStateThread()
                     brain:OnDraw()
 
                     -- communicate to the server that this brain has been defeated
-                    table.insert(Sync.GameResult, { k, string.format("%s %i", 'draw', 0) })
+                    table.insert(Sync.GameResult, { k, "draw 0" })
 
                     -- stop considering it a brain that is still alive
                     aliveBrains[k] = nil
@@ -165,7 +165,7 @@ local function MatchStateThread()
 
             -- check for win
             local win = true 
-            for k, brain in aliveBrains do
+            for _, brain in aliveBrains do
                 win = win and brain.RequestingAlliedVictory
             end
 
@@ -185,7 +185,7 @@ local function MatchStateThread()
                     brain:OnVictory()
 
                     -- communicate to the server that this brain has been defeated
-                    table.insert(Sync.GameResult, { k, string.format("%s %i", 'victory', 10) })
+                    table.insert(Sync.GameResult, { k, "victory 10" })
 
                     -- stop considering it a brain that is still alive
                     aliveBrains[k] = nil

--- a/lua/sim/MatchState.lua
+++ b/lua/sim/MatchState.lua
@@ -185,7 +185,7 @@ local function MatchStateThread()
             end
 
         -- apparently no undefeated brains are left
-        else 
+        else
             CallEndGame()
             break
         end

--- a/lua/sim/MatchState.lua
+++ b/lua/sim/MatchState.lua
@@ -1,0 +1,84 @@
+
+local Conditions = {
+    demoralization = categories.COMMAND,
+    domination = categories.STRUCTURE + categories.ENGINEER - categories.WALL,
+    eradication = categories.ALLUNITS - categories.WALL,
+}
+
+local function CollectDefeatedBrains(aliveBrains, condition, delay)
+    local defeatedBrains = { }
+    for _, index in aliveBrains do
+
+        local defeated = true
+        local brain = allBrains[index]
+
+        ---@type Unit[]
+        local criticalUnits = brain:GetListOfUnits(brain, condition)
+        if criticalUnits then 
+            for k, unit in criticalUnits do 
+                if not IsDestroyed(unit) and unit:GetFractionComplete() == 1 then
+                    defeated = false
+                    break
+                end
+            end
+        end
+
+        if defeated then
+            defeatedBrains[index] = true 
+        end
+
+        WaitTicks(delay)
+    end
+
+    return defeatedBrains
+end
+
+local function MatchStateThread()
+
+    local condition = Conditions[ScenarioInfo.Options.Victory]
+    if not condition then
+        SPEW("Unknown victory condition supplied: " .. ScenarioInfo.Options.Victory .. ", victory conditions defaults to sandbox.")
+        return
+    end
+
+    local allBrains = ArmyBrains
+
+    -- consider all non-civilian brains to be alive
+    local aliveBrains = { }
+    for k, brain in allBrains do
+        local index = brain:GetArmyIndex()
+        if not ArmyIsCivilian(index) then
+            aliveBrains[index] = true
+        end
+    end
+
+    -- keep scanning the gamestate
+    while true do
+
+        -- find brains that are defeated
+        local defeatedBrains = CollectDefeatedBrains(aliveBrains, condition, 5)
+        local defeatedBrainsCount = table.getn(defeatedBrains)
+        if defeatedBrainsCount > 0 then
+
+            -- take into account cascading effects
+            local lastDefeatedBrainsCount = defeatedBrainsCount
+            repeat 
+                WaitTicks(4)
+                -- re-compute the defeated brains until it no longer increases
+                defeatedBrains = CollectDefeatedBrains(aliveBrains, condition, 2)
+                defeatedBrainsCount = table.getn(defeatedBrains)
+            until defeatedBrainsCount == lastDefeatedBrainsCount
+
+            -- call them out as being defeated
+            for brain, _ in defeatedBrains do
+                brain:OnDefeat()
+            end
+        end
+
+        WaitTicks(10)
+
+    end
+
+end
+
+ForkThread(MatchStateThread())

--- a/lua/sim/MatchState.lua
+++ b/lua/sim/MatchState.lua
@@ -5,7 +5,7 @@ local Conditions = {
     eradication = categories.ALLUNITS - categories.WALL,
 }
 
---- Ends the game
+--- Ends the game, processing all events including sending score and statistics to the UI
 function CallEndGame()
     ForkThread(function()
         WaitSeconds(2.9)

--- a/lua/sim/MatchState.lua
+++ b/lua/sim/MatchState.lua
@@ -99,9 +99,6 @@ local function MatchStateThread()
 
     -- keep scanning the gamestate for changes in alliances and brain state
     while true do
-
-        LOG("Checking victory conditions!")
-
         -- check for defeat
         local defeatedBrains = CollectDefeatedBrains(aliveBrains, condition, 4)
         local defeatedBrainsCount = table.getsize(defeatedBrains)
@@ -121,8 +118,6 @@ local function MatchStateThread()
 
             -- call them out as being defeated and exclude them
             for k, brain in defeatedBrains do
-                LOG("Defeated brain: " .. tostring(k))
-
                 -- take the army out of the game, adjust command sources
                 SetArmyOutOfGame(k)
                 ObserverAfterDeath(k)
@@ -158,7 +153,6 @@ local function MatchStateThread()
                     brain:OnDraw()
 
                     -- communicate to the server that this brain has been defeated
-                    LOG("Draw!")
                     table.insert(Sync.GameResult, { k, string.format("%s %i", 'draw', 0) })
 
                     -- stop considering it a brain that is still alive
@@ -191,7 +185,6 @@ local function MatchStateThread()
                     brain:OnVictory()
 
                     -- communicate to the server that this brain has been defeated
-                    LOG("Victory!")
                     table.insert(Sync.GameResult, { k, string.format("%s %i", 'victory', 10) })
 
                     -- stop considering it a brain that is still alive

--- a/lua/sim/MatchState.lua
+++ b/lua/sim/MatchState.lua
@@ -5,26 +5,36 @@ local Conditions = {
     eradication = categories.ALLUNITS - categories.WALL,
 }
 
+--- Ends the game
+function CallEndGame()
+    ForkThread(function()
+        WaitSeconds(2.9)
+        for _, v in GameOverListeners do
+            v()
+        end
+        Sync.GameEnded = true
+        WaitSeconds(0.1)
+        EndGame()
+    end)
+end
+
+--- Finds and collectors the brains that are defeated
+---@param aliveBrains AIBrain[] # Table of brains that are relevant to check for defeat
+---@param condition Categories  # Categories to check for units that are required to remain in the game
+---@param delay number          # Delay between each brain to spread the load over various ticks
+---@return AIBrain[]            # Table of brains that are considered defeated, can be empty
 local function CollectDefeatedBrains(aliveBrains, condition, delay)
     local defeatedBrains = { }
-    for _, index in aliveBrains do
+    for k, brain in aliveBrains do
 
-        local defeated = true
-        local brain = allBrains[index]
-
-        ---@type Unit[]
         local criticalUnits = brain:GetListOfUnits(brain, condition)
         if criticalUnits then 
             for k, unit in criticalUnits do 
                 if not IsDestroyed(unit) and unit:GetFractionComplete() == 1 then
-                    defeated = false
+                    defeatedBrains[k] = brain 
                     break
                 end
             end
-        end
-
-        if defeated then
-            defeatedBrains[index] = true 
         end
 
         WaitTicks(delay)
@@ -33,30 +43,55 @@ local function CollectDefeatedBrains(aliveBrains, condition, delay)
     return defeatedBrains
 end
 
-local function MatchStateThread()
-
-    local condition = Conditions[ScenarioInfo.Options.Victory]
-    if not condition then
-        SPEW("Unknown victory condition supplied: " .. ScenarioInfo.Options.Victory .. ", victory conditions defaults to sandbox.")
-        return
-    end
-
-    local allBrains = ArmyBrains
-
-    -- consider all non-civilian brains to be alive
-    local aliveBrains = { }
-    for k, brain in allBrains do
-        local index = brain:GetArmyIndex()
-        if not ArmyIsCivilian(index) then
-            aliveBrains[index] = true
+--- Determines observer behavior after an army is defeated
+---@param armyIndex number
+function ObserverAfterDeath(armyIndex)
+    if not ScenarioInfo.Options.AllowObservers then return end
+    local humans = {}
+    local humanIndex = 0
+    for i, data in ArmyBrains do
+        if data.BrainType == 'Human' then
+            if IsAlly(armyIndex, i) then
+                if not ArmyIsOutOfGame(i) then
+                    return
+                end
+                table.insert(humans, humanIndex)
+            end
+            humanIndex = humanIndex + 1
         end
     end
 
-    -- keep scanning the gamestate
+    for _, index in humans do
+        for i in ArmyBrains do
+            SetCommandSource(i - 1, index, false)
+        end
+    end
+end
+
+--- Continiously scans the game for brains being defeated or changes in alliances that can cause the game to end
+local function MatchStateThread()
+
+    -- determine game conditions
+    local condition = Conditions[ScenarioInfo.Options.Victory]
+    if not condition and not (ScenarioInfo.Options.Victory == 'sandbox') then
+        SPEW("Unknown victory condition supplied: " .. ScenarioInfo.Options.Victory .. ", victory condition defaults to sandbox.")
+        return
+    end
+
+    -- consider all non-civilian brains to be alive and kicking
+    local aliveBrains = { }
+    for k, brain in ArmyBrains do
+        local index = brain:GetArmyIndex()
+        if not ArmyIsCivilian(index) then
+            aliveBrains[index] = brain
+        end
+    end
+
+    -- keep scanning the gamestate for changes in alliances and brain state
     while true do
 
-        -- find brains that are defeated
-        local defeatedBrains = CollectDefeatedBrains(aliveBrains, condition, 5)
+        -- check for defeat
+        local defeatedBrains = CollectDefeatedBrains(aliveBrains, condition, 4)
         local defeatedBrainsCount = table.getn(defeatedBrains)
         if defeatedBrainsCount > 0 then
 
@@ -65,20 +100,99 @@ local function MatchStateThread()
             repeat 
                 WaitTicks(4)
                 -- re-compute the defeated brains until it no longer increases
-                defeatedBrains = CollectDefeatedBrains(aliveBrains, condition, 2)
+                defeatedBrains = CollectDefeatedBrains(aliveBrains, condition, 1)
                 defeatedBrainsCount = table.getn(defeatedBrains)
             until defeatedBrainsCount == lastDefeatedBrainsCount
 
-            -- call them out as being defeated
-            for brain, _ in defeatedBrains do
+            -- call them out as being defeated and exclude them
+            for k, brain in defeatedBrains do
+
+                -- take the army out of the game, adjust command sources
+                SetArmyOutOfGame(k)
+                ObserverAfterDeath(k)
+
+                -- process on defeat logic of brain
                 brain:OnDefeat()
+
+                -- communicate to the server that this brain has been defeated
+                table.insert(Sync.GameResult, { k, string.format("%s %i", 'defeat', -10) })
+
+                -- stop considering it a brain that is still alive
+                aliveBrains[k] = nil
             end
         end
 
-        WaitTicks(10)
+        -- loop through the brains that are still alive to check for alliance differences
 
+        if table.getn(aliveBrains) > 0 then 
+
+            -- check for draw
+            local draw = true
+            for k, brain in aliveBrains do
+                draw = draw and brain.OfferingDraw
+            end
+
+            if draw then
+                for k, brain in aliveBrains do
+                    -- take the army out of the game, adjust command sources
+                    SetArmyOutOfGame(k)
+                    ObserverAfterDeath(k)
+
+                    -- process on draw logic of brain
+                    brain:OnDraw()
+
+                    -- communicate to the server that this brain has been defeated
+                    table.insert(Sync.GameResult, { k, string.format("%s %i", 'draw', 0) })
+
+                    -- stop considering it a brain that is still alive
+                    aliveBrains[k] = nil
+                end
+
+                CallEndGame()
+                break
+            end
+
+            -- check for win
+            local win = true 
+            for k, brain in aliveBrains do
+                win = win and brain.RequestingAlliedVictory
+            end
+
+            for k, _ in aliveBrains do
+                for l, _ in aliveBrains do
+                    win = win and IsAlly(k, l)
+                end
+            end
+
+            if win then 
+                for k, brain in aliveBrains do
+                    -- take the army out of the game, adjust command sources
+                    SetArmyOutOfGame(k)
+                    ObserverAfterDeath(k)
+
+                    -- process on draw logic of brain
+                    brain:OnVictory()
+
+                    -- communicate to the server that this brain has been defeated
+                    table.insert(Sync.GameResult, { k, string.format("%s %i", 'victory', 0) })
+
+                    -- stop considering it a brain that is still alive
+                    aliveBrains[k] = nil
+                end
+
+                CallEndGame()
+                break
+            end
+
+        -- apparently no undefeated brains are left
+        else 
+            CallEndGame()
+            break
+        end
+
+        WaitTicks(10)
     end
 
 end
 
-ForkThread(MatchStateThread())
+ForkThread(MatchStateThread)

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -354,7 +354,7 @@ function BeginSession()
     import('/lua/sim/score.lua').init()
 
     --start watching for victory conditions
-    ForkThread(import('/lua/victory.lua').CheckVictory, ScenarioInfo)
+    import('/lua/sim/matchstate.lua')
 end
 
 function GameTimeLogger()

--- a/lua/ui/game/gameresult.lua
+++ b/lua/ui/game/gameresult.lua
@@ -23,15 +23,9 @@ local MyArmyResultStrings = {
     replay = "<LOC GAMERESULT_0003>Replay Finished.",
 }
 
-function OnReplayEnd()
-    import('/lua/ui/game/tabs.lua').TabAnnouncement('main', LOC(MyArmyResultStrings.replay))
-    import('/lua/ui/game/tabs.lua').AddModeText("<LOC _Score>", function() import('/lua/ui/dialogs/score.lua').CreateDialog(true) end)
-end
-
 local announced = {}
 
 function DoGameResult(armyIndex, result)
-    LOG("GAMERESULT : ", result)
     local condPos = string.find(result, " ")
     if condPos ~= 0 then
         result = string.sub(result, 1, condPos - 1)

--- a/lua/ui/uimain.lua
+++ b/lua/ui/uimain.lua
@@ -154,8 +154,6 @@ function NoteGameOver()
         GetCursor():Show()
     end
     if SessionIsReplay() then
-        --local scoreDlg = import('/lua/ui/dialogs/score.lua').dialog
-        --import('/lua/ui/game/gameresult.lua').OnReplayEnd()
         import('/lua/ui/game/score.lua').ArmyAnnounce(1, '<LOC _Replay_over>Replay over.')
     else
         import('/lua/ui/game/score.lua').ArmyAnnounce(1, '<LOC _Game_over>Game over.')


### PR DESCRIPTION
Re-implements the code that manages the game results that are send to the server. A few big changes:
 - The brain is no longer responsible for sending game results
 - The file `/lua/victory.lua` is now `/lua/sim/matchstate.lua` and is responsible for sending game results
 - The limit of the number of game results to send has been removed
 - The 'score' game result is removed entirely

Throughout the game we scan for the conditions of the game mode. We'll take assassination as an example. For that game mode the command unit needs to be alive, if it no longer is then the game mode should end. We scan the brains over time to see if they meet this requirement. 

For each brain scanned there is a small delay. If a brain is considered to be defeated (no units alive that are required for the game mode) then it rechecks all of the brains again to ensure that we didn't miss any cascading effects. Once we find no additional defeated brains we flag the considered brains as defeated, process the fact that the brain is defeated and send their game results via the sync to the server.

Once we've dealt with brains that are defeated we check if all the remaining brains agreed to a draw. If that is the case then we consider the brains to be in a 'drawn' state, process that fact and send their game results via the sync to the server. The game ends shortly after.

If not all brains agree with a draw we check if all the remaining brains are part of the same team, and they all agreed to an allied victory. If both of these conditions are true we process the fact that they are all victorious and send their game results via the sync to the server. The game ends shortly after.

If no brains remain (all brains are defeated) then the game ends shortly after.

One particular issue of the previous implementation is the check to `unit.Dead` instead of `IsDestroyed(unit)`. The flag `unit.Dead` may not have been set yet, even though the unit is considered to be destroyed. This is likely due to the execution order in Lua. See also https://github.com/FAForever/fa/pull/3794 that had a similar issue for build effects. 

Relevant quote of @Askaholic from Zulip about how the server operates:

```
It's important to know that 'victory' and 'defeat' are actually misnomers, as they don't mean 'you won the game' or 'you lost the game' but rather 'your ACU survived' and 'your ACU died'.

I think of the processing as happening in 3 stages:

Collect all of the individual reports for each army. Every player who is still connected to the game will report a result for each army when it dies.
Resolve all of the individual army results. So if 3 players reported 'defeat' for army 1 and one player reported 'victory' for that army, the army result will be resolved as 'defeat'. This is the step where we try to determine who's ACU is dead and who's ACU is still alive.
Resolve the team results by looking at the resolved army results. Here we check which team still has ACU's alive if any and make a determination about the game as a whole. If no ACU's are alive then the game is a draw, if only one team has ACU's alive then that team wins, otherwise if both teams have ACU's alive with 'VICTORY' results then we can't determine a winner. In the very rare case that the players used the diplomacy menu to end the game in a draw, all players in the game need to either be defeated or have a 'draw' army result.

Also note that the only results the server looks at are victory, defeat, draw, and mutual_draw. Anything not listed in this enum is ignored: https://github.com/FAForever/server/blob/a13889fe079d8c478a1841ad5f60e5147f3bb557/server/games/game_results.py#L25. That means the score result types are completely ignored.

That's because those 'score' results were supposed to be used to tell us how many ACU kills an army got. (Why they aren't called 'kills' instead of 'score' is beyond me)

Step 2 above happens here: https://github.com/FAForever/server/blob/a13889fe079d8c478a1841ad5f60e5147f3bb557/server/games/game_results.py#L126

Step 3 happens here: https://github.com/FAForever/server/blob/a13889fe079d8c478a1841ad5f60e5147f3bb557/server/games/game_results.py#L248
```