### PR TITLE
Update antiair and antinavy categories-Aeon Experimentals

### DIFF
--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -94,7 +94,6 @@ UnitBlueprint {
         'MOBILE',
         'AIR',
         'DIRECTFIRE',
-        'ANTINAVY',
         'ANTIAIR',
         'HIGHALTAIR',
         'EXPERIMENTAL',


### PR DESCRIPTION
Consistent use of antiair and antinavy categories for experimentals - updates Czar (no changes required to other Aeon experimentals)
Refer to pull request #3952 for discussion on this.