### PR TITLE
Reduce pre-allocated trashbag count

### DIFF
--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -814,18 +814,6 @@ CConstructionStructureUnit = Class(CStructureUnit, CConstructionTemplate) {
             return false
         end
     end,
-
-    CreateReclaimEffects = function(self, target)
-        EffectUtil.PlayReclaimEffects(self, target, self.BuildEffectBones or {0, }, self.ReclaimEffectsBag)
-    end,
-
-    CreateReclaimEndEffects = function(self, target)
-        EffectUtil.PlayReclaimEndEffects(self, target)
-    end,
-
-    CreateCaptureEffects = function(self, target)
-        EffectUtil.PlayCaptureEffects(self, target, self.BuildEffectBones or {0, }, self.CaptureEffectsBag)
-    end,
 }
 
 -- CCommandUnit

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1697,27 +1697,6 @@ MobileUnit = Class(Unit) {
         end
     end,
 
-    ---comment
-    ---@param self MobileUnit
-    ---@param target Unit
-    CreateReclaimEffects = function(self, target)
-        EffectUtil.PlayReclaimEffects(self, target, self.BuildEffectBones or {0, }, self.ReclaimEffectsBag)
-    end,
-
-    ---comment
-    ---@param self MobileUnit
-    ---@param target Unit
-    CreateReclaimEndEffects = function(self, target)
-        EffectUtil.PlayReclaimEndEffects(self, target)
-    end,
-
-    ---comment
-    ---@param self MobileUnit
-    ---@param target Unit
-    CreateCaptureEffects = function(self, target)
-        EffectUtil.PlayCaptureEffects(self, target, self.BuildEffectBones or {0, }, self.CaptureEffectsBag)
-    end,
-
     -- Units with layer change effects (amphibious units like Megalith) need
     -- those changes applied when build ends, so we need to trigger the
     -- layer change event

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -284,9 +284,7 @@ Unit = Class(moho.unit_methods) {
         self.IdleEffectsBag = TrashBag()
         self.TopSpeedEffectsBag = TrashBag()
         self.BeamExhaustEffectsBag = TrashBag()
-        self.TransportBeamEffectsBag = TrashBag()
         self.BuildEffectsBag = TrashBag()
-        self.ReclaimEffectsBag = TrashBag()
         self.OnBeingBuiltEffectsBag = TrashBag()
 
         -- Set up veterancy
@@ -765,6 +763,7 @@ Unit = Class(moho.unit_methods) {
     end,
 
     StartReclaimEffects = function(self, target)
+        self.ReclaimEffectsBag = self.ReclaimEffectsBag or TrashBag()
         self.ReclaimEffectsBag:Add(self:ForkThread(self.CreateReclaimEffects, target))
     end,
 
@@ -1970,6 +1969,10 @@ Unit = Class(moho.unit_methods) {
         TrashDestroy(self.TopSpeedEffectsBag)
         TrashDestroy(self.BeamExhaustEffectsBag)
         TrashDestroy(self.TransportBeamEffectsBag)
+
+        if self.TransportBeamEffectsBag then 
+            self.TransportBeamEffectsBag:Destroy()
+        end
 
         -- destroy remaining trash of weapon
         for k = 1, self.WeaponCount do 
@@ -4109,6 +4112,7 @@ Unit = Class(moho.unit_methods) {
         self:DestroyIdleEffects()
         self:DestroyMovementEffects()
 
+        self.TransportBeamEffectsBag = self.TransportBeamEffectsBag or TrashBag()
         TrashAdd(self.TransportBeamEffectsBag, AttachBeamEntityToEntity(self, -1, transport, bone, self.Army, EffectTemplate.TTransportBeam01))
         TrashAdd(self.TransportBeamEffectsBag, AttachBeamEntityToEntity(transport, bone, self, -1, self.Army, EffectTemplate.TTransportBeam02))
         TrashAdd(self.TransportBeamEffectsBag, CreateEmitterAtBone(transport, bone, self.Army, EffectTemplate.TTransportGlow01))

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -289,7 +289,6 @@ Unit = Class(moho.unit_methods) {
         self.ReclaimEffectsBag = TrashBag()
         self.OnBeingBuiltEffectsBag = TrashBag()
         self.CaptureEffectsBag = TrashBag()
-        self.UpgradeEffectsBag = TrashBag()
 
         -- Set up veterancy
         self.xp = 0
@@ -623,6 +622,7 @@ Unit = Class(moho.unit_methods) {
     end,
 
     StartCaptureEffects = function(self, target)
+        self.CaptureEffectsBag = self.CaptureEffectsBag or TrashBag()
         self.CaptureEffectsBag:Add(self:ForkThread(self.CreateCaptureEffects, target))
     end,
 
@@ -3123,6 +3123,8 @@ Unit = Class(moho.unit_methods) {
         local bp = self.Blueprint.Enhancements[enhancement]
         local effects = TrashBag()
         local scale = math.min(4, math.max(1, (bp.BuildCostEnergy / bp.BuildTime or 1) / 50))
+
+        self.UpgradeEffectsBag = self.UpgradeEffectsBag or TrashBag()
 
         if bp.UpgradeEffectBones then
             for _, v in bp.UpgradeEffectBones do

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -623,6 +623,7 @@ Unit = Class(moho.unit_methods) {
     end,
 
     CreateCaptureEffects = function(self, target)
+        EffectUtilities.PlayCaptureEffects(self, target, self.BuildEffectBones or {0, }, self.CaptureEffectsBag)
     end,
 
     StopCaptureEffects = function(self, target)
@@ -767,9 +768,11 @@ Unit = Class(moho.unit_methods) {
     end,
 
     CreateReclaimEffects = function(self, target)
+        EffectUtilities.PlayReclaimEffects(self, target, self.BuildEffectBones or {0, }, self.ReclaimEffectsBag)
     end,
 
     CreateReclaimEndEffects = function(self, target)
+        EffectUtilities.PlayReclaimEndEffects(self, target)
     end,
 
     StopReclaimEffects = function(self, target)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -290,7 +290,6 @@ Unit = Class(moho.unit_methods) {
         self.OnBeingBuiltEffectsBag = TrashBag()
         self.CaptureEffectsBag = TrashBag()
         self.UpgradeEffectsBag = TrashBag()
-        self.TeleportFxBag = TrashBag()
 
         -- Set up veterancy
         self.xp = 0
@@ -4275,23 +4274,28 @@ Unit = Class(moho.unit_methods) {
         EffectUtilities.TeleportChargingProgress(self, progress)
     end,
 
-    PlayTeleportChargeEffects = function(self, location, orientation, teleDelay)
+    PlayTeleportChargeEffects = function(self, location, orientation, teleDelay)\
+        self.TeleportFxBag = self.TeleportFxBag or TrashBag()
         EffectUtilities.PlayTeleportChargingEffects(self, location, self.TeleportFxBag, teleDelay)
     end,
 
     CleanupTeleportChargeEffects = function(self)
+        self.TeleportFxBag = self.TeleportFxBag or TrashBag()
         EffectUtilities.DestroyTeleportChargingEffects(self, self.TeleportFxBag)
     end,
 
     CleanupRemainingTeleportChargeEffects = function(self)
+        self.TeleportFxBag = self.TeleportFxBag or TrashBag()
         EffectUtilities.DestroyRemainingTeleportChargingEffects(self, self.TeleportFxBag)
     end,
 
     PlayTeleportOutEffects = function(self)
+        self.TeleportFxBag = self.TeleportFxBag or TrashBag()
         EffectUtilities.PlayTeleportOutEffects(self, self.TeleportFxBag)
     end,
 
     PlayTeleportInEffects = function(self)
+        self.TeleportFxBag = self.TeleportFxBag or TrashBag()
         EffectUtilities.PlayTeleportInEffects(self, self.TeleportFxBag)
     end,
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -288,7 +288,6 @@ Unit = Class(moho.unit_methods) {
         self.BuildEffectsBag = TrashBag()
         self.ReclaimEffectsBag = TrashBag()
         self.OnBeingBuiltEffectsBag = TrashBag()
-        self.CaptureEffectsBag = TrashBag()
 
         -- Set up veterancy
         self.xp = 0

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1970,7 +1970,6 @@ Unit = Class(moho.unit_methods) {
         TrashDestroy(self.IdleEffectsBag)
         TrashDestroy(self.TopSpeedEffectsBag)
         TrashDestroy(self.BeamExhaustEffectsBag)
-        TrashDestroy(self.TransportBeamEffectsBag)
 
         if self.TransportBeamEffectsBag then 
             self.TransportBeamEffectsBag:Destroy()
@@ -4284,7 +4283,7 @@ Unit = Class(moho.unit_methods) {
         EffectUtilities.TeleportChargingProgress(self, progress)
     end,
 
-    PlayTeleportChargeEffects = function(self, location, orientation, teleDelay)\
+    PlayTeleportChargeEffects = function(self, location, orientation, teleDelay)
         self.TeleportFxBag = self.TeleportFxBag or TrashBag()
         EffectUtilities.PlayTeleportChargingEffects(self, location, self.TeleportFxBag, teleDelay)
     end,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -284,7 +284,6 @@ Unit = Class(moho.unit_methods) {
         self.IdleEffectsBag = TrashBag()
         self.TopSpeedEffectsBag = TrashBag()
         self.BeamExhaustEffectsBag = TrashBag()
-        self.BuildEffectsBag = TrashBag()
         self.OnBeingBuiltEffectsBag = TrashBag()
 
         -- Set up veterancy
@@ -2576,6 +2575,9 @@ Unit = Class(moho.unit_methods) {
     end,
 
     OnStartBuild = function(self, built, order)
+
+        self.BuildEffectsBag = self.BuildEffectsBag or TrashBag()
+
         -- Prevent UI mods from violating game/scenario restrictions
         local id = built.UnitId
         local bp = built:GetBlueprint()


### PR DESCRIPTION
A lot of trashbags are allocated for a unit even if the unit is incapable of using the bag. One example being the `CaptureEffectsBag`. Instead of pre-allocating, we allocate them as we start using the bags.