### PR TITLE
add logic for army pool detection and disband blocking

### DIFF
--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -1511,6 +1511,7 @@ AIBrain = Class(moho.aibrain_methods) {
         -- TURNING OFF AI POOL PLATOON, I MAY JUST REMOVE THAT PLATOON FUNCTIONALITY LATER
         local poolPlatoon = self:GetPlatoonUniquelyNamed('ArmyPool')
         if poolPlatoon then
+            poolPlatoon.ArmyPool = true
             poolPlatoon:TurnOffPoolAI()
         end
 

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -247,6 +247,10 @@ Platoon = Class(moho.platoon_methods) {
 
     ---@param self Platoon
     PlatoonDisband = function(self)
+        if self.ArmyPool then
+            WARN('AI WARNING: Platoon trying to disband ArmyPool')
+            return
+        end
         local aiBrain = self:GetBrain()
         if self.BuilderHandle then
             self.BuilderHandle:RemoveHandle(self)

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -249,6 +249,7 @@ Platoon = Class(moho.platoon_methods) {
     PlatoonDisband = function(self)
         if self.ArmyPool then
             WARN('AI WARNING: Platoon trying to disband ArmyPool')
+            --LOG(reprsl(debug.traceback()))
             return
         end
         local aiBrain = self:GetBrain()


### PR DESCRIPTION
Closes #4411 
This PR is designed for the next major patch release, should not be included in a hotfix.

## Description of changes
This PR changes adds an ArmyPool detection to the PlatoonDisband function. It is being put in place to stop units from accidentally disbanding the ArmyPool.
This is a relatively brute force method but any units trying to disband the army pool should not be treated as playing nice. I've added a warning for the AI developer so they will know when one of their units are doing this.

Note : because this sets the bool in the InitializeSkirmishSystems function then this has no impact to Sorian.

## Test setup for the changes
Start a skirmish with the default AI. If a units or platoon trys to disband the ArmyPool it will be blocked and a warning will be logged.
From my own testing I saw some interesting results. On a map like Point of Reach V4 I got 800 instances of this warning, where as another 10km map with no water I got none for the test.
