### PR TITLE
Improve normal decals

### DIFF
--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -1125,6 +1125,10 @@ float4 DecalsNormalsPS( VS_OUTPUT inV, uniform bool alphablend ) : COLOR
     float3 decalNormal;
     decalNormal.xz = decalRaw.ag * 2 - 1;
     decalNormal.y = sqrt(1 - dot(decalNormal.xz,decalNormal.xz));
+    // decals are not interpolated correctly with the ground, so we have to improvise by
+    // making them partially transparent and stronger to counteract the transparency
+    float factor = 2.0;
+    decalNormal = normalize(float3(decalNormal.x * factor, decalNormal.y, decalNormal.z * factor));
 
     // rotate the decalnormal by the decal matrix to get the decal into world space
     // from tangent space
@@ -1136,7 +1140,7 @@ float4 DecalsNormalsPS( VS_OUTPUT inV, uniform bool alphablend ) : COLOR
 
     // get decal normal back into 0..1 range and output
     decalNormal = (decalNormal * 0.5) + 0.5;
-    return float4( decalNormal.xzy,  blendFactor * decalMask.w * DecalAlpha);
+    return float4( decalNormal.xzy,  blendFactor * decalMask.w * DecalAlpha / factor);
 }
 
 


### PR DESCRIPTION
Cherry-picked from #4900 refer to there for pictures.
I wanted to keep this commit, because it shows what needs to be done. The problem with the shader approach is that it also affects tarmacs which should completely block out the underlying normals.
Regular normal decals are just slapped on top of the terrain normals, so they completely override the normals from the ground textures. When we use the technique from #4902 this looks even worse, because the visual difference gets even bigger. One solution to this problem is to make the decal partially transparent so the ground normal shines through. This also reduces the strenght of the decal, so the normals need to be beefed up.
Now two things need to happen still.
1. The normal increase the way it is done now is still not entirely correct. The decals still lose strenght and setting the factor to e.g. 4 makes it fall apart even more, so we need to research a better method.
2. The shader approach can be used for rapid prototyping of changes, but for the final result we need to do this conversion in all the decal files that we want to affect instead of the shader, so we save the tarmacs.