### PR TITLE
Allow users to define batching threshold

### DIFF
--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -751,6 +751,18 @@ options = {
             },
 
             {
+                title = "<LOC OPTIONS_RECLAIM_BATCHING_DISTANCE>Reclaim Batching Distance Threshold",
+                key = 'reclaim_batching_distance_treshold',
+                type = 'slider',
+                default = 150,
+                custom = {
+                    min = 150,
+                    max = 600,
+                    inc = 10,
+                },
+            },
+
+            {
                 title = "<LOC OPTIONS_RECLAIMSIZE>Reclaim label scaling factor",
                 key = 'reclaim_overview_size_scale',
                 type = 'slider',

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -180,7 +180,7 @@ Prop = Class(moho.prop_methods) {
         self.TimeReclaim = time
         self.ReclaimLeft = self.ReclaimLeft or 1
 
-        if self.MaxMassReclaim * self.ReclaimLeft > 10 then
+        if self.MaxMassReclaim * self.ReclaimLeft >= 10 then
             self:SetupUILabel()
         end
     end,

--- a/lua/ui/game/reclaim.lua
+++ b/lua/ui/game/reclaim.lua
@@ -377,7 +377,7 @@ local function _CombineReclaim(reclaim)
 
     local zoom = GetCamera('WorldCamera'):SaveSettings().Zoom
 
-    if zoom < ZoomThreshold then
+    if zoom < (Prefs.GetFromCurrentProfile('options.reclaim_batching_distance_treshold') or ZoomThreshold) then
         return false
     end
 


### PR DESCRIPTION
Allows a user to define the batching threshold. Previously this was set to when you can issue reclaim orders, which is about 150.

Based on this suggestion:
- https://forum.faforever.com/topic/5135/i-am-loving-the-new-reclaim-batching-in-2022-10-0/9

![image](https://user-images.githubusercontent.com/15778155/207931293-72eb28db-cffa-4e5f-8f65-3b984b55802e.png)
