### PR TITLE
Improve consistency of occupancy of props (that block pathing)

### DIFF
--- a/env/Aeon/Props/Aeon_Bus_prop.bp
+++ b/env/Aeon/Props/Aeon_Bus_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Aeon Bus',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.5,
     SizeZ = 1,

--- a/env/Aeon/Props/Aeon_Bus_prop.bp
+++ b/env/Aeon/Props/Aeon_Bus_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 75,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Aeon Bus',
     },

--- a/env/Aeon/Props/Aeon_Car_01_prop.bp
+++ b/env/Aeon/Props/Aeon_Car_01_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Aeon Car 01',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.5,
     SizeZ = 0.5,

--- a/env/Aeon/Props/Aeon_Car_01_prop.bp
+++ b/env/Aeon/Props/Aeon_Car_01_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Aeon Car 01',
     },

--- a/env/Aeon/Props/Aeon_Car_02_prop.bp
+++ b/env/Aeon/Props/Aeon_Car_02_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Aeon Car 02',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.5,
     SizeZ = 0.5,

--- a/env/Aeon/Props/Aeon_Car_02_prop.bp
+++ b/env/Aeon/Props/Aeon_Car_02_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Aeon Car 02',
     },

--- a/env/Aeon/Props/Aeon_Fence_prop.bp
+++ b/env/Aeon/Props/Aeon_Fence_prop.bp
@@ -45,14 +45,8 @@ PropBlueprint {
         ReclaimMassMax = 0.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Aeon Fence',
-    },
-    Physics = {
-        BlockPath = false,
     },
     ScriptClass = 'Tree',
     ScriptModule = '/lua/proptree.lua',

--- a/env/Aeon/Props/Aeon_Street_Light_prop.bp
+++ b/env/Aeon/Props/Aeon_Street_Light_prop.bp
@@ -45,14 +45,8 @@ PropBlueprint {
         ReclaimMassMax = 0.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Aeon Streetlight',
-    },
-    Physics = {
-        BlockPath = false,
     },
     ScriptClass = 'Tree',
     ScriptModule = '/lua/proptree.lua',

--- a/env/Ancient-Earth/props/clutter/Log01_pink_prop.bp
+++ b/env/Ancient-Earth/props/clutter/Log01_pink_prop.bp
@@ -29,9 +29,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Log',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/clutter/Log02_pink_prop.bp
+++ b/env/Ancient-Earth/props/clutter/Log02_pink_prop.bp
@@ -29,9 +29,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Very Small Log',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/clutter/Log03_prop.bp
+++ b/env/Ancient-Earth/props/clutter/Log03_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'chad on a Log',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.4,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/clutter/Log03_prop.bp
+++ b/env/Ancient-Earth/props/clutter/Log03_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 0,
         ReclaimTime = 0,
     },
-	Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'chad on a Log',
     },

--- a/env/Ancient-Earth/props/clutter/eg_bush01_pink_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush01_pink_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/eg_bush01_purple_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush01_purple_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/eg_bush01_red_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush01_red_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/eg_bush01_white_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush01_white_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/eg_bush01_yellow_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush01_yellow_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/eg_bush02_pink_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush02_pink_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/eg_bush02_purple_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush02_purple_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/eg_bush02_red_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush02_red_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/eg_bush02_white_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush02_white_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/eg_bush02_yellow_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush02_yellow_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/eg_bush03_pink_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush03_pink_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/eg_bush03_purple_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush03_purple_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/eg_bush03_red_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush03_red_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/eg_bush03_white_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush03_white_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/eg_bush03_yellow_prop.bp
+++ b/env/Ancient-Earth/props/clutter/eg_bush03_yellow_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/flowerBush01_pink_prop.bp
+++ b/env/Ancient-Earth/props/clutter/flowerBush01_pink_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/flowerBush01_purple_prop.bp
+++ b/env/Ancient-Earth/props/clutter/flowerBush01_purple_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/flowerBush01_red_prop.bp
+++ b/env/Ancient-Earth/props/clutter/flowerBush01_red_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/flowerBush01_white_prop.bp
+++ b/env/Ancient-Earth/props/clutter/flowerBush01_white_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/flowerBush01_yellow_prop.bp
+++ b/env/Ancient-Earth/props/clutter/flowerBush01_yellow_prop.bp
@@ -44,9 +44,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.25,
     SizeZ = 0.3,

--- a/env/Ancient-Earth/props/clutter/sw_bush01_pink_prop.bp
+++ b/env/Ancient-Earth/props/clutter/sw_bush01_pink_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush - Swamp',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/clutter/sw_bush01_purple_prop.bp
+++ b/env/Ancient-Earth/props/clutter/sw_bush01_purple_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush - Swamp',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/clutter/sw_bush01_red_prop.bp
+++ b/env/Ancient-Earth/props/clutter/sw_bush01_red_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush - Swamp',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/clutter/sw_bush01_white_prop.bp
+++ b/env/Ancient-Earth/props/clutter/sw_bush01_white_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush - Swamp',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/clutter/sw_bush01_yellow_prop.bp
+++ b/env/Ancient-Earth/props/clutter/sw_bush01_yellow_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush - Swamp',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/clutter/sw_bush02_pink_prop.bp
+++ b/env/Ancient-Earth/props/clutter/sw_bush02_pink_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush - Swamp',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.75,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/clutter/sw_bush02_purple_prop.bp
+++ b/env/Ancient-Earth/props/clutter/sw_bush02_purple_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush - Swamp',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.75,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/clutter/sw_bush02_red_prop.bp
+++ b/env/Ancient-Earth/props/clutter/sw_bush02_red_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush - Swamp',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.75,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/clutter/sw_bush02_white_prop.bp
+++ b/env/Ancient-Earth/props/clutter/sw_bush02_white_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush - Swamp',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.75,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/clutter/sw_bush02_yellow_prop.bp
+++ b/env/Ancient-Earth/props/clutter/sw_bush02_yellow_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Bush - Swamp',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.75,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/rocks/GeoRock01HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock01HD_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rock',
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock01HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock01HD_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Medium Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
 	SizeX = 1,
     SizeY = 1,
     SizeZ = 1,

