### PR TITLE
Fix blocking of innocent sound banks

### DIFF
--- a/init_faf.lua
+++ b/init_faf.lua
@@ -13,10 +13,6 @@ LOG("Game version: " .. tostring(GameVersion))
 LOG("Game type: " .. tostring(GameType))
 
 -- upvalued performance
-local dofile = dofile
-
-local StringFind = string.find 
-local StringGsub = string.gsub
 local StringSub = string.sub
 local StringLower = string.lower
 
@@ -55,6 +51,22 @@ local function LowerHashTable(t)
         o[StringLower(k)] = v 
     end
     return o
+end
+
+local function FindFilesWithExtension(dir, extension, prepend, files)
+    files = files or { }
+
+    for k, file in IoDir(dir .. "/*") do
+        if not (file == '.' or file == '..') then
+            if StringSub(file, -3) == extension then
+                LOG(prepend .. "/" .. file)
+                TableInsert(files, prepend .. "/" .. file)
+            end
+            FindFilesWithExtension(dir .. "/" .. file, extension, prepend .. "/" .. file, files)
+        end
+    end
+
+    return files
 end
 
 -- mods that have been integrated, based on folder name 
@@ -137,8 +149,8 @@ allowedAssetsNxt = LowerHashTable(allowedAssetsNxt)
 
 -- default wave banks to prevent collisions
 local soundsBlocked = { }
-local faSounds = IoDir(fa_path .. '/sounds/*')
-for k, v in faSounds do 
+local sounds = FindFilesWithExtension(fa_path .. '/sounds', "xwb", "/sounds")
+for k, v in sounds do 
     if v == '.' or v == '..' then 
         continue 
     end
@@ -293,19 +305,19 @@ local function MountMapContent(dir)
                     MountDirectory(dir .. "/" .. map .. '/movies', '/movies')
                 end
             elseif folder == 'sounds' then
+                local banks = FindFilesWithExtension(dir .. '/' .. map .. "/sounds", "xwb", "/sounds")
+
                 -- find conflicting files
                 local conflictingFiles = { }
-                for _, file in IoDir(dir .. '/' .. map .. '/sounds/*') do
-                    if not (file == '.' or file == '..') then 
-                        local identifier = StringLower(file) 
-                        if soundsBlocked[identifier] then 
-                            TableInsert(conflictingFiles, { file = file, conflict = soundsBlocked[identifier] })
-                        else 
-                            soundsBlocked[identifier] = StringLower(map)
-                        end
+                for _, bank in banks do
+                    local identifier = StringLower(bank) 
+                    if soundsBlocked[identifier] then 
+                        TableInsert(conflictingFiles, { file = bank, conflict = soundsBlocked[identifier] })
+                    else 
+                        soundsBlocked[identifier] = StringLower(map)
                     end
                 end
-                    
+                
                 -- report them if they exist and do not mount
                 if TableGetn(conflictingFiles) > 0 then 
                     LOG("Found conflicting sound banks for map: '" .. map .. "', cannot mount the sound bank(s):")
@@ -467,26 +479,26 @@ local function MountModContent(dir)
 
         -- look at each directory inside this mod
         for _, folder in IoDir(dir .. '/' .. mod .. '/*') do
-            
+
             -- if we found a directory named 'sounds' then we mount its content
             if folder == 'sounds' then
+                local banks = FindFilesWithExtension(dir .. '/' ..  mod .. "/sounds", "xwb", "/sounds")
+
                 -- find conflicting files
                 local conflictingFiles = { }
-                for _, file in IoDir(dir .. '/' .. mod .. '/sounds/*') do
-                    if not (file == '.' or file == '..') then 
-                        local identifier = StringLower(file) 
-                        if soundsBlocked[identifier] then 
-                            TableInsert(conflictingFiles, { file = file, conflict = soundsBlocked[identifier] })
-                        else 
-                            soundsBlocked[identifier] = StringLower(mod)
-                        end
+                for _, bank in banks do
+                    local identifier = StringLower(bank) 
+                    if soundsBlocked[identifier] then 
+                        TableInsert(conflictingFiles, { file = bank, conflict = soundsBlocked[identifier] })
+                    else
+                        soundsBlocked[identifier] = StringLower(mod)
                     end
                 end
-                    
+
                 -- report them if they exist and do not mount
                 if TableGetn(conflictingFiles) > 0 then 
                     LOG("Found conflicting sound banks for mod: '" .. mod .. "', cannot mount the sound bank(s):")
