### PR TITLE
Keep track of radar structures

### DIFF
--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -26,6 +26,9 @@
 
 --- read more here: https://wiki.faforever.com/en/Blueprints
 ---@class UnitBlueprint: EntityBlueprint
+---@field TechCategory 'TECH1' | 'TECH2' | 'TECH3' | 'EXPERIMENTAL'
+---@field LayerCategory 'LAND' | 'AIR' | 'NAVAL'
+---@field FactionCategory 'UEF' | 'CYBRAN' | 'AEON' | 'SERAPHIM'
 ---@field CategoriesHash table<string, boolean>
 ---@field AI UnitBlueprintAI
 ---@field Air UnitBlueprintAir

--- a/lua/AI/AIBuilders/AIIntelBuilders.lua
+++ b/lua/AI/AIBuilders/AIIntelBuilders.lua
@@ -403,6 +403,7 @@ BuilderGroup {
         BuilderConditions = {
             { EBC, 'GreaterThanEconIncomeOverTime',  { 4, 100 }},
             { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { UCBC, 'ShouldUpgradeRadar', {'LocationType', 'TECH2'}},
             { IBC, 'BrainNotLowPowerMode', {} },
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, categories.RADAR * categories.TECH2 * categories.STRUCTURE } },
         },
@@ -415,6 +416,7 @@ BuilderGroup {
         BuilderConditions = {
             { EBC, 'GreaterThanEconIncomeOverTime',  { 9, 500}},
             { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { UCBC, 'ShouldUpgradeRadar', {'LocationType', 'TECH3'}},
             { IBC, 'BrainNotLowPowerMode', {} },
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, categories.OMNI * categories.STRUCTURE } },
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.STRUCTURE * ( categories.RADAR + categories.OMNI ) } },

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -5040,40 +5040,6 @@ AIBrain = Class(moho.aibrain_methods) {
             WaitTicks(100)
         end
     end,
-
-    -- TODO: where does this fit best?
-
-    ---@param self AIBrain
-    ---@param radar Unit
-    ShouldUpgradeRadar = function(self, radar)
-
-        -- determine what tech we'll be upgrading to
-        local oldTech = radar.Blueprint.TechCategory
-        local newTech = 'TECH2'
-        if oldTech == 'TECH2' then
-            newTech = 'TECH3'
-        end
-
-        -- loop over radars that are one tech higher
-        local rx, _, rz = radar:GetPositionXYZ()
-        local otherRadars = self.Radars[newTech]
-        for _, other in otherRadars do
-
-            -- determine if we're too close to higher tech radars
-            local range = other.Blueprint.Intel.RadarRadius
-            if range then
-                local squared = 0.64 * (range * range)
-                local ox, _, oz = other:GetPositionXYZ()
-                local dx = ox - rx
-                local dz = oz - rz
-                if dx * dx + dz * dz < squared then
-                    return false
-                end
-            end
-        end
-
-        return true
-    end,
 }
 
 -- kept for mod backwards compatibility

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -5040,6 +5040,40 @@ AIBrain = Class(moho.aibrain_methods) {
             WaitTicks(100)
         end
     end,
+
+    -- TODO: where does this fit best?
+
+    ---@param self AIBrain
+    ---@param radar Unit
+    ShouldUpgradeRadar = function(self, radar)
+
+        -- determine what tech we'll be upgrading to
+        local oldTech = radar.Blueprint.TechCategory
+        local newTech = 'TECH2'
+        if oldTech == 'TECH2' then
+            newTech = 'TECH3'
+        end
+
+        -- loop over radars that are one tech higher
+        local rx, _, rz = radar:GetPositionXYZ()
+        local otherRadars = self.Radars[newTech]
+        for _, other in otherRadars do
+
+            -- determine if we're too close to higher tech radars
+            local range = other.Blueprint.Intel.RadarRadius
+            if range then
+                local squared = 0.64 * (range * range)
+                local ox, _, oz = other:GetPositionXYZ()
+                local dx = ox - rx
+                local dz = oz - rz
+                if dx * dx + dz * dz < squared then
+                    return false
+                end
+            end
+        end
+
+        return true
+    end,
 }
 
 -- kept for mod backwards compatibility

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -94,6 +94,7 @@ local Factions = import("/lua/factions.lua").GetFactions(true)
 ---@field PBM AiPlatoonBuildManager
 ---@field PingCallbackList table
 ---@field PlatoonNameCounter? table<string, number>
