### PR TITLE
Remove redundant lines in engineer blueprints

### DIFF
--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -306,7 +306,6 @@ UnitBlueprint {
         },
         MaxBuildDistance = 10,
         NaturalProducer = true,
-        NeedToFaceTargetToBuild = false,
         ProductionPerSecondEnergy = 20,
         ProductionPerSecondMass = 1,
         StorageEnergy = 3900,

--- a/units/UAL0105/UAL0105_unit.bp
+++ b/units/UAL0105/UAL0105_unit.bp
@@ -202,7 +202,6 @@ UnitBlueprint {
             'BUILTBYTIER1ENGINEER AEON',
         },
         MaxBuildDistance = 5,
-        NeedToFaceTargetToBuild = false,
         SacrificeEnergyMult = 0.6,
         SacrificeMassMult = 0.6,
         StorageEnergy = 0,

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -343,7 +343,6 @@ UnitBlueprint {
         },
         MaxBuildDistance = 10,
         NaturalProducer = true,
-        NeedToFaceTargetToBuild = false,
         ProductionPerSecondEnergy = 20,
         ProductionPerSecondMass = 1,
         StorageEnergy = 3900,

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -323,7 +323,6 @@ UnitBlueprint {
         },
         MaxBuildDistance = 10,
         NaturalProducer = true,
-        NeedToFaceTargetToBuild = false,
         ProductionPerSecondEnergy = 20,
         ProductionPerSecondMass = 1,
         StorageEnergy = 3900,

--- a/units/XSL0105/XSL0105_unit.bp
+++ b/units/XSL0105/XSL0105_unit.bp
@@ -224,7 +224,6 @@ UnitBlueprint {
             'BUILTBYTIER1ENGINEER SERAPHIM',
         },
         MaxBuildDistance = 5,
-        NeedToFaceTargetToBuild = false, -- changed to make it build faster
         StorageEnergy = 0,
         StorageMass = 10,
         TeleportEnergyMod = 0.15,

--- a/units/XSL0208/XSL0208_unit.bp
+++ b/units/XSL0208/XSL0208_unit.bp
@@ -220,7 +220,6 @@ UnitBlueprint {
             'BUILTBYTIER2ENGINEER SERAPHIM',
         },
         MaxBuildDistance = 6,
-        NeedToFaceTargetToBuild = false,  -- changed to make faster building like otehr engineers
         StorageEnergy = 0,
         StorageMass = 20,
         TeleportEnergyMod = 0.15,

--- a/units/XSL0309/XSL0309_unit.bp
+++ b/units/XSL0309/XSL0309_unit.bp
@@ -227,7 +227,6 @@ UnitBlueprint {
             'BUILTBYTIER3ENGINEER SERAPHIM',
         },
         MaxBuildDistance = 7,
-        NeedToFaceTargetToBuild = false,
         StorageEnergy = 0,
         StorageMass = 40,
         TeleportEnergyMod = 0.15,


### PR DESCRIPTION
## Issue details
`NeedToFaceTargetToBuild` defaults to `false` when not set in a bp. These lines are therefore unnecessary.

**Additional Information**
They are only there as these attributes were changed from `true` to `false` in 7f3824270 (september 3 2011) to incorporate features from a mod called "CBFP" (community bug fix patch) to: "make the engineers build faster".

**My testing**
I tested this & it runs fine, and the units' build behaviour is the same as before (which makes sense given only some ACUs even have this line & we clearly know they build the same).

## Testing setup:
1. spawn each of the units whose bps have been changed:
`UEL0001`, `UAL0105`, `UAL0001`, `XSL0105`, `XSL0208`, `XSL0309`, `XSL0001`
2. Order them to build something behind them
3. They should not (do not) turn around (although the `BuildBone` will rotate to face the build site)
- To compare to the `NeedToFaceTargetToBuild = true` option, spawn a mantis & order it to assist a unit building, the entire unit will have to move & turn such that the body is facing the construction site.
 
>**Fun fact:**
The only unit with `NeedToFaceTargetToBuild = true` is the mantis.
If you were to set `NeedToFaceTargetToBuild = False` for the mantis it will look like how a hive builds.