### PR TITLE
Reduce the death damage of air T4s

### DIFF
--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -867,7 +867,7 @@ UnitBlueprint {
         },
         {
             AboveWaterTargetsOnly = true,
-            Damage = 10000,
+            Damage = 7000,
             DamageFriendly = true,
             DamageRadius = 15,
             DamageType = 'Normal',

--- a/units/URA0401/URA0401_unit.bp
+++ b/units/URA0401/URA0401_unit.bp
@@ -711,7 +711,7 @@ UnitBlueprint {
         },
         {
             AboveWaterTargetsOnly = true,
-            Damage = 7000,
+            Damage = 5000,
             DamageFriendly = true,
             DamageRadius = 8,
             DamageType = 'Normal',

--- a/units/XSA0402/XSA0402_unit.bp
+++ b/units/XSA0402/XSA0402_unit.bp
@@ -620,7 +620,7 @@ UnitBlueprint {
         },
         {
             AboveWaterTargetsOnly = true,
-            Damage = 10000,
+            Damage = 7000,
             DamageFriendly = true,
             DamageRadius = 10,
             DamageType = 'Normal',


### PR DESCRIPTION
Reduce the death damage of air T4s. Their ability to kill heavily shielded targets by simply dying and hitting them provided the defending player with little counter-play. They still need to deal a considerable amount of damage to not break the immersion of the game but these values will be further reduced if deemed necessary.