### PR TITLE
AI Tune assist builders

### DIFF
--- a/lua/AI/AIBuilders/AIEconomicBuilders.lua
+++ b/lua/AI/AIBuilders/AIEconomicBuilders.lua
@@ -590,7 +590,7 @@ BuilderGroup {
         Priority = 875,
         BuilderConditions = {
             { EBC, 'GreaterThanEconEfficiencyCombined', { 0.5, 0.5 }}, --DUNCAN - was 0.8 mass check
-            { EBC, 'LessThanEconEfficiencyOverTime', { 2.0, 1.4 }},
+            { EBC, 'LessThanEconEfficiencyOverTime', { 2.0, 1.3 }},
             { UCBC, 'EngineerLessAtLocation', { 'LocationType', 1, categories.ENGINEER * ( categories.TECH2 + categories.TECH3 ) } },
         },
         BuilderType = 'Any',
@@ -639,7 +639,7 @@ BuilderGroup {
         BuilderConditions = {
             { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.ENERGYPRODUCTION * ( categories.TECH2 + categories.TECH3 ) }},
             { EBC, 'LessThanEconEfficiencyOverTime', { 2.0, 1.5 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.5, 0.5 } },
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.7, 0.4 } },
         },
         BuilderType = 'Any',
         BuilderData = {
@@ -1499,117 +1499,14 @@ BuilderGroup {
     -- =========================
     --     T1 ENGINEER ASSIST
     -- =========================
-    --Builder {
-    --    BuilderName = 'T1 Engineer Assist Factory',
-    --    PlatoonTemplate = 'EngineerAssist',
-    --    Priority = 600,
-    --    BuilderConditions = {
-    --        { IBC, 'BrainNotLowPowerMode', {} },
-    --        { UCBC, 'LocationFactoriesBuildingGreater', { 'LocationType', 0, 'MOBILE' } },
-    --        { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.2 }},
-    --    },
-    --    InstanceCount = 5,
-    --    BuilderType = 'Any',
-    --    BuilderData = {
-    --        Assist = {
-    --            AssistLocation = 'LocationType',
-    --            PermanentAssist = true,
-    --            AssisteeType = 'Factory',
-    --            Time = 30,
-    --        },
-    --    }
-    --},
-    --Builder {
-    --    BuilderName = 'T1 Engineer Assist FactoryLowerPri',
-    --    PlatoonTemplate = 'EngineerAssist',
-    --    Priority = 500,
-    --    InstanceCount = 50,
-    --    BuilderConditions = {
-    --        { IBC, 'BrainNotLowPowerMode', {} },
-    --        { UCBC, 'LocationFactoriesBuildingGreater', { 'LocationType', 0, 'MOBILE' } },
-    --        { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.2 }},
-    --    },
-    --    BuilderType = 'Any',
-    --    BuilderData = {
-    --        Assist = {
-    --            AssistLocation = 'LocationType',
-    --            PermanentAssist = true,
-    --            AssisteeType = 'Factory',
-    --            Time = 30,
-    --        },
-    --    }
-    --},
-    --DUNCAN - uncommented
-    Builder {
-        BuilderName = 'T1 Engineer Assist Engineer',
-        PlatoonTemplate = 'EngineerAssist',
-        Priority = 1,
-        InstanceCount = 20,
-        BuilderConditions = {
-            { IBC, 'BrainNotLowPowerMode', {} },
-            { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.ALLUNITS } },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.1 }},
-        },
-        BuilderType = 'Any',
-        BuilderData = {
-            Assist = {
-                AssistLocation = 'LocationType',
-                PermanentAssist = true,
-                AssisteeType = 'Engineer',
-                Time = 30,
-            },
-        }
-    },
-    --Builder {
-    --    BuilderName = 'T1 Engineer Assist Shield',
-    --    PlatoonTemplate = 'EngineerAssist',
-    --    Priority = 825,
-    --    BuilderConditions = {
-    --        { IBC, 'BrainNotLowPowerMode', {} },
-    --        { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, 'STRUCTURE SHIELD' }},
-    --        { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.2 }},
-    --    },
-    --    InstanceCount = 2,
-    --    BuilderType = 'Any',
-    --    BuilderData = {
-    --        Assist = {
-    --            AssistLocation = 'LocationType',
-    --            AssisteeType = 'Engineer',
-    --            BeingBuiltCategories = {'SHIELD STRUCTURE'},
-    --            Time = 60,
-    --        },
-    --    }
-    --},
-    --Builder {
-    --    BuilderName = 'T1 Engineer Assist Mass Upgrade',
-    --    PlatoonTemplate = 'EngineerAssist',
-    --    Priority = 850,
-    --    BuilderConditions = {
-    --        { IBC, 'BrainNotLowPowerMode', {} },
-    --        { UCBC, 'BuildingGreaterAtLocation', { 'LocationType', 0, 'MASSEXTRACTION TECH2'}},
-    --        { UCBC, 'HaveLessThanUnitsWithCategory', { 5, categories.MASSEXTRACTION * ( categories.TECH2 + categories.TECH3 ) } },
-    --        { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.2 }},
-    --        { EBC, 'LessThanEconEfficiencyOverTime', { 1.5, 2.0 }},
-    --    },
-    --    InstanceCount = 2,
-    --    BuilderType = 'Any',
-    --    BuilderData = {
-    --        Assist = {
-    --            AssisteeType = 'Structure',
-    --            AssistLocation = 'LocationType',
-    --            BeingBuiltCategories = {'MASSEXTRACTION TECH2'},
-    --            Time = 60,
-    --        },
-    --    }
-    --},
     Builder {
         BuilderName = 'T1 Engineer Assist Power',
         PlatoonTemplate = 'EngineerAssist',
-        Priority = 900,
+        Priority = 950,
         BuilderConditions = {
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.7, 0.1 }},
+            { EBC, 'LessThanEconEfficiencyOverTime', { 2.0, 1.3 }},
             { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.ENERGYPRODUCTION }},
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.7, 0.8 }},
-            { EBC, 'LessThanEconEfficiencyOverTime', { 2.0, 1.4 }},
         },
         InstanceCount = 2,
         BuilderType = 'Any',
