### PR TITLE
AI Naval tuning

### DIFF
--- a/lua/AI/AIBaseTemplates/NavalExpansionLarge.lua
+++ b/lua/AI/AIBaseTemplates/NavalExpansionLarge.lua
@@ -76,7 +76,7 @@ BaseBuilderTemplate {
         end
 
         local personality = ScenarioInfo.ArmySetup[aiBrain.Name].AIPersonality
-        if personality == 'rushnaval' then
+        if personality == 'rushnaval' or personality == 'adaptive' then
             return 100
         end
 

--- a/lua/AI/AIBaseTemplates/RushExpansionNaval.lua
+++ b/lua/AI/AIBaseTemplates/RushExpansionNaval.lua
@@ -13,7 +13,7 @@ BaseBuilderTemplate {
         -- ==== ECONOMY ==== --
         -- Factory upgrades
         'T1BalancedUpgradeBuildersExpansion',
-        'T1BalancedUpgradeBuildersExpansion',
+        'T2BalancedUpgradeBuildersExpansion',
 
         -- Engineer Builders
         'EngineerFactoryBuilders',

--- a/lua/AI/AIBaseTemplates/TurtleExpansion.lua
+++ b/lua/AI/AIBaseTemplates/TurtleExpansion.lua
@@ -134,6 +134,9 @@ BaseBuilderTemplate {
     },
     ExpansionFunction = function(aiBrain, location, markerType)
         -- This is wrong. This would allow the template to potentially be used on ARMY_# marker. Fix later.
+        if markerType == 'Naval Area' then
+            return 0
+        end
         local personality = ScenarioInfo.ArmySetup[aiBrain.Name].AIPersonality
         if not(personality == 'adaptive' or personality == 'turtle') then
             return 0

--- a/lua/AI/AIBuilders/AINavalBuilders.lua
+++ b/lua/AI/AIBuilders/AINavalBuilders.lua
@@ -24,6 +24,23 @@ local PlatoonFile = '/lua/platoon.lua'
 
 ---@alias BuilderGroupsNaval 'NavalExpansionBuilders' | 'NavalExpansionBuilders HighPri' | 'EngineerNavalFactoryBuilder'
 
+local NavalExpansionPriorityAdjust = function(self, aiBrain, builderManager)
+    if aiBrain.IntelData.FrigateRaid then
+        return 1000
+    end
+    if aiBrain.IntelData.MapWaterRatio < 0.20 and not aiBrain.IntelData.MassMarkersInWater then
+        return 0
+    elseif aiBrain.IntelData.MapWaterRatio < 0.30 then
+        return 200
+    elseif aiBrain.IntelData.MapWaterRatio < 0.40 then
+        return 400
+    elseif aiBrain.IntelData.MapWaterRatio < 0.60 then
+        return 675
+    else
+        return 922
+    end
+end
+
 -- For everything but Naval Rush
 BuilderGroup {
     BuilderGroupName = 'NavalExpansionBuilders',
@@ -32,13 +49,14 @@ BuilderGroup {
         BuilderName = 'T1 Naval Builder',
         PlatoonTemplate = 'EngineerBuilder',
         Priority = 922,
+        PriorityFunction = NavalExpansionPriorityAdjust,
         InstanceCount = 1,
         BuilderConditions = {
             { UCBC, 'NavalBaseCheck', { } }, -- related to ScenarioInfo.Options.NavalExpansionsAllowed
             --DUNCAN - Added to limit expansions
             { UCBC, 'NavalBaseCount', { '<', 1 } },
             { UCBC, 'NavalAreaNeedsEngineer', { 'LocationType', 250, -1000, 10, 1, 'AntiSurface' } },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.0 }},
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },
             { UCBC, 'UnitCapCheckLess', { .8 } },
         },
@@ -58,11 +76,6 @@ BuilderGroup {
                 ExpansionRadius = 50,
                 BuildStructures = {
                     'T1SeaFactory',
-                    'T1SeaFactory',
-                    'T1AADefense',
-                    'T1SeaFactory',
-                    'T1Sonar',
-                    --'T1NavalDefense',
                 }
             }
         }

--- a/lua/AI/AIBuilders/AISeaAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AISeaAttackBuilders.lua
@@ -54,7 +54,7 @@ BuilderGroup {
        BuilderConditions = {
             { UCBC,'HaveLessThanUnitsWithCategory', { 2, categories.MOBILE * categories.NAVAL * categories.SUBMERSIBLE } },
             { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},
        },
        BuilderType = 'Sea',
     },
