### PR TITLE
Add batching with or without full redundancy for more orders

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4768,7 +4768,9 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         if queue then
             for k, order in queue do
                 if order.targetId then
-                    order.target = GetEntityById(order.targetId)
+                    local target = GetEntityById(order.targetId)
+                    order.target = target
+                    -- take position of the entity, used to sort the units
                     order.x, order.y, order.z = moho.entity_methods.GetPositionXYZ(target)
                 end
             end

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4769,6 +4769,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             for k, order in queue do
                 if order.targetId then
                     order.target = GetEntityById(order.targetId)
+                    order.x, order.y, order.z = moho.entity_methods.GetPositionXYZ(target)
                 end
             end
         end


### PR DESCRIPTION
Using the generalizations provided in #5278 we can now more easily batch other order types. This drastically reduces the number of orders we issue.

A concern of @Strogoo was that the batching of a move order would cause the units to 'pause' before moving, like when you do as a player when you click a move order. This doesn't happen to be the case. Units are also not moving in formation, they still all want to traverse to the same location (where the order is). Therefore the result is the same, but with drastically less orders 😄 !

Another interesting find is that even though the table that `GetEntityById` returns contains only an engine reference, we can still run entity functions. One such function is being able to retrieve the position of the entity. We use the position to give a sense of order to the units in our selection.