### PR TITLE
Do not refract mesh that is in front of water

### DIFF
--- a/effects/water2.fx
+++ b/effects/water2.fx
@@ -365,6 +365,7 @@ float4 HighFidelityPS( VS_OUTPUT inV,
     // not totally on depth as it gets clamped
     float waterLerp = clamp(waterDepth, waterLerp.x, waterLerp.y);
     refractedPixels.xyz = lerp(refractedPixels.xyz, waterColor, waterLerp);
+	refractedPixels.xyz = lerp(refractedPixels, backGroundPixels, saturate(refractedPixels.w * 255) ).xyz;
 
     // calculate reflections of units
 	// We can't compute wich part of the unit we would hit with our reflection vector,


### PR DESCRIPTION
_Correct behavior, where everything above water remains normal_
https://user-images.githubusercontent.com/15778155/214684971-a31dc634-0238-4115-8f17-8daf5ef252f0.mp4

_Incorrect behavior, notice the edges of the Monkeylord slightly refracting_
https://user-images.githubusercontent.com/15778155/214685189-939d30e7-66bf-48c1-bc48-89f1b859cc47.mp4

