### PR TITLE
Fix lingering bitmap draggers on chat and console window

### DIFF
--- a/lua/maui/window.lua
+++ b/lua/maui/window.lua
@@ -503,6 +503,17 @@ Window = ClassUI(Group) {
         end
     end,
 
+    ---@param self Window
+    ---@param alpha number
+    ---@param affectChildren boolean
+    SetAlpha = function(self, alpha, affectChildren)
+        affectChildren = affectChildren or false
+        Group.SetAlpha(self, alpha, affectChildren)
+
+        -- guarantee that the resize bars remain transparent
+        self._resizeGroup:SetAlpha(0, true)
+    end,
+
     SaveWindowLocation = function(self)
         if self._pref then
             Prefs.SetToCurrentProfile(


### PR DESCRIPTION
The windows have opacity / transparency controls. These would also affect the draggers. The window now enforces that the draggers remain invisible (alpha set to 0)

![image](https://user-images.githubusercontent.com/15778155/224941831-094c72a7-9395-4a29-8c3d-9f7ffbdb35a0.png)

![image](https://user-images.githubusercontent.com/15778155/224940129-5bf8f18a-e7a1-48b7-b534-92ddeeef08cd.png)
