### PR TITLE
refactor AI economy conditions

### DIFF
--- a/lua/editor/EconomyBuildConditions.lua
+++ b/lua/editor/EconomyBuildConditions.lua
@@ -14,7 +14,7 @@ local GetEconomyStoredRatio = moho.aibrain_methods.GetEconomyStoredRatio
 local GetEconomyIncome = moho.aibrain_methods.GetEconomyIncome
 local GetEconomyRequested = moho.aibrain_methods.GetEconomyRequested
 local GetEconomyStored = moho.aibrain_methods.GetEconomyStored
-local ParagonCat = categories.ENERGYPRODUCTION * categories.EXPERIMENTAL * categories.STRUCTURE
+local ParagonCat = categories.STRUCTURE * categories.EXPERIMENTAL * categories.ECONOMIC * categories.ENERGYPRODUCTION * categories.MASSPRODUCTION
 
 local AIUtils = import('/lua/ai/aiutilities.lua')
 

--- a/lua/editor/EconomyBuildConditions.lua
+++ b/lua/editor/EconomyBuildConditions.lua
@@ -8,6 +8,13 @@
 --**
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
+
+local GetEconomyTrend = moho.aibrain_methods.GetEconomyTrend
+local GetEconomyStoredRatio = moho.aibrain_methods.GetEconomyStoredRatio
+local GetEconomyIncome = moho.aibrain_methods.GetEconomyIncome
+local GetEconomyRequested = moho.aibrain_methods.GetEconomyRequested
+local GetEconomyStored = moho.aibrain_methods.GetEconomyStored
+
 local AIUtils = import('/lua/ai/aiutilities.lua')
 
 ---GreaterThanEconStorageRatio = BuildCondition
@@ -16,8 +23,7 @@ local AIUtils = import('/lua/ai/aiutilities.lua')
 ---@param eStorageRatio number
 ---@return boolean
 function GreaterThanEconStorageRatio(aiBrain, mStorageRatio, eStorageRatio)
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if (econ.MassStorageRatio >= mStorageRatio and econ.EnergyStorageRatio >= eStorageRatio) then
+    if GetEconomyStoredRatio(aiBrain, 'MASS') >= mStorageRatio and GetEconomyStoredRatio(aiBrain, 'ENERGY') >= eStorageRatio then
         return true
     end
     return false
@@ -42,8 +48,7 @@ end
 ---@param eStorage integer
 ---@return boolean
 function GreaterThanEconStorageCurrent(aiBrain, mStorage, eStorage)
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if (econ.MassStorage >= mStorage and econ.EnergyStorage >= eStorage) then
+    if GetEconomyStored(aiBrain, 'MASS') >= mStorage and GetEconomyStored(aiBrain, 'ENERGY') >= eStorage then
         return true
     end
     return false
@@ -54,8 +59,7 @@ end
 ---@param eStorage integer
 ---@return boolean
 function GreaterThanEnergyStorageCurrent(aiBrain, eStorage)
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if econ.EnergyStorage > eStorage then
+    if GetEconomyStored(aiBrain, 'ENERGY') > eStorage then
         return true
     end
     return false
@@ -66,8 +70,7 @@ end
 ---@param mStorage integer
 ---@return boolean
 function GreaterThanMassStorageCurrent(aiBrain, mStorage)
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if econ.MassStorage > mStorage then
+    if GetEconomyStored(aiBrain, 'MASS') > mStorage then
         return true
     end
     return false
@@ -79,12 +82,10 @@ end
 ---@param eTrend integer
 ---@return boolean
 function LessThanEconTrend(aiBrain, mTrend, eTrend)
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if (econ.MassTrend < mTrend and econ.EnergyTrend < eTrend) then
+    if GetEconomyTrend(aiBrain, 'MASS') < mTrend and GetEconomyTrend(aiBrain, 'ENERGY') < eTrend then
         return true
-    else
-        return false
     end
+    return false
 end
 
 ---LessThanEconStorageRatio = BuildCondition
