### PR TITLE
Allow Seraphim regeneration effect below water surface

### DIFF
--- a/effects/emitters/seraphim_regenerative_aura_02_emit.bp
+++ b/effects/emitters/seraphim_regenerative_aura_02_emit.bp
@@ -14,7 +14,7 @@ EmitterBlueprint {
 	EmitIfVisible = true,
 	CatchupEmit = true,
 	CreateIfVisible = false,
-	SnapToWaterline = true,
+	SnapToWaterline = false,
 	OnlyEmitOnWater = false,
 	ParticleResistance = false,
 	InterpolateEmission = true,


### PR DESCRIPTION
Bug provided by @Spikey84 on [Discord](https://discord.gg/pK94Dk9hNz)

Old situation: effect is hovering over water surface:
![image](https://github.com/FAForever/fa/assets/15778155/a56ed7f9-e036-4e2a-a33f-7318f3b4669e)

New situation: effect is where the unit is
![image](https://github.com/FAForever/fa/assets/15778155/40629e81-a97c-4f79-a3bf-025b578940ff)

