### PR TITLE
Fix scaling of lobby chat messages

### DIFF
--- a/lua/ui/lobby/chatarea.lua
+++ b/lua/ui/lobby/chatarea.lua
@@ -132,7 +132,7 @@ ChatArea = Class(Group) {
 
     CreateLine = function(self, parent)
         local line = Group(parent)
-        line.Height:Set(self.Style.lineSpacing + self.Style.fontSize())
+        LayoutHelpers.SetHeight(line, self.Style.lineSpacing + self.Style.fontSize())
         line.Width:Set(parent.Width)
         line:DisableHitTest()
 


### PR DESCRIPTION
Fixes #4480

200% scale
Before:
![ForgedAlliance_2022-12-07_11-59-59](https://user-images.githubusercontent.com/10947024/206162466-2e6d78f5-003c-4552-acbc-3cb7e81248fd.png)
After:
![ForgedAlliance_2022-12-07_11-59-32](https://user-images.githubusercontent.com/10947024/206162476-0aec7e3d-a381-4ba7-b188-607bab8690a0.png)
