### PR TITLE
Using the DifferentialUpgradeCostCalculationCost for Radar

### DIFF
--- a/units/UAB3104/UAB3104_unit.bp
+++ b/units/UAB3104/UAB3104_unit.bp
@@ -132,10 +132,11 @@ UnitBlueprint {
         UniformScale = 0.25,
     },
     Economy = {
-        BuildCostEnergy = 30000,
-        BuildCostMass = 2400,
+        BuildCostEnergy = 3432,
+        BuildCostMass = 2660,
         BuildTime = 2575,
         MaintenanceConsumptionPerSecondEnergy = 2000,
+        DifferentialUpgradeCostCalculationCost = true;
         RebuildBonusIds = {
             'uab3104',
         },

--- a/units/UAB3201/UAB3201_unit.bp
+++ b/units/UAB3201/UAB3201_unit.bp
@@ -136,14 +136,15 @@ UnitBlueprint {
         UniformScale = 0.25,
     },
     Economy = {
-        BuildCostEnergy = 3600,
-        BuildCostMass = 180,
+        BuildCostEnergy = 4320,
+        BuildCostMass = 260,
         BuildRate = 21.46,
         BuildTime = 845,
         BuildableCategory = {
             'uab3104',
         },
         MaintenanceConsumptionPerSecondEnergy = 150,
+        DifferentialUpgradeCostCalculationCost = true;
         RebuildBonusIds = {
             'uab3201',
             'uab3104',

--- a/units/UEB3104/UEB3104_unit.bp
+++ b/units/UEB3104/UEB3104_unit.bp
@@ -100,10 +100,11 @@ UnitBlueprint {
         UniformScale = 0.08,
     },
     Economy = {
-        BuildCostEnergy = 30000,
-        BuildCostMass = 2400,
+        BuildCostEnergy = 34320,
+        BuildCostMass = 2660,
         BuildTime = 2575,
         MaintenanceConsumptionPerSecondEnergy = 2000,
+        DifferentialUpgradeCostCalculationCost = true;
         RebuildBonusIds = {
             'ueb3104',
         },

--- a/units/UEB3201/UEB3201_unit.bp
+++ b/units/UEB3201/UEB3201_unit.bp
@@ -104,10 +104,11 @@ UnitBlueprint {
         UniformScale = 0.08,
     },
     Economy = {
-        BuildCostEnergy = 3600,
-        BuildCostMass = 180,
+        BuildCostEnergy = 4320,
+        BuildCostMass = 260,
         BuildRate = 21.46,
         BuildTime = 845,
+        DifferentialUpgradeCostCalculationCost = true;
         BuildableCategory = {
             'ueb3104',
         },

--- a/units/URB3104/URB3104_unit.bp
+++ b/units/URB3104/URB3104_unit.bp
@@ -100,10 +100,11 @@ UnitBlueprint {
         UniformScale = 0.15,
     },
     Economy = {
-        BuildCostEnergy = 30000,
-        BuildCostMass = 2400,
+        BuildCostEnergy = 34320,
+        BuildCostMass = 2660,
         BuildTime = 2575,
         MaintenanceConsumptionPerSecondEnergy = 2000,
+        DifferentialUpgradeCostCalculationCost = true;
         RebuildBonusIds = {
             'urb3104',
         },

--- a/units/URB3201/URB3201_unit.bp
+++ b/units/URB3201/URB3201_unit.bp
@@ -104,14 +104,15 @@ UnitBlueprint {
         UniformScale = 0.15,
     },
     Economy = {
-        BuildCostEnergy = 3600,
-        BuildCostMass = 180,
+        BuildCostEnergy = 4320,
+        BuildCostMass = 260,
         BuildRate = 21.46,
         BuildTime = 845,
         BuildableCategory = {
             'urb3104',
         },
         MaintenanceConsumptionPerSecondEnergy = 150,
+        DifferentialUpgradeCostCalculationCost = true;
         RebuildBonusIds = {
             'urb3201',
             'urb3104',

--- a/units/XSB3104/XSB3104_unit.bp
+++ b/units/XSB3104/XSB3104_unit.bp
@@ -161,10 +161,11 @@ UnitBlueprint {
         UniformScale = 0.065,
     },
     Economy = {
-        BuildCostEnergy = 30000,
-        BuildCostMass = 2400,
+        BuildCostEnergy = 34320,
+        BuildCostMass = 2660,
         BuildTime = 2575,
         MaintenanceConsumptionPerSecondEnergy = 2000,
+        DifferentialUpgradeCostCalculationCost = true;
         RebuildBonusIds = {
             'xsb3104',
         },

--- a/units/XSB3201/XSB3201_unit.bp
+++ b/units/XSB3201/XSB3201_unit.bp
@@ -151,14 +151,15 @@ UnitBlueprint {
         UniformScale = 0.075,
     },
     Economy = {
-        BuildCostEnergy = 3600,
-        BuildCostMass = 180,
+        BuildCostEnergy = 4320,
+        BuildCostMass = 260,
         BuildRate = 21.46,
         BuildTime = 845,
         BuildableCategory = {
             'xsb3104',
         },
         MaintenanceConsumptionPerSecondEnergy = 150,
+        DifferentialUpgradeCostCalculationCost = true;
         RebuildBonusIds = {
             'xsb3201',
             'xsb3104',


### PR DESCRIPTION
using the `DifferentialUpgradeCostCalculationCost` for Radar to make the reclaim more sense the Mass / Energy Values can be debated by the balance team. currently I've just added the previous tier to the next to have the same cost as they are now if uses the upgrade mechanic and makes more expensive if built straight.