### PR TITLE
Change default aix multiplier values.

### DIFF
--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -590,7 +590,7 @@ globalOpts = {
 ---@type ScenarioOption[]
 AIOpts = {
    {
-        default = 11,
+        default = 6,
         label = "<LOC aisettings_0001>>AIx Cheat Multiplier",
         help = "<LOC aisettings_0002>Set the cheat multiplier for the cheating AIs.",
         key = 'CheatMult',
@@ -603,7 +603,7 @@ AIOpts = {
         },
    },
    {
-        default = 11,
+        default = 6,
         label = "<LOC aisettings_0054>AIx Build Multiplier",
         help = "<LOC aisettings_0055>Set the build rate multiplier for the cheating AIs.",
         key = 'BuildMult',
@@ -674,7 +674,7 @@ AIOpts = {
         },
    },
    {
-        default = 1,
+        default = 2,
         label = "<LOC aisettings_0147>AIx Omni Setting",
         help = "<LOC aisettings_0148>Set the AIx global intel toggle",
         key = 'OmniCheat',

--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -674,7 +674,7 @@ AIOpts = {
         },
    },
    {
-        default = 2,
+        default = 1,
         label = "<LOC aisettings_0147>AIx Omni Setting",
         help = "<LOC aisettings_0148>Set the AIx global intel toggle",
         key = 'OmniCheat',


### PR DESCRIPTION
#4324

## Description of changes
This PR changes the default AIX values from 2.0 to 1.5. It has been noted by many new players that the default values are stupidly difficult and many don't realise they can be changed. Lowering the default values will provide new players an easier time moving from non cheating to cheating AI and will also avoid the experience becoming even worse when we get the AI performing better. 

I opted not to change the default OMNI settings yet as I don't have a meaningful intel improvement for the AI so this would potentially be too much of a negative change should I not get the work completed before the next release.


## Test setup for the changes
Start a skirmish lobby with AIX as the AI, set all values to default. Note the default value for the cheat and build multipliers. Start game and confirm that the AI is using those defaults.