### PR TITLE
adjust typing of Class so it works again

### DIFF
--- a/lua/system/class.lua
+++ b/lua/system/class.lua
@@ -157,12 +157,12 @@ function State(...)
     end
 end
 
----@overload fun(specs: fa-class): fa-class
 --- Prepares the construction of a class, referring to the paragraphs of text at the top of this file.
 ---construct a class
 ---@generic T: fa-class
----@param ... fa-class
----@return fun(specs: T): T
+---@generic T_Base: fa-class
+---@param ... T_Base
+---@return fun(specs: T): T|T_Base
 function Class(...)
     -- arg = { 
     --     { 
@@ -176,10 +176,9 @@ function Class(...)
 
     -- Class ({ field=value, field=value, ... })
     if IsSimpleClass(arg) then
-        ---@type fa-class
-        local class = arg[1]
+        local class = arg[1] --[[@as fa-class]]
         setmetatable(class, ClassFactory)
-        return ConstructClass(nil, class)
+        return ConstructClass(nil, class) --[[@as unknown]]
     -- Class(Base1, Base2, ...) ({field = value, field = value, ...})
     else
         local bases = { unpack (arg) }


### PR DESCRIPTION
Basically a while ago I merged in new changes to the extension, and that broke how our class function worked. Looks like some people have tried to fix it with some annotations, but that didn't really seem to work.

This should be a working fine, please confirm we're not seeing any warnings like this:
![image](https://user-images.githubusercontent.com/4575355/184589402-e39c2f71-b6a7-4586-92f5-a7f9f605cf2b.png)
