### PR TITLE
Dynamically compute LODs of units like we do with props

### DIFF
--- a/engine/Core/Blueprints/ProjectileBlueprint.lua
+++ b/engine/Core/Blueprints/ProjectileBlueprint.lua
@@ -11,6 +11,7 @@
 ---@field Physics ProjectileBlueprintPhysics
 
 ---@class ProjectileBlueprintDisplay
+---@field Mesh MeshBlueprint
 --- mesh to use as the display of this projectile
 ---@field MeshBlueprint FileName
 --- uniform scale to apply to mesh

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -663,6 +663,7 @@
 ---@field FadeOut number
 ---@field Length number
 ---@field Normal FileName
+---@field Glow FileName
 ---@field Orientations number[]
 ---@field RemoveWhenDead boolean
 ---@field Width number

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -448,6 +448,10 @@
 
 
 ---@class UnitBlueprintDisplay
+--- Used by the Aeon build animation for a custom mercury pool
+---@field AeonMercuryPool? string
+--- Used by the Aeon build animation to offset the mercury pool
+---@field AeonMercuryPoolOffset? number
 --- Backup abilities shown by the unit view, if the detected ones don't cover them.
 ---@field Abilities UnlocalizedString[]
 --- names that the AI can use to name the unit, provided the AI is programmed to do this

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -429,11 +429,6 @@ Callbacks.BoxFormationSpawn = function(data)
         if unit.SetVeterancy then 
             unit:SetVeterancy(data.veterancy)
         end
