### PR TITLE
AI utility function and rallypoint set change

### DIFF
--- a/lua/AI/aiutilities.lua
+++ b/lua/AI/aiutilities.lua
@@ -2971,7 +2971,7 @@ function ShiftPosition(pos1, pos2, dist, reverse)
     --if the reverse bool is set it will go in the oposite direction e.g towards/away
     --It is multipurpose, used for simple vector3 lerps and enemy avoidence logic
     if not pos1 or not pos2 then
-        WARN('*AI WARNING: ShiftPosition Missing positions')
+        WARN('*AI WARNING: ShiftPosition missing positions')
     end
     local delta
     if reverse then

--- a/lua/AI/aiutilities.lua
+++ b/lua/AI/aiutilities.lua
@@ -2959,3 +2959,30 @@ function AIFindFurthestExpansionAreaNeedsEngineer(aiBrain, locationType, radius,
 
     return retPos, retName
 end
+
+---@param table pos1
+---@param table pos2
+---@param integer dist
+---@param bool reverse
+---@return table
+function ShiftPosition(pos1, pos2, dist, reverse)
+    --This function will lerp a position in two ways
+    --By default it will shift from pos2 to pos1 at the specified distance    
+    --if the reverse bool is set it will go in the oposite direction e.g towards/away
+    --It is multipurpose, used for simple vector3 lerps and enemy avoidence logic
+    if not pos1 or not pos2 then
+        WARN('ShiftPosition* Missing positions ')
+    end
+    local delta
+    if reverse then
+        delta = VDiff(pos1,pos2)
+    else
+        delta = VDiff(pos2,pos1)
+    end
+    local norm = math.max(VDist2(delta[1],delta[3],0,0),1)
+    local x = pos1[1]+dist*delta[1]/norm
+    local z = pos1[3]+dist*delta[3]/norm
+    x = math.min(ScenarioInfo.size[1]-5,math.max(5,x))
+    z = math.min(ScenarioInfo.size[2]-5,math.max(5,z))
+    return {x,GetSurfaceHeight(x,z),z}
+end

--- a/lua/AI/aiutilities.lua
+++ b/lua/AI/aiutilities.lua
@@ -2971,7 +2971,7 @@ function ShiftPosition(pos1, pos2, dist, reverse)
     --if the reverse bool is set it will go in the oposite direction e.g towards/away
     --It is multipurpose, used for simple vector3 lerps and enemy avoidence logic
     if not pos1 or not pos2 then
-        WARN('ShiftPosition* Missing positions ')
+        WARN('*AI WARNING: ShiftPosition Missing positions')
     end
     local delta
     if reverse then

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -1551,6 +1551,9 @@ AIBrain = Class(moho.aibrain_methods) {
 
         -- Add default main location and setup the builder managers
         self.NumBases = 0 -- AddBuilderManagers will increase the number
+        
+        -- Set the map center point
+        self.MapCenterPoint = { (ScenarioInfo.size[1] / 2), GetSurfaceHeight((ScenarioInfo.size[1] / 2), (ScenarioInfo.size[2] / 2)) ,(ScenarioInfo.size[2] / 2) }
 
         self.BuilderManagers = {}
         SUtils.AddCustomUnitSupport(self)

--- a/lua/sim/FactoryBuilderManager.lua
+++ b/lua/sim/FactoryBuilderManager.lua
@@ -538,7 +538,10 @@ FactoryBuilderManager = Class(BuilderManager) {
         -- Use factory location if no other rally or if rally point is far away
         if not rally or VDist2(rally[1], rally[3], position[1], position[3]) > 75 then
             -- DUNCAN - added to try and vary the rally points.
-            position = AIUtils.RandomLocation(position[1],position[3])
+            local locationType = self.LocationType
+            local factoryPos = self.Brain.BuilderManagers[locationType].Position
+            local startDistance = VDist3(self.Brain.MapCenterPoint, factoryPos)
+            position = AIUtils.ShiftPosition(factoryPos, self.Brain.MapCenterPoint, 25)
             rally = position
         end
 

--- a/lua/sim/FactoryBuilderManager.lua
+++ b/lua/sim/FactoryBuilderManager.lua
@@ -540,7 +540,6 @@ FactoryBuilderManager = Class(BuilderManager) {
             -- DUNCAN - added to try and vary the rally points.
             local locationType = self.LocationType
             local factoryPos = self.Brain.BuilderManagers[locationType].Position
-            local startDistance = VDist3(self.Brain.MapCenterPoint, factoryPos)
             position = AIUtils.ShiftPosition(factoryPos, self.Brain.MapCenterPoint, 25)
             rally = position
         end


### PR DESCRIPTION
**Description of changes**
This PR implements a small utility function for the AI to help it perform a few task.
The ShiftPosition function will lerp towards or away from a position based a distance specified. It will be used for simple position shifts and also for avoiding enemy units when that logic is implemented.

The MapCenterPoint attribute is added to the AI brain so that is can easily query it for position references. This will be used for a few things.

The rallypoint logic change. When a map does not contain any rally point markers currently the AI will pick a random position at 30 units somewhere from the current. When used for rally points it means that it can often be placed in front, behind or to the side of a base. Apart from the extra time spent moving it also means that large formations that are formed up at the rally point will have to try and move through the AI base at times. 
Also any platoon returning to base have uncertain return points unless a base center point is used, which causes the same issues. This behaviour can be seen with the attackforceai when it can't find an attack position. It will return to the center point of the base and eventually get stuck. With a more reliable rally point set I can make platoons return to the rally point instead of the base center point and have confidence they won't end up with the same issue.

**How to test**
Start an AI skirmish game on a map that has no rally point markers (crash site for example). Once the AI has built its first factory the rally point should be set towards the map center point at around 25 units from the base center point. 25 units was found to be the sweet spot for various map types and avoiding being too close. Keep in mind that the AI has a rally point monitor that will shift the rally point should a structure be placed on it.

note that we are not using the navmesh yet so a map with no rally point usually means a map with no markers at all. I currently use Uveso's marker generator for these scenarios but it does not create rally point markers. So for this particular scenario it is useful for the test.

This is not a perfect solution for all maps with no rally point markers but it is much better than the current.

p.s I suck at maths, the shift position utility function was gifted by Softles.
p.p.s This doesn't solve the problem of naval factories setting their waypoint to the base one.  I believe this only happens when the naval rush template is selected which we shouldn't be doing anyway.
