### PR TITLE
Fix new enhancement removal

### DIFF
--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -453,7 +453,7 @@ UnitBlueprint {
                 'Left_Upgrade',
             },
             Name = '<LOC enhancements_0005>Remove Enhanced Quantum Disruptor',
-            Prerequisite = 'CrysalisBeam',
+            Prerequisite = 'AdvancedCrysalisBeam',
             RemoveEnhancements = {
                 'CrysalisBeam',
                 'AdvancedCrysalisBeam',

--- a/units/URL0001/URL0001_script.lua
+++ b/units/URL0001/URL0001_script.lua
@@ -221,7 +221,7 @@ URL0001 = ClassUnit(ACUUnit, CCommandUnit) {
                 Buff.RemoveBuff(self, 'CybranACUCloakBonus')
             end
             if Buff.HasBuff(self, 'CybranACURegenerateBonus') then
-                Buff.RemoveBuff(self, 'CybranACUCloakBonus')
+                Buff.RemoveBuff(self, 'CybranACURegenerateBonus')
             end
             if Buff.HasBuff(self, 'CybranACUStealthBonus') then
                 Buff.RemoveBuff(self, 'CybranACUStealthBonus')


### PR DESCRIPTION
Getting the Advanced Quantum Disruptor no longer break upon removal.

Removing the Cloaking Generator now properly removes the Nano regeneration bonus.