### PR TITLE
Fix adjacency warning and properly populate the table

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -565,7 +565,7 @@ StructureUnit = Class(Unit) {
         -- keep track of who is adjacent to who
         self.AdjacentUnits = self.AdjacentUnits or { }
         adjacentUnit.AdjacentUnits = adjacentUnit.AdjacentUnits or { }
-        
+
         self.AdjacentUnits[adjacentUnit.EntityId] = adjacentUnit
         adjacentUnit.AdjacentUnits[self.EntityId] = self
 
@@ -579,7 +579,7 @@ StructureUnit = Class(Unit) {
         adjacentUnit:RequestRefreshUI()
      end,
 
-    -- Called by the engine when two structures are no loner adjacent to each other
+    -- Called by the engine when two structures are no longer adjacent to each other
     ---@param self StructureUnit
     ---@param adjacentUnit StructureUnit
     OnNotAdjacentTo = function(self, adjacentUnit)


### PR DESCRIPTION
Fixes the warning `warning: Precondition Failed: No AdjacentUnits registered for entity: cfunction: 1B43C500` and properly populates the table for both units (both the provider and the recipient). You can now use the table to retrieve units that are providing adjacency bonusses to another unit.