### PR TITLE
Further reduce memory footprint of units

### DIFF
--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -26,10 +26,12 @@
 
 --- read more here: https://wiki.faforever.com/en/Blueprints
 ---@class UnitBlueprint: EntityBlueprint
----@field SizeX number
+---@field SizeX number 
 ---@field SizeY number
 ---@field SizeZ number
----@field SizeVolume number
+---@field SizeVolume number                 Volume based on SizeX, SizeY and SizeZ
+---@field SizeDamageEffects number          Number of damage effects based on volume
+---@field SizeDamageEffectsScale number     Scale of damage effects based on volume
 ---@field TechCategory 'TECH1' | 'TECH2' | 'TECH3' | 'EXPERIMENTAL'
 ---@field LayerCategory 'LAND' | 'AIR' | 'NAVAL'
 ---@field FactionCategory 'UEF' | 'CYBRAN' | 'AEON' | 'SERAPHIM'

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -26,6 +26,10 @@
 
 --- read more here: https://wiki.faforever.com/en/Blueprints
 ---@class UnitBlueprint: EntityBlueprint
+---@field SizeX number
+---@field SizeY number
+---@field SizeZ number
+---@field SizeVolume number
 ---@field TechCategory 'TECH1' | 'TECH2' | 'TECH3' | 'EXPERIMENTAL'
 ---@field LayerCategory 'LAND' | 'AIR' | 'NAVAL'
 ---@field FactionCategory 'UEF' | 'CYBRAN' | 'AEON' | 'SERAPHIM'

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -1935,11 +1935,11 @@ AirUnit = Class(MobileUnit) {
     ---@param scale number
     CreateUnitAirDestructionEffects = function(self, scale)
         local scale = explosion.GetAverageBoundingXZRadius(self)
-        local size = self.Size
+        local blueprint = self.Blueprint
         explosion.CreateDefaultHitExplosion(self, scale)
 
         if self.ShowUnitDestructionDebris then
-            explosion.CreateDebrisProjectiles(self, scale, {size.SizeX, size.SizeY, size.SizeZ})
+            explosion.CreateDebrisProjectiles(self, scale, {blueprint.SizeX, blueprint.SizeY, blueprint.SizeZ})
         end
     end,
 

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -853,7 +853,7 @@ function GuardFormation(formationUnits)
             remainingShields = remainingShields + 1
         end
 
-        local fs = u.FootPrintSize
+        local fs = u:GetBlueprint().Footprint.SizeMax
         footprintCounts[fs] = (footprintCounts[fs] or 0) + 1
     end
 

--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -866,7 +866,6 @@ DefaultProjectileWeapon = Class(Weapon) {
                 unit:SetWorkProgress(1 - clockTime / totalTime)
                 clockTime = clockTime - 1
                 WaitSeconds(0.1)
-
             end
         end,
 

--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -188,11 +188,19 @@ local function PostProcessUnit(unit)
 
     -- Pre-compute various elements
     unit.SizeVolume = (unit.SizeX or 1) * (unit.SizeY or 1) * (unit.SizeZ or 1)
-    unit.Footprint = unit.Footprint or { }
-    if unit.Footprint.SizeX and unit.Footprint.SizeZ then 
-        unit.Footprint.SizeMax = math.max(unit.Footprint.SizeX, unit.Footprint.SizeZ)
+    unit.SizeDamageEffects = 1
+    unit.SizeDamageEffectsScale = 1
+    if unit.SizeVolume > 10 then
+        unit.SizeDamageEffects = 2
+        unit.SizeDamageEffectsScale = 1.5
+        if unit.SizeVolume > 20 then
+            unit.SizeDamageEffects = 3
+            unit.SizeDamageEffectsScale = 2.0
+        end
     end
 
+    unit.Footprint = unit.Footprint or { }
+    unit.Footprint.SizeMax = math.max(unit.Footprint.SizeX or 1, unit.Footprint.SizeZ or 1)
 end
 
 --- Post-processes all units

--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -1,5 +1,5 @@
 --- Post process a unit
----@param unit Unit
+---@param unit UnitBlueprint
 local function PostProcessUnit(unit)
     if table.find(unit.Categories, "SUBCOMMANDER") then
         table.insert(unit.Categories, "SACU_BEHAVIOR")
@@ -185,6 +185,14 @@ local function PostProcessUnit(unit)
     else
         unit.General = {CommandCapsHash = {}}
     end
+
+    -- Pre-compute various elements
+    unit.SizeVolume = (unit.SizeX or 1) * (unit.SizeY or 1) * (unit.SizeZ or 1)
+    unit.Footprint = unit.Footprint or { }
+    if unit.Footprint.SizeX and unit.Footprint.SizeZ then 
+        unit.Footprint.SizeMax = math.max(unit.Footprint.SizeX, unit.Footprint.SizeZ)
+    end
+
 end
 
 --- Post-processes all units

--- a/units/UAA0310/UAA0310_script.lua
+++ b/units/UAA0310/UAA0310_script.lua
@@ -64,10 +64,10 @@ UAA0310 = Class(AirTransport) {
     end,
 
     OnAnimTerrainCollision = function(self, bone,x,y,z)
-        local size = self.Size
+        local blueprint = self.Blueprint
         DamageArea(self, {x,y,z}, 5, 1000, 'Default', true, false)
         explosion.CreateDefaultHitExplosionAtBone(self, bone, 5.0)
-        explosion.CreateDebrisProjectiles(self, explosion.GetAverageBoundingXYZRadius(self), {size.SizeX, size.SizeY, size.SizeZ})
+        explosion.CreateDebrisProjectiles(self, explosion.GetAverageBoundingXYZRadius(self), {blueprint.SizeX, blueprint.SizeY, blueprint.SizeZ})
     end,
 
     OnStopBeingBuilt = function(self,builder,layer)

--- a/units/XSL0401/XSL0401_Script.lua
+++ b/units/XSL0401/XSL0401_Script.lua
@@ -80,7 +80,7 @@ XSL0401 = Class(SWalkingLandUnit) {
     end,
 
     DeathThread = function(self, overkillRatio , instigator)
-        local size = self.Size
+        local blueprint = self.Blueprint
         local bigExplosionBones = {'Torso', 'Head', 'pelvis'}
         local explosionBones = {'Right_Arm_B07', 'Right_Arm_B03',
                                 'Left_Arm_B10', 'Left_Arm_B07',
@@ -89,7 +89,7 @@ XSL0401 = Class(SWalkingLandUnit) {
                                 'Left_Leg_B17', 'Left_Leg_B14', 'Left_Leg_B15'}
         
         explosion.CreateDefaultHitExplosionAtBone(self, bigExplosionBones[Random(1, 3)], 4.0)
-        explosion.CreateDebrisProjectiles(self, explosion.GetAverageBoundingXYZRadius(self), {size.SizeX, size.SizeY, size.SizeZ})
+        explosion.CreateDebrisProjectiles(self, explosion.GetAverageBoundingXYZRadius(self), {blueprint.SizeX, blueprint.SizeY, blueprint.SizeZ})
         WaitSeconds(2)
 
         local RandBoneIter = RandomIter(explosionBones)


### PR DESCRIPTION
Partially reverts #3678, which originated from #3579. The initial issue description was off, and as a result we were allocating a dozen of new tables that were duplicates on each unit. And as the game progresses, this can easily accumulate into tens of thousands of tables that are just duplicates.

The original idea was to make the tables easier accessible. But now that we have the blueprint stored in the unit, instead of via an engine call back, all the information we were caching is already close in scope.

This pull request removes a lot of redundant table operations, further reducing the memory footprint of a unit.

On top of that, introduces a simple way to retain mod compatibility:

```lua
if next(__active_mods) then

    SPEW("Sim mod detected - adding in missing fields to the unit class to improve compatibility")

    local oldUnit = Unit
    Unit = Class(oldUnit) {
        ---@param self Unit
        OnCreate = function(self)
            oldUnit.OnCreate(self)

            self.factionCategory = self.Blueprint.FactionCategory
            self.layerCategory = self.Blueprint.LayerCategory
            self.factionCategory = self.Blueprint.FactionCategory
        end,
    }
end
```

If we detect sim mods then we re-attach some of the fields that are removed. This will be updated as we're informed about mods being incompatible. This allows us to keep reducing the amount of allocated memory of the base game without having to worry about mod compatibility on (duplicated) fields that are created during OnCreate.