### PR TITLE
Give units a sense of order when distributing orders

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -920,6 +920,9 @@ do
     ---@param data any
     ---@param units Unit[]
     Callbacks.DistributeOrders = function(data, units)
+
+        local start = GetSystemTimeSecondsOnlyForProfileUse()
+
         -- prevent cheating
         local units = SecureUnits(units)
         if not (units and units[1]) then
@@ -970,8 +973,9 @@ do
         -----------------------------------------------------------------------
         -- sorting units
 
-        -- we sort the selection to make the order more intuitive. By default the order is defined by
-        -- the entityId, which is essentially random in the average case
+        -- we sort the selection to make the order more intuitive. By default 
+        -- the order is defined by the entityId, which is essentially random in 
+        -- the average case
 
         for _, unit in units do
             local ux, _, uz = unit:GetPositionXYZ()
@@ -1090,6 +1094,8 @@ do
                 end
             end
         end
+
+        LOG(string.format("Processing time: %f", GetSystemTimeSecondsOnlyForProfileUse() - start))
     end
 end
 


### PR DESCRIPTION
The order of the `units` array that we receive in a sim callback depends on the `EntityId` of a unit. For synthetic cases this order is well-defined, but for the average normal use case it is far from it. Therefore we sort the units based on distance to the first reliable point that we can find. 

Note: the bombers in the video are out of fuel 😄 

https://github.com/FAForever/fa/assets/15778155/6b1ecc99-e367-4ea8-a6a0-4eb8c46fd93a

