### PR TITLE
Add toggle to enable / disable always showing splash damage

### DIFF
--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -597,6 +597,19 @@ options = {
                     },
                 },
             },
+
+            {
+                title = "Always show splash damage indicator",
+                key = 'cursor_splash_damage',
+                type = 'toggle',
+                default = 'off',
+                custom = {
+                    states = {
+                        {text = "<LOC _Off>", key = 'off'},
+                        {text = "<LOC _On>", key = 'on'},
+                    },
+                },
+            },
         },
     },
     ui = {

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -550,7 +550,8 @@ WorldView = Class(moho.UIWorldView, Control) {
             local commandData = CommandMode.GetCommandMode()
             local viaCommandMode = commandData[1] and commandData[1] == 'order' and commandData[2].name == 'RULEUCC_Attack'
             if viaCommandMode then
-                self:OnCursorDecals(identifier, enabled or (viaCommandMode != self.ViaCommandModeOld), changed  or (viaCommandMode != self.ViaCommandModeOld), AttackDecalFunc)
+                local commandModeChange = (viaCommandMode != self.ViaCommandModeOld)
+                self:OnCursorDecals(identifier, enabled or commandModeChange, changed or commandModeChange, AttackDecalFunc)
             else 
                 self:OnCursorDecals(identifier, false, changed, AttackDecalFunc)
             end

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -543,9 +543,12 @@ WorldView = Class(moho.UIWorldView, Control) {
             end
         end
 
+        -- if via prefs then we always show the splash indicator
         local viaPrefs = Prefs.GetFromCurrentProfile('options.cursor_splash_damage') == 'on'
         if viaPrefs then
             self:OnCursorDecals(identifier, enabled, changed, AttackDecalFunc)
+
+        -- otherwise we only show it if we're in command mode
         else
             local commandData = CommandMode.GetCommandMode()
             local viaCommandMode = commandData[1] and commandData[1] == 'order' and commandData[2].name == 'RULEUCC_Attack'

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -543,7 +543,19 @@ WorldView = Class(moho.UIWorldView, Control) {
             end
         end
 
-        self:OnCursorDecals(identifier, enabled, changed, AttackDecalFunc)
+        local viaPrefs = Prefs.GetFromCurrentProfile('options.cursor_splash_damage') == 'on'
+        if viaPrefs then
+            self:OnCursorDecals(identifier, enabled, changed, AttackDecalFunc)
+        else
+            local commandData = CommandMode.GetCommandMode()
+            local viaCommandMode = commandData[1] and commandData[1] == 'order' and commandData[2].name == 'RULEUCC_Attack'
+            if viaCommandMode then
+                self:OnCursorDecals(identifier, enabled or (viaCommandMode != self.ViaCommandModeOld), changed  or (viaCommandMode != self.ViaCommandModeOld), AttackDecalFunc)
+            else 
+                self:OnCursorDecals(identifier, false, changed, AttackDecalFunc)
+            end
+            self.ViaCommandModeOld = viaCommandMode
+        end
     end,
 
     --- Called when the order `RULEUCC_Patrol` is being applied

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -424,7 +424,6 @@ local categoriesStructure = categories.STRUCTURE
 --- Called by the engine when a new command has been issued by the player.
 -- @param command Information surrounding the command that has been issued, such as its CommandType or its Target.
 function OnCommandIssued(command)
-    
     -- if we're trying to upgrade hives then this allows us to force the upgrade to happen immediately
     if command.CommandType == "Upgrade" and (command.Blueprint == "xrb0204" or command.Blueprint == "xrb0304") then 
         if not IsKeyDown('Shift') then 

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -424,7 +424,7 @@ local categoriesStructure = categories.STRUCTURE
 --- Called by the engine when a new command has been issued by the player.
 -- @param command Information surrounding the command that has been issued, such as its CommandType or its Target.
 function OnCommandIssued(command)
-
+    
     -- if we're trying to upgrade hives then this allows us to force the upgrade to happen immediately
     if command.CommandType == "Upgrade" and (command.Blueprint == "xrb0204" or command.Blueprint == "xrb0304") then 
         if not IsKeyDown('Shift') then 


### PR DESCRIPTION
As requested by people - not everyone thought this was as useful. People also often end up thinking they can no longer attack individual units. That isn't correct, you still can like usual - it just appears that you can't anymore.