--- a/env/Ancient-Earth/props/rocks/GeoRock01pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock01pink_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rock',
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock01pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock01pink_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Medium Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
 	SizeX = 1,
     SizeY = 1,
     SizeZ = 1,

--- a/env/Ancient-Earth/props/rocks/GeoRock02HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock02HD_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/rocks/GeoRock02HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock02HD_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock02pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock02pink_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/rocks/GeoRock02pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock02pink_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock04HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock04HD_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Tiny Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks/GeoRock04pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock04pink_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Tiny Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks/GeoRock05HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock05HD_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Tiny Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks/GeoRock05pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock05pink_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Tiny Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks/GeoRock06HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock06HD_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/rocks/GeoRock06pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock06pink_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/rocks/Rock01HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock01HD_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Ancient-Earth/props/rocks/Rock01HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock01HD_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Ancient-Earth/props/rocks/Rock01pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock01pink_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Ancient-Earth/props/rocks/Rock01pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock01pink_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Ancient-Earth/props/rocks/Rock02HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock02HD_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.5,
     SizeZ = 1,

--- a/env/Ancient-Earth/props/rocks/Rock02HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock02HD_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Ancient-Earth/props/rocks/Rock02pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock02pink_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.5,
     SizeZ = 1,

--- a/env/Ancient-Earth/props/rocks/Rock02pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock02pink_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Ancient-Earth/props/rocks/Rock03HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock03HD_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Very Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.75,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks/Rock03pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock03pink_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Very Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.75,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks/Rock04HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock04HD_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Very Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks/Rock04pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock04pink_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Very Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks/Rock05HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock05HD_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Very Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks/Rock05pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock05pink_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Very Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock01HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock01HD_dark_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rock',
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock01HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock01HD_dark_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Medium Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
 	SizeX = 1,
     SizeY = 1,
     SizeZ = 1,

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock01pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock01pink_dark_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rock',
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock01pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock01pink_dark_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Medium Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
 	SizeX = 1,
     SizeY = 1,
     SizeZ = 1,

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock02HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock02HD_dark_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock02HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock02HD_dark_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock02pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock02pink_dark_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock02pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock02pink_dark_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock04HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock04HD_dark_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Tiny Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock04pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock04pink_dark_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Tiny Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock05HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock05HD_dark_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Tiny Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock05pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock05pink_dark_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Tiny Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock06HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock06HD_dark_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock06pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock06pink_dark_prop.bp
@@ -27,9 +27,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Ancient-Earth/props/rocks_dark/Rock01HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock01HD_dark_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Ancient-Earth/props/rocks_dark/Rock01HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock01HD_dark_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Ancient-Earth/props/rocks_dark/Rock01pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock01pink_dark_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Ancient-Earth/props/rocks_dark/Rock01pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock01pink_dark_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Ancient-Earth/props/rocks_dark/Rock02HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock02HD_dark_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.5,
     SizeZ = 1,

--- a/env/Ancient-Earth/props/rocks_dark/Rock02HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock02HD_dark_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Ancient-Earth/props/rocks_dark/Rock02pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock02pink_dark_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.5,
     SizeZ = 1,

--- a/env/Ancient-Earth/props/rocks_dark/Rock02pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock02pink_dark_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Ancient-Earth/props/rocks_dark/Rock03HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock03HD_dark_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Very Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.75,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks_dark/Rock03pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock03pink_dark_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Very Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.75,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks_dark/Rock04HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock04HD_dark_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Very Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks_dark/Rock04pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock04pink_dark_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Very Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks_dark/Rock05HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock05HD_dark_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Very Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Ancient-Earth/props/rocks_dark/Rock05pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock05pink_dark_prop.bp
@@ -28,9 +28,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Very Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Common/Props/Markers/marker01_prop.bp
+++ b/env/Common/Props/Markers/marker01_prop.bp
@@ -18,9 +18,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Marker for general use',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 1,
     SizeZ = 1,

--- a/env/Common/Props/marker01_prop.bp
+++ b/env/Common/Props/marker01_prop.bp
@@ -19,9 +19,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Marker for general use',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 1,
     SizeZ = 1,

--- a/env/Common/Props/roadwayMarking01_prop.bp
+++ b/env/Common/Props/roadwayMarking01_prop.bp
@@ -51,14 +51,8 @@ PropBlueprint {
         ReclaimMassMax = 0.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Roadway Marking',
-    },
-    Physics = {
-        BlockPath = false,
     },
     ScriptClass = 'Tree',
     ScriptModule = '/lua/proptree.lua',

--- a/env/Common/Props/seraphim_streetlight_prop.bp
+++ b/env/Common/Props/seraphim_streetlight_prop.bp
@@ -45,14 +45,8 @@ PropBlueprint {
         ReclaimMassMax = 0.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Seraphim Streetlight - Dark',
-    },
-    Physics = {
-        BlockPath = false,
     },
     ScriptClass = 'Tree',
     ScriptModule = '/lua/proptree.lua',

--- a/env/Crystalline-alt/props/crystals-black/BlackCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrysSm01_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Crystalline-alt/props/crystals-black/BlackCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrysSm01_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-black/BlackCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrysSm02_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Crystalline-alt/props/crystals-black/BlackCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrysSm02_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-black/BlackCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrysSm03_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.50,
     SizeZ = 2,

--- a/env/Crystalline-alt/props/crystals-black/BlackCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrysSm03_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-black/BlackCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrysSm04_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.50,
     SizeZ = 2,

