### PR TITLE
Fix terrain alignment issues

### DIFF
--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -923,6 +923,8 @@
 
 
 ---@class UnitBlueprintPhysics
+--- forces terrain alignment for structures
+---@field AlwaysAlignToTerrain boolean
 --- alternate method of locomotion
 ---@field AltMotionType? UnitMotionType
 --- preferred attack height when attacking ground targets (used by dive bombers)

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -78,7 +78,6 @@ StructureUnit = ClassUnit(Unit) {
         end
 
         -- check for terrain orientation
-        local bp = self.Blueprint
         if not (
                 physicsBlueprint.AltitudeToTerrain or
                 physicsBlueprint.StandUpright
@@ -87,8 +86,8 @@ StructureUnit = ClassUnit(Unit) {
             -- rotate structure to match terrain gradient
             local a1, a2 = TerrainUtils.GetTerrainSlopeAngles(
                 self:GetPosition(),
-                bp.Footprint.SizeX or physicsBlueprint.SkirtSizeX,
-                bp.Footprint.SizeZ or physicsBlueprint.SkirtSizeZ
+                blueprint.Footprint.SizeX or physicsBlueprint.SkirtSizeX,
+                blueprint.Footprint.SizeZ or physicsBlueprint.SkirtSizeZ
             )
 
             -- do not orientate structures that are on essentially flat ground
@@ -102,7 +101,7 @@ StructureUnit = ClassUnit(Unit) {
         end
 
         -- create decal below structure
-        if flatten and not self:HasTarmac() and bp.General.FactionName ~= "Seraphim" then
+        if flatten and not self:HasTarmac() and blueprint.General.FactionName ~= "Seraphim" then
             if self.TarmacBag then
                 self:CreateTarmac(true, true, true, self.TarmacBag.Orientation, self.TarmacBag.CurrentBP)
             else
@@ -193,7 +192,6 @@ StructureUnit = ClassUnit(Unit) {
         Unit.OnStartBeingBuilt(self, builder, layer)
 
         -- rotate weaponry towards enemy
-        local bp = self.Blueprint
         if EntityCategoryContains(StructureUnitOnStartBeingBuiltRotateBuildings, self) then
             self:RotateTowardsEnemy()
         end

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -253,7 +253,7 @@ StructureUnit = ClassUnit(Unit) {
         -- hold up one tick to allow upgrades to pass the tarmac bag
         WaitTicks(1)
 
-        -- upgrades pass the tarmac bag, in which case we do nothing
+        -- upgrades pass the tarmac bag, in which case we take ownership and do nothing
         if self:HasTarmac() then
             self.TarmacBag.OwnedByEntity = self.EntityId
             return

--- a/units/UAB5101/UAB5101_unit.bp
+++ b/units/UAB5101/UAB5101_unit.bp
@@ -124,6 +124,7 @@ UnitBlueprint {
     LifeBarOffset = 0.5,
     LifeBarSize = 0.8,
     Physics = {
+        AlwaysAlignToTerrain = true,
         BankingSlope = 0,
         BuildOnLayerCaps = {
             LAYER_Air = false,

--- a/units/UEB5101/UEB5101_unit.bp
+++ b/units/UEB5101/UEB5101_unit.bp
@@ -111,6 +111,7 @@ UnitBlueprint {
     LifeBarOffset = 0.5,
     LifeBarSize = 0.8,
     Physics = {
+        AlwaysAlignToTerrain = true,
         BankingSlope = 0,
         BuildOnLayerCaps = {
             LAYER_Air = false,

--- a/units/URB5101/URB5101_unit.bp
+++ b/units/URB5101/URB5101_unit.bp
@@ -109,6 +109,7 @@ UnitBlueprint {
     LifeBarOffset = 0.5,
     LifeBarSize = 0.8,
     Physics = {
+        AlwaysAlignToTerrain = true,
         BankingSlope = 0,
         BuildOnLayerCaps = {
             LAYER_Air = false,

--- a/units/XSB5101/XSB5101_unit.bp
+++ b/units/XSB5101/XSB5101_unit.bp
@@ -105,6 +105,7 @@ UnitBlueprint {
         },
     },
     General = {
+        AlwaysAlignToTerrain = true,
         CapCost = 0.1,
         Category = 'Defense',
         Classification = 'RULEUC_MiscSupport',


### PR DESCRIPTION
A unit now only orientates to the terrain if it wants to flatten the skirt, with the exception of the player-buildable walls. Units are also no longer orientated when they are build on essentially flat ground.