### PR TITLE
Improves the code style for key actions

### DIFF
--- a/lua/keymap/debugKeyActions.lua
+++ b/lua/keymap/debugKeyActions.lua
@@ -1,11 +1,17 @@
--- This file outlines the interaction between the 'command' (Bound to a key) and the behaviour of that command
--- format is:
---  key - The string referenced by a bound key
---  action - The console command to execute when the key is pressed
---  category - The category to list this action under in the key assign dialog
---  order - The sort order to list this action under its category
---  keyRepeat - A boolean flag that dictates when an action is one that can be held to extend its effect (eg - Zoom)
 
+--- A key action allows a user to bind key bindings to an action. The format 
+--- of a key action is defined in the 'UIKeyAction' annotation class. Key
+--- actions are defined in tables. The key of a key action acts as an
+--- identifier. The same identifier is used to assign a description to the
+--- key action
+
+--- In an ideal world that description would be part of the key action
+--- itself. The system in place is what we have however. The descriptions
+--- of key actions can be found in `/lua/keymap/keydescriptions.lua`
+
+--- Regular key actions can be found in `/lua/keymap/keyactions.lua`
+
+---@type table<string, UIKeyAction>
 local keyActionsDebug = {
     ['toggle_map_utilities_window'] = {
         action = 'UI_Lua import("/lua/ui/game/maputilities.lua").OpenWindow()',
@@ -217,6 +223,7 @@ local keyActionsDebug = {
     },
 }
 
+---@type table<string, UIKeyAction>
 local keyActionsDebugAI = {
     ['toggle_navui'] = {
         action = 'UI_Lua import("/lua/ui/game/navgenerator.lua").OpenWindow()',
@@ -252,6 +259,7 @@ local keyActionsDebugAI = {
     },
 }
 
+---@type table<string, UIKeyAction>
 debugKeyActions = table.combine(
     keyActionsDebug,
     keyActionsDebugAI

--- a/lua/keymap/debugKeyActions.lua
+++ b/lua/keymap/debugKeyActions.lua
@@ -6,93 +6,253 @@
 --  order - The sort order to list this action under its category
 --  keyRepeat - A boolean flag that dictates when an action is one that can be held to extend its effect (eg - Zoom)
 
-debugKeyActions = {
-    ['debug_navpath'] = {action = 'dbg navpath',
-        category = 'debug', order = 1,},
-    ['debug_create_unit'] = {action = 'PopupCreateUnitMenu',
-        category = 'debug', order = 1,},
-    ['debug_teleport'] = {action = 'TeleportSelectedUnits',
-        category = 'debug', order = 1,},
-    ['debug_run_opponent_AI'] = {action = 'AI_RunOpponentAI',
-        category = 'debug', order = 1,},
-    ['debug_blingbling'] = {action = 'BlingBling',
-        category = 'debug', order = 1,},
-    ['debug_destroy_units'] = {action = 'DestroySelectedUnits',
-        category = 'debug', order = 1,},
-    ['debug_graphics_fidelity_0'] = {action = 'graphics_Fidelity 0',
-        category = 'debug', order = 1,},
-    ['debug_graphics_fidelity_2'] = {action = 'graphics_Fidelity 2',
-        category = 'debug', order = 1,},
-    ['debug_scenario_method_f3'] = {action = 'ScenarioMethod OnF3',
-        category = 'debug', order = 1,},
-    ['debug_scenario_method_shift_f3'] = {action = 'ScenarioMethod OnShiftF3',
-        category = 'debug', order = 1,},
-    ['debug_scenario_method_ctrl_f3'] = {action = 'ScenarioMethod OnCtrlF3',
-        category = 'debug', order = 1,},
-    ['debug_scenario_method_shift_f4'] = {action = 'ScenarioMethod OnShiftF4',
-        category = 'debug', order = 1,},
-    ['debug_scenario_method_ctrl_f4'] = {action = 'ScenarioMethod OnCtrlF4',
-        category = 'debug', order = 1,},
-    ['debug_scenario_method_ctrl_alt_f3'] = {action = 'ScenarioMethod OnCtrlAltF4',
-        category = 'debug', order = 1,},
-    ['debug_scenario_method_f4'] = {action = 'ScenarioMethod OnF4',
-        category = 'debug', order = 1,},
-    ['debug_scenario_method_f5'] = {action = 'ScenarioMethod OnF5',
-        category = 'debug', order = 1,},
-    ['debug_scenario_method_shift_f5'] = {action = 'ScenarioMethod OnShiftF5',
-        category = 'debug', order = 1,},
-    ['debug_scenario_method_ctrl_f5'] = {action = 'ScenarioMethod OnCtrlF5',
-        category = 'debug', order = 1,},
-    ['debug_scenario_method_ctrl_alt_f5'] = {action = 'ScenarioMethod OnCtrlAltF5',
-        category = 'debug', order = 1,},
-    ['debug_campaign_instawin'] = {action = 'ui_lua import("/lua/ui/campaign/campaignmanager.lua").InstaWin()',
-        category = 'debug', order = 1,},
-    ['debug_create_entity'] = {action = 'SC_CreateEntityDialog',
-        category = 'debug', order = 1,},
-    ['debug_show_stats'] = {action = 'ShowStats',
-        category = 'debug', order = 1,},
-    ['debug_show_army_stats'] = {action = 'ShowArmyStats',
-        category = 'debug', order = 1,},
-    ['debug_toggle_log_window'] = {action = 'WIN_ToggleLogDialog',
-        category = 'debug', order = 1,},
-    ['debug_open_lua_debugger'] = {action = 'SC_LuaDebugger',
-        category = 'debug', order = 1,},
-    ['debug_show_frame_stats'] = {action = 'ShowStats frame',
-        category = 'debug', order = 1,},
-    ['debug_render_wireframe'] = {action = 'ren_ShowWireframe tog',
-        category = 'debug', order = 1,},
-    ['debug_weapons'] = {action = 'dbg weapons',
-        category = 'debug', order = 1,},
-    ['debug_grid'] = {action = 'dbg grid',
-        category = 'debug', order = 1,},
-    ['debug_show_focus_ui_control'] = {action = 'UI_ShowControlUnderMouse tog',
-        category = 'debug', order = 1,},
-    ['debug_dump_focus_ui_control'] = {action = 'UI_DumpControlsUnderCursor',
-        category = 'debug', order = 1,},
-    ['debug_dump_ui_controls'] = {action = 'UI_DumpControls',
-        category = 'debug', order = 1,},
-    ['debug_skeletons'] = {action = 'Ren_Showskeletons',
-        category = 'debug', order = 1,},
-    ['debug_bones'] = {action = 'Ren_ShowBoneNames',
-        category = 'debug', order = 1,},
-    ['debug_redo_console_command'] = {action = 'CON_ExecuteLastCommand',
-        category = 'debug', order = 1,},
-    ['debug_copy_units'] = {action = 'CopySelectedUnitsToClipboard',
-        category = 'debug', order = 1,},
-    ['debug_paste_units'] = {action = 'ExecutePasteBuffer',
-        category = 'debug', order = 1,},
-    ['debug_nodamage'] = {action = 'Nodamage',
-        category = 'debug', order = 1,},
-    ['debug_show_emmitter_window'] = {action = 'EFX_CreateEmitterWindow',
-        category = 'debug', order = 1,},
-    ['debug_sally_shears'] = {action = 'SallyShears',
-        category = 'debug', order = 1,},
-    ['debug_collision'] = {action = 'dbg Collision',
-        category = 'debug', order = 1,},
-    ['debug_pause_single_step'] = {action = 'WLD_SingleStep',
-        category = 'game', order = 1,},
-    ['debug_restart_session'] = {action = 'UI_Lua RestartSession()',
-        category = 'debug', order = 1,},
-    ['debug_toggle_pannels'] = {action = 'UI_ToggleGamePanels',
-        category = 'debug', order = 2,},
+local keyActionsDebug = {
+    ['toggle_map_utilities_window'] = {
+        action = 'UI_Lua import("/lua/ui/game/maputilities.lua").OpenWindow()',
+        category = 'debug',
+    },
+    ['toggle_ai_screen'] = {
+        action = 'UI_Lua import("/lua/ui/dialogs/aiutilitiesview.lua").OpenWindow()',
+        category = 'debug'
+    },
+    ['toggle_profiler'] = {
+        action = 'UI_Lua import("/lua/ui/game/profiler.lua").ToggleProfiler()',
+        category = 'debug'
+    },
+    ['toggle_profiler_window'] = {
+        action = 'UI_Lua import("/lua/ui/game/profiler.lua").OpenWindow()',
+        category = 'debug'
+    },
+    ['store_camera_settings'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").StoreCameraPosition()',
+        category = 'debug',
+    },
+    ['restore_camera_settings'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").RestoreCameraPosition()',
+        category = 'debug',
+    },
+    ['show_fps'] = {
+        action = 'UI_Lua import("/lua/debug/uidebug.lua").ShowFPS()',
+        category = 'debug',
+    },
+    ['show_network_stats'] = {
+        action = 'ren_ShowNetworkStats',
+        category = 'debug',
+    },
+    ['debug_navpath'] = {
+        action = 'dbg navpath',
+        category = 'debug',
+    },
+    ['debug_create_unit'] = {
+        action = 'PopupCreateUnitMenu',
+        category = 'debug',
+    },
+    ['debug_teleport'] = {
+        action = 'TeleportSelectedUnits',
+        category = 'debug',
+    },
+    ['debug_run_opponent_AI'] = {
+        action = 'AI_RunOpponentAI',
+        category = 'debug',
+    },
+    ['debug_blingbling'] = {
+        action = 'BlingBling',
+        category = 'debug',
+    },
+    ['debug_destroy_units'] = {
+        action = 'DestroySelectedUnits',
+        category = 'debug',
+    },
+    ['debug_graphics_fidelity_0'] = {
+        action = 'graphics_Fidelity 0',
+        category = 'debug',
+    },
+    ['debug_graphics_fidelity_2'] = {
+        action = 'graphics_Fidelity 2',
+        category = 'debug',
+    },
+    ['debug_scenario_method_f3'] = {
+        action = 'ScenarioMethod OnF3',
+        category = 'debug',
+    },
+    ['debug_scenario_method_shift_f3'] = {
+        action = 'ScenarioMethod OnShiftF3',
+        category = 'debug',
+    },
+    ['debug_scenario_method_ctrl_f3'] = {
+        action = 'ScenarioMethod OnCtrlF3',
+        category = 'debug',
+    },
+    ['debug_scenario_method_shift_f4'] = {
+        action = 'ScenarioMethod OnShiftF4',
+        category = 'debug',
+    },
+    ['debug_scenario_method_ctrl_f4'] = {
+        action = 'ScenarioMethod OnCtrlF4',
+        category = 'debug',
+    },
+    ['debug_scenario_method_ctrl_alt_f3'] = {
+        action = 'ScenarioMethod OnCtrlAltF4',
+        category = 'debug',
+    },
+    ['debug_scenario_method_f4'] = {
+        action = 'ScenarioMethod OnF4',
+        category = 'debug',
+    },
+    ['debug_scenario_method_f5'] = {
+        action = 'ScenarioMethod OnF5',
+        category = 'debug',
+    },
+    ['debug_scenario_method_shift_f5'] = {
+        action = 'ScenarioMethod OnShiftF5',
+        category = 'debug',
+    },
+    ['debug_scenario_method_ctrl_f5'] = {
+        action = 'ScenarioMethod OnCtrlF5',
+        category = 'debug',
+    },
+    ['debug_scenario_method_ctrl_alt_f5'] = {
+        action = 'ScenarioMethod OnCtrlAltF5',
+        category = 'debug',
+    },
+    ['debug_campaign_instawin'] = {
+        action = 'ui_lua import("/lua/ui/campaign/campaignmanager.lua").InstaWin()',
+        category = 'debug',
+    },
+    ['debug_create_entity'] = {
+        action = 'SC_CreateEntityDialog',
+        category = 'debug',
+    },
+    ['debug_show_stats'] = {
+        action = 'ShowStats',
+        category = 'debug',
+    },
+    ['debug_show_army_stats'] = {
+        action = 'ShowArmyStats',
+        category = 'debug',
+    },
+    ['debug_toggle_log_window'] = {
+        action = 'WIN_ToggleLogDialog',
+        category = 'debug',
+    },
+    ['debug_open_lua_debugger'] = {
+        action = 'SC_LuaDebugger',
+        category = 'debug',
+    },
+    ['debug_show_frame_stats'] = {
+        action = 'ShowStats frame',
+        category = 'debug',
+    },
+    ['debug_render_wireframe'] = {
+        action = 'ren_ShowWireframe tog',
+        category = 'debug',
+    },
+    ['debug_weapons'] = {
+        action = 'dbg weapons',
+        category = 'debug',
+    },
+    ['debug_grid'] = {
+        action = 'dbg grid',
+        category = 'debug',
+    },
+    ['debug_show_focus_ui_control'] = {
+        action = 'UI_ShowControlUnderMouse tog',
+        category = 'debug',
+    },
+    ['debug_dump_focus_ui_control'] = {
+        action = 'UI_DumpControlsUnderCursor',
+        category = 'debug',
+    },
+    ['debug_dump_ui_controls'] = {
+        action = 'UI_DumpControls',
+        category = 'debug',
+    },
+    ['debug_skeletons'] = {
+        action = 'Ren_Showskeletons',
+        category = 'debug',
+    },
+    ['debug_bones'] = {
+        action = 'Ren_ShowBoneNames',
+        category = 'debug',
+    },
+    ['debug_redo_console_command'] = {
+        action = 'CON_ExecuteLastCommand',
+        category = 'debug',
+    },
+    ['debug_copy_units'] = {
+        action = 'CopySelectedUnitsToClipboard',
+        category = 'debug',
+    },
+    ['debug_paste_units'] = {
+        action = 'ExecutePasteBuffer',
+        category = 'debug',
+    },
+    ['debug_nodamage'] = {
+        action = 'Nodamage',
+        category = 'debug',
+    },
+    ['debug_show_emmitter_window'] = {
+        action = 'EFX_CreateEmitterWindow',
+        category = 'debug',
+    },
+    ['debug_sally_shears'] = {
+        action = 'SallyShears',
+        category = 'debug',
+    },
+    ['debug_collision'] = {
+        action = 'dbg Collision',
+        category = 'debug',
+    },
+    ['debug_pause_single_step'] = {
+        action = 'WLD_SingleStep',
+        category = 'game',
+    },
+    ['debug_restart_session'] = {
+        action = 'UI_Lua RestartSession()',
+        category = 'debug',
+    },
+    ['debug_toggle_pannels'] = {
+        action = 'UI_ToggleGamePanels',
+        category = 'debug',
+    },
 }
+
+local keyActionsDebugAI = {
+    ['toggle_navui'] = {
+        action = 'UI_Lua import("/lua/ui/game/navgenerator.lua").OpenWindow()',
+        category = 'ai'
+    },
+    ['toggle_ai_reclaim_grid_ui'] = {
+        action = 'UI_Lua import("/lua/ui/game/gridreclaim.lua").OpenWindow()',
+        category = 'ai'
+    },
+    ['toggle_ai_presence_grid_ui'] = {
+        action = 'UI_Lua import("/lua/ui/game/gridpresence.lua").OpenWindow()',
+        category = 'ai'
+    },
+    ['toggle_ai_recon_grid_ui'] = {
+        action = 'UI_Lua import("/lua/ui/game/gridrecon.lua").OpenWindow()',
+        category = 'ai'
+    },
+    ['toggle_ai_economy_ui'] = {
+        action = 'UI_Lua import("/lua/ui/game/AIBrainEconomyData.lua").OpenWindow()',
+        category = 'ai'
+    },
+    ['toggle_platoon_behavior_silo'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").AssignPlatoonBehaviorSilo()',
+        category = 'ai'
+    },
+    ['toggle_platoon_simple_raid'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").AIPlatoonSimpleRaidBehavior()',
+        category = 'ai'
+    },
+    ['toggle_platoon_simple_structure'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").AIPlatoonSimpleStructureBehavior()',
+        category = 'ai'
+    },
+}
+
+debugKeyActions = table.combine(
+    keyActionsDebug,
+    keyActionsDebugAI
+)

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -1,11 +1,21 @@
--- This file outlines the interaction between the 'command' (Bound to a key) and the behaviour of that command
--- format is:
---  key - The string referenced by a bound key
---  action - The console command to execute when the key is pressed
---  category - The category to list this action under in the key assign dialog
---  order - The sort order to list this action under its category
---  keyRepeat - A boolean flag that dictates when an action is one that can be held to extend its effect (eg - Zoom)
 
+--- A key action allows a user to bind key bindings to an action. The format 
+--- of a key action is defined in the 'UIKeyAction' annotation class. Key
+--- actions are defined in tables. The key of a key action acts as an
+--- identifier. The same identifier is used to assign a description to the
+--- key action
+
+--- In an ideal world that description would be part of the key action
+--- itself. The system in place is what we have however. The descriptions
+--- of key actions can be found in `/lua/keymap/keydescriptions.lua`
+
+--- Regular key actions can be found in `/lua/keymap/keyactions.lua`
+
+---@class UIKeyAction
+---@field action string
+---@field category string
+
+---@type table<string, UIKeyAction>
 local keyActionsCamera = {
     ['lock_zoom'] = {
         action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").lockZoom()',
@@ -119,11 +129,11 @@ local keyActionsCamera = {
     },
     ['zoom_in'] = {
         action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ZoomIn(.02)',
-        category = 'camera', keyRepeat = true,
+        category = 'camera', 
     },
     ['zoom_out'] = {
         action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ZoomOut(.02)',
-        category = 'camera', keyRepeat = true,
+        category = 'camera', 
     },
     ['zoom_in_fast'] = {
         action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ZoomIn(.08)',
@@ -156,6 +166,7 @@ local keyActionsCamera = {
     },
 }
 
+---@type table<string, UIKeyAction>
 local keyActionsSelection = {
     ['cycle_idle_factories'] = {
         action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").CycleIdleFactories()',
@@ -171,6 +182,7 @@ local keyActionsSelection = {
     },
 }
 
+---@type table<string, UIKeyAction>
 local keyActionsSelectionQuickSelect = {
     ['select_upgrading_extractors'] = {
         action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").SelectAllUpgradingExtractors()',
@@ -398,6 +410,7 @@ local keyActionsSelectionQuickSelect = {
     },
 }
 
+---@type table<string, UIKeyAction>
 local keyActionsSelectionSubgroups = {
     ['split_next'] = {
         action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitNext()',
@@ -453,6 +466,7 @@ local keyActionsSelectionSubgroups = {
     },
 }
 
+---@type table<string, UIKeyAction>
 local keyActionsSelectionControupGroups = {
     ['revert_selection_set'] = {
         action = 'UI_Lua import("/lua/ui/game/selection.lua").RevertSelectionSet()',
@@ -705,6 +719,7 @@ local keyActionsSelectionControupGroups = {
     },
 }
 
+---@type table<string, UIKeyAction>
 local keyActionsHotBuild = {
     ['builders'] = {
         action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Builders")',
@@ -788,6 +803,7 @@ local keyActionsHotBuild = {
     },
 }
 
+---@type table<string, UIKeyAction>
 local keyActionsHotBuildAlternative = {
     ['alt_builders'] = {
         action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Builders")',
@@ -855,6 +871,7 @@ local keyActionsHotBuildAlternative = {
     },
 }
 
+---@type table<string, UIKeyAction>
 local keyActionsHotBuildExtra = {
     ['land_factory'] = {
         action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Land_Factory")',
@@ -1302,6 +1319,7 @@ local keyActionsHotBuildExtra = {
     },
 }
 
+---@type table<string, UIKeyAction>
 local keyActionsOrders = {
 
     ['repair'] = {
@@ -1542,6 +1560,7 @@ local keyActionsOrders = {
     },
 }
 
+---@type table<string, UIKeyAction>
 local keyActionsGame = {
     ['toggle_lifebars'] = {
         action = 'UI_RenderUnitBars',
@@ -1653,6 +1672,7 @@ local keyActionsGame = {
     },
 }
 
+---@type table<string, UIKeyAction>
 local keyActionsChat = {
     ['chat_page_up'] = {
         action = 'UI_Lua import("/lua/ui/game/chat.lua").ChatPageUp(10)',
@@ -1672,6 +1692,7 @@ local keyActionsChat = {
     },
 }
 
+---@type table<string, UIKeyAction>
 local keyActionsUI = {
     ['rename'] = {
         action = 'UI_ShowRenameDialog',
@@ -1739,6 +1760,7 @@ local keyActionsUI = {
     },
 }
 
+---@type table<string, UIKeyAction>
 local keyActionsMisc = {
     ['filter_highest_engineer_and_assist'] = {
         action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").SelectHighestEngineerAndAssist()',
@@ -1746,6 +1768,7 @@ local keyActionsMisc = {
     },
 }
 
+---@type table<string, UIKeyAction>
 keyActions = table.combine(
     keyActionsCamera,
     keyActionsSelection,

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -9,7 +9,7 @@
 --- itself. The system in place is what we have however. The descriptions
 --- of key actions can be found in `/lua/keymap/keydescriptions.lua`
 
---- Regular key actions can be found in `/lua/keymap/keyactions.lua`
+--- Debug key actions can be found in `/lua/keymap/debugKeyactions.lua`
 
 ---@class UIKeyAction
 ---@field action string

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -6,914 +6,1758 @@
 --  order - The sort order to list this action under its category
 --  keyRepeat - A boolean flag that dictates when an action is one that can be held to extend its effect (eg - Zoom)
 
-keyActions = {
-    ['escape'] = {action = 'UI_Lua import("/lua/ui/uimain.lua").EscapeHandler()',
-        category = 'ui', order = 1,},
-    ['pause'] = {action = 'UI_Lua import("/lua/ui/game/tabs.lua").TogglePause()',
-        category = 'ui', order = 3,},
-    ['cap_frame'] = {action = 'Dump_Frame',
-        category = 'ui', order = 4,},
-    ['toggle_lifebars'] = {action = 'UI_RenderUnitBars',
-        category = 'ui', order = 1,},
-    ['tog_military'] = {action = 'UI_Lua import("/lua/ui/game/multifunction.lua").ToggleMilitary()',
-        category = 'ui', order = 5,},
-    ['tog_defense'] = {action = 'UI_Lua import("/lua/ui/game/multifunction.lua").ToggleDefense()',
-        category = 'ui', order = 6,},
-    ['tog_econ'] = {action = 'UI_Lua import("/lua/ui/game/multifunction.lua").ToggleEconomy()',
-        category = 'ui', order = 7,},
-    ['rename'] = {action = 'UI_ShowRenameDialog',
-        category = 'ui', order = 10,},
-    ['split_screen_enable'] = {action = 'UI_Lua import("/lua/ui/game/borders.lua").SplitMapGroup(true)',
-        category = 'ui', order = 13,},
-    ['split_screen_disable'] = {action = 'UI_Lua import("/lua/ui/game/borders.lua").SplitMapGroup(false)',
-        category = 'ui', order = 14,},
-    ['switch_layout_up'] = {action = 'UI_RotateLayout +',
-        category = 'ui', order = 17,},
-    ['switch_layout_down'] = {action = 'UI_RotateLayout -',
-        category = 'ui', order = 18,},
-    ['switch_skin_down'] = {action = 'UI_RotateSkin -',
-        category = 'ui', order = 17,},
-    ['switch_skin_up'] = {action = 'UI_RotateSkin +',
-        category = 'ui', order = 17,},
-    ['toggle_key_bindings'] = {action = 'UI_Lua import("/lua/ui/dialogs/keybindings.lua").CreateUI()',
-        category = 'ui', order = 6,},
-    ['toggle_notify_customiser'] = {action = 'UI_Lua import("/lua/ui/notify/customiser.lua").CreateUI()',
-        category = 'ui', order = 6,},
-    ['toggle_score_screen'] = {action = 'UI_Lua import("/lua/ui/game/tabs.lua").ToggleScore()',
-        category = 'ui', order = 1,},
-    ['toggle_mass_fabricator_panel'] = {action = 'UI_Lua import("/lua/ui/game/tabs.lua").ToggleMassFabricatorPanel()',
-        category = 'ui', order = 1,},
-    ['toggle_voting_panel'] = {action = 'UI_Lua import("/lua/ui/game/tabs.lua").ToggleVotingPanel()',
-        category = 'ui', order = 1,},
-    ['quick_save'] = {action = 'UI_Lua import("/lua/ui/game/gamemain.lua").QuickSave(LOC("<LOC QuickSave>QuickSave"))',
-        category = 'ui', order = 23,},
-    ['toggle_diplomacy_screen'] = {action = 'UI_Lua import("/lua/ui/game/tabs.lua").ToggleTab("diplomacy")',
-        category = 'ui', order = 4,},
-    ['ping_alert'] = {action = 'UI_Lua import("/lua/ui/game/ping.lua").DoPing("alert")',
-        category = 'ui', order = 22,},
-    ['ping_move'] = {action = 'UI_Lua import("/lua/ui/game/ping.lua").DoPing("move")',
-        category = 'ui', order = 23,},
-    ['ping_attack'] = {action = 'UI_Lua import("/lua/ui/game/ping.lua").DoPing("attack")',
-        category = 'ui', order = 24,},
-    ['ping_marker'] = {action = 'UI_Lua import("/lua/ui/game/ping.lua").DoPing("marker")',
-        category = 'ui', order = 25,},
-    ['toggle_main_menu'] = {action = 'UI_Lua import("/lua/ui/game/tabs.lua").ToggleTab("main")',
-        category = 'ui', order = 4,},
-    ['toggle_disconnect_screen'] = {action = 'UI_Lua import("/lua/ui/game/connectivity.lua").CreateUI()',
-        category = 'ui', order = 21,},
-    ['toggle_map_utilities_window'] = {action = 'UI_Lua import("/lua/ui/game/maputilities.lua").OpenWindow()',
-        category = 'debug', order = 21,},
-    ['toggle_reclaim_labels'] = {action = 'UI_Lua import("/lua/ui/game/reclaim.lua").ToggleReclaim()',
-        category = 'ui'},
+local keyActionsCamera = {
+    ['lock_zoom'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").lockZoom()',
+        category = 'camera',
+    },
+    ['zoom_pop'] = {
+        action = "UI_Lua import('/lua/ui/game/zoompopper.lua').ToggleZoomPop()",
+        category = 'camera',
+    },
+    ['cam_free'] = {
+        action = 'Cam_Free',
+        category = 'camera',
+    },
+    ['RestorePreviousCameraPosition'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").RestorePreviousCameraPosition()',
+        category = 'camera',
+    },
+    ['SaveCameraPosition1'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(1)',
+        category = 'camera',
+    },
+    ['SaveCameraPosition2'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(2)',
+        category = 'camera',
+    },
+    ['SaveCameraPosition3'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(3)',
+        category = 'camera',
+    },
+    ['SaveCameraPosition4'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(4)',
+        category = 'camera',
+    },
+    ['SaveCameraPosition5'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(5)',
+        category = 'camera',
+    },
+    ['SaveCameraPosition6'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(6)',
+        category = 'camera',
+    },
+    ['SaveCameraPosition7'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(7)',
+        category = 'camera',
+    },
+    ['SaveCameraPosition8'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(8)',
+        category = 'camera',
+    },
+    ['SaveCameraPosition9'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(9)',
+        category = 'camera',
+    },
+    ['SaveCameraPosition0'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(0)',
+        category = 'camera',
+    },
 
-    ['revert_selection_set'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").RevertSelectionSet()',
-        category = 'selection', order = 0,},
+    ['RestoreCameraPosition1'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(1)',
+        category = 'camera',
+    },
+    ['RestoreCameraPosition2'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(2)',
+        category = 'camera',
+    },
+    ['RestoreCameraPosition3'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(3)',
+        category = 'camera',
+    },
+    ['RestoreCameraPosition4'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(4)',
+        category = 'camera',
+    },
+    ['RestoreCameraPosition5'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(5)',
+        category = 'camera',
+    },
+    ['RestoreCameraPosition6'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(6)',
+        category = 'camera',
+    },
+    ['RestoreCameraPosition7'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(7)',
+        category = 'camera',
+    },
+    ['RestoreCameraPosition8'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(8)',
+        category = 'camera',
+    },
+    ['RestoreCameraPosition9'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(9)',
+        category = 'camera',
+    },
+    ['RestoreCameraPosition0'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(0)',
+        category = 'camera',
+    },
 
-    ['split_next'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitNext()',
-        category = 'selectionSubgroups', order = 1,},
+    ['next_cam_position'] = {
+        action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").RecallCameraPos()',
+        category = 'camera',
+    },
+    ['add_cam_position'] = {
+        action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").SaveCameraPos()',
+        category = 'camera',
+    },
+    ['rem_cam_position'] = {
+        action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").RemoveCamPos()',
+        category = 'camera',
+    },
+    ['zoom_in'] = {
+        action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ZoomIn(.02)',
+        category = 'camera', keyRepeat = true,
+    },
+    ['zoom_out'] = {
+        action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ZoomOut(.02)',
+        category = 'camera', keyRepeat = true,
+    },
+    ['zoom_in_fast'] = {
+        action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ZoomIn(.08)',
+        category = 'camera',
+    },
+    ['zoom_out_fast'] = {
+        action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ZoomOut(.08)',
+        category = 'camera',
+    },
+    ['track_unit'] = {
+        action = 'UI_TrackUnit WorldCamera',
+        category = 'camera',
+    },
+    ['track_unit_minimap'] = {
+        action = 'UI_TrackUnit MiniMap',
+        category = 'camera',
+    },
+    ['track_unit_second_mon'] = {
+        action = 'UI_TrackUnit CameraHead2',
+        category = 'camera',
+    },
+    ['reset_camera'] = {
+        action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ToggleWideView()',
+        category = 'camera',
+    },
 
-    ['split_major_axis'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitMajorAxis()',
-        category = 'selectionSubgroups', order = 1,},
-    ['split_minor_axis'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitMinorAxis()',
-        category = 'selectionSubgroups', order = 1,},
-    ['split_mouse_axis'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitMouseAxis()',
-        category = 'selectionSubgroups', order = 1,},
-    ['split_mouse_axis_orthogonal'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitMouseOrthogonalAxis()',
-        category = 'selectionSubgroups', order = 1,},
-    ['split_engineer_tech'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitEngineerTech()',
-        category = 'selectionSubgroups', order = 1,},
-    ['split_tech'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitTech()',
-        category = 'selectionSubgroups', order = 1,},
-    ['split_layer'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitLayer()',
-        category = 'selectionSubgroups', order = 1,},
-    ['split_into_groups_1'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitIntoGroups(1)',
-        category = 'selectionSubgroups', order = 1,},
-    ['split_into_groups_2'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitIntoGroups(2)',
-        category = 'selectionSubgroups', order = 1,},
-    ['split_into_groups_4'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitIntoGroups(4)',
-        category = 'selectionSubgroups', order = 1,},
-    ['split_into_groups_8'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitIntoGroups(8)',
-        category = 'selectionSubgroups', order = 1,},
-    ['split_into_groups_16'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitIntoGroups(16)',
-        category = 'selectionSubgroups', order = 1,},
-
-    ['group1'] = {action = 'UI_ApplySelectionSet 1',
-        category = 'selection', order = 1,},
-    ['group2'] = {action = 'UI_ApplySelectionSet 2',
-        category = 'selection', order = 2,},
-    ['group3'] = {action = 'UI_ApplySelectionSet 3',
-        category = 'selection', order = 3,},
-    ['group4'] = {action = 'UI_ApplySelectionSet 4',
-        category = 'selection', order = 4,},
-    ['group5'] = {action = 'UI_ApplySelectionSet 5',
-        category = 'selection', order = 5,},
-    ['group6'] = {action = 'UI_ApplySelectionSet 6',
-        category = 'selection', order = 6,},
-    ['group7'] = {action = 'UI_ApplySelectionSet 7',
-        category = 'selection', order = 7,},
-    ['group8'] = {action = 'UI_ApplySelectionSet 8',
-        category = 'selection', order = 8,},
-    ['group9'] = {action = 'UI_ApplySelectionSet 9',
-        category = 'selection', order = 9,},
-    ['group0'] = {action = 'UI_ApplySelectionSet 0',
-
-        category = 'selection', order = 10,},
-    ['set_group1'] = {action = 'UI_MakeSelectionSet 1',
-        category = 'selection', order = 11,},
-    ['set_group2'] = {action = 'UI_MakeSelectionSet 2',
-        category = 'selection', order = 12,},
-    ['set_group3'] = {action = 'UI_MakeSelectionSet 3',
-        category = 'selection', order = 13,},
-    ['set_group4'] = {action = 'UI_MakeSelectionSet 4',
-        category = 'selection', order = 14,},
-    ['set_group5'] = {action = 'UI_MakeSelectionSet 5',
-        category = 'selection', order = 15,},
-    ['set_group6'] = {action = 'UI_MakeSelectionSet 6',
-        category = 'selection', order = 16,},
-    ['set_group7'] = {action = 'UI_MakeSelectionSet 7',
-        category = 'selection', order = 17,},
-    ['set_group8'] = {action = 'UI_MakeSelectionSet 8',
-        category = 'selection', order = 18,},
-    ['set_group9'] = {action = 'UI_MakeSelectionSet 9',
-        category = 'selection', order = 19,},
-    ['set_group0'] = {action = 'UI_MakeSelectionSet 0',
-        category = 'selection', order = 20,},
-
-    ['append_group1'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(1)',
-        category = 'selection', order = 100 },
-    ['append_group2'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(2)',
-        category = 'selection', order = 101 },
-    ['append_group3'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(3)',
-        category = 'selection', order = 102 },
-    ['append_group4'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(4)',
-        category = 'selection', order = 103 },
-    ['append_group5'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(5)',
-        category = 'selection', order = 104 },
-    ['append_group6'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(6)',
-        category = 'selection', order = 105 },
-    ['append_group7'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(7)',
-        category = 'selection', order = 106 },
-    ['append_group8'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(8)',
-        category = 'selection', order = 107 },
-    ['append_group9'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(9)',
-        category = 'selection', order = 108 },
-    ['append_group0'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(0)',
-        category = 'selection', order = 109 },
-
-    ['add_selection_to_selection_set1'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(1)',
-        category = 'selection', order = 110 },
-    ['add_selection_to_selection_set2'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(2)',
-        category = 'selection', order = 111 },
-    ['add_selection_to_selection_set3'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(3)',
-        category = 'selection', order = 112 },
-    ['add_selection_to_selection_set4'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(4)',
-        category = 'selection', order = 113 },
-    ['add_selection_to_selection_set5'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(5)',
-        category = 'selection', order = 114 },
-    ['add_selection_to_selection_set6'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(6)',
-        category = 'selection', order = 115 },
-    ['add_selection_to_selection_set7'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(7)',
-        category = 'selection', order = 116 },
-    ['add_selection_to_selection_set8'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(8)',
-        category = 'selection', order = 117 },
-    ['add_selection_to_selection_set9'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(9)',
-        category = 'selection', order = 118 },
-    ['add_selection_to_selection_set0'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(0)',
-        category = 'selection', order = 119 },
-
-    ['combine_and_select_with_selection_set1'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(1)',
-        category = 'selection', order = 120 },
-    ['combine_and_select_with_selection_set2'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(2)',
-        category = 'selection', order = 121 },
-    ['combine_and_select_with_selection_set3'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(3)',
-        category = 'selection', order = 122 },
-    ['combine_and_select_with_selection_set4'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(4)',
-        category = 'selection', order = 123 },
-    ['combine_and_select_with_selection_set5'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(5)',
-        category = 'selection', order = 124 },
-    ['combine_and_select_with_selection_set6'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(6)',
-        category = 'selection', order = 125 },
-    ['combine_and_select_with_selection_set7'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(7)',
-        category = 'selection', order = 126 },
-    ['combine_and_select_with_selection_set8'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(8)',
-        category = 'selection', order = 127 },
-    ['combine_and_select_with_selection_set9'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(9)',
-        category = 'selection', order = 128 },
-    ['combine_and_select_with_selection_set0'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(0)',
-        category = 'selection', order = 129 },
-
-    ['fac_group1'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(1)',
-        category = 'selection', order = 31,},
-    ['fac_group2'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(2)',
-        category = 'selection', order = 32,},
-    ['fac_group3'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(3)',
-        category = 'selection', order = 33,},
-    ['fac_group4'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(4)',
-        category = 'selection', order = 34,},
-    ['fac_group5'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(5)',
-        category = 'selection', order = 35,},
-    ['fac_group6'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(6)',
-        category = 'selection', order = 36,},
-    ['fac_group7'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(7)',
-        category = 'selection', order = 37,},
-    ['fac_group8'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(8)',
-        category = 'selection', order = 38,},
-    ['fac_group9'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(9)',
-        category = 'selection', order = 39,},
-    ['fac_group0'] = {action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(0)',
-        category = 'selection', order = 40,},
-    ['select_upgrading_extractors'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").SelectAllUpgradingExtractors()',
-        category = 'selection', order = 41,},
-    ['select_air'] = {action = 'UI_SelectByCategory +excludeengineers AIR MOBILE',
-        category = 'selection', order = 41,},
-    ['select_naval'] = {action = 'UI_SelectByCategory +excludeengineers NAVAL MOBILE',
-        category = 'selection', order = 42,},
-    ['select_naval_no_mobile_sonar'] = {action = 'UI_Lua import("/lua/keymap/smartselection.lua").smartSelect("NAVAL MOBILE -MOBILESONAR")',
-        category = 'selection', order = 42,},
-    ['select_land'] = {action = 'UI_SelectByCategory +excludeengineers LAND MOBILE',
-        category = 'selection', order = 43,},
-    ['select_all_units_of_same_type'] = {action = 'UI_ExpandCurrentSelection',
-        category = 'selection', order = 44,},
-    ['select_engineers'] = {action = 'UI_SelectByCategory ENGINEER',
-        category = 'selection', order = 45,},
-    ['goto_engineer'] = {action = 'UI_SelectByCategory +nearest +idle +goto ENGINEER',
-        category = 'selection', order = 46,},
-    ['select_idle_engineer'] = {action = 'UI_SelectByCategory +nearest +idle ENGINEER',
-        category = 'selection', order = 47,},
-    ['cycle_engineers'] = {action = 'UI_Lua import("/lua/ui/game/avatars.lua").GetEngineerGeneric()',
-        category = 'selection', order = 48,},
-    ['goto_commander'] = {action = 'UI_SelectByCategory +nearest +goto COMMAND',
-        category = 'selection', order = 49,},
-    ['select_commander'] = {action = 'UI_SelectByCategory +nearest COMMAND',
-        category = 'selection', order = 50,},
-    ['select_all'] = {action = 'UI_SelectByCategory ALLUNITS',
-        category = 'selection', order = 51,},
-    ['select_all_onscreen'] = {action = 'UI_SelectByCategory +inview ALLUNITS',
-        category = 'selection', order = 52,},
-    ['select_all_eng_onscreen'] = {action = 'UI_SelectByCategory +inview ENGINEER',
-        category = 'selection', order = 53,},
-    ['select_all_factory_onscreen'] = {action = 'UI_SelectByCategory +inview FACTORY',
-        category = 'selection', order = 54,},
-    ['select_nearest_factory'] = {action = 'UI_SelectByCategory +nearest FACTORY',
-        category = 'selection', order = 55,},
-    ['select_nearest_land_factory'] = {action = 'UI_SelectByCategory +nearest LAND FACTORY',
-        category = 'selection', order = 56,},
-    ['select_nearest_air_factory'] = {action = 'UI_SelectByCategory +nearest AIR FACTORY',
-        category = 'selection', order = 57,},
-    ['select_nearest_naval_factory'] = {action = 'UI_SelectByCategory +nearest NAVAL FACTORY',
-        category = 'selection', order = 58,},
-
-    ['repair'] = {action = 'StartCommandMode order RULEUCC_Repair',
-        category = 'orders', order = 9,},
-    ['reclaim'] = {action = 'StartCommandMode order RULEUCC_Reclaim',
-        category = 'orders', order = 7,},
-    ['patrol'] = {action = 'StartCommandMode order RULEUCC_Patrol',
-        category = 'orders', order = 5,},
-    ['attack'] = {action = 'StartCommandMode order RULEUCC_Attack',
-        category = 'orders', order = 13,},
-    ['capture'] = {action = 'StartCommandMode order RULEUCC_Capture',
-        category = 'orders', order = 21,},
-    ['stop'] = {action = 'UI_Lua import("/lua/ui/game/orders.lua").Stop()',
-        category = 'orders', order = 1,},
-    ['soft_stop'] = {action = 'UI_Lua import("/lua/ui/game/orders.lua").SoftStop()',
-        category = 'orders', order = 1,},
-    ['dive'] = {action = 'UI_Lua import("/lua/ui/game/orders.lua").ToggleDiveOrder()',
-        category = 'orders', order = 27,},
-    ['ferry'] = {action = 'StartCommandMode order RULEUCC_Ferry',
-        category = 'orders', order = 19,},
-    ['guard'] = {action = 'StartCommandMode order RULEUCC_Guard',
-        category = 'orders', order = 17,},
-    ['transport'] = {action = 'StartCommandMode order RULEUCC_Transport',
-        category = 'orders', order = 3,},
-    ['launch_tactical'] = {action = 'StartCommandMode order RULEUCC_Tactical',
-        category = 'orders', order = 25,},
-    ['overcharge'] = {action = 'UI_Lua import("/lua/ui/game/orders.lua").EnterOverchargeMode()',
-        category = 'orders', order = 23,},
-    ['move'] = {action = 'StartCommandMode order RULEUCC_Move',
-        category = 'orders', order = 11,},
-    ['move_hard'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").ToggleHardMove()',
-        category = 'orders', order = 11,},
-    ['nuke'] = {action = 'StartCommandMode order RULEUCC_Nuke',
-        category = 'orders', order = 15,},
-    ['shift_repair'] = {action = 'StartCommandMode order RULEUCC_Repair',
-        category = 'orders', order = 10,},
-    ['shift_reclaim'] = {action = 'StartCommandMode order RULEUCC_Reclaim',
-        category = 'orders', order = 8,},
-    ['shift_patrol'] = {action = 'StartCommandMode order RULEUCC_Patrol',
-        category = 'orders', order = 6,},
-    ['shift_attack'] = {action = 'StartCommandMode order RULEUCC_Attack',
-        category = 'orders', order = 14,},
-    ['shift_capture'] = {action = 'StartCommandMode order RULEUCC_Capture',
-        category = 'orders', order = 22,},
-    ['shift_stop'] = {action = 'IssueCommand Stop',
-        category = 'orders', order = 2,},
-    ['shift_dive'] = {action = 'UI_Lua import("/lua/ui/game/orders.lua").ToggleDiveOrder()',
-        category = 'orders', order = 28,},
-    ['shift_ferry'] = {action = 'StartCommandMode order RULEUCC_Ferry',
-        category = 'orders', order = 20,},
-    ['shift_guard'] = {action = 'StartCommandMode order RULEUCC_Guard',
-        category = 'orders', order = 18,},
-    ['shift_transport'] = {action = 'StartCommandMode order RULEUCC_Transport',
-        category = 'orders', order = 4,},
-    ['shift_launch_tactical'] = {action = 'StartCommandMode order RULEUCC_Tactical',
-        category = 'orders', order = 26,},
-    ['shift_overcharge'] = {action = 'UI_Lua import("/lua/ui/game/orders.lua").EnterOverchargeMode()',
-        category = 'orders', order = 24,},
-    ['shift_move'] = {action = 'StartCommandMode order RULEUCC_Move',
-        category = 'orders', order = 12,},
-    ['shift_nuke'] = {action = 'StartCommandMode order RULEUCC_Nuke',
-        category = 'orders', order = 16,},
-    ['toggle_build_mode'] = {action = 'UI_Lua import("/lua/ui/game/buildmode.lua").ToggleBuildMode()',
-        category = 'orders', order = 30,},
-    ['pause_unit'] = {action = 'UI_Lua import("/lua/ui/game/construction.lua").ToggleUnitPause()',
-        category = 'orders', order = 31,},
-    ['mode'] = {action = 'UI_Lua import("/lua/ui/game/orders.lua").CycleRetaliateStateUp()',
-        category = 'orders', order = 32,}, --cut?
-    ['suicide'] = {action = 'UI_Lua import("/lua/ui/game/confirmunitdestroy.lua").ConfirmUnitDestruction(false)',
-        category = 'orders', order = 29,},
-    ['spreadattack'] = {action = 'UI_Lua import("/lua/spreadattack.lua").SpreadAttack()',
-        category = 'orders', order = 33,},
-    ['shift_spreadattack'] = {action = 'UI_Lua import("/lua/spreadattack.lua").SpreadAttack()',
-        category = 'orders', order = 34,},
-    ['set_target_priority'] = {action = 'UI_LUA import("/lua/keymap/misckeyactions.lua").SetWeaponPrioritiesToUnitType()',
-        category = 'orders', order = 35,},
-    ['set_default_target_priority'] = {action = 'UI_LUA import("/lua/keymap/misckeyactions.lua").SetDefaultWeaponPriorities()',
-        category = 'orders', order = 36,},
-    ['decrease_game_speed'] = {action = 'UI_Lua import("/lua/ui/uimain.lua").DecreaseGameSpeed()',
-        category = 'game', order = 1,},
-    ['increase_game_speed'] = {action = 'UI_Lua import("/lua/ui/uimain.lua").IncreaseGameSpeed()',
-        category = 'game', order = 2,},
-    ['reset_game_speed'] = {action = 'WLD_ResetSimRate',
-        category = 'game', order = 3,},
-    ['chat_page_up'] = {action = 'UI_Lua import("/lua/ui/game/chat.lua").ChatPageUp(10)',
-        category = 'chat', order = 2,},
-    ['chat_page_down'] = {action = 'UI_Lua import("/lua/ui/game/chat.lua").ChatPageDown(10)',
-        category = 'chat', order = 3,},
-    ['chat_line_up'] = {action = 'UI_Lua import("/lua/ui/game/chat.lua").ChatPageUp(1)',
-        category = 'chat', order = 4,},
-    ['chat_line_down'] = {action = 'UI_Lua import("/lua/ui/game/chat.lua").ChatPageDown(1)',
-        category = 'chat', order = 5,},
-    ['show_fps'] = {action = 'UI_Lua import("/lua/debug/uidebug.lua").ShowFPS()',
-        category = 'ui', order = 1,},
-    ['create_build_template'] = {action = 'UI_Lua import("/lua/ui/game/build_templates.lua").CreateBuildTemplate()',
-        category = 'selection', order = 100},
-    ['show_objective_screen'] = {action = 'UI_Lua import("/lua/ui/game/objectivedetail.lua").ToggleDisplay()',
-        category = 'ui', order = 23},
-    ['toggle_ai_screen'] = {action = 'UI_Lua import("/lua/ui/dialogs/aiutilitiesview.lua").OpenWindow()',
-        category = 'ui', order = 24},
-    ['toggle_profiler'] = {action = 'UI_Lua import("/lua/ui/game/profiler.lua").ToggleProfiler()',
-        category = 'debug', order = 24},
-    ['toggle_profiler_window'] = {action = 'UI_Lua import("/lua/ui/game/profiler.lua").OpenWindow()',
-        category = 'debug', order = 24},
-    ['toggle_repeat_build'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").ToggleRepeatBuild()',
-        category = 'orders', order = 1,},
-    ['show_enemy_life'] = {action = 'UI_ForceLifbarsOnEnemy',
-        category = 'ui', order = 2,},
-    ['show_network_stats'] = {action = 'ren_ShowNetworkStats',
-        category = 'ui', order = 3,},
-    ['toggle_shield'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Shield")',
-        category = 'orders', order = 6,},
-    ['toggle_weapon'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Weapon")',
-        category = 'orders', order = 7,},
-    ['recheck_targets_of_weapons'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").RecheckTargetsOfWeapons()',
-        category = 'orders', order = 7,},
-    ['toggle_jamming'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Jamming")',
-        category = 'orders', order = 8,},
-    ['toggle_intel'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Intel")',
-        category = 'orders', order = 9,},
-    ['toggle_production'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Production")',
-        category = 'orders', order = 10,},
-    ['toggle_stealth'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Stealth")',
-        category = 'orders', order = 11,},
-    ['toggle_generic'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Generic")',
-        category = 'orders', order = 12,},
-    ['toggle_special'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Special")',
-        category = 'orders', order = 13,},
-    ['toggle_cloak'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Cloak")',
-        category = 'orders', order = 14,},
-    ['toggle_all'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleAllScript()',
-        category = 'orders', order = 15,},
-    ['teleport'] = {action = 'StartCommandMode order RULEUCC_Teleport',
-        category = 'orders', order = 5,},
-    ['military_overlay'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleOverlay("Military")',
-        category = 'ui', order = 16,},
-    ['intel_overlay'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleOverlay("Intel")',
-        category = 'ui', order = 17,},
-    ['filter_highest_engineer_and_assist'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").SelectHighestEngineerAndAssist()',
-        category = 'selection', order = 9,},
-    ['select_all_radars'] = {action = 'UI_SelectByCategory INTELLIGENCE STRUCTURE RADAR, INTELLIGENCE STRUCTURE OMNI',
-        category = 'selection', order = 9,},
-    ['select_all_idle_eng_onscreen'] = {action = 'UI_SelectByCategory +inview +idle ENGINEER',
-        category = 'selection', order = 18,},
-    ['select_all_land_units_onscreen'] = {action = 'UI_SelectByCategory +inview +excludeengineers MOBILE LAND',
-        category = 'selection', order = 18,},
-    ['select_all_air_units_onscreen'] = {action = 'UI_SelectByCategory +inview MOBILE AIR',
-        category = 'selection', order = 18,},
-    ['select_all_naval_units_onscreen'] = {action = 'UI_SelectByCategory +inview MOBILE NAVAL',
-        category = 'selection', order = 18,},
-    ['select_all_similar_units'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").GetSimilarUnits()',
-        category = 'selection', order = 19,},
-    ['select_next_land_factory'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").GetNextLandFactory()',
-        category = 'selection', order = 20,},
-    ['select_next_air_factory'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").GetNextAirFactory()',
-        category = 'selection', order = 21,},
-    ['select_next_naval_factory'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").GetNextNavalFactory()',
-        category = 'selection', order = 22,},
-    ['toggle_cloakjammingstealth'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleCloakJammingStealthScript()',
-        category = 'orders', order = 25,},
-    ['toggle_intelshield'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleIntelShieldScript()',
-        category = 'orders', order = 26,},
-    ['toggle_mdf_panel'] = {action = 'UI_Lua import("/lua/ui/game/multifunction.lua").ToggleMFDPanel()',
-        category = 'ui', order = 27,},
-    ['toggle_tab_display'] = {action = 'UI_Lua import("/lua/ui/game/tabs.lua").ToggleTabDisplay()',
-        category = 'ui', order = 28,},
-    ['select_inview_idle_mex'] = {action = 'UI_SelectByCategory +inview +idle MASSEXTRACTION',
-        category = 'selection', order = 30,},
-    ['select_all_mex'] = {action = 'UI_SelectByCategory MASSEXTRACTION',
-        category = 'selection', order = 31,},
-    ['select_nearest_idle_lt_mex'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").GetNearestIdleLTMex()',
-        category = 'selection', order = 32,},
-    ['acu_select_cg'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").ACUSelectCG()',
-        category = 'selection', order = 33,},
-    ['acu_append_cg'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").ACUAppendCG()',
-        category = 'selection', order = 34,},
-    ['select_nearest_idle_eng_not_acu'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").GetNearestIdleEngineerNotACU()',
-        category = 'selection', order = 35,},
-    ['add_nearest_idle_engineers_seq'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").AddNearestIdleEngineersSeq()',
-        category = 'selection', order = 36,},
-    ['cycle_idle_factories'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").CycleIdleFactories()',
-        category = 'selection', order = 37,},
-    ['cycle_unit_types_in_sel'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").CycleUnitTypesInSel()',
-        category = 'selection', order = 38,},
-    ['create_template_factory'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").CreateTemplateFactory()',
-        category = 'selection', order = 39,},
-    ['select_gunships'] = {action = 'UI_SelectByCategory AIR GROUNDATTACK',
-        category = 'selection', order = 40,},
-    ['select_bombers'] = {action = 'UI_SelectByCategory AIR BOMBER',
-        category = 'selection', order = 41,},
-    ['select_anti_air_fighters'] = {action = 'UI_Lua import("/lua/keymap/smartselection.lua").smartSelect("AIR HIGHALTAIR ANTIAIR -BOMBER -EXPERIMENTAL")',
-        category = 'selection', order = 42,},
-    ['select_nearest_idle_airscout'] = {action = 'UI_SelectByCategory AIR INTELLIGENCE +nearest +idle',
-        category = 'selection', order = 42,},
-    ['select_all_idle_airscouts'] = {action = 'UI_SelectByCategory AIR INTELLIGENCE +idle',
-        category = 'selection', order = 42,},
-    ['select_all_tml'] = {action = 'UI_SelectByCategory STRUCTURE TACTICALMISSILEPLATFORM',
-        category = 'selection', order = 43,},
-    ['select_all_stationdrones'] = {action = 'UI_SelectByCategory AIR STATIONASSISTPOD',
-        category = 'selection', order = 44,},
-    ['select_all_t2_podstations'] = {action = 'UI_SelectByCategory STRUCTURE PODSTAGINGPLATFORM TECH2',
-        category = 'selection', order = 44,},
-    ['select_all_air_exp'] = {action = 'UI_SelectByCategory AIR EXPERIMENTAL',
-        category = 'selection', order = 45,},
-    ['select_all_antinavy_subs'] = {action = 'UI_SelectByCategory SUBMERSIBLE OVERLAYANTINAVY',
-        category = 'selection', order = 46,},
-    ['select_all_land_exp'] = {action = 'UI_SelectByCategory LAND MOBILE OVERLAYDIRECTFIRE EXPERIMENTAL',
-        category = 'selection', order = 47,},
-    ['select_all_land_indirectfire'] = {action = 'UI_SelectByCategory LAND OVERLAYINDIRECTFIRE',
-        category = 'selection', order = 48,},
-    ['select_all_land_directfire'] = {action = 'UI_SelectByCategory +excludeengineers LAND OVERLAYDIRECTFIRE',
-        category = 'selection', order = 49,},
-    ['select_all_air_factories'] = {action = 'UI_SelectByCategory STRUCTURE FACTORY AIR',
-        category = 'selection', order = 50,},
-    ['select_all_land_factories'] = {action = 'UI_SelectByCategory STRUCTURE FACTORY LAND',
-        category = 'selection', order = 51,},
-    ['select_all_naval_factories'] = {action = 'UI_SelectByCategory STRUCTURE FACTORY NAVAL',
-        category = 'selection', order = 52,},
-    ['select_all_t1_engineers'] = {action = 'UI_SelectByCategory LAND TECH1 ENGINEER',
-        category = 'selection', order = 53,},
-    ['select_all_battleships'] = {action = 'UI_SelectByCategory NAVAL BATTLESHIP',
-        category = 'selection', order = 54,},
-    ['Render_SelectionSet_Names'] = {action = 'ui_RenderSelectionSetNames',
-        category = 'ui', order = 55,},
-    ['Render_Custom_Names'] = {action = 'ui_RenderCustomNames',
-        category = 'ui', order = 56,},
-    ['Render_Unit_Bars'] = {action = 'ui_RenderUnitBars',
-        category = 'ui', order = 57,},
-    ['Render_Icons'] = {action = 'ui_RenderIcons',
-        category = 'ui', order = 58,},
-    ['Always_Render_Strategic_Icons'] = {action = 'ui_AlwaysRenderStrategicIcons',
-        category = 'ui', order = 59,},
-    ['Kill_Selected_Units'] = {action = 'UI_Lua import("/lua/ui/game/confirmunitdestroy.lua").ConfirmUnitDestruction(true)',
-        category = 'orders', order = 60,},
-    ['Kill_All'] = {action = 'UI_Lua import("/lua/ui/game/confirmunitdestroy.lua").ConfirmUnitDestruction(true, true)',
-        category = 'orders', order = 61,},
-    ['Show_Bandwidth_Usage'] = {action = 'ren_ShowBandwidthUsage',
-        category = 'ui', order = 62,},
-    ['Execute_Paste_Buffer'] = {action = 'ExecutePasteBuffer',
-        category = 'ui', order = 63,},
-    ['select_air_no_transport'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").airNoTransports()',
-        category = 'selection', order = 64,},
-    ['select_air_transport'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").airTransports()',
-        category = 'selection', order =65,},
-    ['lock_zoom'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").lockZoom()',
-        category = 'camera', order = 666,},
-    ['zoom_pop'] = {action = "UI_Lua import('/lua/ui/game/zoompopper.lua').ToggleZoomPop()",
-        category = 'camera', order = 29,},
-    ['dock'] = {action = 'UI_Lua import("/lua/ui/game/orders.lua").Dock(true)',
-        category = 'orders', order = 35,},
-    ['shift_dock'] = {action = 'UI_Lua import("/lua/ui/game/orders.lua").Dock(false)',
-        category = 'orders', order = 35,},
-
-    -- HOTBUILD
-    ['builders'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Builders")',
-        category = 'hotbuilding', order = 1101,},
-    ['sensors'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Sensors")',
-        category = 'hotbuilding', order = 1102,},
-    ['shields'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Shields")',
-        category = 'hotbuilding', order = 1103,},
-    ['tmd'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("TMD")',
-        category = 'hotbuilding', order = 1104,},
-    ['xp'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("XP")',
-        category = 'hotbuilding', order = 1105,},
-    ['mobilearty'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Mobilearty")',
-        category = 'hotbuilding', order = 1106,},
-    ['mass'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Mass")',
-        category = 'hotbuilding', order = 1107,},
-    ['massfab'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("MassFab")',
-        category = 'hotbuilding', order = 1108,},
-    ['pgen'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Pgen")',
-        category = 'hotbuilding', order = 1109,},
-    ['templates'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Templates")',
-        category = 'hotbuilding', order = 1110,},
-    ['engystation'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("EngyStation")',
-        category = 'hotbuilding', order = 1111,},
-    ['mml'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("MML")',
-        category = 'hotbuilding', order = 1112,},
-    ['mobileshield'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("MobileShield")',
-        category = 'hotbuilding', order = 1113,},
-    ['fieldengy'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("FieldEngy")',
-        category = 'hotbuilding', order = 1114,},
-    ['defense'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Defense")',
-        category = 'hotbuilding', order = 1115,},
-    ['aa'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("AA")',
-        category = 'hotbuilding', order = 1116,},
-    ['torpedo'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Torpedo")',
-        category = 'hotbuilding', order = 1117,},
-    ['arties'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Arties")',
-        category = 'hotbuilding', order = 1118,},
-    ['tml'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("TML")',
-        category = 'hotbuilding', order = 1119,},
-    ['upgrades'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Upgrades")',
-        category = 'hotbuilding', order = 1120,},
-
-    -- Alternative HOTBUILD
-    ['alt_builders'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Builders")',
-        category = 'hotbuildingAlternative', order = 1101,},
-    ['alt_radars'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Radars")',
-        category = 'hotbuildingAlternative', order = 1102,},
-    ['alt_shields'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Shields")',
-        category = 'hotbuildingAlternative', order = 1103,},
-    ['alt_tmd'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_TMD")',
-        category = 'hotbuildingAlternative', order = 1104,},
-    ['alt_xp'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_XP")',
-        category = 'hotbuildingAlternative', order = 1105,},
-    ['alt_sonars'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Sonars")',
-        category = 'hotbuildingAlternative', order = 1106,},
-    ['alt_mass'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Mass")',
-        category = 'hotbuildingAlternative', order = 1107,},
-    ['alt_stealth'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Stealth")',
-        category = 'hotbuildingAlternative', order = 1108,},
-    ['alt_pgen'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Pgen")',
-        category = 'hotbuildingAlternative', order = 1109,},
-    ['alt_templates'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Templates")',
-        category = 'hotbuildingAlternative', order = 1110,},
-    ['alt_engystation'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_EngyStation")',
-        category = 'hotbuildingAlternative', order = 1111,},
-    ['alt_defense'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Defense")',
-        category = 'hotbuildingAlternative', order = 1115,},
-    ['alt_aa'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_AA")',
-        category = 'hotbuildingAlternative', order = 1116,},
-    ['alt_torpedo'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Torpedo")',
-        category = 'hotbuildingAlternative', order = 1117,},
-    ['alt_arties'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Arties")',
-        category = 'hotbuildingAlternative', order = 1118,},
-    ['alt_tml'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_TML")',
-        category = 'hotbuildingAlternative', order = 1119,},
-
-    -- EXTRA
-    ['land_factory'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Land_Factory")',
-        category = 'hotbuildingExtra', order = 1200,},
-    ['air_factory'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Air_Factory")',
-        category = 'hotbuildingExtra', order = 1201,},
-    ['naval_factory'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Naval_Factory")',
-        category = 'hotbuildingExtra', order = 1202,},
-    ['quantum_gateway'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Quantum_Gateway")',
-        category = 'hotbuildingExtra', order = 1203,},
-    ['power_generator'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Power_Generator")',
-        category = 'hotbuildingExtra', order = 1204,},
-    ['hydrocarbon_power_plant'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Hydrocarbon_Power_Plant")',
-        category = 'hotbuildingExtra', order = 1205,},
-    ['mass_extractor'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Mass_Extractor")',
-        category = 'hotbuildingExtra', order = 1206,},
-    ['mass_fabricator'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Mass_Fabricator")',
-        category = 'hotbuildingExtra', order = 1207,},
-    ['energy_storage'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Energy_Storage")',
-        category = 'hotbuildingExtra', order = 1208,},
-    ['mass_storage'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Mass_Storage")',
-        category = 'hotbuildingExtra', order = 1209,},
-    ['point_defense'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Point_Defense")',
-        category = 'hotbuildingExtra', order = 1210,},
-    ['anti_air'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Anti_Air")',
-        category = 'hotbuildingExtra', order = 1211,},
-    ['tactical_missile_launcher'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Tactical_Missile_Launcher")',
-        category = 'hotbuildingExtra', order = 1212,},
-    ['torpedo_launcher'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Torpedo_Launcher")',
-        category = 'hotbuildingExtra', order = 1213,},
-    ['heavy_artillery_installation'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Heavy_Artillery_Installation")',
-        category = 'hotbuildingExtra', order = 1214,},
-    ['artillery_installation'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Artillery_Installation")',
-        category = 'hotbuildingExtra', order = 1215,},
-    ['strategic_missile_launcher'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Strategic_Missile_Launcher")',
-        category = 'hotbuildingExtra', order = 1216,},
-    ['radar_system'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Radar_System")',
-        category = 'hotbuildingExtra', order = 1217,},
-    ['sonar_system'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Sonar_System")',
-        category = 'hotbuildingExtra', order = 1218,},
-    ['omni_sensor'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Omni_Sensor")',
-        category = 'hotbuildingExtra', order = 1219,},
-    ['tactical_missile_defense'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Tactical_Missile_Defense")',
-        category = 'hotbuildingExtra', order = 1220,},
-    ['shield_generator'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Shield_Generator")',
-        category = 'hotbuildingExtra', order = 1221,},
-    ['stealth_field_generator'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Stealth_Field_Generator")',
-        category = 'hotbuildingExtra', order = 1222,},
-    ['heavy_shield_generator'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Heavy_Shield_Generator")',
-        category = 'hotbuildingExtra', order = 1223,},
-    ['strategic_missile_defense'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Strategic_Missile_Defense")',
-        category = 'hotbuildingExtra', order = 1224,},
-    ['wall_section'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Wall_Section")',
-        category = 'hotbuildingExtra', order = 1225,},
-    ['aeon_quantum_gate_beacon'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Aeon_Quantum_Gate_Beacon")',
-        category = 'hotbuildingExtra', order = 1226,},
-    ['air_staging'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Air_Staging")',
-        category = 'hotbuildingExtra', order = 1227,},
-    ['sonar_platform'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Sonar_Platform")',
-        category = 'hotbuildingExtra', order = 1228,},
-    ['rapid_fire_artillery_installation'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Rapid_Fire_Artillery_Installation")',
-        category = 'hotbuildingExtra', order = 1229,},
-    ['quantum_optics_facility'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Quantum_Optics_Facility")',
-        category = 'hotbuildingExtra', order = 1230,},
-    ['engineering_station'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Engineering_Station")',
-        category = 'hotbuildingExtra', order = 1231,},
-    ['heavy_point_defense'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Heavy_Point_Defense")',
-        category = 'hotbuildingExtra', order = 1232,},
-    ['torpedo_ambushing_system'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Torpedo_Ambushing_System")',
-        category = 'hotbuildingExtra', order = 1233,},
-    ['perimeter_monitoring_system'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Perimeter_Monitoring_System")',
-        category = 'hotbuildingExtra', order = 1234,},
-    ['t2_guided_missile'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Guided_Missile")',
-        category = 'hotbuildingExtra', order = 1235,},
-    ['t3_shield_disruptor'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Shield_Disruptor")',
-        category = 'hotbuildingExtra', order = 1236,},
-    ['t2_fighter/bomber'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Fighter/Bomber")',
-        category = 'hotbuildingExtra', order = 1237,},
-    ['t2_gatling_bot'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Gatling_Bot")',
-        category = 'hotbuildingExtra', order = 1238,},
-    ['t2_rocket_bot'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Rocket_Bot")',
-        category = 'hotbuildingExtra', order = 1239,},
-    ['t1_air_scout'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Air_Scout")',
-        category = 'hotbuildingExtra', order = 1240,},
-    ['t1_interceptor'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Interceptor")',
-        category = 'hotbuildingExtra', order = 1241,},
-    ['t1_attack_bomber'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Attack_Bomber")',
-        category = 'hotbuildingExtra', order = 1242,},
-    ['t2_air_transport'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Air_Transport")',
-        category = 'hotbuildingExtra', order = 1243,},
-    ['t1_light_air_transport'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Light_Air_Transport")',
-        category = 'hotbuildingExtra', order = 1244,},
-    ['t2_gunship'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Gunship")',
-        category = 'hotbuildingExtra', order = 1245,},
-    ['t2_torpedo_bomber'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Torpedo_Bomber")',
-        category = 'hotbuildingExtra', order = 1246,},
-    ['t3_spy_plane'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Spy_Plane")',
-        category = 'hotbuildingExtra', order = 1247,},
-    ['t3_air_superiority_fighter'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Air_Superiority_Fighter")',
-        category = 'hotbuildingExtra', order = 1248,},
-    ['t3_strategic_bomber'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Strategic_Bomber")',
-        category = 'hotbuildingExtra', order = 1249,},
-    ['t1_land_scout'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Land_Scout")',
-        category = 'hotbuildingExtra', order = 1250,},
-    ['t1_mobile_light_artillery'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Mobile_Light_Artillery")',
-        category = 'hotbuildingExtra', order = 1251,},
-    ['t1_mobile_anti_air_gun'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Mobile_Anti_Air_Gun")',
-        category = 'hotbuildingExtra', order = 1252,},
-    ['t1_engineer'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Engineer")',
-        category = 'hotbuildingExtra', order = 1253,},
-    ['t1_light_assault_bot'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Light_Assault_Bot")',
-        category = 'hotbuildingExtra', order = 1254,},
-    ['t2_mobile_missile_launcher'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Mobile_Missile_Launcher")',
-        category = 'hotbuildingExtra', order = 1255,},
-    ['t1_tank'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Tank")',
-        category = 'hotbuildingExtra', order = 1256,},
-    ['t2_heavy_tank'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Heavy_Tank")',
-        category = 'hotbuildingExtra', order = 1257,},
-    ['t2_mobile_aa_flak_artillery'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Mobile_AA_Flak_Artillery")',
-        category = 'hotbuildingExtra', order = 1258,},
-    ['t2_engineer'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Engineer")',
-        category = 'hotbuildingExtra', order = 1259,},
-    ['t3_tank'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Tank")',
-        category = 'hotbuildingExtra', order = 1260,},
-    ['t3_mobile_heavy_artillery'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Mobile_Heavy_Artillery")',
-        category = 'hotbuildingExtra', order = 1261,},
-    ['t2_mobile_shield_generator'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Mobile_Shield_Generator")',
-        category = 'hotbuildingExtra', order = 1262,},
-    ['t3_engineer'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Engineer")',
-        category = 'hotbuildingExtra', order = 1263,},
-    ['t1_attack_boat'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Attack_Boat")',
-        category = 'hotbuildingExtra', order = 1264,},
-    ['t1_frigate'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Frigate")',
-        category = 'hotbuildingExtra', order = 1265,},
-    ['t2_destroyer'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Destroyer")',
-        category = 'hotbuildingExtra', order = 1266,},
-    ['t2_cruiser'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Cruiser")',
-        category = 'hotbuildingExtra', order = 1267,},
-    ['t1_attack_submarine'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Attack_Submarine")',
-        category = 'hotbuildingExtra', order = 1268,},
-    ['t3_battleship'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Battleship")',
-        category = 'hotbuildingExtra', order = 1269,},
-    ['t3_aircraft_carrier'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Aircraft_Carrier")',
-        category = 'hotbuildingExtra', order = 1270,},
-    ['t3_strategic_missile_submarine'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Strategic_Missile_Submarine")',
-        category = 'hotbuildingExtra', order = 1271,},
-    ['t3_heavy_gunship'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Heavy_Gunship")',
-        category = 'hotbuildingExtra', order = 1272,},
-    ['t2_amphibious_tank'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Amphibious_Tank")',
-        category = 'hotbuildingExtra', order = 1273,},
-    ['t1_assault_bot'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Assault_Bot")',
-        category = 'hotbuildingExtra', order = 1274,},
-    ['t3_siege_assault_bot'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Siege_Assault_Bot")',
-        category = 'hotbuildingExtra', order = 1275,},
-    ['t2_mobile_stealth_field_system'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Mobile_Stealth_Field_System")',
-        category = 'hotbuildingExtra', order = 1276,},
-    ['t2_combat_fighter'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Combat_Fighter")',
-        category = 'hotbuildingExtra', order = 1277,},
-    ['t3_aa_gunship'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_AA_Gunship")',
-        category = 'hotbuildingExtra', order = 1278,},
-    ['t3_torpedo_bomber'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Torpedo_Bomber")',
-        category = 'hotbuildingExtra', order = 1279,},
-    ['t2_assault_tank'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Assault_Tank")',
-        category = 'hotbuildingExtra', order = 1280,},
-    ['t3_sniper_bot'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Sniper_Bot")',
-        category = 'hotbuildingExtra', order = 1281,},
-    ['t2_submarine_hunter'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Submarine_Hunter")',
-        category = 'hotbuildingExtra', order = 1282,},
-    ['t3_missile_ship'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Missile_Ship")',
-        category = 'hotbuildingExtra', order = 1283,},
-    ['t3_heavy_air_transport'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Heavy_Air_Transport")',
-        category = 'hotbuildingExtra', order = 1284,},
-    ['t2_field_engineer'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Field_Engineer")',
-        category = 'hotbuildingExtra', order = 1285,},
-    ['t3_armored_assault_bot'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Armored_Assault_Bot")',
-        category = 'hotbuildingExtra', order = 1286,},
-    ['t3_mobile_missile_platform'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Mobile_Missile_Platform")',
-        category = 'hotbuildingExtra', order = 1287,},
-    ['t2_torpedo_boat'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Torpedo_Boat")',
-        category = 'hotbuildingExtra', order = 1288,},
-    ['t2_shield_boat'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Shield_Boat")',
-        category = 'hotbuildingExtra', order = 1289,},
-    ['t3_battlecruiser'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Battlecruiser")',
-        category = 'hotbuildingExtra', order = 1290,},
-    ['t1_light_gunship'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Light_Gunship")',
-        category = 'hotbuildingExtra', order = 1291,},
-    ['t2_mobile_bomb'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Mobile_Bomb")',
-        category = 'hotbuildingExtra', order = 1292,},
-    ['t2_submarine_killer'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Submarine_Killer")',
-        category = 'hotbuildingExtra', order = 1293,},
-    ['t2_counter_intelligence_boat'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Counter_Intelligence_Boat")',
-        category = 'hotbuildingExtra', order = 1294,},
-    ['t1_combat_scout'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Combat_Scout")',
-        category = 'hotbuildingExtra', order = 1295,},
-    ['t2_assault_bot'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Assault_Bot")',
-        category = 'hotbuildingExtra', order = 1296,},
-    ['t2_hover_tank'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Hover_Tank")',
-        category = 'hotbuildingExtra', order = 1297,},
-    ['t2_mobile_anti_air_cannon'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Mobile_Anti_Air_Cannon")',
-        category = 'hotbuildingExtra', order = 1298,},
-    ['t3_siege_tank'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Siege_Tank")',
-        category = 'hotbuildingExtra', order = 1299,},
-    ['t3_mobile_shield_generator'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Mobile_Shield_Generator")',
-        category = 'hotbuildingExtra', order = 1300,},
-    ['t3_submarine_hunter'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Submarine_Hunter")',
-        category = 'hotbuildingExtra', order = 1301,},
-    ['t3_mobile_aa'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Mobile_AA")',
-        category = 'hotbuildingExtra', order = 1302,},
-    ['t2_support_factory'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Support_Factory")',
-        category = 'hotbuildingExtra', order = 1303,},
-    ['t2_support_land_factory'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Support_Land_Factory")',
-        category = 'hotbuildingExtra', order = 1304,},
-    ['t2_support_air_factory'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Support_Air_Factory")',
-        category = 'hotbuildingExtra', order = 1305,},
-    ['t2_support_naval_factory'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Support_Naval_Factory")',
-        category = 'hotbuildingExtra', order = 1306,},
-    ['t3_support_factory'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Support_Factory")',
-        category = 'hotbuildingExtra', order = 1307,},
-    ['t3_support_land_factory'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Support_Land_Factory")',
-        category = 'hotbuildingExtra', order = 1308,},
-    ['t3_support_air_factory'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Support_Air_Factory")',
-        category = 'hotbuildingExtra', order = 1309,},
-    ['t3_support_naval_factory'] = {action= 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Support_Naval_Factory")',
-        category = 'hotbuildingExtra', order = 1310,},
-
-    -- camera hotkeys
-
-    ['cam_free'] = {action = 'Cam_Free',
-        category = 'camera', order = 13,},
-
-    ['RestorePreviousCameraPosition'] = {action = 'UI_Lua import("/lua/usercamera.lua").RestorePreviousCameraPosition()',
-        category = 'camera', order = 0,},
-
-    ['SaveCameraPosition1'] = {action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(1)',
-        category = 'camera', order = 1,},
-    ['SaveCameraPosition2'] = {action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(2)',
-        category = 'camera', order = 2,},
-    ['SaveCameraPosition3'] = {action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(3)',
-        category = 'camera', order = 3,},
-    ['SaveCameraPosition4'] = {action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(4)',
-        category = 'camera', order = 4,},
-    ['SaveCameraPosition5'] = {action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(5)',
-        category = 'camera', order = 5,},
-    ['SaveCameraPosition6'] = {action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(6)',
-        category = 'camera', order = 6,},
-    ['SaveCameraPosition7'] = {action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(7)',
-        category = 'camera', order = 7,},
-    ['SaveCameraPosition8'] = {action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(8)',
-        category = 'camera', order = 8,},
-    ['SaveCameraPosition9'] = {action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(9)',
-        category = 'camera', order = 9,},
-    ['SaveCameraPosition0'] = {action = 'UI_Lua import("/lua/usercamera.lua").SaveCameraPosition(0)',
-        category = 'camera', order = 10,},
-
-    ['RestoreCameraPosition1'] = {action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(1)',
-        category = 'camera', order = 11,},
-    ['RestoreCameraPosition2'] = {action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(2)',
-        category = 'camera', order = 12,},
-    ['RestoreCameraPosition3'] = {action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(3)',
-        category = 'camera', order = 13,},
-    ['RestoreCameraPosition4'] = {action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(4)',
-        category = 'camera', order = 14,},
-    ['RestoreCameraPosition5'] = {action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(5)',
-        category = 'camera', order = 15,},
-    ['RestoreCameraPosition6'] = {action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(6)',
-        category = 'camera', order = 16,},
-    ['RestoreCameraPosition7'] = {action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(7)',
-        category = 'camera', order = 17,},
-    ['RestoreCameraPosition8'] = {action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(8)',
-        category = 'camera', order = 18,},
-    ['RestoreCameraPosition9'] = {action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(9)',
-        category = 'camera', order = 19,},
-    ['RestoreCameraPosition0'] = {action = 'UI_Lua import("/lua/usercamera.lua").RestoreCameraPosition(0)',
-        category = 'camera', order = 20,},
-
-
-    ['next_cam_position'] = {action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").RecallCameraPos()',
-        category = 'camera', order = 1,},
-    ['add_cam_position'] = {action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").SaveCameraPos()',
-        category = 'camera', order = 2,},
-    ['rem_cam_position'] = {action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").RemoveCamPos()',
-        category = 'camera', order = 3,},
-    ['zoom_in'] = {action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ZoomIn(.02)',
-        category = 'camera', order = 4, keyRepeat = true,},
-    ['zoom_out'] = {action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ZoomOut(.02)',
-        category = 'camera', order = 5, keyRepeat = true,},
-    ['zoom_in_fast'] = {action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ZoomIn(.08)',
-        category = 'camera', order = 6,},
-    ['zoom_out_fast'] = {action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ZoomOut(.08)',
-        category = 'camera', order = 7,},
-    ['track_unit'] = {action = 'UI_TrackUnit WorldCamera',
-        category = 'camera', order = 8,},
-    ['track_unit_minimap'] = {action = 'UI_TrackUnit MiniMap',
-        category = 'camera', order = 9,},
-    ['track_unit_second_mon'] = {action = 'UI_TrackUnit CameraHead2',
-        category = 'camera', order = 10,},
-    ['reset_camera'] = {action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ToggleWideView()',
-        category = 'camera', order = 11,},
-
-    ['test_2'] = {action = 'UI_Lua import("/lua/usercamera.lua").Test2()',
-        category = 'camera', order = 11,},
-
-    ['store_camera_settings'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").StoreCameraPosition()',
-    category = 'debug', order = 11,},
-
-    ['restore_camera_settings'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").RestoreCameraPosition()',
-    category = 'debug', order = 11,},
-
-    ['toggle_navui'] = {action = 'UI_Lua import("/lua/ui/game/navgenerator.lua").OpenWindow()',
-        category = 'ai', order = 24},
-    ['toggle_ai_reclaim_grid_ui'] = {action = 'UI_Lua import("/lua/ui/game/gridreclaim.lua").OpenWindow()',
-        category = 'ai', order = 24},
-    ['toggle_ai_presence_grid_ui'] = {action = 'UI_Lua import("/lua/ui/game/gridpresence.lua").OpenWindow()',
-        category = 'ai', order = 24},
-    ['toggle_ai_recon_grid_ui'] = {action = 'UI_Lua import("/lua/ui/game/gridrecon.lua").OpenWindow()',
-        category = 'ai', order = 24},
-    ['toggle_ai_economy_ui'] = {action = 'UI_Lua import("/lua/ui/game/AIBrainEconomyData.lua").OpenWindow()',
-        category = 'ai', order = 24},
-
-    ['toggle_platoon_behavior_silo'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").AssignPlatoonBehaviorSilo()',
-        category = 'ai', order = 24},
-    ['toggle_platoon_simple_raid'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").AIPlatoonSimpleRaidBehavior()',
-        category = 'ai', order = 24},
-
-    ['toggle_platoon_simple_structure'] = {action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").AIPlatoonSimpleStructureBehavior()',
-        category = 'ai', order = 24},
-    
+    ['test_2'] = {
+        action = 'UI_Lua import("/lua/usercamera.lua").Test2()',
+        category = 'camera',
+    },
 }
+
+local keyActionsSelection = {
+    ['cycle_idle_factories'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").CycleIdleFactories()',
+        category = 'selection',
+    },
+    ['cycle_unit_types_in_sel'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").CycleUnitTypesInSel()',
+        category = 'selection',
+    },
+    ['create_template_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").CreateTemplateFactory()',
+        category = 'selection',
+    },
+}
+
+local keyActionsSelectionQuickSelect = {
+    ['select_upgrading_extractors'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").SelectAllUpgradingExtractors()',
+        category = 'selection',
+    },
+    ['select_air'] = {
+        action = 'UI_SelectByCategory +excludeengineers AIR MOBILE',
+        category = 'selection',
+    },
+    ['select_naval'] = {
+        action = 'UI_SelectByCategory +excludeengineers NAVAL MOBILE',
+        category = 'selection',
+    },
+    ['select_naval_no_mobile_sonar'] = {
+        action = 'UI_Lua import("/lua/keymap/smartselection.lua").smartSelect("NAVAL MOBILE -MOBILESONAR")',
+        category = 'selection',
+    },
+    ['select_land'] = {
+        action = 'UI_SelectByCategory +excludeengineers LAND MOBILE',
+        category = 'selection',
+    },
+    ['select_all_units_of_same_type'] = {
+        action = 'UI_ExpandCurrentSelection',
+        category = 'selection',
+    },
+    ['select_engineers'] = {
+        action = 'UI_SelectByCategory ENGINEER',
+        category = 'selection',
+    },
+    ['goto_engineer'] = {
+        action = 'UI_SelectByCategory +nearest +idle +goto ENGINEER',
+        category = 'selection',
+    },
+    ['select_idle_engineer'] = {
+        action = 'UI_SelectByCategory +nearest +idle ENGINEER',
+        category = 'selection',
+    },
+    ['cycle_engineers'] = {
+        action = 'UI_Lua import("/lua/ui/game/avatars.lua").GetEngineerGeneric()',
+        category = 'selection',
+    },
+    ['goto_commander'] = {
+        action = 'UI_SelectByCategory +nearest +goto COMMAND',
+        category = 'selection',
+    },
+    ['select_commander'] = {
+        action = 'UI_SelectByCategory +nearest COMMAND',
+        category = 'selection',
+    },
+    ['select_all'] = {
+        action = 'UI_SelectByCategory ALLUNITS',
+        category = 'selection',
+    },
+    ['select_all_onscreen'] = {
+        action = 'UI_SelectByCategory +inview ALLUNITS',
+        category = 'selection',
+    },
+    ['select_all_eng_onscreen'] = {
+        action = 'UI_SelectByCategory +inview ENGINEER',
+        category = 'selection',
+    },
+    ['select_all_factory_onscreen'] = {
+        action = 'UI_SelectByCategory +inview FACTORY',
+        category = 'selection',
+    },
+    ['select_nearest_factory'] = {
+        action = 'UI_SelectByCategory +nearest FACTORY',
+        category = 'selection',
+    },
+    ['select_nearest_land_factory'] = {
+        action = 'UI_SelectByCategory +nearest LAND FACTORY',
+        category = 'selection',
+    },
+    ['select_nearest_air_factory'] = {
+        action = 'UI_SelectByCategory +nearest AIR FACTORY',
+        category = 'selection',
+    },
+    ['select_nearest_naval_factory'] = {
+        action = 'UI_SelectByCategory +nearest NAVAL FACTORY',
+        category = 'selection',
+    },
+    ['select_all_radars'] = {
+        action = 'UI_SelectByCategory INTELLIGENCE STRUCTURE RADAR, INTELLIGENCE STRUCTURE OMNI',
+        category = 'selection',
+    },
+    ['select_all_idle_eng_onscreen'] = {
+        action = 'UI_SelectByCategory +inview +idle ENGINEER',
+        category = 'selection',
+    },
+    ['select_all_land_units_onscreen'] = {
+        action = 'UI_SelectByCategory +inview +excludeengineers MOBILE LAND',
+        category = 'selection',
+    },
+    ['select_all_air_units_onscreen'] = {
+        action = 'UI_SelectByCategory +inview MOBILE AIR',
+        category = 'selection',
+    },
+    ['select_all_naval_units_onscreen'] = {
+        action = 'UI_SelectByCategory +inview MOBILE NAVAL',
+        category = 'selection',
+    },
+    ['select_all_similar_units'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").GetSimilarUnits()',
+        category = 'selection',
+    },
+    ['select_next_land_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").GetNextLandFactory()',
+        category = 'selection',
+    },
+    ['select_next_air_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").GetNextAirFactory()',
+        category = 'selection',
+    },
+    ['select_next_naval_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").GetNextNavalFactory()',
+        category = 'selection',
+    },
+    ['toggle_mdf_panel'] = {
+        action = 'UI_Lua import("/lua/ui/game/multifunction.lua").ToggleMFDPanel()',
+        category = 'ui',
+    },
+    ['toggle_tab_display'] = {
+        action = 'UI_Lua import("/lua/ui/game/tabs.lua").ToggleTabDisplay()',
+        category = 'ui',
+    },
+    ['select_inview_idle_mex'] = {
+        action = 'UI_SelectByCategory +inview +idle MASSEXTRACTION',
+        category = 'selection',
+    },
+    ['select_all_mex'] = {
+        action = 'UI_SelectByCategory MASSEXTRACTION',
+        category = 'selection',
+    },
+    ['select_nearest_idle_lt_mex'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").GetNearestIdleLTMex()',
+        category = 'selection',
+    },
+    ['acu_select_cg'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").ACUSelectCG()',
+        category = 'selection',
+    },
+    ['acu_append_cg'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").ACUAppendCG()',
+        category = 'selection',
+    },
+    ['select_nearest_idle_eng_not_acu'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").GetNearestIdleEngineerNotACU()',
+        category = 'selection',
+    },
+    ['add_nearest_idle_engineers_seq'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").AddNearestIdleEngineersSeq()',
+        category = 'selection',
+    },
+    ['select_gunships'] = {
+        action = 'UI_SelectByCategory AIR GROUNDATTACK',
+        category = 'selection',
+    },
+    ['select_bombers'] = {
+        action = 'UI_SelectByCategory AIR BOMBER',
+        category = 'selection',
+    },
+    ['select_anti_air_fighters'] = {
+        action = 'UI_Lua import("/lua/keymap/smartselection.lua").smartSelect("AIR HIGHALTAIR ANTIAIR -BOMBER -EXPERIMENTAL")',
+        category = 'selection',
+    },
+    ['select_nearest_idle_airscout'] = {
+        action = 'UI_SelectByCategory AIR INTELLIGENCE +nearest +idle',
+        category = 'selection',
+    },
+    ['select_all_idle_airscouts'] = {
+        action = 'UI_SelectByCategory AIR INTELLIGENCE +idle',
+        category = 'selection',
+    },
+    ['select_all_tml'] = {
+        action = 'UI_SelectByCategory STRUCTURE TACTICALMISSILEPLATFORM',
+        category = 'selection',
+    },
+    ['select_all_stationdrones'] = {
+        action = 'UI_SelectByCategory AIR STATIONASSISTPOD',
+        category = 'selection',
+    },
+    ['select_all_t2_podstations'] = {
+        action = 'UI_SelectByCategory STRUCTURE PODSTAGINGPLATFORM TECH2',
+        category = 'selection',
+    },
+    ['select_all_air_exp'] = {
+        action = 'UI_SelectByCategory AIR EXPERIMENTAL',
+        category = 'selection',
+    },
+    ['select_all_antinavy_subs'] = {
+        action = 'UI_SelectByCategory SUBMERSIBLE OVERLAYANTINAVY',
+        category = 'selection',
+    },
+    ['select_all_land_exp'] = {
+        action = 'UI_SelectByCategory LAND MOBILE OVERLAYDIRECTFIRE EXPERIMENTAL',
+        category = 'selection',
+    },
+    ['select_all_land_indirectfire'] = {
+        action = 'UI_SelectByCategory LAND OVERLAYINDIRECTFIRE',
+        category = 'selection',
+    },
+    ['select_all_land_directfire'] = {
+        action = 'UI_SelectByCategory +excludeengineers LAND OVERLAYDIRECTFIRE',
+        category = 'selection',
+    },
+    ['select_all_air_factories'] = {
+        action = 'UI_SelectByCategory STRUCTURE FACTORY AIR',
+        category = 'selection',
+    },
+    ['select_all_land_factories'] = {
+        action = 'UI_SelectByCategory STRUCTURE FACTORY LAND',
+        category = 'selection',
+    },
+    ['select_all_naval_factories'] = {
+        action = 'UI_SelectByCategory STRUCTURE FACTORY NAVAL',
+        category = 'selection',
+    },
+    ['select_all_t1_engineers'] = {
+        action = 'UI_SelectByCategory LAND TECH1 ENGINEER',
+        category = 'selection',
+    },
+    ['select_all_battleships'] = {
+        action = 'UI_SelectByCategory NAVAL BATTLESHIP',
+        category = 'selection',
+    },
+}
+
+local keyActionsSelectionSubgroups = {
+    ['split_next'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitNext()',
+        category = 'selectionSubgroups',
+    },
+    ['split_major_axis'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitMajorAxis()',
+        category = 'selectionSubgroups',
+    },
+    ['split_minor_axis'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitMinorAxis()',
+        category = 'selectionSubgroups',
+    },
+    ['split_mouse_axis'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitMouseAxis()',
+        category = 'selectionSubgroups',
+    },
+    ['split_mouse_axis_orthogonal'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitMouseOrthogonalAxis()',
+        category = 'selectionSubgroups',
+    },
+    ['split_engineer_tech'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitEngineerTech()',
+        category = 'selectionSubgroups',
+    },
+    ['split_tech'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitTech()',
+        category = 'selectionSubgroups',
+    },
+    ['split_layer'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitLayer()',
+        category = 'selectionSubgroups',
+    },
+    ['split_into_groups_1'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitIntoGroups(1)',
+        category = 'selectionSubgroups',
+    },
+    ['split_into_groups_2'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitIntoGroups(2)',
+        category = 'selectionSubgroups',
+    },
+    ['split_into_groups_4'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitIntoGroups(4)',
+        category = 'selectionSubgroups',
+    },
+    ['split_into_groups_8'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitIntoGroups(8)',
+        category = 'selectionSubgroups',
+    },
+    ['split_into_groups_16'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").SplitIntoGroups(16)',
+        category = 'selectionSubgroups',
+    },
+}
+
+local keyActionsSelectionControupGroups = {
+    ['revert_selection_set'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").RevertSelectionSet()',
+        category = 'selectionControlGroups',
+    },
+    ['group1'] = {
+        action = 'UI_ApplySelectionSet 1',
+        category = 'selectionControlGroups',
+    },
+    ['group2'] = {
+        action = 'UI_ApplySelectionSet 2',
+        category = 'selectionControlGroups',
+    },
+    ['group3'] = {
+        action = 'UI_ApplySelectionSet 3',
+        category = 'selectionControlGroups',
+    },
+    ['group4'] = {
+        action = 'UI_ApplySelectionSet 4',
+        category = 'selectionControlGroups',
+    },
+    ['group5'] = {
+        action = 'UI_ApplySelectionSet 5',
+        category = 'selectionControlGroups',
+    },
+    ['group6'] = {
+        action = 'UI_ApplySelectionSet 6',
+        category = 'selectionControlGroups',
+    },
+    ['group7'] = {
+        action = 'UI_ApplySelectionSet 7',
+        category = 'selectionControlGroups',
+    },
+    ['group8'] = {
+        action = 'UI_ApplySelectionSet 8',
+        category = 'selectionControlGroups',
+    },
+    ['group9'] = {
+        action = 'UI_ApplySelectionSet 9',
+        category = 'selectionControlGroups',
+    },
+    ['group0'] = {
+        action = 'UI_ApplySelectionSet 0',
+
+        category = 'selectionControlGroups',
+    },
+    ['set_group1'] = {
+        action = 'UI_MakeSelectionSet 1',
+        category = 'selectionControlGroups',
+    },
+    ['set_group2'] = {
+        action = 'UI_MakeSelectionSet 2',
+        category = 'selectionControlGroups',
+    },
+    ['set_group3'] = {
+        action = 'UI_MakeSelectionSet 3',
+        category = 'selectionControlGroups',
+    },
+    ['set_group4'] = {
+        action = 'UI_MakeSelectionSet 4',
+        category = 'selectionControlGroups',
+    },
+    ['set_group5'] = {
+        action = 'UI_MakeSelectionSet 5',
+        category = 'selectionControlGroups',
+    },
+    ['set_group6'] = {
+        action = 'UI_MakeSelectionSet 6',
+        category = 'selectionControlGroups',
+    },
+    ['set_group7'] = {
+        action = 'UI_MakeSelectionSet 7',
+        category = 'selectionControlGroups',
+    },
+    ['set_group8'] = {
+        action = 'UI_MakeSelectionSet 8',
+        category = 'selectionControlGroups',
+    },
+    ['set_group9'] = {
+        action = 'UI_MakeSelectionSet 9',
+        category = 'selectionControlGroups',
+    },
+    ['set_group0'] = {
+        action = 'UI_MakeSelectionSet 0',
+        category = 'selectionControlGroups',
+    },
+
+    ['append_group1'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(1)',
+        category = 'selectionControlGroups'
+    },
+    ['append_group2'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(2)',
+        category = 'selectionControlGroups'
+    },
+    ['append_group3'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(3)',
+        category = 'selectionControlGroups'
+    },
+    ['append_group4'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(4)',
+        category = 'selectionControlGroups'
+    },
+    ['append_group5'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(5)',
+        category = 'selectionControlGroups'
+    },
+    ['append_group6'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(6)',
+        category = 'selectionControlGroups'
+    },
+    ['append_group7'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(7)',
+        category = 'selectionControlGroups'
+    },
+    ['append_group8'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(8)',
+        category = 'selectionControlGroups'
+    },
+    ['append_group9'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(9)',
+        category = 'selectionControlGroups'
+    },
+    ['append_group0'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSetToSelection(0)',
+        category = 'selectionControlGroups'
+    },
+
+    ['add_selection_to_selection_set1'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(1)',
+        category = 'selectionControlGroups'
+    },
+    ['add_selection_to_selection_set2'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(2)',
+        category = 'selectionControlGroups'
+    },
+    ['add_selection_to_selection_set3'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(3)',
+        category = 'selectionControlGroups'
+    },
+    ['add_selection_to_selection_set4'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(4)',
+        category = 'selectionControlGroups'
+    },
+    ['add_selection_to_selection_set5'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(5)',
+        category = 'selectionControlGroups'
+    },
+    ['add_selection_to_selection_set6'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(6)',
+        category = 'selectionControlGroups'
+    },
+    ['add_selection_to_selection_set7'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(7)',
+        category = 'selectionControlGroups'
+    },
+    ['add_selection_to_selection_set8'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(8)',
+        category = 'selectionControlGroups'
+    },
+    ['add_selection_to_selection_set9'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(9)',
+        category = 'selectionControlGroups'
+    },
+    ['add_selection_to_selection_set0'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").AppendSelectionToSet(0)',
+        category = 'selectionControlGroups'
+    },
+
+    ['combine_and_select_with_selection_set1'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(1)',
+        category = 'selectionControlGroups'
+    },
+    ['combine_and_select_with_selection_set2'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(2)',
+        category = 'selectionControlGroups'
+    },
+    ['combine_and_select_with_selection_set3'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(3)',
+        category = 'selectionControlGroups'
+    },
+    ['combine_and_select_with_selection_set4'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(4)',
+        category = 'selectionControlGroups'
+    },
+    ['combine_and_select_with_selection_set5'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(5)',
+        category = 'selectionControlGroups'
+    },
+    ['combine_and_select_with_selection_set6'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(6)',
+        category = 'selectionControlGroups'
+    },
+    ['combine_and_select_with_selection_set7'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(7)',
+        category = 'selectionControlGroups'
+    },
+    ['combine_and_select_with_selection_set8'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(8)',
+        category = 'selectionControlGroups'
+    },
+    ['combine_and_select_with_selection_set9'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(9)',
+        category = 'selectionControlGroups'
+    },
+    ['combine_and_select_with_selection_set0'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").CombineSelectionAndSet(0)',
+        category = 'selectionControlGroups'
+    },
+
+    ['fac_group1'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(1)',
+        category = 'selectionControlGroups',
+    },
+    ['fac_group2'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(2)',
+        category = 'selectionControlGroups',
+    },
+    ['fac_group3'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(3)',
+        category = 'selectionControlGroups',
+    },
+    ['fac_group4'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(4)',
+        category = 'selectionControlGroups',
+    },
+    ['fac_group5'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(5)',
+        category = 'selectionControlGroups',
+    },
+    ['fac_group6'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(6)',
+        category = 'selectionControlGroups',
+    },
+    ['fac_group7'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(7)',
+        category = 'selectionControlGroups',
+    },
+    ['fac_group8'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(8)',
+        category = 'selectionControlGroups',
+    },
+    ['fac_group9'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(9)',
+        category = 'selectionControlGroups',
+    },
+    ['fac_group0'] = {
+        action = 'UI_Lua import("/lua/ui/game/selection.lua").FactorySelection(0)',
+        category = 'selectionControlGroups',
+    },
+}
+
+local keyActionsHotBuild = {
+    ['builders'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Builders")',
+        category = 'hotbuilding',
+    },
+    ['sensors'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Sensors")',
+        category = 'hotbuilding',
+    },
+    ['shields'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Shields")',
+        category = 'hotbuilding',
+    },
+    ['tmd'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("TMD")',
+        category = 'hotbuilding',
+    },
+    ['xp'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("XP")',
+        category = 'hotbuilding',
+    },
+    ['mobilearty'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Mobilearty")',
+        category = 'hotbuilding',
+    },
+    ['mass'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Mass")',
+        category = 'hotbuilding',
+    },
+    ['massfab'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("MassFab")',
+        category = 'hotbuilding',
+    },
+    ['pgen'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Pgen")',
+        category = 'hotbuilding',
+    },
+    ['templates'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Templates")',
+        category = 'hotbuilding',
+    },
+    ['engystation'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("EngyStation")',
+        category = 'hotbuilding',
+    },
+    ['mml'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("MML")',
+        category = 'hotbuilding',
+    },
+    ['mobileshield'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("MobileShield")',
+        category = 'hotbuilding',
+    },
+    ['fieldengy'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("FieldEngy")',
+        category = 'hotbuilding',
+    },
+    ['defense'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Defense")',
+        category = 'hotbuilding',
+    },
+    ['aa'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("AA")',
+        category = 'hotbuilding',
+    },
+    ['torpedo'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Torpedo")',
+        category = 'hotbuilding',
+    },
+    ['arties'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Arties")',
+        category = 'hotbuilding',
+    },
+    ['tml'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("TML")',
+        category = 'hotbuilding',
+    },
+    ['upgrades'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Upgrades")',
+        category = 'hotbuilding',
+    },
+}
+
+local keyActionsHotBuildAlternative = {
+    ['alt_builders'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Builders")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_radars'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Radars")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_shields'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Shields")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_tmd'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_TMD")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_xp'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_XP")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_sonars'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Sonars")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_mass'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Mass")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_stealth'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Stealth")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_pgen'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Pgen")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_templates'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Templates")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_engystation'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_EngyStation")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_defense'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Defense")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_aa'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_AA")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_torpedo'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Torpedo")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_arties'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_Arties")',
+        category = 'hotbuildingAlternative',
+    },
+    ['alt_tml'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Alt_TML")',
+        category = 'hotbuildingAlternative',
+    },
+}
+
+local keyActionsHotBuildExtra = {
+    ['land_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Land_Factory")',
+        category = 'hotbuildingExtra',
+    },
+    ['air_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Air_Factory")',
+        category = 'hotbuildingExtra',
+    },
+    ['naval_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Naval_Factory")',
+        category = 'hotbuildingExtra',
+    },
+    ['quantum_gateway'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Quantum_Gateway")',
+        category = 'hotbuildingExtra',
+    },
+    ['power_generator'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Power_Generator")',
+        category = 'hotbuildingExtra',
+    },
+    ['hydrocarbon_power_plant'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Hydrocarbon_Power_Plant")',
+        category = 'hotbuildingExtra',
+    },
+    ['mass_extractor'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Mass_Extractor")',
+        category = 'hotbuildingExtra',
+    },
+    ['mass_fabricator'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Mass_Fabricator")',
+        category = 'hotbuildingExtra',
+    },
+    ['energy_storage'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Energy_Storage")',
+        category = 'hotbuildingExtra',
+    },
+    ['mass_storage'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Mass_Storage")',
+        category = 'hotbuildingExtra',
+    },
+    ['point_defense'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Point_Defense")',
+        category = 'hotbuildingExtra',
+    },
+    ['anti_air'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Anti_Air")',
+        category = 'hotbuildingExtra',
+    },
+    ['tactical_missile_launcher'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Tactical_Missile_Launcher")',
+        category = 'hotbuildingExtra',
+    },
+    ['torpedo_launcher'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Torpedo_Launcher")',
+        category = 'hotbuildingExtra',
+    },
+    ['heavy_artillery_installation'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Heavy_Artillery_Installation")',
+        category = 'hotbuildingExtra',
+    },
+    ['artillery_installation'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Artillery_Installation")',
+        category = 'hotbuildingExtra',
+    },
+    ['strategic_missile_launcher'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Strategic_Missile_Launcher")',
+        category = 'hotbuildingExtra',
+    },
+    ['radar_system'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Radar_System")',
+        category = 'hotbuildingExtra',
+    },
+    ['sonar_system'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Sonar_System")',
+        category = 'hotbuildingExtra',
+    },
+    ['omni_sensor'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Omni_Sensor")',
+        category = 'hotbuildingExtra',
+    },
+    ['tactical_missile_defense'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Tactical_Missile_Defense")',
+        category = 'hotbuildingExtra',
+    },
+    ['shield_generator'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Shield_Generator")',
+        category = 'hotbuildingExtra',
+    },
+    ['stealth_field_generator'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Stealth_Field_Generator")',
+        category = 'hotbuildingExtra',
+    },
+    ['heavy_shield_generator'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Heavy_Shield_Generator")',
+        category = 'hotbuildingExtra',
+    },
+    ['strategic_missile_defense'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Strategic_Missile_Defense")',
+        category = 'hotbuildingExtra',
+    },
+    ['wall_section'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Wall_Section")',
+        category = 'hotbuildingExtra',
+    },
+    ['aeon_quantum_gate_beacon'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Aeon_Quantum_Gate_Beacon")',
+        category = 'hotbuildingExtra',
+    },
+    ['air_staging'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Air_Staging")',
+        category = 'hotbuildingExtra',
+    },
+    ['sonar_platform'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Sonar_Platform")',
+        category = 'hotbuildingExtra',
+    },
+    ['rapid_fire_artillery_installation'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Rapid_Fire_Artillery_Installation")',
+        category = 'hotbuildingExtra',
+    },
+    ['quantum_optics_facility'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Quantum_Optics_Facility")',
+        category = 'hotbuildingExtra',
+    },
+    ['engineering_station'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Engineering_Station")',
+        category = 'hotbuildingExtra',
+    },
+    ['heavy_point_defense'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Heavy_Point_Defense")',
+        category = 'hotbuildingExtra',
+    },
+    ['torpedo_ambushing_system'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Torpedo_Ambushing_System")',
+        category = 'hotbuildingExtra',
+    },
+    ['perimeter_monitoring_system'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("Perimeter_Monitoring_System")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_guided_missile'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Guided_Missile")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_shield_disruptor'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Shield_Disruptor")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_fighter/bomber'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Fighter/Bomber")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_gatling_bot'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Gatling_Bot")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_rocket_bot'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Rocket_Bot")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_air_scout'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Air_Scout")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_interceptor'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Interceptor")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_attack_bomber'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Attack_Bomber")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_air_transport'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Air_Transport")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_light_air_transport'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Light_Air_Transport")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_gunship'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Gunship")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_torpedo_bomber'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Torpedo_Bomber")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_spy_plane'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Spy_Plane")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_air_superiority_fighter'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Air_Superiority_Fighter")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_strategic_bomber'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Strategic_Bomber")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_land_scout'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Land_Scout")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_mobile_light_artillery'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Mobile_Light_Artillery")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_mobile_anti_air_gun'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Mobile_Anti_Air_Gun")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_engineer'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Engineer")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_light_assault_bot'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Light_Assault_Bot")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_mobile_missile_launcher'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Mobile_Missile_Launcher")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_tank'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Tank")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_heavy_tank'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Heavy_Tank")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_mobile_aa_flak_artillery'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Mobile_AA_Flak_Artillery")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_engineer'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Engineer")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_tank'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Tank")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_mobile_heavy_artillery'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Mobile_Heavy_Artillery")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_mobile_shield_generator'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Mobile_Shield_Generator")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_engineer'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Engineer")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_attack_boat'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Attack_Boat")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_frigate'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Frigate")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_destroyer'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Destroyer")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_cruiser'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Cruiser")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_attack_submarine'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Attack_Submarine")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_battleship'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Battleship")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_aircraft_carrier'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Aircraft_Carrier")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_strategic_missile_submarine'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Strategic_Missile_Submarine")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_heavy_gunship'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Heavy_Gunship")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_amphibious_tank'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Amphibious_Tank")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_assault_bot'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Assault_Bot")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_siege_assault_bot'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Siege_Assault_Bot")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_mobile_stealth_field_system'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Mobile_Stealth_Field_System")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_combat_fighter'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Combat_Fighter")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_aa_gunship'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_AA_Gunship")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_torpedo_bomber'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Torpedo_Bomber")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_assault_tank'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Assault_Tank")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_sniper_bot'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Sniper_Bot")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_submarine_hunter'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Submarine_Hunter")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_missile_ship'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Missile_Ship")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_heavy_air_transport'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Heavy_Air_Transport")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_field_engineer'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Field_Engineer")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_armored_assault_bot'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Armored_Assault_Bot")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_mobile_missile_platform'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Mobile_Missile_Platform")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_torpedo_boat'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Torpedo_Boat")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_shield_boat'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Shield_Boat")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_battlecruiser'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Battlecruiser")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_light_gunship'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Light_Gunship")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_mobile_bomb'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Mobile_Bomb")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_submarine_killer'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Submarine_Killer")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_counter_intelligence_boat'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Counter_Intelligence_Boat")',
+        category = 'hotbuildingExtra',
+    },
+    ['t1_combat_scout'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T1_Combat_Scout")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_assault_bot'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Assault_Bot")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_hover_tank'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Hover_Tank")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_mobile_anti_air_cannon'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Mobile_Anti_Air_Cannon")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_siege_tank'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Siege_Tank")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_mobile_shield_generator'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Mobile_Shield_Generator")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_submarine_hunter'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Submarine_Hunter")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_mobile_aa'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Mobile_AA")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_support_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Support_Factory")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_support_land_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Support_Land_Factory")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_support_air_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Support_Air_Factory")',
+        category = 'hotbuildingExtra',
+    },
+    ['t2_support_naval_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T2_Support_Naval_Factory")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_support_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Support_Factory")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_support_land_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Support_Land_Factory")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_support_air_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Support_Air_Factory")',
+        category = 'hotbuildingExtra',
+    },
+    ['t3_support_naval_factory'] = {
+        action = 'UI_Lua import("/lua/keymap/hotbuild.lua").buildAction("T3_Support_Naval_Factory")',
+        category = 'hotbuildingExtra',
+    },
+}
+
+local keyActionsOrders = {
+
+    ['repair'] = {
+        action = 'StartCommandMode order RULEUCC_Repair',
+        category = 'orders',
+    },
+    ['reclaim'] = {
+        action = 'StartCommandMode order RULEUCC_Reclaim',
+        category = 'orders',
+    },
+    ['patrol'] = {
+        action = 'StartCommandMode order RULEUCC_Patrol',
+        category = 'orders',
+    },
+    ['attack'] = {
+        action = 'StartCommandMode order RULEUCC_Attack',
+        category = 'orders',
+    },
+    ['capture'] = {
+        action = 'StartCommandMode order RULEUCC_Capture',
+        category = 'orders',
+    },
+    ['stop'] = {
+        action = 'UI_Lua import("/lua/ui/game/orders.lua").Stop()',
+        category = 'orders',
+    },
+    ['soft_stop'] = {
+        action = 'UI_Lua import("/lua/ui/game/orders.lua").SoftStop()',
+        category = 'orders',
+    },
+    ['dive'] = {
+        action = 'UI_Lua import("/lua/ui/game/orders.lua").ToggleDiveOrder()',
+        category = 'orders',
+    },
+    ['ferry'] = {
+        action = 'StartCommandMode order RULEUCC_Ferry',
+        category = 'orders',
+    },
+    ['guard'] = {
+        action = 'StartCommandMode order RULEUCC_Guard',
+        category = 'orders',
+    },
+    ['transport'] = {
+        action = 'StartCommandMode order RULEUCC_Transport',
+        category = 'orders',
+    },
+    ['launch_tactical'] = {
+        action = 'StartCommandMode order RULEUCC_Tactical',
+        category = 'orders',
+    },
+    ['overcharge'] = {
+        action = 'UI_Lua import("/lua/ui/game/orders.lua").EnterOverchargeMode()',
+        category = 'orders',
+    },
+    ['move'] = {
+        action = 'StartCommandMode order RULEUCC_Move',
+        category = 'orders',
+    },
+    ['move_hard'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").ToggleHardMove()',
+        category = 'orders',
+    },
+    ['nuke'] = {
+        action = 'StartCommandMode order RULEUCC_Nuke',
+        category = 'orders',
+    },
+    ['shift_repair'] = {
+        action = 'StartCommandMode order RULEUCC_Repair',
+        category = 'orders',
+    },
+    ['shift_reclaim'] = {
+        action = 'StartCommandMode order RULEUCC_Reclaim',
+        category = 'orders',
+    },
+    ['shift_patrol'] = {
+        action = 'StartCommandMode order RULEUCC_Patrol',
+        category = 'orders',
+    },
+    ['shift_attack'] = {
+        action = 'StartCommandMode order RULEUCC_Attack',
+        category = 'orders',
+    },
+    ['shift_capture'] = {
+        action = 'StartCommandMode order RULEUCC_Capture',
+        category = 'orders',
+    },
+    ['shift_stop'] = {
+        action = 'IssueCommand Stop',
+        category = 'orders',
+    },
+    ['shift_dive'] = {
+        action = 'UI_Lua import("/lua/ui/game/orders.lua").ToggleDiveOrder()',
+        category = 'orders',
+    },
+    ['shift_ferry'] = {
+        action = 'StartCommandMode order RULEUCC_Ferry',
+        category = 'orders',
+    },
+    ['shift_guard'] = {
+        action = 'StartCommandMode order RULEUCC_Guard',
+        category = 'orders',
+    },
+    ['shift_transport'] = {
+        action = 'StartCommandMode order RULEUCC_Transport',
+        category = 'orders',
+    },
+    ['shift_launch_tactical'] = {
+        action = 'StartCommandMode order RULEUCC_Tactical',
+        category = 'orders',
+    },
+    ['shift_overcharge'] = {
+        action = 'UI_Lua import("/lua/ui/game/orders.lua").EnterOverchargeMode()',
+        category = 'orders',
+    },
+    ['shift_move'] = {
+        action = 'StartCommandMode order RULEUCC_Move',
+        category = 'orders',
+    },
+    ['shift_nuke'] = {
+        action = 'StartCommandMode order RULEUCC_Nuke',
+        category = 'orders',
+    },
+    ['toggle_build_mode'] = {
+        action = 'UI_Lua import("/lua/ui/game/buildmode.lua").ToggleBuildMode()',
+        category = 'orders',
+    },
+    ['pause_unit'] = {
+        action = 'UI_Lua import("/lua/ui/game/construction.lua").ToggleUnitPause()',
+        category = 'orders',
+    },
+    ['mode'] = {
+        action = 'UI_Lua import("/lua/ui/game/orders.lua").CycleRetaliateStateUp()',
+        category = 'orders',
+    },
+    ['suicide'] = {
+        action = 'UI_Lua import("/lua/ui/game/confirmunitdestroy.lua").ConfirmUnitDestruction(false)',
+        category = 'orders',
+    },
+    ['spreadattack'] = {
+        action = 'UI_Lua import("/lua/spreadattack.lua").SpreadAttack()',
+        category = 'orders',
+    },
+    ['shift_spreadattack'] = {
+        action = 'UI_Lua import("/lua/spreadattack.lua").SpreadAttack()',
+        category = 'orders',
+    },
+    ['set_target_priority'] = {
+        action = 'UI_LUA import("/lua/keymap/misckeyactions.lua").SetWeaponPrioritiesToUnitType()',
+        category = 'orders',
+    },
+    ['set_default_target_priority'] = {
+        action = 'UI_LUA import("/lua/keymap/misckeyactions.lua").SetDefaultWeaponPriorities()',
+        category = 'orders',
+    },
+    ['toggle_shield'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Shield")',
+        category = 'orders',
+    },
+    ['toggle_weapon'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Weapon")',
+        category = 'orders',
+    },
+    ['recheck_targets_of_weapons'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").RecheckTargetsOfWeapons()',
+        category = 'orders',
+    },
+    ['toggle_jamming'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Jamming")',
+        category = 'orders',
+    },
+    ['toggle_intel'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Intel")',
+        category = 'orders',
+    },
+    ['toggle_production'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Production")',
+        category = 'orders',
+    },
+    ['toggle_stealth'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Stealth")',
+        category = 'orders',
+    },
+    ['toggle_generic'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Generic")',
+        category = 'orders',
+    },
+    ['toggle_special'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Special")',
+        category = 'orders',
+    },
+    ['toggle_cloak'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Cloak")',
+        category = 'orders',
+    },
+    ['toggle_all'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleAllScript()',
+        category = 'orders',
+    },
+    ['teleport'] = {
+        action = 'StartCommandMode order RULEUCC_Teleport',
+        category = 'orders',
+    },
+    ['toggle_repeat_build'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").ToggleRepeatBuild()',
+        category = 'orders',
+    },
+    ['toggle_cloakjammingstealth'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleCloakJammingStealthScript()',
+        category = 'orders',
+    },
+    ['toggle_intelshield'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleIntelShieldScript()',
+        category = 'orders',
+    },
+    ['Kill_Selected_Units'] = {
+        action = 'UI_Lua import("/lua/ui/game/confirmunitdestroy.lua").ConfirmUnitDestruction(true)',
+        category = 'orders',
+    },
+    ['Kill_All'] = {
+        action = 'UI_Lua import("/lua/ui/game/confirmunitdestroy.lua").ConfirmUnitDestruction(true, true)',
+        category = 'orders',
+    },
+    ['dock'] = {
+        action = 'UI_Lua import("/lua/ui/game/orders.lua").Dock(true)',
+        category = 'orders',
+    },
+    ['shift_dock'] = {
+        action = 'UI_Lua import("/lua/ui/game/orders.lua").Dock(false)',
+        category = 'orders',
+    },
+    ['select_air_no_transport'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").airNoTransports()',
+        category = 'selection',
+    },
+    ['select_air_transport'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").airTransports()',
+        category = 'selection', order = 65,
+    },
+}
+
+local keyActionsGame = {
+    ['toggle_lifebars'] = {
+        action = 'UI_RenderUnitBars',
+        category = 'ui',
+    },
+    ['tog_military'] = {
+        action = 'UI_Lua import("/lua/ui/game/multifunction.lua").ToggleMilitary()',
+        category = 'ui',
+    },
+    ['tog_defense'] = {
+        action = 'UI_Lua import("/lua/ui/game/multifunction.lua").ToggleDefense()',
+        category = 'ui',
+    },
+    ['tog_econ'] = {
+        action = 'UI_Lua import("/lua/ui/game/multifunction.lua").ToggleEconomy()',
+        category = 'ui',
+    },
+    ['switch_layout_up'] = {
+        action = 'UI_RotateLayout +',
+        category = 'ui',
+    },
+    ['switch_layout_down'] = {
+        action = 'UI_RotateLayout -',
+        category = 'ui',
+    },
+    ['switch_skin_down'] = {
+        action = 'UI_RotateSkin -',
+        category = 'ui',
+    },
+    ['switch_skin_up'] = {
+        action = 'UI_RotateSkin +',
+        category = 'ui',
+    },
+    ['escape'] = {
+        action = 'UI_Lua import("/lua/ui/uimain.lua").EscapeHandler()',
+        category = 'ui',
+    },
+    ['pause'] = {
+        action = 'UI_Lua import("/lua/ui/game/tabs.lua").TogglePause()',
+        category = 'ui',
+    },
+    ['Render_SelectionSet_Names'] = {
+        action = 'ui_RenderSelectionSetNames',
+        category = 'ui',
+    },
+    ['Render_Custom_Names'] = {
+        action = 'ui_RenderCustomNames',
+        category = 'ui',
+    },
+    ['Render_Unit_Bars'] = {
+        action = 'ui_RenderUnitBars',
+        category = 'ui',
+    },
+    ['Render_Icons'] = {
+        action = 'ui_RenderIcons',
+        category = 'ui',
+    },
+    ['Always_Render_Strategic_Icons'] = {
+        action = 'ui_AlwaysRenderStrategicIcons',
+        category = 'ui',
+    },
+    ['Show_Bandwidth_Usage'] = {
+        action = 'ren_ShowBandwidthUsage',
+        category = 'ui',
+    },
+    ['Execute_Paste_Buffer'] = {
+        action = 'ExecutePasteBuffer',
+        category = 'ui',
+    },
+    ['decrease_game_speed'] = {
+        action = 'UI_Lua import("/lua/ui/uimain.lua").DecreaseGameSpeed()',
+        category = 'game',
+    },
+    ['increase_game_speed'] = {
+        action = 'UI_Lua import("/lua/ui/uimain.lua").IncreaseGameSpeed()',
+        category = 'game',
+    },
+    ['reset_game_speed'] = {
+        action = 'WLD_ResetSimRate',
+        category = 'game',
+    },
+    ['quick_save'] = {
+        action = 'UI_Lua import("/lua/ui/game/gamemain.lua").QuickSave(LOC("<LOC QuickSave>QuickSave"))',
+        category = 'ui',
+    },
+    ['toggle_key_bindings'] = {
+        action = 'UI_Lua import("/lua/ui/dialogs/keybindings.lua").CreateUI()',
+        category = 'ui',
+    },
+    ['create_build_template'] = {
+        action = 'UI_Lua import("/lua/ui/game/build_templates.lua").CreateBuildTemplate()',
+        category = 'selection'
+    },
+    ['cap_frame'] = {
+        action = 'Dump_Frame',
+        category = 'ui',
+    },
+    ['military_overlay'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleOverlay("Military")',
+        category = 'ui',
+    },
+    ['intel_overlay'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleOverlay("Intel")',
+        category = 'ui',
+    },
+    ['show_enemy_life'] = {
+        action = 'UI_ForceLifbarsOnEnemy',
+        category = 'ui',
+    },
+}
+
+local keyActionsChat = {
+    ['chat_page_up'] = {
+        action = 'UI_Lua import("/lua/ui/game/chat.lua").ChatPageUp(10)',
+        category = 'chat',
+    },
+    ['chat_page_down'] = {
+        action = 'UI_Lua import("/lua/ui/game/chat.lua").ChatPageDown(10)',
+        category = 'chat',
+    },
+    ['chat_line_up'] = {
+        action = 'UI_Lua import("/lua/ui/game/chat.lua").ChatPageUp(1)',
+        category = 'chat',
+    },
+    ['chat_line_down'] = {
+        action = 'UI_Lua import("/lua/ui/game/chat.lua").ChatPageDown(1)',
+        category = 'chat',
+    },
+}
+
+local keyActionsUI = {
+    ['rename'] = {
+        action = 'UI_ShowRenameDialog',
+        category = 'ui',
+    },
+    ['split_screen_enable'] = {
+        action = 'UI_Lua import("/lua/ui/game/borders.lua").SplitMapGroup(true)',
+        category = 'ui',
+    },
+    ['split_screen_disable'] = {
+        action = 'UI_Lua import("/lua/ui/game/borders.lua").SplitMapGroup(false)',
+        category = 'ui',
+    },
+    ['toggle_notify_customiser'] = {
+        action = 'UI_Lua import("/lua/ui/notify/customiser.lua").CreateUI()',
+        category = 'ui',
+    },
+    ['toggle_score_screen'] = {
+        action = 'UI_Lua import("/lua/ui/game/tabs.lua").ToggleScore()',
+        category = 'ui',
+    },
+    ['toggle_mass_fabricator_panel'] = {
+        action = 'UI_Lua import("/lua/ui/game/tabs.lua").ToggleMassFabricatorPanel()',
+        category = 'ui',
+    },
+    ['toggle_voting_panel'] = {
+        action = 'UI_Lua import("/lua/ui/game/tabs.lua").ToggleVotingPanel()',
+        category = 'ui',
+    },
+    ['toggle_diplomacy_screen'] = {
+        action = 'UI_Lua import("/lua/ui/game/tabs.lua").ToggleTab("diplomacy")',
+        category = 'ui',
+    },
+    ['ping_alert'] = {
+        action = 'UI_Lua import("/lua/ui/game/ping.lua").DoPing("alert")',
+        category = 'ui',
+    },
+    ['ping_move'] = {
+        action = 'UI_Lua import("/lua/ui/game/ping.lua").DoPing("move")',
+        category = 'ui',
+    },
+    ['ping_attack'] = {
+        action = 'UI_Lua import("/lua/ui/game/ping.lua").DoPing("attack")',
+        category = 'ui',
+    },
+    ['ping_marker'] = {
+        action = 'UI_Lua import("/lua/ui/game/ping.lua").DoPing("marker")',
+        category = 'ui',
+    },
+    ['toggle_main_menu'] = {
+        action = 'UI_Lua import("/lua/ui/game/tabs.lua").ToggleTab("main")',
+        category = 'ui',
+    },
+    ['toggle_disconnect_screen'] = {
+        action = 'UI_Lua import("/lua/ui/game/connectivity.lua").CreateUI()',
+        category = 'ui',
+    },
+    ['toggle_reclaim_labels'] = {
+        action = 'UI_Lua import("/lua/ui/game/reclaim.lua").ToggleReclaim()',
+        category = 'ui'
+    },
+    ['show_objective_screen'] = {
+        action = 'UI_Lua import("/lua/ui/game/objectivedetail.lua").ToggleDisplay()',
+        category = 'ui'
+    },
+}
+
+local keyActionsMisc = {
+    ['filter_highest_engineer_and_assist'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").SelectHighestEngineerAndAssist()',
+        category = 'selection',
+    },
+}
+
+keyActions = table.combine(
+    keyActionsCamera,
+    keyActionsSelection,
+    keyActionsSelectionQuickSelect,
+    keyActionsSelectionSubgroups,
+    keyActionsSelectionControupGroups,
+    keyActionsHotBuild,
+    keyActionsHotBuildAlternative,
+    keyActionsHotBuildExtra,
+    keyActionsOrders,
+    keyActionsGame,
+    keyActionsChat,
+    keyActionsUI,
+    keyActionsMisc
+)

