### PR TITLE
Implement first round of ai fixes and improvements

### DIFF
--- a/lua/AI/AIBaseTemplates/ChallengeMain.lua
+++ b/lua/AI/AIBaseTemplates/ChallengeMain.lua
@@ -84,14 +84,14 @@ BaseBuilderTemplate {
     },
     BaseSettings = {
         FactoryCount = {
-            Land = 2,
+            Land = 3,
             Air = 2,
             Sea = 0,
             Gate = 1,
         },
         EngineerCount = {
-            Tech1 = 6,
-            Tech2 = 3,
+            Tech1 = 8,
+            Tech2 = 4,
             Tech3 = 6,
             SCU = 1,
         },

--- a/lua/AI/AIBehaviors.lua
+++ b/lua/AI/AIBehaviors.lua
@@ -128,6 +128,7 @@ function CDROverCharge(aiBrain, cdr)
     end
 
     if numUnits > 0 or (not cdr.DistressCall and distressLoc and Utilities.XZDistanceTwoVectors(distressLoc, cdrPos) < distressRange) then
+        cdr.Combat = true
         if cdr.UnitBeingBuilt then
             cdr.UnitBeingBuiltBehavior = cdr.UnitBeingBuilt
         end
@@ -234,12 +235,6 @@ function CDROverCharge(aiBrain, cdr)
         until not continueFighting or not aiBrain:PlatoonExists(plat)
 
         IssueClearCommands({cdr})
-
-        -- Finish the unit
-        if cdr.UnitBeingBuiltBehavior and not cdr.UnitBeingBuiltBehavior:BeenDestroyed() and cdr.UnitBeingBuiltBehavior:GetFractionComplete() < 1 then
-            IssueRepair({cdr}, cdr.UnitBeingBuiltBehavior)
-        end
-        cdr.UnitBeingBuiltBehavior = false
     end
 end
 
@@ -268,8 +263,12 @@ function CDRReturnHome(aiBrain, cdr)
             WaitSeconds(7)
         until cdr.Dead or VDist2Sq(cdrPos[1], cdrPos[3], loc[1], loc[3]) <= distSqAway
 
+        cdr.Combat = false
         cdr.GoingHome = false
         IssueClearCommands({cdr})
+    end
+    if not cdr.Dead and cdr.Combat and VDist2Sq(cdrPos[1], cdrPos[3], loc[1], loc[3]) < distSqAway then
+        cdr.Combat = false
     end
 end
 
@@ -308,6 +307,10 @@ function CommanderThread(cdr, platoon)
         if not cdr.Dead then CDRReturnHome(aiBrain, cdr) end
         WaitTicks(1)
 
+        if not cdr.Dead and not cdr.Combat and cdr.UnitBeingBuiltBehavior then
+            cdr:ForkThread(CDRFinishUnit)
+        end
+
         -- Call platoon resume building deal...
         if not cdr.Dead and cdr:IsIdleState() and not cdr.GoingHome and not cdr:IsUnitState("Building")
         and not cdr:IsUnitState("Attacking") and not cdr:IsUnitState("Repairing")
@@ -338,6 +341,10 @@ function CommanderThreadImproved(cdr, platoon)
         -- Go back to base
         if not cdr.Dead then CDRReturnHome(aiBrain, cdr) end
         WaitTicks(1)
+
+        if not cdr.Dead and not cdr.Combat and cdr.UnitBeingBuiltBehavior then
+            cdr:ForkThread(CDRFinishUnit)
+        end
 
         -- Call platoon resume building deal...
         if not cdr.Dead and cdr:IsIdleState() and not cdr.GoingHome and not cdr:IsUnitState("Moving")

--- a/lua/AI/aiattackutilities.lua
+++ b/lua/AI/aiattackutilities.lua
@@ -815,7 +815,6 @@ function AIPlatoonSquadAttackVector(aiBrain, platoon, bAggro)
                 -- force reevaluation
                 platoon.LastAttackDestination = {attackPos}
             else
-                local pathSize = table.getn(path)
                 -- store path
                 platoon.LastAttackDestination = path
                 -- move to new location

--- a/lua/AI/aiattackutilities.lua
+++ b/lua/AI/aiattackutilities.lua
@@ -819,12 +819,10 @@ function AIPlatoonSquadAttackVector(aiBrain, platoon, bAggro)
                 -- store path
                 platoon.LastAttackDestination = path
                 -- move to new location
-                for wpidx,waypointPath in path do
-                    if wpidx == pathSize or bAggro then
-                        platoon:AggressiveMoveToLocation(waypointPath)
-                    else
-                        platoon:MoveToLocation(waypointPath, false)
-                    end
+                if bAggro then
+                    platoon:IssueAggressiveMoveAlongRoute(path)
+                else
+                    platoon:IssueMoveAlongRoute(path)
                 end
             end
         end

--- a/lua/AI/aiutilities.lua
+++ b/lua/AI/aiutilities.lua
@@ -34,16 +34,12 @@ function AIGetEconomyNumbers(aiBrain)
     econ.MassStorage = aiBrain:GetEconomyStored('MASS')
 
     if aiBrain.EconomyMonitorThread then
-        local econTime = aiBrain:GetEconomyOverTime()
-
-        econ.EnergyRequestOverTime = econTime.EnergyRequested
-        econ.MassRequestOverTime = econTime.MassRequested
-
-        econ.EnergyIncomeOverTime = SUtils.Round(econTime.EnergyIncome, 2)
-        econ.MassIncomeOverTime = SUtils.Round(econTime.MassIncome, 2)
-
-        econ.EnergyEfficiencyOverTime = math.min(econTime.EnergyIncome / econTime.EnergyRequested, 2)
-        econ.MassEfficiencyOverTime = math.min(econTime.MassIncome / econTime.MassRequested, 2)
+        econ.EnergyRequestOverTime = aiBrain.EconomyOverTimeCurrent.EnergyRequested
+        econ.MassRequestOverTime = aiBrain.EconomyOverTimeCurrent.MassRequested
+        econ.EnergyIncomeOverTime = aiBrain.EconomyOverTimeCurrentEnergyIncome
+        econ.MassIncomeOverTime = aiBrain.EconomyOverTimeCurrentMassIncome
+        econ.EnergyEfficiencyOverTime = aiBrain.EconomyOverTimeCurrent.EnergyEfficiencyOverTime
+        econ.MassEfficiencyOverTime = aiBrain.EconomyOverTimeCurrent.MassEfficiencyOverTime
     end
 
     if econ.MassStorageRatio ~= 0 then

--- a/lua/AI/aiutilities.lua
+++ b/lua/AI/aiutilities.lua
@@ -36,8 +36,8 @@ function AIGetEconomyNumbers(aiBrain)
     if aiBrain.EconomyMonitorThread then
         econ.EnergyRequestOverTime = aiBrain.EconomyOverTimeCurrent.EnergyRequested
         econ.MassRequestOverTime = aiBrain.EconomyOverTimeCurrent.MassRequested
-        econ.EnergyIncomeOverTime = aiBrain.EconomyOverTimeCurrentEnergyIncome
-        econ.MassIncomeOverTime = aiBrain.EconomyOverTimeCurrentMassIncome
+        econ.EnergyIncomeOverTime = aiBrain.EconomyOverTimeCurrent.EnergyIncome
+        econ.MassIncomeOverTime = aiBrain.EconomyOverTimeCurrent.MassIncome
         econ.EnergyEfficiencyOverTime = aiBrain.EconomyOverTimeCurrent.EnergyEfficiencyOverTime
         econ.MassEfficiencyOverTime = aiBrain.EconomyOverTimeCurrent.MassEfficiencyOverTime
     end

--- a/lua/editor/EconomyBuildConditions.lua
+++ b/lua/editor/EconomyBuildConditions.lua
@@ -36,8 +36,23 @@ end
 ---@param eStorage integer
 ---@return boolean
 function GreaterThanEconStorageMax(aiBrain, mStorage, eStorage)
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if (econ.MassMaxStored >= mStorage and econ.EnergyMaxStored >= eStorage) then
+    local massMaxStored
+    local energyMaxStored
+    local massStorageRatio = GetEconomyStoredRatio(aiBrain, 'MASS')
+    local energyStorageRatio = GetEconomyStoredRatio(aiBrain, 'ENERGY')
+
+    if massStorageRatio ~= 0 then
+        massMaxStored = GetEconomyStored('MASS') / massStorageRatio
+    else
+        massMaxStored = GetEconomyStored('MASS')
+    end
+    if energyStorageRatio ~= 0 then
+        energyMaxStored = GetEconomyStored('ENERGY') / energyStorageRatio
+    else
+        energyMaxStored = GetEconomyStored('ENERGY')
+    end
+
+    if (massMaxStored >= mStorage and energyMaxStored >= eStorage) then
         return true
     end
     return false
@@ -107,8 +122,23 @@ end
 ---@param eStorage integer
 ---@return boolean
 function LessEconStorageMax(aiBrain, mStorage, eStorage)
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if (econ.MassMaxStored < mStorage and econ.EnergyMaxStored < eStorage) then
+    local massMaxStored
+    local energyMaxStored
+    local massStorageRatio = GetEconomyStoredRatio(aiBrain, 'MASS')
+    local energyStorageRatio = GetEconomyStoredRatio(aiBrain, 'ENERGY')
+
+    if massStorageRatio ~= 0 then
+        massMaxStored = GetEconomyStored('MASS') / massStorageRatio
+    else
+        massMaxStored = GetEconomyStored('MASS')
+    end
+    if energyStorageRatio ~= 0 then
+        energyMaxStored = GetEconomyStored('ENERGY') / energyStorageRatio
+    else
+        energyMaxStored = GetEconomyStored('ENERGY')
+    end
+
+    if (massMaxStored < mStorage and energyMaxStored < eStorage) then
         return true
     end
     return false
@@ -238,8 +268,8 @@ function GreaterThanEconEfficiencyOverTime(aiBrain, MassEfficiency, EnergyEffici
         --LOG('*AI DEBUG: Found Paragon')
         return true
     end
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if (econ.MassEfficiencyOverTime >= MassEfficiency and econ.EnergyEfficiencyOverTime >= EnergyEfficiency) then
+    if (aiBrain.EconomyOverTimeCurrent.MassEfficiencyOverTime >= MassEfficiency and 
+    aiBrain.EconomyOverTimeCurrent.EnergyEfficiencyOverTime >= EnergyEfficiency) then
         return true
     end
     return false
@@ -255,8 +285,8 @@ function LessThanEconEfficiencyOverTime(aiBrain, MassEfficiency, EnergyEfficienc
         --LOG('*AI DEBUG: Found Paragon')
         return false
     end
-    local econ = AIUtils.AIGetEconomyNumbers(aiBrain)
-    if (econ.MassEfficiencyOverTime <= MassEfficiency and econ.EnergyEfficiencyOverTime <= EnergyEfficiency) then
+    if (aiBrain.EconomyOverTimeCurrent.MassEfficiencyOverTime <= MassEfficiency and 
+    aiBrain.EconomyOverTimeCurrent.EnergyEfficiencyOverTime <= EnergyEfficiency) then
         return true
     end
     return false
@@ -269,7 +299,6 @@ end
 ---@param unitCategory EntityCategory
 ---@return boolean
 function MassIncomeToUnitRatio(aiBrain, ratio, compareType, unitCategory)
-    local econTime = aiBrain:GetEconomyOverTime()
 
     local testCat = unitCategory
     if type(testCat) == 'string' then
@@ -280,7 +309,7 @@ function MassIncomeToUnitRatio(aiBrain, ratio, compareType, unitCategory)
     -- Find units of this type being built or about to be built
     unitCount = unitCount + aiBrain:GetEngineerManagerUnitsBeingBuilt(testCat)
 
-    local checkRatio = (econTime.MassIncome * 10) / unitCount
+    local checkRatio = (aiBrain.EconomyOverTimeCurrent.MassIncome * 10) / unitCount
 
     return CompareBody(checkRatio, ratio, compareType)
 end
@@ -292,7 +321,6 @@ end
 ---@param t3Drain integer
 ---@return boolean
 function GreaterThanMassIncomeToFactory(aiBrain, t1Drain, t2Drain, t3Drain)
-    local econTime = aiBrain:GetEconomyOverTime()
 
     -- T1 Test
     local testCat = categories.TECH1 * categories.FACTORY
@@ -314,7 +342,7 @@ function GreaterThanMassIncomeToFactory(aiBrain, t1Drain, t2Drain, t3Drain)
 
     massTotal = massTotal + (unitCount * t3Drain)
 
-    if not CompareBody((econTime.MassIncome * 10), massTotal, '>') then
+    if not CompareBody((aiBrain.EconomyOverTimeCurrent.MassIncome * 10), massTotal, '>') then
         return false
     end
 

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -3408,7 +3408,7 @@ Platoon = Class(moho.platoon_methods) {
             end
             if not aPlat.MovementLayer then
                 AIAttackUtils.GetMostRestrictiveLayer(aPlat)
-            en
+            end
 
             -- make sure we're the same movement layer type to avoid hamstringing air of amphibious
             if self.MovementLayer != aPlat.MovementLayer then

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -3074,6 +3074,7 @@ Platoon = Class(moho.platoon_methods) {
         local numberOfUnitsInPlatoon = table.getn(platoonUnits)
         local oldNumberOfUnitsInPlatoon = numberOfUnitsInPlatoon
         local stuckCount = 0
+        local maxPlatoonSize = self.PlatoonData.MaxPlatoonSize or 40
 
         self.PlatoonAttackForce = true
         -- formations have penalty for taking time to form up... not worth it here
@@ -3103,7 +3104,12 @@ Platoon = Class(moho.platoon_methods) {
             end
 
             -- merge with nearby platoons
-            self:MergeWithNearbyPlatoons('AttackForceAI', 10)
+            if numberOfUnitsInPlatoon < self.PlatoonData.MaxPlatoonSize then
+                self.PlatoonFull = false
+                self:MergeWithNearbyPlatoons('AttackForceAI', 10, maxPlatoonSize)
+            else
+                self.PlatoonFull = true
+            end
 
             -- rebuild formation
             platoonUnits = self:GetPlatoonUnits()
@@ -3336,7 +3342,7 @@ Platoon = Class(moho.platoon_methods) {
     ---@param planName string
     ---@param radius number
     ---@return nil
-    MergeWithNearbyPlatoons = function(self, planName, radius)
+    MergeWithNearbyPlatoons = function(self, planName, radius, maxPlatoonCount)
         -- check to see we're not near an ally base
         local aiBrain = self:GetBrain()
         if not aiBrain then
@@ -3351,6 +3357,18 @@ Platoon = Class(moho.platoon_methods) {
         if not platPos then
             return
         end
+
+        -- Count platoon units so that we have adhere to maximums to avoid platoons that are too big to move correctly
+        local platUnits = GetPlatoonUnits(self)
+        local platCount = 0
+        for _, u in platUnits do
+            if not u.Dead then
+                platCount = platCount + 1
+            end
+        end
+        if (maxPlatoonCount and platCount > maxPlatoonCount) or platCount < 1 then
+            return 
+        end 
 
         local radiusSq = radius*radius
         -- if we're too close to a base, forget it
@@ -3376,13 +3394,21 @@ Platoon = Class(moho.platoon_methods) {
                 continue
             end
 
+            if aPlat.PlatoonFull then
+                continue
+            end
+
             local allyPlatPos = aPlat:GetPlatoonPosition()
             if not allyPlatPos or not aiBrain:PlatoonExists(aPlat) then
                 continue
             end
 
-            AIAttackUtils.GetMostRestrictiveLayer(self)
-            AIAttackUtils.GetMostRestrictiveLayer(aPlat)
+            if not self.MovementLayer then
+                AIAttackUtils.GetMostRestrictiveLayer(self)
+            end
+            if not aPlat.MovementLayer then
+                AIAttackUtils.GetMostRestrictiveLayer(aPlat)
+            en
 
             -- make sure we're the same movement layer type to avoid hamstringing air of amphibious
             if self.MovementLayer != aPlat.MovementLayer then

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -6834,7 +6834,7 @@ Platoon = Class(moho.platoon_methods) {
         -- move over the path, store the commands
         local units = self:GetPlatoonUnits()
 
-        for k = fi1rst, count do
+        for k = 1, count do
             local point = path[k]
             local angle = angles[k]
             local command = IssueFormAggressiveMove(units, point, formation, angle)
@@ -6920,12 +6920,15 @@ Platoon = Class(moho.platoon_methods) {
         -- move over the path, store the commands
         local units = self:GetPlatoonUnits()
 
-        for k = 1, count do
+        for k = 1, count -1 do
             local point = path[k]
             local angle = angles[k]
             local command = IssueFormMove(units, point, formation, angle)
             table.insert(commands, command)
         end
+
+        -- aggressive move for the final path node
+        table.insert(commands, IssueFormAggressiveMove(units, path[count], formation, angles[count]))
 
         return commands
     end,

--- a/lua/sim/EngineerManager.lua
+++ b/lua/sim/EngineerManager.lua
@@ -768,7 +768,9 @@ EngineerManager = Class(BuilderManager) {
     ---@param unit Unit
     AssignEngineerTask = function(self, unit)
         --LOG('+ AssignEngineerTask')
-        if unit.UnitBeingAssist or unit.UnitBeingBuilt then
+        if unit.UnitBeingAssist or unit.UnitBeingBuilt or unit.Combat then
+            if unit.Combat then
+            end
             self:DelayAssign(unit, 50)
             return
         end


### PR DESCRIPTION
## Description of changes

This PR implements the first of a series of AI fixes and improvements.
The PR focuses on the following.

Small adjustment to the base template for the 'Normal AI' so that it will build a couple more engineers and one more land factory.

**Improve the AttackForceAI by the following**
Add a maximum platoon size count to stop attack force platoons growing beyond a comfortable size. A PlatoonFull property will be set when the platoon goes beyond its size limit. It will default to 40 if unset.
Add size restrictions to the MergeWithNearbyPlatoons platoon function by way of a maxPlatoonCount param that will check if the platoon is already at maximum size.

**Improve the EconomyMonitor**
Implements a new Economy Over Time thread that will provide a 30 second history (compared to the previous 8) of economy data and will allow more types of economy over time metrics. I've kept the sample length small to minimise impact to the AI behaviour. 
Updated the GetEconomyNumbers function to leverage this data when it is called for backwards compatibility.
Update existing EconomyOverTime build conditions to leverage this data and cut down on excess GetEconomyNumbers calls.

**Improve ACU behavior**
Add a combat property that will be set when the ACU goes into combat and removed after it returns to base. This property will enforce no engineer jobs are assigned to the ACU when it is in combat. This resolves the issues where the ACU would try to build structures while in combat.
Add a structure completion function to the default acu threads to allow the acu to complete structures correctly after it has come out of combat. This will avoid the problem of the acu starting and not completing excess numbers of structures when it is constantly being called into and out of combat due to units popping into range.

## Test setup for the changes
Testing these changes requires logging and observation. 
I have logged the changes to confirm logic is triggering when required and economy data is being passed correctly. 
Platoons that use the updated code will move along paths without re-orientating as much as the direction is pre calculated, this will result in quick and smoother platoon movement. The platoons should not go beyond a maximum of 40 units so that movement issues are limited. Though it must be noted that 40 units will still cause issues on certain maps. The max platoon counts could be limited in the future through the builders but will require tuning so that game play experience is not negatively impacted.
The ACU changes should be easily observed when comparing to the previous behaviours. The acu should no longer try to start building structures while in combat and should complete any structures that it will building when it went into combat but were not finished.

Note : The EconomyOverTime changes will impact the Sorian AI as it leverages the same economic data but based on my testing using a sample length of 30 seconds does not cause any negative impact. No other changes impact the Sorian AI.