### PR TITLE
Stinger and C14 Star Lifter: Fix, so they no longer miss low height units

### DIFF
--- a/projectiles/TDFRiot01/TDFRiot01_proj.bp
+++ b/projectiles/TDFRiot01/TDFRiot01_proj.bp
@@ -44,9 +44,6 @@ ProjectileBlueprint {
         DestroyOnWater = true,
         InitialSpeed = 13,
         UseGravity = false,
-        TrackTarget = true,
-        TurnRate = 25,
-        OnLostTargetLifetime = 0.5,
         VelocityAlign = true,
     },
 }

--- a/projectiles/TDFRiot01/TDFRiot01_proj.bp
+++ b/projectiles/TDFRiot01/TDFRiot01_proj.bp
@@ -44,6 +44,9 @@ ProjectileBlueprint {
         DestroyOnWater = true,
         InitialSpeed = 13,
         UseGravity = false,
+        TrackTarget = true,
+        TurnRate = 25,
+        OnLostTargetLifetime = 0.5,
         VelocityAlign = true,
     },
 }

--- a/projectiles/TDFRiot01/TDFRiot01_proj.bp
+++ b/projectiles/TDFRiot01/TDFRiot01_proj.bp
@@ -44,6 +44,9 @@ ProjectileBlueprint {
         DestroyOnWater = true,
         InitialSpeed = 13,
         UseGravity = false,
+        TrackTarget = true,
+        TurnRate = 15,
+        OnLostTargetLifetime = 0.5,
         VelocityAlign = true,
     },
 }

--- a/units/UEA0203/UEA0203_unit.bp
+++ b/units/UEA0203/UEA0203_unit.bp
@@ -208,7 +208,7 @@ UnitBlueprint{
             MaxRadius = 22,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 40,
+            MuzzleVelocity = 50,
             ProjectileId = "/projectiles/TDFRiot01/TDFRiot01_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.15,
             ProjectilesPerOnFire = 1,

--- a/units/UEA0203/UEA0203_unit.bp
+++ b/units/UEA0203/UEA0203_unit.bp
@@ -57,8 +57,8 @@ UnitBlueprint{
     },
     Defense = {
         ArmorType = "Light",
-        Health = 880,
-        MaxHealth = 880,
+        Health = 920,
+        MaxHealth = 920,
         SurfaceThreatLevel = 7,
     },
     Display = {

--- a/units/UEA0203/UEA0203_unit.bp
+++ b/units/UEA0203/UEA0203_unit.bp
@@ -208,7 +208,7 @@ UnitBlueprint{
             MaxRadius = 22,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 50,
+            MuzzleVelocity = 35,
             ProjectileId = "/projectiles/TDFRiot01/TDFRiot01_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.15,
             ProjectilesPerOnFire = 1,

--- a/units/UEA0203/UEA0203_unit.bp
+++ b/units/UEA0203/UEA0203_unit.bp
@@ -208,7 +208,7 @@ UnitBlueprint{
             MaxRadius = 22,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 60,
+            MuzzleVelocity = 50,
             ProjectileId = "/projectiles/TDFRiot01/TDFRiot01_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.15,
             ProjectilesPerOnFire = 1,

--- a/units/UEA0203/UEA0203_unit.bp
+++ b/units/UEA0203/UEA0203_unit.bp
@@ -57,8 +57,8 @@ UnitBlueprint{
     },
     Defense = {
         ArmorType = "Light",
-        Health = 920,
-        MaxHealth = 920,
+        Health = 880,
+        MaxHealth = 880,
         SurfaceThreatLevel = 7,
     },
     Display = {

--- a/units/UEA0203/UEA0203_unit.bp
+++ b/units/UEA0203/UEA0203_unit.bp
@@ -208,7 +208,7 @@ UnitBlueprint{
             MaxRadius = 22,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 50,
+            MuzzleVelocity = 60,
             ProjectileId = "/projectiles/TDFRiot01/TDFRiot01_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.15,
             ProjectilesPerOnFire = 1,


### PR DESCRIPTION
**Changes:**
Added a slight amount of homing to the Stinger and C14 Star Lifter
MuzzleVelocity 40 --> 35 to prevent the unit from missing low height units (Stinger only)
Health = 880 --> 920 (Stinger only)

Tries to fix the Stinger (and the C14 Star Lifter) missing units it really shouldn't miss. It also gains a slight buff to its hit points in line with its faction's theme.