### PR TITLE
AI Tuning for early power

### DIFF
--- a/lua/AI/AIBuilders/AIEconomicBuilders.lua
+++ b/lua/AI/AIBuilders/AIEconomicBuilders.lua
@@ -48,7 +48,7 @@ BuilderGroup {
         Priority = 850,
         BuilderConditions = {
             { EBC, 'LessThanEnergyTrendOverTime', { 0.0 } },
-            { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.ENGINEER * categories.TECH1 } },
+            { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.ENGINEER } },
             { UCBC, 'EngineerCapCheck', { 'LocationType', 'Tech1' } },
         },
         BuilderType = 'All',
@@ -94,6 +94,17 @@ BuilderGroup {
         BuilderType = 'All',
     },
     Builder {
+        BuilderName = 'T2 Engineer Power',
+        PlatoonTemplate = 'T2BuildEngineer',
+        Priority = 851,
+        BuilderConditions = {
+            { EBC, 'LessThanEnergyTrendOverTime', { 0.0 } },
+            { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.ENGINEER  } },
+            { UCBC, 'EngineerCapCheck', { 'LocationType', 'Tech2' } },
+        },
+        BuilderType = 'All',
+    },
+    Builder {
         BuilderName = 'T2 Engineer Disband - Filler 1',
         PlatoonTemplate = 'T2BuildEngineer',
         Priority = 800,
@@ -130,6 +141,17 @@ BuilderGroup {
         BuilderConditions = {
             { UCBC,'EngineerLessAtLocation', { 'LocationType', 6, categories.ENGINEER * categories.TECH3 }},
             { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.ENGINEER * categories.TECH3 } },
+            { UCBC, 'EngineerCapCheck', { 'LocationType', 'Tech3' } },
+        },
+        BuilderType = 'All',
+    },
+    Builder {
+        BuilderName = 'T3 Engineer Power',
+        PlatoonTemplate = 'T3BuildEngineer',
+        Priority = 852,
+        BuilderConditions = {
+            { EBC, 'LessThanEnergyTrendOverTime', { 0.0 } },
+            { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.ENGINEER  } },
             { UCBC, 'EngineerCapCheck', { 'LocationType', 'Tech3' } },
         },
         BuilderType = 'All',
@@ -1582,27 +1604,29 @@ BuilderGroup {
     --        },
     --    }
     --},
