### PR TITLE
Remove overwritten instances of `CreateProjectileForWeapon`

### DIFF
--- a/lua/aeonweapons.lua
+++ b/lua/aeonweapons.lua
@@ -465,32 +465,7 @@ AIFMortarWeapon = ClassWeapon(DefaultProjectileWeapon) {}
 AIFBombGravitonWeapon = ClassWeapon(DefaultProjectileWeapon) {}
 
 ---@class AIFArtilleryMiasmaShellWeapon : DefaultProjectileWeapon
-AIFArtilleryMiasmaShellWeapon = ClassWeapon(DefaultProjectileWeapon) {
-    ---@param self AIFArtilleryMiasmaShellWeapon
-    ---@param bone Bone
-    ---@return Projectile |nil
-    CreateProjectileForWeapon = function(self, bone)
-        local proj = self:CreateProjectile(bone)
-        local damageTable = self:GetDamageTable()
-        local blueprint = self.Blueprint
-        local data = {
-            Instigator = self.unit,
-            Damage = blueprint.DoTDamage,
-            Duration = blueprint.DoTDuration,
-            Frequency = blueprint.DoTFrequency,
-            Radius = blueprint.DamageRadius,
-            Type = 'Normal',
-            DamageFriendly = blueprint.DamageFriendly,
-        }
-
-        if proj and not proj:BeenDestroyed() then
-            proj:PassDamageData(damageTable)
-            proj:PassData(data)
-        end
-
-        return proj
-    end,
-}
+AIFArtilleryMiasmaShellWeapon = ClassWeapon(DefaultProjectileWeapon) {}
 
 ---@class AIFArtillerySonanceShellWeapon : DefaultProjectileWeapon
 AIFArtillerySonanceShellWeapon = ClassWeapon(DefaultProjectileWeapon) {
@@ -509,97 +484,16 @@ AIFBombQuarkWeapon = ClassWeapon(DefaultProjectileWeapon) {
 ---@class AANDepthChargeBombWeapon : DefaultProjectileWeapon
 AANDepthChargeBombWeapon = ClassWeapon(DefaultProjectileWeapon) {
     FxMuzzleFlash = {'/effects/emitters/antiair_muzzle_fire_02_emit.bp', },
-
-    ---@param self AANDepthChargeBombWeapon
-    ---@param bone Bone
-    ---@return Projectile|nil
-    CreateProjectileForWeapon = function(self, bone)
-        local proj = self:CreateProjectile(bone)
-        local damageTable = self:GetDamageTable()
-        local blueprint = self.Blueprint
-        local data = {
-            Army = self.unit.Army,
-            Instigator = self.unit,
-            StartRadius = blueprint.DOTStartRadius,
-            EndRadius = blueprint.DOTEndRadius,
-            DOTtype = blueprint.DOTtype,
-            Damage = blueprint.DoTDamage,
-            Duration = blueprint.DoTDuration,
-            Frequency = blueprint.DoTFrequency,
-            Type = 'Normal',
-        }
-
-        if proj and not proj:BeenDestroyed() then
-            proj:PassDamageData(damageTable)
-            proj:PassData(data)
-        end
-
-        return proj
-    end,
 }
 
 ---@class AANDepthChargeBombWeapon02 : DefaultProjectileWeapon
 AANDepthChargeBombWeapon02 = ClassWeapon(DefaultProjectileWeapon) {
     FxMuzzleFlash = {'/effects/emitters/antiair_muzzle_fire_01_emit.bp', },
-
-    ---@param self AANDepthChargeBombWeapon02
-    ---@param bone Bone
-    ---@return Projectile|nil
-    CreateProjectileForWeapon = function(self, bone)
-        local proj = self:CreateProjectile(bone)
-        local damageTable = self:GetDamageTable()
-        local blueprint = self.Blueprint
-        local data = {
-            Army = self.unit.Army,
-            Instigator = self.unit,
-            StartRadius = blueprint.DOTStartRadius,
-            EndRadius = blueprint.DOTEndRadius,
-            DOTtype = blueprint.DOTtype,
-            Damage = blueprint.DoTDamage,
-            Duration = blueprint.DoTDuration,
-            Frequency = blueprint.DoTFrequency,
-            Type = 'Normal',
-        }
-
-        if proj and not proj:BeenDestroyed() then
-            proj:PassDamageData(damageTable)
-            proj:PassData(data)
-        end
-
-        return proj
-    end,
 }
 
 ---@class AANTorpedoCluster : DefaultProjectileWeapon
 AANTorpedoCluster = ClassWeapon(DefaultProjectileWeapon) {
     FxMuzzleFlash = {'/effects/emitters/aeon_torpedocluster_flash_01_emit.bp', },
-
-    ---@param self AANTorpedoCluster
-    ---@param bone Bone
-    ---@return Projectile|nil
-    CreateProjectileForWeapon = function(self, bone)
-        local proj = self:CreateProjectile(bone)
-        local damageTable = self:GetDamageTable()
-        local blueprint = self.Blueprint
-        local data = {
-            Army = self.unit.Army,
-            Instigator = self.unit,
-            StartRadius = blueprint.DOTStartRadius,
-            EndRadius = blueprint.DOTEndRadius,
-            DOTtype = blueprint.DOTtype,
-            Damage = blueprint.DoTDamage,
-            Duration = blueprint.DoTDuration,
-            Frequency = blueprint.DoTFrequency,
-            Type = 'Normal',
-        }
-
-        if proj and not proj:BeenDestroyed() then
-            proj:PassDamageData(damageTable)
-            proj:PassData(data)
-        end
-
-        return proj
-    end,
 }
 
 ---@class AIFSmartCharge : DefaultProjectileWeapon

--- a/lua/cybranweapons.lua
+++ b/lua/cybranweapons.lua
@@ -162,30 +162,6 @@ CANNaniteTorpedoWeapon = ClassWeapon(DefaultProjectileWeapon) {
         '/effects/emitters/default_muzzle_flash_02_emit.bp',
         '/effects/emitters/torpedo_underwater_launch_01_emit.bp',
     },
-
-    ---@param self CANNaniteTorpedoWeapon
-    ---@param bone Bone
-    ---@return Projectile|nil
-    CreateProjectileForWeapon = function(self, bone)
-        local projectile = self:CreateProjectile(bone)
-        local damageTable = self:GetDamageTable()
-        local bp = self.Blueprint
-        local data = {
-            Instigator = self.unit,
-            Damage = bp.DoTDamage,
-            Duration = bp.DoTDuration,
-            Frequency = bp.DoTFrequency,
-            Type = 'Normal',
-            PreDamageEffects = {},
-            DuringDamageEffects = {},
-            PostDamageEffects = {},
-        }
-        if projectile and not projectile:BeenDestroyed() then
-            projectile:PassData(data)
-            projectile:PassDamageData(damageTable)
-        end
-        return projectile
-    end,
 }
 
 ---@class CDFMissileMesonWeapon : DefaultProjectileWeapon
@@ -279,26 +255,6 @@ CAABurstCloudFlakArtilleryWeapon = ClassWeapon(DefaultProjectileWeapon) {
         '/effects/emitters/default_muzzle_flash_02_emit.bp'
     },
     FxMuzzleFlashScale = 1.5,
-
-    CreateProjectileForWeapon = function(self, bone)
-        local projectile = self:CreateProjectile(bone)
-        local damageTable = self:GetDamageTable()
-        local blueprint = self.Blueprint
-        local data = {
-            Instigator = self.unit,
-            Damage = blueprint.DoTDamage,
-            Duration = blueprint.DoTDuration,
-            Frequency = blueprint.DoTFrequency,
-            Radius = blueprint.DamageRadius,
-            Type = 'Normal',
-            DamageFriendly = blueprint.DamageFriendly,
-        }
-        if projectile and not projectile:BeenDestroyed() then
-            projectile:PassData(data)
-            projectile:PassDamageData(damageTable)
-        end
-        return projectile
-    end,
 }
 
 ---@class CAAMissileNaniteWeapon : DefaultProjectileWeapon
