### PR TITLE
Add new TransportRequested flag for 3rd party AI compatiblity support.

### DIFF
--- a/lua/AI/AIBaseTemplates/ChallengeMain.lua
+++ b/lua/AI/AIBaseTemplates/ChallengeMain.lua
@@ -35,7 +35,7 @@ BaseBuilderTemplate {
         'ExtractorUpgrades',
 
         -- ACU Builders
-        'Default Initial ACU Builders',
+        'Easy Initial ACU Builders',
         'ACUBuilders',
         'ACUUpgrades',
                         

--- a/lua/AI/AIBaseTemplates/NormalMain.lua
+++ b/lua/AI/AIBaseTemplates/NormalMain.lua
@@ -35,7 +35,7 @@ BaseBuilderTemplate {
         'ExtractorUpgrades',
 
         -- ACU Builders
-        'Default Initial ACU Builders',
+        'Easy Initial ACU Builders',
         'ACUBuilders',
         'ACUUpgrades',
                         

--- a/lua/AI/AIBuilders/AIAirAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AIAirAttackBuilders.lua
@@ -337,7 +337,7 @@ BuilderGroup {
         Priority = 850,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
-            { MIBC, 'ArmyNeedsTransports', {} },
+            { MIBC, 'TransportRequested', {} },
             { MIBC, 'MapGreaterThan', { 256, 256 }},
             { MIBC, 'LessThanGameTime', { 600 } },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.6, 1.0 }},
@@ -352,7 +352,7 @@ BuilderGroup {
         Priority = 560,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
-            { MIBC, 'ArmyNeedsTransports', {} },
+            { MIBC, 'TransportRequested', {} },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, categories.AIR * categories.ANTIAIR } },
             { UCBC, 'HaveLessThanUnitsWithCategory', { 3, categories.TRANSPORTFOCUS } },
@@ -366,7 +366,7 @@ BuilderGroup {
         Priority = 650,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
-            { MIBC, 'ArmyNeedsTransports', {} },
+            { MIBC, 'TransportRequested', {} },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},  --DUNCAN - was 0.9
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 10, categories.LAND * (categories.TECH2 + categories.TECH3) } }, --DUNCAN - added
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
@@ -381,7 +381,7 @@ BuilderGroup {
         Priority = 750,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
-            { MIBC, 'ArmyNeedsTransports', {} },
+            { MIBC, 'TransportRequested', {} },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.05 }},
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 10, categories.LAND * categories.TECH3 } }, --DUNCAN - added
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 10, categories.LAND *  categories.TECH3 } }, --DUNCAN - added
@@ -398,7 +398,7 @@ BuilderGroup {
         Priority = 500,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
-            { MIBC, 'ArmyNeedsTransports', {} },
+            { MIBC, 'TransportRequested', {} },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},  --DUNCAN - was 0.9
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
             { UCBC, 'HaveLessThanUnitsWithCategory', { 5 , categories.TRANSPORTFOCUS} },
@@ -412,7 +412,7 @@ BuilderGroup {
         Priority = 600,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
-            { MIBC, 'ArmyNeedsTransports', {} },
+            { MIBC, 'TransportRequested', {} },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},  --DUNCAN - was 0.9
             { UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, categories.TRANSPORTFOCUS } },
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
@@ -427,7 +427,7 @@ BuilderGroup {
         Priority = 700,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
-            { MIBC, 'ArmyNeedsTransports', {} },
+            { MIBC, 'TransportRequested', {} },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.05 }},
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
             { UCBC, 'HaveLessThanUnitsWithCategory', { 4, categories.TRANSPORTFOCUS * categories.TECH2 } }, --DUNCAN - Added
@@ -444,8 +444,8 @@ BuilderGroup {
         Priority = 700,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
-            { MIBC, 'TransportNeedGreater', { 7 } },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},  --DUNCAN - was 0.9
+            { MIBC, 'TransportRequested', {} },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 1.0, 1.05 }},  --DUNCAN - was 0.9
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
             { UCBC, 'HaveLessThanUnitsWithCategory', { 7, categories.TRANSPORTFOCUS * categories.TECH1 } }, --DUNCAN - added
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.TRANSPORTFOCUS } },
@@ -458,8 +458,8 @@ BuilderGroup {
         Priority = 800,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
-            { MIBC, 'TransportNeedGreater', { 7 } },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},  --DUNCAN - was 0.9
+            { MIBC, 'TransportRequested', {} },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 1.0, 1.05 }},  --DUNCAN - was 0.9
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 10, categories.LAND * (categories.TECH2 + categories.TECH3) } }, --DUNCAN - added
             { UCBC, 'HaveLessThanUnitsWithCategory', { 3, categories.TRANSPORTFOCUS * categories.TECH2 } }, --DUNCAN - added
