### PR TITLE
Add support for distribute transport load order

### DIFF
--- a/lua/sim/commands/distribute.lua
+++ b/lua/sim/commands/distribute.lua
@@ -126,12 +126,36 @@ local CommandInfo = {
         BatchOrders = true,
         FullRedundancy = true,
     },
-    [22] = { Type = "TransportLoadUnits", },
+    [22] = { 
+        Type = "TransportLoadUnits",
+        BatchOrders = true,
+
+        ---@param units Unit[]
+        ---@param transport Unit
+        Callback = function(units, transport)
+            -- a little bit of a hack to make it work properly
+            IssueClearCommands({transport})
+
+            local px, py, pz = 0, 0, 0
+            for k, unit in units do
+                local ux, uy, uz = unit:GetPositionXYZ()
+                px = px + ux
+                py = py + uy
+                pz = pz + uz
+            end
+
+            local count = table.getn(units)
+            local px = px / count
+            local py = py / count
+            local pz = pz / count
+
+            IssueMove({transport}, {px, py, pz})
+            IssueTransportLoad(units, transport)
+        end,
+    },
     [23] = { Type = "TransportReverseLoadUnits", },
     [24] = {
         Type = "TransportUnloadUnits",
-        Callback = IssueTransportUnload,
-        Redundancy = 1,
     },
     [25] = { Type = "TransportUnloadSpecificUnits", },
     [26] = { Type = "DetachFromTransport", },


### PR DESCRIPTION
Now it just needs to become a nudge smarter. Looking into how AIs determine the cargo per transport

https://github.com/FAForever/fa/assets/15778155/ef72e464-27a5-40f1-a98c-83fb895cb05c

