### PR TITLE
Change `self.Fun(self, ...)` to `self:Fun(...)`

### DIFF
--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -174,7 +174,7 @@ end
 function CreateBuilderArmController(unit, turretBone, barrelBone, aimBone)
 end
 
---- Creates a collision detection manipulator, calls the function `self.OnAnimTerrainCollision(self, bone, x, y, z)`
+--- Creates a collision detection manipulator, calls the function `self:OnAnimTerrainCollision(bone, x, y, z)`
 --- when a bone that is being watched collides with the terrain
 ---@param unit Unit
 ---@return moho.CollisionManipulator

--- a/lua/aeonprojectiles.lua
+++ b/lua/aeonprojectiles.lua
@@ -502,7 +502,7 @@ AAAQuantumDisplacementCannonProjectile = Class(NullShell) {
         NullShell.OnCreate(self)
 
         self.TrailEmitters = {}
-        self.CreateTrailFX(self)
+        self:CreateTrailFX()
         self:ForkThread(self.UpdateThread)
     end,
 
@@ -537,13 +537,13 @@ AAAQuantumDisplacementCannonProjectile = Class(NullShell) {
     ---@param self AAAQuantumDisplacementCannonProjectile
     UpdateThread = function(self)
         WaitSeconds(0.3)
-        self.DestroyTrailFX(self)
-        self.CreateTeleportFX(self, self.Army)
+        self:DestroyTrailFX()
+        self:CreateTeleportFX(self.Army)
         local emit = CreateEmitterOnEntity(self, self.Army, self.FxInvisible)
         WaitSeconds(0.45)
         emit:Destroy()
-        self.CreateTeleportFX(self)
-        self.CreateTrailFX(self)
+        self:CreateTeleportFX()
+        self:CreateTrailFX()
     end,
 }
 

--- a/lua/cybranprojectiles.lua
+++ b/lua/cybranprojectiles.lua
@@ -472,7 +472,7 @@ CIFMolecularResonanceShell = Class(SinglePolyTrailProjectile) {
     ---@param self CIFMolecularResonanceShell
     DelayedDestroyThread = function(self)
         WaitSeconds(0.3)
-        self.CreateImpactEffects(self, self.Army, self.FxImpactUnit, self.FxUnitHitScale)
+        self:CreateImpactEffects(self.Army, self.FxImpactUnit, self.FxUnitHitScale)
         self:Destroy()
     end,
 

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -754,7 +754,7 @@ FactoryUnit = Class(StructureUnit) {
             end
         end
 
-        self.DestroyUnitBeingBuilt(self)
+        self:DestroyUnitBeingBuilt()
     end,
 
     ---@param self FactoryUnit
@@ -1403,7 +1403,7 @@ RadarJammerUnit = Class(StructureUnit) {
         StructureUnit.OnIntelEnabled(self)
         if self.IntelEffects and not self.IntelFxOn then
             self.IntelEffectsBag = {}
-            self.CreateTerrainTypeEffects(self, self.IntelEffects, 'FXIdle', self.Layer, nil, self.IntelEffectsBag)
+            self:CreateTerrainTypeEffects(self.IntelEffects, 'FXIdle', self.Layer, nil, self.IntelEffectsBag)
             self.IntelFxOn = true
         end
     end,
@@ -1895,7 +1895,7 @@ AirUnit = Class(MobileUnit) {
         -- Additional stupidity: An idle transport, bot loaded and unloaded, counts as 'Land' layer so it would die with the wreck hovering.
         -- It also wouldn't call this code, and hence the cargo destruction. Awful!
         if self:GetFractionComplete() == 1 and (self.Layer == 'Air' or EntityCategoryContains(categories.TRANSPORTATION, self)) then
-            self.CreateUnitAirDestructionEffects(self, 1.0)
+            self:CreateUnitAirDestructionEffects(1.0)
             self:DestroyTopSpeedEffects()
             self:DestroyBeamExhaust()
             self.OverKillRatio = overkillRatio

--- a/lua/keymap/hotkeylabels.lua
+++ b/lua/keymap/hotkeylabels.lua
@@ -114,9 +114,9 @@ function getKeyTables()
 
     -- Get them from the building tab
     for groupName, groupItems in unitkeygroups do -- Since this file hardcodes all unit ids that can be affected by hotbuild, helpidrelations will get them all
-        local g = groupName.lower(groupName)
+        local g = groupName:lower()
         for _, item in groupItems do
-            local i = item.lower(item)
+            local i = item:lower()
 
             if __blueprints[i] then
                 if not helpIdRelations[i] then
@@ -139,7 +139,7 @@ function getKeyTables()
         for key, value in group do
             if otherRelations[value] then -- Check if the group contained more than just unit IDs
                 for ids, values in pairs(otherRelations[value]) do
-                    table.insert(helpIdRelations[id], values.lower(values))
+                    table.insert(helpIdRelations[id], values:lower())
                 end
             end
         end
@@ -225,17 +225,17 @@ function getKeyUse(key)
     local colour = 1
     if string.find(key, "Shift*") then
         -- No colour change for shift
-        key = key.gsub(key, "Shift.", "")
+        key = key:gsub("Shift.", "")
     end
 
     if string.find(key, "Ctrl*") then
         colour = colour + 1
-        key = key.gsub(key, "Ctrl.", "")
+        key = key:gsub("Ctrl.", "")
     end
 
     if string.find(key, "Alt*") then
         colour = colour + 2
-        key = key.gsub(key, "Alt.", "")
+        key = key:gsub("Alt.", "")
     end
 
     return key, colours[colour]

--- a/lua/proptree.lua
+++ b/lua/proptree.lua
@@ -107,21 +107,21 @@ Tree = Class(Prop) {
             elseif type == 'Nuke' and canBurn then
                 -- slight chance we catch fire
                 if Random(1, 250) < 5 then
-                    self.Burn(self)
+                    self:Burn()
                 end
 
             elseif (type == 'Fire' or type == 'TreeFire') and canBurn then 
 
                 -- fire type damage, slightly higher odds to catch fire
                 if Random(1, 35) <= 2 then
-                    self.Burn(self)
+                    self:Burn()
                 end
             end
             
             if (type ~= 'Force') and (type ~= 'Fire') and canBurn and canFall then 
                 -- any damage type but force can cause a burn
                 if Random(1, 20) <= 1 then
-                    self.Burn(self)
+                    self:Burn()
                 end
             end
         end
@@ -207,8 +207,8 @@ Tree = Class(Prop) {
         effect = CreateLightParticleIntel( self, -1, -1, 1.5, 10, 'glow_03', 'ramp_flare_02' )
 
         -- sounds
-        self.PlayPropSound(self, 'BurnStart')
-        self.PlayPropAmbientSound(self, 'BurnLoop')
+        self:PlayPropSound('BurnStart')
+        self:PlayPropAmbientSound('BurnLoop')
 
         -- wait a bit before we change to a scorched tree
         WaitTicks(50 + Random(0, 10))
@@ -238,7 +238,7 @@ Tree = Class(Prop) {
         DamageArea(self, position, 1, 1, 'TreeFire', true)
 
         -- stop all sound
-        self.PlayPropAmbientSound(self, nil)
+        self:PlayPropAmbientSound(nil)
 
         -- destroy all effects
         for k = 1, effectsHead - 1 do 
@@ -254,7 +254,7 @@ Tree = Class(Prop) {
         -- fall down in a random direction if we didn't before
         if not self.Fallen then 
             self.Fallen = true
-            self.FallThread(self, Random() * 2 - 1, 0, Random() * 2 - 1, 0.25)
+            self:FallThread(Random() * 2 - 1, 0, Random() * 2 - 1, 0.25)
         end
     end,
 }

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -106,13 +106,13 @@ NukeProjectile = Class(NullShell) {
     MovementThread = function(self)
         local launcher = self:GetLauncher()
 		self.Nuke = true
-        self.CreateEffects(self, self.InitialEffects, self.Army, 1)
+        self:CreateEffects(self.InitialEffects, self.Army, 1)
         self:TrackTarget(false)
         WaitSeconds(2.5) -- Height
         self:SetCollision(true)
-        self.CreateEffects(self, self.LaunchEffects, self.Army, 1)
+        self:CreateEffects(self.LaunchEffects, self.Army, 1)
         WaitSeconds(2.5)
-        self.CreateEffects(self, self.ThrustEffects, self.Army, 3)
+        self:CreateEffects(self.ThrustEffects, self.Army, 3)
         WaitSeconds(2.5)
         self:TrackTarget(true) -- Turn ~90 degrees towards target
         self:SetDestroyOnWater(true)

--- a/lua/sim/Entity.lua
+++ b/lua/sim/Entity.lua
@@ -33,7 +33,7 @@ Entity = Class(moho.entity_methods) {
     ---@param self Entity
     ---@param spec EntitySpec
     __post_init = function(self, spec)
-        self.OnCreate(self, spec)
+        self:OnCreate(spec)
     end,
 
     -- kept for backwards compatibility with mods

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -386,7 +386,7 @@ Prop = Class(moho.prop_methods) {
             -- attempt to make the prop
             ok, out = pcall(self.CreatePropAtBone, self, ibone, blueprint)
             if ok then 
-                out.SetMaxReclaimValues(out, time, mass, energy)
+                out:SetMaxReclaimValues(time, mass, energy)
                 props[ibone] = out 
             else 
                 WARN("Unable to split a prop: " .. self.Blueprint.BlueprintId .. " -> " .. blueprint)

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -64,7 +64,7 @@ Prop = Class(moho.prop_methods) {
             -- set by some adaptive maps to influence how much a prop is worth
             local modifier = ScenarioInfo.Options.naturalReclaimModifier or 1
 
-            self.SetMaxReclaimValues(self,
+            self:SetMaxReclaimValues(
                 economy.ReclaimTimeMultiplier or economy.ReclaimMassTimeMultiplier or economy.ReclaimEnergyTimeMultiplier or 1,
                 (economy.ReclaimMassMax * modifier) or 0,
                 (economy.ReclaimEnergyMax * modifier) or 0
@@ -146,15 +146,15 @@ Prop = Class(moho.prop_methods) {
             return 
         end
 
-        self.DoPropCallbacks(self, 'OnKilled')
+        self:DoPropCallbacks('OnKilled')
         EntityDestroy(self)
     end,
 
     --- Called by the engine when the prop is reclaimed.
     -- @param entity The entity that reclaimed the prop.
     OnReclaimed = function(self, entity)
-        self.DoPropCallbacks(self, 'OnReclaimed', entity)
-        self.CreateReclaimEndEffects(self, entity)
+        self:DoPropCallbacks('OnReclaimed', entity)
+        self:CreateReclaimEndEffects(entity)
         EntityDestroy(self)
     end,
 
@@ -203,7 +203,7 @@ Prop = Class(moho.prop_methods) {
     --- Called by the engine when the prop is destroyed.
     OnDestroy = function(self)
         self.Dead = true
-        self.UpdateReclaimLeft(self)
+        self:UpdateReclaimLeft()
         TrashDestroy(self.Trash)
     end,
 
@@ -241,13 +241,13 @@ Prop = Class(moho.prop_methods) {
                 local excess = preHealth
                 local maxHealth = EntityGetMaxHealth(self)
                 if excess < 0 and maxHealth > 0 then
-                    self.Kill(self, instigator, damageType, -excess / maxHealth)
+                    self:Kill(instigator, damageType, -excess / maxHealth)
                 else 
-                    self.Kill(self, instigator, damageType, 0.0)
+                    self:Kill(instigator, damageType, 0.0)
                 end
             end
         else
-            self.UpdateReclaimLeft(self)
+            self:UpdateReclaimLeft()
         end
     end,
 
@@ -266,7 +266,7 @@ Prop = Class(moho.prop_methods) {
         self.MaxEnergyReclaim = energy
         self.TimeReclaim = time
 
-        self.UpdateReclaimLeft(self)
+        self:UpdateReclaimLeft()
     end,
 
     --- Mimics the engine behavior when calculating the reclaim value of a prop.
@@ -281,7 +281,7 @@ Prop = Class(moho.prop_methods) {
         end
 
         -- Notify UI about the mass change
-        self.SyncMassLabel(self)
+        self:SyncMassLabel()
     end,
 
     --- Sets the collision box of the prop.

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2052,7 +2052,7 @@ Unit = Class(moho.unit_methods) {
 
         -- Flying bits of metal and whatnot. More bits for more overkill.
         if self.ShowUnitDestructionDebris and overkillRatio then
-            self.CreateUnitDestructionDebris(self, true, true, overkillRatio > 2)
+            self:CreateUnitDestructionDebris(true, true, overkillRatio > 2)
         end
 
         if shallSink then
@@ -2324,7 +2324,7 @@ Unit = Class(moho.unit_methods) {
     GetWeaponByLabel = function(self, label)
 
         -- if we're sinking then all death weapons should already have been applied
-        if self.Sinking or self.BeenDestroyed(self) then 
+        if self.Sinking or self:BeenDestroyed() then 
             return nil
         end
 
@@ -5219,7 +5219,7 @@ Unit = Class(moho.unit_methods) {
         -- end
 
         -- call the old function
-        self.UpdateBuildRestrictions(self)
+        self:UpdateBuildRestrictions()
     end,
 
     ---@param aiBrain AIBrain

--- a/lua/system/class.lua
+++ b/lua/system/class.lua
@@ -450,7 +450,7 @@ function ChangeState(instance, newstate)
 
     -- call on-exit function
     if instance.OnExitState then
-        instance.OnExitState(instance)
+        instance:OnExitState()
     end
 
     -- keep track of the original thread and forget about it inside the object
@@ -465,7 +465,7 @@ function ChangeState(instance, newstate)
 
     -- call on-enter function
     if instance.OnEnterState then
-        instance.OnEnterState(instance)
+        instance:OnEnterState()
     end
 
     -- start the new main thread if it wasn't already created during an OnEnterState

--- a/lua/ui/controls/filepicker.lua
+++ b/lua/ui/controls/filepicker.lua
@@ -599,7 +599,7 @@ FilePicker = Class(Group) {
         self._filenameErrorMsg:SetText("")
 
         if self._selectAction then
-            self._selectAction(self, self:GetFileInfo())
+            self:_selectAction(self:GetFileInfo())
         end
 
         return true

--- a/lua/ui/dialogs/options.lua
+++ b/lua/ui/dialogs/options.lua
@@ -397,7 +397,7 @@ function CreateDialog(over, exitBehavior)
             {escapeButton = 2, enterButton = 1, worldCover = false})
     end
 
-    UIUtil.MakeInputModal(dialog, function() okBtn.OnClick(okBtn) end, function() dialog.cancelBtn.OnClick(dialog.cancelBtn) end)
+    UIUtil.MakeInputModal(dialog, function() okBtn:OnClick() end, function() dialog.cancelBtn.OnClick(dialog.cancelBtn) end)
 
     -- set up option grid
     local elementWidth, elementHeight = GetTextureDimensions(UIUtil.UIFile('/dialogs/options-02/content-box_bmp.dds'))

--- a/lua/ui/dialogs/options.lua
+++ b/lua/ui/dialogs/options.lua
@@ -397,7 +397,7 @@ function CreateDialog(over, exitBehavior)
             {escapeButton = 2, enterButton = 1, worldCover = false})
     end
 
-    UIUtil.MakeInputModal(dialog, function() okBtn:OnClick() end, function() dialog.cancelBtn.OnClick(dialog.cancelBtn) end)
+    UIUtil.MakeInputModal(dialog, function() okBtn:OnClick() end, function() dialog.cancelBtn:OnClick() end)
 
     -- set up option grid
     local elementWidth, elementHeight = GetTextureDimensions(UIUtil.UIFile('/dialogs/options-02/content-box_bmp.dds'))

--- a/lua/ui/game/tooltip.lua
+++ b/lua/ui/game/tooltip.lua
@@ -356,7 +356,7 @@ function AddControlTooltip(control, tooltipID, delay, width)
         elseif event.Type == 'MouseExit' then
             DestroyMouseoverDisplay()
         end
-        return self.oldHandleEvent(self, event)
+        return self:oldHandleEvent(event)
     end
 end
 
@@ -385,7 +385,7 @@ function AddControlTooltipManual(control, title, description, delay, width, padd
         elseif event.Type == 'MouseExit' then
             DestroyMouseoverDisplay()
         end
-        return self.oldHandleEvent(self, event)
+        return self:oldHandleEvent(event)
     end
 end
 
@@ -405,7 +405,7 @@ function AddForcedControlTooltipManual(control, title, description, delay, width
         elseif event.Type == 'MouseExit' then
             DestroyMouseoverDisplay()
         end
-        return self.oldHandleEvent(self, event)
+        return self:oldHandleEvent(event)
     end
 end
 
@@ -420,7 +420,7 @@ function AddAutoUpdatedControlTooltip(control, displayText, displayBody, delay, 
         elseif event.Type == 'MouseExit' then
             DestroyMouseoverDisplay()
         end
-        return self.oldHandleEvent(self, event)
+        return self:oldHandleEvent(event)
     end
 end
 
@@ -434,7 +434,7 @@ function AddCheckboxTooltip(control, tooltipID, delay, width)
         elseif event.Type == 'MouseExit' then
             DestroyMouseoverDisplay()
         end
-        return self.oldHandleEvent(self, event)
+        return self:oldHandleEvent(event)
     end
 end
 

--- a/lua/ui/lobby/ModsManager.lua
+++ b/lua/ui/lobby/ModsManager.lua
@@ -365,7 +365,7 @@ function CreateDialog(parent, isHost, availableMods, saveBehaviour)
 
         return mods.activated
     end
-    UIUtil.MakeInputModal(dialogContent, function() SaveButton.OnClick(SaveButton) end, function() SaveButton.OnClick(SaveButton) end)
+    UIUtil.MakeInputModal(dialogContent, function() SaveButton:OnClick() end, function() SaveButton:OnClick() end)
 
     RefreshModsList()
     

--- a/lua/ui/lobby/chatarea.lua
+++ b/lua/ui/lobby/chatarea.lua
@@ -77,7 +77,7 @@ ChatArea = Class(Group) {
 
         local chatText = authorName .. messageText
         local customAdvanceFunction = function(chatText)
-            return self.AdvanceFunction(self, chatText, messageStyle)
+            return self:AdvanceFunction(chatText, messageStyle)
         end
 
         local wrapLines = Text.WrapText(chatText, self.Width() - self.Style.padding.left - self.Style.padding.right,

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3204,7 +3204,7 @@ function CreateUI(maxPlayers)
     cbox_ShowChangedOption.OnCheck = function(self, checked)
         HideDefaultOptions = checked
         RefreshOptionDisplayData()
-        GUI.OptionContainer.ScrollSetTop(GUI.OptionContainer, 'Vert', 0)
+        GUI.OptionContainer:ScrollSetTop('Vert', 0)
         Prefs.SetToCurrentProfile('LobbyHideDefaultOptions', tostring(checked))
     end
 

--- a/lua/wreckage.lua
+++ b/lua/wreckage.lua
@@ -55,7 +55,7 @@ Wreckage = Class(Prop) {
 
     OnDamage = function(self, instigator, amount, vector, damageType)
         if self.CanTakeDamage then 
-            self.DoTakeDamage(self, instigator, amount, vector, damageType)
+            self:DoTakeDamage(instigator, amount, vector, damageType)
         end
     end,
 
@@ -64,10 +64,10 @@ Wreckage = Class(Prop) {
         local health = EntityGetHealth(self)
 
         if health <= 0 then
-            self.DoPropCallbacks(self, 'OnKilled')
+            self:DoPropCallbacks('OnKilled')
             EntityDestroy(self)
         else
-            self.UpdateReclaimLeft(self)
+            self:UpdateReclaimLeft()
         end
     end,
 

--- a/lua/wreckage.lua
+++ b/lua/wreckage.lua
@@ -162,8 +162,8 @@ function CreateWreckage(bp, position, orientation, mass, energy, time, deathHitB
     EntitySetHealth(prop, nil, bp.Defense.Health * (bp.Wreckage.HealthMult or 1))
 
     -- set collision box and reclaim values, the latter depends on the health of the wreck
-    prop.SetPropCollision(prop, 'Box', cx, cy, cz, sx, sy, sz)
-    prop.SetMaxReclaimValues(prop, time, mass, energy)
+    prop:SetPropCollision('Box', cx, cy, cz, sx, sy, sz)
+    prop:SetMaxReclaimValues(time, mass, energy)
 
     --FIXME: SetVizToNeurals('Intel') is correct here, so you can't see enemy wreckage appearing
     -- under the fog. However the engine has a bug with prop intel that makes the wreckage

--- a/projectiles/AANDepthCharge01/AANDepthCharge01_script.lua
+++ b/projectiles/AANDepthCharge01/AANDepthCharge01_script.lua
@@ -21,7 +21,7 @@ AANDepthCharge01 = Class(ADepthChargeProjectile) {
         WaitSeconds(self.CountdownLength)
 
         if not self.HasImpacted then
-            self.OnImpact(self, 'Underwater', nil)
+            self:OnImpact('Underwater', nil)
         end
     end,
 

--- a/projectiles/AANDepthCharge03/AANDepthCharge03_script.lua
+++ b/projectiles/AANDepthCharge03/AANDepthCharge03_script.lua
@@ -21,7 +21,7 @@ AANDepthCharge03 = Class(ADepthChargeProjectile) {
         WaitSeconds(self.CountdownLength)
 
         if not self.HasImpacted then
-            self.OnImpact(self, 'Underwater', nil)
+            self:OnImpact('Underwater', nil)
         end
     end,
 

--- a/projectiles/AANTorpedoClusterSplit01/AANTorpedoClusterSplit01_script.lua
+++ b/projectiles/AANTorpedoClusterSplit01/AANTorpedoClusterSplit01_script.lua
@@ -30,7 +30,7 @@ AANTorpedoCluster01 = Class(ATorpedoCluster) {
         WaitSeconds(self.CountdownLength)
 
         if not self.HasImpacted then
-            self.OnImpact(self, 'Underwater', nil)
+            self:OnImpact('Underwater', nil)
         end
     end,
 

--- a/projectiles/CANTorpedoNanite02/CANTorpedoNanite02_script.lua
+++ b/projectiles/CANTorpedoNanite02/CANTorpedoNanite02_script.lua
@@ -40,7 +40,7 @@ CANTorpedoNanite02 = Class(CTorpedoShipProjectile) {
 
     OnEnterWater = function(self)
         CTorpedoShipProjectile.OnEnterWater(self)
-        self.CreateImpactEffects( self, self:GetArmy(), self.FxEnterWater, self.FxSplashScale )
+        self:CreateImpactEffects(self:GetArmy(), self.FxEnterWater, self.FxSplashScale )
         self:StayUnderwater(true)
         self:TrackTarget(true)
         self:SetTurnRate(120)

--- a/projectiles/CANTorpedoNanite03/CANTorpedoNanite03_script.lua
+++ b/projectiles/CANTorpedoNanite03/CANTorpedoNanite03_script.lua
@@ -40,7 +40,7 @@ CANTorpedoNanite03 = Class(CTorpedoShipProjectile) {
 
     OnEnterWater = function(self)
         --CTorpedoShipProjectile.OnEnterWater(self)
-        self.CreateImpactEffects( self, self:GetArmy(), self.FxEnterWater, self.FxSplashScale )
+        self:CreateImpactEffects(self:GetArmy(), self.FxEnterWater, self.FxSplashScale )
         self:StayUnderwater(true)
         self:TrackTarget(true)
         self:SetTurnRate(240)

--- a/projectiles/CIFBrackmanHackPegs02/CIFBrackmanHackPegs02_script.lua
+++ b/projectiles/CIFBrackmanHackPegs02/CIFBrackmanHackPegs02_script.lua
@@ -22,7 +22,7 @@ CIFBrackmanHackPegs02 = Class(import('/lua/cybranprojectiles.lua').CDFBrackmanHa
         self:SetVelocity(0)
         self:SetBallisticAcceleration(0)
         self:ForkThread(self.WaitingForDeath)
-        self.CreateImpactEffects( self, self:GetArmy(), self.FxImpactLand, 1 )
+        self:CreateImpactEffects(self:GetArmy(), self.FxImpactLand, 1 )
         for k, v in EffectTemplate.CBrackmanCrabPegAmbient01 do
 			CreateEmitterOnEntity( self, self:GetArmy(), v )
 		end			

--- a/projectiles/TIFMissileNukeCDR/TIFMissileNukeCDR_Script.lua
+++ b/projectiles/TIFMissileNukeCDR/TIFMissileNukeCDR_Script.lua
@@ -34,12 +34,12 @@ TIFMissileNukeCDR = Class(TIFMissileNuke) {
     MovementThread = function(self)
         local target = self:GetTrackingTarget()
         local launcher = self:GetLauncher()
-        self.CreateEffects(self, self.InitialEffects, self.Army, 1)
+        self:CreateEffects(self.InitialEffects, self.Army, 1)
         self.WaitTime = 0.1
         self:SetTurnRate(8)
         WaitSeconds(0.3)
-        self.CreateEffects(self, self.LaunchEffects, self.Army, 1)
-        self.CreateEffects(self, self.ThrustEffects, self.Army, 1)
+        self:CreateEffects(self.LaunchEffects, self.Army, 1)
+        self:CreateEffects(self.ThrustEffects, self.Army, 1)
         while not self:BeenDestroyed() do
             self:SetTurnRateByDist()
             WaitSeconds(self.WaitTime)

--- a/units/UAL0401/UAL0401_Script.lua
+++ b/units/UAL0401/UAL0401_Script.lua
@@ -150,14 +150,14 @@ UAL0401 = Class(AWalkingLandUnit) {
         -- hopes that this will look better in the future.. =)
         if self.ShowUnitDestructionDebris and overkillRatio then
             if overkillRatio <= 1 then
-                self.CreateUnitDestructionDebris(self, true, true, false)
+                self:CreateUnitDestructionDebris(true, true, false)
             elseif overkillRatio <= 2 then
-                self.CreateUnitDestructionDebris(self, true, true, false)
+                self:CreateUnitDestructionDebris(true, true, false)
             elseif overkillRatio <= 3 then
-                self.CreateUnitDestructionDebris(self, true, true, true)
-                self.CreateUnitDestructionDebris(self, true, true, true)
+                self:CreateUnitDestructionDebris(true, true, true)
+                self:CreateUnitDestructionDebris(true, true, true)
             else -- Vaporized
-                self.CreateUnitDestructionDebris(self, true, true, true)
+                self:CreateUnitDestructionDebris(true, true, true)
             end
         end
 

--- a/units/UEL0301/UEL0301_script.lua
+++ b/units/UEL0301/UEL0301_script.lua
@@ -180,7 +180,7 @@ UEL0301 = Class(CommandUnit) {
         if self.RadarJammerEnh and self:IsIntelEnabled('Jammer') then
             if self.IntelEffects then
                 self.IntelEffectsBag = {}
-                self.CreateTerrainTypeEffects(self, self.IntelEffects, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
+                self:CreateTerrainTypeEffects(self.IntelEffects, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
             end
             self:SetEnergyMaintenanceConsumptionOverride(self:GetBlueprint().Enhancements['RadarJammer'].MaintenanceConsumptionPerSecondEnergy or 0)
             self:SetMaintenanceConsumptionActive()

--- a/units/URL0001/URL0001_script.lua
+++ b/units/URL0001/URL0001_script.lua
@@ -386,14 +386,14 @@ URL0001 = Class(ACUUnit, CCommandUnit) {
             self:SetMaintenanceConsumptionActive()
             if not self.IntelEffectsBag then
                 self.IntelEffectsBag = {}
-                self.CreateTerrainTypeEffects(self, self.IntelEffects.Cloak, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
+                self:CreateTerrainTypeEffects(self.IntelEffects.Cloak, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
             end
         elseif self.StealthEnh and self:IsIntelEnabled('RadarStealth') and self:IsIntelEnabled('SonarStealth') then
             self:SetEnergyMaintenanceConsumptionOverride(self:GetBlueprint().Enhancements['StealthGenerator'].MaintenanceConsumptionPerSecondEnergy or 0)
             self:SetMaintenanceConsumptionActive()
             if not self.IntelEffectsBag then
                 self.IntelEffectsBag = {}
-                self.CreateTerrainTypeEffects(self, self.IntelEffects.Field, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
+                self:CreateTerrainTypeEffects(self.IntelEffects.Field, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
             end
         end
     end,

--- a/units/URL0301/URL0301_script.lua
+++ b/units/URL0301/URL0301_script.lua
@@ -249,14 +249,14 @@ URL0301 = Class(CCommandUnit) {
             self:SetMaintenanceConsumptionActive()
             if not self.IntelEffectsBag then
                 self.IntelEffectsBag = {}
-                self.CreateTerrainTypeEffects(self, self.IntelEffects.Cloak, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
+                self:CreateTerrainTypeEffects(self.IntelEffects.Cloak, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
             end
         elseif self.StealthEnh and self:IsIntelEnabled('RadarStealth') and self:IsIntelEnabled('SonarStealth') then
             self:SetEnergyMaintenanceConsumptionOverride(self:GetBlueprint().Enhancements['StealthGenerator'].MaintenanceConsumptionPerSecondEnergy or 0)
             self:SetMaintenanceConsumptionActive()
             if not self.IntelEffectsBag then
                 self.IntelEffectsBag = {}
-                self.CreateTerrainTypeEffects(self, self.IntelEffects.Field, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
+                self:CreateTerrainTypeEffects(self.IntelEffects.Field, 'FXIdle',  self.Layer, nil, self.IntelEffectsBag)
             end
         end
     end,

--- a/units/URS0201/URS0201_script.lua
+++ b/units/URS0201/URS0201_script.lua
@@ -132,13 +132,13 @@ URS0201 = Class(CSeaUnit) {
             -- Create Initial explosion effects
             if self.ShowUnitDestructionDebris and overkillRatio then
                 if overkillRatio <= 1 then
-                    self.CreateUnitDestructionDebris(self, true, true, false)
+                    self:CreateUnitDestructionDebris(true, true, false)
                 elseif overkillRatio <= 2 then
-                    self.CreateUnitDestructionDebris(self, true, true, false)
+                    self:CreateUnitDestructionDebris(true, true, false)
                 elseif overkillRatio <= 3 then
-                    self.CreateUnitDestructionDebris(self, true, true, true)
+                    self:CreateUnitDestructionDebris(true, true, true)
                 else -- VAPORIZED
-                    self.CreateUnitDestructionDebris(self, true, true, true)
+                    self:CreateUnitDestructionDebris(true, true, true)
                 end
             end
             WaitSeconds(2)

--- a/units/XRB2308/XRB2308_script.lua
+++ b/units/XRB2308/XRB2308_script.lua
@@ -98,7 +98,7 @@ XRB2308 = Class(CStructureUnit) {
 
         -- Flying bits of metal and whatnot. More bits for more overkill.
         if self.ShowUnitDestructionDebris and overkillRatio then
-            self.CreateUnitDestructionDebris(self, true, true, overkillRatio > 2)
+            self:CreateUnitDestructionDebris(true, true, overkillRatio > 2)
         end
 
         self.DisallowCollisions = true

--- a/units/XRB2309/XRB2309_script.lua
+++ b/units/XRB2309/XRB2309_script.lua
@@ -121,7 +121,7 @@ XRB2309 = Class(CStructureUnit) {
 
         -- Flying bits of metal and whatnot. More bits for more overkill.
         if self.ShowUnitDestructionDebris and overkillRatio then
-            self.CreateUnitDestructionDebris(self, true, true, overkillRatio > 2)
+            self:CreateUnitDestructionDebris(true, true, overkillRatio > 2)
         end
 
         self.DisallowCollisions = true

--- a/units/XRL0302/XRL0302_Script.lua
+++ b/units/XRL0302/XRL0302_Script.lua
@@ -95,7 +95,7 @@ XRL0302 = Class(CWalkingLandUnit) {
 
         self.EffectsBagXRL = TrashBag()
         self.AmbientExhaustEffectsBagXRL = TrashBag()
-        self.CreateTerrainTypeEffects(self, self.IntelEffects.Cloak, 'FXIdle',  self.Layer, nil, self.EffectsBag)
+        self:CreateTerrainTypeEffects(self.IntelEffects.Cloak, 'FXIdle',  self.Layer, nil, self.EffectsBag)
         self.PeriodicFXThread = self:ForkThread(self.EmitPeriodicEffects)
     end,
 

--- a/units/XSL0401/XSL0401_Script.lua
+++ b/units/XSL0401/XSL0401_Script.lua
@@ -115,13 +115,13 @@ XSL0401 = Class(SWalkingLandUnit) {
         -- hopes that this will look better in the future.. =)
         if self.ShowUnitDestructionDebris and overkillRatio then
             if overkillRatio <= 1 then
-                self.CreateUnitDestructionDebris(self, true, true, false)
+                self:CreateUnitDestructionDebris(true, true, false)
             elseif overkillRatio <= 2 then
-                self.CreateUnitDestructionDebris(self, true, true, false)
+                self:CreateUnitDestructionDebris(true, true, false)
             elseif overkillRatio <= 3 then
-                self.CreateUnitDestructionDebris(self, true, true, true)
+                self:CreateUnitDestructionDebris(true, true, true)
             else -- Vaporized
-                self.CreateUnitDestructionDebris(self, true, true, true)
+                self:CreateUnitDestructionDebris(true, true, true)
             end
         end
 


### PR DESCRIPTION
This is more efficient bytecode-wise in addition to being more maintainable:

```self.Fun(self)```

compiles to
```
0 - GETTABLE       1    0  250
1 - MOVE           2    0    0
2 - CALL           1    2    1
```

while

```self:Fun()```

compiles to
```
0 - SELF           1    0  250
1 - CALL           1    2    1
```

The speed savings are marginal.

For those looking to win regex golf, this should be fit by the pattern `\b(?!table\b)(?!string\b)(\w+)\s*\.\s*(\w+)\s*\(\s*\1\s*(,\s*|(\)))` ->`$1:$2($4` (though make sure to leave the benchmarking functions the same)