### PR TITLE
Add check if on overcharge if weapon is destroyed

### DIFF
--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -496,10 +496,18 @@ OverchargeProjectile = Class() {
         self.DamageData.DamageAmount = 0
 
         local launcher = self:GetLauncher()
-        if not launcher then return end
+        if not launcher then 
+            return 
+        end
 
         local wep = launcher:GetWeaponByLabel('OverCharge')
-        if not wep then return end
+        if not wep then
+             return 
+            end
+
+        if IsDestroyed(wep) then
+            return
+        end
 
         --  Table layout for Overcharge data section
         --  Overcharge = {


### PR DESCRIPTION
```
WARNING: Error running OnImpact script in Entity /projectiles/tdfovercharge01/tdfovercharge01_proj.bp at 2bb2c000: ...ocuments\delete-me\fa\lua\sim\defaultprojectiles.lua(513): Game object has been destroyed
         stack traceback:
         	[C]: in function `GetBlueprint'
         	...ocuments\delete-me\fa\lua\sim\defaultprojectiles.lua(513): in function `OnImpact'
         	...ojectiles\tdfovercharge01\tdfovercharge01_script.lua(19): in function <...ojectiles\tdfovercharge01\tdfovercharge01_script.lua:18>
```

Technically this means that OC has never done damage when it launched but the ACU got destroyed before the projectile impacted.