### PR TITLE
Fix issues with Ythotha

### DIFF
--- a/units/XSL0401/XSL0401_unit.bp
+++ b/units/XSL0401/XSL0401_unit.bp
@@ -64,7 +64,6 @@ UnitBlueprint {
         'SNIPEMODE',
         'LOWSELECTPRIO',
     },
-    CollisionOffsetY = 3.25,
     CollisionOffsetZ = 0.5,
     Defense = {
         AirThreatLevel = 16,
@@ -212,6 +211,10 @@ UnitBlueprint {
         BuildCostMass = 26500,
         BuildTime = 46875,
     },
+    Footprint = {
+        SizeX = 3,
+        SizeZ = 3,
+    },
     General = {
         Category = 'Direct Fire',
         Classification = 'RULEUC_MilitaryVehicle',
@@ -242,6 +245,7 @@ UnitBlueprint {
     Interface = {
         HelpText = '<LOC xsl0401_help>Experimental Assault Bot',
     },
+
     LifeBarHeight = 0.075,
     LifeBarOffset = 2.3,
     LifeBarSize = 3.25,
@@ -279,7 +283,7 @@ UnitBlueprint {
     SelectionSizeZ = 1.6,
     SelectionThickness = 0.32,
     SizeX = 2.0,
-    SizeY = 4.0,
+    SizeY = 7.5,
     SizeZ = 2.0,
     StrategicIconName = 'icon_experimental_generic',
     StrategicIconSortPriority = 115,


### PR DESCRIPTION
Fixes a few issues that were introduced by https://github.com/FAForever/fa/pull/4084.

Fixes the issue where the collision box no longer extends towards the ground. Apparently bombers always aim at the ground near units, not anywhere else. As a consequence some bombers (Tech 1 Cybran, tech 2 Seraphim) were essentially unable to hit the Ythotha. 

Also fixes the issue where the footprint of the Ythotha was accidentally changed to a 1x1 Amphibious footprint, instead of a 3x3. The footprint is derived from the collision size box, and the latter got changed. As a result the experimental was no longer 'Massive', and could not pass over structures.

And fixes the issue where only one engineer would try and build the Ythotha. Not sure what caused or fixed this exactly - maybe it is because the unit was no longer considered massive?

For those interested, there's a limited set of footprints available. See also https://github.com/FAForever/fa/blob/deploy/fafdevelop/lua/footprints.lua .