### PR TITLE
Fix orientation of structures that launch missiles

### DIFF
--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -961,6 +961,8 @@
 ---@field FuelUseTime number
 --- How much the collision model is offset from the ground. Used to make aircraft land properly.
 ---@field GroundCollisionOffset? number
+--- Used in combination with `FlattenSkirt` to guarantee the result is completely horizontal
+---@field HorizontalSkirt boolean
 --- used by the Seraphim sniper bot script as the speed multiplier when the alternate sniper mode
 --- is activated
 ---@field LandSpeedMultiplier? number

--- a/units/UAB2108/UAB2108_unit.bp
+++ b/units/UAB2108/UAB2108_unit.bp
@@ -193,6 +193,7 @@ UnitBlueprint {
         },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
+        HorizontalSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 0.75,
         MeshExtentsY = 0.35,

--- a/units/UAB2305/UAB2305_unit.bp
+++ b/units/UAB2305/UAB2305_unit.bp
@@ -187,6 +187,7 @@ UnitBlueprint {
     LifeBarSize = 2.5,
     Physics = {
         BankingSlope = 0,
+        StandUpright = true,
         BuildOnLayerCaps = {
             LAYER_Air = false,
             LAYER_Land = true,
@@ -197,6 +198,8 @@ UnitBlueprint {
         },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
+        HorizontalSkirt = true,
+        MaxGroundVariation = 1.0,
         MaxSteerForce = 0,
         MeshExtentsX = 2.1,
         MeshExtentsY = 1,

--- a/units/UEB2108/UEB2108_unit.bp
+++ b/units/UEB2108/UEB2108_unit.bp
@@ -159,6 +159,7 @@ UnitBlueprint {
         },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
+        HorizontalSkirt = true,
         MaxSteerForce = 0,
         MinSpeedPercent = 0,
         MotionType = 'RULEUMT_None',

--- a/units/UEB2305/UEB2305_unit.bp
+++ b/units/UEB2305/UEB2305_unit.bp
@@ -168,6 +168,7 @@ UnitBlueprint {
         },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
+        HorizontalSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 3.6,
         MeshExtentsY = 1.45,

--- a/units/URB2108/URB2108_unit.bp
+++ b/units/URB2108/URB2108_unit.bp
@@ -150,6 +150,7 @@ UnitBlueprint {
         },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
+        HorizontalSkirt = true,
         MaxSteerForce = 0,
         MinSpeedPercent = 0,
         MotionType = 'RULEUMT_None',

--- a/units/URB2305/URB2305_unit.bp
+++ b/units/URB2305/URB2305_unit.bp
@@ -201,6 +201,7 @@ UnitBlueprint {
         },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
+        HorizontalSkirt = true,
         MaxSteerForce = 0,
         MinSpeedPercent = 0,
         MotionType = 'RULEUMT_None',

--- a/units/XSB2108/XSB2108_unit.bp
+++ b/units/XSB2108/XSB2108_unit.bp
@@ -208,6 +208,7 @@ UnitBlueprint {
         },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
+        HorizontalSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 0.75,
         MeshExtentsY = 0.35,

--- a/units/XSB2305/XSB2305_unit.bp
+++ b/units/XSB2305/XSB2305_unit.bp
@@ -197,6 +197,7 @@ UnitBlueprint {
         },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
+        HorizontalSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 2.1,
         MeshExtentsY = 1,

--- a/units/XSB2401/XSB2401_unit.bp
+++ b/units/XSB2401/XSB2401_unit.bp
@@ -222,6 +222,7 @@ UnitBlueprint {
         },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
+        HorizontalSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 2.1,
         MeshExtentsY = 1,


### PR DESCRIPTION
The trajectory of tactical / strategical missiles have the assumption that the projectile starts perfectly vertically. We violated that assumption when we integrated the wonky structures mod.

![image](https://user-images.githubusercontent.com/15778155/230736302-6d705f5a-30d4-4445-b606-182d3b1921b6.png)
