### PR TITLE
Nerf Ahwassa's AoE

### DIFF
--- a/units/XSA0402/XSA0402_unit.bp
+++ b/units/XSA0402/XSA0402_unit.bp
@@ -304,7 +304,7 @@ UnitBlueprint {
             CollideFriendly = false,
             Damage = 11000,
             DamageFriendly = true,
-            DamageRadius = 20,
+            DamageRadius = 19,
             DamageType = 'OtheTacticalBomb',
             DisplayName = 'Othe Tactical Bomb',
             FireTargetLayerCapsTable = {


### PR DESCRIPTION
Decrease Ahwassa's AoE from 20 to 19. A small nerf to Ahwassa decreasing its effectiveness vs Armies and Air grids