### PR TITLE
Adjust reclaim values of mobile units based on tech tier

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1547,24 +1547,20 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         local layer = self.Layer
 
         -- Reduce the mass value based on the tech tier
-        local mass_tech_mult = 1
-        
-        for _, v in bp.Categories do
-            if v == 'TECH1' then
+        -- by default we reduce the mass value 2 times by 90% for a total of 81%
+        local mass_tech_mult = 0.9
+        local tech_category = bp.TechCategory
+
+        -- We reduce the mass value further only for mobile units, structures stay at the original 81%
+        if bp.CategoriesHash['MOBILE'] then
+            if tech_category == 'TECH1' then
                 mass_tech_mult = 0.9
-                break
-            end
-            if v == 'TECH2' then
+            elseif tech_category == 'TECH2' then
                 mass_tech_mult = 0.8
-                break
-            end
-            if v == 'TECH3' then
+            elseif tech_category == 'TECH3' then
                 mass_tech_mult = 0.7
-                break
-            end
-            if v == 'EXPERIMENTAL' then
+            elseif tech_category == 'EXPERIMENTAL' then
                 mass_tech_mult = 0.6
-                break
             end
         end
         mass = mass * mass_tech_mult

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1551,18 +1551,17 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         local mass_tech_mult = 0.9
         local tech_category = bp.TechCategory
 
-        -- We reduce the mass value further only for mobile units, structures stay at the original 81%
-        if bp.CategoriesHash['MOBILE'] then
-            if tech_category == 'TECH1' then
-                mass_tech_mult = 0.9
-            elseif tech_category == 'TECH2' then
-                mass_tech_mult = 0.8
-            elseif tech_category == 'TECH3' then
-                mass_tech_mult = 0.7
-            elseif tech_category == 'EXPERIMENTAL' then
-                mass_tech_mult = 0.6
-            end
+        -- We reduce the mass value based on tech category
+        if tech_category == 'TECH1' then
+            mass_tech_mult = 0.9
+        elseif tech_category == 'TECH2' then
+            mass_tech_mult = 0.8
+        elseif tech_category == 'TECH3' then
+            mass_tech_mult = 0.7
+        elseif tech_category == 'EXPERIMENTAL' then
+            mass_tech_mult = 0.6
         end
+        
         mass = mass * mass_tech_mult
 
         -- Reduce the mass value of submerged wrecks

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1546,6 +1546,29 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         local pos = self:GetPosition()
         local layer = self.Layer
 
+        -- Reduce the mass value based on the tech tier
+        local mass_tech_mult = 1
+        
+        for _, v in bp.Categories do
+            if v == 'TECH1' then
+                mass_tech_mult = 0.9
+                break
+            end
+            if v == 'TECH2' then
+                mass_tech_mult = 0.8
+                break
+            end
+            if v == 'TECH3' then
+                mass_tech_mult = 0.7
+                break
+            end
+            if v == 'EXPERIMENTAL' then
+                mass_tech_mult = 0.6
+                break
+            end
+        end
+        mass = mass * mass_tech_mult
+
         -- Reduce the mass value of submerged wrecks
         if layer == 'Water' or layer == 'Sub' then
             mass = mass * 0.5

--- a/lua/wreckage.lua
+++ b/lua/wreckage.lua
@@ -148,8 +148,8 @@ function CreateWreckage(bp, position, orientation, mass, energy, time, deathHitB
     sz = sz * 0.5
 
     -- set health
-    prop:SetMaxHealth(bp.Defense.Health)
-    prop:SetHealth(nil, bp.Defense.Health * (bp.Wreckage.HealthMult or 1))
+    EntitySetMaxHealth(prop, bp.Defense.Health * (bp.Wreckage.HealthMult or 1))
+    EntitySetHealth(prop, nil, bp.Defense.Health * (bp.Wreckage.HealthMult or 1))
 
     -- set collision box and reclaim values, the latter depends on the health of the wreck
     prop:SetPropCollision('Box', cx, cy, cz, sx, sy, sz)

--- a/lua/wreckage.lua
+++ b/lua/wreckage.lua
@@ -148,8 +148,8 @@ function CreateWreckage(bp, position, orientation, mass, energy, time, deathHitB
     sz = sz * 0.5
 
     -- set health
-    EntitySetMaxHealth(prop, bp.Defense.Health * (bp.Wreckage.HealthMult or 1))
-    EntitySetHealth(prop, nil, bp.Defense.Health * (bp.Wreckage.HealthMult or 1))
+    prop:SetMaxHealth(bp.Defense.Health * (bp.Wreckage.HealthMult or 1))
+    prop:SetHealth(nil, bp.Defense.Health * (bp.Wreckage.HealthMult or 1))
 
     -- set collision box and reclaim values, the latter depends on the health of the wreck
     prop:SetPropCollision('Box', cx, cy, cz, sx, sy, sz)

--- a/units/URL0402/URL0402_script.lua
+++ b/units/URL0402/URL0402_script.lua
@@ -274,7 +274,7 @@ URL0402 = ClassUnit(CWalkingLandUnit) {
         CreateDeathExplosion(self, 'Left_Projectile01', 2)
         self:CreateDamageEffects('Left_Leg03_B03', army)
 
-        self:CreateWreckage(0.1)
+        self:CreateWreckage(0)
         self:Destroy()
     end,
 }

--- a/units/URS0201/URS0201_script.lua
+++ b/units/URS0201/URS0201_script.lua
@@ -152,7 +152,7 @@ URS0201 = ClassUnit(CSeaUnit) {
             if self.PlayDestructionEffects then
                 self:CreateDestructionEffects(self, overkillRatio)
             end
-            self:CreateWreckage(0.1)
+            self:CreateWreckage(0)
             self:Destroy()
         else
             CSeaUnit.DeathThread(self, overkillRatio)

--- a/units/XRL0403/XRL0403_script.lua
+++ b/units/XRL0403/XRL0403_script.lua
@@ -257,7 +257,7 @@ XRL0403 = ClassUnit(CWalkingLandUnit) {
         self:CreateDamageEffects('Left_Leg02_B02', army)
         explosion.CreateFlash(self, 'Right_Leg01_B01', 3.2, army)
 
-        self:CreateWreckage(0.1)
+        self:CreateWreckage(0)
         self:ShakeCamera(3, 2, 0, 0.15)
         self:Destroy()
     end,


### PR DESCRIPTION
Reduce the amount of reclaim that units and structures leave behind based on their tech level.

Tech 1 - 0.9 * 0.9 (81%)
Tech 2 - 0.9 * 0.8 (72%)
Tech 3 - 0.9 * 0.7 (63%)
Experimental - 0.9 * 0.6 (54%)