### PR TITLE
Allow Sparkys to Build Stealth and T1 Factories

### DIFF
--- a/units/XEL0209/XEL0209_unit.bp
+++ b/units/XEL0209/XEL0209_unit.bp
@@ -198,8 +198,8 @@ UnitBlueprint {
         BuildableCategory = {
             'BUILTBYTIER2ENGINEER DEFENSE UEF',
             'BUILTBYTIER2ENGINEER INDIRECTFIRE UEF',
-            'BUILTBYTIER2ENGINEER RADAR UEF',
-            'BUILTBYTIER2ENGINEER SONAR UEF',
+            'BUILTBYTIER2ENGINEER INTELLIGENCE UEF',
+            'BUILTBYTIER1ENGINEER FACTORY UEF',
         },
         MaintenanceConsumptionPerSecondEnergy = 15,
         StorageEnergy = 200,


### PR DESCRIPTION
Adjusted the old way of adding radar and sonar to just adding all `INTELLIGENCE` buildings, this includes stealth gens.  Added t1 factories.

Updates buildables: 
![image](https://user-images.githubusercontent.com/68761514/202930882-158d787a-eb33-4a27-8f8c-dc0c4c32d9a3.png)
![Screenshot from 2022-11-20 17-52-08](https://user-images.githubusercontent.com/68761514/202930893-a524acd4-edd6-4afe-95a1-721f1294fead.png)
