### PR TITLE
Fix lingering decals and add toggle for force alt move

### DIFF
--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -518,6 +518,20 @@ options = {
                     },
                 },
             },
+
+            {
+                title = "<LOC ASSIST_TO_UPGRADE>Hold alt to force attack move",
+                key = 'alt_to_force_attack_move',
+                type = 'toggle',
+                default = 'Off',
+                custom = {
+                    states = {
+                        {text = "<LOC _Off>Off", key = 'Off'},
+                        {text = "<LOC _On>On", key = 'On'},
+                    },
+                },
+            },
+
             {
                 title = "<LOC OPTIONS_0273>Automated Structure Ringing",
                 key = 'structure_capping_feature_01',

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -348,7 +348,7 @@ options = {
                 title = "<LOC OPTIONS_0233>All Faction Templates",
                 key = 'gui_all_race_templates',
                 type = 'toggle',
-                default = 0,
+                default = 1,
                 custom = {
                     states = {
                         {text = "<LOC _Off>", key = 0 },
@@ -408,11 +408,11 @@ options = {
                 title = "<LOC selectionsets0001>Steal from other control groups",
                 key = 'steal_from_other_control_groups',
                 type = 'toggle',
-                default = false,
+                default = 'Off',
                 custom = {
                     states = {
-                        {text = "<LOC _No>No", key = false },
-                        {text = "<LOC _Yes>Yes", key = true },
+                        {text = "<LOC _Off>Off", key = 'Off' },
+                        {text = "<LOC _On>On", key = 'On' },
                     },
                 },
             },
@@ -421,11 +421,11 @@ options = {
                 title = "<LOC selectionsets0004>Add to factory control group",
                 key = 'add_to_factory_control_group',
                 type = 'toggle',
-                default = false,
+                default = 'Off',
                 custom = {
                     states = {
-                        {text = "<LOC _No>No", key = false },
-                        {text = "<LOC _Yes>Yes", key = true },
+                        {text = "<LOC _Off>Off", key = 'Off' },
+                        {text = "<LOC _On>On", key = 'On' },
                     },
                 },
             },
@@ -510,11 +510,11 @@ options = {
                 title = "<LOC OPTIONS_0287>Factories Default to Repeat Build",
                 key = 'repeatbuild',
                 type = 'toggle',
-                default = false,
+                default = 'Off',
                 custom = {
                     states = {
-                        {text = "<LOC _On>", key = true},
-                        {text = "<LOC _Off>", key = false},
+                        {text = "<LOC _Off>", key = 'Off'},
+                        {text = "<LOC _On>", key = 'On'},
                     },
                 },
             },

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -340,7 +340,7 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
             order = self.CursorOverride
 
         -- special override
-        elseif holdAltToAttackMove and IsKeyDown(KeyCodeAlt) and selection then
+        elseif holdAltToAttackMove == 'On' and IsKeyDown(KeyCodeAlt) and selection then
             order = 'RULEUCC_AttackAlt'
 
         -- usual order structure

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -657,7 +657,7 @@ function OnSelectionChanged(oldSelection, newSelection, added, removed)
     if not isOldSelection then
         import("/lua/ui/game/selection.lua").PlaySelectionSound(added)
         import("/lua/ui/game/rallypoint.lua").OnSelectionChanged(newSelection)
-        if Prefs.GetFromCurrentProfile('options.repeatbuild') then
+        if Prefs.GetFromCurrentProfile('options.repeatbuild') == 'On' then
             local factories = EntityCategoryFilterDown(categories.STRUCTURE * categories.FACTORY, added) -- find all newly selected factories
             for _, factory in factories do
                 if not factory.HasBeenSelected then

--- a/lua/ui/game/selection.lua
+++ b/lua/ui/game/selection.lua
@@ -212,10 +212,10 @@ function AddUnitToSelectionSet(name, unit)
     -- bug where name is an index, not a key
     name = tostring(name)
 
-    if Prefs.GetFromCurrentProfile('options.add_to_factory_control_group') then
+    if Prefs.GetFromCurrentProfile('options.add_to_factory_control_group') == 'On' then
 
         -- remove it from existing selection sets
-        if Prefs.GetFromCurrentProfile('options.steal_from_other_control_groups') then
+        if Prefs.GetFromCurrentProfile('options.steal_from_other_control_groups') == 'On' then
             local others = unit:GetSelectionSets()
             for k, other in others do
                 if selectionSets[other] then
@@ -256,7 +256,7 @@ function AddSelectionSet(name, unitArray)
         for _, unit in unitArray do
 
             -- remove it from existing selection sets
-            if Prefs.GetFromCurrentProfile('options.steal_from_other_control_groups') then
+            if Prefs.GetFromCurrentProfile('options.steal_from_other_control_groups') == 'On' then
                 local others = unit:GetSelectionSets()
                 for k, other in others do
                     unit:RemoveSelectionSet(other)

--- a/lua/ui/help/tooltips.lua
+++ b/lua/ui/help/tooltips.lua
@@ -635,6 +635,11 @@ Tooltips = {
         description = "<LOC ASSIST_TO_UPGRADE_DESCRIPTION>When enabled structures automatically queue and pause their upgrade when you issue an assist order",
     },
 
+    options_alt_to_force_attack_move = {
+        title = "<LOC ALT_TO_FORCE_ATTACK_MOVE_TITLE>Hold alt to force attack move",
+        description = "<LOC ALT_TO_FORCE_ATTACK_MOVE_TITLE>When enabled holding alt will always turn orders into an attack move order"
+    },
+
     options_assist_to_unpause = {
         title = "<LOC ASSIST_TO_UNPAUSE_TITLE>Assist to Unpause",
         description = "<LOC ASSIST_TO_UNPAUSE_DESCRIPTION>When enabled structures automatically unpause as engineers start assisting it.",


### PR DESCRIPTION
I personally preferred alt move to always turn into an attack move order, but I was unaware of side effects that players reported, like when they used alt in combination of a hotkey. Therefore it is now optional

Fixes a bug where the splash damage decals could linger on the map

Fixes a bug with various settings that did not toggle properly