### PR TITLE
Fix: Seraphim torpedo bombers doing more than 750 damage Fixes #4261 and delete redudant code.

### DIFF
--- a/projectiles/SANHeavyCavitationTorpedo01/SANHeavyCavitationTorpedo01_script.lua
+++ b/projectiles/SANHeavyCavitationTorpedo01/SANHeavyCavitationTorpedo01_script.lua
@@ -13,7 +13,7 @@ local RandomFloat = import("/lua/utilities.lua").GetRandomFloat
 local EffectTemplate = import("/lua/effecttemplates.lua")
 
 SANHeavyCavitationTorpedo01 = Class(SHeavyCavitationTorpedo) {
-    FxSplashScale = .4,
+    FxSplashScale = 0.4,
     FxEnterWaterEmitter = {
         '/effects/emitters/destruction_water_splash_ripples_01_emit.bp',
         '/effects/emitters/destruction_water_splash_wash_01_emit.bp',
@@ -55,7 +55,7 @@ SANHeavyCavitationTorpedo01 = Class(SHeavyCavitationTorpedo) {
 
         -- Randomization of the spread
         local angleVariation = angle * 0.3 -- Adjusts angle variance spread
-        local spreadMul = .4 -- Adjusts the width of the dispersal
+        local spreadMul = 0.4 -- Adjusts the width of the dispersal
         local xVec = 0
         local yVec = vy
         local zVec = 0
@@ -64,6 +64,8 @@ SANHeavyCavitationTorpedo01 = Class(SHeavyCavitationTorpedo) {
         -- damage, in case the torpedo hits something before it splits.
         local DividedDamageData = self.DamageData
         DividedDamageData.DamageAmount = DividedDamageData.DamageAmount / numProjectiles
+        self.DamageData = nil
+
 
         local FxFragEffect = EffectTemplate.SHeavyCavitationTorpedoSplit
 

--- a/projectiles/SANHeavyCavitationTorpedo02/SANHeavyCavitationTorpedo02_script.lua
+++ b/projectiles/SANHeavyCavitationTorpedo02/SANHeavyCavitationTorpedo02_script.lua
@@ -45,7 +45,7 @@ SANHeavyCavitationTorpedo02 = Class(SHeavyCavitationTorpedo) {
     end,
 
     ProjectileSplit = function(self)
-        WaitSeconds(.1)
+        WaitSeconds(0.1)
         local ChildProjectileBP = '/projectiles/SANHeavyCavitationTorpedo03/SANHeavyCavitationTorpedo03_proj.bp'
         local vx, vy, vz = self:GetVelocity()
         local velocity = 7
@@ -57,7 +57,7 @@ SANHeavyCavitationTorpedo02 = Class(SHeavyCavitationTorpedo) {
 
         -- Randomization of the spread
         local angleVariation = angle * 0.4 -- Adjusts angle variance spread
-        local spreadMul = .4 -- Adjusts the width of the dispersal
+        local spreadMul = 0.4 -- Adjusts the width of the dispersal
         local xVec = 0
         local yVec = vy
         local zVec = 0
@@ -66,6 +66,7 @@ SANHeavyCavitationTorpedo02 = Class(SHeavyCavitationTorpedo) {
         -- damage, in case the torpedo hits something before it splits.
         local DividedDamageData = self.DamageData
         DividedDamageData.DamageAmount = DividedDamageData.DamageAmount / numProjectiles
+        self.DamageData = nil
 
         local FxFragEffect = EffectTemplate.SHeavyCavitationTorpedoSplit
 

--- a/projectiles/SANHeavyCavitationTorpedo03/SANHeavyCavitationTorpedo03_script.lua
+++ b/projectiles/SANHeavyCavitationTorpedo03/SANHeavyCavitationTorpedo03_script.lua
@@ -21,23 +21,12 @@ SANHeavyCavitationTorpedo03 = Class(SHeavyCavitationTorpedo) {
 
     PauseUntilTrack = function(self)
         local distance = self:GetDistanceToTarget()
-        local waittime
         local turnrate = 360
-        -- The pause time needs to scale down depending on how far away the target is, otherwise
-        -- the torpedoes will initially shoot past their target.
-        if distance > 6 then
-            waittime = .1--.45
-            if distance > 12 then
-                waittime = .1--.7
-                if distance > 18 then
-                        waittime = 0.1--1
-                end
-            end
-        else
-            waittime = .1
+        
+        if distance < 6 then
             turnrate = 720
         end
-        WaitSeconds(waittime)
+        WaitSeconds(0.1)
         self:SetMaxSpeed(20)
         self:TrackTarget(true)
         self:SetTurnRate(turnrate)

--- a/projectiles/SANHeavyCavitationTorpedo04/SANHeavyCavitationTorpedo04_script.lua
+++ b/projectiles/SANHeavyCavitationTorpedo04/SANHeavyCavitationTorpedo04_script.lua
@@ -22,23 +22,11 @@ SANHeavyCavitationTorpedo04 = Class(SHeavyCavitationTorpedo) {
 
         PauseUntilTrack = function(self)
                 local distance = self:GetDistanceToTarget()
-                local waittime
                 local turnrate = 360
-                -- The pause time needs to scale down depending on how far away the target is, otherwise
-                -- the torpedoes will initially shoot past their target.
-                if distance > 6 then
-                        waittime = .1 --0.45
-                        if distance > 12 then
-                                waittime = .1--0.7
-                                if distance > 18 then
-                                        waittime = 0.1--1
-                                end
-                        end
-                else
-                        waittime = .2
+                if distance < 6 then
                         turnrate = 720
                 end
-                WaitSeconds(waittime)
+                WaitSeconds(0.1)
                 self:SetMaxSpeed(14)
                 self:TrackTarget(true)
                 self:SetTurnRate(turnrate)
@@ -49,6 +37,6 @@ SANHeavyCavitationTorpedo04 = Class(SHeavyCavitationTorpedo) {
         local mpos = self:GetPosition()
         local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
         return dist
-    end,
+        end,
 }
 TypeClass = SANHeavyCavitationTorpedo04


### PR DESCRIPTION
The bug is way more prominent than i first thought the seraphim torpbomber deals 833 dmg to almost all t3 Naval units and does this by every third ore fourth run(quite common) , this is because after the calculation of the Damage, the original projectile and the childprojectiles share the same Damagetable, so if the parent actually hits the target, it deals damage as an additional projectile 750(9*ca.83(rounded) + ca.83 =833

to fix this, i tried to remove the Damage from the Parentprojectile so if the timing is off and it hits the Target, no additional damage will be dealt. 
I actually dont know if this is the best way to do it and im open for a better solution, but it fixes the bug! 


To test this, just spawn in a t3 ship(i suggest t3 Aoen Battleship  because of lacking AA). I also tested it with a range of other Naval units.

## Additional context
I also deletet some redudant conditions and changed one value, that was not making any sense. Also some refactoring on the numbers was done to stick to our convention  (.1 ->0.1).

Please if you know a more beautiful way to get rid of the Damage value of the parentprojectile tell me :D 