-                    for k, v in conflictingFiles do 
+                    for _, v in conflictingFiles do 
                         LOG(" - Conflicting sound bank: '" .. v.file .. "' of mod '" .. mod .. "' is conflicting with a sound bank from: '" .. v.conflict .. "'" )
                     end
                 -- else, mount folder

--- a/init_fafbeta.lua
+++ b/init_fafbeta.lua
@@ -13,10 +13,6 @@ LOG("Game version: " .. tostring(GameVersion))
 LOG("Game type: " .. tostring(GameType))
 
 -- upvalued performance
-local dofile = dofile
-
-local StringFind = string.find 
-local StringGsub = string.gsub
 local StringSub = string.sub
 local StringLower = string.lower
 
@@ -55,6 +51,22 @@ local function LowerHashTable(t)
         o[StringLower(k)] = v 
     end
     return o
+end
+
+local function FindFilesWithExtension(dir, extension, prepend, files)
+    files = files or { }
+
+    for k, file in IoDir(dir .. "/*") do
+        if not (file == '.' or file == '..') then
+            if StringSub(file, -3) == extension then
+                LOG(prepend .. "/" .. file)
+                TableInsert(files, prepend .. "/" .. file)
+            end
+            FindFilesWithExtension(dir .. "/" .. file, extension, prepend .. "/" .. file, files)
+        end
+    end
+
+    return files
 end
 
 -- mods that have been integrated, based on folder name 
@@ -137,8 +149,8 @@ allowedAssetsNxt = LowerHashTable(allowedAssetsNxt)
 
 -- default wave banks to prevent collisions
 local soundsBlocked = { }
-local faSounds = IoDir(fa_path .. '/sounds/*')
-for k, v in faSounds do 
+local sounds = FindFilesWithExtension(fa_path .. '/sounds', "xwb", "/sounds")
+for k, v in sounds do 
     if v == '.' or v == '..' then 
         continue 
     end
@@ -293,19 +305,19 @@ local function MountMapContent(dir)
                     MountDirectory(dir .. "/" .. map .. '/movies', '/movies')
                 end
             elseif folder == 'sounds' then
+                local banks = FindFilesWithExtension(dir .. '/' .. map .. "/sounds", "xwb", "/sounds")
+
                 -- find conflicting files
                 local conflictingFiles = { }
-                for _, file in IoDir(dir .. '/' .. map .. '/sounds/*') do
-                    if not (file == '.' or file == '..') then 
-                        local identifier = StringLower(file) 
-                        if soundsBlocked[identifier] then 
-                            TableInsert(conflictingFiles, { file = file, conflict = soundsBlocked[identifier] })
-                        else 
-                            soundsBlocked[identifier] = StringLower(map)
-                        end
+                for _, bank in banks do
+                    local identifier = StringLower(bank) 
+                    if soundsBlocked[identifier] then 
+                        TableInsert(conflictingFiles, { file = bank, conflict = soundsBlocked[identifier] })
+                    else 
+                        soundsBlocked[identifier] = StringLower(map)
                     end
                 end
-                    
+                
                 -- report them if they exist and do not mount
                 if TableGetn(conflictingFiles) > 0 then 
                     LOG("Found conflicting sound banks for map: '" .. map .. "', cannot mount the sound bank(s):")
@@ -467,26 +479,26 @@ local function MountModContent(dir)
 
         -- look at each directory inside this mod
         for _, folder in IoDir(dir .. '/' .. mod .. '/*') do
-            
+
             -- if we found a directory named 'sounds' then we mount its content
             if folder == 'sounds' then
+                local banks = FindFilesWithExtension(dir .. '/' ..  mod .. "/sounds", "xwb", "/sounds")
+
                 -- find conflicting files
                 local conflictingFiles = { }
-                for _, file in IoDir(dir .. '/' .. mod .. '/sounds/*') do
-                    if not (file == '.' or file == '..') then 
-                        local identifier = StringLower(file) 
-                        if soundsBlocked[identifier] then 
-                            TableInsert(conflictingFiles, { file = file, conflict = soundsBlocked[identifier] })
-                        else 
-                            soundsBlocked[identifier] = StringLower(mod)
-                        end
+                for _, bank in banks do
+                    local identifier = StringLower(bank) 
+                    if soundsBlocked[identifier] then 
+                        TableInsert(conflictingFiles, { file = bank, conflict = soundsBlocked[identifier] })
+                    else
+                        soundsBlocked[identifier] = StringLower(mod)
                     end
                 end
