### PR TITLE
Introduce various transport and carrier callbacks

### DIFF
--- a/lua/aibrains/platoons/platoon-base.lua
+++ b/lua/aibrains/platoons/platoon-base.lua
@@ -277,6 +277,74 @@ AIPlatoon = Class(moho.platoon_methods) {
     OnShieldDisabled = function(self, unit)
     end,
 
+    --- Called as a unit (with transport capabilities) of this platoon attached a unit to itself
+    ---@param self AIPlatoon
+    ---@param transport Unit
+    ---@param attachBone Bone
+    ---@param attachedUnit Unit
+    OnTransportAttach = function(self, transport, attachBone, attachedUnit)
+    end,
+
+    --- Called as a unit (with transport capabilities) of this platoon deattached a unit from itself
+    ---@param self AIPlatoon
+    ---@param transport Unit
+    ---@param attachBone Bone
+    ---@param deattachedUnit Unit
+    OnTransportDetach = function(self, transport, attachBone, deattachedUnit)
+    end,
+
+    --- Called as a unit (with transport capabilities) of this platoon aborts the a transport order
+    ---@param self AIPlatoon
+    ---@param transport Unit
+    OnTransportAborted = function(self, transport)
+    end,
+
+    --- Called as a unit (with transport capabilities) of this platoon initiates the a transport order
+    ---@param self AIPlatoon
+    ---@param transport Unit
+    OnTransportOrdered = function(self, transport)
+    end,
+
+    --- Called as a unit is killed while being transported by a unit (with transport capabilities) of this platoon
+    ---@param self AIPlatoon
+    ---@param transport Unit
+    OnAttachedKilled = function(self, transport, attached)
+    end,
+
+    --- Called as a unit (with transport capabilities) of this platoon is ready to load in units
+    ---@param self AIPlatoon
+    ---@param transport Unit
+    OnStartTransportLoading = function(self, transport)
+    end,
+
+    --- Called as a unit (with transport capabilities) of this platoon is done loading in units
+    ---@param self AIPlatoon
+    ---@param transport Unit
+    OnStopTransportLoading = function(self, transport)
+    end,
+
+    --- Called as a unit (with carrier capabilities) of this platoon has a change in storage
+    ---@see `OnAddToStorage` and `OnRemoveFromStorage` for the unit in question
+    ---@param self AIPlatoon
+    ---@param carrier Unit
+    ---@param loading boolean
+    OnStorageChange = function(self, carrier, loading)
+    end,
+
+    --- Called as a unit (with carrier capabilities) of this platoon adds a unit to its storage
+    ---@param self AIPlatoon
+    ---@param carrier Unit
+    ---@param unit Unit
+    OnAddToStorage = function(self, carrier, unit)
+    end,
+
+    --- Called as a unit (with carrier capabilities) of this platoon removes a unit from its storage
+    ---@param self AIPlatoon
+    ---@param carrier Unit
+    ---@param unit Unit
+    OnRemoveFromStorage = function(self, carrier, unit)
+    end,
+
     -----------------------------------------------------------------
     -- hooks
 

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2267,8 +2267,6 @@ BaseTransport = ClassSimple {
                 unit.attachmentBone = i
             end
         end
-
-        unit:OnAttachedToTransport(self, attachBone)
     end,
 
     ---@param self BaseTransport
@@ -2279,7 +2277,6 @@ BaseTransport = ClassSimple {
         self:RequestRefreshUI()
         self.slots[unit.attachmentBone] = nil
         unit.attachmentBone = nil
-        unit:OnDetachedFromTransport(self, attachBone)
     end,
 
     -- When one of our attached units gets killed, detach it
@@ -2298,12 +2295,10 @@ BaseTransport = ClassSimple {
         self:GetAIBrain().loadingTransport = self
     end,
 
-    ---comment
-    ---@param ... BaseTransport
-    OnStopTransportLoading = function(...)
+    ---@param self BaseTransport
+    OnStopTransportLoading = function(self)
     end,
 
-    ---comment
     ---@param self BaseTransport
     DestroyedOnTransport = function(self)
     end,
@@ -2338,20 +2333,50 @@ BaseTransport = ClassSimple {
 --- Base class for air transports.
 ---@class AirTransport: AirUnit, BaseTransport
 AirTransport = ClassUnit(AirUnit, BaseTransport) {
-
-    ---@param self AirTransport
-    OnTransportAborted = function(self)
-    end,
-
-    ---@param self AirTransport
-    OnTransportOrdered = function(self)
-    end,
-
     ---@param self AirTransport
     OnCreate = function(self)
         AirUnit.OnCreate(self)
         self.slots = {}
         self.transData = {}
+    end,
+
+    ---@param self AirTransport
+    ---@param attachBone Bone
+    ---@param unit Unit
+    OnTransportAttach = function(self, attachBone, unit)
+        AirUnit.OnTransportAttach(self, attachBone, unit)
+        BaseTransport.OnTransportAttach(self, attachBone, unit)
+    end,
+
+    ---@param self AirTransport
+    ---@param attachBone Bone
+    ---@param unit Unit
+    OnTransportDetach = function(self, attachBone, unit)
+        AirUnit.OnTransportDetach(self, attachBone, unit)
+        BaseTransport.OnTransportDetach(self, attachBone, unit)
+    end,
+
+    OnAttachedKilled = function(self, attached)
+        AirUnit.OnAttachedKilled(self, attached)
+        BaseTransport.OnAttachedKilled(self, attached)
+    end,
+
+    ---@param self AirTransport
+    OnStartTransportLoading = function(self)
+        AirUnit.OnStartTransportLoading(self)
+        BaseTransport.OnStartTransportLoading(self)
+    end,
+
+    ---@param self AirTransport
+    OnStopTransportLoading = function(self)
+        AirUnit.OnStopTransportLoading(self)
+        BaseTransport.OnStopTransportLoading(self)
+    end,
+
+    ---@param self AirTransport
+    DestroyedOnTransport = function(self)
+        -- AirUnit.DestroyedOnTransport(self)
+        BaseTransport.DestroyedOnTransport(self)
     end,
 
     ---@param self AirTransport
@@ -2586,8 +2611,46 @@ SeaUnit = ClassUnit(MobileUnit){
 }
 
 --- Base class for aircraft carriers.
----@class AircraftCarrier : SeaUnit
+---@class AircraftCarrier : SeaUnit, BaseTransport
 AircraftCarrier = ClassUnit(SeaUnit, BaseTransport) {
+    ---@param self AircraftCarrier
+    ---@param attachBone Bone
+    ---@param unit Unit
+    OnTransportAttach = function(self, attachBone, unit)
+        SeaUnit.OnTransportAttach(self, attachBone, unit)
+        BaseTransport.OnTransportAttach(self, attachBone, unit)
+    end,
+
+    ---@param self AircraftCarrier
+    ---@param attachBone Bone
+    ---@param unit Unit
+    OnTransportDetach = function(self, attachBone, unit)
+        SeaUnit.OnTransportDetach(self, attachBone, unit)
+        BaseTransport.OnTransportDetach(self, attachBone, unit)
+    end,
+
+    OnAttachedKilled = function(self, attached)
+        SeaUnit.OnAttachedKilled(self, attached)
+        BaseTransport.OnAttachedKilled(self, attached)
+    end,
+
+    ---@param self AircraftCarrier
+    OnStartTransportLoading = function(self)
+        SeaUnit.OnStartTransportLoading(self)
+        BaseTransport.OnStartTransportLoading(self)
+    end,
+
+    ---@param self AircraftCarrier
+    OnStopTransportLoading = function(self)
+        SeaUnit.OnStopTransportLoading(self)
+        BaseTransport.OnStopTransportLoading(self)
+    end,
+
+    ---@param self AircraftCarrier
+    DestroyedOnTransport = function(self)
+        -- SeaUnit.DestroyedOnTransport(self)
+        BaseTransport.DestroyedOnTransport(self)
+    end,
 
     ---@param self AircraftCarrier
     ---@param instigator Unit

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -197,6 +197,14 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             -- SpecialToggleDisableFunction = false,
             -- OnAttachedToTransport = {}, -- Returns self, transport, bone
             -- OnDetachedFromTransport = {}, -- Returns self, transport, bone
+
+            -- OnTransportAttach = {}
+            -- OnTransportDetach = {}
+            -- OnTransportAborted = {}
+            -- OnTransportOrdered = {}
+            -- OnAttachedKilled = {}
+            -- OnStartTransportLoading = {}
+            -- OnStopTransportLoading = {}
         }
     end,
 
@@ -2721,7 +2729,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     ---@param attachedUnit Unit
     OnTransportAttach = function(self, attachBone, attachedUnit)
         -- awareness of event for campaign scripts
-        local callbacks = self.EventCallbacks['OnTransportAttach'] or { }
+        local callbacks = self.EventCallbacks['OnTransportAttach']
         if callbacks then
             for _, cb in callbacks do
                 cb(self, attachBone, attachedUnit)
@@ -2744,7 +2752,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     ---@param deattachedUnit Unit
     OnTransportDetach = function(self, attachBone, deattachedUnit)
         -- awareness of event for campaign scripts
-        local callbacks = self.EventCallbacks['OnTransportDetach'] or { }
+        local callbacks = self.EventCallbacks['OnTransportDetach']
         if callbacks then
             for _, cb in callbacks do
                 cb(self, attachBone, deattachedUnit)
@@ -2765,7 +2773,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     ---@param self Unit
     OnTransportAborted = function(self)
         -- awareness of event for campaign scripts
-        local callbacks = self.EventCallbacks['OnTransportAborted'] or { }
+        local callbacks = self.EventCallbacks['OnTransportAborted']
         if callbacks then
             for _, cb in callbacks do
                 cb(self)
@@ -2783,7 +2791,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     ---@param self Unit
     OnTransportOrdered = function(self)
         -- awareness of event for campaign scripts
-        local callbacks = self.EventCallbacks['OnTransportOrdered'] or { }
+        local callbacks = self.EventCallbacks['OnTransportOrdered']
         if callbacks then
             for _, cb in callbacks do
                 cb(self)
@@ -2802,7 +2810,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     ---@param attached Unit
     OnAttachedKilled = function(self, attached)
         -- awareness of event for campaign scripts
-        local callbacks = self.EventCallbacks['OnAttachedKilled'] or { }
+        local callbacks = self.EventCallbacks['OnAttachedKilled']
         if callbacks then
             for _, cb in callbacks do
                 cb(self)
@@ -2820,7 +2828,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     ---@param self Unit
     OnStartTransportLoading = function(self)
         -- awareness of event for campaign scripts
-        local callbacks = self.EventCallbacks['OnStartTransportLoading'] or { }
+        local callbacks = self.EventCallbacks['OnStartTransportLoading']
         if callbacks then
             for _, cb in callbacks do
                 cb(self)
@@ -2838,7 +2846,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     ---@param self Unit
     OnStopTransportLoading = function(self)
         -- awareness of event for campaign scripts
-        local callbacks = self.EventCallbacks['OnStopTransportLoading'] or { }
+        local callbacks = self.EventCallbacks['OnStopTransportLoading']
         if callbacks then
             for _, cb in callbacks do
                 cb(self)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2813,7 +2813,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         local callbacks = self.EventCallbacks['OnAttachedKilled']
         if callbacks then
             for _, cb in callbacks do
-                cb(self)
+                cb(self, attached)
             end
         end
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2715,6 +2715,143 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     OnBuildProgress = function(self, unit, oldProg, newProg)
     end,
 
+    --- Called as this unit (with transport capabilities) attached another unit to itself
+    ---@param self Unit
+    ---@param attachBone Bone
+    ---@param attachedUnit Unit
+    OnTransportAttach = function(self, attachBone, attachedUnit)
+        -- awareness of event for campaign scripts
+        local callbacks = self.EventCallbacks['OnTransportAttach'] or { }
+        if callbacks then
+            for _, cb in callbacks do
+                cb(self, attachBone, attachedUnit)
+            end
+        end
+
+        -- manual Lua callback for the unit
+        attachedUnit:OnAttachedToTransport(self, attachBone)
+
+        -- awareness of event for AI
+        local aiPlatoon = self.AIPlatoonReference
+        if aiPlatoon then
+            aiPlatoon:OnTransportAttach(self, attachBone, attachedUnit)
+        end
+    end,
+
+    --- Called as this unit (with transport capabilities) deattached another unit from itself
+    ---@param self Unit
+    ---@param attachBone Bone
+    ---@param deattachedUnit Unit
+    OnTransportDetach = function(self, attachBone, deattachedUnit)
+        -- awareness of event for campaign scripts
+        local callbacks = self.EventCallbacks['OnTransportDetach'] or { }
+        if callbacks then
+            for _, cb in callbacks do
+                cb(self, attachBone, deattachedUnit)
+            end
+        end
+
+        -- manual Lua callback
+        deattachedUnit:OnDetachedFromTransport(self, attachBone)
+
+        -- awareness of event for AI
+        local aiPlatoon = self.AIPlatoonReference
+        if aiPlatoon then
+            aiPlatoon:OnTransportDetach(self, attachBone, deattachedUnit)
+        end
+    end,
+
+    --- Called as a unit (with transport capabilities) aborts the transport order
+    ---@param self Unit
+    OnTransportAborted = function(self)
+        -- awareness of event for campaign scripts
+        local callbacks = self.EventCallbacks['OnTransportAborted'] or { }
+        if callbacks then
+            for _, cb in callbacks do
+                cb(self)
+            end
+        end
+
+        -- awareness of event for AI
+        local aiPlatoon = self.AIPlatoonReference
+        if aiPlatoon then
+            aiPlatoon:OnTransportAborted(self)
+        end
+    end,
+
+    --- Called as a unit (with transport capabilities) initiates the a transport order
+    ---@param self Unit
+    OnTransportOrdered = function(self)
+        -- awareness of event for campaign scripts
+        local callbacks = self.EventCallbacks['OnTransportOrdered'] or { }
+        if callbacks then
+            for _, cb in callbacks do
+                cb(self)
+            end
+        end
+
+        -- awareness of event for AI
+        local aiPlatoon = self.AIPlatoonReference
+        if aiPlatoon then
+            aiPlatoon:OnTransportOrdered(self)
+        end
+    end,
+
+    --- Called as a unit is killed while being transported by a unit (with transport capabilities) of this platoon
+    ---@param self Unit
+    ---@param attached Unit
+    OnAttachedKilled = function(self, attached)
+        -- awareness of event for campaign scripts
+        local callbacks = self.EventCallbacks['OnAttachedKilled'] or { }
+        if callbacks then
+            for _, cb in callbacks do
+                cb(self)
+            end
+        end
+
+        -- awareness of event for AI
+        local aiPlatoon = self.AIPlatoonReference
+        if aiPlatoon then
+            aiPlatoon:OnAttachedKilled(self)
+        end
+    end,
+
+    --- Called as a unit (with transport capabilities) is ready to load in units
+    ---@param self Unit
+    OnStartTransportLoading = function(self)
+        -- awareness of event for campaign scripts
+        local callbacks = self.EventCallbacks['OnStartTransportLoading'] or { }
+        if callbacks then
+            for _, cb in callbacks do
+                cb(self)
+            end
+        end
+
+        -- awareness of event for AI
+        local aiPlatoon = self.AIPlatoonReference
+        if aiPlatoon then
+            aiPlatoon:OnStartTransportLoading(self)
+        end
+    end,
+
+    --- Called as a unit (with transport capabilities) of this platoon is done loading in units
+    ---@param self Unit
+    OnStopTransportLoading = function(self)
+        -- awareness of event for campaign scripts
+        local callbacks = self.EventCallbacks['OnStopTransportLoading'] or { }
+        if callbacks then
+            for _, cb in callbacks do
+                cb(self)
+            end
+        end
+
+        -- awareness of event for AI
+        local aiPlatoon = self.AIPlatoonReference
+        if aiPlatoon then
+            aiPlatoon:OnStopTransportLoading(self)
+        end
+    end,
+
     ---@param self Unit
     ---@param built boolean
     ---@param order string
@@ -3755,6 +3892,111 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         end
     end,
 
+    --- Adds a callback for the `OnTransportAttach` event
+    ---@param self Unit
+    ---@param fn fun(transport: Unit, attachBone: Bone,  attachedUnit: Unit)
+    ---@param id string | nil       # if provided, stores the function using the identifier as key
+    AddOnTransportAttachCallback = function(self, fn, id)
+        local callbacks = self.EventCallbacks['OnTransportAttach'] or { }
+        self.EventCallbacks['OnTransportAttach'] = callbacks
+
+        if id then
+            callbacks[id] = fn
+        else
+            table.insert(callbacks, fn)
+        end
+    end,
+
+    --- Adds a callback for the `OnTransportDetach` event
+    ---@param self Unit
+    ---@param fn fun(transport: Unit, attachBone: Bone,  deattachedUnit: Unit)
+    ---@param id string | nil       # if provided, stores the function using the identifier as key
+    AddOnTransportDetachCallback = function(self, fn, id)
+        local callbacks = self.EventCallbacks['OnTransportDetach'] or { }
+        self.EventCallbacks['OnTransportDetach'] = callbacks
+
+        if id then
+            callbacks[id] = fn
+        else
+            table.insert(callbacks, fn)
+        end
+    end,
+
+    --- Adds a callback for the `OnTransportOrdered` event
+    ---@param self Unit
+    ---@param fn fun(transport: Unit)
+    ---@param id string | nil       # if provided, stores the function using the identifier as key
+    AddOnTransportOrderedCallback = function(self, fn, id)
+        local callbacks = self.EventCallbacks['OnTransportOrdered'] or { }
+        self.EventCallbacks['OnTransportOrdered'] = callbacks
+
+        if id then
+            callbacks[id] = fn
+        else
+            table.insert(callbacks, fn)
+        end
+    end,
+
+    --- Adds a callback for the `OnTransportAborted` event
+    ---@param self Unit
+    ---@param fn fun(transport: Unit)
+    ---@param id string | nil       # if provided, stores the function using the identifier as key
+    AddOnTransportAbortedCallback = function(self, fn, id)
+        local callbacks = self.EventCallbacks['OnTransportAborted'] or { }
+        self.EventCallbacks['OnTransportAborted'] = callbacks
+
+        if id then
+            callbacks[id] = fn
+        else
+            table.insert(callbacks, fn)
+        end
+    end,
+
+    --- Adds a callback for the `OnAttachedKilled` event
+    ---@param self Unit
+    ---@param fn fun(transport: Unit, killedUnit: Unit)
+    ---@param id string | nil       # if provided, stores the function using the identifier as key
+    AddOnAttachedKilledCallback = function(self, fn, id)
+        local callbacks = self.EventCallbacks['OnAttachedKilled'] or { }
+        self.EventCallbacks['OnAttachedKilled'] = callbacks
+
+        if id then
+            callbacks[id] = fn
+        else
+            table.insert(callbacks, fn)
+        end
+    end,
+
+    --- Adds a callback for the `OnStartTransportLoading` event
+    ---@param self Unit
+    ---@param fn fun(transport: Unit)
+    ---@param id string | nil       # if provided, stores the function using the identifier as key
+    AddOnStartTransportLoadingCallback = function(self, fn, id)
+        local callbacks = self.EventCallbacks['OnStartTransportLoading'] or { }
+        self.EventCallbacks['OnStartTransportLoading'] = callbacks
+
+        if id then
+            callbacks[id] = fn
+        else
+            table.insert(callbacks, fn)
+        end
+    end,
+
+    --- Adds a callback for the `OnStopTransportLoading` event
+    ---@param self Unit
+    ---@param fn fun(transport: Unit)
+    ---@param id string | nil       # if provided, stores the function using the identifier as key
+    AddOnStopTransportLoadingCallback = function(self, fn, id)
+        local callbacks = self.EventCallbacks['OnStopTransportLoading'] or { }
+        self.EventCallbacks['OnStopTransportLoading'] = callbacks
+
+        if id then
+            callbacks[id] = fn
+        else
+            table.insert(callbacks, fn)
+        end
+    end,
+
     ---@param self Unit
     ---@param fn function
     AddProjectileDamagedCallback = function(self, fn)
@@ -4112,18 +4354,36 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         self:SetDoNotTarget(loading)
         self:SetReclaimable(not loading)
         self:SetCapturable(not loading)
+
+        -- awareness of event for AI
+        local aiPlatoon = self.AIPlatoonReference
+        if aiPlatoon then
+            aiPlatoon:OnStorageChange(self, loading)
+        end
     end,
 
     ---@param self Unit
     ---@param unit Unit
     OnAddToStorage = function(self, unit)
         self:OnStorageChange(true)
+
+        -- awareness of event for AI
+        local aiPlatoon = self.AIPlatoonReference
+        if aiPlatoon then
+            aiPlatoon:OnAddToStorage(self, unit)
+        end
     end,
 
     ---@param self Unit
     ---@param unit Unit
     OnRemoveFromStorage = function(self, unit)
         self:OnStorageChange(false)
+
+        -- awareness of event for AI
+        local aiPlatoon = self.AIPlatoonReference
+        if aiPlatoon then
+            aiPlatoon:OnRemoveFromStorage(self, unit)
+        end
     end,
 
     -- Animation when being dropped from a transport.
@@ -4336,7 +4596,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     end,
 
     ---@param self Unit
-    ---@param transport BaseTransport
+    ---@param transport Unit
     ---@param bone Bone
     OnAttachedToTransport = function(self, transport, bone)
         self:MarkWeaponsOnTransport(true)
@@ -4352,7 +4612,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     end,
 
     ---@param self Unit
-    ---@param transport BaseTransport
+    ---@param transport Unit
     ---@param bone Bone
     OnDetachedFromTransport = function(self, transport, bone)
         self.Trash:Add(ForkThread(self.OnDetachedFromTransportThread, self, transport, bone))


### PR DESCRIPTION
Introduces various callbacks and platoon events that were missing, including:

- `OnTransportAttach`
- `OnTransportDetach`
- `OnTransportAborted` 
- `OnTransportOrdered`
- `OnAttachedKilled`
- `OnStartTransportLoading`
- `OnStopTransportLoading` 

Additional, adds the following missing events to the new platoon template:

- `OnStorageChange`
- `OnAddToStorage`
- `OnRemoveFromStorage`

They are all annotated. The comments describe when you can expect the event to trigger.