### PR TITLE
Add simplified error messages

### DIFF
--- a/lua/sim/NavUtils.lua
+++ b/lua/sim/NavUtils.lua
@@ -571,32 +571,32 @@ end
 ---@param layer NavLayers
 ---@param position Vector
 ---@return number? 
----@return string?
+---@return ('NotGenerated' | 'InvalidLayer' | 'OutsideMap' | 'SystemError' | 'Unpathable')?
 function GetTerrainLabel(layer, position)
     -- check if generated
     if not NavGenerator.IsGenerated() then
         WarnNoNavMesh()
-        return nil, 'Navigational mesh is not generated'
+        return nil, 'NotGenerated'
     end
 
     -- check layer argument
     local grid = FindGrid(layer)
     if not grid then
-        return nil, 'Invalid layer type - this is likely a typo. The layer is case sensitive'
+        return nil, 'InvalidLayer'
     end
 
     -- check position argument
     local leaf = grid:FindLeaf(position)
     if not leaf then
-        return nil, 'Position is not inside the map'
+        return nil, 'OutsideMap'
     end
 
     if leaf.Label == 0 then
-        return nil, 'Position has no label assigned, report to the maintainers. This should not be possible'
+        return nil, 'SystemError'
     end
 
     if leaf.Label == -1 then
-        return nil, 'Position is unpathable'
+        return nil, 'Unpathable'
     end
 
     return leaf.Label, nil


### PR DESCRIPTION
Partially implements #4894 . All possible error states are part of the annotation system. To sum them up:

- `SystemError`: These should not occur. If this happens then something odd happened
- `NotGenerated`: Navigational mesh is not generated
- `InvalidLayer`: Unknown layer, candidates are: `Land`, `Hover`, `Naval`, `Air` and `Amphibious`
- `OutsideMap`: Point is outside of the map
- `OriginOutsideMap`: Origin is outside of the map
- `OriginUnpathable`: Origin is unpathable
- `DestinationOutsideMap`: Destination is outside of the map
- `DestinationUnpathable`: Destination is unpathable
- `Unpathable`: Path from origin to destination is unpathable (labels do not match)