@@ -66,7 +66,7 @@ BuilderGroup {
        BuilderConditions = {
             { UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.MOBILE * categories.NAVAL * categories.FRIGATE } },
             { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},
        },
     },
     Builder {
@@ -76,7 +76,7 @@ BuilderGroup {
         BuilderConditions = {
             { UCBC, 'HaveUnitRatio', { 0.4, categories.MOBILE * categories.NAVAL * categories.SUBMERSIBLE, '<=', categories.MOBILE * categories.NAVAL}},
             { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.1 }},
         },
         BuilderType = 'Sea',
     },
@@ -87,7 +87,7 @@ BuilderGroup {
         BuilderType = 'Sea',
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.1 }},
         },
     },
     Builder {
@@ -98,7 +98,7 @@ BuilderGroup {
             --DUNCAN - commented out as need some anti all the time.
             --{ TBC, 'EnemyThreatGreaterThanValueAtBase', { 'LocationType', 10, 'Air' } },
             { IBC, 'BrainNotLowPowerMode', {} },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.1 }},
         },
         BuilderType = 'Sea',
     },
@@ -254,7 +254,7 @@ BuilderGroup {
         },
         BuilderConditions = {
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 1, categories.MOBILE * categories.NAVAL * ( categories.TECH2 + categories.TECH3 ) } },
-            { UCBC, 'PoolGreaterAtLocation', { 'LocationType', 1, categories.MOBILE * categories.NAVAL * categories.SUBMERSIBLE } },
+            { UCBC, 'PoolGreaterAtLocation', { 'LocationType', 1, categories.MOBILE * categories.NAVAL * categories.TECH1 * (categories.SUBMERSIBLE + categories.DIRECTFIRE) - categories.ENGINEER - categories.EXPERIMENTAL } },
             { SeaAttackCondition, { 'LocationType', 14 } },
         },
     },
