### PR TITLE
Fix tech 3 mobile anti air being at the front of a formation

### DIFF
--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -81,7 +81,7 @@ end
 local RemainingCategory = { 'RemainingCategory', }
 
 -- === LAND CATEGORIES ===
-local DirectFire = (categories.DIRECTFIRE - (categories.CONSTRUCTION + categories.SNIPER)) * categories.LAND
+local DirectFire = (categories.DIRECTFIRE - (categories.CONSTRUCTION + categories.SNIPER + categories.WEAKDIRECTFIRE)) * categories.LAND
 local Sniper = categories.SNIPER * categories.LAND
 local Artillery = (categories.ARTILLERY + categories.INDIRECTFIRE - categories.SNIPER) * categories.LAND
 local AntiAir = (categories.ANTIAIR - (categories.EXPERIMENTAL + categories.DIRECTFIRE + categories.SNIPER + Artillery)) * categories.LAND

--- a/units/DRLK001/DRLK001_unit.bp
+++ b/units/DRLK001/DRLK001_unit.bp
@@ -31,6 +31,7 @@ UnitBlueprint{
         "SELECTABLE",
         "TECH3",
         "VISIBLETORECON",
+        "WEAKDIRECTFIRE",
     },
     Defense = {
         AirThreatLevel = 33,

--- a/units/DSLK004/DSLK004_unit.bp
+++ b/units/DSLK004/DSLK004_unit.bp
@@ -25,6 +25,7 @@ UnitBlueprint{
         "SERAPHIM",
         "TECH3",
         "VISIBLETORECON",
+        "WEAKDIRECTFIRE",
     },
     Defense = {
         AirThreatLevel = 120,


### PR DESCRIPTION
Manually adds the `WEAKDIRECTIRE` category to the Bouncer and the Lightning tank, and uses the category to exclude units from the `DIRECTFIRE` category when computing the formation of a unit.

![image](https://github.com/FAForever/fa/assets/15778155/61e826f5-e95a-4776-ae68-7d39fa69847a)

![image](https://github.com/FAForever/fa/assets/15778155/f08f222f-5e23-4de9-a007-b6bc00a95180)
