### PR TITLE
Revert damage change of T1 artilleries

### DIFF
--- a/units/UEL0103/UEL0103_unit.bp
+++ b/units/UEL0103/UEL0103_unit.bp
@@ -205,7 +205,7 @@ UnitBlueprint {
             CameraLifetime = 5,
             CameraVisionRadius = 5,
             CollideFriendly = false,
-            Damage = 98, --there is 2 more damage per shell added afterward
+            Damage = 100,
             DamageFriendly = false,
             DamageRadius = 1,
             DamageType = 'Normal',

--- a/units/XSL0103/XSL0103_unit.bp
+++ b/units/XSL0103/XSL0103_unit.bp
@@ -282,7 +282,7 @@ UnitBlueprint {
             },
             BallisticArc = 'RULEUBA_HighArc',
             CollideFriendly = false,
-            Damage = 43, --there is 2 more damage per shell added afterward
+            Damage = 45,
             DamageFriendly = false,
             DamageRadius = 1.5,
             DamageType = 'Normal',


### PR DESCRIPTION
This change was introduced to adjust the total damage done by T1 artilleries at a time when aoe weapons dealt 2 extra damage to break trees. This has been changed since but we forgot to revert this alongside it.