### PR TITLE
Remove force-move mode option

### DIFF
--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -352,18 +352,18 @@ options = {
                 key = '',
             },
 
-            {
-                title = "Ignore mode via CTRL",
-                key = 'commands_ignore_mode',
-                type = 'toggle',
-                default = 'off',
-                custom = {
-                    states = {
-                        {text = "<LOC _Off>", key = 'off'},
-                        {text = "<LOC _On>", key = 'on'},
-                    },
-                },
-            },
+            -- {
+            --     title = "Ignore mode via CTRL",
+            --     key = 'commands_ignore_mode',
+            --     type = 'toggle',
+            --     default = 'off',
+            --     custom = {
+            --         states = {
+            --             {text = "<LOC _Off>", key = 'off'},
+            --             {text = "<LOC _On>", key = 'on'},
+            --         },
+            --     },
+            -- },
 
             {
                 title = 'Cursor features',


### PR DESCRIPTION
This particular option is not stable, as it maps to `CTRL` which internally also maps to formation move. I can't think of a sane key to use here, so for now I'll just disable it.