### PR TITLE
Remove the dive button while diving

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2064,7 +2064,25 @@ SubUnit = ClassUnit(MobileUnit) {
         self.Trash:Add(self.SoundEntity)
         Warp(self.SoundEntity, self:GetPosition())
         self.SoundEntity:AttachTo(self,-1)
+
+
     end,
+
+    ---@param self Unit
+    ---@param new string
+    ---@param old string
+    OnMotionVertEventChange = function(self, new, old)
+        MobileUnit.OnMotionVertEventChange(self, new, old)
+
+        if new == 'Up' or new == 'Down' then
+            self:RemoveCommandCap("RULEUCC_Dive")
+        end
+
+        if new == 'Top' or new == 'Bottom' then
+            self:AddCommandCap("RULEUCC_Dive")
+        end
+    end,
+
 }
 
 -- AIR UNITS

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -2076,10 +2076,12 @@ SubUnit = ClassUnit(MobileUnit) {
 
         if new == 'Up' or new == 'Down' then
             self:RemoveCommandCap("RULEUCC_Dive")
+            self:RequestRefreshUI()
         end
 
         if new == 'Top' or new == 'Bottom' then
             self:AddCommandCap("RULEUCC_Dive")
+            self:RequestRefreshUI()
         end
     end,
 


### PR DESCRIPTION
Closes https://github.com/FAForever/fa/issues/5039

I'm not sure if this is what we should do, but it does work. The dive feature of a unit is temporarily disabled while diving.

https://github.com/FAForever/fa/assets/15778155/8603ffa2-89f1-482c-9e62-b2a3a0798b40

