### PR TITLE
Fix a glitch with the atlantis and gunships with cargo

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4898,11 +4898,18 @@ Unit = Class(moho.unit_methods) {
     ---@param transport BaseTransport
     ---@param bone Bone
     OnDetachedFromTransport = function(self, transport, bone)
+        self.Trash:Add(ForkThread(self.OnDetachedFromTransportThread, self, transport, bone))
         self:MarkWeaponsOnTransport(false)
         self:EnableShield()
         self:EnableDefaultToggleCaps()
         self:TransportAnimation(-1)
         self:DoUnitCallbacks('OnDetachedFromTransport', transport, bone)
+    end,
+
+    OnDetachedFromTransportThread = function(self, transport, bone)
+        if IsDestroyed(transport) then
+            self:Destroy()
+        end
     end,
 
     -- Utility Functions


### PR DESCRIPTION
One could end up with an invisible and invulnerable unit if you'd attach them to the UEF t2 gunship, let that dock with the Atlantis and then the Atlantis gets destroyed. The cargo would live on, as if it is a ghost that will haunt its opponents indefinitely.

Either how, that is fixed now - when a unit is de-attached it will check if the unit it was attached to is destroyed. If it is, then so is the de-attached cargo.