### PR TITLE
Further improve the performance of the navigational mesh

### DIFF
--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -1474,17 +1474,6 @@ function Generate()
 
     GenerateRootInformation(processAmphibious, processHover)
 
-    -- ditch hover / amphibious if they are identical to land
-    if not processAmphibious then
-        SPEW("Hover grid equals land grid - ditching hover grid")
-
-    end
-
-    if not processHover then
-
-
-    end
-
     SPEW(string.format("Generated navigational mesh in %f seconds", GetSystemTimeSecondsOnlyForProfileUse() - start))
 
     local allocatedSizeGrids = import('/lua/system/utils.lua').ToBytes(NavGrids) / (1024 * 1024)

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -1212,7 +1212,9 @@ local function GenerateCompressionGrids(size, threshold)
 end
 
 --- Generates graphs that we can traverse, based on the compression grids
-local function GenerateGraphs()
+---@param processAmphibious boolean
+---@param processHover boolean
+local function GenerateGraphs(processAmphibious, processHover)
     local navLand = NavGrids['Land'] --[[@as NavGrid]]
     local navWater = NavGrids['Water'] --[[@as NavGrid]]
     local navHover = NavGrids['Hover'] --[[@as NavGrid]]
@@ -1220,22 +1222,28 @@ local function GenerateGraphs()
     local navAir = NavGrids['Air'] --[[@as NavGrid]]
 
     navAir:GenerateNeighbors()
-    navLand:GenerateNeighbors()
-    navWater:GenerateNeighbors()
-    navHover:GenerateNeighbors()
-    navAmphibious:GenerateNeighbors()
-
     navAir:GenerateLabels()
-    navLand:GenerateLabels()
-    navWater:GenerateLabels()
-    navAmphibious:GenerateLabels()
-    navHover:GenerateLabels()
-
     navAir:Precompute()
+
+    navLand:GenerateNeighbors()
+    navLand:GenerateLabels()
     navLand:Precompute()
+
+    navWater:GenerateNeighbors()
+    navWater:GenerateLabels()
     navWater:Precompute()
-    navHover:Precompute()
-    navAmphibious:Precompute()
+
+    if processHover then
+        navHover:GenerateNeighbors()
+        navHover:GenerateLabels()
+        navHover:Precompute()
+    end
+
+    if processAmphibious then
+        navAmphibious:GenerateNeighbors()
+        navAmphibious:GenerateLabels()
+        navAmphibious:Precompute()
+    end
 end
 
 --- Culls generated labels that are too small and have no meaning
@@ -1278,21 +1286,25 @@ local function GenerateCullLabels()
 end
 
 --- Generates metadata for markers for quick access
-local function GenerateMarkerMetadata()
+local function GenerateMarkerMetadata(processAmphibious, processHover)
     local navLabels = NavLabels
 
     local grids = {
-        Land = NavGrids['Land'],
-        Amphibious = NavGrids['Amphibious'],
-        Hover = NavGrids['Hover'],
-
-        -- also tackled with amphibious layer 
-        -- Naval = NavGrids['Naval'],
+        NavGrids['Land'],
     }
+
+    if processAmphibious then
+        TableInsert(grids, NavGrids['Amphibious'])
+    end
+
+    if processHover then
+        TableInsert(grids, NavGrids['Hover'])
+    end
 
     local extractors = import("/lua/sim/markerutilities.lua").GetMarkersByType('Mass')
     for id, extractor in extractors do
-        for layer, grid in grids do
+        for _, grid in grids do
+            local layer = grid.Layer
             local label = grid:FindLeaf(extractor.position).Label
 
             if label > 0 then
@@ -1326,13 +1338,27 @@ local function GenerateMarkerMetadata()
 end
 
 --- Computes various fields for the root nodes
-local function GenerateRootInformation()
+local function GenerateRootInformation(processAmphibious, processHover)
 
     local cache = { }
     local size = ScenarioInfo.size[1] / LabelCompressionTreesPerAxis
     local area = ((0.01 * size) * (0.01 * size))
 
