### PR TITLE
Remove unique trashbags instances of weapons

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -161,8 +161,6 @@ Unit = ClassUnit(moho.unit_methods) {
     ---@param self Unit
     OnPreCreate = function(self)
 
-        LOG("Unit OnPreCreate")
-
         -- Each unit has a sync table to replicate values to the global sync table to be copied to the user layer at sync time.
         self.Sync = {}
         self.Sync.id = self:GetEntityId()

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -161,15 +161,15 @@ Unit = ClassUnit(moho.unit_methods) {
     ---@param self Unit
     OnPreCreate = function(self)
 
+        LOG("Unit OnPreCreate")
+
         -- Each unit has a sync table to replicate values to the global sync table to be copied to the user layer at sync time.
         self.Sync = {}
         self.Sync.id = self:GetEntityId()
         self.Sync.army = self:GetArmy()
         setmetatable(self.Sync, SyncMeta)
 
-        if not self.Trash then
-            self.Trash = TrashBag()
-        end
+        self.Trash = self.Trash or TrashBag()
 
         self.IntelDisables = {
             Radar = {NotInitialized = true},
@@ -1392,14 +1392,8 @@ Unit = ClassUnit(moho.unit_methods) {
     ---@param type string
     ---@param overkillRatio number
     OnKilled = function(self, instigator, type, overkillRatio)
-
         local layer = self.Layer
         self.Dead = true
-
-        -- Clear out any remaining projectiles
-        for k = 1, self.WeaponCount do 
-            self.WeaponInstances[k]:ClearProjectileTrash();
-        end
 
         -- Units killed while being invisible because they're teleporting should show when they're killed
         if self.TeleportFx_IsInvisible then
@@ -2201,11 +2195,6 @@ Unit = ClassUnit(moho.unit_methods) {
         if self.TransportBeamEffectsBag then 
             self.TransportBeamEffectsBag:Destroy()
         end
-
-        -- destroy remaining trash of weapon
-        for k = 1, self.WeaponCount do 
-            self.WeaponInstances[k].Trash:Destroy();
-        end
     end,
 
     ---@param self Unit
@@ -2213,12 +2202,6 @@ Unit = ClassUnit(moho.unit_methods) {
         self.Dead = true
 
         -- LOG(string.format("%s -> %s", tostring(self.UnitId), tostring(debug.allocatedsize(self))))
-
-        -- clear out all manipulators, at this point the wreck has been made
-        for k = 1, self.WeaponCount do 
-            self.WeaponInstances[k]:ClearProjectileTrash();
-            self.WeaponInstances[k]:ClearManipulatorTrash();
-        end
 
         if self:GetFractionComplete() < 1 then
             self:SendNotifyMessage('cancelled')
@@ -2235,6 +2218,7 @@ Unit = ClassUnit(moho.unit_methods) {
         Sync.ReleaseIds[self.EntityId] = true
 
         -- Destroy everything added to the trash
+        LOG("Destroyed")
         self.Trash:Destroy()
 
         -- Destroy all extra trashbags in case the DeathTread() has not already destroyed it (modded DeathThread etc.)

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -61,8 +61,6 @@ end
 ---@field Label string
 ---@field NumTargets number
 ---@field Trash TrashBag
----@field TrashManipulators TrashBag
----@field TrashProjectiles TrashBag
 ---@field unit Unit
 Weapon = ClassWeapon(moho.weapon_methods) {
 
@@ -79,6 +77,8 @@ Weapon = ClassWeapon(moho.weapon_methods) {
     ---@param self Weapon
     OnCreate = function(self)
 
+        LOG("Weapon OnCreate")
+
         -- Store blueprint for improved access pattern, see benchmark on blueprints
         local bp = self:GetBlueprint()
         self.Blueprint = bp
@@ -88,14 +88,10 @@ Weapon = ClassWeapon(moho.weapon_methods) {
         self.EnergyRequired = bp.EnergyRequired
         self.EnergyDrainPerSecond = bp.EnergyDrainPerSecond
 
-        -- cache information of unit, weapons get created before unit.OnCreate is called
-        self.Trash = TrashBag()
-        self.TrashProjectiles = TrashBag()
-        self.TrashManipulators = TrashBag()
-
         local unit = self.unit
         self.Brain = unit:GetAIBrain()
         self.Army = unit:GetArmy()
+        self.Trash = unit.Trash
 
         self:SetValidTargetsForCurrentLayer(unit.Layer)
 
@@ -160,7 +156,7 @@ Weapon = ClassWeapon(moho.weapon_methods) {
         end
         local aimControl, aimRight, aimLeft
         if yawBone and pitchBone and muzzleBone then
-            local trashManipulators = self.TrashManipulators
+            local trashManipulators = self.Trash
             if bp.TurretDualManipulators then
                 aimControl = CreateAimController(self, 'Torso', yawBone)
                 aimRight = CreateAimController(self, 'Right', pitchBone, pitchBone, muzzleBone)
@@ -503,18 +499,6 @@ Weapon = ClassWeapon(moho.weapon_methods) {
 
     ---@param self Weapon
     OnDestroy = function(self)
-    end,
-
-    --- Clears out the trash of projectiles, such as beams. Called by the owning unit
-    ---@param self Weapon
-    ClearProjectileTrash = function(self)
-        self.TrashProjectiles:Destroy()
-    end,
-
-    --- Clears out the manipulators. Called by the owning unit
-    ---@param self Weapon
-    ClearManipulatorTrash = function(self)
-        self.TrashManipulators:Destroy()
     end,
 
     ---@param self Weapon

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -76,9 +76,6 @@ Weapon = ClassWeapon(moho.weapon_methods) {
 
     ---@param self Weapon
     OnCreate = function(self)
-
-        LOG("Weapon OnCreate")
-
         -- Store blueprint for improved access pattern, see benchmark on blueprints
         local bp = self:GetBlueprint()
         self.Blueprint = bp


### PR DESCRIPTION
Removes three unique trashbags instances for each weapon, and instead references the trashbag of the unit again. This was introduced a few months ago to fix an issue with weapon manipulators being destroyed before the unit is turned into a prop. At the time I was unable to find a better solution. In retrospect, memory-wise it was a poor direction to take. 