### PR TITLE
Share mouse position of players with observers

### DIFF
--- a/engine/User.lua
+++ b/engine/User.lua
@@ -966,7 +966,7 @@ end
  
 ---
 ---@param client? number | number[] client or clients
----@param message string
+---@param message table | number | string
 function SessionSendChatMessage(client, message)
 end
 

--- a/engine/User/CUIWorldMesh.lua
+++ b/engine/User/CUIWorldMesh.lua
@@ -77,7 +77,7 @@ function CUIWorldMesh:SetScale(scale)
 end
 
 ---
----@param position Position
+---@param position Vector
 ---@param orientation? Quaternion
 function CUIWorldMesh:SetStance(position, orientation)
 end

--- a/engine/User/CUIWorldMesh.lua
+++ b/engine/User/CUIWorldMesh.lua
@@ -67,8 +67,8 @@ function CUIWorldMesh:SetLifetimeParameter(param)
 end
 
 ---
----@param meshDesc string
-function CUIWorldMesh:SetMesh(meshDesc)
+---@param spec table
+function CUIWorldMesh:SetMesh(spec)
 end
 
 ---

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -1,4 +1,4 @@
----@meta
+---@declare-global
 
 
 -- The global sync table is copied from the sim layer every time the main and sim threads are

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -1,3 +1,5 @@
+---@meta
+
 
 -- The global sync table is copied from the sim layer every time the main and sim threads are
 -- synchronized on the sim beat (which is like a tick but happens even when the game is paused)
@@ -22,8 +24,28 @@ local SetPlayableArea = reclaim.SetPlayableArea
 -- this value with mods is forbidden.
 local hasSeenResult = false
 
+local SyncCallbacks = { }
+
+function AddOnSyncCallback(cb, identifier)
+    SyncCallbacks[identifier] = cb
+end
+
+function RemoveOnSyncCallback(identifier)
+    SyncCallbacks[identifier] = nil
+end
+
 -- Here's an opportunity for user side script to examine the Sync table for the new tick
 function OnSync()
+
+    for k, callback in SyncCallbacks do 
+        local ok, msg = pcall(callback, Sync)
+
+        -- if it fails, kick it out
+        if not ok then
+            SyncCallbacks[k] = nil
+            WARN(msg)
+        end
+    end
 
     if Sync.ArmyTransfer then 
         local army = GetFocusArmy()

--- a/lua/maui/control.lua
+++ b/lua/maui/control.lua
@@ -26,6 +26,12 @@
     -- Dump()
 
 ---@class Control : moho.control_methods
