### PR TITLE
Add underwater vision to engis

### DIFF
--- a/units/UAL0105/UAL0105_unit.bp
+++ b/units/UAL0105/UAL0105_unit.bp
@@ -239,7 +239,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 18,
-        WaterVisionRadius = 5,
+        WaterVisionRadius = 10,
     },
     Interface = {
         HelpText = '<LOC ual0105_help>Engineer',

--- a/units/UAL0105/UAL0105_unit.bp
+++ b/units/UAL0105/UAL0105_unit.bp
@@ -239,6 +239,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 18,
+        WaterVisionRadius = 5,
     },
     Interface = {
         HelpText = '<LOC ual0105_help>Engineer',

--- a/units/UAL0208/UAL0208_unit.bp
+++ b/units/UAL0208/UAL0208_unit.bp
@@ -236,6 +236,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 20,
+        WaterVisionRadius = 6,
     },
     Interface = {
         HelpText = '<LOC ual0208_help>Engineer',

--- a/units/UAL0208/UAL0208_unit.bp
+++ b/units/UAL0208/UAL0208_unit.bp
@@ -236,7 +236,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 20,
-        WaterVisionRadius = 6,
+        WaterVisionRadius = 12,
     },
     Interface = {
         HelpText = '<LOC ual0208_help>Engineer',

--- a/units/UAL0309/UAL0309_unit.bp
+++ b/units/UAL0309/UAL0309_unit.bp
@@ -235,6 +235,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 26,
+        WaterVisionRadius = 7,
     },
     Interface = {
         HelpText = '<LOC ual0309_help>Engineer',

--- a/units/UAL0309/UAL0309_unit.bp
+++ b/units/UAL0309/UAL0309_unit.bp
@@ -235,7 +235,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 26,
-        WaterVisionRadius = 7,
+        WaterVisionRadius = 14,
     },
     Interface = {
         HelpText = '<LOC ual0309_help>Engineer',

--- a/units/UEL0105/UEL0105_unit.bp
+++ b/units/UEL0105/UEL0105_unit.bp
@@ -248,7 +248,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 18,
-        WaterVisionRadius = 5,
+        WaterVisionRadius = 10,
     },
     Interface = {
         HelpText = '<LOC uel0105_help>Engineer',

--- a/units/UEL0105/UEL0105_unit.bp
+++ b/units/UEL0105/UEL0105_unit.bp
@@ -248,6 +248,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 18,
+        WaterVisionRadius = 5,
     },
     Interface = {
         HelpText = '<LOC uel0105_help>Engineer',

--- a/units/UEL0208/UEL0208_unit.bp
+++ b/units/UEL0208/UEL0208_unit.bp
@@ -248,6 +248,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 20,
+        WaterVisionRadius = 6,
     },
     Interface = {
         HelpText = '<LOC uel0208_help>Engineer',

--- a/units/UEL0208/UEL0208_unit.bp
+++ b/units/UEL0208/UEL0208_unit.bp
@@ -248,7 +248,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 20,
-        WaterVisionRadius = 6,
+        WaterVisionRadius = 12,
     },
     Interface = {
         HelpText = '<LOC uel0208_help>Engineer',

--- a/units/UEL0309/UEL0309_unit.bp
+++ b/units/UEL0309/UEL0309_unit.bp
@@ -248,7 +248,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 26,
-        WaterVisionRadius = 7,
+        WaterVisionRadius = 14,
     },
     Interface = {
         HelpText = '<LOC uel0309_help>Engineer',

--- a/units/UEL0309/UEL0309_unit.bp
+++ b/units/UEL0309/UEL0309_unit.bp
@@ -248,6 +248,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 26,
+        WaterVisionRadius = 7,
     },
     Interface = {
         HelpText = '<LOC uel0309_help>Engineer',

--- a/units/URL0105/URL0105_unit.bp
+++ b/units/URL0105/URL0105_unit.bp
@@ -236,7 +236,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 18,
-        WaterVisionRadius = 5,
+        WaterVisionRadius = 10,
     },
     Interface = {
         HelpText = '<LOC url0105_help>Engineer',

--- a/units/URL0105/URL0105_unit.bp
+++ b/units/URL0105/URL0105_unit.bp
@@ -236,6 +236,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 18,
+        WaterVisionRadius = 5,
     },
     Interface = {
         HelpText = '<LOC url0105_help>Engineer',

--- a/units/URL0208/URL0208_unit.bp
+++ b/units/URL0208/URL0208_unit.bp
@@ -237,7 +237,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 20,
-        WaterVisionRadius = 6,
+        WaterVisionRadius = 12,
     },
     Interface = {
         HelpText = '<LOC url0208_help>Engineer',

--- a/units/URL0208/URL0208_unit.bp
+++ b/units/URL0208/URL0208_unit.bp
@@ -237,6 +237,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 20,
+        WaterVisionRadius = 6,
     },
     Interface = {
         HelpText = '<LOC url0208_help>Engineer',

--- a/units/URL0309/URL0309_unit.bp
+++ b/units/URL0309/URL0309_unit.bp
@@ -237,7 +237,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 26,
-        WaterVisionRadius = 7,
+        WaterVisionRadius = 14,
     },
     Interface = {
         HelpText = '<LOC url0309_help>Engineer',

--- a/units/URL0309/URL0309_unit.bp
+++ b/units/URL0309/URL0309_unit.bp
@@ -237,6 +237,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 26,
+        WaterVisionRadius = 7,
     },
     Interface = {
         HelpText = '<LOC url0309_help>Engineer',

--- a/units/XSL0105/XSL0105_unit.bp
+++ b/units/XSL0105/XSL0105_unit.bp
@@ -267,7 +267,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 18,
-        WaterVisionRadius = 5,
+        WaterVisionRadius = 10,
     },
     Interface = {
         HelpText = '<LOC xsl0105_help>Engineer',

--- a/units/XSL0105/XSL0105_unit.bp
+++ b/units/XSL0105/XSL0105_unit.bp
@@ -267,6 +267,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 18,
+        WaterVisionRadius = 5,
     },
     Interface = {
         HelpText = '<LOC xsl0105_help>Engineer',

--- a/units/XSL0208/XSL0208_unit.bp
+++ b/units/XSL0208/XSL0208_unit.bp
@@ -269,6 +269,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 20,
+        WaterVisionRadius = 6,
     },
     Interface = {
         HelpText = '<LOC xsl0208_help>Engineer',

--- a/units/XSL0208/XSL0208_unit.bp
+++ b/units/XSL0208/XSL0208_unit.bp
@@ -269,7 +269,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 20,
-        WaterVisionRadius = 6,
+        WaterVisionRadius = 12,
     },
     Interface = {
         HelpText = '<LOC xsl0208_help>Engineer',

--- a/units/XSL0309/XSL0309_unit.bp
+++ b/units/XSL0309/XSL0309_unit.bp
@@ -277,6 +277,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 26,
+        WaterVisionRadius = 7,
     },
     Interface = {
         HelpText = '<LOC xsl0309_help>Engineer',

--- a/units/XSL0309/XSL0309_unit.bp
+++ b/units/XSL0309/XSL0309_unit.bp
@@ -277,7 +277,7 @@ UnitBlueprint {
     },
     Intel = {
         VisionRadius = 26,
-        WaterVisionRadius = 7,
+        WaterVisionRadius = 14,
     },
     Interface = {
         HelpText = '<LOC xsl0309_help>Engineer',


### PR DESCRIPTION
Adds water vision to each engi the size of their build range. This will make underwater mexes visible when attempting to build them.