### PR TITLE
AI Factory Builder Retune phase 1

### DIFF
--- a/lua/AI/AIBaseTemplates/ChallengeExpansion.lua
+++ b/lua/AI/AIBaseTemplates/ChallengeExpansion.lua
@@ -20,7 +20,7 @@ BaseBuilderTemplate {
         'T1EngineerBuilders',
         'T2EngineerBuilders',
         'T3EngineerBuilders',
-        'EngineerFactoryConstruction',
+        'EngineerFactoryConstructionExpansion',
         
         -- ==== LAND UNIT BUILDERS ==== --
         'T1LandFactoryBuilders',

--- a/lua/AI/AIBaseTemplates/ChallengeMain.lua
+++ b/lua/AI/AIBaseTemplates/ChallengeMain.lua
@@ -84,7 +84,7 @@ BaseBuilderTemplate {
     },
     BaseSettings = {
         FactoryCount = {
-            Land = 3,
+            Land = 4,
             Air = 2,
             Sea = 0,
             Gate = 1,
@@ -96,8 +96,8 @@ BaseBuilderTemplate {
             SCU = 1,
         },
         MassToFactoryValues = {
-            T1Value = 6,
-            T2Value = 15,
+            T1Value = 5,
+            T2Value = 14,
             T3Value = 22.5
         },
     },

--- a/lua/AI/AIBaseTemplates/NormalMain.lua
+++ b/lua/AI/AIBaseTemplates/NormalMain.lua
@@ -73,7 +73,7 @@ BaseBuilderTemplate {
     },
     BaseSettings = {
         FactoryCount = {
-            Land = 1,
+            Land = 2,
             Air = 1,
             Sea = 0,
             Gate = 1,
@@ -85,8 +85,8 @@ BaseBuilderTemplate {
             SCU = 1,
         },
         MassToFactoryValues = {
-            T1Value = 6,
-            T2Value = 15,
+            T1Value = 5,
+            T2Value = 14,
             T3Value = 22.5
         },
     },

--- a/lua/AI/AIBaseTemplates/RushExpansionAirFull.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionAirFull.lua
@@ -20,8 +20,7 @@ BaseBuilderTemplate {
         'T1EngineerBuilders',
         'T2EngineerBuilders',
         'T3EngineerBuilders',
-        'EngineerFactoryConstruction',
-        'EngineerFactoryConstructionAirHigherPriority',
+        'EngineerFactoryConstructionExpansion',
         'AirInitialFactoryConstruction',
 
         -- Build Mass low pri at this base
@@ -29,11 +28,6 @@ BaseBuilderTemplate {
 
         -- Build some power, but not much
         'EngineerEnergyBuildersExpansions',
-
-        -- ==== EXPANSION ==== --
-        --DUNCAN - expansions dont build more expansions!
-        --'EngineerExpansionBuildersFull',
-        --'EngineerExpansionBuildersSmall',
 
         -- ==== DEFENSES ==== --
         'T1LightDefenses',

--- a/lua/AI/AIBaseTemplates/RushExpansionAirSmall.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionAirSmall.lua
@@ -20,8 +20,7 @@ BaseBuilderTemplate {
         'T1EngineerBuilders',
         'T2EngineerBuilders',
         'T3EngineerBuilders',
-        'EngineerFactoryConstruction',
-        'EngineerFactoryConstructionAirHigherPriority',
+        'EngineerFactoryConstructionExpansion',
         'AirInitialFactoryConstruction',
 
         -- Build Mass low pri at this base

--- a/lua/AI/AIBaseTemplates/RushExpansionBalancedFull.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionBalancedFull.lua
@@ -20,7 +20,7 @@ BaseBuilderTemplate {
         'T1EngineerBuilders',
         'T2EngineerBuilders',
         'T3EngineerBuilders',
-        'EngineerFactoryConstruction',
+        'EngineerFactoryConstructionExpansion',
         'LandInitialFactoryConstruction',
 
         -- Build Mass low pri at this base
@@ -28,11 +28,6 @@ BaseBuilderTemplate {
 
         -- Build some power, but not much
         'EngineerEnergyBuildersExpansions',
-
-        -- ==== EXPANSION ==== --
-        --DUNCAN - expansions dont build more expansions!
-        --'EngineerExpansionBuildersFull',
-        --'EngineerExpansionBuildersSmall',
 
         -- ==== DEFENSES ==== --
         'T1LightDefenses',

--- a/lua/AI/AIBaseTemplates/RushExpansionBalancedSmall.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionBalancedSmall.lua
@@ -20,7 +20,7 @@ BaseBuilderTemplate {
         'T1EngineerBuilders',
         'T2EngineerBuilders',
         'T3EngineerBuilders',
-        'EngineerFactoryConstruction',
+        'EngineerFactoryConstructionExpansion',
         'LandInitialFactoryConstruction',
 
         -- Extractor building

--- a/lua/AI/AIBaseTemplates/RushExpansionLandFull.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionLandFull.lua
@@ -20,7 +20,7 @@ BaseBuilderTemplate {
         'T1EngineerBuilders',
         'T2EngineerBuilders',
         'T3EngineerBuilders',
-        'EngineerFactoryConstruction',
+        'EngineerFactoryConstructionExpansion',
         'LandInitialFactoryConstruction',
 
         -- Build Mass low pri at this base
@@ -28,11 +28,6 @@ BaseBuilderTemplate {
 
         -- Build some power, but not much
         'EngineerEnergyBuildersExpansions',
-
-        -- ==== EXPANSION ==== --
-        --DUNCAN - expansions dont build more expansions!
-        --'EngineerExpansionBuildersFull',
-        --'EngineerExpansionBuildersSmall',
 
         -- ==== DEFENSES ==== --
         'T1LightDefenses',

--- a/lua/AI/AIBaseTemplates/RushExpansionLandSmall.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionLandSmall.lua
@@ -20,7 +20,7 @@ BaseBuilderTemplate {
         'T1EngineerBuilders',
         'T2EngineerBuilders',
         'T3EngineerBuilders',
-        'EngineerFactoryConstruction',
+        'EngineerFactoryConstructionExpansion',
         'LandInitialFactoryConstruction',
 
         -- Build Mass low pri at this base

--- a/lua/AI/AIBaseTemplates/RushExpansionNaval.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionNaval.lua
@@ -21,17 +21,12 @@ BaseBuilderTemplate {
         'T2EngineerBuilders',
         'T3EngineerBuilders',
         'EngineerFactoryConstruction',
-        'EngineerFactoryConstructionAirHigherPriority',
 
         -- Build Mass high pri at this base
         'EngineerMassBuildersLowerPri',
 
         -- Extractors
         'Time Exempt Extractor Upgrades Expansion',
-
-        -- ==== EXPANSION ==== --
-        --DUNCAN - expansions dont build more expansions!
-        --'EngineerExpansionBuildersFull - Naval',
 
         -- ==== DEFENSES ==== --
         'T2MissileDefenses',

--- a/lua/AI/AIBaseTemplates/RushMainAir.lua
+++ b/lua/AI/AIBaseTemplates/RushMainAir.lua
@@ -21,7 +21,6 @@ BaseBuilderTemplate {
         'T2EngineerBuilders',
         'T3EngineerBuilders',
         'EngineerFactoryConstruction',
-        'EngineerFactoryConstructionAirHigherPriority',
 
         -- Engineer Support buildings
         'EngineeringSupportBuilder',

--- a/lua/AI/AIBaseTemplates/RushMainBalanced.lua
+++ b/lua/AI/AIBaseTemplates/RushMainBalanced.lua
@@ -21,7 +21,6 @@ BaseBuilderTemplate {
         'T2EngineerBuilders',
         'T3EngineerBuilders',
         'EngineerFactoryConstruction',
-        'EngineerFactoryConstruction Balance',
 
         -- Engineer Support buildings
         'EngineeringSupportBuilder',
@@ -166,8 +165,8 @@ BaseBuilderTemplate {
             Gate = 1,
         },
         MassToFactoryValues = {
-            T1Value = 6,
-            T2Value = 15,
+            T1Value = 5,
+            T2Value = 14,
             T3Value = 22.5
         },
     },

--- a/lua/AI/AIBaseTemplates/RushMainLand.lua
+++ b/lua/AI/AIBaseTemplates/RushMainLand.lua
@@ -21,7 +21,6 @@ BaseBuilderTemplate {
         'T2EngineerBuilders',
         'T3EngineerBuilders',
         'EngineerFactoryConstruction',
-        'EngineerFactoryConstructionLandHigherPriority',
 
         -- Engineer Support buildings
         'EngineeringSupportBuilder',
@@ -164,8 +163,8 @@ BaseBuilderTemplate {
             Gate = 1,
         },
         MassToFactoryValues = {
-            T1Value = 6,
-            T2Value = 15,
+            T1Value = 5,
+            T2Value = 14,
             T3Value = 22.5
         },
     },

--- a/lua/AI/AIBaseTemplates/RushMainNaval.lua
+++ b/lua/AI/AIBaseTemplates/RushMainNaval.lua
@@ -21,7 +21,6 @@ BaseBuilderTemplate {
         'T2EngineerBuilders',
         'T3EngineerBuilders',
         'EngineerFactoryConstruction',
-        'EngineerFactoryConstructionAirHigherPriority',
 
         -- Build energy at this base
         'EngineerEnergyBuilders',
@@ -132,7 +131,7 @@ BaseBuilderTemplate {
             Gate = 1,
         },
         MassToFactoryValues = {
-            T1Value = 8,
+            T1Value = 6,
             T2Value = 20,
             T3Value = 40,
         },

--- a/lua/AI/AIBaseTemplates/RushSetons.lua
+++ b/lua/AI/AIBaseTemplates/RushSetons.lua
@@ -21,7 +21,6 @@ BaseBuilderTemplate {
         'T2EngineerBuilders',
         'T3EngineerBuilders',
         'EngineerFactoryConstruction',
-        'EngineerFactoryConstruction Balance',
 
         -- Engineer Support buildings
         'EngineeringSupportBuilder',
@@ -168,8 +167,8 @@ BaseBuilderTemplate {
             Gate = 1,
         },
         MassToFactoryValues = {
-            T1Value = 6,
-            T2Value = 15,
+            T1Value = 5,
+            T2Value = 14,
             T3Value = 22.5
         },
     },

--- a/lua/AI/AIBaseTemplates/TechExpansion.lua
+++ b/lua/AI/AIBaseTemplates/TechExpansion.lua
@@ -20,9 +20,8 @@ BaseBuilderTemplate {
         'T1EngineerBuilders',
         'T2EngineerBuilders',
         'T3EngineerBuilders',
-        'EngineerFactoryConstruction',
+        'EngineerFactoryConstructionExpansion',
         'LandInitialFactoryConstruction',
-        'EngineerFactoryConstructionLandHigherPriority',
 
         -- Build some power, but not much
         'EngineerEnergyBuildersExpansions',

--- a/lua/AI/AIBaseTemplates/TechExpansionSmall.lua
+++ b/lua/AI/AIBaseTemplates/TechExpansionSmall.lua
@@ -20,9 +20,8 @@ BaseBuilderTemplate {
         'T1EngineerBuilders',
         'T2EngineerBuilders',
         'T3EngineerBuilders',
-        'EngineerFactoryConstruction',
+        'EngineerFactoryConstructionExpansion',
         'LandInitialFactoryConstruction',
-        'EngineerFactoryConstructionLandHigherPriority',
 
         -- ==== DEFENSES ==== --
         'T1BaseDefenses',

--- a/lua/AI/AIBaseTemplates/TechMain.lua
+++ b/lua/AI/AIBaseTemplates/TechMain.lua
@@ -21,7 +21,6 @@ BaseBuilderTemplate {
         'T2EngineerBuilders',
         'T3EngineerBuilders',
         'EngineerFactoryConstruction',
-        'EngineerFactoryConstructionAirHigherPriority',
 
         -- Engineer Support buildings
         'EngineeringSupportBuilder',

--- a/lua/AI/AIBaseTemplates/TechSmall.lua
+++ b/lua/AI/AIBaseTemplates/TechSmall.lua
@@ -21,7 +21,6 @@ BaseBuilderTemplate {
         'T2EngineerBuilders',
         'T3EngineerBuilders',
         'EngineerFactoryConstruction',
-        'EngineerFactoryConstructionLandHigherPriority',
 
         -- Engineer Support buildings
         'EngineeringSupportBuilder',

--- a/lua/AI/AIBaseTemplates/TurtleExpansion.lua
+++ b/lua/AI/AIBaseTemplates/TurtleExpansion.lua
@@ -20,8 +20,7 @@ BaseBuilderTemplate {
         'T1EngineerBuilders',
         'T2EngineerBuilders',
         'T3EngineerBuilders',
-        'EngineerFactoryConstruction',
-        'EngineerFactoryConstructionLandHigherPriority',
+        'EngineerFactoryConstructionExpansion',
 
         -- Build some power, but not much
         'EngineerEnergyBuildersExpansions',
@@ -31,16 +30,6 @@ BaseBuilderTemplate {
 
         -- Engineer Support buildings
         'EngineeringSupportBuilder',
-
-        -- ACU Builders
-        'Default Initial ACU Builders',
-        'ACUBuilders',
-        'ACUUpgrades',
-
-        -- ==== EXPANSION ==== --
-        --DUNCAN - expansions dont build expansions!
-        --'EngineerExpansionBuildersFull',
-        --'EngineerFirebaseBuilders',
 
         -- ==== DEFENSES ==== --
         'T1BaseDefenses',
@@ -144,6 +133,7 @@ BaseBuilderTemplate {
         },
     },
     ExpansionFunction = function(aiBrain, location, markerType)
+        -- This is wrong. This would allow the template to potentially be used on ARMY_# marker. Fix later.
         local personality = ScenarioInfo.ArmySetup[aiBrain.Name].AIPersonality
         if not(personality == 'adaptive' or personality == 'turtle') then
             return 0

--- a/lua/AI/AIBaseTemplates/TurtleMain.lua
+++ b/lua/AI/AIBaseTemplates/TurtleMain.lua
@@ -21,7 +21,6 @@ BaseBuilderTemplate {
         'T2EngineerBuilders',
         'T3EngineerBuilders',
         'EngineerFactoryConstruction',
-        'EngineerFactoryConstructionAirHigherPriority',
 
         -- Engineer Support buildings
         'EngineeringSupportBuilder',

--- a/lua/AI/AIBuilders/AIAirAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AIAirAttackBuilders.lua
@@ -350,14 +350,13 @@ BuilderGroup {
         PlatoonTemplate = 'T1AirTransport',
         Priority = 850,
         BuilderConditions = {
-            { MIBC, 'MapGreaterThan', { 256, 256 }},
-            { MIBC, 'ArmyNeedsTransports', {} },
-            { MIBC, 'LessThanGameTime', { 600 } },
-            { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.TRANSPORTFOCUS } },
-            { UCBC, 'HaveLessThanUnitsWithCategory', { 2, categories.TRANSPORTFOCUS } },
-            { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.TRANSPORTFOCUS } },
             { IBC, 'BrainNotLowPowerMode', {} },
+            { MIBC, 'ArmyNeedsTransports', {} },
+            { MIBC, 'MapGreaterThan', { 256, 256 }},
+            { MIBC, 'LessThanGameTime', { 600 } },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.6, 1.05 }},
+            { UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.TRANSPORTFOCUS } },
+            { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.TRANSPORTFOCUS } },
         },
         BuilderType = 'Air',
     },
@@ -366,13 +365,12 @@ BuilderGroup {
         PlatoonTemplate = 'T1AirTransport',
         Priority = 560, --DUNCAN - was 550
         BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
             { MIBC, 'ArmyNeedsTransports', {} },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},  --DUNCAN - was 0.9
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
-            { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.TRANSPORTFOCUS } },
             { UCBC, 'HaveLessThanUnitsWithCategory', { 3, categories.TRANSPORTFOCUS } }, --DUNCAN - was 25
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.TRANSPORTFOCUS } },
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.6, 1.05 }},  --DUNCAN - was 0.9
         },
         BuilderType = 'Air',
     },
@@ -381,14 +379,13 @@ BuilderGroup {
         PlatoonTemplate = 'T2AirTransport',
         Priority = 650,
         BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
             { MIBC, 'ArmyNeedsTransports', {} },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},  --DUNCAN - was 0.9
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 10, categories.LAND * (categories.TECH2 + categories.TECH3) } }, --DUNCAN - added
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
-            { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 2, categories.TRANSPORTFOCUS } },
             { UCBC, 'HaveLessThanUnitsWithCategory', { 3, categories.TRANSPORTFOCUS * categories.TECH2 } }, --DUNCAN - was 25
-            { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.TRANSPORTFOCUS } },
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.6, 1.05 }},  --DUNCAN - was 0.9
+            { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 2, categories.TRANSPORTFOCUS } },
         },
         BuilderType = 'Air',
     },
