### PR TITLE
Make Harbinger behave like SACU's

### DIFF
--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -1,6 +1,10 @@
 --- Post process a unit
 ---@param unit Unit
 local function PostProcessUnit(unit)
+    if table.find(unit.Categories, "SUBCOMMANDER") then
+        table.insert(unit.Categories, "SACU_BEHAVIOR")
+    end
+
     -- create hash tables for quick lookup
     unit.CategoriesCount = 0
     unit.CategoriesHash = {}

--- a/units/UAL0303/UAL0303_unit.bp
+++ b/units/UAL0303/UAL0303_unit.bp
@@ -55,6 +55,7 @@ UnitBlueprint {
         'BOT',
         'OVERLAYDIRECTFIRE',
         'PERSONALSHIELD',
+        'SACU_BEHAVIOR', -- used to get Attack-Move to work properly since the harbinger can reclaim
     },
     CollisionOffsetY = 0,
     Defense = {


### PR DESCRIPTION
As https://github.com/FAForever/fa/pull/4218 points out, there's no good way to solve Harbingers stopping to reclaim with Attack-Move without an engine patch. This PR makes it happen by applying a new category, `SACU_BEHAVIOR`, to the Harbinger. This works due to https://github.com/FAForever/FA-Binary-Patches/pull/13 renaming the `SUBCOMMANDER` category to `SACU_BEHAVIOR` in the engine (and we prevent compatibility issues by automatically adding `SACU_BEHAVIOR` to any unit with `SUBCOMMANDER`). There are no other side-effects because Harbingers cannot rebuild structures.