### PR TITLE
Fixed default terrain type skin function

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2603,7 +2603,7 @@ Unit = Class(moho.unit_methods) {
                 local pos = self:GetPosition()
                 local terrainType = GetTerrainType(pos[1], pos[3])
                 if bpTM[terrainType.Style] then
-                    self:SetMesh(bpTM[terrainType.Style])
+                    self:SetMesh(bpTM[terrainType.Style], true)
                     useTerrainType = true
                 end
             end


### PR DESCRIPTION
Not having the second argument in the terrain type be `true` causes it to destroy any c-objects on the mesh to be destroyed. This includes weapons, thrusters, sliders, and so on. It's an unused feature, but is fully implemented aside from this one typo.