### PR TITLE
Fix duration of death animations

### DIFF
--- a/lua/defaultexplosions.lua
+++ b/lua/defaultexplosions.lua
@@ -101,6 +101,17 @@ function GetUnitSizes(unit)
     return bp.SizeX or 0, bp.SizeY or 0, bp.SizeZ or 0
 end
 
+--- Retrieves the mesh extents of the unit as defined in the blueprint. Do not use in critical code, instead
+-- copy the body into your code for performance reasons.
+---@param unit any
+---@return number
+---@return number
+---@return number
+function GetUnitMeshExtents(unit)
+    local bp = unit.Blueprint or unit:GetBlueprint()
+    return bp.Physics.MeshExtentsX or bp.SizeX or 0, bp.Physics.MeshExtentsY or bp.SizeY or 0, bp.Physics.MeshExtentsZ or bp.SizeZ or 0
+end
+
 --- Retrieves the voume of the unit as defined in the blueprint. Do not use in critical code, instead
 -- copy the body into your code for performance reasons.
 ---@param unit Unit The unit to get the volume of.
@@ -137,8 +148,8 @@ end
 ---@param unit Unit The unit to get the diameter of.
 ---@return number
 function GetAverageBoundingXYZRadius(unit)
-    local bp = unit:GetBlueprint()
-    return ((bp.SizeX or 0) + (bp.SizeY or 0) + (bp.SizeZ or 0)) * 0.333
+    local x, y, z = GetUnitMeshExtents(unit)
+    return (x + y + z) * 0.333
 end
 
 --- Retrieves bounding radius over all axis. Do not use in critical code, instead
@@ -433,13 +444,13 @@ end
 
 ---@param obj Unit
 function CreateTimedStuctureUnitExplosion(obj)
-    local numExplosions = math.floor(GetAverageBoundingXYZRadius(obj) * GetRandomInt(2,5))
-    local x,y,z = GetUnitSizes(obj)
+    local numExplosions = math.floor(0.75 * GetAverageBoundingXYZRadius(obj) * GetRandomInt(2,4))
+    local x,y,z = GetUnitMeshExtents(obj)
     obj:ShakeCamera(30, 1, 0, 0.45 * numExplosions)
     for i = 0, numExplosions do
-        CreateDefaultHitExplosionOffset(obj, 1.0, unpack({GetRandomOffset(x, y, z, 1.2)}))
+        CreateDefaultHitExplosionOffset(obj, 1.0, unpack({GetRandomOffset(x, y, z, 0.8)}))
         obj:PlayUnitSound('DeathExplosion')
-        WaitSeconds(GetRandomFloat(0.2, 0.7))
+        WaitSeconds(GetRandomFloat(0.2, 0.5))
     end
 end
 

--- a/lua/defaultexplosions.lua
+++ b/lua/defaultexplosions.lua
@@ -454,7 +454,7 @@ function CreateTimedStuctureUnitExplosion(obj, deathAnimation)
         while deathAnimation:GetAnimationFraction() < 1 do
             CreateDefaultHitExplosionOffset(obj, 1.0, unpack({GetRandomOffset(x, y, z, 0.8)}))
             obj:PlayUnitSound('DeathExplosion')
-            WaitSeconds(GetRandomFloat(0.2, 0.4))
+            WaitSeconds(GetRandomFloat(0.2, 0.5))
         end
     -- do generic destruction effect
     else

--- a/lua/defaultexplosions.lua
+++ b/lua/defaultexplosions.lua
@@ -443,14 +443,26 @@ function CreateDefaultHitExplosionAtBone(obj, boneName, scale)
 end
 
 ---@param obj Unit
-function CreateTimedStuctureUnitExplosion(obj)
+function CreateTimedStuctureUnitExplosion(obj, deathAnimation)
+
     local numExplosions = math.floor(0.75 * GetAverageBoundingXYZRadius(obj) * GetRandomInt(2,4))
     local x,y,z = GetUnitMeshExtents(obj)
     obj:ShakeCamera(30, 1, 0, 0.45 * numExplosions)
-    for i = 0, numExplosions do
-        CreateDefaultHitExplosionOffset(obj, 1.0, unpack({GetRandomOffset(x, y, z, 0.8)}))
-        obj:PlayUnitSound('DeathExplosion')
-        WaitSeconds(GetRandomFloat(0.2, 0.5))
+
+    -- if there is a death animation, roll with that
+    if deathAnimation then
+        while deathAnimation:GetAnimationFraction() < 1 do
+            CreateDefaultHitExplosionOffset(obj, 1.0, unpack({GetRandomOffset(x, y, z, 0.8)}))
+            obj:PlayUnitSound('DeathExplosion')
+            WaitSeconds(GetRandomFloat(0.2, 0.4))
+        end
+    -- do generic destruction effect
+    else
+        for i = 0, numExplosions do
+            CreateDefaultHitExplosionOffset(obj, 1.0, unpack({GetRandomOffset(x, y, z, 0.8)}))
+            obj:PlayUnitSound('DeathExplosion')
+            WaitSeconds(GetRandomFloat(0.2, 0.5))
+        end
     end
 end
 

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -305,8 +305,8 @@ StructureUnit = Class(Unit) {
         if explosion.GetAverageBoundingXZRadius(self) < 1.0 then
             explosion.CreateScalableUnitExplosion(self)
         else
-            explosion.CreateTimedStuctureUnitExplosion(self)
-            WaitSeconds(0.2)
+            explosion.CreateTimedStuctureUnitExplosion(self, self.DeathAnimManip)
+            WaitSeconds(0.3)
             explosion.CreateScalableUnitExplosion(self)
         end
     end,

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -306,7 +306,7 @@ StructureUnit = Class(Unit) {
             explosion.CreateScalableUnitExplosion(self)
         else
             explosion.CreateTimedStuctureUnitExplosion(self)
-            WaitSeconds(0.5)
+            WaitSeconds(0.2)
             explosion.CreateScalableUnitExplosion(self)
         end
     end,

--- a/lua/utilities.lua
+++ b/lua/utilities.lua
@@ -212,7 +212,7 @@ function GetRandomOffset(sx, sy, sz, scalar)
     sy = sy * scalar
     sz = sz * scalar
     local x = Random() * sx - (sx * 0.5)
-    local y = Random() * sy
+    local y = Random() * sy - (sy * 0.5)
     local z = Random() * sz - (sz * 0.5)
 
     return x, y, z


### PR DESCRIPTION
Related to this change: https://github.com/FAForever/fa/pull/4129/files#diff-2a6f1a4e584cb2b6df034b8760a5bcfb2feaaf3eadd4dfc6caa4e86b96d57433R141

The duration of the death animations (read: number of explosions) was technically not related to the size of the unit, but to the size of the x-axis of the unit. This was (in accident) 'fixed', where as it was purposefully left like that to prevent having to remap a lot of effects. Anyway, ended up doing that now.

The animation duration is now roughly where they were before, but with less randomness in them.