### PR TITLE
Add annotation overrides to `GetBlueprint`

### DIFF
--- a/engine/Sim/Blueprints/WeaponBlueprintDefinition.lua
+++ b/engine/Sim/Blueprints/WeaponBlueprintDefinition.lua
@@ -1,0 +1,5 @@
+---@meta
+---@declare-global
+
+--- read more here: https://wiki.faforever.com/en/Blueprints
+---@class WeaponBlueprint: BlueprintBase

--- a/engine/Sim/Prop.lua
+++ b/engine/Sim/Prop.lua
@@ -1,8 +1,11 @@
 ---@declare-global
 ---@class moho.prop_methods : moho.entity_methods
 local Prop = {}
----
---  derived from Entity
+
+---@return PropBlueprint
+function Prop:GetBlueprint()
+end
+
 function Prop:AddBoundedProp()
 end
 

--- a/engine/Sim/Unit.lua
+++ b/engine/Sim/Unit.lua
@@ -4,6 +4,10 @@ local Unit = {}
 
 ---@class UnitId: string
 
+---@return UnitBlueprint
+function Unit:GetBlueprint()
+end
+
 --- Add a command cap to a unit.
 --- Also adds a button to the UI, or enables it, for the unit to use the new command.
 ---@param capName "RULEUCC_Move"

--- a/engine/Sim/UnitWeapon.lua
+++ b/engine/Sim/UnitWeapon.lua
@@ -2,6 +2,10 @@
 ---@class moho.weapon_methods
 local UnitWeapon = {}
 
+---@return WeaponBlueprint
+function UnitWeapon:GetBlueprint()
+end
+
 ---
 --  UnitWeapon:CanFire()
 function UnitWeapon:CanFire()
@@ -65,11 +69,6 @@ end
 ---
 --  bool = UnitWeapon:FireWeapon()
 function UnitWeapon:FireWeapon()
-end
-
----
---  blueprint = UnitWeapon:GetBlueprint()
-function UnitWeapon:GetBlueprint()
 end
 
 ---


### PR DESCRIPTION
Allows them to return the correct type of blueprint.