### PR TITLE
fix typo in path check thread for AI.

### DIFF
--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -5028,7 +5028,7 @@ AIBrain = Class(moho.aibrain_methods) {
                 elseif self.CanPathToEnemy[OwnIndex][EnemyIndex][k] == 'Amphibious' then
                     WaitTicks(5)
                     continue
-                elseif self.CanPathToEnemyRNG[OwnIndex][EnemyIndex][k] == 'Air' then
+                elseif self.CanPathToEnemy[OwnIndex][EnemyIndex][k] == 'Air' then
                     WaitTicks(5)
                     continue
                 end


### PR DESCRIPTION
**Description of changes**
This PR fixes a small typo in the path check thread running on the AI that caused an if statement to always return false. From a functionality perspective it wasn't visible as it just meant that the AI would constantly recheck pathing on maps (like Air Wars) with no land or amphibious paths available. Not many maps have this scenario.

**Testing changes**
Testing just requires logging the loop if statement check to make sure the thread wouldn't recheck paths on specific maps.