### PR TITLE
Adjust titans and loyalists

### DIFF
--- a/units/UEL0303/UEL0303_unit.bp
+++ b/units/UEL0303/UEL0303_unit.bp
@@ -57,8 +57,8 @@ UnitBlueprint {
         AirThreatLevel = 0,
         ArmorType = 'Normal',
         EconomyThreatLevel = 0,
-        Health = 2600,
-        MaxHealth = 2600,
+        Health = 2400,
+        MaxHealth = 2400,
         RegenRate = 0,
         Shield = {
             ImpactEffects = 'UEFShieldHit01',

--- a/units/URL0303/URL0303_Script.lua
+++ b/units/URL0303/URL0303_Script.lua
@@ -59,8 +59,6 @@ URL0303 = Class(CWalkingLandUnit) {
         WaitSeconds(blueprint.SecondsBeforeChargeKicksIn)
 
         self.ChargingInProgress = true
-        self:SetWeaponEnabledByLabel('Disintigrator', false)
-        self:SetWeaponEnabledByLabel('HeavyBolter', false)
         self:SetAccMult(blueprint.Physics.ChargeAccMult)
         self:SetSpeedMult(blueprint.Physics.ChargeSpeedMult)
         -- EMP duration mult added in DoDeathWeapon 

--- a/units/URL0303/URL0303_unit.bp
+++ b/units/URL0303/URL0303_unit.bp
@@ -448,7 +448,7 @@ UnitBlueprint {
             WeaponCategory = 'Direct Fire',
         },
     },
-    SecondsBeforeChargeKicksIn = 4,
+    SecondsBeforeChargeKicksIn = 3,
     SecondsBeforeExplosionWhenCharging = 6,
     Wreckage = {
         Blueprint = '/props/DefaultWreckage/DefaultWreckage_prop.bp',


### PR DESCRIPTION
Titans:
Decrease HP by 200
Loyalists:
No longer disable weapons while charging, and decrease the time it takes for the charge to kick in (4 -> 3 seconds)

After T3 rebalance Titans with their fast recharging shields became a bit too oppressive and they are currently stronger than loyalists. A small HP nerf should put the unit in the right place while not taking away from its specialty of constantly dashing in and out and letting its shield recharge.
Loyalists' ability has been underwhelming and thus it's getting a well-deserved buff, we hope this will be enough to make mixing in Loyalists in your army in later stages a more viable option instead of being a gimmick that is rarely used.