### PR TITLE
Make stationary stealth fields more useful

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -3030,7 +3030,7 @@ Unit = Class(moho.unit_methods) {
 
     ---@param self Unit
     ---@param disabler string
-    ---@param intel string
+    ---@param intel IntelType
     DisableUnitIntel = function(self, disabler, intel)
         local function DisableOneIntel(disabler, intel)
             local intDisabled = false
@@ -3078,7 +3078,7 @@ Unit = Class(moho.unit_methods) {
 
     ---@param self Unit
     ---@param disabler string
-    ---@param intel string
+    ---@param intel IntelType
     EnableUnitIntel = function(self, disabler, intel)
         local function EnableOneIntel(disabler, intel)
             local intEnabled = false
@@ -3122,16 +3122,19 @@ Unit = Class(moho.unit_methods) {
         end
 
         if intEnabled then
-            self:OnIntelEnabled()
+            self:OnIntelEnabled(intel)
         end
     end,
 
     ---@param self Unit
-    OnIntelEnabled = function(self)
+    ---@param type IntelType
+    OnIntelEnabled = function(self, type)
     end,
 
     ---@param self Unit
-    OnIntelDisabled = function(self)
+    ---@param disabler string
+    ---@param type IntelType
+    OnIntelDisabled = function(self, disabler, type)
     end,
 
     ---@param self Unit

--- a/units/UAB4203/UAB4203_unit.bp
+++ b/units/UAB4203/UAB4203_unit.bp
@@ -167,10 +167,9 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        RadarStealthFieldRadius = 24,
+        RadarStealthFieldRadius = 32,
         ReactivateTime = 5,
-        SonarStealthFieldRadius = 24,
-        VisionRadius = 20,
+        VisionRadius = 32,
     },
     Interface = {
         HelpText = '<LOC uab4203_help>Stealth Field Generator',

--- a/units/UAB4203/UAB4203_unit.bp
+++ b/units/UAB4203/UAB4203_unit.bp
@@ -167,9 +167,9 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        RadarStealthFieldRadius = 24,
+        RadarStealthFieldRadius = 26,
         ReactivateTime = 5,
-        VisionRadius = 24,
+        VisionRadius = 26,
     },
     Interface = {
         HelpText = '<LOC uab4203_help>Stealth Field Generator',

--- a/units/UAB4203/UAB4203_unit.bp
+++ b/units/UAB4203/UAB4203_unit.bp
@@ -167,9 +167,9 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        RadarStealthFieldRadius = 32,
+        RadarStealthFieldRadius = 24,
         ReactivateTime = 5,
-        VisionRadius = 32,
+        VisionRadius = 24,
     },
     Interface = {
         HelpText = '<LOC uab4203_help>Stealth Field Generator',

--- a/units/UEB4203/UEB4203_unit.bp
+++ b/units/UEB4203/UEB4203_unit.bp
@@ -140,14 +140,9 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        RadarStealthFieldRadius = 32,
+        RadarStealthFieldRadius = 26,
         ReactivateTime = 5,
-        VisionRadius = 20,
-        JamRadius = {
-            Max = 30,
-            Min = 0,
-        },
-        JammerBlips = 6,
+        VisionRadius = 22,
     },
     Interface = {
         HelpText = '<LOC ueb4203_help>Stealth Field Generator',

--- a/units/UEB4203/UEB4203_unit.bp
+++ b/units/UEB4203/UEB4203_unit.bp
@@ -140,7 +140,7 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        RadarStealthFieldRadius = 26,
+        RadarStealthFieldRadius = 28,
         ReactivateTime = 5,
         VisionRadius = 22,
     },

--- a/units/UEB4203/UEB4203_unit.bp
+++ b/units/UEB4203/UEB4203_unit.bp
@@ -140,10 +140,14 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        RadarStealthFieldRadius = 24,
+        RadarStealthFieldRadius = 32,
         ReactivateTime = 5,
-        SonarStealthFieldRadius = 24,
         VisionRadius = 20,
+        JamRadius = {
+            Max = 30,
+            Min = 0,
+        },
+        JammerBlips = 6,
     },
     Interface = {
         HelpText = '<LOC ueb4203_help>Stealth Field Generator',

--- a/units/URB4203/URB4203_unit.bp
+++ b/units/URB4203/URB4203_unit.bp
@@ -141,9 +141,9 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        RadarStealthFieldRadius = 42,
+        RadarStealthFieldRadius = 32,
         ReactivateTime = 5,
-        VisionRadius = 26,
+        VisionRadius = 18,
     },
     Interface = {
         HelpText = '<LOC urb4203_help>Stealth Field Generator',

--- a/units/URB4203/URB4203_unit.bp
+++ b/units/URB4203/URB4203_unit.bp
@@ -141,7 +141,7 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        RadarStealthFieldRadius = 32,
+        RadarStealthFieldRadius = 34,
         ReactivateTime = 5,
         VisionRadius = 18,
     },

--- a/units/URB4203/URB4203_unit.bp
+++ b/units/URB4203/URB4203_unit.bp
@@ -141,10 +141,9 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        RadarStealthFieldRadius = 32,
+        RadarStealthFieldRadius = 42,
         ReactivateTime = 5,
-        SonarStealthFieldRadius = 32,
-        VisionRadius = 20,
+        VisionRadius = 26,
     },
     Interface = {
         HelpText = '<LOC urb4203_help>Stealth Field Generator',

--- a/units/XSB4203/XSB4203_script.lua
+++ b/units/XSB4203/XSB4203_script.lua
@@ -8,8 +8,11 @@
 --****************************************************************************
 
 local SRadarJammerUnit = import("/lua/seraphimunits.lua").SRadarJammerUnit
+local EffectTemplates = import("/lua/effecttemplates.lua")
 
 ---@class XSB4203 : SRadarJammerUnit
+---@field StealthEffectsBag TrashBag
+---@field StealthRotator moho.RotateManipulator
 XSB4203 = Class(SRadarJammerUnit) {
     IntelEffects = {
 		{
@@ -24,6 +27,54 @@ XSB4203 = Class(SRadarJammerUnit) {
 			Type = 'Jammer01',
 		},
     },
+
+	OnCreate = function(self)
+		SRadarJammerUnit.OnCreate(self)
+		self.StealthEffectsBag = TrashBag()
+		self.StealthRotator = CreateRotator(self, 'N01', "y", nil, 0, 1, 12)
+
+		self.Trash:Add(self.StealthEffectsBag)
+		self.Trash:Add(self.StealthRotator)
+	end,
+
+	DestroyAllTrashBags = function(self)
+		SRadarJammerUnit.DestroyAllTrashBags(self)
+		self.StealthEffectsBag:Destroy()
+	end,
+
+    ---@param self XSB4203
+    ---@param type IntelType
+    OnIntelEnabled = function(self, type)
+		SRadarJammerUnit.OnIntelEnabled(self)
+		if type == "RadarStealthField" or type == nil then
+			local army = self.Army
+			local trash = self.StealthEffectsBag
+			self.StealthRotator:SetSpinDown(false)
+			self.StealthRotator:SetTargetSpeed(12)
+			self.StealthRotator:SetAccel(1)
+
+			-- center
+			for _, v in EffectTemplates.SeraphimSubCommanderGateway02 do
+				trash:Add(CreateAttachedEmitter(self, 'XSB4203', army, v):OffsetEmitter(0, 0.3, -0.5):ScaleEmitter(0.5))
+			end
+
+			-- top
+			for _, v in EffectTemplates.SeraphimSubCommanderGateway02 do
+				trash:Add(CreateAttachedEmitter(self, 'N01', army, v):OffsetEmitter(0, 0.7, -1))
+			end
+		end
+	end,
+
+    ---@param self XSB4203
+    ---@param disabler string
+    ---@param type IntelType
+    OnIntelDisabled = function(self, disabler, type)
+		SRadarJammerUnit.OnIntelDisabled(self)
+
+		self.StealthRotator:SetTargetSpeed(0)
+		self.StealthRotator:SetSpinDown(true)
+		self.StealthEffectsBag:Destroy()
+	end,
 }
 
 TypeClass = XSB4203

--- a/units/XSB4203/XSB4203_unit.bp
+++ b/units/XSB4203/XSB4203_unit.bp
@@ -176,10 +176,9 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        RadarStealthFieldRadius = 24,
+        RadarStealthFieldRadius = 32,
         ReactivateTime = 5,
-        SonarStealthFieldRadius = 24,
-        VisionRadius = 20,
+        VisionRadius = 26,
     },
     Interface = {
         HelpText = '<LOC xsb4203_help>Stealth Field Generator',

--- a/units/XSB4203/XSB4203_unit.bp
+++ b/units/XSB4203/XSB4203_unit.bp
@@ -176,7 +176,7 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        RadarStealthFieldRadius = 30,
+        RadarStealthFieldRadius = 28,
         ReactivateTime = 5,
         VisionRadius = 24,
     },

--- a/units/XSB4203/XSB4203_unit.bp
+++ b/units/XSB4203/XSB4203_unit.bp
@@ -176,9 +176,9 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
-        RadarStealthFieldRadius = 32,
+        RadarStealthFieldRadius = 30,
         ReactivateTime = 5,
-        VisionRadius = 26,
+        VisionRadius = 24,
     },
     Interface = {
         HelpText = '<LOC xsb4203_help>Stealth Field Generator',


### PR DESCRIPTION
Stationary stealth fields is one of those units that I never see around usually. In this pull request we give them a buff (1) , and on top of that we also add in some faction-specific flavors (2).

(1) All stealth fields have a larger stealth radius. They no longer provide sonar stealth, as that doesn't make sense at all. I was also unaware of them providing it. See the changes for the exact stats.

(2) All stealth fields could use a bit of a 'faction flavor', therefore:

- Aeon: similar to the ACU radar upgrade, the stealth field provides a large vision radius
- UEF: similar to other jamming units, the stealth field provides jamming blips. Unintentionally but quite nice, these jamming blips do not look like units - they look like structures 😄 
- Cybran: a larger stealth field than all the other factions
- Seraphim: a jamming crystal behavior, where instead of providing stationary blips they'd move around just like the jamming crystal. 

The jamming crystal one is not part of this pull request - yet. I can implement that when it is accepted.