--- a/env/Crystalline-alt/props/crystals-black/BlackCrystal01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrystal01_prop.bp
@@ -26,7 +26,7 @@ PropBlueprint {
         ReclaimTime = 5,
     },
     Footprint = {
-        OccupancyCaps = 0,
+        OccupancyCaps = 3,
     },
     Interface = {
         HelpText = 'Crystal Formation',

--- a/env/Crystalline-alt/props/crystals-black/BlackCrystal02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrystal02_prop.bp
@@ -27,13 +27,13 @@ PropBlueprint {
         ReclaimTime = 5,
     },
     Footprint = {
-        OccupancyCaps = 0,
+        OccupancyCaps = 3,
     },
     Interface = {
         HelpText = 'Crystal Formation',
     },
     Physics = {
-        BlockPath = false,
+        BlockPath = true,
     },
     SizeX = 2,
     SizeY = 2.25,

--- a/env/Crystalline-alt/props/crystals-black/BlackCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrystal03_prop.bp
@@ -32,9 +32,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Crystal Formation',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 2,
     SizeY = 2.25,
     SizeZ = 3,

--- a/env/Crystalline-alt/props/crystals-black/BlackCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrystal03_prop.bp
@@ -26,9 +26,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Crystal Formation',
     },

--- a/env/Crystalline-alt/props/crystals-green/GreenCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrysSm01_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Crystalline-alt/props/crystals-green/GreenCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrysSm01_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-green/GreenCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrysSm03_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.50,
     SizeZ = 2,

--- a/env/Crystalline-alt/props/crystals-green/GreenCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrysSm03_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-green/GreenCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrysSm04_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.50,
     SizeZ = 2,

