### PR TITLE
Make changelog slightly transparent

### DIFF
--- a/lua/ui/lobby/changelog.lua
+++ b/lua/ui/lobby/changelog.lua
@@ -66,7 +66,7 @@ Changelog = Class(Group) {
         LayoutHelpers.FillParent(self.Background, GetFrame(0))
 
         self.DialogBackground = Bitmap(self.CommonUI)
-        self.DialogBackground:SetSolidColor("ff111111")
+        self.DialogBackground:SetSolidColor("99111111")
         LayoutHelpers.FillParent(self.DialogBackground, self.CommonUI)
 
         -- header


### PR DESCRIPTION
As part of a request of a community member.

![image](https://user-images.githubusercontent.com/15778155/200197405-dfec9bea-69af-438d-96a1-9d1b0d08dbe3.png)
