### PR TITLE
change FactoryFinishBuilding callback to use transportpool flag

### DIFF
--- a/lua/sim/FactoryBuilderManager.lua
+++ b/lua/sim/FactoryBuilderManager.lua
@@ -471,7 +471,7 @@ FactoryBuilderManager = Class(BuilderManager) {
                 factory.Trash:Destroy()
 				return self:FactoryDestroyed(factory)
 			end
-		elseif self.Brain.TransportRequested and EntityCategoryContains(categories.TRANSPORTFOCUS - categories.uea0203, finishedUnit ) then
+		elseif self.Brain.TransportPool and EntityCategoryContains(categories.TRANSPORTFOCUS - categories.uea0203, finishedUnit ) then
             self.Brain.TransportRequested = nil
             finishedUnit:ForkThread( import('/lua/ai/transportutilities.lua').AssignTransportToPool, finishedUnit:GetAIBrain() )
         end


### PR DESCRIPTION
This PR modifies the AI FactoryFinishBuilding callback in the factory manager to check if a transport pool exist before trying to assign transports that are built into the pool. This is to avoid compatibility issues with 3rd party AI.