### PR TITLE
Clean up projectile blueprints

### DIFF
--- a/projectiles/AAAAutocannonQuantum01/AAAAutocannonQuantum01_proj.bp
+++ b/projectiles/AAAAutocannonQuantum01/AAAAutocannonQuantum01_proj.bp
@@ -26,11 +26,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'ANTIAIR',
-        },
         Faction = 'Aeon',
         TechLevel = 3,
         Weapon = 'Displacement Cannon',

--- a/projectiles/AAALightDisplacementAutoCannonMissile01/AAALightDisplacementAutoCannonMissile01_proj.bp
+++ b/projectiles/AAALightDisplacementAutoCannonMissile01/AAALightDisplacementAutoCannonMissile01_proj.bp
@@ -36,12 +36,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'ANTIAIR',
-            'MISSILE',
-        },
         Faction = 'Aeon',
         TechLevel = 3,
         Weapon = 'Light Displacement Autocannon AA Missile',

--- a/projectiles/AAASonicPulse01/AAASonicPulse01_proj.bp
+++ b/projectiles/AAASonicPulse01/AAASonicPulse01_proj.bp
@@ -26,11 +26,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'ANTIAIR',
-        },
         Faction = 'Aeon',
         TechLevel = 1,
         Weapon = 'Sonic Pulse Battery',

--- a/projectiles/AAAZealotMissile01/AAAZealotMissile01_proj.bp
+++ b/projectiles/AAAZealotMissile01/AAAZealotMissile01_proj.bp
@@ -36,12 +36,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'ANTIAIR',
-            'MISSILE',
-        },
         Faction = 'Aeon',
         TechLevel = 3,
         Weapon = 'Zealot AA Missile',

--- a/projectiles/AAAZealotMissile02/AAAZealotMissile02_proj.bp
+++ b/projectiles/AAAZealotMissile02/AAAZealotMissile02_proj.bp
@@ -36,12 +36,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'ANTIAIR',
-            'MISSILE',
-        },
         Faction = 'Aeon',
         TechLevel = 3,
         Weapon = 'Zealot AA Missile',

--- a/projectiles/AANDepthCharge03/AANDepthCharge03_proj.bp
+++ b/projectiles/AANDepthCharge03/AANDepthCharge03_proj.bp
@@ -56,12 +56,12 @@ ProjectileBlueprint {
         DestroyOnWater = false,
         Lifetime = 20,
         MaxSpeed = 14,
-        RealisticOrdinance = true,--added
+        RealisticOrdinance = true,
         StayUnderwater = true,
         StayUpright = true,
         TrackTarget = false,
         TurnRate = 230,
-        UseGravity = true,--added
+        UseGravity = true,
         VelocityAlign = true,
     },
 }

--- a/projectiles/AANTorpedo02/AANTorpedo02_proj.bp
+++ b/projectiles/AANTorpedo02/AANTorpedo02_proj.bp
@@ -27,13 +27,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Navy',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'ANTINAVY',
-            'TORPEDO',
-            'NOSPLASHDAMAGE',
-        },
         Faction = 'Aeon',
         Weapon = 'Chrono Torpedo',
     },

--- a/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_proj.bp
+++ b/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_proj.bp
@@ -35,13 +35,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Navy',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'ANTINAVY',
-            'TORPEDO',
-            'NOSPLASHDAMAGE',
-        },
         Faction = 'Aeon',
         Weapon = 'Chrono Torpedo',
     },

--- a/projectiles/ADFDisruptor01/ADFDisruptor01_proj.bp
+++ b/projectiles/ADFDisruptor01/ADFDisruptor01_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
         Weapon = 'Disruptor Cannon',
     },

--- a/projectiles/ADFGraviton01/ADFGraviton01_proj.bp
+++ b/projectiles/ADFGraviton01/ADFGraviton01_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
         Weapon = 'Graviton Projector',
     },

--- a/projectiles/ADFLaserHeavy01/ADFLaserHeavy01_proj.bp
+++ b/projectiles/ADFLaserHeavy01/ADFLaserHeavy01_proj.bp
@@ -9,11 +9,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
     },
     Interface = {

--- a/projectiles/ADFLaserHighIntensity01/ADFLaserHighIntensity01_proj.bp
+++ b/projectiles/ADFLaserHighIntensity01/ADFLaserHighIntensity01_proj.bp
@@ -26,11 +26,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
         Weapon = 'High Intensity Laser',
     },

