### PR TITLE
Disable UI of shields when turned off

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -816,7 +816,7 @@ Shield = Class(moho.shield_methods, Entity) {
 
             -- remove the shield and the shield bar
             self:RemoveShield()
-            self:UpdateShieldRatio(-1)
+            self:UpdateShieldRatio(0)
 
             -- inform the owner that the shield is disabled
             self.Owner:OnShieldDisabled()


### PR DESCRIPTION
Removes the shield bar when the shield is turned off, as it was before #3681. See also [this](https://forum.faforever.com/topic/4449/all-factions-shield-generator-mobile-shields-bug) forum post about it.

![image](https://user-images.githubusercontent.com/15778155/180637675-5cc12c29-2cc3-4684-9cc9-6c0facd25ff9.png)
