### PR TITLE
Add guards for recall

### DIFF
--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -938,23 +938,32 @@ end
 function FakeTeleportUnits(units, killUnits)
     IssueStop(units)
     IssueClearCommands(units)
+
     for _, unit in units do
-        unit.CanBeKilled = false
-        unit:PlayTeleportChargeEffects(unit:GetPosition(), unit:GetOrientation())
-        unit:PlayUnitSound('GateCharge')
+        if not IsDestroyed(unit) then
+            unit.CanBeKilled = false
+            unit:PlayTeleportChargeEffects(unit:GetPosition(), unit:GetOrientation())
+            unit:PlayUnitSound('GateCharge')
+        end
     end
+
     WaitSeconds(2)
 
     for _, unit in units do
-        unit:CleanupTeleportChargeEffects()
-        unit:PlayTeleportOutEffects()
-        unit:PlayUnitSound('GateOut')
+        if not IsDestroyed(unit) then
+            unit:CleanupTeleportChargeEffects()
+            unit:PlayTeleportOutEffects()
+            unit:PlayUnitSound('GateOut')
+        end
     end
+
     WaitSeconds(1)
 
     if killUnits then
         for _, unit in units do
-            unit:Destroy()
+            if not IsDestroyed(unit) then
+                unit:Destroy()
+            end
         end
     end
 end

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1335,6 +1335,12 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     ---@param type string
     ---@param overkillRatio number
     OnKilled = function(self, instigator, type, overkillRatio)
+
+        -- invulnerable little fella
+        if not (self.CanBeKilled) then
+            return
+        end
+
         VeterancyComponent.VeterancyDispersal(self)
         local layer = self.Layer
         self.Dead = true


### PR DESCRIPTION
I suspect this is what could block recall from finishing up, causing the 'look ma, I'm invulnerable' bug when recalling. One should always check if the units still exist after waiting 😄 

Also adds a fix for units being flagged as indestructible to still... being able to get destroyed.

```
WARNING: Error running lua script: ...gramdata\faforever\gamedata\lua.nx2\lua\sim\unit.lua(4297): Game object has been destroyed
         stack traceback:
         	[C]: in function `SetAmbientSound'
         	...gramdata\faforever\gamedata\lua.nx2\lua\sim\unit.lua(4297): in function `StopUnitAmbientSound'
         	...a\faforever\gamedata\lua.nx2\lua\effectutilities.lua(1459): in function `DestroyTeleportChargingEffects'
         	...gramdata\faforever\gamedata\lua.nx2\lua\sim\unit.lua(4864): in function `CleanupTeleportChargeEffects'
         	...faforever\gamedata\lua.nx2\lua\scenarioframework.lua(950): in function `FakeTeleportUnits'
         	...ogramdata\faforever\gamedata\lua.nx2\lua\aibrain.lua(1293): in function <...ogramdata\faforever\gamedata\lua.nx2\lua\aibrain.lua:1291>
```

