### PR TITLE
Enable switching between linear and exponential water absorption

### DIFF
--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -378,6 +378,12 @@ struct SHIELDIMPACT_VERTEX
 ///
 ///////////////////////////////////////
 
+bool IsExperimentalShader() {
+    // lightMultiplier is one of the few variables that is driven by the map,
+    // but accessible by the mesh shader.
+    return lightMultiplier > 2.1;
+}
+
 /// ComputeMatrix
 ///
 /// Compute matrix from scale, translation, and quaternion.
@@ -596,8 +602,8 @@ float3 ApplyWaterColor(float depth, float3 viewDirection, float3 color, float3 e
     // disable the whole thing on land-only maps
     if (surfaceElevation > 0) {
         float4 waterColor = tex1D(WaterRampSampler, -depth / (surfaceElevation - abyssElevation));
-        // we use lightMultiplier as a switch to match it with the terrain shader coloration
-        if (lightMultiplier > 2.1) {
+        // we need this switch to make it consistent with the terrain shader coloration
+        if (IsExperimentalShader()) {
             float3 up = float3(0,1,0);
             // To simplify, we assume that the light enters vertically into the water,
             // this is the length that the light travels underwater back to the camera


### PR DESCRIPTION
This enables switching between linear and exponential water absorption based on the value of lightMultiplier.
 
The upcoming terrain shaders will use exponential water absorption. The challenge now is to use the right absorption in the mesh shader. Originally we thought about having a map script change the unit shaders accordingly, but this gets messy because we have a lot of different shader techniques that would need to be changed and there are also prop and wreckage shaders. All of these would need a second variant, so we can switch them out. All of this only became necessary because the mesh shader doesn't know which terrain shader is being used.
Instead I came up with a different idea. There is in fact another variable that the map author can use to relay this information. The lightMultiplier. Its existence is not strictly necessary, because its value could just internally be multiplied with the sun and ambient color before saving the map file. Both the gpg and ozonex editor only allow setting this value in the 0 to 2 range. But as it is a float it could have any other value. If we set this value to e.g. 2.5 when using a terrain shader that uses exponential water absorption, then we check if this value is above the threshold in the mesh shader and switch our water color calculations accordingly. The elegance of this is that we don't even have to touch the lighting calculations, because 2.5 is still a reasonable enough value to work with. Our future map visualizer/editor would make sure to internally divide the values that get set for the sun and ambient color by 2.5 so the user doesn't even have to worry about this.