### PR TITLE
Flatten the air layer instead of compressing it

### DIFF
--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -386,7 +386,8 @@ CompressedLabelTree = ClassCompressedLabelTree {
         end
     end,
 
-    --- Flattens the label tree, disregarding the actual values
+    --- Flattens the label tree into a leaf
+    ---@see Compress
     ---@param self CompressedLabelTreeNode
     ---@param bx number             # Location of top-left corner, in world space
     ---@param bz number             # Location of top-left corner, in world space

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -386,6 +386,27 @@ CompressedLabelTree = ClassCompressedLabelTree {
         end
     end,
 
+    --- Flattens the label tree, disregarding the actual values
+    ---@param self CompressedLabelTreeNode
+    ---@param bx number             # Location of top-left corner, in world space
+    ---@param bz number             # Location of top-left corner, in world space
+    ---@param ox number             # Offset from top-left corner, in local space
+    ---@param oz number             # Offset from top-left corner, in local space
+    ---@param size number           # Element count starting at { bx + ox, bz + oz }
+    ---@param label -1 | 0
+    ---@param layer NavLayers
+    Flatten = function(self, bx, bz, ox, oz, size, root, label, layer)
+        self.Label = label
+        self.Size = size
+        self.Root = root
+
+        if self.Label >= 0 then
+            NavLayerData[layer].PathableLeafs = NavLayerData[layer].PathableLeafs + 1
+        else
+            NavLayerData[layer].UnpathableLeafs = NavLayerData[layer].UnpathableLeafs + 1
+        end
+    end,
+
     --- Generates the following neighbors, when they are valid:
     ---@param self CompressedLabelTreeLeaf
     ---@param bx number             # Location of top-left corner, in world space
@@ -946,19 +967,6 @@ function ComputeAmphPathingMatrix(size, daCache, pCache, bCache, rCache)
     end
 end
 
----@param size number
----@param daCache NavAverageDepthCache
----@param bCache NavTerrainBlockCache
----@param pCache NavPathCache
----@param rCache NavLabelCache
-function ComputeAirPathingMatrix(size, daCache, pCache, bCache, rCache)
-    for z = 1, size do
-        for x = 1, size do
-            rCache[z][x] = 0
-        end
-    end
-end
-
 --- Generates the compression grids based on the heightmap
 ---@param size number (square) size of each cell of the compression grid
 ---@param threshold number (square) size of the smallest acceptable leafs, used for culling
@@ -1001,8 +1009,7 @@ local function GenerateCompressionGrids(size, threshold)
             labelTreeAmph:Compress(bx, bz, 0, 0, size, labelTreeAmph, rCache, threshold, 'Amphibious')
             navAmphibious:AddTree(z, x, labelTreeAmph)
 
-            ComputeAirPathingMatrix(size, daCache, pCache, bCache, rCache)
-            labelTreeAir:Compress(bx, bz, 0, 0, size, labelTreeAir, rCache, threshold, 'Air')
+            labelTreeAir:Flatten(bx, bz, 0, 0, size, labelTreeAir, 0, 'Air')
             navAir:AddTree(z, x, labelTreeAir)
         end
     end
@@ -1016,23 +1023,23 @@ local function GenerateGraphs()
     local navAmphibious = NavGrids['Amphibious'] --[[@as NavGrid]]
     local navAir = NavGrids['Air'] --[[@as NavGrid]]
 
+    navAir:GenerateNeighbors()
     navLand:GenerateNeighbors()
     navWater:GenerateNeighbors()
     navHover:GenerateNeighbors()
     navAmphibious:GenerateNeighbors()
-    navAir:GenerateNeighbors()
 
+    navAir:GenerateLabels()
     navLand:GenerateLabels()
     navWater:GenerateLabels()
     navAmphibious:GenerateLabels()
     navHover:GenerateLabels()
-    navAir:GenerateLabels()
 
+    navAir:Precompute()
     navLand:Precompute()
     navWater:Precompute()
     navHover:Precompute()
     navAmphibious:Precompute()
-    navAir:Precompute()
 end
 
 --- Culls generated labels that are too small and have no meaning


### PR DESCRIPTION
The air layer is always valid to path. There is no need to compress it. We now skip the compression and just instantiate a leaf. A minor performance improvement.