-    for _, grid in NavGrids do
+    local grids = {
+        NavGrids['Land'],
+        NavGrids['Water'],
+        NavGrids['Air'],
+    }
+
+    if processAmphibious then
+        TableInsert(grids, NavGrids['Amphibious'])
+    end
+
+    if processHover then
+        TableInsert(grids, NavGrids['Hover'])
+    end
+
+    for _, grid in grids do
         for z = 0, LabelCompressionTreesPerAxis - 1 do
             for x = 0, LabelCompressionTreesPerAxis - 1 do
                 ---@type CompressedLabelTreeRoot
@@ -1405,25 +1431,30 @@ function Generate()
     GenerateCompressionGrids(CompressionTreeSize, compressionThreshold)
     print(string.format("generated compression trees: %f", GetSystemTimeSecondsOnlyForProfileUse() - start))
 
-    GenerateGraphs()
-    print(string.format("generated neighbors and labels: %f", GetSystemTimeSecondsOnlyForProfileUse() - start))
+    local processAmphibious = true
+    if  NavLayerData['Land'].PathableLeafs == NavLayerData['Amphibious'].PathableLeafs and
+        NavLayerData['Land'].Subdivisions == NavLayerData['Amphibious'].Subdivisions and
+        NavLayerData['Land'].UnpathableLeafs == NavLayerData['Amphibious'].UnpathableLeafs
+    then
+        SPEW(string.format("NavGenerator - replacing amphibious grid with land grid to conserve memory"))
+        processAmphibious = false
 
-    GenerateMarkerMetadata()
-    print(string.format("generated marker metadata: %f", GetSystemTimeSecondsOnlyForProfileUse() - start))
+        NavGrids['Amphibious'] = NavGrids['Land']
+        NavLayerData['Amphibious'].Labels = 0
+        NavLayerData['Amphibious'].Neighbors = 0
+        NavLayerData['Amphibious'].PathableLeafs = 0
+        NavLayerData['Amphibious'].Subdivisions = 0
+        NavLayerData['Amphibious'].UnpathableLeafs = 0
+    end
 
-    GenerateCullLabels()
-    print(string.format("cleaning up generated data: %f", GetSystemTimeSecondsOnlyForProfileUse() - start))
-
-    GenerateRootInformation()
-
-    -- ditch hover / amphibious if they are identical to land
-    if  NavLayerData['Land'].Labels == NavLayerData['Hover'].Labels and
-        NavLayerData['Land'].Neighbors == NavLayerData['Hover'].Neighbors and
-        NavLayerData['Land'].PathableLeafs == NavLayerData['Hover'].PathableLeafs and
+    local processHover = true
+    if  NavLayerData['Land'].PathableLeafs == NavLayerData['Hover'].PathableLeafs and
         NavLayerData['Land'].Subdivisions == NavLayerData['Hover'].Subdivisions and
         NavLayerData['Land'].UnpathableLeafs == NavLayerData['Hover'].UnpathableLeafs
     then
-        SPEW("Hover grid equals land grid - ditching hover grid")
+        SPEW(string.format("NavGenerator - replacing hover grid with land grid to conserve memory"))
+        processHover = false
+
         NavGrids['Hover'] = NavGrids['Land']
         NavLayerData['Hover'].Labels = 0
         NavLayerData['Hover'].Neighbors = 0
@@ -1432,19 +1463,26 @@ function Generate()
         NavLayerData['Hover'].UnpathableLeafs = 0
     end
 
-    if  NavLayerData['Land'].Labels == NavLayerData['Amphibious'].Labels and
-        NavLayerData['Land'].Neighbors == NavLayerData['Amphibious'].Neighbors and
-        NavLayerData['Land'].PathableLeafs == NavLayerData['Amphibious'].PathableLeafs and
-        NavLayerData['Land'].Subdivisions == NavLayerData['Amphibious'].Subdivisions and
-        NavLayerData['Land'].UnpathableLeafs == NavLayerData['Amphibious'].UnpathableLeafs
-    then
-        SPEW("Amphibious grid equals land grid - ditching amphibious grid")
-        NavGrids['Amphibious'] = NavGrids['Land']
-        NavLayerData['Amphibious'].Labels = 0
-        NavLayerData['Amphibious'].Neighbors = 0
-        NavLayerData['Amphibious'].PathableLeafs = 0
-        NavLayerData['Amphibious'].Subdivisions = 0
-        NavLayerData['Amphibious'].UnpathableLeafs = 0
+    GenerateGraphs(processAmphibious, processHover)
+    print(string.format("generated neighbors and labels: %f", GetSystemTimeSecondsOnlyForProfileUse() - start))
+
+    GenerateMarkerMetadata(processAmphibious, processHover)
+    print(string.format("generated marker metadata: %f", GetSystemTimeSecondsOnlyForProfileUse() - start))
+
+    GenerateCullLabels()
+    print(string.format("cleaning up generated data: %f", GetSystemTimeSecondsOnlyForProfileUse() - start))
+
+    GenerateRootInformation(processAmphibious, processHover)
+
+    -- ditch hover / amphibious if they are identical to land
+    if not processAmphibious then
+        SPEW("Hover grid equals land grid - ditching hover grid")
+
+    end
+
+    if not processHover then
+
+
     end
 
     SPEW(string.format("Generated navigational mesh in %f seconds", GetSystemTimeSecondsOnlyForProfileUse() - start))


