### PR TITLE
Fix AI Error in ReturnToBaseAI and Change GuardMarker 'None' next move behavior.

### DIFF
--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -639,7 +639,7 @@ Platoon = Class(moho.platoon_methods) {
             if bestBase and bestDefense < threshold then
                 local path, reason = AIAttackUtils.PlatoonGenerateSafePathTo(aiBrain, self.MovementLayer, self:GetPlatoonPosition(), bestBase.Position, 200)
 
-                IssueClearCommands(self)
+                IssueClearCommands(self:GetPlatoonUnits())
 
                 if path then
                     local pathLength = table.getn(path)
@@ -1140,7 +1140,7 @@ Platoon = Class(moho.platoon_methods) {
                 --Can we get there safely?
                 local path, reason = AIAttackUtils.PlatoonGenerateSafePathTo(aiBrain, self.MovementLayer, scout:GetPosition(), targetData.Position, 400) --DUNCAN - Increase threatwieght from 100
 
-                IssueClearCommands(self)
+                IssueClearCommands(self:GetPlatoonUnits())
 
                 if path then
                     local pathLength = table.getn(path)
@@ -5212,7 +5212,7 @@ Platoon = Class(moho.platoon_methods) {
                 --Can we get there safely?
                 local path, reason = AIAttackUtils.PlatoonGenerateSafePathTo(aiBrain, self.MovementLayer, scout:GetPosition(), targetData.Position, 100)
 
-                IssueClearCommands(self)
+                IssueClearCommands(self:GetPlatoonUnits())
 
                 if path then
                     local pathLength = table.getn(path)
@@ -5808,7 +5808,7 @@ Platoon = Class(moho.platoon_methods) {
         if bestBase then
             AIAttackUtils.GetMostRestrictiveLayer(self)
             local path, reason = AIAttackUtils.PlatoonGenerateSafePathTo(aiBrain, self.MovementLayer, self:GetPlatoonPosition(), bestBase.Position, 200)
-            IssueClearCommands(self)
+            IssueClearCommands(self:GetPlatoonUnits())
 
             if path then
                 local pathLength = table.getn(path)

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -3232,7 +3232,6 @@ Platoon = Class(moho.platoon_methods) {
     --- for a new platoon
     ---@param self Platoon
     ReturnToBaseAI = function(self)
-        LOG('ReturnToBaseAI initialized')
         local aiBrain = self:GetBrain()
 
         if not aiBrain:PlatoonExists(self) or not self:GetPlatoonPosition() then
@@ -3255,7 +3254,6 @@ Platoon = Class(moho.platoon_methods) {
         end
 
         if bestBase then
-            LOG('ReturnToBaseAI returning to '..repr(bestBase.Position))
             AIAttackUtils.GetMostRestrictiveLayer(self)
             local path, reason = AIAttackUtils.PlatoonGenerateSafePathTo(aiBrain, self.MovementLayer, self:GetPlatoonPosition(), bestBase.Position, 200)
             -- remove any formation settings to ensure a quick return to base.
@@ -3272,7 +3270,6 @@ Platoon = Class(moho.platoon_methods) {
 
             local oldDistSq = 0
             while aiBrain:PlatoonExists(self) do
-                LOG('ReturnToBaseAI waiting to arrive, current distance is  '..VDist2Sq(platPos[1], platPos[3], bestBase.Position[1], bestBase.Position[3]))
                 WaitSeconds(10)
                 platPos = self:GetPlatoonPosition()
                 local distSq = VDist2Sq(platPos[1], platPos[3], bestBase.Position[1], bestBase.Position[3])
@@ -3282,14 +3279,12 @@ Platoon = Class(moho.platoon_methods) {
                 end
                 -- if we haven't moved in 10 seconds... go back to attacking
                 if (distSq - oldDistSq) < 5 then
-                    LOG('ReturnToBaseAI hasnt moved so breaking loop')
                     break
                 end
                 oldDistSq = distSq
             end
         end
         -- default to returning to attacking
-        LOG('ReturnToBaseAI is going back to attackforceai')
         return self:AttackForceAI()
     end,
 

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -1010,8 +1010,7 @@ Platoon = Class(moho.platoon_methods) {
             if moveNext == 'None' then
                 -- this won't be 0... see above
                 WaitSeconds(guardTimer)
-                self:PlatoonDisband()
-                return
+                return self:ReturnToBaseAI()
             end
 
             if moveNext == 'Guard Base' then
@@ -3233,6 +3232,7 @@ Platoon = Class(moho.platoon_methods) {
     --- for a new platoon
     ---@param self Platoon
     ReturnToBaseAI = function(self)
+        LOG('ReturnToBaseAI initialized')
         local aiBrain = self:GetBrain()
 
         if not aiBrain:PlatoonExists(self) or not self:GetPlatoonPosition() then
@@ -3255,9 +3255,12 @@ Platoon = Class(moho.platoon_methods) {
         end
 
         if bestBase then
+            LOG('ReturnToBaseAI returning to '..repr(bestBase.Position))
             AIAttackUtils.GetMostRestrictiveLayer(self)
             local path, reason = AIAttackUtils.PlatoonGenerateSafePathTo(aiBrain, self.MovementLayer, self:GetPlatoonPosition(), bestBase.Position, 200)
-            IssueClearCommands(self)
+            -- remove any formation settings to ensure a quick return to base.
+            self:SetPlatoonFormationOverride('NoFormation')
+            self:Stop()
 
             if path then
                 local pathLength = table.getn(path)
@@ -3269,21 +3272,24 @@ Platoon = Class(moho.platoon_methods) {
 
             local oldDistSq = 0
             while aiBrain:PlatoonExists(self) do
+                LOG('ReturnToBaseAI waiting to arrive, current distance is  '..VDist2Sq(platPos[1], platPos[3], bestBase.Position[1], bestBase.Position[3]))
                 WaitSeconds(10)
                 platPos = self:GetPlatoonPosition()
                 local distSq = VDist2Sq(platPos[1], platPos[3], bestBase.Position[1], bestBase.Position[3])
-                if distSq < 10 then
+                if distSq < 100 then
                     self:PlatoonDisband()
                     return
                 end
                 -- if we haven't moved in 10 seconds... go back to attacking
                 if (distSq - oldDistSq) < 5 then
+                    LOG('ReturnToBaseAI hasnt moved so breaking loop')
                     break
                 end
                 oldDistSq = distSq
             end
         end
         -- default to returning to attacking
+        LOG('ReturnToBaseAI is going back to attackforceai')
         return self:AttackForceAI()
     end,
 


### PR DESCRIPTION
##Description of changes
This PR fixes an error in the default AI code's ReturnToBaseAI function and modifies the GuardMarkers behaviour when the next move is set to 'None'. Fix other instances of IssueClearCommands being used incorrectly in platoon.lua

**Fix to ReturnToBaseAI**
Fixes an error where IssueClearCommands was used but passed the platoon object instead of a table of units, this resulted in the platoon queuing orders instead of clearing original ones, if a platoon was set to guard or assist then they would continue doing that and the function would fail to achieve the desired result and exit silently while putting the platoon into AttackForceAI. Have replaced with the platoon Stop() command which achieves the same thing in this situation, have also added a formation removal to improve the speed that the platoon returns to base.


**Add return to base exit when GuardMarker is set to 'None' for moveNext**
The default behaviour will disband the platoon which results in a bunch of units sitting doing nothing for the rest of the game or until an expansion is created where they are located.

##Test setup for the changes
Logging can be used to validate the correct logic calls are being made.
Observing this would be easiest using Uveso's platoon debug so the reviewer can observe the platoon names used. For the test case the 'Start Location Attack' builder was used on a map with empty start locations present that are relatively close to the AI start position and pathable. Any builder that has the platoon data 'MoveNext' set to 'None' would exhibit the same behaviour. 
Previously this would go to the closest unused start marker, guard for a period of time then disband and be unable to be reused for other platoons. This platoon will now return to base. Any other platoons leveraging the returntobase function should show an improved result.
Fixing other instances of the IssueClearCommands using the platoon instead of platoon units would be observed as the platoon no longer queuing commands on top of previous ones and instead clearing them before issuing new ones.

