### PR TITLE
Fix an odd CommandMode related bug with queueing factory orders

### DIFF
--- a/lua/keymap/hotbuild.lua
+++ b/lua/keymap/hotbuild.lua
@@ -263,7 +263,6 @@ function availableTemplate(allTemplates,buildable)
 end
 
 function factoryHotkey(units, count)
-    LOG("factoryHotkey")
     CommandMode.StartCommandMode("build", {name = ''})
     worldview.HandleEvent = function(self, event)
         if event.Type == 'ButtonPress' then

--- a/lua/keymap/hotbuild.lua
+++ b/lua/keymap/hotbuild.lua
@@ -263,6 +263,7 @@ function availableTemplate(allTemplates,buildable)
 end
 
 function factoryHotkey(units, count)
+    LOG("factoryHotkey")
     CommandMode.StartCommandMode("build", {name = ''})
     worldview.HandleEvent = function(self, event)
         if event.Type == 'ButtonPress' then

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -81,7 +81,7 @@ function AddEndBehavior(behavior)
     TableInsert(endBehaviors, behavior)
 end
 
---- ???
+--- usually changing selection ends the command mode, this allows us to ignore that
 local ignoreSelection = false
 function SetIgnoreSelection(ignore)
     ignoreSelection = ignore
@@ -111,13 +111,22 @@ end
 -- @param isCancel Is set to true when it cancels a current command mode for a new one.
 function EndCommandMode(isCancel)
 
-    --- ???
-    if ignoreSelection or not modeData then
+    if ignoreSelection then
+        return
+    end
+
+    -- in case we want to end the command mode, without knowing it has already ended or not
+    if not modeData then
+        -- update our local state
+        commandMode = false
+        modeData = false
+        issuedOneCommand = false
+
         return
     end
 
     -- regain selection if we were cheating in units
-    if modeData.cheat then 
+    if modeData.cheat then
         if modeData.ids and modeData.index <= table.getn(modeData.ids) then 
             local modeData = table.deepcopy(modeData)
             ForkThread(
@@ -422,6 +431,7 @@ local categoriesStructure = categories.STRUCTURE
 --- Called by the engine when a new command has been issued by the player.
 -- @param command Information surrounding the command that has been issued, such as its CommandType or its Target.
 function OnCommandIssued(command)
+
     -- if we're trying to upgrade hives then this allows us to force the upgrade to happen immediately
     if command.CommandType == "Upgrade" and (command.Blueprint == "xrb0204" or command.Blueprint == "xrb0304") then 
         if not IsKeyDown('Shift') then 


### PR DESCRIPTION
Fixes the issue where if you issue (heh) the command to produce a unit the command mode would end in an indefinite loop, and by doing so it would cancel the first order you try to give. This fixes that by properly resetting the command mode state, which didn't happen previously.

And a video of the issue: https://youtu.be/_v2U8sVnGlw

With thanks to @FemtoZetta for reporting it