### PR TITLE
Forward ACU kills to the user layer

### DIFF
--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -415,6 +415,11 @@ function OnSync()
         import("/lua/ui/dialogs/hotstats.lua").scoreData = Sync.ScoreAccum
     end
 
+    if Sync.AcuKill then
+        local victim, instigator = Sync.AcuKill.victim, Sync.AcuKill.instigator
+        import("/lua/ui/game/gameresult.lua").DoGameResultKills(victim, instigator)
+    end
+
     -- Game <-> server communications
 
     -- Adjusting the behavior of this part of the sync is strictly forbidden and is considered

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -415,9 +415,15 @@ function OnSync()
         import("/lua/ui/dialogs/hotstats.lua").scoreData = Sync.ScoreAccum
     end
 
-    if Sync.AcuKill then
-        local victim, instigator = Sync.AcuKill.victim, Sync.AcuKill.instigator
-        import("/lua/ui/game/gameresult.lua").DoGameResultKills(victim, instigator)
+    local events = Sync.Events
+    if events then
+        local acuDestroyed = events.ACUDestroyed
+        if acuDestroyed then
+            for k, event in acuDestroyed do
+                local victim, instigator = event.KilledArmy, event.InstigatorArmy
+                import("/lua/ui/game/gameresult.lua").DoGameResultKills(victim, instigator)
+            end
+        end
     end
 
     -- Game <-> server communications

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -414,18 +414,7 @@ function OnSync()
         LOG("Score data received!")
         import("/lua/ui/dialogs/hotstats.lua").scoreData = Sync.ScoreAccum
     end
-
-    local events = Sync.Events
-    if events then
-        local acuDestroyed = events.ACUDestroyed
-        if acuDestroyed then
-            for k, event in acuDestroyed do
-                local victim, instigator = event.KilledArmy, event.InstigatorArmy
-                import("/lua/ui/game/gameresult.lua").DoGameResultKills(victim, instigator)
-            end
-        end
-    end
-
+    
     -- Game <-> server communications
 
     -- Adjusting the behavior of this part of the sync is strictly forbidden and is considered

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2926,7 +2926,11 @@ ACUUnit = ClassUnit(CommandUnit) {
             if IsAlly(self.Army, instigator.Army) and not ((type == 'DeathExplosion' or type == 'Nuke' or type == 'Deathnuke') and not instigator.SelfDestructed) then
                 WARN('Teamkill detected')
                 Sync.Teamkill = {killTime = GetGameTimeSeconds(), instigator = instigator.Army, victim = self.Army}
+            else
+                -- Store who performed the Acu kill, so it can be handed down to the ui layer
+                Sync.AcuKill = {killTime = GetGameTimeSeconds(), instigator = instigator.Army, victim = self.Army}
             end
+
         end
         ArmyBrains[self.Army].CommanderKilledBy = (instigator or self).Army
     end,

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2926,10 +2926,21 @@ ACUUnit = ClassUnit(CommandUnit) {
             if IsAlly(self.Army, instigator.Army) and not ((type == 'DeathExplosion' or type == 'Nuke' or type == 'Deathnuke') and not instigator.SelfDestructed) then
                 WARN('Teamkill detected')
                 Sync.Teamkill = {killTime = GetGameTimeSeconds(), instigator = instigator.Army, victim = self.Army}
-            else
-                -- Store who performed the Acu kill, so it can be handed down to the ui layer
-                Sync.AcuKill = {killTime = GetGameTimeSeconds(), instigator = instigator.Army, victim = self.Army}
             end
+
+            -- prepare sync
+            local sync = Sync
+            local events = sync.Events or { }
+            sync.Events = events
+            local acuDestroyed = events.ACUDestroyed or { }
+            events.ACUDestroyed = acuDestroyed
+
+            -- sync the event
+            table.insert(acuDestroyed, {
+                Timestamp = GetGameTimeSeconds(),
+                InstigatorArmy = instigator.Army,
+                KilledArmy = self.Army
+            })
 
         end
         ArmyBrains[self.Army].CommanderKilledBy = (instigator or self).Army

--- a/lua/ui/game/gameresult.lua
+++ b/lua/ui/game/gameresult.lua
@@ -77,8 +77,8 @@ end
 
 function DoGameResultKills(victim, instigator)
     -- Uncommenting the lines below will show a kill notification without using mods
-    -- local tabs = import("/lua/ui/game/tabs.lua")
+    local tabs = import("/lua/ui/game/tabs.lua")
     
-    -- local armies = GetArmiesTable().armiesTable
-    -- tabs.TabAnnouncement('main', tostring(armies[victim].nickname) .. " has been defeated by" .. tostring(armies[instigator].nickname))
+    local armies = GetArmiesTable().armiesTable
+    tabs.TabAnnouncement('main', tostring(armies[victim].nickname) .. " has been defeated by" .. tostring(armies[instigator].nickname))
 end

--- a/lua/ui/game/gameresult.lua
+++ b/lua/ui/game/gameresult.lua
@@ -74,3 +74,11 @@ function DoGameResult(armyIndex, result)
             {escapeButton = 2, enterButton = 1, worldCover = true})
     end)
 end
+
+function DoGameResultKills(victim, instigator)
+    -- Uncommenting the lines below will show a kill notification without using mods
+    -- local tabs = import("/lua/ui/game/tabs.lua")
+    
+    -- local armies = GetArmiesTable().armiesTable
+    -- tabs.TabAnnouncement('main', tostring(armies[victim].nickname) .. " has been defeated by" .. tostring(armies[instigator].nickname))
+end

--- a/lua/ui/game/gameresult.lua
+++ b/lua/ui/game/gameresult.lua
@@ -74,11 +74,3 @@ function DoGameResult(armyIndex, result)
             {escapeButton = 2, enterButton = 1, worldCover = true})
     end)
 end
-
-function DoGameResultKills(victim, instigator)
-    -- Uncommenting the lines below will show a kill notification without using mods
-    local tabs = import("/lua/ui/game/tabs.lua")
-    
-    local armies = GetArmiesTable().armiesTable
-    tabs.TabAnnouncement('main', tostring(armies[victim].nickname) .. " has been defeated by" .. tostring(armies[instigator].nickname))
-end


### PR DESCRIPTION
Currently the user layer does not know who performed a kill on an ACU.
This information however is not supposed to be hidden, as it is clearly a UI related thing.

This information actually used to be available, until this big change broke this unintentionally:
https://github.com/FAForever/fa/pull/4016

This leads to a side effect, that e.g the Supreme Scoreboard Mod assumes that every kill was a ctrl+k, even if it was a normal kill.
Most of the streamers use this mod, and rely on this information, especially if there is a lot of going on. Like in 8vs8 games.

Using this change the Supreme Scoreboard Mod can also be fixed very easily to show the kills once again correctly.

Please look at the changes and tell me if fits the behavior of existing code.

I basically copied the existing Sync.Teamkill and used its interface.