### PR TITLE
Change global vars to local where appropriate 

### DIFF
--- a/lua/AI/AIBehaviors.lua
+++ b/lua/AI/AIBehaviors.lua
@@ -53,7 +53,7 @@ function CDRRunAway(aiBrain, cdr)
                         if canTeleport then
                             IssueTeleport({cdr}, runSpot)
                         else
-                            cmd = plat:MoveToLocation(runSpot, false)
+                            plat:MoveToLocation(runSpot, false)
                         end
                     end
                 end
@@ -149,11 +149,13 @@ function CDROverCharge(aiBrain, cdr)
         local counter = 0
         local cdrThreat = cdr:GetBlueprint().Defense.SurfaceThreatLevel or 60
         local enemyThreat
+        local enemyCdrThreat 
+        local friendlyThreat
         repeat
             overCharging = false
             if counter >= 5 or not target or target.Dead or Utilities.XZDistanceTwoVectors(cdrPos, target:GetPosition()) > maxRadius then
                 counter = 0
-                searchRadius = 30
+                local searchRadius = 30
                 repeat
                     searchRadius = searchRadius + 30
                     for k, v in priList do
@@ -1086,7 +1088,7 @@ TempestBehavior = function(self)
         if aiBrain:PlatoonExists(self) and not self.Patrolling then
             self:Stop()
             self.Patrolling = true
-            scoutPath = AIUtils.AIGetSortedNavalLocations(self:GetBrain())
+            local scoutPath = AIUtils.AIGetSortedNavalLocations(self:GetBrain())
             for k, v in scoutPath do
                 self:Patrol(v)
             end
@@ -1654,6 +1656,7 @@ function CDROverChargeSorian(aiBrain, cdr)
     local distressRange = 100
     local maxRadius = weapon.MaxRadius * 4.55
     local weapRange = weapon.MaxRadius
+    local shieldPercent
     cdr.UnitBeingBuiltBehavior = false
 
     local cdrPos = cdr.CDRHome
@@ -1728,6 +1731,8 @@ function CDROverChargeSorian(aiBrain, cdr)
         local counter = 0
         local cdrThreat = cdr:GetBlueprint().Defense.SurfaceThreatLevel or 60
         local enemyThreat
+        local enemyCdrThreat
+        local friendlyThreat
         repeat
             overCharging = false
             local cdrCurrentPos = cdr:GetPosition()
@@ -1943,8 +1948,8 @@ function CommanderThreadSorian(cdr, platoon)
         SUtils.AISendChat('all', ArmyBrains[aiBrain:GetArmyIndex()].Nickname, 'badmap')
     end
 
-    moveOnNext = false
-    moveWait = 0
+    local moveOnNext = false
+    local moveWait = 0
     local Mult = cdr.Mult or 1
     local Delay = platoon.PlatoonData.Delay or 165
     local WaitTaunt = 600 + Random(1, 600)
@@ -2487,7 +2492,7 @@ AhwassaBehaviorSorian = function(self)
         self:MergeWithNearbyPlatoonsSorian('ExperimentalAIHubSorian', 50, true)
         if targetLocation and targetLocation ~= oldTargetLocation then
             IssueClearCommands(platoonUnits)
-            cmd = ExpPathToLocation(aiBrain, self, 'Air', targetLocation, 'AttackDest', 62500)
+            ExpPathToLocation(aiBrain, self, 'Air', targetLocation, 'AttackDest', 62500)
             IssueAttack(platoonUnits, targetLocation)
             WaitSeconds(25)
         end

--- a/lua/AI/aiattackutilities.lua
+++ b/lua/AI/aiattackutilities.lua
@@ -465,6 +465,8 @@ end
 function GetNavalPlatoonMaxRange(aiBrain, platoon)
     local maxRange = 0
     local platoonUnits = platoon:GetPlatoonUnits()
+    local isTech1 = false
+    
     for _,unit in platoonUnits do
         if unit.Dead then
             continue

--- a/lua/AI/aibuildstructures.lua
+++ b/lua/AI/aibuildstructures.lua
@@ -314,7 +314,7 @@ function DoHackyLogic(buildingType, builder)
                 if not unitInstance then
                     unitInstance = builder.UnitBeingBuilt
                 end