### PR DESCRIPTION
We conserved memory by replacing the reference of the Amphibious grid and the Hover grid with the Land grid if we learned they are equal statistically. This happens when the map has no water. This was done at the end of the generation phase. We now do this equality check as soon as possible to allow us to skip various computations on the amphibious and hover grids. This can result in up to 50% faster generation on land only maps. The effect is less significant on larger maps because the dominant factor is not the post processing of the grid but the number of height samples that we need to process to construct the grid.

Old
```
Ian's Cross:
DEBUG: NavGenerator - Flattened 836 sections
DEBUG: NavGenerator - culled 1512 labels
DEBUG: Hover grid equals land grid - ditching hover grid
DEBUG: Amphibious grid equals land grid - ditching amphibious grid
DEBUG: Generated navigational mesh in 3.422852 seconds
DEBUG: Allocated megabytes for navigational mesh: 13.228302
DEBUG: Allocated megabytes for labels: 0.510406

Open Palms: FAF version
DEBUG: NavGenerator - Flattened 908 sections
DEBUG: NavGenerator - culled 102 labels
DEBUG: Hover grid equals land grid - ditching hover grid
DEBUG: Amphibious grid equals land grid - ditching amphibious grid
DEBUG: Generated navigational mesh in 1.071777 seconds
DEBUG: Allocated megabytes for navigational mesh: 4.909599
DEBUG: Allocated megabytes for labels: 0.080338

Syrtis Major - FAF version:
DEBUG: NavGenerator - Flattened 857 sections
DEBUG: NavGenerator - culled 312 labels
DEBUG: Hover grid equals land grid - ditching hover grid
DEBUG: Amphibious grid equals land grid - ditching amphibious grid
DEBUG: Generated navigational mesh in 1.595215 seconds
DEBUG: Allocated megabytes for navigational mesh: 7.185905
DEBUG: Allocated megabytes for labels: 0.131805
```

New

```
Ian's Cross:
DEBUG: NavGenerator - Flattened 836 sections
DEBUG: NavGenerator - replacing amphibious grid with land grid to conserve memory
DEBUG: NavGenerator - replacing hover grid with land grid to conserve memory
DEBUG: NavGenerator - culled 504 labels
DEBUG: Generated navigational mesh in 1.794434 seconds
DEBUG: Allocated megabytes for navigational mesh: 13.228302
DEBUG: Allocated megabytes for labels: 0.197205

Open Palms - FAF version:
DEBUG: NavGenerator - Flattened 908 sections
DEBUG: NavGenerator - replacing amphibious grid with land grid to conserve memory
DEBUG: NavGenerator - replacing hover grid with land grid to conserve memory
DEBUG: NavGenerator - culled 34 labels
DEBUG: Generated navigational mesh in 0.519043 seconds
DEBUG: Allocated megabytes for navigational mesh: 4.909599
DEBUG: Allocated megabytes for labels: 0.055145

Syrtis Major - FAF version:
DEBUG: NavGenerator - Flattened 857 sections
DEBUG: NavGenerator - replacing amphibious grid with land grid to conserve memory
DEBUG: NavGenerator - replacing hover grid with land grid to conserve memory
DEBUG: NavGenerator - culled 104 labels
DEBUG: Generated navigational mesh in 0.686523 seconds
DEBUG: Allocated megabytes for navigational mesh: 7.185905
DEBUG: Allocated megabytes for labels: 0.063507
```
