### PR TITLE
Veterancy value changes for T3 game enders

### DIFF
--- a/units/UAB2302/UAB2302_unit.bp
+++ b/units/UAB2302/UAB2302_unit.bp
@@ -183,6 +183,13 @@ UnitBlueprint {
         Level4 = 120,
         Level5 = 150,
     },
+    VeteranMass = {
+        73200,
+        73200,
+        73200,
+        73200,
+        73200,
+    },
     Weapon = {
         {
             AboveWaterTargetsOnly = true,

--- a/units/UEB2302/UEB2302_unit.bp
+++ b/units/UEB2302/UEB2302_unit.bp
@@ -177,6 +177,13 @@ UnitBlueprint {
         Level4 = 120,
         Level5 = 150,
     },
+    VeteranMass = {
+        72000,
+        72000,
+        72000,
+        72000,
+        72000,
+    },
     Weapon = {
         {
             AboveWaterTargetsOnly = true,

--- a/units/URB2302/URB2302_unit.bp
+++ b/units/URB2302/URB2302_unit.bp
@@ -167,6 +167,13 @@ UnitBlueprint {
         Level4 = 120,
         Level5 = 150,
     },
+    VeteranMass = {
+        69600,
+        69600,
+        69600,
+        69600,
+        69600,
+    },
     Weapon = {
         {
             AboveWaterTargetsOnly = true,

--- a/units/XSB2302/XSB2302_unit.bp
+++ b/units/XSB2302/XSB2302_unit.bp
@@ -193,6 +193,13 @@ UnitBlueprint {
         Level4 = 120,
         Level5 = 150,
     },
+    VeteranMass = {
+        70800,
+        70800,
+        70800,
+        70800,
+        70800,
+    },
     Weapon = {
         {
             AboveWaterTargetsOnly = true,


### PR DESCRIPTION
**T3 Artilleries:**
Mass required for one level of veterancy: 1.25*mass cost --> mass cost