### PR TITLE
Reorder Lobby Options

### DIFF
--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -166,6 +166,39 @@ teamOptions =
 ---@type ScenarioOption[]
 globalOpts = {
     {
+         default = 2,
+         label = "<LOC lobui_0740>Share Conditions",
+         help = "<LOC lobui_0741>Set what happens to a player's units when they are defeated",
+         key = 'Share',
+         values = {
+             {
+                 text = "<LOC lobui_0742>Full Share",
+                 help = "<LOC lobui_0743>Your units will be transferred to your highest scoring ally when you die. Previously transferred units will stay where they are.",
+                 key = 'FullShare',
+             },
+             {
+                 text = "<LOC lobui_0744>Share Until Death",
+                 help = "<LOC lobui_0745>All units you have built this game will be destroyed when you die, except those captured by the enemy.",
+                 key = 'ShareUntilDeath',
+             },
+             {
+                 text = "<LOC lobui_0762>Traitors",
+                 help = "<LOC lobui_0763>Your units will be transferred to the control of your killer.",
+                 key = 'TransferToKiller',
+             },
+             {
+                 text = "<LOC lobui_0766>Defectors",
+                 help = "<LOC lobui_0767>Your units will be transferred to the enemy with the highest score when you die.",
+                 key = 'Defectors',
+             },
+             {
+                 text = "<LOC lobui_0764>Civilian Desertion",
+                 help = "<LOC lobui_0765>Your units will be transferred to the Civilian AI, if there is one, when you die.",
+                 key = 'CivilianDeserter',
+             },
+         },
+     },
+    {
         default = 1,
         label = "<LOC lobui_0802>Unrate",
         help = "<LOC lobui_0803>Provides a toggle to unrate a game. Note that if this is set to no the game can still be unrated due to other lobby options, unrated sim mods and / or the map being unrated.",
@@ -182,6 +215,24 @@ globalOpts = {
                   key = 'Yes',
               },
           },
+    },
+    {
+        default = 2,
+        label = "<LOC lobui_0592>Allow Observers",
+        help = "<LOC lobui_0593>Are observers permitted after the game has started?",
+        key = 'AllowObservers',
+        values = {
+            {
+                text = "<LOC _Yes>Yes",
+                help = "<LOC lobui_0594>Observers are allowed",
+                key = true,
+            },
+            {
+                text = "<LOC _No>No",
+                help = "<LOC lobui_0595>Observers are not allowed",
+                key = false,
+            },
+        },
     },
     {
         default = 8,
@@ -336,24 +387,6 @@ globalOpts = {
         },
     },
     {
-        default = 2,
-        label = "<LOC lobui_0592>Allow Observers",
-        help = "<LOC lobui_0593>Are observers permitted after the game has started?",
-        key = 'AllowObservers',
-        values = {
-            {
-                text = "<LOC _Yes>Yes",
-                help = "<LOC lobui_0594>Observers are allowed",
-                key = true,
-            },
-            {
-                text = "<LOC _No>No",
-                help = "<LOC lobui_0595>Observers are not allowed",
-                key = false,
-            },
-        },
-    },
-    {
         default = 1,
         label = "<LOC lobui_0208>Cheating",
         help = "<LOC lobui_0209>Enable cheat codes",
@@ -484,39 +517,6 @@ globalOpts = {
                 text = "<LOC _Off>Off",
                 help = "<LOC lobui_0730>Score is disabled",
                 key = 'no',
-            },
-        },
-    },
-   {
-        default = 2,
-        label = "<LOC lobui_0740>Share Conditions",
-        help = "<LOC lobui_0741>Set what happens to a player's units when they are defeated",
-        key = 'Share',
-        values = {
-            {
-                text = "<LOC lobui_0742>Full Share",
-                help = "<LOC lobui_0743>Your units will be transferred to your highest scoring ally when you die. Previously transferred units will stay where they are.",
-                key = 'FullShare',
-            },
-            {
-                text = "<LOC lobui_0744>Share Until Death",
-                help = "<LOC lobui_0745>All units you have built this game will be destroyed when you die, except those captured by the enemy.",
-                key = 'ShareUntilDeath',
-            },
-            {
-                text = "<LOC lobui_0762>Traitors",
-                help = "<LOC lobui_0763>Your units will be transferred to the control of your killer.",
-                key = 'TransferToKiller',
-            },
-            {
-                text = "<LOC lobui_0766>Defectors",
-                help = "<LOC lobui_0767>Your units will be transferred to the enemy with the highest score when you die.",
-                key = 'Defectors',
-            },
-            {
-                text = "<LOC lobui_0764>Civilian Desertion",
-                help = "<LOC lobui_0765>Your units will be transferred to the Civilian AI, if there is one, when you die.",
-                key = 'CivilianDeserter',
             },
         },
     },


### PR DESCRIPTION
Just a QoL change that makes share condition the top option in its options list and allow observers third (as opposed to both being lower down on the list)