### PR TITLE
Fix/ai factory manager not removing factories after upgrade.

### DIFF
--- a/lua/sim/BuilderManager.lua
+++ b/lua/sim/BuilderManager.lua
@@ -375,6 +375,23 @@ BuilderManager = ClassSimple {
             end
         end
     end,
+    
+    ---@param self, BuilderManager
+    ---@param oldtable, Table
+    ---@return tempTable, Table
+    RebuildTable = function(self, oldtable)
+        local temptable = {}
+        for k, v in oldtable do
+            if v ~= nil then
+                if type(k) == 'string' then
+                    temptable[k] = v
+                else
+                    table.insert(temptable, v)
+                end
+            end
+        end
+        return temptable
+    end,
 }
 
 

--- a/lua/sim/FactoryBuilderManager.lua
+++ b/lua/sim/FactoryBuilderManager.lua
@@ -282,7 +282,7 @@ FactoryBuilderManager = Class(BuilderManager) {
         for k,v in guards do
             if not v.Dead and v.AssistPlatoon then
                 if self.Brain:PlatoonExists(v.AssistPlatoon) then
-                    v.AssistPlatoon:ForkThread(v.AssistPlatoon.EconAssistBodyRNG)
+                    v.AssistPlatoon:ForkThread(v.AssistPlatoon.EconAssistBody)
                 else
                     v.AssistPlatoon = nil
                 end

--- a/lua/sim/FactoryBuilderManager.lua
+++ b/lua/sim/FactoryBuilderManager.lua
@@ -278,19 +278,24 @@ FactoryBuilderManager = Class(BuilderManager) {
     ---@param factory Unit
     FactoryDestroyed = function(self, factory)
         local guards = factory:GetGuards()
+        local factoryDestroyed = false
         for k,v in guards do
             if not v.Dead and v.AssistPlatoon then
                 if self.Brain:PlatoonExists(v.AssistPlatoon) then
-                    v.AssistPlatoon:ForkThread(v.AssistPlatoon.EconAssistBody)
+                    v.AssistPlatoon:ForkThread(v.AssistPlatoon.EconAssistBodyRNG)
                 else
                     v.AssistPlatoon = nil
                 end
             end
         end
         for k,v in self.FactoryList do
-            if v == factory then
+            if (not v.Sync.id) or v.Dead then
                 self.FactoryList[k] = nil
+                factoryDestroyed = true
             end
+        end
+        if factoryDestroyed then
+            self.FactoryList = self:RebuildTable(self.FactoryList)
         end
         for k,v in self.FactoryList do
             if not v.Dead then
@@ -465,13 +470,18 @@ FactoryBuilderManager = Class(BuilderManager) {
 
     ---@param self FactoryBuilderManager
     ---@param factory Unit
-    ---@param finishedUnit boolean
+    ---@param finishedUnit Unit
     FactoryFinishBuilding = function(self,factory,finishedUnit)
         if EntityCategoryContains(categories.ENGINEER, finishedUnit) then
             self.Brain.BuilderManagers[self.LocationType].EngineerManager:AddUnit(finishedUnit)
-        elseif EntityCategoryContains(categories.FACTORY, finishedUnit) then
-            self:AddFactory(finishedUnit)
-        end
+        elseif EntityCategoryContains(categories.FACTORY * categories.STRUCTURE, finishedUnit ) then
+			if finishedUnit:GetFractionComplete() == 1 then
+				self:AddFactory(finishedUnit )			
+				factory.Dead = true
+                factory.Trash:Destroy()
+				return self:FactoryDestroyed(factory)
+			end
+		end
         self:AssignBuildOrder(factory, factory.BuilderManagerData.BuilderType)
     end,
 

--- a/lua/sim/FactoryBuilderManager.lua
+++ b/lua/sim/FactoryBuilderManager.lua
@@ -289,7 +289,7 @@ FactoryBuilderManager = Class(BuilderManager) {
             end
         end
         for k,v in self.FactoryList do
-            if (not v.Sync.id) or v.Dead then
+            if IsDestroyed(v) then
                 self.FactoryList[k] = nil
                 factoryDestroyed = true
             end


### PR DESCRIPTION
Description of changes
This PR fixes a long standing issue with the default factory manager. When a factory is upgraded the original factory is never destroyed or removed from the AI's factory manager list. This in turn causes the FactoryLessAtLocation and FactoryGreaterAtLocation conditions to return incorrect results. Any AI logic that queries factory counts from this list will be invalid after the first factory has upgraded.

Note : I wasn't sure about adding the table rebuild function. But it seemed like a valid requirement for maintaining the factory list table.

Test setup for the changes
With the default code add logging to the factory manager that will provide the list of factories that the AI has (or a count). When the AI upgrades a factory you will see that the factory list increases by one instead of remaining the same because the old factory is still in the list. This in turn makes any factory counts invalid.
With this fix applied the number will remain correct after factory upgrades are completed.