### PR TITLE
Update antiair and antinavy categories-UEF Experimentals

### DIFF
--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -111,8 +111,6 @@ UnitBlueprint {
         'FACTORY',
         'NEEDMOBILEBUILD',
         'AMPHIBIOUS',
-        'ANTIAIR',
-        'ANTINAVY',
         'VISIBLETORECON',
         'RECLAIMABLE',
         'DRAGBUILD',

--- a/units/XSL0401/XSL0401_unit.bp
+++ b/units/XSL0401/XSL0401_unit.bp
@@ -52,7 +52,6 @@ UnitBlueprint {
         'DIRECTFIRE',
         'EXPERIMENTAL',
         'BOT',
-        'ANTIAIR',
         'AMPHIBIOUS',
         'NEEDMOBILEBUILD',
         'VISIBLETORECON',


### PR DESCRIPTION
Consistent use of antiair and antinavy categories for experimentals - updates Fatboy (no changes required to other UEF experimentals)
Refer to pull request #3952 for discussion on this.