### PR TITLE
Remove `NaturalProducer` from `C-D2 "Rover"`

### DIFF
--- a/units/UEA0003/UEA0003_unit.bp
+++ b/units/UEA0003/UEA0003_unit.bp
@@ -130,7 +130,6 @@ UnitBlueprint {
         BuildableCategory = {
             'BUILTBYTIER3ENGINEER UEF',
         },
-        NaturalProducer = true,
     },
     Footprint = {
         MaxSlope = 0.25,


### PR DESCRIPTION
`C-D2 "Rover"` produces no resources, so should not have this attribute. The only units that should have it are the ACUs and sACUs.

Closes #4498