-                    
+
                 -- report them if they exist and do not mount
                 if TableGetn(conflictingFiles) > 0 then 
                     LOG("Found conflicting sound banks for mod: '" .. mod .. "', cannot mount the sound bank(s):")
-                    for k, v in conflictingFiles do 
+                    for _, v in conflictingFiles do 
                         LOG(" - Conflicting sound bank: '" .. v.file .. "' of mod '" .. mod .. "' is conflicting with a sound bank from: '" .. v.conflict .. "'" )
                     end
                 -- else, mount folder

--- a/init_fafdevelop.lua
+++ b/init_fafdevelop.lua
@@ -13,10 +13,6 @@ LOG("Game version: " .. tostring(GameVersion))
 LOG("Game type: " .. tostring(GameType))
 
 -- upvalued performance
-local dofile = dofile
-
-local StringFind = string.find 
-local StringGsub = string.gsub
 local StringSub = string.sub
 local StringLower = string.lower
 
@@ -55,6 +51,22 @@ local function LowerHashTable(t)
         o[StringLower(k)] = v 
     end
     return o
+end
+
+local function FindFilesWithExtension(dir, extension, prepend, files)
+    files = files or { }
+
+    for k, file in IoDir(dir .. "/*") do
+        if not (file == '.' or file == '..') then
+            if StringSub(file, -3) == extension then
+                LOG(prepend .. "/" .. file)
+                TableInsert(files, prepend .. "/" .. file)
+            end
+            FindFilesWithExtension(dir .. "/" .. file, extension, prepend .. "/" .. file, files)
+        end
+    end
+
+    return files
 end
 
 -- mods that have been integrated, based on folder name 
@@ -137,8 +149,8 @@ allowedAssetsNxt = LowerHashTable(allowedAssetsNxt)
 
 -- default wave banks to prevent collisions
 local soundsBlocked = { }
-local faSounds = IoDir(fa_path .. '/sounds/*')
-for k, v in faSounds do 
+local sounds = FindFilesWithExtension(fa_path .. '/sounds', "xwb", "/sounds")
+for k, v in sounds do 
     if v == '.' or v == '..' then 
         continue 
     end
@@ -293,19 +305,19 @@ local function MountMapContent(dir)
                     MountDirectory(dir .. "/" .. map .. '/movies', '/movies')
                 end
             elseif folder == 'sounds' then
+                local banks = FindFilesWithExtension(dir .. '/' .. map .. "/sounds", "xwb", "/sounds")
+
                 -- find conflicting files
                 local conflictingFiles = { }
-                for _, file in IoDir(dir .. '/' .. map .. '/sounds/*') do
-                    if not (file == '.' or file == '..') then 
-                        local identifier = StringLower(file) 
-                        if soundsBlocked[identifier] then 
-                            TableInsert(conflictingFiles, { file = file, conflict = soundsBlocked[identifier] })
-                        else 
-                            soundsBlocked[identifier] = StringLower(map)
-                        end
+                for _, bank in banks do
+                    local identifier = StringLower(bank) 
+                    if soundsBlocked[identifier] then 
+                        TableInsert(conflictingFiles, { file = bank, conflict = soundsBlocked[identifier] })
+                    else 
+                        soundsBlocked[identifier] = StringLower(map)
                     end
                 end
-                    
+                
                 -- report them if they exist and do not mount
                 if TableGetn(conflictingFiles) > 0 then 
                     LOG("Found conflicting sound banks for map: '" .. map .. "', cannot mount the sound bank(s):")
@@ -467,26 +479,26 @@ local function MountModContent(dir)
 
         -- look at each directory inside this mod
         for _, folder in IoDir(dir .. '/' .. mod .. '/*') do
-            
+
             -- if we found a directory named 'sounds' then we mount its content
             if folder == 'sounds' then
+                local banks = FindFilesWithExtension(dir .. '/' ..  mod .. "/sounds", "xwb", "/sounds")
+
                 -- find conflicting files
                 local conflictingFiles = { }
