### PR TITLE
Take into account playable area for skirmish maps

### DIFF
--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -1150,17 +1150,6 @@ local function GenerateMarkerMetadata()
     end
 end
 
----@param mapSize number
----@param compressionTreeSize number
----@param compressionThreshold number
-local function GenerateWithWater(mapSize, compressionTreeSize, compressionThreshold)
-
-end
-
-local function GenerateWithNoWater()
-
-end
-
 --- Generates a navigational mesh based on the heightmap
 function Generate()
 
@@ -1191,19 +1180,6 @@ function Generate()
     -- 40x40+
     if MapSize >= 2048 then
         compressionThreshold = 2 * compressionThreshold
-    end
-
-    ---@type moho.aibrain_methods
-    local brain = ArmyBrains[1]
-    local waterRatio
-    if brain then
-        waterRatio = brain:GetMapWaterRatio()
-    end
-
-    if waterRatio and waterRatio <= 0 then
-
-    else
-
     end
 
     NavGrids['Land'] = NavGrid('Land', CompressionTreeSize)


### PR DESCRIPTION
Introduces basic support for the playable area of a map. It does not re-generate the navigational mesh when the playable area is changed. The playable area is ignored for a non-skirmish (read: campaign) map. It takes a few assumptions:

- The code assumes the playable area is set immediately in the map script, with no delays. This is usually the case
- The code assumes that the navigational mesh is generated _after_ the map scripts have run. This is the case when you generate the navigational mesh in the recent introduced `OnBeginSession` callback of the brain. See also https://github.com/FAForever/fa/blob/nav-mesh/playable-area/lua/aibrains/easy-ai.lua#L52-L70

As an example of the result:

![image](https://github.com/FAForever/fa/assets/15778155/560f6673-6e30-4bc7-a8c4-8d4489320bb8)
