### PR TITLE
Toggle reclaim effects when units are (un)paused

### DIFF
--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -263,8 +263,7 @@ keyDescriptions = {
     ['debug_toggle_flavah'] = "<LOC key_desc_0178>Toggle the world flavor text on/off",
     ['debug_ssmode'] = '<LOC key_desc_0001>Toggles Screen Shot mode',
     ['debug_toggle_pannels'] = '<LOC key_desc_0180>Toggle UI panels on/off',
-    ['spreadattack'] = '<LOC key_desc_0182>Spread attack',
-    ['shift_spreadattack'] = '<LOC key_desc_0183>Spread attack',
+
     ['show_objective_screen'] = '<LOC key_desc_0184>Show Scenario Options/Objectives Window',
     ['toggle_ai_screen'] = 'Toggle AI blueprint information window, requires cheats to be enabled',
     ['toggle_markers_screen'] = 'Toggle marker information window, requires cheats to be enabled',

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -121,6 +121,7 @@ local cUnit = moho.unit_methods
 ---@field TerrainType TerrainType
 ---@field EngineCommandCap? table<string, boolean>
 ---@field UnitBeingBuilt Unit?
+---@field EntityBeingReclaimed Unit | Prop | nil
 ---@field SoundEntity? Unit | Entity
 ---@field AutoModeEnabled? boolean
 Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
@@ -519,6 +520,14 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             self:SetActiveConsumptionInactive()
             self:StopUnitAmbientSound('ConstructLoop')
         end
+
+        -- When paused we reclaim at a speed of 0, with thanks to:
+        -- - https://github.com/FAForever/FA-Binary-Patches/pull/19
+        if self:IsUnitState('Reclaiming') then
+            self:StopReclaimEffects(self.EntityBeingReclaimed)
+            self:StopUnitAmbientSound('ReclaimLoop')
+            self:PlayUnitSound('StopReclaim')
+        end
     end,
 
     ---@param self Unit
@@ -526,6 +535,14 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         if self:IsUnitState('Building') or self:IsUnitState('Upgrading') or self:IsUnitState('Repairing') then
             self:SetActiveConsumptionActive()
             self:PlayUnitAmbientSound('ConstructLoop')
+        end
+
+        -- When paused we reclaim at a speed of 0, with thanks to:
+        -- - https://github.com/FAForever/FA-Binary-Patches/pull/19
+        if self.EntityBeingReclaimed then
+            self:StartReclaimEffects(self.EntityBeingReclaimed)
+            self:PlayUnitSound('StartReclaim')
+            self:PlayUnitAmbientSound('ReclaimLoop')
         end
     end,
 
@@ -761,13 +778,20 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     ---@param self Unit
     ---@param target Unit | Prop
     OnStartReclaim = function(self, target)
+
+        -- When paused we reclaim at a speed of 0, with thanks to:
+        -- - https://github.com/FAForever/FA-Binary-Patches/pull/19
+        if not self:IsPaused() then
+            self:StartReclaimEffects(target)
+            self:PlayUnitSound('StartReclaim')
+            self:PlayUnitAmbientSound('ReclaimLoop')
+        end
+
+        self:DoUnitCallbacks('OnStartReclaim', target)
         self:SetUnitState('Reclaiming', true)
         self:SetFocusEntity(target)
         self:CheckAssistersFocus()
-        self:DoUnitCallbacks('OnStartReclaim', target)
-        self:StartReclaimEffects(target)
-        self:PlayUnitSound('StartReclaim')
-        self:PlayUnitAmbientSound('ReclaimLoop')
+        self.EntityBeingReclaimed = target
 
         -- Force me to move on to the guard properly when done
         local guard = self:GetGuardedUnit()

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -787,11 +787,11 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             self:PlayUnitAmbientSound('ReclaimLoop')
         end
 
-        self:DoUnitCallbacks('OnStartReclaim', target)
+        self.EntityBeingReclaimed = target
         self:SetUnitState('Reclaiming', true)
         self:SetFocusEntity(target)
         self:CheckAssistersFocus()
-        self.EntityBeingReclaimed = target
+        self:DoUnitCallbacks('OnStartReclaim', target)
 
         -- Force me to move on to the guard properly when done
         local guard = self:GetGuardedUnit()


### PR DESCRIPTION
Closes #3832

Engineers that are paused stop everything, except reclaiming. Reclaiming is now 'stopped' too. It allows you to pause the flow of resources without cancelling the command queue.

With thanks to @Strogoo for https://github.com/FAForever/FA-Binary-Patches/pull/19