### PR TITLE
AI - Fix no threat being assigning to mobile indirect fire units

### DIFF
--- a/lua/system/blueprints-ai.lua
+++ b/lua/system/blueprints-ai.lua
@@ -204,7 +204,7 @@ function SetUnitThreatValues(unitBPs)
                 local surfaceMult = 0.1
 
                 -- determines if we apply dps to economic or anti surface threat
-                local blockedByArtilleryShield = weapon.ArtilleryShieldBlocks and not mobileUnit
+                local blockedByArtilleryShield = weapon.ArtilleryShieldBlocks and (not mobileUnit or weapon.MinRadius > 80)
 
                 -- Anti air
                 if weapon.RangeCategory == 'UWRC_AntiAir' or weapon.TargetRestrictOnlyAllow == 'AIR' or StringFind(weapon.WeaponCategory or 'nope', 'Anti Air') then

--- a/lua/system/blueprints-ai.lua
+++ b/lua/system/blueprints-ai.lua
@@ -127,6 +127,8 @@ function SetUnitThreatValues(unitBPs)
             cache.HealthThreat = bp.Defense.MaxHealth * 0.01
         end
 
+        local mobileUnit = bp.CategoriesHash.MOBILE
+
         if bp.Defense.Shield then
             local shield = bp.Defense.Shield                                               -- ShieldProjectionRadius entirely only for the Pillar of Prominence
             local shieldarea = (shield.ShieldProjectionRadius or shield.ShieldSize or 0) * (shield.ShieldProjectionRadius or shield.ShieldSize or 0) * math.pi
@@ -202,7 +204,7 @@ function SetUnitThreatValues(unitBPs)
                 local surfaceMult = 0.1
 
                 -- determines if we apply dps to economic or anti surface threat
-                local blockedByArtilleryShield = weapon.ArtilleryShieldBlocks
+                local blockedByArtilleryShield = weapon.ArtilleryShieldBlocks and not mobileUnit
 
                 -- Anti air
                 if weapon.RangeCategory == 'UWRC_AntiAir' or weapon.TargetRestrictOnlyAllow == 'AIR' or StringFind(weapon.WeaponCategory or 'nope', 'Anti Air') then

--- a/lua/system/blueprints-ai.lua
+++ b/lua/system/blueprints-ai.lua
@@ -204,7 +204,7 @@ function SetUnitThreatValues(unitBPs)
                 local surfaceMult = 0.1
 
                 -- determines if we apply dps to economic or anti surface threat
-                local blockedByArtilleryShield = weapon.ArtilleryShieldBlocks and (not mobileUnit or weapon.MinRadius > 80)
+                local weaponIsEconomicThreat = (weapon.DamageType == 'Nuke' or weapon.ArtilleryShieldBlocks) and (not mobileUnit or weapon.MinRadius > 80)
 
                 -- Anti air
                 if weapon.RangeCategory == 'UWRC_AntiAir' or weapon.TargetRestrictOnlyAllow == 'AIR' or StringFind(weapon.WeaponCategory or 'nope', 'Anti Air') then
@@ -219,7 +219,7 @@ function SetUnitThreatValues(unitBPs)
                 -- Direct fire or artillery
                 elseif weapon.RangeCategory == 'UWRC_DirectFire' or StringFind(weapon.WeaponCategory or 'nope', 'Direct Fire')
                         or weapon.RangeCategory == 'UWRC_IndirectFire' or StringFind(weapon.WeaponCategory or 'nope', 'Artillery') then
-                    if blockedByArtilleryShield then
+                    if weaponIsEconomicThreat then
                         cache.EconomyThreatLevel = cache.EconomyThreatLevel + dps * econMult
                     else
                         cache.SurfaceThreatLevel = cache.SurfaceThreatLevel + dps * surfaceMult


### PR DESCRIPTION
This PR corrects a couple of issues with the blueprint threat assignment logic where 
No surface threat was being assigned to indirect fire units.
Surface threat was being applied to nuke weapons.

The logic is support to provide economic threat to things like static T3 artillery and Nukes etc so that AI would understand that they are not a direct risk to units but are valuable to target. This is used by detecting the weapon.ArtilleryShieldBlocks attribute on unit weapons.

The consequence of this is that T1/T3 mobile artillery and T2 MML's get no surface threat assigned to them. This makes them invisible from the AI's threat perspective. Which will lead to things like an ACU thinking it can attack a infinite number of T1 artillery with no risk, or not considering T2 MML a risk to its base etc.

The other issue is that surface threat was being applied to Nuke weapons. This made a strategic missile launcher have over 2000 surface threat which would scare away any AI from wanting to directly attack it if it was considering surface threat to determine the risk factor of directly assaulting a unit. This can be seen with the attackforceai when an enemy has a nuke launcher the platoons will refuse to attack the base due to the surface threat of it being too high.

We now check if a unit is mobile and if so it will be assigned surface threat rather than economy threat. We also check if the weapon is a nuke and if so assign economic threat instead of surface.

There is one consequence to this which is the Scathis and nuke subs as that could be considered an economic target but has a MOBILE category. 

The change is that the blueprint logic will check.
If the weapon is indirect fire and (ArtilleryShieldBlocks OR DamageType is 'Nuke' ) AND (not mobile OR weapon.MinRadius > 80) then it is considered economic threat. 
