### PR TITLE
Update antiair and antinavy categories-UEF Experimentals

### DIFF
--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -111,8 +111,6 @@ UnitBlueprint {
         'FACTORY',
         'NEEDMOBILEBUILD',
         'AMPHIBIOUS',
-        'ANTIAIR',
-        'ANTINAVY',
         'VISIBLETORECON',
         'RECLAIMABLE',
         'DRAGBUILD',


### PR DESCRIPTION
Consistent use of antiair and antinavy categories for experimentals - updates Fatboy (no changes required to other UEF experimentals)
Refer to pull request #3952 for discussion on this.