### PR TITLE
Update base-ai callbacks to reference engineer manager correctly.

### DIFF
--- a/lua/aibrains/base-ai.lua
+++ b/lua/aibrains/base-ai.lua
@@ -1754,7 +1754,7 @@ AIBrain = Class(StandardBrain) {
 
         -- register unit at managers of base
         local managers = self.BuilderManagers[nearestBaseIdentifier]
-        if managers.EngineerManager then
+        if managers and managers.EngineerManager then
             managers.EngineerManager:OnUnitStartBeingBuilt(unit, builder, layer)
         end
     end,
@@ -1774,7 +1774,7 @@ AIBrain = Class(StandardBrain) {
         end
 
         local managers = self.BuilderManagers[baseIdentifier]
-        if managers.EngineerManager then
+        if managers and managers.EngineerManager then
             managers.EngineerManager:OnUnitStopBeingBuilt(unit, builder, layer)
         end
     end,
@@ -1791,7 +1791,7 @@ AIBrain = Class(StandardBrain) {
         end
 
         local managers = self.BuilderManagers[baseIdentifier]
-        if managers.EngineerManager then
+        if managers and managers.EngineerManager then
             managers.EngineerManager:OnUnitStopBeingBuilt(unit)
         end
     end,
@@ -1809,7 +1809,7 @@ AIBrain = Class(StandardBrain) {
         end
 
         local managers = self.BuilderManagers[baseIdentifier]
-        if managers.EngineerManager then
+        if managers and managers.EngineerManager then
             managers.EngineerManager:OnUnitStartBuilding(unit)
         end
     end,
@@ -1827,7 +1827,7 @@ AIBrain = Class(StandardBrain) {
         end
 
         local managers = self.BuilderManagers[baseIdentifier]
-        if managers.EngineerManager then
+        if managers and managers.EngineerManager then
             managers.EngineerManager:OnUnitStopBuilding(unit)
         end
     end,

--- a/lua/aibrains/base-ai.lua
+++ b/lua/aibrains/base-ai.lua
@@ -1754,7 +1754,7 @@ AIBrain = Class(StandardBrain) {
 
         -- register unit at managers of base
         local managers = self.BuilderManagers[nearestBaseIdentifier]
-        if managers then
+        if managers.EngineerManager then
             managers.EngineerManager:OnUnitStartBeingBuilt(unit, builder, layer)
         end
     end,
@@ -1774,7 +1774,7 @@ AIBrain = Class(StandardBrain) {
         end
 
         local managers = self.BuilderManagers[baseIdentifier]
-        if managers then
+        if managers.EngineerManager then
             managers.EngineerManager:OnUnitStopBeingBuilt(unit, builder, layer)
         end
     end,
@@ -1791,7 +1791,7 @@ AIBrain = Class(StandardBrain) {
         end
 
         local managers = self.BuilderManagers[baseIdentifier]
-        if managers then
+        if managers.EngineerManager then
             managers.EngineerManager:OnUnitStopBeingBuilt(unit)
         end
     end,
@@ -1809,7 +1809,7 @@ AIBrain = Class(StandardBrain) {
         end
 
         local managers = self.BuilderManagers[baseIdentifier]
-        if managers then
+        if managers.EngineerManager then
             managers.EngineerManager:OnUnitStartBuilding(unit)
         end
     end,
@@ -1827,7 +1827,7 @@ AIBrain = Class(StandardBrain) {
         end
 
         local managers = self.BuilderManagers[baseIdentifier]
-        if managers then
+        if managers.EngineerManager then
             managers.EngineerManager:OnUnitStopBuilding(unit)
         end
     end,


### PR DESCRIPTION
This PR changes some of the new base-ai callbacks so they will check if the engineer manager exists before trying to call a function against it.

Callback list updated:
OnUnitStopBuilding
OnUnitStartBuilding
OnUnitDestroyed
OnUnitStopBeingBuilt
OnUnitStartBeingBuilt

Test.
Run an AI game and wait until there is a decent number of units. Then kill one of the AI's. Previously you would get callback errors on unit deaths due to the engineer manager having been destroyed. Now you should get none.