@@ -1625,71 +1522,51 @@ BuilderGroup {
             },
         }
     },
-    --Builder {
-    --    BuilderName = 'T1 Engineer Assist Transport',
-    --    PlatoonTemplate = 'EngineerAssist',
-    --    Priority = 875,
-    --    BuilderConditions = {
-    --        { UCBC, 'LocationFactoriesBuildingGreater', { 'LocationType', 0, 'TRANSPORTFOCUS' } },
-    --        { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.2 }},
-    --    },
-    --    InstanceCount = 2,
-    --    BuilderType = 'Any',
-    --    BuilderData = {
-    --        Assist = {
-    --            AssistLocation = 'LocationType',
-    --            PermanentAssist = false,
-    --            BeingBuiltCategories = {'TRANSPORTFOCUS'},
-    --            AssisteeType = 'Factory',
-    --            Time = 60,
-    --        },
-    --    },
-    --},
-    --Builder {
-    --    BuilderName = 'T1 Engineer Assist T2 Factory Upgrade',
-    --    PlatoonTemplate = 'EngineerAssist',
-    --    Priority = 875,
-    --    BuilderConditions = {
-    --        { IBC, 'BrainNotLowPowerMode', {} },
-    --        { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, 'ENGINEER TECH1'}},
-    --        { UCBC, 'LocationFactoriesBuildingGreater', { 'LocationType', 0, 'FACTORY TECH2' }},
-    --        { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.2 }},
-    --    },
-    --    InstanceCount = 4,
-    --    BuilderType = 'Any',
-    --    BuilderData = {
-    --        Assist = {
-    --            AssistLocation = 'LocationType',
-    --            PermanentAssist = true,
-    --            BeingBuiltCategories = {'FACTORY TECH2'},
-    --            AssisteeType = 'Factory',
-    --            Time = 60,
-    --        },
-    --    }
-    --},
-    --Builder {
-    --    BuilderName = 'T1 Engineer Assist T3 Factory Upgrade',
-    --    PlatoonTemplate = 'EngineerAssist',
-    --    Priority = 900,
-    --    BuilderConditions = {
-    --        { IBC, 'BrainNotLowPowerMode', {} },
-    --        { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, 'ENGINEER TECH1'}},
-    --        { UCBC, 'LocationFactoriesBuildingGreater', { 'LocationType', 0, categories.FACTORY * categories.TECH3 }},
-    --        { UCBC, 'HaveLessThanUnitsWithCategory', { 3, 'TECH3 FACTORY' } },
-    --        { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.2 }},
-    --    },
-    --    InstanceCount = 8,
-    --    BuilderType = 'Any',
-    --    BuilderData = {
-    --        Assist = {
-    --            AssistLocation = 'LocationType',
-    --            PermanentAssist = true,
-    --            BeingBuiltCategories = {'FACTORY TECH3'},
-    --            AssisteeType = 'Factory',
-    --            Time = 60,
-    --        },
-    --    }
-    --},
+
+    Builder {
+        BuilderName = 'T1 Engineer Assist T2 Factory Upgrade',
+        PlatoonTemplate = 'EngineerAssist',
+        Priority = 875,
+        InstanceCount = 4,
+        BuilderType = 'Any',
+        BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.2 }},
+            { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, categories.ENGINEER * categories.TECH1 }},
+            { UCBC, 'LocationFactoriesBuildingGreater', { 'LocationType', 0, categories.FACTORY * categories.TECH2 }},
+        },
+        BuilderData = {
+            Assist = {
+                AssistLocation = 'LocationType',
+                PermanentAssist = true,
+                BeingBuiltCategories = {'FACTORY TECH2'},
+                AssisteeType = 'Factory',
+                Time = 45,
+            },
+        }
+    },
+    Builder {
+        BuilderName = 'T1 Engineer Assist Mass Upgrade',
+        PlatoonTemplate = 'EngineerAssist',
+        Priority = 850,
+        InstanceCount = 2,
+        BuilderType = 'Any',
+        BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.1, 1.2 }},
+            { EBC, 'LessThanEconEfficiencyOverTime', { 1.5, 2.0 }},
+            { UCBC, 'BuildingGreaterAtLocation', { 'LocationType', 0, categories.MASSEXTRACTION * (categories.TECH2 + categories.TECH3) }},
+            { UCBC, 'HaveLessThanUnitsWithCategory', { 5, categories.MASSEXTRACTION * ( categories.TECH2 + categories.TECH3 ) } },
+        },
+        BuilderData = {
+            Assist = {
+                AssisteeType = 'Structure',
+                AssistLocation = 'LocationType',
+                BeingBuiltCategories = {'MASSEXTRACTION TECH2', 'MASSEXTRACTION TECH3'},
+                Time = 30,
+            },
+        }
+    },
 }
 
 BuilderGroup {
@@ -1763,12 +1640,12 @@ BuilderGroup {
         BuilderName = 'T2 Engineer Assist Energy',
         PlatoonTemplate = 'T2EngineerAssist',
         Priority = 900,
-        InstanceCount = 3,
+        InstanceCount = 5,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
+            { EBC, 'LessThanEconEfficiencyOverTime', { 2.0, 1.3 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.7, 0.1 } },
             { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.ENERGYPRODUCTION * ( categories.TECH2 + categories.TECH3 ) } },
-            { EBC, 'LessThanEconEfficiencyOverTime', { 2.0, 1.5 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.7, 0.5 } },
         },
         BuilderType = 'Any',
         BuilderData = {
@@ -1787,12 +1664,12 @@ BuilderGroup {
         BuilderName = 'T2 Engineer Assist Factory',
         PlatoonTemplate = 'T2EngineerAssist',
         Priority = 500,
-        InstanceCount = 50,
+        InstanceCount = 25,
         BuilderType = 'Any',
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { UCBC, 'LocationFactoriesBuildingGreater', { 'LocationType', 0, categories.MOBILE } },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.1 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.1 }},
         },
         BuilderData = {
             Assist = {
@@ -1809,8 +1686,10 @@ BuilderGroup {
         PlatoonTemplate = 'T2EngineerAssist',
         Priority = 875,
         BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.1 }},
             { UCBC, 'LocationFactoriesBuildingGreater', { 'LocationType', 0, categories.TRANSPORTFOCUS } },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.1 }},
