### PR TITLE
Hive & Kennel Rebalance

### DIFF
--- a/units/XEA3204/XEA3204_unit.bp
+++ b/units/XEA3204/XEA3204_unit.bp
@@ -110,8 +110,8 @@ UnitBlueprint {
         AirThreatLevel = 0,
         ArmorType = 'Light',
         EconomyThreatLevel = 1,
-        Health = 50,
-        MaxHealth = 50,
+        Health = 100,
+        MaxHealth = 100,
         RegenRate = 0,
         SubThreatLevel = 0,
         SurfaceThreatLevel = 0,
@@ -135,10 +135,10 @@ UnitBlueprint {
         UniformScale = 0.011,
     },
     Economy = {
-        BuildCostEnergy = 1000,
-        BuildCostMass = 100,
-        BuildRate = 25,
-        BuildTime = 500,
+        BuildCostEnergy = 150,
+        BuildCostMass = 15,
+        BuildRate = 30,
+        BuildTime = 300,
     },
     General = {
         BuildBones = {

--- a/units/XEB0204/XEB0204_unit.bp
+++ b/units/XEB0204/XEB0204_unit.bp
@@ -126,7 +126,7 @@ UnitBlueprint {
         BuildCostEnergy = 5250,
         BuildCostMass = 840,
         BuildRate = 20,
-        BuildTime = 2000,
+        BuildTime = 2222,
         DifferentialUpgradeCostCalculation = true,
         EngineeringPods = {
             {

--- a/units/XRB0104/XRB0104_unit.bp
+++ b/units/XRB0104/XRB0104_unit.bp
@@ -143,7 +143,7 @@ UnitBlueprint {
     Economy = {
         BuildCostEnergy = 1750,
         BuildCostMass = 350,
-        BuildRate = 25,
+        BuildRate = 17,
         BuildTime = 1171,
         BuildableCategory = {
             'xrb0204',

--- a/units/XRB0204/XRB0204_unit.bp
+++ b/units/XRB0204/XRB0204_unit.bp
@@ -143,13 +143,13 @@ UnitBlueprint {
     Economy = {
         BuildCostEnergy = 4083.33,
         BuildCostMass = 700,
-        BuildRate = 50,
-        BuildTime = 1171,
+        BuildRate = 34,
+        BuildTime = 1000,
         BuildableCategory = {
             'xrb0304',
         },
         DifferentialUpgradeCostCalculation = true,
-        MaxBuildDistance = 20,
+        MaxBuildDistance = 18,
         RebuildBonusIds = {
             'xrb0104',
         },

--- a/units/XRB0304/XRB0304_unit.bp
+++ b/units/XRB0304/XRB0304_unit.bp
@@ -141,10 +141,10 @@ UnitBlueprint {
     Economy = {
         BuildCostEnergy = 6416.66,
         BuildCostMass = 1050,
-        BuildRate = 75,
-        BuildTime = 1171,
+        BuildRate = 51,
+        BuildTime = 1000,
         DifferentialUpgradeCostCalculation = true,
-        MaxBuildDistance = 25,
+        MaxBuildDistance = 22,
         RebuildBonusIds = {
             'xrb0104',
         },


### PR DESCRIPTION
Kennels currently are very bad and basically no one uses them. Hives are too strong in some cases and provide better versatility in the late game than engineers can provide (like instantly changing your bp to something different; high concentration of bp in a small area). Recently we had a few discussions about it on Discord and that's why I decided to make an attempt at rebalancing.


This rebalance aims to make the Kennel more useful and makes losing drones a lot less punishing. With the better build power Kennels are now more mass efficient than Hives (still a lot less than the current Hives though), and losing the drones isn't so bad anymore. The health buff makes them able to at least take 1 or 2 hits from AA without dying like before.

Hives get a big build power nerf (still better than current Kennel) and a slight build range nerf. This should make them worse at being super concentrated build power, but they should still be a useful building for the lategame where mass efficiency is less important than versatility.

Old Hive range:
![grafik](https://user-images.githubusercontent.com/61892809/187546834-6d664470-a05b-4381-820f-2d989a64e367.png)

New Hive range:
![grafik](https://user-images.githubusercontent.com/61892809/187546932-fa895fb3-ab75-416d-8e1c-deb315ac0cc8.png)

