### PR TITLE
Improve sun reflections

### DIFF
--- a/effects/water2.fx
+++ b/effects/water2.fx
@@ -385,9 +385,9 @@ float4 HighFidelityPS( VS_OUTPUT inV,
 	float4 skyReflection = texCUBE(SkySampler, R);
 	// The alpha channel acts as a mask for unit parts above the water and probably
 	// uses unitReflectionAmount as the positive value of the mask
-    reflectedPixels = lerp(skyReflection, reflectedPixels, saturate(reflectedPixels.a));
+    reflectedPixels.xyz = lerp(skyReflection.xyz, reflectedPixels.xyz, saturate(reflectedPixels.a));
    
-   	//Schlick approximation for fresnel
+   	// Schlick approximation for fresnel
     float NDotV = saturate(dot(viewVector, N));
 	float F0 = 0.08;
     float fresnel = F0 + (1.0 - F0) * pow(1.0 - NDotV, 5.0);
@@ -400,6 +400,8 @@ float4 HighFidelityPS( VS_OUTPUT inV,
     // add in the sun reflection
 	float3 sunReflection = pow(saturate(dot(-R, SunDirection)), SunShininess) * SunColor;
     sunReflection = sunReflection * fresnel;
+	// the sun shouldn't be visible where a unit reflection is
+	sunReflection *= (1 - saturate(reflectedPixels.a * 2));
     refractedPixels.xyz +=  sunReflection;
 
     // Lerp in the wave crests


### PR DESCRIPTION
Currently the sun reflection can be seen on the entire water surface. This is implausible, because units on the water should block out the sun reflection where the unit reflection is visible. This PR fixes that.

![Screenshot 2023-05-18 223454](https://github.com/FAForever/fa/assets/52536103/2e144696-daac-4efa-8c30-8c9eb369a632)
![Screenshot 2023-05-18 223544](https://github.com/FAForever/fa/assets/52536103/4451bfc4-04a4-46be-8a9b-20cb80b75633)
