### PR TITLE
Decouple UI intialization and laying out

### DIFF
--- a/engine/User/UserUnit.lua
+++ b/engine/User/UserUnit.lua
@@ -167,7 +167,7 @@ function UserUnit:IsIdle()
 end
 
 ---
----@param category moho.EntityCategory
+---@param category CategoryName
 ---@return boolean
 function UserUnit:IsInCategory(category)
 end

--- a/lua/maui/border.lua
+++ b/lua/maui/border.lua
@@ -14,7 +14,7 @@
 
 local Control = import('/lua/maui/control.lua').Control
 
----@class Border : moho.border_methods, Control, InternalObject
+---@class MauiBorder : moho.border_methods, Control, InternalObject
 ---@field BorderWidth LazyVar
 ---@field BorderHeight LazyVar
 Border = Class(moho.border_methods, Control) {

--- a/lua/maui/layouthelpers.lua
+++ b/lua/maui/layouthelpers.lua
@@ -15,17 +15,29 @@
 -- scaled (e.g. large UI mode) the pixel scale factor will keep the layout correct.
 
 
+local iscallable = iscallable
+local GetTextureDimensions = GetTextureDimensions
 local MathFloor = math.floor
 local MathCeil = math.ceil
 
-local Prefs = import('/lua/user/prefs.lua')
+
+
+------------------------------
+-- UI Scaling
+------------------------------
+
 -- Store and set the current pixel scale multiplier. This will be used when the
 -- artwork is scaled up or down so that offsets scale up and down appropriately.
 -- Note that if you add a new layout helper function that uses offsets, you need
 -- to scale the offset with this factor or your layout may get funky when the
 -- art is changed
 ---@type number
-local pixelScaleFactor = Prefs.GetFromCurrentProfile('options').ui_scale or 1
+local pixelScaleFactor = import("/lua/user/prefs.lua").GetFromCurrentProfile("options").ui_scale or 1
+
+
+----------
+-- Scale manipulation functions
+----------
 
 --- Sets new pixel scale factor for fixed offset in layout functions
 ---@param newFactor number
@@ -38,6 +50,25 @@ end
 function GetPixelScaleFactor()
     return pixelScaleFactor
 end
+
+--- Scales a number by the pixel scale factor
+---@param number number
+---@return number scaledNumber
+function ScaleNumber(number)
+    return MathFloor(number * pixelScaleFactor)
+end
+
+--- Unscales a number by the pixel scale factor
+---@param scaledNumber number
+---@return number number
+function InvScaleNumber(scaledNumber)
+    return MathCeil(scaledNumber / pixelScaleFactor)
+end
+
+
+----------
+-- Dimensional functions
+----------
 
 --- Sets fixed width of a control, scaled by the pixel scale factor
 ---@param control Control
@@ -66,6 +97,97 @@ function SetDimensions(control, width, height)
     SetHeight(control, height)
 end
 
+--- Scales a control's dimensions by the pixel scale factor
+---@param control Control
+function Scale(control)
+    SetDimensions(control, control.Width(), control.Height())
+end
+
+
+----------
+-- Texture functions
+----------
+
+--- Sets a control's height to the height of a texture (with optional padding)
+---@param control Control
+---@param filename Lazy<FileName>
+---@param padding? number
+function SetHeightFromTexture(control, filename, padding)
+    if iscallable(filename) then -- skinnable file
+        control.Height:SetFunction(function()
+            local _, height = GetTextureDimensions(filename())
+            if padding then
+                return height + ScaleNumber(padding)
+            end
+            return MathFloor(height)
+        end)
+    else -- UI file
+        local _, height = GetTextureDimensions(filename)
+        if padding then
+            height = height + ScaleNumber(padding)
+        end
+        control.Height:SetValue(MathFloor(height))
+    end
+end
+
+--- Sets a control's width to the width of a texture (with optional padding)
+---@param control Control
+---@param filename Lazy<FileName>
+---@param padding? number defaults to 0, not 1
+function SetWidthFromTexture(control, filename, padding)
+    if iscallable(filename) then -- skinnable file
+        control.Width:SetFunction(function()
+            local width = GetTextureDimensions(filename())
+            if padding then
+                return width + ScaleNumber(padding)
+            end
+            return MathFloor(width)
+        end)
+    else -- UI file
+        local width = GetTextureDimensions(filename)
+        if padding then
+            width = width + ScaleNumber(padding)
+        end
+        control.Width:SetValue(MathFloor(width))
+    end
+end
+
+--- Set a control's dimensions to the dimensions of a texture (with an optional border)
+---@param control Control
+---@param filename Lazy<FileName>
+---@param border? number defaults to 0, not 1
+function SetDimensionsFromTexture(control, filename, border)
+    if iscallable(filename) then -- skinnable file
+        control.Width:SetFunction(function()
+            local width = GetTextureDimensions(filename())
+            if border then
+                return width + ScaleNumber(border)
+            end
+            return width
+        end)
+        control.Height:SetFunction(function()
+            local _, height = GetTextureDimensions(filename())
+            if border then
+                return height + ScaleNumber(border)
+            end
+            return height
+        end)
+    else -- UI file
+        local width, height = GetTextureDimensions(filename)
+        if border then
+            border = ScaleNumber(border)
+            width = width + border
+            height = height + border
+        end
+        control.Width:SetValue(width)
+        control.Height:SetValue(height)
+    end
+end
+
+
+----------
+-- Depth functions
+----------
 
 --- Sets depth of a control to be above a parent
 ---@param control Control
@@ -91,30 +213,64 @@ function DepthUnderParent(control, parent, depth)
     end
 end
 
---- Scales a control's dimensions by the pixel scale factor
----@param control Control
-function Scale(control)
-    SetDimensions(control, control.Width(), control.Height())
-end
-
---- Scales a number by the pixel scale factor
----@param number number
----@return number scaledNumber
-function ScaleNumber(number)
-    return MathFloor(number * pixelScaleFactor)
-end
-
---- Unscales a number by the pixel scale factor
----@param scaledNumber number
----@return number number
-function InvScaleNumber(scaledNumber)
-    return MathCeil(scaledNumber / pixelScaleFactor)
-end
 
 
+------------------------------
 -- Single positioning functions
+------------------------------
 
+-- These function set only one layout property of the six a control has
+
+----------
+-- Reset functions
+----------
+
+--- Resets a control's left edge to be calculated from its right edge and width.  
+--- Make sure `control.Right` and `control.Width` are not reset.
+---@param control Control
+function ResetLeft(control)
+    control.Left:SetFunction(function() return control.Right() - control.Width() end)
+end
+
+--- Resets a control's top edge to be calculated from its bottom edge and height.  
+--- Make sure `control.Bottom` and `control.Height` are not reset.
+---@param control Control
+function ResetTop(control)
+    control.Top:SetFunction(function() return control.Bottom() - control.Height() end)
+end
+
+--- Resets a control's right edge to be calculated from its left edge and width.  
+--- Make sure `control.Left` and `control.Width` are not reset.
+---@param control Control
+function ResetRight(control)
+    control.Right:SetFunction(function() return control.Left() + control.Width() end)
+end
+
+--- Resets a control's bottom edge to be calculated from its top edge and height.  
+--- Make sure `control.Top` and `control.Height` are not reset.
+---@param control Control
+function ResetBottom(control)
+    control.Bottom:SetFunction(function() return control.Top() + control.Height() end)
+end
+
+--- Resets a control's width to be calculated from its left and right edges.  
+--- Make sure `control.Left` and `control.Right` are not reset.
+---@param control Control
+function ResetWidth(control)
+    control.Width:SetFunction(function() return control.Right() - control.Left() end)
+end
+
+--- Resets a control's height to be calculated from its top and bottom edges.  
+--- Make sure `control.Top` and `control.Bottom` are not reset.
+---@param control Control
+function ResetHeight(control)
+    control.Height:SetFunction(function() return control.Bottom() - control.Top() end)
+end
+
+
+----------
 -- Anchor functions lock the appropriate edge of a control to the edge of another control
+----------
 
 --- Anchors a control's right edge to the left edge of a parent, with optional padding
 ---@param control Control
@@ -167,12 +323,16 @@ function AnchorToBottom(control, parent, padding)
     end
 end
 
--- These functions will set the controls position to be placed relative to
--- its parents dimensions.
+
+----------
+-- Inside offset functions
+----------
+
+-- These functions will set the control's position to be placed relative to its parent's dimensions.
 -- Note that the offset is in the opposite direction as placement, to position
 -- the controls further inside the parent.
 
--- These are generally most useful for elements that don't change size, they can also be
+-- These are generally most useful for elements that don't change size, though they can also be
 -- used for controls that stretch to match parent.
 
 --- Centers a control horizontally on a parent, with optional rightward offset.
@@ -183,11 +343,11 @@ end
 function AtHorizontalCenterIn(control, parent, leftOffset)
     if leftOffset then
         control.Left:SetFunction(function()
-            return MathFloor(parent.Left() + (parent.Width() - control.Width()) / 2 + leftOffset * pixelScaleFactor)
+            return MathFloor(parent.Left() + (parent.Width() - control.Width()) * 0.5 + leftOffset * pixelScaleFactor)
         end)
     else
         control.Left:SetFunction(function()
-            return MathFloor(parent.Left() + (parent.Width() - control.Width()) / 2)
+            return MathFloor(parent.Left() + (parent.Width() - control.Width()) * 0.5)
         end)
     end
 end
@@ -200,11 +360,11 @@ end
 function AtVerticalCenterIn(control, parent, topOffset)
     if topOffset then
         control.Top:SetFunction(function()
-            return MathFloor(parent.Top() + (parent.Height() - control.Height()) / 2 + topOffset * pixelScaleFactor)
+            return MathFloor(parent.Top() + (parent.Height() - control.Height()) * 0.5 + topOffset * pixelScaleFactor)
         end)
     else
         control.Top:SetFunction(function()
-            return MathFloor(parent.Top() + (parent.Height() - control.Height()) / 2)
+            return MathFloor(parent.Top() + (parent.Height() - control.Height()) * 0.5)
         end)
     end
 end
@@ -215,7 +375,9 @@ end
 ---@param leftOffset? number Offset of the control's left edge in the rightward direction, scaled by the pixel scale factor. Defaults to 0.
 function AtLeftIn(control, parent, leftOffset)
     if leftOffset and leftOffset ~= 0 then
-        control.Left:SetFunction(function() return MathFloor(parent.Left() + leftOffset * pixelScaleFactor) end)
+        control.Left:SetFunction(function()
+            return MathFloor(parent.Left() + leftOffset * pixelScaleFactor)
+        end)
     else
         control.Left:SetFunction(function() return parent.Left() end)
     end
@@ -227,7 +389,9 @@ end
 ---@param topOffset? number Offset of the control's top edge in the downward direction, scaled by the pixel scale factor. Defaults to 0.
 function AtTopIn(control, parent, topOffset)
     if topOffset and topOffset ~= 0 then
-        control.Top:SetFunction(function() return MathFloor(parent.Top() + topOffset * pixelScaleFactor) end)
+        control.Top:SetFunction(function()
+            return MathFloor(parent.Top() + topOffset * pixelScaleFactor)
+        end)
     else
         control.Top:SetFunction(function() return parent.Top() end)
     end
@@ -239,7 +403,9 @@ end
 ---@param rightOffset? number Offset of the control's right edge in the leftward direction, scaled by the pixel scale factor. Defaults to 0.
 function AtRightIn(control, parent, rightOffset)
     if rightOffset and rightOffset ~= 0 then
-        control.Right:SetFunction(function() return MathFloor(parent.Right() - rightOffset * pixelScaleFactor) end)
+        control.Right:SetFunction(function()
+            return MathFloor(parent.Right() - rightOffset * pixelScaleFactor)
+        end)
     else
         control.Right:SetFunction(function() return parent.Right() end)
     end
@@ -251,11 +417,18 @@ end
 ---@param bottomOffset? number Offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor. Defaults to 0.
 function AtBottomIn(control, parent, bottomOffset)
     if bottomOffset and bottomOffset ~= 0 then
-        control.Bottom:SetFunction(function() return MathFloor(parent.Bottom() - bottomOffset * pixelScaleFactor) end)
+        control.Bottom:SetFunction(function()
+            return MathFloor(parent.Bottom() - bottomOffset * pixelScaleFactor)
+        end)
     else
         control.Bottom:SetFunction(function() return parent.Bottom() end)
     end
 end
+
+
+----------
+-- Inside percentage functions
+----------
 
 -- These functions use percentages to place the item rather than offsets so they will
 -- stay proportially spaced when the parent resizes
@@ -267,9 +440,11 @@ end
 ---@param leftPercent? number defaults to 0.00 (all the way to left)
 function FromLeftIn(control, parent, leftPercent)
     if leftPercent and leftPercent ~= 0 then
-        control.Left:SetFunction(function() return MathFloor(parent.Left() + leftPercent * parent.Width()) end)
+        control.Left:SetFunction(function()
+            return MathFloor(parent.Left() + leftPercent * parent.Width())
+        end)
     else
-        control.Left:SetFunction(function() return parent.Left() end)
+        AtLeftIn(control, parent)
     end
 end
 
@@ -280,9 +455,11 @@ end
 ---@param topPercent? number defaults to 0.00 (all the way at the top)
 function FromTopIn(control, parent, topPercent)
     if topPercent and topPercent ~= 0 then
-        control.Top:SetFunction(function() return MathFloor(parent.Top() + topPercent * parent.Height()) end)
+        control.Top:SetFunction(function()
+            return MathFloor(parent.Top() + topPercent * parent.Height())
+        end)
     else
-        control.Top:SetFunction(function() return parent.Top() end)
+        AtTopIn(control, parent)
     end
 end
 
@@ -293,9 +470,11 @@ end
 ---@param rightPercent? number defaults to 0.00 (all the way right)
 function FromRightIn(control, parent, rightPercent)
     if rightPercent and rightPercent ~= 0 then
-        control.Right:SetFunction(function() return MathFloor(parent.Right() - rightPercent * parent.Width()) end)
+        control.Right:SetFunction(function()
+            return MathFloor(parent.Right() - rightPercent * parent.Width())
+        end)
     else
-        control.Right:SetFunction(function() return parent.Right() end)
+        AtRightIn(control, parent)
     end
 end
 
@@ -306,61 +485,84 @@ end
 ---@param bottomPercent? number defaults to 0.00 (all the way at the bottom)
 function FromBottomIn(control, parent, bottomPercent)
     if bottomPercent and bottomPercent ~= 0 then
-        control.Bottom:SetFunction(function() return MathFloor(parent.Bottom() - bottomPercent * parent.Height()) end)
+        control.Bottom:SetFunction(function()
+            return MathFloor(parent.Bottom() - bottomPercent * parent.Height())
+        end)
     else
-        control.Bottom:SetFunction(function() return parent.Bottom() end)
-        --control.Bottom:SetFunction(parent.Bottom)
+        AtBottomIn(control, parent)
     end
 end
 
--- These functions reset a control to be calculated from the others
 
---- Resets a control's left edge to be calculated from its right edge and width.  
---- Make sure `control:Right` and `control:Width` are not reset.
+----------
+-- Inside space functions
+----------
+
+--- Places the control's left edge a percentage along the horizontal space of a parent,
+--- with 0.00 at the parent's left edge (this requires the control's width to be set)
 ---@param control Control
