### PR TITLE
Allow hovering over the Ythotha storm

### DIFF
--- a/lua/seraphimunits.lua
+++ b/lua/seraphimunits.lua
@@ -591,6 +591,7 @@ SEnergyBallUnit = Class(SHoverLandUnit) {
 
     OnCreate = function(self)
         SHoverLandUnit.OnCreate(self)
+        self:SetUnSelectable(true)
         self.CanTakeDamage = false
         self.CanBeKilled = false
         self:PlayUnitSound('Spawn')

--- a/units/XSL0402/XSL0402_unit.bp
+++ b/units/XSL0402/XSL0402_unit.bp
@@ -39,7 +39,7 @@ UnitBlueprint {
         'EXPERIMENTAL',
         'HOVER',
         'VISIBLETORECON',
-        'UNSELECTABLE',
+        'SELECTABLE',
         'UNTARGETABLE',
     },
     CollisionOffsetY = -0.25,
@@ -196,6 +196,14 @@ UnitBlueprint {
     SizeZ = 0.5,
     StrategicIconName = 'icon_experimental_generic',
     StrategicIconSortPriority = 105,
+    Veteran = {
+        Level1 = 70,
+        Level2 = 140,
+        Level3 = 210,
+        Level4 = 280,
+        Level5 = 350,
+    },
+    VeteranMassMult = 13250,
     Weapon = {
         {
             AboveWaterTargetsOnly = true,


### PR DESCRIPTION
Originates from [this forum post](https://forum.faforever.com/topic/4441/make-the-ion-storm-selectable-as-a-neutral-unit-and-give-it-a-veterancy-bar/3). Allows a player to hover over the storm that originates from the Ythotha upon dying. This allows players to see how much experience the storm gained over its life span.

https://user-images.githubusercontent.com/15778155/197402658-a64df719-acc9-49e2-80c9-20072b555d91.mp4

I've look at the example mod (Othuy mass killed) - the implementation in this pull request preserves the original behavior.