### PR TITLE
add factory being built to forcepath limit condition.

### DIFF
--- a/lua/editor/UnitCountBuildConditions.lua
+++ b/lua/editor/UnitCountBuildConditions.lua
@@ -1454,11 +1454,10 @@ function ForcePathLimit(aiBrain, locationType, unitCategory, pathType, unitCount
         if factoryManager.LocationActive then
             local numUnits = factoryManager:GetNumCategoryFactories(testCat) or 0
             if numUnits > unitCount then
-                LOG('numunits greater than unit count')
                 return false
             end
             local unitsBuilding = aiBrain:GetListOfUnits(categories.CONSTRUCTION, false)
-            for unitNum, unit in unitsBuilding do
+            for _, unit in unitsBuilding do
                 if not unit:BeenDestroyed() and unit:IsUnitState('Building') then
                     local buildingUnit = unit.UnitBeingBuilt
                     if buildingUnit and not buildingUnit:BeenDestroyed() and EntityCategoryContains(unitCategory, buildingUnit) then
@@ -1467,7 +1466,6 @@ function ForcePathLimit(aiBrain, locationType, unitCategory, pathType, unitCount
                 end
             end
             if numUnits > unitCount then
-                LOG('numUnits being built and numunits greater than unit count')
                 return false
             end
         end


### PR DESCRIPTION
Description of changes
This PR changes fixes an issue detected in the forcepath limit condition. The condition is designed to check how many factories the AI currently has so it can force a limit on maps where you want to limit them based on if the AI can path to the enemy. The issue was that it was not taking into account factories that are currently being built by engineers. So there were cases where the AI would have over the factory limit due to ones currently building but would not know it when building more.

Test setup for the changes
Within the ForcePathLimit funciton in the unitcountbuildconditions.lua file.
Add a log to line 1457 and 1470, the function is designed to break out if its already got more than the unitCount parameter, if it doesn't then it will look at currently building factories and break out if the number it has plus the number building is above the unitCount parameter.
