### PR TITLE
Adjust network parameters in an attempt to reduce lag

### DIFF
--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -183,14 +183,14 @@ function CreateUI(isReplay)
     ConExecute('d3d_WindowsCursor on')
 
     -- tweak networking parameters
-    ConExecute('net_MinResendDelay 100')
-    ConExecute('net_MaxResendDelay 1000')
+    ConExecute('net_MinResendDelay 10')
+    ConExecute('net_MaxResendDelay 100')
 
-    ConExecute('net_MaxSendRate 8192')
-    ConExecute('net_MaxBacklog 8192')
+    ConExecute('net_MaxSendRate 32768')
+    ConExecute('net_MaxBacklog 32768')
 
-    ConExecute('net_SendDelay 5')
-    ConExecute('net_AckDelay 5')
+    ConExecute('net_SendDelay 1')
+    ConExecute('net_AckDelay 1')
 
     -- enable experimental graphics
     if  Prefs.GetFromCurrentProfile('options.fidelity') >= 2 and

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -191,6 +191,7 @@ function CreateUI(isReplay)
 
     ConExecute('net_SendDelay 1')
     ConExecute('net_AckDelay 1')
+    ConExecute('net_ResendDelayBias 1')
 
     -- enable experimental graphics
     if  Prefs.GetFromCurrentProfile('options.fidelity') >= 2 and


### PR DESCRIPTION
With thanks to Wotan (on Discord) we continue experimenting with the network parameters. In todays episode we force the game to resend packages more often, which should reduce the time it takes for the game to notice a package is lost