### PR TITLE
Re-introduce the 'OnUnitKilled' callback

### DIFF
--- a/lua/aibrains/base-ai.lua
+++ b/lua/aibrains/base-ai.lua
@@ -1719,21 +1719,23 @@ AIBrain = Class(StandardBrain) {
         local ux, _, uz = position[1], nil, position[3]
         local nearestManagerIdentifier = nil
         local nearestDistance = nil
-        for id, managers in self.BuilderManagers do
-            if nearestManagerIdentifier then
-                local location = managers.Position
-                local dx, dz = location[1] - ux, location[3] - uz
-                local distance = dx * dx + dz * dz
-                if distance < nearestDistance then
-                    nearestDistance = distance
+        if self.BuilderManagers then
+            for id, managers in self.BuilderManagers do
+                if nearestManagerIdentifier then
+                    local location = managers.Position
+                    local dx, dz = location[1] - ux, location[3] - uz
+                    local distance = dx * dx + dz * dz
+                    if distance < nearestDistance then
+                        nearestDistance = distance
 
+                        nearestManagerIdentifier = id
+                    end
+                else
+                    local location = managers.Position
+                    local dx, dz = location[1] - ux, location[3] - uz
+                    nearestDistance = dx * dx + dz * dz
                     nearestManagerIdentifier = id
                 end
-            else
-                local location = managers.Position
-                local dx, dz = location[1] - ux, location[3] - uz
-                nearestDistance = dx * dx + dz * dz
-                nearestManagerIdentifier = id
             end
         end
 

--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -703,9 +703,6 @@ VeterancyComponent = ClassSimple {
         self:AddVetExperience(massKilled, noLimit)
     end,
 
-    -- kept for backwards compatibility with mods, but should really not be used anymore
-
-    ---@deprecated
     ---@param self Unit | VeterancyComponent
     ---@param instigator Unit
     OnKilledUnit = function (self, unitThatIsDying, experience)
@@ -718,6 +715,8 @@ VeterancyComponent = ClassSimple {
             self:AddVetExperience(vetWorth, false)
         end
     end,
+
+    -- kept for backwards compatibility with mods, but should really not be used anymore
 
     ---@deprecated
     ---@param self Unit | VeterancyComponent

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -650,7 +650,7 @@ function InitializeArmies()
     for iArmy, strArmy in tblArmy do
         local setup = armySetups[strArmy]
         if setup.Civilian then
-            if strArmy == 'ARMY_17' or strArmy == 'ARMY_09' then
+            if strArmy == 'ARMY_17' or strArmy == 'ARMY_09' or strArmy == 'ARMY_9' then
                 hostileCivilians = iArmy
                 break
             end

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1396,8 +1396,12 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             return
         end
 
-        local layer = self.Layer
+        -- this flag is used to skip the need of `IsDestroyed`
         self.Dead = true
+
+        local layer = self.Layer
+        local bp = self.Blueprint
+        local army = self.Army
 
         -- Units killed while being invisible because they're teleporting should show when they're killed
         if self.TeleportFx_IsInvisible then
@@ -1405,7 +1409,6 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             self:ShowEnhancementBones()
         end
 
-        local bp = self.Blueprint
         if layer == 'Water' and bp.Physics.MotionType == 'RULEUMT_Hover' then
             self:PlayUnitSound('HoverKilledOnWater')
         elseif layer == 'Land' and bp.Physics.MotionType == 'RULEUMT_AmphibiousFloating' then
@@ -1428,8 +1431,6 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             self.UnitBeingTeleported = nil
         end
 
-        ArmyBrains[self:GetArmy()].LastUnitKilledBy = (instigator or self):GetArmy()
-
         if self.DeathWeaponEnabled ~= false then
             self:DoDeathWeapon()
         end
@@ -1441,12 +1442,28 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         self:DisableUnitIntel('Killed')
         self:ForkThread(self.DeathThread, overkillRatio , instigator)
 
-        ArmyBrains[self.Army]:AddUnitStat(self.UnitId, "lost", 1)
+        -- awareness for traitor game mode and game statistics
+        ArmyBrains[army].LastUnitKilledBy = (instigator or self).Army
+        ArmyBrains[army]:AddUnitStat(self.UnitId, "lost", 1)
+
+        -- awareness of instigator that it killed a unit
+        if instigator then
+            instigator:OnKilledUnit(self)
+        end
 
         -- awareness of event for AI
         local aiPlatoon = self.AIPlatoonReference
         if aiPlatoon then
             aiPlatoon:OnKilled(self, instigator, type, overkillRatio)
+        end
+    end,
+
+    ---@param self Unit
+    ---@param unitKilled Unit
+    ---@param experience number | nil
+    OnKilledUnit = function (self, unitKilled, experience)
+        if experience then
+            VeterancyComponent.OnKilledUnit(self, unitKilled, experience)
         end
     end,
 


### PR DESCRIPTION
We deprecated the `OnUnitKilled` callback thinking that it wasn't being used. But - as with anything after more than 10 years - it was being used by for example the Zone Control maps. The callback is now being called again and you can earn cash in Zone Control 😄 

![image](https://github.com/FAForever/fa/assets/15778155/ef5b71fd-e58a-499c-8fd9-f75157971f26)