--- a/projectiles/ADFLaserLight01/ADFLaserLight01_proj.bp
+++ b/projectiles/ADFLaserLight01/ADFLaserLight01_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
     },
     Interface = {
         HelpText = 0,

--- a/projectiles/ADFLaserLight02/ADFLaserLight02_proj.bp
+++ b/projectiles/ADFLaserLight02/ADFLaserLight02_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
     },
     Interface = {
         HelpText = 0,

--- a/projectiles/ADFOblivionCannon01/ADFOblivionCannon01_proj.bp
+++ b/projectiles/ADFOblivionCannon01/ADFOblivionCannon01_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
         Weapon = 'Oblivion Cannon',
     },

--- a/projectiles/ADFOblivionCannon02/ADFOblivionCannon02_proj.bp
+++ b/projectiles/ADFOblivionCannon02/ADFOblivionCannon02_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
         Weapon = 'Oblivion Cannon',
     },

--- a/projectiles/ADFOblivionCannon03/ADFOblivionCannon03_proj.bp
+++ b/projectiles/ADFOblivionCannon03/ADFOblivionCannon03_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
         Weapon = 'Oblivion Cannon',
     },

--- a/projectiles/ADFOblivionCannon04/ADFOblivionCannon04_proj.bp
+++ b/projectiles/ADFOblivionCannon04/ADFOblivionCannon04_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
         Weapon = 'Oblivion Cannon',
     },

--- a/projectiles/ADFOblivionCannon05/ADFOblivionCannon05_proj.bp
+++ b/projectiles/ADFOblivionCannon05/ADFOblivionCannon05_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
         Weapon = 'Oblivion Cannon',
     },

--- a/projectiles/ADFQuadLaserLight01/ADFQuadLaserLight01_proj.bp
+++ b/projectiles/ADFQuadLaserLight01/ADFQuadLaserLight01_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
     },
     Interface = {
         HelpText = 0,

--- a/projectiles/ADFQuantumCannon01/ADFQuantumCannon01_proj.bp
+++ b/projectiles/ADFQuantumCannon01/ADFQuantumCannon01_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
         Weapon = 'Quantum Cannon',
     },

--- a/projectiles/ADFQuantumCannon02/ADFQuantumCannon02_proj.bp
+++ b/projectiles/ADFQuantumCannon02/ADFQuantumCannon02_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
         Weapon = 'Quantum Cannon',
     },

--- a/projectiles/ADFReactonCannon01/ADFReactonCannon01_proj.bp
+++ b/projectiles/ADFReactonCannon01/ADFReactonCannon01_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
     },
     Interface = {

--- a/projectiles/ADFReactonCannon02/ADFReactonCannon02_proj.bp
+++ b/projectiles/ADFReactonCannon02/ADFReactonCannon02_proj.bp
@@ -9,11 +9,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
     },
     Interface = {

--- a/projectiles/ADFRocket01/ADFRocket01_proj.bp
+++ b/projectiles/ADFRocket01/ADFRocket01_proj.bp
@@ -11,11 +11,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
     },
     Interface = {

--- a/projectiles/ADFShieldDisruptor01/ADFShieldDisruptor01_proj.bp
+++ b/projectiles/ADFShieldDisruptor01/ADFShieldDisruptor01_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
         Weapon = 'Disruptor Cannon',
     },

--- a/projectiles/ADFSonicPulsar01/ADFSonicPulsar01_proj.bp
+++ b/projectiles/ADFSonicPulsar01/ADFSonicPulsar01_proj.bp
@@ -12,11 +12,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'Aeon',
     },
     Interface = {

--- a/projectiles/AIFBombGraviton01/AIFBombGraviton01_proj.bp
+++ b/projectiles/AIFBombGraviton01/AIFBombGraviton01_proj.bp
@@ -41,11 +41,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Bomb',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'INDIRECTFIRE',
-        },
         Faction = 'Aeon',
         Weapon = 'Graviton Bomb',
     },

--- a/projectiles/AIFBombQuark01/AIFBombQuark01_proj.bp
+++ b/projectiles/AIFBombQuark01/AIFBombQuark01_proj.bp
@@ -36,11 +36,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Bomb',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'INDIRECTFIRE',
-        },
         Faction = 'Aeon',
         Weapon = 'Quark Bomb',
     },

