### PR TITLE
Fix issue with cheat window and UEF build animation

### DIFF
--- a/lua/EffectUtilitiesUEF.lua
+++ b/lua/EffectUtilitiesUEF.lua
@@ -34,6 +34,8 @@ local BuilderSlicePeriod = 6
 ---@param buildEffectBones string[] The effect bones of the builder
 ---@param buildEffectsBag TrashBag The effects bag of the builder
 function CreateDefaultBuildBeams(builder, unitBeingBuilt, buildEffectBones, buildEffectsBag)
+    WaitTicks(1)
+
     local ProjectileSetVelocity = ProjectileSetVelocity
     local WaitTicks = WaitTicks
 
@@ -81,6 +83,8 @@ end
 ---@param buildEffectBones string[] The effect bones of the builder
 ---@param buildEffectsBag TrashBag The effects bag of the builder
 function CreateUEFBuildSliceBeams(builder, unitBeingBuilt, buildEffectBones, buildEffectsBag)
+    WaitTicks(1)
+    
     -- store as locals for performance
     local UnitGetFractionComplete = UnitGetFractionComplete
     local ProjectileSetVelocity = ProjectileSetVelocity
@@ -257,6 +261,8 @@ end
 --- @param buildEffectBones string[] The effect bones of the builder
 --- @param buildEffectsBag TrashBag The effects bag of the builder
 function CreateUEFCommanderBuildSliceBeams(builder, unitBeingBuilt, buildEffectBones, buildEffectsBag)
+    WaitTicks(1)
+    
     -- localize for optimal access
     local Warp = Warp
     local WaitTicks = WaitTicks

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -135,7 +135,6 @@ function EndCommandMode(isCancel)
             else 
                 if modeData.selection then
                     SelectUnits(modeData.selection)
-                    return
                 end
             end
         end
@@ -148,6 +147,7 @@ function EndCommandMode(isCancel)
             ClearBuildTemplates()
         end
     end
+    
     -- do end behaviors
     for i,v in endBehaviors do
         v(commandMode, modeData)

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -137,6 +137,11 @@ function EndCommandMode(isCancel)
                     SelectUnits(modeData.selection)
                 end
             end
+
+            -- we can end up here because we re-start the command mode
+            if not modeData then
+                return
+            end
         end
 
         -- add information to modeData for end behavior
@@ -147,7 +152,7 @@ function EndCommandMode(isCancel)
             ClearBuildTemplates()
         end
     end
-    
+
     -- do end behaviors
     for i,v in endBehaviors do
         v(commandMode, modeData)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15778155/200200332-b3bedcdf-f1ec-4b7b-a47d-5952b79246df.png)
![image](https://user-images.githubusercontent.com/15778155/200200339-659ff243-ccb7-46c0-9bac-7e8ecd7c5059.png)

Fixes these issues, where the beams are in the factory. The functions need to wait until the end of the current tick to make sure the unit that they are building is in the correct position.