### PR TITLE
Check whether the target is at least an entity

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4769,9 +4769,11 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             for k, order in queue do
                 if order.targetId then
                     local target = GetEntityById(order.targetId)
-                    order.target = target
-                    -- take position of the entity, used to sort the units
-                    order.x, order.y, order.z = moho.entity_methods.GetPositionXYZ(target)
+                    if target and IsEntity(target) then
+                        order.target = target
+                        -- take position of the entity, used to sort the units
+                        order.x, order.y, order.z = moho.entity_methods.GetPositionXYZ(target)
+                    end
                 end
             end
         end


### PR DESCRIPTION
Add a guard to check whether it is an entity. 

```
WARNING: Error running lua script: ...gramdata\faforever\gamedata\lua.nx5\lua\sim\unit.lua(4774): Expected a game object. (Did you call with '.' instead of ':'?)
         stack traceback:
             [C]: in function `GetPositionXYZ'
             ...gramdata\faforever\gamedata\lua.nx5\lua\sim\unit.lua(4774): in function `GetCommandQueue'
             ...nder forged alliance\mods\m28ai\lua\ai\m28orders.lua(171): in function `UpdateRecordedOrders'
```