### PR TITLE
Give engineers and drones resistance against ACU explosions 

### DIFF
--- a/lua/armordefinition.lua
+++ b/lua/armordefinition.lua
@@ -33,6 +33,7 @@
 ---| "ASF"
 ---| "Commander"
 ---| "Default"
+---| "Engineer"
 ---| "Experimental"
 ---| "ExperimentalStructure"
 ---| "Light"
@@ -108,5 +109,13 @@ armordefinition = {
         -- Armor Definition
         'Normal 1.0',
         'TacticalMissile 0.55',
+    },
+    {
+        -- Armor Type Name
+        'Engineer',
+
+        -- Armor Definition
+        'Normal 1.0',
+        'Deathnuke 0.032',
     },
 }

--- a/lua/armordefinition.lua
+++ b/lua/armordefinition.lua
@@ -33,6 +33,7 @@
 ---| "ASF"
 ---| "Commander"
 ---| "Default"
+---| "Drone"
 ---| "Engineer"
 ---| "Experimental"
 ---| "ExperimentalStructure"
@@ -117,5 +118,13 @@ armordefinition = {
         -- Armor Definition
         'Normal 1.0',
         'Deathnuke 0.032',
+    },
+    {
+        -- Armor Type Name
+        'Drone',
+
+        -- Armor Definition
+        'Normal 1.0',
+        'Deathnuke 0',
     },
 }

