### PR TITLE
Fix glitches with colossus tracking

### DIFF
--- a/engine/Sim/UnitWeapon.lua
+++ b/engine/Sim/UnitWeapon.lua
@@ -86,7 +86,7 @@ function UnitWeapon:GetBlueprint()
 end
 
 ---
----@return Blip | nil
+---@return Blip | Unit | nil
 function UnitWeapon:GetCurrentTarget()
 end
 

--- a/engine/Sim/UnitWeapon.lua
+++ b/engine/Sim/UnitWeapon.lua
@@ -86,7 +86,7 @@ function UnitWeapon:GetBlueprint()
 end
 
 ---
----@return Entity | Unit | nil
+---@return Blip | nil
 function UnitWeapon:GetCurrentTarget()
 end
 

--- a/lua/aeonweapons.lua
+++ b/lua/aeonweapons.lua
@@ -98,9 +98,12 @@ ADFTractorClaw = Class(Weapon) {
 
         ---@type Blip | Unit
         local blipOrUnit = self:GetCurrentTarget()
-        local target = self:GetUnitBehindTarget(blipOrUnit)
+        if not blipOrUnit then
+            return
+        end
 
         -- only tractor actual units
+        local target = self:GetUnitBehindTarget(blipOrUnit)
         if not target then
             self:ForkThread(self.OnInvalidTargetThread)
             return
@@ -274,7 +277,7 @@ ADFTractorClaw = Class(Weapon) {
         end
 
         -- if the unit is magically already destroyed, then just return - nothing we can do,
-        --  we'll likely end up with a flying wreck :)
+        -- we'll likely end up with a flying wreck :)
         if IsDestroyed(target) then
             return
         end
@@ -330,6 +333,8 @@ ADFTractorClaw = Class(Weapon) {
     MakeImmune = function (self, target)
         if not IsDestroyed(target) then
             target:SetDoNotTarget(true)
+            target.CanTakeDamage = false
+            target.DisallowCollisions = true
         end
     end,
 
@@ -338,6 +343,8 @@ ADFTractorClaw = Class(Weapon) {
     MakeVulnerable = function (self, target)
         if not IsDestroyed(target) then
             target:SetDoNotTarget(false)
+            target.CanTakeDamage = true
+            target.DisallowCollisions = false
         end
     end,
 }

--- a/lua/aeonweapons.lua
+++ b/lua/aeonweapons.lua
@@ -345,6 +345,7 @@ ADFTractorClaw = Class(Weapon) {
             target:SetDoNotTarget(false)
             target.CanTakeDamage = true
             target.DisallowCollisions = false
+            target.Tractored = nil
         end
     end,
 }

--- a/lua/aeonweapons.lua
+++ b/lua/aeonweapons.lua
@@ -295,18 +295,15 @@ ADFTractorClaw = Class(Weapon) {
             projectile:SetVelocity(10 * vx, 10 * vy, 10 * vz)
             Warp(projectile, target:GetPosition(), target:GetOrientation())
 
+            -- happens when the projectile is created underwater
+            if IsDestroyed(projectile) then
+                target:Kill()
+            end
+
             projectile.OnImpact = function(projectile)
                 if not IsDestroyed(target) then
                     target.CanTakeDamage = true
-                    if not IsDestroyed(self.unit) then
-                        if target.MyShield and target.MyShield:IsOn() then
-                            Damage(self.unit, self.unit:GetPosition(muzzle), target.MyShield, target.MyShield:GetHealth() + 1, 'Disintegrate')
-                        end
-                        Damage(self.unit, self.unit:GetPosition(muzzle), target, target:GetHealth() + 1, 'Disintegrate')
-                        
-                    else
-                        target:Kill()
-                    end
+                    target:Kill()
 
                     CreateLightParticle(target, 0, self.Army, 4, 2, 'glow_02', 'ramp_blue_16')
 
@@ -333,8 +330,6 @@ ADFTractorClaw = Class(Weapon) {
     MakeImmune = function (self, target)
         if not IsDestroyed(target) then
             target:SetDoNotTarget(true)
-            target.CanTakeDamage = false
-            target.DisallowCollisions = true
         end
     end,
 
@@ -343,8 +338,6 @@ ADFTractorClaw = Class(Weapon) {
     MakeVulnerable = function (self, target)
         if not IsDestroyed(target) then
             target:SetDoNotTarget(false)
-            target.CanTakeDamage = true
-            target.DisallowCollisions = false
         end
     end,
 }

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -538,13 +538,11 @@ StructureUnit = Class(Unit) {
         return wreckage
     end,
 
-    -- Called by the engine when two structures are adjacent to each other
+    -- Called by the engine when a structure is finished building for each adjacent unit
     ---@param self StructureUnit
     ---@param adjacentUnit StructureUnit
     ---@param triggerUnit StructureUnit
     OnAdjacentTo = function(self, adjacentUnit, triggerUnit)
-
-        LOG("OnAdjacentTo")
 
         -- make sure we're both finished building
         if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt() then
@@ -574,7 +572,7 @@ StructureUnit = Class(Unit) {
         adjacentUnit:RequestRefreshUI()
      end,
 
-    -- Called by the engine when two structures are no longer adjacent to each other
+    -- Called by the engine when a structure is destroyed for each adjacent unit
     ---@param self StructureUnit
     ---@param adjacentUnit StructureUnit
     OnNotAdjacentTo = function(self, adjacentUnit)

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -543,6 +543,9 @@ StructureUnit = Class(Unit) {
     ---@param adjacentUnit StructureUnit
     ---@param triggerUnit StructureUnit
     OnAdjacentTo = function(self, adjacentUnit, triggerUnit)
+
+        LOG("OnAdjacentTo")
+
         -- make sure we're both finished building
         if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt() then
             return
@@ -575,6 +578,12 @@ StructureUnit = Class(Unit) {
     ---@param self StructureUnit
     ---@param adjacentUnit StructureUnit
     OnNotAdjacentTo = function(self, adjacentUnit)
+
+        -- make sure we're both finished building
+        if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt() then
+            return
+        end
+
         -- make sure we have buffs to remove
         local adjBuffs = self.Blueprint.Adjacency
         if not adjBuffs then

--- a/units/UAL0401/UAL0401_Script.lua
+++ b/units/UAL0401/UAL0401_Script.lua
@@ -27,7 +27,20 @@ local SignCheck = Vector(1, 0, 0)
 ---@class UAL0401 : AWalkingLandUnit
 UAL0401 = Class(AWalkingLandUnit) {
     Weapons = {
-        EyeWeapon = Class(ADFPhasonLaser) {},
+        EyeWeapon = Class(ADFPhasonLaser) {
+            CreateProjectileAtMuzzle = function(self, muzzle)
+                ADFPhasonLaser.CreateProjectileAtMuzzle(self, muzzle)
+
+                -- if possible, try not to fire on units that we're tractoring
+                local target = self:GetCurrentTarget()
+                if target then
+                    local unit = (IsUnit(target) and target) or target:GetSource()
+                    if unit and unit.Tractored then
+                        self:ResetTarget()
+                    end
+                end
+            end,
+        },
         RightArmTractor = Class(ADFTractorClaw) {},
         LeftArmTractor = Class(ADFTractorClaw) {},
     },


### PR DESCRIPTION
Units that are tractored into the water get killed now. The colossus will also try and actively prefer beaming units that are not tractored, the only exception when this doesn't happen is when the player specifically orders the colossus to attack a given unit. 

In the 'usual' cases (where you just walk) it works better now.