### PR TITLE
Annotate and refactor the builder manager of AIs

### DIFF
--- a/lua/aibrains/base-ai.lua
+++ b/lua/aibrains/base-ai.lua
@@ -128,7 +128,6 @@ AIBrain = Class(StandardBrain) {
 
         self.UnitBuiltTriggerList = {}
         self.FactoryAssistList = {}
-        self.DelayEqualBuildPlattons = {}
     end,
 
     ---@param self AIBrain

--- a/lua/aibrains/base-ai.lua
+++ b/lua/aibrains/base-ai.lua
@@ -81,6 +81,7 @@ local StandardBrain = import("/lua/aibrain.lua").AIBrain
 ---@field TacticalBases? table
 ---@field targetoveride boolean
 ---@field Team number The team this brain's army belongs to. Note that games with unlocked teams behave like free-for-alls.
+---@field DelayEqualBuildPlattons table<string, number>     # Used to delay builders, the key is the builder name and the number is the game time in seconds that the builder remains delayed
 AIBrain = Class(StandardBrain) {
     ---@param self AIBrain
     ---@param planName string
@@ -128,6 +129,7 @@ AIBrain = Class(StandardBrain) {
 
         self.UnitBuiltTriggerList = {}
         self.FactoryAssistList = {}
+        self.DelayEqualBuildPlattons = {}
     end,
 
     ---@param self AIBrain

--- a/lua/editor/UnitCountBuildConditions.lua
+++ b/lua/editor/UnitCountBuildConditions.lua
@@ -1419,17 +1419,6 @@ function GetGuards(aiBrain, Unit)
     return count
 end
 
---- Buildcondition to check if a platoon is still delayed
----@param aiBrain AIBrain
----@param PlatoonName string
----@return boolean
-function CheckBuildPlattonDelay(aiBrain, PlatoonName)
-    if aiBrain.DelayEqualBuildPlattons[PlatoonName] and aiBrain.DelayEqualBuildPlattons[PlatoonName] > GetGameTimeSeconds() then
-        return false
-    end
-    return true
-end
-
 --- Buildcondition to limit the number of factories 
 ---@param aiBrain AIBrain
 ---@param locationType string

--- a/lua/editor/UnitCountBuildConditions.lua
+++ b/lua/editor/UnitCountBuildConditions.lua
@@ -1510,3 +1510,13 @@ function CanBuildOnHydroLessThanDistance(aiBrain, locationType, distance, threat
     end
     return false
 end
+
+-----------------------------------------
+--- deprecated conditions
+
+--- The following build conditions no longer have the logic foundation to be supported. They
+--- will always return true
+
+function CheckBuildPlattonDelay(aiBrain, PlatoonName)
+    return true
+end

--- a/lua/editor/UnitCountBuildConditions.lua
+++ b/lua/editor/UnitCountBuildConditions.lua
@@ -1511,12 +1511,14 @@ function CanBuildOnHydroLessThanDistance(aiBrain, locationType, distance, threat
     return false
 end
 
------------------------------------------
---- deprecated conditions
-
---- The following build conditions no longer have the logic foundation to be supported. They
---- will always return true
-
+--- Checks whether the builder / task is intentionally delayed
+---@param aiBrain AIBrain
+---@param PlatoonName string
+---@return boolean
 function CheckBuildPlattonDelay(aiBrain, PlatoonName)
+    local timeToDelay = aiBrain.DelayEqualBuildPlattons[PlatoonName]
+    if timeToDelay and timeToDelay > GetGameTimeSeconds() then
+        return false
+    end
     return true
 end

--- a/lua/sim/Builder.lua
+++ b/lua/sim/Builder.lua
@@ -14,6 +14,7 @@
 ---@field BuilderName string 
 ---@field BuilderType BuilderType 
 ---@field BuilderConditions function[]
+---@field DelayEqualBuildPlattons { [1]: string, [2]: number }
 ---@field InstantCheck boolean
 Builder = ClassSimple {
 
@@ -39,6 +40,8 @@ Builder = ClassSimple {
         self.BuilderName = data.BuilderName
 
         self.ReportFailure = data.ReportFailure
+
+        self.DelayEqualBuildPlattons = data.DelayEqualBuildPlattons
 
         self:SetupBuilderConditions(data, locationType)
 

--- a/lua/sim/Builder.lua
+++ b/lua/sim/Builder.lua
@@ -146,9 +146,6 @@ Builder = ClassSimple {
     ---@param self Builder
     ---@return boolean
     GetBuilderStatus = function(self)
-        if self.GetStatusFunction then
-            self.GetStatusFunction()
-        end
         self:CheckBuilderConditions()
         return self.BuilderStatus
     end,

--- a/lua/sim/Builder.lua
+++ b/lua/sim/Builder.lua
@@ -15,7 +15,6 @@
 ---@field BuilderType BuilderType 
 ---@field BuilderConditions function[]
 ---@field InstantCheck boolean
----@field NeedSort boolean
 Builder = ClassSimple {
 
     ---@param self Builder

--- a/lua/sim/Builder.lua
+++ b/lua/sim/Builder.lua
@@ -12,21 +12,24 @@
 ---@field Priority number
 ---@field OriginalPriority number
 ---@field BuilderName string 
----@field BuilderType string 
----@field BuilderData table 
+---@field BuilderType BuilderType 
 ---@field BuilderConditions function[]
+---@field InstantCheck boolean
+---@field NeedSort boolean
 Builder = ClassSimple {
-    
+
     ---@param self Builder
     ---@param brain AIBrain
-    ---@param data table
+    ---@param data BuilderSpec
     ---@param locationType string
     ---@return boolean
     Create = function(self, brain, data, locationType)
         -- make sure the table of strings exist, they are required for the builder
         local verifyDictionary = { 'Priority', 'BuilderName' }
         for k,v in verifyDictionary do
-            if not self:VerifyDataName(v, data) then return false end
+            if not self:VerifyDataName(v, data) then
+                return false
+            end
         end
 
         self.Priority = data.Priority

--- a/lua/sim/Builder.lua
+++ b/lua/sim/Builder.lua
@@ -132,7 +132,7 @@ Builder = ClassSimple {
     end,
 
     ---@param self Builder
-    ---@return 'Air'|'Any'|'Land'|'Sea'
+    ---@return BuilderType
     GetBuilderType = function(self)
         return Builders[self.BuilderName].BuilderType
     end,

--- a/lua/sim/Builder.lua
+++ b/lua/sim/Builder.lua
@@ -38,8 +38,6 @@ Builder = ClassSimple {
 
         self.BuilderName = data.BuilderName
 
-        self.DelayEqualBuildPlattons = data.DelayEqualBuildPlattons
-
         self.ReportFailure = data.ReportFailure
 
         self:SetupBuilderConditions(data, locationType)

--- a/lua/sim/BuilderManager.lua
+++ b/lua/sim/BuilderManager.lua
@@ -10,18 +10,39 @@
 local Builder = import("/lua/sim/builder.lua")
 
 -- upvalue scope for performance
+local TableSort = table.sort
+local TableInsert =
+
 local ForkThread = ForkThread
 
+---@alias LocationType
+--- can only be applied to the main base
+--- | 'MAIN'
+--- can be applied by any base
+--- | 'LocationType'
+--- name of expansion marker of the base
+--- | string
+
+---@param a Builder
+---@param b Builder
+local function BuilderSortLambda(a, b)
+    return a.Priority > b.Priority
+end
+
+--- Abstract manager that contains shared logic between the various managers that inherit from it
 ---@class BuilderManager
----@field Trash TrashBag
 ---@field Brain AIBrain
 ---@field BuilderData table
 ---@field BuilderCheckInterval number
 ---@field BuilderList boolean
----@field BuilderThread? thread             # Is defined when manager is enabled
----@field Active boolean                    # True when manager is enabled
+---@field BuilderThread? thread             # is defined when manager is enabled
+---@field Active boolean                    # true when manager is enabled
+---@field Location Vector
+---@field LocationType LocationType
 ---@field NumBuilders number
+---@field Trash TrashBag
 BuilderManager = ClassSimple {
+
     ---@param self BuilderManager
     ---@param brain AIBrain
     Create = function(self, brain)
@@ -40,6 +61,194 @@ BuilderManager = ClassSimple {
         self.Trash:Destroy()
     end,
 
+    -----------------------
+    -- builder interface --
+
+    --- Adds a builder to the manager, usually this function is overwritten by the managers that inherit this builder
+    ---@param self BuilderManager
+    ---@param builderData BuilderSpec
+    ---@param locationType LocationType
+    ---@param builderType BuilderType
+    AddBuilder = function(self, builderData, locationType, builderType)
+        local newBuilder = Builder.CreateBuilder(self.Brain, builderData, locationType)
+        self:AddInstancedBuilder(newBuilder, builderType)
+    end,
+
+    --- Adds an abstract builder to the manager
+    ---@param self BuilderManager
+    ---@param newBuilder Builder
+    ---@param builderType BuilderType
+    AddInstancedBuilder = function(self, newBuilder, builderType)
+        -- can't proceed without a builder
+        if not newBuilder then
+            WARN('[' ..
+                string.gsub(debug.getinfo(1).source, ".*\\(.*.lua)", "%1") ..
+                ', line:' .. debug.getinfo(1).currentline .. '] *BUILDERMANAGER ERROR: Invalid builder!')
+            return
+        end
+
+        -- can't proceed without a builder type
+        builderType = builderType or newBuilder:GetBuilderType()
+        if not builderType then
+            WARN('[' ..
+                string.gsub(debug.getinfo(1).source, ".*\\(.*.lua)", "%1") ..
+                ', line:' ..
+                debug.getinfo(1).currentline ..
+                '] *BUILDERMANAGER ERROR: Invalid builder type: ' ..
+                repr(builderType) .. ' - in builder: ' .. newBuilder.BuilderName)
+            return
+        end
+
+        -- can't proceed without a builder type that we support
+        if not self.BuilderData[builderType] then
+            WARN('[' ..
+                string.gsub(debug.getinfo(1).source, ".*\\(.*.lua)", "%1") ..
+                ', line:' ..
+                debug.getinfo(1).currentline ..
+                '] *BUILDERMANAGER ERROR: No BuilderData for builder: ' .. newBuilder.BuilderName)
+            return
+        end
+
+        -- register the builder
+        TableInsert(self.BuilderData[builderType].Builders, newBuilder)
+        self.BuilderData[builderType].NeedSort = true
+
+        -- update internal state
+        self.BuilderList = true
+        self.NumBuilders = self.NumBuilders + 1
+
+        -- process the builder
+        if newBuilder.InstantCheck then
+            self:ManagerLoopBody(newBuilder)
+        end
+    end,
+
+    --- Retrieves the first builder with a matching `BuilderName` field
+    ---@param self BuilderManager
+    ---@param builderName string
+    ---@return Builder?
+    GetBuilder = function(self, builderName)
+        for _, bType in self.BuilderData do
+            for _, builder in bType.Builders do
+                if builder.BuilderName == builderName then
+                    return builder
+                end
+            end
+        end
+    end,
+
+    --- Retrieves the highest builder that is valid with the given parameters, or false if there is none
+    ---@param self BuilderManager
+    ---@param bType BuilderType
+    ---@param params any
+    ---@return Builder | false
+    GetHighestBuilder = function(self, bType, params)
+        if not self.BuilderData[bType] then
+            error('*BUILDERMANAGER ERROR: Invalid builder type - ' .. bType)
+        end
+        if not self.Brain.BuilderManagers[self.LocationType] then
+            return false
+        end
+
+        local found = false
+        local possibleBuilders = {}
+        for k, v in self.BuilderData[bType].Builders do
+            if v.Priority >= 1 and self:BuilderParamCheck(v, params) and (not found or v.Priority == found) and
+                v:GetBuilderStatus() then
+                if not self:IsPlattonBuildDelayed(v.DelayEqualBuildPlattons) then
+                    found = v.Priority
+                    TableInsert(possibleBuilders, k)
+                end
+            elseif found and v.Priority < found then
+                break
+            end
+        end
+
+        if found and found > 0 then
+            local whichBuilder = Random(1, table.getn(possibleBuilders))
+            return self.BuilderData[bType].Builders[ possibleBuilders[whichBuilder] ]
+        end
+        return false
+    end,
+
+    --- Returns true if the given builders matches the manager-specific parameters
+    ---@param self BuilderManager
+    ---@param builder Builder
+    ---@param params table
+    ---@return boolean
+    BuilderParamCheck = function(self, builder, params)
+        return true
+    end,
+
+    --- Retrieves the priority of a builder
+    ---@param self BuilderManager
+    ---@param builderName string
+    ---@return number?
+    GetBuilderPriority = function(self, builderName)
+        local builder = self:GetBuilder(builderName)
+        if builder then
+            return builder.Priority
+        end
+    end,
+
+    --- Defines the priority of a builder
+    ---@param self BuilderManager
+    ---@param builderName string
+    ---@param priority integer
+    ---@param temporary? boolean
+    ---@param setbystrat? boolean
+    SetBuilderPriority = function(self, builderName, priority, temporary, setbystrat)
+        local builder = self:GetBuilder(builderName)
+        if builder then
+            return builder:SetPriority(priority, temporary, setbystrat)
+        end
+    end,
+
+    --- Resets the priority of a builder
+    ---@param self BuilderManager
+    ---@param builderName string
+    ResetBuilderPriority = function(self, builderName)
+        local builder = self:GetBuilder(builderName)
+        if builder then
+            builder:ResetPriority()
+        end
+    end,
+
+    --------------------------------
+    -- builder list interface --
+
+    --- Clears all builders
+    ---@param self BuilderManager
+    ClearBuilderLists = function(self)
+        for k, v in self.Builders do
+            v.Builders = {}
+            v.NeedSort = false
+        end
+        self.BuilderList = false
+    end,
+
+    --- Returns true if this manager has one or more builders
+    ---@param self BuilderManager
+    HasBuilderList = function(self)
+        return self.BuilderList
+    end,
+
+    --- Sorts the builders of this manager so that high priority builders are checked first
+    ---@param self BuilderManager
+    ---@param bType BuilderType
+    ---@return boolean
+    SortBuilderList = function(self, bType)
+        -- Make sure there is a type
+        local
+        if not self.BuilderData[bType] then
+            error('*BUILDMANAGER ERROR: Trying to sort platoons of invalid builder type - ' .. bType)
+            return false
+        end
+
+        TableSort(self.BuilderData[bType].Builders, BuilderSortLambda)
+        self.BuilderData[bType].NeedSort = false
+    end,
+
     ---@param self BuilderManager
     ---@param enable boolean
     SetEnabled = function(self, enable)
@@ -53,138 +262,71 @@ BuilderManager = ClassSimple {
         end
     end,
 
+    -- We delay buildplatoons to give engineers the time to move and start building before we call this builder again.
     ---@param self BuilderManager
-    ---@param bType string
+    ---@param DelayEqualBuildPlattons integer
     ---@return boolean
-    SortBuilderList = function(self, bType)
-        -- Make sure there is a type
-        if not self.BuilderData[bType] then
-            error('*BUILDMANAGER ERROR: Trying to sort platoons of invalid builder type - ' .. bType)
-            return false
-        end
-
-        -- TODO: use the built-in sort
-        local sortedList = {}
-        --Simple selection sort, this can be made faster later if we decide we need it.
-        for i = 1, table.getn(self.BuilderData[bType].Builders) do
-            local highest = -1
-            local key, value
-            for k, v in self.BuilderData[bType].Builders do
-                if v.Priority > highest then
-                    highest = v.Priority
-                    value = v
-                    key = k
-                end
-            end
-            sortedList[i] = value
-            table.remove(self.BuilderData[bType].Builders, key)
-        end
-        self.BuilderData[bType].Builders = sortedList
-        self.BuilderData[bType].NeedSort = false
-    end,
-
-    ---@param self BuilderManager
-    ---@param builderData BuilderSpec
-    ---@param locationType string
-    ---@param builderType string
-    AddBuilder = function(self, builderData, locationType, builderType)
-        local newBuilder = Builder.CreateBuilder(self.Brain, builderData, locationType)
-        self:AddInstancedBuilder(newBuilder, builderType)
-    end,
-
-    ---@param self BuilderManager
-    ---@param newBuilder Builder
-    ---@param builderType string
-    AddInstancedBuilder = function(self, newBuilder, builderType)
-        -- can't proceed without a builder
-        if not newBuilder then
-            WARN('['..string.gsub(debug.getinfo(1).source, ".*\\(.*.lua)", "%1")..', line:'..debug.getinfo(1).currentline..'] *BUILDERMANAGER ERROR: Invalid builder!')
-            return
-        end
-
-        -- can't proceed without a builder type
-        builderType = builderType or newBuilder:GetBuilderType()
-        if not builderType then
-            WARN('['..string.gsub(debug.getinfo(1).source, ".*\\(.*.lua)", "%1")..', line:'..debug.getinfo(1).currentline..'] *BUILDERMANAGER ERROR: Invalid builder type: ' .. repr(builderType) .. ' - in builder: ' .. newBuilder.BuilderName)
-            return
-        end
-
-        -- can't proceed without a valid builder type
-        if not self.BuilderData[builderType] then
-            WARN('['..string.gsub(debug.getinfo(1).source, ".*\\(.*.lua)", "%1")..', line:'..debug.getinfo(1).currentline..'] *BUILDERMANAGER ERROR: No BuilderData for builder: ' .. newBuilder.BuilderName)
-            return
-        end
-
-        -- register the builder
-        table.insert(self.BuilderData[builderType].Builders, newBuilder)
-        self.BuilderData[builderType].NeedSort = true
-
-        -- update internal state
-        self.BuilderList = true
-        self.NumBuilders = self.NumBuilders + 1
-
-        -- process the builder
-        if newBuilder.InstantCheck then
-            self:ManagerLoopBody(newBuilder)
-        end
-    end,
-
-    ---@param self BuilderManager
-    ---@param builderName string
-    ---@return number|false
-    GetBuilderPriority = function(self, builderName)
-        for _,bType in self.BuilderData do
-            for _,builder in bType.Builders do
-                if builder.BuilderName == builderName then
-                    return builder.Priority
-                end
+    IsPlattonBuildDelayed = function(self, DelayEqualBuildPlattons)
+        if DelayEqualBuildPlattons then
+            local CheckDelayTime = GetGameTimeSeconds()
+            local PlatoonName = DelayEqualBuildPlattons[1]
+            if not self.Brain.DelayEqualBuildPlattons[PlatoonName] or
+                self.Brain.DelayEqualBuildPlattons[PlatoonName] < CheckDelayTime then
+                --LOG('Setting '..DelayEqualBuildPlattons[2]..' sec. delaytime for builder ['..PlatoonName..']')
+                self.Brain.DelayEqualBuildPlattons[PlatoonName] = CheckDelayTime + DelayEqualBuildPlattons[2]
+                return false
+            else
+                --LOG('Builder ['..PlatoonName..'] still delayed for '..(CheckDelayTime - self.Brain.DelayEqualBuildPlattons[PlatoonName])..' seconds.')
+                return true
             end
         end
-        return false
     end,
 
+    -- Called every 13 seconds to perform any cleanup; Provides better inheritance
     ---@param self BuilderManager
-    ---@param builderName string
-    ---@return number|false
-    GetActivePriority = function(self, builderName)
-        for _,bType in self.BuilderData do
-            for _,builder in bType.Builders do
-                if builder.BuilderName == builderName then
-                    return builder:GetActivePriority()
-                end
-            end
-        end
-        return false
-    end,
-
-    ---@param self BuilderManager
-    ---@param builderName string
-    ---@param priority integer
-    ---@param temporary number
-    ---@param setbystrat number
-    SetBuilderPriority = function(self,builderName,priority,temporary,setbystrat)
-        for _,bType in self.BuilderData do
-            for _,builder in bType.Builders do
-                if builder.BuilderName == builderName then
-                    builder:SetPriority(priority, temporary, setbystrat)
-                    return
-                end
+    ManagerThreadCleanup = function(self)
+        for bType, bTypeData in self.BuilderData do
+            if bTypeData.NeedSort then
+                self:SortBuilderList(bType)
             end
         end
     end,
 
     ---@param self BuilderManager
-    ---@param builderName string
-    ResetBuilderPriority = function(self,builderName)
-        for _,bType in self.BuilderData do
-            for _,builder in bType.Builders do
-                if builder.BuilderName == builderName then
-                    builder:ResetPriority()
-                    return
+    ---@param builder Unit
+    ---@param bType string
+    ManagerLoopBody = function(self, builder, bType)
+        if builder:CalculatePriority(self) then
+            self.BuilderData[bType].NeedSort = true
+        end
+        --builder:CheckBuilderConditions(self.Brain)
+    end,
+
+    ---@param self BuilderManager
+    ManagerThread = function(self)
+        while self.Active do
+            self:ManagerThreadCleanup()
+            local numPerTick = math.ceil(self.NumBuilders / (self.BuilderCheckInterval * 10))
+            local numTicks = 0
+            local numTested = 0
+            for bType, bTypeData in self.BuilderData do
+                for bNum, bData in bTypeData.Builders do
+                    numTested = numTested + 1
+                    if numTested >= numPerTick then
+                        WaitTicks(1)
+                        numTicks = numTicks + 1
+                    end
+                    self:ManagerLoopBody(bData, bType)
                 end
+            end
+            if numTicks <= (self.BuilderCheckInterval * 10) then
+                WaitTicks((self.BuilderCheckInterval * 10) - numTicks)
             end
         end
     end,
+
+    ----------------
+    -- properties --
 
     ---@param self BuilderManager
     GetLocationCoords = function(self)
@@ -200,14 +342,9 @@ BuilderManager = ClassSimple {
     end,
 
     ---@param self BuilderManager
+    ---@return number
     GetLocationRadius = function(self)
-       return self.Radius
-    end,
-
-    ---@param self BuilderManager
-    ---@param type string
-    AddBuilderType = function(self, type)
-        self.BuilderData[type] = { Builders = {}, NeedSort = false }
+        return self.Radius
     end,
 
     ---@param self BuilderManager
@@ -216,142 +353,29 @@ BuilderManager = ClassSimple {
         self.BuildCheckInterval = interval
     end,
 
-    ---@param self BuilderManager
-    ClearBuilderLists = function(self)
-        for k,v in self.Builders do
-            v.Builders = {}
-            v.NeedSort = false
-        end
-        self.BuilderList = false
-    end,
+    ------------------------------
+    -- deprecated functionality --
 
-    ---@param self BuilderManager
-    HasBuilderList = function(self)
-        return self.BuilderList
-    end,
-
-    -- Function that is run in GetHighestBuilder; allows us to test if the builder is valid
-    -- within a certain type of builder mananger (ie: can factories build the builder)
-    ---@param self BuilderManager
-    ---@param builder Unit
-    ---@param params any
-    ---@return boolean
-    BuilderParamCheck = function(self,builder,params)
-        return true
-    end,
-
+    ---@deprecated
     ---@param self BuilderManager
     ---@param builderName string
-    ---@return any
-    GetBuilder = function(self, builderName)
-        for _,bType in self.BuilderData do
-            for _,builder in bType.Builders do
+    ---@return number|false
+    GetActivePriority = function(self, builderName)
+        for _, bType in self.BuilderData do
+            for _, builder in bType.Builders do
                 if builder.BuilderName == builderName then
-                    return builder
+                    return builder:GetActivePriority()
                 end
             end
         end
         return false
     end,
 
-    -- We delay buildplatoons to give engineers the time to move and start building before we call this builder again.
+    ---@deprecated
     ---@param self BuilderManager
-    ---@param DelayEqualBuildPlattons integer
-    ---@return boolean
-    IsPlattonBuildDelayed = function(self, DelayEqualBuildPlattons)
-        if DelayEqualBuildPlattons then
-            local CheckDelayTime = GetGameTimeSeconds()
-            local PlatoonName = DelayEqualBuildPlattons[1]
-            if not self.Brain.DelayEqualBuildPlattons[PlatoonName] or self.Brain.DelayEqualBuildPlattons[PlatoonName] < CheckDelayTime then
-                --LOG('Setting '..DelayEqualBuildPlattons[2]..' sec. delaytime for builder ['..PlatoonName..']')
-                self.Brain.DelayEqualBuildPlattons[PlatoonName] = CheckDelayTime + DelayEqualBuildPlattons[2]
-                return false
-            else
-                --LOG('Builder ['..PlatoonName..'] still delayed for '..(CheckDelayTime - self.Brain.DelayEqualBuildPlattons[PlatoonName])..' seconds.')
-                return true
-            end
-        end
-    end,
-
-    ---@param self BuilderManager
-    ---@param bType string
-    ---@param params any
-    ---@return boolean
-    GetHighestBuilder = function(self,bType,params)
-        if not self.BuilderData[bType] then
-            error('*BUILDERMANAGER ERROR: Invalid builder type - ' .. bType)
-        end
-        if not self.Brain.BuilderManagers[self.LocationType] then
-            return false
-        end
-
-        local found = false
-        local possibleBuilders = {}
-        for k,v in self.BuilderData[bType].Builders do
-            if v.Priority >= 1 and self:BuilderParamCheck(v,params) and (not found or v.Priority == found) and v:GetBuilderStatus() then
-                if not self:IsPlattonBuildDelayed(v.DelayEqualBuildPlattons) then
-                    found = v.Priority
-                    table.insert(possibleBuilders, k)
-                end
-            elseif found and v.Priority < found then
-                break
-            end
-        end
-        if found and found > 0 then
-            local whichBuilder = Random(1,table.getn(possibleBuilders))
-            return self.BuilderData[bType].Builders[ possibleBuilders[whichBuilder] ]
-        end
-        return false
-    end,
-
-    -- Called every 13 seconds to perform any cleanup; Provides better inheritance
-    ---@param self BuilderManager
-    ManagerThreadCleanup = function(self)
-        for bType,bTypeData in self.BuilderData do
-            if bTypeData.NeedSort then
-                self:SortBuilderList(bType)
-            end
-        end
-    end,
-
-    ---@param self BuilderManager
-    ---@param builder Unit
-    ---@param bType string
-    ManagerLoopBody = function(self,builder,bType)
-        if builder:CalculatePriority(self) then
-            self.BuilderData[bType].NeedSort = true
-        end
-        --builder:CheckBuilderConditions(self.Brain)
-    end,
-
-    ---@param self BuilderManager
-    ManagerThread = function(self)
-        while self.Active do
-            self:ManagerThreadCleanup()
-            local numPerTick = math.ceil(self.NumBuilders / (self.BuilderCheckInterval * 10))
-            local numTicks = 0
-            local numTested = 0
-            for bType,bTypeData in self.BuilderData do
-                for bNum,bData in bTypeData.Builders do
-                    numTested = numTested + 1
-                    if numTested >= numPerTick then
-                        WaitTicks(1)
-                        numTicks = numTicks + 1
-                    end
-                    self:ManagerLoopBody(bData,bType)
-                end
-            end
-            if numTicks <= (self.BuilderCheckInterval * 10) then
-                WaitTicks((self.BuilderCheckInterval * 10) - numTicks)
-            end
-        end
-    end,
-    
-    ---@param self, BuilderManager
-    ---@param oldtable, Table
-    ---@return tempTable, Table
+    ---@param oldtable table
+    ---@return table
     RebuildTable = function(self, oldtable)
-        LOG("RebuildTable")
         local temptable = {}
         for k, v in oldtable do
             if v ~= nil then
@@ -365,7 +389,8 @@ BuilderManager = ClassSimple {
         return temptable
     end,
 
-    -- forking and storing a thread on the monitor
+
+    -- Root of all performance evil, do not use - inline the function instead
     ---@deprecated
     ---@param self BuilderManager
     ---@param fn function

--- a/lua/sim/BuilderManager.lua
+++ b/lua/sim/BuilderManager.lua
@@ -243,7 +243,6 @@ BuilderManager = ClassSimple {
     ---@return boolean
     SortBuilderList = function(self, bType)
         -- Make sure there is a type
-        local
         if not self.BuilderData[bType] then
             error('*BUILDMANAGER ERROR: Trying to sort platoons of invalid builder type - ' .. bType)
             return false

--- a/lua/sim/BuilderManager.lua
+++ b/lua/sim/BuilderManager.lua
@@ -292,7 +292,7 @@ BuilderManager = ClassSimple {
             local CheckDelayTime = GetGameTimeSeconds()
             local PlatoonName = specs[1] --[[@as string]]
             local timeThreshold = self.Brain.DelayEqualBuildPlattons[PlatoonName]
-            if not timeThreshold or timeThreshold < CheckDelayTime then
+            if (not timeThreshold) or (timeThreshold < CheckDelayTime) then
                 self.Brain.DelayEqualBuildPlattons[PlatoonName] = CheckDelayTime + specs[2]
                 return false
             else

--- a/lua/sim/BuilderManager.lua
+++ b/lua/sim/BuilderManager.lua
@@ -38,7 +38,7 @@ end
 ---@class BuilderManager
 ---@field Brain AIBrain                                     # A reference to the brain that this manager belongs to
 ---@field BuilderData table<BuilderType, AIBuilderData>     # List of builders that is managed by this manager
----@field BuilderCheckInterval number   # Interval (in seconds) 
+---@field BuilderCheckInterval number   # Interval (in seconds)
 ---@field BuilderList boolean           # Is true when there is at least one builder in this manager
 ---@field BuilderThread? thread         # Thread that runs the loop, does not exist when the manager is not active
 ---@field Active boolean                # Is true when the manager is enabled, use `SetEnabled` to toggle it
@@ -83,21 +83,21 @@ BuilderManager = ClassSimple {
     -- builder interface
 
     -- This is where the majority of the magic happens. There are two main phases:
-    -- 
+    --
     -- 1. Initialisation
     --
-    -- During initialisation the builders are introduced. Usually no builders are introduced 
+    -- During initialisation the builders are introduced. Usually no builders are introduced
     -- after the manager is created. Note that all builders have unique instances in memory.
     --
     -- 2. Retrieving the highest priority builder
     --
     -- Once all builders are in place we constantly look for the highest possible builder. We
     -- consider the name 'Builder' to be poorly choosen, one should rather read it as a 'Task'
-    -- 
+    --
     -- A task has a priority. The tasks with the highest priority are evaluated first. Each
     -- task has a series of conditions attached to it. These conditions are evaluated as
     -- we are searching for a task.
-    -- 
+    --
     -- Once a task is found it can be assigned. This abstract manager does not manage that, it
     -- is merely an abstraction to interact with the various builders.
 

--- a/lua/sim/BuilderManager.lua
+++ b/lua/sim/BuilderManager.lua
@@ -11,7 +11,7 @@ local Builder = import("/lua/sim/builder.lua")
 
 -- upvalue scope for performance
 local TableSort = table.sort
-local TableInsert =
+local TableInsert = table.insert
 
 local ForkThread = ForkThread
 
@@ -63,6 +63,10 @@ BuilderManager = ClassSimple {
 
     -----------------------
     -- builder interface --
+
+    AddBuilderType = function(self, type)
+        self.BuilderData[type] = { Builders = {}, NeedSort = false }
+    end,
 
     --- Adds a builder to the manager, usually this function is overwritten by the managers that inherit this builder
     ---@param self BuilderManager

--- a/lua/sim/BuilderManager.lua
+++ b/lua/sim/BuilderManager.lua
@@ -57,7 +57,6 @@ BuilderManager = ClassSimple {
     ---@param bType string
     ---@return boolean
     SortBuilderList = function(self, bType)
-        LOG("SortBuilderList")
         -- Make sure there is a type
         if not self.BuilderData[bType] then
             error('*BUILDMANAGER ERROR: Trying to sort platoons of invalid builder type - ' .. bType)
@@ -309,7 +308,7 @@ BuilderManager = ClassSimple {
         if not self.Brain.BuilderManagers[self.LocationType] then
             return false
         end
-        
+
         local found = false
         local possibleBuilders = {}
         for k,v in self.BuilderData[bType].Builders do

--- a/lua/sim/BuilderManager.lua
+++ b/lua/sim/BuilderManager.lua
@@ -187,11 +187,6 @@ BuilderManager = ClassSimple {
     end,
 
     ---@param self BuilderManager
-    GetLocationType = function(self)
-        return self.LocationType
-    end,
-
-    ---@param self BuilderManager
     GetLocationCoords = function(self)
         if not self.Location then
             return false

--- a/lua/sim/BuilderManager.lua
+++ b/lua/sim/BuilderManager.lua
@@ -84,25 +84,6 @@ BuilderManager = ClassSimple {
     end,
 
     ---@param self BuilderManager
-    ---@param builderName string
-    ---@param changeTable table
-    AlterBuilder = function(self, builderName, changeTable)
-        for k,v in self.BuilderData do
-            for num,builder in v.Builders do
-                if builder.BuilderName == builderName then
-                    for key,change in changeTable do
-                        builder.key = change
-                        if key == BuilderConditions then
-                            ChangeState(builder, builder.SetupState)
-                        end
-                    end
-                end
-                break
-            end
-        end
-    end,
-
-    ---@param self BuilderManager
     ---@param builderData BuilderSpec
     ---@param locationType string
     ---@param builderType string

--- a/lua/sim/EngineerManager.lua
+++ b/lua/sim/EngineerManager.lua
@@ -15,21 +15,22 @@ local TableGetn = table.getn
 EngineerManager = Class(BuilderManager) {
     ---@param self EngineerManager
     ---@param brain AIBrain
-    ---@param lType any
+    ---@param lType LocationType
     ---@param location Vector
     ---@param radius number
     ---@return boolean
     Create = function(self, brain, lType, location, radius)
-        BuilderManager.Create(self,brain)
+        BuilderManager.Create(self,brain, lType, location, radius)
 
         if not lType or not location or not radius then
             error('*PLATOOM FORM MANAGER ERROR: Invalid parameters; requires locationType, location, and radius')
             return false
         end
 
-        self.Location = location
-        self.Radius = radius
-        self.LocationType = lType
+        -- backwards compatibility for mods
+        self.Location = self.Location or location
+        self.Radius = self.Radius or radius
+        self.LocationType = self.LocationType or lType
 
         self.ConsumptionUnits = {
             Engineers = { Category = categories.ENGINEER, Units = {}, UnitsList = {}, Count = 0, },

--- a/lua/sim/FactoryBuilderManager.lua
+++ b/lua/sim/FactoryBuilderManager.lua
@@ -479,10 +479,11 @@ FactoryBuilderManager = Class(BuilderManager) {
 
     -- Check if given factory can build the builder
     ---@param self FactoryBuilderManager
-    ---@param builder Unit
-    ---@param params any
+    ---@param builder Builder
+    ---@param params FactoryUnit[]
     ---@return boolean
-    BuilderParamCheck = function(self,builder,params)
+    BuilderParamCheck = function(self, builder, params)
+
         -- params[1] is factory, no other params
         local template = self:GetFactoryTemplate(builder:GetPlatoonTemplate(), params[1])
         if not template then

--- a/lua/sim/FactoryBuilderManager.lua
+++ b/lua/sim/FactoryBuilderManager.lua
@@ -13,7 +13,17 @@ local Builder = import("/lua/sim/builder.lua")
 
 local TableGetn = table.getn
 
+
+
 ---@class FactoryBuilderManager : BuilderManager
+---@field Location Vector
+---@field Radius number
+---@field LocationType LocationType
+---@field RallyPoint Vector | false
+---@field LocationActive boolean
+---@field RandomSamePriority boolean
+---@field PlatoonListEmpty boolean
+---@field UseCenterPoint boolean
 FactoryBuilderManager = Class(BuilderManager) {
     ---@param self FactoryBuilderManager
     ---@param brain AIBrain
@@ -92,8 +102,8 @@ FactoryBuilderManager = Class(BuilderManager) {
     end,
 
     ---@param self FactoryBuilderManager
-    ---@param builderData table
-    ---@param locationType string
+    ---@param builderData BuilderSpec
+    ---@param locationType LocationType
     ---@return boolean
     AddBuilder = function(self, builderData, locationType)
         local newBuilder = Builder.CreateFactoryBuilder(self.Brain, builderData, locationType)
@@ -108,7 +118,7 @@ FactoryBuilderManager = Class(BuilderManager) {
     end,
 
     ---@param self FactoryBuilderManager
-    ---@return Platoon
+    ---@return boolean
     HasPlatoonList = function(self)
         return self.PlatoonListEmpty
     end,
@@ -456,7 +466,7 @@ FactoryBuilderManager = Class(BuilderManager) {
             self.Brain.BuilderManagers[self.LocationType].EngineerManager:AddUnit(finishedUnit)
         elseif EntityCategoryContains(categories.FACTORY * categories.STRUCTURE, finishedUnit ) then
 			if finishedUnit:GetFractionComplete() == 1 then
-				self:AddFactory(finishedUnit )			
+				self:AddFactory(finishedUnit )
 				factory.Dead = true
                 factory.Trash:Destroy()
 				return self:FactoryDestroyed(factory)

--- a/lua/sim/FactoryBuilderManager.lua
+++ b/lua/sim/FactoryBuilderManager.lua
@@ -33,7 +33,7 @@ FactoryBuilderManager = Class(BuilderManager) {
     ---@param useCenterPoint boolean
     ---@return boolean
     Create = function(self, brain, lType, location, radius, useCenterPoint)
-        BuilderManager.Create(self,brain)
+        BuilderManager.Create(self,brain, lType, location, radius)
 
         if not lType or not location or not radius then
             error('*FACTORY BUILDER MANAGER ERROR: Invalid parameters; requires locationType, location, and radius')
@@ -45,9 +45,11 @@ FactoryBuilderManager = Class(BuilderManager) {
             self:AddBuilderType(v)
         end
 
-        self.Location = location
-        self.Radius = radius
-        self.LocationType = lType
+        -- backwards compatibility for mods
+        self.Location = self.Location or location
+        self.Radius = self.Radius or radius
+        self.LocationType = self.LocationType or lType
+
         self.RallyPoint = false
 
         self.FactoryList = {}

--- a/lua/sim/PlatoonFormManager.lua
+++ b/lua/sim/PlatoonFormManager.lua
@@ -15,21 +15,22 @@ local Builder = import("/lua/sim/builder.lua")
 PlatoonFormManager = Class(BuilderManager) {
     ---@param self PlatoonFormManager
     ---@param brain AIBrain
-    ---@param lType any
+    ---@param lType LocationType
     ---@param location Vector
     ---@param radius number
     ---@return boolean
     Create = function(self, brain, lType, location, radius)
-        BuilderManager.Create(self,brain)
+        BuilderManager.Create(self, brain, lType, location, radius)
 
         if not lType or not location or not radius then
             error('*PLATOOM FORM MANAGER ERROR: Invalid parameters; requires locationType, location, and radius')
             return false
         end
 
-        self.Location = location
-        self.Radius = radius
-        self.LocationType= lType
+        -- backwards compatibility for mods
+        self.Location = self.Location or location
+        self.Radius = self.Radius or radius
+        self.LocationType = self.LocationType or lType
 
         self:AddBuilderType('Any')
 

--- a/lua/sim/StrategyManager.lua
+++ b/lua/sim/StrategyManager.lua
@@ -14,16 +14,16 @@ local StrategyBuilder = import("/lua/sim/strategybuilder.lua")
 StrategyManager = Class(BuilderManager) {
     ---@param self StrategyManager
     ---@param brain AIBrain
-    ---@param lType any
+    ---@param lType LocationType
     ---@param location Vector
     ---@param radius number
     ---@param useCenterPoint boolean
     Create = function(self, brain, lType, location, radius, useCenterPoint)
-        BuilderManager.Create(self,brain)
+        BuilderManager.Create(self, brain, lType, location, radius)
 
-        self.Location = location
-        self.Radius = radius
-        self.LocationType = lType
+        self.Location = self.Location or location
+        self.Radius = self.Radius or radius
+        self.LocationType = self.LocationType or lType
 
         self.LastChange = 0
         self.NextChange = 300

--- a/lua/system/GlobalBuilderTemplate.lua
+++ b/lua/system/GlobalBuilderTemplate.lua
@@ -21,13 +21,15 @@
 ---@field [2] FunctionReference
 ---@field [3] FunctionParameters
 
----@alias BuilderType 'Air' | 'Land' | 'Sea' | 'Any'
+---@alias BuilderType 'Any' | 'Land' | 'Air' | 'Sea' | 'Gate' 
 
 ---@class BuilderSpec
 ---@field BuilderName BuilderNames
 ---@field BuilderType BuilderType
+---@field BuilderData table
 ---@field PlatoonTemplate string
 ---@field Priority number
+---@field InstanceCount number
 ---@field BuilderConditions BuilderCondition[]
 
 -- Global list of all builders found in the game


### PR DESCRIPTION
Improves the annotations of the builder manager and refactors the file to make it more intuitive to understand for new contributors.

- [x] Document `BuilderManager.lua`

The entire flow was undocumented. All functions have correct annotations and additional comments where necessary.

- [x] Pass location, location type and radius to base class

These properties were used by all instances.

- [x] Deprecate various unused functions

These merely clutter the code base

Improve performance of:
- [x] `SortBuilderList`: No longer creates a new table and uses the built-in sorting algorithm
- [x] `GetLocationCoords `: Returns the location of the manager instead of a newly-allocated table
- [x] `GetHighestBuilder`: Significant reduction in table operations and removes the `possibleBuilders` local in favor of re-using tables