--- a/env/Crystalline-alt/props/crystals-green/GreenCrystal01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrystal01_prop.bp
@@ -26,7 +26,7 @@ PropBlueprint {
         ReclaimTime = 5,
     },
     Footprint = {
-        OccupancyCaps = 0,
+        OccupancyCaps = 3,
     },
     Interface = {
         HelpText = 'Crystal Formation',

--- a/env/Crystalline-alt/props/crystals-green/GreenCrystal02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrystal02_prop.bp
@@ -26,14 +26,8 @@ PropBlueprint {
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Crystal Formation',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 2,
     SizeY = 2.25,

--- a/env/Crystalline-alt/props/crystals-green/GreenCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrystal03_prop.bp
@@ -32,9 +32,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Crystal Formation',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 2,
     SizeY = 2.25,
     SizeZ = 3,

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm01_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm01_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm02_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
-    },
-    Physics = {
-        BlockPath = true,
     },
     SizeX = 0.5,
     SizeY = 0.25,

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm03_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.50,
     SizeZ = 2,

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm03_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm04_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.50,
     SizeZ = 2,

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrystal01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrystal01_prop.bp
@@ -26,7 +26,7 @@ PropBlueprint {
         ReclaimTime = 5,
     },
     Footprint = {
-        OccupancyCaps = 0,
+        OccupancyCaps = 3,
     },
     Interface = {
         HelpText = 'Crystal Formation',

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrystal02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrystal02_prop.bp
@@ -27,13 +27,13 @@ PropBlueprint {
         ReclaimTime = 5,
     },
     Footprint = {
-        OccupancyCaps = 0,
+        OccupancyCaps = 3,
     },
     Interface = {
         HelpText = 'Crystal Formation',
     },
     Physics = {
-        BlockPath = false,
+        BlockPath = true,
     },
     SizeX = 2,
     SizeY = 2.25,

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrystal03_prop.bp
@@ -32,9 +32,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Crystal Formation',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 2,
     SizeY = 2.25,
     SizeZ = 3,

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrystal03_prop.bp
@@ -26,9 +26,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Crystal Formation',
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm01_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm01_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm02_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm03_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.50,
     SizeZ = 2,

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm03_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm04_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.50,
     SizeZ = 2,

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm04_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrystal01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrystal01_prop.bp
@@ -26,7 +26,7 @@ PropBlueprint {
         ReclaimTime = 5,
     },
     Footprint = {
-        OccupancyCaps = 0,
+        OccupancyCaps = 3,
     },
     Interface = {
         HelpText = 'Crystal Formation',

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrystal02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrystal02_prop.bp
@@ -27,13 +27,13 @@ PropBlueprint {
         ReclaimTime = 5,
     },
     Footprint = {
-        OccupancyCaps = 0,
+        OccupancyCaps = 3,
     },
     Interface = {
         HelpText = 'Crystal Formation',
     },
     Physics = {
-        BlockPath = false,
+        BlockPath = true,
     },
     SizeX = 2,
     SizeY = 2.25,

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrystal03_prop.bp
@@ -32,9 +32,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Crystal Formation',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 2,
     SizeY = 2.25,
     SizeZ = 3,

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrystal03_prop.bp
@@ -26,9 +26,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Crystal Formation',
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrysSm01_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Crystalline-alt/props/crystals-red/RedCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrysSm01_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrysSm02_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Crystalline-alt/props/crystals-red/RedCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrysSm02_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrysSm03_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.50,
     SizeZ = 2,

--- a/env/Crystalline-alt/props/crystals-red/RedCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrysSm03_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrysSm04_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.50,
     SizeZ = 2,

--- a/env/Crystalline-alt/props/crystals-red/RedCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrysSm04_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrystal01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrystal01_prop.bp
@@ -26,7 +26,7 @@ PropBlueprint {
         ReclaimTime = 5,
     },
     Footprint = {
-        OccupancyCaps = 0,
+        OccupancyCaps = 3,
     },
     Interface = {
         HelpText = 'Crystal Formation',

--- a/env/Crystalline-alt/props/crystals-red/RedCrystal02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrystal02_prop.bp
@@ -27,13 +27,13 @@ PropBlueprint {
         ReclaimTime = 5,
     },
     Footprint = {
-        OccupancyCaps = 0,
+        OccupancyCaps = 3,
     },
     Interface = {
         HelpText = 'Crystal Formation',
     },
     Physics = {
-        BlockPath = false,
+        BlockPath = true,
     },
     SizeX = 2,
     SizeY = 2.25,

--- a/env/Crystalline-alt/props/crystals-red/RedCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrystal03_prop.bp
@@ -32,9 +32,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Crystal Formation',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 2,
     SizeY = 2.25,
     SizeZ = 3,

--- a/env/Crystalline-alt/props/crystals-red/RedCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrystal03_prop.bp
@@ -26,9 +26,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Crystal Formation',
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrysSm01_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrysSm01_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrysSm02_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrysSm03_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.50,
     SizeZ = 2,

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrysSm03_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrysSm04_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.50,
     SizeZ = 2,

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrysSm04_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrystal01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrystal01_prop.bp
@@ -26,7 +26,7 @@ PropBlueprint {
         ReclaimTime = 5,
     },
     Footprint = {
-        OccupancyCaps = 0,
+        OccupancyCaps = 3,
     },
     Interface = {
         HelpText = 'Crystal Formation',

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrystal02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrystal02_prop.bp
@@ -27,13 +27,13 @@ PropBlueprint {
         ReclaimTime = 5,
     },
     Footprint = {
-        OccupancyCaps = 0,
+        OccupancyCaps = 3,
     },
     Interface = {
         HelpText = 'Crystal Formation',
     },
     Physics = {
-        BlockPath = false,
+        BlockPath = true,
     },
     SizeX = 2,
     SizeY = 2.25,

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrystal03_prop.bp
@@ -32,9 +32,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Crystal Formation',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 2,
     SizeY = 2.25,
     SizeZ = 3,

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrystal03_prop.bp
@@ -26,9 +26,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Crystal Formation',
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm01_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm01_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm02_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm02_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm03_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.50,
     SizeZ = 2,

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm03_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm04_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.50,
     SizeZ = 2,

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm04_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrystal01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrystal01_prop.bp
@@ -26,7 +26,7 @@ PropBlueprint {
         ReclaimTime = 5,
     },
     Footprint = {
-        OccupancyCaps = 0,
+        OccupancyCaps = 3,
     },
     Interface = {
         HelpText = 'Crystal Formation',

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrystal02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrystal02_prop.bp
@@ -27,13 +27,13 @@ PropBlueprint {
         ReclaimTime = 5,
     },
     Footprint = {
-        OccupancyCaps = 0,
+        OccupancyCaps = 3,
     },
     Interface = {
         HelpText = 'Crystal Formation',
     },
     Physics = {
-        BlockPath = false,
+        BlockPath = true,
     },
     SizeX = 2,
     SizeY = 2.25,

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrystal03_prop.bp
@@ -32,9 +32,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Crystal Formation',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 2,
     SizeY = 2.25,
     SizeZ = 3,

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrystal03_prop.bp
@@ -26,9 +26,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Crystal Formation',
     },

--- a/env/Crystalline/Props/Clutter/Crys_clutter01_prop.bp
+++ b/env/Crystalline/Props/Clutter/Crys_clutter01_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 1,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Tiny Crystal',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.1,
     SizeY = 0.1,

--- a/env/Crystalline/Props/Clutter/Crys_clutter02_prop.bp
+++ b/env/Crystalline/Props/Clutter/Crys_clutter02_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Crystal',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Crystalline/Props/Clutter/Crys_clutter03_prop.bp
+++ b/env/Crystalline/Props/Clutter/Crys_clutter03_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 1,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Tiny Crystal',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.1,
     SizeY = 0.1,

--- a/env/Crystalline/Props/Rocks/CrysCrystal03_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal03_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Crystal Formation',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1.5,
     SizeY = 1,
     SizeZ = 1.5,

--- a/env/Crystalline/Props/Rocks/CrysCrystal04_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal04_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 7.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Small Crystal Formation',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.5,

--- a/env/Crystalline/Props/Rocks/CrysCrystal05_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal05_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Crystal Formation',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.3,

--- a/env/Crystalline/Props/Rocks/CrysCrystal08_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal08_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Crystal',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Crystalline/Props/Rocks/CrysCrystal10_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal10_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Crystal',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Crystalline/Props/Rocks/CrysCrystal11_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal11_prop.bp
@@ -30,6 +30,9 @@ PropBlueprint {
     Interface = {
         HelpText = 'Huge Crystal',
     },
+    Physics = {
+        Blockpath = true
+    },
     SizeX = 2,
     SizeY = 1,
     SizeZ = 0.5,

--- a/env/Crystalline/Props/Rocks/CrysCrystal11_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal11_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Huge Crystal',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 2,
     SizeY = 1,
     SizeZ = 0.5,

--- a/env/Crystalline/Props/Rocks/CrysSmRock01_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock01_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Huge Seraphim Crystal',
     },

--- a/env/Crystalline/Props/Rocks/CrysSmRock01_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock01_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Huge Seraphim Crystal',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Crystalline/Props/Rocks/CrysSmRock02_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock02_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Ice Crystal',
     },

--- a/env/Crystalline/Props/Rocks/CrysSmRock02_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock02_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Ice Crystal',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Crystalline/Props/Rocks/CrysSmRock03_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock03_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Small Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.5,
     SizeY = 0.25,

--- a/env/Crystalline/Props/Rocks/CrysSmRock04_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock04_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Small Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.5,
     SizeY = 0.25,

--- a/env/Crystalline/Props/Rocks/CrysSmRock05_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock05_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Small Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.5,
     SizeY = 0.25,

--- a/env/Crystalline/Props/Rocks/CrysSmRock06_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock06_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Small Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.5,
     SizeY = 0.25,

--- a/env/Crystalline/Props/Rocks/CrysSmRock07_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock07_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Small Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.5,
     SizeY = 0.25,

--- a/env/Crystalline/Props/Rocks/CrysSmRock08_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock08_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Small Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.5,
     SizeY = 0.25,

--- a/env/Cybran/Props/CybranAdjacencyNodeThree_prop.bp
+++ b/env/Cybran/Props/CybranAdjacencyNodeThree_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Cybran Adjacency Node',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0,
     SizeY = 0,
     SizeZ = 0,

--- a/env/Cybran/Props/CybranAdjacencyNodeTwo_prop.bp
+++ b/env/Cybran/Props/CybranAdjacencyNodeTwo_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Cybran Adjacency Node',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0,
     SizeY = 0,
     SizeZ = 0,

--- a/env/Cybran/Props/CybranAdjacencyNodeTwo_prop.bp
+++ b/env/Cybran/Props/CybranAdjacencyNodeTwo_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 1,
         ReclaimTime = 1,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Cybran Adjacency Node',
     },

--- a/env/Cybran/Props/Cybran_Street_Light_prop.bp
+++ b/env/Cybran/Props/Cybran_Street_Light_prop.bp
@@ -45,14 +45,8 @@ PropBlueprint {
         ReclaimMassMax = 0.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Cybran Streetlight',
-    },
-    Physics = {
-        BlockPath = false,
     },
     ScriptClass = 'Tree',
     ScriptModule = '/lua/proptree.lua',

--- a/env/Desert/Props/Rocks/Des_boulder02_prop.bp
+++ b/env/Desert/Props/Rocks/Des_boulder02_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Small Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.5,
     SizeY = 0.25,

--- a/env/Desert/Props/Rocks/Des_boulder03_prop.bp
+++ b/env/Desert/Props/Rocks/Des_boulder03_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Small Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.5,
     SizeY = 0.25,

--- a/env/Desert/Props/Rocks/Des_boulder04_prop.bp
+++ b/env/Desert/Props/Rocks/Des_boulder04_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Small Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.6,
     SizeY = 0.25,

--- a/env/Desert/Props/Rocks/Des_boulder05_prop.bp
+++ b/env/Desert/Props/Rocks/Des_boulder05_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Small Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Desert/Props/Rocks/Des_boulder06_prop.bp
+++ b/env/Desert/Props/Rocks/Des_boulder06_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rock',
-    },
-    Physics = {
-        BlockPath = true,
     },
     SizeX = 0.75,
     SizeY = 0.75,

--- a/env/DevTest/Props/rock01_prop.bp
+++ b/env/DevTest/Props/rock01_prop.bp
@@ -26,14 +26,8 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Round Thing',
-    },
-    Physics = {
-        BlockPath = true,
     },
     SizeX = 0.5,
     SizeY = 0.5,

--- a/env/Evergreen/Props/Rocks/Rock01_prop.bp
+++ b/env/Evergreen/Props/Rocks/Rock01_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Evergreen/Props/Rocks/Rock01_prop.bp
+++ b/env/Evergreen/Props/Rocks/Rock01_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Evergreen/Props/Rocks/Rock02_prop.bp
+++ b/env/Evergreen/Props/Rocks/Rock02_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Evergreen/Props/Rocks/Rock02_prop.bp
+++ b/env/Evergreen/Props/Rocks/Rock02_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.5,
     SizeZ = 1,

--- a/env/Evergreen/Props/Rocks/Rock03_prop.bp
+++ b/env/Evergreen/Props/Rocks/Rock03_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Small Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.75,
     SizeY = 0.25,

--- a/env/Evergreen/Props/Rocks/Rock04_prop.bp
+++ b/env/Evergreen/Props/Rocks/Rock04_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Small Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Evergreen/Props/Rocks/Rock05_prop.bp
+++ b/env/Evergreen/Props/Rocks/Rock05_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Small Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Evergreen/Props/Rocks/RockPile01_prop.bp
+++ b/env/Evergreen/Props/Rocks/RockPile01_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rockpile',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Evergreen/Props/Rocks/RockPile02_prop.bp
+++ b/env/Evergreen/Props/Rocks/RockPile02_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Small Rockpile',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.75,
     SizeY = 0.25,

--- a/env/Geothermal/Props/Rocks/GeoRock01_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock01_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rock',
     },

