### PR TITLE
fix logic for getting closest manager.

### DIFF
--- a/lua/aibrains/base-ai.lua
+++ b/lua/aibrains/base-ai.lua
@@ -422,18 +422,18 @@ AIBrain = Class(StandardBrain) {
     FindClosestBuilderManagerPosition = function(self, position)
         local distance, closest
         for k, v in self.BuilderManagers do
-            if v.EngineerManager:GetNumCategoryUnits('Engineers', categories.ALLUNITS) <= 0 and v.FactoryManager:GetNumCategoryFactories(categories.ALLUNITS) <= 0 then
-                continue
-            end
-            if position and v.Position then
-                if not closest then
-                    distance = VDist3(position, v.Position)
-                    closest = v.Position
-                else
-                    local tempDist = VDist3(position, v.Position)
-                    if tempDist < distance then
-                        distance = tempDist
+            if v.EngineerManager and v.EngineerManager:GetNumCategoryUnits('Engineers', categories.ALLUNITS) > 0
+            and v.FactoryManager and v.FactoryManager:GetNumCategoryFactories(categories.ALLUNITS) > 0 then
+                if position and v.Position then
+                    if not closest then
+                        distance = VDist3(position, v.Position)
                         closest = v.Position
+                    else
+                        local tempDist = VDist3(position, v.Position)
+                        if tempDist < distance then
+                            distance = tempDist
+                            closest = v.Position
+                        end
                     end
                 end
             end


### PR DESCRIPTION
fixes #4878

Description.
This PR fixes a logic flaw in the function FindClosestBuilderManagerPosition where it was not validating if the base managers existed before making function calls to them. It also removes the use of a continue statement since its not required.