### PR TITLE
Nerf E drain of Aeon Mobile Shield

### DIFF
--- a/units/UAL0307/UAL0307_unit.bp
+++ b/units/UAL0307/UAL0307_unit.bp
@@ -165,7 +165,7 @@ UnitBlueprint {
         BuildCostEnergy = 1080,
         BuildCostMass = 220,
         BuildTime = 792,
-        MaintenanceConsumptionPerSecondEnergy = 45,
+        MaintenanceConsumptionPerSecondEnergy = 55,
         TeleportEnergyMod = 0.15,
         TeleportMassMod = 1,
         TeleportTimeMod = 0.01,


### PR DESCRIPTION
45 e/s -> 55 e/s
Nerf Aeon Mobile Shield E-drain cost.
Aeon T2 land has become arguably the best with a combination of powerful tanks, cheap shields, and the best ACU. This minor nerf aims at reducing the oppressiveness of Aeon T2 Obsidian + mobile shield spam.