### PR TITLE
Category update - obsidian

### DIFF
--- a/units/UAL0202/UAL0202_unit.bp
+++ b/units/UAL0202/UAL0202_unit.bp
@@ -57,7 +57,7 @@ UnitBlueprint {
         'LAND',
         'TECH2',
         'DIRECTFIRE',
-        'SHIELD',
+        'PERSONALSHIELD',
         'VISIBLETORECON',
         'RECLAIMABLE',
         'TANK',


### PR DESCRIPTION
Makes category more consistent - it has a personal shield, and other units with personal shield have the category PERSONALSHIELD instead of SHIELD (e.g. titan)