### PR TITLE
Fix: Remove ability for rebuild bonus #4493

### DIFF
--- a/units/XSB3202/XSB3202_unit.bp
+++ b/units/XSB3202/XSB3202_unit.bp
@@ -126,9 +126,6 @@ UnitBlueprint {
         BuildCostMass = 400,
         BuildTime = 600,
         MaintenanceConsumptionPerSecondEnergy = 200,
-        RebuildBonusIds = {
-            'xsb3202',
-        },
     },
     Footprint = {
         MinWaterDepth = 1.5,


### PR DESCRIPTION
## Description of the changes
Removed ability for a Rebuildbonus as suggested by @haifron by removing.
https://github.com/FAForever/fa/blob/develop/units/XSB3202/XSB3202_unit.bp#L128-L130

## Test setup for the changes
Spawn in a Engineer and a Sonar, destroy the sonar and rebuild it in the same spot.