-function ResetLeft(control)
-    control.Left:SetFunction(function() return control.Right() - control.Width() end)
+---@param parent Control
+---@param leftPercent? number
+function FromLeftWith(control, parent, leftPercent)
+    if leftPercent and leftPercent ~= 0 then
+        control.Left:SetFunction(function()
+            return MathFloor(parent.Left() + leftPercent * (parent.Width() - control.Width()))
+        end)
+    else
+        AtLeftIn(control, parent)
+    end
 end
 
---- Resets a control's top edge to be calculated from its bottom edge and height.  
---- Make sure `control:Bottom` and `control:Height` are not reset.
+--- Places the control's top edge a percentage along the vertical space of a parent
+--- with 0.00 at the parent's top edge (this requires the control's height to be set)
 ---@param control Control
-function ResetTop(control)
-    control.Top:SetFunction(function() return control.Bottom() - control.Height() end)
+---@param parent Control
+---@param topPercent? number
+function FromTopWith(control, parent, topPercent)
+    if topPercent and topPercent ~= 0 then
+        control.Top:SetFunction(function()
+            return MathFloor(parent.Top() + topPercent * (parent.Height() - control.Height()))
+        end)
+    else
+        AtTopIn(control, parent)
+    end
 end
 
---- Resets a control's right edge to be calculated from its left edge and width.  
---- Make sure `control:Left` and `control:Width` are not reset.
+--- Places the control's right edge a percentage along the horizontal space of a parent,
+--- with 0.00 at the parent's right edge (this requires the control's width to be set)
 ---@param control Control
-function ResetRight(control)
-    control.Right:SetFunction(function() return control.Left() + control.Width() end)
+---@param parent Control
+---@param rightPercent? number
+function FromRightWith(control, parent, rightPercent)
+    if rightPercent and rightPercent ~= 0 then
+        control.Right:SetFunction(function()
+            return MathFloor(parent.Right() - rightPercent * (parent.Width() - control.Width()))
+        end)
+    else
+        AtRightIn(control, parent)
+    end
 end
 
---- Resets a control's bottom edge to be calculated from its top edge and height.  
---- Make sure `control:Top` and `control:Height` are not reset.
+--- Places the control's bottom edge a percentage along the vertical space of a parent
+--- with 0.00 at the parent's bottom edge (this requires the control's height to be set)
 ---@param control Control
-function ResetBottom(control)
-    control.Bottom:SetFunction(function() return control.Top() + control.Height() end)
-end
-
---- Resets a control's width to be calculated from its left and right edges.  
---- Make sure `control:Left` and `control:Right` are not reset.
----@param control Control
-function ResetWidth(control)
-    control.Width:SetFunction(function() return control.Right() - control.Left() end)
-end
-
---- Resets a control's height to be calculated from its top and bottom edges.  
---- Make sure `control:Top` and `control:Bottom` are not reset.
----@param control Control
-function ResetHeight(control)
-    control.Height:SetFunction(function() return control.Bottom() - control.Top() end)
+---@param parent Control
+---@param bottomPercent? number
+function FromBottomWith(control, parent, bottomPercent)
+    if bottomPercent and bottomPercent ~= 0 then
+        control.Bottom:SetFunction(function()
+            return MathFloor(parent.Bottom() - bottomPercent * (parent.Height() - control.Height()))
+        end)
+    else
+        AtBottomIn(control, parent)
+    end
 end
 
 
---**********
---* Composite Functions
---**********
+
+------------------------------
+-- Double-positioning Functions
+------------------------------
 
 --- Places a control in the center of a parent, with optional offsets.
 --- This sets the control's left and top edges.  
@@ -373,6 +575,11 @@ function AtCenterIn(control, parent, topOffset, leftOffset)
     AtHorizontalCenterIn(control, parent, leftOffset)
     AtVerticalCenterIn(control, parent, topOffset)
 end
+
+
+----------
+-- Outside edge positioning functions
+----------
 
 --- Lock right edge of a control to left edge of a parent, centered vertically.
 --- This sets the control's right and top edges.
@@ -414,7 +621,10 @@ function CenteredBelow(control, parent, padding)
     AnchorToBottom(control, parent, padding)
 end
 
--- Set to a position inside the parent
+
+----------
+-- Inside 8-way positioning functions
+----------
 
 --- Places left edge of the control vertically centered inside of a parent's, with optional offsets.
 --- This sets the control's left and top edges.
@@ -502,6 +712,11 @@ function AtLeftBottomIn(control, parent, leftOffset, bottomOffset)
     AtBottomIn(control, parent, bottomOffset)
 end
 
+
+----------
+-- Flow-positioning functions
+----------
+
 -- These functions will set the controls position relative to another, usually a sibling
 
 --- Lock top right of a control to top left of a parent
@@ -541,6 +756,49 @@ function Below(control, parent, padding)
 end
 
 
+
+------------------------------
+-- Axial Functions
+------------------------------
+
+-- These functions set two of the three axial properties a control has
+-- (the third can be reset or left alone)
+
+--- Sets a control to fill the horizontal space of a parent
+---@param control Control
+---@param parent Control
+function FillHorizontally(control, parent)
+    AtLeftIn(control, parent)
+    AtRightIn(control, parent)
+end
+
+--- Sets a control to fill the vertical space of a parent
+---@param control Control
+---@param parent Control
+function FillVertically(control, parent)
+    AtTopIn(control, parent)
+    AtBottomIn(control, parent)
+end
+
+
+
+------------------------------
+-- Composite Functions
+------------------------------
+
+--- Reset all edges and dimensions to the default layout functions.  
+--- You should call `control:ResetLayout()` instead unless you cannot rely on overriden behavior.  
+--- Remember to redefine two horizontal and two vertical properties to avoid circular dependencies.
+---@param control Control
+function Reset(control)
+    ResetLeft(control)
+    ResetTop(control)
+    ResetRight(control)
+    ResetBottom(control)
+    ResetWidth(control)
+    ResetHeight(control)
+end
+
 -- These functions will place the control and resize in a specified location within the parent.
 -- Note that the offset version is more useful than hard coding the location
 -- as it will take advantage of the pixel scale factor
@@ -575,17 +833,17 @@ function PercentIn(control, parent, left, top, right, bottom)
     FromBottomIn(control, parent, bottom)
 end
 
--- These functions will stretch the control to fill the parent and provide an optional border
 
---- Sets a control to fill a parent.
---- Note that this function copies the parent's edges (it does not refer) so they must be set first.
+----------
+-- Fill functions
+----------
+
+--- Sets a control to fill a parent
 ---@param control Control
 ---@param parent Control
 function FillParent(control, parent)
-    control.Top:SetFunction(parent.Top)
-    control.Left:SetFunction(parent.Left)
-    control.Bottom:SetFunction(parent.Bottom)
-    control.Right:SetFunction(parent.Right)
+    FillHorizontally(control, parent)
+    FillVertically(control, parent)
 end
 
 --- Sets a control to fill a parent's with fixed padding on all edges
@@ -617,32 +875,23 @@ function FillParentPreserveAspectRatio(control, parent)
     end
 
     control.Top:SetFunction(function()
-        return MathFloor(parent.Top() + (parent.Height() - control.Height() * GetRatio(control, parent)) / 2)
+        return MathFloor(parent.Top() + (parent.Height() - control.Height() * GetRatio(control, parent)) * 0.5)
     end)
     control.Bottom:SetFunction(function()
-        return MathFloor(parent.Bottom() - (parent.Height() - control.Height() * GetRatio(control, parent)) / 2)
+        return MathFloor(parent.Bottom() - (parent.Height() - control.Height() * GetRatio(control, parent)) * 0.5)
     end)
     control.Left:SetFunction(function()
-        return MathFloor(parent.Left() + (parent.Width() - control.Width() * GetRatio(control, parent)) / 2)
+        return MathFloor(parent.Left() + (parent.Width() - control.Width() * GetRatio(control, parent)) * 0.5)
     end)
     control.Right:SetFunction(function()
-        return MathFloor(parent.Right() - (parent.Width() - control.Width() * GetRatio(control, parent)) / 2)
+        return MathFloor(parent.Right() - (parent.Width() - control.Width() * GetRatio(control, parent)) * 0.5)
     end)
 end
 
---- Reset all edges and dimensions to the default layout functions.  
---- You should call `control:ResetLayout()` instead unless you cannot rely on overriden behavior.  
---- Remember to redefine two horizontal and two vertical properties to avoid circular dependencies.
----@param control Control
-function Reset(control)
-    ResetLeft(control)
-    ResetTop(control)
-    ResetRight(control)
-    ResetBottom(control)
-    ResetWidth(control)
-    ResetHeight(control)
-end
 
+----------
+-- Maui functions
+----------
 
 -- The following functions use layout files created with the Maui Photoshop Exporter to position controls
 -- Layout files contain a single table in this format:
@@ -675,7 +924,7 @@ function RelativeTo(control, parent, fileName, controlName, parentName, topOffse
         local layoutTable = import(fileName()).layout
         return MathFloor(parent.Top() + (layoutTable[controlName].top - layoutTable[parentName].top + topOffset) * pixelScaleFactor)
     end)
