### PR TITLE
Allow death weapons to knock over trees

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2133,6 +2133,7 @@ AirUnit = ClassUnit(MobileUnit) {
         elseif self.DeathCrashDamage > 0 then -- It was completely absorbed by a shield!
             local deathWep = self.deathWep -- Use a local copy for speed and easy reading
             DamageArea(self, self:GetPosition(), deathWep.DamageRadius, self.DeathCrashDamage, deathWep.DamageType, deathWep.DamageFriendly)
+            DamageArea(self, self:GetPosition(), deathWep.DamageRadius, 1, 'TreeForce', false)
         end
 
         if with == 'Water' then

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1704,6 +1704,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     DeathWeaponDamageThread = function(self, damageRadius, damage, damageType, damageFriendly)
         WaitSeconds(0.1)
         DamageArea(self, self:GetPosition(), damageRadius or 1, damage or 1, damageType or 'Normal', damageFriendly or false)
+        DamageArea(self, self:GetPosition(), damageRadius or 1, 1, 'TreeForce', false)
     end,
 
     ---@param self Unit

--- a/units/UAA0310/UAA0310_script.lua
+++ b/units/UAA0310/UAA0310_script.lua
@@ -65,7 +65,9 @@ UAA0310 = ClassUnit(AirTransport) {
 
     OnAnimTerrainCollision = function(self, bone, x, y, z)
         local blueprint = self.Blueprint
-        DamageArea(self, { x, y, z }, 5, 1000, 'Default', true, false)
+        local position = { x, y, z }
+        DamageArea(self, position, 5, 1000, 'Default', true, false)
+        DamageArea(self, position, 5, 1, 'TreeForce', false)
         explosion.CreateDefaultHitExplosionAtBone(self, bone, 5.0)
         explosion.CreateDebrisProjectiles(self, explosion.GetAverageBoundingXYZRadius(self),
             { blueprint.SizeX, blueprint.SizeY, blueprint.SizeZ })

--- a/units/XSA0402/XSA0402_script.lua
+++ b/units/XSA0402/XSA0402_script.lua
@@ -43,7 +43,9 @@ XSA0402 = ClassUnit(SAirUnit) {
     end,
 
     OnAnimTerrainCollision = function(self, bone,x,y,z)
-        DamageArea(self, {x,y,z}, 5, 1000, 'Default', true, false)
+        local position = {x, y, z}
+        DamageArea(self, position, 5, 1000, 'Default', true, false)
+        DamageArea(self, position, 5, 1, 'TreeForce', false)
         explosion.CreateDefaultHitExplosionAtBone( self, bone, 5.0 )
         explosion.CreateDebrisProjectiles(self, explosion.GetAverageBoundingXYZRadius(self), {self:GetUnitSizes()})
     end,


### PR DESCRIPTION
Closes https://github.com/FAForever/fa/issues/4976

This does not implement the wave as suggested by the issue. It requires quite a bit more work, but this pull request on its own achieves the described effect.

![image](https://github.com/FAForever/fa/assets/15778155/0dca9a78-2a64-416d-ae27-2fef14799613)

