### PR TITLE
Add more imports to break cycle in import dependencies

### DIFF
--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -513,7 +513,10 @@ function OnPostLoad()
     end
 end
 
--- due to cyclic dependencies we need to import these files to break the cycle them
+-- these imports break cycle dependencies of import sequences of mods
 
-import('/lua/ScenarioFramework.lua')
-import('/lua/sim/ScenarioUtilities.lua')
+import('/lua/scenarioframework.lua')
+import('/lua/sim/scenarioutilities.lua')
+import("/lua/ai/aiutilities.lua")
+import("/lua/ai/sorianutilities.lua")
+import("/lua/ai/aiattackutilities.lua")


### PR DESCRIPTION
```
warning: ...ance\mods\rngai\lua\intelmanagement\intelmanager.lua(7): access to nonexistent global variable GetClosestPathNodeInRadiusByLayerRNG
warning: stack traceback:
warning:         [C]: in function `error'
warning:         ...ata\faforever\gamedata\lua.nx5\lua\system\config.lua(55): in function <...ata\faforever\gamedata\lua.nx5\lua\system\config.lua:54>
warning:         ...ance\mods\rngai\lua\intelmanagement\intelmanager.lua(7): in main chunk
warning:         [C]: in function `doscript'
warning:         [C]: ?
warning:         ...ata\faforever\gamedata\lua.nx5\lua\system\import.lua(61): in function <...ata\faforever\gamedata\lua.nx5\lua\system\import.lua:41>
warning:         ...ata\faforever\gamedata\lua.nx5\lua\system\import.lua(155): in function `import'
warning:         ...ata\faforever\gamedata\lua.nx5\lua\system\import.lua(131): in function `import'
warning:         ...r forged alliance\mods\rngai\lua\ai\rngutilities.lua(6): in main chunk
warning:         [C]: in function `doscript'
warning:         [C]: ?
warning:         ...
warning:         [C]: ?
warning:         ...ata\faforever\gamedata\lua.nx5\lua\system\import.lua(61): in function <...ata\faforever\gamedata\lua.nx5\lua\system\import.lua:41>
warning:         ...ata\faforever\gamedata\lua.nx5\lua\system\import.lua(155): in function `import'
warning:         ...ata\faforever\gamedata\lua.nx5\lua\system\import.lua(131): in function `import'
warning:         ...er forged alliance\mods\m27ai\lua\ai\m27overseer.lua(4): in main chunk
warning:         [C]: in function `doscript'
warning:         [C]: ?
warning:         ...ata\faforever\gamedata\lua.nx5\lua\system\import.lua(61): in function <...ata\faforever\gamedata\lua.nx5\lua\system\import.lua:41>
warning:         ...ata\faforever\gamedata\lua.nx5\lua\system\import.lua(155): in function `import'
warning:         ...ogramdata\faforever\gamedata\lua.nx5\lua\siminit.lua(525): in main chunk
```