+            
         },
         InstanceCount = 2,
         BuilderType = 'Any',
@@ -1828,12 +1707,12 @@ BuilderGroup {
         BuilderName = 'T2 Engineer Assist Engineer',
         PlatoonTemplate = 'T2EngineerAssist',
         Priority = 500,
-        InstanceCount = 50,
+        InstanceCount = 15,
         BuilderType = 'Any',
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
-            { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.ALLUNITS } },
             { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.1 }},
+            { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.ALLUNITS } },
         },
         BuilderData = {
             Assist = {
@@ -1849,14 +1728,14 @@ BuilderGroup {
         BuilderName = 'T2 Engineer Assist T3 Factory Upgrade',
         PlatoonTemplate = 'T2EngineerAssist',
         Priority = 975,
-        BuilderConditions = {
-            { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, categories.ENGINEER * categories.TECH1}},
-            { UCBC, 'LocationFactoriesBuildingGreater', { 'LocationType', 0, categories.FACTORY * categories.TECH3 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.5, 1.1 }},
-            { IBC, 'BrainNotLowPowerMode', {} },
-        },
         InstanceCount = 5,
         BuilderType = 'Any',
+        BuilderConditions = {
+            { IBC, 'BrainNotLowPowerMode', {} },
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.1 }},
+            { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, categories.ENGINEER * categories.TECH1}},
+            { UCBC, 'LocationFactoriesBuildingGreater', { 'LocationType', 0, categories.FACTORY * categories.TECH3 }},
+        },
         BuilderData = {
             Assist = {
                 AssistLocation = 'LocationType',
@@ -1897,11 +1776,11 @@ BuilderGroup {
         BuilderName = 'T3 Engineer Assist T3 Energy Production',
         PlatoonTemplate = 'T3EngineerAssist',
         Priority = 950,
-        InstanceCount = 3,
+        InstanceCount = 5,
         BuilderConditions = {
             { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.ENERGYPRODUCTION * categories.TECH3 }},
             { EBC, 'LessThanEconEfficiencyOverTime', { 2, 1.3}},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.7, 0.5 } },
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.7, 0.1 } },
         },
         BuilderType = 'Any',
         BuilderData = {
@@ -1942,11 +1821,11 @@ BuilderGroup {
         Priority = 800,
         InstanceCount = 1,
         BuilderConditions = {
+                { IBC, 'BrainNotLowPowerMode', {} },
+                { EBC, 'LessThanEconEfficiencyOverTime', { 1.0, 2.0}},
+                { EBC, 'GreaterThanEconEfficiencyCombined', { 0.6, 1.1}},
                 { UCBC, 'EngineerGreaterAtLocation', { 'LocationType', 1, categories.ENGINEER * categories.TECH3 }},
                 { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.MASSPRODUCTION * categories.TECH3 }},
-                { EBC, 'LessThanEconEfficiencyOverTime', { 0.9, 2.0}},
-                { EBC, 'GreaterThanEconEfficiencyCombined', { 0.6, 1.1}},
-                { IBC, 'BrainNotLowPowerMode', {} },
             },
         BuilderType = 'Any',
         BuilderData = {
@@ -1964,10 +1843,10 @@ BuilderGroup {
         Priority = 750,
         InstanceCount = 1,
         BuilderConditions = {
-            { UCBC, 'EngineerGreaterAtLocation', { 'LocationType', 1, categories.ENGINEER * categories.TECH3 }},
-            { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.STRUCTURE * categories.DEFENSE }},
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.1} },
+            { UCBC, 'EngineerGreaterAtLocation', { 'LocationType', 1, categories.ENGINEER * categories.TECH3 }},
+            { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.STRUCTURE * categories.DEFENSE }},
         },
         BuilderType = 'Any',
         BuilderData = {
@@ -1985,9 +1864,9 @@ BuilderGroup {
         Priority = 750,
         InstanceCount = 2,
         BuilderConditions = {
-            { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.STRUCTURE * categories.SHIELD }},
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.1} },
+            { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.STRUCTURE * categories.SHIELD }},
         },
         BuilderType = 'Any',
         BuilderData = {
@@ -2005,9 +1884,9 @@ BuilderGroup {
         Priority = 700,
         InstanceCount = 20,
         BuilderConditions = {
-            { UCBC, 'LocationFactoriesBuildingGreater', { 'LocationType', 0, categories.MOBILE }},
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.1} },
+            { UCBC, 'LocationFactoriesBuildingGreater', { 'LocationType', 0, categories.MOBILE }},
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, categories.EXPERIMENTAL } }, --DUNCAN - added
         },
         BuilderType = 'Any',
