### PR TITLE
AI Manage Engineer Guard removal, cdr completion, forcepathlimit fix

### DIFF
--- a/lua/AI/AIBehaviors.lua
+++ b/lua/AI/AIBehaviors.lua
@@ -341,7 +341,7 @@ function CommanderThreadImproved(cdr, platoon)
         WaitTicks(1)
 
         if not cdr.Dead and not cdr.Combat and cdr.UnitBeingBuiltBehavior then
-            cdr:ForkThread(CDRFinishUnit)
+            CDRFinishUnit(cdr)
         end
 
         -- Call platoon resume building deal...

--- a/lua/AI/AIBuilders/AIEconomicBuilders.lua
+++ b/lua/AI/AIBuilders/AIEconomicBuilders.lua
@@ -21,6 +21,7 @@ local EBC = '/lua/editor/economybuildconditions.lua'
 local PCBC = '/lua/editor/platooncountbuildconditions.lua'
 local SAI = '/lua/scenarioplatoonai.lua'
 local TBC = '/lua/editor/threatbuildconditions.lua'
+local SBC = '/lua/editor/SorianBuildConditions.lua'
 local PlatoonFile = '/lua/platoon.lua'
 
 ---@alias BuilderGroupsEconomic 'EngineerFactoryBuilders' | 'Engineer Transfers' | 'Land Rush Initial ACU Builders' | 'Balanced Rush Initial ACU Builders' | 'Air Rush Initial ACU Builders' | 'Naval Rush Initial ACU Builders' | 'Default Initial ACU Builders' | 'ACUBuilders' | 'ACUUpgrades - Gun improvements' | 'ACUUpgrades - Tech 2 Engineering' | 'ACUUpgrades - Shields' | 'ACUUpgrades' | 'T1EngineerBuilders' | 'T2EngineerBuilders' | 'T3EngineerBuilders' | 'EngineerMassBuildersHighPri' | 'EngineerMassBuilders - Naval' | 'EngineerMassBuildersLowerPri' | 'EngineerMassBuildersMidPriSingle' | 'EngineerEnergyBuilders' | 'EngineerEnergyBuildersExpansions' | 'EngineeringSupportBuilder'