-                aiBrain = builder:GetAIBrain()
+                local aiBrain = builder:GetAIBrain()
                 if unitInstance then
                     TriggerFile.CreateUnitStopBeingBuiltTrigger(function(unitBeingBuilt)
                         local newPlatoon = aiBrain:MakePlatoon('', '')

--- a/lua/AI/aiutilities.lua
+++ b/lua/AI/aiutilities.lua
@@ -121,9 +121,9 @@ function AIGetSortedScoutingLocations(aiBrain, maxNum)
     local markers = AISortMarkersFromStartPos(aiBrain, markerList, maxNum or 1000)
     local retMarkers = {}
     local numMarkers = table.getn(markers)
-    local rand
+
     for i = 1, numMarkers do
-        rand = Random(1, numMarkers + 1 - i)
+        local rand = Random(1, numMarkers + 1 - i)
         table.insert(retMarkers, markers[rand])
         table.remove(markers, rand)
     end

--- a/lua/AI/aiutilities.lua
+++ b/lua/AI/aiutilities.lua
@@ -121,6 +121,7 @@ function AIGetSortedScoutingLocations(aiBrain, maxNum)
     local markers = AISortMarkersFromStartPos(aiBrain, markerList, maxNum or 1000)
     local retMarkers = {}
     local numMarkers = table.getn(markers)
+    local rand
     for i = 1, numMarkers do
         rand = Random(1, numMarkers + 1 - i)
         table.insert(retMarkers, markers[rand])
@@ -1358,7 +1359,7 @@ function GetNearestPathingPoint(position)
     end
     local x = math.floor(position[1] / 8)
     local z = math.floor(position[3] / 8)
-    retPos = {(x * 8) , 0,  (z * 8)}
+    local retPos = {(x * 8) , 0,  (z * 8)}
     if retPos[1] == 0 then
         retPos[1] = 1
     elseif retPos[1] == ScenarioInfo.size[1] then
@@ -2580,6 +2581,7 @@ function AIFindPingTargetInRangeSorian(aiBrain, platoon, squad, maxRange, atkPri
             end
             if retUnit and targetShields > 0 then
                 local platoonUnits = platoon:GetPlatoonUnits()
+                local unit
                 for _, w in platoonUnits do
                     if not w.Dead then
                         unit = w
@@ -2629,6 +2631,7 @@ function AIFindAirAttackTargetInRangeSorian(aiBrain, platoon, squad, atkPri, pos
             end
         end
         if retUnit and targetShields > 0 then
+            local unit
             local platoonUnits = platoon:GetPlatoonUnits()
             for _, v in platoonUnits do
                 if not v.Dead then
@@ -2757,6 +2760,7 @@ function AIFindBrainTargetInRangeSorian(aiBrain, platoon, squad, maxRange, atkPr
             end
         end
         if retUnit and targetShields > 0 then
+            local unit
             local platoonUnits = platoon:GetPlatoonUnits()
             for _, w in platoonUnits do
                 if not w.Dead then
@@ -2809,6 +2813,7 @@ function AIFindUndefendedBrainTargetInRangeSorian(aiBrain, platoon, squad, maxRa
             end
         end
         if retUnit and targetShields > 0 then
+            local unit
             local platoonUnits = platoon:GetPlatoonUnits()
             for _, w in platoonUnits do
                 if not w.Dead then

--- a/lua/AI/sorianutilities.lua
+++ b/lua/AI/sorianutilities.lua
@@ -248,7 +248,7 @@ function AIHandleLandIntel(aiBrain, intel)
         end
     end
     -- Mark location for a defensive point
-    nextBase = (table.getn(aiBrain.TacticalBases) + 1)
+    local nextBase = (table.getn(aiBrain.TacticalBases) + 1)
     table.insert(aiBrain.TacticalBases,
         {
         Position = intel.Position,
@@ -563,7 +563,7 @@ end
 ---@param aiBrain AIBrain
 function AIRandomizeTaunt(aiBrain)
     local factionIndex = aiBrain:GetFactionIndex()
-    tauntid = Random(1,table.getn(AITaunts[factionIndex]))
+    local tauntid = Random(1,table.getn(AITaunts[factionIndex]))
     aiBrain.LastVocTaunt = GetGameTimeSeconds()
     AISendChat('all', aiBrain.Nickname, '/'..AITaunts[factionIndex][tauntid])
 end
@@ -642,7 +642,7 @@ end
 ---@param pingData table
 function AIHandlePing(aiBrain, pingData)
     if pingData.Type == 'move' then
-        nextping = (table.getn(aiBrain.TacticalBases) + 1)
+        local nextping = (table.getn(aiBrain.TacticalBases) + 1)
         table.insert(aiBrain.TacticalBases,
             {
             Position = pingData.Location,
@@ -1073,7 +1073,7 @@ function FindUnfinishedUnits(aiBrain, locationType, buildCat)
     local unfinished = aiBrain:GetUnitsAroundPoint(buildCat, engineerManager:GetLocationCoords(), engineerManager.Radius, 'Ally')
     local retUnfinished = false
     for num, unit in unfinished do
-        donePercent = unit:GetFractionComplete()
+        local donePercent = unit:GetFractionComplete()
         if donePercent < 1 and GetGuards(aiBrain, unit) < 1 and not unit:IsUnitState('Upgrading') then
             retUnfinished = unit
             break
@@ -1093,7 +1093,7 @@ function FindDamagedShield(aiBrain, locationType, buildCat)
     local retShield = false
     for num, unit in shields do
         if not unit.Dead and unit:ShieldIsOn() then
-            shieldPercent = (unit.MyShield:GetHealth() / unit.MyShield:GetMaxHealth())
+            local shieldPercent = (unit.MyShield:GetHealth() / unit.MyShield:GetMaxHealth())
             if shieldPercent < 1 and GetGuards(aiBrain, unit) < 3 then
                 retShield = unit
                 break
@@ -1177,6 +1177,8 @@ end
 ---@param places number Number of places to round to
 ---@return number
 function Round(x, places)
+    local result
+    local shift
     if places then
         shift = 10 ^ places
         result = math.floor(x * shift + 0.5) / shift

--- a/lua/AI/sorianutilities.lua
+++ b/lua/AI/sorianutilities.lua
@@ -1180,7 +1180,7 @@ function Round(x, places)
     local result
     local shift
     if places then
-        shift = 10 ^ places
+        shift = math.pow(10, places)
         result = math.floor(x * shift + 0.5) / shift
         return result
     else

--- a/lua/defaultexplosions.lua
+++ b/lua/defaultexplosions.lua
@@ -879,7 +879,7 @@ end
 ---@return Projectile
 function CreateExplosionMesh(object, projBP, posX, posY, posZ, scale, scaleVelocity, Lifetime, velX, velY, VelZ, orientRot, orientX, orientY, orientZ)
 
-    proj = object:CreateProjectile(projBP, posX, posY, posZ, nil, nil, nil)
+    local proj = object:CreateProjectile(projBP, posX, posY, posZ, nil, nil, nil)
     proj:SetScale(scale,scale,scale):SetScaleVelocity(scaleVelocity):SetLifetime(Lifetime):SetVelocity(velX, velY, VelZ)
 
     local orient = {0, 0, 0, 0}

--- a/lua/editor/UnitCountBuildConditions.lua
+++ b/lua/editor/UnitCountBuildConditions.lua
@@ -1389,7 +1389,7 @@ function UnfinishedUnits(aiBrain, locationType, category)
     end
     local unfinished = aiBrain:GetUnitsAroundPoint(category, engineerManager:GetLocationCoords(), engineerManager.Radius, 'Ally')
     for num, unit in unfinished do
-        donePercent = unit:GetFractionComplete()
+        local donePercent = unit:GetFractionComplete()
         if donePercent < 1 and GetGuards(aiBrain, unit) < 1 then
             return true
         end

--- a/lua/ui/maputil.lua
+++ b/lua/ui/maputil.lua
@@ -211,7 +211,7 @@ function GetStartPositions(scenario)
     if not table.empty(armyPositions) then
         for army, position in armyPositions do
             if saveData.Scenario.MasterChain['_MASTERCHAIN_'].Markers[army] then
-                pos = saveData.Scenario.MasterChain['_MASTERCHAIN_'].Markers[army].position
+                local pos = saveData.Scenario.MasterChain['_MASTERCHAIN_'].Markers[army].position
                 -- x and z value are of interest so ignore y (index 2)
                 position[1] = pos[1]
                 position[2] = pos[3]


### PR DESCRIPTION
closes #4717 
Description of changes
This PR changes some of the vars that were accidentally set as global to locals. The main reason is to avoid concurrent AI from getting incorrect values for various vars when they are running functions.



Test setup for the changes
Confirm that all vars that have been changed to local are valid.
Observe AI games, Sorian is the most impacted AI from the changes. But it impacts the normal AI as well. There are some edge cases where two AI would call functions and have the local vars overwritten by a global in the same file.