### PR TITLE
Refactor module reloading

### DIFF
--- a/lua/sim/NavDebug.lua
+++ b/lua/sim/NavDebug.lua
@@ -219,7 +219,7 @@ end
 local ScanningThread = ForkThread(Scan)
 
 --- Called by the module manager when this module is dirty due to a disk change
-function __OnDirtyModule()
+function __moduleinfo.OnDirty()
     if ScanningThread then
         ScanningThread:Destroy()
     end

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -970,7 +970,7 @@ function Generate()
 end
 
 --- Called by the module manager when this module is dirty due to a disk change
-function __OnDirtyModule()
+function __moduleinfo.OnDirty()
 end
 
 

--- a/lua/system/import.lua
+++ b/lua/system/import.lua
@@ -15,6 +15,8 @@ local error = error
 
 --- Table of all loaded modules, indexed by name.
 __modules = {}
+-- temporary place to store reloading modules
+local oldModules = {}
 
 --- Common metatable used by all modules, which forwards global references to _G
 ---@class Module
@@ -27,6 +29,8 @@ __module_metatable = {
 ---@field name string
 ---@field used_by table<string, true>
 ---@field track_imports boolean
+---@field OnDirty? fun()
+---@field OnReload? fun(newmod: Module)
 
 -- these values can be adjusted by hooking into this file
 local informDevOfLoad = false
@@ -61,6 +65,11 @@ function import(name)
         used_by = {},
         track_imports = true,
     }
+    -- make any old data available to the new one while it reloads
+    local oldMod = oldModules[name]
+    if oldMod then
+        moduleinfo.old = oldMod
+    end
 
     -- set up an environment for the new module
     ---@type Module
@@ -89,6 +98,16 @@ function import(name)
 
     -- try to add content to the environment
     local ok, msg = pcall(doscript, name, module)
+    if oldMod then
+        -- now clear the old module
+        oldModules[name] = nil
+        moduleinfo.old = nil
+        -- let the old module load data into the new one, if they'd prefer to do it that way
+        local onReload = oldMod.__moduleinfo.OnReload
+        if onReload then
+            onReload(module)
+        end
+    end
     if not ok then
         -- we failed: report back
         modules[name] = nil
@@ -113,16 +132,19 @@ function dirty_module(name, why)
         if why then LOG("Module '", name, "' changed on disk") end
         LOG("  marking '", name, "' for reload")
 
+        local moduleinfo = module.__moduleinfo
         -- allow us to run code when a module is ejected
-        if rawget(module, '__OnDirtyModule') then
-            local ok, msg = pcall(module.__OnDirtyModule)
+        local onDirty = moduleinfo.OnDirty
+        if onDirty then
+            local ok, msg = pcall(onDirty)
             if not ok then
                 WARN(msg)
             end
         end
+        oldModules[name] = module
 
         modules[name] = nil
-        local deps = module.__moduleinfo.used_by
+        local deps = moduleinfo.used_by
         if deps then
             for k, _ in deps do
                 dirty_module(k)

--- a/lua/ui/game/NavGenerator.lua
+++ b/lua/ui/game/NavGenerator.lua
@@ -606,7 +606,7 @@ function CloseWindow()
 end
 
 --- Called by the module manager when this module is dirty due to a disk change
-function __OnDirtyModule()
+function __moduleinfo.OnDirty()
     if Root then
         Root:Destroy()
     end


### PR DESCRIPTION
Moves `__OnDirtyModule()` to `__moduleinfo.OnDirty()` and introduces a mechanism for old modules to share their data new modules either via `__moduleinfo.old` (set in the new module while it loads) or `__moduleinfo.OnReload(newmod)` (called from the *old* module with the new one as the argument).