### PR TITLE
Fix bug with build drones becoming immobile

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4314,6 +4314,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     ---@param transport BaseTransport
     ---@param bone Bone
     OnStartTransportBeamUp = function(self, transport, bone)
+        self.TransportBeamEffectsBag = self.TransportBeamEffectsBag or TrashBag()
+
         local slot = transport.slots[bone]
         if slot then
             self:GetAIBrain():OnTransportFull()
@@ -4324,7 +4326,6 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         self:DestroyIdleEffects()
         self:DestroyMovementEffects()
 
-        self.TransportBeamEffectsBag = self.TransportBeamEffectsBag or TrashBag()
         TrashAdd(self.TransportBeamEffectsBag, AttachBeamEntityToEntity(self, -1, transport, bone, self.Army, EffectTemplate.TTransportBeam01))
         TrashAdd(self.TransportBeamEffectsBag, AttachBeamEntityToEntity(transport, bone, self, -1, self.Army, EffectTemplate.TTransportBeam02))
         TrashAdd(self.TransportBeamEffectsBag, CreateEmitterAtBone(transport, bone, self.Army, EffectTemplate.TTransportGlow01))

--- a/units/UEL0301/UEL0301_script.lua
+++ b/units/UEL0301/UEL0301_script.lua
@@ -83,6 +83,22 @@ UEL0301 = ClassUnit(CommandUnit) {
         end
     end,
 
+    ---@param self UEL0301
+    ---@param bone Bone
+    ---@param attachee Unit
+    OnTransportAttach = function(self, bone, attachee)
+        CommandUnit.OnTransportAttach(self, bone, attachee)
+        attachee:SetDoNotTarget(true)
+    end,
+
+    ---@param self UEL0301
+    ---@param bone Bone
+    ---@param attachee Unit
+    OnTransportDetach = function(self, bone, attachee)
+        CommandUnit.OnTransportDetach(self, bone, attachee)
+        attachee:SetDoNotTarget(false)
+    end,
+
     CreateEnhancement = function(self, enh)
         CommandUnit.CreateEnhancement(self, enh)
         local bp = self:GetBlueprint().Enhancements[enh]


### PR DESCRIPTION
As described on the forums:

- https://forum.faforever.com/topic/6190/developers-iteration-ii-of-2023/10

Fixes the following error that happens when a unit tries to occupy a slot on a transport that is already occupied:

```
warning: Error running OnStopTransportBeamUp script in Entity url0107 at 2c7a6e08: g:\code\relent0r\fa\lua\system\trashbag.lua(74): attempt to loop over local `self' (a nil value)
         stack traceback:
             g:\code\relent0r\fa\lua\system\trashbag.lua(74): in function <g:\code\relent0r\fa\lua\system\trashbag.lua:66>
             g:\code\relent0r\fa\lua\sim\unit.lua(4339): in function <g:\code\relent0r\fa\lua\sim\unit.lua:4336>
             [C]: in function `IssueClearCommands'
             g:\code\relent0r\fa\lua\sim\unit.lua(4320): in function <g:\code\relent0r\fa\lua\sim\unit.lua:4316>
```

And fixes the problem where docked engineer drones for the UEF SACU would still be targeted by anti air.
