### PR TITLE
Hide mass fabricator and recall panel as you switch to observer

### DIFF
--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -161,6 +161,7 @@ function OnSync()
     end
 
     if Sync.FocusArmyChanged then
+        import("/lua/ui/game/recall.lua").FocusArmyChanged()
         import("/lua/ui/game/massfabs.lua").FocusArmyChanged()
         import("/lua/ui/game/avatars.lua").FocusArmyChanged()
         import("/lua/ui/game/multifunction.lua").FocusArmyChanged()

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -161,6 +161,7 @@ function OnSync()
     end
 
     if Sync.FocusArmyChanged then
+        import("/lua/ui/game/massfabs.lua").FocusArmyChanged()
         import("/lua/ui/game/avatars.lua").FocusArmyChanged()
         import("/lua/ui/game/multifunction.lua").FocusArmyChanged()
         import("/lua/ui/notify/notify.lua").focusArmyChanged()

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -161,7 +161,6 @@ function OnSync()
     end
 
     if Sync.FocusArmyChanged then
-        import("/lua/ui/game/recall.lua").FocusArmyChanged()
         import("/lua/ui/game/massfabs.lua").FocusArmyChanged()
         import("/lua/ui/game/avatars.lua").FocusArmyChanged()
         import("/lua/ui/game/multifunction.lua").FocusArmyChanged()

--- a/lua/ui/game/massfabs.lua
+++ b/lua/ui/game/massfabs.lua
@@ -34,6 +34,15 @@ function ToggleControl()
     end
 end
 
+function FocusArmyChanged()
+    local focusArmy = GetFocusArmy()
+    if focusArmy == -1 then
+        if panel then
+            panel:Hide()
+        end
+    end
+end
+
 ---@class MassFabPanel : Group
 MassFabPanel = ClassUI(Group) {
 

--- a/lua/ui/game/recall.lua
+++ b/lua/ui/game/recall.lua
@@ -25,6 +25,15 @@ function Create(parent)
     return panel
 end
 
+function FocusArmyChanged()
+    local focusArmy = GetFocusArmy()
+    if focusArmy == -1 then
+        if panel then
+            panel:Hide()
+        end
+    end
+end
+
 function SetLayout()
     Layouter(panel)
         :AtLeftIn(panel.parent, panel:LoadPosition().left)

--- a/lua/ui/game/recall.lua
+++ b/lua/ui/game/recall.lua
@@ -25,15 +25,6 @@ function Create(parent)
     return panel
 end
 
-function FocusArmyChanged()
-    local focusArmy = GetFocusArmy()
-    if focusArmy == -1 then
-        if panel then
-            panel:Hide()
-        end
-    end
-end
-
 function SetLayout()
     Layouter(panel)
         :AtLeftIn(panel.parent, panel:LoadPosition().left)


### PR DESCRIPTION
Was watching a cast and noticed that the panel sticks around after switching to observer.

![image](https://user-images.githubusercontent.com/15778155/224566286-4dec66fc-d533-4134-9902-1f51a6c968c9.png)
