### PR TITLE
Fix The Mass Left Behind when the upgrade kennel is destroyed

### DIFF
--- a/units/XEB0204/XEB0204_unit.bp
+++ b/units/XEB0204/XEB0204_unit.bp
@@ -123,7 +123,7 @@ UnitBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        BuildCostEnergy = 2500,
+        BuildCostEnergy = 5250,
         BuildCostMass = 1050,
         BuildRate = 20,
         BuildTime = 2000,

--- a/units/XEB0204/XEB0204_unit.bp
+++ b/units/XEB0204/XEB0204_unit.bp
@@ -124,9 +124,10 @@ UnitBlueprint {
     },
     Economy = {
         BuildCostEnergy = 2500,
-        BuildCostMass = 500,
+        BuildCostMass = 1050,
         BuildRate = 20,
         BuildTime = 2000,
+        DifferentialUpgradeCostCalculation = true,
         EngineeringPods = {
             {
                 CreateWithUnit = true,


### PR DESCRIPTION
- Set BuildCostMass to `1050` from `500` to allow for the Differential Upgrade Cost Calculation Parameter to work correctly
- Set BuildCostEnergy to `2500` from `5250`
- Add `DifferentialUpgradeCostCalculation = true`
