### PR TITLE
Allow building on top of trees

### DIFF
--- a/engine/Core/Categories.lua
+++ b/engine/Core/Categories.lua
@@ -351,6 +351,7 @@ categories = {
 ---| "NOSPLASHDAMAGE"
 ---| "NUKE"
 ---| "NUKESUB"
+---| "OBSTRUCTSBUILDING"
 ---| "OMNI"
 ---| "OPERATION"
 ---| "OPTICS"

--- a/env/Aeon/Props/Aeon_Bus_prop.bp
+++ b/env/Aeon/Props/Aeon_Bus_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Aeon/Props/Aeon_Car_01_prop.bp
+++ b/env/Aeon/Props/Aeon_Car_01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Aeon/Props/Aeon_Car_02_prop.bp
+++ b/env/Aeon/Props/Aeon_Car_02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Aeon/Props/Aeon_Dock_prop.bp
+++ b/env/Aeon/Props/Aeon_Dock_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Ancient-Earth/props/Other/wood_structure1_60m_prop.bp
+++ b/env/Ancient-Earth/props/Other/wood_structure1_60m_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Display = {
         Mesh = {
@@ -17,7 +18,6 @@ PropBlueprint {
         UniformScale = 0.035,
     },
     Economy = {
-        ReclaimEnergyMax = '',
         ReclaimMassMax = 60,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/Other/wood_structure2_40m_prop.bp
+++ b/env/Ancient-Earth/props/Other/wood_structure2_40m_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Display = {
         Mesh = {
@@ -17,7 +18,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/Other/wood_structure3_50m_prop.bp
+++ b/env/Ancient-Earth/props/Other/wood_structure3_50m_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Display = {
         Mesh = {
@@ -17,7 +18,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 50,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/buildings/jbuild/jbuild01_prop.bp
+++ b/env/Ancient-Earth/props/buildings/jbuild/jbuild01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 2000,

--- a/env/Ancient-Earth/props/buildings/jbuild/jbuild02_prop.bp
+++ b/env/Ancient-Earth/props/buildings/jbuild/jbuild02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 3000,

--- a/env/Ancient-Earth/props/buildings/jwall/jwall01_prop.bp
+++ b/env/Ancient-Earth/props/buildings/jwall/jwall01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING',
 		'WALL',
     },
     Defense = {

--- a/env/Ancient-Earth/props/buildings/jwall/jwall02_prop.bp
+++ b/env/Ancient-Earth/props/buildings/jwall/jwall02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING',
 		'WALL',
     },
     Defense = {

--- a/env/Ancient-Earth/props/buildings/jwall/jwallgate_prop.bp
+++ b/env/Ancient-Earth/props/buildings/jwall/jwallgate_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 4000,

--- a/env/Ancient-Earth/props/buildings/jwall/jwalltower_prop.bp
+++ b/env/Ancient-Earth/props/buildings/jwall/jwalltower_prop.bp
@@ -2,6 +2,7 @@ PropBlueprint {
     Categories = {
         'RECLAIMABLE',
 		'WALL',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 2000,

--- a/env/Ancient-Earth/props/buildings/statues/budda_prop.bp
+++ b/env/Ancient-Earth/props/buildings/statues/budda_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 2000,

--- a/env/Ancient-Earth/props/gates/sak_GATE_prop.bp
+++ b/env/Ancient-Earth/props/gates/sak_GATE_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.06,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 80,
         ReclaimTime = 6,
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock01HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock01HD_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock01pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock01pink_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock02HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock02HD_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock02pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock02pink_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock04HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock04HD_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock04pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock04pink_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,6 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock05HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock05HD_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock05pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock05pink_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock06HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock06HD_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock06pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock06pink_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock07HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock07HD_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.5,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 75,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/GeoRock07pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/GeoRock07pink_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.5,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 75,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/Rock01HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock01HD_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/Rock01pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock01pink_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/Rock02HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock02HD_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/Rock02pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock02pink_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/Rock03HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock03HD_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/Rock03pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock03pink_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,6 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/Rock04HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock04HD_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/Rock04pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock04pink_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/Rock05HD_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock05HD_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,6 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/Rock05pink_prop.bp
+++ b/env/Ancient-Earth/props/rocks/Rock05pink_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/fieldstone03A_175m_prop.bp
+++ b/env/Ancient-Earth/props/rocks/fieldstone03A_175m_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.015,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 175,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/fieldstone04A_112.5m_prop.bp
+++ b/env/Ancient-Earth/props/rocks/fieldstone04A_112.5m_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 112.5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks/large_rock_with_symbols_140m_prop.bp
+++ b/env/Ancient-Earth/props/rocks/large_rock_with_symbols_140m_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 300,

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock01HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock01HD_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock01pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock01pink_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 37.5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock02HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock02HD_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock02pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock02pink_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock04HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock04HD_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock04pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock04pink_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock05HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock05HD_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock05pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock05pink_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 2.5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock06HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock06HD_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock06pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock06pink_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock07HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock07HD_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.5,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 75,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/GeoRock07pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/GeoRock07pink_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.5,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 75,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/Rock01HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock01HD_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/Rock01pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock01pink_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/Rock02HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock02HD_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/Rock02pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock02pink_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/Rock03HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock03HD_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/Rock03pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock03pink_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/Rock04HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock04HD_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/Rock04pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock04pink_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/Rock05HD_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock05HD_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },

--- a/env/Ancient-Earth/props/rocks_dark/Rock05pink_dark_prop.bp
+++ b/env/Ancient-Earth/props/rocks_dark/Rock05pink_dark_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 5,
         ReclaimTime = 5,
     },

--- a/env/Common/Props/Kelp_01_prop.bp
+++ b/env/Common/Props/Kelp_01_prop.bp
@@ -19,8 +19,8 @@ PropBlueprint {
         UniformScale = 0.2,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
         },
 
    

--- a/env/Common/Props/LavaSteam01_prop.bp
+++ b/env/Common/Props/LavaSteam01_prop.bp
@@ -13,8 +13,8 @@ PropBlueprint {
         UniformScale = 0,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Water surface mist',

--- a/env/Common/Props/LavaSteam02_prop.bp
+++ b/env/Common/Props/LavaSteam02_prop.bp
@@ -13,8 +13,8 @@ PropBlueprint {
         UniformScale = 0,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Water surface mist',

--- a/env/Common/Props/LavaSteam03_prop.bp
+++ b/env/Common/Props/LavaSteam03_prop.bp
@@ -13,8 +13,8 @@ PropBlueprint {
         UniformScale = 0,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Small lava steam steam',

--- a/env/Common/Props/LavaSteam04_prop.bp
+++ b/env/Common/Props/LavaSteam04_prop.bp
@@ -13,8 +13,8 @@ PropBlueprint {
         UniformScale = 0,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Large Lava steam volume',

--- a/env/Common/Props/Markers/M_Blank_prop.bp
+++ b/env/Common/Props/Markers/M_Blank_prop.bp
@@ -11,8 +11,8 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Marker for general use',

--- a/env/Common/Props/Markers/M_Camera_prop.bp
+++ b/env/Common/Props/Markers/M_Camera_prop.bp
@@ -11,8 +11,8 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Marker for general use',

--- a/env/Common/Props/Markers/M_Combatzone_prop.bp
+++ b/env/Common/Props/Markers/M_Combatzone_prop.bp
@@ -11,8 +11,8 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Marker for general use',

--- a/env/Common/Props/Markers/M_Defensive_prop.bp
+++ b/env/Common/Props/Markers/M_Defensive_prop.bp
@@ -11,8 +11,8 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Marker for general use',

--- a/env/Common/Props/Markers/M_Expansion_prop.bp
+++ b/env/Common/Props/Markers/M_Expansion_prop.bp
@@ -11,8 +11,8 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Marker for general use',

--- a/env/Common/Props/Markers/M_Hydrocarbon_prop.bp
+++ b/env/Common/Props/Markers/M_Hydrocarbon_prop.bp
@@ -11,8 +11,8 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Marker for general use',

--- a/env/Common/Props/Markers/M_Mass_prop.bp
+++ b/env/Common/Props/Markers/M_Mass_prop.bp
@@ -11,8 +11,8 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Marker for general use',

--- a/env/Common/Props/Markers/M_Path_prop.bp
+++ b/env/Common/Props/Markers/M_Path_prop.bp
@@ -11,8 +11,8 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Used as a node in a path graph.',

--- a/env/Common/Props/Markers/marker01_prop.bp
+++ b/env/Common/Props/Markers/marker01_prop.bp
@@ -11,7 +11,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 0,
         ReclaimTime = 0,
     },

--- a/env/Common/Props/UnderwaterBubbles01_prop.bp
+++ b/env/Common/Props/UnderwaterBubbles01_prop.bp
@@ -13,8 +13,8 @@ PropBlueprint {
         UniformScale = 0,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Underwater bubbles',

--- a/env/Common/Props/WaterSurfaceMist01_prop.bp
+++ b/env/Common/Props/WaterSurfaceMist01_prop.bp
@@ -13,8 +13,8 @@ PropBlueprint {
         UniformScale = 0,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Water surface mist',

--- a/env/Common/Props/marker01_prop.bp
+++ b/env/Common/Props/marker01_prop.bp
@@ -12,7 +12,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 0,
         ReclaimTime = 0,
     },

--- a/env/Common/Props/sphere_prop.bp
+++ b/env/Common/Props/sphere_prop.bp
@@ -17,7 +17,7 @@ PropBlueprint {
         UniformScale = 20,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 0,
         ReclaimTime = 0,
     },

--- a/env/Common/Props/spherez_prop.bp
+++ b/env/Common/Props/spherez_prop.bp
@@ -17,7 +17,7 @@ PropBlueprint {
         UniformScale = 20,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 0,
         ReclaimTime = 0,
     },

--- a/env/Crystalline-alt/props/crystals-black/BlackCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrysSm01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-black/BlackCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrysSm02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-black/BlackCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrysSm03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },

--- a/env/Crystalline-alt/props/crystals-black/BlackCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrysSm04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },

--- a/env/Crystalline-alt/props/crystals-black/BlackCrysSm05_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrysSm05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.15,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 30,
         ReclaimTime = 15,
     },

--- a/env/Crystalline-alt/props/crystals-black/BlackCrysSm06_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrysSm06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.2,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 20,
     },

--- a/env/Crystalline-alt/props/crystals-black/BlackCrystal01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrystal01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.275,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 50,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-black/BlackCrystal02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrystal02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -22,7 +23,6 @@ PropBlueprint {
         UniformScale = 0.250,
     },
     Economy = {
-        ReclaimEnergyMax = '',
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-black/BlackCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrystal03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -22,7 +23,7 @@ PropBlueprint {
         UniformScale = 0.325,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-black/BlackCrystal06_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrystal06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-black/BlackCrystal07_prop.bp
+++ b/env/Crystalline-alt/props/crystals-black/BlackCrystal07_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-green/GreenCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrysSm01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-green/GreenCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrysSm02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-green/GreenCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrysSm03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,6 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },

--- a/env/Crystalline-alt/props/crystals-green/GreenCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrysSm04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },

--- a/env/Crystalline-alt/props/crystals-green/GreenCrysSm05_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrysSm05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.15,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 30,
         ReclaimTime = 15,
     },

--- a/env/Crystalline-alt/props/crystals-green/GreenCrysSm06_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrysSm06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.2,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 20,
     },

--- a/env/Crystalline-alt/props/crystals-green/GreenCrystal01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrystal01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.275,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 50,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-green/GreenCrystal02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrystal02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -22,7 +23,7 @@ PropBlueprint {
         UniformScale = 0.250,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-green/GreenCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrystal03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -22,7 +23,6 @@ PropBlueprint {
         UniformScale = 0.325,
     },
     Economy = {
-        ReclaimEnergyMax = '',
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-green/GreenCrystal06_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrystal06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-green/GreenCrystal07_prop.bp
+++ b/env/Crystalline-alt/props/crystals-green/GreenCrystal07_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm05_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.15,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 30,
         ReclaimTime = 15,
     },

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm06_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrysSm06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.2,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 20,
     },

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrystal01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrystal01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.275,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 50,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrystal02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrystal02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -22,7 +23,7 @@ PropBlueprint {
         UniformScale = 0.250,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrystal03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -22,7 +23,7 @@ PropBlueprint {
         UniformScale = 0.325,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrystal06_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrystal06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-orange/OrangeCrystal07_prop.bp
+++ b/env/Crystalline-alt/props/crystals-orange/OrangeCrystal07_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm05_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.15,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 30,
         ReclaimTime = 15,
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm06_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrysSm06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.2,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 20,
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrystal01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrystal01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.275,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 50,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrystal02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrystal02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -22,7 +23,7 @@ PropBlueprint {
         UniformScale = 0.250,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrystal03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -22,7 +23,7 @@ PropBlueprint {
         UniformScale = 0.325,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrystal06_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrystal06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-purple/PurpleCrystal07_prop.bp
+++ b/env/Crystalline-alt/props/crystals-purple/PurpleCrystal07_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrysSm01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrysSm02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrysSm03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrysSm04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrysSm05_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrysSm05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,6 @@ PropBlueprint {
         UniformScale = 0.15,
     },
     Economy = {
-        ReclaimEnergyMax = '',
         ReclaimMassMax = 30,
         ReclaimTime = 15,
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrysSm06_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrysSm06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.2,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 20,
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrystal01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrystal01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.275,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 50,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrystal02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrystal02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -22,7 +23,7 @@ PropBlueprint {
         UniformScale = 0.250,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrystal03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -22,7 +23,6 @@ PropBlueprint {
         UniformScale = 0.325,
     },
     Economy = {
-        ReclaimEnergyMax = '',
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrystal06_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrystal06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-red/RedCrystal07_prop.bp
+++ b/env/Crystalline-alt/props/crystals-red/RedCrystal07_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrysSm01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrysSm02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrysSm03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrysSm04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrysSm05_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrysSm05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.15,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 30,
         ReclaimTime = 15,
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrysSm06_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrysSm06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.2,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 20,
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrystal01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrystal01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.275,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 50,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrystal02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrystal02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -22,7 +23,7 @@ PropBlueprint {
         UniformScale = 0.250,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrystal03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -22,7 +23,7 @@ PropBlueprint {
         UniformScale = 0.325,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrystal06_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrystal06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-white/WhiteCrystal07_prop.bp
+++ b/env/Crystalline-alt/props/crystals-white/WhiteCrystal07_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.05,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm04_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 20,
         ReclaimTime = 10,
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm05_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.15,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 30,
         ReclaimTime = 15,
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm06_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrysSm06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -20,7 +21,7 @@ PropBlueprint {
         UniformScale = 0.2,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 20,
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrystal01_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrystal01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.275,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 50,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrystal02_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrystal02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -22,7 +23,7 @@ PropBlueprint {
         UniformScale = 0.250,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrystal03_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrystal03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -22,7 +23,7 @@ PropBlueprint {
         UniformScale = 0.325,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 10,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrystal06_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrystal06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline-alt/props/crystals-yellow/YellowCrystal07_prop.bp
+++ b/env/Crystalline-alt/props/crystals-yellow/YellowCrystal07_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,
@@ -21,7 +22,7 @@ PropBlueprint {
         UniformScale = 0.02,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 40,
         ReclaimTime = 5,
     },

--- a/env/Crystalline/Props/Clutter/Crys_clutter01_prop.bp
+++ b/env/Crystalline/Props/Clutter/Crys_clutter01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Clutter/Crys_clutter02_prop.bp
+++ b/env/Crystalline/Props/Clutter/Crys_clutter02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Clutter/Crys_clutter03_prop.bp
+++ b/env/Crystalline/Props/Clutter/Crys_clutter03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysCrystal01_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysCrystal02_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysCrystal03_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysCrystal04_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysCrystal05_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysCrystal06_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysCrystal07_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal07_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysCrystal08_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal08_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysCrystal09_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal09_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysCrystal10_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal10_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysCrystal11_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysCrystal11_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysSmRock01_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysSmRock02_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysSmRock03_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysSmRock04_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysSmRock05_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysSmRock06_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysSmRock07_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock07_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrysSmRock08_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrysSmRock08_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrystalRock01_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrystalRock01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Crystalline/Props/Rocks/CrystalRock02_prop.bp
+++ b/env/Crystalline/Props/Rocks/CrystalRock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Cybran/Props/Cybran_Bus_prop.bp
+++ b/env/Cybran/Props/Cybran_Bus_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Cybran/Props/Cybran_Car2_prop.bp
+++ b/env/Cybran/Props/Cybran_Car2_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Cybran/Props/Cybran_Car_prop.bp
+++ b/env/Cybran/Props/Cybran_Car_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Cybran/Props/Cybran_Dock_prop.bp
+++ b/env/Cybran/Props/Cybran_Dock_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Cybran/Props/Cybran_Fence_prop.bp
+++ b/env/Cybran/Props/Cybran_Fence_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Desert/Props/Emitters/DesertBlowingSand01_prop.bp
+++ b/env/Desert/Props/Emitters/DesertBlowingSand01_prop.bp
@@ -13,8 +13,8 @@ PropBlueprint {
         UniformScale = 0,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Desert Blowing Sand',

--- a/env/Desert/Props/Emitters/DesertBlowingSand02_prop.bp
+++ b/env/Desert/Props/Emitters/DesertBlowingSand02_prop.bp
@@ -13,8 +13,8 @@ PropBlueprint {
         UniformScale = 0,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Desert Blowing Sand (dark)',

--- a/env/Desert/Props/Rocks/Des_boulder01_prop.bp
+++ b/env/Desert/Props/Rocks/Des_boulder01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Desert/Props/Rocks/Des_boulder02_prop.bp
+++ b/env/Desert/Props/Rocks/Des_boulder02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Desert/Props/Rocks/Des_boulder03_prop.bp
+++ b/env/Desert/Props/Rocks/Des_boulder03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Desert/Props/Rocks/Des_boulder04_prop.bp
+++ b/env/Desert/Props/Rocks/Des_boulder04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Desert/Props/Rocks/Des_boulder05_prop.bp
+++ b/env/Desert/Props/Rocks/Des_boulder05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Desert/Props/Rocks/Des_boulder06_prop.bp
+++ b/env/Desert/Props/Rocks/Des_boulder06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/DevTest/Props/Platpipes_01_prop.bp
+++ b/env/DevTest/Props/Platpipes_01_prop.bp
@@ -19,7 +19,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 0,
         ReclaimTime = 5,
     },

--- a/env/DevTest/Props/rock01_prop.bp
+++ b/env/DevTest/Props/rock01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/DevTest/Props/rock02_prop.bp
+++ b/env/DevTest/Props/rock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/DevTest/Props/sphere01_prop.bp
+++ b/env/DevTest/Props/sphere01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/DevTest/Props/thermal_vent_01_prop.bp
+++ b/env/DevTest/Props/thermal_vent_01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Evergreen/Props/Rocks/Rock01_prop.bp
+++ b/env/Evergreen/Props/Rocks/Rock01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Evergreen/Props/Rocks/Rock02_prop.bp
+++ b/env/Evergreen/Props/Rocks/Rock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Evergreen/Props/Rocks/Rock03_prop.bp
+++ b/env/Evergreen/Props/Rocks/Rock03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Evergreen/Props/Rocks/Rock04_prop.bp
+++ b/env/Evergreen/Props/Rocks/Rock04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Evergreen/Props/Rocks/Rock05_prop.bp
+++ b/env/Evergreen/Props/Rocks/Rock05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Evergreen/Props/Rocks/RockPile01_prop.bp
+++ b/env/Evergreen/Props/Rocks/RockPile01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Evergreen/Props/Rocks/RockPile02_prop.bp
+++ b/env/Evergreen/Props/Rocks/RockPile02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Evergreen/Props/Rocks/SeaRock01_prop.bp
+++ b/env/Evergreen/Props/Rocks/SeaRock01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Evergreen/Props/Rocks/SeaRock02_prop.bp
+++ b/env/Evergreen/Props/Rocks/SeaRock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Evergreen/Props/Rocks/fieldstone01_prop.bp
+++ b/env/Evergreen/Props/Rocks/fieldstone01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Evergreen/Props/Rocks/fieldstone02_prop.bp
+++ b/env/Evergreen/Props/Rocks/fieldstone02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Evergreen/Props/Rocks/fieldstone03_prop.bp
+++ b/env/Evergreen/Props/Rocks/fieldstone03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Evergreen/Props/Rocks/fieldstone04_prop.bp
+++ b/env/Evergreen/Props/Rocks/fieldstone04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Geothermal/Props/Rocks/GeoRock01_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Geothermal/Props/Rocks/GeoRock02_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Geothermal/Props/Rocks/GeoRock03_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Geothermal/Props/Rocks/GeoRock04_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Geothermal/Props/Rocks/GeoRock05_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Geothermal/Props/Rocks/GeoRock06_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Geothermal/Props/Rocks/GeoRock07_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRock07_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Geothermal/Props/Rocks/GeoRockGroup01_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRockGroup01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Geothermal/Props/Rocks/GeoRockGroup02_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRockGroup02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Geothermal/Props/Rocks/GeoRockGroup03_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRockGroup03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Geothermal/Props/Rocks/GeoRockGroup04_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRockGroup04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Geothermal/Props/Rocks/GeoRockGroup05_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRockGroup05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Geothermal/Props/Rocks/GeoRockGroup06_prop.bp
+++ b/env/Geothermal/Props/Rocks/GeoRockGroup06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/LV_LavaBerg02_prop.bp
+++ b/env/Lava/Props/Rocks/LV_LavaBerg02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/LV_LavaBerg03_prop.bp
+++ b/env/Lava/Props/Rocks/LV_LavaBerg03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/LV_Rock01_prop.bp
+++ b/env/Lava/Props/Rocks/LV_Rock01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/LV_Rock02_prop.bp
+++ b/env/Lava/Props/Rocks/LV_Rock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/Lav_Rock01_prop.bp
+++ b/env/Lava/Props/Rocks/Lav_Rock01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/Lav_Rock02_prop.bp
+++ b/env/Lava/Props/Rocks/Lav_Rock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/Lav_Rock03_prop.bp
+++ b/env/Lava/Props/Rocks/Lav_Rock03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/Lav_Rock04_prop.bp
+++ b/env/Lava/Props/Rocks/Lav_Rock04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/Lav_Rock05_prop.bp
+++ b/env/Lava/Props/Rocks/Lav_Rock05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/LavaBerg02_prop.bp
+++ b/env/Lava/Props/Rocks/LavaBerg02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/LavaBerg03_prop.bp
+++ b/env/Lava/Props/Rocks/LavaBerg03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/LavaBerg04_prop.bp
+++ b/env/Lava/Props/Rocks/LavaBerg04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/LavaRock02_prop.bp
+++ b/env/Lava/Props/Rocks/LavaRock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/SeaRock01_prop.bp
+++ b/env/Lava/Props/Rocks/SeaRock01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Lava/Props/Rocks/SeaRock02_prop.bp
+++ b/env/Lava/Props/Rocks/SeaRock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Boulder01_prop.bp
+++ b/env/RedRocks/Props/Boulder01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Boulder02_prop.bp
+++ b/env/RedRocks/Props/Boulder02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Boulder03_prop.bp
+++ b/env/RedRocks/Props/Boulder03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Boulder04_prop.bp
+++ b/env/RedRocks/Props/Boulder04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Boulder05_prop.bp
+++ b/env/RedRocks/Props/Boulder05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Boulder06_prop.bp
+++ b/env/RedRocks/Props/Boulder06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Pod01_prop.bp
+++ b/env/RedRocks/Props/Pod01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Pod02_prop.bp
+++ b/env/RedRocks/Props/Pod02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Rock03_prop.bp
+++ b/env/RedRocks/Props/Rock03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Rock_SM01_prop.bp
+++ b/env/RedRocks/Props/Rock_SM01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Rock_SM02_prop.bp
+++ b/env/RedRocks/Props/Rock_SM02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Rock_SM03_prop.bp
+++ b/env/RedRocks/Props/Rock_SM03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Rock_SM04_prop.bp
+++ b/env/RedRocks/Props/Rock_SM04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Rock_SM05_prop.bp
+++ b/env/RedRocks/Props/Rock_SM05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Rock_SM06_prop.bp
+++ b/env/RedRocks/Props/Rock_SM06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/Rock_SM07_prop.bp
+++ b/env/RedRocks/Props/Rock_SM07_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/SeaRock01_prop.bp
+++ b/env/RedRocks/Props/SeaRock01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/RedRocks/Props/SeaRock02_prop.bp
+++ b/env/RedRocks/Props/SeaRock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Seraphim II/Props/Emitters/SnowSeraphim1_prop.bp
+++ b/env/Seraphim II/Props/Emitters/SnowSeraphim1_prop.bp
@@ -12,10 +12,6 @@ PropBlueprint {
         },
         UniformScale = 0,
     },
-    Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
-    },
     Interface = {
         HelpText = 'Tundra blowing snow',
     },

--- a/env/Seraphim II/Props/Emitters/SnowSeraphim2_prop.bp
+++ b/env/Seraphim II/Props/Emitters/SnowSeraphim2_prop.bp
@@ -13,8 +13,8 @@ PropBlueprint {
         UniformScale = 0,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Tundra blowing snow',

--- a/env/Seraphim II/Props/Emitters/SnowSeraphimBigCloud_prop.bp
+++ b/env/Seraphim II/Props/Emitters/SnowSeraphimBigCloud_prop.bp
@@ -13,8 +13,8 @@ PropBlueprint {
         UniformScale = 1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Tundra blowing snow',

--- a/env/Seraphim II/Props/Floe_prop.bp
+++ b/env/Seraphim II/Props/Floe_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Seraphim II/Props/IceDebris_prop.bp
+++ b/env/Seraphim II/Props/IceDebris_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Seraphim II/Props/Rock5_prop.bp
+++ b/env/Seraphim II/Props/Rock5_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'INVULNERABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Seraphim/Props/Seraphim_Bus_prop.bp
+++ b/env/Seraphim/Props/Seraphim_Bus_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Seraphim/Props/Seraphim_Car_01_prop.bp
+++ b/env/Seraphim/Props/Seraphim_Car_01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Seraphim/Props/Seraphim_Car_02_prop.bp
+++ b/env/Seraphim/Props/Seraphim_Car_02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Seraphim/Props/Seraphim_Crystal_prop.bp
+++ b/env/Seraphim/Props/Seraphim_Crystal_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Seraphim/Props/Seraphim_Dock_prop.bp
+++ b/env/Seraphim/Props/Seraphim_Dock_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Structures/Props/320_prop.bp
+++ b/env/Structures/Props/320_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Structures/Props/UEF_Building_001_prop.bp
+++ b/env/Structures/Props/UEF_Building_001_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Structures/Props/UEF_Building_002_prop.bp
+++ b/env/Structures/Props/UEF_Building_002_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Structures/Props/UEF_Condo01_prop.bp
+++ b/env/Structures/Props/UEF_Condo01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Structures/Props/UEF_Hydro_Bay01_prop.bp
+++ b/env/Structures/Props/UEF_Hydro_Bay01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Structures/Props/UEF_Nano_Lab01_prop.bp
+++ b/env/Structures/Props/UEF_Nano_Lab01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Structures/Props/UEF_Power01_prop.bp
+++ b/env/Structures/Props/UEF_Power01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING',
     },
     Defense = {
         Health = 50,

--- a/env/Structures/Props/UEF_Warehouse01_prop.bp
+++ b/env/Structures/Props/UEF_Warehouse01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Swamp/Props/Bush/sw_bush03_prop.bp
+++ b/env/Swamp/Props/Bush/sw_bush03_prop.bp
@@ -38,7 +38,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 10,
-        ReclaimMassMax = 1,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Swamp/Props/Bush/sw_fern03_prop.bp
+++ b/env/Swamp/Props/Bush/sw_fern03_prop.bp
@@ -38,7 +38,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 10,
-        ReclaimMassMax = 1,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Swamp/Props/Rocks/boulder01_prop.bp
+++ b/env/Swamp/Props/Rocks/boulder01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Swamp/Props/Rocks/boulder02_prop.bp
+++ b/env/Swamp/Props/Rocks/boulder02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING',
     },
     Defense = {
         Health = 50,

--- a/env/Swamp/Props/Rocks/boulder03_prop.bp
+++ b/env/Swamp/Props/Rocks/boulder03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Swamp/Props/Rocks/outcrop01_prop.bp
+++ b/env/Swamp/Props/Rocks/outcrop01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tropical/Props/Rocks/Rock01_prop.bp
+++ b/env/Tropical/Props/Rocks/Rock01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tropical/Props/Rocks/Rock02_prop.bp
+++ b/env/Tropical/Props/Rocks/Rock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tropical/Props/Rocks/Rock03_prop.bp
+++ b/env/Tropical/Props/Rocks/Rock03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tropical/Props/Rocks/Rock04_prop.bp
+++ b/env/Tropical/Props/Rocks/Rock04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tropical/Props/Rocks/Rock05_prop.bp
+++ b/env/Tropical/Props/Rocks/Rock05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tropical/Props/Rocks/RockPile01_prop.bp
+++ b/env/Tropical/Props/Rocks/RockPile01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tropical/Props/Rocks/RockPile02_prop.bp
+++ b/env/Tropical/Props/Rocks/RockPile02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tropical/Props/Rocks/SeaRock02_prop.bp
+++ b/env/Tropical/Props/Rocks/SeaRock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tropical/Props/Rocks/lavaRock01_prop.bp
+++ b/env/Tropical/Props/Rocks/lavaRock01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tropical/Props/TrRock01_prop.bp
+++ b/env/Tropical/Props/TrRock01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/Emitters/BlowingSnow01_prop.bp
+++ b/env/Tundra/Props/Emitters/BlowingSnow01_prop.bp
@@ -13,8 +13,8 @@ PropBlueprint {
         UniformScale = 0,
     },
     Economy = {
-        ReclaimEnergyMax = '',
-        ReclaimMassMax = '',
+        ReclaimEnergyMax = 0,
+        ReclaimMassMax = 0,
     },
     Interface = {
         HelpText = 'Tundra blowing snow',

--- a/env/Tundra/Props/IceBerg01_prop.bp
+++ b/env/Tundra/Props/IceBerg01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/IceBerg02_prop.bp
+++ b/env/Tundra/Props/IceBerg02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/IceBerg03_prop.bp
+++ b/env/Tundra/Props/IceBerg03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/IceBerg04_prop.bp
+++ b/env/Tundra/Props/IceBerg04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/IceRock01_prop.bp
+++ b/env/Tundra/Props/IceRock01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/IceRock02_prop.bp
+++ b/env/Tundra/Props/IceRock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/IceRockSm01_prop.bp
+++ b/env/Tundra/Props/IceRockSm01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/IceRockSm02_prop.bp
+++ b/env/Tundra/Props/IceRockSm02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/IceRockSm03_prop.bp
+++ b/env/Tundra/Props/IceRockSm03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/IceRockSm04_prop.bp
+++ b/env/Tundra/Props/IceRockSm04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/Iceberg05_prop.bp
+++ b/env/Tundra/Props/Iceberg05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/Iceberg06_prop.bp
+++ b/env/Tundra/Props/Iceberg06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/Rocks/Ice_Crystal_01_prop.bp
+++ b/env/Tundra/Props/Rocks/Ice_Crystal_01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/Rocks/Tund_Rock02_prop.bp
+++ b/env/Tundra/Props/Rocks/Tund_Rock02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/Rocks/Tund_Rock03_prop.bp
+++ b/env/Tundra/Props/Rocks/Tund_Rock03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/Rocks/Tund_Rock04_prop.bp
+++ b/env/Tundra/Props/Rocks/Tund_Rock04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Tundra/Props/Rocks/Tund_Rock05_prop.bp
+++ b/env/Tundra/Props/Rocks/Tund_Rock05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/UEF/Props/UEF_Bus_prop.bp
+++ b/env/UEF/Props/UEF_Bus_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/UEF/Props/UEF_Car1_prop.bp
+++ b/env/UEF/Props/UEF_Car1_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/UEF/Props/UEF_Dock_prop.bp
+++ b/env/UEF/Props/UEF_Dock_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/UEF/Props/UEF_truck_prop.bp
+++ b/env/UEF/Props/UEF_truck_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Wreckage/props/Aeon/UAL0202_Wreckage_prop.bp
+++ b/env/Wreckage/props/Aeon/UAL0202_Wreckage_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Wreckage/props/Generic/Wreckage01_prop.bp
+++ b/env/Wreckage/props/Generic/Wreckage01_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Wreckage/props/Generic/Wreckage02_prop.bp
+++ b/env/Wreckage/props/Generic/Wreckage02_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Wreckage/props/Generic/Wreckage03_prop.bp
+++ b/env/Wreckage/props/Generic/Wreckage03_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Wreckage/props/Generic/Wreckage04_prop.bp
+++ b/env/Wreckage/props/Generic/Wreckage04_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Wreckage/props/Generic/Wreckage05_prop.bp
+++ b/env/Wreckage/props/Generic/Wreckage05_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Wreckage/props/Generic/Wreckage06_prop.bp
+++ b/env/Wreckage/props/Generic/Wreckage06_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Wreckage/props/Generic/Wreckage07_prop.bp
+++ b/env/Wreckage/props/Generic/Wreckage07_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/env/Wreckage/props/Generic/Wreckage08_prop.bp
+++ b/env/Wreckage/props/Generic/Wreckage08_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     Defense = {
         Health = 50,

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -212,7 +212,13 @@ StructureUnit = ClassUnit(Unit) {
 
         -- procedure to remove props that do not obstruct the building
         local blueprint = self.Blueprint
-        if layer == 'Land' and blueprint.General.UpgradesFrom != builder.Blueprint.BlueprintId then
+        if 
+            -- do not apply for naval factories
+            layer == 'Land' and
+
+            -- do not apply to upgrades
+            blueprint.General.UpgradesFrom != builder.Blueprint.BlueprintId
+        then
             local CreateLightParticle = CreateLightParticle
 
             local army = self.Army

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -200,7 +200,7 @@ StructureUnit = ClassUnit(Unit) {
     end,
 
     ---@param self StructureUnit
-    ---@param builder Builder
+    ---@param builder Unit
     ---@param layer Layer
     OnStartBeingBuilt = function(self, builder, layer)
         Unit.OnStartBeingBuilt(self, builder, layer)
@@ -210,13 +210,13 @@ StructureUnit = ClassUnit(Unit) {
             self:RotateTowardsEnemy()
         end
 
-        -- knock over trees
-        if layer == 'Land' then
+        -- procedure to remove props that do not obstruct the building
+        local blueprint = self.Blueprint
+        if layer == 'Land' and blueprint.General.UpgradesFrom != builder.Blueprint.BlueprintId then
             local CreateLightParticle = CreateLightParticle
 
             local army = self.Army
             local position = self:GetPosition()
-            local blueprint = self.Blueprint
             local blueprintPhysics = blueprint.Physics
 
             -- matches what we do for build effects

--- a/lua/system/blueprints-props.lua
+++ b/lua/system/blueprints-props.lua
@@ -1,10 +1,27 @@
-
 ---@param prop PropBlueprint
 local function PostProcessProp(prop)
+
+    prop.Categories = prop.Categories or {}
+
+    prop.CategoriesHash = {}
+    for k, category in prop.Categories do
+        prop.CategoriesHash[category] = true
+    end
+
+    -- make invulnerable props actually invulnerable
     if prop.Categories then
         if table.find(prop.Categories, 'INVULNERABLE') then
             prop.ScriptClass = 'PropInvulnerable'
             prop.ScriptModule = '/lua/sim/prop.lua'
+        end
+    end
+
+    -- check for props that should block pathing
+    if not (prop.ScriptClass == "Tree" or prop.ScriptClass == "TreeGroup") and prop.CategoriesHash['RECLAIMABLE'] then
+        if prop.Economy and prop.Economy.ReclaimMassMax and prop.Economy.ReclaimMassMax > 0 and not prop.CategoriesHash['OBSTRUCTSBUILDING'] then
+            if not prop.CategoriesHash['OBSTRUCTSBUILDING'] then
+                WARN("Prop is missing 'OBSTRUCTSBUILDING' category: " .. prop.BlueprintId)
+            end
         end
     end
 end

--- a/meshes/explosions/oblivion_explosion01_prop.bp
+++ b/meshes/explosions/oblivion_explosion01_prop.bp
@@ -15,7 +15,7 @@ PropBlueprint {
         UniformScale = 0.1,
     },
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 0,
         ReclaimTime = 5,
     },

--- a/props/DefaultWreckage/DefaultWreckage_prop.bp
+++ b/props/DefaultWreckage/DefaultWreckage_prop.bp
@@ -1,10 +1,11 @@
 PropBlueprint {
     Categories = {
         'RECLAIMABLE',
+        'OBSTRUCTSBUILDING'
     },
     UnitWreckage = true,
     Economy = {
-        ReclaimEnergyMax = '',
+        ReclaimEnergyMax = 0,
         ReclaimMassMax = 1,
         ReclaimTime = 5,
     },


### PR DESCRIPTION
While poking the bear with a [Discord topic](https://discord.com/channels/197033481883222026/1126539305423212731) about adjusting the reclaim value of trees we found one issue: it would make it a lot more difficult to clear the base of trees for buildings.

As a general quality of life improvement this will allow you to build on top of props that are used commonly on maps but usually have little value or meaning. As a few examples:

- All trees and tree groups
- All bushes
- All logs
- All cactus
- All fens

The general rule of thumb: a prop that is a wreck, rock or has a significant reclaim value are required to be reclaimed before building. Anything else is destroyed instantly when building on top of it. You gain no resources of the props that are destroyed. 

To see it in action:

https://github.com/FAForever/fa/assets/15778155/e2529d0d-c537-4cd3-b926-89a355064c53

This pull request requires https://github.com/FAForever/FA-Binary-Patches/pull/16 to work. With thanks to @4z0t for the assembly patch

