### PR TITLE
Prevent loading navigational mesh by default and fix issues with M27AI

### DIFF
--- a/lua/AI/AIBuilders/AIAirAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AIAirAttackBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("AIAirAttackBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/AIArtilleryBuilders.lua
+++ b/lua/AI/AIBuilders/AIArtilleryBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("AIArtilleryBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/AIDefenseBuilders.lua
+++ b/lua/AI/AIBuilders/AIDefenseBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("AIDefenseBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/AIEconomicBuilders.lua
+++ b/lua/AI/AIBuilders/AIEconomicBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("AIEconomicBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/AIEconomyUpgradeBuilders.lua
+++ b/lua/AI/AIBuilders/AIEconomyUpgradeBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("AIEconomyUpgradeBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/AIExpansionBuilders.lua
+++ b/lua/AI/AIBuilders/AIExpansionBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("AIExpansionBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/AIExperimentalBuilders.lua
+++ b/lua/AI/AIBuilders/AIExperimentalBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("AIExperimentalBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/AIFactoryConstructionBuilders.lua
+++ b/lua/AI/AIBuilders/AIFactoryConstructionBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("AIFactoryConstructionBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/AIIntelBuilders.lua
+++ b/lua/AI/AIBuilders/AIIntelBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("AIIntelBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/AILandAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AILandAttackBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("AILandAttackBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/AINavalBuilders.lua
+++ b/lua/AI/AIBuilders/AINavalBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("AINavalBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/AISeaAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AISeaAttackBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("AISeaAttackBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/SorianAirAttackBuilders.lua
+++ b/lua/AI/AIBuilders/SorianAirAttackBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("SorianAirAttackBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/SorianArtilleryBuilders.lua
+++ b/lua/AI/AIBuilders/SorianArtilleryBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("SorianArtilleryBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/SorianDefenseBuilders.lua
+++ b/lua/AI/AIBuilders/SorianDefenseBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("SorianDefenseBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/SorianEconomicBuilders.lua
+++ b/lua/AI/AIBuilders/SorianEconomicBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("SorianEconomicBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/SorianEconomyUpgradeBuilders.lua
+++ b/lua/AI/AIBuilders/SorianEconomyUpgradeBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("SorianEconomyUpgradeBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/SorianExpansionBuilders.lua
+++ b/lua/AI/AIBuilders/SorianExpansionBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("SorianExpansionBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/SorianExperimentalBuilders.lua
+++ b/lua/AI/AIBuilders/SorianExperimentalBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("SorianExperimentalBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/SorianFactoryConstructionBuilders.lua
+++ b/lua/AI/AIBuilders/SorianFactoryConstructionBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("SorianFactoryConstructionBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/SorianIntelBuilders.lua
+++ b/lua/AI/AIBuilders/SorianIntelBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("SorianIntelBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/SorianLandAttackBuilders.lua
+++ b/lua/AI/AIBuilders/SorianLandAttackBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("SorianLandAttackBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/SorianNavalBuilders.lua
+++ b/lua/AI/AIBuilders/SorianNavalBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("SorianNavalBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/SorianSeaAttackBuilders.lua
+++ b/lua/AI/AIBuilders/SorianSeaAttackBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("SorianSeaAttackBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local UCBC = '/lua/editor/unitcountbuildconditions.lua'
 local IBC = '/lua/editor/instantbuildconditions.lua'
 local TBC = '/lua/editor/threatbuildconditions.lua'

--- a/lua/AI/AIBuilders/SorianStrategyBuilders.lua
+++ b/lua/AI/AIBuilders/SorianStrategyBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("SorianStrategyBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local BBTmplFile = '/lua/basetemplates.lua'
 local BuildingTmpl = 'BuildingTemplates'
 local BaseTmpl = 'BaseTemplates'

--- a/lua/AI/AIBuilders/SorianStrategyPlatoonBuilders.lua
+++ b/lua/AI/AIBuilders/SorianStrategyPlatoonBuilders.lua
@@ -7,10 +7,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("SorianStrategyPlatoonBuilders loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 local ExBaseTmpl = 'ExpansionBaseTemplates'
 local UCBC = '/lua/editor/unitcountbuildconditions.lua'
 local MIBC = '/lua/editor/miscbuildconditions.lua'

--- a/lua/BuildingTemplates.lua
+++ b/lua/BuildingTemplates.lua
@@ -11,10 +11,6 @@
 ---- Base Templates                       --
 ----------------------------------------------------------------------------------
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("Building templates loaded in a non-ai game from:" .. reprs(debug.traceback()))
-end
-
 BuildingTemplates =
 {
     -- UEF Building List

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -822,10 +822,12 @@ Callbacks.LoadIntoTransports = function(data, selection)
     end
 end
 
-Callbacks.NavGenerate = import("/lua/sim/navgenerator.lua").Generate
 Callbacks.NavToggleScanLayer = import("/lua/sim/navdebug.lua").ToggleScanLayer
 Callbacks.NavToggleScanLabels = import("/lua/sim/navdebug.lua").ToggleScanLabels
 Callbacks.NavDebugCanPathTo = import("/lua/sim/navdebug.lua").CanPathTo
 Callbacks.NavDebugPathTo = import("/lua/sim/navdebug.lua").PathTo
 Callbacks.NavDebugGetLabel = import("/lua/sim/navdebug.lua").GetLabel
 Callbacks.NavDebugGetLabelMetadata = import("/lua/sim/navdebug.lua").GetLabelMeta
+Callbacks.NavGenerate = function()
+    import("/lua/sim/navgenerator.lua").Generate(true)
+end

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -828,6 +828,4 @@ Callbacks.NavDebugCanPathTo = import("/lua/sim/navdebug.lua").CanPathTo
 Callbacks.NavDebugPathTo = import("/lua/sim/navdebug.lua").PathTo
 Callbacks.NavDebugGetLabel = import("/lua/sim/navdebug.lua").GetLabel
 Callbacks.NavDebugGetLabelMetadata = import("/lua/sim/navdebug.lua").GetLabelMeta
-Callbacks.NavGenerate = function()
-    import("/lua/sim/navgenerator.lua").Generate(true)
-end
+Callbacks.NavGenerate = import("/lua/sim/navgenerator.lua").Generate

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -223,6 +223,10 @@ AIBrain = Class(moho.aibrain_methods) {
         self.BrainType = 'AI'
     end,
 
+    IsBaseAI = function(self)
+        return ScenarioInfo.ArmySetup[self.Name].BaseAI
+    end,
+
     --- Adds a HQ so that the engi mod knows we have it
     ---@param self AIBrain
     ---@param faction HqFaction 

--- a/lua/basetemplates.lua
+++ b/lua/basetemplates.lua
@@ -11,10 +11,6 @@
 -- Base Templates                       --
 --------------------------------------------------------------------------------
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("Base templates loaded in a non-ai game: " .. reprs(debug.traceback()))
-end
-
 BaseTemplates =
 {
 -- UEF BaseTemplates Building List

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -1131,12 +1131,7 @@ local function GenerateMarkerMetadata()
 end
 
 --- Generates a navigational mesh based on the heightmap
-function Generate(force)
-
-    -- do not run multiple times
-    if not force and IsGenerated() then
-        return
-    end
+function Generate()
 
     -- reset state
     NavGrids = { }

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -1131,7 +1131,12 @@ local function GenerateMarkerMetadata()
 end
 
 --- Generates a navigational mesh based on the heightmap
-function Generate()
+function Generate(force)
+
+    -- do not run multiple times
+    if not force and IsGenerated() then
+        return
+    end
 
     -- reset state
     NavGrids = { }

--- a/lua/sim/NavUtils.lua
+++ b/lua/sim/NavUtils.lua
@@ -31,7 +31,7 @@ function IsGenerated()
     return NavGenerator.IsGenerated()
 end
 
---- Generates the navigational mesh if it has not been generated yet. 
+--- Generates the navigational mesh if it is not generated yet
 function Generate()
     if not IsGenerated() then
         NavGenerator.Generate()
@@ -39,8 +39,8 @@ function Generate()
 end
 
 --- Produces various warning messages in the logs to inform the developer
-local function WarnNoMesh()
-    WARN("Navigational utilities are used without a generated navigational mesh.")
+local function WarnNoNavMesh()
+    WARN("Navigational utilities are used without a generated navigational mesh")
     WARN("For AI development: ")
     WARN(" - Add in the field `requiresNavMesh = true` to each of your AI entries in  `lua/AI/CustomAIs_v2`")
     WARN("For map or regular mod development: ")
@@ -56,8 +56,8 @@ end
 function CanPathTo(layer, origin, destination)
     -- check if generated
     if not NavGenerator.IsGenerated() then
-        WarnNoMesh()
-        return nil, 'Navigational mesh is not generated.'
+        WarnNoNavMesh()
+        return nil, 'Navigational mesh is not generated'
     end
 
     -- check layer argument
@@ -140,8 +140,8 @@ end
 function PathTo(layer, origin, destination, options)
     -- check if generated
     if not NavGenerator.IsGenerated() then
-        WarnNoMesh()
-        return nil, 'Navigational mesh is not generated.'
+        WarnNoNavMesh()
+        return nil, 'Navigational mesh is not generated'
     end
 
     -- check if we can path
@@ -252,8 +252,8 @@ end
 function GetLabel(layer, position)
     -- check if generated
     if not NavGenerator.IsGenerated() then
-        WarnNoMesh()
-        return nil, 'Navigational mesh is not generated.'
+        WarnNoNavMesh()
+        return nil, 'Navigational mesh is not generated'
     end
 
     -- check layer argument
@@ -286,8 +286,8 @@ end
 function GetLabelMetadata(id)
     -- check if generated
     if not NavGenerator.IsGenerated() then
-        WarnNoMesh()
-        return nil, 'Navigational mesh is not generated.'
+        WarnNoNavMesh()
+        return nil, 'Navigational mesh is not generated'
     end
 
     -- check id argument

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -312,7 +312,7 @@ function BeginSessionAI()
 
         for k, brain in ArmyBrains do
             if ScenarioInfo.ArmySetup[brain.Name].RequiresNavMesh then
-                import('/lua/sim/navgenerator.lua').Generate()
+                import('/lua/sim/navutils.lua').Generate()
                 break
             end
         end

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -310,7 +310,12 @@ function BeginSessionAI()
     Sync.GameHasAIs = ScenarioInfo.GameHasAIs
     if ScenarioInfo.GameHasAIs then
 
-        import("/lua/sim/navgenerator.lua").Generate()
+        for k, brain in ArmyBrains do
+            if ScenarioInfo.ArmySetup[brain.Name].RequiresNavMesh then
+                import('/lua/sim/navgenerator.lua').Generate()
+                break
+            end
+        end
 
         local simMods = __active_mods or {}
         for Index, ModData in simMods do

--- a/lua/ui/lobby/aitypes.lua
+++ b/lua/ui/lobby/aitypes.lua
@@ -13,36 +13,43 @@ function GetAItypes()
             key = 'easy',
             name = "<LOC lobui_0347>AI: Easy",
             requiresNavMesh = true,
+            baseAI = true,
         },
         {
             key = 'medium',
             name = "<LOC lobui_0349>AI: Normal",
             requiresNavMesh = true,
+            baseAI = true,
         },
         {
             key = 'adaptive',
             name = "<LOC lobui_0368>AI: Adaptive",
             requiresNavMesh = true,
+            baseAI = true,
         },
         {
             key = 'rush',
             name = "<LOC lobui_0360>AI: Rush",
             requiresNavMesh = true,
+            baseAI = true,
         },
         {
             key = 'turtle',
             name = "<LOC lobui_0372>AI: Turtle",
             requiresNavMesh = true,
+            baseAI = true,
         },
         {
             key = 'tech',
             name = "<LOC lobui_0370>AI: Tech",
             requiresNavMesh = true,
+            baseAI = true,
         },
         {
             key = 'random',
             name = "<LOC lobui_0374>AI: Random",
             requiresNavMesh = true,
+            baseAI = true,
         }
     }
 
@@ -99,11 +106,11 @@ function GetAItypes()
     end
 
     --Default GPG Cheating AIs
-    table.insert(aitypes, { key = 'adaptivecheat', name = "<LOC lobui_0379>AIx: Adaptive", requiresNavMesh = true, })
-    table.insert(aitypes, { key = 'rushcheat', name = "<LOC lobui_0380>AIx: Rush", requiresNavMesh = true, })
-    table.insert(aitypes, { key = 'turtlecheat', name = "<LOC lobui_0384>AIx: Turtle", requiresNavMesh = true, })
-    table.insert(aitypes, { key = 'techcheat', name = "<LOC lobui_0385>AIx: Tech", requiresNavMesh = true, })
-    table.insert(aitypes, { key = 'randomcheat', name = "<LOC lobui_0395>AIx: Random", requiresNavMesh = true, })
+    table.insert(aitypes, { key = 'adaptivecheat', name = "<LOC lobui_0379>AIx: Adaptive", requiresNavMesh = true, baseAI = true })
+    table.insert(aitypes, { key = 'rushcheat', name = "<LOC lobui_0380>AIx: Rush", requiresNavMesh = true, baseAI = true })
+    table.insert(aitypes, { key = 'turtlecheat', name = "<LOC lobui_0384>AIx: Turtle", requiresNavMesh = true,  baseAI = true})
+    table.insert(aitypes, { key = 'techcheat', name = "<LOC lobui_0385>AIx: Tech", requiresNavMesh = true, baseAI = true })
+    table.insert(aitypes, { key = 'randomcheat', name = "<LOC lobui_0395>AIx: Random", requiresNavMesh = true, baseAI = true })
 
     --Load Custom Cheating AIs - old style
     for i, v in AIFilesold do

--- a/lua/ui/lobby/aitypes.lua
+++ b/lua/ui/lobby/aitypes.lua
@@ -11,31 +11,38 @@ function GetAItypes()
     local aitypes = {
         {
             key = 'easy',
-            name = "<LOC lobui_0347>AI: Easy"
+            name = "<LOC lobui_0347>AI: Easy",
+            requiresNavMesh = true,
         },
         {
             key = 'medium',
-            name = "<LOC lobui_0349>AI: Normal"
+            name = "<LOC lobui_0349>AI: Normal",
+            requiresNavMesh = true,
         },
         {
             key = 'adaptive',
-            name = "<LOC lobui_0368>AI: Adaptive"
+            name = "<LOC lobui_0368>AI: Adaptive",
+            requiresNavMesh = true,
         },
         {
             key = 'rush',
-            name = "<LOC lobui_0360>AI: Rush"
+            name = "<LOC lobui_0360>AI: Rush",
+            requiresNavMesh = true,
         },
         {
             key = 'turtle',
-            name = "<LOC lobui_0372>AI: Turtle"
+            name = "<LOC lobui_0372>AI: Turtle",
+            requiresNavMesh = true,
         },
         {
             key = 'tech',
-            name = "<LOC lobui_0370>AI: Tech"
+            name = "<LOC lobui_0370>AI: Tech",
+            requiresNavMesh = true,
         },
         {
             key = 'random',
-            name = "<LOC lobui_0374>AI: Random"
+            name = "<LOC lobui_0374>AI: Random",
+            requiresNavMesh = true,
         }
     }
 
@@ -92,11 +99,11 @@ function GetAItypes()
     end
 
     --Default GPG Cheating AIs
-    table.insert(aitypes, { key = 'adaptivecheat', name = "<LOC lobui_0379>AIx: Adaptive" })
-    table.insert(aitypes, { key = 'rushcheat', name = "<LOC lobui_0380>AIx: Rush" })
-    table.insert(aitypes, { key = 'turtlecheat', name = "<LOC lobui_0384>AIx: Turtle" })
-    table.insert(aitypes, { key = 'techcheat', name = "<LOC lobui_0385>AIx: Tech" })
-    table.insert(aitypes, { key = 'randomcheat', name = "<LOC lobui_0395>AIx: Random" })
+    table.insert(aitypes, { key = 'adaptivecheat', name = "<LOC lobui_0379>AIx: Adaptive", requiresNavMesh = true, })
+    table.insert(aitypes, { key = 'rushcheat', name = "<LOC lobui_0380>AIx: Rush", requiresNavMesh = true, })
+    table.insert(aitypes, { key = 'turtlecheat', name = "<LOC lobui_0384>AIx: Turtle", requiresNavMesh = true, })
+    table.insert(aitypes, { key = 'techcheat', name = "<LOC lobui_0385>AIx: Tech", requiresNavMesh = true, })
+    table.insert(aitypes, { key = 'randomcheat', name = "<LOC lobui_0395>AIx: Random", requiresNavMesh = true, })
 
     --Load Custom Cheating AIs - old style
     for i, v in AIFilesold do

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -474,10 +474,13 @@ function GetAIPlayerData(name, AIPersonality, slot)
         AIColor = GetAvailableColor()
     end
 
+    -- retrieve properties from AI table
+    local baseAI = false
     local requiresNavMesh = false
     for k, entry in aitypes do 
         if entry.key == AIPersonality then
             requiresNavMesh = requiresNavMesh or entry.requiresNavMesh
+            baseAI = baseAI or entry.baseAI
         end
     end
 
@@ -490,7 +493,10 @@ function GetAIPlayerData(name, AIPersonality, slot)
             AIPersonality = AIPersonality,
             PlayerColor = AIColor,
             ArmyColor = AIColor,
-            RequiresNavMesh = requiresNavMesh
+
+            -- properties from AI table
+            RequiresNavMesh = requiresNavMesh,
+            BaseAI = baseAI
         }
 )
 end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -473,6 +473,14 @@ function GetAIPlayerData(name, AIPersonality, slot)
     if not AIColor then
         AIColor = GetAvailableColor()
     end
+
+    local requiresNavMesh = false
+    for k, entry in aitypes do 
+        if entry.key == AIPersonality then
+            requiresNavMesh = requiresNavMesh or entry.requiresNavMesh
+        end
+    end
+
     return PlayerData(
         {
             OwnerID = hostID,
@@ -482,6 +490,7 @@ function GetAIPlayerData(name, AIPersonality, slot)
             AIPersonality = AIPersonality,
             PlayerColor = AIColor,
             ArmyColor = AIColor,
+            RequiresNavMesh = requiresNavMesh
         }
 )
 end

--- a/lua/unittemplates.lua
+++ b/lua/unittemplates.lua
@@ -8,10 +8,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("Unit templates loaded in a non-ai game:" .. reprs(debug.traceback()))
-end
-
 UnitTemplates =
 {
     -- Earth Unit List

--- a/lua/upgradetemplates.lua
+++ b/lua/upgradetemplates.lua
@@ -9,10 +9,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-if not ScenarioInfo.GameHasAIs then
-    WARN("Upgrade templates loaded in a non-ai game: " .. reprs(debug.traceback()))
-end
-
 UnitUpgradeTemplates =
 {
     -- earth unit upgrades


### PR DESCRIPTION
Prevents the navigational mesh from always loading when an AI is detected. Instead, it only loads when an AI specifically mentions it requires it. This is set in `aitypes.lua` or for mods in their `CustomAIs_v2` folder setup, as an example - changing this:
```lua
        {
            key = 'RNGStandardExperimental',
            name = "<LOC RNG_0002>AI: RNG Standard Experimental",
        },
```
To this:
```
        {
            key = 'RNGStandardExperimental',
            name = "<LOC RNG_0002>AI: RNG Standard Experimental",
            requiresNavMesh = true
        },
```

Will guarantee that the navigational mesh is generated at the start of the game. The `Generate` function of the generator by default prevents generating a new mesh if one already exists - this allows maps, mods or other scripts that may rely on the generate to call this by default without having to check if it is already generated.

This pull request also removes various checks in the builder files as those cause issues for M27AI.