### PR TITLE
Fix encoding issues

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -174,7 +174,7 @@ local function MountAllowedContent(dir, pattern, allowedAssets)
     for _,entry in IoDir(dir .. pattern) do
         if entry != '.' and entry != '..' then
             local mp = StringLower(entry)
-            if allowedAssets[mp] then 
+            if (not allowedAssets) or allowedAssets[mp] then
                 LOG("mounting content: " .. entry)
                 MountDirectory(dir .. "/" .. entry, '/')
             end
@@ -366,7 +366,7 @@ end
 ---@param modinfo FileName
 ---@return string|nil | false
 local function GetModVersion(modinfo)
-    local handle = io.open(modinfo, 'r')
+    local handle = io.open(modinfo, 'rb')
     if not handle then
         return false -- can't read file
     end

--- a/init_faf.lua
+++ b/init_faf.lua
@@ -174,7 +174,7 @@ local function MountAllowedContent(dir, pattern, allowedAssets)
     for _,entry in IoDir(dir .. pattern) do
         if entry != '.' and entry != '..' then
             local mp = StringLower(entry)
-            if allowedAssets[mp] then 
+            if (not allowedAssets) or allowedAssets[mp] then
                 LOG("mounting content: " .. entry)
                 MountDirectory(dir .. "/" .. entry, '/')
             end
@@ -366,7 +366,7 @@ end
 ---@param modinfo FileName
 ---@return string|nil | false
 local function GetModVersion(modinfo)
-    local handle = io.open(modinfo, 'r')
+    local handle = io.open(modinfo, 'rb')
     if not handle then
         return false -- can't read file
     end

--- a/init_fafbeta.lua
+++ b/init_fafbeta.lua
@@ -174,7 +174,7 @@ local function MountAllowedContent(dir, pattern, allowedAssets)
     for _,entry in IoDir(dir .. pattern) do
         if entry != '.' and entry != '..' then
             local mp = StringLower(entry)
-            if allowedAssets[mp] then 
+            if (not allowedAssets) or allowedAssets[mp] then
                 LOG("mounting content: " .. entry)
                 MountDirectory(dir .. "/" .. entry, '/')
             end
@@ -366,7 +366,7 @@ end
 ---@param modinfo FileName
 ---@return string|nil | false
 local function GetModVersion(modinfo)
-    local handle = io.open(modinfo, 'r')
+    local handle = io.open(modinfo, 'rb')
     if not handle then
         return false -- can't read file
     end

--- a/init_fafdevelop.lua
+++ b/init_fafdevelop.lua
@@ -174,7 +174,7 @@ local function MountAllowedContent(dir, pattern, allowedAssets)
     for _,entry in IoDir(dir .. pattern) do
         if entry != '.' and entry != '..' then
             local mp = StringLower(entry)
-            if allowedAssets[mp] then 
+            if (not allowedAssets) or allowedAssets[mp] then
                 LOG("mounting content: " .. entry)
                 MountDirectory(dir .. "/" .. entry, '/')
             end
@@ -366,7 +366,7 @@ end
 ---@param modinfo FileName
 ---@return string|nil | false
 local function GetModVersion(modinfo)
-    local handle = io.open(modinfo, 'r')
+    local handle = io.open(modinfo, 'rb')
     if not handle then
         return false -- can't read file
     end

--- a/init_shared.lua
+++ b/init_shared.lua
@@ -174,7 +174,7 @@ local function MountAllowedContent(dir, pattern, allowedAssets)
     for _,entry in IoDir(dir .. pattern) do
         if entry != '.' and entry != '..' then
             local mp = StringLower(entry)
-            if allowedAssets[mp] then 
+            if (not allowedAssets) or allowedAssets[mp] then
                 LOG("mounting content: " .. entry)
                 MountDirectory(dir .. "/" .. entry, '/')
             end
@@ -366,7 +366,7 @@ end
 ---@param modinfo FileName
 ---@return string|nil | false
 local function GetModVersion(modinfo)
-    local handle = io.open(modinfo, 'r')
+    local handle = io.open(modinfo, 'rb')
     if not handle then
         return false -- can't read file
     end


### PR DESCRIPTION
Apparently reading it non-binary like can change the encoding:
- https://forums.solar2d.com/t/how-to-read-file-in-utf-8-mode/341199

As a result, the preference file could be encoded with ANSI if there are special characters in it. Some mods use the copyright symbol, which can end up in the preference file. As a result, the client would no longer be able to read the preference file properly and it would cause all the issues that people have been experiencing with trying to start a game.