### PR TITLE
Add platoon form callbacks for conditional builds

### DIFF
--- a/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
+++ b/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
@@ -265,6 +265,7 @@ function ConditionalBuildDied(conditionalUnit)
             BuildCondition = selectedBuild.data.BuildCondition,
             PlatoonAIFunction = selectedBuild.data.PlatoonAIFunction,
             PlatoonData = selectedBuild.data.PlatoonData,
+            FormCallbacks = selectedBuild.data.FormCallbacks,
             Retry = selectedBuild.data.Retry,
             KeepAlive = true,
             Amount = 1,
@@ -288,6 +289,16 @@ function ConditionalBuildSuccessful(conditionalUnit)
 
     if selectedBuild.data.PlatoonAIFunction then
         newPlatoon:ForkAIThread(import(selectedBuild.data.PlatoonAIFunction[1])[selectedBuild.data.PlatoonAIFunction[2]])
+    end
+
+    if selectedBuild.data.FormCallbacks then
+        for _, callback in selectedBuild.data.FormCallbacks do
+            if type(callback) == "function" then
+                newPlatoon:ForkThread(callback)
+            else
+                newPlatoon:ForkThread(import(callback[1])[callback[2]])
+            end
+        end
     end
 
     -- Set up a death wait thing for it to rebuild


### PR DESCRIPTION
Adds platoon form callbacks for campaign conditional builds, those are used for single units like experimentals or sonars that needs to be built by engineers.

Callback can be defined as a function or table with path and function name. (it's the same as for OpAI)

Example of how to use it:
```LUA
opai = M1RhizaBase:AddOpAI('M1_Sonar',
    {
        Amount = 1,
        FormCallbacks = {
            Test1,
            {'/maps/X1CA_Coop_003/X1CA_Coop_003_m1rhizaai.lua', 'Test2'},
        },
        KeepAlive = true,
        MaxAssist = 1,
        Retry = true,
    }
)
```