@@ -397,15 +394,14 @@ BuilderGroup {
         PlatoonTemplate = 'T3AirTransport',
         Priority = 750,
         BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
             { MIBC, 'ArmyNeedsTransports', {} },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.05 }},
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 10, categories.LAND * categories.TECH3 } }, --DUNCAN - added
-            { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 2, categories.TRANSPORTFOCUS } },
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 10, categories.LAND *  categories.TECH3 } }, --DUNCAN - added
             { UCBC, 'HaveLessThanUnitsWithCategory', { 4, categories.TRANSPORTFOCUS * categories.TECH2 } },
             { UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.TRANSPORTFOCUS * categories.TECH3 } }, --DUNCAN - was 25
-            { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.TRANSPORTFOCUS } },
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.05 }},
+            { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 2, categories.TRANSPORTFOCUS } },
         },
         BuilderType = 'Air',
     },
@@ -415,12 +411,12 @@ BuilderGroup {
         PlatoonTemplate = 'T1AirTransport',
         Priority = 500,
         BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
+            { MIBC, 'ArmyNeedsTransports', {} },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},  --DUNCAN - was 0.9
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
             { UCBC, 'HaveLessThanUnitsWithCategory', { 5 , categories.TRANSPORTFOCUS} },
-            { MIBC, 'ArmyNeedsTransports', {} },
             { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.TRANSPORTFOCUS } },
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.6, 1.05 }},  --DUNCAN - was 0.9
         },
         BuilderType = 'Air',
     },
