### PR TITLE
Add hotkeys to store the current camera position in the preference file

### DIFF
--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -891,6 +891,12 @@ keyActions = {
     ['test_2'] = {action = 'UI_Lua import("/lua/usercamera.lua").Test2()',
         category = 'camera', order = 11,},
 
+    ['store_camera_settings'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").StoreCameraPosition()',
+    category = 'debug', order = 11,},
+
+    ['restore_camera_settings'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").RestoreCameraPosition()',
+    category = 'debug', order = 11,},
+
     ['toggle_navui'] = {action = 'UI_Lua import("/lua/ui/game/navgenerator.lua").OpenWindow()',
         category = 'ai', order = 24},
     ['toggle_ai_reclaim_grid_ui'] = {action = 'UI_Lua import("/lua/ui/game/gridreclaim.lua").OpenWindow()',

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -508,5 +508,8 @@ keyDescriptions = {
     ['toggle_ai_economy_ui'] = 'Toggle the debugging UI for the economy brain data',
 
     ['toggle_platoon_behavior_silo'] = 'Applies the simple silo AI behavior to your selection',
-    ['toggle_platoon_simple_raid'] = 'Applies the simple raid AI behavior to your selection'
+    ['toggle_platoon_simple_raid'] = 'Applies the simple raid AI behavior to your selection',
+
+    ['store_camera_settings'] = 'Store the current camera settings in the preference file',
+    ['restore_camera_settings'] = 'Apply the camera settings stored in the preference file',
 }

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -561,3 +561,16 @@ end
 AIPlatoonSimpleStructureBehavior = function()
     SimCallback({Func = 'AIPlatoonSimpleStructureBehavior', Args = {}}, true)
 end
+
+StoreCameraPosition = function()
+    local camera = GetCamera('WorldCamera')
+    local settings = camera:SaveSettings()
+    Prefs.SetToCurrentProfile('DebugCameraPosition', settings)
+end
+
+RestoreCameraPosition = function ()
+    -- ConExecute('cam_Free 1')
+    local camera = GetCamera('WorldCamera')
+    local settings = Prefs.GetFromCurrentProfile('DebugCameraPosition') --[[@as UserCameraSettings]]
+    camera:MoveTo(settings.Focus, { settings.Heading, settings.Pitch, 0}, settings.Zoom, 0)
+end


### PR DESCRIPTION
This is useful to create comparison pictures across game sessions. As an example:
- https://wiki.faforever.com/en/nvidia-settings

![image](https://github.com/FAForever/fa/assets/15778155/5b5b6e8d-2d02-4327-bc8e-798fa26f050d)

![image](https://github.com/FAForever/fa/assets/15778155/ad6fee35-da97-4c38-8039-6d58614b1b22)
