### PR TITLE
AI refactor GetEconomyOverTime to work with new EconomyMonitor metrics

### DIFF
--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -2133,25 +2133,14 @@ AIBrain = Class(moho.aibrain_methods) {
     end,
 
     ---@param self AIBrain
+    ---@return table
     GetEconomyOverTime = function(self)
-        local eIncome = 0
-        local mIncome = 0
-        local eRequested = 0
-        local mRequested = 0
-        local num = 0
-        for k, v in self.EconomyData do
-            num = k
-            eIncome = eIncome + v.EnergyIncome
-            mIncome = mIncome + v.MassIncome
-            eRequested = eRequested + v.EnergyRequested
-            mRequested = mRequested + v.MassRequested
-        end
 
         local retTable = {}
-        retTable.EnergyIncome = eIncome / num
-        retTable.MassIncome = mIncome / num
-        retTable.EnergyRequested = eRequested / num
-        retTable.MassRequested = mRequested / num
+        retTable.EnergyIncome = self.EconomyOverTimeCurrent.EnergyIncome or 0
+        retTable.MassIncome = self.EconomyOverTimeCurrent.MassIncome or 0
+        retTable.EnergyRequested = self.EconomyOverTimeCurrent.EnergyRequested or 0
+        retTable.MassRequested = self.EconomyOverTimeCurrent.MassRequested or 0
 
         return retTable
     end,


### PR DESCRIPTION
**Description of changes**

This PR refactors the GetEconomyOverTime function so that it returns the same data as previously. When the EconomyMonitor was rewritten this function was never updated as it wasn't used across the default codebase but it was later found that a 3rd party mod used it. Its unknown what others might so I've updated it to return the correct data instead of throwing a nil exception.

**Test setup for changes**
Get something to perform the function call during an AI skirmish game. It will return a table with the AI's current over time metrics based on the original data setup.