### PR TITLE
Fix water coloration on land maps

### DIFF
--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -5131,7 +5131,26 @@ technique NormalMappedTerrain
 /// Unit
 ///
 /// Basic unit techniques.
+technique Unit_HighFidelity
+<
+    string abstractTechnique = "Unit";
+    int fidelity = FIDELITY_HIGH;
 
+    string cartographicTechnique = "CartographicUnit";
+    string depthTechnique = "Depth";
+    int renderStage = STAGE_DEPTH + STAGE_REFLECTION + STAGE_PREWATER + STAGE_PREEFFECT;
+    int parameter = PARAM_FRACTIONCOMPLETE;
+>
+{
+    pass P0
+    {
+        RasterizerState( Rasterizer_Cull_CW )
+
+        VertexShader = compile vs_1_1 NormalMappedVS();
+        //PixelShader = compile ps_2_a NormalMappedPS(true,true,true, false,0,0 );
+        PixelShader = compile ps_2_a NormalMappedPS_02(true,true,true,false,0,0 );
+    }
+}
 
 technique Unit_MedFidelity
 <
@@ -10077,26 +10096,5 @@ technique PBR_SeraphimBuild
 
         VertexShader = compile vs_1_1 SeraphimBuildVS();
         PixelShader = compile ps_3_0 PBR_SeraphimBuildPS(true);
-    }
-}
-
-technique Unit_HighFidelity
-<
-    string abstractTechnique = "Unit";
-    int fidelity = FIDELITY_HIGH;
-
-    string cartographicTechnique = "CartographicUnit";
-    string depthTechnique = "Depth";
-    int renderStage = STAGE_DEPTH + STAGE_REFLECTION + STAGE_PREWATER + STAGE_PREEFFECT;
-    int parameter = PARAM_FRACTIONCOMPLETE;
->
-{
-    pass P0
-    {
-        RasterizerState( Rasterizer_Cull_CW )
-
-        VertexShader = compile vs_1_1 NormalMappedVS();
-        //PixelShader = compile ps_2_a NormalMappedPS(true,true,true, false,0,0 );
-        PixelShader = compile ps_3_0 PBR_UEF_PS(true,true,false,0,0 );
     }
 }

--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -592,8 +592,12 @@ float3 ComputeNormal( sampler2D source, float2 uv, float3x3 rotationMatrix)
 }
 
 float3 ApplyWaterColor(float depth, float3 color) {
-    float4 waterColor = tex1D(WaterRampSampler, -depth / (surfaceElevation - abyssElevation));
-    return lerp(color, waterColor.rgb, waterColor.w);
+    if (surfaceElevation > 0) {
+        float4 waterColor = tex1D(WaterRampSampler, -depth / (surfaceElevation - abyssElevation));
+        color = lerp(color, waterColor.rgb, waterColor.w);
+    } 
+    return color;
+    
 }
 
 ///////////////////////////////////////
@@ -5127,26 +5131,7 @@ technique NormalMappedTerrain
 /// Unit
 ///
 /// Basic unit techniques.
-technique Unit_HighFidelity
-<
-    string abstractTechnique = "Unit";
-    int fidelity = FIDELITY_HIGH;
 
-    string cartographicTechnique = "CartographicUnit";
-    string depthTechnique = "Depth";
-    int renderStage = STAGE_DEPTH + STAGE_REFLECTION + STAGE_PREWATER + STAGE_PREEFFECT;
-    int parameter = PARAM_FRACTIONCOMPLETE;
->
-{
-    pass P0
-    {
-        RasterizerState( Rasterizer_Cull_CW )
-
-        VertexShader = compile vs_1_1 NormalMappedVS();
-        //PixelShader = compile ps_2_a NormalMappedPS(true,true,true, false,0,0 );
-        PixelShader = compile ps_2_a NormalMappedPS_02(true,true,true,false,0,0 );
-    }
-}
 
 technique Unit_MedFidelity
 <
