### PR TITLE
Feature/ai structure manager

### DIFF
--- a/lua/AI/AIBaseTemplates/ChallengeMain.lua
+++ b/lua/AI/AIBaseTemplates/ChallengeMain.lua
@@ -32,7 +32,7 @@ BaseBuilderTemplate {
         'EngineerMassBuildersHighPri',
                 
         -- Extractors
-        'ExtractorUpgrades',
+        --'ExtractorUpgrades',
 
         -- ACU Builders
         'Default Initial ACU Builders',

--- a/lua/AI/AIBaseTemplates/NormalMain.lua
+++ b/lua/AI/AIBaseTemplates/NormalMain.lua
@@ -32,7 +32,7 @@ BaseBuilderTemplate {
         'EngineerMassBuildersHighPri',
                 
         -- Extractors
-        'ExtractorUpgrades',
+        --'ExtractorUpgrades',
 
         -- ACU Builders
         'Default Initial ACU Builders',

--- a/lua/AI/AIBaseTemplates/RushExpansionBalancedFull.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionBalancedFull.lua
@@ -44,7 +44,7 @@ BaseBuilderTemplate {
         'T3NukeDefenseBehaviors',
 
         -- Extractors
-        'Time Exempt Extractor Upgrades Expansion',
+        --'Time Exempt Extractor Upgrades Expansion',
 
         -- ==== NAVAL EXPANSION ==== --
         'NavalExpansionBuilders',

--- a/lua/AI/AIBaseTemplates/RushExpansionLandFull.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionLandFull.lua
@@ -44,7 +44,7 @@ BaseBuilderTemplate {
         'T3NukeDefenseBehaviors',
 
         -- Extractors
-        'Time Exempt Extractor Upgrades Expansion',
+        --'Time Exempt Extractor Upgrades Expansion',
 
         -- ==== NAVAL EXPANSION ==== --
         'NavalExpansionBuilders',

--- a/lua/AI/AIBaseTemplates/RushExpansionNaval.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionNaval.lua
@@ -27,7 +27,7 @@ BaseBuilderTemplate {
         'EngineerMassBuildersLowerPri',
 
         -- Extractors
-        'Time Exempt Extractor Upgrades Expansion',
+        --'Time Exempt Extractor Upgrades Expansion',
 
         -- ==== EXPANSION ==== --
         --DUNCAN - expansions dont build more expansions!

--- a/lua/AI/AIBaseTemplates/RushMainAir.lua
+++ b/lua/AI/AIBaseTemplates/RushMainAir.lua
@@ -33,7 +33,7 @@ BaseBuilderTemplate {
         'EngineerMassBuildersHighPri',
 
         -- Extractors
-        'Time Exempt Extractor Upgrades',
+        --'Time Exempt Extractor Upgrades',
 
         -- ACU Builders
         'Air Rush Initial ACU Builders',

--- a/lua/AI/AIBaseTemplates/RushMainBalanced.lua
+++ b/lua/AI/AIBaseTemplates/RushMainBalanced.lua
@@ -33,7 +33,7 @@ BaseBuilderTemplate {
         'EngineerMassBuildersHighPri',
 
         -- Extractors
-        'Time Exempt Extractor Upgrades',
+        --'Time Exempt Extractor Upgrades',
 
         -- ACU Builders
         'Balanced Rush Initial ACU Builders',

--- a/lua/AI/AIBaseTemplates/RushMainLand.lua
+++ b/lua/AI/AIBaseTemplates/RushMainLand.lua
@@ -33,7 +33,7 @@ BaseBuilderTemplate {
         'EngineerMassBuildersHighPri',
 
         -- Extractors
-        'Time Exempt Extractor Upgrades',
+        --'Time Exempt Extractor Upgrades',
 
         -- ACU Builders
         'Land Rush Initial ACU Builders',

--- a/lua/AI/AIBaseTemplates/RushMainNaval.lua
+++ b/lua/AI/AIBaseTemplates/RushMainNaval.lua
@@ -30,7 +30,7 @@ BaseBuilderTemplate {
         'EngineerMassBuilders - Naval',
 
         -- Extractors
-        'Time Exempt Extractor Upgrades',
+        --'Time Exempt Extractor Upgrades',
 
         -- ACU Builders
         'Naval Rush Initial ACU Builders',

--- a/lua/AI/AIBaseTemplates/RushSetons.lua
+++ b/lua/AI/AIBaseTemplates/RushSetons.lua
@@ -33,7 +33,7 @@ BaseBuilderTemplate {
         'EngineerMassBuildersHighPri',
 
         -- Extractors
-        'Time Exempt Extractor Upgrades',
+        --'Time Exempt Extractor Upgrades',
 
         -- ACU Builders
         'Land Rush Initial ACU Builders',

--- a/lua/AI/AIBaseTemplates/TechMain.lua
+++ b/lua/AI/AIBaseTemplates/TechMain.lua
@@ -33,7 +33,7 @@ BaseBuilderTemplate {
         'EngineerMassBuildersHighPri',
 
         -- Extractors
-        'Time Exempt Extractor Upgrades',
+        --'Time Exempt Extractor Upgrades',
 
         -- ACU Builders
         'Default Initial ACU Builders',

--- a/lua/AI/AIBaseTemplates/TechSmall.lua
+++ b/lua/AI/AIBaseTemplates/TechSmall.lua
@@ -33,7 +33,7 @@ BaseBuilderTemplate {
         'EngineerMassBuildersHighPri',
 
         -- Extractors
-        'Time Exempt Extractor Upgrades',
+        --'Time Exempt Extractor Upgrades',
 
         -- ACU Builders
         'Land Rush Initial ACU Builders',

--- a/lua/AI/AIBaseTemplates/TurtleMain.lua
+++ b/lua/AI/AIBaseTemplates/TurtleMain.lua
@@ -33,7 +33,7 @@ BaseBuilderTemplate {
         'EngineerMassBuildersHighPri',
 
         -- Extractors
-        'Time Exempt Extractor Upgrades',
+        --'Time Exempt Extractor Upgrades',
 
         -- ACU Builders
         'Default Initial ACU Builders',

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -1564,6 +1564,11 @@ AIBrain = Class(moho.aibrain_methods) {
             plat:ForkThread(plat.BaseManagersDistressAI)
         end
 
+        if not self.Sorian then
+            self.StructureManager = StructureManager.CreateStructureManager(self)
+            self.StructureManager:Run()
+        end
+
         self.DeadBaseThread = self:ForkThread(self.DeadBaseMonitor)
         if self.Sorian then
             self.EnemyPickerThread = self:ForkThread(self.PickEnemySorian)

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -18,6 +18,7 @@ local FactoryManager = import("/lua/sim/factorybuildermanager.lua")
 local PlatoonFormManager = import("/lua/sim/platoonformmanager.lua")
 local BrainConditionsMonitor = import("/lua/sim/brainconditionsmonitor.lua")
 local EngineerManager = import("/lua/sim/engineermanager.lua")
+local StructureManager = import("/lua/sim/structuremanager.lua")
 
 local SUtils = import("/lua/ai/sorianutilities.lua")
 local StratManager = import("/lua/sim/strategymanager.lua")
@@ -1564,7 +1565,7 @@ AIBrain = Class(moho.aibrain_methods) {
             plat:ForkThread(plat.BaseManagersDistressAI)
         end
 
-        if not self.Sorian then
+        if self:IsDefaultAI() then
             self.StructureManager = StructureManager.CreateStructureManager(self)
             self.StructureManager:Run()
         end
@@ -5047,6 +5048,18 @@ AIBrain = Class(moho.aibrain_methods) {
             end
             WaitTicks(100)
         end
+    end,
+
+    ---@param self AIBrain
+    IsDefaultAI = function(self)
+        local per = ScenarioInfo.ArmySetup[self.Name].AIPersonality
+        if per == 'easy' or per == 'easycheat' or per == 'medium' or per == 'mediumcheat'
+            or per == 'adaptive' or per == 'adaptivecheat' or per == 'rush' or per == 'rushcheat'
+            or per == 'turtle' or per == 'turtlecheat' or per == 'tech' or per == 'techcheat'
+            or per == 'random' or per == 'randomcheat' then
+            return true
+        end
+        return false
     end,
 }
 

--- a/lua/sim/StructureManager.lua
+++ b/lua/sim/StructureManager.lua
@@ -77,7 +77,7 @@ StructureManager = Class {
                 self.CurrentEconomyUpgradeSpend = 0.30
             end
             local extractorTable = self:ExtractorsBeingUpgraded()
-            LOG('Total Spend is '..self.TotalExtractorSpend..' income with ratio is '..upgradeSpend)
+            --LOG('Total Spend is '..self.TotalExtractorSpend..' income with ratio is '..upgradeSpend)
             local massStorage = GetEconomyStored( self.Brain, 'MASS')
             local energyStorage = GetEconomyStored( self.Brain, 'ENERGY')
             -- We have alot of excess mass and no upgrading T2 extractors, lets upgrade one and dump the mass into that

--- a/lua/sim/StructureManager.lua
+++ b/lua/sim/StructureManager.lua
@@ -1,0 +1,405 @@
+local GetEconomyStoredRatio = moho.aibrain_methods.GetEconomyStoredRatio
+local GetEconomyIncome = moho.aibrain_methods.GetEconomyIncome
+local GetEconomyRequested = moho.aibrain_methods.GetEconomyRequested
+local GetEconomyStored = moho.aibrain_methods.GetEconomyStored
+local GetEconomyStoredRatio = moho.aibrain_methods.GetEconomyStoredRatio
+local GetEconomyTrend = moho.aibrain_methods.GetEconomyTrend
+
+local TableGetn = table.getn
+local TableInsert = table.insert
+local TableRemove = table.remove
+local TableSort = table.sort
+
+StructureManager = Class {
+    Create = function(self, brain)
+        self.Brain = brain
+        self.Initialized = false
+        self.Debug = false
+        self.UpgradeStrategy = 'balanced'
+        self.ExtractorData = {
+            EconomyUpgradeSpendDefault = 0.20,
+            CurrentEconomyUpgradeSpend = 0.30,
+            ExtractorsUpgrading = { TECH1 = 0, TECH2 = 0 },
+            CurrentExtractorCount = { TECH1 = 0, TECH2 = 0, TECH3 = 0},
+            EcoMassUpgradeTimeout = 180,
+            TotalExtractorSpend = 0
+        }
+        if brain.CheatEnabled then
+            self.EcoMultiplier = tonumber(ScenarioInfo.Options.CheatMult) or 1.0
+        else
+            self.EcoMultiplier = 1.0
+        end
+        local per = ScenarioInfo.ArmySetup[self.Name].AIPersonality
+        if per == 'turtle' or per == 'turtlecheat' then
+            self.UpgradeStrategy = 'eco'
+            CurrentEconomyUpgradeSpend = 0.35
+        end
+    end,
+
+    Run = function(self)
+        self:ForkThread(self.ExtractorUpgradeThread, self.Brain)
+        if self.Debug then
+            self:ForkThread(self.StructureDebugThread)
+        end
+        self.Initialized = true
+    end,
+
+    ForkThread = function(self, fn, ...)
+        if fn then
+            local thread = ForkThread(fn, self, unpack(arg))
+            self.Brain.Trash:Add(thread)
+            return thread
+        else
+            return nil
+        end
+    end,
+
+    --- Main extractor upgrade loop, this checks economic metrics and upgrades extractors
+    ---@param self Structure Manager
+    ExtractorUpgradeThread = function(self)
+    -- Keep track of how many extractors are currently upgrading
+    -- Right now this is less about making the best decision to upgrade and more about managing the economy while that upgrade is happening.
+        WaitTicks(Random(5,20))
+        while true do
+            local gameTime = GetGameTimeSeconds()
+            local upgradeTrigger = false
+            local upgradeSpend = (self.Brain.EconomyOverTimeCurrent.MassIncome*10)*self.ExtractorData.CurrentEconomyUpgradeSpend
+            if upgradeSpend > 5 or gameTime > (420 / self.EcoMultiplier) then
+                upgradeTrigger = true
+            end
+            if gameTime > (480 / self.EcoMultiplier) and self.CurrentEconomyUpgradeSpend < 0.35 and self.UpgradeStrategy ~= 'eco' then
+                self.CurrentEconomyUpgradeSpend = 0.30
+            end
+            local extractorTable = self:ExtractorsBeingUpgraded()
+            LOG('Total Spend is '..self.TotalExtractorSpend..' income with ratio is '..upgradeSpend)
+            local massStorage = GetEconomyStored( self.Brain, 'MASS')
+            local energyStorage = GetEconomyStored( self.Brain, 'ENERGY')
+            -- We have alot of excess mass and no upgrading T2 extractors, lets upgrade one and dump the mass into that
+            if massStorage > 2500 and energyStorage > 8000 and self.Brain.EconomyOverTimeCurrent.EnergyEfficiencyOverTime >= 1.05 and self.ExtractorData.ExtractorsUpgrading.TECH2 < 1 then
+                self:SelectClosestExtractor(extractorTable, true)
+                WaitTicks(60)
+                continue
+            end
+            if self.ExtractorData.ExtractorsUpgrading.TECH1 < 2 and self.ExtractorData.ExtractorsUpgrading.TECH2 < 1 and upgradeTrigger then
+                -- Check if we can upgrade an extractor now with available upgrade spend and energy efficiency over time
+                if self.TotalExtractorSpend < upgradeSpend and self.Brain.EconomyOverTimeCurrent.EnergyEfficiencyOverTime >= 1.05 then
+                    -- Logic for comparing ratios and income to decide to we should try T1 upgrades only or T1 and T2.
+                    if (self.ExtractorData.CurrentExtractorCount.TECH1 / self.ExtractorData.CurrentExtractorCount.TECH2 >= 1.2) and upgradeSpend - self.TotalExtractorSpend > self.T3ExtractorCost then
+                        self:SelectClosestExtractor(extractorTable, true)
+                    elseif (self.ExtractorData.CurrentExtractorCount.TECH1 / self.ExtractorData.CurrentExtractorCount.TECH2 >= 1.7) or upgradeSpend < 15 then
+                        --LOG('Extractor Ratio of T1 to T2 is >= 1.5 or upgrade spend under 15')
+                        self:SelectClosestExtractor(extractorTable, false)
+                    else
+                        --LOG('Else all tiers upgrade')
+                        self:SelectClosestExtractor(extractorTable, true)
+                    end
+                end
+                WaitTicks(30)
+                -- We have more than a few extractors upgrading. Do we still have excess mass? Lets try more T1 Extractors
+            elseif self.ExtractorData.ExtractorsUpgrading.TECH1 < 5 and massStorage > 150 and upgradeTrigger then
+                if self.TotalExtractorSpend < upgradeSpend and self.Brain.EconomyOverTimeCurrent.EnergyEfficiencyOverTime >= 1.05 then
+                    self:SelectClosestExtractor(extractorTable, false)
+                    WaitTicks(30)
+                end
+                -- We still have excess mass? Lets try another T2 extractor
+            elseif massStorage > 500 and energyStorage > 3000 and self.ExtractorData.ExtractorsUpgrading.TECH2 < 2 then
+                if self.Brain.EconomyOverTimeCurrent.MassEfficiencyOverTime >= 1.05 and self.Brain.EconomyOverTimeCurrent.EnergyEfficiencyOverTime >= 1.05 then
+                    --LOG('We Could upgrade an extractor now with over time')
+                    local massIncome = GetEconomyIncome(self.Brain, 'MASS')
+                    local massRequested = GetEconomyRequested(self.Brain, 'MASS')
+                    local energyIncome = GetEconomyIncome(self.Brain, 'ENERGY')
+                    local energyRequested = GetEconomyRequested(self.Brain, 'ENERGY')
+                    local massEfficiency = math.min(massIncome / massRequested, 2)
+                    local energyEfficiency = math.min(energyIncome / energyRequested, 2)
+                    if energyEfficiency >= 1.05 and massEfficiency >= 1.05 then
+                        --LOG('We Could upgrade an extractor now with instant energyefficiency and mass efficiency')
+                        if self.ExtractorData.CurrentExtractorCount.TECH1 / self.ExtractorData.CurrentExtractorCount.TECH2 >= 1.5 or upgradeSpend < 15 then
+                            --LOG('Trigger all tiers false')
+                            self:SelectClosestExtractor(extractorTable, false)
+                        else
+                            --LOG('Trigger all tiers true')
+                            self:SelectClosestExtractor(extractorTable, true)
+                        end
+                    end
+                    WaitTicks(30)
+                end
+                -- We have alot of excess mass, chances are we just reclaimed something big. Lets throw it at an upgrade.
+            elseif massStorage > 2500 and energyStorage > 8000 then
+                if self.Brain.EconomyOverTimeCurrent.MassEfficiencyOverTime >= 0.8 and self.Brain.EconomyOverTimeCurrent.EnergyEfficiencyOverTime >= 1.05 then
+                    -- We Could upgrade an extractor now with over time efficiency
+                    local massIncome = GetEconomyIncome(self.Brain, 'MASS')
+                    local massRequested = GetEconomyRequested(self.Brain, 'MASS')
+                    local energyIncome = GetEconomyIncome(self.Brain, 'ENERGY')
+                    local energyRequested = GetEconomyRequested(self.Brain, 'ENERGY')
+                    local massEfficiency = math.min(massIncome / massRequested, 2)
+                    local energyEfficiency = math.min(energyIncome / energyRequested, 2)
+                    if energyEfficiency >= 1.0 and massEfficiency >= 0.8 then
+                        -- We Could upgrade an extractor now with instant efficiency
+                        -- Trigger all tiers true
+                        self:SelectClosestExtractor(extractorTable, true)
+                    end
+                    WaitTicks(30)
+                end
+            end
+            WaitTicks(30)
+        end
+    end,
+
+
+    --- Triggers an extractor upgrade after identifying the closest.
+    ---@param self Structure Manager
+    ---@param cats extractorTable a table of extractors that should be available for upgrade
+    ---@param allTiers boolean true/false consider T1 and T2 extractors or just T1
+    SelectClosestExtractor = function(self, extractorTable, allTiers)
+        -- We are going to find the closest extractor to the main base that isn't already upgrading or paused
+        -- You could do smart things select safer extractors here but thats what the initial delay is supposed to do
+        local UnitPos
+        local DistanceToBase
+        local LowestDistanceToBase
+        local lowestUnit = false
+        local BasePosition = self.Brain.BuilderManagers['MAIN'].Position
+        if extractorTable then            
+            if not allTiers then
+                for _, c in extractorTable.TECH1 do
+                    if c and not c.Dead then
+                        if c.InitialDelayCompleted then
+                            if not c:IsUnitState('Upgrading') and not c:IsPaused() then
+                                UnitPos = c:GetPosition()
+                                DistanceToBase = VDist2Sq(BasePosition[1] or 0, BasePosition[3] or 0, UnitPos[1] or 0, UnitPos[3] or 0)
+                                if not LowestDistanceToBase or DistanceToBase < LowestDistanceToBase then
+                                    LowestDistanceToBase = DistanceToBase
+                                    lowestUnit = c
+                                end
+                            end
+                        end
+                    end
+                end
+            else
+                for _, c in extractorTable.TECH1 do
+                    if c and not c.Dead then
+                        if c.InitialDelayCompleted then
+                            if not c:IsUnitState('Upgrading') and not c:IsPaused() then
+                                UnitPos = c:GetPosition()
+                                DistanceToBase = VDist2Sq(BasePosition[1] or 0, BasePosition[3] or 0, UnitPos[1] or 0, UnitPos[3] or 0)
+                                if not LowestDistanceToBase or DistanceToBase < LowestDistanceToBase then
+                                    LowestDistanceToBase = DistanceToBase
+                                    lowestUnit = c
+                                end
+                            end
+                        end
+                    end
+                end
+                for _, c in extractorTable.TECH2 do
+                    if c and not c.Dead then
+                        if c.InitialDelayCompleted then
+                            if not c:IsUnitState('Upgrading') and not c:IsPaused() then
+                                UnitPos = c:GetPosition()
+                                DistanceToBase = VDist2Sq(BasePosition[1] or 0, BasePosition[3] or 0, UnitPos[1] or 0, UnitPos[3] or 0)
+                                if not LowestDistanceToBase or DistanceToBase < LowestDistanceToBase then
+                                    LowestDistanceToBase = DistanceToBase
+                                    lowestUnit = c
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+            if lowestUnit then
+                lowestUnit.CentralBrainExtractorUpgrade = true
+                lowestUnit.DistanceToBase = LowestDistanceToBase
+                if not self.CentralBrainExtractorUnitUpgradeClosest then
+                    self.CentralBrainExtractorUnitUpgradeClosest = lowestUnit
+                end
+                LOG('Closest Extractor is upgrades, distance is '..LowestDistanceToBase)
+                self:ForkThread(self.UpgradeExtractor, lowestUnit, LowestDistanceToBase)
+            else
+                --LOG('There is no lowestUnit')
+            end
+        end
+    end,
+    
+    --- Upgrades an extractor and pauses extractor upgrades if economy is hurting
+    ---@param self Structure Manager
+    ---@param extractorUnit unit Extractor that is going to be upgraded
+    ---@param distanceToBase integer Extractors distance to the main base
+    UpgradeExtractor = function(self, extractorUnit, distanceToBase)
+        LOG('Upgrading Extractor from central brain thread')
+        local upgradeID = extractorUnit.Blueprint.General.UpgradesTo or false
+        if upgradeID then
+            IssueUpgrade({extractorUnit}, upgradeID)
+            WaitTicks(2)
+            local fractionComplete
+            local upgradeTimeStamp = GetGameTimeSeconds()
+            local bypassEcoManager = false
+            local extractorUpgradeTimeoutReached = false
+            local upgradedExtractor = extractorUnit.UnitBeingBuilt
+            if not upgradedExtractor.Dead then
+                fractionComplete = upgradedExtractor:GetFractionComplete()
+            end
+            while extractorUnit and not extractorUnit.Dead and fractionComplete < 1 do
+                --LOG('Upgrading Extractor Loop')
+                --LOG('Unit is '..fractionComplete..' fraction complete')
+                if not self.CentralBrainExtractorUnitUpgradeClosest or self.CentralBrainExtractorUnitUpgradeClosest.Dead then
+                    self.CentralBrainExtractorUnitUpgradeClosest = extractorUnit
+                elseif self.CentralBrainExtractorUnitUpgradeClosest.DistanceToBase > distanceToBase then
+                    self.CentralBrainExtractorUnitUpgradeClosest = extractorUnit
+                    --LOG('This is a new closest extractor upgrading at '..distanceToBase)
+                end
+                if not bypassEcoManager and fractionComplete < 0.65 then
+                    if (GetEconomyTrend(self.Brain, 'MASS') <= 0.0 and GetEconomyStored(self.Brain, 'MASS') <= 150) or GetEconomyStored( self.Brain, 'ENERGY') < 200 then
+                        if not extractorUnit:IsPaused() then
+                            extractorUnit:SetPaused(true)
+                            WaitTicks(10)
+                        end
+                    else
+                        if extractorUnit:IsPaused() then
+                            if self.ExtractorData.ExtractorsUpgrading.TECH1 > 1 or self.ExtractorData.ExtractorsUpgrading.TECH2 > 0 then
+                                if self.CentralBrainExtractorUnitUpgradeClosest and not self.CentralBrainExtractorUnitUpgradeClosest.Dead 
+                                and self.CentralBrainExtractorUnitUpgradeClosest.DistanceToBase == distanceToBase then
+                                    extractorUnit:SetPaused(false)
+                                    WaitTicks(30)
+                                elseif self.ExtractorData.ExtractorsUpgrading.TECH2 > 0 and EntityCategoryContains(categories.TECH1, extractorUnit) then
+                                    extractorUnit:SetPaused(false)
+                                    if extractorUpgradeTimeoutReached then
+                                        WaitTicks(30)
+                                    end
+                                    WaitTicks(30)
+                                elseif GetEconomyStored(self.Brain, 'MASS') > 250 then
+                                    extractorUnit:SetPaused(false)
+                                    WaitTicks(30)
+                                end
+                            else
+                                extractorUnit:SetPaused(false)
+                                WaitTicks(20)
+                            end
+                        end
+                    end
+                end
+                WaitTicks(30)
+                if upgradedExtractor and not upgradedExtractor.Dead then
+                    fractionComplete = upgradedExtractor:GetFractionComplete()
+                end
+                if not extractorUpgradeTimeoutReached then
+                    if GetGameTimeSeconds() - upgradeTimeStamp > self.ExtractorData.EcoMassUpgradeTimeout then
+                        extractorUpgradeTimeoutReached = true
+                    end
+                end
+                if fractionComplete < 1 and extractorUpgradeTimeoutReached and (self.CentralBrainExtractorUnitUpgradeClosest.DistanceToBase == distanceToBase or extractorUnit.MAINBASE) then
+                    bypassEcoManager = true
+                    if extractorUnit:IsPaused() then
+                        extractorUnit:SetPaused(false)
+                    end
+                end
+            end
+            if upgradedExtractor and not upgradedExtractor.Dead then
+                if VDist3Sq(upgradedExtractor:GetPosition(), self.Brain.BuilderManagers['MAIN'].Position) < 6400 then
+                    upgradedExtractor.MAINBASE = true
+                end
+            end
+        else
+            WARN('No upgrade id provided to UpgradeExtractor, unit id is '..extractorUnit.UnitId)
+        end
+        WaitTicks(80)
+    end,
+
+    --- Stops the unit from being upgraded until it has been alive for a certain amount of time
+    ---@param self Structure Manager
+    ---@param unit unit Extractor
+    ExtractorInitialDelay = function(self, unit)
+        local initial_delay = 0
+        local ecoStartTime = GetGameTimeSeconds()
+        local ecoTimeOut = 300
+
+        unit.InitialDelayCompleted = false
+        unit.InitialDelayStarted = true
+        --LOG('Initial Delay loop starting')
+        while initial_delay < (50 / self.EcoMultiplier) do
+            if not IsDestroyed(unit) then
+                if GetEconomyStored( self.Brain, 'ENERGY') >= 150 and unit:GetFractionComplete() == 1 then
+                    initial_delay = initial_delay + 10
+                    if (GetGameTimeSeconds() - ecoStartTime) > ecoTimeOut then
+                        initial_delay = 50
+                    end
+                end
+            else
+                return
+            end
+            WaitTicks(100)
+        end
+        unit.InitialDelayCompleted = true
+    end,
+
+    ExtractorsBeingUpgraded = function(self)
+        -- Returns number of extractors upgrading
+        local ALLBPS = __blueprints
+        local extractors = self.Brain:GetListOfUnits(categories.MASSEXTRACTION, false)
+        local tech1ExtNumBuilding = 0
+        local tech2ExtNumBuilding = 0
+        local tech1Total = 0
+        local tech2Total = 0
+        local tech3Total = 0
+        local totalSpend = 0
+        local extractorTable = {
+            TECH1 = {},
+            TECH2 = {}
+        }
+
+        -- loop over all units and search for upgrading units
+        for _, extractor in extractors do
+            if not IsDestroyed(extractor) and extractor:GetFractionComplete() == 1 then
+                if not extractor.InitialDelayStarted then
+                    self:ForkThread(self.ExtractorInitialDelay, extractor)
+                end
+                if extractor.Blueprint.CategoriesHash.TECH1 then
+                    tech1Total = tech1Total + 1
+                    if not self.T2ExtractorCost then
+                        local upgradeId = extractor.Blueprint.General.UpgradesTo
+                        self.T2ExtractorCost = (ALLBPS[upgradeId].Economy.BuildCostMass / ALLBPS[upgradeId].Economy.BuildTime * (ALLBPS[extractor.UnitId].Economy.BuildRate * self.EcoMultiplier))
+                    end
+                    if extractor:IsUnitState('Upgrading') then
+                        local upgradeId = extractor.Blueprint.General.UpgradesTo
+                        totalSpend = totalSpend +  (ALLBPS[upgradeId].Economy.BuildCostMass / ALLBPS[upgradeId].Economy.BuildTime * (ALLBPS[extractor.UnitId].Economy.BuildRate * self.EcoMultiplier))
+                        LOG('Extractor Spend T1 '..(ALLBPS[upgradeId].Economy.BuildCostMass / ALLBPS[upgradeId].Economy.BuildTime * (ALLBPS[extractor.UnitId].Economy.BuildRate * self.EcoMultiplier)))
+                        tech1ExtNumBuilding = tech1ExtNumBuilding + 1
+                    else
+                        TableInsert(extractorTable.TECH1, extractor)
+                    end
+                elseif extractor.Blueprint.CategoriesHash.TECH2 then
+                    tech2Total = tech2Total + 1
+                    if not self.T3ExtractorCost then
+                        local upgradeId = extractor.Blueprint.General.UpgradesTo
+                        self.T3ExtractorCost = (ALLBPS[upgradeId].Economy.BuildCostMass / ALLBPS[upgradeId].Economy.BuildTime * (ALLBPS[extractor.UnitId].Economy.BuildRate * self.EcoMultiplier))
+                    end
+                    if extractor:IsUnitState('Upgrading') then
+                        local upgradeId = extractor.Blueprint.General.UpgradesTo
+                        totalSpend = totalSpend + (ALLBPS[upgradeId].Economy.BuildCostMass / ALLBPS[upgradeId].Economy.BuildTime * (ALLBPS[extractor.UnitId].Economy.BuildRate * self.EcoMultiplier))
+                        LOG('Extractor Spend T2 '..(ALLBPS[upgradeId].Economy.BuildCostMass / ALLBPS[upgradeId].Economy.BuildTime * (ALLBPS[extractor.UnitId].Economy.BuildRate * self.EcoMultiplier)))
+                        tech2ExtNumBuilding = tech2ExtNumBuilding + 1
+                    else
+                        TableInsert(extractorTable.TECH2, extractor)
+                    end
+                elseif extractor.Blueprint.CategoriesHash.TECH3 then
+                    tech3Total = tech3Total + 1
+                end
+            end
+        end
+        self.TotalExtractorSpend = totalSpend
+        self.ExtractorData.ExtractorsUpgrading.TECH1 = tech1ExtNumBuilding
+        self.ExtractorData.ExtractorsUpgrading.TECH2 = tech2ExtNumBuilding
+        self.ExtractorData.CurrentExtractorCount.TECH1 = tech1Total
+        self.ExtractorData.CurrentExtractorCount.TECH2 = tech2Total
+        self.ExtractorData.CurrentExtractorCount.TECH3 = tech3Total
+        return extractorTable
+    end,
+}
+
+function CreateStructureManager(brain)
+    local sm 
+    sm = StructureManager()
+    sm:Create(brain)
+    return sm
+end
+
+function GetStructureManager(brain)
+    return brain.StructureManager
+end


### PR DESCRIPTION
**Description of changes**
This PR implements the Structure Mananger. Along with a first implementation of its use which is extractor upgrades.

**Goal of the Structure Manager**
The structure managers primary goal is to allow the AI to perform structure upgrades without using the Platoon Former Manager. Currently all upgrades leverage the platoon former. This places stress on the manager who's primary design goal is to form platoons of units for combat etc. By moving upgraders away from the platoon former the AI will have more responsive platoon formers and a shorter condition loop.

The other main advantage of the Structure Mananger is that its a centralized logic thread so there is only a single source of triggers. Historically all the builder conditions are checked individually which can/will result in the AI being unable to control which upgrades take place without complex builder conditions and even then the nature of conditions could mean multiples triggers could happen when they are unwanted.

I've tried to make the Structure Manager as self contained as possible. So most data is held within it where possible. This is to try and avoid future developers making changes to other parts of the AI without realising they may be impacting this class.

**Current framework**
The manager is desired to be modular in its approach so they other types of structure upgrades can be added easily. Currently it doesn't really do that. I would like assistance on how to better make this a part of it without losing the advantages of logic potential for each structure type.
It currently will spin up a single structure upgrade thread which runs on a 3 second loop if no upgrades are available and 6 seconds if they are.
Compared to the builder manager equivalents this is a much slower thread loop but consistent. The default condition monitors loop time can range from 0.15 seconds to 40 seconds depending on the strain on the condition monitor.

**The Extractor thread**
I've put an excessive amount of comments in the extractor thread so the readers both technical and non technical will understand what is going on.

For Players wanting to review logic. You want to be looking at 
ExtractorUpgradeThread -- Responsible for upgrade triggers.
SelectClosestExtractor -- Responsible for selecting a specific extractor to upgrade once the trigger has happened.
UpgradeExtractor -- Responsible for the upgrade thread that runs on each extractor, will pause extractor upgrades if economy is hurting up to a certain time limit.

**Help Wanted**
I'm open to any and all technical advice on improving the framework and structure of this class as I don't have much experience with lua classes and general best practice programming.
I'm open to advice for improving logic triggers and other game play based decision making. I think some of the advanced FAF players could help alot in this area.

Notes about trigger logic and why I made some of the decisions.
It must be taken into account that this logic needs to be able to function across a range of maps and gameplay styles.
From maps where the player only gets 4 or 5 extractors to maps where they get many.
From gameplay styles like ladder to team play to turtle styles.

There may well be other metrics (like mass point share, team game spawn positions etc) that could help influence the logic and I'm open to advice on this as well . The goal is to try and have the AI more intelligently manage its structure upgrades without getting stuck down a certain style of play or map type. Keep in mind that people still play the game on potatoes so performance is a consideration.


**Test setup for the changes**
This branch contains all changes required to make the Structure Manager function for all default AI so you just need to start a skirmish game with a default AI and it will be operational. The existing builders for extractor are commented out but will be removed before this is merged.
Note that the extractor upgrades will try to work with the AI's current economic situation. But the if the AI is making bad decisions (which is does) then it will struggle to get upgrades done. 
I've done tuning for the AI's early game to assist the structure manager in this way. But the T3 phase can cause issues. Mainly due to the wild swings that different construction projects create on the economy and the mass consumption a engineer will have on one project vs another.


**Future functionality**
I'd like the Structure Manager to more easily be able to have more structure types added rather than having to build now threads of each type. For things like extractors and factories I'm not sure that is possible but for things like radars and shields it might be.
For extractors I'd like the manager to take into account imap threat and rather than selecting the closest extractor, selecting the best.