### PR TITLE
Add annotation to ignore some file specific non errors

### DIFF
--- a/lua/EffectTemplates.lua
+++ b/lua/EffectTemplates.lua
@@ -1,3 +1,4 @@
+---@diagnostic disable:local-limit
 -- ****************************************************************************
 -- **
 -- **  File     :  /data/lua/EffectTemplates.lua

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -240,7 +240,7 @@ function OnSync()
     end
 
     if Sync.Cheaters then
-        # Ted, this is where you would hook in better cheater reporting.
+        --Ted, this is where you would hook in better cheater reporting.
         local names = ''
         local isare = LOC('<LOC cheating_fragment_0000>is')
         local srcs = SessionGetCommandSourceNames()

--- a/lua/lazyvar.lua
+++ b/lua/lazyvar.lua
@@ -109,6 +109,7 @@ function LazyVarMetaTable:Destroy()
 end
 
 function Create(initial)
+    ---@diagnostic disable-next-line:miss-symbol,unknown-symbol
     local result = {&1&4}
     setmetatable(result, LazyVarMetaTable)
     if initial == nil then 

--- a/lua/ui/game/vo_computer.lua
+++ b/lua/ui/game/vo_computer.lua
@@ -1,4 +1,4 @@
-﻿
+﻿---@diagnostic disable:local-limit
 --*****************************************************************************
 --* File: C:\work\rts\main\data\lua\modules\ui\game\vo_computer.lua
 --* Author: (BOT)Sam Demulling & (BOT)Marshall Macy II

--- a/lua/ui/game/vo_xgg.lua
+++ b/lua/ui/game/vo_xgg.lua
@@ -1,4 +1,4 @@
-
+---@diagnostic disable:local-limit
 --*****************************************************************************
 --* File: C:\work\rts\main\data\lua\ui\game\vo_xgg.lua
 --* Author: (BOT)Sam Demulling 


### PR DESCRIPTION
These files had errors from the extension because there's so many locals declared and it gives up at some point, this just disables those errors. And a few other minor errors.