### PR TITLE
Wait 10 seconds before killing remaining units after recall

### DIFF
--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -1319,7 +1319,6 @@ AIBrain = Class(AIBrainHQComponent, AIBrainStatisticsComponent, AIBrainJammerCom
         end
 
         -- This part determines the share condition
-
         local shareOption = ScenarioInfo.Options.Share
         if shareOption == 'CivilianDeserter' then
             TransferUnitsToBrain(civilians)
@@ -1327,11 +1326,16 @@ AIBrain = Class(AIBrainHQComponent, AIBrainStatisticsComponent, AIBrainJammerCom
             TransferUnitsToHighestBrain(enemies)
         end
 
+        -- let the average, team vs team game end first
+        WaitSeconds(10.0)
+
         -- Kill all units left over
         local tokill = self:GetListOfUnits(categories.ALLUNITS - categories.WALL, false)
         if tokill then
             for _, unit in tokill do
-                unit:Kill()
+                if not IsDestroyed(unit) then
+                    unit:Kill()
+                end
             end
         end
 


### PR DESCRIPTION
Originates from this forum post
- https://forum.faforever.com/topic/6302/don-t-destroy-all-units-upon-recall

All units now remain alive for 10 additional seconds. This is long enough to preserve the units at the end of a regular setup while still allowing units to be destroyed eventually for unusual setups such as FFA.