### PR TITLE
Fix remote code exploit

### DIFF
--- a/lua/SimHooks.lua
+++ b/lua/SimHooks.lua
@@ -1,5 +1,8 @@
 
-
+do 
+    -- can only cause issues, like remote code exploit
+    _G.loadstring = nil
+end
 
 do
 

--- a/lua/sim/CategoryUtils.lua
+++ b/lua/sim/CategoryUtils.lua
@@ -154,7 +154,6 @@ function ParseEntityCategoryProperly(categoryExpression)
 
         return currentCategory
     end
-
     return _parseSubexpression(1, numTokens)
 end
 -- converts specified category expression to a string

--- a/lua/sim/CategoryUtils.lua
+++ b/lua/sim/CategoryUtils.lua
@@ -8,8 +8,8 @@
 -- There's not really any error handling. In the presence of malformed category expressions the
 -- behaviour is undefined, possibly resulting in native-code crashes due to invalid calls to the
 -- native category classes.
----@param categoryExpression any
----@return number|nil
+---@param categoryExpression string
+---@return EntityCategory | nil
 function ParseEntityCategoryProperly(categoryExpression)
     local tokens = {}
 


### PR DESCRIPTION
By carefully tweaking the string that should represent a table of categories, one could execute any code in the simulation and have it synced too. This was found by @iczero , and provided a sample:

```lua
local derp_orig = "for k, v in ArmyBrains do " ..
    "if not IsAlly(v:GetArmyIndex(), __OWN_ARMY__) then " ..    
        "print('army: ' .. v.Nickname .. ' ' .. v.Name) " ..                             
        "for _, u in v:GetListOfUnits(categories.COMMAND, false) do " ..                 
            "u:Kill() " ..                                                               
        "end " ..                                                                       
    "end " ..                                                                           
"end return categories.COMMAND"                                                      
local derp_string = '{ loadstring "' .. string.gsub(derp_orig, '%(', '\\x28') .. '" \'\' }'
function DoReallyBadThings()                                                         
    local ownArmy = GetFocusArmy()
    SetWeaponPriorities(string.gsub(derp_string, '__OWN_ARMY__', tostring(ownArmy)), 'derp', false)
end                                                                                                                 
KeyMapper.SetUserKeyAction('Derp', {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").DoReallyBadThings()', category = 'Target priorities', order = 75})
```

This particular example is quite obvious, but you can imagine any subtle advantage can be gained using this same technique.

We completely remove the use of `loadstring` from the simulation side and manually parse the table of strings that is passed down to us via a callback. 