### PR TITLE
Allow negative aix cheat multipliers

### DIFF
--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -595,26 +595,28 @@ globalOpts = {
 ---@type ScenarioOption[]
 AIOpts = {
    {
-        default = 6,
+        default = 11,
         label = "<LOC aisettings_0001>>AIx Cheat Multiplier",
         help = "<LOC aisettings_0002>Set the cheat multiplier for the cheating AIs.",
         key = 'CheatMult',
         value_text = "%s",
         value_help = "<LOC aisettings_0003>Cheat multiplier of %s",
         values = {
+            '0.5', '0.6', '0.7', '0.8', '0.9',
             '1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9',
             '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '2.8', '2.9', '3.0', '3.1', '3.2', '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9',
             '4.0', '4.1', '4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8', '5.9',
         },
    },
    {
-        default = 6,
+        default = 11,
         label = "<LOC aisettings_0054>AIx Build Multiplier",
         help = "<LOC aisettings_0055>Set the build rate multiplier for the cheating AIs.",
         key = 'BuildMult',
         value_text = "%s",
         value_help = "<LOC aisettings_0056>Build multiplier of %s",
         values = {
+            '0.5', '0.6', '0.7', '0.8', '0.9',
             '1.0', '1.1', '1.2', '1.3', '1.4', '1.5', '1.6', '1.7', '1.8', '1.9',
             '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '2.8', '2.9', '3.0', '3.1', '3.2', '3.3', '3.4', '3.5', '3.6', '3.7', '3.8', '3.9',
             '4.0', '4.1', '4.2', '4.3', '4.4', '4.5', '4.6', '4.7', '4.8', '4.9', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7', '5.8', '5.9',


### PR DESCRIPTION
### Description of changes:
I saw this mentioned here but couldn't find an open issue/pr for the change. https://github.com/FAForever/fa/issues/4324#issuecomment-1304788478

This PR changes the range of selectable aix cheat values to include negative multipliers. 0.5->0.9.

This also required a change to the default selection value as 5 entries are being added to the start of the list. The same default of 1.5 is retained.

This will allow players to choose a harder cheating aix in terms of resources, but lowering their build speed to allow more time for the player to react. Alternatively a player could restrict an aix's resources but retain its build speed.

### Testing:
Open a lobby and observe the default value has retained at 1.5 and now values less than 1.0 are selectable.
![image](https://user-images.githubusercontent.com/116189545/209223125-fb1bea37-8a9d-4f7b-a343-fc256411b078.png)
![image](https://user-images.githubusercontent.com/116189545/209223139-420d3caf-b034-436a-acf2-122a7e49b36c.png)

Open a skirmish match with aix and observe their resource production and build speed match the value set in the lobby. 
I set 0.5 for both in this example.
![image](https://user-images.githubusercontent.com/116189545/209223494-aee261c2-af70-4219-8527-d35f2ab668fe.png)

https://user-images.githubusercontent.com/116189545/209223565-782f6e79-05e2-4ce2-8264-c7c6fe2866a5.mp4


ps - This is my first contribution to FAF so please let me know if I'm missing anything here!