### PR TITLE
Fix slot swapping from map preview

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -4808,10 +4808,11 @@ function ConfigureMapListeners(mapCtrl, scenario)
         local marker = mapCtrl.startPositions[inSlot]
 
         marker.OnRollover = function(self, state)
+            local slotName = GUI.slots[slot].name
             if state == 'enter' then
-                GUI.slots[slot].name.HandleEvent(self, {Type='MouseEnter'})
+                slotName:HandleEvent({Type = 'MouseEnter'})
             elseif state == 'exit' then
-                GUI.slots[slot].name.HandleEvent(self, {Type='MouseExit'})
+                slotName:HandleEvent({Type = 'MouseExit'})
             end
         end
 


### PR DESCRIPTION
The slight change to not upvalue `self` into `Combo`'s methods by not closing each in the initializer (so that it could become part of the class) in [this PR](https://github.com/FAForever/fa/pull/4471#issuecomment-1370132276) revealed a latent bug in how the map preview ACUButton is dealt with in the lobby. Namely, its roll over callback was passing itself as the instance in the slot name combo event handler, which it is not able to cope with before passing on the event to the slot's default event handler. This produces this pair of warnings, which prevents the rest of the event getting handled:
```
warning: Error running HandleEvent script in CScriptObject at 12a7cdc0: \lua\ui\controls\combo.lua(471): attempt to call method `IsHidden' (a nil value)
         stack traceback:
         	\lua\ui\controls\combo.lua(471): in function `HandleEvent'
         	\lua\ui\lobby\lobby.lua(4812): in function `OnRollover'
         	\lua\ui\controls\acubutton.lua(73): in function `OnRolloverEvent'
         	\lua\maui\button.lua(78): in function <c:\hdt\vsc\fa\lua\maui\button.lua:66>
warning: Error running HandleEvent script in CScriptObject at 12a7cdc0: \lua\ui\controls\combo.lua(485): attempt to call method `IsHidden' (a nil value)
         stack traceback:
         	\lua\ui\controls\combo.lua(485): in function `HandleEvent'
         	\lua\ui\lobby\lobby.lua(4814): in function `OnRollover'
         	\lua\ui\controls\acubutton.lua(73): in function `OnRolloverEvent'
         	\lua\maui\button.lua(88): in function <\lua\maui\button.lua:66>
```