### PR TITLE
Improve memory management of treads

### DIFF
--- a/lua/AI/AIBuilders/AIAirAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AIAirAttackBuilders.lua
@@ -428,10 +428,10 @@ BuilderGroup {
             { IBC, 'BrainNotLowPowerMode', {} },
             { MIBC, 'ArmyNeedsTransports', {} },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},  --DUNCAN - was 0.9
+            { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.TRANSPORTFOCUS } },
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 8, categories.LAND * (categories.TECH2 + categories.TECH3) } }, --DUNCAN - added
             { UCBC, 'HaveLessThanUnitsWithCategory', { 3 , categories.TRANSPORTFOCUS * categories.TECH2} },
-            { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.TRANSPORTFOCUS } },
         },
         BuilderType = 'Air',
     },

--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -65,7 +65,8 @@ TreadComponent = ClassSimple {
             self:AddThreadScroller(1.0, treads.ScrollMultiplier or 0.2)
 
             local treadMarks = treads.TreadMarks
-            if treadMarks and self.TerrainType.Treads ~= 'None' then
+            local treadType = self.TerrainType.Treads
+            if treadMarks and treadType and treadType ~= 'None' then
                 self:CreateTreads(treadMarks)
             end
         end

--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -1,4 +1,3 @@
-
 ---@class ShieldEffectsComponent : Unit
 ---@field Trash TrashBag
 ---@field ShieldEffectsBag TrashBag
@@ -6,7 +5,7 @@
 ---@field ShieldEffectsScale number
 ShieldEffectsComponent = ClassSimple {
 
-    ShieldEffects = { },
+    ShieldEffects = {},
     ShieldEffectsBone = 0,
     ShieldEffectsScale = 1,
 
@@ -20,12 +19,124 @@ ShieldEffectsComponent = ClassSimple {
     OnShieldEnabled = function(self)
         self.ShieldEffectsBag:Destroy()
         for _, v in self.ShieldEffects do
-            self.ShieldEffectsBag:Add(CreateAttachedEmitter(self, self.ShieldEffectsBone, self.Army, v):ScaleEmitter(self.ShieldEffectsScale))
+            self.ShieldEffectsBag:Add(CreateAttachedEmitter(self, self.ShieldEffectsBone, self.Army, v):ScaleEmitter(self
+                .ShieldEffectsScale))
         end
     end,
 
     ---@param self ShieldEffectsComponent
     OnShieldDisabled = function(self)
         self.ShieldEffectsBag:Destroy()
+    end,
+}
+
+
+---@type table<string, number>
+local TechToDuration = {
+    TECH1 = 0.5,
+    TECH2 = 2,
+    TECH3 = 8,
+    EXPERIMENTAL = 32,
+}
+local TechToLOD = {
+    TECH1 = 120,
+    TECH2 = 180,
+    TECH3 = 240,
+    EXPERIMENTAL = 320,
+}
+
+---@class TreadComponent
+---@field TreadBlueprint UnitBlueprintTreads
+---@field TreadSuspend? boolean
+---@field TreadThreads? table<number, thread>
+TreadComponent = ClassSimple {
+
+    ---@param self Unit | TreadComponent
+    OnCreate = function(self)
+        self.TreadBlueprint = self.Blueprint.Display.MovementEffects.Land.Treads
+    end,
+
+    ---@param self Unit | TreadComponent
+    CreateMovementEffects = function(self)
+        LOG("CreateMovementEffects")
+        local treads = self.TreadBlueprint
+        if treads then
+            self:AddThreadScroller(1.0, treads.ScrollMultiplier or 0.2)
+
+            local treadMarks = treads.TreadMarks
+            if treadMarks then
+                self:CreateTreads(treadMarks)
+            end
+        end
+    end,
+
+    ---@param self Unit | TreadComponent
+    DestroyMovementEffects = function(self)
+        LOG("DestroyMovementEffects")
+        local treads = self.TreadBlueprint
+        if treads then
+            self:RemoveScroller()
+
+            if self.TreadThreads then
+                self.TreadSuspend = true
+            end
+        end
+    end,
+
+    ---@param self Unit | TreadComponent
+    ---@param treadsBlueprint UnitBlueprintTreadMarks
+    CreateTreads = function(self, treadsBlueprint)
+        local treadThreads = self.TreadThreads
+        if not treadThreads then
+            treadThreads = { }
+
+            for k, treadBlueprint in treadsBlueprint do
+                local thread = ForkThread(self.CreateTreadsThread, self, treadBlueprint)
+                treadThreads[k] = thread
+                self.Trash:Add(thread)
+            end
+
+            self.TreadThreads = treadThreads
+        else
+            self.TreadSuspend = nil
+            for k, v in treadThreads do
+                ResumeThread(treadThreads[k])
+            end
+        end
+    end,
+
+    ---@param self Unit | TreadComponent
+    ---@param treads UnitBlueprintTreadMarks
+    CreateTreadsThread = function(self, treads)
+
+        -- to local scope for performance
+        local WaitTicks = WaitTicks
+        local CreateSplatOnBone = CreateSplatOnBone
+
+        local tech = self.Blueprint.TechCategory
+        local sizeX = treads.TreadMarksSizeX
+        local sizeZ = treads.TreadMarksSizeZ
+        local interval = 10 * treads.TreadMarksInterval
+        local treadOffset = treads.TreadOffset
+        local treadBone = treads.BoneName or 0
+        local treadTexture = treads.TreadMarks
+
+        local duration = treads.TreadLifeTime or TechToDuration[tech] or 1
+        local lod = TechToLOD[tech] or 120
+        local army = self.Army
+
+        while true do
+            LOG("Creating treads!")
+            while not self.TreadSuspend do
+                CreateSplatOnBone(self, treadOffset, treadBone, treadTexture, sizeX, sizeZ, lod, duration, army)
+                WaitTicks(interval)
+            end
+
+            LOG("Suspending...")
+
+            SuspendCurrentThread()
+            self.TreadSuspend = nil
+            WaitTicks(interval)
+        end
     end,
 }

--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -38,6 +38,8 @@ local TechToDuration = {
     TECH3 = 4,
     EXPERIMENTAL = 16,
 }
+
+---@type table<string, number>
 local TechToLOD = {
     TECH1 = 120,
     TECH2 = 180,
@@ -63,7 +65,7 @@ TreadComponent = ClassSimple {
             self:AddThreadScroller(1.0, treads.ScrollMultiplier or 0.2)
 
             local treadMarks = treads.TreadMarks
-            if treadMarks then
+            if treadMarks and self.TerrainType.Treads ~= 'None' then
                 self:CreateTreads(treadMarks)
             end
         end
@@ -132,7 +134,7 @@ TreadComponent = ClassSimple {
 
             SuspendCurrentThread()
             self.TreadSuspend = nil
-            WaitTicks(interval)
+            WaitTicks(1)
         end
     end,
 }

--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -33,10 +33,10 @@ ShieldEffectsComponent = ClassSimple {
 
 ---@type table<string, number>
 local TechToDuration = {
-    TECH1 = 0.5,
+    TECH1 = 1,
     TECH2 = 2,
-    TECH3 = 8,
-    EXPERIMENTAL = 32,
+    TECH3 = 4,
+    EXPERIMENTAL = 16,
 }
 local TechToLOD = {
     TECH1 = 120,
@@ -58,7 +58,6 @@ TreadComponent = ClassSimple {
 
     ---@param self Unit | TreadComponent
     CreateMovementEffects = function(self)
-        LOG("CreateMovementEffects")
         local treads = self.TreadBlueprint
         if treads then
             self:AddThreadScroller(1.0, treads.ScrollMultiplier or 0.2)
@@ -72,7 +71,6 @@ TreadComponent = ClassSimple {
 
     ---@param self Unit | TreadComponent
     DestroyMovementEffects = function(self)
-        LOG("DestroyMovementEffects")
         local treads = self.TreadBlueprint
         if treads then
             self:RemoveScroller()
@@ -99,8 +97,8 @@ TreadComponent = ClassSimple {
             self.TreadThreads = treadThreads
         else
             self.TreadSuspend = nil
-            for k, v in treadThreads do
-                ResumeThread(treadThreads[k])
+            for k, thread in treadThreads do
+                ResumeThread(thread)
             end
         end
     end,
@@ -112,6 +110,7 @@ TreadComponent = ClassSimple {
         -- to local scope for performance
         local WaitTicks = WaitTicks
         local CreateSplatOnBone = CreateSplatOnBone
+        local SuspendCurrentThread = SuspendCurrentThread
 
         local tech = self.Blueprint.TechCategory
         local sizeX = treads.TreadMarksSizeX
@@ -126,13 +125,10 @@ TreadComponent = ClassSimple {
         local army = self.Army
 
         while true do
-            LOG("Creating treads!")
             while not self.TreadSuspend do
                 CreateSplatOnBone(self, treadOffset, treadBone, treadTexture, sizeX, sizeZ, lod, duration, army)
                 WaitTicks(interval)
             end
-
-            LOG("Suspending...")
 
             SuspendCurrentThread()
             self.TreadSuspend = nil

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2441,8 +2441,23 @@ SlowHoverLandUnit = ClassUnit(HoverLandUnit) {
 }
 
 -- AMPHIBIOUS LAND UNITS
----@class AmphibiousLandUnit : MobileUnit
-AmphibiousLandUnit = ClassUnit(MobileUnit) { }
+---@class AmphibiousLandUnit : MobileUnit, TreadComponent
+AmphibiousLandUnit = ClassUnit(MobileUnit, TreadComponent) {
+    OnCreate = function(self)
+        MobileUnit.OnCreate(self)
+        TreadComponent.OnCreate(self)
+    end,
+
+    CreateMovementEffects = function(self, effectsBag, typeSuffix, terrainType)
+        MobileUnit.CreateMovementEffects(self, effectsBag, typeSuffix, terrainType)
+        TreadComponent.CreateMovementEffects(self)
+    end,
+
+    DestroyMovementEffects = function(self)
+        MobileUnit.DestroyMovementEffects(self)
+        TreadComponent.DestroyMovementEffects(self)
+    end,
+}
 
 ---@class SlowAmphibiousLandUnit : AmphibiousLandUnit
 SlowAmphibiousLandUnit = ClassUnit(AmphibiousLandUnit) {

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -16,6 +16,9 @@ local AdjacencyBuffs = import("/lua/sim/adjacencybuffs.lua")
 local FireState = import("/lua/game.lua").FireState
 local ScenarioFramework = import("/lua/scenarioframework.lua")
 
+local TreadComponent = import("/lua/defaultcomponents.lua").TreadComponent
+
+
 local RolloffUnitTable = { nil }
 local RolloffPositionTable = { 0, 0, 0 }
 
@@ -2213,9 +2216,23 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
     end,
 }
 
--- LAND UNITS
----@class LandUnit : MobileUnit
-LandUnit = ClassUnit(MobileUnit) {}
+---@class LandUnit : MobileUnit, TreadComponent
+LandUnit = ClassUnit(MobileUnit, TreadComponent) {
+    OnCreate = function(self)
+        MobileUnit.OnCreate(self)
+        TreadComponent.OnCreate(self)
+    end,
+
+    CreateMovementEffects = function(self, effectsBag, typeSuffix, terrainType)
+        MobileUnit.CreateMovementEffects(self, effectsBag, typeSuffix, terrainType)
+        TreadComponent.CreateMovementEffects(self)
+    end,
+
+    DestroyMovementEffects = function(self)
+        MobileUnit.DestroyMovementEffects(self)
+        TreadComponent.DestroyMovementEffects(self)
+    end,
+}
 
 --  CONSTRUCTION UNITS
 ---@class ConstructionUnit : MobileUnit

--- a/lua/proptree.lua
+++ b/lua/proptree.lua
@@ -62,6 +62,8 @@ Tree = Class(Prop) {
             return
         end
 
+        LOG("Helloooo")
+
         if self.Fallen then
             return
         end
@@ -140,6 +142,7 @@ Tree = Class(Prop) {
     ---@param depth number
     FallThread = function(self, dx, dy, dz, depth)
 
+        LOG("FallThread")
         -- make it fall down
         local motor = self:FallDown()
         motor:Whack(dx, dy, dz, depth, true)

--- a/lua/proptree.lua
+++ b/lua/proptree.lua
@@ -62,8 +62,6 @@ Tree = Class(Prop) {
             return
         end
 
-        LOG("Helloooo")
-
         if self.Fallen then
             return
         end
@@ -141,8 +139,6 @@ Tree = Class(Prop) {
     ---@param dz number
     ---@param depth number
     FallThread = function(self, dx, dy, dz, depth)
-
-        LOG("FallThread")
         -- make it fall down
         local motor = self:FallDown()
         motor:Whack(dx, dy, dz, depth, true)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4095,8 +4095,6 @@ Unit = ClassUnit(moho.unit_methods) {
             return false
         end
 
-        LOG("Creating footfall manipulators")
-
         self.Detector = CreateCollisionDetector(self)
         self.Trash:Add(self.Detector)
         for _, v in footfall.Bones do

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1693,6 +1693,8 @@ Unit = ClassUnit(moho.unit_methods) {
         end
     end,
 
+    
+
     --- Called when a unit collides with a projectile to check if the collision is valid
     ---@param self Unit The unit we're checking the collision for
     ---@param other Projectile The projectile we're checking the collision with

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -110,6 +110,7 @@ local cUnit = moho.unit_methods
 ---@field EventCallbacks table<string, function[]>
 ---@field Blueprint UnitBlueprint
 ---@field EngineFlags any
+---@field TerrainType TerrainType
 ---@field EngineCommandCap? table<string, boolean>
 ---@field UnitBeingBuilt Unit?
 Unit = ClassUnit(moho.unit_methods) {
@@ -3693,6 +3694,7 @@ Unit = ClassUnit(moho.unit_methods) {
     ---@param new string
     ---@param old string
     OnTerrainTypeChange = function(self, new, old)
+        self.TerrainType = new
         if self.MovementEffectsExist then
             self:DestroyMovementEffects()
             self:CreateMovementEffects(self.MovementEffectsBag, nil, new)
@@ -3814,14 +3816,6 @@ Unit = ClassUnit(moho.unit_methods) {
         end
     end,
 
-    ---@param self Unit
-    ---@param pos Vector
-    ---@return TerrainTreadType
-    GetTTTreadType = function(self, pos)
-        local terrainType = GetTerrainType(pos[1], pos[3])
-        return terrainType.Treads or 'None'
-    end,
-
     ---@param fxType TerrainEffectType
     ---@param layer Layer
     ---@param pos Vector
@@ -3940,12 +3934,6 @@ Unit = ClassUnit(moho.unit_methods) {
             bpTable = bpTable[layer]
             local effectTypeGroups = bpTable.Effects
 
-            if bpTable.Treads then
-                self:CreateTreads(bpTable.Treads)
-            else
-                self:RemoveScroller()
-            end
-
             if not effectTypeGroups or (effectTypeGroups and (table.empty(effectTypeGroups))) then
                 if not self.Footfalls and bpTable.Footfall then
                     WARN('*WARNING: No movement effect groups defined for unit ', repr(self.UnitId), ', Effect groups with bone lists must be defined to play movement effects. Add these to the Display.MovementEffects', layer, '.Effects table in unit blueprint. ')
@@ -4000,18 +3988,6 @@ Unit = ClassUnit(moho.unit_methods) {
             if shake and shake.Radius and shake.MaxShakeEpicenter and shake.MinShakeAtRadius then
                 self:ShakeCamera(shake.Radius, shake.MaxShakeEpicenter * 0.25, shake.MinShakeAtRadius * 0.25, 1)
             end
-        end
-
-        -- Clean up treads
-        if self.TreadThreads then
-            for k, v in self.TreadThreads do
-                KillThread(v)
-            end
-            self.TreadThreads = {}
-        end
-
-        if bpTable[layer].Treads.ScrollTreads then
-            self:RemoveScroller()
         end
     end,
 
@@ -4109,44 +4085,6 @@ Unit = ClassUnit(moho.unit_methods) {
     end,
 
     ---@param self Unit
-    ---@param treads UnitBlueprintTreads
-    CreateTreads = function(self, treads)
-        if treads.ScrollTreads then
-            self:AddThreadScroller(1.0, treads.ScrollMultiplier or 0.2)
-        end
-
-        self.TreadThreads = {}
-        if treads.TreadMarks then
-            local type = self:GetTTTreadType(self:GetPosition())
-            if type ~= 'None' then
-                for k, v in treads.TreadMarks do
-                    table.insert(self.TreadThreads, self:ForkThread(self.CreateTreadsThread, v, type))
-                end
-            end
-        end
-    end,
-
-    ---@param self Unit
-    ---@param treads UnitBlueprintTreadMarks
-    ---@param type string
-    CreateTreadsThread = function(self, treads, type)
-        local sizeX = treads.TreadMarksSizeX
-        local sizeZ = treads.TreadMarksSizeZ
-        local interval = treads.TreadMarksInterval
-        local treadOffset = treads.TreadOffset
-        local treadBone = treads.BoneName or 0
-        local treadTexture = treads.TreadMarks
-        local duration = treads.TreadLifeTime or 10
-
-        while true do
-            -- Syntactic reference
-            -- CreateSplatOnBone(entity, offset, boneName, textureName, sizeX, sizeZ, lodParam, duration, army)
-            CreateSplatOnBone(self, treadOffset, treadBone, treadTexture, sizeX, sizeZ, 130, duration, self.Army)
-            WaitSeconds(interval)
-        end
-    end,
-
-    ---@param self Unit
     ---@param footfall boolean
     ---@return boolean
     CreateFootFallManipulators = function(self, footfall)
@@ -4154,6 +4092,8 @@ Unit = ClassUnit(moho.unit_methods) {
             WARN('*WARNING: No footfall bones defined for unit ', repr(self.UnitId), ', ', 'these must be defined to animation collision detector and foot plant controller')
             return false
         end
+
+        LOG("Creating footfall manipulators")
 
         self.Detector = CreateCollisionDetector(self)
         self.Trash:Add(self.Detector)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -5121,6 +5121,14 @@ Unit = ClassUnit(moho.unit_methods) {
 
     --- Deprecated functionality
 
+    ---@param self Unit
+    ---@param pos Vector
+    ---@return TerrainTreadType
+    GetTTTreadType = function(self, pos)
+        local terrainType = GetTerrainType(pos[1], pos[3])
+        return terrainType.Treads or 'None'
+    end,
+
     ---@deprecated
     ---@param self Unit
     ---@param fn function

--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -244,7 +244,7 @@ UnitBlueprint {
                             TreadOffset = {
                                 0,
                                 0,
-                                -1.5,
+                                -0.5,
                             },
                         },
                         {
@@ -255,7 +255,7 @@ UnitBlueprint {
                             TreadOffset = {
                                 0,
                                 0,
-                                -5.5,
+                                -4.5,
                             },
                         },
                     },

--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -238,7 +238,7 @@ UnitBlueprint {
                     TreadMarks = {
                         {
                             TreadMarks = 'tank_treads06_albedo',
-                            TreadMarksInterval = 0.6,
+                            TreadMarksInterval = 0.3,
                             TreadMarksSizeX = 5,
                             TreadMarksSizeZ = 5.5,
                             TreadOffset = {
@@ -249,7 +249,7 @@ UnitBlueprint {
                         },
                         {
                             TreadMarks = 'tank_treads06_albedo',
-                            TreadMarksInterval = 0.6,
+                            TreadMarksInterval = 0.3,
                             TreadMarksSizeX = 5.5,
                             TreadMarksSizeZ = 5.5,
                             TreadOffset = {


### PR DESCRIPTION
An interesting one, every time a unit would: 

- Transition to or from 'Stopping' movement state
- Transition to a new terrain type
- Get beamed up / down from a transport

A unit with treads would:

- Re-allocate the `TreadThreads` table multiple times
- Kill all treads, if they exist
- Allocate new threads, if we need them

And then something like this happens, that constantly triggers the transition events:

https://user-images.githubusercontent.com/15778155/214961016-2da33897-3604-48df-ade9-14eb819cac83.mp4

On top of that, this pull request decreases the time that a splat (a tread mark) exists by tech while increasing the LOD by tech. See also: 

- https://github.com/FAForever/fa/pull/4640/files#diff-4efe2c03fd02522260393e6dde9105da93b49718bc4100b67d194f8b06084c35R34-R46
