### PR TITLE
Category update - Amphibious - Engineers

### DIFF
--- a/units/UEL0105/UEL0105_unit.bp
+++ b/units/UEL0105/UEL0105_unit.bp
@@ -76,6 +76,7 @@ UnitBlueprint {
         'BUILTBYTIER3FACTORY',
         'UEF',
         'MOBILE',
+        'AMPHIBIOUS',
         'LAND',
         'TECH1',
         'CONSTRUCTION',

--- a/units/UEL0208/UEL0208_unit.bp
+++ b/units/UEL0208/UEL0208_unit.bp
@@ -75,6 +75,7 @@ UnitBlueprint {
         'BUILTBYTIER3FACTORY',
         'UEF',
         'MOBILE',
+        'AMPHIBIOUS',
         'LAND',
         'TECH2',
         'CONSTRUCTION',

--- a/units/UEL0309/UEL0309_unit.bp
+++ b/units/UEL0309/UEL0309_unit.bp
@@ -74,6 +74,7 @@ UnitBlueprint {
         'BUILTBYTIER3FACTORY',
         'UEF',
         'MOBILE',
+        'AMPHIBIOUS',
         'LAND',
         'TECH3',
         'CONSTRUCTION',

--- a/units/URL0105/URL0105_unit.bp
+++ b/units/URL0105/URL0105_unit.bp
@@ -74,6 +74,7 @@ UnitBlueprint {
         'BUILTBYTIER3FACTORY',
         'CYBRAN',
         'MOBILE',
+        'AMPHIBIOUS',
         'LAND',
         'TECH1',
         'CONSTRUCTION',

--- a/units/URL0208/URL0208_unit.bp
+++ b/units/URL0208/URL0208_unit.bp
@@ -73,6 +73,7 @@ UnitBlueprint {
         'BUILTBYTIER3FACTORY',
         'CYBRAN',
         'MOBILE',
+        'AMPHIBIOUS',
         'LAND',
         'TECH2',
         'CONSTRUCTION',

--- a/units/URL0309/URL0309_unit.bp
+++ b/units/URL0309/URL0309_unit.bp
@@ -72,6 +72,7 @@ UnitBlueprint {
         'BUILTBYTIER3FACTORY',
         'CYBRAN',
         'MOBILE',
+        'AMPHIBIOUS',
         'LAND',
         'TECH3',
         'CONSTRUCTION',

--- a/units/XEL0209/XEL0209_unit.bp
+++ b/units/XEL0209/XEL0209_unit.bp
@@ -76,6 +76,7 @@ UnitBlueprint {
         'BUILTBYNAVALTIER3FACTORY',
         'UEF',
         'MOBILE',
+        'AMPHIBIOUS',
         'LAND',
         'TECH2',
         'CONSTRUCTION',


### PR DESCRIPTION
Consistent use of AMPHIBIOUS for units with amphibious pathing - updates engineer units that are missing this category.

Part of wider change also impacting engineers where all units with amphibious pathing are updated to have the AMPHIBIOUS category - code used to check for such units is:
https://github.com/maudlin27/M27AI/commit/01e45116eb77f8b9adca5af1eb1c4816e8646800