--- a/env/Geothermal/Props/Rocks/GeoRock01_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock01_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Medium Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.75,
     SizeY = 0.75,
     SizeZ = 0.75,

--- a/env/Geothermal/Props/Rocks/GeoRock02_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock02_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Geothermal/Props/Rocks/GeoRock02_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock02_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Geothermal/Props/Rocks/GeoRock03_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock03_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Geothermal/Props/Rocks/GeoRock03_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock03_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Geothermal/Props/Rocks/GeoRock04_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock04_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Geothermal/Props/Rocks/GeoRock05_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock05_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Geothermal/Props/Rocks/GeoRock06_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock06_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/Geothermal/Props/Rocks/GeoRock06_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock06_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Geothermal/Props/Rocks/GeoRockGroup01_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRockGroup01_prop.bp
@@ -23,14 +23,8 @@ PropBlueprint {
         ReclaimMassMax = 175,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rockpile',
-    },
-    Physics = {
-        BlockPath = true,
     },
     SizeX = 4,
     SizeY = 0.5,

--- a/env/Geothermal/Props/Rocks/GeoRockGroup02_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRockGroup02_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 175,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rockpile',
-    },
-    Physics = {
-        BlockPath = true,
     },
     SizeX = 2.5,
     SizeY = 0.75,

--- a/env/Geothermal/Props/Rocks/GeoRockGroup03_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRockGroup03_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 175,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rockpile',
-    },
-    Physics = {
-        BlockPath = true,
     },
     SizeX = 5,
     SizeY = 0.25,

--- a/env/Geothermal/Props/Rocks/GeoRockGroup04_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRockGroup04_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 175,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rockpile',
-    },
-    Physics = {
-        BlockPath = true,
     },
     SizeX = 4,
     SizeY = 0.25,

--- a/env/Geothermal/Props/Rocks/GeoRockGroup05_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRockGroup05_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 175,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rockpile',
-    },
-    Physics = {
-        BlockPath = true,
     },
     SizeX = 5,
     SizeY = 0.25,

--- a/env/Geothermal/Props/Rocks/GeoRockGroup06_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRockGroup06_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 175,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rockpile',
-    },
-    Physics = {
-        BlockPath = true,
     },
     SizeX = 4,
     SizeY = 0.25,

--- a/env/Lava/Props/Rocks/LV_LavaBerg02_prop.bp
+++ b/env/Lava/Props/Rocks/LV_LavaBerg02_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Medium Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1.5,
     SizeY = 0.25,
     SizeZ = 1.5,

--- a/env/Lava/Props/Rocks/LV_LavaBerg02_prop.bp
+++ b/env/Lava/Props/Rocks/LV_LavaBerg02_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rock',
     },

--- a/env/Lava/Props/Rocks/LV_LavaBerg03_prop.bp
+++ b/env/Lava/Props/Rocks/LV_LavaBerg03_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Medium Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1.5,
     SizeY = 0.25,
     SizeZ = 1.5,

