### PR TITLE
Update Seraphim T1 pgn wreck

### DIFF
--- a/units/XSB1101/XSB1101_unit.bp
+++ b/units/XSB1101/XSB1101_unit.bp
@@ -62,14 +62,6 @@ UnitBlueprint {
         Abilities = {
             '<LOC ability_deathaoe>Volatile',
         },
-        AnimationDeath = {
-            {
-                Animation = '/units/xsb1101/xsb1101_ADeath.sca',
-                AnimationRateMax = 1,
-                AnimationRateMin = 1,
-                Weight = 100,
-            },
-        },
         DamageEffects = {
             {
                 Bone = 0,


### PR DESCRIPTION
Completes #4335

-Removed death animation to make pgn wreckage after death consistent.

![Screenshot (122)](https://github.com/FAForever/fa/assets/106542089/1fc4ddb4-36b1-47ba-8407-72435d067ed7)
