### PR TITLE
update IsPlattonDelay logic to work correctly in BuilderManager

### DIFF
--- a/lua/sim/BuilderManager.lua
+++ b/lua/sim/BuilderManager.lua
@@ -219,22 +219,23 @@ BuilderManager = ClassSimple {
             end
         end
 
-        -- only one candidate
+        -- only one builder found
+        local candidate
         if candidateNext == 2 then
-            if candidates[1].DelayEqualBuildPlattons then
-                local delay = candidates[1].DelayEqualBuildPlattons
-                self.Brain.DelayEqualBuildPlattons[delay[1]] = GetGameTimeSeconds() + delay[2]
-            end
-            return candidates[1]
-        -- multiple candidates, choose one at random
+            candidate = candidates[1]
+
+        -- multiple builders found
         elseif candidateNext > 2 then
-            local candidateSelection = candidates[Random(1, candidateNext - 1)]
-            if candidateSelection.DelayEqualBuildPlattons then
-                local delay = candidateSelection.DelayEqualBuildPlattons
-                self.Brain.DelayEqualBuildPlattons[delay[1]] = GetGameTimeSeconds() + delay[2]
-            end
-            return candidateSelection
+            candidate = candidates[Random(1, candidateNext - 1)]
         end
+
+        -- apply the builder delay
+        if candidate and candidate.DelayEqualBuildPlattons then
+            local delay = candidate.DelayEqualBuildPlattons
+            self.Brain.DelayEqualBuildPlattons[delay[1]] = GetGameTimeSeconds() + delay[2]
+        end
+
+        return candidate
     end,
 
     --- Returns true if the given builders matches the manager-specific parameters

--- a/lua/sim/BuilderManager.lua
+++ b/lua/sim/BuilderManager.lua
@@ -221,11 +221,19 @@ BuilderManager = ClassSimple {
 
         -- only one candidate
         if candidateNext == 2 then
+            if candidates[1].DelayEqualBuildPlattons then
+                local delay = candidates[1].DelayEqualBuildPlattons
+                self.Brain.DelayEqualBuildPlattons[delay[1]] = GetGameTime() + delay[2]
+            end
             return candidates[1]
-
         -- multiple candidates, choose one at random
         elseif candidateNext > 2 then
-            return candidates[Random(1, candidateNext - 1)]
+            local candidateSelection = candidates[Random(1, candidateNext - 1)]
+            if candidateSelection.DelayEqualBuildPlattons then
+                local delay = candidateSelection.DelayEqualBuildPlattons
+                self.Brain.DelayEqualBuildPlattons[delay[1]] = GetGameTime() + delay[2]
+            end
+            return candidateSelection
         end
     end,
 
@@ -286,7 +294,6 @@ BuilderManager = ClassSimple {
             local PlatoonName = specs[1] --[[@as string]]
             local timeThreshold = self.Brain.DelayEqualBuildPlattons[PlatoonName]
             if (not timeThreshold) or (timeThreshold < CheckDelayTime) then
-                self.Brain.DelayEqualBuildPlattons[PlatoonName] = CheckDelayTime + specs[2]
                 return false
             else
                 return true

--- a/lua/sim/BuilderManager.lua
+++ b/lua/sim/BuilderManager.lua
@@ -223,7 +223,7 @@ BuilderManager = ClassSimple {
         if candidateNext == 2 then
             if candidates[1].DelayEqualBuildPlattons then
                 local delay = candidates[1].DelayEqualBuildPlattons
-                self.Brain.DelayEqualBuildPlattons[delay[1]] = GetGameTime() + delay[2]
+                self.Brain.DelayEqualBuildPlattons[delay[1]] = GetGameTimeSeconds() + delay[2]
             end
             return candidates[1]
         -- multiple candidates, choose one at random
@@ -231,7 +231,7 @@ BuilderManager = ClassSimple {
             local candidateSelection = candidates[Random(1, candidateNext - 1)]
             if candidateSelection.DelayEqualBuildPlattons then
                 local delay = candidateSelection.DelayEqualBuildPlattons
-                self.Brain.DelayEqualBuildPlattons[delay[1]] = GetGameTime() + delay[2]
+                self.Brain.DelayEqualBuildPlattons[delay[1]] = GetGameTimeSeconds() + delay[2]
             end
             return candidateSelection
         end


### PR DESCRIPTION
This PR updates the BuilderManager logic to handle the builder delay logic.

Updates the IsPlattonBuildDelayed to no longer update the brain table for the delay. This was causing any builder that passed through the builder manager to update.

It shifts the delay update to the builder return logic statement. This means that only the builder that is selected will be updated.

Testing 
In order to validate this logic you will need to 
add logs to line 299 that will tell you when a builder fails the delay check.
add logs to line 226 and 234 to log when the delay is added.

The delay is triggered when a builder gets triggered multiple times. The goal of the delay is to stop a situation where an engineer gets a job and starts moving to the builder location, then another engineer gets the same job before the first could start the construction. This trys to avoid situations where multiple builders or multiple instances of the builder will trigger because the conditions are right for the seconds it takes for the engineer to move to the build location.

in draft so I can quickly test this tonight.

As a side note. There are only 3 AI using this functionality at the moment(incase we want to consider fixing the typo in the name).