-    --Builder {
-    --    BuilderName = 'T1 Engineer Assist Power',
-    --    PlatoonTemplate = 'EngineerAssist',
-    --    Priority = 900,
-    --    BuilderConditions = {
-    --        { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, 'ENERGYPRODUCTION' }},
-    --        { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.7, 0.8 }},
-    --        { EBC, 'LessThanEconEfficiencyOverTime', { 2.0, 1.4 }},
-    --    },
-    --    InstanceCount = 2,
-    --    BuilderType = 'Any',
-    --    BuilderData = {
-    --        Assist = {
-    --            AssistLocation = 'LocationType',
-    --            PermanentAssist = true,
-    --            BeingBuiltCategories = {'ENERGYPRODUCTION TECH3', 'ENERGYPRODUCTION TECH2', 'ENERGYPRODUCTION'},
-    --            AssisteeType = 'Engineer',
-    --            Time = 60,
-    --        },
-    --    }
-    --},
+    Builder {
+        BuilderName = 'T1 Engineer Assist Power',
+        PlatoonTemplate = 'EngineerAssist',
+        Priority = 900,
+        BuilderConditions = {
+            { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, 'ENERGYPRODUCTION' }},
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.7, 0.8 }},
+            { EBC, 'LessThanEconEfficiencyOverTime', { 2.0, 1.4 }},
+        },
+        InstanceCount = 2,
+        BuilderType = 'Any',
+        BuilderData = {
+            Assist = {
+                AssistLocation = 'LocationType',
+                AssistRange = 65,
+                AssistUntilFinished = true,
+                AssistClosestUnit = true,
+                BeingBuiltCategories = {'ENERGYPRODUCTION TECH3', 'ENERGYPRODUCTION TECH2', 'ENERGYPRODUCTION'},
+                AssisteeType = 'Engineer',
+                AssisteeCategory = categories.ENGINEER,
+            },
+        }
+    },
     --Builder {
     --    BuilderName = 'T1 Engineer Assist Transport',
     --    PlatoonTemplate = 'EngineerAssist',
@@ -1752,10 +1776,12 @@ BuilderGroup {
         BuilderData = {
             Assist = {
                 AssistLocation = 'LocationType',
-                PermanentAssist = true,
-                BeingBuiltCategories = { 'ENERGYPRODUCTION TECH3', 'ENERGYPRODUCTION TECH2', },
+                AssistRange = 65,
+                AssistUntilFinished = true,
+                AssistClosestUnit = true,
+                BeingBuiltCategories = {'ENERGYPRODUCTION TECH3', 'ENERGYPRODUCTION TECH2'},
                 AssisteeType = 'Engineer',
-                Time = 60,
+                AssisteeCategory = categories.ENGINEER,
             },
         }
     },
@@ -1883,10 +1909,12 @@ BuilderGroup {
         BuilderData = {
             Assist = {
                 AssistLocation = 'LocationType',
-                PermanentAssist = true,
+                AssistRange = 65,
+                AssistUntilFinished = true,
+                AssistClosestUnit = true,
                 BeingBuiltCategories = {'ENERGYPRODUCTION TECH3'},
                 AssisteeType = 'Engineer',
-                Time = 60,
+                AssisteeCategory = categories.ENGINEER,
             },
         }
     },
@@ -2659,12 +2687,12 @@ BuilderGroup {
         BuilderName = 'T1 Power Engineer',
         PlatoonTemplate = 'EngineerBuilder',
         Priority = 1000,
+        InstanceCount = 2,
         BuilderConditions = {
-            { UCBC, 'EngineerLessAtLocation', { 'LocationType', 3, categories.ENGINEER * (categories.TECH2 + categories.TECH3) } },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 0.5 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.7, 0.1 }},
             { EBC, 'LessThanEconEfficiencyOverTime', { 2.0, 1.35 }},
+            { UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.ENERGYPRODUCTION * (categories.TECH2 + categories.TECH3) }},
         },
-        --InstanceCount = 2,
         BuilderType = 'Any',
         BuilderData = {
             Construction = {

--- a/lua/AI/AIBuilders/AIEconomicBuilders.lua
+++ b/lua/AI/AIBuilders/AIEconomicBuilders.lua
@@ -1609,7 +1609,7 @@ BuilderGroup {
         PlatoonTemplate = 'EngineerAssist',
         Priority = 900,
         BuilderConditions = {
-            { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, 'ENERGYPRODUCTION' }},
+            { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.ENERGYPRODUCTION }},
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.7, 0.8 }},
             { EBC, 'LessThanEconEfficiencyOverTime', { 2.0, 1.4 }},
         },


### PR DESCRIPTION

**Description of changes**
This PR tunes the default AI's power builders and supporting builders.

Add second instance of T1 pgen builder. While technically not correct, the AI has a tendency to assign power jobs to engineers that are not within a viable radius of the base, with only a single instance this can lead to big delays in building a T1 pgen which when approaching a stall can be game ending. So having a second builder gives it redundancy in those situations.

Reintroduce T1 engineer power assist. This was previously disabled and misconfigured. I've configured it correctly so that the engineers will be more responsive once an assisted pgen is completed. Previously they would have a static 60 second assist timer which meant that once the pgen was completed they would sit there for another x number of seconds doing nothing.
Reconfigured T2 and T3 power assist builders correctly.

Added emergency engineer builders for power stalls. Each tier will builder engineers priorities should mean that T3 goes first. This is for situations where a power stall is going to happen, limited to only a single engineer being built and will stop at base template engineer cap.



**Test setup for the changes**
This is an observation based test. The AI should be able to recover from power stalls a little quicker and avoid running out of power as easily in the T1 phase. The assisting engineers will not sit there doing nothing after initially assisting a pgen build.