### PR TITLE
Added missing VK code for keybinds

### DIFF
--- a/loc/guidelines.md
+++ b/loc/guidelines.md
@@ -1,16 +1,19 @@
 
-Translation guidelines
-----------------------
+# Translation guidelines
+
 
 1) *Compliance with the game's UI*
-- Text should never overflow
-- Maintain a few pixels of margin between the text and its parent element boundaries
-- Use obvious abbreviations if a shorter translation is impossible, but the abbreviation should be made in a way that it is clear and obvious. Keywords from the game should never be abbreviated.
 
+    - Text should never overflow
+    - Maintain a few pixels of margin between the text and its parent element boundaries
+    - Use obvious abbreviations if a shorter translation is impossible, but the abbreviation should be made in a way that it is clear and obvious. Keywords from the game should never be abbreviated.
+&nbsp;
 2) *Gender-neutral writing*
-- The translation should never adopt gendered formulations when addressing the player directly, and should respect gender-neutral writing everywhere possible
-- Median point and/or parentheses, or gendering a word twice, should be avoided to the maximum.
 
+    - The translation should never adopt gendered formulations when addressing the player directly, and should respect gender-neutral writing everywhere possible
+    - Median point and/or parentheses, or gendering a word twice, should be avoided to the maximum.
+&nbsp;
 3) *Consistency of keywords*
-- Game specific keywords, like unit names and building names, should always be translated in the same manner consistently across the whole game.
-- If a new keyword appears, that is not translated elsewhere, it should be translated in a consistent manner regarding the other translated keywords.
+
+    - Game specific keywords, like unit names and building names, should always be translated in the same manner consistently across the whole game.
+    - If a new keyword appears, that is not translated elsewhere, it should be translated in a consistent manner regarding the other translated keywords.

--- a/lua/keymap/keyNames.lua
+++ b/lua/keymap/keyNames.lua
@@ -157,6 +157,7 @@ keyNames = {
     ['DC'] = 'Backslash',
     ['DD'] = 'RightBracket',
     ['DE'] = 'Quote',
+    ['DF'] = 'Backtick',
     ['E5'] = 'ImeProcess',
     ['E7'] = 'UnicodePacket',
     ['F6'] = 'Attn',

--- a/lua/keymap/keybindResources.md
+++ b/lua/keymap/keybindResources.md
@@ -1,0 +1,4 @@
+# Keybind Resources
+
+- [List of virtual key codes](https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes)
+- [keyboard layouts & their virtual keys & scancodes](https://kbdlayout.info/)

--- a/lua/keymap/properKeyNames.lua
+++ b/lua/keymap/properKeyNames.lua
@@ -168,4 +168,5 @@ properKeyNames = {
     ['PA1'] = '<LOC properkeyname_0164>PA1',
     ['OemClear'] = '<LOC properkeyname_0165>OemClear',
     ['Chevron'] = '<LOC properkeyname_0166>Chevron',
+    ['Backtick'] = '<LOC properkeyname_0167>Backtick',
 }


### PR DESCRIPTION
#### Description of changes
- Added the virtual key (VK) code `DF` to `keyNames.lua` & its name to `properKeyNames.lua`. It's used on [these keyboards](https://kbdlayout.info/features/virtualkeys/VK_OEM_8). Also see [this list of virtual key codes](https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes).

  I tested it and now I can bind commands to this key.

  The key is the backtick `` ` `` on the UK keyboard layout (and I think it's the exclamation mark `!` on the french keyboard and dash/minus `-` on the spanish one).

- I also added a `keybindResources.md` file to `/lua/keymap` to help anyone in future find out exactly what any VK code refers to, on any keyboard layout.

#### To test the new key:
1. set keyboard layout to UK
2. enter hotkeys menu, and select a keybind option
3.  type `` ` ``
4.  "Backtick" should appear as the keybind.