### PR TITLE
Give the Aloha missile its vulnerability back

### DIFF
--- a/projectiles/TIFMissileCruise01/TIFMissileCruise01_Script.lua
+++ b/projectiles/TIFMissileCruise01/TIFMissileCruise01_Script.lua
@@ -22,6 +22,7 @@ TIFMissileCruise01 = ClassProjectile(TMissileCruiseProjectile) {
 
     OnCreate = function(self)
         TMissileCruiseProjectile.OnCreate(self)
+        self:SetCollisionShape('Sphere', 0, 0, 0, 2.0)
         self.Trash:Add(ForkThread( self.MovementThread,self ))
     end,
     


### PR DESCRIPTION
An interesting find: if something has no collision box then it appears to be skipped when a weapon scans for targets.