### PR TITLE
Let numbers be passed into LOC

### DIFF
--- a/lua/system/Localization.lua
+++ b/lua/system/Localization.lua
@@ -1,4 +1,7 @@
 ---@declare-global
+
+local StringSub = string.sub
+
 local loc_table
 
 ---@alias LocalizedString string
@@ -165,11 +168,8 @@ function LOC(str)
     if str == nil then
         return str
     end
-    if type(str) == "number" then
-        return tostring(str)
-    end
 
-    if str:sub(1, 5) ~= [[<LOC ]] then
+    if StringSub(str, 1, 5) ~= [[<LOC ]] then
         return LocExpand(str)
     end
 

--- a/lua/system/Localization.lua
+++ b/lua/system/Localization.lua
@@ -5,7 +5,7 @@ local StringSub = string.sub
 local loc_table
 
 ---@alias LocalizedString string
----@alias UnlocalizedString string
+---@alias UnlocalizedString string | number
 
 -- Special tokens that can be included in a loc string via {g Player} etc. The
 -- Player name gets replaced with the current selected player name.
@@ -160,7 +160,7 @@ end
 ---@overload fun(str: nil): nil
 --- If `str` is a string with a localization tag, like "<LOC HW1234>Hello World",
 --- returns a localized version of it
----@param str UnlocalizedString | number
+---@param str UnlocalizedString
 ---@return LocalizedString
 function LOC(str)
     -- Note - we use [[foo]] string syntax here instead of "foo", so the localizing

--- a/lua/system/Localization.lua
+++ b/lua/system/Localization.lua
@@ -157,13 +157,16 @@ end
 ---@overload fun(str: nil): nil
 --- If `str` is a string with a localization tag, like "<LOC HW1234>Hello World",
 --- returns a localized version of it
----@param str UnlocalizedString
+---@param str UnlocalizedString | number
 ---@return LocalizedString
 function LOC(str)
     -- Note - we use [[foo]] string syntax here instead of "foo", so the localizing
     -- script won't try to mess with *our* strings.
     if str == nil then
         return str
+    end
+    if type(str) == "number" then
+        return tostring(str)
     end
 
     if str:sub(1, 5) ~= [[<LOC ]] then

--- a/lua/system/Localization.lua
+++ b/lua/system/Localization.lua
@@ -19,8 +19,10 @@ local StringSub = string.sub
 
 ---@type table<string, UnlocalizedString>
 local loc_table
+---@type table<string, UnlocalizedString>
+local usdb = {}
 
--- Special tokens that can be included in a loc string via {g Player} etc. The
+-- Special tokens that can be included in a loc string via `{g Player}` etc. The
 -- Player name gets replaced with the current selected player name.
 local UpLocGlobals = {
     PlayerName = "Player",
@@ -38,7 +40,7 @@ local function dbFilename(la)
 end
 
 -- Check whether the given language is installed; if so, return it;
--- otherwise return some language that is installed.
+-- otherwise, return some language that is installed.
 ---@param la Language
 ---@return Language
 local function okLanguage(la)
@@ -53,11 +55,6 @@ local function okLanguage(la)
     local dbfiles = DiskFindFiles("/loc", "*strings_db.lua")
     la = dbfiles[1]:gsub(".*/(.*)/.*", "%1")
     return la
-end
-
-local usdb = {}
-if okLanguage("us") then
-    doscript(dbFilename("us"), usdb)
 end
 
 ---@param la Language
@@ -111,7 +108,7 @@ function LocalisationAILobby()
     end
 end
 
---- Called from `string.gsub` in `LocExpand()` to expand a single `{op ident}` element
+--- Called from `string.gsub` in `LocExpand()` to expand a single `{op ident}` directive
 ---@param op string
 ---@param ident string
 ---@return string
@@ -198,8 +195,7 @@ end
 ---@return LocalizedString
 function LOCF(...)
     for k, v in arg do
-        local tt = type(v)
-        if tt == "string" or tt == "number" then
+        if type(v) == "string" then
             arg[k] = LOC(v)
         end
     end
@@ -224,4 +220,11 @@ function language(la)
     SetPreference("options_overrides.language", __language)
 end
 
-loadLanguage(__language)
+
+do
+    local us = dbFilename "us"
+    if exists(us) then
+        doscript(us, usdb)
+    end
+    loadLanguage(__language)
+end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2688,7 +2688,7 @@ function CreateSlotsUI(makeLabel)
         newSlot.HandleEvent = defaultHandler
 
         -- Slot number
-        local slotNumber = UIUtil.CreateText(newSlot, tostring(i), 14, 'Arial')
+        local slotNumber = UIUtil.CreateText(newSlot, i, 14, 'Arial')
         newSlot.slotNumber = slotNumber
         LayoutHelpers.SetWidth(slotNumber, COLUMN_WIDTHS[1])
         slotNumber.Height:Set(newSlot.Height)


### PR DESCRIPTION
In an attempt to increase type safety, `LOC()` was prevented from having numbers passed in as an argument. While this uncovered several bugs, it appears to have broken several mods that try to localize numbers this way and needs fixing.