### PR TITLE
Fix props breaking bomber targeting

### DIFF
--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -260,8 +260,9 @@ DefaultProjectileWeapon = Class(Weapon) {
                     targetPos = EntityGetPosition(target)
                     data.targetpos = targetPos
                 end
-        else
-            targetPos = data.targetpos
+            else
+                targetPos = data.targetpos
+            end
         end
         if not targetPos then
             -- put the bomb cluster in free-fall

--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -20,11 +20,22 @@ local Weapon = import('/lua/sim/Weapon.lua').Weapon
 local CollisionBeam = import('/lua/sim/CollisionBeam.lua').CollisionBeam
 local XZDist = import('/lua/utilities.lua').XZDistanceTwoVectors
 
-local MathMax = math.max
-local MathMin = math.min
+local MathClamp = math.clamp
+
+---@class WeaponSalvoData
+---@field target? Unit | Prop   if absent, will use `targetpos` instead
+---@field targetpos Vector      stores the last location of the target, or the ground fire location
+---@field lastAccel number      stores the last acceleration that was used
+---@field usestore? boolean     a flag that indicates if the target was lost
 
 -- Most weapons derive from this class, including beam weapons later in this file
----@class DefaultProjectileWeapon: Weapon
+---@class DefaultProjectileWeapon : Weapon
+---@field CurrentSalvoNumber number
+---@field CurrentRackSalvoNumber number
+---@field CurrentSalvoData? WeaponSalvoData
+---@field AdjustedSalvoDelay? number if the weapon blueprint requests a trajectory fix, this is set to the effective duration of the salvo in ticks used to calculate projectile spread
+---@field DropBombShortRatio? number if the weapon blueprint requests a trajectory fix, this is set to the ratio of the distance to the target that the projectile is launched short to
+---@field SalvoSpreadStart? number   if the weapon blueprint requests a trajectory fix, this is set to the value that centers the projectile spread for `CurrentSalvoNumber` shot on the optimal target position
 DefaultProjectileWeapon = Class(Weapon) {
 
     FxRackChargeMuzzleFlash = {},
@@ -113,7 +124,7 @@ DefaultProjectileWeapon = Class(Weapon) {
         if bp.FixBombTrajectory then
             local dropShort = bp.DropBombShort
             if dropShort then
-                self.DropBombShortRatio = MathMax(0, MathMin(1 - dropShort, 1))
+                self.DropBombShortRatio = MathClamp(1 - dropShort, 0, 1)
             end
             if muzzleSalvoSize > 1 then
                 -- center the spread on the target
@@ -172,121 +183,148 @@ DefaultProjectileWeapon = Class(Weapon) {
             return 4.75
         end
 
+        local UnitGetVelocity = UnitGetVelocity
+        local VDist2 = VDist2
         -- Get projectile position and velocity
         -- velocity will need to be multiplied by 10 due to being returned /tick instead of /s
         local projPosX, projPosY, projPosZ = EntityGetPositionXYZ(projectile)
         local projVelX,    _    , projVelZ = UnitGetVelocity(launcher)
 
-        local target = UnitGetTargetEntity(launcher)
-
         local targetPos
-        local targetVelX, targetVelZ
-        if target then
-            -- target is a unit / prop
-            targetPos = EntityGetPosition(target)
-            targetVelX, _, targetVelZ = UnitGetVelocity(target)
-        else
-            -- target is a position i.e. attack ground
-            targetPos = self:GetCurrentTargetPos()
-            targetVelX, targetVelZ = 0, 0
-        end
+        local targetVelX, targetVelZ = 0, 0
 
         local data = self.CurrentSalvoData
 
         -- if it's the first time...
         if not data then
-            local salvoSize = self.Blueprint.MuzzleSalvoSize
-            -- and there's going to be a second time
-            if salvoSize > 1 then
-                -- calculate & cache a couple things only the first time
-                data = {
-                    lastAccel = 4.75,
-                    targetpos = targetPos,
-                }
-                self.CurrentSalvoData = data
-            else
+            -- setup target (which won't change mid-bombing run)
+            local target = UnitGetTargetEntity(launcher)
+            if target then -- target is a unit / prop
+                targetPos = EntityGetPosition(target)
+            else -- target is a position i.e. attack ground
+                targetPos = self:GetCurrentTargetPos()
+            end
+
+            -- and there's not going to be a second time
+            if self.Blueprint.MuzzleSalvoSize <= 1 then
+                -- do the calculation but skip any cache or salvo logic
                 if not targetPos then
                     return 4.75
                 end
-                local targetPosX, targetPosZ = targetPos[1], targetPos[3]
-                -- otherwise, do the same calculation but skip any cache or salvo logic
-                if target.Dead then
-                    return 4.75
+                if not target.IsProp then
+                    targetVelX, _, targetVelZ = UnitGetVelocity(target)
                 end
+                local targetPosX, targetPosZ = targetPos[1], targetPos[3]
                 local distVel = VDist2(projVelX, projVelZ, targetVelX, targetVelZ)
                 if distVel == 0 then
                     return 4.75
                 end
                 local distPos = VDist2(projPosX, projPosZ, targetPosX, targetPosZ)
-                local dropShort = self.DropBombShortRatio
-                if dropShort then
-                    distPos = distPos * dropShort
+                do
+                    local dropShort = self.DropBombShortRatio
+                    if dropShort then
+                        distPos = distPos * dropShort
+                    end
                 end
                 if distPos == 0 then
                     return 4.75
                 end
                 local time = distPos / distVel
-                local targetNewPosX = targetPosX + time * targetVelX
-                local targetNewPosZ = targetPosZ + time * targetVelZ
-                local targetNewPosY = GetSurfaceHeight(targetNewPosX, targetNewPosZ)
-                return 200 * (projPosY - targetNewPosY) / (time*time)
+                projPosY = projPosY - GetSurfaceHeight(targetPosX + time * targetVelX, targetPosZ + time * targetVelZ)
+                return 200 * projPosY / (time*time)
+            else -- otherwise, calculate & cache a couple things the first time only
+                data = {
+                    lastAccel = 4.75,
+                    targetpos = targetPos,
+                }
+                if target then
+                    if target.Dead then
+                        data.usestore = true
+                    else
+                        data.target = target
+                    end
+                end
+                self.CurrentSalvoData = data
             end
-        elseif targetPos then
-            data.targetpos = targetPos
+        else -- if it's a successive bomb drop, get the targeting data
+            local target = data.target
+            if target then
+                if target.Dead then -- if the unit is destroyed, use the last known position
+                    data.target = nil
+                    data.usestore = true -- flag that we lost the target
+                    targetPos = data.targetpos
+                else
+                    if not target.IsProp then
+                        targetVelX, _, targetVelZ = UnitGetVelocity(target)
+                    end
+                    targetPos = EntityGetPosition(target)
+                    data.targetpos = targetPos
+                end
         else
             targetPos = data.targetpos
         end
+        if not targetPos then
+            -- put the bomb cluster in free-fall
+            local GetSurfaceHeight = GetSurfaceHeight
+            local MathSqrt = math.sqrt
+            local spread = self.AdjustedSalvoDelay * (self.SalvoSpreadStart + self.CurrentSalvoNumber)
+            -- nominal acceleration is 4.75; however, bomb clusters adjust the time it takes to land
+            -- so we convert the acceleration to time to add the spread and convert back:
+            -- h = unitY - surfaceY         =>  h2 = 0.5 * (unitY - surfaceHeight(unitX, unitZ))
+            -- t = sqrt(2 h / a) + spread   =>  t = sqrt(4 / 4.75 * h2) + spread
+            -- a = 0.5 h / t^2              =>  a = h2 / t^2
+            local halfHeight = 0.5 * (projPosY - GetSurfaceHeight(projPosX, projPosZ))
+            if halfHeight < 0.01 then return 4.75 end
+            local time = MathSqrt(0.842105263158 * halfHeight) + spread
 
-        -- check if we lost the target (or if we previously did; regaining a target mid-run shouldn't
-        -- suddenly divert some of the bombs)
-        if target.Dead or data.usestore or not targetPos then
-            -- use same acceleration as last bomb
-            data.usestore = true
-            return data.lastAccel
+            -- now that we know roughly when we'll land, we can find a better guess for where
+            -- we'll land, and thus guess the true falling height better as well
+            halfHeight = 0.5 * (projPosY - GetSurfaceHeight(projPosX + time * projVelX, projPosX + time * projVelX))
+            time = MathSqrt(0.842105263158 * halfHeight) + spread
+
+            local acc = halfHeight / (time*time)
+            data.lastAccel = acc
+            return acc
         end
-
-        local targetPosX, targetPosZ = targetPos[1], targetPos[3]
 
         -- calculate flat (exclude y-axis) distance and velocity between projectile and target
         -- velocity will eventually need to multiplied by 10 due to being per tick instead of per second
         local distVel = VDist2(projVelX, projVelZ, targetVelX, targetVelZ)
         if distVel == 0 then
+            data.lastAccel = 4.75
             return 4.75
         end
+        local targetPosX, targetPosZ = targetPos[1], targetPos[3]
+
+        -- calculate the distance for this particular bomb
         local distPos = VDist2(projPosX, projPosZ, targetPosX, targetPosZ)
-
-        local dropShort = self.DropBombShortRatio
-        if dropShort then
-            distPos = distPos * dropShort
-        end
-
-        -- calculate the position for this particular bomb
-        -- (centers the individual bomb release positions around the optimal position)
-        distPos = distPos + self.AdjustedSalvoDelay * distVel * (self.SalvoSpreadStart + self.CurrentSalvoNumber)
-        if distPos == 0 then
-            return 4.75
+        do
+            local dropShort = self.DropBombShortRatio
+            if dropShort then
+                distPos = distPos * dropShort
+            end
         end
 
         -- how many ticks until the bomb hits the target in xz-space
-        local time = distPos / distVel
+        local time = distPos / distVel + self.AdjustedSalvoDelay * (self.SalvoSpreadStart + self.CurrentSalvoNumber)
+        if time == 0 then
+            data.lastAccel = 4.75
+            return 4.75
+        end
 
         -- find out where the target will be at that point in time (it could be moving)
         -- (time and velocity being in ticks cancel out)
-        local targetNewPosX = targetPosX + time * targetVelX
-        local targetNewPosZ = targetPosZ + time * targetVelZ
-        -- what is the height at that future position
-        local targetNewPosY = GetSurfaceHeight(targetNewPosX, targetNewPosZ)
+        -- what is the height difference at that future position
+        projPosY = projPosY - GetSurfaceHeight(targetPosX + time * targetVelX, targetPosZ + time * targetVelZ)
 
-        -- The basic formula for displacement over time is x = v0*t + 0.5*a*t^2
-        -- x: displacement, v0: initial velocity, a: acceleration, t: time
-        -- v0 is zero due to projectiles not inheriting y-speed of bomber
+        -- The basic formula for displacement over time is h = 0.5 * a * t^2
+        -- h: displacement, a: acceleration, t: time
         -- now we can calculate what acceleration we need to make it hit the target in the y-axis
-        -- a = 2 * (1/t)^2 * x
+        -- a = 2 * h / t^2
 
         -- also convert time from ticks to seconds (multiply by 10, twice)
-        local acc = 200 * (projPosY - targetNewPosY) / (time*time)
+        local acc = 200 * projPosY / (time*time)
 
-        -- store last acceleration in case target dies in the middle of carpet bomb run
         data.lastAccel = acc
         return acc
     end,
@@ -915,6 +953,7 @@ DefaultProjectileWeapon = Class(Weapon) {
                         end
                     end
                 end
+                self.CurrentSalvoData = nil -- once the salvo is done, reset the data
                 self:PlayFxRackReloadSequence()
                 local currentRackSalvoNumber = self.CurrentRackSalvoNumber
                 if currentRackSalvoNumber <= rackBoneCount then


### PR DESCRIPTION
* Props no longer break the targeting of bombers
* Salvo data is now reset once the salvo cycle is complete
* Improved free-falling of bomb clusters in the failure mode
* More hyper-optimization of `CalculateBallisticAcceleration`