### PR TITLE
Category update - Amphibious - ACUs

### DIFF
--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -118,6 +118,7 @@ UnitBlueprint {
         'SELECTABLE',
         'AEON',
         'MOBILE',
+        'AMPHIBIOUS',
         'ECONOMIC',
         'COMMAND',
         'MASSPRODUCTION',

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -118,6 +118,7 @@ UnitBlueprint {
         'SELECTABLE',
         'UEF',
         'MOBILE',
+        'AMPHIBIOUS',
         'ECONOMIC',
         'COMMAND',
         'MASSPRODUCTION',

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -120,6 +120,7 @@ UnitBlueprint {
         'SELECTABLE',
         'CYBRAN',
         'MOBILE',
+        'AMPHIBIOUS',
         'ECONOMIC',
         'COMMAND',
         'MASSPRODUCTION',

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -130,6 +130,7 @@ UnitBlueprint {
         'SELECTABLE',
         'SERAPHIM',
         'MOBILE',
+        'AMPHIBIOUS',
         'ECONOMIC',
         'COMMAND',
         'MASSPRODUCTION',


### PR DESCRIPTION
Consistent use of AMPHIBIOUS for units with amphibious pathing - updates ACU units that are missing this category.

Part of wider change also impacting engineers where all units with amphibious pathing are updated to have the AMPHIBIOUS category - code used to check for such units is:
https://github.com/maudlin27/M27AI/commit/01e45116eb77f8b9adca5af1eb1c4816e8646800