### PR TITLE
Attempt at fixing engineer behavior for Seraphim air factories

### DIFF
--- a/lua/seraphimunits.lua
+++ b/lua/seraphimunits.lua
@@ -128,17 +128,12 @@ SAirFactoryUnit = Class(AirFactoryUnit) {
                 unitBuilding:DetachFrom(true)
                 self:DetachAll(self.Blueprint.Display.BuildAttachBone or 0)
 
-                CreateLightParticle(unitBuilding, -1, unitBuilding.Army, 4, 12, 'glow_02', 'ramp_blue_22')
+                CreateEmitterAtBone(unitBuilding, -1, unitBuilding.Army, '/effects/emitters/seraphim_rifter_mobileartillery_hit_07_emit.bp'):OffsetEmitter(0, -1, 0)
+                CreateEmitterAtBone(unitBuilding, -1, unitBuilding.Army, '/effects/emitters/seraphim_rifter_mobileartillery_hit_07_emit.bp'):OffsetEmitter(0, -1, 0)
                 unitBuilding:HideBone(0, true)
             end
 
-            WaitTicks(1)
-            CreateLightParticle(self, 'B01', self.Army, 4, 12, 'glow_02', 'ramp_blue_22')
-
-            WaitTicks(1)
-            CreateLightParticle(self, 'B03', self.Army, 4, 12, 'glow_02', 'ramp_blue_22')
-
-            WaitTicks(2)
+            WaitTicks(4)
 
             if not IsDestroyed(unitBuilding) then
                 CreateLightParticle(unitBuilding, -1, unitBuilding.Army, 4, 12, 'glow_02', 'ramp_blue_22')

--- a/lua/seraphimunits.lua
+++ b/lua/seraphimunits.lua
@@ -96,26 +96,15 @@ SAirFactoryUnit = Class(AirFactoryUnit) {
     end,
 
     CreateRollOffEffects = function(self)
-        local unitB = self.UnitBeingBuilt
-        if not self.ReleaseEffectsBag then self.ReleaseEffectsBag = {} end
-        for _, v in self.RollOffBones do
-            local fx = AttachBeamEntityToEntity(self, v, unitB, -1, self.Army, EffectTemplate.TTransportBeam01)
-            table.insert(self.ReleaseEffectsBag, fx)
-            self.Trash:Add(fx)
-            fx = AttachBeamEntityToEntity(unitB, -1, self, v, self.Army, EffectTemplate.TTransportBeam02)
-            table.insert(self.ReleaseEffectsBag, fx)
-            self.Trash:Add(fx)
-            fx = CreateEmitterAtBone(self, v, self.Army, EffectTemplate.TTransportGlow01)
-            table.insert(self.ReleaseEffectsBag, fx)
-            self.Trash:Add(fx)
-        end
     end,
 
     DestroyRollOffEffects = function(self)
-        for _, v in self.ReleaseEffectsBag do
-            v:Destroy()
+        if self.ReleaseEffectsBag then 
+            for _, v in self.ReleaseEffectsBag do
+                v:Destroy()
+            end
+            self.ReleaseEffectsBag = {}
         end
-        self.ReleaseEffectsBag = {}
     end,
 
     RollOffUnit = function(self)
@@ -134,32 +123,37 @@ SAirFactoryUnit = Class(AirFactoryUnit) {
         if not EntityCategoryContains(categories.LAND, unitBuilding) then
             AirFactoryUnit.RolloffBody(self)
         else
-            -- Engineers need to be slid off the factory
-            local bp = self:GetBlueprint()
-            if not self.AttachmentSliderManip then
-                self.AttachmentSliderManip = CreateSlider(self, bp.Display.BuildAttachBone or 0)
-            end
 
-            self:CreateRollOffEffects()
-            self.AttachmentSliderManip:SetSpeed(50)  -- Was 30, increased to help engineers move faster off of it
-            self.AttachmentSliderManip:SetGoal(0, 0, 60)
-            WaitFor(self.AttachmentSliderManip)
-
-            self.AttachmentSliderManip:SetGoal(0, -55, 60)
-            WaitFor(self.AttachmentSliderManip)
-
-            if not unitBuilding.Dead then
+            if not IsDestroyed(unitBuilding) then
                 unitBuilding:DetachFrom(true)
-                self:DetachAll(bp.Display.BuildAttachBone or 0)
+                self:DetachAll(self.Blueprint.Display.BuildAttachBone or 0)
+
+                CreateLightParticle(unitBuilding, -1, unitBuilding.Army, 4, 12, 'glow_02', 'ramp_blue_22')
+                unitBuilding:HideBone(0, true)
             end
 
-            if self.AttachmentSliderManip then
-                self.AttachmentSliderManip:Destroy()
-                self.AttachmentSliderManip = nil
+            WaitTicks(1)
+            CreateLightParticle(self, 'B01', self.Army, 4, 12, 'glow_02', 'ramp_blue_22')
+
+            WaitTicks(1)
+            CreateLightParticle(self, 'B03', self.Army, 4, 12, 'glow_02', 'ramp_blue_22')
+
+            WaitTicks(2)
+
+            if not IsDestroyed(unitBuilding) then
+                CreateLightParticle(unitBuilding, -1, unitBuilding.Army, 4, 12, 'glow_02', 'ramp_blue_22')
+                unitBuilding:ShowBone(0, true)
+
+                CreateEmitterAtBone(unitBuilding, -1, unitBuilding.Army, '/effects/emitters/seraphim_rifter_mobileartillery_hit_04_emit.bp'):OffsetEmitter(0, -1, 0)
+                CreateEmitterAtBone(unitBuilding, -1, unitBuilding.Army, '/effects/emitters/seraphim_rifter_mobileartillery_hit_05_emit.bp'):OffsetEmitter(0, -1, 0)
+                CreateEmitterAtBone(unitBuilding, -1, unitBuilding.Army, '/effects/emitters/seraphim_rifter_mobileartillery_hit_06_emit.bp'):OffsetEmitter(0, -1, 0)
+                CreateEmitterAtBone(unitBuilding, -1, unitBuilding.Army, '/effects/emitters/seraphim_rifter_mobileartillery_hit_07_emit.bp'):OffsetEmitter(0, -1, 0)
+                CreateEmitterAtBone(unitBuilding, -1, unitBuilding.Army, '/effects/emitters/seraphim_rifter_mobileartillery_hit_08_emit.bp'):OffsetEmitter(0, -1, 0)
             end
-            self:DestroyRollOffEffects()
+
+            WaitTicks(8)
+
             self:SetBusy(false)
-
             ChangeState(self, self.IdleState)
         end
     end,


### PR DESCRIPTION
In response to [this forum post](https://forum.faforever.com/topic/4965/sera-airfab-engineers-are-not-selectable-in-the-unloading-process). I always found it annoying too 😄 

Appears there is no easy solution with the existing approach (where the engineer is 'tethered' off), but why not just 'blink' it off? Like a rabbit from a magicians hat:

https://user-images.githubusercontent.com/15778155/194754212-5e56257a-3f06-4dbf-bdb5-1baf4731bbb0.mp4

I'm not entirely sure about the effects being used, open to suggestions for alternative effects. But this would be the only viable solution that I can see so far.
