### PR TITLE
Cast shadows on all props

### DIFF
--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -2599,7 +2599,7 @@ float4 NormalMappedTerrainPS( NORMALMAPPED_VERTEX vertex ) : COLOR
 
     float4 albedo = tex2D( albedoSampler, vertex.texcoord0.xy);
     albedo.rgb = albedo.rgb * vertex.color.rgb;
-    float3 light = ComputeLight( dotLightNormal, 1);
+    float3 light = ComputeLight( dotLightNormal, ComputeShadow(vertex.shadow, true));
     float alpha = mirrored ? 0.5 : glowMinimum;
 
     float3 color = light * albedo.rgb;
@@ -5083,7 +5083,7 @@ technique NormalMappedTerrain
 #endif
 
         VertexShader = compile vs_1_1 NormalMappedVS();
-        PixelShader = compile ps_2_0 NormalMappedTerrainPS();
+        PixelShader = compile ps_2_a NormalMappedTerrainPS();
     }
 }
 


### PR DESCRIPTION
Some rocks were using a shader that didn't calculate shadows, making them look odd when they received shadows from units. So I fixed it.

![Screenshot 2023-04-20 110005](https://user-images.githubusercontent.com/52536103/233318706-c1e62615-3751-44c4-b081-2704e7631fb6.png)
![Screenshot 2023-04-20 105856](https://user-images.githubusercontent.com/52536103/233318725-b737e211-bbf2-421a-9a91-6021fd1bd8aa.png)