@@ -93,8 +94,7 @@ end
 ---@param eStorageRatio integer
 ---@return boolean
 function LessThanEconStorageRatio(aiBrain, mStorageRatio, eStorageRatio)
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if (econ.MassStorageRatio < mStorageRatio and econ.EnergyStorageRatio < eStorageRatio) then
+    if GetEconomyStoredRatio(aiBrain, 'MASS') < mStorageRatio and GetEconomyStoredRatio(aiBrain, 'ENERGY') < eStorageRatio then
         return true
     end
     return false
@@ -119,8 +119,7 @@ end
 ---@param eStorage integer
 ---@return boolean
 function LessEconStorageCurrent(aiBrain, mStorage, eStorage)
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if (econ.MassStorage < mStorage and econ.EnergyStorage < eStorage) then
+    if GetEconomyStored(aiBrain, 'MASS') < mStorage and GetEconomyStored(aiBrain, 'ENERGY') < eStorage then
         return true
     end
     return false
@@ -131,8 +130,7 @@ end
 ---@param eStorage integer
 ---@return boolean
 function LessThanEnergyStorageCurrent(aiBrain, eStorage)
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if econ.EnergyStorage < eStorage then
+    if GetEconomyStored(aiBrain, 'ENERGY') < eStorage then
         return true
     end
     return false
@@ -143,8 +141,7 @@ end
 ---@param mStorage integer
 ---@return boolean
 function LessThanMassStorageCurrent(aiBrain, mStorage)
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if econ.MassStorage < mStorage then
+    if GetEconomyStored(aiBrain, 'MASS') < mStorage then
         return true
     end
     return false
@@ -156,8 +153,7 @@ end
 ---@param EnergyTrend integer
 ---@return boolean
 function GreaterThanEconTrend(aiBrain, MassTrend, EnergyTrend)
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if (econ.MassTrend >= MassTrend and econ.EnergyTrend >= EnergyTrend) then
+    if GetEconomyTrend(aiBrain, 'MASS') >= MassTrend and GetEconomyTrend(aiBrain, 'ENERGY') >= EnergyTrend then
         return true
     end
     return false
@@ -169,12 +165,11 @@ end
 ---@param EnergyIncome integer
 ---@return boolean
 function GreaterThanEconIncome(aiBrain, MassIncome, EnergyIncome)
-    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, 'ENERGYPRODUCTION EXPERIMENTAL STRUCTURE') then
+    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, categories.ENERGYPRODUCTION * categories.EXPERIMENTAL * categories.STRUCTURE) then
         --LOG('*AI DEBUG: Found Paragon')
         return true
     end
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if (econ.MassIncome >= MassIncome and econ.EnergyIncome >= EnergyIncome) then
+    if (GetEconomyIncome(aiBrain,'MASS') >= MassIncome and GetEconomyIncome(aiBrain,'ENERGY') >= EnergyIncome) then
         return true
     end
     return false
@@ -186,12 +181,11 @@ end
 ---@param EnergyIncome integer
 ---@return boolean
 function LessThanEconIncome(aiBrain, MassIncome, EnergyIncome)
-    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, 'ENERGYPRODUCTION EXPERIMENTAL STRUCTURE') then
+    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, categories.ENERGYPRODUCTION * categories.EXPERIMENTAL * categories.STRUCTURE) then
         --LOG('*AI DEBUG: Found Paragon')
         return false
     end
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if (econ.MassIncome < MassIncome and econ.EnergyIncome < EnergyIncome) then
+    if (GetEconomyIncome(aiBrain,'MASS') < MassIncome and GetEconomyIncome(aiBrain,'ENERGY') < EnergyIncome) then
         return true
     end
     return false
@@ -203,12 +197,13 @@ end
 ---@param EnergyEfficiency integer
 ---@return boolean
 function GreaterThanEconEfficiency(aiBrain, MassEfficiency, EnergyEfficiency)
