### PR TITLE
Temporary wailer fix

### DIFF
--- a/units/XRA0305/XRA0305_unit.bp
+++ b/units/XRA0305/XRA0305_unit.bp
@@ -294,7 +294,7 @@ UnitBlueprint {
             AutoInitiateAttackCommand = true,
             BallisticArc = 'RULEUBA_LowArc',
             CollideFriendly = false,
-            Damage = 140,
+            Damage = 233,
             DamageType = 'Normal',
             DisplayName = 'Disintegrator Pulse Laser',
             FireTargetLayerCapsTable = {
@@ -333,7 +333,7 @@ UnitBlueprint {
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = 'UWRC_DirectFire',
-            RateOfFire = 1.6,
+            RateOfFire = 1,
             TargetPriorities = {
                 'ANTIAIR',
                 'GROUNDATTACK',


### PR DESCRIPTION
This fixes the wailer's dps decreasing when using its aa weapon by setting the fire rate to 1. Until someone can figure out why it does that, this could be used as a substitute.