### PR TITLE
Fix the guard return radius of naval units

### DIFF
--- a/units/UAS0102/UAS0102_unit.bp
+++ b/units/UAS0102/UAS0102_unit.bp
@@ -1,4 +1,7 @@
 UnitBlueprint {
+    AI = {
+        GuardReturnRadius = 40,
+    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'UAS',

--- a/units/UAS0103/UAS0103_unit.bp
+++ b/units/UAS0103/UAS0103_unit.bp
@@ -1,6 +1,7 @@
 UnitBlueprint {
     AI = {
         AttackAngle = 60,
+        GuardScanRadius = 40,
     },
     Audio = {
         AmbientMove = Sound {

--- a/units/UAS0201/UAS0201_unit.bp
+++ b/units/UAS0201/UAS0201_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint {
     AI = {
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 30,
     },
     Audio = {
         AmbientMove = Sound {

--- a/units/UAS0202/UAS0202_unit.bp
+++ b/units/UAS0202/UAS0202_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint {
     AI = {
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 30,
     },
     Audio = {
         AmbientMove = Sound {

--- a/units/UAS0203/UAS0203_unit.bp
+++ b/units/UAS0203/UAS0203_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint {
     AI = {
-        GuardReturnRadius = 130,        
+        GuardReturnRadius = 40,        
         TargetBones = {
             'UAS0203',
             'upper_target',

--- a/units/UAS0302/UAS0302_unit.bp
+++ b/units/UAS0302/UAS0302_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         AttackAngle = 60,
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 15,
         TargetBones = {
             'UAS0302',
             'Turret_Middle',

--- a/units/UAS0303/UAS0303_unit.bp
+++ b/units/UAS0303/UAS0303_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint {
         RepairConsumeEnergy = 30,
         RepairConsumeMass = 0,
         StagingPlatformScanRadius = 300,
+        GuardReturnRadius = 15,
         TargetBones = {
             'UAS0303',
             'Exhaust01',

--- a/units/UAS0304/UAS0304_unit.bp
+++ b/units/UAS0304/UAS0304_unit.bp
@@ -1,6 +1,7 @@
 UnitBlueprint {
     AI = {
         InitialAutoMode = false,
+        GuardReturnRadius = 0,
         TargetBones = {
             'Muzzle_04',
             'Muzzle_05',

--- a/units/UAS0401/UAS0401_unit.bp
+++ b/units/UAS0401/UAS0401_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint {
     AI = {
+        GuardReturnRadius = 0,
         TargetBones = {
             'UAS0401',
             'Turret',

--- a/units/UES0103/UES0103_unit.bp
+++ b/units/UES0103/UES0103_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint {
     AI = {
+        GuardReturnRadius = 30,
         TargetBones = {
             'Front_Turret',
             'Back_Turret',

--- a/units/UES0201/UES0201_unit.bp
+++ b/units/UES0201/UES0201_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         AttackAngle = 90,
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 30,
         TargetBones = {
             'UES0202',
             'Back_Wake',

--- a/units/UES0202/UES0202_unit.bp
+++ b/units/UES0202/UES0202_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         AttackAngle = 90,
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 30,
         InitialAutoMode = true,
         TargetBones = {
             'UES0202',

--- a/units/UES0203/UES0203_unit.bp
+++ b/units/UES0203/UES0203_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint {
     AI = {
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 30,
         TargetBones = {
             'Spinner',
             'UES0203',

--- a/units/UES0302/UES0302_unit.bp
+++ b/units/UES0302/UES0302_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         AttackAngle = 60,
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 15,
         TargetBones = {
             'UES0302',
             'Front_Turret01',

--- a/units/UES0304/UES0304_unit.bp
+++ b/units/UES0304/UES0304_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint {
     AI = {
+        GuardReturnRadius = 15,
         InitialAutoMode = false,
         TargetBones = {
             'Tower_Target',

--- a/units/UES0304/UES0304_unit.bp
+++ b/units/UES0304/UES0304_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint {
     AI = {
-        GuardReturnRadius = 15,
+        GuardReturnRadius = 0,
         InitialAutoMode = false,
         TargetBones = {
             'Tower_Target',

--- a/units/UES0401/UES0401_unit.bp
+++ b/units/UES0401/UES0401_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint {
         RepairConsumeEnergy = 30,
         RepairConsumeMass = 0,
         StagingPlatformScanRadius = 300,
+        GuardReturnRadius = 0,
         TargetBones = {
             'Front_Left_Projectile02',
             'Front_Right_Projectile02',

--- a/units/URS0103/URS0103_unit.bp
+++ b/units/URS0103/URS0103_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint {
     AI = {
+        GuardScanRadius = 40,
         TargetBones = {
             'Front_Turret',
             'Back_Turret',

--- a/units/URS0201/URS0201_unit.bp
+++ b/units/URS0201/URS0201_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint {
     AI = {
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 30,
         TargetBones = {
             'URS0201',
             'Muzzle_Back',

--- a/units/URS0202/URS0202_unit.bp
+++ b/units/URS0202/URS0202_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         AttackAngle = 0,
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 30,
         StagingPlatformScanRadius = 300,
         RefuelingMultiplier = 50,
         RefuelingRepairAmount = 500,

--- a/units/URS0203/URS0203_unit.bp
+++ b/units/URS0203/URS0203_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint {
     AI = {
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 40,
         TargetBones = {
             'Turret',
             'URS0203',

--- a/units/URS0302/URS0302_unit.bp
+++ b/units/URS0302/URS0302_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         AttackAngle = 60,
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 15,
         TargetBones = {
             'URS0302',
             'Back_Wake',

--- a/units/URS0303/URS0303_unit.bp
+++ b/units/URS0303/URS0303_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint {
         RepairConsumeEnergy = 30,
         RepairConsumeMass = 0,
         StagingPlatformScanRadius = 300,
+        GuardReturnRadius = 15,
         TargetBones = {
             'URS0303',
             'Back_Wake',

--- a/units/URS0304/URS0304_unit.bp
+++ b/units/URS0304/URS0304_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint {
     AI = {
+        GuardReturnRadius = 0,
         InitialAutoMode = false,
     },
     Audio = {

--- a/units/XAS0204/XAS0204_unit.bp
+++ b/units/XAS0204/XAS0204_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint {
     AI = {
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 30,
     },
     Audio = {
         AmbientMove = Sound {

--- a/units/XAS0306/XAS0306_unit.bp
+++ b/units/XAS0306/XAS0306_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         AttackAngle = 60,
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 15,
         TargetBones = {
             'Turret_Front',
             'Turret_Back',

--- a/units/XES0102/XES0102_unit.bp
+++ b/units/XES0102/XES0102_unit.bp
@@ -1,4 +1,7 @@
 UnitBlueprint {
+    AI = {
+        GuardReturnRadius = 30,
+    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'XES',

--- a/units/XES0205/XES0205_unit.bp
+++ b/units/XES0205/XES0205_unit.bp
@@ -1,4 +1,7 @@
 UnitBlueprint {
+    AI = {
+        GuardReturnRadius = 30,
+    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'XES',

--- a/units/XES0307/XES0307_unit.bp
+++ b/units/XES0307/XES0307_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         AttackAngle = 60,
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 15,
         TargetBones = {
             'Front_Turret01',
             'Front_Turret02',

--- a/units/XRS0204/XRS0204_unit.bp
+++ b/units/XRS0204/XRS0204_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint {
     AI = {
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 30,
         TargetBones = {
             'XRS0204',
         },

--- a/units/XRS0205/XRS0205_unit.bp
+++ b/units/XRS0205/XRS0205_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint {
     AI = {
+        GuardReturnRadius = 30,
         TargetBones = {
             'point_midhigh',
             'point_midlow',

--- a/units/XSS0103/XSS0103_unit.bp
+++ b/units/XSS0103/XSS0103_unit.bp
@@ -1,4 +1,7 @@
 UnitBlueprint {
+    AI = {
+        GuardReturnRadius = 40,
+    },
     Audio = {
         AmbientMove = Sound {
             Bank = 'XSS',

--- a/units/XSS0201/XSS0201_unit.bp
+++ b/units/XSS0201/XSS0201_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         AttackAngle = 70,
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 30,
     },
     Audio = {
         AmbientMove = Sound {

--- a/units/XSS0202/XSS0202_unit.bp
+++ b/units/XSS0202/XSS0202_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint {
     AI = {
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 30,
     },
     Audio = {
         AmbientMove = Sound {

--- a/units/XSS0203/XSS0203_unit.bp
+++ b/units/XSS0203/XSS0203_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint {
     AI = {
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 40,
         TargetBones = {
             'AntiTorpedo',
             'Projectile01',

--- a/units/XSS0302/XSS0302_unit.bp
+++ b/units/XSS0302/XSS0302_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint {
     AI = {
         AttackAngle = 60,
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 15,
         TargetBones = {
             'xss0302',
             'Back_Turret01',

--- a/units/XSS0303/XSS0303_unit.bp
+++ b/units/XSS0303/XSS0303_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint {
         RepairConsumeEnergy = 30,
         RepairConsumeMass = 0,
         StagingPlatformScanRadius = 300,
+        GuardReturnRadius = 15,
     },
     Audio = {
         AmbientMove = Sound {

--- a/units/XSS0304/XSS0304_unit.bp
+++ b/units/XSS0304/XSS0304_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint {
     AI = {
-        GuardReturnRadius = 130,
+        GuardReturnRadius = 15,
         TargetBones = {
             'Front_Turret_Barrel01',
         },


### PR DESCRIPTION
The guard return radius is used when a unit that is patrolling engages, and follows a unit. Once it exceeds the distance, it returns back to the patrol area. This radius was set to 130 for almost all naval units, causing them to take a journey of their own until their target is destroyed or they have moved a distance of more than 130.

The return distance is now set to:

- 40 for tech 1 naval units
- 30 for tech 2 naval units
- 15 for tech 3 naval units
- 0 for experimental naval units and strategic submarines

Closes #1629