-    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, 'ENERGYPRODUCTION EXPERIMENTAL STRUCTURE') then
+    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, categories.ENERGYPRODUCTION * categories.EXPERIMENTAL * categories.STRUCTURE) then
         --LOG('*AI DEBUG: Found Paragon')
         return true
     end
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if (econ.MassEfficiency >= MassEfficiency and econ.EnergyEfficiency >= EnergyEfficiency) then
+    local EnergyEfficiencyCurrent = math.min(GetEconomyIncome(aiBrain,'ENERGY') / GetEconomyRequested(aiBrain,'ENERGY'), 2)
+    local MassEfficiencyCurrent = math.min(GetEconomyIncome(aiBrain,'MASS') / GetEconomyRequested(aiBrain,'MASS'), 2)
+    if (MassEfficiencyCurrent >= MassEfficiency and EnergyEfficiencyCurrent >= EnergyEfficiency) then
         return true
     end
     return false
@@ -220,12 +215,13 @@ end
 ---@param EnergyEfficiency integer
 ---@return boolean
 function LessThanEconEfficiency(aiBrain, MassEfficiency, EnergyEfficiency)
-    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, 'ENERGYPRODUCTION EXPERIMENTAL STRUCTURE') then
+    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, categories.ENERGYPRODUCTION * categories.EXPERIMENTAL * categories.STRUCTURE) then
         --LOG('*AI DEBUG: Found Paragon')
         return false
     end
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if (econ.MassEfficiency <= MassEfficiency and econ.EnergyEfficiency <= EnergyEfficiency) then
+    local EnergyEfficiencyCurrent = math.min(GetEconomyIncome(aiBrain,'ENERGY') / GetEconomyRequested(aiBrain,'ENERGY'), 2)
+    local MassEfficiencyCurrent = math.min(GetEconomyIncome(aiBrain,'MASS') / GetEconomyRequested(aiBrain,'MASS'), 2)
+    if (MassEfficiencyCurrent <= MassEfficiency and EnergyEfficiencyCurrent <= EnergyEfficiency) then
         return true
     end
     return false
@@ -237,7 +233,7 @@ end
 ---@param EnergyEfficiency integer
 ---@return boolean
 function GreaterThanEconEfficiencyOverTime(aiBrain, MassEfficiency, EnergyEfficiency)
-    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, 'ENERGYPRODUCTION EXPERIMENTAL STRUCTURE') then
+    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, categories.ENERGYPRODUCTION * categories.EXPERIMENTAL * categories.STRUCTURE) then
         --LOG('*AI DEBUG: Found Paragon')
         return true
     end
@@ -254,7 +250,7 @@ end
 ---@param EnergyEfficiency integer
 ---@return boolean
 function LessThanEconEfficiencyOverTime(aiBrain, MassEfficiency, EnergyEfficiency)
-    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, 'ENERGYPRODUCTION EXPERIMENTAL STRUCTURE') then
+    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, categories.ENERGYPRODUCTION * categories.EXPERIMENTAL * categories.STRUCTURE) then
         --LOG('*AI DEBUG: Found Paragon')
         return false
     end

--- a/lua/editor/EconomyBuildConditions.lua
+++ b/lua/editor/EconomyBuildConditions.lua
@@ -14,6 +14,7 @@ local GetEconomyStoredRatio = moho.aibrain_methods.GetEconomyStoredRatio
 local GetEconomyIncome = moho.aibrain_methods.GetEconomyIncome
 local GetEconomyRequested = moho.aibrain_methods.GetEconomyRequested
 local GetEconomyStored = moho.aibrain_methods.GetEconomyStored
+local ParagonCat = categories.ENERGYPRODUCTION * categories.EXPERIMENTAL * categories.STRUCTURE
 
 local AIUtils = import('/lua/ai/aiutilities.lua')
 
@@ -165,7 +166,7 @@ end
 ---@param EnergyIncome integer
 ---@return boolean
 function GreaterThanEconIncome(aiBrain, MassIncome, EnergyIncome)
