### PR TITLE
Fix - AI pgen reclaim builders to ignore hydros

### DIFF
--- a/lua/AI/AIBuilders/AIEconomicBuilders.lua
+++ b/lua/AI/AIBuilders/AIEconomicBuilders.lua
@@ -1356,12 +1356,12 @@ BuilderGroup {
         InstanceCount = 1,
         BuilderConditions = {
                 { EBC, 'GreaterThanEconEfficiencyCombined', { 0.1, 1.1 }},
-                { UCBC, 'UnitsGreaterAtLocation', { 'LocationType', 1, categories.TECH3 * categories.ENERGYPRODUCTION}},
-                { UCBC, 'UnitsGreaterAtLocation', { 'LocationType', 0, categories.TECH1 * categories.ENERGYPRODUCTION * categories.DRAGBUILD }},
+                { UCBC, 'UnitsGreaterAtLocation', { 'LocationType', 1, categories.TECH3 * categories.ENERGYPRODUCTION }},
+                { UCBC, 'UnitsGreaterAtLocation', { 'LocationType', 0, categories.TECH1 * categories.ENERGYPRODUCTION * categories.DRAGBUILD - categories.HYDROCARBON }},
             },
         BuilderData = {
             Location = 'LocationType',
-            Reclaim = {'STRUCTURE ENERGYPRODUCTION TECH1 DRAGBUILD'},
+            Reclaim = { categories.STRUCTURE * categories.ENERGYPRODUCTION * categories.TECH1 * categories.DRAGBUILD - categories.HYDROCARBON },
         },
         BuilderType = 'Any',
     },
@@ -1623,11 +1623,11 @@ BuilderGroup {
         BuilderConditions = {
                 { EBC, 'GreaterThanEconEfficiencyCombined', { 0.1, 1.1 }},
                 { UCBC, 'UnitsGreaterAtLocation', { 'LocationType', 1, categories.TECH3 * categories.ENERGYPRODUCTION}},
-                { UCBC, 'UnitsGreaterAtLocation', { 'LocationType', 0, categories.TECH1 * categories.ENERGYPRODUCTION * categories.DRAGBUILD }},
+                { UCBC, 'UnitsGreaterAtLocation', { 'LocationType', 0, categories.TECH1 * categories.ENERGYPRODUCTION * categories.DRAGBUILD - categories.HYDROCARBON }},
             },
         BuilderData = {
             Location = 'LocationType',
-            Reclaim = {'STRUCTURE ENERGYPRODUCTION TECH1 DRAGBUILD'},
+            Reclaim = { categories.STRUCTURE * categories.ENERGYPRODUCTION * categories.TECH1 * categories.DRAGBUILD - categories.HYDROCARBON },
         },
         BuilderType = 'Any',
     },


### PR DESCRIPTION
**Description of changes**

This PR fixes an issue with the default AI reclaim builders that would target hydro carbons when they are not supposed to which would result in the hydros getting reclaimed then rebuilt over and over.

fixes #4887 