### PR TITLE
Refactor Shield-Structure/Units to use ShieldEffectsComponent #4628

### DIFF
--- a/units/UEB4301/UEB4301_script.lua
+++ b/units/UEB4301/UEB4301_script.lua
@@ -8,12 +8,13 @@
 ----**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 ----****************************************************************************
 local TShieldStructureUnit = import("/lua/terranunits.lua").TShieldStructureUnit
+local ShieldEffectsComponent = import("/lua/defaultcomponents.lua").ShieldEffectsComponent
 
 ---@class UEB4301 : TShieldStructureUnit
 ---@field Rotator1? moho.RotateManipulator
 ---@field Rotator2? moho.RotateManipulator
 ---@field ShieldEffectsBag TrashBag
-UEB4301 = ClassUnit(TShieldStructureUnit) {
+UEB4301 = ClassUnit(TShieldStructureUnit, ShieldEffectsComponent) {
     ShieldEffects = {
         '/effects/emitters/terran_shield_generator_t2_01_emit.bp',
         '/effects/emitters/terran_shield_generator_T3_02_emit.bp',
@@ -23,8 +24,7 @@ UEB4301 = ClassUnit(TShieldStructureUnit) {
     ---@param self UEB4301
     OnCreate = function(self)
         TShieldStructureUnit.OnCreate(self)
-        self.ShieldEffectsBag = TrashBag()
-        self.Trash:Add(self.ShieldEffectsBag)
+        ShieldEffectsComponent.OnCreate(self)        
     end,
 
     ---@param self UEB4301
@@ -41,25 +41,21 @@ UEB4301 = ClassUnit(TShieldStructureUnit) {
     ---@param self UEB4301
     OnShieldEnabled = function(self)
         TShieldStructureUnit.OnShieldEnabled(self)
+        ShieldEffectsComponent.OnShieldEnabled(self)
         if self.Rotator1 then
             self.Rotator1:SetTargetSpeed(10)
         end
         if self.Rotator2 then
             self.Rotator2:SetTargetSpeed(-10)
         end
-        
-        self.ShieldEffectsBag:Destroy()
-        for k, v in self.ShieldEffects do
-            self.ShieldEffectsBag:Add(CreateAttachedEmitter(self, 0, self.Army, v))
-        end
     end,
 
     ---@param self UEB4301
     OnShieldDisabled = function(self)
         TShieldStructureUnit.OnShieldDisabled(self)
+        ShieldEffectsComponent.OnShieldDisabled(self)
         self.Rotator1:SetTargetSpeed(0)
         self.Rotator2:SetTargetSpeed(0)
-        self.ShieldEffectsBag:Destroy()
     end,
 }
 

--- a/units/URB4202/URB4202_script.lua
+++ b/units/URB4202/URB4202_script.lua
@@ -22,11 +22,9 @@ URB4202 = ClassUnit(CShieldStructureUnit, ShieldEffectsComponent) {
     ShieldEffectsBone = 'Shaft',
     
     ---@param self URB4202
-    OnCreate = function(self) -- Are these missng on purpose?
-        -- self.ShieldEffectsBone = 'Shaft'
+    OnCreate = function(self)
         CShieldStructureUnit.OnCreate(self)
         ShieldEffectsComponent.OnCreate(self)
-        -- LOG(self.ShieldEffectsBone)
     end,
 
     ---@param self URB4202
@@ -35,7 +33,6 @@ URB4202 = ClassUnit(CShieldStructureUnit, ShieldEffectsComponent) {
     OnStopBeingBuilt = function(self, builder, layer)
         CShieldStructureUnit.OnStopBeingBuilt(self, builder, layer)
         self.Rotator1 = CreateRotator(self, 'Shaft', 'z', nil, 30, 5, 30)
-        -- LOG(self.ShieldEffectsBone)
         self.Trash:Add(self.Rotator1)
     end,
 

--- a/units/URB4202/URB4202_script.lua
+++ b/units/URB4202/URB4202_script.lua
@@ -8,49 +8,51 @@
 ----**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 ----****************************************************************************
 local CShieldStructureUnit = import("/lua/cybranunits.lua").CShieldStructureUnit
+local ShieldEffectsComponent = import("/lua/defaultcomponents.lua").ShieldEffectsComponent
 
 ---@class URB4202 : CShieldStructureUnit
-URB4202 = ClassUnit(CShieldStructureUnit) {
+---@field Rotator1? moho.RotateManipulator
+URB4202 = ClassUnit(CShieldStructureUnit, ShieldEffectsComponent) {
     ShieldEffects = {
         '/effects/emitters/cybran_shield_01_generator_01_emit.bp',
         '/effects/emitters/cybran_shield_01_generator_02_emit.bp',
         '/effects/emitters/cybran_shield_01_generator_03_emit.bp',
     },
 
+    ShieldEffectsBone = 'Shaft',
+    
+    ---@param self URB4202
+    OnCreate = function(self) -- Are these missng on purpose?
+        -- self.ShieldEffectsBone = 'Shaft'
+        CShieldStructureUnit.OnCreate(self)
+        ShieldEffectsComponent.OnCreate(self)
+        -- LOG(self.ShieldEffectsBone)
+    end,
+
+    ---@param self URB4202
+    ---@param builder Unit
+    ---@param layer Layer
     OnStopBeingBuilt = function(self, builder, layer)
         CShieldStructureUnit.OnStopBeingBuilt(self, builder, layer)
         self.Rotator1 = CreateRotator(self, 'Shaft', 'z', nil, 30, 5, 30)
+        -- LOG(self.ShieldEffectsBone)
         self.Trash:Add(self.Rotator1)
-        self.ShieldEffectsBag = {}
     end,
 
+    ---@param self URB4202
     OnShieldEnabled = function(self)
         CShieldStructureUnit.OnShieldEnabled(self)
+        ShieldEffectsComponent.OnShieldEnabled(self)
         if self.Rotator1 then
             self.Rotator1:SetTargetSpeed(10)
-        end
-
-        if self.ShieldEffectsBag then
-            for k, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
-        for k, v in self.ShieldEffects do
-            table.insert( self.ShieldEffectsBag, CreateAttachedEmitter(self, 'Shaft', self.Army, v))
-        end
+        end    
     end,
 
+    ---@param self URB4202
     OnShieldDisabled = function(self)
         CShieldStructureUnit.OnShieldDisabled(self)
-        self.Rotator1:SetTargetSpeed(0)
-        
-        if self.ShieldEffectsBag then
-            for k, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
+        ShieldEffectsComponent.OnShieldDisabled(self)
+        self.Rotator1:SetTargetSpeed(0)        
     end,
 }
 

--- a/units/URB4204/URB4204_script.lua
+++ b/units/URB4204/URB4204_script.lua
@@ -8,50 +8,51 @@
 ----**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 ----****************************************************************************
 local CShieldStructureUnit = import("/lua/cybranunits.lua").CShieldStructureUnit
+local ShieldEffectsComponent = import("/lua/defaultcomponents.lua").ShieldEffectsComponent
+
 
 ---@class URB4204 : CShieldStructureUnit
-URB4204 = ClassUnit(CShieldStructureUnit) {
+---@field Rotator1? moho.RotateManipulator
+URB4204 = ClassUnit(CShieldStructureUnit, ShieldEffectsComponent) {
     ShieldEffects = {
         '/effects/emitters/cybran_shield_02_generator_01_emit.bp',
         '/effects/emitters/cybran_shield_02_generator_02_emit.bp',
         '/effects/emitters/cybran_shield_02_generator_03_emit.bp',
     },
 
+    ShieldEffectsBone = 'Shaft',
+
+    ---@param self URB4204
+    OnCreate = function(self) -- Are these missng on purpose?
+        CShieldStructureUnit.OnCreate(self)
+        ShieldEffectsComponent.OnCreate(self)
+    end,
+
+    ---@param self URB4204
+    ---@param builder Unit
+    ---@param layer Layer
     OnStopBeingBuilt = function(self, builder, layer)
         CShieldStructureUnit.OnStopBeingBuilt(self, builder, layer)
         self.Rotator1 = CreateRotator(self, 'Shaft', 'z', nil, 30, 5, 30)
         self.Trash:Add(self.Rotator1)
-        self.ShieldEffectsBag = {}
     end,
 
+    ---@param self URB4204
     OnShieldEnabled = function(self)
         CShieldStructureUnit.OnShieldEnabled(self)
+        ShieldEffectsComponent.OnShieldEnabled(self)
+
         if self.Rotator1 then
             self.Rotator1:SetTargetSpeed(10)
-        end
-
-        if self.ShieldEffectsBag then
-            for k, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
-
-        for k, v in self.ShieldEffects do
-            table.insert( self.ShieldEffectsBag, CreateAttachedEmitter(self, 'Shaft', self.Army, v))
-        end
+        end        
     end,
 
+    ---@param self URB4204
     OnShieldDisabled = function(self)
         CShieldStructureUnit.OnShieldDisabled(self)
-        self.Rotator1:SetTargetSpeed(0)
+        ShieldEffectsComponent.OnShieldDisabled(self)
 
-        if self.ShieldEffectsBag then
-            for k, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
+        self.Rotator1:SetTargetSpeed(0)        
     end,
 }
 

--- a/units/URB4205/URB4205_script.lua
+++ b/units/URB4205/URB4205_script.lua
@@ -8,50 +8,49 @@
 ----**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 ----****************************************************************************
 local CShieldStructureUnit = import("/lua/cybranunits.lua").CShieldStructureUnit
+local ShieldEffectsComponent = import("/lua/defaultcomponents.lua").ShieldEffectsComponent
 
 ---@class URB4205 : CShieldStructureUnit
-URB4205 = ClassUnit(CShieldStructureUnit) {
+---@field Rotator1? moho.RotateManipulator
+URB4205 = ClassUnit(CShieldStructureUnit, ShieldEffectsComponent) {
     ShieldEffects = {
         '/effects/emitters/cybran_shield_03_generator_01_emit.bp',
         '/effects/emitters/cybran_shield_03_generator_02_emit.bp',
         '/effects/emitters/cybran_shield_03_generator_03_emit.bp',
     },
 
+    ShieldEffectsBone = 'Shaft',
+
+---@param self URB4205
+    OnCreate = function(self) -- Are these missng on purpose?
+        CShieldStructureUnit.OnCreate(self)
+        ShieldEffectsComponent.OnCreate(self)
+    end,
+
+    ---@param self URB4205
+    ---@param builder Unit
+    ---@param layer Layer
     OnStopBeingBuilt = function(self,builder,layer)
         CShieldStructureUnit.OnStopBeingBuilt(self,builder,layer)
         self.Rotator1 = CreateRotator(self, 'Shaft', 'z', nil, 30, 5, 30)
         self.Trash:Add(self.Rotator1)
-        self.ShieldEffectsBag = {}
     end,
-
+    
+    ---@param self URB4205
     OnShieldEnabled = function(self)
         CShieldStructureUnit.OnShieldEnabled(self)
+        ShieldEffectsComponent.OnShieldEnabled(self)
+
         if self.Rotator1 then
             self.Rotator1:SetTargetSpeed(10)
         end
-
-        if self.ShieldEffectsBag then
-            for k, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
-
-        for k, v in self.ShieldEffects do
-            table.insert(self.ShieldEffectsBag, CreateAttachedEmitter(self, 'Shaft', self.Army, v))
-        end
     end,
 
+    ---@param self URB4205
     OnShieldDisabled = function(self)
         CShieldStructureUnit.OnShieldDisabled(self)
+        ShieldEffectsComponent.OnShieldDisabled(self)
         self.Rotator1:SetTargetSpeed(0)
-        
-        if self.ShieldEffectsBag then
-            for k, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
     end,
 }
 

--- a/units/URB4206/URB4206_script.lua
+++ b/units/URB4206/URB4206_script.lua
@@ -10,9 +10,9 @@
 local CShieldStructureUnit = import("/lua/cybranunits.lua").CShieldStructureUnit
 local ShieldEffectsComponent = import("/lua/defaultcomponents.lua").ShieldEffectsComponent
 
----@class URB4206 : CShieldStructureUnit
+---@class URB4206 : CShieldStructureUnit, ShieldEffectsComponent
 ---@field Rotator1? moho.RotateManipulator
-URB4206 = ClassUnit(CShieldStructureUnit) {
+URB4206 = ClassUnit(CShieldStructureUnit,ShieldEffectsComponent) {
     ShieldEffects = { 
         '/effects/emitters/cybran_shield_04_generator_01_emit.bp',
         '/effects/emitters/cybran_shield_04_generator_02_emit.bp',
@@ -22,7 +22,7 @@ URB4206 = ClassUnit(CShieldStructureUnit) {
     ShieldEffectsBone = 'Shaft',
 
     ---@param self URB4206
-    OnCreate = function(self) -- Are these missng on purpose?
+    OnCreate = function(self)
         CShieldStructureUnit.OnCreate(self)
         ShieldEffectsComponent.OnCreate(self)
     end,

--- a/units/URB4206/URB4206_script.lua
+++ b/units/URB4206/URB4206_script.lua
@@ -8,8 +8,10 @@
 ----**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 ----****************************************************************************
 local CShieldStructureUnit = import("/lua/cybranunits.lua").CShieldStructureUnit
+local ShieldEffectsComponent = import("/lua/defaultcomponents.lua").ShieldEffectsComponent
 
 ---@class URB4206 : CShieldStructureUnit
+---@field Rotator1? moho.RotateManipulator
 URB4206 = ClassUnit(CShieldStructureUnit) {
     ShieldEffects = { 
         '/effects/emitters/cybran_shield_04_generator_01_emit.bp',
@@ -17,41 +19,38 @@ URB4206 = ClassUnit(CShieldStructureUnit) {
         '/effects/emitters/cybran_shield_04_generator_03_emit.bp',
     },
 
+    ShieldEffectsBone = 'Shaft',
+
+    ---@param self URB4206
+    OnCreate = function(self) -- Are these missng on purpose?
+        CShieldStructureUnit.OnCreate(self)
+        ShieldEffectsComponent.OnCreate(self)
+    end,
+
+    ---@param self URB4206
+    ---@param builder Unit
+    ---@param layer Layer
     OnStopBeingBuilt = function(self, builder, layer)
         CShieldStructureUnit.OnStopBeingBuilt(self, builder, layer)
         self.Rotator1 = CreateRotator(self, 'Shaft', 'z', nil, 30, 5, 30)
         self.Trash:Add(self.Rotator1)
-        self.ShieldEffectsBag = {}
     end,
 
+    ---@param self URB4206
     OnShieldEnabled = function(self)
         CShieldStructureUnit.OnShieldEnabled(self)
+        ShieldEffectsComponent.OnShieldEnabled(self)
+
         if self.Rotator1 then
             self.Rotator1:SetTargetSpeed(10)
         end
-
-        if self.ShieldEffectsBag then
-            for k, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
-
-        for k, v in self.ShieldEffects do
-            table.insert(self.ShieldEffectsBag, CreateAttachedEmitter(self, 'Shaft', self.Army, v))
-        end
     end,
 
+    ---@param self URB4206
     OnShieldDisabled = function(self)
         CShieldStructureUnit.OnShieldDisabled(self)
-        self.Rotator1:SetTargetSpeed(0)
-        
-        if self.ShieldEffectsBag then
-            for k, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
+        ShieldEffectsComponent.OnShieldDisabled(self)
+        self.Rotator1:SetTargetSpeed(0)            
     end,
 }
 

--- a/units/URB4207/URB4207_script.lua
+++ b/units/URB4207/URB4207_script.lua
@@ -8,51 +8,48 @@
 ----**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 ----****************************************************************************
 local CShieldStructureUnit = import("/lua/cybranunits.lua").CShieldStructureUnit
+local ShieldEffectsComponent = import("/lua/defaultcomponents.lua").ShieldEffectsComponent
 
 ---@class URB4207 : CShieldStructureUnit
-URB4207 = ClassUnit(CShieldStructureUnit) {
-    ShieldEffects = {
+---@field Rotator1? moho.RotateManipulator
+URB4207 = ClassUnit(CShieldStructureUnit, ShieldEffectsComponent) {
+ShieldEffects = {
         '/effects/emitters/cybran_shield_05_generator_01_emit.bp',
         '/effects/emitters/cybran_shield_05_generator_02_emit.bp',
         '/effects/emitters/cybran_shield_05_generator_03_emit.bp',
         '/effects/emitters/cybran_shield_05_generator_04_emit.bp',
     },
+    ShieldEffectsBone = 'Shaft',
 
+    ---@param self URB4207
+    OnCreate = function(self) -- Are these missng on purpose?
+        CShieldStructureUnit.OnCreate(self)
+        ShieldEffectsComponent.OnCreate(self)
+    end,
+
+    ---@param self URB4207
+    ---@param builder Unit
+    ---@param layer Layer
     OnStopBeingBuilt = function(self, builder, layer)
         CShieldStructureUnit.OnStopBeingBuilt(self, builder, layer)
         self.Rotator1 = CreateRotator(self, 'Shaft', 'z', nil, 30, 5, 30)
         self.Trash:Add(self.Rotator1)
-        self.ShieldEffectsBag = {}
     end,
 
+    ---@param self URB4207
     OnShieldEnabled = function(self)
         CShieldStructureUnit.OnShieldEnabled(self)
+        ShieldEffectsComponent.OnShieldEnabled(self)
         if self.Rotator1 then
             self.Rotator1:SetTargetSpeed(10)
-        end
-        
-        if self.ShieldEffectsBag then
-            for k, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
-
-        for k, v in self.ShieldEffects do
-            table.insert(self.ShieldEffectsBag, CreateAttachedEmitter(self, 'Shaft', self.Army, v))
-        end
+        end        
     end,
 
+    ---@param self URB4207
     OnShieldDisabled = function(self)
         CShieldStructureUnit.OnShieldDisabled(self)
+        ShieldEffectsComponent.OnShieldDisabled(self)
         self.Rotator1:SetTargetSpeed(0)
-        
-        if self.ShieldEffectsBag then
-            for k, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
     end,
 }
 

--- a/units/XES0205/XES0205_script.lua
+++ b/units/XES0205/XES0205_script.lua
@@ -8,44 +8,45 @@
 ----**  Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 ----****************************************************************************
 local TShieldSeaUnit = import("/lua/terranunits.lua").TShieldSeaUnit
+local ShieldEffectsComponent = import("/lua/defaultcomponents.lua").ShieldEffectsComponent
 
 ---@class XES0205 : TShieldSeaUnit
-XES0205 = ClassUnit(TShieldSeaUnit) {
+XES0205 = ClassUnit(TShieldSeaUnit, ShieldEffectsComponent) {
     ShieldEffects = {
         '/effects/emitters/terran_shield_generator_shipmobile_01_emit.bp',
         '/effects/emitters/terran_shield_generator_shipmobile_02_emit.bp',
     },
 
+    ShieldEffectsBone = 'XES0205',
+
+    ---@param self XES0205
+    OnCreate = function(self) -- Are these missng on purpose?
+        TShieldSeaUnit.OnCreate(self)
+        ShieldEffectsComponent.OnCreate(self)
+    end,
+
+    ---@param self XES0205
+    ---@param builder Unit
+    ---@param layer Layer
     OnStopBeingBuilt = function(self, builder, layer)
         TShieldSeaUnit.OnStopBeingBuilt(self, builder, layer)
-        self.ShieldEffectsBag = {}
     end,
 
+    ---@param self XES0205
     OnShieldEnabled = function(self)
         TShieldSeaUnit.OnShieldEnabled(self)
-
-        if self.ShieldEffectsBag then
+        ShieldEffectsComponent.OnShieldEnabled(self)
+        if self.ShieldEffectsBag then 
             for _, v in self.ShieldEffectsBag do
-                v:Destroy()
+                v:OffsetEmitter(0, -0.15, 0.35)
             end
-            self.ShieldEffectsBag = {}
-        end
-        for _, v in self.ShieldEffects do
-            local emitter = CreateAttachedEmitter(self, 'XES0205', self:GetArmy(), v)
-            emitter:OffsetEmitter(0, -0.15, 0.35)
-            table.insert(self.ShieldEffectsBag, emitter)
         end
     end,
 
+    ---@param self XES0205
     OnShieldDisabled = function(self)
         TShieldSeaUnit.OnShieldDisabled(self)
-
-        if self.ShieldEffectsBag then
-            for _, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
+        ShieldEffectsComponent.OnShieldDisabled(self)
     end,
 }
 

--- a/units/XSB4202/XSB4202_script.lua
+++ b/units/XSB4202/XSB4202_script.lua
@@ -9,13 +9,15 @@
 local SShieldStructureUnit = import("/lua/seraphimunits.lua").SShieldStructureUnit
 local ShieldEffectsComponent = import("/lua/defaultcomponents.lua").ShieldEffectsComponent
 
----@class XSB4202 : SShieldStructureUnit
+---@class XSB4202 : SShieldStructureUnit, ShieldEffectsComponent
 XSB4202 = ClassUnit(SShieldStructureUnit, ShieldEffectsComponent) {
     ShieldEffects = {
         '/effects/emitters/seraphim_shield_generator_t2_01_emit.bp',
         '/effects/emitters/seraphim_shield_generator_t3_03_emit.bp',
         '/effects/emitters/seraphim_shield_generator_t2_03_emit.bp',
     },
+
+    ShieldEffectsScale = 0.75,
 
     ---@param self XSB4202
     OnCreate = function(self) -- Are these missng on purpose?
@@ -46,9 +48,7 @@ XSB4202 = ClassUnit(SShieldStructureUnit, ShieldEffectsComponent) {
     OnKilled = function(self, instigator, type, overkillRatio)
         SShieldStructureUnit.OnKilled(self, instigator, type, overkillRatio)
         if self.ShieldEffectsBag then
-            for k,v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
+            ShieldEffectsComponent.OnShieldDisabled(self)
         end
     end,
 }

--- a/units/XSB4202/XSB4202_script.lua
+++ b/units/XSB4202/XSB4202_script.lua
@@ -7,47 +7,45 @@
 ----**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 ----****************************************************************************
 local SShieldStructureUnit = import("/lua/seraphimunits.lua").SShieldStructureUnit
+local ShieldEffectsComponent = import("/lua/defaultcomponents.lua").ShieldEffectsComponent
 
 ---@class XSB4202 : SShieldStructureUnit
-XSB4202 = ClassUnit(SShieldStructureUnit) {
+XSB4202 = ClassUnit(SShieldStructureUnit, ShieldEffectsComponent) {
     ShieldEffects = {
         '/effects/emitters/seraphim_shield_generator_t2_01_emit.bp',
         '/effects/emitters/seraphim_shield_generator_t3_03_emit.bp',
         '/effects/emitters/seraphim_shield_generator_t2_03_emit.bp',
     },
 
+    ---@param self XSB4202
+    OnCreate = function(self) -- Are these missng on purpose?
+        SShieldStructureUnit.OnCreate(self)
+        ShieldEffectsComponent.OnCreate(self)
+    end,
+
+    ---@param self XSB4202
+    ---@param builder Unit
+    ---@param layer Layer
     OnStopBeingBuilt = function(self, builder, layer)
         SShieldStructureUnit.OnStopBeingBuilt(self, builder, layer)
-        self.ShieldEffectsBag = {}
     end,
 
+    ---@param self XSB4202
     OnShieldEnabled = function(self)
         SShieldStructureUnit.OnShieldEnabled(self)
-        if self.ShieldEffectsBag then
-            for k, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
-
-        for k, v in self.ShieldEffects do
-            table.insert(self.ShieldEffectsBag, CreateAttachedEmitter(self, 0, self.Army, v):ScaleEmitter(0.75))
-        end
+        ShieldEffectsComponent.OnShieldEnabled(self)        
     end,
 
+    ---@param self XSB4202
     OnShieldDisabled = function(self)
         SShieldStructureUnit.OnShieldDisabled(self)
-        if self.ShieldEffectsBag then
-            for k, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
+        ShieldEffectsComponent.OnShieldDisabled(self)                
     end,
 
+    ---@param self XSB4202
     OnKilled = function(self, instigator, type, overkillRatio)
         SShieldStructureUnit.OnKilled(self, instigator, type, overkillRatio)
-        if self.ShieldEffctsBag then
+        if self.ShieldEffectsBag then
             for k,v in self.ShieldEffectsBag do
                 v:Destroy()
             end

--- a/units/XSB4301/XSB4301_script.lua
+++ b/units/XSB4301/XSB4301_script.lua
@@ -7,9 +7,10 @@
 ----**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 ----****************************************************************************
 local SShieldStructureUnit = import("/lua/seraphimunits.lua").SShieldStructureUnit
+local ShieldEffectsComponent = import("/lua/defaultcomponents.lua").ShieldEffectsComponent
 
 ---@class XSB4301 : SShieldStructureUnit
-XSB4301 = ClassUnit(SShieldStructureUnit) {
+XSB4301 = ClassUnit(SShieldStructureUnit, ShieldEffectsComponent) {
     ShieldEffects = {
         --'/effects/emitters/seraphim_shield_generator_t3_01_emit.bp',
         '/effects/emitters/seraphim_shield_generator_t3_02_emit.bp',
@@ -18,37 +19,35 @@ XSB4301 = ClassUnit(SShieldStructureUnit) {
         --'/effects/emitters/seraphim_shield_generator_t3_05_emit.bp',
     },
 
+    ---@param self XSB4301
+    OnCreate = function(self) -- Are these missng on purpose?
+        SShieldStructureUnit.OnCreate(self)
+        ShieldEffectsComponent.OnCreate(self)
+    end,
+
+    ---@param self XSB4301
+    ---@param builder Unit
+    ---@param layer Layer
     OnStopBeingBuilt = function(self, builder, layer)
         SShieldStructureUnit.OnStopBeingBuilt(self, builder, layer)
-        self.ShieldEffectsBag = {}
     end,
 
+    ---@param self XSB4301
     OnShieldEnabled = function(self)
         SShieldStructureUnit.OnShieldEnabled(self)
-        if self.ShieldEffectsBag then
-            for k, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
-        for k, v in self.ShieldEffects do
-            table.insert(self.ShieldEffectsBag, CreateAttachedEmitter(self, 0, self.Army, v))
-        end
+        ShieldEffectsComponent.OnShieldEnabled(self)        
     end,
 
+    ---@param self XSB4301
     OnShieldDisabled = function(self)
         SShieldStructureUnit.OnShieldDisabled(self)
-        if self.ShieldEffectsBag then
-            for k, v in self.ShieldEffectsBag do
-                v:Destroy()
-            end
-            self.ShieldEffectsBag = {}
-        end
+        ShieldEffectsComponent.OnShieldDisabled(self)        
     end,
 
+    ---@param self XSB4301
     OnKilled = function(self, instigator, type, overkillRatio)
         SShieldStructureUnit.OnKilled(self, instigator, type, overkillRatio)
-        if self.ShieldEffctsBag then
+        if self.ShieldEffectsBag then
             for k,v in self.ShieldEffectsBag do
                 v:Destroy()
             end


### PR DESCRIPTION
#4628 

Refactored following units to use the new  ShieldEffectsComponent:
UEB4301, URB4202, URB4204, URB4205, URB4206, URB4207, XES205, XSB4202, XSB4301

Added bone name as to the cybran shield-gens and UEF-shield boat, so OnShieldEnabled function knows which bone to attach the emitters to. 

![image](https://user-images.githubusercontent.com/23396667/227595065-5678b6b1-4f76-4385-be45-083e6cf83225.png)


![Screenshot from 2023-03-23 17-28-49](https://user-images.githubusercontent.com/23396667/227592692-870cecd6-773a-446b-b1f4-5b9c1d7335c8.png)

