### PR TITLE
Fix the Ythotha storm ignoring allies and empty space

### DIFF
--- a/lua/defaultcollisionbeams.lua
+++ b/lua/defaultcollisionbeams.lua
@@ -10,6 +10,7 @@
 
 local CollisionBeam = import("/lua/sim/collisionbeam.lua").CollisionBeam
 local EffectTemplate = import("/lua/effecttemplates.lua")
+local VisionMarkerOpti = import("/lua/sim/VizMarker.lua").VisionMarkerOpti
 local Util = import("/lua/utilities.lua")
 
 -------------------------------
@@ -403,12 +404,22 @@ UnstablePhasonLaserCollisionBeam = Class(SCCollisionBeam) {
     OnImpact = function(self, impactType, targetEntity)
         if impactType ~= 'Shield' and impactType ~= 'Water' and impactType ~= 'Air' and impactType ~= 'UnitAir' and impactType ~= 'Projectile' then
             if self.Scorching == nil then
-                self.Scorching = self:ForkThread( self.ScorchThread )   
+                self.Scorching = self:ForkThread( self.ScorchThread )
             end
         else
             KillThread(self.Scorching)
             self.Scorching = nil
         end
+
+        -- add vision to make sure we can see the impact effect
+        local position = self:GetPosition(1)
+        if position then
+            local marker = VisionMarkerOpti({Owner = self.unit})
+            marker:UpdatePosition(position[1], position[3])
+            marker:UpdateDuration(1)
+            marker:UpdateIntel(self.Army, 4, 'Vision', true)
+        end
+
         CollisionBeam.OnImpact(self, impactType, targetEntity)
     end,
 

--- a/units/XSL0402/XSL0402_script.lua
+++ b/units/XSL0402/XSL0402_script.lua
@@ -14,7 +14,12 @@ local EffectTemplate = import("/lua/effecttemplates.lua")
 ---@class XSL0402 : SEnergyBallUnit
 XSL0402 = ClassUnit(SEnergyBallUnit) {
     Weapons = {
-        PhasonBeam = ClassWeapon(SDFUnstablePhasonBeam) {},
+        PhasonBeam = ClassWeapon(SDFUnstablePhasonBeam) {
+            -- we intentionally do not call the base class as that would immediately
+            -- remove the beam again, we remove the beam in the base class of the unit
+            OnLostTarget = function(self)
+            end,
+        },
     },
 
     OnCreate = function(self)


### PR DESCRIPTION
The bug that we fix here is that the Ythotha storm is rather calm when there are only allied or no units around it. It would essentially only attack hostile units. The bug was introduced by https://github.com/FAForever/fa/pull/4863

Because of states the actual hierarchy is not always processed. The functions `OnGotTarget` and `OnLostTarget` are prime candidates for that, so are various states.  In #4863, we fixed that beams would linger on by creating a way to execute the actual hierarchy. But for beam weapons this means that it ends up calling `OnLostTarget` of the default projectile weapon, which ends up returning the weapon to the idle state. And in the idle state the beam is removed again.

An allied unit, or a patch of ground, is considered to be a target it immediately loses. And when it does, the beam is immediately destroyed.

This PR also adds a little bit of vision where the beam ends up hitting to make sure the effects are visible.