### PR TITLE
Fix state being unable to call the base class

### DIFF
--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -1034,7 +1034,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         end,
 
         OnLostTarget = function(self)
-            Weapon.OnLostTarget(self)
+            self.__base.OnLostTarget(self)
             if self.Blueprint.WeaponUnpacks then
                 ChangeState(self, self.WeaponPackingState)
             end

--- a/lua/system/class.lua
+++ b/lua/system/class.lua
@@ -91,6 +91,7 @@ local TableEmpty = table.empty
 local TableGetn = table.getn
 
 local Exclusions = {
+    __base = true,
     __index = true,
     n = true,
     __name = true,
@@ -553,6 +554,7 @@ function ConstructClass(bases, specs)
             local d = Deepcopy(v)
 
             -- set meta table information
+            d.__base = class
             d.__index = d
             setmetatable(d, class)
 


### PR DESCRIPTION
A state was unable to call the correct base class. We introduce a `__base` field to each state so that it can do so. This fixes the bug where the beam of the colossus can linger on after tractoring a unit.