### PR TITLE
Normalize Economy stats of T2 PDs

### DIFF
--- a/units/UAB2301/UAB2301_unit.bp
+++ b/units/UAB2301/UAB2301_unit.bp
@@ -89,9 +89,9 @@ UnitBlueprint {
         UniformScale = 0.4,
     },
     Economy = {
-        BuildCostEnergy = 3648,
-        BuildCostMass = 528,
-        BuildTime = 701,
+        BuildCostEnergy = 3780,
+        BuildCostMass = 540,
+        BuildTime = 675,
         RebuildBonusIds = {
             'uab2301',
         },

--- a/units/UEB2301/UEB2301_unit.bp
+++ b/units/UEB2301/UEB2301_unit.bp
@@ -88,9 +88,9 @@ UnitBlueprint {
         UniformScale = 0.2,
     },
     Economy = {
-        BuildCostEnergy = 3600,
+        BuildCostEnergy = 3780,
         BuildCostMass = 540,
-        BuildTime = 664,
+        BuildTime = 675,
         RebuildBonusIds = {
             'ueb2301',
         },

--- a/units/URB2301/URB2301_unit.bp
+++ b/units/URB2301/URB2301_unit.bp
@@ -88,7 +88,7 @@ UnitBlueprint {
         UniformScale = 0.06,
     },
     Economy = {
-        BuildCostEnergy = 3400,
+        BuildCostEnergy = 3360,
         BuildCostMass = 480,
         BuildTime = 600,
         RebuildBonusIds = {

--- a/units/XSB2301/XSB2301_unit.bp
+++ b/units/XSB2301/XSB2301_unit.bp
@@ -103,9 +103,9 @@ UnitBlueprint {
         UniformScale = 0.06,
     },
     Economy = {
-        BuildCostEnergy = 3648,
-        BuildCostMass = 528,
-        BuildTime = 727,
+        BuildCostEnergy = 3780,
+        BuildCostMass = 540,
+        BuildTime = 675,
         RebuildBonusIds = {
             'xsb2301',
         },


### PR DESCRIPTION
The economy Stats of a lot of units are all over the place currently with ratios between factions being close but not the same for no apparent reason (Take the Sera and Aeon PD which have the same cost but Sera randomly costs 26 more BT). This PR brings them more in line while having minimal impact on the Balance.