### PR TITLE
Fix various bugs with the unit restrictions menu

### DIFF
--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -891,6 +891,8 @@ local function SpawnMenuDummyChanges(all_bps)
                     Categories = {
                         'DRAGBUILD',
                         'UNSPAWNABLE',
+                        'INSIGNIFICANTUNIT',
+                        'DUMMYUNIT',
                     },
                     Display = {
                         BuildMeshBlueprint = '/meshes/game/nil_mesh',

--- a/lua/ui/lobby/UnitsAnalyzer.lua
+++ b/lua/ui/lobby/UnitsAnalyzer.lua
@@ -52,6 +52,7 @@ CategoriesSkipped  = {
     ["NOFORMATION"] = true,
     ["UNSELECTABLE"] = true,
     ["UNTARGETABLE"] = true,
+    ["DUMMYUNIT"] = true,
     ["zxa0001"] = true,    -- Dummy unit for gifting unfinished buildings
     ["uab5103"] = true,    -- Aeon Quantum Gate Beacon
     ["uab5204"] = true,    -- Concrete
@@ -491,14 +492,19 @@ end
 
 -- Get specs for a weapon with projectiles
 function GetWeaponProjectile(bp, weapon)
+    -- Multipliers is needed to properly calculate split projectiles.
+    -- Unfortunately these numbers hard-coded here are not available in the blueprint,
+    -- but specified in the .lua files for corresponding projectiles.
+    local multipliers = {
+        -- Lobo
+        ['/projectiles/TIFFragmentationSensorShell01/TIFFragmentationSensorShell01_proj.bp'] = 4,
+        -- Zthuee
+        ['/projectiles/SIFThunthoArtilleryShell01/SIFThunthoArtilleryShell01_proj.bp'] = 5
+    }
 
-    local split = 1
-    local projPhysics = __blueprints[weapon.ProjectileId].Physics
-    while projPhysics do
-        split = split * (projPhysics.Fragments or 1)
-        projPhysics = __blueprints[projPhysics.FragmentId].Physics
+    if weapon.ProjectileId then
+       weapon.Multi = multipliers[weapon.ProjectileId] or 1
     end
-    weapon.Multi = split
 
     -- NOTE that weapon.ProjectilesPerOnFire is not used at all in FA game
     if weapon.MuzzleSalvoSize > 1 then


### PR DESCRIPTION
Closes https://github.com/FAForever/fa/issues/5263

Units with the categories `INSIGNIFICANTUNIT` and `DUMMYUNIT` are now ignored. Units with the `INSIGNIFICANTUNIT` category are ignored in the command graph. Units with the `DUMMYUNIT` category usually inherit from the [DummyUnit](https://github.com/FAForever/fa/blob/deploy/fafdevelop/lua/sim/Unit.lua#L5218) class which has essentially none of the properties that you'd expect from a regular unit. It exists to reduce the impact of the unit to a minimum, used primarily by Cybran build drones as described in:

- https://forum.faforever.com/topic/2334/questions-about-performance-cybran-build-drones

Reverts a small patch from #4513 that assumes the `__blueprints` value is populated. This is not the case in the lobby

![image](https://github.com/FAForever/fa/assets/15778155/5d8b576a-1e26-43e9-b75f-b9600a424b7b)
