### PR TITLE
Attempt at fixing harbingers

### DIFF
--- a/units/UAL0303/UAL0303_unit.bp
+++ b/units/UAL0303/UAL0303_unit.bp
@@ -55,6 +55,10 @@ UnitBlueprint {
         'BOT',
         'OVERLAYDIRECTFIRE',
         'PERSONALSHIELD',
+
+        -- this is technically incorrect, but it is for now the only way to let them ignore
+        -- reclaim. Sadly - the pile of issues is so large that we can't have that either
+        -- 'SUBCOMMANDER',
     },
     CollisionOffsetY = 0,
     Defense = {


### PR DESCRIPTION
It appears there is no viable solution without an engine patch. We either remove the `RECLAIM` category, but then they can no longer reclaim (besides having the command caps). Or we add the `SUBCOMMANDER` category but then they are recognized as support command units by essentially any mod that bothers checking for that category. There are 108 results in the repository alone on the `SUBCOMMANDER` property, so that isn't viable either.