### PR TITLE
fix platoon former for engineers

### DIFF
--- a/lua/AI/PlatoonTemplates/EngineerPlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/EngineerPlatoonTemplates.lua
@@ -133,7 +133,7 @@ PlatoonTemplate {
     Name = 'T123EngineerBuilder',
     Plan = 'EngineerBuildAI',
     GlobalSquads = {
-        { categories.ENGINEER - categories.ENGINEERSTATION - categories.COMMAND, 1, 1, 'support', 'none' },
+        { categories.ENGINEER * (categories.TECH1 + categories.TECH2 + categories.TECH3) - categories.ENGINEERSTATION - categories.COMMAND, 1, 1, 'support', 'none' },
     },
 }
 

--- a/lua/AI/PlatoonTemplates/LandPlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/LandPlatoonTemplates.lua
@@ -83,7 +83,6 @@ PlatoonTemplate {
     GlobalSquads = {
         --DUNCAN - was 15 to 25
         { categories.MOBILE * categories.LAND - categories.EXPERIMENTAL - categories.ENGINEER, 5, 25, 'Attack', 'none' },
-        { categories.ENGINEER - categories.COMMAND, 1, 1, 'Attack', 'none' },
     },
 }
 PlatoonTemplate {


### PR DESCRIPTION
Description.
This PR fixes a couple of platoon templates that were accidentally pulling the cybran engineer drone into them.

One of them I have completely removed engineers from as it had a rather silly premise. It expected an engineer to join an attack platoon. Then move to a start location, disband the platoon then have the engineer 'happen' to pick up a start location expansion builder. It had a small chance of succeeding. There are better ways of protecting an engineer that is expanding.

fixes #4844