### PR TITLE
Buff to the torpedo DPS of amphibious tanks

### DIFF
--- a/units/URL0203/URL0203_unit.bp
+++ b/units/URL0203/URL0203_unit.bp
@@ -353,7 +353,7 @@ UnitBlueprint {
             },
             BallisticArc = 'RULEUBA_None',
             CollideFriendly = false,
-            Damage = 15,
+            Damage = 20,
             DamageType = 'Normal',
             DisplayName = 'Meson Torpedo',
             FireTargetLayerCapsTable = {

--- a/units/XSL0303/XSL0303_unit.bp
+++ b/units/XSL0303/XSL0303_unit.bp
@@ -491,7 +491,7 @@ UnitBlueprint {
             },
             BallisticArc = 'RULEUBA_None',
             CollideFriendly = false,
-            Damage = 30,
+            Damage = 40,
             DamageType = 'Normal',
             DisplayName = 'Uall Cavitation Torpedo Launcher',
             FireTargetLayerCapsTable = {


### PR DESCRIPTION
Right now, ACUs can stand inside an army of submerged amphibious tanks and just shrug off with regen for the most part. These changes buff their torpedoes, so they are at least somewhat useful. Note that even with this considerable buff, they still have low DPS as to not interfere with naval/submarine balance too much. 

**url0203 Amphibious Tank**
Damage: 15 --> 20 
DPS: 7.5 --> 10

**xsl0303 Siege Tank**
Damage: 30 --> 40
DPS:  15 --> 20

The Brick does not get a buff, because it has torpedo defense and a lot of health.
