### PR TITLE
Apply adjacency buffs to missile being built

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -777,15 +777,14 @@ StructureUnit = ClassUnit(Unit) {
             -- edge case for missile construction: the buff doesn't apply to the missile under construction
             if adjacentUnit.Blueprint.CategoriesHash["SILO"] then
                 if adjacentUnit:IsUnitState('SiloBuildingAmmo') then
-                    local autoModeEnabled = adjacentUnit.AutoModeEnabled
+                    local autoModeEnabled = adjacentUnit.AutoModeEnabled or false
                     local progress = adjacentUnit:GetWorkProgress()
                     if progress < 0.99 then
                         adjacentUnit:StopSiloBuild()
                         IssueSiloBuildTactical({adjacentUnit})
                         adjacentUnit:GiveNukeSiloBlocks(progress)
-                        if autoModeEnabled then
-                            adjacentUnit:SetAutoMode(true)
-                        end
+                        LOG(autoModeEnabled)
+                        adjacentUnit:SetAutoMode(autoModeEnabled)
                     end
                 end
             end
@@ -829,15 +828,13 @@ StructureUnit = ClassUnit(Unit) {
             -- edge case for missile construction: the buff doesn't apply to the missile under construction
             if adjacentUnit.Blueprint.CategoriesHash["SILO"] then
                 if adjacentUnit:IsUnitState('SiloBuildingAmmo') then
-                    local autoModeEnabled = adjacentUnit.AutoModeEnabled
+                    local autoModeEnabled = adjacentUnit.AutoModeEnabled or false
                     local progress = adjacentUnit:GetWorkProgress()
                     if progress < 0.99 then
                         adjacentUnit:StopSiloBuild()
                         IssueSiloBuildTactical({adjacentUnit})
                         adjacentUnit:GiveNukeSiloBlocks(progress)
-                        if autoModeEnabled then
-                            adjacentUnit:SetAutoMode(true)
-                        end
+                        adjacentUnit:SetAutoMode(autoModeEnabled)
                     end
                 end
             end

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -777,12 +777,15 @@ StructureUnit = ClassUnit(Unit) {
             -- edge case for missile construction: the buff doesn't apply to the missile under construction
             if adjacentUnit.Blueprint.CategoriesHash["SILO"] then
                 if adjacentUnit:IsUnitState('SiloBuildingAmmo') then
+                    local autoModeEnabled = adjacentUnit.AutoModeEnabled
                     local progress = adjacentUnit:GetWorkProgress()
                     if progress < 0.99 then
                         adjacentUnit:StopSiloBuild()
                         IssueSiloBuildTactical({adjacentUnit})
-                        adjacentUnit:SetAutoMode(true)
                         adjacentUnit:GiveNukeSiloBlocks(progress)
+                        if autoModeEnabled then
+                            adjacentUnit:SetAutoMode(true)
+                        end
                     end
                 end
             end
@@ -826,12 +829,15 @@ StructureUnit = ClassUnit(Unit) {
             -- edge case for missile construction: the buff doesn't apply to the missile under construction
             if adjacentUnit.Blueprint.CategoriesHash["SILO"] then
                 if adjacentUnit:IsUnitState('SiloBuildingAmmo') then
+                    local autoModeEnabled = adjacentUnit.AutoModeEnabled
                     local progress = adjacentUnit:GetWorkProgress()
                     if progress < 0.99 then
                         adjacentUnit:StopSiloBuild()
                         IssueSiloBuildTactical({adjacentUnit})
-                        adjacentUnit:SetAutoMode(true)
                         adjacentUnit:GiveNukeSiloBlocks(progress)
+                        if autoModeEnabled then
+                            adjacentUnit:SetAutoMode(true)
+                        end
                     end
                 end
             end

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4646,7 +4646,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     end,
 
     OnAutoModeOff = function(self)
-        self.AutoModeEnabled = true
+        self.AutoModeEnabled = false
     end,
 
     -- Utility Functions

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -114,6 +114,7 @@ local cUnit = moho.unit_methods
 ---@field EngineCommandCap? table<string, boolean>
 ---@field UnitBeingBuilt Unit?
 ---@field SoundEntity? Unit | Entity
+---@field AutoModeEnabled? boolean
 Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
 
     IsUnit = true,
@@ -4638,6 +4639,14 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         if IsDestroyed(transport) then
             self:Destroy()
         end
+    end,
+
+    OnAutoModeOn = function(self)
+        self.AutoModeEnabled = true
+    end,
+
+    OnAutoModeOff = function(self)
+        self.AutoModeEnabled = true
     end,
 
     -- Utility Functions


### PR DESCRIPTION
Closes #5029 and https://github.com/FAForever/fa/issues/3641

With thanks to @Strogoo for his [engine patch](https://github.com/FAForever/FA-Binary-Patches/pull/15) we can now create a work around to allow adjacency to update the costs of producing a missile. Previously this would only happen when constructing a new missile. This is still the case, but through the engine patch we can restore the progression on the construction.

https://github.com/FAForever/fa/assets/15778155/5929ad56-ea53-4000-a58c-9da49086c86d
