### PR TITLE
Fix issues with the Mercy

### DIFF
--- a/effects/emitters/X1Mercy_cloud_emit.bp
+++ b/effects/emitters/X1Mercy_cloud_emit.bp
@@ -10,7 +10,7 @@ EmitterBlueprint {
 	AlignRotation = false,
 	AlignToBone = false,
 	Flat = false,
-	LODCutoff = 100.00,
+	LODCutoff = 300.00,
 	EmitIfVisible = true,
 	CatchupEmit = true,
 	CreateIfVisible = false,

--- a/projectiles/AIFGuidedMissile01/AIFGuidedMissile01_Script.lua
+++ b/projectiles/AIFGuidedMissile01/AIFGuidedMissile01_Script.lua
@@ -35,6 +35,7 @@ AIFGuidedMissile = ClassProjectile(AGuidedMissileProjectile) {
         local xVec = 0 
         local yVec = vy*0.8
         local zVec = 0
+        
         -- Adjust damage by number of split projectiles
         self.DamageData.DamageAmount = self.DamageData.DamageAmount / numProjectiles
 

--- a/projectiles/AIFGuidedMissile01/AIFGuidedMissile01_proj.bp
+++ b/projectiles/AIFGuidedMissile01/AIFGuidedMissile01_proj.bp
@@ -3,11 +3,10 @@ ProjectileBlueprint {
         'AEON',
         'PROJECTILE',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Display = {
         CameraFollowsProjectile = true,
-
-        -- ----MeshBlueprint = '/units/DAA0206/DAA0206_mesh.bp',
         StrategicIconSize = 2,
         UniformScale = 0.09,
     },

--- a/projectiles/AIFGuidedMissile02/AIFGuidedMissile02_Script.lua
+++ b/projectiles/AIFGuidedMissile02/AIFGuidedMissile02_Script.lua
@@ -24,8 +24,6 @@ AIFGuidedMissile02 = ClassProjectile(AGuidedMissileProjectile) {
 	OnImpact = function(self, TargetType, TargetEntity)
         AMiasmaProjectile.OnImpact(self, TargetType, TargetEntity)
 
-        --WARN(tostring(TargetType) .. " - " .. tostring(TargetEntity))
-        --Sounds for all other impacts, ie: Impact<TargetTypeName>
         local bp = self:GetBlueprint().Audio
         local snd = bp['Impact'.. TargetType]
         if snd then
@@ -41,7 +39,7 @@ AIFGuidedMissile02 = ClassProjectile(AGuidedMissileProjectile) {
     
         local px, py, pz = self:GetPositionXYZ()
         entity:UpdatePosition(px, pz)
-        entity:UpdateIntel(self.Army, 10, 'Vision', true)
+        entity:UpdateIntel(self.Army, 12, 'Vision', true)
         entity:UpdateDuration(10)
 
         -- Transplanted AIFMiasmaShell02 code
@@ -50,19 +48,11 @@ AIFGuidedMissile02 = ClassProjectile(AGuidedMissileProjectile) {
         local radius = self.DamageData.DamageRadius
         local FriendlyFire = self.DamageData.DamageFriendly and radius ~=0
 
-        
-
-        DamageArea( self, pos, radius, 1, 'Force', FriendlyFire )
-        DamageArea( self, pos, radius, 1, 'Force', FriendlyFire )
-
-        self.DamageData.DamageAmount = self.DamageData.DamageAmount - 2
-
-
-        -- One initial projectile following same directional path as the original, old code in case it breaks
-        --local child = self:CreateChildProjectile('/projectiles/AIFMiasmaShell02/AIFMiasmaShell02_proj.bp' ):SetVelocity(x,y,z):SetVelocity(speed)
+        DamageArea( self, pos, 0.5 * radius, 1, 'TreeFire', FriendlyFire )
+        DamageArea( self, pos, 0.5 * radius, 1, 'TreeFire', FriendlyFire )
 
         local emitter = CreateEmitterAtEntity(self, self.Army, '/effects/emitters/X1Mercy_cloud_emit.bp')
-        emitter:ScaleEmitter(self.DamageData.DamageRadius / 5 * 2):SetEmitterCurveParam('EMITRATE_CURVE',self.DamageData.DamageRadius * 2,20):SetEmitterCurveParam('Y_POSITION_CURVE', -0.5, 1)
+        emitter:ScaleEmitter(self.DamageData.DamageRadius / 5 * 2):SetEmitterCurveParam('EMITRATE_CURVE',self.DamageData.DamageRadius, 30):SetEmitterCurveParam('Y_POSITION_CURVE', -0.5, 1)
 
         self:Destroy()
     end,

--- a/projectiles/AIFGuidedMissile02/AIFGuidedMissile02_proj.bp
+++ b/projectiles/AIFGuidedMissile02/AIFGuidedMissile02_proj.bp
@@ -20,6 +20,7 @@ ProjectileBlueprint {
         'AEON',
         'PROJECTILE',
         'MISSILE',
+        'NOSPLASHDAMAGE'
     },
     Defense = {
         MaxHealth = 1,
@@ -49,7 +50,8 @@ ProjectileBlueprint {
         MaxSpeed = 35,
         MaxZigZag = 10,
         TrackTarget = false,
-        TurnRate = 180,
+        TurnRate = 40,
+        TurnRateRange = 30,
         UseGravity = false,
         VelocityAlign = true,
         ZigZagFrequency = 0.2,

--- a/projectiles/AIFGuidedMissile02/AIFGuidedMissile02_proj.bp
+++ b/projectiles/AIFGuidedMissile02/AIFGuidedMissile02_proj.bp
@@ -51,7 +51,7 @@ ProjectileBlueprint {
         MaxZigZag = 10,
         TrackTarget = false,
         TurnRate = 40,
-        TurnRateRange = 30,
+        TurnRateRange = 10,
         UseGravity = false,
         VelocityAlign = true,
         ZigZagFrequency = 0.2,

--- a/units/DAA0206/DAA0206_unit.bp
+++ b/units/DAA0206/DAA0206_unit.bp
@@ -161,7 +161,7 @@ UnitBlueprint{
             },
             BallicsticArc = "RULEUBA_None",
             CollideFriendly = true,
-            Damage = 79,
+            Damage = 30,
             DamageFriendly = true,
             DamageRadius = 7.5,
             DamageType = "Normal",


### PR DESCRIPTION
The effect is now well visible when zoomed out. It creates less particles. The projectiles of the Mercy are immune to its own splash damage, and the projectiles no longer hit _exactly_ where you aimed, but instead scattered a little bit as you'd expect. And last but not least: the unit now does the intended damage

https://github.com/FAForever/fa/assets/15778155/69e3a5c8-233c-41b3-b66b-892b9ad62f3e