-                for _, file in IoDir(dir .. '/' .. mod .. '/sounds/*') do
-                    if not (file == '.' or file == '..') then 
-                        local identifier = StringLower(file) 
-                        if soundsBlocked[identifier] then 
-                            TableInsert(conflictingFiles, { file = file, conflict = soundsBlocked[identifier] })
-                        else 
-                            soundsBlocked[identifier] = StringLower(mod)
-                        end
+                for _, bank in banks do
+                    local identifier = StringLower(bank) 
+                    if soundsBlocked[identifier] then 
+                        TableInsert(conflictingFiles, { file = bank, conflict = soundsBlocked[identifier] })
+                    else
+                        soundsBlocked[identifier] = StringLower(mod)
                     end
                 end
-                    
+
                 -- report them if they exist and do not mount
                 if TableGetn(conflictingFiles) > 0 then 
                     LOG("Found conflicting sound banks for mod: '" .. mod .. "', cannot mount the sound bank(s):")
-                    for k, v in conflictingFiles do 
+                    for _, v in conflictingFiles do 
                         LOG(" - Conflicting sound bank: '" .. v.file .. "' of mod '" .. mod .. "' is conflicting with a sound bank from: '" .. v.conflict .. "'" )
                     end
                 -- else, mount folder

--- a/init_shared.lua
+++ b/init_shared.lua
@@ -13,10 +13,6 @@ LOG("Game version: " .. tostring(GameVersion))
 LOG("Game type: " .. tostring(GameType))
 
 -- upvalued performance
-local dofile = dofile
-
-local StringFind = string.find 
-local StringGsub = string.gsub
 local StringSub = string.sub
 local StringLower = string.lower
 
@@ -55,6 +51,22 @@ local function LowerHashTable(t)
         o[StringLower(k)] = v 
     end
     return o
+end
+
+local function FindFilesWithExtension(dir, extension, prepend, files)
+    files = files or { }
+
+    for k, file in IoDir(dir .. "/*") do
+        if not (file == '.' or file == '..') then
+            if StringSub(file, -3) == extension then
+                LOG(prepend .. "/" .. file)
+                TableInsert(files, prepend .. "/" .. file)
+            end
+            FindFilesWithExtension(dir .. "/" .. file, extension, prepend .. "/" .. file, files)
+        end
+    end
+
+    return files
 end
 
 -- mods that have been integrated, based on folder name 
@@ -137,8 +149,8 @@ allowedAssetsNxt = LowerHashTable(allowedAssetsNxt)
 
 -- default wave banks to prevent collisions
 local soundsBlocked = { }
-local faSounds = IoDir(fa_path .. '/sounds/*')
-for k, v in faSounds do 
+local sounds = FindFilesWithExtension(fa_path .. '/sounds', "xwb", "/sounds")
+for k, v in sounds do 
     if v == '.' or v == '..' then 
         continue 
     end
@@ -293,19 +305,19 @@ local function MountMapContent(dir)
                     MountDirectory(dir .. "/" .. map .. '/movies', '/movies')
                 end
             elseif folder == 'sounds' then
+                local banks = FindFilesWithExtension(dir .. '/' .. map .. "/sounds", "xwb", "/sounds")
+
                 -- find conflicting files
                 local conflictingFiles = { }
-                for _, file in IoDir(dir .. '/' .. map .. '/sounds/*') do
-                    if not (file == '.' or file == '..') then 
-                        local identifier = StringLower(file) 
-                        if soundsBlocked[identifier] then 
-                            TableInsert(conflictingFiles, { file = file, conflict = soundsBlocked[identifier] })
-                        else 
-                            soundsBlocked[identifier] = StringLower(map)
-                        end
+                for _, bank in banks do
+                    local identifier = StringLower(bank) 
+                    if soundsBlocked[identifier] then 
+                        TableInsert(conflictingFiles, { file = bank, conflict = soundsBlocked[identifier] })
+                    else 
+                        soundsBlocked[identifier] = StringLower(map)
                     end
                 end
-                    
+                
                 -- report them if they exist and do not mount
                 if TableGetn(conflictingFiles) > 0 then 
                     LOG("Found conflicting sound banks for map: '" .. map .. "', cannot mount the sound bank(s):")
@@ -467,26 +479,26 @@ local function MountModContent(dir)
 
         -- look at each directory inside this mod
         for _, folder in IoDir(dir .. '/' .. mod .. '/*') do
-            
+
             -- if we found a directory named 'sounds' then we mount its content
             if folder == 'sounds' then
