### PR TITLE
Default AI string removal from builders

### DIFF
--- a/lua/AI/AIBuilders/AIDefenseBuilders.lua
+++ b/lua/AI/AIBuilders/AIDefenseBuilders.lua
@@ -275,10 +275,10 @@ BuilderGroup {
             NumAssistees = 0, --DUNCAN - was 2
             Construction = {
                 BuildClose = true,
-                AvoidCategory = 'TECH3 ANTIAIR STRUCTURE',
+                AvoidCategory = categories.TECH3 * categories.ANTIAIR * categories.STRUCTURE,
                 maxUnits = 1,
                 maxRadius = 10,
-                AdjacencyCategory = 'SHIELD STUCTURE, FACTORY TECH3, FACTORY TECH2, FACTORY',
+                AdjacencyCategory = categories.SHIELD * categories.STRUCTURE + categories.FACTORY * (categories.TECH3 + categories.TECH2),
                 BuildStructures = {
                     'T3AADefense',
                 },
@@ -903,10 +903,10 @@ BuilderGroup {
         BuilderData = {
             NumAssistees = 2,
             Construction = {
-                AdjacencyCategory = 'ENERGYPRODUCTION EXPERIMENTAL, ENERGYPRODUCTION TECH3, FACTORY TECH3, FACTORY TECH2, ENERGYPRODUCTION TECH2, FACTORY',
+                AdjacencyCategory = categories.ENERGYPRODUCTION * categories.EXPERIMENTAL + categories.ENERGYPRODUCTION * categories.TECH3 + categories.FACTORY * (categories.TECH2 + categories.TECH3) + categories.ENERGYPRODUCTION * categories.TECH2,
                 AdjacencyDistance = 60,
                 BuildClose = false,
-                AvoidCategory = 'SHIELD',
+                AvoidCategory = categories.SHIELD,
                 maxUnits = 1,
                 maxRadius = 10,
                 BuildStructures = {
@@ -1010,10 +1010,10 @@ BuilderGroup {
         BuilderData = {
             NumAssistees = 2,
             Construction = {
-                AdjacencyCategory = 'ENERGYPRODUCTION EXPERIMENTAL, ENERGYPRODUCTION TECH3, FACTORY TECH3, FACTORY TECH2, ENERGYPRODUCTION TECH2, FACTORY',
+                AdjacencyCategory = categories.ENERGYPRODUCTION * categories.EXPERIMENTAL + categories.ENERGYPRODUCTION * categories.TECH3 + categories.FACTORY * (categories.TECH3 + categories.TECH2) - categories.NAVAL + categories.ENERGYPRODUCTION * categories.TECH2,
                 AdjacencyDistance = 60,
                 BuildClose = false,
-                AvoidCategory = 'SHIELD',
+                AvoidCategory = categories.SHIELD,
                 maxUnits = 1,
                 maxRadius = 10,
                 BuildStructures = {
@@ -1051,7 +1051,7 @@ BuilderGroup {
             NumAssistees = 5,
             Construction = {
                 BuildClose = false,
-                AdjacencyCategory = 'FACTORY - NAVAL',
+                AdjacencyCategory = categories.FACTORY - categories.NAVAL,
                 AdjacencyDistance = 100,
                 BuildStructures = {
                     'T3StrategicMissileDefense',
@@ -1379,7 +1379,7 @@ BuilderGroup {
         BuilderData = {
             NumAssistees = 2,
             Construction = {
-                AvoidCategory = 'SHIELD',
+                AvoidCategory = categories.SHIELD,
                 maxUnits = 1,
                 maxRadius = 10,
                 NearUnitCategory = 'COMMAND',
@@ -1413,7 +1413,7 @@ BuilderGroup {
         BuilderData = {
             NumAssistees = 2,
             Construction = {
-                AvoidCategory = 'SHIELD',
+                AvoidCategory = categories.SHIELD,
                 maxUnits = 1,
                 maxRadius = 10,
                 NearUnitCategory = 'COMMAND',

--- a/lua/AI/AIBuilders/AIEconomicBuilders.lua
+++ b/lua/AI/AIBuilders/AIEconomicBuilders.lua
@@ -563,7 +563,7 @@ BuilderGroup {
         BuilderData = {
             DesiresAssist = false,
             Construction = {
-                AdjacencyCategory = 'FACTORY',
+                AdjacencyCategory = categories.FACTORY,
                 BuildStructures = {
                     'T1EnergyProduction',
                 },
@@ -1368,7 +1368,7 @@ BuilderGroup {
         BuilderType = 'Any',
         BuilderData = {
             Construction = {
-                AdjacencyCategory = 'MASSEXTRACTION TECH3, MASSEXTRACTION TECH2',
+                AdjacencyCategory = categories.MASSEXTRACTION * categories.TECH3 + categories.MASSEXTRACTION * categories.TECH2,
                 AdjacencyDistance = 100,
                 BuildClose = false,
                 ThreatMin = -3,
@@ -1434,7 +1434,7 @@ BuilderGroup {
         BuilderType = 'Any',
         BuilderData = {
             Construction = {
-                AdjacencyCategory = 'ENERGYPRODUCTION TECH3',
+                AdjacencyCategory = categories.ENERGYPRODUCTION * categories.TECH3,
                 AdjacencyDistance = 100,
                 BuildClose = false,
                 BuildStructures = {
@@ -2165,7 +2165,7 @@ BuilderGroup {
             NumAssistees = 2,
             Construction = {
                 BuildClose = false, --DUNCAN - seems to work better at placing next to power
-                AdjacencyCategory = 'ENERGYPRODUCTION TECH3, ENERGYPRODUCTION TECH2',
+                AdjacencyCategory = categories.ENERGYPRODUCTION * (categories.TECH3 + categories.TECH2),
                 BuildStructures = {
                     'T3MassCreation',
                 },
@@ -2351,7 +2351,7 @@ BuilderGroup {
             NumAssistees = 2,
             Construction = {
                 BuildClose = true,
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
                 BuildStructures = {
                     'T3MassCreation',
                 },
@@ -2600,7 +2600,7 @@ BuilderGroup {
         BuilderType = 'Any',
         BuilderData = {
             Construction = {
-                AdjacencyCategory = 'FACTORY',
+                AdjacencyCategory = categories.FACTORY * categories.STRUCTURE - categories.NAVAL,
                 BuildStructures = {
                     'T1EnergyProduction',
                 },
@@ -2620,7 +2620,7 @@ BuilderGroup {
         BuilderType = 'Any',
         BuilderData = {
             Construction = {
-                AdjacencyCategory = 'FACTORY',
+                AdjacencyCategory = categories.FACTORY * categories.STRUCTURE - categories.NAVAL,
                 BuildStructures = {
                     'T1EnergyProduction',
                 },
@@ -2641,10 +2641,10 @@ BuilderGroup {
         BuilderData = {
             Construction = {
                 BuildClose = true,
-                AvoidCategory = 'ENERGYPRODUCTION TECH2',
+                AvoidCategory = categories.ENERGYPRODUCTION * categories.TECH2,
                 maxUnits = 5,
                 maxRadius = 15,
-                AdjacencyCategory = 'SHIELD STUCTURE, FACTORY TECH3, FACTORY TECH2, FACTORY TECH1',
+                AdjacencyCategory = categories.SHIELD * categories.STRUCTURE + categories.FACTORY * categories.STRUCTURE - categories.NAVAL,
                 BuildStructures = {
                     'T2EnergyProduction',
                 },
@@ -2665,8 +2665,8 @@ BuilderGroup {
         BuilderData = {
             Construction = {
                 BuildClose = true,
-                AdjacencyCategory = 'SHIELD STUCTURE, FACTORY TECH3, FACTORY TECH2, FACTORY TECH1',
-                AvoidCategory = 'ENERGYPRODUCTION TECH3',
+                AdjacencyCategory = categories.SHIELD * categories.STRUCTURE + categories.FACTORY * categories.STRUCTURE - categories.NAVAL,
+                AvoidCategory = categories.ENERGYPRODUCTION * categories.TECH3,
                 maxUnits = 5,
                 maxRadius = 15,
                 BuildStructures = {
@@ -2763,7 +2763,7 @@ BuilderGroup {
         BuilderType = 'Any',
         BuilderData = {
             Construction = {
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
                 BuildClose = true,
                 FactionIndex = 1,
                 BuildStructures = {
@@ -2787,7 +2787,7 @@ BuilderGroup {
         BuilderType = 'Any',
         BuilderData = {
             Construction = {
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
                 BuildClose = true,
                 FactionIndex = 3,
                 BuildStructures = {
@@ -2811,7 +2811,7 @@ BuilderGroup {
         BuilderType = 'Any',
         BuilderData = {
             Construction = {
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
                 BuildClose = true,
                 FactionIndex = 1,
                 BuildStructures = {
@@ -2835,7 +2835,7 @@ BuilderGroup {
         BuilderType = 'Any',
         BuilderData = {
             Construction = {
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
                 BuildClose = true,
                 FactionIndex = 3,
                 BuildStructures = {

--- a/lua/AI/AIBuilders/AIEconomicBuilders.lua
+++ b/lua/AI/AIBuilders/AIEconomicBuilders.lua
@@ -1368,7 +1368,7 @@ BuilderGroup {
         BuilderType = 'Any',
         BuilderData = {
             Construction = {
-                AdjacencyCategory = categories.MASSEXTRACTION * categories.TECH3 + categories.MASSEXTRACTION * categories.TECH2,
+                AdjacencyCategory = categories.MASSEXTRACTION * ( categories.TECH2 + categories.TECH3 ),
                 AdjacencyDistance = 100,
                 BuildClose = false,
                 ThreatMin = -3,

--- a/lua/AI/AIBuilders/AIFactoryConstructionBuilders.lua
+++ b/lua/AI/AIBuilders/AIFactoryConstructionBuilders.lua
@@ -110,7 +110,7 @@ BuilderGroup {
                     'T1AirFactory',
                 },
                 Location = 'LocationType',
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
             }
         }
     },
@@ -134,7 +134,7 @@ BuilderGroup {
                     'T1AirFactory',
                 },
                 Location = 'LocationType',
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
             }
         }
     },
@@ -183,7 +183,7 @@ BuilderGroup {
                     'T1LandFactory',
                 },
                 Location = 'LocationType',
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
             }
         }
     },
@@ -206,7 +206,7 @@ BuilderGroup {
                     'T1LandFactory',
                 },
                 Location = 'LocationType',
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
             }
         }
     },
@@ -257,7 +257,7 @@ BuilderGroup {
                     'T1LandFactory',
                 },
                 Location = 'LocationType',
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
             }
         }
     },
@@ -305,7 +305,7 @@ BuilderGroup {
                     'T1AirFactory',
                 },
                 Location = 'LocationType',
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
             }
         }
     },
@@ -358,7 +358,7 @@ BuilderGroup {
                     'T1LandFactory',
                 },
                 Location = 'LocationType',
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
             }
         },
     },
@@ -405,7 +405,7 @@ BuilderGroup {
                     'T1AirFactory',
                 },
                 Location = 'LocationType',
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
             }
         }
     },
@@ -455,7 +455,7 @@ BuilderGroup {
                     'T1AirFactory',
                 },
                 Location = 'LocationType',
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
             }
         }
     },
@@ -484,7 +484,7 @@ BuilderGroup {
                     'T3QuantumGate',
                 },
                 Location = 'LocationType',
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
             }
         }
     },

--- a/lua/AI/AIBuilders/AIIntelBuilders.lua
+++ b/lua/AI/AIBuilders/AIIntelBuilders.lua
@@ -381,7 +381,7 @@ BuilderGroup {
         BuilderType = 'Any',
         BuilderData = {
             Construction = {
-                AdjacencyCategory = 'FACTORY -NAVAL',
+                AdjacencyCategory = categories.FACTORY * categories.STRUCTURE - categories.NAVAL,
                 AdjacencyDistance = 100,
                 BuildClose = false,
                 BuildStructures = {
@@ -470,7 +470,7 @@ BuilderGroup {
         BuilderType = 'Any',
         BuilderData = {
             Construction = {
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
                 AdjacencyDistance = 100,
                 BuildClose = false,
                 BuildStructures = {
@@ -498,7 +498,7 @@ BuilderGroup {
         BuilderType = 'Any',
         BuilderData = {
             Construction = {
-                AdjacencyCategory = 'ENERGYPRODUCTION',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
                 AdjacencyDistance = 100,
                 BuildClose = false,
                 BuildStructures = {


### PR DESCRIPTION
**Description of changes**
This PR replaces strings in the default AI's AvoidCategory and AdjacencyCategory properties from builders to userdata. This saves the AI from having to parse all the strings before using them, decreasing function calls.


**Test setup for the changes**
Run an AI skirmish game and confirm no category errors.
Proof read my category maths