### PR TITLE
Guarantee that units are finished building when updating adjacency

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -538,13 +538,11 @@ StructureUnit = Class(Unit) {
         return wreckage
     end,
 
-    -- Called by the engine when two structures are adjacent to each other
+    -- Called by the engine when a structure is finished building for each adjacent unit
     ---@param self StructureUnit
     ---@param adjacentUnit StructureUnit
     ---@param triggerUnit StructureUnit
     OnAdjacentTo = function(self, adjacentUnit, triggerUnit)
-
-        LOG("OnAdjacentTo")
 
         -- make sure we're both finished building
         if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt() then
@@ -574,7 +572,7 @@ StructureUnit = Class(Unit) {
         adjacentUnit:RequestRefreshUI()
      end,
 
-    -- Called by the engine when two structures are no longer adjacent to each other
+    -- Called by the engine when a structure is destroyed for each adjacent unit
     ---@param self StructureUnit
     ---@param adjacentUnit StructureUnit
     OnNotAdjacentTo = function(self, adjacentUnit)

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -543,6 +543,9 @@ StructureUnit = Class(Unit) {
     ---@param adjacentUnit StructureUnit
     ---@param triggerUnit StructureUnit
     OnAdjacentTo = function(self, adjacentUnit, triggerUnit)
+
+        LOG("OnAdjacentTo")
+
         -- make sure we're both finished building
         if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt() then
             return
@@ -575,6 +578,12 @@ StructureUnit = Class(Unit) {
     ---@param self StructureUnit
     ---@param adjacentUnit StructureUnit
     OnNotAdjacentTo = function(self, adjacentUnit)
+
+        -- make sure we're both finished building
+        if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt() then
+            return
+        end
+
         -- make sure we have buffs to remove
         local adjBuffs = self.Blueprint.Adjacency
         if not adjBuffs then


### PR DESCRIPTION
The functions `OnAdjacentTo` and `OnNotAdjacentTo` are called to all adjacent structures when a structure is finished or destroyed. It does not take into account whether the adjacent structure is finished too.

This additional check guarantees that 😄 