+---@field Left LazyVar
+---@field Top LazyVar
+---@field Right LazyVar
+---@field Bottom LazyVar
+---@field Width LazyVar
+---@field Height LazyVar
 Control = Class(moho.control_methods) {
 
     -- reset the control's layout to the defaults, in this case

--- a/lua/ui/game/casting/mouse.lua
+++ b/lua/ui/game/casting/mouse.lua
@@ -164,6 +164,8 @@ local function SendData(Sync)
     -- retrieve position and elevation
     local position = GetMouseWorldPos()
 
+    -- TODO: add check if we've actually moved the mouse
+
     -- do not send nils
     if position and position[1] then
 

--- a/lua/ui/game/casting/mouse.lua
+++ b/lua/ui/game/casting/mouse.lua
@@ -2,15 +2,10 @@
 local clients = GetSessionClients()
 local armies = GetArmiesTable().armiesTable
 
----@class CastingMouseData
----@field [1] number # x coordinate
----@field [2] number # y coordinate
----@field [3] number # z coordinate
----@field [4] number # elevation
-
 ---@class CastingMouseMessage
 ---@field CastingMouse boolean 
----@field data  CastingMouseData
+---@field Position Vector
+---@field Tick number
 
 -- determine if there are observers
 local clientCount = table.getn(clients)
@@ -94,6 +89,7 @@ local Locations = { }
 
 --- Processes the mouse position send by players
 ---@param sender string
+---@param info CastingMouseMessage
 local function ProcessData(sender, info)
 
     -- prepare first time data is send

--- a/lua/ui/game/casting/mouse.lua
+++ b/lua/ui/game/casting/mouse.lua
@@ -126,6 +126,8 @@ local function ProcessData(sender, info)
     table.insert(Locations[sender], info)
 end
 
+--- Cleans up previous received mouse data
+---@param Sync any
 local function CleanupData(Sync)
 
     local tick = GameTick()

--- a/lua/ui/game/casting/mouse.lua
+++ b/lua/ui/game/casting/mouse.lua
@@ -161,10 +161,6 @@ end
 ---@param Sync any
 local function SendData(Sync)
 
-    if GetFocusArmy() == -1 then
-        return
-    end
-
     -- retrieve position and elevation
     local position = GetMouseWorldPos()
 

--- a/lua/ui/game/casting/mouse.lua
+++ b/lua/ui/game/casting/mouse.lua
@@ -1,0 +1,185 @@
+
+local clients = GetSessionClients()
+local armies = GetArmiesTable().armiesTable
+
+---@class CastingMouseData
+---@field [1] number # x coordinate
+---@field [2] number # y coordinate
+---@field [3] number # z coordinate
+---@field [4] number # elevation
+
+---@class CastingMouseMessage
+---@field CastingMouse boolean 
+---@field data  CastingMouseData
+
+-- determine if there are observers
+local clientCount = table.getn(clients)
+local playerCount = 0
+for k, data in armies do
+    if data.human then
+        playerCount = playerCount + 1
+    end
+end
+
+--- Returns the terrain elevation on the mouse position, hefty function at the moment
+---@return number
+local function GetMouseElevation ()
+    if __EngineStats and __EngineStats.Children then
+        for _, a in __EngineStats.Children do
+            if a.Name == 'Camera' then
+                for _, b in a.Children do
+                    if b.Name == 'Cursor' then
+                        for _, c in b.Children do
+                            if c.Name == 'Elevation' then
+                                return c.Value
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    return 0
+end
+
+--- Returns a list of clients that are considered observers
+---@return number[]
+local function GetObserverClients()
+
+    local observers = { 1 }
+    for k, client in clients do
+        local isPlayer = false
+        for l, army in armies do
+            if army.nickname == client.name then
+                isPlayer = true
+            end
+        end
+
+        if not isPlayer then
+            table.insert(observers, k)
+        end
+    end
+
+    return observers
+end
+
+local UIUtil = import('/lua/ui/uiutil.lua')
+local WorldMesh = import('/lua/ui/controls/worldmesh.lua').WorldMesh
+local WorldViewManager = import('/lua/ui/game/worldview.lua')
+local meshSphere = '/env/Common/Props/sphere_lod0.scm'
+
+---@type WorldMesh[]
+local Entities = { }
+
+---@type Control[]
+local Labels = { }
+
+---@type number
+local LastUpdate = 0
+
+---@type table<string, Vector>
+local LocationsNext = { }
+
+---@type table<string, Vector>
+local LocationsCurr = { }
+
+--- Processes the mouse position send by players
+---@param sender string
+local function ProcessMouse(sender, info)
+
+    -- prepare first time data is send
+    if not Entities[sender] then
+        Entities[sender] = WorldMesh()
+        Entities[sender]:SetMesh({
+            MeshName = meshSphere,
+            TextureName = '/meshes/game/Assist_albedo.dds',
+            ShaderName = 'FakeRings',
+            UniformScale = 1
+        })
+
+        Entities[sender]:SetStance(info.Position)
+        Entities[sender]:SetHidden(false)
+
+        Labels[sender] = UIUtil.CreateText(GetFrame(0), sender, 12, UIUtil.bodyFont, true)
+        Labels[sender].Left:Set(-100)
+        Labels[sender].Top:Set(-100)
+
+        LocationsNext[sender] = info.Position
+        LocationsCurr[sender] = info.Position
+    end
+
+    LastUpdate = GetGameTimeSeconds()
+    LocationsCurr[sender] = LocationsNext[sender]
+    LocationsNext[sender] = info.Position
+
+    -- local label = labels[sender]
+    -- local screen = UnProject({data[1], data[2], data[3]})
+end
+
+--- Sends the mouse position to observers
+local function SendMouse()
+
+    -- retrieve position and elevation
+    local position = GetMouseWorldPos()
+    local elevation = GetMouseElevation()
+
+    -- do not send nils
+    if position and position[1] then
+
+        ---@type CastingMouseMessage
+        local msg = {
+            -- identifier used to pass mouse information
+            CastingMouse = true,
+
+            -- mouse information
+            Position = position,
+            Time = GetGameTime()
+        }
+
+        SessionSendChatMessage(GetObserverClients(), msg)
+    end
+end
+
+--- Interpolates the mouse position between updates
+local function DisplayMouseThread()
+    while true do 
+
+        local time = GetGameTimeSeconds()
+        for id, entity in Entities do
+
+            -- determine interpolated position
+            local diff = 10 * (time - LastUpdate)
+            if diff > 1 then
+                diff = 1
+            end
+            local curr = LocationsCurr[id]
+            local next = LocationsNext[id]
+
+            local x = next[1] * diff + curr[1] * (1 - diff)
+            local y = next[2] * diff + curr[2] * (1 - diff)
+            local z = next[3] * diff + curr[3] * (1 - diff)
+
+            local position = {x, y, z}
+
+            -- update everything
+
+            if x and y and z then
+                entity:SetStance(position)
+
+                local label = Labels[id]
+                local screen = WorldViewManager.viewLeft:Project(position)
+                label.Left:Set(screen[1] - 0.5 * label.Width())
+                label.Top:Set(screen[2] - 30)
+            end
+        end
+
+        WaitFrames(1)
+    end
+end
+
+if clientCount > playerCount or true then
+    AddOnSyncCallback(SendMouse, 'CastingMouse')
+    import('/lua/ui/game/gamemain.lua').RegisterChatFunc(ProcessMouse, 'CastingMouse')
+    ForkThread(DisplayMouseThread)
+end

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -155,6 +155,10 @@ function CreateUI(isReplay)
 
     import('/lua/system/performance.lua')
 
+    -- # Casting tools 
+
+    import('/lua/ui/game/casting/mouse.lua')
+
     -- # Overwrite some globals for performance / safety
 
     -- ensure logger is turned off for the average user


### PR DESCRIPTION
A useful feature for casters: being able to see where the mouse of the players is pointing at! The feature isn't smooth yet, still needs some polishing. But the idea works and it is cheat free. We 'abuse' the chat system that allows you to send any data to any client. The data is properly culled by the engine, as a result players that should not receive the data has no idea that information has been send. There's no way to retrieve this via the UI.

https://user-images.githubusercontent.com/15778155/187092955-a22027f5-af25-44fe-868a-f1e801b6db97.mp4

Things to take care of:

- [ ] Use army color for the mesh
- [x] Take into account the 500 ms delay, this should also help with the lag issues

And nice to have features:

- [ ] Find out if we can skip an update if the mouse didn't move

This pull requests adds in the tracking of the mouse of players. But similarly, we could track their camera settings (to see what they are seeing) and other interesting information that can be used for casting.