### PR TITLE
Targeted prefetching of assets

### DIFF
--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -78,16 +78,9 @@ function ShuffleStartPositions(syncNewPositions)
     end
 end
 
-Prefetcher = CreatePrefetchSet()
-
 --SetupSession will be called by the engine after ScenarioInfo is set
 --but before any armies are created.
 function SetupSession()
-
-    -- start prefetching
-    -- local template = import("/lua/sim/prefetchtemplates.lua").DefaultUnits
-    -- local prefetchData = import("/lua/sim/PrefetchUtilities.lua").CreatePrefetchSetFromBlueprints(template)
-    -- Prefetcher:Update(prefetchData)
 
     import("/lua/ai/gridreclaim.lua").Setup()
 

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -224,7 +224,7 @@ function CreateUI(isReplay)
 
     ConExecute("Cam_Free off")
 
-    -- UI assets should be loaded fast into memory to prevent stutter
+    -- load it all fast to prevent stutters
     ConExecute('res_AfterPrefetchDelay 2')
     ConExecute('res_PrefetcherActivityDelay 1')
 

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -148,6 +148,7 @@ function OnFirstUpdate()
 end
 
 function CreateUI(isReplay)
+
     -- overwrite some globals for performance / safety
 
     import("/lua/ui/override/exit.lua")
@@ -222,7 +223,39 @@ function CreateUI(isReplay)
     OriginalFocusArmy = focusArmy
 
     ConExecute("Cam_Free off")
+
+    -- UI assets should be loaded fast into memory to prevent stutter
+    ConExecute('res_AfterPrefetchDelay 2')
+    ConExecute('res_PrefetcherActivityDelay 1')
+
     local prefetchTable = { models = {}, anims = {}, d3d_textures = {}, batch_textures = {} }
+
+    prefetchTable.batch_textures = table.concatenate(
+        DiskFindFiles("/textures/ui", "*.dds")
+    )
+
+    prefetchTable.d3d_textures = table.concatenate(
+        DiskFindFiles("/textures/particles", "*.dds"),
+        DiskFindFiles("/textures/effects", "*.dds"),
+        DiskFindFiles("/projectiles", "*.dds"),
+        DiskFindFiles("/meshes/", "*.dds")
+    )
+
+    prefetchTable.models = table.concatenate(
+        DiskFindFiles("/projectiles", "*.scm"),
+        DiskFindFiles("/meshes/", "*.scm")
+    )
+
+    prefetchTable.anims = table.concatenate(
+        DiskFindFiles("/units/", "*.sca")
+    )
+
+    SPEW(string.format("Preloading %d batch textures", table.getn(prefetchTable.batch_textures)))
+    SPEW(string.format("Preloading %d d3d textures", table.getn(prefetchTable.d3d_textures)))
+    SPEW(string.format("Preloading %d models", table.getn(prefetchTable.models)))
+    SPEW(string.format("Preloading %d animations", table.getn(prefetchTable.anims)))
+
+    Prefetcher:Update(prefetchTable)
 
     -- Set up our layout change function
     UIUtil.changeLayoutFunction = SetLayout
@@ -231,8 +264,6 @@ function CreateUI(isReplay)
     if focusArmy >= 1 then
         LocGlobals.PlayerName = GetArmiesTable().armiesTable[focusArmy].nickname
     end
-
-    GameCommon.InitializeUnitIconBitmaps(prefetchTable.batch_textures)
 
     controls.gameParent = UIUtil.CreateScreenGroup(GetFrame(0), "GameMain ScreenGroup")
     gameParent = controls.gameParent
@@ -305,11 +336,6 @@ function CreateUI(isReplay)
         end
         return false
     end
-
-    Prefetcher:Update(prefetchTable)
-    -- UI assets should be loaded fast into memory to prevent stutter
-    ConExecute('res_AfterPrefetchDelay 100')
-    ConExecute('res_PrefetcherActivityDelay 1')
 
     if SessionIsReplay() then
         ForkThread(SendChat)


### PR DESCRIPTION
There has been a lot of attempts to utilize prefetching. One of them being #4406. For a long time this was very much guess work and we made a few mistakes while experimenting. But lately I found out about the console commands that are related to resources:

- `res_AfterPrefetchDelay`
- `res_PrefetcherActivityDelay` 
- `res_EnablePrefetching`
- `res_SpewLoadSpam` 

And in particular the last one is critical: it tells us _exactly_ when and what the game is loading an asset and how it is loading it! With that we managed to learn one important rule:

- All assets remain in memory as long as **they are in active use**

And that sounds logical, but what matters is that assets are actively unloaded as they are no longer used. The one exception is assets used by emitters: they remain loaded. But maybe that is because we're not cleaning them up properly, I'm not sure at this point.

What matters here is that there are a lot of assets that we continuously reload throughout a game. A few, perhaps unexpected, examples:

- Projectiles with meshes (and related assets, such as textures) are (re) loaded all the time, as an example:
- - Various triad-like units (such as the tech 1 UEF tank)
- - Various bombers
- Shield collision effects are (re) loaded all the time
- Animations are (re) loaded all the time
- The 'command issued' little blue mesh is (re) loaded all the time

Take as an example this replay: https://replay.faforever.com/20224637 (13 minutes long)

- `projectiles\shieldcollider\shieldcollider_lod0.scm` is (re) loaded 50+ times
- `units\xsl0101\xsl0101_awalk01.sca` is (re) loaded 15+ times
- `projectiles\caamissilenanite01\caamissilenanite01_lod0.scm` is (re) loaded 5+ times
- `units\xsb3101\xsb3101_adeath.sca` is (re) loaded 5+ times
- `projectiles\tifnapalmcarpetbomb01\tifnapalmcarpetbomb01_albedo.dds` is (re) loaded 13+ times
- `meshes\game\ping_attack_lod0.scm` used for pinging, is (re) loaded as many times there are pings
- `projectiles\sinker\sinker_lod0.scm` used for sinking, is (re) loaded 29+ times even though the mesh always hidden (!)

Every time the game is loading an asset it involves a rather expensive disk operation, decompressing the files and then serializing the files for use. Especially the disk operation can be quite expensive. After a bit of testing between replays we found a few proper candidates to preload:

- (1) All UI assets that are inside `/textures/ui`
- (2) All particle textures
- (3) All effect related textures, meshes
- (4) All projectile related textures, meshes
- (5) All common entities related textures, meshes
- (6) All (unit) animations

We prefetch (1) to prevent the sampling of the disk throughout the game for UI related assets. We prefetch (2) because they will all end up in memory regardless. We prefetch (3), (4), (5) and (6) because these are assets that are usually a one-time use and are therefore de-allocated accordingly. By prefetching them they remain in memory and are no longer constantly reloaded

In total this prefetches the following assets:

```
DEBUG: Preloading 10005 batch textures
DEBUG: Preloading 967 d3d textures
DEBUG: Preloading 110 models
DEBUG: Preloading 532 animations
```

The batch textures are UI-related. This sounds like a lot, but you have to remember that the average UI texture has four different states and that they are usually very small. In total (all prefetching combined) it is roughly 300 megabytes worth of information. Which is fine as a lot of these assets end up being loaded in regardless. And we recently gained one additional gigabyte of memory 😄 