+                local banks = FindFilesWithExtension(dir .. '/' ..  mod .. "/sounds", "xwb", "/sounds")
+
                 -- find conflicting files
                 local conflictingFiles = { }
-                for _, file in IoDir(dir .. '/' .. mod .. '/sounds/*') do
-                    if not (file == '.' or file == '..') then 
-                        local identifier = StringLower(file) 
-                        if soundsBlocked[identifier] then 
-                            TableInsert(conflictingFiles, { file = file, conflict = soundsBlocked[identifier] })
-                        else 
-                            soundsBlocked[identifier] = StringLower(mod)
-                        end
+                for _, bank in banks do
+                    local identifier = StringLower(bank) 
+                    if soundsBlocked[identifier] then 
+                        TableInsert(conflictingFiles, { file = bank, conflict = soundsBlocked[identifier] })
+                    else
+                        soundsBlocked[identifier] = StringLower(mod)
                     end
                 end
-                    
+
                 -- report them if they exist and do not mount
                 if TableGetn(conflictingFiles) > 0 then 
                     LOG("Found conflicting sound banks for mod: '" .. mod .. "', cannot mount the sound bank(s):")
-                    for k, v in conflictingFiles do 
+                    for _, v in conflictingFiles do 
                         LOG(" - Conflicting sound bank: '" .. v.file .. "' of mod '" .. mod .. "' is conflicting with a sound bank from: '" .. v.conflict .. "'" )
                     end
                 -- else, mount folder


### PR DESCRIPTION
All init files have logic to prevent sound banks being mounted onto the same path. This logic was supposed to work on the file names, but it did not take into account the folder structure. It was busted, it should be:

```
INFO: /sounds/AEONSelect.xwb
INFO: /sounds/AmbientTest.xwb
INFO: /sounds/CYBRANSelect.xwb
INFO: /sounds/Explosions.xwb
INFO: /sounds/ExplosionsStream.xwb
INFO: /sounds/FMV_BG.xwb
INFO: /sounds/Impacts.xwb
INFO: /sounds/Interface.xwb
INFO: /sounds/Music.xwb
INFO: /sounds/Op_Briefing.xwb
INFO: /sounds/SeraphimSelect.xwb
INFO: /sounds/UAA.xwb
INFO: /sounds/UAADestroy.xwb
INFO: /sounds/UAAWeapon.xwb
INFO: /sounds/UAB.xwb
INFO: /sounds/UAL.xwb
INFO: /sounds/UALDestroy.xwb
INFO: /sounds/UALWeapon.xwb
INFO: /sounds/UAS.xwb
INFO: /sounds/UASDestroy.xwb
INFO: /sounds/UASWeapon.xwb
INFO: /sounds/UEA.xwb
INFO: /sounds/UEADestroy.xwb
INFO: /sounds/UEAWeapon.xwb
INFO: /sounds/UEB.xwb
INFO: /sounds/UEFSelect.xwb
INFO: /sounds/UEL.xwb
INFO: /sounds/UELDestroy.xwb
INFO: /sounds/UELWeapon.xwb
INFO: /sounds/UES.xwb
INFO: /sounds/UESDestroy.xwb
INFO: /sounds/UESWeapon.xwb
INFO: /sounds/UnitRumble.xwb
INFO: /sounds/UnitsGlobal.xwb
INFO: /sounds/URA.xwb
INFO: /sounds/URADestroy.xwb
INFO: /sounds/URAWeapon.xwb
INFO: /sounds/URB.xwb
INFO: /sounds/URL.xwb
INFO: /sounds/URLDestroy.xwb
INFO: /sounds/URLWeapon.xwb
INFO: /sounds/URS.xwb
INFO: /sounds/URSDestroy.xwb
INFO: /sounds/URSStream.xwb
INFO: /sounds/URSWeapon.xwb
INFO: /sounds/Voice/US/Briefings.xwb
INFO: /sounds/Voice/US/Seraphim_Language.xwb
INFO: /sounds/Voice/US/X01_VO.xwb
INFO: /sounds/Voice/US/X02_VO.xwb
INFO: /sounds/Voice/US/X03_VO.xwb
INFO: /sounds/Voice/US/X04_VO.xwb
INFO: /sounds/Voice/US/X05_VO.xwb
INFO: /sounds/Voice/US/X06_VO.xwb
INFO: /sounds/Voice/US/X1T_VO.xwb
INFO: /sounds/Voice/US/XGG.xwb
INFO: /sounds/Voice/US/X_FMV.xwb
INFO: /sounds/XAA_Weapon.xwb
INFO: /sounds/XAB.xwb
INFO: /sounds/XAL.xwb
INFO: /sounds/XAL_Weapon.xwb
INFO: /sounds/XAS.xwb
INFO: /sounds/XAS_Weapons.xwb
INFO: /sounds/XEA.xwb
INFO: /sounds/XEA_Weapons.xwb
INFO: /sounds/XEB.xwb
INFO: /sounds/XEL.xwb
INFO: /sounds/XEL_Weapons.xwb
INFO: /sounds/XES.xwb
INFO: /sounds/XES_Destroy.xwb
INFO: /sounds/XES_Weapons.xwb
INFO: /sounds/XRA.xwb
INFO: /sounds/XRA_Weapon.xwb
INFO: /sounds/XRB.xwb
INFO: /sounds/XRL.xwb
INFO: /sounds/XRL_Stream.xwb
INFO: /sounds/XRL_Weapon.xwb
INFO: /sounds/XRS.xwb
INFO: /sounds/XRS_Weapon.xwb
INFO: /sounds/XSA.xwb
INFO: /sounds/XSA_Destroy.xwb
INFO: /sounds/XSA_Weapon.xwb
INFO: /sounds/XSB.xwb
INFO: /sounds/XSB_Weapon.xwb
INFO: /sounds/XSL.xwb
INFO: /sounds/XSL_Destroy.xwb
INFO: /sounds/XSL_Weapon.xwb
INFO: /sounds/XSS.xwb
INFO: /sounds/XSS_Destroy.xwb
```

