### PR TITLE
Fix internal state of HQs

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -741,7 +741,9 @@ FactoryUnit = Class(StructureUnit) {
     OnDestroy = function(self)
         StructureUnit.OnDestroy(self)
         
-        if self.Blueprint.CategoriesHash["RESEARCH"] then
+        if self.Blueprint.CategoriesHash["RESEARCH"] and self:GetFractionComplete() == 1.0 then
+
+            LOG("OnDestroy")
 
             -- update internal state
             self.Brain:RemoveHQ(self.factionCategory, self.layerCategory, self.techCategory)
@@ -783,13 +785,6 @@ FactoryUnit = Class(StructureUnit) {
     OnStartBuild = function(self, unitBeingBuilt, order)
         StructureUnit.OnStartBuild(self, unitBeingBuilt, order)
 
-        -- related to HQ systems
-        if self.Blueprint.CategoriesHash["RESEARCH"] then
-            if EntityCategoryContains(categories.RESEARCH, self) then
-                unitBeingBuilt.UpgradedHQFromTech = self.techCategory
-            end
-        end
-
         self.BuildingUnit = true
         if order ~= 'Upgrade' then
             ChangeState(self, self.BuildingState)
@@ -823,11 +818,6 @@ FactoryUnit = Class(StructureUnit) {
         StructureUnit.OnStopBeingBuilt(self, builder, layer)
 
         if self.Blueprint.CategoriesHash["RESEARCH"] then
-            -- if we're an upgrade then remove the HQ we came from
-            if self.UpgradedHQFromTech then
-                self.Brain:RemoveHQ(self.factionCategory, self.layerCategory, self.UpgradedHQFromTech)
-            end
-
             -- update internal state
             self.Brain:AddHQ(self.factionCategory, self.layerCategory, self.techCategory)
             self.Brain:SetHQSupportFactoryRestrictions(self.factionCategory, self.layerCategory)

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -742,9 +742,7 @@ FactoryUnit = Class(StructureUnit) {
         StructureUnit.OnDestroy(self)
         
         if self.Blueprint.CategoriesHash["RESEARCH"] and self:GetFractionComplete() == 1.0 then
-
-            LOG("OnDestroy")
-
+            
             -- update internal state
             self.Brain:RemoveHQ(self.factionCategory, self.layerCategory, self.techCategory)
             self.Brain:SetHQSupportFactoryRestrictions(self.factionCategory, self.layerCategory)


### PR DESCRIPTION
As mentioned on Discord and on [the forums](https://forum.faforever.com/topic/4696/cant-build-support-factories) there's an issue with the internal state of HQs. When refactoring it to fix an issue we didn't properly check the edge cases. In particular:

- if an hq would be cancelled during construction then the internal state becomes corrupt
- if an hq tech 3 is finished, the previous tech is removed twice: corrupting the internal state again