--- a/env/Lava/Props/Rocks/LV_Rock01_prop.bp
+++ b/env/Lava/Props/Rocks/LV_Rock01_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Lava/Props/Rocks/LV_Rock01_prop.bp
+++ b/env/Lava/Props/Rocks/LV_Rock01_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Lava/Props/Rocks/LV_Rock02_prop.bp
+++ b/env/Lava/Props/Rocks/LV_Rock02_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.75,
     SizeY = 0.5,
     SizeZ = 1,

--- a/env/Lava/Props/Rocks/LV_Rock02_prop.bp
+++ b/env/Lava/Props/Rocks/LV_Rock02_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Lava/Props/Rocks/Lav_Rock01_prop.bp
+++ b/env/Lava/Props/Rocks/Lav_Rock01_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Lava/Props/Rocks/Lav_Rock01_prop.bp
+++ b/env/Lava/Props/Rocks/Lav_Rock01_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Lava/Props/Rocks/Lav_Rock02_prop.bp
+++ b/env/Lava/Props/Rocks/Lav_Rock02_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.75,
     SizeY = 0.5,
     SizeZ = 1,

--- a/env/Lava/Props/Rocks/Lav_Rock03_prop.bp
+++ b/env/Lava/Props/Rocks/Lav_Rock03_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Lava/Props/Rocks/Lav_Rock04_prop.bp
+++ b/env/Lava/Props/Rocks/Lav_Rock04_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Lava/Props/Rocks/Lav_Rock05_prop.bp
+++ b/env/Lava/Props/Rocks/Lav_Rock05_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Lava/Props/Rocks/LavaBerg02_prop.bp
+++ b/env/Lava/Props/Rocks/LavaBerg02_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Medium Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1.5,
     SizeY = 0.25,
     SizeZ = 1.5,

--- a/env/Lava/Props/Rocks/LavaBerg02_prop.bp
+++ b/env/Lava/Props/Rocks/LavaBerg02_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rock',
     },

--- a/env/Lava/Props/Rocks/LavaBerg03_prop.bp
+++ b/env/Lava/Props/Rocks/LavaBerg03_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Medium Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1.5,
     SizeY = 0.25,
     SizeZ = 1.5,

--- a/env/Lava/Props/Rocks/LavaBerg03_prop.bp
+++ b/env/Lava/Props/Rocks/LavaBerg03_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rock',
     },

--- a/env/Lava/Props/Rocks/LavaBerg04_prop.bp
+++ b/env/Lava/Props/Rocks/LavaBerg04_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Lava/Props/Rocks/LavaBerg04_prop.bp
+++ b/env/Lava/Props/Rocks/LavaBerg04_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.8,
     SizeY = 0.25,
     SizeZ = 0.8,

--- a/env/RedRocks/Props/Boulder02_prop.bp
+++ b/env/RedRocks/Props/Boulder02_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/RedRocks/Props/Boulder03_prop.bp
+++ b/env/RedRocks/Props/Boulder03_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/RedRocks/Props/Boulder04_prop.bp
+++ b/env/RedRocks/Props/Boulder04_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/RedRocks/Props/Boulder04_prop.bp
+++ b/env/RedRocks/Props/Boulder04_prop.bp
@@ -24,11 +24,11 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
+    },
+    Physics = {
+        BlockPath = false,
     },
     SizeX = 0.5,
     SizeY = 0.25,

--- a/env/RedRocks/Props/Boulder05_prop.bp
+++ b/env/RedRocks/Props/Boulder05_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/RedRocks/Props/Boulder05_prop.bp
+++ b/env/RedRocks/Props/Boulder05_prop.bp
@@ -24,11 +24,11 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
+    },
+    Physics = {
+        BlockPath = false,
     },
     SizeX = 0.5,
     SizeY = 0.25,

--- a/env/RedRocks/Props/Boulder06_prop.bp
+++ b/env/RedRocks/Props/Boulder06_prop.bp
@@ -24,11 +24,11 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
+    },
+    Physics = {
+        BlockPath = false,
     },
     SizeX = 0.5,
     SizeY = 0.5,

--- a/env/RedRocks/Props/Boulder06_prop.bp
+++ b/env/RedRocks/Props/Boulder06_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.5,
     SizeZ = 0.5,

--- a/env/RedRocks/Props/Pod01_prop.bp
+++ b/env/RedRocks/Props/Pod01_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 1,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Medium Pod',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.5,
     SizeY = 0.5,

--- a/env/RedRocks/Props/Pod02_prop.bp
+++ b/env/RedRocks/Props/Pod02_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 0.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Small Pod',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.3,
     SizeY = 0.25,

--- a/env/RedRocks/Props/Pod03_prop.bp
+++ b/env/RedRocks/Props/Pod03_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Pod',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/RedRocks/Props/Rock01_prop.bp
+++ b/env/RedRocks/Props/Rock01_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 1,
     SizeY = 1,

--- a/env/RedRocks/Props/Rock02_prop.bp
+++ b/env/RedRocks/Props/Rock02_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 1,
     SizeY = 1,

