### PR TITLE
Apply water color to wreckages, props, shield and unit shaders

### DIFF
--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -2339,6 +2339,7 @@ float4 NormalMappedPS( NORMALMAPPED_VERTEX vertex,
 
     float emissive = glowMultiplier * specular.b;
     float3 color = albedo.rgb * ( emissive.r + light + phongMultiplicative) + phongAdditive;
+    color = ApplyWaterColor(vertex.depth.x, color);
 
     float alpha = mirrored ? 0.5 : ( glow ? ( specular.b + glowMinimum ) : ( vertex.material.g * albedo.a ));
 


### PR DESCRIPTION
The currently used shaders could do with some water effects as well. This implementation is more simple as I have to accomodate for the way the water ramp is applied to the terrain and I don't want to change that for existing maps. But it works well enough.
![Screenshot 2023-05-24 203709](https://github.com/FAForever/fa/assets/52536103/98f34617-1d98-4219-bfb5-b4973c9473f5)
![Screenshot 2023-05-24 203348](https://github.com/FAForever/fa/assets/52536103/04b6085f-853d-42e5-9429-796d98e0351f)
