### PR TITLE
Cull duplicated orders in groups of orders

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -960,7 +960,6 @@ do
             local targetId = order.targetId
             if targetId then
                 if seen[targetId] then
-                    LOG("Skipping an order!")
                     continue
                 end
                 seen[targetId] = true


### PR DESCRIPTION
The complexity of the function is based on the number of orders in a group. If `k` is the number of orders in a group then the orders we end up creating is `O(k^2)` when we do batching. Eventually all orders that aim at entities will use batching. The average user is impeccable at clicking. But those that are not may create duplicated orders where they click an attack order on the same unit multiple times. Given the complexity this can create a lot of unintended orders. Therefore we try and filter them out.

