### PR TITLE
Adjust death damage of t2 air units

### DIFF
--- a/units/UAA0104/UAA0104_unit.bp
+++ b/units/UAA0104/UAA0104_unit.bp
@@ -551,7 +551,7 @@ UnitBlueprint {
         },
         {
             AboveWaterTargetsOnly = true,
-            Damage = 25,
+            Damage = 250,
             DamageFriendly = true,
             DamageRadius = 1,
             DamageType = 'Normal',

--- a/units/UEA0104/UEA0104_unit.bp
+++ b/units/UEA0104/UEA0104_unit.bp
@@ -550,7 +550,7 @@ UnitBlueprint {
         },
         {
             AboveWaterTargetsOnly = true,
-            Damage = 25,
+            Damage = 250,
             DamageFriendly = true,
             DamageRadius = 1,
             DamageType = 'Normal',

--- a/units/URA0104/URA0104_unit.bp
+++ b/units/URA0104/URA0104_unit.bp
@@ -414,7 +414,7 @@ UnitBlueprint {
         },
         {
             AboveWaterTargetsOnly = true,
-            Damage = 25,
+            Damage = 250,
             DamageFriendly = true,
             DamageRadius = 1,
             DamageType = 'Normal',

--- a/units/XSA0104/XSA0104_unit.bp
+++ b/units/XSA0104/XSA0104_unit.bp
@@ -492,7 +492,7 @@ UnitBlueprint {
         },
         {
             AboveWaterTargetsOnly = true,
-            Damage = 25,
+            Damage = 250,
             DamageFriendly = true,
             DamageRadius = 1,
             DamageType = 'Normal',

--- a/units/XSA0202/XSA0202_unit.bp
+++ b/units/XSA0202/XSA0202_unit.bp
@@ -491,7 +491,7 @@ UnitBlueprint {
         },
         {
             AboveWaterTargetsOnly = true,
-            Damage = 25,
+            Damage = 200,
             DamageFriendly = true,
             DamageRadius = 1,
             DamageType = 'Normal',


### PR DESCRIPTION
T2 transports dealt 25 damage on crash even though the T1 transports dealt 100. With these changes, we also hope to nerf T1 arty drops since now the arties will die if the transport's wreck lands on top of them.

Notha for some reason had 25 crush damage instead of 200 like the other T2 F/B