--- a/lua/keymap/keycategories.lua
+++ b/lua/keymap/keycategories.lua
@@ -3,6 +3,8 @@
 keyCategories = {
     ['ui'] = "<LOC keymap_category_0000>UI",
     ['selection'] = "<LOC keymap_category_0004>Selection",
+    ['selectionQuickSelect'] = "<LOC keymap_category_0004>Selection - Quick select",
+    ['selectionControlGroups'] = "<LOC keymap_selection_control_group>Selection - Control groups",
     ['selectionSubgroups'] = "<LOC keymap_selection_fragments>Selection - Subgroups",
     ['camera'] = "<LOC keymap_category_0025>Camera",
     ['orders'] = "<LOC keymap_category_0036>Orders",
@@ -21,6 +23,8 @@ keyCategories = {
 keyCategoryOrder = {
     'orders',
     'selection',
+    'selectionQuickSelect',
+    'selectionControlGroups',
     'selectionSubgroups',
     'hotbuilding',
     'hotbuildingAlternative',

--- a/lua/keymap/keymapper.lua
+++ b/lua/keymap/keymapper.lua
@@ -212,9 +212,9 @@ function GetKeyActions()
         end
     end
 
-    -- remove invalid key actions
     for k,v in ret do
         if string.find(k, '-') then
+            WARN(string.format("Removed invalid key action '%s' for using '-'", k))
             ret[k] = nil
         end
     end

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -394,6 +394,21 @@ function table.reverse(t)
     return r
 end
 
+--- Combines a series of tables into one table. Returns a new table. The parameters are merged into the new table in order
+---@see `table.assimilate`
+---@param ... table[]
+---@return table
+function table.combine(...)
+    local combined = { }
+    for k = 1, arg.n do
+        for key, value in arg[k] do
+            combined[key] = value
+        end
+    end
+
+    return combined
+end
+
 --- Converts hash table to a new table with keys from 1 to size of table and the same values
 --- it is useful for preparing hash table before sorting its values
 --- table.indexize { [a] = 'one', [b] = 'two', [c] = 'three' } =>


### PR DESCRIPTION
The old style is:

```lua
    ['escape'] = {action = 'UI_Lua import("/lua/ui/uimain.lua").EscapeHandler()',
        category = 'ui', order = 1,},
    ['pause'] = {action = 'UI_Lua import("/lua/ui/game/tabs.lua").TogglePause()',
        category = 'ui', order = 3,},
    ['cap_frame'] = {action = 'Dump_Frame',
        category = 'ui', order = 4,},
```

The new style is:

```lua
    ['select_upgrading_extractors'] = {
        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").SelectAllUpgradingExtractors()',
        category = 'selection',
    },
    ['select_air'] = {
        action = 'UI_SelectByCategory +excludeengineers AIR MOBILE',
        category = 'selection',
    },
```

With that we now have:

- The 'order' field is not used in FAForever, and therefore removed
- The table is visually unpacked, instead of cramped across two lines

When an invalid key is found the user receives a warning in the log instead of the key being ignored silently. These changes should not affect any existing key binding setups or any existing (ui) mods. Technically the system should work the same. Introduces the `Selection - Control groups` category for all key bindings related to control groups.