### PR TITLE
Minor fix to mercy targeting

### DIFF
--- a/units/DAA0206/DAA0206_unit.bp
+++ b/units/DAA0206/DAA0206_unit.bp
@@ -248,8 +248,8 @@ UnitBlueprint {
             EffectiveRadius = 0,
             FireTargetLayerCapsTable = {
                 Air = 'Land|Seabed|Water',
-                Land = 'Air|Land|Seabed|Water',
-                Water = 'Air|Land|Seabed|Water',
+                Land = 'Land|Seabed|Water',
+                Water = 'Land|Seabed|Water',
             },
             FiringTolerance = 6,
             Label = 'Suicide',


### PR DESCRIPTION
The mercy was allowed to target units on the `Air` layer (i.e flying units) while it was on `Land`/`Water` i.e landed. Now it cannot.

I wasn't able to get it to actually hit an flying unit, but you could give it an order to attack them & it would just cancel the order after taking off, which could lead to players thinking they've given a valid order but they'd misclicked on an air unit.