### PR TITLE
Recover missile progress when gifting a unit

### DIFF
--- a/engine/Sim/Unit.lua
+++ b/engine/Sim/Unit.lua
@@ -309,7 +309,8 @@ end
 --- This is the method to call for both SML's and SMD's.
 ---@see GiveTacticalSiloAmmo() # for tactical missiles
 ---@param amount number
-function Unit:GiveNukeSiloAmmo(amount)
+---@param inBlocks? boolean
+function Unit:GiveNukeSiloAmmo(amount, inBlocks)
 end
 
 --- Adds tactical missiles to the unit

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -110,6 +110,7 @@ function TransferUnitsOwnership(units, toArmy, captured)
 
         -- B E F O R E
         local orientation = unit:GetOrientation()
+        local workprogress = unit:GetWorkProgress()
         local numNukes = unit:GetNukeSiloAmmoCount() -- nuclear missiles; SML or SMD
         local numTacMsl = unit:GetTacticalSiloAmmoCount()
         local massKilled = unit.VetExperience
@@ -223,6 +224,10 @@ function TransferUnitsOwnership(units, toArmy, captured)
 
         if numTacMsl and numTacMsl > 0 then
             newUnit:GiveTacticalSiloAmmo(numTacMsl - newUnit:GetTacticalSiloAmmoCount())
+        end
+
+        if newUnit.Blueprint.CategoriesHash["SILO"] then
+            newUnit:GiveNukeSiloBlocks(workprogress)
         end
 
         local newShield = newUnit.MyShield

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4325,6 +4325,34 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         end
     end,
 
+    ---@param self Unit
+    ---@param count number
+    GiveNukeSiloAmmo = function(self, count)
+        cUnit.GiveNukeSiloAmmo(self, count)
+    end,
+
+    ---@param self Unit
+    ---@param fraction number
+    GiveNukeSiloBlocks = function(self, fraction)
+        if fraction < 0 or fraction > 1 then
+            return
+        end
+
+        local buildRate = self.Blueprint.Economy.BuildRate
+        if not buildRate then
+            return
+        end
+
+        local buildTime = self:GetWeapon(1):GetProjectileBlueprint().Economy.BuildTime
+        if not buildTime then
+            return
+        end
+
+        local total = 10 * (buildTime / buildRate)
+        local blocks = math.ceil(fraction * total)
+        cUnit.GiveNukeSiloAmmo(self, blocks, true)
+    end,
+
     --- Stuns the unit, if it isn't set to be immune by the flag unit.ImmuneToStun
     ---@param self Unit A reference to the unit itself, automatically set when you use the ':' notation
     ---@param duration number Stun duration in seconds


### PR DESCRIPTION
Relates to: https://github.com/FAForever/FA-Binary-Patches/pull/15

Allows a (strategic) missile launcher to recover the progression of a missile when the unit is gifted.