@@ -473,8 +473,8 @@ BuilderGroup {
         Priority = 900,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
-            { MIBC, 'TransportNeedGreater', { 7 } },
-            { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.05 }},
+            { MIBC, 'TransportRequested', {} },
+            { EBC, 'GreaterThanEconEfficiencyOverTime', { 1.0, 1.05 }},
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.AIR * categories.ANTIAIR } }, --DUNCAN - added
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 10, categories.LAND * categories.TECH3 } }, --DUNCAN - added
             { UCBC, 'HaveLessThanUnitsWithCategory', { 4, categories.TRANSPORTFOCUS * categories.TECH2 } },
@@ -491,7 +491,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { MIBC, 'IsIsland', { true } },
-            { MIBC, 'ArmyNeedsTransports', {} },
+            { MIBC, 'TransportRequested', {} },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},
             { UCBC, 'HaveLessThanUnitsWithCategory', { 7 , categories.TRANSPORTFOCUS * categories.TECH1} },
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.TRANSPORTFOCUS } },
@@ -505,7 +505,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { MIBC, 'IsIsland', { true } },
-            { MIBC, 'ArmyNeedsTransports', {} },
+            { MIBC, 'TransportRequested', {} },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.8, 1.05 }},
             { UCBC, 'HaveLessThanUnitsWithCategory', { 3 , categories.TRANSPORTFOCUS * categories.TECH2} },
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 10, categories.LAND * (categories.TECH2 + categories.TECH3) } }, --DUNCAN - added
@@ -520,7 +520,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { MIBC, 'IsIsland', { true } },
-            { MIBC, 'ArmyNeedsTransports', {} },
+            { MIBC, 'TransportRequested', {} },
             { EBC, 'GreaterThanEconEfficiencyOverTime', { 0.9, 1.05 }},
             { UCBC, 'HaveLessThanUnitsWithCategory', { 4, categories.TRANSPORTFOCUS * categories.TECH2 } },
             { UCBC, 'HaveLessThanUnitsWithCategory', { 2 , categories.TRANSPORTFOCUS * categories.TECH3} },

--- a/lua/AI/AIBuilders/AIEconomicBuilders.lua
+++ b/lua/AI/AIBuilders/AIEconomicBuilders.lua
@@ -23,7 +23,7 @@ local SAI = '/lua/scenarioplatoonai.lua'
 local TBC = '/lua/editor/threatbuildconditions.lua'
 local PlatoonFile = '/lua/platoon.lua'
 
