### PR TITLE
Add check whether platoon function is available

### DIFF
--- a/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
+++ b/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
@@ -285,7 +285,10 @@ function ConditionalBuildSuccessful(conditionalUnit)
     aiBrain:AssignUnitsToPlatoon(newPlatoon, {conditionalUnit}, 'Attack', 'None')
     newPlatoon:StopAI()
     newPlatoon:SetPlatoonData(selectedBuild.data.PlatoonData)
-    newPlatoon:ForkAIThread(import(selectedBuild.data.PlatoonAIFunction[1])[selectedBuild.data.PlatoonAIFunction[2]])
+
+    if selectedBuild.data.PlatoonAIFunction then
+        newPlatoon:ForkAIThread(import(selectedBuild.data.PlatoonAIFunction[1])[selectedBuild.data.PlatoonAIFunction[2]])
+    end
 
     -- Set up a death wait thing for it to rebuild
     if bManager.ConditionalBuildData.WaitSecondsAfterDeath then


### PR DESCRIPTION
As an example, take the co-op map Red Flag:

```
    opai = SeraphimM2SouthBase:AddOpAI('M2_Seraph_Sonar_South',
        {
            Amount = 1,
            KeepAlive = true,
            MaxAssist = 1,
            Retry = true,
        }
    )
```

There is no AI defined here, and the manager would throw an error upon importing.