@@ -429,13 +425,13 @@ BuilderGroup {
         PlatoonTemplate = 'T2AirTransport',
         Priority = 600,
         BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
+            { MIBC, 'ArmyNeedsTransports', {} },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},  --DUNCAN - was 0.9
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 8, categories.LAND * (categories.TECH2 + categories.TECH3) } }, --DUNCAN - added
             { UCBC, 'HaveLessThanUnitsWithCategory', { 3 , categories.TRANSPORTFOCUS * categories.TECH2} },
-            { MIBC, 'ArmyNeedsTransports', {} },
             { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.TRANSPORTFOCUS } },
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.6, 1.05 }},  --DUNCAN - was 0.9
         },
         BuilderType = 'Air',
     },
@@ -444,14 +440,14 @@ BuilderGroup {
         PlatoonTemplate = 'T3AirTransport',
         Priority = 700,
         BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
+            { MIBC, 'ArmyNeedsTransports', {} },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.05 }},
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
             { UCBC, 'HaveLessThanUnitsWithCategory', { 4, categories.TRANSPORTFOCUS * categories.TECH2 } }, --DUNCAN - Added
             { UCBC, 'HaveLessThanUnitsWithCategory', { 2 , categories.TRANSPORTFOCUS * categories.TECH3} },
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 10, categories.LAND * categories.TECH3 } }, --DUNCAN - added
-            { MIBC, 'ArmyNeedsTransports', {} },
             { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.TRANSPORTFOCUS } },
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.05 }},
         },
         BuilderType = 'Air',
     },
