### PR TITLE
Update NavalForceAI to use IssueAggressiveMoveAlongRoute

### DIFF
--- a/lua/AI/aiattackutilities.lua
+++ b/lua/AI/aiattackutilities.lua
@@ -694,19 +694,9 @@ function AIPlatoonNavalAttackVector(aiBrain, platoon)
     end
 
     if path then
-        local pathSize = table.getn(path)
-        -- store path
         platoon.LastAttackDestination = path
         -- move to new location
-        for wpidx,waypointPath in path do
-            if wpidx == pathSize then
-                platoon:AggressiveMoveToLocation(waypointPath)
-                --platoon:MoveToLocation(waypointPath, false)
-            else
-                platoon:AggressiveMoveToLocation(waypointPath)
-                --platoon:MoveToLocation(waypointPath, false)
-            end
-        end
+        platoon:IssueAggressiveMoveAlongRoute(path)
     end
 
     -- return current command queue


### PR DESCRIPTION
## Description of changes
This PR updates the default platoon function NavalForceAI to use the IssueAggressiveMoveAlongRoute method for pathing movement instead of AggressiveMoveToLocation. This improves the platoon movement mechanics and movement speed along complex routes when the platoon size is greater than 3.


## Test setup for the changes
Setup an AI game with a default normal AI on a naval map. Once they have established a naval expansion spawn a bunch of frigates/destroyers/navalunits and the AI should form a platoon using the NavalForceAI. Similar to the screenshot. The platoon should have a much smoother form of movement compared to previously, especially once the number of units in the platoon gets up. Because it is using an aggressive move then platoon members may stop to try and shoot something that will hold up the platoon movement at times. This is expected and is not a bug.

Note : You can use Uveso's platoon debug to confirm that the correct builder/platoon template is being used by the platoon.

![NavalForceAI](https://user-images.githubusercontent.com/34614077/198384331-062b0f13-7919-4a7c-836d-33724e79cc47.JPG)
