### PR TITLE
Fix a bug where the Cybran extractors would not turn off their animation

### DIFF
--- a/lua/cybranunits.lua
+++ b/lua/cybranunits.lua
@@ -578,6 +578,14 @@ CLandUnit = ClassUnit(DefaultUnitsFile.LandUnit) {}
 ---@field AnimationManipulator moho.AnimationManipulator
 CMassCollectionUnit = ClassUnit(MassCollectionUnit) {
 
+    OnStartBuild = function(self, unitBeingBuilt, order)
+        MassCollectionUnit.OnStartBuild(self, unitBeingBuilt, order)
+        if not self.AnimationManipulator then return end
+        self.AnimationManipulator:SetRate(0)
+        self.AnimationManipulator:Destroy()
+        self.AnimationManipulator = nil
+    end,
+
     ---@param self CMassCollectionUnit
     PlayActiveAnimation = function(self)
         MassCollectionUnit.PlayActiveAnimation(self)


### PR DESCRIPTION
From Discord:
- https://discord.com/channels/197033481883222026/1125926692335124500

https://github.com/FAForever/fa/assets/15778155/1c8a5715-8214-4fdb-8d75-3cc727b4566b

With thanks to Sladow for reporting it