### PR TITLE
Add `GetTerrainLabel` for label at the given position

### DIFF
--- a/lua/sim/NavUtils.lua
+++ b/lua/sim/NavUtils.lua
@@ -530,7 +530,8 @@ function PathToWithThreatThreshold(layer, origin, destination, aibrain, threatFu
     return path, head, distance
 end
 
---- Returns a label that indicates to what sub-graph it belongs to, these graphs can be visualised using the Nav UI
+--- Returns a label that indicates to what sub-graph it belongs to. Unlike `GetTerrainLabel` this function will try to find the nearest valid neighbor
+---@see GetTerrainLabel
 ---@param layer NavLayers
 ---@param position Vector
 ---@return number? 
@@ -550,6 +551,42 @@ function GetLabel(layer, position)
 
     -- check position argument
     local leaf = FindLeaf(grid, position)
+    if not leaf then
+        return nil, 'Position is not inside the map'
+    end
+
+    if leaf.Label == 0 then
+        return nil, 'Position has no label assigned, report to the maintainers. This should not be possible'
+    end
+
+    if leaf.Label == -1 then
+        return nil, 'Position is unpathable'
+    end
+
+    return leaf.Label, nil
+end
+
+--- Returns a label that indicates to what sub-graph it belongs to. Unlike `GetLabel` this function does not try to find valid neighbors
+---@see GetLabel
+---@param layer NavLayers
+---@param position Vector
+---@return number? 
+---@return string?
+function GetTerrainLabel(layer, position)
+    -- check if generated
+    if not NavGenerator.IsGenerated() then
+        WarnNoNavMesh()
+        return nil, 'Navigational mesh is not generated'
+    end
+
+    -- check layer argument
+    local grid = FindGrid(layer)
+    if not grid then
+        return nil, 'Invalid layer type - this is likely a typo. The layer is case sensitive'
+    end
+
+    -- check position argument
+    local leaf = grid:FindLeaf(position)
     if not leaf then
         return nil, 'Position is not inside the map'
     end


### PR DESCRIPTION
This new function does not try to find the nearest valid neighbor. It always returns the label of the leaf that the position is in.