### PR TITLE
Reintroduce upper albedo scale as shader switch

### DIFF
--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -1973,10 +1973,7 @@ technique TerrainPBR <
     }
 }
 
-/* # Similar to TTerrainXP, but upperAlbedo is used for map-wide #
-   # textures and we use better water color calculations         # */
-
-float4 Terrain001NormalsPS( VS_OUTPUT pixel ) : COLOR
+float4 Terrain002NormalsPS( VS_OUTPUT pixel ) : COLOR
 {
     float4 mask0 = saturate(tex2D(UtilitySamplerA,pixel.mTexWT*TerrainScale) * 2 - 1);
     float4 mask1 = saturate(tex2D(UtilitySamplerB,pixel.mTexWT*TerrainScale) * 2 - 1);
@@ -2055,7 +2052,25 @@ float4 Terrain001AlbedoPS ( VS_OUTPUT inV) : COLOR
     return float4(albedo.rgb, 0.01f);
 }
 
-technique Terrain001Normals
+/* # Similar to TTerrainXP, but upperAlbedo is used for map-wide #
+   # textures and we use better water color calculations.        #
+   # It is designed to be a drop-in replacement for TTerrainXP.  # */
+technique Terrain001 <
+    string usage = "composite";
+    string normals = "TTerrainNormalsXP"; 
+>
+{
+    pass P0
+    {
+        AlphaState( AlphaBlend_Disable_Write_RGBA )
+        DepthState( Depth_Enable )
+
+        VertexShader = compile vs_1_1 TerrainVS(true);
+        PixelShader = compile ps_2_a Terrain001AlbedoPS();
+    }
+}
+
+technique Terrain002Normals
 {
     pass P0
     {
@@ -2063,13 +2078,15 @@ technique Terrain001Normals
         DepthState( Depth_Enable )
 
         VertexShader = compile vs_1_1 TerrainVS(false);
-        PixelShader = compile ps_2_a Terrain001NormalsPS();
+        PixelShader = compile ps_2_a Terrain002NormalsPS();
     }
 }
 
-technique Terrain001 <
+/* # Very similar to Terrain001, but makes the used value ranges #
+   # in the texture masks consistent between normal and albedo.  # */
+technique Terrain002 <
     string usage = "composite";
-    string normals = "Terrain001Normals"; 
+    string normals = "Terrain002Normals"; 
 >
 {
     pass P0

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -534,6 +534,17 @@ float3 PBR(VS_OUTPUT inV, float3 albedo, float3 n, float roughness) {
     // In the future we could write another shader that does exactly this, so
     // mappers can choose to use that if they want to make a shiny map.
 
+    // used textures:
+    // lowerAlbedo
+    // Albedo stratum 0-7
+    // upperAlbedo
+    // NormalTexture
+    // ShadowTexture
+    // UtilityTextureA
+    // UtilityTextureB
+    // UtilityTextureC
+    // WaterRamp
+
     return color;
 }
 

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -347,6 +347,9 @@ bool IsExperimentalShader() {
     // The tile value basically says how often the texture gets repeated on the map.
     // A value less than one doesn't make sense under normal conditions, so it is
     // relatively save to use it as our switch.
+
+    // in order to trigger this you can set the albedo scale to be bigger than the map 
+    // size. Use the value 10000 to be safe for any map
     return UpperAlbedoTile.x < 1.0;
 }
 

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -343,6 +343,13 @@ VS_OUT FixedFuncVS( VS_IN In )
     return Out;
 }
 
+bool IsExperimentalShader() {
+    // The tile value basically says how often the texture gets repeated on the map.
+    // A value less than one doesn't make sense under normal conditions, so it is
+    // relatively save to use it as our switch.
+    return UpperAlbedoTile.x < 1.0;
+}
+
 // sample a texture that is another buffer the same size as the one
 // we are rendering into and with the viewport setup the same way.
 float4 SampleScreen(sampler inSampler, float4 inTex)
@@ -410,7 +417,7 @@ float4 CalculateLighting( float3 inNormal, float3 inViewPosition, float3 inAlbed
     float4 color = float4( 0, 0, 0, 0 );
 
     float shadow = ( inShadows && ( 1 == ShadowsEnabled ) ) ? ComputeShadow( inShadow ) : 1;
-    if (UpperAlbedoTile.x < 1.0) {
+    if (IsExperimentalShader()) {
         float3 position = TerrainScale * inViewPosition;
         float mapShadow = saturate(1 - tex2D(Stratum7AlbedoSampler, position.xy).b);
         shadow = shadow * mapShadow;
@@ -805,7 +812,7 @@ float4 TerrainBasisPS( VS_OUTPUT inV ) : COLOR
 float4 TerrainBasisPSBiCubic( VS_OUTPUT inV ) : COLOR
 {
     float4 result;
-    if (UpperAlbedoTile.x < 1.0) {
+    if (IsExperimentalShader()) {
         float4 position = TerrainScale * inV.mTexWT;
         result = (float4(1, 1, tex2D(UpperAlbedoSampler, position.xy).xy));
 
@@ -1302,7 +1309,7 @@ float4 DecalsPS( VS_OUTPUT inV, uniform bool inShadows) : COLOR
     float waterDepth = tex2Dproj(UtilitySamplerC, inV.mTexWT * TerrainScale).g;
 
     float3 color;
-    if (UpperAlbedoTile.x < 1.0) {
+    if (IsExperimentalShader()) {
         float roughness = 1 - decalSpec.r;
         color = PBR(inV, decalAlbedo, normal, roughness);
         color = ApplyWaterColorExponentially(inV, waterDepth, color);


### PR DESCRIPTION
Reintroduces the scale of the upper albedo as a switch for which shader to use. To my understanding the AlbedoTile variables basically store how often the texture is supposed to show up on the map. If we check for < 1.0 that means the texture would not even fit on the map. Hopefully nobody set his texture scales to these nonsensical values, so we don't break any existing maps. I am pretty confident in this, because in the ozonex editor you would have to set the scale to greater than 256 and the editor doesn't allow this.
This different value in the editor is because the scale in the editor is basically "how big should your texture be in ogrids"

I am not sure if I agree with the addition of the Terrain001NormalsPS. Yes, it makes the layer masks more consistent, but it prevents us from using this shader as a drop-in replacement for existing maps.
Depending on our goals we should maybe offer both variants? I.e. one that uses Terrain001NormalsPS and one that uses TerrainNormalsXP.