### PR TITLE
Improve workflow for testing

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,20 @@ on:
   pull_request:
 
 jobs:
-  test:
+  syntax:
+    name: Syntax
+    runs-on: ubuntu-latest
+    container: faforever/lua:v5.0-1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install bash
+        run: apk add bash findutils
+      - name: Run lua tests
+        run: "bash ./run_lua_syntax_checker.sh"
+  tests:
+    name: Tests
+    needs: syntax
     runs-on: ubuntu-latest
     container: faforever/lua:v5.0-1
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install bash
         run: apk add bash findutils
-      - name: Run lua tests
+      - name: Check Lua syntax
         run: "bash ./run_lua_syntax_checker.sh"
   tests:
     name: Tests
@@ -26,5 +26,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Install bash
         run: apk add bash findutils
-      - name: Run lua tests
+      - name: Run Lua tests
         run: "bash ./run_lua_tests.sh"

--- a/run_lua_syntax_checker.sh
+++ b/run_lua_syntax_checker.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Simple lua code syntax checker using https://github.com/FAForever/lua-lang
+# Assumes that FAF lua is installed as `luac`
+
+had_error=0
+files_checked=0
+
+check_file() {
+  file="$1"
+
+  output="$(luac -p "$file" 2>&1 \
+    | sed "s:/dev/fd/[0-9]\+:$file:g")"
+
+  if [[ $output != "" ]]; then
+    echo "$output" > /dev/fd/2
+    had_error=1
+  fi
+}
+
+# Some files have spaces in their name so we use this syntax to make sure the
+# output from `find` is split by line.
+while read file; do
+  # file contains table pre-allocation synax ( {&1&4} ) that is not supported at the moment
+  if [ "$file" != "./lua/lazyvar.lua" ]; then
+    if [ "$file" != "./.vscode/fa-plugin.lua" ]; then
+      check_file "$file"
+      (( files_checked++ ))
+    fi
+  fi
+done < <(find . -type d \( -path ./testmaps -o -path ./engine \) -prune -false -o -name '*.lua' -o -name '*.bp')
+
+echo "Checked $files_checked files"
+
+if [[ $had_error != 0 ]]; then
+  echo "Syntax errors detected."
+  exit $had_error
+else
+  echo "Syntax OK."
+fi

--- a/run_lua_tests.sh
+++ b/run_lua_tests.sh
@@ -14,14 +14,14 @@ run_test() {
 
   if [[ $output != "" ]]; then
     echo "$output" > /dev/fd/2
-    if [[ {$output#FAIL} != "" ]]; then
+    if [[ "$output" != *"PASS"* ]]; then
       had_error=1
     fi
   fi
 }
 
 # make sure the test files run in the tests directory
-pushd tests
+pushd tests >/dev/null
 while read file; do
   # exclude the unit tester module
   if [ "$file" != "./lust.lua" ]; then
@@ -29,7 +29,7 @@ while read file; do
     ((tests_complete ++))
   fi
 done < <(find . -name '*.lua')
-popd
+popd >/dev/null
 
 echo "Ran $tests_complete tests"
 

--- a/run_lua_tests.sh
+++ b/run_lua_tests.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 
 # Simple lua code syntax checker using https://github.com/FAForever/lua-lang
-# Assumes that FAF lua is installed as `luac`
+# Assumes that FAF lua is installed as `lua`
 
 had_error=0
-files_checked=0
-check_file() {
+tests_complete=0
+
+run_test() {
   file="$1"
 
-  output="$(luac -p "$file" 2>&1 \
+  output="$(lua "$file" 2>&1 \
     | sed "s:/dev/fd/[0-9]\+:$file:g")"
 
   if [[ $output != "" ]]; then
@@ -17,28 +18,22 @@ check_file() {
   fi
 }
 
-# Some files have spaces in their name so we use this syntax to make sure the
-# output from `find` is split by line.
+# make sure the test files run in the tests directory
+pushd tests
 while read file; do
-
-  # file contains table pre-allocation synax ( {&1&4} ) that is not supported at the moment
-  if [ "$file" != "./lua/lazyvar.lua" ]; then 
-    if [ "$file" != "./.vscode/fa-plugin.lua" ]; then 
-      check_file "$file"
-      (( files_checked++ ))
-    fi
+  # exclude the unit tester module
+  if [ "$file" != "./lust.lua" ]; then
+    run_test "$file"
+    ((tests_complete ++))
   fi
-done < <(find . -type d \( -path ./testmaps -o -path ./engine \) -prune -false -o -name '*.lua' -o -name '*.bp')
+done < <(find . -name '*.lua')
+popd
 
-echo "Checked $files_checked files"
+echo "Ran $tests_complete tests"
 
 if [[ $had_error != 0 ]]; then
-  echo "Syntax errors detected."
+  echo "Tests returned errors."
   exit $had_error
 else
-  echo "Syntax OK."
+  echo "Tests OK."
 fi
-
-pushd tests && lua test_utils.lua && popd
-pushd tests && lua test_stringmatch.lua && popd
-pushd tests && lua test_class.lua && popd

--- a/run_lua_tests.sh
+++ b/run_lua_tests.sh
@@ -14,7 +14,7 @@ run_test() {
 
   if [[ $output != "" ]]; then
     echo "$output" > /dev/fd/2
-    if [[ "$output" != *"PASS"* ]]; then
+    if [[ "$output" == *"FAIL"* ]]; then
       had_error=1
     fi
   fi

--- a/run_lua_tests.sh
+++ b/run_lua_tests.sh
@@ -14,7 +14,9 @@ run_test() {
 
   if [[ $output != "" ]]; then
     echo "$output" > /dev/fd/2
-    had_error=1
+    if [[ {$output#FAIL} != "" ]]; then
+      had_error=1
+    fi
   fi
 }
 

--- a/tests/test_class.lua
+++ b/tests/test_class.lua
@@ -114,6 +114,8 @@ lust.describe(
 
             -- check the meta table
             lust.expect(tostring(getmetatable(instance))).to.equal(tostring(Entity))
+
+            lust.expect(true).to.equal(false)
           end
         )
 

--- a/tests/test_class.lua
+++ b/tests/test_class.lua
@@ -114,8 +114,6 @@ lust.describe(
 
             -- check the meta table
             lust.expect(tostring(getmetatable(instance))).to.equal(tostring(Entity))
-
-            lust.expect(true).to.equal(false)
           end
         )
 


### PR DESCRIPTION
Currently, all testing in the workflow is hardcoded to the end of the syntax checker. This PR will separate them out, and support all test files in `/tests`.