### PR TITLE
Introduces custom classes to initiate the data structures

### DIFF
--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -152,9 +152,9 @@ NavGrid = ClassNavGrid {
     OnCreate = function(self, layer, treeSize)
         self.Layer = layer
         self.TreeSize = treeSize
-        self.Trees = {}
+        self.Trees = {&0 &16}
         for z = 0, LabelCompressionTreesPerAxis - 1 do
-            self.Trees[z] = {}
+            self.Trees[z] = {&0 &16}
         end
     end,
 

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -126,15 +126,30 @@ function DrawSquare(px, pz, c, color, inset)
     DrawLine(br, tr, color)
 end
 
+local FactoryNavGrid = {
+    __call = function(self, layer, treeSize)
+        local instance = {&3 &0}
+        setmetatable(instance, self)
+        instance:OnCreate(layer, treeSize)
+        return instance
+    end
+}
+
+---@param meta any
+local ClassNavGrid = function(meta)
+    meta.__index = meta
+    return setmetatable(meta, FactoryNavGrid)
+end
+
 ---@class NavGrid
 ---@field Layer NavLayers
 ---@field TreeSize number
 ---@field Trees CompressedLabelTreeNode[][]
-NavGrid = ClassSimple {
+NavGrid = ClassNavGrid {
 
     ---@param self NavGrid
     ---@param layer NavLayers
-    __init = function(self, layer, treeSize)
+    OnCreate = function(self, layer, treeSize)
         self.Layer = layer
         self.TreeSize = treeSize
         self.Trees = {}
@@ -249,6 +264,18 @@ NavGrid = ClassSimple {
     end,
 }
 
+local FactoryCompressedLabelTree = {
+    __call = function(self, layer, treeSize)
+        return setmetatable({&0 &4}, self)
+    end
+}
+
+---@param meta any
+local ClassCompressedLabelTree = function(meta)
+    meta.__index = meta
+    return setmetatable(meta, FactoryCompressedLabelTree)
+end
+
 -- defined here, as it is a recursive class
 local CompressedLabelTree
 
@@ -278,7 +305,7 @@ local CompressedLabelTree
 ---@field [2] CompressedLabelTreeNode?
 ---@field [3] CompressedLabelTreeNode?
 ---@field [4] CompressedLabelTreeNode?
-CompressedLabelTree = ClassSimple {
+CompressedLabelTree = ClassCompressedLabelTree {
 
     --- Compresses the cache using a quad tree, significantly reducing the amount of data stored. At this point
     --- the label cache only exists of 0s and -1s

--- a/run_lua_syntax_checker.sh
+++ b/run_lua_syntax_checker.sh
@@ -25,7 +25,7 @@ while read file; do
   if [ "$file" != "./lua/lazyvar.lua" ]; then
     if [ "$file" != "./.vscode/fa-plugin.lua" ]; then
       if [ "$file" != "./lua/system/class.lua" ]; then
-        if [ "$file" != "./lua/sim/navgenerator.lua" ]; then
+        if [ "$file" != "./lua/sim/NavGenerator.lua" ]; then
           check_file "$file"
           (( files_checked++ ))
         fi

--- a/run_lua_syntax_checker.sh
+++ b/run_lua_syntax_checker.sh
@@ -25,8 +25,10 @@ while read file; do
   if [ "$file" != "./lua/lazyvar.lua" ]; then
     if [ "$file" != "./.vscode/fa-plugin.lua" ]; then
       if [ "$file" != "./lua/system/class.lua" ]; then
-        check_file "$file"
-        (( files_checked++ ))
+        if [ "$file" != "./lua/sim/navgenerator.lua" ]; then
+          check_file "$file"
+          (( files_checked++ ))
+        fi
       fi
     fi
   fi


### PR DESCRIPTION
Slightly decreases the time it takes to generate the navigational mesh by using class constructors that properly pre-allocate the tables and prevent the generic `...` from allocating when creating a class. There is still more room to gain by making a distinction between a node and a leaf. But at the moment there is no such distinction code-wise, hence we'll leave it at this.

### Statistics

The `(min, max)` time before and after applying this pull request.

Open Palms: `(0.431, 0.447)` -> `(0.424 -> 0.435 )`
Seton's Clutch: `(1.40, 1.41)` -> `(1.39, 1.40)`