### PR TITLE
Fix a bug with the file picker being case sensitive

### DIFF
--- a/engine/User.lua
+++ b/engine/User.lua
@@ -419,7 +419,7 @@ end
 
 --- Returns a table of strings which are the names of files in special locations (currently SaveFile, Replay)
 ---@param type string
----@return table
+---@return { extension: string, directory: string, files: table<string, string[]> }
 function GetSpecialFiles(type)
 end
 

--- a/lua/ui/controls/filepicker.lua
+++ b/lua/ui/controls/filepicker.lua
@@ -625,14 +625,16 @@ FilePicker = ClassUI(Group) {
 
         self._currentDir = filesData.directory
         self._currentExt = filesData.extension
-
         self._currentFiles = {}
 
         if (self._onlyMineCheckbox == nil) or self._onlyMineCheckbox:IsChecked() then
-            local curProfileName = Prefs.GetCurrentProfile().Name
-            if filesData.files[curProfileName] then
-                for index, file in filesData.files[curProfileName] do
-                    table.insert(self._currentFiles, {curProfileName, file})
+            -- find the current profile in a case insensitive manner
+            local curProfileName = string.lower(Prefs.GetCurrentProfile().Name)
+            for id, files in filesData.files do
+                if string.lower(id) == curProfileName then
+                    for index, file in files do
+                        table.insert(self._currentFiles, {curProfileName, file})
+                    end
                 end
             end
         else


### PR DESCRIPTION
Specifically the following could happen:

```
INFO:  - directory: C:\Users\Jip\Documents\My Games\Gas Powered Games\Supreme Commander Forged Alliance\replays\
INFO:  - extension: SCFAReplay
INFO:  - files: table: 11812460
INFO:  -    1: table: 11812488
INFO:  -       1: LastGame
INFO:  -       2: temp
INFO:  -    FAF_Az0t: table: 118129B0
INFO:  -       1: LastGame
INFO:  -    Jip: table: 118124B0
INFO:  -       1: LastGame
INFO:  -       2: temp
INFO:  -    a: table: 11812A00
INFO:  -       1: LastGame
INFO:  -    b: table: 11812A28
INFO:  -       1: LastGame
INFO:  -    be: table: 11812A50
INFO:  -       1: LastGame
INFO:  -    jip-dev: table: 11812A78
INFO:  -       1: 210710-0104 Painted Desert
INFO:  -       2: LastGame
INFO: jip
```

The last line represents the name of the profile, as returned by `Prefs.GetCurrentProfile().Name`. But using `GetSpecialFiles(self._fileType)` would return the profile using a capital `J`. As a result no files were shown.

![image](https://github.com/FAForever/fa/assets/15778155/635c34f4-82db-40d6-accf-466ee286ccdb)
