### PR TITLE
Revert changes to prefetch set

### DIFF
--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -461,17 +461,20 @@ Prefetcher = CreatePrefetchSet()
 
 function DefaultPrefetchSet()
     local set = { models = {}, anims = {}, d3d_textures = {} }
-   for k,file in DiskFindFiles('/units/', '*.scm') do
-       table.insert(set.models,file)
-   end
 
-   for k,file in DiskFindFiles('/units/', '*.sca') do
-       table.insert(set.anims,file)
-   end
+    -- causes an out-of-memory exception
 
-   for k,file in DiskFindFiles('/units/', '*.dds') do
-       table.insert(set.d3d_textures,file)
-   end
+    -- for k,file in DiskFindFiles('/units/', '*.scm') do
+    --     table.insert(set.models,file)
+    -- end
+
+    -- for k,file in DiskFindFiles('/units/', '*.sca') do
+    --     table.insert(set.anims,file)
+    -- end
+
+    -- for k,file in DiskFindFiles('/units/', '*.dds') do
+    --     table.insert(set.d3d_textures,file)
+    -- end
 
     return set
 end


### PR DESCRIPTION
We didn't fully understand the behavior and as a result the game would keep loading and loading in the assets. During testing this didn't happen. But during live games some people keep loading and loading (and crash, at roughly the same time) while other people do not.

Alas, it did help with making the game smoother. But we need a better understanding before we can continue.