### PR TITLE
Fix Cybran T3 Shield Strategic Icons

### DIFF
--- a/units/URB4206/URB4206_unit.bp
+++ b/units/URB4206/URB4206_unit.bp
@@ -214,7 +214,7 @@ UnitBlueprint {
     SizeX = 2,
     SizeY = 5,
     SizeZ = 2,
-    StrategicIconName = 'icon_structure2_shield',
+    StrategicIconName = 'icon_structure3_shield',
     StrategicIconSortPriority = 200,
     Wreckage = {
         Blueprint = '/props/DefaultWreckage/DefaultWreckage_prop.bp',

--- a/units/URB4207/URB4207_unit.bp
+++ b/units/URB4207/URB4207_unit.bp
@@ -202,7 +202,7 @@ UnitBlueprint {
     SizeX = 2,
     SizeY = 5,
     SizeZ = 2,
-    StrategicIconName = 'icon_structure2_shield',
+    StrategicIconName = 'icon_structure3_shield',
     StrategicIconSortPriority = 200,
     Wreckage = {
         Blueprint = '/props/DefaultWreckage/DefaultWreckage_prop.bp',


### PR DESCRIPTION
The ED4 & ED5 has the T2 Shield Strategic Icons this changes them to the T3 Variant 