### PR TITLE
Adjust elevation of strategic bombers to make them easier to hit

### DIFF
--- a/units/UAA0304/UAA0304_unit.bp
+++ b/units/UAA0304/UAA0304_unit.bp
@@ -222,7 +222,7 @@ UnitBlueprint {
             LAYER_Sub = false,
             LAYER_Water = false,
         },
-        Elevation = 20,
+        Elevation = 14,
         FuelRechargeRate = 15,
         FuelUseTime = 1500,
         GroundCollisionOffset = 2,

--- a/units/UEA0304/UEA0304_unit.bp
+++ b/units/UEA0304/UEA0304_unit.bp
@@ -257,7 +257,7 @@ UnitBlueprint {
             LAYER_Sub = false,
             LAYER_Water = false,
         },
-        Elevation = 20,
+        Elevation = 14,
         FuelRechargeRate = 15,
         FuelUseTime = 1500,
         GroundCollisionOffset = 2,

--- a/units/URA0304/URA0304_unit.bp
+++ b/units/URA0304/URA0304_unit.bp
@@ -258,7 +258,7 @@ UnitBlueprint {
             LAYER_Sub = false,
             LAYER_Water = false,
         },
-        Elevation = 20,
+        Elevation = 14,
         FuelRechargeRate = 15,
         FuelUseTime = 1000,
         GroundCollisionOffset = 2,

--- a/units/XSA0304/XSA0304_unit.bp
+++ b/units/XSA0304/XSA0304_unit.bp
@@ -242,7 +242,7 @@ UnitBlueprint {
             LAYER_Sub = false,
             LAYER_Water = false,
         },
-        Elevation = 20,
+        Elevation = 14,
         FuelRechargeRate = 15,
         FuelUseTime = 1500,
         GroundCollisionOffset = 2,


### PR DESCRIPTION
Adjusts the elevation from `20` to `14`. All the other units could really use a checkup too, they are all over the place. Some transports have an elevation of around 10, others of around 18. The latter lands slower and is a lot more difficult to hit.

In general I'd say:

- Tech 1 at a height of 10 - 12, with an exception for scouts (maybe 14)
- Tech 2 at a height of 12 - 14
- Tech 3 at a height of 14 - 16, with an exception for scouts (maybe 18)
- Tech 4 is at a height of 16 - 18

But that is for the future.