### PR TITLE
Tech 1 Sonar buff

### DIFF
--- a/units/UAB3102/UAB3102_unit.bp
+++ b/units/UAB3102/UAB3102_unit.bp
@@ -144,7 +144,7 @@ UnitBlueprint {
     },
     Intel = {
         ShowIntelOnSelect = true,
-        SonarRadius = 115,
+        SonarRadius = 130,
         VisionRadius = 20,
     },
     Interface = {

--- a/units/UEB3102/UEB3102_unit.bp
+++ b/units/UEB3102/UEB3102_unit.bp
@@ -147,7 +147,7 @@ UnitBlueprint {
     Intel = {
         ReactivateTime = 10,
         ShowIntelOnSelect = true,
-        SonarRadius = 115,
+        SonarRadius = 130,
         VisionRadius = 20,
     },
     Interface = {

--- a/units/URB3102/URB3102_unit.bp
+++ b/units/URB3102/URB3102_unit.bp
@@ -141,7 +141,7 @@ UnitBlueprint {
     },
     Intel = {
         ShowIntelOnSelect = true,
-        SonarRadius = 115,
+        SonarRadius = 130,
         VisionRadius = 20,
     },
     Interface = {

--- a/units/XSB3102/XSB3102_unit.bp
+++ b/units/XSB3102/XSB3102_unit.bp
@@ -151,7 +151,7 @@ UnitBlueprint {
     },
     Intel = {
         ShowIntelOnSelect = true,
-        SonarRadius = 115,
+        SonarRadius = 130,
         VisionRadius = 20,
     },
     Interface = {


### PR DESCRIPTION
At the same sensor range as tech 1 radars, tech 1 sonars were not very useful even with their cheaper price. This is due to naval units being much faster than land units. This change tries to alleviate this issue.

**Intel:**
SonarRadius of all tech 1 Sonar Systems: 115 --> 130
