### PR TITLE
Fix the template rotation feature

### DIFF
--- a/lua/keymap/hotbuild.lua
+++ b/lua/keymap/hotbuild.lua
@@ -491,30 +491,6 @@ function buildActionTemplate(modifier)
     ClearBuildTemplates()
     CommandMode.StartCommandMode("build", {name = cmd})
     SetActiveBuildTemplate(template.templateData)
-
-    if options.gui_template_rotator ~= 0 then
-        -- Rotating templates
-        local worldview = import("/lua/ui/game/worldview.lua").viewLeft
-        local oldHandleEvent = worldview.HandleEvent
-        worldview.HandleEvent = function(self, event)
-            if event.Type == 'ButtonPress' then
-                if event.Modifiers.Middle then
-                    ClearBuildTemplates()
-                    local tempTemplate = table.deepcopy(template.templateData)
-                    template.templateData[1] = tempTemplate[2]
-                    template.templateData[2] = tempTemplate[1]
-                    for i = 3, table.getn(template.templateData) do
-                        local index = i
-                        template.templateData[index][3] = 0 - tempTemplate[index][4]
-                        template.templateData[index][4] = tempTemplate[index][3]
-                    end
-                    SetActiveBuildTemplate(template.templateData)
-                elseif not event.Modifiers.Shift then
-                    worldview.HandleEvent = oldHandleEvent
-                end
-            end
-        end
-    end
 end
 
 function buildActionUnit(name, modifier)

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -909,7 +909,7 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
             self.zoomed = true
         end
 
-        -- template rotation feature that relies on a math trick that allows for rotating 2 dimensional positions at 90 degrees, see also;
+        -- template rotation feature that relies on a math trick that allows for rotating 2 dimensional positions at 90 degrees, see also:
         -- - https://en.wikipedia.org/wiki/Rotation_matrix#Common_2D_rotations
 
         if  event.Type == 'ButtonPress' and
@@ -922,7 +922,6 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
                 template[1] = template[2]
                 template[2] = temp
                 for i = 3, table.getn(template) do
-
                     local temp = template[i][3]
                     template[i][3] = -1 * template[i][4]
                     template[i][4] = temp

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -17,6 +17,8 @@ local Prefs = import("/lua/user/prefs.lua")
 local OverchargeCanKill = import("/lua/ui/game/unitview.lua").OverchargeCanKill
 local CommandMode = import("/lua/ui/game/commandmode.lua")
 
+
+
 WorldViewParams = {
     ui_SelectTolerance = 7.0,
     ui_DisableCursorFixing = false,
@@ -906,7 +908,26 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
         elseif event.Type == 'WheelRotation' then
             self.zoomed = true
         end
-        
+
+        -- template rotation feature
+        if  event.Type == 'ButtonPress' and
+            event.Modifiers.Middle and
+            Prefs.GetFromCurrentProfile('options.selection_threshold_replay') ~= 0
+        then
+            local template = GetActiveBuildTemplate()
+            if template and not table.empty(template) then
+                local temp = template[1]
+                template[1] = template[2]
+                template[2] = temp
+                for i = 3, table.getn(template) do
+                    local temp = template[i][3]
+                    template[i][3] = 0 - template[i][4]
+                    template[i][4] = temp
+                end
+                SetActiveBuildTemplate(template)
+            end
+        end
+
         return false
     end,
 

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -909,7 +909,9 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
             self.zoomed = true
         end
 
-        -- template rotation feature
+        -- template rotation feature that relies on a math trick that allows for rotating 2 dimensional positions at 90 degrees, see also;
+        -- - https://en.wikipedia.org/wiki/Rotation_matrix#Common_2D_rotations
+
         if  event.Type == 'ButtonPress' and
             event.Modifiers.Middle and
             Prefs.GetFromCurrentProfile('options.selection_threshold_replay') ~= 0
@@ -920,8 +922,9 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
                 template[1] = template[2]
                 template[2] = temp
                 for i = 3, table.getn(template) do
+
                     local temp = template[i][3]
-                    template[i][3] = 0 - template[i][4]
+                    template[i][3] = -1 * template[i][4]
                     template[i][4] = temp
                 end
                 SetActiveBuildTemplate(template)

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -1512,32 +1512,6 @@ function OnClickHandler(button, modifiers)
             SetActiveBuildTemplate(item.template.templateData)
         end
 
-        if options.gui_template_rotator ~= 0 then
-            LOG("Hello!")
-            local item = button.Data
-            local activeTemplate = item.template.templateData
-            local worldview = import("/lua/ui/game/worldview.lua").viewLeft
-            local oldHandleEvent = worldview.HandleEvent
-            worldview.HandleEvent = function(self, event)
-                if event.Type == 'ButtonPress' then
-                    if event.Modifiers.Middle then
-                        ClearBuildTemplates()
-                        local tempTemplate = table.deepcopy(activeTemplate)
-                        activeTemplate[1] = tempTemplate[2]
-                        activeTemplate[2] = tempTemplate[1]
-                        for i = 3, table.getn(activeTemplate) do
-                            local index = i
-                            activeTemplate[index][3] = 0 - tempTemplate[index][4]
-                            activeTemplate[index][4] = tempTemplate[index][3]
-                        end
-                        SetActiveBuildTemplate(activeTemplate)
-                    elseif event.Modifiers.Shift then
-                    else
-                        worldview.HandleEvent = oldHandleEvent
-                    end
-                end
-            end
-        end
     elseif item.type == 'enhancement' and button.Data.TooltipOnly == false then
         local doOrder = true
         local clean = not modifiers.Shift

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -1513,6 +1513,7 @@ function OnClickHandler(button, modifiers)
         end
 
         if options.gui_template_rotator ~= 0 then
+            LOG("Hello!")
             local item = button.Data
             local activeTemplate = item.template.templateData
             local worldview = import("/lua/ui/game/worldview.lua").viewLeft


### PR DESCRIPTION
The old implementation would create closures and it would only work on templates that originate from hotbuild or the construction UI. It now works for all templates, regardless of their source and there are no more closures 😄 !