### PR TITLE
Add new event when ACU enters transporter.

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2230,6 +2230,23 @@ BaseTransport = ClassSimple {
             end
         end
 
+        --any ACU : Cybran, Aeon, Seraphim, Uef
+        if SessionIsReplay()  and (unit.UnitId == 'url0001' or unit.UnitId == 'ual0001' or unit.UnitId == 'xsl0001' or unit.UnitId == 'uel0001') then
+            -- prepare sync
+            local sync = Sync
+            local events = sync.Events or { }
+            sync.Events = events
+            local AcuEntersTransporter = events.ACUEntersTransporter or { }
+            events.ACUEntersTransporter = AcuEntersTransporter
+
+            -- sync the event
+            table.insert(AcuEntersTransporter, {
+                Timestamp = GetGameTimeSeconds(),
+                ACUArmyID = unit.Army
+            })
+        end
+
+
         unit:OnAttachedToTransport(self, attachBone)
     end,
 

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2231,7 +2231,7 @@ BaseTransport = ClassSimple {
         end
 
         --any ACU : Cybran, Aeon, Seraphim, Uef
-        if SessionIsReplay()  and (unit.UnitId == 'url0001' or unit.UnitId == 'ual0001' or unit.UnitId == 'xsl0001' or unit.UnitId == 'uel0001') then
+        if SessionIsReplay() and EntityCategoryContains(categories.COMMAND, unit) then
             -- prepare sync
             local sync = Sync
             local events = sync.Events or { }


### PR DESCRIPTION
As seen in the discord suggestion channel, this could be a handy event for casters.
Whenever an ACU is put into a transport, there is likely some action going to take place.
So getting notified about this when casting could put the caster in the middle of the action.

The event is only created for replays, as it needs to be hidden from the enemy team.