### PR TITLE
Add annotations for the command queue

### DIFF
--- a/engine/Sim/Entity.lua
+++ b/engine/Sim/Entity.lua
@@ -3,7 +3,7 @@
 ---@class moho.entity_methods : Destroyable
 local Entity = {}
 
----@alias EntityId number
+---@alias EntityId string
 
 ---@class CollisionExtents
 ---@field Max Vector

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -1009,7 +1009,10 @@ do
         ---@type number | nil
         local pz = nil
 
+        ---@type UnitCommand[][]
         local groups = { {} }
+
+        ---@type UnitCommand[]
         local orders = units[1]:GetCommandQueue()
         for k, order in orders do
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -83,6 +83,14 @@ SyncMeta = {
     end,
 }
 
+---@class UnitCommand
+---@field x number
+---@field y number
+---@field z number
+---@field targetId? EntityId
+---@field target? Entity
+---@field commandType string 
+
 ---@class AIUnitProperties
 ---@field AIPlatoonReference AIPlatoon
 ---@field AIBaseManager LocationType
@@ -4763,6 +4771,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         cUnit.GiveNukeSiloAmmo(self, blocks, true)
     end,
 
+    ---@param self Unit
+    ---@return UnitCommand[]
     GetCommandQueue = function(self)
         local queue = cUnit.GetCommandQueue(self)
         if queue then


### PR DESCRIPTION
Adds missing annotations to the unit command queue. Updates the type of `EntityId` which is always a string, even though it looks like a number.