### PR TITLE
Fix Solace not having the bomber category

### DIFF
--- a/units/XAA0306/XAA0306_unit.bp
+++ b/units/XAA0306/XAA0306_unit.bp
@@ -91,6 +91,7 @@ UnitBlueprint {
         'MOBILE',
         'AIR',
         'HIGHALTAIR',
+        'BOMBER',
         'TECH3',
         'ANTINAVY',
         'VISIBLETORECON',


### PR DESCRIPTION
Just like all the other torpedo bombers.