### PR TITLE
Re-introduce a hotkey that people were using a lot

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -521,7 +521,25 @@ Callbacks.FlagShield = function(data, units)
     end
 end
 
+-------------------------------------------------------------------------------
+--#region Advanced orders
+
 Callbacks.WeaponPriorities = import("/lua/weaponpriorities.lua").SetWeaponPriorities
+
+---@param data any
+---@param selection any
+Callbacks.SelectHighestEngineerAndAssist = function(data, selection)
+    if selection then
+        -- check for cheats
+        local target = GetUnitById(data.TargetId) --[[@as Unit]]
+        if not target or not target.Army then return end
+        if not OkayToMessWithArmy(target.Army) then return end
+
+        local noACU = EntityCategoryFilterDown(categories.ALLUNITS - categories.COMMAND, selection)
+        IssueClearCommands(noACU)
+        IssueGuard(noACU, target)
+    end
+end
 
 do
     -- upvalue for performance
@@ -595,8 +613,10 @@ do
     end
 end
 
+--#endregion
+
 -------------------------------------------------------------------------------
---@region Development / debug related functionality
+--#region Development / debug related functionality
 
 --- An anti cheat check that passes when there is only 1 player or cheats are enabled
 ---@return boolean
@@ -629,8 +649,6 @@ local PassesAIAntiCheatCheck = function()
     -- allow when cheats are enabled
     return PassesAntiCheatCheck()
 end
-
-
 
 local SpawnedMeshes = {}
 

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -1559,6 +1559,13 @@ local keyActionsOrders = {
     },
 }
 
+local keyActionsOrdersAdvanced = {
+    ['filter_highest_engineer_and_assist'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").SelectHighestEngineerAndAssist()',
+        category = 'ordersAdvanced',
+    },
+}
+
 ---@type table<string, UIKeyAction>
 local keyActionsGame = {
     ['toggle_lifebars'] = {
@@ -1775,6 +1782,7 @@ keyActions = table.combine(
     keyActionsHotBuildAlternative,
     keyActionsHotBuildExtra,
     keyActionsOrders,
+    keyActionsOrdersAdvanced,
     keyActionsGame,
     keyActionsChat,
     keyActionsUI,

--- a/lua/keymap/keycategories.lua
+++ b/lua/keymap/keycategories.lua
@@ -8,6 +8,7 @@ keyCategories = {
     ['selectionSubgroups'] = "<LOC keymap_selection_fragments>Selection - Subgroups",
     ['camera'] = "<LOC keymap_category_0025>Camera",
     ['orders'] = "<LOC keymap_category_0036>Orders",
+    ['ordersAdvanced'] = "<LOC keymap_orders_advanced>Orders - Advanced",
     ['game'] = "<LOC keymap_category_0079>Game",
     ['chat'] = "<LOC keymap_category_0087>Chat",
     ['debug'] = "<LOC keymap_category_0088>Debug",
@@ -22,6 +23,7 @@ keyCategories = {
 
 keyCategoryOrder = {
     'orders',
+    'ordersAdvanced',
     'selection',
     'selectionQuickSelect',
     'selectionControlGroups',

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -169,6 +169,7 @@ keyDescriptions = {
     ['toggle_build_mode'] = '<LOC key_desc_0102>Toggles keyboard build command mode on and off',
     ['toggle_reclaim_labels'] = '<LOC key_desc_0103>Toggles reclaim labels on and off',
     ['select_upgrading_extractors'] = '<LOC key_desc_select_upgrading_extractors>Select all extractors that are upgrading',
+    ['filter_highest_engineer_and_assist'] = '<LOC key_desc_filter_highest_engineer_and_assist>Filter the selection to the most advanced engineer, all other engineers assist that engineer',
     ['select_all_radars'] = '<LOC key_desc_select_all_radars>Select all radars',
     ['decrease_game_speed'] = '<LOC key_desc_0079>Decrease game speed',
     ['increase_game_speed'] = '<LOC key_desc_0080>Increase game speed',

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -558,13 +558,13 @@ function SelectHighestEngineerAndAssist()
 
         if next(sACUs) then
             SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = sACUs[1]:GetEntityId() }}, true)
-            SelectUnits({sACUs})
+            SelectUnits(sACUs)
         elseif next(tech3) then
             SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = tech3[1]:GetEntityId() }}, true)
-            SelectUnits({tech3})
+            SelectUnits(tech3)
         elseif next(tech2) then
             SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = tech2[1]:GetEntityId() }}, true)
-            SelectUnits({tech2})
+            SelectUnits(tech2)
         else
             -- do nothing
         end

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -558,13 +558,13 @@ function SelectHighestEngineerAndAssist()
 
         if next(sACUs) then
             SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = sACUs[1]:GetEntityId() }}, true)
-            SelectUnits({sACUs[1]})
+            SelectUnits({sACUs})
         elseif next(tech3) then
             SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = tech3[1]:GetEntityId() }}, true)
-            SelectUnits({tech3[1]})
+            SelectUnits({tech3})
         elseif next(tech2) then
             SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = tech2[1]:GetEntityId() }}, true)
-            SelectUnits({tech2[1]})
+            SelectUnits({tech2})
         else
             -- do nothing
         end

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -545,3 +545,28 @@ RestoreCameraPosition = function ()
     local settings = Prefs.GetFromCurrentProfile('DebugCameraPosition') --[[@as UserCameraSettings]]
     camera:MoveTo(settings.Focus, { settings.Heading, settings.Pitch, 0}, settings.Zoom, 0)
 end
+
+function SelectHighestEngineerAndAssist()
+    local selection = GetSelectedUnits()
+
+    if selection then
+
+        local tech1 = EntityCategoryFilterDown(categories.TECH1 - categories.COMMAND, selection)
+        local tech2 = EntityCategoryFilterDown(categories.TECH2 - categories.COMMAND, selection)
+        local tech3 = EntityCategoryFilterDown(categories.TECH3 - categories.COMMAND, selection)
+        local sACUs = EntityCategoryFilterDown(categories.SUBCOMMANDER - categories.COMMAND, selection)
+
+        if next(sACUs) then
+            SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = sACUs[1]:GetEntityId() }}, true)
+            SelectUnits({sACUs[1]})
+        elseif next(tech3) then
+            SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = tech3[1]:GetEntityId() }}, true)
+            SelectUnits({tech3[1]})
+        elseif next(tech2) then
+            SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = tech2[1]:GetEntityId() }}, true)
+            SelectUnits({tech2[1]})
+        else
+            -- do nothing
+        end
+    end
+end

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -551,7 +551,6 @@ function SelectHighestEngineerAndAssist()
 
     if selection then
 
-        local tech1 = EntityCategoryFilterDown(categories.TECH1 - categories.COMMAND, selection)
         local tech2 = EntityCategoryFilterDown(categories.TECH2 - categories.COMMAND, selection)
         local tech3 = EntityCategoryFilterDown(categories.TECH3 - categories.COMMAND, selection)
         local sACUs = EntityCategoryFilterDown(categories.SUBCOMMANDER - categories.COMMAND, selection)


### PR DESCRIPTION
With https://github.com/FAForever/fa/pull/4994 we removed two hotkeys. We're returning one of them: the ability to quickly select the highest tech and have everything else assist one of the high tech engineers.

Includes a suggestion of @ChessBerry to select all the high tech engineers, instead of just one

