### PR TITLE
Allow personal shields in transports

### DIFF
--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -133,6 +133,9 @@ end
 ---@class Shield : moho.shield_methods, Entity
 ---@field Brain AIBrain
 Shield = ClassShield(moho.shield_methods, Entity) {
+
+    RemainEnabledWhenAttached = false,
+
     __init = function(self, spec, owner)
         -- This key deviates in name from the blueprints...
         spec.Size = spec.ShieldSize
@@ -1172,6 +1175,9 @@ TransportShield = ClassShield(Shield) {
 -- grants extra health.
 ---@class PersonalShield : Shield
 PersonalShield = ClassShield(Shield){
+
+    RemainEnabledWhenAttached = true,
+
     OnCreate = function(self, spec)
         Shield.OnCreate(self, spec)
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4632,7 +4632,9 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     OnAttachedToTransport = function(self, transport, bone)
         self:MarkWeaponsOnTransport(true)
         if self:ShieldIsOn() or self.MyShield.Charging then
-            if not self.MyShield.SkipAttachmentCheck then 
+
+            local shield = self.MyShield
+            if shield and not (shield.SkipAttachmentCheck or shield.RemainEnabledWhenAttached) then
                 self:DisableShield()
             end
 


### PR DESCRIPTION
Allows personal shields to remain enabled on a transport. This also allows them to recharge while they are on a transport, unlike other bubble shields