@@ -9288,22 +9273,25 @@ float3 PBR_PS(
 }
 
 float3 ApplyWaterColorExponentially(NORMALMAPPED_VERTEX vertex, float3 color, float3 emission) {
-    float4 waterColor = tex1D(WaterRampSampler, -vertex.depth.x / (surfaceElevation - abyssElevation));
-    float3 v = normalize(vertex.viewDirection);
-    float3 up = float3(0,1,0);
-    // To simplify, we assume that the light enters vertically into the water,
-    // this is the length that the light travels underwater back to the camera
-    float oneOverCosV = 1 / max(dot(up, v), 0.0001);
-    // light gets absorbed exponentially
-    float waterAbsorption = saturate(exp(-waterColor.w * (1 + oneOverCosV)));
-    // when the mesh emits light, then the path from the surface to the mesh doesn't apply
-    float emissionAbsorption = saturate(exp(-waterColor.w * oneOverCosV));
-    // darken the color first to simulate the light absorption on the way in and out
-    color *= waterAbsorption;
-    // lerp in the watercolor to simulate the scattered light from the dirty water
-    color = lerp(waterColor.rgb, color, waterAbsorption);
-    // similarly tune down the emission light
-    color += emission * emissionAbsorption;
+    // the constants go crazy when water is disabled on the map
+    if (surfaceElevation > 0) {
+        float4 waterColor = tex1D(WaterRampSampler, -vertex.depth.x / (surfaceElevation - abyssElevation));
+        float3 v = normalize(vertex.viewDirection);
+        float3 up = float3(0,1,0);
+        // To simplify, we assume that the light enters vertically into the water,
+        // this is the length that the light travels underwater back to the camera
+        float oneOverCosV = 1 / max(dot(up, v), 0.0001);
+        // light gets absorbed exponentially
+        float waterAbsorption = saturate(exp(-waterColor.w * (1 + oneOverCosV)));
+        // when the mesh emits light, then the path from the surface to the mesh doesn't apply
+        float emissionAbsorption = saturate(exp(-waterColor.w * oneOverCosV));
+        // darken the color first to simulate the light absorption on the way in and out
+        color *= waterAbsorption;
+        // lerp in the watercolor to simulate the scattered light from the dirty water
+        color = lerp(waterColor.rgb, color, waterAbsorption);
+        // similarly tune down the emission light
+        color += emission * emissionAbsorption;
+    }
     return color;
 }
 
@@ -10089,5 +10077,26 @@ technique PBR_SeraphimBuild
 
         VertexShader = compile vs_1_1 SeraphimBuildVS();
         PixelShader = compile ps_3_0 PBR_SeraphimBuildPS(true);
+    }
+}
+
+technique Unit_HighFidelity
+<
+    string abstractTechnique = "Unit";
+    int fidelity = FIDELITY_HIGH;
+
+    string cartographicTechnique = "CartographicUnit";
+    string depthTechnique = "Depth";
+    int renderStage = STAGE_DEPTH + STAGE_REFLECTION + STAGE_PREWATER + STAGE_PREEFFECT;
+    int parameter = PARAM_FRACTIONCOMPLETE;
+>
+{
+    pass P0
+    {
+        RasterizerState( Rasterizer_Cull_CW )
+
+        VertexShader = compile vs_1_1 NormalMappedVS();
+        //PixelShader = compile ps_2_a NormalMappedPS(true,true,true, false,0,0 );
+        PixelShader = compile ps_3_0 PBR_UEF_PS(true,true,false,0,0 );
     }
 }


### PR DESCRIPTION
When a map has water disabled, then the values for the water elevation are not filled. They seem to default to a very large negative value. In consequence all units and props get colored as if they were on abyss height. We need to add a check to prevent that.
The screenshots are from Fancylands.
![Screenshot 2023-05-31 233704](https://github.com/FAForever/fa/assets/52536103/46f45559-d62f-4f94-8f29-d52b4e8ac44a)
![Screenshot 2023-05-31 233512](https://github.com/FAForever/fa/assets/52536103/027d16a0-4a74-49d6-86fa-3f64a075cb60)