--- a/projectiles/AIFFragmentationSensorShell03/AIFFragmentationSensorShell03_proj.bp
+++ b/projectiles/AIFFragmentationSensorShell03/AIFFragmentationSensorShell03_proj.bp
@@ -15,11 +15,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Artillery',
-        EntityCategory = {
-            'UEF',
-            'PROJECTILE',
-            'INDIRECTFIRE',
-        },
         Faction = 'UEF',
     },
     Interface = {

--- a/projectiles/AIFGuidedMissile01/AIFGuidedMissile01_proj.bp
+++ b/projectiles/AIFGuidedMissile01/AIFGuidedMissile01_proj.bp
@@ -13,11 +13,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'MISSILE',
-        },
         Faction = 'Aeon',
         TechLevel = 3,
         Weapon = 'Guided Missile',

--- a/projectiles/AIFGuidedMissile02/AIFGuidedMissile02_proj.bp
+++ b/projectiles/AIFGuidedMissile02/AIFGuidedMissile02_proj.bp
@@ -23,18 +23,11 @@ ProjectileBlueprint {
     },
     Display = {
         CameraFollowsProjectile = true,
-
-        -- ----MeshBlueprint = '/units/DAA0206/DAA0206_mesh.bp',
         StrategicIconSize = 1,
         UniformScale = 0.045,
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'MISSILE',
-        },
         Faction = 'Aeon',
         TechLevel = 3,
         Weapon = 'Guided Missile',

--- a/projectiles/AIFMiasmaShell01/AIFMiasmaShell01_proj.bp
+++ b/projectiles/AIFMiasmaShell01/AIFMiasmaShell01_proj.bp
@@ -37,11 +37,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Artillery',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'INDIRECTFIRE',
-        },
         Faction = 'Aeon',
         TechLevel = 2,
         Weapon = 'Miasma Artillery',

--- a/projectiles/AIFMiasmaShell02/AIFMiasmaShell02_proj.bp
+++ b/projectiles/AIFMiasmaShell02/AIFMiasmaShell02_proj.bp
@@ -9,11 +9,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Artillery',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'INDIRECTFIRE',
-        },
         Faction = 'Aeon',
         TechLevel = 2,
         Weapon = 'Miasma Artillery',

--- a/projectiles/AIFMissileSerpentine01/AIFMissileSerpentine01_proj.bp
+++ b/projectiles/AIFMissileSerpentine01/AIFMissileSerpentine01_proj.bp
@@ -44,13 +44,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Missile',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'INDIRECTFIRE',
-            'MISSILE',
-            'NOSPLASHDAMAGE',
-        },
         Faction = 'Aeon',
     },
     Interface = {

--- a/projectiles/AIFMortar01/AIFMortar01_proj.bp
+++ b/projectiles/AIFMortar01/AIFMortar01_proj.bp
@@ -30,11 +30,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Artillery',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'INDIRECTFIRE',
-        },
         Faction = 'Aeon',
         TechLevel = 1,
         Weapon = 'Concussion Artillery',

--- a/projectiles/AIFMortar02/AIFMortar02_proj.bp
+++ b/projectiles/AIFMortar02/AIFMortar02_proj.bp
@@ -30,11 +30,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Artillery',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'INDIRECTFIRE',
-        },
         Faction = 'Aeon',
         TechLevel = 1,
         Weapon = 'Concussion Artillery',

--- a/projectiles/AIFQuanticCluster03/AIFQuanticCluster03_proj.bp
+++ b/projectiles/AIFQuanticCluster03/AIFQuanticCluster03_proj.bp
@@ -15,11 +15,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Artillery',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'INDIRECTFIRE',
-        },
         Faction = 'AEON',
     },
     Interface = {

--- a/projectiles/AIFQuantumWarhead01/AIFQuantumWarhead01_proj.bp
+++ b/projectiles/AIFQuantumWarhead01/AIFQuantumWarhead01_proj.bp
@@ -55,14 +55,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Missile',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'INDIRECTFIRE',
-            'STRATEGIC',
-            'MISSILE',
-            'NOSPLASHDAMAGE',
-        },
         Faction = 'Aeon',
     },
     Interface = {

--- a/projectiles/AIFQuantumWarhead03/AIFQuantumWarhead03_proj.bp
+++ b/projectiles/AIFQuantumWarhead03/AIFQuantumWarhead03_proj.bp
@@ -48,14 +48,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Missile',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'INDIRECTFIRE',
-            'STRATEGIC',
-            'MISSILE',
-            'NOSPLASHDAMAGE',
-        },
         Faction = 'Aeon',
     },
     Interface = {

--- a/projectiles/AIMFactoryBlob01/AIMFactoryBlob01_proj.bp
+++ b/projectiles/AIMFactoryBlob01/AIMFactoryBlob01_proj.bp
@@ -7,9 +7,6 @@ ProjectileBlueprint {
         UniformScale = 0.005,
     },
     General = {
-        EntityCategory = {
-            'UNTARGETABLE',
-        },
     },
     Interface = {
         HelpText = 0,

--- a/projectiles/AIMFlare01/AIMFlare01_proj.bp
+++ b/projectiles/AIMFlare01/AIMFlare01_proj.bp
@@ -29,11 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Defense',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'ANTIMISSILE',
-        },
         Faction = 'Aeon',
         Weapon = 'Will O Wisp Anti Missile',
     },

