### PR TITLE
Add check to prevent canpathtoenemy from running for non baseai

### DIFF
--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -3694,7 +3694,9 @@ AIBrain = Class(moho.aibrain_methods) {
             PlatoonAlertSounded = false,
         }
         self:ForkThread(self.BaseMonitorThread)
-        self:ForkThread(self.CanPathToCurrentEnemy)
+        if self:IsBaseAI() then
+            self:ForkThread(self.CanPathToCurrentEnemy)
+        end
     end,
 
     ---@param self AIBrain

--- a/lua/editor/MiscBuildConditions.lua
+++ b/lua/editor/MiscBuildConditions.lua
@@ -330,6 +330,7 @@ function MapLessThan(aiBrain, sizeX, sizeZ)
 end
 
 --- Buildcondition to check pathing to current enemy 
+--- Note this requires the CanPathToCurrentEnemy thread to be running
 ---@param aiBrain AIBrain
 ---@param locationType string
 ---@param pathType string


### PR DESCRIPTION
Description of changes

This PR adds a base ai check to the CanPathToCurrentEnemy function that is run during AI initialization.

This is to prevent the navmesh getting loaded when 3rd party AI's are using the default BaseMonitorInitialization thread