But it was:

```
INFO: urb.xwb
INFO: kingofthehill.xsb
INFO: op_briefing.xwb
INFO: ursweapon.xwb
INFO: tmmm_sounds.xwb
INFO: memesounds.xgs
INFO: uaadestroy.xwb
INFO: explosions.xwb
INFO: xrb.xwb
INFO: memes.xwb
INFO: uesdestroy.xwb
INFO: music.xsb
INFO: ta_music.xsb
INFO: xcs.xsb
INFO: ueadestroy.xsb
INFO: nomadsprojectiles.xsb
INFO: xes_destroy.xwb
INFO: urldestroy.xwb
INFO: uel.xwb
INFO: xel.xwb
INFO: tmmm_cues.xsb
INFO: tm_aeonweaponsounds.xwb
INFO: nomadsprojectiles.xwb
INFO: ta_sound.xsb
INFO: ualdestroy.xwb
INFO: a06_vo.xwb
INFO: xes_weapons.xwb
INFO: unitsglobal.xwb
INFO: url.xsb
INFO: xss.xwb
INFO: xcl.xsb
INFO: ursweapon.xsb
INFO: urs.xsb
INFO: tm_cybranweapons.xsb
INFO: xrl_stream.xsb
INFO: ueaweapon.xwb
INFO: xab.xwb
INFO: tm_uefweaponsounds.xwb
INFO: impacts.xwb
INFO: xsb_weapon.xwb
INFO: uab.xwb
INFO: uesweapon.xwb
INFO: nomadsweapons.xwb
INFO: urlweapon.xsb
INFO: unitsglobal.xsb
INFO: ualdestroy.xsb
INFO: uaaweapon.xsb
INFO: xes.xsb
INFO: ues.xsb
INFO: xsl_weapon.xsb
INFO: unitrumble.xsb
INFO: ueb.xsb
INFO: xrs_weapon.xsb
INFO: xeb.xsb
INFO: ursdestroy.xwb
INFO: xsa_destroy.xwb
INFO: ambienttest.xwb
INFO: uesdestroy.xsb
INFO: ues.xwb
INFO: ursstream.xsb
INFO: uaa.xsb
INFO: urldestroy.xsb
INFO: oof.xwb
INFO: nomadsweapons.xsb
INFO: xaa.xsb
INFO: xsl_destroy.xwb
INFO: uaa.xwb
INFO: xes.xwb
INFO: xas_weapon.xsb
INFO: ura.xwb
INFO: explosions.xsb
INFO: test.xwb
INFO: tm_robotsounds.xsb
INFO: impacts.xsb
INFO: xsa.xsb
INFO: uesweapon.xsb
INFO: xal_weapon.xwb
INFO: tm_explosionsounds.xwb
INFO: url.xwb
INFO: tm_cybranweaponsounds.xwb
INFO: blackopswb.xwb
INFO: ueadestroy.xwb
INFO: xaa_weapon.xsb
INFO: nomadsunits.xsb
INFO: tm_aircrafts.xsb
INFO: uradestroy.xwb
INFO: tm_aeonweapons.xsb
INFO: nomadsunits.xwb
INFO: uraweapon.xsb
INFO: xss_weapon.xwb
INFO: ta_music.xwb
INFO: test.xsb
INFO: xss_destroy.xsb
INFO: urb.xsb
INFO: xca.xsb
INFO: xra_weapon.xwb
INFO: uraweapon.xwb
INFO: xrl.xwb
INFO: oof.xsb
INFO: xsa_destroy.xsb
INFO: xaa_weapon.xwb
INFO: xcb.xsb
INFO: uel.xsb
INFO: xel.xsb
INFO: uaadestroy.xsb
INFO: memes.xsb
INFO: uelweapon.xsb
INFO: uab.xsb
INFO: upsoundbank.xsb
INFO: unitrumble.xwb
INFO: xss.xsb
INFO: voice           <--- this entry in particular was a problem
INFO: xsa.xwb
INFO: ual.xwb
INFO: blackopssb.xsb
INFO: tm_robotsounds.xwb
INFO: ueldestroy.xwb
INFO: uradestroy.xsb
INFO: xab.xsb
INFO: a06_vo.xsb
INFO: xas_weapons.xwb
INFO: fmv_bg.xwb
INFO: ta_sound.xwb
INFO: xss_weapon.xsb
INFO: xss_destroy.xwb
INFO: upbank.xwb
INFO: xsa_weapon.xwb
INFO: uasdestroy.xwb
INFO: xsl_weapon.xwb
INFO: ueb.xwb
INFO: xrl.xsb
INFO: xsl.xwb
INFO: tm_explosions.xsb
INFO: xsb_weapon.xsb
INFO: xeb.xwb
INFO: xal_weapon.xsb
INFO: xsb.xsb
INFO: ueldestroy.xsb
INFO: xsa_weapon.xsb
INFO: xrs_weapon.xwb
INFO: uasweapon.xwb
INFO: xra.xwb
INFO: xes_destroy.xsb
INFO: xrs.xsb
INFO: xrl_weapon.xwb
INFO: urs.xwb
INFO: xes_weapons.xsb
INFO: xrl_stream.xwb
INFO: xrl_destroy.xsb
INFO: xsl_destroy.xsb
INFO: xrs.xwb
INFO: interface.xwb
INFO: xrb.xsb
INFO: xra_weapon.xsb
INFO: uelweapon.xwb
INFO: uea.xsb
INFO: xsl.xsb
INFO: uasweapon.xsb
INFO: xea_weapon.xsb
INFO: music.xwb
INFO: uas.xsb
INFO: xrl_weapon.xsb
INFO: xel_weapons.xwb
INFO: xas.xsb
INFO: seraphimselect.xsb
INFO: kingofthehill.xwb
INFO: ursdestroy.xsb
INFO: op_briefing.xsb
INFO: explosionsstream.xwb
INFO: xra.xsb
INFO: seraphimselect.xwb
INFO: ualweapon.xwb
INFO: xea.xsb
INFO: cybranselect.xwb
INFO: uas.xwb
INFO: uasdestroy.xsb
INFO: oof.xgs
INFO: ual.xsb
INFO: xel_weapons.xsb
INFO: tm_uefweapons.xsb
INFO: aeonselect.xwb
INFO: fmv_bg.xsb
INFO: ura.xsb
INFO: xsb.xwb
INFO: xal.xwb
INFO: xal.xsb
INFO: uea.xwb
INFO: uaaweapon.xwb
INFO: supcom.xgs
INFO: xea.xwb
INFO: interface.xsb
INFO: ambienttest.xsb
INFO: xea_weapons.xwb
INFO: xas.xwb
INFO: tm_aircraftsounds.xwb
INFO: ursstream.xwb
INFO: ueaweapon.xsb
INFO: uefselect.xwb
INFO: urlweapon.xwb
INFO: nomadsdestroy.xwb
INFO: ualweapon.xsb
```