### PR TITLE
Add guard if the weapon has been destroyed

### DIFF
--- a/units/UAL0307/UAL0307_script.lua
+++ b/units/UAL0307/UAL0307_script.lua
@@ -89,8 +89,11 @@ UAL0307 = Class(AShieldHoverLandUnit) {
     OnLayerChange = function(self, new, old)
         AShieldHoverLandUnit.OnLayerChange(self, new, old)
         
-        if self.PointerEnabled == false then
-            self.TargetPointer:SetFireTargetLayerCaps('None') --since its reset on layer change we need to do this. unfortunate.
+        if not IsDestroyed(self) then
+            if self.PointerEnabled == false then
+                -- since its reset on layer change we need to do this, unfortunate
+                self.TargetPointer:SetFireTargetLayerCaps('None') 
+            end
         end
     end,
 }

--- a/units/UEL0307/UEL0307_script.lua
+++ b/units/UEL0307/UEL0307_script.lua
@@ -119,8 +119,10 @@ UEL0307 = Class(TShieldLandUnit) {
     OnLayerChange = function(self, new, old)
         TShieldLandUnit.OnLayerChange(self, new, old)
         
-        if self.PointerEnabled == false then
-            self.TargetPointer:SetFireTargetLayerCaps('None') --since its reset on layer change we need to do this. unfortunate.
+        if not IsDestroyed(self) then 
+            if self.PointerEnabled == false then
+                self.TargetPointer:SetFireTargetLayerCaps('None') --since its reset on layer change we need to do this. unfortunate.
+            end
         end
     end,
 }

--- a/units/XRL0403/XRL0403_script.lua
+++ b/units/XRL0403/XRL0403_script.lua
@@ -92,8 +92,6 @@ XRL0403 = Class(CWalkingLandUnit) {
     OnLayerChange = function(self, new, old)
         CWalkingLandUnit.OnLayerChange(self, new, old)
 
-        --LOG("Mega Layerchange from ", old, " to ", new)
-
         if new == 'Land' then
             self:DisableUnitIntel('Layer', 'Sonar')
             -- Set movement speed to default

--- a/units/XSL0307/XSL0307_script.lua
+++ b/units/XSL0307/XSL0307_script.lua
@@ -79,8 +79,10 @@ XSL0307 = Class(SShieldHoverLandUnit) {
     OnLayerChange = function(self, new, old)
         SShieldHoverLandUnit.OnLayerChange(self, new, old)
         
-        if self.PointerEnabled == false then
-            self.TargetPointer:SetFireTargetLayerCaps('None') --since its reset on layer change we need to do this. unfortunate.
+        if not IsDestroyed(self) then 
+            if self.PointerEnabled == false then
+                self.TargetPointer:SetFireTargetLayerCaps('None') --since its reset on layer change we need to do this. unfortunate.
+            end
         end
     end,
 }


### PR DESCRIPTION
Closes #4019 

Adds a guard to check if the weapon still exists (on the c-side), especially relevant when units are sinking. They hit a single `OnLayerChange` call right at the bottom.