### PR TITLE
Add event message for moderation

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -483,6 +483,26 @@ Callbacks.CheatSpawnUnit = function(data)
     end
 end
 
+---@param data { fromFocusArmy: Army, event: string }
+Callbacks.EventMessage = function(data)
+    local army = data.fromFocusArmy
+    if OkayToMessWithArmy(army) then
+        local brain = GetArmyBrain(army)
+        if brain then
+            SPEW(string.format("%s: %s", brain.Nickname, data.event))
+        end
+    else
+        -- something funky happened
+        local brain = GetArmyBrain(GetCurrentCommandSource())
+        if brain then
+            SPEW(string.format("%s: send an odd event message", brain.Nickname))
+        end
+
+        -- add a 'is trying to cheat!' thing
+        CheatsEnabled()
+    end
+end
+
 Callbacks.BreakAlliance = SimUtils.BreakAlliance
 
 Callbacks.GiveUnitsToPlayer = SimUtils.GiveUnitsToPlayer

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -495,7 +495,7 @@ keyActions = {
         category = 'ui', order = 59,},
     ['Kill_Selected_Units'] = {action = 'UI_Lua import("/lua/ui/game/confirmunitdestroy.lua").ConfirmUnitDestruction(true)',
         category = 'orders', order = 60,},
-    ['Kill_All'] = {action = 'KillAll',
+    ['Kill_All'] = {action = 'UI_Lua import("/lua/ui/game/confirmunitdestroy.lua").ConfirmUnitDestruction(true, true)',
         category = 'orders', order = 61,},
     ['Show_Bandwidth_Usage'] = {action = 'ren_ShowBandwidthUsage',
         category = 'ui', order = 62,},

--- a/lua/selfdestruct.lua
+++ b/lua/selfdestruct.lua
@@ -1,13 +1,9 @@
 
-local GetEntityById = GetEntityById
 local OkayToMessWithArmy = OkayToMessWithArmy
 local StartCountdown = StartCountdown
 local CancelCountdown = CancelCountdown
 local ForkThread = ForkThread
 local KillThread = KillThread
-
-local TableInsert = table.insert
-
 
 -- prevent magic numbers
 local countdownDuration = 5
@@ -16,16 +12,16 @@ local countdownDuration = 5
 ---@param unit Unit
 local function SelfDestructThread(unit)
     WaitSeconds(countdownDuration)
-    if unit:BeenDestroyed() then 
-        return 
+    if unit:BeenDestroyed() then
+        return
     end
 
     unit:Kill()
 end
 
 --- Toggles the destruction of the units
----@param data table
----@param units Unit
+---@param data { owner: number, noDelay: boolean, allUnits: boolean }
+---@param units Unit[]
 function ToggleSelfDestruct(data, units)
 
     -- suppress self destruct in tutorial missions as they screw up the mission end
@@ -34,30 +30,35 @@ function ToggleSelfDestruct(data, units)
     end
 
     -- do not allow observers to use this
-    if data.owner ~= -1 then
+    if data.owner ~= -1 and OkayToMessWithArmy(data.owner) then
+
+        -- if we want to destroy all units
+        if data.allUnits then
+            units = GetArmyBrain(data.owner):GetListOfUnits(categories.ALLUNITS, false, false)
+        end
 
         -- just take them all out
-        if data.noDelay then 
+        if data.noDelay then
             for _, unit in units do
-                if OkayToMessWithArmy(unit.Army) then 
-                    if not (unit.Dead or unit:BeenDestroyed()) then 
+                if OkayToMessWithArmy(unit.Army) then
+                    if not (unit.Dead or unit:BeenDestroyed()) then
                         unit:Kill()
                     end
                 end
             end
 
         -- wait a few seconds, then destroy
-        else 
+        else
 
             -- if one is in the process of being destroyed, remove all destruction threads
             local togglingOff = false
             for _, unit in units do
-                if OkayToMessWithArmy(unit.Army) then 
+                if OkayToMessWithArmy(unit.Army) then
                     if unit.SelfDestructThread then
                         togglingOff = true
                         KillThread(unit.SelfDestructThread)
                         unit.SelfDestructThread = false
-                        CancelCountdown(unit.EntityId)                          -- as defined in SymSync.lua
+                        CancelCountdown(unit.EntityId) -- as defined in SymSync.lua
                     end
                 end
             end
@@ -65,15 +66,15 @@ function ToggleSelfDestruct(data, units)
             -- if none are in the process of being destroyed, destroy them after a delay
             if not togglingOff then
                 for _, unit in units do
-                    if OkayToMessWithArmy(unit.Army) then 
-                        
+                    if OkayToMessWithArmy(unit.Army) then
+
                         -- allows fire beetle to be destroyed immediately
-                        if unit.Blueprint.General.InstantDeathOnSelfDestruct then 
+                        if unit.Blueprint.General.InstantDeathOnSelfDestruct then
                             unit:Kill()
 
-                        -- destroy everything else after five seconds
-                        else 
-                            StartCountdown(unit.EntityId, countdownDuration)    -- as defined in SymSync.lua
+                            -- destroy everything else after five seconds
+                        else
+                            StartCountdown(unit.EntityId, countdownDuration) -- as defined in SymSync.lua
                             unit.SelfDestructThread = ForkThread(SelfDestructThread, unit)
                         end
                     end

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -806,6 +806,7 @@ function ChatPageDown(mod)
 end
 
 function ReceiveChat(sender, msg)
+    reprsl(msg)
     if not msg.ConsoleOutput then
         SimCallback({Func="GiveResourcesToPlayer", Args={ From=GetFocusArmy(), To=GetFocusArmy(), Mass=0, Energy=0, Sender=sender, Msg=msg},} , true)
     end

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -806,7 +806,6 @@ function ChatPageDown(mod)
 end
 
 function ReceiveChat(sender, msg)
-    reprsl(msg)
     if not msg.ConsoleOutput then
         SimCallback({Func="GiveResourcesToPlayer", Args={ From=GetFocusArmy(), To=GetFocusArmy(), Mass=0, Energy=0, Sender=sender, Msg=msg},} , true)
     end

--- a/lua/ui/game/confirmunitdestroy.lua
+++ b/lua/ui/game/confirmunitdestroy.lua
@@ -15,13 +15,9 @@ function ConfirmUnitDestruction(instant, allUnits)
 
         CreateAnnouncement('<LOC confirm_0001>You cannot self destruct during an operation!')
     else
-        SimCallback({ Func = "GiveResourcesToPlayer",
-            Args = { From = GetFocusArmy(), To = GetFocusArmy(), Mass = 0, Energy = 0, Msg = {
-                Chat = true,
-                sender = GetFocusArmy(),
-                to = 'allies',
-                text = 'bob',
-            } }, }, true)
+        msg = { to = 0, text = string.format('boo') }
+        SimCallback({ Func = "GiveResourcesToPlayer", Args = { From = 0, To = 0, Mass = 0, Energy = 0, Sender = -1,
+            Msg = msg }, }, true)
         SimCallback({ Func = 'ToggleSelfDestruct',
             Args = { owner = GetFocusArmy(), noDelay = instant, allUnits = allUnits } }, true)
     end

--- a/lua/ui/game/confirmunitdestroy.lua
+++ b/lua/ui/game/confirmunitdestroy.lua
@@ -1,31 +1,28 @@
 -- Copyright GPG 2007
 
-local UIUtil = import("/lua/ui/uiutil.lua")
-local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
-local Group = import("/lua/maui/group.lua").Group
-local Prefs = import("/lua/user/prefs.lua")
 local CreateAnnouncement = import("/lua/ui/game/announcement.lua").CreateAnnouncement
 
-local destructingUnits = {}
-local controls = {}
-local countdownThreads = {}
-
-function ConfirmUnitDestruction(instant)
-
-    -- get selected units
+---@param instant boolean
+---@param allUnits boolean
+function ConfirmUnitDestruction(instant, allUnits)
     local units = GetSelectedUnits()
 
-    if  
-        -- if we're in campaign mode
-        import("/lua/ui/campaign/campaignmanager.lua").campaignMode  
 
-        -- and we're trying to self destruct a command unit
-        and not table.empty(EntityCategoryFilterDown(categories.COMMAND, units)) 
+    if -- do not allow self destructing of command units
+    import("/lua/ui/campaign/campaignmanager.lua").campaignMode and
+        not table.empty(EntityCategoryFilterDown(categories.COMMAND, units))
     then
-        -- don't allow that, as it would end the operation
+
         CreateAnnouncement('<LOC confirm_0001>You cannot self destruct during an operation!')
     else
-        -- do the callback accordingly
-        SimCallback({Func = 'ToggleSelfDestruct', Args = { owner = GetFocusArmy(), noDelay = instant }}, true)
+        SimCallback({ Func = "GiveResourcesToPlayer",
+            Args = { From = GetFocusArmy(), To = GetFocusArmy(), Mass = 0, Energy = 0, Msg = {
+                Chat = true,
+                sender = GetFocusArmy(),
+                to = 'allies',
+                text = 'bob',
+            } }, }, true)
+        SimCallback({ Func = 'ToggleSelfDestruct',
+            Args = { owner = GetFocusArmy(), noDelay = instant, allUnits = allUnits } }, true)
     end
 end

--- a/lua/ui/game/confirmunitdestroy.lua
+++ b/lua/ui/game/confirmunitdestroy.lua
@@ -15,9 +15,13 @@ function ConfirmUnitDestruction(instant, allUnits)
 
         CreateAnnouncement('<LOC confirm_0001>You cannot self destruct during an operation!')
     else
-        msg = { to = 0, text = string.format('boo') }
-        SimCallback({ Func = "GiveResourcesToPlayer", Args = { From = 0, To = 0, Mass = 0, Energy = 0, Sender = -1,
-            Msg = msg }, }, true)
+
+        if allUnits then
+            SimCallback({ Func = "EventMessage", Args = { fromFocusArmy = GetFocusArmy(), event = string.format('Self destruction of all units') }})
+        else
+            SimCallback({ Func = "EventMessage", Args = { fromFocusArmy = GetFocusArmy(), event = string.format('Self destruction of %d units', table.getn(GetSelectedUnits())) }})
+        end
+
         SimCallback({ Func = 'ToggleSelfDestruct',
             Args = { owner = GetFocusArmy(), noDelay = instant, allUnits = allUnits } }, true)
     end


### PR DESCRIPTION
Adds a new callback to signify events. These events can then be read by the parser of the client so that they end up in the chat history of a replay.

See also: https://github.com/FAForever/faf-java-commons/pull/102