### PR TITLE
Update buildmodedata.lua

### DIFF
--- a/lua/ui/game/buildmodedata.lua
+++ b/lua/ui/game/buildmodedata.lua
@@ -16,6 +16,7 @@ local AeonT1Eng = {
     ['T'] = 'uab2109',
     ['I'] = 'uab3101',
     ['O'] = 'uab3102',
+    ['G'] = 'uab5202',
 }
 
 local AeonT2Eng = {
@@ -32,7 +33,6 @@ local AeonT2Eng = {
     ['C'] = 'uab4203',
     ['I'] = 'uab3201',
     ['O'] = 'uab3202',
-    ['G'] = 'uab5202',
 }
 
 local AeonT3Eng = {
@@ -148,6 +148,7 @@ local UEFT1Eng = {
     ['T'] = 'ueb2109',
     ['I'] = 'ueb3101',
     ['O'] = 'ueb3102',
+    ['G'] = 'ueb5202',
 }
 
 local UEFT2Eng = {
@@ -165,7 +166,6 @@ local UEFT2Eng = {
     ['C'] = 'ueb4203',
     ['I'] = 'ueb3201',
     ['O'] = 'ueb3202',
-    ['G'] = 'ueb5202',
 }
 
 local UEFT3Eng = {
@@ -283,6 +283,7 @@ local CybranT1Eng = {
     ['T'] = 'urb2109',
     ['I'] = 'urb3101',
     ['O'] = 'urb3102',
+    ['G'] = 'urb5202',
 }
 
 local CybranT2Eng = {
@@ -300,11 +301,10 @@ local CybranT2Eng = {
     ['C'] = 'urb4203',
     ['I'] = 'urb3201',
     ['O'] = 'urb3202',
-    ['G'] = 'urb5202',
 }
 
 local CybranT3Eng = {
-    ['V'] = 'xrb3301',
+    ['C'] = 'xrb3301',
     ['T'] = 'xrb2308',
     ['E'] = 'urb1302',
     ['F'] = 'urb1303',
@@ -313,6 +313,7 @@ local CybranT3Eng = {
     ['R'] = 'urb2302',
     ['M'] = 'urb2305',
     ['K'] = 'urb4302',
+    ['V'] = 'urb4206',
     ['O'] = 'urs0305',
     ['I'] = 'urb3104',
     ['Q'] = 'urb0304',
@@ -422,6 +423,7 @@ local SeraphimT1Eng = {
     ['T'] = 'xsb2109',
     ['I'] = 'xsb3101',
     ['O'] = 'xsb3102',
+    ['G'] = 'xsb5202',
 }
 
 local SeraphimT2Eng = {
@@ -438,7 +440,6 @@ local SeraphimT2Eng = {
     ['C'] = 'xsb4203',
     ['I'] = 'xsb3201',
     ['O'] = 'xsb3202',
-    ['G'] = 'xsb5202',
 }
 
 local SeraphimT3Eng = {
@@ -539,43 +540,50 @@ buildModeKeys = {
         [3] = AeonT3Eng,
         [4] = AeonT4Eng,
     },
+    -- subcommander
+    ['ual0301'] = {
+        [1] = AeonT1Eng,
+        [2] = AeonT2Eng,
+        [3] = AeonT3Eng,
+        [4] = AeonT4Eng,
+    },    
     -- subcommander - ras preset
-    ['ual0301_RAS'] = {
+    ['ual0301_ras'] = {
         [1] = AeonT1Eng,
         [2] = AeonT2Eng,
         [3] = AeonT3Eng,
         [4] = AeonT4Eng,
     },
     -- subcommander - combatant preset
-    ['ual0301_SimpleCombat'] = {
+    ['ual0301_simplecombat'] = {
         [1] = AeonT1Eng,
         [2] = AeonT2Eng,
         [3] = AeonT3Eng,
         [4] = AeonT4Eng,
     },
     -- subcommander - engineer preset
-    ['ual0301_Engineer'] = {
+    ['ual0301_engineer'] = {
         [1] = AeonT1Eng,
         [2] = AeonT2Eng,
         [3] = AeonT3Eng,
         [4] = AeonT4Eng,
     },
     -- subcommander - nano combatant preset
-    ['ual0301_NanoCombat'] = {
+    ['ual0301_nanocombat'] = {
         [1] = AeonT1Eng,
         [2] = AeonT2Eng,
         [3] = AeonT3Eng,
         [4] = AeonT4Eng,
     },
     -- subcommander - shield combatant preset
-    ['ual0301_ShieldCombat'] = {
+    ['ual0301_shieldcombat'] = {
         [1] = AeonT1Eng,
         [2] = AeonT2Eng,
         [3] = AeonT3Eng,
         [4] = AeonT4Eng,
     },
     -- subcommander - rambo preset
-    ['ual0301_Rambo'] = {
+    ['ual0301_rambo'] = {
         [1] = AeonT1Eng,
         [2] = AeonT2Eng,
         [3] = AeonT3Eng,
@@ -751,42 +759,42 @@ buildModeKeys = {
         [4] = UEFT4Eng,
     },
     -- subcommander - resource allocation preset
-    ['uel0301_RAS'] = {
+    ['uel0301_ras'] = {
         [1] = UEFT1Eng,
         [2] = UEFT2Eng,
         [3] = UEFT3Eng,
         [4] = UEFT4Eng,
     },
     -- subcommander - combatant preset
-    ['uel0301_Combat'] = {
+    ['uel0301_combat'] = {
         [1] = UEFT1Eng,
         [2] = UEFT2Eng,
         [3] = UEFT3Eng,
         [4] = UEFT4Eng,
     },
     -- subcommander - engineer preset
-    ['uel0301_Engineer'] = {
+    ['uel0301_engineer'] = {
         [1] = UEFT1Eng,
         [2] = UEFT2Eng,
         [3] = UEFT3Eng,
         [4] = UEFT4Eng,
     },
     -- subcommander - rambo preset
-    ['uel0301_Rambo'] = {
+    ['uel0301_rambo'] = {
         [1] = UEFT1Eng,
         [2] = UEFT2Eng,
         [3] = UEFT3Eng,
         [4] = UEFT4Eng,
     },
     -- subcommander - shield preset
-    ['uel0301_BubbleShield'] = {
+    ['uel0301_bubbleshield'] = {
         [1] = UEFT1Eng,
         [2] = UEFT2Eng,
         [3] = UEFT3Eng,
         [4] = UEFT4Eng,
     },
     -- subcommander - intel jammer preset
-    ['uel0301_IntelJammer'] = {
+    ['uel0301_intelkammer'] = {
         [1] = UEFT1Eng,
         [2] = UEFT2Eng,
         [3] = UEFT3Eng,
@@ -963,49 +971,49 @@ buildModeKeys = {
         [4] = CybranT4Eng,
     },
     -- subcommander - ras preset
-    ['url0301_RAS'] = {
+    ['url0301_ras'] = {
         [1] = CybranT1Eng,
         [2] = CybranT2Eng,
         [3] = CybranT3Eng,
         [4] = CybranT4Eng,
     },
     -- subcommander - combatant preset
-    ['url0301_Combat'] = {
+    ['url0301_combat'] = {
         [1] = CybranT1Eng,
         [2] = CybranT2Eng,
         [3] = CybranT3Eng,
         [4] = CybranT4Eng,
     },
     -- subcommander - engineer preset
-    ['url0301_Engineer'] = {
+    ['url0301_engineer'] = {
         [1] = CybranT1Eng,
         [2] = CybranT2Eng,
         [3] = CybranT3Eng,
         [4] = CybranT4Eng,
     },
     -- subcommander - rambo preset
-    ['url0301_Rambo'] = {
+    ['url0301_rambo'] = {
         [1] = CybranT1Eng,
         [2] = CybranT2Eng,
         [3] = CybranT3Eng,
         [4] = CybranT4Eng,
     },
     -- subcommander - stealth preset
-    ['url0301_Stealth'] = {
+    ['url0301_stealth'] = {
         [1] = CybranT1Eng,
         [2] = CybranT2Eng,
         [3] = CybranT3Eng,
         [4] = CybranT4Eng,
     },
     -- subcommander - cloak preset
-    ['url0301_Cloak'] = {
+    ['url0301_cloak'] = {
         [1] = CybranT1Eng,
         [2] = CybranT2Eng,
         [3] = CybranT3Eng,
         [4] = CybranT4Eng,
     },
     -- subcommander - anti-air preset
-    ['url0301_AntiAir'] = {
+    ['url0301_antiair'] = {
         [1] = CybranT1Eng,
         [2] = CybranT2Eng,
         [3] = CybranT3Eng,
@@ -1186,42 +1194,42 @@ buildModeKeys = {
         [4] = SeraphimT4Eng,
     },
     -- subcommander - combatant preset
-    ['xsl0301_Combat'] = {
+    ['xsl0301_combat'] = {
         [1] = SeraphimT1Eng,
         [2] = SeraphimT2Eng,
         [3] = SeraphimT3Eng,
         [4] = SeraphimT4Eng,
     },
     -- subcommander - engineer preset
-    ['xsl0301_Engineer'] = {
+    ['xsl0301_engineer'] = {
         [1] = SeraphimT1Eng,
         [2] = SeraphimT2Eng,
         [3] = SeraphimT3Eng,
         [4] = SeraphimT4Eng,
     },
     -- subcommander - nano combatant preset
-    ['xsl0301_NanoCombat'] = {
+    ['xsl0301_nanocombat'] = {
         [1] = SeraphimT1Eng,
         [2] = SeraphimT2Eng,
         [3] = SeraphimT3Eng,
         [4] = SeraphimT4Eng,
     },
     -- subcommander - advanced combatant preset
-    ['xsl0301_AdvancedCombat'] = {
+    ['xsl0301_advancedcombat'] = {
         [1] = SeraphimT1Eng,
         [2] = SeraphimT2Eng,
         [3] = SeraphimT3Eng,
         [4] = SeraphimT4Eng,
     },
     -- subcommander - rambo preset
-    ['xsl0301_Rambo'] = {
+    ['xsl0301_rambo'] = {
         [1] = SeraphimT1Eng,
         [2] = SeraphimT2Eng,
         [3] = SeraphimT3Eng,
         [4] = SeraphimT4Eng,
     },
     -- subcommander - missile preset
-    ['xsl0301_Missile'] = {
+    ['xsl0301_missile'] = {
         [1] = SeraphimT1Eng,
         [2] = SeraphimT2Eng,
         [3] = SeraphimT3Eng,


### PR DESCRIPTION
Fixes some issues with buildmode:
- Added Aeon SACU, it was missing completely
- Updated SACU Preset names to be all lower case
- Updated T1 Engineers of all factions to be able to build Air Stagings using Build-Mode
- Removed Air Stagings for T2 Engineers, as they can now build it because of inheritance
- Changed Cybran Soothsayer key from 'V' to 'C', similar as the Aeon Eye
- Added Cybran T3 shield with the now free 'C'