### PR TITLE
Prevent intel from hijacking the progress bar during an enhancement

### DIFF
--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -253,11 +253,20 @@ IntelComponent = ClassSimple {
 
             --- display progress
             for k = 1, ticks do
-                self:SetWorkProgress((k / ticks))
+
+                -- prevent changing work progress when we are doing work (such as an enhancement)
+                if not self.WorkItem then
+                    self:SetWorkProgress((k / ticks))
+                end
+
                 WaitTicks(1)
             end
 
-            self:SetWorkProgress(-1)
+            -- prevent changing work progress when we are doing work (such as an enhancement)
+            if not self.WorkItem then
+                self:SetWorkProgress(-1)
+            end
+
             self:OnIntelRecharged()
         end
     end,


### PR DESCRIPTION
Bug report originates from Discord:
- https://discord.com/channels/197033481883222026/1133373766051836035

See also the Cybran ACU at around minute 13:40:
- https://youtu.be/e6FYy2XGSo4?t=818

The work progress remains untouched when recharging intel when there is a work item. Work items are populated when an enhancement starts and cleared when an enhancement stops.