### PR TITLE
Integrated STP with Category Support

### DIFF
--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -273,6 +273,8 @@ keyActions = {
         category = 'orders', order = 34,},
     ['set_target_priority'] = {action = 'UI_LUA import("/lua/keymap/misckeyactions.lua").SetWeaponPrioritiesSpecific()',
         category = 'orders', order = 35,},
+    ['set_default_target_priority'] = {action = 'UI_LUA import("/lua/keymap/misckeyactions.lua").SetDefaultWeaponPriorities()',
+        category = 'orders', order = 36,},
     ['decrease_game_speed'] = {action = 'UI_Lua import("/lua/ui/uimain.lua").DecreaseGameSpeed()',
         category = 'game', order = 1,},
     ['increase_game_speed'] = {action = 'UI_Lua import("/lua/ui/uimain.lua").IncreaseGameSpeed()',

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -271,7 +271,7 @@ keyActions = {
         category = 'orders', order = 33,},
     ['shift_spreadattack'] = {action = 'UI_Lua import("/lua/spreadattack.lua").SpreadAttack()',
         category = 'orders', order = 34,},
-    ['set_target_priority'] = {action = 'UI_LUA import("/lua/keymap/misckeyactions.lua").SetWeaponPrioritiesSpecific()',
+    ['set_target_priority'] = {action = 'UI_LUA import("/lua/keymap/misckeyactions.lua").SetWeaponPrioritiesToUnitType()',
         category = 'orders', order = 35,},
     ['set_default_target_priority'] = {action = 'UI_LUA import("/lua/keymap/misckeyactions.lua").SetDefaultWeaponPriorities()',
         category = 'orders', order = 36,},

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -271,6 +271,8 @@ keyActions = {
         category = 'orders', order = 33,},
     ['shift_spreadattack'] = {action = 'UI_Lua import("/lua/spreadattack.lua").SpreadAttack()',
         category = 'orders', order = 34,},
+    ['set_target_priority'] = {action = 'UI_LUA import("/lua/keymap/misckeyactions.lua").SetWeaponPrioritiesSpecific()',
+        category = 'orders', order = 35,},
     ['decrease_game_speed'] = {action = 'UI_Lua import("/lua/ui/uimain.lua").DecreaseGameSpeed()',
         category = 'game', order = 1,},
     ['increase_game_speed'] = {action = 'UI_Lua import("/lua/ui/uimain.lua").IncreaseGameSpeed()',

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -455,6 +455,6 @@ keyDescriptions = {
     ['t3_support_naval_factory'] = '<LOC key_desc_0387>build T3 Support Naval Factory',
 
     ['recheck_targets_of_weapons'] = 'Recheck targets of weapons of selected units',
-    ['set_target_priority'] = 'Set unit target priority to unit type',
-    ['set_default_target_priority'] = 'Set unit target priotity to default',
+    ['set_target_priority'] = 'Set weapon target priorities to the type of unit that you hover over with the mouse',
+    ['set_default_target_priority'] = 'Set weapon target priorities of selected units to their defaults',
 }

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -455,6 +455,6 @@ keyDescriptions = {
     ['t3_support_naval_factory'] = '<LOC key_desc_0387>build T3 Support Naval Factory',
 
     ['recheck_targets_of_weapons'] = 'Recheck targets of weapons of selected units',
-    ['set_target_priority'] = 'Set Target Priority',
-    ['set_default_target_priority'] = 'Set to Default Target Priority',
+    ['set_target_priority'] = 'Set unit target priority to unit type',
+    ['set_default_target_priority'] = 'Set unit target priotity to default',
 }

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -455,4 +455,6 @@ keyDescriptions = {
     ['t3_support_naval_factory'] = '<LOC key_desc_0387>build T3 Support Naval Factory',
 
     ['recheck_targets_of_weapons'] = 'Recheck targets of weapons of selected units',
+    ['set_target_priority'] = 'Set Target Priority',
+    ['set_default_target_priority'] = 'Set to Default Target Priority',
 }

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -410,50 +410,44 @@ function SetDefaultWeaponPriorities()
 end
 
 local categoriesToCheck = {
-    ['tech'] = {"TECH1", "TECH2", "TECH3"},
+    ['tech'] = {"TECH1", "TECH2", "TECH3", "EXPERIMENTAL", 'COMMAND'},
     ['faction'] = {"CYBRAN", "UEF", "AEON", "SERAPHIM"},
-    ['type'] = {"ANTIAIR", "DIRECTFIRE"},
+    ['type'] = {'SCOUT', "DIRECTFIRE", 'INDIRECTFIRE', 'DEFENSE', "ANTIAIR", 'TRANSPORTATION', "ENGINEER",},
     ['field'] = {"NAVAL", "AIR", "LAND", "STRUCTURE"},
 }
 
 function findPriority(bpID)
     local bp = __blueprints[bpID]
-    local categories = bp.Categories
+    local categories = bp.CategoriesHash
 
     local tech
     local faction
-    local type
+    local unitType
     local field
 
-    for _, c in categories do 
-        for _, ctc in categoriesToCheck['tech'] do
-            if c == ctc then tech = c end
-        end
-
-        for _, ctc in categoriesToCheck['faction'] do
-            if c == ctc then faction = c end
-        end
-
-        for _, ctc in categoriesToCheck['type'] do
-            if c == ctc then type = c end
-        end
-
-        for _, ctc in categoriesToCheck['field'] do
-            if c == ctc then field = c end
-        end
+    for _, c in categoriesToCheck['tech'] do
+        if categories[c] then tech = c end
+    end
+    for _, c in categoriesToCheck['faction'] do
+        if categories[c] then faction = c end
+    end
+    for _, c in categoriesToCheck['type'] do
+        if categories[c] then unitType = c end
+    end
+    for _, c in categoriesToCheck['field'] do
+        if categories[c] then field = c end
+    end
+    
+    if not (tech and faction and unitType and field) then
+        return string.format("{categories.%s}", bpID)
     end
 
-    tech = "categories." .. tech
-    faction = "categories." .. faction
-    type = "categories." .. type
-    field = "categories." .. field
+    local tp = string.format("categories.%s * categories.%s * categories.%s * categories.%s", tech, faction, unitType, field)
+    local tp2 = string.format("categories.%s * categories.%s * categories.%s", tech, unitType, field)
+    local tp3 = string.format("categories.%s * categories.%s", unitType, field)
+    local tp4 = string.format("categories.%s", field)
 
-    local tp = tech .. " * " .. faction .. " * " .. type .. " * " .. field
-    local tp2 = tech .. " * " .. type .. " * " .. field
-    local tp3 = type .. " * " .. field
-    local tp4 = field
-
-    local masterTP = "{categories." .. bpID .. ", " .. tp .. ", " .. tp2 .. ", " .. tp3 .. ", " .. tp4 .. "}"
+    local masterTP = string.format("{categories.%s, %s, %s, %s, %s}", bpID, tp, tp2, tp3, tp4)
     return masterTP
 end
 

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -1,7 +1,6 @@
 -- This file contains key bindable actions that don't fit elsewhere
 
 local Prefs = import('/lua/user/prefs.lua')
-local targeting = import('/lua/keymap/targeting.lua').targetingMap
 
 local lockZoomEnable = false
 function lockZoom()
@@ -398,87 +397,63 @@ function SetWeaponPrioritiesSpecific()
         local bpId = info.blueprintId
         local text = LOC(__blueprints[bpId].General.UnitName)     
         if text then
-            text = "\n" .. text .. " — " .. LOC(__blueprints[bpId].Interface.HelpText)
+            text = "\n" .. text
         else
             text = "\n" .. LOC(__blueprints[bpId].Interface.HelpText)
         end
-
-        local target = targeting[string.upper(bpId)]
-
-        
-        if target then
-            SetWeaponPriorities(target, text, false)
-        else
-            SetWeaponPriorities(findPriority(bpId), text, false)
-        end 
-        SimCallback({Func = 'RecheckTargetsOfWeapons', Args = { }}, true)
+        SetWeaponPriorities(findPriority(bpId), text, false)
     end
 end
+
+function SetDefaultWeaponPriorities()
+    SetWeaponPriorities(0, "Default", false)
+end
+
+local categoriesToCheck = {
+    ['tech'] = {"TECH1", "TECH2", "TECH3"},
+    ['faction'] = {"CYBRAN", "UEF", "AEON", "SERAPHIM"},
+    ['type'] = {"ANTIAIR", "DIRECTFIRE"},
+    ['field'] = {"NAVAL", "AIR", "LAND", "STRUCTURE"},
+}
 
 function findPriority(bpID)
     local bp = __blueprints[bpID]
     local categories = bp.Categories
+
     local tech
     local faction
     local type
     local field
 
-
-    for _, c in categories do
-        LOG(c)
-    end
-
     for _, c in categories do 
-        if c == "TECH1" then
-            tech = "TECH1"
-        elseif c == "TECH2" then
-            tech = "TECH2"
-        elseif c == "TECH3" then
-            tech = "TECH3"
-        elseif c == "CYBRAN" then
-            faction = "CYBRAN"
-        elseif c == "UEF" then
-            faction = "UEF"
-        elseif c == "AEON" then
-            faction = "AEON"
-        elseif c == "SERAPHIM" then
-            faction = "SERAPHIM"
-        elseif c == "ANTIAIR" then
-            type = "ANTIAIR"
-        elseif c == "DIRECTFIRE" then
-            type = "DIRECTFIRE"
-        elseif c == "NAVY" then
-            field = "NAVY"
-        elseif c == "AIR" then
-            field = "AIR"
-        elseif c == "LAND" then
-            field = "LAND"
-        elseif c == "STRUCTURE" then
-            field = "STRUCTURE"
+        for _, ctc in categoriesToCheck['tech'] do
+            if c == ctc then tech = c end
+        end
+
+        for _, ctc in categoriesToCheck['faction'] do
+            if c == ctc then faction = c end
+        end
+
+        for _, ctc in categoriesToCheck['type'] do
+            if c == ctc then type = c end
+        end
+
+        for _, ctc in categoriesToCheck['field'] do
+            if c == ctc then field = c end
         end
     end
-
-    LOG(tech)
-    LOG(faction)
-    LOG(type)
 
     tech = "categories." .. tech
     faction = "categories." .. faction
     type = "categories." .. type
     field = "categories." .. field
 
-    local tp = "{" .. tech .. " + " .. faction .. " + " .. type .. " + " .. field .. "}"
-    local tp2 = "{" .. tech .. " + " .. type .. " + " .. field .."}"
-    local tp3 = "{" .. type .. " + " .. field .."}"
-    local tp4 = "{" .. field .."}"
+    local tp = tech .. " * " .. faction .. " * " .. type .. " * " .. field
+    local tp2 = tech .. " * " .. type .. " * " .. field
+    local tp3 = type .. " * " .. field
+    local tp4 = field
 
-    local masterTP = tp .. ", " .. tp2 .. ", " .. tp3 .. ", " .. tp4
-    LOG(tp)
-    LOG(tp2)
-    LOG(tp3)
-    LOG(tp4)
-    LOG(masterTP)
-
+    local masterTP = "{categories." .. bpID .. ", " .. tp .. ", " .. tp2 .. ", " .. tp3 .. ", " .. tp4 .. "}"
     return masterTP
 end
 

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -413,7 +413,7 @@ end
 local categoriesToCheck = {
     ['tech'] = {"TECH1", "TECH2", "TECH3", "EXPERIMENTAL", 'COMMAND'},
     ['faction'] = {"CYBRAN", "UEF", "AEON", "SERAPHIM"},
-    ['type'] = {'SCOUT', "DIRECTFIRE", 'INDIRECTFIRE', 'DEFENSE', "ANTIAIR", 'TRANSPORTATION', "ENGINEER",},
+    ['type'] = {"FACTORY", 'SCOUT', "DIRECTFIRE", 'INDIRECTFIRE', 'DEFENSE', "ANTIAIR", 'TRANSPORTATION', "ENGINEER",},
     ['field'] = {"NAVAL", "AIR", "LAND", "STRUCTURE"},
 }
 

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -405,13 +405,81 @@ function SetWeaponPrioritiesSpecific()
 
         local target = targeting[string.upper(bpId)]
 
+        
         if target then
             SetWeaponPriorities(target, text, false)
         else
-            SetWeaponPriorities("{categories." .. bpId .. "}", text, false)
+            SetWeaponPriorities(findPriority(bpId), text, false)
         end 
         SimCallback({Func = 'RecheckTargetsOfWeapons', Args = { }}, true)
     end
+end
+
+function findPriority(bpID)
+    local bp = __blueprints[bpID]
+    local categories = bp.Categories
+    local tech
+    local faction
+    local type
+    local field
+
+
+    for _, c in categories do
+        LOG(c)
+    end
+
+    for _, c in categories do 
+        if c == "TECH1" then
+            tech = "TECH1"
+        elseif c == "TECH2" then
+            tech = "TECH2"
+        elseif c == "TECH3" then
+            tech = "TECH3"
+        elseif c == "CYBRAN" then
+            faction = "CYBRAN"
+        elseif c == "UEF" then
+            faction = "UEF"
+        elseif c == "AEON" then
+            faction = "AEON"
+        elseif c == "SERAPHIM" then
+            faction = "SERAPHIM"
+        elseif c == "ANTIAIR" then
+            type = "ANTIAIR"
+        elseif c == "DIRECTFIRE" then
+            type = "DIRECTFIRE"
+        elseif c == "NAVY" then
+            field = "NAVY"
+        elseif c == "AIR" then
+            field = "AIR"
+        elseif c == "LAND" then
+            field = "LAND"
+        elseif c == "STRUCTURE" then
+            field = "STRUCTURE"
+        end
+    end
+
+    LOG(tech)
+    LOG(faction)
+    LOG(type)
+
+    tech = "categories." .. tech
+    faction = "categories." .. faction
+    type = "categories." .. type
+    field = "categories." .. field
+
+    local tp = "{" .. tech .. " + " .. faction .. " + " .. type .. " + " .. field .. "}"
+    local tp2 = "{" .. tech .. " + " .. type .. " + " .. field .."}"
+    local tp3 = "{" .. type .. " + " .. field .."}"
+    local tp4 = "{" .. field .."}"
+
+    local masterTP = tp .. ", " .. tp2 .. ", " .. tp3 .. ", " .. tp4
+    LOG(tp)
+    LOG(tp2)
+    LOG(tp3)
+    LOG(tp4)
+    LOG(masterTP)
+
+    return masterTP
 end
 
 function RecheckTargetsOfWeapons()

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -390,6 +390,7 @@ function SetWeaponPriorities(prioritiesString, name, exclusive)
     SimCallback({Func = 'WeaponPriorities', Args = {SelectedUnits = unitIds, prioritiesTable = priotable, name = name, exclusive = exclusive or false }})
 end
 
+--- Sets selected units to target the unit (and similar units) that is hovered over
 function SetWeaponPrioritiesSpecific()
     local info = GetRolloverInfo()
     if info and info.blueprintId ~= "unknown" then
@@ -404,7 +405,7 @@ function SetWeaponPrioritiesSpecific()
         SetWeaponPriorities(findPriority(bpId), text, false)
     end
 end
-
+--- Sets selected units to their default target priority
 function SetDefaultWeaponPriorities()
     SetWeaponPriorities(0, "Default", false)
 end
@@ -416,6 +417,8 @@ local categoriesToCheck = {
     ['field'] = {"NAVAL", "AIR", "LAND", "STRUCTURE"},
 }
 
+--- Creates a target priority that includes the tech, faction, type, and field of a unit
+    ---@param bpId The ID of the unit which is to be targetted
 function findPriority(bpID)
     local bp = __blueprints[bpID]
     local categories = bp.CategoriesHash

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -1,6 +1,7 @@
 -- This file contains key bindable actions that don't fit elsewhere
 
 local Prefs = import('/lua/user/prefs.lua')
+local targeting = import('/lua/keymap/targeting.lua').targetingMap
 
 local lockZoomEnable = false
 function lockZoom()
@@ -388,6 +389,29 @@ function SetWeaponPriorities(prioritiesString, name, exclusive)
     end
 
     SimCallback({Func = 'WeaponPriorities', Args = {SelectedUnits = unitIds, prioritiesTable = priotable, name = name, exclusive = exclusive or false }})
+end
+
+function SetWeaponPrioritiesSpecific()
+    local info = GetRolloverInfo()
+    if info and info.blueprintId ~= "unknown" then
+
+        local bpId = info.blueprintId
+        local text = LOC(__blueprints[bpId].General.UnitName)     
+        if text then
+            text = "\n" .. text .. " — " .. LOC(__blueprints[bpId].Interface.HelpText)
+        else
+            text = "\n" .. LOC(__blueprints[bpId].Interface.HelpText)
+        end
+
+        local target = targeting[string.upper(bpId)]
+
+        if target then
+            SetWeaponPriorities(target, text, false)
+        else
+            SetWeaponPriorities("{categories." .. bpId .. "}", text, false)
+        end 
+        SimCallback({Func = 'RecheckTargetsOfWeapons', Args = { }}, true)
+    end
 end
 
 function RecheckTargetsOfWeapons()

--- a/lua/keymap/targeting.lua
+++ b/lua/keymap/targeting.lua
@@ -1,4 +1,0 @@
-targetingMap = {
-    ['XSL0205'] = '{categories.ANTIAIR + categories.TECH2 + categories.MOBILE}',
-    ['UAL0205'] = '{categories.ANTIAIR + categories.TECH2 + categories.MOBILE}',
-}

--- a/lua/keymap/targeting.lua
+++ b/lua/keymap/targeting.lua
@@ -1,0 +1,4 @@
+targetingMap = {
+    ['XSL0205'] = '{categories.ANTIAIR + categories.TECH2 + categories.MOBILE}',
+    ['UAL0205'] = '{categories.ANTIAIR + categories.TECH2 + categories.MOBILE}',
+}


### PR DESCRIPTION
This PR integrates @4z0t's ui mod called Specific Target Priorities to the game. This mod allows a player to select with a hotkey the kind of unit they with their units to target. In addition to integrating the current mod i am also making modifications that will allow the targeting of all variations of units (different factions) without selecting each on individually.