### PR TITLE
fix for game victory in case no team is set.

### DIFF
--- a/lua/sim/MatchState.lua
+++ b/lua/sim/MatchState.lua
@@ -169,13 +169,11 @@ local function MatchStateThread()
 
             -- check for win
             local win = true 
-            for _, brain in aliveBrains do
-                win = win and brain.RequestingAlliedVictory
-            end
-
-            for k, _ in aliveBrains do
+            for k, brain in aliveBrains do
                 for l, _ in aliveBrains do
-                    win = win and IsAlly(k, l)
+                    if k ~= l then
+                        win = win and IsAlly(k, l) and brain.RequestingAlliedVictory
+                    end
                 end
             end
 


### PR DESCRIPTION
in case there is no team set in lobby, then brain.RequestingAlliedVictory is nil.
