### PR TITLE
Share tarmacs when gifting a structure

### DIFF
--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -114,6 +114,7 @@ function TransferUnitsOwnership(units, toArmy, captured)
         local numTacMsl = unit:GetTacticalSiloAmmoCount()
         local massKilled = unit.VetExperience
         local unitHealth = unit:GetHealth()
+        local tarmacs = unit.TarmacBag
         local shieldIsOn = false
         local shieldHealth = 0
         local hasFuel = false
@@ -215,6 +216,10 @@ function TransferUnitsOwnership(units, toArmy, captured)
 
         if hasFuel then
             newUnit:SetFuelRatio(fuelRatio)
+        end
+        
+        if tarmacs then
+            newUnit.TarmacBag = tarmacs
         end
 
         if numNukes and numNukes > 0 then


### PR DESCRIPTION
Prevents the stacking of tarmacs as you (involuntarily) gift a structure to another player