### PR TITLE
GC Claw Adjustment

### DIFF
--- a/lua/aeonweapons.lua
+++ b/lua/aeonweapons.lua
@@ -51,9 +51,9 @@ ADFTractorClaw = Class(Weapon) {
     BeamFx = { EffectTemplate.ACollossusTractorBeam01 },
 
     SliderVelocity = {
-        TECH3 = 1,
-        TECH2 = 7,
-        TECH1 = 13,
+        TECH3 = 10,
+        TECH2 = 13,
+        TECH1 = 16,
     },
 
     --- Adds logic to catch edge cases
@@ -232,6 +232,14 @@ ADFTractorClaw = Class(Weapon) {
                 WaitTicks(1)
 
                 if not IsDestroyed(unit) then 
+                    
+
+                    self:MakeVulnerable(target)
+                    while not IsDestroyed(target) and not IsDestroyed(unit) do
+                        WaitSeconds(0.1)
+                        Damage(unit, bonePosition, target, 1, "Normal")
+                    end
+
                     CreateLightParticle(unit, muzzle, self.Army, 4, 2, 'glow_02', 'ramp_blue_16')
                     Explosion.CreateScalableUnitExplosion(target, 3, true)
 
@@ -247,6 +255,7 @@ ADFTractorClaw = Class(Weapon) {
                     -- create thread to take into account the fall
                     self:ForkThread(self.TargetFallThread, target, trash, muzzle)
                     self:ResetTarget()
+                    LOG("0")
                 else 
                     self:MakeVulnerable(target)
                     trash:Destroy()

--- a/lua/aeonweapons.lua
+++ b/lua/aeonweapons.lua
@@ -127,7 +127,7 @@ ADFTractorClaw = Class(Weapon) {
     OnInvalidTargetThread = function(self)
         self:ResetTarget()
         self:SetEnabled(false)
-        WaitSeconds(0.4)
+        WaitSeconds(10)
         if not IsDestroyed(self) then
             self:SetEnabled(true)
         end

--- a/lua/aeonweapons.lua
+++ b/lua/aeonweapons.lua
@@ -51,9 +51,9 @@ ADFTractorClaw = Class(Weapon) {
     BeamFx = { EffectTemplate.ACollossusTractorBeam01 },
 
     SliderVelocity = {
-        TECH3 = 10,
-        TECH2 = 13,
-        TECH1 = 16,
+        TECH3 = 1,
+        TECH2 = 7,
+        TECH1 = 13,
     },
 
     --- Adds logic to catch edge cases
@@ -127,7 +127,7 @@ ADFTractorClaw = Class(Weapon) {
     OnInvalidTargetThread = function(self)
         self:ResetTarget()
         self:SetEnabled(false)
-        WaitSeconds(10)
+        WaitSeconds(0.4)
         if not IsDestroyed(self) then
             self:SetEnabled(true)
         end

--- a/lua/aeonweapons.lua
+++ b/lua/aeonweapons.lua
@@ -234,10 +234,12 @@ ADFTractorClaw = Class(Weapon) {
                 if not IsDestroyed(unit) then 
                     
 
-                    self:MakeVulnerable(target)
-                    while not IsDestroyed(target) and not IsDestroyed(unit) do
+                    target.CanTakeDamage = true
+                    while not IsDestroyed(target) and not IsDestroyed(unit) and target:GetHealth() >= 73 do
                         WaitSeconds(0.1)
-                        Damage(unit, bonePosition, target, 1, "Normal")
+                        if target:GetHealth() > 73 then
+                            Damage(unit, bonePosition, target, 72, "Normal")
+                        end
                     end
 
                     CreateLightParticle(unit, muzzle, self.Army, 4, 2, 'glow_02', 'ramp_blue_16')

--- a/lua/aeonweapons.lua
+++ b/lua/aeonweapons.lua
@@ -235,11 +235,10 @@ ADFTractorClaw = Class(Weapon) {
                     
 
                     target.CanTakeDamage = true
-                    while not IsDestroyed(target) and not IsDestroyed(unit) and target:GetHealth() >= 73 do
-                        WaitSeconds(0.1)
-                        if target:GetHealth() > 73 then
-                            Damage(unit, bonePosition, target, 72, "Normal")
-                        end
+                    while not IsDestroyed(target) and not IsDestroyed(unit) and target:GetHealth() >= 730 do
+                        Damage(unit, bonePosition, target, 729, "Normal")
+                        Explosion.CreateScalableUnitExplosion(target, 1, true)
+                        WaitTicks(11)
                     end
 
                     CreateLightParticle(unit, muzzle, self.Army, 4, 2, 'glow_02', 'ramp_blue_16')
@@ -257,7 +256,6 @@ ADFTractorClaw = Class(Weapon) {
                     -- create thread to take into account the fall
                     self:ForkThread(self.TargetFallThread, target, trash, muzzle)
                     self:ResetTarget()
-                    LOG("0")
                 else 
                     self:MakeVulnerable(target)
                     trash:Destroy()


### PR DESCRIPTION
Compensates for the GC's claws working correctly. To accomplish this the claws are changed to not instantly kill units that enter them, now they do 720 damage per second until the unit is killed. The pull velocity remains the same. This results in the gc being slightly better than its original form before the claw change.  All data used to come to this conclusion can can be found [here](https://docs.google.com/spreadsheets/d/1zmevPyRNKlI2gxxqL646FgmVULIta2bRDR_0A4iJCYA/edit?usp=sharing). These numbers have not yet been passed by Tagada and are subject to change. Below are examples of my testing.

![Screenshot from 2022-11-23 17-32-10](https://user-images.githubusercontent.com/68761514/203658498-cc8f6679-69ee-4a77-99f0-05639a3665ad.png)

![Screenshot from 2022-11-23 16-05-27](https://user-images.githubusercontent.com/68761514/203658503-35e3f9a7-2ea3-42f8-9ebb-bea0e05665df.png)
![Screenshot from 2022-11-23 15-55-27](https://user-images.githubusercontent.com/68761514/203658509-93f39d8b-a086-415a-b498-9a2d2e9a78fc.png)

https://replay.faforever.com/18584864