--- a/units/UAL0105/UAL0105_unit.bp
+++ b/units/UAL0105/UAL0105_unit.bp
@@ -89,7 +89,7 @@ UnitBlueprint {
     CollisionOffsetY = -0.25,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Normal',
+        ArmorType = 'Engineer',
         EconomyThreatLevel = 0,
         Health = 120,
         MaxHealth = 120,

--- a/units/UAL0208/UAL0208_unit.bp
+++ b/units/UAL0208/UAL0208_unit.bp
@@ -88,7 +88,7 @@ UnitBlueprint {
     CollisionOffsetY = -0.25,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Normal',
+        ArmorType = 'Engineer',
         EconomyThreatLevel = 0,
         Health = 340,
         MaxHealth = 340,

--- a/units/UAL0309/UAL0309_unit.bp
+++ b/units/UAL0309/UAL0309_unit.bp
@@ -87,7 +87,7 @@ UnitBlueprint {
     CollisionOffsetY = -0.25,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Normal',
+        ArmorType = 'Engineer',
         EconomyThreatLevel = 0,
         Health = 680,
         MaxHealth = 680,

--- a/units/UEA0001/UEA0001_unit.bp
+++ b/units/UEA0001/UEA0001_unit.bp
@@ -91,7 +91,7 @@ UnitBlueprint {
     CollisionOffsetY = -0.5,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Light',
+        ArmorType = 'Drone',
         EconomyThreatLevel = 1,
         Health = 6,
         MaxHealth = 6,

--- a/units/UEA0003/UEA0003_unit.bp
+++ b/units/UEA0003/UEA0003_unit.bp
@@ -91,7 +91,7 @@ UnitBlueprint {
     CollisionOffsetY = -0.5,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Light',
+        ArmorType = 'Drone',
         EconomyThreatLevel = 1,
         Health = 6,
         MaxHealth = 6,

--- a/units/UEL0105/UEL0105_unit.bp
+++ b/units/UEL0105/UEL0105_unit.bp
@@ -90,7 +90,7 @@ UnitBlueprint {
     CollisionOffsetZ = -0.1,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Normal',
+        ArmorType = 'Engineer',
         EconomyThreatLevel = 0,
         Health = 150,
         MaxHealth = 150,

--- a/units/UEL0208/UEL0208_unit.bp
+++ b/units/UEL0208/UEL0208_unit.bp
@@ -89,7 +89,7 @@ UnitBlueprint {
     CollisionOffsetZ = -0.05,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Normal',
+        ArmorType = 'Engineer',
         EconomyThreatLevel = 0,
         Health = 400,
         MaxHealth = 400,

--- a/units/UEL0309/UEL0309_unit.bp
+++ b/units/UEL0309/UEL0309_unit.bp
@@ -88,7 +88,7 @@ UnitBlueprint {
     CollisionOffsetZ = -0.1,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Normal',
+        ArmorType = 'Engineer',
         EconomyThreatLevel = 0,
         Health = 800,
         MaxHealth = 800,

--- a/units/URL0105/URL0105_unit.bp
+++ b/units/URL0105/URL0105_unit.bp
@@ -90,7 +90,7 @@ UnitBlueprint {
     CollisionOffsetY = -0.25,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Normal',
+        ArmorType = 'Engineer',
         EconomyThreatLevel = 0,
         Health = 145,
         MaxHealth = 145,

--- a/units/URL0208/URL0208_unit.bp
+++ b/units/URL0208/URL0208_unit.bp
@@ -89,7 +89,7 @@ UnitBlueprint {
     CollisionOffsetY = -0.25,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Normal',
+        ArmorType = 'Engineer',
         EconomyThreatLevel = 0,
         Health = 390,
         MaxHealth = 390,

--- a/units/URL0309/URL0309_unit.bp
+++ b/units/URL0309/URL0309_unit.bp
@@ -88,7 +88,7 @@ UnitBlueprint {
     CollisionOffsetY = -0.25,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Normal',
+        ArmorType = 'Engineer',
         EconomyThreatLevel = 0,
         Health = 740,
         MaxHealth = 740,

--- a/units/XEA3204/XEA3204_unit.bp
+++ b/units/XEA3204/XEA3204_unit.bp
@@ -108,7 +108,7 @@ UnitBlueprint {
     CollisionOffsetZ = -0.07,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Light',
+        ArmorType = 'Drone',
         EconomyThreatLevel = 1,
         Health = 50,
         MaxHealth = 50,

--- a/units/XEL0209/XEL0209_unit.bp
+++ b/units/XEL0209/XEL0209_unit.bp
@@ -97,7 +97,7 @@ UnitBlueprint {
     CollisionOffsetZ = -0.05,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Normal',
+        ArmorType = 'Engineer',
         EconomyThreatLevel = 0,
         Health = 1040,
         MaxHealth = 1040,

--- a/units/XSL0105/XSL0105_unit.bp
+++ b/units/XSL0105/XSL0105_unit.bp
@@ -89,7 +89,7 @@ UnitBlueprint {
     CollisionOffsetY = -0.15,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Normal',
+        ArmorType = 'Engineer',
         EconomyThreatLevel = 0,
         Health = 125,
         MaxHealth = 125,

--- a/units/XSL0208/XSL0208_unit.bp
+++ b/units/XSL0208/XSL0208_unit.bp
@@ -88,7 +88,7 @@ UnitBlueprint {
     CollisionOffsetY = -0.15,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Normal',
+        ArmorType = 'Engineer',
         EconomyThreatLevel = 0,
         Health = 350,
         MaxHealth = 350,

--- a/units/XSL0309/XSL0309_unit.bp
+++ b/units/XSL0309/XSL0309_unit.bp
@@ -87,7 +87,7 @@ UnitBlueprint {
     CollisionOffsetY = -0.25,
     Defense = {
         AirThreatLevel = 0,
-        ArmorType = 'Normal',
+        ArmorType = 'Engineer',
         EconomyThreatLevel = 0,
         Health = 700,
         MaxHealth = 700,


### PR DESCRIPTION
**1. Adds the ArmorType “Engineer”**

**2. All engineers**
ArmorType: “Normal” --> “Engineer”

- ACU explosions no longer lead to the crippling loss of all build power in the base.
- Especially relevant in light of the recent connection issues. Gives the team which loses a player to a DC more of a fighting chance.
- Also related to (and partially fixes) #5006

This commit tackles all engineers. I will make another commit for drones, which have the same problem and will have a damage resistance of 100%.

**Edit:** Added the changes to drones here to prevent conflicts.