--- a/projectiles/CAAAutocannon01/CAAAutocannon01_proj.bp
+++ b/projectiles/CAAAutocannon01/CAAAutocannon01_proj.bp
@@ -26,11 +26,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'CYBRAN',
-            'PROJECTILE',
-            'ANTIAIR',
-        },
         Faction = 'Cybran',
         TechLevel = 1,
         Weapon = 'Electron Autocannon',

--- a/projectiles/CAAAutocannon02/CAAAutocannon02_proj.bp
+++ b/projectiles/CAAAutocannon02/CAAAutocannon02_proj.bp
@@ -26,11 +26,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'CYBRAN',
-            'PROJECTILE',
-            'ANTIAIR',
-        },
         Faction = 'Cybran',
         TechLevel = 1,
         Weapon = 'Electron Autocannon',

--- a/projectiles/CAAAutocannon03/CAAAutocannon03_proj.bp
+++ b/projectiles/CAAAutocannon03/CAAAutocannon03_proj.bp
@@ -26,11 +26,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'CYBRAN',
-            'PROJECTILE',
-            'ANTIAIR',
-        },
         Faction = 'Cybran',
         TechLevel = 1,
         Weapon = 'Electron Autocannon',

--- a/projectiles/CAABurstCloud01/CAABurstCloud01_proj.bp
+++ b/projectiles/CAABurstCloud01/CAABurstCloud01_proj.bp
@@ -26,11 +26,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'CYBRAN',
-            'PROJECTILE',
-            'ANTIAIR',
-        },
         Faction = 'Cybran',
         TechLevel = 2,
         Weapon = 'Electron Flak',

--- a/projectiles/CAAMissileNanite01/CAAMissileNanite01_proj.bp
+++ b/projectiles/CAAMissileNanite01/CAAMissileNanite01_proj.bp
@@ -38,12 +38,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'CYBRAN',
-            'PROJECTILE',
-            'ANTIAIR',
-            'MISSILE',
-        },
         Faction = 'Cybran',
         TechLevel = 3,
         Weapon = 'Nanite Missile System',

--- a/projectiles/CAAMissileNanite02/CAAMissileNanite02_proj.bp
+++ b/projectiles/CAAMissileNanite02/CAAMissileNanite02_proj.bp
@@ -29,12 +29,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'CYBRAN',
-            'PROJECTILE',
-            'ANTIAIR',
-            'MISSILE',
-        },
         Faction = 'Cybran',
         TechLevel = 3,
         Weapon = 'Nanite Missile System',

--- a/projectiles/CAAMissileNanite03/CAAMissileNanite03_proj.bp
+++ b/projectiles/CAAMissileNanite03/CAAMissileNanite03_proj.bp
@@ -38,12 +38,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'CYBRAN',
-            'PROJECTILE',
-            'ANTIAIR',
-            'MISSILE',
-        },
         Faction = 'Cybran',
         TechLevel = 3,
         Weapon = 'Nanite Missile System',

--- a/projectiles/aaserpentine/AASerpentine_proj.bp
+++ b/projectiles/aaserpentine/AASerpentine_proj.bp
@@ -36,12 +36,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Anti Air',
-        EntityCategory = {
-            'AEON',
-            'PROJECTILE',
-            'ANTIAIR',
-            'MISSILE',
-        },
         Faction = 'Aeon',
         TechLevel = 3,
         Weapon = 'Serpentine AA Missile',


### PR DESCRIPTION
Partially removes the `EntityCategory` field from the `General` table of projectiles. Appears to be a left over from a previous implementation