@@ -2026,9 +1905,9 @@ BuilderGroup {
         Priority = 700,
         InstanceCount = 20,
         BuilderConditions = {
-            { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.STRUCTURE * categories.TECH3 + categories.EXPERIMENTAL }},
             { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.1} }, --DUNCAN - was 1.0, 1.1
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.1} }, --DUNCAN - was 1.0, 1.1
+            { UCBC, 'LocationEngineersBuildingAssistanceGreater', { 'LocationType', 0, categories.STRUCTURE * categories.TECH3 + categories.EXPERIMENTAL }},
         },
         BuilderType = 'Any',
         BuilderData = {
@@ -2092,7 +1971,7 @@ BuilderGroup {
         BuilderName = 'T1ResourceEngineer 250',
         PlatoonTemplate = 'EngineerBuilder',
         Priority = 970,
-        InstanceCount = 4,
+        InstanceCount = 3,
         BuilderConditions = {
                 --{ UCBC, 'EngineerLessAtLocation', { 'LocationType', 3, categories.ENGINEER * (categories.TECH2 + categories.TECH3) }},
                 { MABC, 'CanBuildOnMassLessThanDistance', { 'LocationType', 250, -500, 1, 0, 'AntiSurface', 1 }},
@@ -2112,7 +1991,7 @@ BuilderGroup {
         BuilderName = 'T1ResourceEngineer 450',
         PlatoonTemplate = 'EngineerBuilder',
         Priority = 800,
-        InstanceCount = 4,
+        InstanceCount = 3,
         BuilderConditions = {
                 --{ UCBC, 'EngineerLessAtLocation', { 'LocationType', 3, categories.ENGINEER * (categories.TECH2 + categories.TECH3) }},
                 { MABC, 'CanBuildOnMassLessThanDistance', { 'LocationType', 450, -500, 1, 0, 'AntiSurface', 1 }},
@@ -2205,27 +2084,9 @@ BuilderGroup {
         }
     },
     Builder {
-        BuilderName = 'T3 T3Resource Engineer 500 range',
-        PlatoonTemplate = 'T3EngineerBuilder',
-        --DUNCAN - Changed from 850
-        Priority = 0,
-        BuilderConditions = {
-                { MABC, 'CanBuildOnMassLessThanDistance', { 'LocationType', 1000, -500, 1, 0, 'AntiSurface', 1 }},
-            },
-        BuilderType = 'Any',
-        BuilderData = {
-            DesiresAssist = false,
-            Construction = {
-                BuildStructures = {
-                    'T3Resource',
-                }
-            }
-        }
-    },
-    Builder {
         BuilderName = 'T3 Mass Fab Engineer',
         PlatoonTemplate = 'T3EngineerBuilder',
-        Priority = 1200, --DUNCAN - was 900
+        Priority = 980, --DUNCAN - was 900
         BuilderConditions = {
                 { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.MASSFABRICATION } },
                 { EBC, 'LessThanEconEfficiencyOverTime', { 0.95, 2.0}}, --DUNCAN - was 0.8

--- a/lua/AI/AIBuilders/AIExperimentalBuilders.lua
+++ b/lua/AI/AIBuilders/AIExperimentalBuilders.lua
@@ -157,9 +157,9 @@ BuilderGroup {
         BuilderName = 'T4 Exp Land',
         PlatoonAddPlans = {'NameUnits'},
         PlatoonTemplate = 'T4ExperimentalLand',
-        Priority = 10001,
+        Priority = 1000,
         FormRadius = 10000,
-        InstanceCount = 50,
+        InstanceCount = 10,
         BuilderConditions = {
             { UCBC, 'HaveUnitsWithCategoryAndAlliance', { false, 1, categories.NUKE * categories.STRUCTURE, 'Enemy'}},
             { UCBC, 'HaveUnitsWithCategoryAndAlliance', { false, 2, categories.TACTICALMISSILEPLATFORM, 'Enemy'}},
@@ -177,9 +177,9 @@ BuilderGroup {
         BuilderName = 'T4 Exp Land Group',
         PlatoonAddPlans = {'NameUnits'},
         PlatoonTemplate = 'T4ExperimentalLandGroup',
-        Priority = 10000,
+        Priority = 1000,
         FormRadius = 10000,
-        InstanceCount = 50,
+        InstanceCount = 10,
         BuilderType = 'Any',
         BuilderData = {
             ThreatWeights = {


### PR DESCRIPTION
**Description of changes**

This PR does a small tune on the default AI assist builders. Its goal is to provide a slightly higher economic trigger threshold on the builders so that the AI won't try and dump a bunch of assisting engineers into something (power building is a bit of an exception here) when its already stalling mass. We also re-enable a couple of previously disabled assist builders and keep them on a small timer.
All up this is not a noticeable change but is a way to trying to keep the AI's economy stalling as much in the mid-late game.

There are also some minor changes to experimental platoon formers such as decreasing the priority. For land experimentals it was set to 10,000 which indicates someone trying to fix an unrelated problem with priorities. If testing shows this has caused an issue I'll track down the true cause.

**Test setup for changes**
These are observational changes and hard to notice. No differences should be observed in experimental platoon formers, and the assisting builders should not trigger as often when the AI economy is stalling. Except in the case of power builders but even then only if its energy efficiency is below a threshold.