--- a/env/RedRocks/Props/Rock_SM01_prop.bp
+++ b/env/RedRocks/Props/Rock_SM01_prop.bp
@@ -25,14 +25,8 @@ PropBlueprint {
         ReclaimMassMax = 1,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/RedRocks/Props/Rock_SM02_prop.bp
+++ b/env/RedRocks/Props/Rock_SM02_prop.bp
@@ -25,14 +25,8 @@ PropBlueprint {
         ReclaimMassMax = 1,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/RedRocks/Props/Rock_SM03_prop.bp
+++ b/env/RedRocks/Props/Rock_SM03_prop.bp
@@ -25,14 +25,8 @@ PropBlueprint {
         ReclaimMassMax = 1,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/RedRocks/Props/Rock_SM04_prop.bp
+++ b/env/RedRocks/Props/Rock_SM04_prop.bp
@@ -25,14 +25,8 @@ PropBlueprint {
         ReclaimMassMax = 1,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/RedRocks/Props/Rock_SM05_prop.bp
+++ b/env/RedRocks/Props/Rock_SM05_prop.bp
@@ -25,14 +25,8 @@ PropBlueprint {
         ReclaimMassMax = 1,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/RedRocks/Props/Rock_SM06_prop.bp
+++ b/env/RedRocks/Props/Rock_SM06_prop.bp
@@ -25,14 +25,8 @@ PropBlueprint {
         ReclaimMassMax = 1,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/RedRocks/Props/Rock_SM07_prop.bp
+++ b/env/RedRocks/Props/Rock_SM07_prop.bp
@@ -25,14 +25,8 @@ PropBlueprint {
         ReclaimMassMax = 1,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/RedRocks/Props/ThetaBridge01_prop.bp
+++ b/env/RedRocks/Props/ThetaBridge01_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 1,
         ReclaimTime = 1,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Large Rock - Theta Bridge',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 12,
     SizeY = 5.5,

--- a/env/Swamp/Props/Rocks/boulder01_prop.bp
+++ b/env/Swamp/Props/Rocks/boulder01_prop.bp
@@ -29,9 +29,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Medium Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.5,
     SizeZ = 1.5,

--- a/env/Swamp/Props/Rocks/boulder01_prop.bp
+++ b/env/Swamp/Props/Rocks/boulder01_prop.bp
@@ -23,9 +23,6 @@ PropBlueprint {
         ReclaimMassMax = 15,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Medium Rock',
     },

--- a/env/Swamp/Props/Rocks/boulder02_prop.bp
+++ b/env/Swamp/Props/Rocks/boulder02_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Swamp/Props/Rocks/boulder02_prop.bp
+++ b/env/Swamp/Props/Rocks/boulder02_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.75,
     SizeY = 0.5,
     SizeZ = 0.75,

--- a/env/Swamp/Props/Rocks/boulder03_prop.bp
+++ b/env/Swamp/Props/Rocks/boulder03_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Tropical/Props/Rocks/Rock02_prop.bp
+++ b/env/Tropical/Props/Rocks/Rock02_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.5,
     SizeY = 0.25,

--- a/env/Tropical/Props/Rocks/Rock03_prop.bp
+++ b/env/Tropical/Props/Rocks/Rock03_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Tropical/Props/Rocks/Rock03_prop.bp
+++ b/env/Tropical/Props/Rocks/Rock03_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.5,
     SizeZ = 1,

--- a/env/Tropical/Props/Rocks/Rock04_prop.bp
+++ b/env/Tropical/Props/Rocks/Rock04_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Tropical/Props/Rocks/Rock05_prop.bp
+++ b/env/Tropical/Props/Rocks/Rock05_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 1,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Tropical/Props/Rocks/RockPile01_prop.bp
+++ b/env/Tropical/Props/Rocks/RockPile01_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 1,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Very Tiny Rockpile',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Tropical/Props/TrRock01_prop.bp
+++ b/env/Tropical/Props/TrRock01_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.25,
     SizeY = 0.25,
     SizeZ = 0.25,

--- a/env/Tundra/Props/IceBerg04_prop.bp
+++ b/env/Tundra/Props/IceBerg04_prop.bp
@@ -23,9 +23,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock - Ice',
     },

--- a/env/Tundra/Props/IceBerg04_prop.bp
+++ b/env/Tundra/Props/IceBerg04_prop.bp
@@ -29,9 +29,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock - Ice',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.75,
     SizeY = 0.25,
     SizeZ = 0.75,

--- a/env/Tundra/Props/IceRockSm01_prop.bp
+++ b/env/Tundra/Props/IceRockSm01_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock - Ice',
     },

--- a/env/Tundra/Props/IceRockSm02_prop.bp
+++ b/env/Tundra/Props/IceRockSm02_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock - Ice',
     },

--- a/env/Tundra/Props/IceRockSm03_prop.bp
+++ b/env/Tundra/Props/IceRockSm03_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock - Ice',
     },

--- a/env/Tundra/Props/IceRockSm04_prop.bp
+++ b/env/Tundra/Props/IceRockSm04_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock - Ice',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Tundra/Props/Iceberg05_prop.bp
+++ b/env/Tundra/Props/Iceberg05_prop.bp
@@ -29,9 +29,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock - Ice',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 1,
     SizeZ = 1,

--- a/env/Tundra/Props/Rocks/Ice_Crystal_01_prop.bp
+++ b/env/Tundra/Props/Rocks/Ice_Crystal_01_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Ice Crystal',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.75,
     SizeY = 0.75,

--- a/env/Tundra/Props/Rocks/Tund_Rock02_prop.bp
+++ b/env/Tundra/Props/Rocks/Tund_Rock02_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.5,
     SizeY = 0.25,

--- a/env/Tundra/Props/Rocks/Tund_Rock03_prop.bp
+++ b/env/Tundra/Props/Rocks/Tund_Rock03_prop.bp
@@ -30,9 +30,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'Small Rock',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.5,
     SizeY = 0.25,
     SizeZ = 1,

--- a/env/Tundra/Props/Rocks/Tund_Rock03_prop.bp
+++ b/env/Tundra/Props/Rocks/Tund_Rock03_prop.bp
@@ -24,9 +24,6 @@ PropBlueprint {
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Small Rock',
     },

--- a/env/Tundra/Props/Rocks/Tund_Rock04_prop.bp
+++ b/env/Tundra/Props/Rocks/Tund_Rock04_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/Tundra/Props/Rocks/Tund_Rock05_prop.bp
+++ b/env/Tundra/Props/Rocks/Tund_Rock05_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'Tiny Rock',
-    },
-    Physics = {
-        BlockPath = false,
     },
     SizeX = 0.25,
     SizeY = 0.25,

--- a/env/UEF/Props/UEF_Bus_prop.bp
+++ b/env/UEF/Props/UEF_Bus_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'UEF Bus',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.3,
     SizeY = 0.5,
     SizeZ = 0.7,

--- a/env/UEF/Props/UEF_Bus_prop.bp
+++ b/env/UEF/Props/UEF_Bus_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 75,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'UEF Bus',
     },

--- a/env/UEF/Props/UEF_Car1_prop.bp
+++ b/env/UEF/Props/UEF_Car1_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'UEF Car 1',
     },

