### PR TITLE
Tighter formation for the Shard

### DIFF
--- a/units/UAS0102/UAS0102_unit.bp
+++ b/units/UAS0102/UAS0102_unit.bp
@@ -91,8 +91,8 @@ UnitBlueprint{
         BuildTime = 600,
     },
     Footprint = {
-        SizeX = 2,
-        SizeZ = 6,
+        SizeX = 3,
+        SizeZ = 3,
     },
     General = {
         CommandCaps = {


### PR DESCRIPTION
The Shard had a very spread out formation for a unit of its size, this change addresses this and enables it to deal more concentrated DPS when used in groups.