### PR TITLE
Add guard around attack reticules tracking

### DIFF
--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -53,13 +53,15 @@ local function GetSelectedWeaponsWithReticules(predicate)
     end
 
     -- find valid units
-    for i, u in selectedUnits do
-        local bp = u:GetBlueprint()
-        if bp.CategoriesHash['SHOWATTACKRETICLE'] and (not weapons[bp.BlueprintId]) then
-            for k, v in bp.Weapon do
-                if predicate(v) then
-                    weapons[bp.BlueprintId] = v
-                    break
+    if selectedUnits then
+        for i, u in selectedUnits do
+            local bp = u:GetBlueprint()
+            if bp.CategoriesHash['SHOWATTACKRETICLE'] and (not weapons[bp.BlueprintId]) then
+                for k, v in bp.Weapon do
+                    if predicate(v) then
+                        weapons[bp.BlueprintId] = v
+                        break
+                    end
                 end
             end
         end


### PR DESCRIPTION
Allows the attack ping to function as expected again, as that uses the same cursor.