### PR TITLE
AI - Change ReturnToBaseAI to use factorymanager rallypoint

### DIFF
--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -3269,10 +3269,8 @@ Platoon = Class(moho.platoon_methods) {
             AIAttackUtils.GetMostRestrictiveLayer(self)
             if bestBase.FactoryManager.RallyPoint then
                 returnPos = bestBase.FactoryManager.RallyPoint
-                LOG('Return to base using rally point of '..repr(returnPos))
             else
                 returnPos = bestBase.Position
-                LOG('Return to base using base position '..repr(returnPos))
             end
             local path, reason = AIAttackUtils.PlatoonGenerateSafePathTo(aiBrain, self.MovementLayer, self:GetPlatoonPosition(), returnPos, 200)
             -- remove any formation settings to ensure a quick return to base.

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -3253,6 +3253,7 @@ Platoon = Class(moho.platoon_methods) {
         local bestBaseName = ""
         local bestDistSq = 999999999
         local platPos = self:GetPlatoonPosition()
+        local returnPos
 
         for baseName, base in aiBrain.BuilderManagers do
             local distSq = VDist2Sq(platPos[1], platPos[3], base.Position[1], base.Position[3])
@@ -3266,7 +3267,14 @@ Platoon = Class(moho.platoon_methods) {
 
         if bestBase then
             AIAttackUtils.GetMostRestrictiveLayer(self)
-            local path, reason = AIAttackUtils.PlatoonGenerateSafePathTo(aiBrain, self.MovementLayer, self:GetPlatoonPosition(), bestBase.Position, 200)
+            if bestBase.FactoryManager.RallyPoint then
+                returnPos = bestBase.FactoryManager.RallyPoint
+                LOG('Return to base using rally point of '..repr(returnPos))
+            else
+                returnPos = bestBase.Position
+                LOG('Return to base using base position '..repr(returnPos))
+            end
+            local path, reason = AIAttackUtils.PlatoonGenerateSafePathTo(aiBrain, self.MovementLayer, self:GetPlatoonPosition(), returnPos, 200)
             -- remove any formation settings to ensure a quick return to base.
             self:SetPlatoonFormationOverride('NoFormation')
             self:Stop()
@@ -3277,13 +3285,13 @@ Platoon = Class(moho.platoon_methods) {
                     self:MoveToLocation(path[i], false)
                 end
             end
-            self:MoveToLocation(bestBase.Position, false)
+            self:MoveToLocation(returnPos, false)
 
             local oldDistSq = 0
             while aiBrain:PlatoonExists(self) do
-                WaitSeconds(10)
+                WaitTicks(100)
                 platPos = self:GetPlatoonPosition()
-                local distSq = VDist2Sq(platPos[1], platPos[3], bestBase.Position[1], bestBase.Position[3])
+                local distSq = VDist2Sq(platPos[1], platPos[3], returnPos[1], returnPos[3])
                 if distSq < 100 then
                     self:PlatoonDisband()
                     return


### PR DESCRIPTION
**Description of changes**
This PR changes how the default ReturnToBaseAI function sets its destination. Previously it would return to the base position, which is the center of the base. This causes issues when a platoon returns to base multiple times within quick succession leading to platoons moving closer to the center point. Which in turn will cause pathing issues in the late game within the base and contribute to the classic symptom of AI's units being stuck in the base.

The platoons will now return to the base rally point. As long as the rally point is in the front of the base(there is another PR in that makes this more likely) then units will not traverse through the AI base to get to the return to base position or moving from the base position to where ever they are going.


**How to test**
Run an AI game (you will need to log the ReturnToBaseAI funciton). You can log the positions selected from line 3271 and 3273 of the platoon.lua file to confirm if the units are getting the correct position.
If the base has a factory manager running then they will return to the factory manager rally point. If not they will return to the base position.