### PR TITLE
Add guard when creating impact effects

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -573,6 +573,10 @@ Shield = Class(moho.shield_methods, Entity) {
 
     CreateImpactEffect = function(self, vector)
 
+        if IsDestroyed(self) then
+            return
+        end
+
         -- keep track of this entity
         self.LiveImpactEntities = self.LiveImpactEntities + 1
 
@@ -1202,6 +1206,10 @@ PersonalShield = Class(Shield){
 
     CreateImpactEffect = function(self, vector)
 
+        if IsDestroyed(self) then
+            return
+        end
+
         -- keep track of this entity
         self.LiveImpactEntities = self.LiveImpactEntities + 1
 
@@ -1318,6 +1326,10 @@ CzarShield = Class(PersonalShield) {
 
 
     CreateImpactEffect = function(self, vector)
+
+        if IsDestroyed(self) then
+            return
+        end
 
         self.LiveImpactEntities = self.LiveImpactEntities + 1
 


### PR DESCRIPTION
```
WARNING: Error running lua script: c:\users\jip\documents\delete-me\fa\lua\shield.lua(593): Game object has been destroyed
         stack traceback:
         	[C]: ?
         	c:\users\jip\documents\delete-me\fa\lua\shield.lua(593): in function <c:\users\jip\documents\delete-me\fa\lua\shield.lua:574>
```

Adds a guard to check if the shield still exists when we create the impact effects.