### PR TITLE
Prevent weapon scanning of picking up docked shoulder drones

### DIFF
--- a/units/UEL0001/UEL0001_script.lua
+++ b/units/UEL0001/UEL0001_script.lua
@@ -146,6 +146,22 @@ UEL0001 = ClassUnit(ACUUnit) {
         end
     end,
 
+    ---@param self UEL0001
+    ---@param bone Bone
+    ---@param attachee Unit
+    OnTransportAttach = function(self, bone, attachee)
+        ACUUnit.OnTransportAttach(self, bone, attachee)
+        attachee:SetDoNotTarget(true)
+    end,
+
+    ---@param self UEL0001
+    ---@param bone Bone
+    ---@param attachee Unit
+    OnTransportDetach = function(self, bone, attachee)
+        ACUUnit.OnTransportDetach(self, bone, attachee)
+        attachee:SetDoNotTarget(false)
+    end,
+
     CreateEnhancement = function(self, enh)
         ACUUnit.CreateEnhancement(self, enh)
 


### PR DESCRIPTION
Closes #5035 

This provides the same behavior of the Kennel drones to the Shoulder drones: when weapons scan for targets they will be ignored if they are docked. It doesn't prevent them to be targeted entirely. A user can still order an attack command on them

https://github.com/FAForever/fa/assets/15778155/7924a447-9810-4cdd-904e-63c2a8085fbe