-    
+
     control.Left:SetFunction(function()
         local layoutTable = import(fileName()).layout
         return MathFloor(parent.Left() + (layoutTable[controlName].left - layoutTable[parentName].left + leftOffset) * pixelScaleFactor)
@@ -786,593 +1035,1248 @@ function DimensionsRelativeTo(control, fileName, controlName)
 end
 
 
---**********************************
---*********  Layouter  *************
---**********************************
 
----@class Layouter : moho.aibrain_methods
----@field c Control
-local LayouterMetaTable = {}
-LayouterMetaTable.__index = LayouterMetaTable
+------------------------------
+-- Compound Functions
+------------------------------
 
+-- These functions layout multiple controls at once
 
--- Get control
----@return Control c
-function LayouterMetaTable:Get()
-    return self.c
-end
-
--- Controls' mostly used methods
-
---- Sets the name of the control
----@param debugName string
----@return Layouter
-function LayouterMetaTable:Name(debugName)
-    self.c:SetName(debugName)
-    return self
-end
-
---- Disables the control
----@return Layouter
-function LayouterMetaTable:Disable()
-    self.c:Disable()
-    return self
-end
-
---- Hides the control
----@return Layouter
-function LayouterMetaTable:Hide()
-    self.c:Hide()
-    return self
-end
-
---- Sets the color of the control
----@param color string color as a hexcode
----@return Layouter
-function LayouterMetaTable:Color(color)
-    if self.c.SetSolidColor then
-        self.c:SetSolidColor(color)
-    elseif self.c.SetColor then
-        self.c:SetColor(color)
+---@param left Control
+---@param right Control
+---@param parent Control
+---@param percentage number
+---@param sep? number
+function SplitHorizontallyIn(left, right, parent, percentage, sep)
+    AtRightIn(right, parent)
+    FillVertically(right, parent)
+    if sep then
+        right.Left:SetFunction(function()
+            return parent.Left() + MathFloor(percentage * parent.Width() + ScaleNumber(sep) * 0.5)
+        end)
     else
-        WARN(string.format("Unable to set color for control \"%s\"", self.c:GetName()))
+        FromLeftIn(right, parent, percentage)
     end
-    return self
+
+    AtLeftIn(left, parent)
+    FillVertically(left, parent)
+    AnchorToLeft(left, right, sep)
 end
 
---- Sets if the control has a drop shadow
----@param hasShadow boolean
----@return Layouter
-function LayouterMetaTable:DropShadow(hasShadow)
-    self.c:SetDropShadow(hasShadow)
-    return self
-end
-
---- Sets the control's texture
----@param texture string resource location
----@param border? Border
----@return Layouter
-function LayouterMetaTable:Texture(texture, border)
-    self.c:SetTexture(texture, border)
-    return self
-end
-
---- Enables the control's hit test
----@param isRecursive? boolean
----@return Layouter
-function LayouterMetaTable:EnableHitTest(isRecursive)
-    self.c:EnableHitTest(isRecursive)
-    return self
-end
-
---- Disables the control's hit test
----@param isRecursive? boolean
----@return Layouter
-function LayouterMetaTable:DisableHitTest(isRecursive)
-    self.c:DisableHitTest(isRecursive)
-    return self
-end
-
---- Sets if the control needs a frame update
----@param needsUpdate boolean
----@return Layouter
-function LayouterMetaTable:NeedsFrameUpdate(needsUpdate)
-    self.c:SetNeedsFrameUpdate(needsUpdate)
-    return self
-end
-
---- Sets the alpha of the control
----@param alpha number
----@param forChildren boolean
----@return Layouter
-function LayouterMetaTable:Alpha(alpha, forChildren)
-    self.c:SetAlpha(alpha, forChildren)
-    return self
-end
-
--- Raw setting
----@alias lazyvarType function|number
-
---- Sets the left edge of the control
----@param left lazyvarType
----@return Layouter
-function LayouterMetaTable:Left(left)
-    self.c.Left:Set(left)
-    return self
-end
-
---- Sets the top edge of the control
----@param top lazyvarType
----@return Layouter
-function LayouterMetaTable:Top(top)
-    self.c.Top:Set(top)
-    return self
-end
-
---- Sets the right edge of the control
----@param right lazyvarType
----@return Layouter
-function LayouterMetaTable:Right(right)
-    self.c.Right:Set(right)
-    return self
-end
-
---- Sets the bottom edge of the control
----@param bottom lazyvarType
----@return Layouter
-function LayouterMetaTable:Bottom(bottom)
-    self.c.Bottom:Set(bottom)
-    return self
-end
-
---- Sets the width of the control
----@param width lazyvarType if a number, width will be scaled by the pixel factor
----@return Layouter
-function LayouterMetaTable:Width(width)
-    if iscallable(width) then
-        self.c.Width:SetFunction(width)
+---@param top Control
+---@param bottom Control
+---@param parent Control
+---@param percentage number
+---@param sep? number
+function SplitVerticallyIn(top, bottom, parent, percentage, sep)
+    FillHorizontally(bottom, parent)
+    AtBottomIn(bottom, parent)
+    if sep then
+        bottom.Top:SetFunction(function()
+            return parent.Top() + MathFloor(percentage * parent.Height() + ScaleNumber(sep) * 0.5)
+        end)
     else
-        self.c.Width:SetValue(ScaleNumber(width))
-    end
-    return self
-end
-
---- Sets the height of the control
----@param height lazyvarType #if a number, height will be scaled by the pixel factor
----@return Layouter
-function LayouterMetaTable:Height(height)
-    if iscallable(height) then
-        self.c.Height:SetFunction(height)
-    else
-        self.c.Height:SetValue(ScaleNumber(height))
-    end
-    return self
-end
-
-
--- Depth
-
---- Sets depth of the control to be above a parent
----@param parent Control
----@param depth? integer defaults to 1
----@return Layouter
-function LayouterMetaTable:Over(parent, depth)
-    DepthOverParent(self.c, parent, depth)
-    return self
-end
-
-
---- Sets depth of the control to be below a parent
----@param parent Control
----@param depth? integer defaults to 1
----@return Layouter
-function LayouterMetaTable:Under(parent, depth)
-    DepthUnderParent(self.c, parent, depth)
-    return self
-end
-
-
-
--- Single positioning methods
-
--- Anchors
-
---- Anchors the control's right edge to the left edge of a parent, with optional padding
----@param parent Control
----@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
----@return Layouter
-function LayouterMetaTable:AnchorToLeft(parent, padding)
-    AnchorToLeft(self.c, parent, padding)
-    return self
-end
-
---- Anchors the control's bottom edge to the top edge of a parent, with optional padding
----@param parent Control
----@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
----@return Layouter
-function LayouterMetaTable:AnchorToTop(parent, padding)
-    AnchorToTop(self.c, parent, padding)
-    return self
-end
-
---- Anchors the control's left edge to the right edge of a parent, with optional padding
----@param parent Control
----@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
----@return Layouter
-function LayouterMetaTable:AnchorToRight(parent, padding)
-    AnchorToRight(self.c, parent, padding)
-    return self
-end
-
---- Anchors the control's top edge to the bottom edge of a parent, with optional padding
----@param parent Control
----@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
----@return Layouter
-function LayouterMetaTable:AnchorToBottom(parent, padding)
-    AnchorToBottom(self.c, parent, padding)
-    return self
-end
-
--- Centered
-
---- Centers the control horizontally on a parent, with optional rightward offset.
---- This sets the control's left edge.
----@param parent Control
----@param leftOffset? number Offset of control's left edge in the rightward direction, scaled by the pixel scale factor. Defaults to 0.
----@return Layouter
-function LayouterMetaTable:AtHorizontalCenterIn(parent, leftOffset)
-    AtHorizontalCenterIn(self.c, parent, leftOffset)
-    return self
-end
-
---- Centers the control vertically on a parent, with optional downward offset.
---- This sets the control's top edge.
----@param parent Control
----@param topOffset? number Offset of the control's top edge in the downward direction, scaled by the pixel scale factor. Defaults to 0.
----@return Layouter
-function LayouterMetaTable:AtVerticalCenterIn(parent, topOffset)
-    AtVerticalCenterIn(self.c, parent, topOffset)
-    return self
-end
-
--- Inside
-
---- Places the control's left edge inside of a parent's, with optional rightward offset
----@param parent Control
----@param leftOffset? number Offset of the control's left edge in the rightward direction, scaled by the pixel scale factor. Defaults to 0.
----@return Layouter
-function LayouterMetaTable:AtLeftIn(parent, leftOffset)
-    AtLeftIn(self.c, parent, leftOffset)
-    return self
-end
-
---- Places the control's top edge inside of a parent's, with optional downward offset
----@param parent Control
----@param topOffset? number Offset of the control's top edge in the downward direction, scaled by the pixel scale factor. Defaults to 0.
----@return Layouter
-function LayouterMetaTable:AtTopIn(parent, topOffset)
-    AtTopIn(self.c, parent, topOffset)
-    return self
-end
-
---- Places the control's right edge inside of a parent's, with optional leftward offset
----@param parent Control
----@param rightOffset? number Offset of the control's right edge in the leftward direction, scaled by the pixel scale factor. Defaults to 0.
----@return Layouter
-function LayouterMetaTable:AtRightIn(parent, rightOffset)
-    AtRightIn(self.c, parent, rightOffset)
-    return self
-end
-
---- Places the control's bottom edge inside of a parent's, with optional upward offset
----@param parent Control
----@param bottomOffset? number Offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor. Defaults to 0.
----@return Layouter
-function LayouterMetaTable:AtBottomIn(parent, bottomOffset)
-    AtBottomIn(self.c, parent, bottomOffset)
-    return self
-end
-
--- Resets
-
---- Resets the control's left edge to be calculated from its right edge and width.  
---- Make sure `control:Right` and `control:Width` are not reset.
----@return Layouter
-function LayouterMetaTable:ResetLeft()
-    ResetLeft(self.c)
-    return self
-end
-
---- Resets the control's top edge to be calculated from its bottom edge and height.  
---- Make sure `control:Bottom` and `control:Height` are not reset.
----@return Layouter
-function LayouterMetaTable:ResetTop()
-    ResetTop(self.c)
-    return self
-end
-
---- Resets the control's right edge to be calculated from its left edge and width.  
---- Make sure `control:Left` and `control:Width` are not reset.
----@return Layouter
-function LayouterMetaTable:ResetRight()
-    ResetRight(self.c)
-    return self
-end
-
---- Resets the control's bottom edge to be calculated from its top edge and height.  
---- Make sure `control:Top` and `control:Height` are not reset.
----@return Layouter
-function LayouterMetaTable:ResetBottom()
-    ResetBottom(self.c)
-    return self
-end
-
---- Resets the control's width to be calculated from its left and right edges.  
---- Make sure `control:Left` and `control:Right` are not reset.
----@return Layouter
-function LayouterMetaTable:ResetWidth()
-    ResetWidth(self.c)
-    return self
-end
-
---- Resets the control's height to be calculated from its top and bottom edges.  
---- Make sure `control:Top` and `control:Bottom` are not reset.
----@return Layouter
-function LayouterMetaTable:ResetHeight()
-    ResetHeight(self.c)
-    return self
-end
-
---**********
---* Composite positioning
---**********
-
---- Surround positioning
-
---- Lock right edge of the control to the left edge of a parent, centered vertically.
---- This sets the control's right and top edges.
----@param parent Control
----@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
----@return Layouter
-function LayouterMetaTable:CenteredLeftOf(parent, padding)
-    CenteredLeftOf(self.c, parent, padding)
-    return self
-end
-
---- Lock bottom edge of the control to the top edge of a parent, centered horizontally.
---- This sets the control's left and bottom edges.
----@param parent Control
----@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
----@return Layouter
-function LayouterMetaTable:CenteredAbove(parent, padding)
-    CenteredAbove(self.c, parent, padding)
-    return self
-end
-
---- Lock left edge of the control to the right edge of a parent, centered vertically.
---- This sets the control's left and top edges.
----@param parent Control
----@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
----@return Layouter
-function LayouterMetaTable:CenteredRightOf(parent, padding)
-    CenteredRightOf(self.c, parent, padding)
-    return self
-end
-
---- Lock top edge of the control to the bottom edge of parent, centered horizontally.
---- This sets the controls's left and top edges.
----@param parent Control
----@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
----@return Layouter
-function LayouterMetaTable:CenteredBelow(parent, padding)
-    CenteredBelow(self.c, parent, padding)
-    return self
-end
-
--- Inside positioning
--- Note that the inside-edge layouts don't have a function counterpart like
--- the inside-corner layouts do.
-
---- Places the control in the center of the parent, with optional offsets.
---- This sets the control's left and top edges.  
---- Note the argument order.
----@param parent Control
----@param topOffset? number offset of top edge in downward direction, scaled by the pixel scale factor
----@param leftOffset? number offset of left edge in rightward direction, scaled by the pixel scale factor
----@return Layouter
-function LayouterMetaTable:AtCenterIn(parent, topOffset, leftOffset)
-    AtCenterIn(self.c, parent, topOffset, leftOffset)
-    return self
-end
-
---- Places left edge of the control vertically centered inside of a parent's, with optional offsets.
---- This sets the control's left and top edges.
----@param parent Control
----@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
----@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
----@return Layouter
-function LayouterMetaTable:AtLeftCenterIn(parent, leftOffset, topOffset)
-    AtLeftCenterIn(self.c, parent, leftOffset, topOffset)
-    return self
-end
-
---- Places top left corner of the control inside of a parent's, with optional offsets
----@param parent Control
----@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
----@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
----@return Layouter
-function LayouterMetaTable:AtLeftTopIn(parent, leftOffset, topOffset)
-    AtLeftTopIn(self.c, parent, leftOffset, topOffset)
-    return self
-end
-
---- Places top edge of the control horizontally centered inside of a parent's, with optional offsets.
---- Sets the control's left and top edges.  
---- Note the argument order.
----@param parent Control
----@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
----@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
----@return Layouter
-function LayouterMetaTable:AtTopCenterIn(parent, topOffset, leftOffset)
-    AtTopCenterIn(self.c, parent, topOffset, leftOffset)
-    return self
-end
-
---- Places top right corner of the control inside of a parent's, with optional offsets
----@param parent Control
----@param rightOffset? number offset of the control's right edge in the leftward direction, scaled by the pixel scale factor
----@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
----@return Layouter
-function LayouterMetaTable:AtRightTopIn(parent, rightOffset, topOffset)
-    AtRightTopIn(self.c, parent, rightOffset, topOffset)
-    return self
-end
-
---- Places right edge of the control vertically centered inside of a parent's, with optional offsets.
---- Sets the control's right and top edges.
----@param parent Control
----@param rightOffset? number offset of the control's right edge in the leftward direction, scaled by the pixel scale factor
----@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
----@return Layouter
-function LayouterMetaTable:AtRightCenterIn(parent, rightOffset, topOffset)
-    AtRightCenterIn(self.c, parent, rightOffset, topOffset)
-    return self
-end
-
---- Places bottom right corner of the control inside of a parent's, with optional offsets
----@param parent Control
----@param rightOffset? number offset of the control's right edge in the leftward direction, scaled by the pixel scale factor
----@param bottomOffset? number offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor
----@return Layouter
-function LayouterMetaTable:AtRightBottomIn(parent, rightOffset, bottomOffset)
-    AtRightBottomIn(self.c, parent, rightOffset, bottomOffset)
-    return self
-end
-
---- Places bottom edge of the control horizontally centered inside of a parent's, with optional offsets.
---- Sets the control's left and bottom edges.  
---- Note the argument order.
----@param parent Control
----@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
----@param bottomOffset? number offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor
----@return Layouter
-function LayouterMetaTable:AtBottomCenterIn(parent, bottomOffset, leftOffset)
-    AtBottomCenterIn(self.c, parent, bottomOffset, leftOffset)
-    return self
-end
-
---- Places bottom left corner of the control inside of a parent's, with optional offsets
----@param parent Control
----@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
----@param bottomOffset? number offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor
----@return Layouter
-function LayouterMetaTable:AtLeftBottomIn(parent, leftOffset, bottomOffset)
-    AtLeftBottomIn(self.c, parent, leftOffset, bottomOffset)
-    return self
-end
-
--- Out-of positioning
-
---- Lock top right of the control to the top left of a parent
----@param parent Control
----@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
----@return Layouter
-function LayouterMetaTable:LeftOf(parent, padding)
-    LeftOf(self.c, parent, padding)
-    return self
-end
-
---- Lock top left of the control to the top right of a parent
----@param parent Control
----@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
----@return Layouter
-function LayouterMetaTable:RightOf(parent, padding)
-    RightOf(self.c, parent, padding)
-    return self
-end
-
---- Lock bottom left of the control to the top left of a parent
----@param parent Control
----@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
----@return Layouter
-function LayouterMetaTable:Above(parent, padding)
-    Above(self.c, parent, padding)
-    return self
-end
-
---- Lock top left of the control to the bottom left of a parent
----@param parent Control
----@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
----@return Layouter
-function LayouterMetaTable:Below(parent, padding)
-    Below(self.c, parent, padding)
-    return self
-end
-
--- Fill parent
-
---- Sets the control to fill a parent.
---- Note that this function copies the parent's edges (it does not refer) so they must be set first.
----@param parent Control
----@return Layouter
-function LayouterMetaTable:Fill(parent)
-    FillParent(self.c, parent)
-    return self
-end
-
---- Sets the control to fill a parent's with fixed padding
----@param parent Control
----@param offset? number
----@return Layouter
-function LayouterMetaTable:FillFixedBorder(parent, offset)
-    FillParentFixedBorder(self.c, parent, offset)
-    return self
-end
-
-
--- Calculates the control's Properties to determine its layout completion and returns it.  
--- Remember, if parent has incomplete layout it will warn you anyway.
----@return Control
-function LayouterMetaTable:End()
-    if not pcall(self.c.Top) or not pcall(self.c.Bottom) or not pcall(self.c.Height) then
-        WARN(string.format("Incorrect layout for \"%s\" Top-Height-Bottom", self.c:GetName()))
-        WARN(debug.traceback())
+        FromTopIn(bottom, parent, percentage)
     end
 
-    if not pcall(self.c.Left) or not pcall(self.c.Right) or not pcall(self.c.Width)  then
-        WARN(string.format("Incorrect layout for \"%s\" Left-Width-Right", self.c:GetName()))
-        WARN(debug.traceback())
-    end
-
-    return self.c
+    FillHorizontally(top, parent)
+    AtTopIn(top, parent)
+    AnchorToTop(top, bottom, sep)
 end
 
 
-function LayouterMetaTable:__newindex(key, value)
-    error("attempt to set new index for a Layouter object")
-end
 
 
---- Returns a layouter for a control
----@param control Control
----@return Layouter
-function LayoutFor(control)
-    local result = {
-        c = control
-    }
-    setmetatable(result, LayouterMetaTable)
-    return result
-end
+--------------------------------------------------------------------------------
+-- Layouters
+--------------------------------------------------------------------------------
 
-local layouter = {
-    c = false
+-- An extremely helpful design pattern for laying out components, it is intended to make
+-- UI code readable, maintainable, robust, and easily diagnosable
+--
+-- To use it, start by making sure these lines are at the top of your UI file
+--[[
+local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
+local Layouter = LayouterHelper.ReusedLayouter
+--]]
+-- (This is mostly for readability, but there's also efficiency reasons)
+--
+-- After that, you can use the Layouter to replace most calls to a LayoutHelper.lua function by
+-- using its daisy-chain semantics:
+--[[
+Layouter(component)
+    :AtLeftIn(parent, 3)
+    :AnchorToBottom(previousComponent)
+    :End()
+--]]
+-- Whenever a Layouter calls `End()` it makes sure its positional properties don't have any
+-- lingering circular dependencies and it returns the control. Additionally, if the control it just
+-- finished laying out has a method called `Layout()`, it is called and this is why:
+--
+-- Any UI components you initialize should only initialize child components, it should NOT layout
+-- anything inside of the `__init` function. This is because a UI component should be built with
+-- reusability and encapsulation in mind--a component should not lay itself out because it is up to
+-- its parent to decide where it goes. Therefore, any children that component has also should not be
+-- laid out in the initializer since they depend on its layout to be positioned correctly.
+--
+-- Not only that, but it's possible that your class needs to change how it looks when the layout
+-- skin changes (either by it rotating or different faction being selected).
+--
+-- (Calling `Layouter` also calls a control's `OnLayout()` method, but you shouldn't need to use
+-- that unless there's some dynamic component instantiation going on that requires external data)
+-- If you need to establish layout defaults that are easily overwritten and would need to be done in
+-- `__init()`, you still shouldn't lay anything out there as it actually belongs in the `OnInit()`
+-- function (as with any overriden function, make sure to call your parent's `OnInit()` first).
+--
+-- Thus, a basic UI class might end up looking something like this:
+--[[
+UIComponent = Class(Group) {
+    __init = function(self, parent)
+        Group.__init(self, parent)
+
+        self.component = UIUtil.CreateText( ... )
+        ...
+    end;
+
+    Layout = function(self)
+        local component = Layouter(self.component)
+            :AtTopLeftIn(self)
+            ...
+    end;
 }
-setmetatable(layouter, LayouterMetaTable)
+--]]
+-- This means that the only thing that needs to happen is either for another UI class to use this
+-- component in their layout, or to create a top-level creation functions for singleton classes
+-- like this:
+--[[
+local GUI = false
 
---- Use if you don't cache layouter object
+function Create(parent)
+    local component = GUI
+    if component then
+        return component
+    end
+    component = UIComponent(parent)
+    GUI = component
+    return component
+end
+
+function SetLayout()
+    Layouter(GUI)
+        :AtTopLeftIn(parent)
+        :Width(364)
+        :Height(180)
+        :End()
+end
+--]]
+-- Do not try to layout more than control at a time; it is confusing and will break the default
+-- layouter. However, should it be absolutely necessary (e.g. for UIUtils that may not create a
+-- control with a valid hierarchy), you can use a new layouter object from the class
+-- (`LayoutHelpers.Layouter(control)`) instead of the reused layouter.
+
+
+--- Returns the control a layout represents, whether a layouter or an actual control
+---@param layout Layouter | Control
+---@return Control
+function GetControl(layout)
+    return layout.c or layout
+end
+
+--------------------------------------------------
+-- Control Attribute
+--------------------------------------------------
+
+---@class LayouterAttributeControl
+local LayouterAttributeControl = ClassSimple {
+    --- Sets the name of the control
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param debugName string
+    ---@return T
+    Name = function(self, debugName)
+        self.c:SetName(debugName)
+        return self
+    end;
+
+    --- Disables the control
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@return T
+    Disable = function(self)
+        self.c:Disable()
+        return self
+    end;
+
+    --- Hides the control
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@return T
+    Hide = function(self)
+        self.c:Hide()
+        return self
+    end;
+
+    --- Enables the control's hit test
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param isRecursive? boolean
+    ---@return T
+    EnableHitTest = function(self, isRecursive)
+        self.c:EnableHitTest(isRecursive)
+        return self
+    end;
+
+    --- Disables the control's hit test
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param isRecursive? boolean
+    ---@return T
+    DisableHitTest = function(self, isRecursive)
+        self.c:DisableHitTest(isRecursive)
+        return self
+    end;
+
+    --- Sets if the control needs a frame update
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param needsUpdate boolean
+    ---@return T
+    NeedsFrameUpdate = function(self, needsUpdate)
+        self.c:SetNeedsFrameUpdate(needsUpdate)
+        return self
+    end;
+
+    --- Sets the alpha of the control
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param alpha number
+    ---@param forChildren? boolean
+    ---@return T
+    Alpha = function(self, alpha, forChildren)
+        self.c:SetAlpha(alpha, forChildren)
+        return self
+    end;
+
+
+
+    ------------------------------
+    -- Property Setters
+    ------------------------------
+
+    ----------
+    -- Positional setters
+    ----------
+
+    --- Sets the left edge of the control
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param left Lazy<number>
+    ---@return T
+    Left = function(self, left)
+        self.c.Left:Set(left)
+        return self
+    end;
+
+    --- Sets the top edge of the control
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param top Lazy<number>
+    ---@return T
+    Top = function(self, top)
+        self.c.Top:Set(top)
+        return self
+    end;
+
+    --- Sets the right edge of the control
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param right Lazy<number>
+    ---@return T
+    Right = function(self, right)
+        self.c.Right:Set(right)
+        return self
+    end;
+
+    --- Sets the bottom edge of the control
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param bottom Lazy<number>
+    ---@return T
+    Bottom = function(self, bottom)
+        self.c.Bottom:Set(bottom)
+        return self
+    end;
+
+
+    ----------
+    -- Dimensional setters
+    ----------
+
+    --- Sets the width of the control
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param width Lazy<number> if a number, width will be scaled by the pixel factor
+    ---@return T
+    Width = function(self, width)
+        local controlWidth = self.c.Width
+        if iscallable(width) then
+            controlWidth:SetFunction(width)
+        else
+            controlWidth:SetValue(ScaleNumber(width))
+        end
+        return self
+    end;
+
+    --- Sets the height of the control
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param height Lazy<number> if a number, height will be scaled by the pixel factor
+    ---@return T
+    Height = function(self, height)
+        local controlHeight = self.c.Height
+        if iscallable(height) then
+            controlHeight:SetFunction(height)
+        else
+            controlHeight:SetValue(ScaleNumber(height))
+        end
+        return self
+    end;
+
+    --- Sets the width of the control to a texture
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param filename Lazy<FileName>
+    ---@param padding? number defaults to 0, not 1
+    ---@return T
+    WidthFromTexture = function(self, filename, padding)
+        SetWidthFromTexture(self.c, filename, padding)
+        return self
+    end;
+
+    --- Sets the height of the control to a texture
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param filename Lazy<FileName>
+    ---@param padding? number defaults to 0, not 1
+    ---@return T
+    HeightFromTexture = function(self, filename, padding)
+        SetHeightFromTexture(self.c, filename, padding)
+        return self
+    end;
+
+    --- Sets the dimensions of the control to a texture
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param filename Lazy<FileName>
+    ---@param padding? number defaults to 0, not 1
+    ---@return T
+    DimensionsFromTexture = function(self, filename, padding)
+        SetDimensionsFromTexture(self.c, filename, padding)
+        return self
+    end;
+
+
+    ----------
+    -- Depth setters
+    ----------
+
+    --- Sets depth of the control to be above a parent
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param depth? integer defaults to 1
+    ---@return T
+    Over = function(self, parent, depth)
+        DepthOverParent(self.c, GetControl(parent), depth)
+        return self
+    end;
+
+
+    --- Sets depth of the control to be below a parent
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param depth? integer defaults to 1
+    ---@return T
+    Under = function(self, parent, depth)
+        DepthUnderParent(self.c, GetControl(parent), depth)
+        return self
+    end;
+
+
+
+    ------------------------------
+    -- Single positioning methods
+    ------------------------------
+
+    ----------
+    -- Reset methods
+    ----------
+
+    --- Resets the control's left edge to be calculated from its right edge and width.  
+    --- Make sure `control.Right` and `control.Width` are not reset.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@return T
+    ResetLeft = function(self)
+        ResetLeft(self.c)
+        return self
+    end;
+
+    --- Resets the control's top edge to be calculated from its bottom edge and height.  
+    --- Make sure `control.Bottom` and `control.Height` are not reset.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@return T
+    ResetTop = function(self)
+        ResetTop(self.c)
+        return self
+    end;
+
+    --- Resets the control's right edge to be calculated from its left edge and width.  
+    --- Make sure `control.Left` and `control.Width` are not reset.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@return T
+    ResetRight = function(self)
+        ResetRight(self.c)
+        return self
+    end;
+
+    --- Resets the control's bottom edge to be calculated from its top edge and height.  
+    --- Make sure `control.Top` and `control.Height` are not reset.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@return T
+    ResetBottom = function(self)
+        ResetBottom(self.c)
+        return self
+    end;
+
+    --- Resets the control's width to be calculated from its left and right edges.  
+    --- Make sure `control.Left` and `control.Right` are not reset.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@return T
+    ResetWidth = function(self)
+        ResetWidth(self.c)
+        return self
+    end;
+
+    --- Resets the control's height to be calculated from its top and bottom edges.  
+    --- Make sure `control.Top` and `control.Bottom` are not reset.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@return T
+    ResetHeight = function(self)
+        ResetHeight(self.c)
+        return self
+    end;
+
+
+    ----------
+    -- Anchor methods
+    ----------
+
+    --- Anchors the control's right edge to the left edge of a parent, with optional padding
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
+    ---@return T
+    AnchorToLeft = function(self, parent, padding)
+        AnchorToLeft(self.c, GetControl(parent), padding)
+        return self
+    end;
+
+    --- Anchors the control's bottom edge to the top edge of a parent, with optional padding
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
+    ---@return T
+    AnchorToTop = function(self, parent, padding)
+        AnchorToTop(self.c, GetControl(parent), padding)
+        return self
+    end;
+
+    --- Anchors the control's left edge to the right edge of a parent, with optional padding
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
+    ---@return T
+    AnchorToRight = function(self, parent, padding)
+        AnchorToRight(self.c, GetControl(parent), padding)
+        return self
+    end;
+
+    --- Anchors the control's top edge to the bottom edge of a parent, with optional padding
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param padding? number fixed padding between control and parent, scaled by the pixel scale factor
+    ---@return T
+    AnchorToBottom = function(self, parent, padding)
+        AnchorToBottom(self.c, GetControl(parent), padding)
+        return self
+    end;
+
+
+    ----------
+    -- Inside offset methods
+    ----------
+
+    --- Centers the control horizontally on a parent, with optional rightward offset.
+    --- This sets the control's left edge.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param leftOffset? number Offset of control's left edge in the rightward direction, scaled by the pixel scale factor. Defaults to 0.
+    ---@return T
+    AtHorizontalCenterIn = function(self, parent, leftOffset)
+        AtHorizontalCenterIn(self.c, GetControl(parent), leftOffset)
+        return self
+    end;
+
+    --- Centers the control vertically on a parent, with optional downward offset.
+    --- This sets the control's top edge.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param topOffset? number Offset of the control's top edge in the downward direction, scaled by the pixel scale factor. Defaults to 0.
+    ---@return T
+    AtVerticalCenterIn = function(self, parent, topOffset)
+        AtVerticalCenterIn(self.c, GetControl(parent), topOffset)
+        return self
+    end;
+
+    --- Places the control's left edge inside of a parent's, with optional rightward offset
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param leftOffset? number Offset of the control's left edge in the rightward direction, scaled by the pixel scale factor. Defaults to 0.
+    ---@return T
+    AtLeftIn = function(self, parent, leftOffset)
+        AtLeftIn(self.c, GetControl(parent), leftOffset)
+        return self
+    end;
+
+    --- Places the control's top edge inside of a parent's, with optional downward offset
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param topOffset? number Offset of the control's top edge in the downward direction, scaled by the pixel scale factor. Defaults to 0.
+    ---@return T
+    AtTopIn = function(self, parent, topOffset)
+        AtTopIn(self.c, GetControl(parent), topOffset)
+        return self
+    end;
+
+    --- Places the control's right edge inside of a parent's, with optional leftward offset
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param rightOffset? number Offset of the control's right edge in the leftward direction, scaled by the pixel scale factor. Defaults to 0.
+    ---@return T
+    AtRightIn = function(self, parent, rightOffset)
+        AtRightIn(self.c, GetControl(parent), rightOffset)
+        return self
+    end;
+
+    --- Places the control's bottom edge inside of a parent's, with optional upward offset
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param bottomOffset? number Offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor. Defaults to 0.
+    ---@return T
+    AtBottomIn = function(self, parent, bottomOffset)
+        AtBottomIn(self.c, GetControl(parent), bottomOffset)
+        return self
+    end;
+
+
+    ----------
+    -- Inside percentage methods
+    ----------
+
+    --- Places the control's left edge at a percentage along the width of a parent,
+    --- with 0.00 at the parent's left edge
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param leftPercent? number defaults to 0.00 (all the way to left)
+    FromLeftIn = function(self, parent, leftPercent)
+        FromLeftIn(self.c, GetControl(parent), leftPercent)
+        return self
+    end;
+
+    --- Places the control's top edge at a percentage along the height of a parent,
+    --- with 0.00 at the parent's top edge
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param topPercent? number defaults to 0.00 (all the way at the top)
+    FromTopIn = function(self, parent, topPercent)
+        FromTopIn(self.c, GetControl(parent), topPercent)
+        return self
+    end;
+
+    --- Places the control's right edge at a percentage along the width of a parent,
+    --- with 0.00 at the parent's right edge
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param rightPercent? number defaults to 0.00 (all the way right)
+    FromRightIn = function(self, parent, rightPercent)
+        FromRightIn(self.c, GetControl(parent), rightPercent)
+        return self
+    end;
+
+    --- Places the control's bottom edge at a percentage along the height of a parent,
+    --- with 0.00 at the parent's bottom edge
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param bottomPercent? number defaults to 0.00 (all the way at the bottom)
+    FromBottomIn = function(self, parent, bottomPercent)
+        FromBottomIn(self.c, GetControl(parent), bottomPercent)
+        return self
+    end;
+
+
+    ----------
+    -- Inside space methods
+    ----------
+
+    --- Places the control's left edge a percentage along the horizontal space of a parent
+    --- with 0.00 at the parent's left edge (this requires the control's width to be set)
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param leftPercent? number
+    ---@return T
+    FromLeftWith = function(self, parent, leftPercent)
+        FromLeftWith(self.c, GetControl(parent), leftPercent)
+        return self
+    end;
+
+    --- Places the control's top edge a percentage along the vertical space of a parent
+    --- with 0.00 at the parent's top edge (this requires the control's height to be set)
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param topPercent? number
+    ---@return T
+    FromTopWith = function(self, parent, topPercent)
+        FromTopWith(self.c, GetControl(parent), topPercent)
+        return self
+    end;
+
+    --- Places the control's right edge a percentage along the horizontal space of a parent
+    --- with 0.00 at the parent's right edge (this requires the control's width to be set)
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param rightPercent? number
+    ---@return T
+    FromRightWith = function(self, parent, rightPercent)
+        FromRightWith(self.c, GetControl(parent), rightPercent)
+        return self
+    end;
+
+    --- Places the control's bottom edge a percentage along the vertical space of a parent
+    --- with 0.00 at the parent's bottom edge (this requires the control's height to be set)
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param bottomPercent? number
+    ---@return T
+    FromBottomWith = function(self, parent, bottomPercent)
+        FromBottomWith(self.c, GetControl(parent), bottomPercent)
+        return self
+    end;
+
+
+
+    ------------------------------
+    -- Double positioning methods
+    ------------------------------
+
+    --- Places the control in the center of the parent, with optional offsets.
+    --- This sets the control's left and top edges.  
+    --- Note the argument order.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param topOffset? number offset of top edge in downward direction, scaled by the pixel scale factor
+    ---@param leftOffset? number offset of left edge in rightward direction, scaled by the pixel scale factor
+    ---@return T
+    AtCenterIn = function(self, parent, topOffset, leftOffset)
+        AtCenterIn(self.c, GetControl(parent), topOffset, leftOffset)
+        return self
+    end;
+
+
+    ----------
+    -- Outside edge positioning methods
+    ----------
+
+    --- Lock right edge of the control to the left edge of a parent, centered vertically.
+    --- This sets the control's right and top edges.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
+    ---@return T
+    CenteredLeftOf = function(self, parent, padding)
+        CenteredLeftOf(self.c, GetControl(parent), padding)
+        return self
+    end;
+
+    --- Lock bottom edge of the control to the top edge of a parent, centered horizontally.
+    --- This sets the control's left and bottom edges.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
+    ---@return T
+    CenteredAbove = function(self, parent, padding)
+        CenteredAbove(self.c, GetControl(parent), padding)
+        return self
+    end;
+
+    --- Lock left edge of the control to the right edge of a parent, centered vertically.
+    --- This sets the control's left and top edges.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
+    ---@return T
+    CenteredRightOf = function(self, parent, padding)
+        CenteredRightOf(self.c, GetControl(parent), padding)
+        return self
+    end;
+
+    --- Lock top edge of the control to the bottom edge of parent, centered horizontally.
+    --- This sets the controls's left and top edges.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
+    ---@return T
+    CenteredBelow = function(self, parent, padding)
+        CenteredBelow(self.c, GetControl(parent), padding)
+        return self
+    end;
+
+
+    ----------
+    -- Inside positioning methods
+    ----------
+
+    --- Places left edge of the control vertically centered inside of a parent's, with optional offsets.
+    --- This sets the control's left and top edges.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
+    ---@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
+    ---@return T
+    AtLeftCenterIn = function(self, parent, leftOffset, topOffset)
+        AtLeftCenterIn(self.c, GetControl(parent), leftOffset, topOffset)
+        return self
+    end;
+
+    --- Places top left corner of the control inside of a parent's, with optional offsets
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
+    ---@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
+    ---@return T
+    AtLeftTopIn = function(self, parent, leftOffset, topOffset)
+        AtLeftTopIn(self.c, GetControl(parent), leftOffset, topOffset)
+        return self
+    end;
+
+    --- Places top edge of the control horizontally centered inside of a parent's, with optional offsets.
+    --- Sets the control's left and top edges.  
+    --- Note the argument order.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
+    ---@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
+    ---@return T
+    AtTopCenterIn = function(self, parent, topOffset, leftOffset)
+        AtTopCenterIn(self.c, GetControl(parent), topOffset, leftOffset)
+        return self
+    end;
+
+    --- Places top right corner of the control inside of a parent's, with optional offsets
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param rightOffset? number offset of the control's right edge in the leftward direction, scaled by the pixel scale factor
+    ---@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
+    ---@return T
+    AtRightTopIn = function(self, parent, rightOffset, topOffset)
+        AtRightTopIn(self.c, GetControl(parent), rightOffset, topOffset)
+        return self
+    end;
+
+    --- Places right edge of the control vertically centered inside of a parent's, with optional offsets.
+    --- Sets the control's right and top edges.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param rightOffset? number offset of the control's right edge in the leftward direction, scaled by the pixel scale factor
+    ---@param topOffset? number offset of the control's top edge in the downward direction, scaled by the pixel scale factor
+    ---@return T
+    AtRightCenterIn = function(self, parent, rightOffset, topOffset)
+        AtRightCenterIn(self.c, GetControl(parent), rightOffset, topOffset)
+        return self
+    end;
+
+    --- Places bottom right corner of the control inside of a parent's, with optional offsets
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param rightOffset? number offset of the control's right edge in the leftward direction, scaled by the pixel scale factor
+    ---@param bottomOffset? number offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor
+    ---@return T
+    AtRightBottomIn = function(self, parent, rightOffset, bottomOffset)
+        AtRightBottomIn(self.c, GetControl(parent), rightOffset, bottomOffset)
+        return self
+    end;
+
+    --- Places bottom edge of the control horizontally centered inside of a parent's, with optional offsets.
+    --- Sets the control's left and bottom edges.  
+    --- Note the argument order.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
+    ---@param bottomOffset? number offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor
+    ---@return T
+    AtBottomCenterIn = function(self, parent, bottomOffset, leftOffset)
+        AtBottomCenterIn(self.c, GetControl(parent), bottomOffset, leftOffset)
+        return self
+    end;
+
+    --- Places bottom left corner of the control inside of a parent's, with optional offsets
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param leftOffset? number offset of the control's left edge in the rightward direction, scaled by the pixel scale factor
+    ---@param bottomOffset? number offset of the control's bottom edge in the upward direction, scaled by the pixel scale factor
+    ---@return T
+    AtLeftBottomIn = function(self, parent, leftOffset, bottomOffset)
+        AtLeftBottomIn(self.c, GetControl(parent), leftOffset, bottomOffset)
+        return self
+    end;
+
+
+    ----------
+    -- Flow-positioning methods
+    ----------
+
+    --- Lock top right of the control to the top left of a parent
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
+    ---@return T
+    LeftOf = function(self, parent, padding)
+        LeftOf(self.c, GetControl(parent), padding)
+        return self
+    end;
+
+    --- Lock top left of the control to the top right of a parent
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
+    ---@return T
+    RightOf = function(self, parent, padding)
+        RightOf(self.c, GetControl(parent), padding)
+        return self
+    end;
+
+    --- Lock bottom left of the control to the top left of a parent
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
+    ---@return T
+    Above = function(self, parent, padding)
+        Above(self.c, GetControl(parent), padding)
+        return self
+    end;
+
+    --- Lock top left of the control to the bottom left of a parent
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param padding? number Fixed padding between control and parent, scaled by the pixel scale factor. Defaults to 0.
+    ---@return T
+    Below = function(self, parent, padding)
+        Below(self.c, GetControl(parent), padding)
+        return self
+    end;
+
+
+
+    ------------------------------
+    -- Axial methods
+    ------------------------------
+
+    --- Sets a control to fill the horizontal space of a parent
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@return T
+    FillHorizontally = function(self, parent)
+        FillHorizontally(self.c, GetControl(parent))
+        return self
+    end;
+
+    --- Sets a control to fill the vertical space of a parent
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@return T
+    FillVertically = function(self, parent)
+        FillVertically(self.c, GetControl(parent))
+        return self
+    end;
+
+
+
+    ------------------------------
+    -- Composite methods
+    ------------------------------
+
+    --- Sets all edges of a control to be a certain amount inside of a parent.
+    --- Offsets are optional and scaled by the pixel scale factor.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param left? number
+    ---@param top? number
+    ---@param right? number
+    ---@param bottom? number
+    ---@return T
+    OffsetIn = function(self, parent, left, top, right, bottom)
+        OffsetIn(self.c, GetControl(parent), left, top, right, bottom)
+        return self
+    end;
+
+    --- Sets all edges of the control to be a certain percentage inside of a parent.
+    --- Percentages are optional.
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param left? number
+    ---@param top? number
+    ---@param right? number
+    ---@param bottom? number
+    ---@return T
+    PercentIn = function(self, parent, left, top, right, bottom)
+        PercentIn(self.c, GetControl(parent), left, top, right, bottom)
+        return self
+    end;
+
+
+    ----------
+    -- Fill methods
+    ----------
+
+    --- Sets the control to fill a parent
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@return T
+    Fill = function(self, parent)
+        FillParent(self.c, GetControl(parent))
+        return self
+    end;
+
+    --- Sets the control to fill a parent's with fixed padding
+    ---@generic T : LayouterAttributeControl
+    ---@param self T
+    ---@param parent Layouter | Control
+    ---@param offset? number
+    ---@return T
+    FillFixedBorder = function(self, parent, offset)
+        FillParentFixedBorder(self.c, GetControl(parent), offset)
+        return self
+    end;
+}
+
+------------------------------
+-- Drop Shadow Attribute
+------------------------------
+
+---@class LayouterAttributeDropShadow
+local LayouterAttributeDropShadow = ClassSimple {
+    --- Sets if the control has a drop shadow
+    ---@generic T : LayouterAttributeDropShadow
+    ---@param self T
+    ---@param hasShadow boolean
+    ---@return T
+    DropShadow = function(self, hasShadow)
+        local control = self.c
+        local setDropShadow = control.SetDropShadow
+        if setDropShadow then
+            setDropShadow(control, hasShadow)
+        else
+            WARN("Cannot set drop shadow for \"" .. control:GetName() .. '\"')
+        end
+        return self
+    end;
+}
+
+------------------------------
+-- Font Attribute
+------------------------------
+
+---@class LayouterAttributeFont
+local LayouterAttributeFont = ClassSimple {
+    --- Sets the font of the control
+    ---@generic T : LayouterAttributeFont
+    ---@param self T
+    ---@param font Lazy<string>
+    ---@param size number
+    ---@return T
+    Font = function(self, font, size)
+        local control = self.c
+        local setFont = control.SetFont
+        if setFont then
+            setFont(control, font, size)
+        else
+            WARN("Cannot set font for \"" .. control:GetName() .. '\"')
+        end
+        return self
+    end;
+}
+
+------------------------------
+-- Editor Attribute
+------------------------------
+
+---@class LayouterAttributeEditor : LayouterAttributeFont
+local LayouterAttributeEditor = Class(LayouterAttributeFont) {
+    --- Sets up the editor of the control
+    ---@generic T : LayouterAttributeEditor
+    ---@param self T
+    ---@param foreColor? Lazy<Color>
+    ---@param backColor? Lazy<Color>
+    ---@param highlightFore? Lazy<Color>
+    ---@param highlightBack? Lazy<Color>
+    ---@param fontFace? Lazy<string>
+    ---@param fontSize? number
+    ---@param charLimit? number
+    ---@return T
+    Setup = function(self, foreColor, backColor, highlightFore, highlightBack, fontFace, fontSize, charLimit)
+        import("/lua/ui/uiutil.lua").SetupEditStd(self.c,
+                foreColor, backColor, highlightFore, highlightBack, fontFace, fontSize, charLimit)
+        return self
+    end;
+}
+
+------------------------------
+-- Color Attribute
+------------------------------
+
+---@class LayouterAttributeColor
+local LayouterAttributeColor = ClassSimple {
+    --- Sets the color of the control
+    ---@generic T : LayouterAttributeColor
+    ---@param self T
+    ---@param color Lazy<Color> color as a hexcode
+    ---@return T
+    Color = function(self, color)
+        local control = self.c
+        local setColor = control.SetColor or control.SetSolidColor
+        if setColor then
+            setColor(control, color)
+        else
+            WARN("Cannot set color for \"" .. control:GetName() .. '\"')
+        end
+        return self
+    end;
+}
+
+------------------------------
+-- Texture Attribute
+------------------------------
+
+---@class LayouterAttributeTexture : LayouterAttributeColor
+local LayouterAttributeTexture = Class(LayouterAttributeColor) {
+    --- Sets the control's texture
+    ---@generic T : LayouterAttributeTexture
+    ---@param self T
+    ---@param texture Lazy<string> resource location
+    ---@param border? Border
+    ---@return T
+    Texture = function(self, texture, border)
+        local control = self.c
+        local setTexture = control.SetTexture
+        if setTexture then
+            setTexture(control, texture, border)
+        else
+            WARN("Cannot set texture for \"" .. control:GetName() .. '\"')
+        end
+        return self
+    end;
+}
+
+------------------------------
+-- Selection Color Attribute
+------------------------------
+
+---@class LayouterAttributeSelection
+local LayouterAttributeSelection = ClassSimple {
+    --- Sets the list's selection colors
+    ---@generic T : LayouterAttributeSelection
+    ---@param self T
+    ---@param fore? Lazy<Color>
+    ---@param back? Lazy<Color>
+    ---@param selectedFore? Lazy<Color>
+    ---@param selectedBack? Lazy<Color>
+    ---@param mouseoverFore? Lazy<Color>
+    ---@param mouseoverBack? Lazy<Color>
+    ---@return T
+    Colors = function(self, fore, back, selectedFore, selectedBack, mouseoverFore, mouseoverBack)
+        local control = self.c
+        local setColors = control.SetColors
+        if setColors then
+            setColors(control, fore, back, selectedFore, selectedBack, mouseoverFore, mouseoverBack)
+        else
+            WARN("Cannot set colors for \"" .. control:GetName() .. '\"')
+        end
+        return self
+    end;
+
+    --- Sets the list's mouseover behavior
+    ---@generic T : LayouterAttributeSelection
+    ---@param self T
+    ---@param show boolean
+    ---@return T
+    MouseoverItem = function(self, show)
+        local control = self.c
+        local showMouseoverItem = control.ShowMouseoverItem
+        if showMouseoverItem then
+            showMouseoverItem(control, show)
+        else
+            WARN("Cannot set show mouseover item for \"" .. control:GetName() .. '\"')
+        end
+        return self
+    end;
+}
+
+
+
+--------------------------------------------------------------------------------
+-- Base Layouter
+--------------------------------------------------------------------------------
+
+-- While it can be useful to build specific layouters for individual controls, this monolithic
+-- class is the most versatile
+
+---@class Layouter : LayouterAttributeControl, LayouterAttributeDropShadow, LayouterAttributeEditor, LayouterAttributeTexture, LayouterAttributeSelection
+---@operator call(Control): Layouter
+---@field c Control
+Layouter = Class(LayouterAttributeControl, LayouterAttributeDropShadow, LayouterAttributeEditor, LayouterAttributeTexture, LayouterAttributeSelection) {
+    ---@param self Layouter
+    ---@param control Control
+    __init = function(self, control)
+        if control == nil then
+            control = false -- field needs to exist to not trigger the `__newindex` error
+        else
+            control = GetControl(control)
+            local onLayout = control.OnLayout
+            if onLayout then
+                onLayout(control)
+            end
+        end
+        if self.c ~= nil then
+            self.c = control
+            return
+        end
+        rawset(self, "c", control)
+    end;
+
+    __newindex = function(key, value)
+        error("attempt to set new index for a Layouter object")
+    end;
+
+    OnInit = function(self)
+        SPEW("LAYOUTERING")
+    end;
+
+    -- Gets the control
+    ---@param self Layouter
+    ---@return Control c
+    Get = function(self)
+        return self.c
+    end;
+
+    --- Computes the control's properties and returns it.
+    --- This calls the `Layout()` method from the control if it exists.  
+    --- Remember, if a parent has an incomplete layout it will warn you anyway.
+    ---@param self Layouter
+    ---@return Control
+    End = function(self)
+        local control = self.c
+
+        local ok, error = pcall(control.Top)
+        if ok then ok, error = pcall(control.Bottom) end
+        if ok then ok, error = pcall(control.Height) end
+        if not ok then
+            WARN("Incorrect layout for \"" .. control:GetName() .. "\" Top-Height-Bottom: " .. error)
+        end
+
+        ok, error = pcall(control.Left)
+        if ok then ok, error = pcall(control.Right) end
+        if ok then ok, error = pcall(control.Width) end
+        if not ok then
+            WARN("Incorrect layout for \"" .. control:GetName() .. "\" Left-Width-Right: " .. error)
+        end
+
+        self.c = false
+        local layout = control.Layout
+        if layout then
+            layout(control)
+        end
+
+        return control
+    end;
+}
+
+
+local reusedLayouter = Layouter()
+--- Returns the cached layouter applied to a control--this is usually what you want to use unless
+--- you're doing some advanced interlacing of the layout. This calls `OnLayout()` from the control
+--- if it exists. Make sure to call `End()` when you're done laying out the control (which calls
+--- `Layout()` from the control if it exists).
 ---@param control Control
 ---@return Layouter #cached layouter
