### PR TITLE
Introduce an upper limit in distance when searching for neighbors

### DIFF
--- a/lua/sim/NavUtils.lua
+++ b/lua/sim/NavUtils.lua
@@ -83,10 +83,13 @@ local function FindLeaf(grid, position)
             ---@type CompressedLabelTreeLeaf
             local neighbor = leaf[k]
             if neighbor.Label > 0 then
+                local size = 2 * neighbor.Size
+                size = size * size
+
                 local dx = px - neighbor.px
                 local dz = pz - neighbor.pz
                 local d = dx * dx + dz * dz
-                if d < distance then
+                if d < distance and d < size then
                     distance = d
                     nearest = neighbor
                 end

--- a/lua/ui/game/NavGenerator.lua
+++ b/lua/ui/game/NavGenerator.lua
@@ -81,7 +81,7 @@ NavUIGetLabel = ClassUI(Group) {
                 "build",
                 {
                     -- default information required
-                    name = 'ual0105',
+                    name = 'uaa0101',
 
                     --- 
                     ---@param mode CommandModeDataBuild
@@ -282,7 +282,7 @@ NavUIPathTo = ClassUI(Group) {
                 "build",
                 {
                     -- default information required
-                    name = 'ual0105',
+                    name = 'uaa0101',
 
                     --- 
                     ---@param mode CommandModeDataBuild
@@ -311,7 +311,7 @@ NavUIPathTo = ClassUI(Group) {
                 "build",
                 {
                     -- default information required
-                    name = 'ual0105',
+                    name = 'uaa0101',
 
                     --- 
                     ---@param mode CommandModeDataBuild
@@ -406,7 +406,7 @@ NavUICanPathTo = ClassUI(Group) {
                 "build",
                 {
                     -- default information required
-                    name = 'ual0105',
+                    name = 'uaa0101',
 
                     --- 
                     ---@param mode CommandModeDataBuild
@@ -435,7 +435,7 @@ NavUICanPathTo = ClassUI(Group) {
                 "build",
                 {
                     -- default information required
-                    name = 'ual0105',
+                    name = 'uaa0101',
 
                     --- 
                     ---@param mode CommandModeDataBuild


### PR DESCRIPTION
Closes #4687

It is not a perfect fix, but there are no perfect solutions when you make an approximation that can be as coarse as the navigational mesh at times.

When we try to find the leaf we're on we'll take into account a distance such that we do not end up finding a valid leaf while we're on the other side of a gigantic invalid leaf. See also the issue

![image](https://user-images.githubusercontent.com/15778155/222365730-8e9a9f6d-a11f-4a60-a3b1-11c271a353c4.png)

Where white means that no label is found