-    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, categories.ENERGYPRODUCTION * categories.EXPERIMENTAL * categories.STRUCTURE) then
+    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, ParagonCat) then
         --LOG('*AI DEBUG: Found Paragon')
         return true
     end
@@ -181,7 +182,7 @@ end
 ---@param EnergyIncome integer
 ---@return boolean
 function LessThanEconIncome(aiBrain, MassIncome, EnergyIncome)
-    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, categories.ENERGYPRODUCTION * categories.EXPERIMENTAL * categories.STRUCTURE) then
+    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, ParagonCat) then
         --LOG('*AI DEBUG: Found Paragon')
         return false
     end
@@ -197,7 +198,7 @@ end
 ---@param EnergyEfficiency integer
 ---@return boolean
 function GreaterThanEconEfficiency(aiBrain, MassEfficiency, EnergyEfficiency)
-    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, categories.ENERGYPRODUCTION * categories.EXPERIMENTAL * categories.STRUCTURE) then
+    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, ParagonCat) then
         --LOG('*AI DEBUG: Found Paragon')
         return true
     end
@@ -215,7 +216,7 @@ end
 ---@param EnergyEfficiency integer
 ---@return boolean
 function LessThanEconEfficiency(aiBrain, MassEfficiency, EnergyEfficiency)
-    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, categories.ENERGYPRODUCTION * categories.EXPERIMENTAL * categories.STRUCTURE) then
+    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, ParagonCat) then
         --LOG('*AI DEBUG: Found Paragon')
         return false
     end
@@ -233,7 +234,7 @@ end
 ---@param EnergyEfficiency integer
 ---@return boolean
 function GreaterThanEconEfficiencyOverTime(aiBrain, MassEfficiency, EnergyEfficiency)
-    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, categories.ENERGYPRODUCTION * categories.EXPERIMENTAL * categories.STRUCTURE) then
+    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, ParagonCat) then
         --LOG('*AI DEBUG: Found Paragon')
         return true
     end
@@ -250,7 +251,7 @@ end
 ---@param EnergyEfficiency integer
 ---@return boolean
 function LessThanEconEfficiencyOverTime(aiBrain, MassEfficiency, EnergyEfficiency)
-    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, categories.ENERGYPRODUCTION * categories.EXPERIMENTAL * categories.STRUCTURE) then
+    if HaveGreaterThanUnitsWithCategory(aiBrain, 0, ParagonCat) then
         --LOG('*AI DEBUG: Found Paragon')
         return false
     end


### PR DESCRIPTION
## Description of the changes
This PR replaces some of the default economy condition functions. By default all conditions perform a call to the function aiutilities.lua AIGetEconomyNumbers. This function runs 13 economy functions and does a few other calculations then returns a table. The economy condition then takes the economy property its interested in from this.
For instant build conditions this gets called each time the build condition monitor performs its condition check. This PR removes the excess calls by making the build conditions only call the functions they need for the data required.

## Test setup for the changes
Perform an AI game and record the number of times the economy based functions are called using the built in profiler. Then rerun the same game via replay with the refactored code. Ensure no desync due to errors and compare the number of times the functions are called. The refactored set should be less by a number of thousands over a period of time.

Note : I haven't touched the EconOverTime functions or StorageMax functions as these require extra calculations that are done within the AIGetEconomyNumbers function. There are also a bunch of function calls in the file SorianInstantBuildConditions. Some are custom and others are duplicates, would recommend removing the duplicates and re pointing the builders to the default conditions via a different PR.

This is the number of calls made prior to refactor over a 10 minute game.
![FunctionCallsPreRefactor](https://user-images.githubusercontent.com/34614077/186762539-62c837a0-bb54-4a95-b7f7-61415790cc67.JPG)

This is the number of calls made post refactor across the same 10 minute game.
![FunctionCallsPostRefactor](https://user-images.githubusercontent.com/34614077/186762702-80c0cfc4-dbf8-4fe5-bc6f-ac10d3225e7a.JPG)

