### PR TITLE
Improve performance of the Heap data structure

### DIFF
--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -2563,7 +2563,7 @@ float4 WreckagePS( NORMALMAPPED_VERTEX vertex) : COLOR0
     float4 specular = tex2D( specularSampler, texcoord * 5.15);
 
     /// Wreckage should not receive shadows (the "random" crunchiness makes for bad artifacts.)
-    float3 color = albedo * ComputeLight( dotLightNormal, 1);
+    float3 color = albedo * ComputeLight( dotLightNormal, 0);
 
     if( specular.g < 0.22 )
         color *= (albedo + specular.r + specular.a) * specular.b * 2.5;

--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -2563,7 +2563,7 @@ float4 WreckagePS( NORMALMAPPED_VERTEX vertex) : COLOR0
     float4 specular = tex2D( specularSampler, texcoord * 5.15);
 
     /// Wreckage should not receive shadows (the "random" crunchiness makes for bad artifacts.)
-    float3 color = albedo * ComputeLight( dotLightNormal, 0);
+    float3 color = albedo * ComputeLight( dotLightNormal, 1);
 
     if( specular.g < 0.22 )
         color *= (albedo + specular.r + specular.a) * specular.b * 2.5;

--- a/lua/sim/NavDatastructures.lua
+++ b/lua/sim/NavDatastructures.lua
@@ -69,58 +69,59 @@ NavPathToHeap = ClassSimple {
 
     ---@param self NavPathToHeap
     Heapify = function(self)
+        local heap = self.Heap
+        local heap_size = self.HeapSize
+
         local index = 1
         -- find the left / right child
-        local left = self:ToLeftChild(index)
-        local right = self:ToRightChild(index)
+        local left = 2 * index
+        local right = 2 * index + 1
         -- if there is no left child it means we restored heap properties
-        while self.Heap[left] do
+        while left <= heap_size do
             local min = left
 
             -- if there is a right child, compare its value with the left one
             -- if right is smaller, then assign min = right. Else, keep min on left.
-            if self.Heap[right] and (self.Heap[right].TotalCosts < self.Heap[left].TotalCosts) then
+            if heap[right] and (heap[right].TotalCosts < heap[left].TotalCosts) then
                 min = right
             end
-            
-            -- if min has higher value than the index it means we restored heap properties 
+
+            -- if min has higher value than the index it means we restored heap properties
             -- and can break the loop
-            if self.Heap[min].TotalCosts > self.Heap[index].TotalCosts then
+            if heap[min].TotalCosts > heap[index].TotalCosts then
                 return
             end
             -- otherwise, swap the two values.
-            self:Swap(index, min)
+            local tmp = heap[min]
+            heap[min] = heap[index]
+            heap[index] = tmp
             -- and update index, left and right indexes.
             index = min
-            left = self:ToLeftChild(index)
-            right = self:ToRightChild(index)
+            left = 2 * index
+            right = 2 * index + 1
         end
     end,
 
     ---@param self NavPathToHeap
     Rootify = function(self)
+        local heap = self.Heap
         local index = self.HeapSize
-        local parent = self:ToParent(index)
+        -- index / 2
+        local parent = index >> 1
         while parent >= 1 do
             -- if parent value is smaller than index value it means we restored correct order of the elements
-            if self.Heap[parent].TotalCosts < self.Heap[index].TotalCosts then
+            if heap[parent].TotalCosts < heap[index].TotalCosts then
                 return
             end
             -- otherwise, swap the values
-            self:Swap(parent, index)
-            -- and update index and parend indexes
+            local tmp = heap[parent]
+            heap[parent] = heap[index]
+            heap[index] = tmp
+            -- and update index and parent indexes
             index = parent
-            parent = self:ToParent(index)
+            -- parent / 2
+            parent = parent >> 1
         end
-    end,
-
-    ---@param self NavPathToHeap
-    ---@param a number
-    ---@param b number
-    Swap = function(self, a, b)
-        local l = self.Heap[a]
-        self.Heap[a] = self.Heap[b]
-        self.Heap[b] = l
     end,
 
     ---@param self NavPathToHeap
@@ -133,29 +134,5 @@ NavPathToHeap = ClassSimple {
         else
             WARN("given object to Heap was nil!")
         end
-    end,
-
-    ---@param self NavPathToHeap
-    ---@param index number
-    ---@return number
-    ToParent = function(self, index)
-        -- index / 2
-        return index >> 1
-    end,
-
-    ---@param self NavPathToHeap
-    ---@param index number
-    ---@return number
-    ToRightChild = function(self, index)
-        -- 2 * index + 1
-        return 2 * index + 1
-    end,
-
-    ---@param self NavPathToHeap
-    ---@param index number
-    ---@return number
-    ToLeftChild = function(self, index)
-        -- 2 * index
-        return 2 * index
     end,
 }

--- a/lua/sim/NavDatastructures.lua
+++ b/lua/sim/NavDatastructures.lua
@@ -39,8 +39,10 @@ NavPathToHeap = ClassSimple {
 
     ---@param self NavPathToHeap
     Clear = function(self)
+        local heap = self.Heap
+
         for k = 1, self.HeapSize do
-            self.Heap[k] = nil
+            heap[k] = nil
         end
         self.HeapSize = 0
     end,
@@ -48,18 +50,21 @@ NavPathToHeap = ClassSimple {
     ---@param self NavPathToHeap
     ---@return CompressedLabelTreeLeaf?
     ExtractMin = function(self)
+        local heap = self.Heap
+        local heapSize = self.HeapSize
+
         -- if the Heap is empty, we got nothing to return!
-        if self.HeapSize == 0 then
+        if heapSize == 0 then
             return nil
         end
 
         -- keep a reference to the top value.
-        local value = self.Heap[1]
+        local value = heap[1]
 
         -- put our highest value at the top.
-        self.Heap[1] = self.Heap[self.HeapSize]
-        self.Heap[self.HeapSize] = nil
-        self.HeapSize = self.HeapSize - 1
+        heap[1] = heap[heapSize]
+        heap[heapSize] = nil
+        self.HeapSize = heapSize - 1
 
         -- fix its position.
         self:Heapify()
@@ -67,17 +72,19 @@ NavPathToHeap = ClassSimple {
         return value
     end,
 
+    --- 'Bubble down' operation, applied when we extract an element from the heap
     ---@param self NavPathToHeap
     Heapify = function(self)
         local heap = self.Heap
-        local heap_size = self.HeapSize
+        local heapSize = self.HeapSize
 
-        local index = 1
         -- find the left / right child
+        local index = 1
         local left = 2 * index
         local right = 2 * index + 1
+
         -- if there is no left child it means we restored heap properties
-        while left <= heap_size do
+        while left <= heapSize do
             local min = left
 
             -- if there is a right child, compare its value with the left one
@@ -91,10 +98,12 @@ NavPathToHeap = ClassSimple {
             if heap[min].TotalCosts > heap[index].TotalCosts then
                 return
             end
+
             -- otherwise, swap the two values.
             local tmp = heap[min]
             heap[min] = heap[index]
             heap[index] = tmp
+
             -- and update index, left and right indexes.
             index = min
             left = 2 * index
@@ -102,24 +111,30 @@ NavPathToHeap = ClassSimple {
         end
     end,
 
+    --- 'Bubble up' operation, applied when we insert a new element into the heap
     ---@param self NavPathToHeap
     Rootify = function(self)
         local heap = self.Heap
         local index = self.HeapSize
-        -- index / 2
+
+        -- math.floor(index / 2)
         local parent = index >> 1
         while parent >= 1 do
+
             -- if parent value is smaller than index value it means we restored correct order of the elements
             if heap[parent].TotalCosts < heap[index].TotalCosts then
                 return
             end
+
             -- otherwise, swap the values
             local tmp = heap[parent]
             heap[parent] = heap[index]
             heap[index] = tmp
+
             -- and update index and parent indexes
             index = parent
-            -- parent / 2
+
+            -- math.floor(parent / 2)
             parent = parent >> 1
         end
     end,
@@ -127,12 +142,8 @@ NavPathToHeap = ClassSimple {
     ---@param self NavPathToHeap
     ---@param element CompressedLabelTreeLeaf
     Insert = function(self, element)
-        if element then
-            self.HeapSize = self.HeapSize + 1
-            self.Heap[self.HeapSize] = element
-            self:Rootify()
-        else
-            WARN("given object to Heap was nil!")
-        end
+        self.HeapSize = self.HeapSize + 1
+        self.Heap[self.HeapSize] = element
+        self:Rootify()
     end,
 }

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -232,7 +232,7 @@ local CompressedLabelTree
 ---@field pz number                                         # z-coordinate of center in world space
 ---@field From CompressedLabelTreeLeaf
 ---@field AcquiredCosts number
----@field ExpectedCosts number
+---@field TotalCosts number
 ---@field Seen number   
 
 --- A simplified quad tree that acts as a compression of the pathing capabilities of a section of the heightmap

--- a/lua/sim/NavUtils.lua
+++ b/lua/sim/NavUtils.lua
@@ -165,7 +165,7 @@ function PathTo(layer, origin, destination, options)
                 neighbor.From = leaf
                 neighbor.Seen = seenIdentifier
                 neighbor.AcquiredCosts = leaf.AcquiredCosts + leaf.neighborDistances[id] + 2 + preferLargeNeighbor
-                -- TotalCosts = AcquiredCosts * ExpectedCosts
+                -- TotalCosts = AcquiredCosts + ExpectedCosts
                 neighbor.TotalCosts = neighbor.AcquiredCosts + 0.25 * destinationLeaf:DistanceTo(neighbor)
 
                 PathToHeap:Insert(neighbor)

--- a/lua/sim/NavUtils.lua
+++ b/lua/sim/NavUtils.lua
@@ -135,13 +135,13 @@ function PathTo(layer, origin, destination, options)
 
     originLeaf.From = nil
     originLeaf.AcquiredCosts = 0
-    originLeaf.ExpectedCosts = originLeaf:DistanceTo(destinationLeaf)
+    originLeaf.TotalCosts = originLeaf:DistanceTo(destinationLeaf)
     originLeaf.Seen = seenIdentifier
     PathToHeap:Insert(originLeaf)
 
     destinationLeaf.From = nil
     destinationLeaf.AcquiredCosts = 0
-    destinationLeaf.ExpectedCosts = 0
+    destinationLeaf.TotalCosts = 0
     destinationLeaf.Seen = 0
 
     -- search iterations
@@ -165,7 +165,8 @@ function PathTo(layer, origin, destination, options)
                 neighbor.From = leaf
                 neighbor.Seen = seenIdentifier
                 neighbor.AcquiredCosts = leaf.AcquiredCosts + leaf.neighborDistances[id] + 2 + preferLargeNeighbor
-                neighbor.ExpectedCosts = 0.25 * destinationLeaf:DistanceTo(neighbor)
+                -- TotalCosts = AcquiredCosts * ExpectedCosts
+                neighbor.TotalCosts = neighbor.AcquiredCosts + 0.25 * destinationLeaf:DistanceTo(neighbor)
 
                 PathToHeap:Insert(neighbor)
             else 

--- a/tests/test_NavDatastructures.lua
+++ b/tests/test_NavDatastructures.lua
@@ -7,8 +7,8 @@ require "../lua/sim/NavDatastructures.lua"
 
 ---@param cost number
 local function AsLeaf(cost)
-    -- Heap computes value of current node using this two values
-    return { AcquiredCosts = cost, ExpectedCosts = 0 }
+    -- Heap computes value of current node using this value
+    return { TotalCosts = cost }
 end
 
 luft.describe("NavDatastructures", function()


### PR DESCRIPTION
Closes #4295 

## Brief
Main goad of the #4295  was to improve performance of the Heap datastructure, how it went?
Well, I got about ~~11% of performance improvement~~ 60% after @Garanas suggestions, tested using following scenario:
```lua
...
---@param heap NavPathToHeap
local function AddAndPop(heap)
    for i = 1, 5000, 1 do
        for _ = 1, 4, 1 do
            heap:Insert(AsLeaf(math.random()))
        end
        for _ = 1, 1, 1 do
            heap:ExtractMin()
        end
    end
    heap:Clear()
end
...
```

## Changes
- As suggested in the issue `ExpectedCost` was replaced with `TotalCost`
- `Heapify` and `Rootify` functions in NavDatastructures have been replaced by their iterative versions.
- Adjusted UTs to use `TotalCost` instead of `ExpectedCost`