### PR TITLE
Fix/ai acu threat values in blueprints

### DIFF
--- a/lua/AI/aiattackutilities.lua
+++ b/lua/AI/aiattackutilities.lua
@@ -212,7 +212,7 @@ function GetBestThreatTarget(aiBrain, platoon, bSkipPathability)
 
     -- Need to use overall so we can get all the threat points on the map and then filter from there
     -- if a specific threat is used, it will only report back threat locations of that type
-    local enemyIndex = nil
+    local enemyIndex = -1
     if aiBrain:GetCurrentEnemy() and TargetCurrentEnemy then
         enemyIndex = aiBrain:GetCurrentEnemy():GetArmyIndex()
     end

--- a/lua/AI/aiattackutilities.lua
+++ b/lua/AI/aiattackutilities.lua
@@ -212,7 +212,7 @@ function GetBestThreatTarget(aiBrain, platoon, bSkipPathability)
 
     -- Need to use overall so we can get all the threat points on the map and then filter from there
     -- if a specific threat is used, it will only report back threat locations of that type
-    local enemyIndex = -1
+    local enemyIndex = nil
     if aiBrain:GetCurrentEnemy() and TargetCurrentEnemy then
         enemyIndex = aiBrain:GetCurrentEnemy():GetArmyIndex()
     end

--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -69,7 +69,7 @@ UnitBlueprint{
         RegenRate = 10,
         SkipDynamicThreatCalculations = true,
         SubThreatLevel = 0,
-        SurfaceThreatLevel = 765,
+        SurfaceThreatLevel = 45,
     },
     Display = {
         Abilities = {

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -76,7 +76,7 @@ UnitBlueprint{
         RegenRate = 10,
         SkipDynamicThreatCalculations = true,
         SubThreatLevel = 0,
-        SurfaceThreatLevel = 765,
+        SurfaceThreatLevel = 45,
     },
     Display = {
         Abilities = {

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -71,7 +71,7 @@ UnitBlueprint{
         RegenRate = 18,
         SkipDynamicThreatCalculations = true,
         SubThreatLevel = 0,
-        SurfaceThreatLevel = 1519,
+        SurfaceThreatLevel = 45,
     },
     Display = {
         Abilities = {

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -82,7 +82,7 @@ UnitBlueprint{
         RegenRate = 10,
         SkipDynamicThreatCalculations = true,
         SubThreatLevel = 0,
-        SurfaceThreatLevel = 765,
+        SurfaceThreatLevel = 45,
     },
     Display = {
         Abilities = {


### PR DESCRIPTION
A previous PR ran the threat calculation on ACU's which produced overinflated surface threat values due to the overcharge weapons.
This PR reverts the values to a number that is between a standard ACU and a gun upgraded ACU. This will avoid the AI from refusing to engage with ACUs due to the massive amounts of threat they were generating.

