### PR TITLE
Remove force-move mode due to lack of a key to use

### DIFF
--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -451,18 +451,18 @@ options = {
                 key = '',
             },
 
-            {
-                title = "Ignore mode via CTRL",
-                key = 'commands_ignore_mode',
-                type = 'toggle',
-                default = 'off',
-                custom = {
-                    states = {
-                        {text = "<LOC _Off>", key = 'off'},
-                        {text = "<LOC _On>", key = 'on'},
-                    },
-                },
-            },
+            -- {
+            --     title = "Ignore mode via CTRL",
+            --     key = 'commands_ignore_mode',
+            --     type = 'toggle',
+            --     default = 'off',
+            --     custom = {
+            --         states = {
+            --             {text = "<LOC _Off>", key = 'off'},
+            --             {text = "<LOC _On>", key = 'on'},
+            --         },
+            --     },
+            -- },
 
             {
                 title = "<LOC OPTIONS_0273>Automated Structure Ringing",


### PR DESCRIPTION
This particular option is not stable, as it maps to `CTRL` which internally also maps to formation move. I can't think of a sane key to use here, so for now I'll just disable it.