-function ReusedLayoutFor(control)
-    layouter.c = control or false
-    return layouter
+function ReusedLayouter(control)
+    local reusedLayouter = reusedLayouter
+    local cur = reusedLayouter.c
+    if cur then
+        if cur == control then
+            -- same object, probably some inherited laying out, let it go
+            return reusedLayouter
+        else
+            -- uh-oh, someone is interlacing the default layouter!
+            WARN(_TRACEBACK(1, "Reused layouter is already in use! (did you forget to call `End()` or use the non-reused version?)"))
+            return Layouter(control)
+        end
+    end
+    Layouter.__init(reusedLayouter, control)
+    return reusedLayouter
 end

--- a/lua/maui/layouthelpers.lua
+++ b/lua/maui/layouthelpers.lua
@@ -1097,7 +1097,7 @@ end
 -- To use it, start by making sure these lines are at the top of your UI file
 --[[
 local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
-local Layouter = LayouterHelper.ReusedLayouter
+local Layouter = LayoutHelpers.ReusedLayoutFor
 --]]
 -- (This is mostly for readability, but there's also efficiency reasons)
 --
@@ -2257,6 +2257,17 @@ Layouter = Class(LayouterAttributeControl, LayouterAttributeDropShadow, Layouter
 }
 
 
+--- Returns a layouter for a control--you usually want to use `ReusedLayoutFor()` unless
+--- you're doing some advanced interlacing of the layout. This calls `OnLayout()` from the control
+--- if it exists. Make sure to call `End()` when you're done laying out the control (which calls
+--- `Layout()` from the control if it exists).
+---@param control Control
+---@return Layouter
+function LayoutFor(control)
+    return Layouter(control)
+end
+
+
 local reusedLayouter = Layouter()
 --- Returns the cached layouter applied to a control--this is usually what you want to use unless
 --- you're doing some advanced interlacing of the layout. This calls `OnLayout()` from the control
