### PR TITLE
Allow all experimentals to walk backwards

### DIFF
--- a/units/UAL0401/UAL0401_Script.lua
+++ b/units/UAL0401/UAL0401_Script.lua
@@ -176,6 +176,18 @@ UAL0401 = Class(AWalkingLandUnit) {
 
         self:Destroy()
     end,
+
+    OnMotionHorzEventChange = function(self, new, old)
+        AWalkingLandUnit.OnMotionHorzEventChange(self, new, old)
+
+        if (old == 'Stopped') then
+            local bpDisplay = self:GetBlueprint().Display
+            if bpDisplay.AnimationWalk and self.Animator then
+                self.Animator:SetDirectionalAnim(true)
+                self.Animator:SetRate(bpDisplay.AnimationWalkRate)
+            end
+         end
+    end,
 }
 
 TypeClass = UAL0401

--- a/units/UAL0401/UAL0401_unit.bp
+++ b/units/UAL0401/UAL0401_unit.bp
@@ -230,6 +230,7 @@ UnitBlueprint {
     LifeBarOffset = 1.55,
     LifeBarSize = 3.25,
     Physics = {
+        BackUpDistance = 20,
         BankingSlope = 0,
         BuildOnLayerCaps = {
             LAYER_Air = false,
@@ -244,7 +245,7 @@ UnitBlueprint {
         MaxAcceleration = 2.5,
         MaxBrake = 2.5,
         MaxSpeed = 2.5,
-        MaxSpeedReverse = 0,
+        MaxSpeedReverse = 1.25,
         MaxSteerForce = 10,
         MeshExtentsX = 2.75,
         MeshExtentsY = 6.75,

--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -361,7 +361,7 @@ UnitBlueprint {
     LifeBarOffset = 4.35,
     LifeBarSize = 5.75,
     Physics = {
-        BackUpDistance = 15,
+        BackUpDistance = 20,
         BankingSlope = 3,
         BuildOnLayerCaps = {
             LAYER_Air = false,
@@ -377,7 +377,7 @@ UnitBlueprint {
         MaxAcceleration = 1.75,
         MaxBrake = 1.75,
         MaxSpeed = 1.75,
-        MaxSpeedReverse = 1.75,
+        MaxSpeedReverse = 1.5,
         MaxSteerForce = 1000,
         MeshExtentsX = 8,
         MeshExtentsY = 2,

--- a/units/URL0402/URL0402_script.lua
+++ b/units/URL0402/URL0402_script.lua
@@ -286,6 +286,18 @@ URL0402 = Class(CWalkingLandUnit) {
         self:CreateWreckage(0.1)
         self:Destroy()
     end,
+
+    OnMotionHorzEventChange = function(self, new, old)
+        CWalkingLandUnit.OnMotionHorzEventChange(self, new, old)
+
+        if (old == 'Stopped') then
+            local bpDisplay = self:GetBlueprint().Display
+            if bpDisplay.AnimationWalk and self.Animator then
+                self.Animator:SetDirectionalAnim(true)
+                self.Animator:SetRate(bpDisplay.AnimationWalkRate)
+            end
+         end
+    end,
 }
 
 TypeClass = URL0402

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -287,7 +287,7 @@ UnitBlueprint {
     LifeBarOffset = 3.25,
     LifeBarSize = 6,
     Physics = {
-        BackupDistance = 0,
+        BackupDistance = 20,
         BankingSlope = 0,
         BuildOnLayerCaps = {
             LAYER_Air = false,
@@ -301,7 +301,7 @@ UnitBlueprint {
         LayerChangeOffsetHeight = -3,
         MaxAcceleration = 2.5,
         MaxSpeed = 2.5,
-        MaxSpeedReverse = 0,
+        MaxSpeedReverse = 1.25,
         MaxSteerForce = 0,
         MinSpeedPercent = 0,
         MotionType = 'RULEUMT_Amphibious',

--- a/units/XRL0403/XRL0403_unit.bp
+++ b/units/XRL0403/XRL0403_unit.bp
@@ -272,7 +272,7 @@ UnitBlueprint {
     LifeBarOffset = 3.7,
     LifeBarSize = 9,
     Physics = {
-        BackUpDistance = 12,
+        BackUpDistance = 20,
         BankingSlope = 0,
         BuildOnLayerCaps = {
             LAYER_Air = false,

--- a/units/XSL0401/XSL0401_Script.lua
+++ b/units/XSL0401/XSL0401_Script.lua
@@ -146,6 +146,18 @@ XSL0401 = Class(SWalkingLandUnit) {
         self:Destroy()
     end,
 
+    OnMotionHorzEventChange = function(self, new, old)
+        SWalkingLandUnit.OnMotionHorzEventChange(self, new, old)
+
+        if (old == 'Stopped') then
+            local bpDisplay = self:GetBlueprint().Display
+            if bpDisplay.AnimationWalk and self.Animator then
+                self.Animator:SetDirectionalAnim(true)
+                self.Animator:SetRate(bpDisplay.AnimationWalkRate)
+            end
+         end
+    end,
+
 }
 
 TypeClass = XSL0401

--- a/units/XSL0401/XSL0401_unit.bp
+++ b/units/XSL0401/XSL0401_unit.bp
@@ -250,6 +250,7 @@ UnitBlueprint {
     LifeBarOffset = 2.3,
     LifeBarSize = 3.25,
     Physics = {
+        BackUpDistance = 20,
         BankingSlope = 0,
         BuildOnLayerCaps = {
             LAYER_Air = false,
@@ -264,7 +265,7 @@ UnitBlueprint {
         MaxAcceleration = 2.5,
         MaxBrake = 2.5,
         MaxSpeed = 2.5,
-        MaxSpeedReverse = 0,
+        MaxSpeedReverse = 1.25,
         MaxSteerForce = 10,
         MeshExtentsX = 2.75,
         MeshExtentsY = 6.75,


### PR DESCRIPTION
As the title states - allows all (land) experimentals to move backwards. They will all have the same backup distance. Similar to the Megalith, all non-fatboy experimentals will move backwards at half their usual movement speed.