### PR TITLE
Remove cache concept of units

### DIFF
--- a/lua/EffectUtilitiesAeon.lua
+++ b/lua/EffectUtilitiesAeon.lua
@@ -181,7 +181,7 @@ local function SharedBuildThread(pool, unitBeingBuilt, trash, onStopBeingBuiltTr
     -- -- Determine offset for hover units
     local offset = 0
     local slider = nil
-    if unitBeingBuilt.Cache.HashedCats["HOVER"] then
+    if unitBeingBuilt.Blueprint.CategoriesHash["HOVER"] then
         -- set elevation offset
         offset = unitBeingBuilt.Blueprint.Elevation or 0
         -- create a slider

--- a/lua/EffectUtilitiesSeraphim.lua
+++ b/lua/EffectUtilitiesSeraphim.lua
@@ -70,7 +70,7 @@ function CreateSeraphimFactoryBuildingEffects(builder, unitBeingBuilt, effectBon
 
     -- do not apply offsets for subs and air units
     local offset = 0
-    if unitBeingBuilt.Cache.HashedCats["HOVER"] then
+    if unitBeingBuilt.Blueprint.CategoriesHash["HOVER"] then
         offset = bp.Elevation or 0
     end
 

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -663,7 +663,7 @@ Shield = Class(moho.shield_methods, Entity) {
         end
 
         -- special behavior for projectiles that represent strategic missiles
-        local otherHashedCats = other.Cache.HashedCats
+        local otherHashedCats = other.Blueprint.CategoriesHash
         if otherHashedCats['STRATEGIC'] and otherHashedCats['MISSILE'] then
             return false
         end


### PR DESCRIPTION
Removes the caching concept that was introduced a while back with https://github.com/FAForever/fa/issues/3691. The concept didn't work out, it was better to just put the data in the blueprint during blueprint loading and store a reference to the blueprint in the unit.

Builds on top of #4138 to prevent collisions