### PR TITLE
Fix various issues

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1378,9 +1378,11 @@ Unit = ClassUnit(moho.unit_methods) {
     ---@param self Unit
     DestroyAllDamageEffects = function(self)
         local damageEffectsBags = self.DamageEffectsBag
-        damageEffectsBags[1]:Destroy()
-        damageEffectsBags[2]:Destroy()
-        damageEffectsBags[3]:Destroy()
+        if damageEffectsBags then
+            damageEffectsBags[1]:Destroy()
+            damageEffectsBags[2]:Destroy()
+            damageEffectsBags[3]:Destroy()
+        end
     end,
 
     -- On killed: this function plays when the unit takes a mortal hit. Plays death effects and spawns wreckage, dependant on overkill

--- a/lua/system/class.lua
+++ b/lua/system/class.lua
@@ -739,9 +739,21 @@ UnitFactory = {
     ---@return table
     __call = function (self)
         -- LOG(string.format("%s -> %s", "UnitFactory", tostring(self.__name)))
-        -- needs a hash part of one for the _c_object field
         local instance = {&31 &0}
-        return setmetatable(instance, self)
+        setmetatable(instance, self)
+
+        -- ACUs use this function
+        local initfn = self.__init
+        if initfn then
+            initfn(instance)
+        end
+
+        local postinitfn = self.__post_init
+        if postinitfn then
+            postinitfn(instance)
+        end
+
+        return instance
     end
 }
 


### PR DESCRIPTION
Fixes issues with the damage effects bag not existing, as introduced by #4444
Fixes issue with units (ACUs) still using the `__init` functions, likely a mistake but for backwards compatibility we re-introduced calling those functions for units. As introduced by https://github.com/FAForever/fa/pull/4540