### PR TITLE
Fix Rover drones being untargetable

### DIFF
--- a/lua/terranunits.lua
+++ b/lua/terranunits.lua
@@ -552,6 +552,7 @@ TPodTowerUnit = ClassUnit(TStructureUnit) {
     ---@param attachee Unit
     OnTransportAttach = function(self, bone, attachee)
         attachee:SetDoNotTarget(true)
+        
         self:PlayUnitSound('Close')
         self:RequestRefreshUI()
         local PodPresent = 0
@@ -576,6 +577,8 @@ TPodTowerUnit = ClassUnit(TStructureUnit) {
     ---@param bone Bone
     ---@param attachee Unit
     OnTransportDetach = function(self, bone, attachee)
+        attachee:SetDoNotTarget(false)
+
         self:PlayUnitSound('Open')
         self:RequestRefreshUI()
         if not self.OpeningAnimationStarted then


### PR DESCRIPTION
Closes #4897

The drones are flagged to prevent them from being picked up by weapons scanning for targets when they dock in the Kennel. The flag was not removed when they took off. It is now, allowing weapons to properly engage the drones again 