### PR TITLE
Readd PBMGetLocationRadius base-ai brain.

### DIFF
--- a/lua/aibrains/base-ai.lua
+++ b/lua/aibrains/base-ai.lua
@@ -329,7 +329,7 @@ AIBrain = Class(StandardBrain) {
 
     ---@param self BaseAIBrain
     ---@param loc Vector
-    ---@return boolean
+    ---@return number
     PBMGetLocationRadius = function(self, loc)
         if not loc then
             return false

--- a/lua/aibrains/base-ai.lua
+++ b/lua/aibrains/base-ai.lua
@@ -327,6 +327,25 @@ AIBrain = Class(StandardBrain) {
         return false
     end,
 
+    ---@param self BaseAIBrain
+    ---@param loc Vector
+    ---@return boolean
+    PBMGetLocationRadius = function(self, loc)
+        if not loc then
+            return false
+        end
+        if self.HasPlatoonList then
+            for k, v in self.PBM.Locations do
+                if v.LocationType == loc then
+                   return v.Radius
+                end
+            end
+        elseif self.BuilderManagers[loc] then
+            return self.BuilderManagers[loc].FactoryManager.Radius
+        end
+        return false
+    end,
+
     ---SKIRMISH AI HELPER SYSTEMS
     ---@param self BaseAIBrain
     InitializeSkirmishSystems = function(self)

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -1623,7 +1623,6 @@ Platoon = Class(moho.platoon_methods) {
         self:Stop()
         local aiBrain = self:GetBrain()
         local data = self.PlatoonData
-        local radius = aiBrain:PBMGetLocationRadius(data.Location)
         local categories = data.Reclaim
         local counter = 0
         local reclaimcat


### PR DESCRIPTION
This PR removes an unused instance of the PBMGetLocationRadius function in the AI reclaim function.

It also readds the function back to the base-ai brain to stop failures in AI engineer calls that are failing due to it not existing anymore.