-
-        -- only structures have this function
-        if unit.CreateTarmac and __blueprints[data.bpId].Display and __blueprints[data.bpId].Display.Tarmacs then
-            unit:CreateTarmac(true,true,true,false,false)
-        end
     end
 end
 

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -427,9 +427,6 @@ AIBrain = Class(moho.aibrain_methods) {
             -- Place resource structures down
             for k, v in resourceStructures do
                 local unit = self:CreateResourceBuildingNearest(v, posX, posY)
-                if unit ~= nil and unit:GetBlueprint().Physics.FlattenSkirt then
-                    unit:CreateTarmac(true, true, true, false, false)
-                end
             end
         end
 
@@ -437,9 +434,6 @@ AIBrain = Class(moho.aibrain_methods) {
             -- Place initial units down
             for k, v in initialUnits do
                 local unit = self:CreateUnitNearSpot(v, posX, posY)
-                if unit ~= nil and unit:GetBlueprint().Physics.FlattenSkirt then
-                    unit:CreateTarmac(true, true, true, false, false)
-                end
             end
         end
 

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -215,9 +215,18 @@ StructureUnit = ClassUnit(Unit) {
     ---@param lifeTime number
     ---@return boolean
     CreateTarmac = function(self, albedo, normal, glow, orientation, specTarmac, lifeTime)
-        if self.Layer ~= 'Land' then return end
+        if self.Layer ~= 'Land' then
+            return
+        end
+
         local tarmac
+        local blueprintDisplay = self.Blueprint.Display
+        local blueprintPhysics = self.Blueprint.Physics
+
+
         local bp = self.Blueprint.Display.Tarmacs
+
+
         if not specTarmac then
             if bp and not table.empty(bp) then
                 local num = Random(1, table.getn(bp))
@@ -231,7 +240,8 @@ StructureUnit = ClassUnit(Unit) {
 
         local w = tarmac.Width
         local l = tarmac.Length
-        local fadeout = tarmac.FadeOut
+        local fadeout = math.max(blueprintPhysics.SkirtSizeX or 1, blueprintPhysics.SkirtSizeZ or 1) * 70
+        LOG(fadeout)
 
         local x, y, z = self:GetPositionXYZ()
 
@@ -279,7 +289,7 @@ StructureUnit = ClassUnit(Unit) {
         end
 
         if normal and tarmac.Normal then
-            local tarmacHndl = CreateDecal(self:GetPosition(), orient, tarmac.Normal .. GetTarmac(faction, terrainName), '', 'Alpha Normals', w, l, fadeout, lifeTime or 0, self.Army, 0)
+            local tarmacHndl = CreateDecal(self:GetPosition(), orient, tarmac.Normal .. GetTarmac(faction, terrainName), '', 'Alpha Normals', w, l, 0.5 * fadeout, lifeTime or 0, self.Army, 0)
 
             table.insert(self.TarmacBag.Decals, tarmacHndl)
             if tarmac.RemoveWhenDead then
@@ -288,7 +298,7 @@ StructureUnit = ClassUnit(Unit) {
         end
 
         if glow and tarmac.Glow then
-            local tarmacHndl = CreateDecal(self:GetPosition(), orient, tarmac.Glow .. GetTarmac(faction, terrainName), '', 'Glow', w, l, fadeout, lifeTime or 0, self.Army, 0)
+            local tarmacHndl = CreateDecal(self:GetPosition(), orient, tarmac.Glow .. GetTarmac(faction, terrainName), '', 'Glow', w, l, 0.5 * fadeout, lifeTime or 0, self.Army, 0)
 
             table.insert(self.TarmacBag.Decals, tarmacHndl)
             if tarmac.RemoveWhenDead then

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -239,9 +239,7 @@ StructureUnit = ClassUnit(Unit) {
     ---@param lifeTime number
     CreateTarmacThread = function(self, albedo, normal, glow, orientation, tarmac, lifeTime)
         -- hold up one tick to allow upgrades to pass the tarmac bag
-        -- LOG(GetGameTick())
-        -- WaitTicks(1)
-        -- LOG(GetGameTick())
+        WaitTicks(1)
 
         -- upgrades pass the tarmac bag, in which case we do nothing
         if self:HasTarmac() then
@@ -620,7 +618,6 @@ StructureUnit = ClassUnit(Unit) {
 
     ---@param self StructureUnit
     PlayActiveAnimation = function(self)
-
     end,
 
     ---@param self StructureUnit
@@ -637,8 +634,8 @@ StructureUnit = ClassUnit(Unit) {
         end
 
         Unit.OnKilled(self, instigator, type, overkillRatio)
-        -- Adding into OnKilled the ability to destroy the tarmac but put a new one down that looks exactly like it but
-        -- will time out over the time spec'd or 300 seconds.
+
+        -- re-create tarmac bag, but with a life time
         local orient = self.TarmacBag.Orientation
         local currentBP = self.TarmacBag.CurrentBP
         self:DestroyTarmac()

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -16,6 +16,15 @@ local AdjacencyBuffs = import("/lua/sim/adjacencybuffs.lua")
 local FireState = import("/lua/game.lua").FireState
 local ScenarioFramework = import("/lua/scenarioframework.lua")
 
+local FactionToTarmacIndex = {
+    UEF = 1,
+    AEON = 2,
+    CYBRAN = 3,
+    SERAPHIM = 4,
+    NOMADS = 5,
+}
+
+local GetTarmac = import("/lua/tarmacs.lua").GetTarmacType
 local TreadComponent = import("/lua/defaultcomponents.lua").TreadComponent
 
 
@@ -74,6 +83,15 @@ StructureUnit = ClassUnit(Unit) {
             -- the mod package that it originates from. Originates from the BrewLan mod suite
             if not bp.Physics.FlattenSkirt then
                 self.TerrainSlope = {}
+            end
+        end
+
+        -- create decal below structure
+        if bp.Physics.FlattenSkirt and not self:HasTarmac() and bp.General.FactionName ~= "Seraphim" then
+            if self.TarmacBag then
+                self:CreateTarmac(true, true, true, self.TarmacBag.Orientation, self.TarmacBag.CurrentBP)
+            else
+                self:CreateTarmac(true, true, true, false, false)
             end
         end
     end,
@@ -164,15 +182,6 @@ StructureUnit = ClassUnit(Unit) {
         if EntityCategoryContains(StructureUnitOnStartBeingBuiltRotateBuildings, self) then
             self:RotateTowardsEnemy()
         end
-
-        -- create decal below structure
-        if bp.Physics.FlattenSkirt and not self:HasTarmac() and bp.General.FactionName ~= "Seraphim" then
-            if self.TarmacBag then
-                self:CreateTarmac(true, true, true, self.TarmacBag.Orientation, self.TarmacBag.CurrentBP)
-            else
-                self:CreateTarmac(true, true, true, false, false)
-            end
-        end
     end,
 
     ---@param self StructureUnit
@@ -193,16 +202,8 @@ StructureUnit = ClassUnit(Unit) {
     end,
 
     ---@param self StructureUnit
-    OnFailedToBeBuilt = function(self)
-        Unit.OnFailedToBeBuilt(self)
-        self:DestroyTarmac()
-    end,
-
-    ---@param self StructureUnit
     FlattenSkirt = function(self)
-        local x, y, z = self:GetPositionXYZ()
         local x0, z0, x1, z1 = self:GetSkirtRect()
-
         import('/lua/sim/TerrainUtils.lua').FlattenGradientMapRect(x0, z0, x1 - x0, z1 - z0)
     end,
 
@@ -210,119 +211,212 @@ StructureUnit = ClassUnit(Unit) {
     ---@param albedo string
     ---@param normal string
     ---@param glow string
-    ---@param orientation number
-    ---@param specTarmac string
+    ---@param orientation? number
+    ---@param tarmac? UnitBlueprintTarmac
     ---@param lifeTime number
     ---@return boolean
-    CreateTarmac = function(self, albedo, normal, glow, orientation, specTarmac, lifeTime)
+    CreateTarmac = function(self, albedo, normal, glow, orientation, tarmac, lifeTime)
+        self.Trash:Add(
+            ForkThread(
+                self.CreateTarmacThread,
+                self,
+                albedo,
+                normal,
+                glow, 
+                orientation,
+                tarmac,
+                lifeTime
+            )
+        )
+    end,
+
+    ---@param self StructureUnit
+    ---@param albedo string
+    ---@param normal string
+    ---@param glow string
+    ---@param orientation? number
+    ---@param tarmac? UnitBlueprintTarmac
+    ---@param lifeTime number
+    CreateTarmacThread = function(self, albedo, normal, glow, orientation, tarmac, lifeTime)
+        -- hold up one tick to allow upgrades to pass the tarmac bag
+        -- LOG(GetGameTick())
+        -- WaitTicks(1)
+        -- LOG(GetGameTick())
+
+        -- upgrades pass the tarmac bag, in which case we do nothing
+        if self:HasTarmac() then
+            self.TarmacBag.OwnedByEntity = self.EntityId
+            return
+        end
+
+        -- no tarmacs underwater
         if self.Layer ~= 'Land' then
             return
         end
 
-        local tarmac
-        local blueprintDisplay = self.Blueprint.Display
-        local blueprintPhysics = self.Blueprint.Physics
+        -- bring into local scope for performance
+        local CreateDecal = CreateDecal
+        local GetTarmac = GetTarmac
+        local TableEmpty = table.empty
+        local TableRandom = table.random
 
-
-        local bp = self.Blueprint.Display.Tarmacs
-
-
-        if not specTarmac then
-            if bp and not table.empty(bp) then
-                local num = Random(1, table.getn(bp))
-                tarmac = bp[num]
+        -- determine tarmac to place
+        if not tarmac then
+            local tarmacBlueprints = self.Blueprint.Display.Tarmacs
+            if tarmacBlueprints and not TableEmpty(tarmacBlueprints) then
+                tarmac = TableRandom(tarmacBlueprints)
             else
-                return false
+                return
             end
-        else
-            tarmac = specTarmac
         end
 
+        -- determine lod cutoff
+        local meshBlueprint = self.Blueprint.Display.Mesh
+        local cutoffOthers = meshBlueprint.LODs[1].LODCutoff
+        local cutoffAlbedo = meshBlueprint.LODs[2].LODCutoff
+        if not cutoffAlbedo then
+            cutoffAlbedo = cutoffOthers
+            cutoffOthers = 0.4 * cutoffOthers
+        else
+            cutoffOthers = 0.8 * cutoffOthers
+        end
+
+        -- take into account the fading of the decal
+        cutoffAlbedo = 1.1 * cutoffAlbedo
+        cutoffOthers = 1.1 * cutoffOthers
+
+        -- determine orientation
+        if not orientation then
+            if tarmac.Orientations and not TableEmpty(tarmac.Orientations) then
+                orientation = TableRandom(tarmac.Orientations)
+                -- convert to radians
+                orientation = (0.01745 * orientation)
+            else
+                orientation = 0
+            end
+        end
+
+        -- determine size
         local w = tarmac.Width
         local l = tarmac.Length
-        local fadeout = math.max(blueprintPhysics.SkirtSizeX or 1, blueprintPhysics.SkirtSizeZ or 1) * 70
-        LOG(fadeout)
 
-        local x, y, z = self:GetPositionXYZ()
+        -- determine faction
+        local factionIndex  = FactionToTarmacIndex[self.Blueprint.FactionCategory]
 
-        -- I'm disabling this for now since there are so many things wrong with it
-        local orient = orientation
-        if not orientation then
-            if tarmac.Orientations and not table.empty(tarmac.Orientations) then
-                orient = table.random(tarmac.Orientations)
-                orient = (0.01745 * orient)
-            else
-                orient = 0
-            end
-        end
-
-        if not self.TarmacBag then
-            self.TarmacBag = {
-                Decals = {},
-                Orientation = orient,
-                CurrentBP = tarmac,
-            }
-        end
-
-        local GetTarmac = import("/lua/tarmacs.lua").GetTarmacType
-
-        local terrain = GetTerrainType(x, z)
-        local terrainName
+        -- determine terrain name for tarmacs based on terrain type
+        local position = self:GetPosition()
+        local terrain = GetTerrainType(position[1], position[3])
+        local terrainName = ''
         if terrain then
             terrainName = terrain.Name
         end
 
-        -- Players and AI can build buildings outside of their faction. Get the *building's* faction to determine the correct tarrain-specific tarmac
-        local factionTable = {e = 1, a = 2, r = 3, s = 4}
-        local faction  = factionTable[string.sub(self.UnitId, 2, 2)]
+        -- create a new bag
+        self.TarmacBag = {
+            Decals = TrashBag(),
+            OwnedByEntity = self.EntityId,
+            Orientation = orientation,
+            CurrentBP = tarmac,
+        }
+        local bag = self.TarmacBag.Decals
+
+        -- create albedo tarmac, note that it may have a 2nd texture for specular properties
         if albedo and tarmac.Albedo then
             local albedo2 = tarmac.Albedo2
             if albedo2 then
-                albedo2 = albedo2 .. GetTarmac(faction, terrain)
+                albedo2 = albedo2 .. GetTarmac(factionIndex, terrain)
             end
 
-            local tarmacHndl = CreateDecal(self:GetPosition(), orient, tarmac.Albedo .. GetTarmac(faction, terrainName) , albedo2 or '', 'Albedo', w, l, fadeout, lifeTime or 0, self.Army, 0)
-            table.insert(self.TarmacBag.Decals, tarmacHndl)
+            local handle = CreateDecal(
+                position,
+                orientation,
+                tarmac.Albedo .. GetTarmac(factionIndex, terrainName),
+                albedo2 or '',
+                'Albedo',
+                w,
+                l,
+                cutoffAlbedo, 
+                lifeTime or 0,
+                self.Army,
+                0
+            )
+
+            bag:Add(handle)
             if tarmac.RemoveWhenDead then
-                self.Trash:Add(tarmacHndl)
+                self.Trash:Add(handle)
             end
         end
 
+        -- create normals tarmac, note not the usual normals shader
         if normal and tarmac.Normal then
-            local tarmacHndl = CreateDecal(self:GetPosition(), orient, tarmac.Normal .. GetTarmac(faction, terrainName), '', 'Alpha Normals', w, l, 0.5 * fadeout, lifeTime or 0, self.Army, 0)
+            local handle = CreateDecal(
+                position,
+                orientation,
+                tarmac.Normal .. GetTarmac(factionIndex, terrainName),
+                '',
+                'Alpha Normals',
+                w,
+                l,
+                cutoffOthers,
+                lifeTime or 0,
+                self.Army,
+                0
+            )
 
-            table.insert(self.TarmacBag.Decals, tarmacHndl)
+            bag:Add(handle)
             if tarmac.RemoveWhenDead then
-                self.Trash:Add(tarmacHndl)
+                self.Trash:Add(handle)
             end
         end
 
+        -- create glow tarmacs, not used by the base game
         if glow and tarmac.Glow then
-            local tarmacHndl = CreateDecal(self:GetPosition(), orient, tarmac.Glow .. GetTarmac(faction, terrainName), '', 'Glow', w, l, 0.5 * fadeout, lifeTime or 0, self.Army, 0)
+            local handle = CreateDecal(
+                position,
+                orientation,
+                tarmac.Glow .. GetTarmac(factionIndex, terrainName),
+                '',
+                'Glow',
+                w,
+                l,
+                cutoffOthers,
+                lifeTime or 0,
+                self.Army,
+                0
+            )
 
-            table.insert(self.TarmacBag.Decals, tarmacHndl)
+            bag:Add(handle)
             if tarmac.RemoveWhenDead then
-                self.Trash:Add(tarmacHndl)
+                self.Trash:Add(handle)
             end
         end
     end,
 
     ---@param self StructureUnit
     DestroyTarmac = function(self)
-        if not self.TarmacBag then return end
-
-        for k, v in self.TarmacBag.Decals do
-            v:Destroy()
+        -- no bag to clean up
+        local bag = self.TarmacBag
+        if not bag then
+            return
         end
 
-        self.TarmacBag.Orientation = nil
-        self.TarmacBag.CurrentBP = nil
+        -- not our responsibility to clean up
+        if not bag.OwnedByEntity == self.EntityId then
+            return
+        end
+
+        -- ok, clean the bag
+        bag.Decals:Destroy()
     end,
 
     ---@param self StructureUnit
     HasTarmac = function(self)
-        if not self.TarmacBag then return false end
-        return not table.empty(self.TarmacBag.Decals)
+        local bag = self.TarmacBag
+        if not bag then
+            return false
+        end
+
+        return not bag.Decals:Empty()
     end,
 
     ---@param self StructureUnit
@@ -403,14 +497,17 @@ StructureUnit = ClassUnit(Unit) {
 
     UpgradingState = State {
         Main = function(self)
-            self:DestroyTarmac()
             self:PlayUnitSound('UpgradeStart')
             self:DisableDefaultToggleCaps()
 
+            -- give ownership of tarmac bag
+            local unitBuilding = self.UnitBeingBuilt
+            local tarmacBag = self.TarmacBag
+            tarmacBag.OwnedByEntity = unitBuilding.EntityId
+            unitBuilding.TarmacBag = tarmacBag
+
             local animation = self:GetUpgradeAnimation(self.UnitBeingBuilt)
             if animation then
-
-                local unitBuilding = self.UnitBeingBuilt
                 self.AnimatorUpgradeManip = CreateAnimator(self)
                 self.Trash:Add(self.AnimatorUpgradeManip)
                 local fractionOfComplete = 0
@@ -445,13 +542,14 @@ StructureUnit = ClassUnit(Unit) {
             Unit.OnFailedToBuild(self)
             self:EnableDefaultToggleCaps()
 
+            self.TarmacBag.OwnedByEntity = self.EntityId
+
             if self.AnimatorUpgradeManip then
                 self.AnimatorUpgradeManip:Destroy()
             end
 
             self:PlayUnitSound('UpgradeFailed')
             self:PlayActiveAnimation()
-            self:CreateTarmac(true, true, true, self.TarmacBag.Orientation, self.TarmacBag.CurrentBP)
             ChangeState(self, self.IdleState)
         end,
     },

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -44,10 +44,12 @@ local StructureUnitOnStartBeingBuiltRotateBuildings = categories.STRUCTURE * (ca
 ---@field Orientation number
 ---@field CurrentBP UnitBlueprintTarmac
 ---@field Lifetime number
+---@field OwnedByEntity EntityId
 
 -- STRUCTURE UNITS
 ---@class StructureUnit : Unit
 ---@field AdjacentUnits? Unit[]
+---@field TarmacBag StructureTarmacBag
 StructureUnit = ClassUnit(Unit) {
     LandBuiltHiddenBones = {'Floatation'},
     MinConsumptionPerSecondEnergy = 1,
@@ -202,9 +204,6 @@ StructureUnit = ClassUnit(Unit) {
         end
 
         self:PlayActiveAnimation()
-
-        -- remove land bones if the structure has them
-        self:HideLandBones()
     end,
 
     ---@param self StructureUnit

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -248,9 +248,6 @@ function CreateArmyUnit(strArmy, strUnit)
             tblUnit.Position[1], tblUnit.Position[2], tblUnit.Position[3],
             tblUnit.Orientation[1], tblUnit.Orientation[2], tblUnit.Orientation[3]
         )
-        if unit:GetBlueprint().Physics.FlattenSkirt then
-            unit:CreateTarmac(true, true, true, false, false)
-        end
         local platoon
         if tblUnit.platoon ~= nil and tblUnit.platoon ~= '' then
             local i = 3
@@ -936,9 +933,6 @@ function CreatePlatoons(strArmy, tblNode, tblResult, platoonList, currPlatoon, t
                                  tblData.Position[1], tblData.Position[2], tblData.Position[3],
                                  tblData.Orientation[1], tblData.Orientation[2], tblData.Orientation[3]
                              )
-            if unit:GetBlueprint().Physics.FlattenSkirt then
-                unit:CreateTarmac(true, true, true, false, false)
-            end
             table.insert(tblResult, unit)
             treeResult[strName] = unit
             if ScenarioInfo.UnitNames[armyIndex] then
@@ -1105,9 +1099,6 @@ function CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, tblNode, platoon
                                  tblData.Position[1], tblData.Position[2], tblData.Position[3],
                                  tblData.Orientation[1], tblData.Orientation[2], tblData.Orientation[3]
                              )
-            if unit:GetBlueprint().Physics.FlattenSkirt then
-                unit:CreateTarmac(true, true, true, false, false)
-            end
             if ScenarioInfo.UnitNames[armyIndex] then
                 ScenarioInfo.UnitNames[armyIndex][strName] = unit
             end

--- a/lua/system/blueprints-lod.lua
+++ b/lua/system/blueprints-lod.lua
@@ -1,7 +1,6 @@
 ---@declare-global
 local MathSqrt = math.sqrt
 
---- Calculates the LODs of a single prop
 ---@param prop PropBlueprint to compute the LODs for
 local function CalculateLODOfProp(prop)
     local sx = prop.SizeX or 1
@@ -14,49 +13,69 @@ local function CalculateLODOfProp(prop)
         weighted = 3
     end
 
-    -- 1 -> ~ 330
-    -- 2 -> ~ 470
-    -- 3 -> ~ 580
-    -- 4 -> ~ 670
-    -- 5 -> ~ 750
-    -- 6 -> ~ 820
-    -- https://www.desmos.com/calculator/amw5fi5569 (1.5 * sqrt(100 * 500 * x))
-    local lod = 1.30 * MathSqrt(100 * 500 * weighted)
+    -- https://www.desmos.com/calculator (1.1 * sqrt(100 * 500 * x))
+    local lod = 1.10 * MathSqrt(100 * 500 * weighted)
 
     if prop.Display and prop.Display.Mesh and prop.Display.Mesh.LODs then
-        -- used for scaling the LODs
         local n = table.getn(prop.Display.Mesh.LODs)
-
-        -- read LODs in order
-        for k = 1, table.getn(prop.Display.Mesh.LODs) do 
+        for k = 1, n do
             local data = prop.Display.Mesh.LODs[k]
 
-            -- 1/1 -> 1/1
-            -- 1/2 -> 1/4
-            -- 1/3 -> 1/9
-            -- 1/4 -> 1/16
-            -- https://www.desmos.com/calculator/keue6viu3b (x * x)
+            -- https://www.desmos.com/calculator (x * x)
             local factor = (k / n) * (k / n)
-
-            -- if prop.ScriptClass and prop.ScriptClass == "TreeGroup" then 
-            --     LOG("Mapping ( " .. tostring(weighted) .. "): " .. tostring(data.LODCutoff) .. " -> " .. tostring(factor * lod))
-            -- end
-
-            data.LODCutoff = factor * lod + 10
+            local LODCutoff = factor * lod + 50
+            -- LOG(string.format("(%s) / %d: %d -> %d", unit.BlueprintId, k, data.LODCutoff, LODCutoff))
+            data.LODCutoff = LODCutoff
         end
     end
 end
 
---- Calculates the LODs of a list of props
----@param props PropBlueprint[] list of props to tweak the LODs for
+---@param unit UnitBlueprint
+local function CalculateLODOfUnit(unit)
+    local sx = unit.Physics.SkirtSizeX or unit.SizeX or 1
+    local sy = unit.SizeY or 1
+    local sz = unit.Physics.SkirtSizeZ or unit.SizeZ or 1
+
+    -- give more emphasis to the x / z value as that is easier to see in the average camera angle
+    local weighted = 0.40 * sx + 0.2 * sy + 0.4 * sz
+
+    -- https://www.desmos.com/calculator (0.7 * sqrt(100 * 500 * x))
+    local lod = 0.7 * MathSqrt(100 * 500 * weighted)
+
+    if unit.Display and unit.Display.Mesh and unit.Display.Mesh.LODs then
+        local n = table.getn(unit.Display.Mesh.LODs)
+        for k = 1, n do
+            local data = unit.Display.Mesh.LODs[k]
+
+            -- slight offset to give more preference to LOD0
+            local lk = k + 1
+            local ln = n + 1
+
+            -- https://www.desmos.com/calculator (x * x)
+            local factor = (lk / ln) * (lk / ln)
+            local LODCutoff = factor * lod + 50
+            -- LOG(string.format("(%s) / %d: %d -> %d", unit.BlueprintId, k, data.LODCutoff, LODCutoff))
+            data.LODCutoff = LODCutoff
+        end
+    end
+end
+
+---@param props PropBlueprint[]
 local function CalculateLODsOfProps(props)
     for _, prop in props do
         CalculateLODOfProp(prop)
     end
 end
 
---- Calculates the LODs of all entities
----@param bps BlueprintsTable all available blueprints
+---@param units UnitBlueprint[]
+local function CalculateLODsOfUnits(units)
+    for _, unit in units do
+        CalculateLODOfUnit(unit)
+    end
+end
+
+---@param bps BlueprintsTable
 function CalculateLODs(bps)
     CalculateLODsOfProps(bps.Prop)
+    CalculateLODsOfUnits(bps.Unit)
 end

--- a/lua/tarmacs.lua
+++ b/lua/tarmacs.lua
@@ -13,19 +13,18 @@ local TarmacTable =
 {
     --UEF Tarmac Overrides
     [1] = {
-        
     },
-    
+
     --Aeon Tarmac Overrides
     [2] = {
     },
-    
+
     --Cybran Tarmac Overrides
     [3] = {
     },
-    
+
     --Seraphim Tarmac Overrides.
-    [4] = {        
+    [4] = {
         Dirt01 = '',
         Dirt02 = '_Evergreen',
         Dirt03 = '',
@@ -33,16 +32,16 @@ local TarmacTable =
         Dirt06 = '_RedRock',
         Dirt07 = '_Desert',
         Dirt08 = '_Desert',
-        
+
         Sand01 = '_Tropical',
         Sand02 = '_Evergreen',
-        
+
         Vegetation01 = '',
         Vegetation02 = '_Evergreen',
         Vegetation03 = '_Evergreen',
         Vegetation04 = '_Evergreen',
         Vegetation05 = '_Tropical',
-        
+
         Rocky01 = '',
         Rocky02 = '_Evergreen',
         Rocky03 = '_Tundra',
@@ -56,16 +55,14 @@ local TarmacTable =
         Rocky11 = '_Geothermal',
         Rocky12 = '_Geothermal',
         Rocky13 = '_Geothermal',
-        
+
         Concrete01 = '',
-        
+
         Snowy01 = '_Tundra',
         Snowy02 = '_Tundra',
-        Snowy03 = '_Tundra',  
+        Snowy03 = '_Tundra',
     },
 }
-
-
 
 function GetTarmacType(factionIdx, terrainType, tarmacLayer)
     return TarmacTable[factionIdx][terrainType] or ''


### PR DESCRIPTION
This pull request consists of three parts:

- (1) Dynamically computes the LODs of units
- (2) Dynamically determine the LODs of tarmacs of units
- (3) Fix tarmacs switching up when structure starts / stops upgrading

(1) is only partially complete, a second pull request will finalize it. In this pull request we force the re-computation of all LODs of all units. It uses a similar approach to props, as found in: https://github.com/FAForever/fa/pull/3662 . The second pull request will only compute the LOD value of units that have none, after which we remove all the pre-defined cutoffs of units and props. That way mods we do not 'enforce' these rules on mods.

(2) is a visual thing, where previously:

- (a) Cutoff was the same for different types of decals
- (b) Cutoff was the same, regardless of size

(a) could introduce noise when zoomed out, especially for the Cybran normals. (b) doesn't make a lot of sense, where the decal pops into view sooner than a power generator does, but later than a factory would. We streamline this such that:

- All albedo decals share the same cutoff as the LOD1 mesh blueprint of the unit, if present
- All normal / glow decals share the same cutoff as the LOD0 mesh blueprint of the unit, if present

As a result decals fade in more naturally, where we initially only see the albedo and then as we zoom in we get rewarded with the details provided by the normals decal.

(3) is the technical bug that caused me to look into this. It was reported by Madmax, but I'm sure everyone notices it the moment they know decals can switch up as you start upgrading. This no longer happens - instead decals are inherited and the structure that is responsible ends up destroying them.