### PR TITLE
Fix for mods that replace default platoon template files

### DIFF
--- a/lua/AI/PlatoonTemplates/AirPlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/AirPlatoonTemplates.lua
@@ -7,6 +7,7 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
+-- Note some mods will replace this file, any new templates that need to be added should be added to AirPlatoonNewTemplates.lua
 -- ==== Global Form platoons ==== --
 PlatoonTemplate {
     Name = 'AirAttack',

--- a/lua/AI/PlatoonTemplates/EngineerPlatoonNewTemplates.lua
+++ b/lua/AI/PlatoonTemplates/EngineerPlatoonNewTemplates.lua
@@ -1,0 +1,58 @@
+--------------------------------------------------------------------------*
+--
+--  File     :  /lua/ai/EngineerPlatoonNewTemplates.lua
+--
+--  Summary  : Global platoon templates
+--
+--  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+----------------------------------------------------------------------------
+
+-- Engineer platoons to be formed
+
+PlatoonTemplate {
+    Name = 'T123EngineerBuilder',
+    Plan = 'EngineerBuildAI',
+    GlobalSquads = {
+        { categories.ENGINEER * (categories.TECH1 + categories.TECH2 + categories.TECH3) - categories.ENGINEERSTATION - categories.COMMAND, 1, 1, 'support', 'none' },
+    },
+}
+
+PlatoonTemplate {
+    Name = 'T1EngineerGridReclaimer',
+    Plan = 'ReclaimGridAI',
+    GlobalSquads = {
+        { categories.ENGINEER * categories.TECH1, 1, 1, 'support', 'None' }
+    },
+}
+
+PlatoonTemplate {
+    Name = 'T2EngineerGridReclaimer',
+    Plan = 'ReclaimGridAI',
+    GlobalSquads = {
+        { categories.ENGINEER * categories.TECH2, 1, 1, 'support', 'None' }
+    },
+}
+
+PlatoonTemplate {
+    Name = 'T3EngineerGridReclaimer',
+    Plan = 'ReclaimGridAI',
+    GlobalSquads = {
+        { categories.ENGINEER * categories.TECH3, 1, 1, 'support', 'None' }
+    },
+}
+
+PlatoonTemplate {
+    Name = 'EngineerDrop',
+    Plan = 'EngineerDropAI',
+    GlobalSquads = {
+        { categories.ENGINEER * categories.TECH1, 6, 6, 'support', 'None' }
+    },
+}
+
+PlatoonTemplate {
+    Name = 'CommanderInitialBuilder',
+    Plan = 'CommanderInitialBOAI',
+    GlobalSquads = {
+        { categories.COMMAND, 1, 1, 'support', 'None' }
+    },
+}

--- a/lua/AI/PlatoonTemplates/EngineerPlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/EngineerPlatoonTemplates.lua
@@ -26,14 +26,6 @@ PlatoonTemplate {
 }
 
 PlatoonTemplate {
-    Name = 'CommanderInitialBuilder',
-    Plan = 'CommanderInitialBOAI',
-    GlobalSquads = {
-        { categories.COMMAND, 1, 1, 'support', 'None' }
-    },
-}
-
-PlatoonTemplate {
     Name = 'CommanderEnhance',
     Plan = 'EnhanceAI',
     GlobalSquads = {
@@ -58,45 +50,12 @@ PlatoonTemplate {
 }
 
 PlatoonTemplate {
-    Name = 'EngineerDrop',
-    Plan = 'EngineerDropAI',
-    GlobalSquads = {
-        { categories.ENGINEER * categories.TECH1, 6, 6, 'support', 'None' }
-    },
-}
-
-PlatoonTemplate {
     Name = 'T1EngineerReclaimer',
     Plan = 'ReclaimAI',
     GlobalSquads = {
         { categories.ENGINEER * categories.TECH1, 1, 1, 'support', 'None' }
     },
 }
-
-PlatoonTemplate {
-    Name = 'T1EngineerGridReclaimer',
-    Plan = 'ReclaimGridAI',
-    GlobalSquads = {
-        { categories.ENGINEER * categories.TECH1, 1, 1, 'support', 'None' }
-    },
-}
-
-PlatoonTemplate {
-    Name = 'T2EngineerGridReclaimer',
-    Plan = 'ReclaimGridAI',
-    GlobalSquads = {
-        { categories.ENGINEER * categories.TECH2, 1, 1, 'support', 'None' }
-    },
-}
-
-PlatoonTemplate {
-    Name = 'T3EngineerGridReclaimer',
-    Plan = 'ReclaimGridAI',
-    GlobalSquads = {
-        { categories.ENGINEER * categories.TECH3, 1, 1, 'support', 'None' }
-    },
-}
-
 
 PlatoonTemplate {
     Name = 'T2EngineerAssist',
@@ -159,14 +118,6 @@ PlatoonTemplate {
     Plan = 'TransferAI',
     GlobalSquads = {
         { categories.ENGINEER * categories.TECH3 - categories.ENGINEERSTATION, 1, 1, 'support', 'none' },
-    },
-}
-
-PlatoonTemplate {
-    Name = 'T123EngineerBuilder',
-    Plan = 'EngineerBuildAI',
-    GlobalSquads = {
-        { categories.ENGINEER * (categories.TECH1 + categories.TECH2 + categories.TECH3) - categories.ENGINEERSTATION - categories.COMMAND, 1, 1, 'support', 'none' },
     },
 }
 

--- a/lua/AI/PlatoonTemplates/EngineerPlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/EngineerPlatoonTemplates.lua
@@ -7,6 +7,7 @@
 --  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 ----------------------------------------------------------------------------
 
+-- Note some mods will replace this file, any new templates that need to be added should be added to EngineerPlatoonNewTemplates.lua
 -- Engineer platoons to be formed
 
 PlatoonTemplate {

--- a/lua/AI/PlatoonTemplates/LandPlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/LandPlatoonTemplates.lua
@@ -7,6 +7,7 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
+-- Note some mods will replace this file, any new templates that need to be added should be added to LandPlatoonNewTemplates.lua
 -- ==== Global Form platoons ==== --
 PlatoonTemplate {
     Name = 'LandAttack',

--- a/lua/AI/PlatoonTemplates/SeaPlatoonNewTemplates.lua
+++ b/lua/AI/PlatoonTemplates/SeaPlatoonNewTemplates.lua
@@ -1,0 +1,18 @@
+--***************************************************************************
+--*
+--**  File     :  /lua/ai/SeaPlatoonTemplates.lua
+--**
+--**  Summary  : Global platoon templates
+--**
+--**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
+--****************************************************************************
+
+-- ==== Global Form platoons ==== --
+
+PlatoonTemplate {
+    Name = 'SeaRaid',
+    Plan = 'GuardMarker',
+    GlobalSquads = {
+        { categories.MOBILE * categories.NAVAL * categories.SUBMERSIBLE * categories.TECH1, 1, 3, 'Attack', 'none' }
+    },
+}

--- a/lua/AI/PlatoonTemplates/SeaPlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/SeaPlatoonTemplates.lua
@@ -7,6 +7,7 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
+-- Note some mods will replace this file, any new templates that need to be added should be added to SeaPlatoonNewTemplates.lua
 -- ==== Global Form platoons ==== --
 PlatoonTemplate {
     Name = 'SeaAttack',

--- a/lua/AI/PlatoonTemplates/SeaPlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/SeaPlatoonTemplates.lua
@@ -17,14 +17,6 @@ PlatoonTemplate {
 }
 
 PlatoonTemplate {
-    Name = 'SeaRaid',
-    Plan = 'GuardMarker',
-    GlobalSquads = {
-        { categories.MOBILE * categories.NAVAL * categories.SUBMERSIBLE * categories.TECH1, 1, 3, 'Attack', 'none' }
-    },
-}
-
-PlatoonTemplate {
     Name = 'SeaNuke',
     Plan = 'NavalForceAI',
     GlobalSquads = {

--- a/lua/AI/PlatoonTemplates/StructurePlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/StructurePlatoonTemplates.lua
@@ -7,6 +7,7 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
+-- Note some mods will replace this file, any new templates that need to be added should be added to StructurePlatoonNewTemplates.lua
 -- ==== Factory Upgrades ==== --
 PlatoonTemplate {
     Name = 'T1LandFactoryUpgrade',

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -4454,7 +4454,7 @@ Platoon = Class(moho.platoon_methods) {
         -- The small build logic code loop should be put into a utility function rather than repeating it.
 
         local aiBrain = self:GetBrain()
-        local buildingTmpl, buildingTmplFile, baseTmplFile, baseTmplDefault
+        local buildingTmpl, buildingTmplFile, baseTmplFile, baseTmplDefault, templateKey
         local whatToBuild
         local hydroPresent = false
         local buildLocation = false
@@ -4478,7 +4478,14 @@ Platoon = Class(moho.platoon_methods) {
         eng.Initializing = true
         -- Small note on the base template file. This is using a custom one so the acu doesnt try to select 
         -- a build location that causes it to move from its spawn position. But there are maps where it wont quite work and he'll move.
-        baseTmplFile = import(self.PlatoonData.Construction.BaseTemplateFile or '/lua/BaseTemplates.lua')
+        local templateKey = 'BaseTemplates'
+        if factionIndex < 5 then
+            templateKey = 'ACUBaseTemplate'
+            baseTmplFile = import(self.PlatoonData.Construction.BaseTemplateFile or '/lua/BaseTemplates.lua')
+        else
+            templateKey = 'BaseTemplates'
+            baseTmplFile = import('/lua/BaseTemplates.lua')
+        end
         baseTmplDefault = import('/lua/BaseTemplates.lua')
         buildingTmplFile = import(self.PlatoonData.Construction.BuildingTemplateFile or '/lua/BuildingTemplates.lua')
         buildingTmpl = buildingTmplFile[('BuildingTemplates')][factionIndex]
@@ -4516,13 +4523,13 @@ Platoon = Class(moho.platoon_methods) {
         -- Check if we spawned in water. In which case we want a naval factory first up, and hope for the best.
         local inWater = GetTerrainHeight(engPos[1], engPos[3]) < GetSurfaceHeight(engPos[1], engPos[3])
         if inWater then
-            buildLocation, whatToBuild, borderWarning = AIUtils.GetBuildLocation(aiBrain, buildingTmpl, baseTmplFile['ACUBaseTemplate'][factionIndex], 'T1SeaFactory', eng, false, nil, nil, true)
+            buildLocation, whatToBuild, borderWarning = AIUtils.GetBuildLocation(aiBrain, buildingTmpl, baseTmplFile[templateKey][factionIndex], 'T1SeaFactory', eng, false, nil, nil, true)
         else
             -- If our personality is rushair then we will go air first else land.
             if personality ==  'rushair' then
-                buildLocation, whatToBuild, borderWarning = AIUtils.GetBuildLocation(aiBrain, buildingTmpl, baseTmplFile['ACUBaseTemplate'][factionIndex], 'T1AirFactory', eng, false, nil, nil, true)
+                buildLocation, whatToBuild, borderWarning = AIUtils.GetBuildLocation(aiBrain, buildingTmpl, baseTmplFile[templateKey][factionIndex], 'T1AirFactory', eng, false, nil, nil, true)
             else
-                buildLocation, whatToBuild, borderWarning = AIUtils.GetBuildLocation(aiBrain, buildingTmpl, baseTmplFile['ACUBaseTemplate'][factionIndex], 'T1LandFactory', eng, false, nil, nil, true)
+                buildLocation, whatToBuild, borderWarning = AIUtils.GetBuildLocation(aiBrain, buildingTmpl, baseTmplFile[templateKey][factionIndex], 'T1LandFactory', eng, false, nil, nil, true)
             end
         end
         if borderWarning and buildLocation and whatToBuild then

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -4478,7 +4478,6 @@ Platoon = Class(moho.platoon_methods) {
         eng.Initializing = true
         -- Small note on the base template file. This is using a custom one so the acu doesnt try to select 
         -- a build location that causes it to move from its spawn position. But there are maps where it wont quite work and he'll move.
-        local templateKey = 'BaseTemplates'
         if factionIndex < 5 then
             templateKey = 'ACUBaseTemplate'
             baseTmplFile = import(self.PlatoonData.Construction.BaseTemplateFile or '/lua/BaseTemplates.lua')


### PR DESCRIPTION
This PR reverts platoon templates back to where they were prior to the base ai work being started. It then created new template files for any that have been changed and move the new template into them.

This should resolve issues where mods replace existing platoon templates.

To Test : 
Run a game of nomads with AI added. It AI should now start building its base normally.

Issues noticed with nomads specifically.
There is a duplicate of the template called `T2MassHuntersCategory`
The platoon template for T4ExperimentalSea in nomads is invalid and it will overwrite the default which will break the platoon former once one gets built.