### PR TITLE
Remove ability to cap air factories

### DIFF
--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -386,13 +386,13 @@ function CapStructure(command)
                 pStructure1 = nil
                 pStructure2 = nil
 
-            -- if we have a T3 Air Factory, create T3 pgens around it
-            elseif structure:IsInCategory('AIR') and structure:IsInCategory('FACTORY') and isTech3 then
-                SimCallback({ Func = 'CapStructure', Args = { target = command.Target.EntityId, layer = 1, id = "b1301" } }, true)
-                -- reset state
-                structure = nil
-                pStructure1 = nil
-                pStructure2 = nil
+            -- -- if we have a T3 Air Factory, create T3 pgens around it
+            -- elseif structure:IsInCategory('AIR') and structure:IsInCategory('FACTORY') and isTech3 then
+            --     SimCallback({ Func = 'CapStructure', Args = { target = command.Target.EntityId, layer = 1, id = "b1301" } }, true)
+            --     -- reset state
+            --     structure = nil
+            --     pStructure1 = nil
+            --     pStructure2 = nil
 
             -- if we have a radar, create T1 pgens around it
             elseif structure:IsInCategory('RADAR')

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -386,14 +386,6 @@ function CapStructure(command)
                 pStructure1 = nil
                 pStructure2 = nil
 
-            -- -- if we have a T3 Air Factory, create T3 pgens around it
-            -- elseif structure:IsInCategory('AIR') and structure:IsInCategory('FACTORY') and isTech3 then
-            --     SimCallback({ Func = 'CapStructure', Args = { target = command.Target.EntityId, layer = 1, id = "b1301" } }, true)
-            --     -- reset state
-            --     structure = nil
-            --     pStructure1 = nil
-            --     pStructure2 = nil
-
             -- if we have a radar, create T1 pgens around it
             elseif structure:IsInCategory('RADAR')
                 and (


### PR DESCRIPTION
This change got pushed into the release branch by accident when releasing the latest hotfix. In general, this particular cap wasn't experienced as being useful. It is also mentioned to be a noob trap.

We remove it for now so that we have the old behavior here again. The next hotfix we may introduce it, but with the ability to toggle it off.