### PR TITLE
Fix infinite loop of treads

### DIFF
--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -118,7 +118,7 @@ TreadComponent = ClassSimple {
         local tech = self.Blueprint.TechCategory
         local sizeX = treads.TreadMarksSizeX
         local sizeZ = treads.TreadMarksSizeZ
-        local interval = 10 * treads.TreadMarksInterval
+        local interval = 10 * (treads.TreadMarksInterval or 0.1)
         local treadOffset = treads.TreadOffset
         local treadBone = treads.BoneName or 0
         local treadTexture = treads.TreadMarks
@@ -126,6 +126,11 @@ TreadComponent = ClassSimple {
         local duration = treads.TreadLifeTime or TechToDuration[tech] or 1
         local lod = TechToLOD[tech] or 120
         local army = self.Army
+
+        -- prevent infinite loops
+        if interval < 1 then
+            interval = 1
+        end
 
         while true do
             while not self.TreadSuspend do

--- a/units/URL0104/URL0104_unit.bp
+++ b/units/URL0104/URL0104_unit.bp
@@ -93,7 +93,7 @@ UnitBlueprint {
                     TreadMarks = {
                         {
                             TreadMarks = 'tank_treads03_albedo',
-                            TreadMarksInterval = 0.01,
+                            TreadMarksInterval = 0.1,
                             TreadMarksSizeX = 0.6,
                             TreadMarksSizeZ = 0.9,
                             TreadOffset = {


### PR DESCRIPTION
The code no longer checked if the interval was one that makes sense: anything smaller than 1 would cause an infinite loop. It now guarantees that it is at least 1.

Related to:

https://forum.faforever.com/topic/5556/beginning-gameplay-freeze-error-message/4?_=1675201056209

With thanks to @maudlin27 