### PR TITLE
Fix order of execution of overcharge projectiles

### DIFF
--- a/projectiles/ADFOverCharge01/ADFOverCharge01_script.lua
+++ b/projectiles/ADFOverCharge01/ADFOverCharge01_script.lua
@@ -14,13 +14,13 @@ TDFOverCharge01 = ClassProjectile(ALaserBotProjectile, OverchargeProjectile) {
     FxImpactLand = EffectTemplate.ACommanderOverchargeHit01,
 
     OnImpact = function(self, targetType, targetEntity)
-        OverchargeProjectile.OnImpact(self, targetType, targetEntity)
         ALaserBotProjectile.OnImpact(self, targetType, targetEntity)
+        OverchargeProjectile.OnImpact(self, targetType, targetEntity)
     end,
 
     OnCreate = function(self)
-        OverchargeProjectile.OnCreate(self)
         ALaserBotProjectile.OnCreate(self)
+        OverchargeProjectile.OnCreate(self)
     end,
 }
 TypeClass = TDFOverCharge01

--- a/projectiles/CDFCannonMolecularOvercharge01/CDFCannonMolecularOvercharge01_script.lua
+++ b/projectiles/CDFCannonMolecularOvercharge01/CDFCannonMolecularOvercharge01_script.lua
@@ -14,13 +14,13 @@ CDFCannonMolecular01 = ClassProjectile(CMolecularCannonProjectile, OverchargePro
     FxImpactLand = EffectTemplate.CCommanderOverchargeHit01,
 
     OnImpact = function(self, targetType, targetEntity)
-        OverchargeProjectile.OnImpact(self, targetType, targetEntity)
         CMolecularCannonProjectile.OnImpact(self, targetType, targetEntity)
+        OverchargeProjectile.OnImpact(self, targetType, targetEntity)
     end,
     
     OnCreate = function(self)
-        OverchargeProjectile.OnCreate(self)
         CMolecularCannonProjectile.OnCreate(self)
+        OverchargeProjectile.OnCreate(self)
     end,
 }
 

--- a/projectiles/SDFChronatronCannon02/SDFChronatronCannon02_script.lua
+++ b/projectiles/SDFChronatronCannon02/SDFChronatronCannon02_script.lua
@@ -8,13 +8,13 @@ local OverchargeProjectile = import("/lua/sim/DefaultProjectiles.lua").Overcharg
 
 SDFChronatronCannon02 = ClassProjectile(SChronatronCannonOverCharge, OverchargeProjectile) {
     OnImpact = function(self, targetType, targetEntity)
-        OverchargeProjectile.OnImpact(self, targetType, targetEntity)
         SChronatronCannonOverCharge.OnImpact(self, targetType, targetEntity)
+        OverchargeProjectile.OnImpact(self, targetType, targetEntity)
     end,
 
     OnCreate = function(self)
-        OverchargeProjectile.OnCreate(self)
         SChronatronCannonOverCharge.OnCreate(self)
+        OverchargeProjectile.OnCreate(self)
     end,
 }
 TypeClass = SDFChronatronCannon02

--- a/projectiles/SDFLightChronatronCannon02/SDFLightChronatronCannon02_script.lua
+++ b/projectiles/SDFLightChronatronCannon02/SDFLightChronatronCannon02_script.lua
@@ -8,13 +8,13 @@ local OverchargeProjectile = import("/lua/sim/DefaultProjectiles.lua").Overcharg
 
 SDFLightChronatronCannon02 = ClassProjectile(SLightChronatronCannonOverCharge, OverchargeProjectile) {
     OnImpact = function(self, targetType, targetEntity)
-        OverchargeProjectile.OnImpact(self, targetType, targetEntity)
         SLightChronatronCannonOverCharge.OnImpact(self, targetType, targetEntity)
+        OverchargeProjectile.OnImpact(self, targetType, targetEntity)
     end,
 
     OnCreate = function(self)
-        OverchargeProjectile.OnCreate(self)
         SLightChronatronCannonOverCharge.OnCreate(self)
+        OverchargeProjectile.OnCreate(self)
     end,
 }
 TypeClass = SDFLightChronatronCannon02

--- a/projectiles/TDFOverCharge01/TDFOverCharge01_script.lua
+++ b/projectiles/TDFOverCharge01/TDFOverCharge01_script.lua
@@ -15,13 +15,13 @@ TDFOverCharge01 = ClassProjectile(TLaserBotProjectile, OverchargeProjectile) {
     FxImpactAirUnit =  EffectTemplate.TCommanderOverchargeHit01,
 
     OnImpact = function(self, targetType, targetEntity)
-        OverchargeProjectile.OnImpact(self, targetType, targetEntity)
         TLaserBotProjectile.OnImpact(self, targetType, targetEntity)
+        OverchargeProjectile.OnImpact(self, targetType, targetEntity)
     end,
     
     OnCreate = function(self)
-        OverchargeProjectile.OnCreate(self)
         TLaserBotProjectile.OnCreate(self)
+        OverchargeProjectile.OnCreate(self)
     end,
 }
 


### PR DESCRIPTION
This could prevent them to be initialized properly.