### PR TITLE
Increase muzzle velocity and aoe for uef and seraphim gunship

### DIFF
--- a/units/UEA0203/UEA0203_unit.bp
+++ b/units/UEA0203/UEA0203_unit.bp
@@ -280,6 +280,7 @@ UnitBlueprint {
             BallisticArc = 'RULEUBA_None',
             CollideFriendly = false,
             Damage = 20,
+            DamageRadius = 1,
             DamageType = 'Normal',
             DisplayName = 'Hells Fury Riot Gun',
             FireTargetLayerCapsTable = {
@@ -293,7 +294,7 @@ UnitBlueprint {
             MaxRadius = 22,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 40,
+            MuzzleVelocity = 60,
             ProjectileId = '/projectiles/TDFRiot01/TDFRiot01_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.15,
             ProjectilesPerOnFire = 1,

--- a/units/XSA0203/XSA0203_unit.bp
+++ b/units/XSA0203/XSA0203_unit.bp
@@ -316,6 +316,7 @@ UnitBlueprint {
             BallisticArc = 'RULEUBA_None',
             CollideFriendly = false,
             Damage = 16,
+            DamageRadius = 1,
             DamageType = 'Normal',
             DisplayName = 'Heavy Phasic Autogun',
             FireTargetLayerCapsTable = {
@@ -327,7 +328,7 @@ UnitBlueprint {
             MaxRadius = 22,
             MuzzleSalvoDelay = 0.2,
             MuzzleSalvoSize = 2,
-            MuzzleVelocity = 40,
+            MuzzleVelocity = 60,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = '/projectiles/SDFHeavyPhasicAutogun02/SDFHeavyPhasicAutogun02_proj.bp',
             ProjectileLifetimeUsesMultiplier = 1.15,


### PR DESCRIPTION
This fixes the issue where a single flak can circle dodge vs uef and seraphim gunships and take no damage. In my tests muzzle velocity increases alone were insufficient to counter circle dodge so a combination of aoe increases and muzzle velocity increases to achieve the desired result.

Muzzle velocity 40 -> 60
Damage radius 0 -> 1