### PR TITLE
Introduce grid that allows an AI to understand map presence

### DIFF
--- a/engine/Sim/CAiBrain.lua
+++ b/engine/Sim/CAiBrain.lua
@@ -366,6 +366,7 @@ end
 ---@param position Vector
 ---@param radius number
 ---@param alliance AllianceType
+---@return Unit[]
 function CAiBrain:GetUnitsAroundPoint(category, position, radius, alliance)
 end
 

--- a/lua/AI/GridPresence.lua
+++ b/lua/AI/GridPresence.lua
@@ -79,6 +79,25 @@ GridPresence = Class(Grid) {
         self:DebugUpdate()
     end,
 
+    --- Converts a world position to a cell
+    ---@param self AIGridPresence
+    ---@param wx number     # in world space
+    ---@param wz number     # in world space
+    ---@return AIGridPresenceCell
+    ToCellFromWorldSpace = function(self, wx, wz)
+        local gx, gz = self:ToGridSpace(wx, wz)
+        return self.Cells[gx][gz]
+    end,
+
+    --- Converts a grid position to a cell
+    ---@param self AIGridPresence
+    ---@param gx number     # in grid space
+    ---@param gz number     # in grid space
+    ---@return AIGridPresenceCell
+    ToCellFromGridSpace = function(self, gx, gz)
+        return self.Cells[gx][gz]
+    end,
+
     ---@param self AIGridPresence
     Update = function(self)
         ForkThread(
@@ -271,30 +290,10 @@ GridPresence = Class(Grid) {
                 DebugUpdateData.InferredTick = GetGameTick()
                 DebugUpdateData.InferredTime = GetSystemTimeSecondsOnlyForProfileUse() - start
                 Sync.GridPresenceUIDebugUpdate = DebugUpdateData
-                reprsl(DebugUpdateData)
             end
 
             WaitTicks(29)
         end
-    end,
-
-    --- Converts a world position to a cell
-    ---@param self AIGridPresence
-    ---@param wx number     # in world space
-    ---@param wz number     # in world space
-    ---@return AIGridPresenceCell
-    ToCellFromWorldSpace = function(self, wx, wz)
-        local gx, gz = self:ToGridSpace(wx, wz)
-        return self.Cells[gx][gz]
-    end,
-
-    --- Converts a grid position to a cell
-    ---@param self AIGridPresence
-    ---@param gx number     # in grid space
-    ---@param gz number     # in grid space
-    ---@return AIGridPresenceCell
-    ToCellFromGridSpace = function(self, gx, gz)
-        return self.Cells[gx][gz]
     end,
 
     --- Contains various debug logic

--- a/lua/AI/GridPresence.lua
+++ b/lua/AI/GridPresence.lua
@@ -336,19 +336,20 @@ GridPresence = Class(Grid) {
                     Sync.GridPresenceUIDebugCell = DebugCellData
 
                     if cell.Inferred[label] == 'Allied' then
-                        self:DrawCell(cell.X, cell.Z, math.sqrt(label) + 0.075, '00ff00')
-                        self:DrawCell(cell.X, cell.Z, math.sqrt(label) - 0.075, '00ff00')
+                        self:DrawCell(cell.X, cell.Z, math.log(label) + 0.075, '00ff00')
+                        self:DrawCell(cell.X, cell.Z, math.log(label) - 0.075, '00ff00')
                     elseif cell.Inferred[label] == 'Hostile' then
-                        self:DrawCell(cell.X, cell.Z, math.sqrt(label) + 0.075, 'ff0000')
-                        self:DrawCell(cell.X, cell.Z, math.sqrt(label) - 0.075, 'ff0000')
+                        self:DrawCell(cell.X, cell.Z, math.log(label) + 0.075, 'ff0000')
+                        self:DrawCell(cell.X, cell.Z, math.log(label) - 0.075, 'ff0000')
                     elseif cell.Inferred[label] == 'Contested' then
-                        self:DrawCell(cell.X, cell.Z, math.sqrt(label) + 0.075, 'FFD900')
-                        self:DrawCell(cell.X, cell.Z, math.sqrt(label) - 0.075, 'FFD900')
+                        self:DrawCell(cell.X, cell.Z, math.log(label) + 0.075, 'FFD900')
+                        self:DrawCell(cell.X, cell.Z, math.log(label) - 0.075, 'FFD900')
                     else
-                        self:DrawCell(cell.X, cell.Z, math.sqrt(label) + 0.075, 'A0FFFFFF')
-                        self:DrawCell(cell.X, cell.Z, math.sqrt(label) - 0.075, 'A0FFFFFF')
+                        self:DrawCell(cell.X, cell.Z, math.log(label) + 0.075, 'A0FFFFFF')
+                        self:DrawCell(cell.X, cell.Z, math.log(label) - 0.075, 'A0FFFFFF')
                     end
                 end
+
                 -- draw the status of the cells
                 for lx = -1, 1 do
                     for lz = -1, 1 do 
@@ -357,13 +358,13 @@ GridPresence = Class(Grid) {
                             for label, _ in alt.Labels do
 
                                 if alt.Inferred[label] == 'Allied' then
-                                    self:DrawCell(alt.X, alt.Z, math.sqrt(label), '00ff00')
+                                    self:DrawCell(alt.X, alt.Z, math.log(label), '00ff00')
                                 elseif alt.Inferred[label] == 'Hostile' then
-                                    self:DrawCell(alt.X, alt.Z, math.sqrt(label), 'ff0000')
+                                    self:DrawCell(alt.X, alt.Z, math.log(label), 'ff0000')
                                 elseif alt.Inferred[label] == 'Contested' then
-                                    self:DrawCell(alt.X, alt.Z, math.sqrt(label), 'FFD900')
+                                    self:DrawCell(alt.X, alt.Z, math.log(label), 'FFD900')
                                 else
-                                    self:DrawCell(alt.X, alt.Z, math.sqrt(label), 'A0FFFFFF')
+                                    self:DrawCell(alt.X, alt.Z, math.log(label), 'A0FFFFFF')
                                 end
                             end
 

--- a/lua/AI/GridPresence.lua
+++ b/lua/AI/GridPresence.lua
@@ -296,6 +296,17 @@ GridPresence = Class(Grid) {
         end
     end,
 
+    ---@param self AIGridPresence
+    ---@param position Vector
+    ---@return ('Allied' | 'Hostile' | 'Contested' | 'Unoccupied')?
+    GetInferredStatus = function(self, position)
+        local cell = self:ToCellFromWorldSpace(position[1], position[3])
+        local label = NavUtils.GetLabel('Hover', position)
+        if label then
+            return cell.Inferred[label]
+        end
+    end,
+
     --- Contains various debug logic
     ---@param self AIGridPresence
     DebugUpdate = function(self)

--- a/lua/AI/GridPresence.lua
+++ b/lua/AI/GridPresence.lua
@@ -1,0 +1,320 @@
+local Grid = import("/lua/ai/grid.lua").Grid
+local MarkerUtilities = import("/lua/sim/MarkerUtilities.lua")
+local NavUtils = import("/lua/sim/NavUtils.lua")
+
+local Debug = false
+function EnableDebugging()
+    if ScenarioInfo.GameHasAIs or CheatsEnabled() then
+        Debug = true
+    end
+end
+
+function DisableDebugging()
+    if ScenarioInfo.GameHasAIs or CheatsEnabled() then
+        Debug = false
+    end
+end
+
+---@class AIGridPresenceCell : AIGridCell
+---@field Labels table<number, boolean>         # <label, boolean>
+---@field Inferred table<number, 'Allied' | 'Hostile' | 'Contested' | 'Unoccupied'>     # <label, status>
+---@field StatusQuo table<number, 'Allied' | 'Hostile' | 'Contested' | 'Unoccupied'>    # <label, status>
+---@field CountHostile table<number, number>    # <label, count>
+---@field CountAllied table<number, number>     # <label, count>
+
+---@class AIGridPresence : AIGrid
+---@field Brain moho.aibrain_methods        # Brain we compute presence for
+---@field Labels table<number, boolean>     # <label, boolean>
+---@field Cells AIGridPresenceCell[][]
+GridPresence = Class(Grid) {
+
+    ---@param self AIGridPresence
+    __init = function(self, brain)
+        Grid.__init(self)
+
+        self.Brain = brain
+        self.Labels = { }
+
+        local cellCount = self.CellCount
+        local cells = self.Cells
+
+        for gx = 1, cellCount do
+            for gz = 1, cellCount do
+                local cell = cells[gx][gz]
+                cell.Labels = NavUtils.GetLabelsofIMAP('Hover', gz, gx) or { }
+
+                cell.Inferred = { }
+                for label, _ in cell.Labels do
+                    cell.Inferred[label] = 'Unoccupied'
+                end
+
+                cell.StatusQuo = { }
+                for label, _ in cell.Labels do
+                    cell.StatusQuo[label] = 'Unoccupied'
+                end
+
+                cell.CountAllied = { }
+                for label, _ in cell.Labels do
+                    cell.CountAllied[label] = 0
+                end
+
+                cell.CountHostile = { }
+                for label, _ in cell.Labels do
+                    cell.CountHostile[label] = 0
+                end
+            end
+        end
+
+        self:Update()
+        self:DebugUpdate()
+    end,
+
+    ---@param self AIGridPresence
+    Update = function(self)
+        ForkThread(
+            self.UpdateThread,
+            self
+        )
+    end,
+
+    ---@param self AIGridPresence
+    UpdateThread = function(self)
+        local cellCount = self.CellCount
+        local cells = self.Cells
+        local brain = self.Brain
+
+        ---@type AIGridPresenceCell[]
+        local iterationA = { }
+
+        ---@type AIGridPresenceCell[]
+        local iterationB = { }
+
+        while true do
+
+            -- counting of extractors
+            local massMarkers, extractorCount = MarkerUtilities.GetMarkersByType('Mass')
+            for k = 1, extractorCount do
+                local massMarker = massMarkers[k]
+                local position = massMarker.position
+
+                -- compute hostile / allied units
+                local countHostile = table.getn(brain:GetUnitsAroundPoint(categories.STRUCTURE, position, 6, 'Enemy'))
+                local countAllied = table.getn(brain:GetUnitsAroundPoint(categories.STRUCTURE, position, 6, 'Ally'))
+
+                -- update status quo
+                local label = NavUtils.GetLabel('Hover', position)
+                if label and label > 0 then
+                    local cell = self:ToCellFromWorldSpace(position[1], position[3])
+                    cell.CountAllied[label] = (cell.CountAllied[label] or 0) + countAllied
+                    cell.CountHostile[label] = (cell.CountHostile[label] or 0) + countHostile
+
+                    self.Labels[label] = true
+                end
+            end
+
+            WaitTicks(1)
+
+            -- initial status quo
+            for k = 1, cellCount do
+                for l = 1, cellCount do
+                    local cell = cells[k][l]
+
+                    for label, _ in cell.Labels do
+                        local allied = cell.CountAllied[label]
+                        local hostile = cell.CountHostile[label]
+                        if allied and hostile then
+                            if allied > hostile then
+                                cell.StatusQuo[label] = 'Allied'
+                            elseif hostile > allied then
+                                cell.StatusQuo[label] = 'Hostile'
+                            elseif hostile == allied and hostile > 0 then
+                                cell.StatusQuo[label] = 'Contested'
+                            else
+                                cell.StatusQuo[label] = 'Unoccupied'
+                            end
+                        else
+                            cell.StatusQuo[label] = 'Unoccupied'
+                        end
+
+                        cell.CountAllied[label] = 0
+                        cell.CountHostile[label] = 0
+                    end
+                end
+            end
+
+            -- initial inferred
+            for k = 1, cellCount do
+                for l = 1, cellCount do
+                    local cell = cells[k][l]
+
+                    for label, _ in cell.Labels do
+                        cell.Inferred[label] = 'Unoccupied'
+                    end
+                end
+            end
+
+            -- use status quo to populate inferred fields
+            for label, _ in self.Labels do
+
+                local headA = 1
+
+                -- first iteration to populate initial inferred fields
+                for k = 1, cellCount do
+                    for l = 1, cellCount do
+                        local cell = cells[k][l]
+                        if cell.Labels[label] and cell.StatusQuo[label] != 'Unoccupied' then
+                            cell.Inferred[label] = cell.StatusQuo[label]
+                            iterationA[headA] = cell
+                            headA = headA + 1
+                        end
+                    end
+                end
+
+                -- consecutive iterations until all inferred fields are populated
+                repeat
+
+                    -- shuffle the order
+                    for k = headA - 1, 1, -1 do
+
+                        local j = (Random() * (k - 1) + 1) ^ 0;
+                        local value = iterationA[j];
+                        iterationA[j] = iterationA[k];
+                        iterationA[k] = value;
+                    end
+
+                    -- expand
+                    local headB = 1
+                    for k = 1, headA - 1 do
+                        local cell = iterationA[k]
+                        for lx = -1, 1 do
+                            for lz = -1, 1 do
+                                local neighbor = cells[cell.X + lx][cell.Z + lz]
+                                if neighbor and neighbor != cell then
+                                    if neighbor.Labels[label] then
+                                        if (neighbor.Inferred[label] == 'Unoccupied') then
+                                            neighbor.Inferred[label] = cell.Inferred[label]
+                                            iterationB[headB] = neighbor
+                                            headB = headB + 1
+                                        end
+                                    end
+                                end
+                            end
+                        end
+                    end
+
+                    -- switch them up
+                    local iterationT = iterationA
+                    iterationA = iterationB
+                    iterationB = iterationT
+                    headA = headB
+
+                    WaitTicks(1)
+
+                until headA <= 1
+            end
+
+            WaitTicks(1)
+
+            -- use status quo to populate status quo fields
+            for label, _ in self.Labels do
+                for k = 1, cellCount do
+                    for l = 1, cellCount do
+                        local cell = cells[k][l]
+                        cell.StatusQuo[label] = cell.Inferred[label]
+                    end
+                end
+            end
+
+            WaitTicks(1)
+
+            -- use status quo to finalize the inferred fields
+            for label, _ in self.Labels do
+                for k = 1, cellCount do
+                    for l = 1, cellCount do
+                        local cell = cells[k][l]
+
+                        if cell.Labels[label] then
+                            for lx = -1, 1 do
+                                for lz = -1, 1 do
+                                    local neighbor = cells[cell.X + lx][cell.Z + lz]
+                                    if neighbor and neighbor != cell and neighbor.Labels[label] then
+                                        if cell.StatusQuo[label] != neighbor.StatusQuo[label] then
+                                            cell.Inferred[label] = 'Contested'
+                                            break
+                                        end
+                                    end
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+
+            WaitTicks(1)
+        end
+    end,
+
+    --- Converts a world position to a cell
+    ---@param self AIGridPresence
+    ---@param wx number     # in world space
+    ---@param wz number     # in world space
+    ---@return AIGridPresenceCell
+    ToCellFromWorldSpace = function(self, wx, wz)
+        local gx, gz = self:ToGridSpace(wx, wz)
+        return self.Cells[gx][gz]
+    end,
+
+    --- Converts a grid position to a cell
+    ---@param self AIGridPresence
+    ---@param gx number     # in grid space
+    ---@param gz number     # in grid space
+    ---@return AIGridPresenceCell
+    ToCellFromGridSpace = function(self, gx, gz)
+        return self.Cells[gx][gz]
+    end,
+
+    --- Contains various debug logic
+    ---@param self AIGridPresence
+    DebugUpdate = function(self)
+        ForkThread(
+            self.DebugUpdateThread,
+            self
+        )
+    end,
+
+    --- Allows us to scan the map
+    ---@param self AIGridPresence
+    DebugUpdateThread = function(self)
+
+        local cellCount = self.CellCount
+        local cells = self.Cells
+        local brain = self.Brain
+
+        while true do
+            for k = 1, cellCount do
+                for l = 1, cellCount do
+                    local cell = cells[k][l]
+                    for label, _ in cell.Labels do
+                        if cell.Inferred[label] == 'Allied' then
+                            self:DrawCell(cell.X, cell.Z, math.sqrt(label), '00ff00')
+                        elseif cell.Inferred[label] == 'Hostile' then
+                            self:DrawCell(cell.X, cell.Z, math.sqrt(label), 'ff0000')
+                        elseif cell.Inferred[label] == 'Contested' then
+                            self:DrawCell(cell.X, cell.Z, math.sqrt(label), 'FFD900')
+                        else
+                            self:DrawCell(cell.X, cell.Z, math.sqrt(label), 'A0FFFFFF')
+                        end
+                    end
+                end
+            end
+
+            WaitTicks(1)
+        end
+    end,
+}
+
+---@param brain moho.aibrain_methods
+---@return AIGridPresence
+Setup = function(brain)
+    return GridPresence(brain)
+end

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -858,6 +858,8 @@ Callbacks.GridReclaimDebugEnable = import("/lua/ai/gridreclaim.lua").EnableDebug
 Callbacks.GridReclaimDebugDisable = import("/lua/ai/gridreclaim.lua").DisableDebugging
 Callbacks.GridReconDebugEnable = import("/lua/ai/gridrecon.lua").EnableDebugging
 Callbacks.GridReconDebugDisable = import("/lua/ai/gridrecon.lua").DisableDebugging
+Callbacks.GridPresenceDebugEnable = import("/lua/ai/gridpresence.lua").EnableDebugging
+Callbacks.GridPresenceDebugDisable = import("/lua/ai/gridpresence.lua").DisableDebugging
 
 Callbacks.AIBrainEconomyDebugEnable = import("/lua/aibrains/components/economy.lua").EnableDebugging
 Callbacks.AIBrainEconomyDebugDisable = import("/lua/aibrains/components/economy.lua").DisableDebugging

--- a/lua/aibrains/easy-ai.lua
+++ b/lua/aibrains/easy-ai.lua
@@ -63,7 +63,7 @@ AIBrain = Class(StandardBrain, EconomyComponent) {
         self.GridReclaim = import("/lua/ai/gridreclaim.lua").Setup(self)
         self.GridBrain = import("/lua/ai/gridbrain.lua").Setup()
         self.GridRecon = import("/lua/ai/gridrecon.lua").Setup(self)
-
+        self.GridPresence = import("/lua/AI/GridPresence.lua").Setup(self)
 
     end,
 

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -899,6 +899,8 @@ keyActions = {
         category = 'ai', order = 24},
     ['toggle_ai_reclaim_grid_ui'] = {action = 'UI_Lua import("/lua/ui/game/gridreclaim.lua").OpenWindow()',
         category = 'ai', order = 24},
+    ['toggle_ai_presence_grid_ui'] = {action = 'UI_Lua import("/lua/ui/game/gridpresence.lua").OpenWindow()',
+        category = 'ai', order = 24},
     ['toggle_ai_recon_grid_ui'] = {action = 'UI_Lua import("/lua/ui/game/gridrecon.lua").OpenWindow()',
         category = 'ai', order = 24},
     ['toggle_ai_economy_ui'] = {action = 'UI_Lua import("/lua/ui/game/AIBrainEconomyData.lua").OpenWindow()',

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -503,6 +503,7 @@ keyDescriptions = {
     ['toggle_navui'] = 'Toggle the debugging UI for the navigational mesh',
     ['toggle_ai_reclaim_grid_ui'] = 'Toggle the debugging UI for the reclaim grid',
     ['toggle_ai_recon_grid_ui'] = 'Toggle the debugging UI for the recon grid',
+    ['toggle_ai_presence_grid_ui'] = 'Toggle the debugging UI for the presence grid',
 
     ['toggle_ai_economy_ui'] = 'Toggle the debugging UI for the economy brain data',
 

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -165,6 +165,39 @@ NavGrid = ClassNavGrid {
         self.Trees[z][x] = labelTree
     end,
 
+    ---@param self NavGrid
+    ---@param position Vector A position in world space
+    ---@return CompressedLabelTreeRoot?
+    FindRoot = function(self, position)
+        return self:FindRootXZ(position[1], position[3])
+    end,
+
+    ---@param self NavGrid
+    ---@param x number x-coordinate, in world space
+    ---@param z number z-coordinate, in world space
+    ---@return CompressedLabelTreeRoot?
+    FindRootXZ = function(self, x, z)
+        if x > 0 and z > 0 then
+            local size = self.TreeSize
+            local trees = self.Trees
+
+            local bx = (x / size) ^ 0
+            local bz = (z / size) ^ 0
+            local root = trees[bz][bx] --[[@as CompressedLabelTreeRoot]]
+            return root
+        end
+
+        return nil
+    end,
+
+    ---@param self NavGrid
+    ---@param gx number x-coordinate, in grid space
+    ---@param gz number z-coordinate, in grid space
+    ---@return CompressedLabelTreeRoot?
+    FindRootGridspaceXZ = function(self, gx, gz)
+        return self.Trees[gx][gz] --[[@as CompressedLabelTreeRoot]]
+    end,
+
     --- Returns the leaf that encompasses the position, or nil if no leaf does
     ---@param self NavGrid
     ---@param position Vector A position in world space

--- a/lua/sim/NavUtils.lua
+++ b/lua/sim/NavUtils.lua
@@ -558,7 +558,7 @@ function GetLabelsofIMAP(layer, gx, gz)
     end
 
     -- check position argument
-    local root = grid:FindRootGridspaceXZ(gx - 1, gz - 1)
+    local root = grid:FindRootGridspaceXZ(gz - 1, gx - 1)
     if not root then
         return nil, 'OutsideMap'
     end

--- a/lua/sim/NavUtils.lua
+++ b/lua/sim/NavUtils.lua
@@ -539,6 +539,37 @@ function GetLabel(layer, position)
     return leaf.Label, nil
 end
 
+--- Returns a table with all labels in the current iMAP cell. The keys represent the labels. The values represent the ratio of area it occupies in the cell
+---@param layer NavLayers
+---@param gx number
+---@param gz number
+---@return table<number, number>? 
+---@return ('NotGenerated' | 'InvalidLayer' | 'OutsideMap' | 'SystemError' | 'Unpathable')?
+function GetLabelsofIMAP(layer, gx, gz)
+    -- check if generated
+    if not NavGenerator.IsGenerated() then
+        return nil, 'NotGenerated'
+    end
+
+    -- check layer argument
+    local grid = FindGrid(layer)
+    if not grid then
+        return nil, 'InvalidLayer'
+    end
+
+    -- check position argument
+    local root = grid:FindRootGridspaceXZ(gx - 1, gz - 1)
+    if not root then
+        return nil, 'OutsideMap'
+    end
+
+    if not root.Labels then
+        return nil, 'SystemError'
+    end
+
+    return root.Labels, nil
+end
+
 --- Returns a label that indicates to what sub-graph it belongs to. Unlike `GetLabel` this function does not try to find valid neighbors
 ---@see GetLabel
 ---@param layer NavLayers

--- a/lua/ui/game/GridPresence.lua
+++ b/lua/ui/game/GridPresence.lua
@@ -1,0 +1,214 @@
+local UIUtil = import("/lua/ui/uiutil.lua")
+local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
+
+local Window = import("/lua/maui/window.lua").Window
+local Group = import("/lua/maui/group.lua").Group
+
+local Root = false
+
+---@class GridPresenceUIDebugCell
+---@field Inferred 'Allied' | 'Hostile' | 'Contested' | 'Unoccupied'
+---@field Label number
+
+---@class GridPresenceUIDebugUpdate
+---@field ResourcePointsTime number
+---@field ResourcePointsTick number
+---@field InferredTime number
+---@field InferredTick number
+
+---@class GridPresenceUICell : Group
+---@field Title Text
+---@field Inferred Text
+---@field Label Text
+GridPresenceUICell = ClassUI(Group) {
+
+    ---@param self GridPresenceUICell
+    ---@param parent Control
+    __init = function(self, parent)
+        Group.__init(self, parent, 'GridPresenceUICell')
+
+        self.Title = UIUtil.CreateText(self, 'Scanning information', 14)
+        self.Inferred = UIUtil.CreateText(self, 'Inferred status: ...', 12)
+        self.Label = UIUtil.CreateText(self, 'Of label: ...', 12)
+
+        AddOnSyncHashedCallback(
+        ---@param data GridPresenceUIDebugCell
+            function(data)
+                if Root then
+                    self.Inferred:SetText(string.format('Inferred status: %s', data.Inferred))
+                    self.Label:SetText(string.format('Of label: %d', data.Label))
+                end
+            end, 'GridPresenceUIDebugCell', 'Alice'
+        )
+
+        AddOnSyncHashedCallback(
+            function(data)
+                if Root then
+                    self.Inferred:SetText(string.format('Inferred status: ...'))
+                    self.Label:SetText(string.format('Of label: ...'))
+                end
+            end, 'FocusArmyChanged', 'GridPresenceCell'
+        )
+    end,
+
+    ---@param self GridPresenceUICell
+    ---@param parent Control
+    __post_init = function(self, parent)
+        LayoutHelpers.LayoutFor(self.Title)
+            :Over(self, 5)
+            :AtLeftTopIn(self, 14, 4)
+            :End()
+
+        LayoutHelpers.LayoutFor(self.Inferred)
+            :Over(self, 5)
+            :Below(self.Title, 4)
+            :End()
+
+        LayoutHelpers.LayoutFor(self.Label)
+            :Over(self, 5)
+            :Below(self.Inferred, 4)
+            :End()
+    end,
+}
+
+---@class GridPresenceUIUpdate : Group
+---@field Title Text
+---@field CountingTime Text
+---@field CountingTick Text
+---@field InferredTime Text
+---@field InferredTick Text
+GridPresenceUIUpdate = ClassUI(Group) {
+
+    ---@param self GridPresenceUIUpdate
+    ---@param parent Control
+    __init = function(self, parent)
+        Group.__init(self, parent, 'GridPresenceUIUpdate')
+
+        self.Title = UIUtil.CreateText(self, 'Update information', 14)
+        self.CountingTime = UIUtil.CreateText(self, 'Time to count: ... (ms)', 12)
+        self.CountingTick = UIUtil.CreateText(self, 'Tick we counted: ...', 12)
+        self.InferredTime = UIUtil.CreateText(self, 'Time to infer: ... (ms)', 12)
+        self.InferredTick = UIUtil.CreateText(self, 'Tick we inferred: ...', 12)
+
+        AddOnSyncHashedCallback(
+        ---@param data GridPresenceUIDebugUpdate
+            function(data)
+                if Root then
+                    self.CountingTime:SetText(string.format('Time to count: %.2f (ms)', 1000 * data.ResourcePointsTime))
+                    self.CountingTick:SetText(string.format('Tick we counted: %d', data.ResourcePointsTick))
+                    self.InferredTime:SetText(string.format('Time to infer: %.2f (ms)', 1000 * data.InferredTime))
+                    self.InferredTick:SetText(string.format('Tick we inferred: %d', data.InferredTick))
+                end
+            end, 'GridPresenceUIDebugUpdate', 'Alice'
+        )
+
+        AddOnSyncHashedCallback(
+            function(data)
+                if Root then
+                    self.CountingTime:SetText(string.format('Time to count: ... (ms)'))
+                    self.CountingTick:SetText(string.format('Tick we counted: ...'))
+                    self.InferredTime:SetText(string.format('Time to infer: ... (ms)'))
+                    self.InferredTick:SetText(string.format('Tick we inferred: ...'))
+                end
+            end, 'FocusArmyChanged', 'GridPresenceUpdate'
+        )
+    end,
+
+    ---@param self GridPresenceUIUpdate
+    ---@param parent Control
+    __post_init = function(self, parent)
+        LayoutHelpers.LayoutFor(self.Title)
+            :Over(self, 5)
+            :AtLeftTopIn(self, 14, 4)
+            :End()
+
+        LayoutHelpers.LayoutFor(self.CountingTime)
+            :Over(self, 5)
+            :Below(self.Title, 4)
+            :End()
+
+        LayoutHelpers.LayoutFor(self.CountingTick)
+            :Over(self, 5)
+            :Below(self.CountingTime, 2)
+            :End()
+
+        LayoutHelpers.LayoutFor(self.InferredTime)
+            :Over(self, 5)
+            :Below(self.CountingTick, 2)
+            :End()
+
+        LayoutHelpers.LayoutFor(self.InferredTick)
+            :Over(self, 5)
+            :Below(self.InferredTime, 2)
+            :End()
+    end,
+}
+
+---@class GridPresenceUI : Window
+GridPresenceUI = ClassUI(Window) {
+
+    __init = function(self, parent)
+        Window.__init(self, parent, "Grid Presence UI", false, false, false, true, false, "GridPresenceUI6", {
+            Left = 10,
+            Top = 300,
+            Right = 310,
+            Bottom = 515
+        })
+
+        self.CellInfo = LayoutHelpers.LayoutFor(GridPresenceUICell(self))
+            :Left(self.Left)
+            :Right(self.Right)
+            :AtTopIn(self, 30)
+            :Height(70)
+            :End()
+
+        self.UpdateInfo = LayoutHelpers.LayoutFor(GridPresenceUIUpdate(self))
+            :Left(self.Left)
+            :Right(self.Right)
+            :Below(self.CellInfo)
+            :Bottom(self.Bottom)
+            :End()
+    end,
+
+    OnClose = function(self)
+        SimCallback({
+            Func = 'GridPresenceDebugDisable',
+            Args = {}
+        }, false)
+
+        self:Hide()
+    end,
+}
+
+function OpenWindow()
+    if Root then
+        Root:Show()
+    else
+        Root = GridPresenceUI(GetFrame(0))
+        Root:Show()
+    end
+
+    SimCallback({
+        Func = 'GridPresenceDebugEnable',
+        Args = {}
+    }, false)
+end
+
+function CloseWindow()
+    if Root then
+        Root:Hide()
+
+        SimCallback({
+            Func = 'GridPresenceDebugDisable',
+            Args = {}
+        }, false)
+    end
+end
+
+--- Called by the module manager when this module is dirty due to a disk change
+function __moduleinfo.OnDirty()
+    if Root then
+        Root:Destroy()
+        Root = false
+    end
+end


### PR DESCRIPTION
Introduces a grid-based data structure that allows an AI to understand his presence on a map. The grid takes into account whether it can path to a given location. The grid uses the `Hover` layer to determine pathability. A small peak:

![image](https://github.com/FAForever/fa/assets/15778155/afbb6534-aad6-442d-bdab-2e7ade54a9b2)

This is from the perspective of the blue player. Green means it is considered safe. Red means it is considered hostile. Yellow means it is considered contested - it doesn't necessarily belong to either player.

The initial phase of the data structure is based on what mass points have structures on top or around it. This takes into account intel - if the AI is unaware of structures then it won't take them into account. The second phase is a randomized breath first search. The search is randomized to prevent an initial order (top left to bottom right) to influence the results. As a consequence the results are always slightly different, but that is fine. The last phase determines which cells are contested. It does so by scanning the neighbors - if one neighbor is considered hostile then the cell is considered contested.

- [x] Add debugging UI

A little animation that shows the process:

https://github.com/FAForever/fa/assets/15778155/f0affea0-ebce-4b1a-a433-184e6f9f5431

https://github.com/FAForever/fa/assets/15778155/0b218c58-93db-444b-a05d-9b3861309d02