### PR TITLE
Clean up key actions

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -724,48 +724,6 @@ do
     end
 end
 
-do
-    --- Allows the player to force a target recheck on the selected units
-    ---@param data table   an empty table
-    ---@param units Unit[] table of units
-    Callbacks.RecheckTargetsOfWeapons = function(data, units)
-
-        -- make sure we have valid units with the correct command source
-        units = SecureUnits(units)
-        local tick = GetGameTick()
-        local rechecks = 0 
-
-        -- reset their weapons
-        for k, unit in units do
-            if
-                -- unit should still exist
-                not unit:BeenDestroyed() and
-                (   -- do not allow players to spam this
-                    not unit.RecheckTargetsOfWeaponsTick or
-                    (tick - unit.RecheckTargetsOfWeaponsTick > 10)
-                ) 
-            then
-                rechecks = rechecks + 1
-                unit.RecheckTargetsOfWeaponsTick = tick
-                for l = 1, unit.WeaponCount do
-                    unit:GetWeapon(l):ResetTarget()
-                end
-            end
-        end
-
-        -- user feedback
-        if rechecks > 0 then 
-            if units[1].Army == GetFocusArmy() then
-                if rechecks == 1 then 
-                    print("1 weapon target recheck")
-                else 
-                    print(string.format("%d weapon target rechecks", rechecks))
-                end
-            end
-        end
-    end
-end
-
 Callbacks.MapResoureCheck = function(data)
     import("/lua/sim/maputilities.lua").MapResourceCheck()
 end

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -782,68 +782,8 @@ Callbacks.iMapToggleThreat = function(data)
     import("/lua/sim/maputilities.lua").iMapToggleThreat(data.Identifier)
 end
 
-Callbacks.SelectHighestEngineerAndAssist = function(data, selection)
-    if selection then
-
-        local noACU = EntityCategoryFilterDown(categories.ALLUNITS - categories.COMMAND, selection)
-
-        ---@type Unit
-        local target = GetEntityById(data.TargetId)
-
-        IssueClearCommands(noACU)
-        IssueGuard(noACU, target)
-    end
-end
-
----@class CargoSlots
----@field Large number 
----@field Medium number 
----@field Small number
-
----@type CargoSlots[]
-local GetCargoSlotsCache = {}
-
----@param unit Unit
----@return CargoSlots
-local function GetCargoSlots(unit)
-
-    -- try the cache first
-    if GetCargoSlotsCache[unit.UnitId] then 
-        return GetCargoSlotsCache[unit.UnitId]
-    end
-
-    ---@type CargoSlots
-    local slots = {
-        Large = 0,
-        Medium = 0,
-        Small = 0,
-    }
-
-    -- based on attachment points
-    for i = 1, unit:GetBoneCount() do
-        if unit:GetBoneName(i) ~= nil then
-            if string.find(unit:GetBoneName(i), 'Attachpoint_Lrg') then
-                slots.Large = slots.Large + 1
-            elseif string.find(unit:GetBoneName(i), 'Attachpoint_Med') then
-                slots.Medium = slots.Medium + 1
-            elseif string.find(unit:GetBoneName(i), 'Attachpoint') then
-                slots.Small = slots.Small + 1
-            end
-        end
-    end
-
-    -- based on blueprint definitions
-    slots.Large = math.min(slots.Large, unit.Blueprint.Transport.SlotsLarge or slots.Large)
-    slots.Medium = math.min(slots.Medium, unit.Blueprint.Transport.SlotsMedium or slots.Medium)
-    slots.Small = math.min(slots.Small, unit.Blueprint.Transport.SlotsSmall or slots.Small)
-
-    -- cache it and return
-    GetCargoSlotsCache[unit.UnitId] = slots
-    return slots
-end
-
-Callbacks.NavEnableDebugging = import("/lua/sim/NavDebug.lua").EnableDebugging
-Callbacks.NavDisableDebugging = import("/lua/sim/NavDebug.lua").DisableDebugging
+Callbacks.NavEnableDebugging = import("/lua/sim/navdebug.lua").EnableDebugging
+Callbacks.NavDisableDebugging = import("/lua/sim/navdebug.lua").DisableDebugging
 Callbacks.NavToggleScanLayer = import("/lua/sim/navdebug.lua").ToggleScanLayer
 Callbacks.NavToggleScanLabels = import("/lua/sim/navdebug.lua").ToggleScanLabels
 Callbacks.NavDebugStatisticsToUI = import("/lua/sim/navdebug.lua").StatisticsToUI

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -1,5 +1,4 @@
-
---- A key action allows a user to bind key bindings to an action. The format 
+--- A key action allows a user to bind key bindings to an action. The format
 --- of a key action is defined in the 'UIKeyAction' annotation class. Key
 --- actions are defined in tables. The key of a key action acts as an
 --- identifier. The same identifier is used to assign a description to the
