### PR TITLE
[4295] Part zero - fix bugs found in luft.lua

### DIFF
--- a/lua/shared/color.lua
+++ b/lua/shared/color.lua
@@ -476,7 +476,7 @@ function HSLtoHSV(hue, sat, lit)
     if val == 0 then
         return hue, 0, 0
     end
-    return hue, 2 - 2 / (1 + sat), val
+    return hue, 2 - 2  * lit / val, val
 end
 
 

--- a/tests/luft.lua
+++ b/tests/luft.lua
@@ -41,7 +41,7 @@ local Assertion = {}
 ---@field Alias? string
 ---@field NotName? string
 ---@field NotAlias? string
----@field Chain?  fun(a: LuftAssertion)  called after simple chaining e.g. a`.b`.c 
+---@field Chain?  fun(a: LuftAssertion)  called after simple chaining e.g. a`.b`.c
 ---@field ChainCall?  fun(a: LuftAssertion, ...)  called after chained calling e.g. a`.b()`.c
 ---@field Test?  fun(...): boolean        function to test with all arguments (from the starting values, calling arguments, and support values); expects both `FailString` formatters to be defined
 ---@field Parameters number               number of parameters the test function has
@@ -583,9 +583,6 @@ function Luft.expect(...)
 end
 
 Assertion.__index = function(self, word)
-    if word:lower() ~= word then
-        return Assertion[word]
-    end
     local node = Assertion.GetCurrentNode(self)
     local next_node, process_next = node:GetNext(word)
     if next_node then
@@ -595,7 +592,7 @@ Assertion.__index = function(self, word)
                 chain(self)
             end
             self.head = next_node
-            next_node, process_next = node:GetNext(process_next)
+            next_node, process_next = next_node:GetNext(process_next)
         end
         local chain = next_node.Chain
         if chain then
@@ -756,7 +753,7 @@ PathNode.Nodes = {}
 
 ---@param word string
 ---@return LuftPathNode
----@return string? next_word 
+---@return string? next_word
 function PathNode:GetNext(word)
     local pos = word:find('_', 1, true)
     local next_word
@@ -764,11 +761,7 @@ function PathNode:GetNext(word)
         next_word = word:sub(pos + 1)
         word = word:sub(1, pos - 1)
     end
-    local node = self[word]
-    if node then
-        return node, next_word
-    end
-    node = self['!' .. word]
+    local node = self['!' .. word]
     if node then
         local not_node = self.Nodes["not"]
         if next_word then
@@ -776,7 +769,7 @@ function PathNode:GetNext(word)
         end
         return not_node, self.Name
     end
-    return self.Nodes[word]
+    return self[word], next_word
 end
 
 
