### PR TITLE
Introduce debug UI to visualize AI perception of reclaim

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -850,3 +850,6 @@ Callbacks.NavDebugPathTo = import("/lua/sim/navdebug.lua").PathTo
 Callbacks.NavDebugGetLabel = import("/lua/sim/navdebug.lua").GetLabel
 Callbacks.NavDebugGetLabelMetadata = import("/lua/sim/navdebug.lua").GetLabelMeta
 Callbacks.NavGenerate = import("/lua/sim/navgenerator.lua").Generate
+
+Callbacks.GridReclaimDebugEnable = import("/lua/ai/gridreclaim.lua").EnableDebugging
+Callbacks.GridReclaimDebugDisable = import("/lua/ai/gridreclaim.lua").DisableDebugging

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -365,6 +365,8 @@ keyActions = {
         category = 'debug', order = 24},
     ['toggle_navui'] = {action = 'UI_Lua import("/lua/ui/game/navgenerator.lua").OpenWindow()',
         category = 'debug', order = 24},
+    ['toggle_ai_reclaim_grid_ui'] = {action = 'UI_Lua import("/lua/ui/game/gridreclaim.lua").OpenWindow()',
+        category = 'debug', order = 24},
     ['toggle_profiler_window'] = {action = 'UI_Lua import("/lua/ui/game/profiler.lua").OpenWindow()',
         category = 'debug', order = 24},
     ['toggle_repeat_build'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").ToggleRepeatBuild()',

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -19,7 +19,7 @@ local TableInsert = table.insert
 ---@field CachePosition Vector
 ---@field MaxMassReclaim number
 ---@field MaxEnergyReclaim number
----@field TimeReclaim number
+---@field TimeReclaim number        # This is a multiplier and not the actual total time
 ---@field ReclaimLeft number
 ---@field SyncData? table
 ---@field Extents? table

--- a/lua/ui/game/GridReclaim.lua
+++ b/lua/ui/game/GridReclaim.lua
@@ -1,0 +1,166 @@
+local UIUtil = import("/lua/ui/uiutil.lua")
+local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
+
+local Window = import("/lua/maui/window.lua").Window
+local Group = import("/lua/maui/group.lua").Group
+local Bitmap = import("/lua/maui/bitmap.lua").Bitmap
+local Combo = import("/lua/ui/controls/combo.lua").Combo
+
+local Root = false
+
+---@class GridReclaimUIDebugCell
+---@field TotalMass number
+---@field TotalEnergy number
+---@field ReclaimCount number
+---@field X number
+---@field Z number
+
+---@class GridReclaimUIDebugUpdate
+---@field Tick number
+---@field Time number
+---@field Memory number
+---@field Updates number
+---@field Processed number
+
+GridReclaimUICell = ClassUI(Group) {
+    __init = function(self, parent)
+        Group.__init(self, parent, 'GridReclaimUICell')
+
+        self.Title = LayoutHelpers.LayoutFor(UIUtil.CreateText(self, 'Scanning information', 14))
+            :Over(self, 5)
+            :AtLeftTopIn(self, 14, 4)
+            :End()
+
+        self.Mass = LayoutHelpers.LayoutFor(UIUtil.CreateText(self, 'Mass in cell: ...', 12))
+            :Over(self, 5)
+            :Below(self.Title, 4)
+            :End()
+
+        self.Energy = LayoutHelpers.LayoutFor(UIUtil.CreateText(self, 'Energy in cell: ...', 12))
+            :Over(self, 5)
+            :Below(self.Mass, 2)
+            :End()
+
+        self.Count = LayoutHelpers.LayoutFor(UIUtil.CreateText(self, 'Number of reclaim: ...', 12))
+            :Over(self, 5)
+            :Below(self.Energy, 2)
+            :End()
+
+        AddOnSyncHashedCallback(
+        ---@param data GridReclaimUIDebugCell
+            function(data)
+                if Root then
+                    self.Mass:SetText(string.format('Mass in cell: %d', data.TotalMass))
+                    self.Energy:SetText(string.format('Energy in cell: %d', data.TotalEnergy))
+                    self.Count:SetText(string.format('Number of reclaim: %d', data.ReclaimCount))
+                end
+            end, 'GridReclaimUIDebugCell', 'Alice'
+        )
+    end
+}
+
+GridReclaimUIUpdate = ClassUI(Group) {
+    __init = function(self, parent)
+        Group.__init(self, parent, 'GridReclaimUIUpdate')
+
+        self.Title = LayoutHelpers.LayoutFor(UIUtil.CreateText(self, 'Update information', 14))
+            :Over(self, 5)
+            :AtLeftTopIn(self, 14, 4)
+            :End()
+
+        self.Time = LayoutHelpers.LayoutFor(UIUtil.CreateText(self, 'Time to compute: ... (ms)', 12))
+            :Over(self, 5)
+            :Below(self.Title, 4)
+            :End()
+
+        self.Updates = LayoutHelpers.LayoutFor(UIUtil.CreateText(self, 'Updates processed: ...', 12))
+            :Over(self, 5)
+            :Below(self.Time, 2)
+            :End()
+
+        self.Processed = LayoutHelpers.LayoutFor(UIUtil.CreateText(self, 'Props processed: ...', 12))
+            :Over(self, 5)
+            :Below(self.Updates, 2)
+            :End()
+
+        AddOnSyncHashedCallback(
+        ---@param data GridReclaimUIDebugUpdate
+            function(data)
+                if Root then
+                    self.Time:SetText(string.format('Time to compute: %.2f (ms)', 1000 * data.Time))
+                    self.Updates:SetText(string.format('Updates processed: %d', data.Updates))
+                    self.Processed:SetText(string.format('Props processed: %d', data.Processed))
+                end
+            end, 'GridReclaimUIDebugUpdate', 'Alice'
+        )
+    end
+}
+
+---@class GridReclaimUI : Window
+GridReclaimUI = ClassUI(Window) {
+
+    __init = function(self, parent)
+        Window.__init(self, parent, "Grid reclaim UI", false, false, false, true, false, "GridReclaimUI4", {
+            Left = 10,
+            Top = 300,
+            Right = 310,
+            Bottom = 525
+        })
+
+        self.CellInfo = LayoutHelpers.LayoutFor(GridReclaimUICell(self))
+            :Left(self.Left)
+            :Right(self.Right)
+            :AtTopIn(self, 30)
+            :Height(100)
+            :End()
+
+        self.UpdateInfo = LayoutHelpers.LayoutFor(GridReclaimUIUpdate(self))
+            :Left(self.Left)
+            :Right(self.Right)
+            :Below(self.CellInfo)
+            :Bottom(self.Bottom)
+            :End()
+    end,
+
+    OnClose = function(self)
+        SimCallback({
+            Func = 'GridReclaimDebugDisable',
+            Args = {}
+        }, false)
+
+        self:Hide()
+    end,
+}
+
+function OpenWindow()
+    if Root then
+        Root:Show()
+    else
+        Root = GridReclaimUI(GetFrame(0))
+        Root:Show()
+    end
+
+    SimCallback({
+        Func = 'GridReclaimDebugEnable',
+        Args = {}
+    }, false)
+end
+
+function CloseWindow()
+    if Root then
+        Root:Hide()
+
+        SimCallback({
+            Func = 'GridReclaimDebugDisable',
+            Args = {}
+        }, false)
+    end
+end
+
+--- Called by the module manager when this module is dirty due to a disk change
+function __moduleinfo.OnDirty()
+    if Root then
+        Root:Destroy()
+        Root = false
+    end
+end


### PR DESCRIPTION

https://user-images.githubusercontent.com/15778155/226161531-e8505a3a-a4ff-489a-b872-4ea521083063.mp4

Allows us to visualize the AI perception of reclaim. You can toggle the window via a hotkey. You can find that in the usual key bindings menu:

![image](https://user-images.githubusercontent.com/15778155/226161569-118c286b-ab31-4d36-a06c-fa20337d8e00.png)

@relent0r apparently the `time` value that we kept track of previous were not the total time values but a multiplier. It doesn't make any sense to record that. It is now excluded.

@Hdt80bro this pull request also contains an example where we loop over the sync and see if we can find matching callbacks. I'm already a fan of this pattern. We just need to document how we intend people to use it. See the following snippet:

```lua
    for k, data in Sync do
        local callbacks = HashedSyncCallbacks[k]
        if callbacks then
            for l, callback in callbacks do
                callback(data)
            end
        end
   end
```

The idea is that the first key represents the category (e.g., `GridReclaimDebugDisable`) and the second key represents a unique key in that category for a function. This allows us to override the function, as an example:

```lua
        AddOnSyncHashedCallback(
        ---@param data GridReclaimUIDebugUpdate
            function(data)
                if Root then
                    self.Time:SetText(string.format('Time to compute: %.2f (ms)', 1000 * data.Time))
                    self.Updates:SetText(string.format('Updates processed: %d', data.Updates))
                    self.Processed:SetText(string.format('Props processed: %d', data.Processed))
                end
            end, 'GridReclaimUIDebugUpdate', 'Alice'
        )
```

Everytime we change the code of the UI we override the old function with the new function. The key needs to be unique within the category. `Alice` works, but perhaps there's a better convention that we can encourage. Maybe the file name?