### PR TITLE
Optimize range shaders

### DIFF
--- a/effects/range.fx
+++ b/effects/range.fx
@@ -26,9 +26,9 @@ Vertex vertexShader( float3 vertex : POSITION0, float2 coeff : TEXCOORD0, float2
 
 technique Cast
 {
-  pass FrontFace
+  pass P0
   {
-    CullMode = CCW;
+    CullMode = none;
 
     ColorWriteEnable = 0x00;
 
@@ -37,38 +37,19 @@ technique Cast
     ZFunc = less;
 
     StencilEnable = true;
-    StencilFunc = notequal;
+    StencilWriteMask = 0x7F;
     StencilRef = 0xFF;
     StencilMask = 0x80;
 
-    StencilWriteMask = 0x7F;
+    TwoSidedStencilMode = true;
     StencilFail = zero;
-    StencilPass = keep;
-
     StencilZFail = incr;
-
-    VertexShader = compile vs_2_0 vertexShader();
-  }
-  pass BackFace
-  {
-    CullMode = CW;
-
-    ColorWriteEnable = 0x00;
-
-    ZWriteEnable = false;
-    ZEnable = true;
-    ZFunc = less;
-
-    StencilEnable = true;
-    StencilFunc = notequal;
-    StencilRef = 0xFF;
-    StencilMask = 0x80;
-
-    StencilWriteMask = 0x7F;
-    StencilFail = zero;
     StencilPass = keep;
-
-    StencilZFail = decr;
+    StencilFunc = notequal;
+    CCW_StencilFail = zero;
+    CCW_StencilZFail = decr;
+    CCW_StencilPass = keep;
+    CCW_StencilFunc = notequal;
 
     VertexShader = compile vs_2_0 vertexShader();
   }

--- a/effects/vision.fx
+++ b/effects/vision.fx
@@ -9,7 +9,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #define CCW_BOUNDARY_BIAS	 0.00001
-#define CW_BOUNDARY_BIAS	-0.00001 
+#define CW_BOUNDARY_BIAS	-0.00001
 
 float4x4 viewMatrix;
 float4x4 projMatrix;
@@ -25,20 +25,20 @@ typedef Vertex Pixel;
 Vertex boundaryVertexShader( float3 vertex : POSITION0 )
 {
 	Vertex result = (Vertex)0;
-	
+
 	float3 position = boxExtent * vertex + boxCenter;
 	result.position = mul(float4(position,1),mul(viewMatrix,projMatrix));
-	
+
 	return result;
 }
 
 Vertex visionVertexShader( float3 vertex : POSITION0, float2 position : POSITION1, float radius : TEXCOORD0 )
 {
 	Vertex result = (Vertex)0;
-	
+
 	vertex.xz = radius.xx * vertex.xz + position.xy;
 	result.position = mul(float4(vertex,1),mul(viewMatrix,projMatrix));
-	
+
 	return result;
 }
 
@@ -49,53 +49,34 @@ float4 pixelShader( Pixel pixel) : COLOR0
 
 technique CastVision
 {
-	pass FrontFace
+	pass P0
 	{
-		CullMode = CCW;
-		
+		CullMode = none;
+
 		AlphaBlendEnable = false;
 		AlphaTestEnable = false;
-		
-	    ColorWriteEnable = 0x00;
+
+		ColorWriteEnable = 0x00;
 
 		ZWriteEnable = false;
 		ZEnable = true;
 		ZFunc = less;
-		
+
 		StencilEnable = true;
 		StencilWriteMask = 0xFF;
 		StencilMask = 0xFF;
 		StencilRef = 0x00;
-		StencilFunc = always;
+
+		TwoSidedStencilMode = true;
 		StencilFail = keep;
 		StencilZFail = incr;
 		StencilPass = keep;
-
-		VertexShader = compile vs_2_0 visionVertexShader();
-		PixelShader = compile ps_2_0 pixelShader();
-	}
-	pass BackFace
-	{
-		CullMode = CW;
-		
-		AlphaBlendEnable = false;
-		AlphaTestEnable = false;
-		
-	    ColorWriteEnable = 0x00;
-
-		ZWriteEnable = false;
-		ZEnable = true;
-		ZFunc = less;
-	    
-		StencilEnable = true;
-		StencilWriteMask = 0xFF;
-		StencilMask = 0xFF;
-		StencilRef = 0x00;
 		StencilFunc = always;
-		StencilFail = keep;
-		StencilZFail = decr;
-		StencilPass = keep;
-		
+		CCW_StencilFail = keep;
+		CCW_StencilZFail = decr;
+		CCW_StencilPass = keep;
+		CCW_StencilFunc = always;
+
 		VertexShader = compile vs_2_0 visionVertexShader();
 		PixelShader = compile ps_2_0 pixelShader();
 	}
@@ -106,10 +87,10 @@ technique CastBoundaryCCW
 	pass FrontFace
 	{
 		CullMode = CCW;
-		
+
 	    ColorWriteEnable = 0x00;
 		DepthBias = CCW_BOUNDARY_BIAS;
-		
+
 		ZWriteEnable = false;
 		ZEnable = true;
 		ZFunc = less;
@@ -129,7 +110,7 @@ technique CastBoundaryCCW
 	pass BackFace
 	{
 		CullMode = CW;
-		
+
 	    ColorWriteEnable = 0x00;
 		DepthBias = CW_BOUNDARY_BIAS;
 
@@ -156,7 +137,7 @@ technique CastBoundaryCW
 	pass FrontFace
 	{
 		CullMode = CW;
-		
+
 	    ColorWriteEnable = 0x00;
 		DepthBias = CW_BOUNDARY_BIAS;
 
@@ -179,7 +160,7 @@ technique CastBoundaryCW
 	pass BackFace
 	{
 		CullMode = CCW;
-		
+
 	    ColorWriteEnable = 0x00;
 		DepthBias = CCW_BOUNDARY_BIAS;
 


### PR DESCRIPTION
Another optimization range rings and vision.
TwoSidedStencil hardware support is required.
Since DX9 is very old, I think there will be no problems.