@@ -333,31 +289,6 @@ CIFBombNeutronWeapon = ClassWeapon(DefaultProjectileWeapon) {
 ---@class CIFNaniteTorpedoWeapon : DefaultProjectileWeapon
 CIFNaniteTorpedoWeapon = ClassWeapon(DefaultProjectileWeapon) {
     FxMuzzleFlash = {'/effects/emitters/antiair_muzzle_fire_02_emit.bp',},
-
-    ---@param self CIFNaniteTorpedoWeapon
-    ---@param bone Bone
-    ---@return Projectile|nil
-    CreateProjectileForWeapon = function(self, bone)
-        local proj = self:CreateProjectile(bone)
-        local damageTable = self:GetDamageTable()
-        local bp = self.Blueprint
-        local data = {
-            Instigator = self.unit,
-            Damage = bp.DoTDamage,
-            Duration = bp.DoTDuration,
-            Frequency = bp.DoTFrequency,
-            Type = 'Normal',
-            PreDamageEffects = {},
-            DuringDamageEffects = {},
-            PostDamageEffects = {},
-        }
-
-        if proj and not proj:BeenDestroyed() then
-            proj:PassDamageData(damageTable)
-            proj:PassData(data)
-        end
-        return proj
-    end,
 }
 
 ---@class CIFMissileLoaWeapon : DefaultProjectileWeapon

--- a/lua/terranweapons.lua
+++ b/lua/terranweapons.lua
@@ -122,32 +122,6 @@ TDFHiroPlasmaCannon = ClassWeapon(DefaultBeamWeapon) {
 ---@class TAAFlakArtilleryCannon : DefaultProjectileWeapon
 TAAFlakArtilleryCannon = ClassWeapon(DefaultProjectileWeapon) {
     FxMuzzleFlash = EffectTemplate.TFlakCannonMuzzleFlash01,
-
-    --- Custom over-ride for this weapon, so it passes data and damageTable
-    ---@param self TAAFlakArtilleryCannon
-    ---@param bone Bone
-    ---@return Projectile|nil
-    CreateProjectileForWeapon = function(self, bone)
-        local proj = self:CreateProjectile(bone)
-        local damageTable = self:GetDamageTable()
-        local blueprint = self.Blueprint
-        local data = {
-            Instigator = self.unit,
-            Damage = blueprint.DoTDamage,
-            Duration = blueprint.DoTDuration,
-            Frequency = blueprint.DoTFrequency,
-            Radius = blueprint.DamageRadius,
-            Type = 'Normal',
-            DamageFriendly = blueprint.DamageFriendly,
-        }
-
-        if proj and not proj:BeenDestroyed() then
-            proj:PassDamageData(damageTable)
-            proj:PassData(data)
-        end
-
-        return proj
-    end
 }
 
 ---@class TAALinkedRailgun : DefaultProjectileWeapon
@@ -221,29 +195,6 @@ TIFArtilleryWeapon = ClassWeapon(DefaultProjectileWeapon) {
 ---@class TIFCarpetBombWeapon : DefaultProjectileWeapon
 TIFCarpetBombWeapon = ClassWeapon(DefaultProjectileWeapon) {
     FxMuzzleFlash = {'/effects/emitters/antiair_muzzle_fire_02_emit.bp',},
-
-    ---@param self TIFCarpetBombWeapon
-    ---@param bone Bone
-    ---@return Projectile | nil
-    CreateProjectileForWeapon = function(self, bone)
-        local projectile = self:CreateProjectile(bone)
-        local damageTable = self:GetDamageTable()
-        local blueprint = self.Blueprint
-        local data = {
-            Instigator = self.unit,
-            Damage = blueprint.DoTDamage,
-            Duration = blueprint.DoTDuration,
-            Frequency = blueprint.DoTFrequency,
-            Radius = blueprint.DamageRadius,
-            Type = 'Normal',
-            DamageFriendly = blueprint.DamageFriendly,
-        }
-        if projectile and not projectile:BeenDestroyed() then
-            projectile:PassData(data)
-            projectile:PassDamageData(damageTable)
-        end
-        return projectile
-    end,
 
     --- This function creates the projectile, and happens when the unit is trying to fire
     --- Called from inside RackSalvoFiringState

--- a/projectiles/ADFShieldDisruptor01/ADFShieldDisruptor01_script.lua
+++ b/projectiles/ADFShieldDisruptor01/ADFShieldDisruptor01_script.lua
@@ -15,7 +15,7 @@ ADFShieldDisruptor01 = ClassProjectile(ADisruptorProjectile) {
         if not TargetEntity then return end
 
         -- Never cause overspill damage to the unit, 1 min to avoid logspam with 0 declared damage
-        local damage = math.max(math.min(1300, TargetEntity:GetHealth()), 1)
+        local damage = math.max(math.min(1300, TargetEntity:GetHealth()), 1) -- TODO: find a better way to pass this damage
         Damage(self, {0,0,0}, TargetEntity, damage, 'Normal')
     end,
 }

--- a/projectiles/ADFShieldDisruptor01/ADFShieldDisruptor01_script.lua
+++ b/projectiles/ADFShieldDisruptor01/ADFShieldDisruptor01_script.lua
@@ -15,7 +15,7 @@ ADFShieldDisruptor01 = ClassProjectile(ADisruptorProjectile) {
         if not TargetEntity then return end
 
         -- Never cause overspill damage to the unit, 1 min to avoid logspam with 0 declared damage
-        local damage = math.max(math.min(self.Data, TargetEntity:GetHealth()), 1)
+        local damage = math.max(math.min(1300, TargetEntity:GetHealth()), 1)
         Damage(self, {0,0,0}, TargetEntity, damage, 'Normal')
     end,
 }

--- a/projectiles/AIFFragmentationSensorShell01/AIFFragmentationSensorShell01_script.lua
+++ b/projectiles/AIFFragmentationSensorShell01/AIFFragmentationSensorShell01_script.lua
@@ -47,16 +47,7 @@ AIFFragmentationSensorShell01 = ClassProjectile(AArtilleryFragmentationSensorShe
             proj:SetVelocity(velocity)
             proj.DamageData = self.DamageData
         end
-        local pos = self:GetPosition()
-        local spec = {
-            X = pos[1],
-            Z = pos[3],
-            Radius = self.Data.Radius,
-            LifeTime = self.Data.Lifetime,
-            Army = self.Data.Army,
-            Omni = false,
-            WaterVision = false,
-        }
+        
         self:Destroy()
     end,
 }

--- a/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_script.lua
+++ b/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_script.lua
@@ -45,16 +45,6 @@ AIFFragmentationSensorShell02 = ClassProjectile(AArtilleryFragmentationSensorShe
 	            proj:SetVelocity(velocity)
 	            proj.DamageData = self.DamageData
 	        end
-	        local pos = self:GetPosition()
-	        local spec = {
-	            X = pos[1],
-	            Z = pos[3],
-	            Radius = self.Data.Radius,
-	            LifeTime = self.Data.Lifetime,
-	            Army = self.Data.Army,
-	            Omni = false,
-	            WaterVision = false,
-	        }
 	        self:Destroy()
 		else
 	        self:DoDamage( self, self.DamageData, TargetEntity)

--- a/projectiles/AIFMiasmaShell01/AIFMiasmaShell01_script.lua
+++ b/projectiles/AIFMiasmaShell01/AIFMiasmaShell01_script.lua
@@ -25,4 +25,4 @@ AIFMiasmaShell01 = ClassProjectile(AMiasmaProjectile) {
         self:Destroy()
     end,
 }
-TypeClass = AIFMiasmaShell01
+TypeClass = AIFMiasmaShell01v

--- a/projectiles/CDFTracker01/CDFTracker01_script.lua
+++ b/projectiles/CDFTracker01/CDFTracker01_script.lua
@@ -7,7 +7,7 @@ CDFTracker01 = ClassProjectile(CDFTrackerProjectile) {
     OnImpact = function(self, TargetType, TargetEntity)
         if TargetEntity then
             local x,y,z = unpack(TargetEntity:GetPosition())
-            local tracker = CreateUnit('URB5206', self.Data.Parent.Army, x, y, z, 0, 0, 0, 0)
+            local tracker = CreateUnit('URB5206', self.Army, x, y, z, 0, 0, 0, 0)
             tracker:AttachTo(TargetEntity, -1)
         end
         CDFTrackerProjectile.OnImpact(self, TargetType, TargetEntity)


### PR DESCRIPTION
These instances would not call the base class, only to continue passing some new table that ends up being unused. It was likely left over code for this function in [defaultdamage.lua](https://github.com/FAForever/fa/blob/deploy/fafdevelop/lua/sim/DefaultDamage.lua#L82-L103), as that is the only place where a property named `Frequency` is accessed. The full (deprecated) function is the following, used for area damage that scales over time.

```lua
-- SCALABLE RADIUS AREA DOT
-- - Allows for a scalable damage radius that begins with DamageStartRadius and ends
-- - with DamageEndRadius, interpolates between based on frequency and duration.
---@param entity Entity
function ScalableRadiusAreaDoT(entity)
    local spec = entity.Spec.Data

    -- FIX ME
    -- Change this to get position from the entity, once we have the tech to set the entity's position
    -- local position = entity:GetPosition()
    local position = entity.Spec.Position
    local radius = spec.StartRadius or 0
    local freq = spec.Frequency or 1
    local dur = spec.Duration or 1
    if dur != freq then
        local reductionScalar = (radius - (spec.EndRadius or 1) ) * freq / (dur - freq)
        local duration = math.floor(dur / freq)

        for i = 1, duration do
            DamageArea(entity, position, radius, spec.Damage, spec.Type, spec.DamageFriendly)
            radius = radius - reductionScalar
            WaitSeconds(freq)
        end
    end
    entity:Destroy()
end
```