@@ -444,4 +444,26 @@ BuilderGroup {
 BuilderGroup {
     BuilderGroupName = 'MassHunterSeaFormBuilders',
     BuildersType = 'PlatoonFormBuilder',
+    Builder {
+        BuilderName = 'Frequent Sea Mass Raid',
+        PlatoonTemplate = 'SeaRaid',
+        Priority = 300,
+        InstanceCount = 2,
+        BuilderConditions = {  
+            { MIBC, 'WaterMassMarkersPresent', {} },
+            { UCBC, 'PoolGreaterAtLocation', { 'LocationType', 0, categories.MOBILE * categories.NAVAL * categories.SUBMERSIBLE * categories.TECH1 } },
+            },
+        BuilderData = {
+            MarkerType = 'Mass',        
+            MoveFirst = 'Random',
+            MoveNext = 'Threat',
+            ThreatType = 'Economy',
+            FindHighestThreat = true,
+            MaxThreatThreshold = 1000,
+            MinThreatThreshold = 50,
+            AggressiveMove = true,   
+            AvoidClosestRadius = 50,
+        },
+        BuilderType = 'Any',
+    },
 }

--- a/lua/AI/PlatoonTemplates/SeaPlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/SeaPlatoonTemplates.lua
@@ -17,6 +17,14 @@ PlatoonTemplate {
 }
 
 PlatoonTemplate {
+    Name = 'SeaRaid',
+    Plan = 'GuardMarker',
+    GlobalSquads = {
+        { categories.MOBILE * categories.NAVAL * categories.SUBMERSIBLE * categories.TECH1, 1, 3, 'Attack', 'none' }
+    },
+}
+
+PlatoonTemplate {
     Name = 'SeaNuke',
     Plan = 'NavalForceAI',
     GlobalSquads = {

--- a/lua/AI/aiattackutilities.lua
+++ b/lua/AI/aiattackutilities.lua
@@ -2360,7 +2360,6 @@ function NavalAttackCheck(aiBrain)
             -- Check for underwater mass points, can subs hit mass points
             -- We could also do this by pre-populating which mass markers are under water in the marker cache
             if v.NavLayer == 'Amphibious' then
-                table.insert( underWaterMarkers, v )
                 markersUnderWater = markersUnderWater + 1
             else
                 local checkPoints = DrawCirclePoints(6, 26, v.position)

--- a/lua/AI/aiattackutilities.lua
+++ b/lua/AI/aiattackutilities.lua
@@ -2333,6 +2333,66 @@ function InWaterCheck(platoon)
     return inWater
 end
 
+function NavalAttackCheck(aiBrain)
+    -- This function will check if there are mass markers that can be hit by frigates. This can trigger faster naval factory builds initially.
+    -- points = number of points around the extractor, doesn't need to have too many.
+    -- radius = the radius that the points will be, be set this a little lower than a frigates max weapon range
+    -- center = the x,y values for the position of the mass extractor. e.g {x = 0, y = 0} 
+    local function DrawCirclePoints(points, radius, center)
+        local extractorPoints = {}
+        local slice = 2 * math.pi / points
+        for i=1, points do
+            local angle = slice * i
+            local newX = center[1] + radius * math.cos(angle)
+            local newY = center[3] + radius * math.sin(angle)
+            table.insert(extractorPoints, { newX, 0 , newY})
+        end
+        return extractorPoints
+    end
+    local frigateRaidMarkers = {}
+    local markers, en = import("/lua/sim/markerutilities.lua").GetMarkersByType('Mass')
+    if markers then
+        local markerCount = 0
+        local markerCountNotBlocked = 0
+        local markerCountBlocked = 0
+        local markersUnderWater = 0
+        for _, v in markers do 
+            -- Check for underwater mass points, can subs hit mass points
+            -- We could also do this by pre-populating which mass markers are under water in the marker cache
+            if v.NavLayer == 'Amphibious' then
+                table.insert( underWaterMarkers, v )
+                markersUnderWater = markersUnderWater + 1
+            else
+                local checkPoints = DrawCirclePoints(6, 26, v.position)
+                if checkPoints then
+                    for _, m in checkPoints do
+                        -- Check if the position within weapon range is in water
+                        if GetTerrainHeight(m[1], m[3]) < GetSurfaceHeight(m[1], m[3]) then
+                            local pointSurfaceHeight = GetSurfaceHeight(m[1], m[3]) + 0.36
+                            markerCount = markerCount + 1
+                            -- Check if any terrain is blocking position
+                            if not aiBrain:CheckBlockingTerrain({m[1], pointSurfaceHeight, m[3]}, v.position, 'low') then
+                                markerCountNotBlocked = markerCountNotBlocked + 1
+                                table.insert( frigateRaidMarkers, { Position=v.position, Name=v.name } )
+                            else
+                                markerCountBlocked = markerCountBlocked + 1
+                            end
+                            break
+                        end
+                    end
+                end
+            end
+        end
+        if markerCountNotBlocked > 8 then
+            aiBrain.IntelData.FrigateRaid = true
+        end
+        if markersUnderWater > 0 then
+            aiBrain.IntelData.WaterMassMarkersPresent = true
+        end
+        aiBrain.IntelData.FrigateRaidMassMarkers = frigateRaidMarkers
+    end
+end
+
 -- Deprecated functions / unused
 function GraphExists(layer)
     WARN('[aiattackutilities.lua '..debug.getinfo(1).currentline..'] - Deprecated function GraphExists(layer) called. Use GetPathGraphs()[layer] instead.')

--- a/lua/AI/aiattackutilities.lua
+++ b/lua/AI/aiattackutilities.lua
@@ -2366,7 +2366,7 @@ function NavalAttackCheck(aiBrain)
                 if checkPoints then
                     for _, m in checkPoints do
                         -- Check if the position within weapon range is in water
-                        if GetTerrainHeight(m[1], m[3]) < GetSurfaceHeight(m[1], m[3]) then
+                        if (GetTerrainHeight(m[1], m[3]) + 1.1) < GetSurfaceHeight(m[1], m[3]) then
                             local pointSurfaceHeight = GetSurfaceHeight(m[1], m[3]) + 0.36
                             markerCount = markerCount + 1
                             -- Check if any terrain is blocking position

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -1904,6 +1904,7 @@ AIBrain = Class(moho.aibrain_methods) {
             BuilderHandles = {},
             Position = position,
             BaseType = Scenario.MasterChain._MASTERCHAIN_.Markers[baseName].type or 'MAIN',
+            Layer = baseLayer,
         }
         self.NumBases = self.NumBases + 1
     end,

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -1608,6 +1608,9 @@ AIBrain = Class(moho.aibrain_methods) {
         }
 
         self:IMAPConfiguration()
+        if self:IsBaseAI() then
+            self:ForkThread(self.MapAnalysis)
+        end
     end,
 
     ---@param self AIBrain
@@ -1885,6 +1888,14 @@ AIBrain = Class(moho.aibrain_methods) {
     ---@param baseName string
     ---@param useCenter boolean
     AddBuilderManagers = function(self, position, radius, baseName, useCenter)
+
+        local baseLayer = 'Land'
+        position[2] = GetTerrainHeight( position[1], position[3] )
+        if GetSurfaceHeight( position[1], position[3] ) > position[2] then
+            position[2] = GetSurfaceHeight( position[1], position[3] )
+            baseLayer = 'Water'
+        end
+
         self.BuilderManagers[baseName] = {
             FactoryManager = FactoryManager.CreateFactoryBuilderManager(self, baseName, position, radius, useCenter),
             PlatoonFormManager = PlatoonFormManager.CreatePlatoonFormManager(self, baseName, position, radius, useCenter),
@@ -5098,6 +5109,16 @@ AIBrain = Class(moho.aibrain_methods) {
             self.IMAPConfig.IMAPSize = 256
             self.IMAPConfig.Rings = 0
         end
+    end,
+
+    MapAnalysis = function(self)
+        -- This function will provide various means of the AI populating intel data
+        -- Due to it potentially influencing buider/base template decisions it needs to run before the AI creates its first buildermanager
+        WaitTicks(10)
+        self.IntelData.MapWaterRatio = self:GetMapWaterRatio()
+        local AIAttackUtils = import("/lua/ai/aiattackutilities.lua")
+        AIAttackUtils.NavalAttackCheck(self)
+
     end,
 }
 

--- a/lua/editor/MiscBuildConditions.lua
+++ b/lua/editor/MiscBuildConditions.lua
@@ -347,5 +347,12 @@ function PathToEnemy(aiBrain, locationType, pathType)
     return false
 end
 
+function WaterMassMarkersPresent(aiBrain)
+    if aiBrain.IntelData.WaterMassMarkersPresent then
+        return true
+    end
+    return false
+end
+
 -- unused imports kept for mod support
 local Utils = import("/lua/utilities.lua")

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -3255,7 +3255,7 @@ Platoon = Class(moho.platoon_methods) {
         local returnPos
 
         for baseName, base in aiBrain.BuilderManagers do
-            if self.MovementLayer == 'Water' and base.Layer ~= 'Water' then
+            if (self.MovementLayer == 'Water' and base.Layer ~= 'Water') or (self.MovementLayer == 'Land' and base.Layer == 'Water') then
                 continue
             end
             local distSq = VDist2Sq(platPos[1], platPos[3], base.Position[1], base.Position[3])

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -3255,6 +3255,9 @@ Platoon = Class(moho.platoon_methods) {
         local returnPos
 
         for baseName, base in aiBrain.BuilderManagers do
+            if self.MovementLayer == 'Water' and base.Layer ~= 'Water' then
+                continue
+            end
             local distSq = VDist2Sq(platPos[1], platPos[3], base.Position[1], base.Position[3])
 
             if distSq < bestDistSq then


### PR DESCRIPTION
**Description of changes**
This PR retunes some aspects of the AI naval play. 

- Fixes a an errors where the AI would not upgrade beyond T2 if the navalrush ai was selected.
- The AI would use the Turtle expansion base template for naval expansions, naval area markers are now excluded.
- Allows the adaptive AI to use the NavalExpansionLarge base template, previously it would build the naval factory and then do nothing else.
- Decrease factory counts on the expansion builder for T1 Naval so the AI did not ruin its economy.
- Add logic for detecting which mass markers could be hit by frigates and if there are under water mass markers. Happy for someone to help make this better. Its weakness currently is that it will detect a position in water but not understand the water depth so it may decide a raid position even though the frigate couldn't get close enough to shoot it due to water depth. Edit. Modified so it will require a minimum 1.1 depth.
- Add a priority function that will adjust depending on map water ratio and naval raiding capability.
- Adding of a submarine based mass marker raiding platoon, requires underwater mass points.
- Add platoon template for submarine mass marker raiders
- Add support for naval platoons to use the guardmarker platoon function.
- Add a Layer property to bases so the AI can easily distinguish between land and naval builder managers.
- Add a layer check to the returntobaseai function so that naval units will return to naval bases and land units with not return to naval bases.

**Test setup for the changes**
Some of the testing here requires logging, and some observation.
You can log the bool brain attributes to validate if under water mass points are detected correctly and if the frigate raiding mass points are detected and added to the frigate raid table correctly (note the naval raiding logic does not use this table yet).
The other changes are mainly observation, making sure that the correct AI are able to use naval bases.

There are still a many issues with naval play but this will help the AI from completely ruining its naval chances instantly.

p.s in regards to the naval expansion builder, the priority function could be tuned better/ access more data to try and make a better decision for the situation. the default code base doesn't use priority functions but they have value as a way to enable/disable builders and improve builder selection based on available data. I believe if we had a good data set rather than function calls then you could use them in ways that are similar to the unused strategy manager but without all the performance cost.