+---@field Radars table<string, Unit[]>
 ---@field RepeatExecution boolean
 ---@field Result? AIResult
 ---@field SelfMonitor AiSelfMonitor
@@ -336,6 +337,14 @@ AIBrain = Class(moho.aibrain_methods) {
                 end 
             end
         end
+
+        -- keep track of radars
+        self.Radars = { 
+            TECH1 = { },
+            TECH2 = { },
+            TECH3 = { },
+            EXPERIMENTAL = { },
+        }
 
         -- restrict all support factories by default
         AddBuildRestriction(self:GetArmyIndex(), (categories.TECH3 + categories.TECH2) * categories.SUPPORTFACTORY)

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1378,12 +1378,33 @@ MassStorageUnit = Class(StructureUnit) { }
 ---@class RadarUnit : StructureUnit
 RadarUnit = Class(StructureUnit) {
 
+    OnCreate = function(self)
+        StructureUnit.OnCreate(self)
+
+        -- keep track of radars
+        self.Brain.Radars[self.Blueprint.TechCategory][self.EntityId] = self
+    end,
+
     ---@param self RadarUnit
     ---@param builder Unit
     ---@param layer Layer
     OnStopBeingBuilt = function(self, builder, layer)
         StructureUnit.OnStopBeingBuilt(self, builder, layer)
         self:SetMaintenanceConsumptionActive()
+    end,
+
+    OnKilled = function (self, instigator, type, overkillRatio)
+        StructureUnit.OnKilled(self, instigator, type, overkillRatio)
+
+        -- keep track of radars
+        self.Brain.Radars[self.Blueprint.TechCategory][self.EntityId] = nil
+    end,
+
+    OnDestroy = function (self)
+        StructureUnit.OnDestroy(self)
+
+        -- keep track of radars
+        self.Brain.Radars[self.Blueprint.TechCategory][self.EntityId] = nil
     end,
 
     ---@param self RadarUnit

--- a/lua/editor/UnitCountBuildConditions.lua
+++ b/lua/editor/UnitCountBuildConditions.lua
@@ -1449,3 +1449,32 @@ function ForcePathLimit(aiBrain, locationType, unitCategory, pathType, unitCount
     end
     return true
 end
+
+
+-- TODO: where does this fit best?
+
+--- Buildcondition to decide if radars should upgrade based on other radar locations.
+---@param aiBrain AIBrain
+---@param locationType string
+---@param radarTech string
+---@return boolean
+function ShouldUpgradeRadar(aiBrain, locationType, radarTech)
+
+    -- loop over radars that are one tech higher
+    local basePos = aiBrain.BuilderManagers[locationType].Position
+    local otherRadars = aiBrain.Radars[radarTech]
+    for _, other in otherRadars do
+        -- determine if we're too close to higher tech radars
+        local range = other.Blueprint.Intel.RadarRadius
+        if range then
+            local squared = 0.64 * (range * range)
+            local ox, _, oz = other:GetPositionXYZ()
+            local dx = ox - basePos[1]
+            local dz = oz - basePos[3]
+            if dx * dx + dz * dz < squared then
+                return false
+            end
+        end
+    end
+    return true
+end

--- a/lua/editor/UnitCountBuildConditions.lua
+++ b/lua/editor/UnitCountBuildConditions.lua
@@ -1450,9 +1450,6 @@ function ForcePathLimit(aiBrain, locationType, unitCategory, pathType, unitCount
     return true
 end
 
-
--- TODO: where does this fit best?
-
 --- Buildcondition to decide if radars should upgrade based on other radar locations.
 ---@param aiBrain AIBrain
 ---@param locationType string


### PR DESCRIPTION
@relent0r with regards to our discussion about radar management, I'd take the approach of this pull request.

Roughly speaking it:
- (1) Keeps track of radars at each tech level
- (2) Adds a build condition to check for nearby radars of 1 tech higher

(1) is cheap performance wise as usually a player (and an AI) will not have hundreds of radars. (2) is cheap because once you have an omni somewhere it usually covers the entire map. Meaning the condition will usually only pass for one radar. Except for 20x20 maps, where radars near the edge may also get a green light for an upgrade. Which is what you'd want, as then you carefully expand the radar presence.

Note that (2) should likely be a build condition of some kind, but I'm not familiar enough with those to make that work. I imagine a simple radar manager (similar to a factory manager) may be sufficient though, no build conditions required.