----@alias BuilderGroupsEconomic 'EngineerFactoryBuilders' | 'Engineer Transfers' | 'Land Rush Initial ACU Builders' | 'Balanced Rush Initial ACU Builders' | 'Air Rush Initial ACU Builders' | 'Naval Rush Initial ACU Builders' | 'Default Initial ACU Builders' | 'ACUBuilders' | 'ACUUpgrades - Gun improvements' | 'ACUUpgrades - Tech 2 Engineering' | 'ACUUpgrades - Shields' | 'ACUUpgrades' | 'T1EngineerBuilders' | 'T2EngineerBuilders' | 'T3EngineerBuilders' | 'EngineerMassBuildersHighPri' | 'EngineerMassBuilders - Naval' | 'EngineerMassBuildersLowerPri' | 'EngineerMassBuildersMidPriSingle' | 'EngineerEnergyBuilders' | 'EngineerEnergyBuildersExpansions' | 'EngineeringSupportBuilder'
+---@alias BuilderGroupsEconomic 'EngineerFactoryBuilders' | 'Engineer Transfers' | 'Land Rush Initial ACU Builders' | 'Balanced Rush Initial ACU Builders' | 'Air Rush Initial ACU Builders' | 'Naval Rush Initial ACU Builders' | 'Default Initial ACU Builders' | 'Easy Initial ACU Builders' | 'ACUBuilders' | 'ACUUpgrades - Gun improvements' | 'ACUUpgrades - Tech 2 Engineering' | 'ACUUpgrades - Shields' | 'ACUUpgrades' | 'T1EngineerBuilders' | 'T2EngineerBuilders' | 'T3EngineerBuilders' | 'EngineerMassBuildersHighPri' | 'EngineerMassBuilders - Naval' | 'EngineerMassBuildersLowerPri' | 'EngineerMassBuildersMidPriSingle' | 'EngineerEnergyBuilders' | 'EngineerEnergyBuildersExpansions' | 'EngineeringSupportBuilder'
 
 BuilderGroup {
     BuilderGroupName = 'EngineerFactoryBuilders',
@@ -453,12 +453,12 @@ BuilderGroup {
 }
 
 BuilderGroup {
-    BuilderGroupName = 'Default Initial ACU Builders',
+    BuilderGroupName = 'Easy Initial ACU Builders',
     BuildersType = 'EngineerBuilder',
 
     -- Initial builder
     Builder {
-        BuilderName = 'CDR Initial Default',
+        BuilderName = 'CDR Initial Easy',
         PlatoonAddBehaviors = { 'CommanderBehaviorImproved', },
         PlatoonTemplate = 'CommanderBuilder',
         Priority = 1000,
@@ -485,6 +485,56 @@ BuilderGroup {
                     'T1EnergyProduction',
                     'T1LandFactory',
                 }
+            }
+        }
+    },
+    Builder {
+        BuilderName = 'CDR Initial PreBuilt Easy',
+        PlatoonAddBehaviors = { 'CommanderBehaviorImproved', },
+        PlatoonTemplate = 'CommanderBuilder',
+        Priority = 1000,
+        BuilderConditions = {
+                { IBC, 'PreBuiltBase', {}},
+            },
+        InstantCheck = true,
+        BuilderType = 'Any',
+        PlatoonAddFunctions = { {SAI, 'BuildOnce'}, },
+        BuilderData = {
+            Construction = {
+                BuildStructures = {
+                    'T1EnergyProduction',
+                    'T1EnergyProduction',
+                    'T1EnergyProduction',
+                    'T1EnergyProduction',
+                    'T1EnergyProduction',
+                    'T1AirFactory',
+                    'T1EnergyProduction',
+                }
+            }
+        }
+    },
+}
+
+BuilderGroup {
+    BuilderGroupName = 'Default Initial ACU Builders',
+    BuildersType = 'EngineerBuilder',
+
+    -- Initial builder
+    Builder {
+        BuilderName = 'CDR Initial Default',
+        PlatoonAddBehaviors = { 'CommanderBehaviorImproved', },
+        PlatoonTemplate = 'CommanderInitialBuilder',
+        Priority = 1000,
+        BuilderConditions = {
+                { IBC, 'NotPreBuilt', {}},
+            },
+        InstantCheck = true,
+        BuilderType = 'Any',
+        PlatoonAddFunctions = { {SAI, 'BuildOnce'}, },
+        BuilderData = {
+            Construction = {
+                BaseTemplateFile = '/lua/AI/AIBaseTemplates/ACUBaseTemplate.lua',
+                BaseTemplate = 'ACUBaseTemplate',
             }
         }
     },

--- a/lua/AI/AIBuilders/AIFactoryConstructionBuilders.lua
+++ b/lua/AI/AIBuilders/AIFactoryConstructionBuilders.lua
@@ -316,7 +316,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { UCBC, 'FactoryCapCheck', { 'LocationType', 'Air' } },
-            { MIBC, 'ArmyNeedsTransports', {} },
+            { MIBC, 'TransportRequested', {} },
             { UCBC, 'FactoryLessAtLocation', { 'LocationType', 1, categories.AIR * categories.FACTORY } },
             { UCBC, 'UnitCapCheckLess', { .8 } },
             { EBC, 'MassToFactoryRatioBaseCheck', { 'LocationType' } },

--- a/lua/AI/Transportutilities.lua
+++ b/lua/AI/Transportutilities.lua
@@ -232,7 +232,7 @@ function GetTransports( platoon, aiBrain)
         if TransportDialog then
             LOG("*AI DEBUG "..aiBrain.Nickname.." "..platoon.BuilderName.." there are no transports at all")
         end
-        aiBrain.NeedTransports = true   -- turn on need flag
+        aiBrain.TransportRequested = true   -- turn on need flag
         return false, false
     end
 
@@ -412,7 +412,7 @@ function GetTransports( platoon, aiBrain)
             if TransportDialog then
                 LOG("*AI DEBUG "..aiBrain.Nickname.." "..platoon.BuilderName.." no transports available")
             end
-            aiBrain.NeedTransports = true
+            aiBrain.TransportRequested = true
         end
 		platoon.UsingTransport = false
 		return false, false
@@ -604,7 +604,7 @@ function GetTransports( platoon, aiBrain)
 	if not CanUseTransports then
 		if not out_of_range then
 			-- let the brain know we couldn't fill a transport request by a ground platoon
-			aiBrain.NeedTransports = true
+			aiBrain.TransportRequested = true
 		end
         
         if TransportDialog then
@@ -757,7 +757,7 @@ end
 -- whenever the AI cannot find enough transports to move a platoon it sets a value on the brain indicating that need
 -- this function is run whenever a factory responds to that need and starts building them - clearing the need flag
 function ResetBrainNeedsTransport( aiBrain )
-    aiBrain.NeedTransports = nil
+    aiBrain.TransportRequested = nil
 end
 
 --  This routine should get transports on the way back to an existing base 

--- a/lua/AI/aiattackutilities.lua
+++ b/lua/AI/aiattackutilities.lua
@@ -644,11 +644,10 @@ function AIPlatoonSquadAttackVector(aiBrain, platoon, bAggro)
         local usedTransports = false
         local position = platoon:GetPlatoonPosition()
         if (not path and reason == 'NoPath') or bNeedTransports then
-            
-            usedTransports = TransportUtils.SendPlatoonWithTransports(aiBrain, platoon, attackPos, 1, true)
+            usedTransports = TransportUtils.SendPlatoonWithTransports(aiBrain, platoon, attackPos, 3, true)
         -- Require transports over 500 away
         elseif VDist2Sq(position[1], position[3], attackPos[1], attackPos[3]) > 512*512 then
-            usedTransports = TransportUtils.SendPlatoonWithTransports(aiBrain, platoon, attackPos, 1, true)
+            usedTransports = TransportUtils.SendPlatoonWithTransports(aiBrain, platoon, attackPos, 2, true)
         -- use if possible at 250
         elseif VDist2Sq(position[1], position[3], attackPos[1], attackPos[3]) > 256*256 then
             usedTransports = TransportUtils.SendPlatoonWithTransports(aiBrain, platoon, attackPos, 1, false)

--- a/lua/AI/aiutilities.lua
+++ b/lua/AI/aiutilities.lua
@@ -2096,7 +2096,7 @@ function EngineerMoveWithSafePath(aiBrain, unit, destination)
 
         -- Skip the last move... we want to return and do a build
         -- needTransports need to fix this
-        bUsedTransports = TransportUtils.SendPlatoonWithTransports(aiBrain, unit.PlatoonHandle, destination, 1, true)
+        bUsedTransports = TransportUtils.SendPlatoonWithTransports(aiBrain, unit.PlatoonHandle, destination, 3, true)
         if bUsedTransports then
             return true
         elseif VDist2Sq(pos[1], pos[3], destination[1], destination[3]) > 512 * 512 then

--- a/lua/aibrains/base-ai.lua
+++ b/lua/aibrains/base-ai.lua
@@ -1721,7 +1721,7 @@ AIBrain = Class(StandardBrain) {
         local nearestDistance = nil
         for id, managers in self.BuilderManagers do
             if nearestManagerIdentifier then
-                local location = managers.FactoryManager.Location
+                local location = managers.Position
                 local dx, dz = location[1] - ux, location[3] - uz
                 local distance = dx * dx + dz * dz
                 if distance < nearestDistance then
@@ -1730,7 +1730,7 @@ AIBrain = Class(StandardBrain) {
                     nearestManagerIdentifier = id
                 end
             else
-                local location = managers.FactoryManager.Location
+                local location = managers.Position
                 local dx, dz = location[1] - ux, location[3] - uz
                 nearestDistance = dx * dx + dz * dz
                 nearestManagerIdentifier = id

--- a/lua/aibrains/base-ai.lua
+++ b/lua/aibrains/base-ai.lua
@@ -465,7 +465,7 @@ AIBrain = Class(StandardBrain) {
         local distance, closest
         for k, v in self.BuilderManagers do
             if v.EngineerManager and v.EngineerManager:GetNumCategoryUnits('Engineers', categories.ALLUNITS) > 0
-            and v.FactoryManager and v.FactoryManager:GetNumCategoryFactories(categories.ALLUNITS) > 0 then
+            and v.FactoryManager and v.FactoryManager.LocationActive and v.FactoryManager:GetNumCategoryFactories(categories.ALLUNITS) > 0 then
                 if position and v.Position then
                     if not closest then
                         distance = VDist3(position, v.Position)

--- a/lua/editor/MiscBuildConditions.lua
+++ b/lua/editor/MiscBuildConditions.lua
@@ -204,14 +204,26 @@ end
 
 ---@param aiBrain AIBrain
 ---@return true | nil
-function ArmyNeedsTransports(aiBrain)
+function TransportRequested(aiBrain)
     if aiBrain then
-        if aiBrain.NeedTransports and aiBrain:GetNoRushTicks() <= 0 then
+        if aiBrain.TransportRequested and aiBrain:GetNoRushTicks() <= 0 then
             return true
         end
     end
 end
 
+-- deprecated kept for compatibility
+---@param aiBrain AIBrain
+---@return true | nil
+function ArmyNeedsTransports(aiBrain)
+    if aiBrain then
+        if aiBrain.NeedTransports > 0 and aiBrain:GetNoRushTicks() <= 0 then
+            return true
+        end
+    end
+end
+
+-- deprecated kept for compatibility
 ---@param aiBrain AIBrain
 ---@param number number
 ---@return true | nil

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -949,7 +949,7 @@ Platoon = Class(moho.platoon_methods) {
             if path then
                 local position = self:GetPlatoonPosition()
                 if not success or VDist2(position[1], position[3], bestMarker.position[1], bestMarker.position[3]) > 512 then
-                    usedTransports = TransportUtils.SendPlatoonWithTransports(aiBrain, self, bestMarker.position, 1, true)
+                    usedTransports = TransportUtils.SendPlatoonWithTransports(aiBrain, self, bestMarker.position, 2, true)
                 elseif VDist2(position[1], position[3], bestMarker.position[1], bestMarker.position[3]) > 256 then
                     usedTransports = TransportUtils.SendPlatoonWithTransports(aiBrain, self, bestMarker.position, 1, false)
                 end
@@ -965,7 +965,7 @@ Platoon = Class(moho.platoon_methods) {
                 end
             elseif (not path and reason == 'NoPath') and self.MovementLayer ~= 'Water' then
                 --LOG('Guardmarker requesting transports')
-                local foundTransport = TransportUtils.SendPlatoonWithTransports(aiBrain, self, bestMarker.position, 1, true)
+                local foundTransport = TransportUtils.SendPlatoonWithTransports(aiBrain, self, bestMarker.position, 3, true)
                 --DUNCAN - if we need a transport and we cant get one the disband
                 if not foundTransport then
                     --LOG('Guardmarker no transports')

--- a/lua/sim/FactoryBuilderManager.lua
+++ b/lua/sim/FactoryBuilderManager.lua
@@ -471,8 +471,8 @@ FactoryBuilderManager = Class(BuilderManager) {
                 factory.Trash:Destroy()
 				return self:FactoryDestroyed(factory)
 			end
-		elseif EntityCategoryContains(categories.TRANSPORTFOCUS - categories.uea0203, finishedUnit ) and self.Brain.NeedTransports then
-            self.Brain.NeedTransports = nil
+		elseif self.Brain.TransportRequested and EntityCategoryContains(categories.TRANSPORTFOCUS - categories.uea0203, finishedUnit ) then
+            self.Brain.TransportRequested = nil
             finishedUnit:ForkThread( import('/lua/ai/transportutilities.lua').AssignTransportToPool, finishedUnit:GetAIBrain() )
         end
         self:AssignBuildOrder(factory, factory.BuilderManagerData.BuilderType)


### PR DESCRIPTION
This PR makes the following changes.
Updates the new transport logic to leverage a flag called TransportRequested when more transports are needed.
Previously it used the default NeedTransports flag but this has been found to cause issues with 3rd party AI that are still using the old transport logic due to a callback updating the flag while the old transport code is in a time wait loop.
I've updated all the corresponding functions and build conditions to match and marked the originals as deprecated.

It also fixes a small issue with the FindNearestBaseIdentifier in the base-ai class so that the position search will still work if no factory manager is available (this was already corrected in the easy-ai but not brought across).

It also makes a small update to the TechMain and TurtleMain AI base template to use the new initial bo function. This is to avoid resource stalls early game. The original Default Initial ACU builder group has been renamed to 'Easy Initial ACU Builders' and it used for the Easy and Normal AI.

Testing requirements.
In order to test the transport change. A game can be run with a 3rd party AI that uses the default transport logic. It will no longer error while units are waiting for transports that are being built at factories.