### PR TITLE
Fix missed replacement

### DIFF
--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -187,7 +187,7 @@ function BuffWorkThread(unit, buffName, instigator)
     local buffDef = Buffs[buffName]
 
     --Non-Pulsing Buff
-    local totPulses = buffTable.DurationPulse
+    local totPulses = buffDef.DurationPulse
 
     if not totPulses then
         WaitSeconds(buffDef.Duration)


### PR DESCRIPTION
```
WARNING: Error running lua script: ...gramdata\faforever\gamedata\lua.nx5\lua\sim\buff.lua(190): access to nonexistent global variable buffTable
         stack traceback:
         	[C]: in function `error'
         	...ata\faforever\gamedata\lua.nx5\lua\system\config.lua(55): in function <...ata\faforever\gamedata\lua.nx5\lua\system\config.lua:54>
         	...gramdata\faforever\gamedata\lua.nx5\lua\sim\buff.lua(190): in function <...gramdata\faforever\gamedata\lua.nx5\lua\sim\buff.lua:186>
```