@@ -2264,7 +2275,7 @@ local reusedLayouter = Layouter()
 --- `Layout()` from the control if it exists).
 ---@param control Control
 ---@return Layouter #cached layouter
-function ReusedLayouter(control)
+function ReusedLayoutFor(control)
     local reusedLayouter = reusedLayouter
     local cur = reusedLayouter.c
     if cur then

--- a/lua/maui/window.lua
+++ b/lua/maui/window.lua
@@ -280,7 +280,7 @@ Window = Class(Group) {
         end
 
         self.ClientGroup = Group(self, 'window client group')
-        LayoutHelpers.ReusedLayoutFor(self.ClientGroup)
+        LayoutHelpers.Layouter(self.ClientGroup)
             :Top(self.TitleGroup.Bottom)
             :Left(self.ml.Right)
             :Height(function() return self.bm.Top() - self.TitleGroup.Bottom() end)

--- a/lua/system/class.lua
+++ b/lua/system/class.lua
@@ -117,14 +117,20 @@ local function IsSimpleClass(arg)
     return arg.n == 1 and getmetatable(arg[1]) == emptyMetaTable
 end
 
----@class fa-class
----@operator call: fun(...): table
+---@class fa-class : function
+---@operator call(...): table
 ---@field __init? fun(self, ...)
 ---@field __post_init? fun(self, ...)
 
+---@class State
+
+---@class fa-class-state : fa-class
+---@field __State true
+---@field __StateIdentifier number
+
 --- Prepares the construction of a state, , referring to the paragraphs of text at the top of this file.
 local StateIdentifier = 0
----@generic T: fa-class
+---@generic T: fa-class-state
 ---@param ... T
 ---@return T
 function State(...)
@@ -428,15 +434,12 @@ ClassFactory = {
 
         -- call class initialisation functions, if they exist
         local initfn = self.__init
+        if initfn then
+            initfn(instance, unpack(arg))
+        end
         local postinitfn = self.__post_init
-        if initfn or postinitfn then
-            if initfn then
-                initfn(instance, unpack(arg))
-            end
-
-            if postinitfn then
-                postinitfn(instance, unpack(arg))
-            end
+        if postinitfn then
+            postinitfn(instance, unpack(arg))
         end
 
         return instance
@@ -445,7 +448,7 @@ ClassFactory = {
 
 --- Switches up the sate of a class instance by inserting the new state between the instance and its class
 ---@param instance table The current instance we want to switch states for
----@param newState State the state we want to insert between the instance and its base class
+---@param newstate State the state we want to insert between the instance and its base class
 function ChangeState(instance, newstate)
 
     -- call on-exit function

--- a/lua/ui/game/cursor/hover.lua
+++ b/lua/ui/game/cursor/hover.lua
@@ -1,0 +1,182 @@
+
+local Prefs = import('/lua/user/prefs.lua')
+local WorldMesh = import('/lua/ui/controls/worldmesh.lua').WorldMesh
+
+local meshSphere = '/env/Common/Props/sphere_lod0.scm'
+local meshCylinder = '/meshes/game/PathRing_LOD0.scm'
+
+local MeshCylinder = nil
+local MeshOnTerrain = nil
+local MeshesInBetween = { }
+local MeshesInbetweenCount = 4
+local MeshFadeDistance = 300
+
+local Trash = TrashBag()
+local Selection = { }
+
+--- Checks conditions for scanning
+local function CheckConditions()
+    local option = Prefs.GetFromCurrentProfile('options.cursor_hover_scanning')
+
+    -- easy picking
+    if option == 'on' then
+        return true
+    end
+
+    if option == 'off' then
+        return false
+    end
+
+    return true
+end
+
+--- Defines the transparency curve
+---@param camera Camera
+---@param distance number
+---@param terrainHeight number
+---@param surfaceHeight number
+---@return number
+local function ComputeTransparency(camera, distance, terrainHeight, surfaceHeight)
+    -- visibility based on camera distance
+    local zoom = camera:GetZoom()
+    local f1 = math.max(0, 1 - (zoom / distance))
+
+    -- visibility based on terrain difference
+    local f2 = math.clamp(surfaceHeight - terrainHeight - 1, 0, 1)
+    return f1
+end
+
+--- Runs a depth scanning process to help the player understand where his cursor 
+--- really is (when it is on top of water)
+local function HoverScanningThread()
+
+    local scenario = SessionGetScenarioInfo()
+    local Exit = import('/lua/ui/override/Exit.lua')
+    
+    -- clear out all entities before we exit
+    Exit.AddOnExitCallback(
+        'HoverScanning',
+        function(event)
+            Trash:Destroy()
+        end
+    )
+
+    -- keep track of the current selection
+    import('/lua/ui/game/gamemain.lua').ObserveSelection:AddObserver(
+        function(selectionData)
+            Selection = selectionData.newSelection
+        end
+    )
+
+    -- allocate mesh that is on the terrain
+    MeshOnTerrain = WorldMesh()
+    MeshOnTerrain:SetMesh({
+        MeshName = meshSphere,
+        TextureName = '/meshes/game/Assist_albedo.dds',
+        ShaderName = 'FakeRings',
+        UniformScale = 0.3,
+        LODCutoff = MeshFadeDistance
+    })
+
+    MeshCylinder = WorldMesh()
+    MeshCylinder:SetMesh({
+        MeshName = meshCylinder,
+        TextureName = '/meshes/game/Assist_albedo.dds',
+        ShaderName = 'FakeRings',
+        UniformScale = 0.3,
+        LODCutoff = MeshFadeDistance
+    })
+
+    Trash:Add(MeshOnTerrain)
+
+    -- allocate intermediate bits
+    for k = 1, MeshesInbetweenCount do
+
+        local bit = WorldMesh()
+        bit:SetMesh({
+            MeshName = meshSphere,
+            TextureName = '/meshes/game/Assist_albedo.dds',
+            ShaderName = 'FakeRings',
+            UniformScale = 0.15,
+            LODCutoff = MeshFadeDistance
+        })
+
+        MeshesInBetween[k] = bit
+        Trash:Add(bit)
+    end
+
+    -- pre-allocate all locals for performance
+    local camera, position, elevation, transparency, location, size
+    location = { }
+    while true do
+        
+        -- hide by default
+        MeshCylinder:SetHidden(true)
+        MeshOnTerrain:SetHidden(true)
+        for k = 1, MeshesInbetweenCount do
+            MeshesInBetween[k]:SetHidden(true)
+        end
+
+        -- only works if we have 1 selected unit
+        if Selection[1] and not Selection[2] then
+
+            -- only works for bombers
+            local bomber = Selection[1]
+            local blueprint = bomber:GetBlueprint()
+            if blueprint.CategoriesHash['BOMBER'] then
+
+                camera = GetCamera('WorldCamera')
+                position = GetMouseWorldPos()
+                elevation = blueprint.Physics.Elevation
+                size = 0.1 * (blueprint.SizeSphere or math.max(blueprint.SizeX or 1, blueprint.SizeY or 1, blueprint.SizeZ or 1))
+
+                -- check if we have all the data required
+                if position and position[1] and elevation and size and CheckConditions() then
+
+                    position[1] = math.clamp(position[1], 0, scenario.size[1])
+                    position[3] = math.clamp(position[3], 0, scenario.size[2])
+
+                    -- determine location on the terrain
+                    location[1] = position[1]
+                    location[2] = position[2] + elevation
+                    location[3] = position[3]
+
+                    -- update visibility terrain mesh
+                    transparency = ComputeTransparency(camera, MeshFadeDistance, elevation, position[2])
+                    if transparency > 0.05 then
+                        MeshOnTerrain:SetHidden(false)
+                        MeshOnTerrain:SetStance(location)
+                        MeshOnTerrain:SetFractionCompleteParameter(transparency)
+
+                        MeshCylinder:SetHidden(false)
+                        MeshCylinder:SetStance(location)
+                        MeshCylinder:SetFractionCompleteParameter(transparency)
+                        MeshCylinder:SetScale({size, 1, size})
+                    else
+                        MeshOnTerrain:SetHidden(true)
+                        MeshCylinder:SetHidden(true)
+                    end
+
+                    -- update visiblity intermediate dots
+                    for k = 1, MeshesInbetweenCount do
+                        local bit = MeshesInBetween[k]
+                        location[2] = position[2] + (0.2 * k) * elevation
+
+                        transparency = ComputeTransparency(camera, MeshFadeDistance, elevation, position[2])
+                        if transparency > 0.05 then
+                            bit:SetHidden(false)
+                            bit:SetStance(location)
+                            bit:SetFractionCompleteParameter(transparency)
+                        else
+                            bit:SetHidden(true)
+                        end
+                    end
+                end
+            end
+        end
+
+        WaitFrames(1)
+    end
+end
+
+Trash:Add(ForkThread(HoverScanningThread))

--- a/lua/ui/game/diplomacy.lua
+++ b/lua/ui/game/diplomacy.lua
@@ -15,7 +15,7 @@ local Tooltip = import('/lua/ui/game/tooltip.lua')
 local Tabs = import('/lua/ui/game/tabs.lua')
 
 local ScaleNumber = LayoutHelpers.ScaleNumber
-local Layouter = LayoutHelpers.Layouter
+local Layouter = LayoutHelpers.LayoutFor
 local CreateBitmap = UIUtil.CreateBitmap
 local CreateBitmapStd = UIUtil.CreateBitmapStd
 

--- a/lua/ui/game/diplomacy.lua
+++ b/lua/ui/game/diplomacy.lua
@@ -15,7 +15,7 @@ local Tooltip = import('/lua/ui/game/tooltip.lua')
 local Tabs = import('/lua/ui/game/tabs.lua')
 
 local ScaleNumber = LayoutHelpers.ScaleNumber
-local Layouter = LayoutHelpers.ReusedLayoutFor
+local Layouter = LayoutHelpers.Layouter
 local CreateBitmap = UIUtil.CreateBitmap
 local CreateBitmapStd = UIUtil.CreateBitmapStd
 

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -155,6 +155,7 @@ function CreateUI(isReplay)
 
     import('/lua/system/performance.lua')
     import('/lua/ui/game/cursor/depth.lua')
+    import('/lua/ui/game/cursor/hover.lua')
 
     -- # Casting tools 
 

--- a/lua/ui/game/recall.lua
+++ b/lua/ui/game/recall.lua
@@ -7,7 +7,7 @@ local Prefs = import("/lua/user/prefs.lua")
 local Tooltip = import('/lua/ui/game/tooltip.lua')
 local UIUtil = import("/lua/ui/uiutil.lua")
 
-local Layouter = LayoutHelpers.ReusedLayoutFor
+local Layouter = LayoutHelpers.ReusedLayouter
 
 -- seconds to see recall voting results
 local reviewResultsDuration = 5
@@ -17,6 +17,35 @@ local panel
 function Create(parent)
     panel = RecallPanel(parent)
     return panel
+end
+
+function SetLayout()
+    Layouter(panel)
+        :AtLeftIn(panel.parent, panel:LoadPosition().left)
+        -- set to uncollapsed position; lets us layout the collapse button and setup the height
+        -- so we know where the panel's actual inital position is
+        :Top(panel.parent.Top() + LayoutHelpers.ScaleNumber(4) + panel.t.Height())
+        :Width(panel.DefaultWidth)
+        :Height(function()
+            local panel = panel
+            local Scale = LayoutHelpers.ScaleNumber
+            local height = Scale(-4) + panel.label.Height() + Scale(5) + panel.votes.Height()
+            -- make sure these register as a dependency
+            local voteHeight = panel.buttonAccept.Height()
+            local progHeight = panel.progressBarBG.Height()
+            if panel.canVote() then
+                height = height + Scale(5) + voteHeight
+                if panel.startTime() > 0 then
+                    height = height + Scale(2) + progHeight
+                end
+            elseif panel.startTime() > 0 then
+                height = height + Scale(10) + progHeight
+            end
+            return height + Scale(-2)
+        end)
+        :Hide()
+        :End()
+    panel.Top:Set(panel.parent.Top() - panel:TotalHeight())
 end
 
 function RequestHandler(data)
@@ -51,48 +80,31 @@ RecallPanel = Class(NinePatch.NinePatch) {
         self.progressBarBG = UIUtil.CreateBitmapColor(self, "Gray")
         self.progressBar = UIUtil.CreateBitmapColor(self.progressBarBG, "Yellow")
 
+        self.progressBarBG.Height:Set(LayoutHelpers.ScaleNumber(4))
+        self.votes.Height:Set(LayoutHelpers.ScaleNumber(1))
+
         self.votes.blocks = 0
         self.canVote = Lazyvar(true)
         self.startTime = Lazyvar(-9999)
-        self:Layout()
+
         self:Logic()
     end;
 
     Layout = function(self)
-        Layouter(self)
-            :AtLeftIn(self.parent, self:LoadPosition().left)
-            :Top(self.parent.Top() + LayoutHelpers.ScaleNumber(4) + self.t.Height())
-            :Width(self.DefaultWidth)
-            :Height(function()
-                local Scale = LayoutHelpers.ScaleNumber
-                local height = Scale(-4) + self.label.Height() + Scale(5) + self.votes.Height()
-                -- make sure these register as a dependency
-                local voteHeight = self.buttonAccept.Height()
-                local progHeight = self.progressBarBG.Height()
-                if self.canVote() then
-                    height = height + Scale(5) + voteHeight
-                    if self.startTime() > 0 then
-                        height = height + Scale(2) + progHeight
-                    end
-                elseif self.startTime() > 0 then
-                    height = height + Scale(10) + progHeight
-                end
-                return height + Scale(-2)
-            end)
-            :Hide()
-
         Layouter(self.collapseArrow)
             :Top(self.t.Top() - 7)
             :AtHorizontalCenterIn(self)
             :Over(self, 10)
             :Disable()
             :Hide()
+            :End()
 
-        Layouter(self.label)
+        local label = Layouter(self.label)
             :AtTopCenterIn(self, -4)
+            :End()
 
-        Layouter(self.votes)
-            :AnchorToBottom(self.label, 5)
+        local votes = Layouter(self.votes)
+            :AnchorToBottom(label, 5)
             :AtHorizontalCenterIn(self)
             :Width(function() return self.Width() - LayoutHelpers.ScaleNumber(16) end)
             :Height(function()
@@ -100,31 +112,34 @@ RecallPanel = Class(NinePatch.NinePatch) {
                 if vote then return vote.Height() end
                 return 1
             end)
+            :End()
 
-        Layouter(self.buttonAccept)
+        local buttonAccept = Layouter(self.buttonAccept)
             :AtLeftIn(self, 8)
-            :AnchorToBottom(self.votes, 5)
+            :AnchorToBottom(votes, 5)
+            :End()
 
-        Layouter(self.buttonVeto)
+        local buttonVeto = Layouter(self.buttonVeto)
             :AtRightIn(self, 8)
-            :AnchorToBottom(self.votes, 5)
+            :AnchorToBottom(votes, 5)
+            :End()
 
-        Layouter(self.progressBarBG)
-            :AtBottomCenterIn(self, -2)
+        local progressBarBG = Layouter(self.progressBarBG)
             :Width(function() return self.Width() - LayoutHelpers.ScaleNumber(16) end)
             :Height(4)
+            :AtBottomCenterIn(self, -2)
+            :End()
 
         Layouter(self.progressBar)
-            :AtHorizontalCenterIn(self.progressBarBG)
-            :Top(self.progressBarBG.Top)
-            :Bottom(self.progressBarBG.Bottom)
-            :Width(function() return (self.Width() - LayoutHelpers.ScaleNumber(16)) * 0.42 end)
-            :Over(self.progressBarBG, 10)
+            :AtHorizontalCenterIn(progressBarBG)
+            :Top(progressBarBG.Top)
+            :Bottom(progressBarBG.Bottom)
+            :Width(function() return (self.Width() - LayoutHelpers.ScaleNumber(16)) end)
+            :Over(progressBarBG, 10)
+            :End()
 
-        self.Top:Set(self.parent.Top() - self:TotalHeight())
-
-        Tooltip.AddButtonTooltip(self.buttonAccept, "dip_recall_request_accept")
-        Tooltip.AddButtonTooltip(self.buttonVeto, "dip_recall_request_veto")
+        Tooltip.AddButtonTooltip(buttonAccept, "dip_recall_request_accept")
+        Tooltip.AddButtonTooltip(buttonVeto, "dip_recall_request_veto")
     end;
 
     LayoutBlocks = function(self, blocks)
@@ -396,7 +411,6 @@ RecallPanel = Class(NinePatch.NinePatch) {
                 collapse:Hide()
             else
                 collapse:Show()
-                SPEW("SHOWING")
             end
         end
         return supress

--- a/lua/ui/game/recall.lua
+++ b/lua/ui/game/recall.lua
@@ -7,7 +7,7 @@ local Prefs = import("/lua/user/prefs.lua")
 local Tooltip = import('/lua/ui/game/tooltip.lua')
 local UIUtil = import("/lua/ui/uiutil.lua")
 
-local Layouter = LayoutHelpers.ReusedLayouter
+local Layouter = LayoutHelpers.ReusedLayoutFor
 
 -- seconds to see recall voting results
 local reviewResultsDuration = 5

--- a/lua/ui/lobby/data/watchedvalue/watchedvalue.lua
+++ b/lua/ui/lobby/data/watchedvalue/watchedvalue.lua
@@ -4,7 +4,7 @@
 --- This also destroys the dependency system used by LazyVar. A WatchedValue cannot induce an `OnDirty`
 --- on another WatchedValue (except explicitly in the caller's `OnDirty` handler).
 ---@class WatchedValue : Destroyable, OnDirtyListener
----@operator call: fun(): any
+---@operator call: any
 local WatchedValueMetaTable = {}
 
 WatchedValueMetaTable.__index = WatchedValueMetaTable

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -27,7 +27,7 @@ local NinePatch = import('/lua/ui/controls/ninepatch.lua').NinePatch
 local InputDialog = import('/lua/ui/controls/popups/inputdialog.lua').InputDialog
 local skins = import('/lua/skins/skins.lua').skins
 
-local Layouter = LayoutHelpers.ReusedLayoutFor
+local Layouter = LayoutHelpers.Layouter
 
 
 --* Handy global variables to assist skinning
@@ -1267,22 +1267,22 @@ end
 
 
 ---@param parent Control
----@param filename string
+---@param filename FileName
 ---@return Group
 function CreateVertFillGroup(parent, filename)
     local group = Group(parent)
-
     local top = CreateBitmap(group, filename .. "_bmp_t.dds")
+    local bottom = CreateBitmap(group, filename .. "_bmp_b.dds")
+    local middle = CreateBitmap(group, filename .. "_bmp_m.dds")
+
     Layouter(top)
         :Over(group, 0)
         :AtLeftTopIn(group)
 
-    local bottom = CreateBitmap(group, filename .. "_bmp_b.dds")
     Layouter(bottom)
         :Over(group, 0)
         :AtLeftBottomIn(group)
 
-    local middle = CreateBitmap(group, filename .. "_bmp_m.dds")
     Layouter(middle)
         :Over(group, 0)
         :AtLeftIn(group)
@@ -1298,22 +1298,22 @@ end
 
 
 ---@param parent Control
----@param filename string
+---@param filename FileName
 ---@return Group
 function CreateHorzFillGroup(parent, filename)
     local group = Group(parent)
-
     local left = CreateBitmap(group, filename .. "_bmp_l.dds")
+    local right = CreateBitmap(group, filename .. "_bmp_r.dds")
+    local middle = CreateBitmap(group, filename .. "_bmp_m.dds")
+
     Layouter(left)
         :Over(group, 0)
         :AtLeftTopIn(group)
 
-    local right = CreateBitmap(group, filename .. "_bmp_r.dds")
     Layouter(right)
         :Over(group, 0)
         :AtRightTopIn(group)
 
-    local middle = CreateBitmap(group, filename .. "_bmp_m.dds")
     Layouter(middle)
         :Over(group, 0)
         :AtTopIn(group)

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -27,7 +27,7 @@ local NinePatch = import('/lua/ui/controls/ninepatch.lua').NinePatch
 local InputDialog = import('/lua/ui/controls/popups/inputdialog.lua').InputDialog
 local skins = import('/lua/skins/skins.lua').skins
 
-local Layouter = LayoutHelpers.Layouter
+local Layouter = LayoutHelpers.LayoutFor
 
 
 --* Handy global variables to assist skinning


### PR DESCRIPTION
This PR introduces Layouter support for the `Layout()` pattern by having the Layouter call it on `End()`. This moves laying-out out of the initializer so that controls can be completely created before they're laid out--something very handy when `End()` requires the entire component hierarchy to be complete to function properly. This also eliminates the need for a component to layout itself to layout its children, and thus increases modularity. In addition, controls can now set their layout to depend on children attributes without needing to interlace their layouts in a confusing manner.

See the [documentation](https://github.com/Hdt80bro/fa/blob/layout-pattern/lua/maui/layouthelpers.lua#L1090-L1175) for more details.