@@ -461,11 +457,11 @@ BuilderGroup {
         PlatoonTemplate = 'T1AirTransport',
         Priority = 700,
         BuilderConditions = {
-            { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
-            { MIBC, 'TransportNeedGreater', { 7 } },
-            { UCBC, 'HaveLessThanUnitsWithCategory', { 7, categories.TRANSPORTFOCUS * categories.TECH1 } }, --DUNCAN - added
             { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.6, 1.05 }},  --DUNCAN - was 0.9
+            { MIBC, 'TransportNeedGreater', { 7 } },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},  --DUNCAN - was 0.9
+            { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
+            { UCBC, 'HaveLessThanUnitsWithCategory', { 7, categories.TRANSPORTFOCUS * categories.TECH1 } }, --DUNCAN - added
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.TRANSPORTFOCUS } },
         },
         BuilderType = 'Air',
@@ -475,12 +471,12 @@ BuilderGroup {
         PlatoonTemplate = 'T2AirTransport',
         Priority = 800,
         BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
+            { MIBC, 'TransportNeedGreater', { 7 } },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},  --DUNCAN - was 0.9
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 10, categories.LAND * (categories.TECH2 + categories.TECH3) } }, --DUNCAN - added
-            { MIBC, 'TransportNeedGreater', { 7 } },
             { UCBC, 'HaveLessThanUnitsWithCategory', { 3, categories.TRANSPORTFOCUS * categories.TECH2 } }, --DUNCAN - added
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.6, 1.05 }},  --DUNCAN - was 0.9
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.TRANSPORTFOCUS } },
         },
         BuilderType = 'Air',
@@ -490,13 +486,13 @@ BuilderGroup {
         PlatoonTemplate = 'T3AirTransport',
         Priority = 900,
         BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
+            { MIBC, 'TransportNeedGreater', { 7 } },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.05 }},
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 10, categories.LAND * categories.TECH3 } }, --DUNCAN - added
-            { MIBC, 'TransportNeedGreater', { 7 } },
             { UCBC, 'HaveLessThanUnitsWithCategory', { 4, categories.TRANSPORTFOCUS * categories.TECH2 } },
             { UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.TRANSPORTFOCUS * categories.TECH3 } }, --DUNCAN - added
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.05 }},
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.TRANSPORTFOCUS } },
         },
         BuilderType = 'Air',
@@ -507,11 +503,11 @@ BuilderGroup {
         PlatoonTemplate = 'T1AirTransport',
         Priority = 700,
         BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
             { MIBC, 'IsIsland', { true } },
             { MIBC, 'ArmyNeedsTransports', {} },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},
             { UCBC, 'HaveLessThanUnitsWithCategory', { 7 , categories.TRANSPORTFOCUS * categories.TECH1} },
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.6, 1.05 }},
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.TRANSPORTFOCUS } },
         },
         BuilderType = 'Air',
