### PR TITLE
Fix various issues with the navigational mesh

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -793,6 +793,7 @@ end
 
 Callbacks.NavToggleScanLayer = import("/lua/sim/navdebug.lua").ToggleScanLayer
 Callbacks.NavToggleScanLabels = import("/lua/sim/navdebug.lua").ToggleScanLabels
+Callbacks.NavDebugStatisticsToUI = import("/lua/sim/navdebug.lua").StatisticsToUI
 Callbacks.NavDebugCanPathTo = import("/lua/sim/navdebug.lua").CanPathTo
 Callbacks.NavDebugPathTo = import("/lua/sim/navdebug.lua").PathTo
 Callbacks.NavDebugGetLabel = import("/lua/sim/navdebug.lua").GetLabel

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -97,7 +97,7 @@ StructureUnit = ClassUnit(Unit) {
             if a1 != 0 or a2 != 0 then
                 -- quaternion magic incoming, be prepared! Note that the yaw axis is inverted, but then
                 -- re-inverted again by multiplying it with the original orientation
-                local quatSlope = Quaternion.fromAngle({ p = 0, y = 0 - a2, r = -1 * a1})
+                local quatSlope = Quaternion.fromAngle(0, 0 - a2,-1 * a1)
                 local quatOrient = setmetatable(self:GetOrientation(), Quaternion)
                 local quat = quatOrient * quatSlope
                 self:SetOrientation(quat, true)

--- a/lua/sim/NavDebug.lua
+++ b/lua/sim/NavDebug.lua
@@ -53,6 +53,10 @@ function ToggleScanLabels(data)
     ScanState[keyLayer] = false
 end
 
+function StatisticsToUI()
+    Sync.NavLayerData = NavGenerator.NavLayerData
+end
+
 ---@type NavDebugCanPathToState
 local CanPathToState = { }
 

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -90,7 +90,7 @@ end
 -- Shared data with UI
 
 ---@type NavLayerData
-local NavLayerData = Shared.CreateEmptyNavLayerData()
+NavLayerData = Shared.CreateEmptyNavLayerData()
 
 local tl = { 0, 0, 0 }
 local tr = { 0, 0, 0 }
@@ -1182,6 +1182,11 @@ function Generate()
     then
         SPEW("Hover grid equals land grid - ditching hover grid")
         NavGrids['Hover'] = NavGrids['Land']
+        NavLayerData['Hover'].Labels = 0
+        NavLayerData['Hover'].Neighbors = 0
+        NavLayerData['Hover'].PathableLeafs = 0
+        NavLayerData['Hover'].Subdivisions = 0
+        NavLayerData['Hover'].UnpathableLeafs = 0
     end
 
     if  NavLayerData['Land'].Labels == NavLayerData['Amphibious'].Labels and
@@ -1192,6 +1197,11 @@ function Generate()
     then
         SPEW("Amphibious grid equals land grid - ditching amphibious grid")
         NavGrids['Amphibious'] = NavGrids['Land']
+        NavLayerData['Amphibious'].Labels = 0
+        NavLayerData['Amphibious'].Neighbors = 0
+        NavLayerData['Amphibious'].PathableLeafs = 0
+        NavLayerData['Amphibious'].Subdivisions = 0
+        NavLayerData['Amphibious'].UnpathableLeafs = 0
     end
 
     SPEW(string.format("Generated navigational mesh in %f seconds", GetSystemTimeSecondsOnlyForProfileUse() - start))

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -262,7 +262,6 @@ function BeginSession()
     import("/lua/sim/matchstate.lua").Setup()
     import("/lua/sim/markerutilities.lua").Setup()
 
-    BeginSessionGenerateNavMesh()
     BeginSessionAI()
     BeginSessionMapSetup()
     BeginSessionEffects()
@@ -272,6 +271,7 @@ function BeginSession()
     import("/lua/sim/scenarioutilities.lua").CreateResources()
 
     BeginSessionGenerateMarkers()
+    BeginSessionGenerateNavMesh()
 
     import("/lua/sim/score.lua").init()
     import("/lua/sim/recall.lua").init()

--- a/lua/ui/game/NavGenerator.lua
+++ b/lua/ui/game/NavGenerator.lua
@@ -576,8 +576,14 @@ NavUILayerStatistics = ClassUI(Group) {
         self.ToggleLabelGrid.OnClick = function()
             SimCallback({ Func = 'NavToggleScanLabels', Args = { Layer = layer }}, false)
         end
-    
 
+        -- tell sim to send the known stats
+        SimCallback({
+            Func = "NavDebugStatisticsToUI",
+            Args = { }
+        })
+
+        -- list to sim sending us stats
         AddOnSyncCallback(
             function(Sync)
                 if Sync.NavLayerData then


### PR DESCRIPTION
The nav window now requests the statistics of the current generated navigational mesh. We also fix the order of execution so that the extractors are created _before_ we create the navigational mesh, that way we can take them into account properly 😄 !