### PR TITLE
Re-implement the tractor beams of the colossus

### DIFF
--- a/effects/emitters/tractor_01_emit.bp
+++ b/effects/emitters/tractor_01_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'aeon_gate_01',
+	Lifetime = -0.20,
+	Repeattime = 0.20,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = true,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = true,
+	LODCutoff = 500.00,
+	EmitIfVisible = true,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = '/textures/particles/quantum_generator_add_03.dds',
+	RampTexture = '/textures/particles/ramp_quantum_01.dds',
+	XDirectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=2.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.011,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=2.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.000,y=1.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=15.000,z=3.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.001,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.094,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.101,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 0,
+		Keys = {
+			{ x=0.0,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.068,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.100 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.108,y=3.000,z=0.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 0.20,
+		Keys = {
+			{ x=0.100,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/tractor_02_emit.bp
+++ b/effects/emitters/tractor_02_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'aeon_gate_02',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = true,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 150.00,
+	EmitIfVisible = true,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = '/textures/particles/reacton_hit_flare_01.dds',
+	RampTexture = '/textures/particles/ramp_purple_01.dds',
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=2.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=2.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=2.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=3.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=11.148,y=15.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.010,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 0.00,
+		Keys = {
+			{ x=0.000,y=0,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.100,z=0.000 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=2.250,z=1.000 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/effects/emitters/tractor_03_emit.bp
+++ b/effects/emitters/tractor_03_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+	BlueprintId = 'aeon_gate_03',
+	Lifetime = -1.00,
+	Repeattime = 50.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 150.00,
+	EmitIfVisible = true,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 0.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = '/textures/particles/energy_01.dds',
+	RampTexture = '/textures/particles/ramp_blue_08.dds',
+	XDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.500,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=13.588,y=20.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=15.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 0.00,
+		Keys = {
+			{ x=0.000,y=0,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.100,z=0.000 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.500,z=0.100 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 50.00,
+		Keys = {
+			{ x=25.000,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/lua/EffectTemplates.lua
+++ b/lua/EffectTemplates.lua
@@ -661,6 +661,13 @@ AQuantumGateAmbient = {
     EmtBpPath .. 'aeon_gate_03_emit.bp',
 }
 
+ATractorAmbient = {
+    EmtBpPath .. 'tractor_01_emit.bp',
+    EmtBpPath .. 'tractor_02_emit.bp',
+    EmtBpPath .. 'tractor_03_emit.bp',
+}
+
+
 AResourceGenAmbient = {
     EmtBpPath .. 'aeon_rgen_ambient_01_emit.bp',
     EmtBpPath .. 'aeon_rgen_ambient_02_emit.bp',

--- a/lua/aeonweapons.lua
+++ b/lua/aeonweapons.lua
@@ -79,10 +79,12 @@ ADFTractorClaw = Class(Weapon) {
 
                     -- reset target state
                     local target = self:GetCurrentTarget()
-                    local unit = self:GetUnitBehindTarget(target)
-                    if unit then
-                        unit.DisallowCollisions = false
-                        unit:SetDoNotTarget(false)
+                    if not IsDestroyed(target) then 
+                        local unit = self:GetUnitBehindTarget(target)
+                        if unit then
+                            unit.DisallowCollisions = false
+                            unit:SetDoNotTarget(false)
+                        end
                     end
 
                     -- detach everything from this weapon

--- a/lua/sim/Blip.lua
+++ b/lua/sim/Blip.lua
@@ -8,6 +8,7 @@
 --**  Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
+---@class Blip
 Blip = Class(moho.blip_methods) {
 
     AddDestroyHook = function(self,hook)

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -38,6 +38,7 @@ local function ParsePriorities()
 end
 
 ---@class Weapon : moho.weapon_methods
+---@field Blueprint WeaponBlueprint
 Weapon = Class(moho.weapon_methods) {
     __init = function(self, unit)
         self.unit = unit

--- a/units/UAL0401/UAL0401_Script.lua
+++ b/units/UAL0401/UAL0401_Script.lua
@@ -43,7 +43,7 @@ UAL0401 = Class(AWalkingLandUnit) {
         while not self.Dead do 
 
             -- only perform this logic if the unit is on the move
-            if self:IsUnitState("Moving") then 
+            if self:IsUnitState("Moving") then
 
                 -- compute the direction of the heading
                 local sx, sy, sz = self:GetPositionXYZ()

--- a/units/UAL0401/UAL0401_unit.bp
+++ b/units/UAL0401/UAL0401_unit.bp
@@ -62,6 +62,7 @@ UnitBlueprint {
         'RECLAIMABLE',
         'DRAGBUILD',
         'OVERLAYDIRECTFIRE',
+        'OVERLAYINDIRECTFIRE',
         'OVERLAYOMNI',
         'CQUEMOV', --"CQUEMOV" enables the selection and move commands during construction
         'SNIPEMODE',
@@ -374,6 +375,11 @@ UnitBlueprint {
             WeaponUnpacks = false,
         },
         {
+            -- sim-performance related values
+            TargetCheckInterval = 0.2,
+            AlwaysRecheckTarget = false,
+            TrackingRadius = 1.1,
+
             AboveWaterFireOnly = true,
             AboveWaterTargetsOnly = true,
             Audio = {
@@ -399,7 +405,7 @@ UnitBlueprint {
             HeadingArcCenter = -35,
             HeadingArcRange = 40,
             Label = 'RightArmTractor',
-            MaxRadius = 40,
+            MaxRadius = 41,
             MinRadius = 2,
             MuzzleChargeDelay = 0,
             MuzzleSalvoDelay = 0,
@@ -422,15 +428,15 @@ UnitBlueprint {
             RackSalvoReloadTime = 0,
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
-            RateOfFire = 0.15,
+            RangeCategory = 'UWRC_IndirectFire',
+            RateOfFire = 2,
             TargetPriorities = {
                 'TECH3 MOBILE',
                 'TECH2 MOBILE',
                 'TECH1 MOBILE',
-                '(STRUCTURE * DEFENSE - ANTIMISSILE)',
                 'ALLUNITS',
             },
-            TargetRestrictDisallow = 'UNTARGETABLE',
+            TargetRestrictDisallow = 'UNTARGETABLE,STRUCTURE,COMMAND,EXPERIMENTAL,NAVAL,SUBCOMMANDER',
             TurretBoneMuzzle = 'Right_Arm_Muzzle01',
             TurretBonePitch = 'Right_Arm_B02',
             TurretBoneYaw = 'Right_Arm_B01',
@@ -447,6 +453,11 @@ UnitBlueprint {
             WeaponUnpacks = false,
         },
         {
+            -- sim-performance related values
+            TargetCheckInterval = 0.2, 
+            AlwaysRecheckTarget = false, 
+            TrackingRadius = 1.1,
+
             AboveWaterFireOnly = true,
             AboveWaterTargetsOnly = true,
             Audio = {
@@ -487,7 +498,7 @@ UnitBlueprint {
             HeadingArcCenter = 35,
             HeadingArcRange = 40,
             Label = 'LeftArmTractor',
-            MaxRadius = 40,
+            MaxRadius = 41,
             MinRadius = 2,
             MuzzleChargeDelay = 0,
             MuzzleSalvoDelay = 0,
@@ -510,15 +521,15 @@ UnitBlueprint {
             RackSalvoReloadTime = 0,
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
-            RateOfFire = 0.15,
+            RangeCategory = 'UWRC_IndirectFire',
+            RateOfFire = 2,
             TargetPriorities = {
                 'TECH3 MOBILE',
                 'TECH2 MOBILE',
                 'TECH1 MOBILE',
-                '(STRUCTURE * DEFENSE - ANTIMISSILE)',
                 'ALLUNITS',
             },
-            TargetRestrictDisallow = 'UNTARGETABLE',
+            TargetRestrictDisallow = 'UNTARGETABLE,STRUCTURE,COMMAND,EXPERIMENTAL,NAVAL,SUBCOMMANDER',
             TurretBoneMuzzle = 'Left_Arm_Muzzle01',
             TurretBonePitch = 'Left_Arm_B02',
             TurretBoneYaw = 'Left_Arm_B01',


### PR DESCRIPTION
Completely re-implements the tractor beams, fixing all the critical issues with them. Similar to #4020, closes https://github.com/FAForever/fa/issues/2342 .

This pull request tackles:

- The units being sucked up now leave wreckages
- The tractor beam weapons actually properly function, as the previous implementation could cause them to not work at all

And it pimps the behavior slightly:

- More effects to give it a bigger 'oof' factor
- Unit that is being sucked up rotates randomly, like the Aeon Power Generators do. Gives a feeling of 'helplessness' when the unit occasionally manages to aim and fire a shot or two at the colossus

https://user-images.githubusercontent.com/15778155/178206449-965c7bb8-2e88-4aed-8625-b62d33e6bc13.mp4

