### PR TITLE
Prevent infinite creation of team mode options

### DIFF
--- a/lua/ui/game/multifunction.lua
+++ b/lua/ui/game/multifunction.lua
@@ -1378,11 +1378,18 @@ local function CreateTeamColorSettings()
     LayoutHelpers.AtLeftTopIn(window.CheckBoxScoreColors, window.CheckBoxAutoEnable, 0, 20)
     window.CheckBoxScoreColors.text = UIUtil.CreateText(window, "Change colors in scoreboard", 14, UIUtil.bodyFont)
     LayoutHelpers.AtLeftTopIn(window.CheckBoxScoreColors.text, window.CheckBoxScoreColors, 20, 0)
+
+    return window
 end
 
 function TeamColorHandler(self, modifiers)
     if modifiers.Right then
-        CreateTeamColorSettings()
+        if self.Dropout then
+            self.Dropout:Destroy()
+            self.Dropout = nil
+        else
+            self.Dropout = CreateTeamColorSettings()
+        end
     else
         if self._checkState == "checked" then
             TeamColorMode(false)


### PR DESCRIPTION
Makes right-clicking the team colors buttons act as a toggle for the team colors options panels instead of always creating a new one.

This is only phase 1 of the planned changes - the window doesn't interact well with saving state or the UI, but that isn't something that will get fixed before the release.