### PR TITLE
Improve the retrieval of the (nearest) valid leaf of a position

### DIFF
--- a/lua/shared/NavGenerator.lua
+++ b/lua/shared/NavGenerator.lua
@@ -98,6 +98,10 @@ end
 ---@param label number
 ---@return string
 function LabelToColor(label)
+    if label == -1 then
+        return 'ff0000'
+    end
+
     local r = string.format("%x", math.mod(math.sin(label) * 256 + 512, 256) ^ 0)
     local g = string.format("%x", math.mod(math.sin(label + 2) * 256 + 512, 256) ^ 0)
     local b = string.format("%x", math.mod(math.cos(label) * 256 + 512, 256) ^ 0)

--- a/lua/sim/NavDebug.lua
+++ b/lua/sim/NavDebug.lua
@@ -98,26 +98,38 @@ function GetLabelMeta(data)
     end
 end
 
+---comment
+---@param mouse Vector
+---@param layer NavLayers
 function ScanOver(mouse, layer)
     if mouse then
-        -- local over = NavGenerator.NavGrids[layer]:FindLeaf(mouse)
-        -- if over then 
-        --     if over.Label > 0 then
-        --         local color = Shared.LabelToColor(over.Label)
-        --         over:Draw(color, 0.1)
-        --         over:Draw(color, 0.15)
-        --         over:Draw(color, 0.2)
+        ---@type NavGrid
+        local navGrid = NavGenerator.NavGrids[layer]
+        local over = navGrid:FindLeaf(mouse)
+        if over then
+            if over.Label then
+                local color = Shared.LabelToColor(over.Label)
+                local size = over.Size
+                local h = 0.5 * size
+                NavGenerator.DrawSquare(over.px - h, over.pz - h, size, color, 0.1)
+                NavGenerator.DrawSquare(over.px - h, over.pz - h, size, color, 0.15)
+                NavGenerator.DrawSquare(over.px - h, over.pz - h, size, color, 0.2)
 
-        --         for k = 1, table.getn(over) do
-        --              local neighbor = over[k]
-        --              neighbor:Draw(color, 0.25)
-        --         end
-        --     else
-        --         over:Draw('ff0000', 0.1)
-        --         over:Draw('ff0000', 0.15)
-        --         over:Draw('ff0000', 0.2)
-        --     end
-        -- end
+                for k = 1, table.getn(over) do
+                     local neighbor = over[k]
+                     local size = neighbor.Size
+                     local h = 0.5 * size
+                     NavGenerator.DrawSquare(neighbor.px - h, neighbor.pz - h, size, color, 0.1)
+                end
+            else
+                local color = 'ff0000'
+                local size = over.Size
+                local h = 0.5 * size
+                NavGenerator.DrawSquare(over.px - h, over.pz -  h, size, color, 0.1)
+                NavGenerator.DrawSquare(over.px - h, over.pz -  h, size, color, 0.15)
+                NavGenerator.DrawSquare(over.px - h, over.pz -  h, size, color, 0.2)
+            end
+        end
     end
 end
 

--- a/lua/sim/NavDebug.lua
+++ b/lua/sim/NavDebug.lua
@@ -119,6 +119,7 @@ function ScanOver(mouse, layer)
                      local neighbor = over[k]
                      local size = neighbor.Size
                      local h = 0.5 * size
+                     local color = Shared.LabelToColor(neighbor.Label)
                      NavGenerator.DrawSquare(neighbor.px - h, neighbor.pz - h, size, color, 0.1)
                 end
             else


### PR DESCRIPTION
Units tend to get themselves to edge cases quite quickly. As a result a query for a path can easily end up failing because the origin location is not 'valid', even though it technically is valid.

Specifically, this pull requests adds in:

- (1) Neighbors for invalid leaves
- (2) Special utility functions to retrieve grid and leaf
- (3) Further reduction of navigational mesh resolution

In case of (1), a leaf that is invalid does not look for corner elements. As an example, it only searches for:

```text
0|x|0
x| |x
0|x|0
```

While the corners are not considered valid.