### PR TITLE
Replace `table.getsize` and `table.empty` with assembly alternatives

### DIFF
--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -387,7 +387,7 @@ function table.reverse(t)
     if not t then return {} end -- prevents looping over nil table
     local r = {}
     local items = table.indexize(t) -- convert from hash table
-    local itemsCount = table.getsize(t)
+    local itemsCount = table.getn(t)
     for k, v in ipairs(items) do
         r[itemsCount + 1 - k] = v
     end

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -110,8 +110,8 @@ function safecall(msg, fn, ...)
 end
 
 --- Returns actual size of a table, including string keys
-table.getsize = table.getsize2
-table.empty = table.empty2
+table.getsize = table.getsize2 or table.getsize
+table.empty = table.empty2 or table.empty
 
 --- table.copy(t) returns a shallow copy of t.
 function table.copy(t)

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -109,6 +109,10 @@ function safecall(msg, fn, ...)
     end
 end
 
+--- Returns actual size of a table, including string keys
+table.getsize = table.getsize2
+table.empty = table.empty2
+
 --- table.copy(t) returns a shallow copy of t.
 function table.copy(t)
     if not t then return end -- prevents looping over nil table
@@ -363,21 +367,6 @@ function sortedpairs(t, comp)
     end
 end
 
---- Returns actual size of a table, including string keys
-function table.getsize(t)
-    -- handling nil table like empty tables so that no need to check
-    -- for nil table and then size of table:
-    -- if t and not table.empty(t) then
-    -- do some thing
-    -- end
-    if type(t) ~= 'table' then return 0 end
-    local size = 0
-    for k, v in t do
-        size = size + 1
-    end
-    return size
-end
-
 --- Returns a table with keys and values from t reversed.
 --- e.g. table.inverse {'one','two','three'} => {one=1, two=2, three=3}
 ---      table.inverse {foo=17, bar=100}     => {[17]=foo, [100]=bar}
@@ -474,12 +463,6 @@ function table.map(fn, t)
         r[k] = fn(v)
     end
     return r
-end
-
---- table.empty(t) returns true iff t has no keys/values.
-function table.empty(t)
-    if type(t) ~= 'table' then return true end
-    return next(t) == nil
 end
 
 --- table.shuffle(t) returns a shuffled table


### PR DESCRIPTION
An assembly implementation is usually faster than one in Lua. Especially when the Lua implementation adds a lot of additional overhead by checking the type 😄 