### PR TITLE
Fix splash damage being able to destroy certain projectiles

### DIFF
--- a/engine/Core/Categories.lua
+++ b/engine/Core/Categories.lua
@@ -114,6 +114,7 @@ categories = {
     NAVAL = categoryValue,
     NEEDMOBILEBUILD = categoryValue,
     NOFORMATION = categoryValue,
+    --- Prevents splash damage being applied to the entity
     NOSPLASHDAMAGE = categoryValue,
     NUKE = categoryValue,
     NUKESUB = categoryValue,

--- a/projectiles/AANTorpedo01/AANTorpedo01_proj.bp
+++ b/projectiles/AANTorpedo01/AANTorpedo01_proj.bp
@@ -16,6 +16,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_proj.bp
+++ b/projectiles/AANTorpedoChronoPack01/AANTorpedoChronoPack01_proj.bp
@@ -16,6 +16,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         MaxHealth = 1,

--- a/projectiles/AANTorpedoCluster01/AANTorpedoCluster01_proj.bp
+++ b/projectiles/AANTorpedoCluster01/AANTorpedoCluster01_proj.bp
@@ -21,6 +21,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/AANTorpedoClusterSplit01/AANTorpedoClusterSplit01_proj.bp
+++ b/projectiles/AANTorpedoClusterSplit01/AANTorpedoClusterSplit01_proj.bp
@@ -21,6 +21,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/AIFMissileSerpentine01/AIFMissileSerpentine01_proj.bp
+++ b/projectiles/AIFMissileSerpentine01/AIFMissileSerpentine01_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 2,

--- a/projectiles/AIFMissileSerpentine02/AIFMissileSerpentine02_proj.bp
+++ b/projectiles/AIFMissileSerpentine02/AIFMissileSerpentine02_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 3,

--- a/projectiles/AIFMissileTactical01/AIFMissileTactical01_proj.bp
+++ b/projectiles/AIFMissileTactical01/AIFMissileTactical01_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 2,

--- a/projectiles/CANTorpedoNanite01/CANTorpedoNanite01_proj.bp
+++ b/projectiles/CANTorpedoNanite01/CANTorpedoNanite01_proj.bp
@@ -16,6 +16,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/CANTorpedoNanite02/CANTorpedoNanite02_proj.bp
+++ b/projectiles/CANTorpedoNanite02/CANTorpedoNanite02_proj.bp
@@ -21,6 +21,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/CANTorpedoNanite03/CANTorpedoNanite03_proj.bp
+++ b/projectiles/CANTorpedoNanite03/CANTorpedoNanite03_proj.bp
@@ -21,6 +21,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/CIFMissileTactical01/CIFMissileTactical01_proj.bp
+++ b/projectiles/CIFMissileTactical01/CIFMissileTactical01_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/CIFMissileTactical02/CIFMissileTactical02_proj.bp
+++ b/projectiles/CIFMissileTactical02/CIFMissileTactical02_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/CIFMissileTactical03/CIFMissileTactical03_proj.bp
+++ b/projectiles/CIFMissileTactical03/CIFMissileTactical03_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/SANHeavyCavitationTorpedo01/SANHeavyCavitationTorpedo01_proj.bp
+++ b/projectiles/SANHeavyCavitationTorpedo01/SANHeavyCavitationTorpedo01_proj.bp
@@ -20,6 +20,7 @@ ProjectileBlueprint {
         'SERAPHIM',
         'PROJECTILE',
         'ANTINAVY',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/SANHeavyCavitationTorpedo02/SANHeavyCavitationTorpedo02_proj.bp
+++ b/projectiles/SANHeavyCavitationTorpedo02/SANHeavyCavitationTorpedo02_proj.bp
@@ -21,6 +21,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/SANHeavyCavitationTorpedo03/SANHeavyCavitationTorpedo03_proj.bp
+++ b/projectiles/SANHeavyCavitationTorpedo03/SANHeavyCavitationTorpedo03_proj.bp
@@ -21,6 +21,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/SANHeavyCavitationTorpedo04/SANHeavyCavitationTorpedo04_proj.bp
+++ b/projectiles/SANHeavyCavitationTorpedo04/SANHeavyCavitationTorpedo04_proj.bp
@@ -21,6 +21,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/SANUallCavitationTorpedo01/SANUallCavitationTorpedo01_proj.bp
+++ b/projectiles/SANUallCavitationTorpedo01/SANUallCavitationTorpedo01_proj.bp
@@ -21,6 +21,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         MaxHealth = 1,

--- a/projectiles/SANUallCavitationTorpedo02/SANUallCavitationTorpedo02_proj.bp
+++ b/projectiles/SANUallCavitationTorpedo02/SANUallCavitationTorpedo02_proj.bp
@@ -21,6 +21,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         MaxHealth = 1,

--- a/projectiles/SANUallCavitationTorpedo03/SANUallCavitationTorpedo03_proj.bp
+++ b/projectiles/SANUallCavitationTorpedo03/SANUallCavitationTorpedo03_proj.bp
@@ -21,6 +21,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         MaxHealth = 1,

--- a/projectiles/SANUallCavitationTorpedo04/SANUallCavitationTorpedo04_proj.bp
+++ b/projectiles/SANUallCavitationTorpedo04/SANUallCavitationTorpedo04_proj.bp
@@ -21,6 +21,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense =  {
         MaxHealth = 1,

--- a/projectiles/SIFLaanseTacticalMissile02/SIFLaanseTacticalMissile02_proj.bp
+++ b/projectiles/SIFLaanseTacticalMissile02/SIFLaanseTacticalMissile02_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/SIFLaanseTacticalMissile03/SIFLaanseTacticalMissile03_proj.bp
+++ b/projectiles/SIFLaanseTacticalMissile03/SIFLaanseTacticalMissile03_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/SIFLaanseTacticalMissile04/SIFLaanseTacticalMissile04_proj.bp
+++ b/projectiles/SIFLaanseTacticalMissile04/SIFLaanseTacticalMissile04_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 2,

--- a/projectiles/SIFLaanseTacticalMissileCDR/SIFLaanseTacticalMissileCDR_proj.bp
+++ b/projectiles/SIFLaanseTacticalMissileCDR/SIFLaanseTacticalMissileCDR_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 2,

--- a/projectiles/SIFLaanseTacticalMissileSCU/SIFLaanseTacticalMissileSCU_proj.bp
+++ b/projectiles/SIFLaanseTacticalMissileSCU/SIFLaanseTacticalMissileSCU_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 2,

--- a/projectiles/TANAnglerTorpedo01/TANAnglerTorpedo01_proj.bp
+++ b/projectiles/TANAnglerTorpedo01/TANAnglerTorpedo01_proj.bp
@@ -21,6 +21,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         MaxHealth = 1,

--- a/projectiles/TANAnglerTorpedo02/TANAnglerTorpedo02_proj.bp
+++ b/projectiles/TANAnglerTorpedo02/TANAnglerTorpedo02_proj.bp
@@ -16,6 +16,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         MaxHealth = 1,

--- a/projectiles/TANAnglerTorpedo03/TANAnglerTorpedo03_proj.bp
+++ b/projectiles/TANAnglerTorpedo03/TANAnglerTorpedo03_proj.bp
@@ -16,6 +16,7 @@ ProjectileBlueprint {
         'PROJECTILE',
         'ANTINAVY',
         'TORPEDO',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         MaxHealth = 1,

--- a/projectiles/TIFMissileCruise01/TIFMissileCruise01_proj.bp
+++ b/projectiles/TIFMissileCruise01/TIFMissileCruise01_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 2,

--- a/projectiles/TIFMissileCruise02/TIFMissileCruise02_proj.bp
+++ b/projectiles/TIFMissileCruise02/TIFMissileCruise02_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 3,

--- a/projectiles/TIFMissileCruise03/TIFMissileCruise03_proj.bp
+++ b/projectiles/TIFMissileCruise03/TIFMissileCruise03_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/TIFMissileCruise04/TIFMissileCruise04_proj.bp
+++ b/projectiles/TIFMissileCruise04/TIFMissileCruise04_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 2,

--- a/projectiles/TIFMissileCruise05/TIFMissileCruise05_proj.bp
+++ b/projectiles/TIFMissileCruise05/TIFMissileCruise05_proj.bp
@@ -22,6 +22,7 @@ ProjectileBlueprint {
         'INDIRECTFIRE',
         'TACTICAL',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 1,

--- a/projectiles/TIFMissileNukeCDR/TIFMissileNukeCDR_proj.bp
+++ b/projectiles/TIFMissileNukeCDR/TIFMissileNukeCDR_proj.bp
@@ -23,6 +23,7 @@ ProjectileBlueprint {
         'TACTICAL',
         'TACTICALNUKE',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         Health = 4,


### PR DESCRIPTION
This bug was introduced with #5000 where we removed the category, thinking it was some legacy category that projectiles can have. But this particular category prevents the projectile from being taken into account when splash damage is processed. Without it we end up with a situation such as this:

![image](https://github.com/FAForever/fa/assets/15778155/c2a75c16-0a2e-4493-a426-371c364cb98b)

Where tactical missiles can destroy (friendly) other tactical missiles. Or where torpedo's can be destroyed by projectiles on the surface