@@ -809,19 +802,15 @@ do
     end
 
     nodes["root"] = {
-        To = {"not", "to"},
+        To = { "to" },
     }
     nodes["not"] = {
-        To = "to",
         Chain = negate,
+        To = { "succeed", "be", "have", "equal" },
     }
     nodes["to"] = {
-        NotName = "not_to",
-        To = {"to.not", "succeed", "to.equal", "be", "have"},
-    }
-    nodes["to.not"] = {
-        To = {"succeed", "to.equal", "be", "have"},
-        Chain = negate,
+        NotName = "to_not",
+        To = { "succeed", "be", "have", "not", "equal", "exist" },
     }
     nodes["succeed"] = {
         Alias = "pass",
@@ -833,11 +822,6 @@ do
         Parameters = 1,
         FailString = strings.expectation1:format("$1", strings.condition_unnegated, strings.cond_succeed),
         NotFailString = strings.expectation1:format("$1", strings.condition_unnegated, strings.cond_fail),
-    }
-    nodes["to.equal"] = {
-        test = strict_eq,
-        Parameters = 2,
-        FailFormat = strings.expectation2be:format("$1", "$2", "%s", strings.cond_strict_eq),
     }
     nodes["have"] = {
         ---@param t any
@@ -866,13 +850,12 @@ do
     }
     nodes["be"] = {
         To = {
-            "equal", "unequal",
             "greater", "less",
             "positive", "negative",
             "falsy",
             "nil", "userdata",
-            "within", "close",
-            "an",
+            "within", "close", "an",
+            "function", "integer", "string", "number", "boolean"
         },
         Test = function(v, x)
             return v == x
@@ -882,23 +865,20 @@ do
         NotFailString = strings.expectation2be:format("$1", "$2", strings.condition_unnegated, strings.cond_unequal),
     }
     nodes["equal"] = {
-        To = "equal.to",
-    }
-    nodes["equal.to"] = {
-        test = strict_eq,
+        Test = strict_eq,
         Parameters = 2,
-        FailFormat = nodes["to.equal"].FailFormat,
+        FailFormat = strings.expectation2be:format("$1", "$2", "%s", strings.cond_strict_eq),
     }
     nodes["greater"] = {
         To = "than",
         Chain = function(sert)
-            sert.support = {true}
+            sert.support = { true }
         end;
     }
     nodes["less"] = {
         To = "than",
         Chain = function(sert)
-            sert.support = {false}
+            sert.support = { false }
         end;
     }
     nodes["than"] = {
@@ -942,12 +922,9 @@ do
         RequiresSupport = true,
     }
     nodes["close"] = {
-        To = "close.to",
         Chain = function(sert)
-            sert.support = {Luft.margin_of_error, n = 1}
+            sert.support = { Luft.margin_of_error, n = 1 }
         end;
-    }
-    nodes["close.to"] = {
         Test = nodes["of"].Test,
         Parameters = nodes["of"].Parameters,
         FailFormat = nodes["of"].FailFormat,

--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -73,7 +73,7 @@ end
 local function HSVtoHSLsimp(h, s, v)
     local lit = v * (1 - s / 2)
     local sat = 0
-    if v ~= 0 and v ~= 1 then
+    if lit ~= 0 and lit ~= 1 then
         sat = (v - lit) / math.min(lit, 1 - lit)
     end
     return h, sat, lit
@@ -159,24 +159,24 @@ luft.describe("Color functions", function()
             local ro, go, bo = col[1], col[2], col[3]
             local r, g, b = RGBtoFloat(ro, go, bo)
             local f1, f2, f3 = testForward(r, g, b)
-            luft.expect(f1, f2, f3).to.be.close.to(compareForward(r, g, b))
-            luft.expect(compareBackward(f1, f2, f3)).to.be.close.to(r, g, b)
+            luft.expect(f1, f2, f3).to.be.close(compareForward(r, g, b))
+            luft.expect(compareBackward(f1, f2, f3)).to.be.close(r, g, b)
         end)
         luft.test_all("Back conversion", testColors, function(col)
             local ro, go, bo = col[1], col[2], col[3]
             local r, g, b = RGBtoFloat(ro, go, bo)
             local f1, f2, f3 = testForward(r, g, b)
             local b1, b2, b3 = testBackward(f1, f2, f3)
-            luft.expect(b1, b2, b3).to.be.close.to(compareBackward(f1, f2, f3))
-            luft.expect(compareForward(b1, b2, b3)).to.be.close.to(f1, f2, f3)
+            luft.expect(b1, b2, b3).to.be.close(compareBackward(f1, f2, f3))
+            luft.expect(compareForward(b1, b2, b3)).to.be.close(f1, f2, f3)
         end)
         luft.test_all("Round conversion", testColors, function(col)
             local ro, go, bo = col[1], col[2], col[3]
             local r, g, b = RGBtoFloat(ro, go, bo)
             local r1, g1, b1 = testBackward(testForward(r, g, b))
-            luft.expect(r1, g1, b1).to.be.close.to(r, g, b)
+            luft.expect(r1, g1, b1).to.be.close(r, g, b)
             if ro > 1 or go > 1 or bo > 1 then
-                luft.expect(ColorRGB(r1, g1, b1)).to.equal(ro, go, bo)
+                luft.expect(ColorRGB(r1, g1, b1)).to.equal(("%02X%02X%02X"):format(ro, go, bo))
             end
         end)
     end)

--- a/tests/test_utils.lua
+++ b/tests/test_utils.lua
@@ -121,7 +121,7 @@ luft.describe("Utils", function()
 
     luft.test("string.gmatch iterates over word pairs correctly", function()
         local iterator = test:gmatch("[^ ]+ [^ ]+")
-        luft.expect(iterator).to.be.a "function"
+        luft.expect(iterator).to.be_function()
         luft.expect(iterator()).to.equal "The quick"
         luft.expect(iterator()).to.equal "brown FOX745"
         luft.expect(iterator()).to.equal "JUMPS over"
@@ -131,7 +131,7 @@ luft.describe("Utils", function()
 
     luft.test("string.gmatch correctly returns multiple arguments", function()
         local iterator = test:gmatch("([^ ]+) ([^ ]+)")
-        luft.expect(iterator).to.be.a "function"
+        luft.expect(iterator).to.be_function()
         luft.expect(iterator()).to.equal("The", "quick")
         luft.expect(iterator()).to.equal("brown", "FOX745")
         luft.expect(iterator()).to.equal("JUMPS", "over")


### PR DESCRIPTION
## Introduction
Please have in mind that this is my first contact with **Lua**.
I've started working on first task from #4295 and found out that `equal` function in Luft is not working (always returns `true`).
I created this PR to address found problems and provide potential improvements

## Changes
### Luft
- `to.equal` node had assigned `test` function instead of `Test`, so testing function was not invoked, and tests using it returned `true` - fixed

- ~~Each `PathNode` in `Luft` has `To` field, I assume it was added to describe how nodes should be combined, e.g.:
`Test.expect().to.equal()` is correct
`Test.expect().to.equal.equal()` is not
The `PathNode:GetNext(word) -> PathNode` at the end of the function was always checking if there is matching `PathNode` for current word in list of all possible nodes instead of `To` nodes of the current node, so as long as there was some Node matching current word the sequence was correct. 
In the PR the check is removed.~~
- ~~Removed nonexisting nodes from PathNodes  `To` and added missing~~

### Colors
- After fixing equal funciton tests started failing, as I see:
  - in the unit tests `HSVtoHSLsimp` was incorrect - fixed
  - in the colors implmentation `HSLtoHSV` was incorrect - fixed