### PR TITLE
Fix the Quantum Optics of being self conscious

### DIFF
--- a/lua/RemoteViewing.lua
+++ b/lua/RemoteViewing.lua
@@ -146,9 +146,11 @@ function RemoteViewing(SuperClass)
                 fraction = self:GetResourceConsumed()
             end
             if self.RemoteViewingData.IntelButton then
-                self.RemoteViewingData.DisableCounter = self.RemoteViewingData.DisableCounter + 1
-                self.RemoteViewingData.ResourceThread = self:ForkThread(self.EnableResourceMonitor)
                 self:DisableVisibleEntity()
+                if fraction > 0 then
+                    self.RemoteViewingData.DisableCounter = self.RemoteViewingData.DisableCounter + 1
+                    self.RemoteViewingData.ResourceThread = self:ForkThread(self.EnableResourceMonitor)
+                end
             end
         end,
 

--- a/lua/RemoteViewing.lua
+++ b/lua/RemoteViewing.lua
@@ -147,10 +147,8 @@ function RemoteViewing(SuperClass)
             end
             if self.RemoteViewingData.IntelButton then
                 self:DisableVisibleEntity()
-                if fraction > 0 then
-                    self.RemoteViewingData.DisableCounter = self.RemoteViewingData.DisableCounter + 1
-                    self.RemoteViewingData.ResourceThread = self:ForkThread(self.EnableResourceMonitor)
-                end
+                self.RemoteViewingData.DisableCounter = self.RemoteViewingData.DisableCounter + 1
+                self.RemoteViewingData.ResourceThread = self:ForkThread(self.EnableResourceMonitor)
             end
         end,
 

--- a/units/XAB3301/XAB3301_unit.bp
+++ b/units/XAB3301/XAB3301_unit.bp
@@ -181,6 +181,7 @@ UnitBlueprint {
         UnitWeight = 1,
     },
     Intel = {
+        OmniRadius = 15,
         ReactivateTime = 10,
         RemoteViewingRadius = 25,
         VisionRadius = 15,


### PR DESCRIPTION
The Quantum Optics would turn itself back on after 10 seconds when turned off by a player. The problem existed since the new intel framework. It wouldn't call the intel enabled / disabled because technically the unit *itself* has no intel