### PR TITLE
Pbr terrain improvement

### DIFF
--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -1862,14 +1862,14 @@ float4 TerrainPBRAlbedoPS ( VS_OUTPUT inV) : COLOR
 
     float cameraFractionNear = 1;
 
-    lowerAlbedo    = CorrectedAddition(lowerAlbedo,    tex2D(LowerAlbedoSampler,    position.xy * LowerNormalTile.xy),    lBrightness,  cameraFractionNear);
-    stratum0Albedo = CorrectedAddition(stratum0Albedo, tex2D(Stratum0AlbedoSampler, position.xy * Stratum0NormalTile.xy), s0Brightness, cameraFractionNear);
-    stratum1Albedo = CorrectedAddition(stratum1Albedo, tex2D(Stratum1AlbedoSampler, position.xy * Stratum1NormalTile.xy), s1Brightness, cameraFractionNear);
-    stratum2Albedo = CorrectedAddition(stratum2Albedo, tex2D(Stratum2AlbedoSampler, position.xy * Stratum2NormalTile.xy), s2Brightness, cameraFractionNear);
-    stratum3Albedo = CorrectedAddition(stratum3Albedo, tex2D(Stratum3AlbedoSampler, position.xy * Stratum3NormalTile.xy), s3Brightness, cameraFractionNear);
-    stratum4Albedo = CorrectedAddition(stratum4Albedo, tex2D(Stratum4AlbedoSampler, position.xy * Stratum4NormalTile.xy), s4Brightness, cameraFractionNear);
-    stratum5Albedo = CorrectedAddition(stratum5Albedo, tex2D(Stratum5AlbedoSampler, position.xy * Stratum5NormalTile.xy), s5Brightness, cameraFractionNear);
-    stratum6Albedo = CorrectedAddition(stratum6Albedo, tex2D(Stratum6AlbedoSampler, position.xy * Stratum6NormalTile.xy), s6Brightness, cameraFractionNear);
+    lowerAlbedo    = CorrectedAddition(tex2D(LowerAlbedoSampler,    position.xy * LowerNormalTile.xy),    lowerAlbedo,    lBrightness,  cameraFractionNear);
+    stratum0Albedo = CorrectedAddition(tex2D(Stratum0AlbedoSampler, position.xy * Stratum0NormalTile.xy), stratum0Albedo, s0Brightness, cameraFractionNear);
+    stratum1Albedo = CorrectedAddition(tex2D(Stratum1AlbedoSampler, position.xy * Stratum1NormalTile.xy), stratum1Albedo, s1Brightness, cameraFractionNear);
+    stratum2Albedo = CorrectedAddition(tex2D(Stratum2AlbedoSampler, position.xy * Stratum2NormalTile.xy), stratum2Albedo, s2Brightness, cameraFractionNear);
+    stratum3Albedo = CorrectedAddition(tex2D(Stratum3AlbedoSampler, position.xy * Stratum3NormalTile.xy), stratum3Albedo, s3Brightness, cameraFractionNear);
+    stratum4Albedo = CorrectedAddition(tex2D(Stratum4AlbedoSampler, position.xy * Stratum4NormalTile.xy), stratum4Albedo, s4Brightness, cameraFractionNear);
+    stratum5Albedo = CorrectedAddition(tex2D(Stratum5AlbedoSampler, position.xy * Stratum5NormalTile.xy), stratum5Albedo, s5Brightness, cameraFractionNear);
+    stratum6Albedo = CorrectedAddition(tex2D(Stratum6AlbedoSampler, position.xy * Stratum6NormalTile.xy), stratum6Albedo, s6Brightness, cameraFractionNear);
 
     // First value is height, second is roughness
     float2 lowerHRNear    = atlas2D(Stratum7AlbedoSampler, 0.3 * position.xy * LowerAlbedoTile.xy,    float2(0.0, 0.0)).xy;

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -481,9 +481,12 @@ float3 PBR(VS_OUTPUT inV, float3 albedo, float3 n, float roughness) {
     // See https://blog.selfshadow.com/publications/s2013-shading-course/
 
     float4 position = TerrainScale * inV.mTexWT;
-    float mapShadow = 1 - tex2D(UpperAlbedoSampler, position.xy).z; // 1 where sun is, 0 where shadow is
-    float shadow = tex2D(ShadowSampler, inV.mShadow.xy).g; // 1 where sun is, 0 where shadow is
-    shadow = shadow * mapShadow;
+    float shadow = 1;
+    if (ShadowsEnabled == 1) {
+        float mapShadow = 1 - tex2D(UpperAlbedoSampler, position.xy).z; // 1 where sun is, 0 where shadow is
+        shadow = tex2D(ShadowSampler, inV.mShadow.xy).g; // 1 where sun is, 0 where shadow is
+        shadow *= mapShadow;
+    }
 
     float3 v = normalize(-inV.mViewDirection);
     float3 F0 = float3(0.04, 0.04, 0.04);

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -1845,13 +1845,13 @@ float4 TerrainPBRNormalsPS ( VS_OUTPUT inV ) : COLOR
     float4 stratum5Normal = sampleNormal(Stratum5NormalSampler, position, Stratum5AlbedoTile, rotationMask);
     float4 stratum6Normal = sampleNormal(Stratum6NormalSampler, position, Stratum6AlbedoTile, rotationMask);
 
-    float stratum0Height = sampleHeight(position, 2 * Stratum0NormalTile, 0.6 * Stratum0NormalTile, 1).x;
-    float stratum1Height = sampleHeight(position, 2 * Stratum1NormalTile, 0.6 * Stratum1NormalTile, 2).x;
-    float stratum2Height = sampleHeight(position, 2 * Stratum2NormalTile, 0.6 * Stratum2NormalTile, 3).x;
-    float stratum3Height = sampleHeight(position, 2 * Stratum3NormalTile, 0.6 * Stratum3NormalTile, 0).y;
-    float stratum4Height = sampleHeight(position, 2 * Stratum4NormalTile, 0.6 * Stratum4NormalTile, 1).y;
-    float stratum5Height = sampleHeight(position, 2 * Stratum5NormalTile, 0.6 * Stratum5NormalTile, 2).y;
-    float stratum6Height = sampleHeight(position, 2 * Stratum6NormalTile, 0.6 * Stratum6NormalTile, 3).y;
+    float stratum0Height = sampleHeight(position, Stratum0AlbedoTile, Stratum0NormalTile, 1).x;
+    float stratum1Height = sampleHeight(position, Stratum1AlbedoTile, Stratum1NormalTile, 2).x;
+    float stratum2Height = sampleHeight(position, Stratum2AlbedoTile, Stratum2NormalTile, 3).x;
+    float stratum3Height = sampleHeight(position, Stratum3AlbedoTile, Stratum3NormalTile, 0).y;
+    float stratum4Height = sampleHeight(position, Stratum4AlbedoTile, Stratum4NormalTile, 1).y;
+    float stratum5Height = sampleHeight(position, Stratum5AlbedoTile, Stratum5NormalTile, 2).y;
+    float stratum6Height = sampleHeight(position, Stratum6AlbedoTile, Stratum6NormalTile, 3).y;
 
     float4 normal = lowerNormal;
     normal = splatBlendNormal(normal, stratum0Normal, 1.0, stratum0Height, mask0.x);
@@ -1886,13 +1886,13 @@ float4 TerrainPBRAlbedoPS ( VS_OUTPUT inV) : COLOR
     float4 stratum5Albedo = sampleAlbedo(Stratum5AlbedoSampler, position, Stratum5AlbedoTile, rotationMask);
     float4 stratum6Albedo = sampleAlbedo(Stratum6AlbedoSampler, position, Stratum6AlbedoTile, rotationMask);
 
-    float stratum0Height = sampleHeight(position, 2 * Stratum0NormalTile, 0.6 * Stratum0NormalTile, 1).x;
-    float stratum1Height = sampleHeight(position, 2 * Stratum1NormalTile, 0.6 * Stratum1NormalTile, 2).x;
-    float stratum2Height = sampleHeight(position, 2 * Stratum2NormalTile, 0.6 * Stratum2NormalTile, 3).x;
-    float stratum3Height = sampleHeight(position, 2 * Stratum3NormalTile, 0.6 * Stratum3NormalTile, 0).y;
-    float stratum4Height = sampleHeight(position, 2 * Stratum4NormalTile, 0.6 * Stratum4NormalTile, 1).y;
-    float stratum5Height = sampleHeight(position, 2 * Stratum5NormalTile, 0.6 * Stratum5NormalTile, 2).y;
-    float stratum6Height = sampleHeight(position, 2 * Stratum6NormalTile, 0.6 * Stratum6NormalTile, 3).y;
+    float stratum0Height = sampleHeight(position, Stratum0AlbedoTile, Stratum0NormalTile, 1).x;
+    float stratum1Height = sampleHeight(position, Stratum1AlbedoTile, Stratum1NormalTile, 2).x;
+    float stratum2Height = sampleHeight(position, Stratum2AlbedoTile, Stratum2NormalTile, 3).x;
+    float stratum3Height = sampleHeight(position, Stratum3AlbedoTile, Stratum3NormalTile, 0).y;
+    float stratum4Height = sampleHeight(position, Stratum4AlbedoTile, Stratum4NormalTile, 1).y;
+    float stratum5Height = sampleHeight(position, Stratum5AlbedoTile, Stratum5NormalTile, 2).y;
+    float stratum6Height = sampleHeight(position, Stratum6AlbedoTile, Stratum6NormalTile, 3).y;
 
     // store roughness in albedo so we get the roughness splatting for free
     lowerAlbedo.a    = sampleRoughness(position, LowerAlbedoTile,    0, rotationMask).x;


### PR DESCRIPTION
Instead of layering two textures at different scales we now sample at the same scale but with two different rotations. Then we blend between them with a relatively sharp transition to make the visual texture repetition go away.

![Screenshot 2023-05-26 211430](https://github.com/FAForever/fa/assets/52536103/ba112ccc-145b-4557-98be-f51b40747bde)
![Screenshot 2023-05-27 140856](https://github.com/FAForever/fa/assets/52536103/bf0f9eef-48db-420f-86a2-50e225de2d45)
![Screenshot 2023-05-27 141439](https://github.com/FAForever/fa/assets/52536103/a8bd908f-d3f5-40d7-bee0-b4d60cdc35a6)
![Screenshot 2023-05-27 141228](https://github.com/FAForever/fa/assets/52536103/542a1716-9891-41e9-924c-baf84c3448aa)