@@ -521,12 +517,12 @@ BuilderGroup {
         PlatoonTemplate = 'T2AirTransport',
         Priority = 800,
         BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
             { MIBC, 'IsIsland', { true } },
             { MIBC, 'ArmyNeedsTransports', {} },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},
             { UCBC, 'HaveLessThanUnitsWithCategory', { 3 , categories.TRANSPORTFOCUS * categories.TECH2} },
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 10, categories.LAND * (categories.TECH2 + categories.TECH3) } }, --DUNCAN - added
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.6, 1.05 }},
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.TRANSPORTFOCUS } },
         },
         BuilderType = 'Air',
@@ -536,13 +532,13 @@ BuilderGroup {
         PlatoonTemplate = 'T3AirTransport',
         Priority = 900,
         BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
             { MIBC, 'IsIsland', { true } },
             { MIBC, 'ArmyNeedsTransports', {} },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.05 }},
             { UCBC, 'HaveLessThanUnitsWithCategory', { 4, categories.TRANSPORTFOCUS * categories.TECH2 } },
             { UCBC, 'HaveLessThanUnitsWithCategory', { 2 , categories.TRANSPORTFOCUS * categories.TECH3} },
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 10, categories.LAND * categories.TECH3 } }, --DUNCAN - added
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.6, 1.05 }},
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.TRANSPORTFOCUS } },
         },
         BuilderType = 'Air',

--- a/lua/AI/AIBuilders/AIEconomicBuilders.lua
+++ b/lua/AI/AIBuilders/AIEconomicBuilders.lua
@@ -1382,6 +1382,7 @@ BuilderGroup {
             Assist = {
                 AssistLocation = 'LocationType',
                 AssisteeType = 'Engineer',
+                AssistUntilFinished = true,
                 BeingBuiltCategories = {'STRUCTURE STRATEGIC, STRUCTURE ECONOMIC, STRUCTURE'},
                 Time = 20,
             },

--- a/lua/AI/AIBuilders/AIFactoryConstructionBuilders.lua
+++ b/lua/AI/AIBuilders/AIFactoryConstructionBuilders.lua
@@ -25,7 +25,7 @@ local PlatoonFile = '/lua/platoon.lua'
 
 local ExtractorToFactoryRatio = 2.2
 
----@alias BuilderGroupsFactoryConstruction 'LandInitialFactoryConstruction' | 'AirInitialFactoryConstruction' | 'EngineerFactoryConstructionAirHigherPriority' | 'EngineerFactoryConstructionLandHigherPriority' | 'EngineerFactoryConstruction Balance' | 'EngineerFactoryConstruction'
+---@alias BuilderGroupsFactoryConstruction 'LandInitialFactoryConstruction' | 'AirInitialFactoryConstruction' | 'EngineerFactoryConstructionAirHigherPriority' | 'EngineerFactoryConstruction Balance' | 'EngineerFactoryConstruction'
 
 BuilderGroup {
     BuilderGroupName = 'LandInitialFactoryConstruction',
@@ -84,95 +84,20 @@ BuilderGroup {
 }
 
 BuilderGroup {
-    BuilderGroupName = 'EngineerFactoryConstructionAirHigherPriority',
+    BuilderGroupName = 'EngineerFactoryConstructionExpansion',
     BuildersType = 'EngineerBuilder',
     -- ============================
     --     Air Factory Builders
     -- ============================
     Builder {
-        BuilderName = 'T2 Air Factory Builder Higher Pri',
-        PlatoonTemplate = 'T2EngineerBuilder',
-        Priority = 775,
-        BuilderConditions = {
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { UCBC, 'EngineerLessAtLocation', { 'LocationType', 1, categories.ENGINEER * categories.TECH3 } },
-            { UCBC, 'FactoryLessAtLocation', { 'LocationType', 3, categories.AIR } },
-            { UCBC, 'FactoryCapCheck', { 'LocationType', 'Air' } },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.1} },
-            { UCBC, 'UnitCapCheckLess', { .8 } },
-            { UCBC, 'HaveUnitRatio', { ExtractorToFactoryRatio, categories.MASSEXTRACTION, '>=', categories.FACTORY } },
-            { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
-        },
-        BuilderType = 'Any',
-        BuilderData = {
-            Construction = {
-                BuildStructures = {
-                    'T1AirFactory',
-                },
-                Location = 'LocationType',
-                AdjacencyCategory = categories.ENERGYPRODUCTION,
-            }
-        }
-    },
-    Builder {
-        BuilderName = 'T3 Air Factory Builder Higher Pri',
-        PlatoonTemplate = 'T3EngineerBuilder',
-        Priority = 775,
-        BuilderConditions = {
-            { UCBC, 'FactoryCapCheck', { 'LocationType', 'Air' } },
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.1} },
-            { UCBC, 'FactoryLessAtLocation', { 'LocationType', 3, categories.AIR } },
-            { UCBC, 'UnitCapCheckLess', { .8 } },
-            { UCBC, 'HaveUnitRatio', { ExtractorToFactoryRatio, categories.MASSEXTRACTION, '>=', categories.FACTORY } },
-            { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
-        },
-        BuilderType = 'Any',
-        BuilderData = {
-            Construction = {
-                BuildStructures = {
-                    'T1AirFactory',
-                },
-                Location = 'LocationType',
-                AdjacencyCategory = categories.ENERGYPRODUCTION,
-            }
-        }
-    },
-    Builder {
-        BuilderName = 'CDR T1 Air Factory Higher Pri',
-        PlatoonTemplate = 'CommanderBuilder',
-        Priority = 905, --DUNCAN - was 900
-        BuilderConditions = {
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.0} },
-            { UCBC, 'FactoryCapCheck', { 'LocationType', 'Air' } },
-            { UCBC, 'UnitCapCheckLess', { .8 } },
-        },
-        BuilderType = 'Any',
-        BuilderData = {
-            Construction = {
-                BuildClose = true,
-                BuildStructures = {
-                    'T1AirFactory',
-                },
-            }
-        }
-    },
-}
-
-
-BuilderGroup {
-    BuilderGroupName = 'EngineerFactoryConstructionLandHigherPriority',
-    BuildersType = 'EngineerBuilder',
-    Builder {
-        BuilderName = 'T2 Land Factory Builder Higher Pri',
-        PlatoonTemplate = 'T2EngineerBuilder',
+        BuilderName = 'Air Factory Builder Expansion',
+        PlatoonTemplate = 'T123EngineerBuilder',
         Priority = 750,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
-            { UCBC, 'EngineerLessAtLocation', { 'LocationType', 1, categories.ENGINEER * categories.TECH3 } },
-            { UCBC, 'FactoryLessAtLocation', { 'LocationType', 3, categories.LAND } },
-            { UCBC, 'FactoryCapCheck', { 'LocationType', 'Land' } },
+            { UCBC, 'FactoryCapCheck', { 'LocationType', 'Air' } },
             { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.1} },
+            { UCBC, 'FactoryLessAtLocation', { 'LocationType', 3, categories.AIR } },
             { UCBC, 'UnitCapCheckLess', { .8 } },
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
         },