@@ -129,11 +128,11 @@ local keyActionsCamera = {
     },
     ['zoom_in'] = {
         action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ZoomIn(.02)',
-        category = 'camera', 
+        category = 'camera',
     },
     ['zoom_out'] = {
         action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ZoomOut(.02)',
-        category = 'camera', 
+        category = 'camera',
     },
     ['zoom_in_fast'] = {
         action = 'UI_Lua import("/lua/ui/game/zoomslider.lua").ZoomIn(.08)',
@@ -1482,10 +1481,6 @@ local keyActionsOrders = {
         action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Weapon")',
         category = 'orders',
     },
-    ['recheck_targets_of_weapons'] = {
-        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").RecheckTargetsOfWeapons()',
-        category = 'orders',
-    },
     ['toggle_jamming'] = {
         action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").toggleScript("Jamming")',
         category = 'orders',
@@ -1762,10 +1757,7 @@ local keyActionsUI = {
 
 ---@type table<string, UIKeyAction>
 local keyActionsMisc = {
-    ['filter_highest_engineer_and_assist'] = {
-        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").SelectHighestEngineerAndAssist()',
-        category = 'selection',
-    },
+
 }
 
 ---@type table<string, UIKeyAction>

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -168,7 +168,6 @@ keyDescriptions = {
     ['toggle_build_mode'] = '<LOC key_desc_0102>Toggles keyboard build command mode on and off',
     ['toggle_reclaim_labels'] = '<LOC key_desc_0103>Toggles reclaim labels on and off',
     ['select_upgrading_extractors'] = '<LOC key_desc_select_upgrading_extractors>Select all extractors that are upgrading',
-    ['filter_highest_engineer_and_assist'] = '<LOC key_desc_filter_highest_engineer_and_assist>Filter the selection to the most advanced engineer, all other engineers assist that engineer',
     ['select_all_radars'] = '<LOC key_desc_select_all_radars>Select all radars',
     ['decrease_game_speed'] = '<LOC key_desc_0079>Decrease game speed',
     ['increase_game_speed'] = '<LOC key_desc_0080>Increase game speed',
@@ -496,7 +495,6 @@ keyDescriptions = {
     ['t3_support_air_factory'] = '<LOC key_desc_0386>build T3 Support Air Factory',
     ['t3_support_naval_factory'] = '<LOC key_desc_0387>build T3 Support Naval Factory',
 
-    ['recheck_targets_of_weapons'] = 'Recheck targets of weapons of selected units',
     ['set_target_priority'] = 'Set weapon target priorities to the type of unit that you hover over with the mouse',
     ['set_default_target_priority'] = 'Set weapon target priorities of selected units to their defaults',
 

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -464,10 +464,6 @@ function findPriority(bpID)
     end
 end
 
-function RecheckTargetsOfWeapons()
-    SimCallback({Func = 'RecheckTargetsOfWeapons', Args = { }}, true)
-end
-
 function SelectAllUpgradingExtractors()
 
     -- by default, hide playing the selection sound

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -498,31 +498,6 @@ function SelectAllUpgradingExtractors()
     SelectionUtils.EnableSelectionSound(true)
 end
 
-function SelectHighestEngineerAndAssist()
-    local selection = GetSelectedUnits()
-
-    if selection then
-
-        local tech1 = EntityCategoryFilterDown(categories.TECH1 - categories.COMMAND, selection)
-        local tech2 = EntityCategoryFilterDown(categories.TECH2 - categories.COMMAND, selection)
-        local tech3 = EntityCategoryFilterDown(categories.TECH3 - categories.COMMAND, selection)
-        local sACUs = EntityCategoryFilterDown(categories.SUBCOMMANDER - categories.COMMAND, selection)
-
-        if next(sACUs) then
-            SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = sACUs[1]:GetEntityId() }}, true)
-            SelectUnits({sACUs[1]})
-        elseif next(tech3) then
-            SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = tech3[1]:GetEntityId() }}, true)
-            SelectUnits({tech3[1]})
-        elseif next(tech2) then
-            SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = tech2[1]:GetEntityId() }}, true)
-            SelectUnits({tech2[1]})
-        else
-            -- do nothing
-        end
-    end
-end
-
 local hardMoveEnabled = false
 function ToggleHardMove()
     ---@type WorldView


### PR DESCRIPTION
Removes the following key actions:

- (`recheck_targets_of_weapons`) `Recheck targets of weapons of selected units`

The average unit rechecks the targeting of its weapons regardless.

- (`filter_highest_engineer_and_assist`) `Filter the selection to the most advanced engineer, all other engineers assist that engineer`

The implementation is undesired. It issues orders for the given player. The key action was introduced to help a player quickly select the highest tech engineer from a selection. The alternative is that the player filters the selection using subgroups. Specifically the following combination:

- (1) (`split_engineer_tech`) `Divides a selection over SACUs, tech 3, tech 2 and tech 1 engineers`
- (2) (`split_next`) `Select the next subgroup, or the original selection if there is no next subgroup`
