### PR TITLE
Fix "reveal civilians" not resetting civilians to neutral

### DIFF
--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -605,8 +605,6 @@ function InitializeArmies()
             local setup = armySetups[strArmy]
             local brain = GetArmyBrain(strArmy)
 
-            --LOG("*DEBUG: InitializeArmies, army = ", strArmy)
-
             local econ = tblData.Economy
             SetArmyEconomy(strArmy, econ.mass, econ.energy)
 
@@ -721,9 +719,6 @@ function InitializeScenarioArmies()
         if tblData then
             local setup = armySetups[strArmy]
             local brain = GetArmyBrain(strArmy)
-
-            LOG("*DEBUG: InitializeScenarioArmies, army = ", strArmy)
-
 
             local econ = tblData.Economy
             SetArmyEconomy(strArmy, econ.mass, econ.energy)

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -641,19 +641,18 @@ function InitializeArmies()
 
             ----[ irumsey                                                         ]--
             ----[ Temporary defaults.  Make sure some fighting will break out.    ]--
-            for iEnemy, strEnemy in tblArmy do
+            for iEnemy, _ in tblArmy do
                 -- only do it once for each pair
                 if iEnemy >= iArmy then
                     continue
                 end
-                local enemySetup = armySetups[strEnemy]
                 local state = "Enemy"
                 if armyIsCiv then
                     if civOpt == "neutral" or strArmy == "NEUTRAL_CIVILIAN" then
                         state = "Neutral"
                     end
 
-                    if revealCivilians and enemySetup.Human then
+                    if revealCivilians then
                         ForkThread(function(civ, army)
                             WaitSeconds(0.1)
 

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -645,37 +645,38 @@ function InitializeArmies()
             for iEnemy, strEnemy in tblArmy do
                 local enemySetup = armySetups[strEnemy]
                 local enemyIsCiv = enemySetup.Civilian
-                local a, e = iArmy, iEnemy
                 local state = 'Enemy'
 
-                if a ~= e then
+                if iArmy ~= iEnemy then
                     if armyIsCiv or enemyIsCiv then
                         if civOpt == 'neutral' or strArmy == 'NEUTRAL_CIVILIAN' or strEnemy == 'NEUTRAL_CIVILIAN' then
                             state = 'Neutral'
                         end
 
                         if revealCivilians and enemySetup.Human then
+                            -- make sure the upvalues don't change in the thread 
+                            local iArmy, iEnemy = iArmy, iEnemy
                             ForkThread(function()
                                 WaitSeconds(0.1)
-                                local real_state = IsAlly(a, e) and 'Ally' or IsEnemy(a, e) and 'Enemy' or 'Neutral'
+                                local real_state = IsAlly(iArmy, iEnemy) and 'Ally' or IsEnemy(iArmy, iEnemy) and 'Enemy' or 'Neutral'
 
                                 brain:SetupArmyIntelTrigger({
                                     Category = categories.ALLUNITS,
                                     Type = 'LOSNow',
                                     Value = true,
                                     OnceOnly = true,
-                                    TargetAIBrain = brain,
+                                    TargetAIBrain = GetArmyBrain(iEnemy),
                                     CallbackFunction = function()
-                                        SetAlliance(a, e, real_state)
+                                        SetAlliance(iArmy, iEnemy, real_state)
                                     end,
                                 })
-                                SetAlliance(a, e, 'Ally')
+                                SetAlliance(iArmy, iEnemy, 'Ally')
                             end)
                         end
                     end
 
                     if state then
-                        LocalSetAlliance(a, e, state)
+                        LocalSetAlliance(iArmy, iEnemy, state)
                     end
                 end
             end


### PR DESCRIPTION
Got broken in the recall patch; this fixes it