### PR TITLE
Add experimental approach to reduce decal flickering

### DIFF
--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -200,14 +200,15 @@ function CreateUI(isReplay)
             WaitSeconds(1.0)
 
             if Prefs.GetFromCurrentProfile('options.level_of_detail') == 2 then
-                -- allow meshes and effects to be seen from further away
-                ConExecute("cam_SetLOD WorldCamera 0.65")
+                ConExecute("cam_SetLOD WorldCamera 0.70")
             end
 
             if Prefs.GetFromCurrentProfile('options.shadow_quality') == 3 then
-                -- improve shadow LOD and resolution
                 ConExecute("ren_ShadowLOD 1024")
                 ConExecute("ren_ShadowSize 2048")
+
+                ConExecute("ren_ClipDecalLevel 4")          -- standard value of 2, causes a lot of clipping
+                ConExecute("ren_DecalFadeFraction 0.25")    -- standard value of 0.5, causes decals to suddenly pop into screen
             end
         end)
     end

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -192,6 +192,10 @@ function CreateUI(isReplay)
     ConExecute('net_SendDelay 5')
     ConExecute('net_AckDelay 5')
 
+    ConExecute("ren_ViewError 0.004")           -- standard value of 0.003, the higher the value the less flickering but the less accurate the terrain is      
+    ConExecute("ren_ClipDecalLevel 4")          -- standard value of 2, causes a lot of clipping
+    ConExecute("ren_DecalFadeFraction 0.25")    -- standard value of 0.5, causes decals to suddenly pop into screen
+
     -- enable experimental graphics
     if  Prefs.GetFromCurrentProfile('options.fidelity') >= 2 and
         Prefs.GetFromCurrentProfile('options.experimental_graphics') == 1
@@ -206,10 +210,6 @@ function CreateUI(isReplay)
             if Prefs.GetFromCurrentProfile('options.shadow_quality') == 3 then
                 ConExecute("ren_ShadowLOD 1024")
                 ConExecute("ren_ShadowSize 2048")
-
-                ConExecute("ren_ViewError 0.004")           -- standard value of 0.003, the higher the value the less flickering but the less accurate the terrain is      
-                ConExecute("ren_ClipDecalLevel 4")          -- standard value of 2, causes a lot of clipping
-                ConExecute("ren_DecalFadeFraction 0.25")    -- standard value of 0.5, causes decals to suddenly pop into screen
             end
         end)
     end

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -207,6 +207,7 @@ function CreateUI(isReplay)
                 ConExecute("ren_ShadowLOD 1024")
                 ConExecute("ren_ShadowSize 2048")
 
+                ConExecute("ren_ViewError 0.004")           -- standard value of 0.003, the higher the value the less flickering but the less accurate the terrain is      
                 ConExecute("ren_ClipDecalLevel 4")          -- standard value of 2, causes a lot of clipping
                 ConExecute("ren_DecalFadeFraction 0.25")    -- standard value of 0.5, causes decals to suddenly pop into screen
             end


### PR DESCRIPTION
A common nuisance among map authors is the flickering of decals. It turns out that there are console commands to influence the clipping behavior. Requires the extended graphics to be enabled.

Current behavior:

https://github.com/FAForever/fa/assets/15778155/1dc54d44-7a8b-40ee-acf3-9c6fbdcea74f

New behavior:

https://github.com/FAForever/fa/assets/15778155/0620efda-2f52-48b1-8cc7-6f4bf184be65

This doesn't work for all maps. As an example: Corona Hourglass is still affected by this behavior