### PR TITLE
Prefetch session and unit assets

### DIFF
--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -461,17 +461,17 @@ Prefetcher = CreatePrefetchSet()
 
 function DefaultPrefetchSet()
     local set = { models = {}, anims = {}, d3d_textures = {} }
---    for k,file in DiskFindFiles('/units/', '*.scm') do
---        table.insert(set.models,file)
---    end
+   for k,file in DiskFindFiles('/units/', '*.scm') do
+       table.insert(set.models,file)
+   end
 
---    for k,file in DiskFindFiles('/units/', '*.sca') do
---        table.insert(set.anims,file)
---    end
+   for k,file in DiskFindFiles('/units/', '*.sca') do
+       table.insert(set.anims,file)
+   end
 
---    for k,file in DiskFindFiles('/units/', '*.dds') do
---        table.insert(set.d3d_textures,file)
---    end
+   for k,file in DiskFindFiles('/units/', '*.dds') do
+       table.insert(set.d3d_textures,file)
+   end
 
     return set
 end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2314,8 +2314,8 @@ local function UpdateGame()
             -- to have custom icon support over having a slightly faster loading
             -- time we skip the prefetching
 
-            -- local mods = Mods.GetGameMods(gameInfo.GameMods)
-            -- PrefetchSession(scenarioInfo.map, mods, true)
+            local mods = Mods.GetGameMods(gameInfo.GameMods)
+            PrefetchSession(scenarioInfo.map, mods, true)
 
         else
             AlertHostMapMissing()

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2308,11 +2308,9 @@ local function UpdateGame()
 
             -- PREFETCHING --
 
-            -- we can't prefetch in combination with PreGameData as the prefs file
-            -- is not updated accordingly, as a result when it is retrieved in
-            -- blueprints.lua it may use the old values. As it is more relevant
-            -- to have custom icon support over having a slightly faster loading
-            -- time we skip the prefetching
+            -- Note that the PreGameData is not properly updated,
+            -- hence we can not rely on mod and / or lobby option
+            -- changes to be present.
 
             local mods = Mods.GetGameMods(gameInfo.GameMods)
             PrefetchSession(scenarioInfo.map, mods, true)


### PR DESCRIPTION
Enables prefetching of the session and the prefetching of unit assets. 

A consequence of prefetching the session is that mods that populate `PreGameData` in the prefs file, like strategic icon mods, require a restart to be updated. The reason for this is simple: the prefs file is not updated until the lobby starts. That happens rarely though, one doesn't switch icon mods that often. 

There is no consequence of prefetching the unit assets, besides less stutters during the game.