--- a/env/UEF/Props/UEF_Car1_prop.bp
+++ b/env/UEF/Props/UEF_Car1_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'UEF Car 1',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 0.2,
     SizeY = 0.25,
     SizeZ = 0.5,

--- a/env/UEF/Props/UEF_Fence_prop.bp
+++ b/env/UEF/Props/UEF_Fence_prop.bp
@@ -45,14 +45,8 @@ PropBlueprint {
         ReclaimMassMax = 0.5,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 0,
-    },
     Interface = {
         HelpText = 'UEF Fence',
-    },
-    Physics = {
-        BlockPath = false,
     },
     ScriptClass = 'Tree',
     ScriptModule = '/lua/proptree.lua',

--- a/env/UEF/Props/UEF_truck_prop.bp
+++ b/env/UEF/Props/UEF_truck_prop.bp
@@ -31,9 +31,6 @@ PropBlueprint {
     Interface = {
         HelpText = 'UEF Truck',
     },
-    Physics = {
-        BlockPath = true,
-    },
     SizeX = 1,
     SizeY = 0.5,
     SizeZ = 1.5,

--- a/env/UEF/Props/UEF_truck_prop.bp
+++ b/env/UEF/Props/UEF_truck_prop.bp
@@ -25,9 +25,6 @@ PropBlueprint {
         ReclaimMassMax = 150,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'UEF Truck',
     },

--- a/env/Wreckage/props/Aeon/UAL0202_Wreckage_prop.bp
+++ b/env/Wreckage/props/Aeon/UAL0202_Wreckage_prop.bp
@@ -24,14 +24,8 @@ PropBlueprint {
         ReclaimMassMax = 150,
         ReclaimTime = 5,
     },
-    Footprint = {
-        OccupancyCaps = 3,
-    },
     Interface = {
         HelpText = 'Obsidian Wreckage',
-    },
-    Physics = {
-        BlockPath = true,
     },
     ScriptClass = 'Wreckage',
     ScriptModule = '/lua/wreckage.lua',

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -39,6 +39,8 @@ local StringGsub = string.gsub
 -- upvalue table functions for performance
 local TableInsert = table.insert
 
+local once = true
+
 ---@class Prop : moho.prop_methods
 Prop = Class(moho.prop_methods) {
 
@@ -93,6 +95,11 @@ Prop = Class(moho.prop_methods) {
         EntitySetHealth(self, self, maxHealth)
         self.CanTakeDamage = (not self.Blueprint.Categories.INVULNERABLE) or false
         self.CanBeKilled = true
+
+        if self.Blueprint.Economy.ReclaimMassMax == 10 and once then
+            once = false
+            reprsl(self:GetBlueprint())
+        end
     end,
 
     --- Adds a prop callback.

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -39,8 +39,6 @@ local StringGsub = string.gsub
 -- upvalue table functions for performance
 local TableInsert = table.insert
 
-local once = true
-
 ---@class Prop : moho.prop_methods
 Prop = Class(moho.prop_methods) {
 
@@ -95,11 +93,6 @@ Prop = Class(moho.prop_methods) {
         EntitySetHealth(self, self, maxHealth)
         self.CanTakeDamage = (not self.Blueprint.Categories.INVULNERABLE) or false
         self.CanBeKilled = true
-
-        if self.Blueprint.Economy.ReclaimMassMax == 10 and once then
-            once = false
-            reprsl(self:GetBlueprint())
-        end
     end,
 
     --- Adds a prop callback.


### PR DESCRIPTION
There are a lot of tiny rocks that block pathing. As a result, the pathing of units gets all messed up because we do not have flow pathing, but more realistic-like pathing. We can fix this properly now that we have all the base game script and blueprint files. All small rocks (value < 50) no longer impact pathing. All rocks that look flat also no longer impact pathing. Only the actual bigger rocks (sea rocks, field stones) still impact pathing.

As a practical result of this change, take the map Syrtis Major where units path near the cliff where a lot of rocks are:

_old behavior_

https://user-images.githubusercontent.com/15778155/195585281-50d7e41b-7849-4d78-bd36-e543a64bfb4e.mp4

_new behavior_

https://user-images.githubusercontent.com/15778155/195585310-43439c9b-fc70-4734-b6e8-a5ba17f940bf.mp4

This is best seen in-game. You can view the occupancy maps (or pathing maps) with this hotkey:
![image](https://user-images.githubusercontent.com/15778155/195584706-bc61b53c-08a7-40ba-acf2-839af0b3868e.png)

A few examples of how that looked before / after:

_old pathing map for Syrtis Major_
![image](https://user-images.githubusercontent.com/15778155/195582824-6f68519d-d26c-461e-b568-afcbdde9df65.png)

_new pathing map for Syrtis Major_
![image](https://user-images.githubusercontent.com/15778155/195582559-78fa0d1e-6989-4753-bc00-7f2f00c982c1.png)

_old pathing map for Archsimkats Valley_
![image](https://user-images.githubusercontent.com/15778155/195583027-0bba4b8f-c941-4ae3-a967-a983719e52d1.png)

_new pathing map for Archsimkats Valley_
![image](https://user-images.githubusercontent.com/15778155/195583184-c155fe75-28d1-476e-b2ea-11b6e663ce2b.png)

_old pathing for Open Palms_
![image](https://user-images.githubusercontent.com/15778155/195583557-48788bf1-3aa3-4971-942a-e284062ef315.png)

_new pathing for Open Palms_
![image](https://user-images.githubusercontent.com/15778155/195583449-e3ff0f45-e162-4d56-86e2-5f47742a5c8e.png)

_old pathing for Daroza's Sanctuary_
![image](https://user-images.githubusercontent.com/15778155/195584140-5d74b92f-fee6-4b46-96ac-d598ad79bab5.png)

_new pathing for Daroza's Sanctuary_
![image](https://user-images.githubusercontent.com/15778155/195584252-41635b2a-2d8a-4bed-9043-bdc9d3d294a7.png)

Reason for the last one is that all these 'groups of rocks' block a lot of pathing:

![image](https://user-images.githubusercontent.com/15778155/195584599-6150e258-4cbc-4db5-bab1-81c345f8c32c.png)

