### PR TITLE
Add 'Spawn' to search for spawn markers that are in use by players

### DIFF
--- a/lua/sim/MarkerUtilities.lua
+++ b/lua/sim/MarkerUtilities.lua
@@ -20,14 +20,17 @@
 local StringSplit = import("/lua/system/utils.lua").StringSplit
 local TableDeepCopy = table.deepcopy
 
+---@alias MarkerType 'Mass' | 'Hydrocarbon' | 'Spawn' | 'Air Path Node' | 'Land Path Node' | 'Water Path Node' | 'Ampibious Path Node' | 'Transport Marker' | 'Naval Area' | 'Naval Link' | 'Rally Point' | 'Expansion Area' | 'Protected Experimental Construction'
+
 ---@class MarkerData
 ---@field size number
 ---@field resource boolean
 ---@field type string
 ---@field orientation Vector
 ---@field position Vector
----@field color Color | nil 
+---@field color Color | nil
 ---@field adjacentTo string         # used by old pathing markers to identify the neighbors
+---@field name? string              # used by spawn markers
 ---@field NavLayer NavLayers        # Navigational layer that this marker is on, only defined for resources
 ---@field NavLabel number | nil     # Navigational label of the graph this marker is on, only defined for resources and when AIs are in-game
 
@@ -52,12 +55,24 @@ local MarkerCache = {}
 -- Pre-enable the caching of resource markers, to support adaptive maps
 MarkerCache["Mass"] = { Count = 0, Markers = {} }
 MarkerCache["Hydrocarbon"] = { Count = 0, Markers = {} }
+MarkerCache["Spawn"] = { Count = 0, Markers = {} }
+
+local armies = table.hash(ListArmies())
+for k, marker in AllMarkers do
+    if armies[k] then
+        marker.name = k
+        MarkerCache["Spawn"].Count = MarkerCache["Spawn"].Count + 1
+        MarkerCache["Spawn"].Markers[MarkerCache["Spawn"].Count] = marker
+    end
+end
+
+reprsl(MarkerCache)
 
 --- Retrieves all markers of a given type. This is a shallow copy,
 -- which means the reference is copied but the values are not. If you
 -- need a copy with unique values use GetMarkerByTypeDeep instead.
 -- Common marker types are:
--- - "Mass", "Hydrocarbon"
+-- - "Mass", "Hydrocarbon", "Spawn"
 -- - "Air Path Node", "Land Path Node", "Water Path Node", "Amphibious Path Node"
 -- - "Transport Marker", "Naval Area", "Naval Link", "Rally Point", "Expansion Area"
 -- - "Protected Experimental Construction"
@@ -117,7 +132,7 @@ end
 function FlushMarkerCacheByType(type)
 
     -- give developer a warning, you can't do this
-    if type == "Mass" or type == "Hydrocarbon" then
+    if type == "Mass" or type == "Hydrocarbon" or type == "Spawn" then
         WARN("Unable to flush resource markers from the cache - it can cause issues for adaptive maps.")
         return
     end
@@ -128,10 +143,11 @@ end
 --- Flushes the entire marker cache. Does not remove existing references.
 function FlushMarkerCache()
 
-    -- copy over mass / hydro for consistency with adaptive maps
+    -- copy over for consistency
     local cache = {}
     cache.Mass = MarkerCache.Mass
     cache.Hydrocarbon = MarkerCache.Hydrocarbon
+    cache.Spawn = MarkerCache.Spawn
 
     MarkerCache = cache
 end

--- a/lua/sim/MarkerUtilities.lua
+++ b/lua/sim/MarkerUtilities.lua
@@ -66,8 +66,6 @@ for k, marker in AllMarkers do
     end
 end
 
-reprsl(MarkerCache)
-
 --- Retrieves all markers of a given type. This is a shallow copy,
 -- which means the reference is copied but the values are not. If you
 -- need a copy with unique values use GetMarkerByTypeDeep instead.


### PR DESCRIPTION
Closes #4453

```
INFO:  - Spawn: table: 19880FC8
INFO:  -    Count: 1
INFO:  -    Markers: table: 19880D48
INFO:  -       1: table: 13B58050
INFO:  -          color: ff800080
INFO:  -          name: ARMY_1
INFO:  -          orientation: table: 13B58028
INFO:  -             1: 0
INFO:  -             2: 0
INFO:  -             3: 0
INFO:  -             type: VECTOR3
INFO:  -          position: table: 18B0E280
INFO:  -             1: 178.5
INFO:  -             2: 47.776359558105
INFO:  -             3: 182.5
INFO:  -             type: VECTOR3
INFO:  -          prop: /env/common/props/markers/M_Blank_prop.bp
INFO:  -          type: Blank Marker
```