### PR TITLE
Revert some of the network settings

### DIFF
--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -183,14 +183,14 @@ function CreateUI(isReplay)
     ConExecute('d3d_WindowsCursor on')
 
     -- tweak networking parameters
-    ConExecute('net_MinResendDelay 100')
-    ConExecute('net_MaxResendDelay 1000')
+    ConExecute('net_MinResendDelay 100')        -- standard value of 100
+    ConExecute('net_MaxResendDelay 1000')       -- standard value of 1000
 
-    ConExecute('net_MaxSendRate 2048')
-    ConExecute('net_MaxBacklog 2048')
+    ConExecute('net_MaxSendRate 2048')          -- standard value of 1024 bytes
+    ConExecute('net_MaxBacklog 2048')           -- standard value of 1024 bytes
 
-    ConExecute('net_SendDelay 5')
-    ConExecute('net_AckDelay 5')
+    ConExecute('net_SendDelay 5')               -- standard value of 25
+    ConExecute('net_AckDelay 5')                -- standard value of 25
 
     ConExecute("ren_ViewError 0.004")           -- standard value of 0.003, the higher the value the less flickering but the less accurate the terrain is      
     ConExecute("ren_ClipDecalLevel 4")          -- standard value of 2, causes a lot of clipping

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -192,6 +192,7 @@ function CreateUI(isReplay)
     ConExecute('net_SendDelay 5')               -- standard value of 25ms
     ConExecute('net_AckDelay 5')                -- standard value of 25ms
 
+    -- tweak decal properties
     ConExecute("ren_ViewError 0.004")           -- standard value of 0.003, the higher the value the less flickering but the less accurate the terrain is      
     ConExecute("ren_ClipDecalLevel 4")          -- standard value of 2, causes a lot of clipping
     ConExecute("ren_DecalFadeFraction 0.25")    -- standard value of 0.5, causes decals to suddenly pop into screen

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -183,14 +183,14 @@ function CreateUI(isReplay)
     ConExecute('d3d_WindowsCursor on')
 
     -- tweak networking parameters
-    ConExecute('net_MinResendDelay 100')        -- standard value of 100
-    ConExecute('net_MaxResendDelay 1000')       -- standard value of 1000
+    ConExecute('net_MinResendDelay 100')        -- standard value of 100ms
+    ConExecute('net_MaxResendDelay 1000')       -- standard value of 1000ms
 
     ConExecute('net_MaxSendRate 2048')          -- standard value of 1024 bytes
     ConExecute('net_MaxBacklog 2048')           -- standard value of 1024 bytes
 
-    ConExecute('net_SendDelay 5')               -- standard value of 25
-    ConExecute('net_AckDelay 5')                -- standard value of 25
+    ConExecute('net_SendDelay 5')               -- standard value of 25ms
+    ConExecute('net_AckDelay 5')                -- standard value of 25ms
 
     ConExecute("ren_ViewError 0.004")           -- standard value of 0.003, the higher the value the less flickering but the less accurate the terrain is      
     ConExecute("ren_ClipDecalLevel 4")          -- standard value of 2, causes a lot of clipping

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -186,8 +186,8 @@ function CreateUI(isReplay)
     ConExecute('net_MinResendDelay 100')
     ConExecute('net_MaxResendDelay 1000')
 
-    ConExecute('net_MaxSendRate 8192')
-    ConExecute('net_MaxBacklog 8192')
+    ConExecute('net_MaxSendRate 2048')
+    ConExecute('net_MaxBacklog 2048')
 
     ConExecute('net_SendDelay 5')
     ConExecute('net_AckDelay 5')


### PR DESCRIPTION
We've been working with the default network settings for years and they have been sufficient all that time. This pull request further reduces the changes that we've made.

These numbers are multiplied by the number of clients. In a 12 player game you have 11 open connections, each pushing several kilobytes of data. We reduce the traffic with this pull request, reverting back to a more sane number.