### PR TITLE
Weapon Priority Fix

### DIFF
--- a/lua/WeaponPriorities.lua
+++ b/lua/WeaponPriorities.lua
@@ -31,7 +31,7 @@ function ParseTableOfCategories(inputString)
             full = { }
             for k, category in categories do
                 if not (category == '') then
-                    local parsed = cachedTablePriorities[category] or ParseEntityCategory(category)
+                    local parsed = cachedTablePriorities[category] or ParseEntityCategoryProperly(category)
                     cachedTablePriorities[category] = parsed
                     if parsed then
                         table.insert(full, parsed)

--- a/lua/WeaponPriorities.lua
+++ b/lua/WeaponPriorities.lua
@@ -30,9 +30,11 @@ function ParseTableOfCategories(inputString)
 
             full = { }
             for k, category in categories do
+                LOG(category)
                 if not (category == '') then
                     local parsed = cachedTablePriorities[category] or ParseEntityCategoryProperly(category)
                     cachedTablePriorities[category] = parsed
+                    LOG(parsed)
                     if parsed then
                         table.insert(full, parsed)
                     end
@@ -42,9 +44,11 @@ function ParseTableOfCategories(inputString)
             -- excludes the use of the COMMAND category, to prevent sniping with Mantis
             limited = { }
             for k, category in categories do
+                LOG(category)
                 if not (category == '' or string.find(category, 'COMMAND')) then
                     local parsed = cachedLimitedTablePriorities[category] or ParseEntityCategoryProperly(string.format('(%s) - COMMAND', category))
                     cachedLimitedTablePriorities[category] = parsed
+                    LOG(parsed)
                     if parsed then
                         table.insert(limited, parsed)
                     end
@@ -91,7 +95,11 @@ function SetWeaponPriorities(data)
     end
 
     if not editedPriorities[1] then
+        LOG("no entries, defaulting")
         default = true
+    end
+    for k,v in ipairs(editedPriorities) do
+        LOG(k,v)
     end
 
     --work out what message to send to the player for changing their priority list

--- a/lua/WeaponPriorities.lua
+++ b/lua/WeaponPriorities.lua
@@ -30,11 +30,9 @@ function ParseTableOfCategories(inputString)
 
             full = { }
             for k, category in categories do
-                LOG(category)
                 if not (category == '') then
                     local parsed = cachedTablePriorities[category] or ParseEntityCategoryProperly(category)
                     cachedTablePriorities[category] = parsed
-                    LOG(parsed)
                     if parsed then
                         table.insert(full, parsed)
                     end
@@ -44,11 +42,9 @@ function ParseTableOfCategories(inputString)
             -- excludes the use of the COMMAND category, to prevent sniping with Mantis
             limited = { }
             for k, category in categories do
-                LOG(category)
                 if not (category == '' or string.find(category, 'COMMAND')) then
                     local parsed = cachedLimitedTablePriorities[category] or ParseEntityCategoryProperly(string.format('(%s) - COMMAND', category))
                     cachedLimitedTablePriorities[category] = parsed
-                    LOG(parsed)
                     if parsed then
                         table.insert(limited, parsed)
                     end
@@ -95,11 +91,7 @@ function SetWeaponPriorities(data)
     end
 
     if not editedPriorities[1] then
-        LOG("no entries, defaulting")
         default = true
-    end
-    for k,v in ipairs(editedPriorities) do
-        LOG(k,v)
     end
 
     --work out what message to send to the player for changing their priority list

--- a/lua/sim/CategoryUtils.lua
+++ b/lua/sim/CategoryUtils.lua
@@ -50,6 +50,12 @@ function ParseEntityCategoryProperly(categoryExpression)
             currentIdentifier = currentIdentifier .. c
         end
     end)
+    
+    -- gsub tokenizer stops before end of string character, without a chance to add the last currentidentifier as a token. So need to check once at the end if there is a remaining identifier.
+    if currentIdentifier ~= "" then
+        table.insert(tokens, currentIdentifier)
+    end
+
 
     local numTokens = table.getn(tokens)
 

--- a/lua/sim/CategoryUtils.lua
+++ b/lua/sim/CategoryUtils.lua
@@ -51,6 +51,11 @@ function ParseEntityCategoryProperly(categoryExpression)
         end
     end)
 
+    -- gsub tokenizer stops before end of string character, without a chance to add the last currentidentifier as a token. So need to check once at the end if there is a remaining identifier.
+    if currentIdentifier ~= "" then
+        table.insert(tokens, currentIdentifier)
+    end
+
     local numTokens = table.getn(tokens)
 
     local function explode(error)

--- a/lua/sim/CategoryUtils.lua
+++ b/lua/sim/CategoryUtils.lua
@@ -51,11 +51,6 @@ function ParseEntityCategoryProperly(categoryExpression)
         end
     end)
 
-    -- gsub tokenizer stops before end of string character, without a chance to add the last currentidentifier as a token. So need to check once at the end if there is a remaining identifier.
-    if currentIdentifier ~= "" then
-        table.insert(tokens, currentIdentifier)
-    end
-
     local numTokens = table.getn(tokens)
 
     local function explode(error)


### PR DESCRIPTION
Investigated weapon priority issues after reports of the advanced targeting priorities mod being broken.

Tested and noticed they worked correctly for certain units (t1 tanks) but not others (acu, experimentals). dug in a bit and saw it must be a difference between the limited category parser and the full category parser.

confirmed by switching them around that the issue was in the parser used, guessing this was an autocomplete typo after splitting up the category parsing into full and limited sections in #4338.