### PR TITLE
Veterancy value changes for T4 game enders

### DIFF
--- a/units/UEB2401/UEB2401_unit.bp
+++ b/units/UEB2401/UEB2401_unit.bp
@@ -186,6 +186,13 @@ UnitBlueprint {
         Level4 = 200,
         Level5 = 250,
     },
+    VeteranMass = {
+        225000,
+        225000,
+        225000,
+        225000,
+        225000,
+    },
     Weapon = {
         {
             AboveWaterTargetsOnly = true,

--- a/units/URL0401/URL0401_unit.bp
+++ b/units/URL0401/URL0401_unit.bp
@@ -255,6 +255,13 @@
         Level4 = 200,
         Level5 = 250,
     },
+    VeteranMass = {
+        220000,
+        220000,
+        220000,
+        220000,
+        220000,
+    },
     Weapon = {
         {
             AboveWaterTargetsOnly = true,

--- a/units/XAB2307/XAB2307_unit.bp
+++ b/units/XAB2307/XAB2307_unit.bp
@@ -181,6 +181,13 @@ UnitBlueprint {
         Level4 = 200,
         Level5 = 250,
     },
+    VeteranMass = {
+        202500,
+        202500,
+        202500,
+        202500,
+        202500,
+    },
     Weapon = {
         {
             AboveWaterTargetsOnly = true,

--- a/units/XSB2401/XSB2401_unit.bp
+++ b/units/XSB2401/XSB2401_unit.bp
@@ -249,6 +249,13 @@ UnitBlueprint {
         Level4 = 200,
         Level5 = 250,
     },
+    VeteranMass = {
+        187500,
+        187500,
+        187500,
+        187500,
+        187500,
+    },
     Weapon = {
         {
             AboveWaterTargetsOnly = true,


### PR DESCRIPTION
The previous values resulted in higher veterancy levels being essentially unobtainable in normal games. For example, a Mavor needed 2.25 million mass to reach 5 Stars. With this PR, the amount of mass required to attain one level of veterancy is halved and is now about equal to the cost of the unit. 

**Mavor** 
Mass required for one level of veterancy: ~450k --> 225k 
(Each level requires 225k)

**Scathis**
Mass required for one level of veterancy: 440k --> 220k

**Salvation**
Mass required for one level of veterancy: 405k --> 202.5k

**Yolona Oss**
Mass required for one level of veterancy: ~375k --> 187.5k