### PR TITLE
Fix reset of construction menu when selecting a structure

### DIFF
--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -398,7 +398,6 @@ function CreateTabs(type)
     local desiredTabs = 0
     -- Construction tab, this is called before fac templates have been added
     if type == 'construction' and allFactories and options.gui_templates_factory ~= 0 then
-        LOG("Set templates")
         -- nil value would cause refresh issues if templates tab is currently selected
         sortedOptions.templates = {}
 
@@ -507,14 +506,7 @@ function CreateTabs(type)
         end
     end
 
-    LOG(string.format("%s -> %s", tostring(previousTabSet), tostring(type)))
-    LOG(string.format("%s -> %s", tostring(previousTabSize), tostring(numActive)))
-
     if previousTabSet ~= type or previousTabSize ~= numActive then
-
-        reprsl(debug.traceback())
-
-
         if defaultTab then
             defaultTab:SetCheck(true)
         end

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -398,6 +398,7 @@ function CreateTabs(type)
     local desiredTabs = 0
     -- Construction tab, this is called before fac templates have been added
     if type == 'construction' and allFactories and options.gui_templates_factory ~= 0 then
+        LOG("Set templates")
         -- nil value would cause refresh issues if templates tab is currently selected
         sortedOptions.templates = {}
 
@@ -408,7 +409,9 @@ function CreateTabs(type)
             local numActive = 0
             for _, tab in controls.tabs do
                 if sortedOptions[tab.ID] and not table.empty(sortedOptions[tab.ID]) then
-                    numActive = numActive + 1
+                    if tab.ID != 'templates' then
+                        numActive = numActive + 1
+                    end
                 end
             end
             previousTabSize = numActive
@@ -489,7 +492,11 @@ function CreateTabs(type)
     for _, tab in controls.tabs do
         if sortedOptions[tab.ID] and not table.empty(sortedOptions[tab.ID]) then
             tab:Enable()
-            numActive = numActive + 1
+
+            if tab.ID != 'templates' then
+                numActive = numActive + 1
+            end
+
             if defaultTabOrder[tab.ID] then
                 if not defaultTab or defaultTabOrder[tab.ID] < defaultTabOrder[defaultTab.ID] then
                     defaultTab = tab
@@ -500,7 +507,14 @@ function CreateTabs(type)
         end
     end
 
+    LOG(string.format("%s -> %s", tostring(previousTabSet), tostring(type)))
+    LOG(string.format("%s -> %s", tostring(previousTabSize), tostring(numActive)))
+
     if previousTabSet ~= type or previousTabSize ~= numActive then
+
+        reprsl(debug.traceback())
+
+
         if defaultTab then
             defaultTab:SetCheck(true)
         end
@@ -2667,6 +2681,7 @@ function OnSelection(buildableCategories, selection, isOldSelection)
         end
 
         -- Allow all races to build other races templates
+        LOG("Check for templates!")
         if options.gui_all_race_templates ~= 0 then
             local templates = Templates.GetTemplates()
             local buildableUnits = EntityCategoryGetUnitList(buildableCategories)
@@ -2835,6 +2850,7 @@ function SetCurrentTechTab(techLevel)
 end
 
 function GetCurrentTechTab()
+    reprsl(debug.traceback())
     if GetTabByID('t1'):IsChecked() then
         return 1
     elseif GetTabByID('t2'):IsChecked() then

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -2673,7 +2673,6 @@ function OnSelection(buildableCategories, selection, isOldSelection)
         end
 
         -- Allow all races to build other races templates
-        LOG("Check for templates!")
         if options.gui_all_race_templates ~= 0 then
             local templates = Templates.GetTemplates()
             local buildableUnits = EntityCategoryGetUnitList(buildableCategories)
@@ -2842,7 +2841,6 @@ function SetCurrentTechTab(techLevel)
 end
 
 function GetCurrentTechTab()
-    reprsl(debug.traceback())
     if GetTabByID('t1'):IsChecked() then
         return 1
     elseif GetTabByID('t2'):IsChecked() then

--- a/lua/ui/game/selectionsort.lua
+++ b/lua/ui/game/selectionsort.lua
@@ -7,6 +7,8 @@ local techCats = {
 
 -- TODO: refactor this for better performance :)))
 function insertIntoTableLowestTechFirst(units, t, isLowFuel, isIdleCon)
+
+
     local didInsert = false
     local isPut = false
     for _, tech in techCats do

--- a/lua/ui/game/selectionsort.lua
+++ b/lua/ui/game/selectionsort.lua
@@ -7,8 +7,6 @@ local techCats = {
 
 -- TODO: refactor this for better performance :)))
 function insertIntoTableLowestTechFirst(units, t, isLowFuel, isIdleCon)
-
-
     local didInsert = false
     local isPut = false
     for _, tech in techCats do


### PR DESCRIPTION
Also closes https://github.com/FAForever/fa/issues/4601 . The reset was caused by the option `gui_all_race_templates`, which represents `All Faction Templates`. The sequence was:

- Click structure to build
- Update UI: no templates, so 1 less active tab
- Add templates from all faction templates option
- Update UI: templates, so 1 more active tab

As a result, the construction menu 'changed' from 5 to 4 tabs, and then back from 4 to 5 tabs. Because the number of tabs changed the default tab (which is the highest tech, up to tech 3) was reselected. The code is quite spaghetti, but it was missing the sauce. So to fix it we add an if statement that skips checking for a change in templates.

The 'quick fix' for those that encounter this is to give each faction at least 1 template that you made with that faction.