### PR TITLE
OnMissileImpactTerrain changes required for functional callback

### DIFF
--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -266,7 +266,7 @@ Projectile = Class(moho.projectile_methods) {
 
         -- callbacks for launcher to have an idea what is going on for AIs
         local categoriesHash = self.Blueprint.CategoriesHash
-        if categoriesHash['TACTICAL'] or categoriesHash['STRATEGICAL'] then
+        if categoriesHash['TACTICAL'] or categoriesHash['STRATEGIC'] then
             -- we have a target, but got caught by terrain
             if targetType == 'Terrain' then
                 if not IsDestroyed(self.Launcher) then

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -103,7 +103,7 @@ local cUnit = moho.unit_methods
 ---@field Army Army
 ---@field UnitId UnitId
 ---@field EntityId EntityId
----@field EventCallbacks function[]
+---@field EventCallbacks table<string, function[]>
 Unit = Class(moho.unit_methods) {
 
     Weapons = {},

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -103,6 +103,7 @@ local cUnit = moho.unit_methods
 ---@field Army Army
 ---@field UnitId UnitId
 ---@field EntityId EntityId
+---@field EventCallbacks function[]
 Unit = Class(moho.unit_methods) {
 
     Weapons = {},
@@ -224,9 +225,6 @@ Unit = Class(moho.unit_methods) {
 
         -- used to fix engine related bugs
         self.EngineFlags = { }
-
-        -- Initialize callbacks table
-        self.Callbacks = { }
 
         -- Store size information for performance
         self.Footprint = { SizeX = bp.Footprint.SizeX, SizeZ = bp.Footprint.SizeZ }
@@ -4962,8 +4960,8 @@ Unit = Class(moho.unit_methods) {
     ---@param position Vector Location where the missile got intercepted
     OnMissileIntercepted = function(self, target, defense, position)
         -- try and run callbacks
-        if self.Callbacks['OnMissileIntercepted'] then
-            for k, callback in self.Callbacks['OnMissileIntercepted'] do
+        if self.EventCallbacks['OnMissileIntercepted'] then
+            for k, callback in self.EventCallbacks['OnMissileIntercepted'] do
                 local ok, msg = pcall(callback, target, defense, position)
                 if not ok then
                     WARN("OnMissileIntercepted callback triggered an error:")
@@ -4981,8 +4979,8 @@ Unit = Class(moho.unit_methods) {
     ---@param position Vector Location where the missile hit the shield
     OnMissileImpactShield = function(self, target, shield, position)
         -- try and run callbacks
-        if self.Callbacks['OnMissileImpactShield'] then
-            for k, callback in self.Callbacks['OnMissileImpactShield'] do
+        if self.EventCallbacks['OnMissileImpactShield'] then
+            for k, callback in self.EventCallbacks['OnMissileImpactShield'] do
                 local ok, msg = pcall(callback, target, shield, position)
                 if not ok then
                     WARN("OnMissileImpactShield callback triggered an error:")
@@ -4998,8 +4996,8 @@ Unit = Class(moho.unit_methods) {
     ---@param position Vector Location where the missile hit the terrain
     OnMissileImpactTerrain = function(self, target, position)
         -- try and run callbacks
-        if self.Callbacks['OnMissileImpactTerrain'] then
-            for k, callback in self.Callbacks['OnMissileImpactTerrain'] do
+        if self.EventCallbacks['OnMissileImpactTerrain'] then
+            for k, callback in self.EventCallbacks['OnMissileImpactTerrain'] do
                 local ok, msg = pcall(callback, self, target, position)
                 if not ok then
                     WARN("OnMissileImpactTerrain callback triggered an error:")
@@ -5013,24 +5011,24 @@ Unit = Class(moho.unit_methods) {
     ---@param self Unit
     ---@param callback function<Vector, Unit, Vector>
     AddMissileInterceptedCallback = function(self, callback)
-        self.Callbacks['OnMissileIntercepted'] = self.Callbacks['OnMissileIntercepted'] or { }
-        table.insert(self.Callbacks['OnMissileIntercepted'], callback)
+        self.EventCallbacks['OnMissileIntercepted'] = self.EventCallbacks['OnMissileIntercepted'] or { }
+        table.insert(self.EventCallbacks['OnMissileIntercepted'], callback)
     end,
 
     --- Add a callback when a missile launched by this unit hits a shield
     ---@param self Unit
     ---@param callback function<Vector, Unit, Vector>
     AddMissileImpactShieldCallback = function(self, callback)
-        self.Callbacks['OnMissileImpactShield'] = self.Callbacks['OnMissileImpactShield'] or { }
-        table.insert(self.Callbacks['OnMissileImpactShield'], callback)
+        self.EventCallbacks['OnMissileImpactShield'] = self.EventCallbacks['OnMissileImpactShield'] or { }
+        table.insert(self.EventCallbacks['OnMissileImpactShield'], callback)
     end,
 
     --- Add a callback when a missile launched by this unit hits the terrain, note that this can be the same location as the target
     ---@param self Unit
     ---@param callback function<Vector, Vector>
     AddMissileImpactTerrainCallback = function(self, callback)
-        self.Callbacks['OnMissileImpactTerrain'] = self.Callbacks['OnMissileImpactTerrain'] or { }
-        table.insert(self.Callbacks['OnMissileImpactTerrain'], callback)
+        self.EventCallbacks['OnMissileImpactTerrain'] = self.EventCallbacks['OnMissileImpactTerrain'] or { }
+        table.insert(self.EventCallbacks['OnMissileImpactTerrain'], callback)
     end,
 
     --- Various callback-like functions

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -225,6 +225,9 @@ Unit = Class(moho.unit_methods) {
         -- used to fix engine related bugs
         self.EngineFlags = { }
 
+        -- Initialize callbacks table
+        self.Callbacks = { }
+
         -- Store size information for performance
         self.Footprint = { SizeX = bp.Footprint.SizeX, SizeZ = bp.Footprint.SizeZ }
         self.SkirtOffset = { OffsetX = bp.Physics.SkirtOffsetX, OffsetZ = bp.Physics.SkirtOffsetZ }
@@ -4997,7 +5000,7 @@ Unit = Class(moho.unit_methods) {
         -- try and run callbacks
         if self.Callbacks['OnMissileImpactTerrain'] then
             for k, callback in self.Callbacks['OnMissileImpactTerrain'] do
-                local ok, msg = pcall(callback, target, position)
+                local ok, msg = pcall(callback, self, target, position)
                 if not ok then
                     WARN("OnMissileImpactTerrain callback triggered an error:")
                     WARN(msg)


### PR DESCRIPTION
## Description of the changes

This PR corrects a small typo and makes some changes to enable callback functionality for the previously created callback `OnMissileImpactTerrain`. I'm not 100% on initializing the self.Callbacks table in the OnCreate function for the unit class but it seemed like the way to go.
I'll work my way through testing the other OnMissile callbacks against the AI when I can get time.

## Test setup for the changes
This PR was tested against the RNGAI sim mod by the following method.
Within the tactical missile platoon function it will loop through all available launchers.
It will then perform the following.
```
                if not tml.terraincallbackset then
                    tml:AddMissileImpactTerrainCallback(missileTerrainCallbackRNG)
                    tml.terraincallbackset = true
                end
```

The callback function

```
function MissileCallbackRNG(unit, targetPos, impactPos)
    if unit and not unit.Dead and targetPos then
        if not unit.TargetBlackList then
            unit.TargetBlackList = {}
        end
        unit.TargetBlackList[targetPos[1]] = {}
        unit.TargetBlackList[targetPos[1]][targetPos[3]] = true
        return true, "target position added to tml blacklist"
    end
    return false, "something something error?"
end
```

When the tactical missile platoon is evaluating targets it will perform the following check against each tactical missile launcher is has which allows it to skip the target if its position is blacklisted from that particular launcher.
```
if tml.TargetBlackList then
        if tml.TargetBlackList[targetPosition[1]][targetPosition[3]] then
              RNGLOG('TargetPos found in blacklist, skip')
              continue
        end
end
```


Attached is the visual of the terrain block check performed. The red T2 extractor is behind terrain. The AI's TML fires a missile, after hitting the terrain the launcher platoon will add the blacklisted position to the launcher unit and will no longer fire missiles at it.

![MissileLaunch](https://user-images.githubusercontent.com/34614077/189055902-4fd7b68b-b519-473f-a282-17ca25d926d5.JPG)


Logs were generated to confirm the launcher had added the target position to its blacklist and when the launcher skipped the target during target acquisition.
Logs generated within callback validating launcher UnitId, target position and impact position.
```
info: MissileCallbackRNG
info: xsb2108
info: 
info:  - 1: 199.5
info:  - 2: 21.578125
info:  - 3: 266.5
info: 
info:  - 1: 205.69364929199
info:  - 2: 27.374061584473
info:  - 3: 249.92608642578
info: TargetPos Added to blacklist
```

Logs generated when blacklisted unit position found.
```
info: TargetPos found in blacklist, skip
```