### PR TITLE
Reduce impact of walls on simulation

### DIFF
--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -280,10 +280,12 @@ function TransferUnitsOwnership(units, toArmy, captured)
     -- add delay on turning on each weapon 
     for _, unit in newUnits do
         -- disable all weapons, enable with a delay
-        for k = 1, unit.WeaponCount do
-            local weapon = unit:GetWeapon(k)
-            weapon:SetEnabled(false)
-            weapon:ForkThread(TransferUnitsOwnershipDelayedWeapons)
+        if unit.WeaponCount then
+            for k = 1, unit.WeaponCount do
+                local weapon = unit:GetWeapon(k)
+                weapon:SetEnabled(false)
+                weapon:ForkThread(TransferUnitsOwnershipDelayedWeapons)
+            end
         end
     end
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -734,6 +734,7 @@ Unit = ClassUnit(moho.unit_methods) {
     ---@param self Unit
     ---@param unit Unit
     OnStartRepair = function(self, unit)
+        unit.Repairers = unit.Repairers or { }
         unit.Repairers[self.EntityId] = self
 
         if unit.WorkItem ~= self.WorkItem then


### PR DESCRIPTION
Drastically reduces the number of table fields for a wall structure. They now only have what is expected of every unit. Sadly, to do this they'd either inherit from a DummyUnit or break the hierarchy of the usual unit class. In this pull request I've chosen for the second approach, but I'm open to suggestions.