### PR TITLE
Fix vision bug for neutral factions where they see the entire map

### DIFF
--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -755,8 +755,8 @@ AIBrain = Class(moho.aibrain_methods) {
     ---@param reconType ReconTypes
     ---@param val boolean
     OnIntelChange = function(self, blip, reconType, val)
-        if reconType == 'LOSNow' or reconType == 'Omni' then
-            if not val then
+        if not val then
+            if reconType == 'LOSNow' or reconType == 'Omni' then
                 local unit = blip:GetSource()
                 if unit.Blueprint.Intel.JammerBlips > 0 then
                     unit.ResetJammer = self.JammerResetTime

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -755,6 +755,7 @@ AIBrain = Class(moho.aibrain_methods) {
     ---@param reconType ReconTypes
     ---@param val boolean
     OnIntelChange = function(self, blip, reconType, val)
+        LOG(self.Army)
         if reconType == 'LOSNow' or reconType == 'Omni' then
             if not val then
                 local unit = blip:GetSource()

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -755,7 +755,6 @@ AIBrain = Class(moho.aibrain_methods) {
     ---@param reconType ReconTypes
     ---@param val boolean
     OnIntelChange = function(self, blip, reconType, val)
-        LOG(self.Army)
         if reconType == 'LOSNow' or reconType == 'Omni' then
             if not val then
                 local unit = blip:GetSource()

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -582,7 +582,7 @@ function InitializeArmies()
     local FindUnitGroup = FindUnitGroup
     local CreatePlatoons = CreatePlatoons
     local CreateWreckageUnit = CreateWreckageUnit
-    local LocalSetAlliance = SetAlliance
+    local SetAlliance = SetAlliance
 
     local armySetups = ScenarioInfo.ArmySetup
     local civOpt = ScenarioInfo.Options.CivilianAlliance
@@ -634,39 +634,46 @@ function InitializeArmies()
                 end
             end
 
-            ----[ irumsey                                                         ]--
-            ----[ Temporary defaults.  Make sure some fighting will break out.    ]--
+
             for iEnemy, _ in tblArmy do
-                -- only do it once for each pair
+
+                -- only run this logic once for each pair
                 if iEnemy >= iArmy then
                     continue
                 end
+
+                -- by default we are enemies
                 local state = "Enemy"
                 if armyIsCiv then
+
+                    -- or neutral, to the neutral civilians
                     if civOpt == "neutral" or strArmy == "NEUTRAL_CIVILIAN" then
                         state = "Neutral"
                     end
 
+                    -- temporarily ally them to gain vision
                     if revealCivilians then
                         ForkThread(function(civ, army)
-                            WaitSeconds(0.1)
-
+                            -- keep track of army status
                             local real_state = IsAlly(civ, army) and "Ally" or IsEnemy(civ, army) and "Enemy" or "Neutral"
-                            GetArmyBrain(army):SetupArmyIntelTrigger({
-                                Category = categories.ALLUNITS,
-                                Type = "LOSNow",
-                                Value = true,
-                                OnceOnly = true,
-                                TargetAIBrain = GetArmyBrain(civ),
-                                CallbackFunction = function()
-                                    SetAlliance(civ, army, real_state)
-                                end,
-                            })
+
+                            -- guarantee the army has _some_ vision at _some_ point, to prevent them from
+                            -- having complete vision. The intel / vision system defaults to giving complete
+                            -- vision over a map when an army did not have a single unit at some point. This 
+                            -- prevents the triggering of intel for each unit creation of every player. The
+                            -- behavior is easiest spotted on Seton's clutch
+                            local dummy = CreateUnitHPR('xsl0101', civ, 0, 0, 0, 0, 0, 0)
                             SetAlliance(civ, army, "Ally")
+                            WaitTicks(5)
+
+                            -- revert army status and destroy the dummy unit
+                            SetAlliance(civ, army, real_state)
+                            dummy:Destroy()
                         end, iArmy, iEnemy)
                     end
                 end
-                LocalSetAlliance(iArmy, iEnemy, state)
+
+                SetAlliance(iArmy, iEnemy, state)
             end
         end
     end


### PR DESCRIPTION
Add `LOG(string.format("%d with %s for value %s", self.Army, reconType, tostring(val)))` to `OnIntelChange` of the brain class. It constantly triggers for all four intel types throughout the entire game for every unit created or destroyed.

![image](https://user-images.githubusercontent.com/15778155/219738324-0c3232bf-1c38-437a-9923-efcb202cbbb7.png)