@@ -180,7 +105,7 @@ BuilderGroup {
         BuilderData = {
             Construction = {
                 BuildStructures = {
-                    'T1LandFactory',
+                    'T1AirFactory',
                 },
                 Location = 'LocationType',
                 AdjacencyCategory = categories.ENERGYPRODUCTION,
@@ -188,14 +113,14 @@ BuilderGroup {
         }
     },
     Builder {
-        BuilderName = 'T3 Land Factory Builder Higher Pri',
-        PlatoonTemplate = 'T3EngineerBuilder',
+        BuilderName = 'Land Factory Builder Expansion',
+        PlatoonTemplate = 'T123EngineerBuilder',
         Priority = 750,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Land' } },
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.1} },
             { UCBC, 'FactoryLessAtLocation', { 'LocationType', 3, categories.LAND } },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.1} },
             { UCBC, 'UnitCapCheckLess', { .8 } },
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
         },
@@ -210,127 +135,7 @@ BuilderGroup {
             }
         }
     },
-    Builder {
-        BuilderName = 'CDR T1 Land Factory Higher Pri',
-        PlatoonTemplate = 'CommanderBuilder',
-        Priority = 905, --DUNCAN - was 900
-        BuilderConditions = {
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.0} },
-            { UCBC, 'FactoryCapCheck', { 'LocationType', 'Land' } },
-            { UCBC, 'UnitCapCheckLess', { .8 } },
-            { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
-        },
-        BuilderType = 'Any',
-        BuilderData = {
-            Construction = {
-                BuildClose = true,
-                BuildStructures = {
-                    'T1LandFactory',
-                },
-            }
-        }
-    },
-}
-
-BuilderGroup {
-    BuilderGroupName = 'EngineerFactoryConstruction Balance',
-    BuildersType = 'EngineerBuilder',
-    -- =============================
-    --     Land Factory Builders
-    -- =============================
-    Builder {
-        BuilderName = 'T1 Land Factory Builder Balance',
-        PlatoonTemplate = 'EngineerBuilder',
-        Priority = 905,
-        BuilderConditions = {
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { UCBC, 'FactoryCapCheck', { 'LocationType', 'Land' } },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.1} },
-            { UCBC, 'UnitCapCheckLess', { .8 } },
-            { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
-            { UCBC, 'FactoryRatioLessAtLocation', { 'LocationType', categories.LAND, categories.AIR } },
-        },
-        BuilderType = 'Any',
-        BuilderData = {
-            Construction = {
-                BuildStructures = {
-                    'T1LandFactory',
-                },
-                Location = 'LocationType',
-                AdjacencyCategory = categories.ENERGYPRODUCTION,
-            }
-        }
-    },
-    Builder {
-        BuilderName = 'CDR T1 Land Factory Balance',
-        PlatoonTemplate = 'CommanderBuilder',
-        Priority = 905,
-        BuilderConditions = {
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.0} },
-            { UCBC, 'FactoryCapCheck', { 'LocationType', 'Land' } },
-            { UCBC, 'UnitCapCheckLess', { .8 } },
-            { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
-            { UCBC, 'FactoryRatioLessAtLocation', { 'LocationType', categories.LAND, categories.AIR } },
-        },
-        BuilderType = 'Any',
-        BuilderData = {
-            Construction = {
-                BuildClose = true,
-                BuildStructures = {
-                    'T1LandFactory',
-                },
-            }
-        }
-    },
-
-    -- ============================
-    --     Air Factory Builders
-    -- ============================
-    Builder {
-        BuilderName = 'T1 Air Factory Builder Balance',
-        PlatoonTemplate = 'EngineerBuilder',
-        Priority = 905,
-        BuilderConditions = {
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { UCBC, 'FactoryCapCheck', { 'LocationType', 'Air' } },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.1} },
-            { UCBC, 'UnitCapCheckLess', { .8 } },
-            { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
-            { UCBC, 'FactoryRatioLessAtLocation', { 'LocationType', categories.AIR, categories.LAND } },
-        },
-        BuilderType = 'Any',
-        BuilderData = {
-            Construction = {
-                BuildStructures = {
-                    'T1AirFactory',
-                },
-                Location = 'LocationType',
-                AdjacencyCategory = categories.ENERGYPRODUCTION,
-            }
-        }
-    },
-
-    Builder {
-        BuilderName = 'CDR T1 Air Factory Balance',
-        PlatoonTemplate = 'CommanderBuilder',
-        Priority = 905,
-        BuilderConditions = {
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.0} },
-            { UCBC, 'FactoryCapCheck', { 'LocationType', 'Air' } },
-            { UCBC, 'UnitCapCheckLess', { .8 } },
-            { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
-            { UCBC, 'FactoryRatioLessAtLocation', { 'LocationType', categories.AIR, categories.LAND } },
-        },
-        BuilderType = 'Any',
-        BuilderData = {
-            Construction = {
-                BuildClose = true,
-                BuildStructures = {
-                    'T1AirFactory',
-                },
-            }
-        }
-    },
+    
 }
 
 BuilderGroup {
@@ -341,13 +146,13 @@ BuilderGroup {
     -- =============================
     Builder {
         BuilderName = 'T1 Land Factory Primary Builder',
-        PlatoonTemplate = 'EngineerBuilder',
+        PlatoonTemplate = 'T123EngineerBuilder',
         Priority = 1000,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Land' } },
             { UCBC, 'FactoryLessAtLocation', { 'MAIN', 1, categories.STRUCTURE * categories.FACTORY * categories.LAND - categories.SUPPORTFACTORY }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 0.8} },
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 0.8 } },
             { UCBC, 'UnitCapCheckLess', { .8 } },
         },
         BuilderType = 'Any',
