### PR TITLE
Fix orientation of a unit after being gifted

### DIFF
--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -197,7 +197,8 @@ function TransferUnitsOwnership(units, toArmy, captured)
         newUnit.oldowner = oldowner
 
         -- A F T E R
-        unit:SetOrientation(orientation, true)
+
+        newUnit:SetOrientation(orientation, true)
 
         if massKilled and massKilled > 0 then
             newUnit:CalculateVeterancyLevelAfterTransfer(massKilled, true)

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -92,7 +92,6 @@ StructureUnit = ClassUnit(Unit) {
             ) and (flatten or physicsBlueprint.AlwaysAlignToTerrain)
             and (layer == 'Land' or layer == 'Seabed')
         then
-            LOG("OnCreate - SetOrientation")
             -- rotate structure to match terrain gradient
             local a1, a2 = TerrainUtils.GetTerrainSlopeAnglesDegrees(
                 self:GetPosition(),

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -92,6 +92,7 @@ StructureUnit = ClassUnit(Unit) {
             ) and (flatten or physicsBlueprint.AlwaysAlignToTerrain)
             and (layer == 'Land' or layer == 'Seabed')
         then
+            LOG("OnCreate - SetOrientation")
             -- rotate structure to match terrain gradient
             local a1, a2 = TerrainUtils.GetTerrainSlopeAnglesDegrees(
                 self:GetPosition(),


### PR DESCRIPTION
Closes #5293 

One reference in https://github.com/FAForever/fa/pull/4820 was not taken into account. Structures that are gifted are now properly orientated