@@ -1289,7 +1290,7 @@ BuilderGroup {
         Priority = 1000,
         BuilderConditions = {
                 { UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.HYDROCARBON}},
-                { MABC, 'MarkerLessThanDistance',  { 'Hydrocarbon', 160}},
+                { SBC, 'CanBuildOnHydroLessThanDistance', { 'LocationType', 160, -500, 0, 0, 'AntiSurface', 1 }},
             },
         BuilderType = 'Any',
         BuilderData = {
@@ -1304,15 +1305,11 @@ BuilderGroup {
         BuilderName = 'T1 Hydrocarbon Engineer',
         PlatoonTemplate = 'EngineerBuilder',
         --DUNCAN - Changed from 850
-        Priority = 980,
+        Priority = 950,
         BuilderConditions = {
-                --DUNCAN - commented out
-                --{ UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.ENGINEER * (categories.TECH2 + categories.TECH3) } },
-                --DUNCAN - Changed to 3
                 { UCBC, 'HaveLessThanUnitsWithCategory', { 3, categories.HYDROCARBON}},
-                --DUNCAN - Added so doenst build before a few mass exs
                 { UCBC, 'HaveGreaterThanUnitsWithCategory', { 4, categories.MASSEXTRACTION}},
-                { MABC, 'MarkerLessThanDistance',  { 'Hydrocarbon', 200}}, --DUNCAN - was 150
+                { SBC, 'CanBuildOnHydroLessThanDistance', { 'LocationType', 200, -500, 0, 0, 'AntiSurface', 1 }},
             },
         BuilderType = 'Any',
         BuilderData = {

--- a/lua/AI/AIBuilders/AIFactoryConstructionBuilders.lua
+++ b/lua/AI/AIBuilders/AIFactoryConstructionBuilders.lua
@@ -198,7 +198,7 @@ BuilderGroup {
             { IBC, 'BrainNotLowPowerMode', {} },
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Land' } },
             { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.05 } },
-            { MIBC, 'ForcePathLimit', {'LocationType', categories.FACTORY * categories.LAND, 'Land', 2}},
+            { UCBC, 'ForcePathLimit', {'LocationType', categories.FACTORY * categories.LAND, 'Land', 2}},
             { UCBC, 'UnitCapCheckLess', { .8 } },
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
         },
@@ -220,7 +220,7 @@ BuilderGroup {
         BuilderConditions = {
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Land' } },
             { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.0 } },
-            { MIBC, 'ForcePathLimit', {'LocationType', categories.FACTORY * categories.LAND, 'Land', 2}},
+            { UCBC, 'ForcePathLimit', {'LocationType', categories.FACTORY * categories.LAND, 'Land', 2}},
             { UCBC, 'UnitCapCheckLess', { .8 } },
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
         },

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -1580,6 +1580,14 @@ AIBrain = Class(moho.aibrain_methods) {
         else
             self.EnemyPickerThread = self:ForkThread(self.PickEnemy)
         end
+        
+        self.IMAPConfig = {
+            OgridRadius = 0,
+            IMAPSize = 0,
+            Rings = 0,
+        }
+
+        self:IMAPConfiguration()
     end,
 
     ---@param self AIBrain
@@ -5051,6 +5059,33 @@ AIBrain = Class(moho.aibrain_methods) {
                 WaitTicks(5)
             end
             WaitTicks(100)
+        end
+    end,
+
+    IMAPConfiguration = function(self)
+        -- Used to configure imap values, used for setting threat ring sizes depending on map size to try and get a somewhat decent radius
+        local maxmapdimension = math.max(ScenarioInfo.size[1],ScenarioInfo.size[2])
+
+        if maxmapdimension == 256 then
+            self.IMAPConfig.OgridRadius = 22.5
+            self.IMAPConfig.IMAPSize = 32
+            self.IMAPConfig.Rings = 2
+        elseif maxmapdimension == 512 then
+            self.IMAPConfig.OgridRadius = 22.5
+            self.IMAPConfig.IMAPSize = 32
+            self.IMAPConfig.Rings = 2
+        elseif maxmapdimension == 1024 then
+            self.IMAPConfig.OgridRadius = 45.0
+            self.IMAPConfig.IMAPSize = 64
+            self.IMAPConfig.Rings = 1
+        elseif maxmapdimension == 2048 then
+            self.IMAPConfig.OgridRadius = 89.5
+            self.IMAPConfig.IMAPSize = 128
+            self.IMAPConfig.Rings = 0
+        else
+            self.IMAPConfig.OgridRadius = 180.0
+            self.IMAPConfig.IMAPSize = 256
+            self.IMAPConfig.Rings = 0
         end
     end,
 }

--- a/lua/editor/MiscBuildConditions.lua
+++ b/lua/editor/MiscBuildConditions.lua
@@ -329,26 +329,6 @@ function MapLessThan(aiBrain, sizeX, sizeZ)
     end
 end
 
---- Buildcondition to limit the number of factories 
----@param aiBrain AIBrain
----@param locationType string
----@param unitCategory EntityCategory
----@param pathType string
----@param unitCount integer
----@return boolean
-function ForcePathLimit(aiBrain, locationType, unitCategory, pathType, unitCount)
-    local currentEnemy = aiBrain:GetCurrentEnemy()
-    if not currentEnemy then
-        return true
-    end
-    local enemyIndex = aiBrain:GetCurrentEnemy():GetArmyIndex()
-    local selfIndex = aiBrain:GetArmyIndex()
-    if aiBrain.CanPathToEnemy[selfIndex][enemyIndex][locationType] ~= pathType and FactoryComparisonAtLocation(aiBrain, locationType, unitCount, unitCategory, '>=') then
-        return false
-    end
-    return true
-end
-
 --- Buildcondition to check pathing to current enemy 
 ---@param aiBrain AIBrain
 ---@param locationType string

--- a/lua/editor/UnitCountBuildConditions.lua
+++ b/lua/editor/UnitCountBuildConditions.lua
@@ -1433,6 +1433,26 @@ function CheckBuildPlattonDelay(aiBrain, PlatoonName)
     return true
 end
 
+--- Buildcondition to limit the number of factories 
+---@param aiBrain AIBrain
+---@param locationType string
+---@param unitCategory EntityCategory
+---@param pathType string
+---@param unitCount integer
+---@return boolean
+function ForcePathLimit(aiBrain, locationType, unitCategory, pathType, unitCount)
+    local currentEnemy = aiBrain:GetCurrentEnemy()
+    if not currentEnemy then
+        return true
+    end
+    local enemyIndex = aiBrain:GetCurrentEnemy():GetArmyIndex()
+    local selfIndex = aiBrain:GetArmyIndex()
+    if aiBrain.CanPathToEnemy[selfIndex][enemyIndex][locationType] ~= pathType and FactoryComparisonAtLocation(aiBrain, locationType, unitCount, unitCategory, '>=') then
+        return false
+    end
+    return true
+end
+
 --- Buildcondition to decide if radars should upgrade based on other radar locations.
 ---@param aiBrain AIBrain
 ---@param locationType string

--- a/lua/sim/EngineerManager.lua
+++ b/lua/sim/EngineerManager.lua
@@ -605,18 +605,6 @@ EngineerManager = Class(BuilderManager) {
     ---@param self EngineerManager
     ---@param unit Unit
     RemoveUnit = function(self, unit)
-        local guards = unit:GetGuards()
-        for k,v in guards do
-            if not v.Dead and v.AssistPlatoon then
-                if self.Brain.Sorian and self.Brain:PlatoonExists(v.AssistPlatoon) then
-                    v.AssistPlatoon:ForkThread(v.AssistPlatoon.SorianEconAssistBody)
-                elseif self.Brain:PlatoonExists(v.AssistPlatoon) then
-                    v.AssistPlatoon:ForkThread(v.AssistPlatoon.EconAssistBody)
-                else
-                    v.AssistPlatoon = nil
-                end
-            end
-        end
 
         local found = false
         for k,v in self.ConsumptionUnits do
@@ -678,18 +666,6 @@ EngineerManager = Class(BuilderManager) {
         end
         if finishedUnit:GetAIBrain():GetArmyIndex() == self.Brain:GetArmyIndex() then
             self:AddUnit(finishedUnit)
-        end
-        local guards = unit:GetGuards()
-        for k,v in guards do
-            if not v.Dead and v.AssistPlatoon then
-                if self.Brain.Sorian and self.Brain:PlatoonExists(v.AssistPlatoon) then
-                    v.AssistPlatoon:ForkThread(v.AssistPlatoon.SorianEconAssistBody)
-                elseif self.Brain:PlatoonExists(v.AssistPlatoon) then
-                    v.AssistPlatoon:ForkThread(v.AssistPlatoon.EconAssistBody)
-                else
-                    v.AssistPlatoon = nil
-                end
-            end
         end
     end,
 

--- a/lua/sim/FactoryBuilderManager.lua
+++ b/lua/sim/FactoryBuilderManager.lua
@@ -277,17 +277,7 @@ FactoryBuilderManager = Class(BuilderManager) {
     ---@param self FactoryBuilderManager
     ---@param factory Unit
     FactoryDestroyed = function(self, factory)
-        local guards = factory:GetGuards()
         local factoryDestroyed = false
-        for k,v in guards do
-            if not v.Dead and v.AssistPlatoon then
-                if self.Brain:PlatoonExists(v.AssistPlatoon) then
-                    v.AssistPlatoon:ForkThread(v.AssistPlatoon.EconAssistBody)
-                else
-                    v.AssistPlatoon = nil
-                end
-            end
-        end
         for k,v in self.FactoryList do
             if IsDestroyed(v) then
                 self.FactoryList[k] = nil
@@ -310,16 +300,6 @@ FactoryBuilderManager = Class(BuilderManager) {
     ---@param bType string
     ---@param time number
     DelayBuildOrder = function(self,factory,bType,time)
-        local guards = factory:GetGuards()
-        for k,v in guards do
-            if not v.Dead and v.AssistPlatoon then
-                if self.Brain:PlatoonExists(v.AssistPlatoon) then
-                    v.AssistPlatoon:ForkThread(v.AssistPlatoon.EconAssistBody)
-                else
-                    v.AssistPlatoon = nil
-                end
-            end
-        end
         if factory.DelayThread then
             return
         end


### PR DESCRIPTION
**Description of changes**
This PR contains the following changes.

- Fix issues with forcepathlimit. I shifted this to the MIBC previously without realising it had dependencies on UCBC. Have shifted back.
- Change CDRCompletion function to be no longer forked. The ACU was causing issues with structure completion due to this being forked. I've set this to no longer fork. It will limit the number of the times the acu can be interrupted. But the alternative is alot of extra logic
- Add the IMAP configuration values to the brain. These will be used for ring based imap selection in the future. I didn't realise that I hadn't done this yet.
- Replace the default hydro marker condition with Sorians. This is due to the condition only checking for a marker within a certain distance and not if its build able. This was causing builder trashing. This is temporary as I was to refactor and replace the Sorian condition function but I'd like to see how other AI's devs want to handle changes like that which will impact other AI.
- Removes the engineer guard logic from the following functions
EngineerManager - UnitConstructionFinished and RemoveUnit
FactoryManager - FactoryDestroyed and DelayBuildOrder

I've been troubleshooting issues with the AI's assist functions and it was tracked down to the following logic.
```
local guards = unit:GetGuards()
        for k,v in guards do
            if not v.Dead and v.AssistPlatoon then
                if self.Brain.Sorian and self.Brain:PlatoonExists(v.AssistPlatoon) then
                    v.AssistPlatoon:ForkThread(v.AssistPlatoon.SorianEconAssistBody)
                elseif self.Brain:PlatoonExists(v.AssistPlatoon) then
                    v.AssistPlatoon:ForkThread(v.AssistPlatoon.EconAssistBody)
                else
                    v.AssistPlatoon = nil
                end
            end
        end
```
When the engineers were assisting factories the DelayBuildOrder function would stop the engineers from going back into the army pool and make them behave strangely. I can't see reasons why this logic exists except for certain instances where you might want to force engineers off a wait timer during an assist loop. I discussed with Sprouto and we cant see why this code exist. We can only surmise someone put it in with faf to try and fix an issue. 
I've done testing and cannot see issues caused by no longer having this code present in the default AI but can see issues with keeping it. 


**Test for changes**

To test run a skirmish AI. The ACU should complete any projects it was previously doing after it is interrupted. But will only accept a single interruption. I don't believe this will be an issue but if in testing it does I'll need to go down a different avenue.

The AI's engineers that assist factories will no longer produce strange behaviours, previously they would get stuck in a strange loop of assisting for a second then going idle until the unit was completed. This means that any assist that went for a duration then would check the economy before picking up the job again would keep the economy stalled.

In the mid game the AI used to start spamming the `T1 Hydrocarbon Engineer Single` and `T1 Hydrocarbon Engineer` builders even though no hydro's were available to build on. This will no longer happen.
