### PR TITLE
Revert accidental footprint changes to Titan, Loya and Ilsha

### DIFF
--- a/units/UEL0303/UEL0303_unit.bp
+++ b/units/UEL0303/UEL0303_unit.bp
@@ -163,6 +163,10 @@ UnitBlueprint {
         TeleportMassMod = 1,
         TeleportTimeMod = 0.01,
     },
+    Footprint = {
+        SizeX = 1,
+        SizeZ = 1,
+    },
     General = {
         Category = 'Direct Fire',
         Classification = 'RULEUC_MilitaryVehicle',

--- a/units/URL0303/URL0303_unit.bp
+++ b/units/URL0303/URL0303_unit.bp
@@ -163,6 +163,10 @@ UnitBlueprint {
         TeleportMassMod = 1,
         TeleportTimeMod = 0.01,
     },
+    Footprint = {
+        SizeX = 1,
+        SizeZ = 1,
+    },
     General = {
         Category = 'Direct Fire',
         Classification = 'RULEUC_MilitaryVehicle',

--- a/units/XSL0202/XSL0202_unit.bp
+++ b/units/XSL0202/XSL0202_unit.bp
@@ -179,6 +179,10 @@ UnitBlueprint {
         TeleportMassMod = 1,
         TeleportTimeMod = 0.01,
     },
+    Footprint = {
+        SizeX = 1,
+        SizeZ = 1,
+    },
     General = {
         Category = 'Direct Fire',
         Classification = 'RULEUC_MilitaryVehicle',


### PR DESCRIPTION
If the footprint is undefined it is derived from the collision box. As a consequence, the footprint of Titans, Loyalists and Ilsavohs were pushed from 1x1 to 2x2 by accident. This pull request reverts them back to 1x1.