@@ -362,14 +167,38 @@ BuilderGroup {
         },
     },
     Builder {
+        BuilderName = 'T1 Land Factory Builder Land Path',
+        PlatoonTemplate = 'T123EngineerBuilder',
+        Priority = 950,
+        BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
+            { UCBC, 'FactoryCapCheck', { 'LocationType', 'Land' } },
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.85, 1.0 } },
+            { MIBC, 'PathToEnemy', { 'LocationType', 'Land' }},
+            { UCBC, 'FactoryLessAtLocation', { 'MAIN', 4, categories.STRUCTURE * categories.FACTORY * categories.LAND }},
+            { UCBC, 'UnitCapCheckLess', { .8 } },
+            { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
+        },
+        BuilderType = 'Any',
+        BuilderData = {
+            Construction = {
+                BuildStructures = {
+                    'T1LandFactory',
+                },
+                Location = 'LocationType',
+                AdjacencyCategory = categories.ENERGYPRODUCTION,
+            }
+        },
+    },
+    Builder {
         BuilderName = 'T1 Land Factory Builder',
-        PlatoonTemplate = 'EngineerBuilder',
+        PlatoonTemplate = 'T123EngineerBuilder',
         Priority = 900,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Land' } },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.1} },
-            { UCBC, 'ForcePathLimit', {'LocationType', categories.FACTORY * categories.LAND, 'Land', 2}},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.05 } },
+            { MIBC, 'ForcePathLimit', {'LocationType', categories.FACTORY * categories.LAND, 'Land', 2}},
             { UCBC, 'UnitCapCheckLess', { .8 } },
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
         },
@@ -390,8 +219,8 @@ BuilderGroup {
         Priority = 900,
         BuilderConditions = {
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Land' } },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.0} },
-            { UCBC, 'ForcePathLimit', {'LocationType', categories.FACTORY * categories.LAND, 'Land', 2}},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.0 } },
+            { MIBC, 'ForcePathLimit', {'LocationType', categories.FACTORY * categories.LAND, 'Land', 2}},
             { UCBC, 'UnitCapCheckLess', { .8 } },
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
         },
@@ -411,13 +240,13 @@ BuilderGroup {
     -- ============================
     Builder {
         BuilderName = 'T1 Air Factory Primary Builder',
-        PlatoonTemplate = 'EngineerBuilder',
+        PlatoonTemplate = 'T123EngineerBuilder',
         Priority = 1000,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Air' } },
             { UCBC, 'FactoryLessAtLocation', { 'MAIN', 1, categories.STRUCTURE * categories.FACTORY * categories.AIR - categories.SUPPORTFACTORY }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 0.8} },
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 0.8 } },
             { UCBC, 'UnitCapCheckLess', { .8 } },
         },
         BuilderType = 'Any',
@@ -433,12 +262,12 @@ BuilderGroup {
     },
     Builder {
         BuilderName = 'T1 Air Factory Builder',
-        PlatoonTemplate = 'EngineerBuilder',
+        PlatoonTemplate = 'T123EngineerBuilder',
         Priority = 900,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Air' } },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.1} },
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.95, 1.05 } },
             { UCBC, 'UnitCapCheckLess', { .8 } },
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
         },
@@ -459,7 +288,7 @@ BuilderGroup {
         PlatoonTemplate = 'CommanderBuilder',
         Priority = 900,
         BuilderConditions = {
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.0} },
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.0 } },
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Air' } },
             { UCBC, 'UnitCapCheckLess', { .8 } },
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
@@ -480,16 +309,14 @@ BuilderGroup {
     -- ====================================== --
     Builder {
         BuilderName = 'T1 Air Factory Transport Needed',
-        PlatoonTemplate = 'EngineerBuilder',
+        PlatoonTemplate = 'T123EngineerBuilder',
         Priority = 900,
         BuilderConditions = {
-            { UCBC, 'EngineerLessAtLocation', { 'LocationType', 1, categories.ENGINEER * ( categories.TECH2 + categories.TECH3 ) } },
-            { UCBC, 'FactoryCapCheck', { 'LocationType', 'Air' } },
-            { UCBC, 'FactoryLessAtLocation', { 'LocationType', 2, categories.AIR * categories.FACTORY } },
-            { MIBC, 'ArmyNeedsTransports', {} },
             { IBC, 'BrainNotLowPowerMode', {} },
+            { UCBC, 'FactoryCapCheck', { 'LocationType', 'Air' } },
+            { MIBC, 'ArmyNeedsTransports', {} },
+            { UCBC, 'FactoryLessAtLocation', { 'LocationType', 1, categories.AIR * categories.FACTORY } },
             { UCBC, 'UnitCapCheckLess', { .8 } },
-            { UCBC, 'HaveUnitRatio', { ExtractorToFactoryRatio, categories.MASSEXTRACTION, '>=', categories.FACTORY } },
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
         },
         BuilderType = 'Any',
@@ -533,4 +360,3 @@ BuilderGroup {
         }
     },
 }
