### PR TITLE
Adjust factory behavior when building and finished building a unit

### DIFF
--- a/engine/Core.lua
+++ b/engine/Core.lua
@@ -201,7 +201,7 @@ function IsAlly(army1, army2)
 end
 
 --- Checks if the C-side of an object is destroyed / de-allocated
----@param entity InternalObject
+---@param entity? InternalObject
 ---@return boolean
 function IsDestroyed(entity)
 end

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -26,6 +26,7 @@
 
 --- read more here: https://wiki.faforever.com/en/Blueprints
 ---@class UnitBlueprint: EntityBlueprint
+---@field CategoriesHash table<string, boolean>
 ---@field AI UnitBlueprintAI
 ---@field Air UnitBlueprintAir
 ---@field Adjacency UnitBlueprintAdjacency|string

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -4932,7 +4932,7 @@ AIBrain = Class(moho.aibrain_methods) {
     ---@param self AIBrain
     ---@param cats EntityCategory Unit's category, example: categories.TECH2 .
     ---@param needToBeIdle boolean true/false Unit has to be idle (appears to be not functional).
-    ---@param requireBuilt boolean true/false defaults to false which excludes units that are NOT finished (appears to be not functional).
+    ---@param requireBuilt? boolean true/false defaults to false which excludes units that are NOT finished (appears to be not functional).
     ---@return table 
     GetListOfUnits = function(self, cats, needToBeIdle, requireBuilt)
         -- defaults to false, prevent sending nil

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -15,6 +15,9 @@ local AdjacencyBuffs = import('/lua/sim/AdjacencyBuffs.lua')
 local FireState = import('/lua/game.lua').FireState
 local ScenarioFramework = import('/lua/ScenarioFramework.lua')
 
+local RolloffUnitTable = { nil }
+local RolloffPositionTable = { 0, 0, 0 }
+
 -- allows us to skip ai-specific functionality
 local GameHasAIs = ScenarioInfo.GameHasAIs
 
@@ -922,7 +925,10 @@ FactoryUnit = Class(StructureUnit) {
     RollOffUnit = function(self)
         local spin, x, y, z = self:CalculateRollOffPoint()
         self.UnitBeingBuilt:SetRotation(spin)
-        IssueMove({self.UnitBeingBuilt}, Vector(x, y, z))
+
+        RolloffUnitTable[1] = self.UnitBeingBuilt
+        RolloffPositionTable[1], RolloffPositionTable[2], RolloffPositionTable[3] = x, y, z
+        IssueMove(RolloffUnitTable, RolloffPositionTable)
     end,
 
     ---@param self FactoryUnit

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -944,7 +944,7 @@ FactoryUnit = Class(StructureUnit) {
         -- find our rally point, or of the factory that we're assisting
         local rally = self:GetRallyPoint()
         local focus = self:GetGuardedUnit()
-        while focus do
+        while focus and focus != self do
             local next = focus:GetGuardedUnit()
             if next then
                 focus = next

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -956,8 +956,6 @@ FactoryUnit = Class(StructureUnit) {
             return 0, px, py, pz
         end
 
-        DrawCircle(rally, 4, 'ffffff')
-
         -- find nearest roll off point for rally point
         local nearestRollOffPoint = nil
         local d, dx, dz, lowest = 0, 0, 0, nil
@@ -977,8 +975,6 @@ FactoryUnit = Class(StructureUnit) {
         local fx = nearestRollOffPoint.X + px
         local fy = nearestRollOffPoint.Y + py
         local fz = nearestRollOffPoint.Z + pz
-
-        DrawCircle({fx, fy, fz}, 2, 'ff0000')
 
         return spin, fx, fy, fz
     end,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -107,6 +107,7 @@ local cUnit = moho.unit_methods
 ---@field Blueprint UnitBlueprint
 ---@field EngineFlags any
 ---@field EngineCommandCap? table<string, boolean>
+---@field UnitBeingBuilt Unit?
 Unit = Class(moho.unit_methods) {
 
     Weapons = {},


### PR DESCRIPTION
This pull request fixes various issues with factories:
- (1) A factory that assists another factory uses the rally point of the other factory to compute the correct roll off point
- (2) A factory can now spin the unit to the correct roll off point when the unit is finished building, see also:

https://user-images.githubusercontent.com/15778155/197396006-eac6737a-aa3b-4012-be22-0579abb667a4.mp4

- (3) A factory no longer waits for the unit that is being built to finish its first order. That order can get cancelled by a player (or an AI) and by doing so, artificially decreasing the 'roll off costs'. Instead, the function takes into account the distance of the unit to the build pad. If unit is sufficiently far away it will start building the next unit

https://user-images.githubusercontent.com/15778155/197396129-d25ee02c-f486-4746-8cba-9432647b494a.mp4

All in all, a reduction of the frustrations surrounding of units leaving the factories.

