### PR TITLE
AI - Remove IgnoreWeakerTargetsRatio from attackforceai target logic

### DIFF
--- a/lua/AI/aiattackutilities.lua
+++ b/lua/AI/aiattackutilities.lua
@@ -203,9 +203,7 @@ function GetBestThreatTarget(aiBrain, platoon, bSkipPathability)
     -- is less than this level, then just outright ignore it as a threat
     local IgnoreThreatLessThan = 15
     -- if the platoon is stronger than this threat level, then ignore weaker targets if the platoon is stronger
-    -- by the given ratio
     local IgnoreWeakerTargetsIfStrongerThan = 20
-    local IgnoreWeakerTargetsRatio = 5
 
     -- When evaluating threat, how many rings in the threat grid do we look at
     local EnemyThreatRings = 1
@@ -237,7 +235,6 @@ function GetBestThreatTarget(aiBrain, platoon, bSkipPathability)
         SecondaryTargetThreatType = SecondaryTargetThreatType or ThreatWeights.SecondaryTargetThreatType
         IgnoreCommanderStrength = IgnoreCommanderStrength or ThreatWeights.IgnoreCommanderStrength
         IgnoreWeakerTargetsIfStrongerThan = ThreatWeights.IgnoreWeakerTargetsIfStrongerThan or IgnoreWeakerTargetsIfStrongerThan
-        IgnoreWeakerTargetsRatio = ThreatWeights.IgnoreWeakerTargetsRatio or IgnoreWeakerTargetsRatio
         IgnoreThreatLessThan = ThreatWeights.IgnoreThreatLessThan or IgnoreThreatLessThan
         PrimaryTargetThreatType = ThreatWeights.PrimaryTargetThreatType or PrimaryTargetThreatType
         SecondaryTargetThreatType = ThreatWeights.SecondaryTargetThreatType or SecondaryTargetThreatType
@@ -355,7 +352,6 @@ function GetBestThreatTarget(aiBrain, platoon, bSkipPathability)
         if myThreat <= IgnoreStrongerTargetsIfWeakerThan
                 and (myThreat == 0 or enemyThreat / (myThreat + friendlyThreat) > IgnoreStrongerTargetsRatio)
                 and unitCapRatio < IgnoreStrongerUnitCap then
-            --LOG('*AI DEBUG: Skipping threat')
             continue
         end
 
@@ -364,7 +360,7 @@ function GetBestThreatTarget(aiBrain, platoon, bSkipPathability)
             threat[3] = threat[3] + threatDiff * WeakAttackThreatWeight
         else
             -- ignore overall threats that are really low, otherwise we want to defeat the enemy wherever they are
-            if (baseThreat <= IgnoreThreatLessThan) or (myThreat >= IgnoreWeakerTargetsIfStrongerThan and (enemyThreat == 0 or myThreat / enemyThreat > IgnoreWeakerTargetsRatio)) then
+            if (baseThreat <= IgnoreThreatLessThan) then
                 continue
             end
             threat[3] = threat[3] + threatDiff * StrongAttackThreatWeight


### PR DESCRIPTION
**Description of changes**
This PR removes some bad logic from the GetBestThreatTarget function which the attackforceai uses.
The logic in question created a target acquisition failure loop in the late game. The platoon would try and search for a target. It would get a primary or secondary threat. Then it would check for enemy threat in the positions.
If the enemy was weaker or there was no intel to provide Land/Antisurface threat numbers back then the platoon would deem itself too powerful and ignore the position. Then the platoon would merge into a larger platoon and perform the same check.
It would eventually enter an endless cycle of deeming all other threat unworthy depending on what the enemy was doing and end up with large groups of units bunched up at a base position.

To simplify the explanation. If you put a diamond in a room the AI would only want to steal it if you had armed guards that were similar to its heist team. Else they wouldn't bother stealing it.

**Testing changes**
This test would need to be confirmed using replays. But it is a bit of a pain to setup the scenario.
You would need to have the AI in a position where its enemy is weakened and is not generating much threat while the AI has attackforceai platoon with many T3 units etc propping up its platoon threat into the 100s.
Once this happened the platoons would start ignoring targets due to lower enemy threat at those positions.

p.s in team games this also relies on PR 4460 to make sure dead enemies are never selected as the current enemy else the `if (baseThreat <= IgnoreThreatLessThan) then` statement would go true due to a strange interaction of Overall threat being present but all other threat types being zero.