-

--- a/lua/AI/PlatoonTemplates/EngineerPlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/EngineerPlatoonTemplates.lua
@@ -130,6 +130,14 @@ PlatoonTemplate {
 }
 
 PlatoonTemplate {
+    Name = 'T123EngineerBuilder',
+    Plan = 'EngineerBuildAI',
+    GlobalSquads = {
+        { categories.ENGINEER - categories.ENGINEERSTATION - categories.COMMAND, 1, 1, 'support', 'none' },
+    },
+}
+
+PlatoonTemplate {
     Name = 'AeonT3EngineerBuilder',
     Plan = 'EngineerBuildAI',
     GlobalSquads = {

--- a/lua/AI/PlatoonTemplates/LandPlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/LandPlatoonTemplates.lua
@@ -83,7 +83,7 @@ PlatoonTemplate {
     GlobalSquads = {
         --DUNCAN - was 15 to 25
         { categories.MOBILE * categories.LAND - categories.EXPERIMENTAL - categories.ENGINEER, 5, 25, 'Attack', 'none' },
-        { categories.ENGINEER, 1, 1, 'Attack', 'none' },
+        { categories.ENGINEER - categories.COMMAND, 1, 1, 'Attack', 'none' },
     },
 }
 PlatoonTemplate {

--- a/lua/editor/MiscBuildConditions.lua
+++ b/lua/editor/MiscBuildConditions.lua
@@ -329,6 +329,43 @@ function MapLessThan(aiBrain, sizeX, sizeZ)
     end
 end
 
+--- Buildcondition to limit the number of factories 
+---@param aiBrain AIBrain
+---@param locationType string
+---@param unitCategory EntityCategory
+---@param pathType string
+---@param unitCount integer
+---@return boolean
+function ForcePathLimit(aiBrain, locationType, unitCategory, pathType, unitCount)
+    local currentEnemy = aiBrain:GetCurrentEnemy()
+    if not currentEnemy then
+        return true
+    end
+    local enemyIndex = aiBrain:GetCurrentEnemy():GetArmyIndex()
+    local selfIndex = aiBrain:GetArmyIndex()
+    if aiBrain.CanPathToEnemy[selfIndex][enemyIndex][locationType] ~= pathType and FactoryComparisonAtLocation(aiBrain, locationType, unitCount, unitCategory, '>=') then
+        return false
+    end
+    return true
+end
+
+--- Buildcondition to check pathing to current enemy 
+---@param aiBrain AIBrain
+---@param locationType string
+---@param pathType string
+---@return boolean
+function PathToEnemy(aiBrain, locationType, pathType)
+    local currentEnemy = aiBrain:GetCurrentEnemy()
+    if not currentEnemy then
+        return true
+    end
+    local enemyIndex = aiBrain:GetCurrentEnemy():GetArmyIndex()
+    local selfIndex = aiBrain:GetArmyIndex()
+    if aiBrain.CanPathToEnemy[selfIndex][enemyIndex][locationType] == pathType then
+        return true
+    end
+    return false
+end
 
 -- unused imports kept for mod support
 local Utils = import("/lua/utilities.lua")

--- a/lua/editor/UnitCountBuildConditions.lua
+++ b/lua/editor/UnitCountBuildConditions.lua
@@ -1433,23 +1433,6 @@ function CheckBuildPlattonDelay(aiBrain, PlatoonName)
     return true
 end
 
---- Buildcondition to limit the number of factories 
----@param aiBrain AIBrain
----@param locationType string
----@param unitCategory EntityCategory
----@param pathType string
----@param unitCount integer
----@return boolean
-function ForcePathLimit(aiBrain, locationType, unitCategory, pathType, unitCount)
-    local EnemyIndex = aiBrain:GetCurrentEnemy():GetArmyIndex()
-    local OwnIndex = aiBrain:GetArmyIndex()
-    if aiBrain.CanPathToEnemy[OwnIndex][EnemyIndex][locationType] ~= pathType and FactoryComparisonAtLocation(aiBrain, locationType, unitCount, unitCategory, '>=') then
-        --LOG('ForcePathLimit has no path and is equal to or more than '..unitCount..' land factories')
-        return false
-    end
-    return true
-end
-
 --- Buildcondition to decide if radars should upgrade based on other radar locations.
 ---@param aiBrain AIBrain
 ---@param locationType string


### PR DESCRIPTION
**Description of changes**
This PR tunes the default AI's factory builders and removes the pointless complexity of the original.

Remove some of the factory builder groups and make sure the main factory builder group provides the same functionality. 

Add a minimum factory builder so that on land maps where the AI has pathing to the enemy it will get 4 land factories quicker. This is still checking the factory cap on the base template so certain AI personalities like easy will remain with a low count.

Decrease the mass to factory requirements for the main bases for the T1 phase so the AI will get the minimum factory counts up in the early game rather than having to wait for the mid T2 phase.

Makes changes to some base templates where the number of land factories was too low.

Changes the eco requirements for transports in general. The requirements were so low that the AI could only build transports when its eco was hurting. The transport builders need alot more work and they are needlessly complex and excessive. But that is for another PR.

Add a multi tier engineer platoon template. This will allow the first available engineer to take on certain builders. Rather than needing a specific tier of engineer.

Added a pathing check condition for builders that want to checking if a specific path is available to the current enemy. Used for a factory builder and will be used in future for amphib tank decision making etc.
Also fixed a logic flaw for the pathing conditions when an AI doesn't have a current enemy.

Test setup for the changes
This is an observation based test. The AI should be better about making sure it has a viable number of land factories during the T1 phase rather than waiting until the T2 phase depending on resources. AI should not be quite as excessive about building transports, but still bad. 
