### PR TITLE
Double the Valiant's anti-air damage

### DIFF
--- a/units/UES0201/UES0201_unit.bp
+++ b/units/UES0201/UES0201_unit.bp
@@ -319,7 +319,7 @@ UnitBlueprint{
             BallisticArc = "RULEUBA_None",
             CannotAttackGround = true,
             CollideFriendly = false,
-            Damage = 10,
+            Damage = 20,
             DamageType = "Normal",
             DisplayName = "Linked Railgun",
             EffectiveRadius = 57,


### PR DESCRIPTION
For all intents and purposes, the Valiant’s anti-air solution was almost useless. This PR aims to make it more useful, while still keeping it slightly worse than the Salem’s, in accordance with the themes of both factions (stronger cruiser AA, weaker frigate/destroyer AA versus weaker cruiser AA, stronger frigate/destroyer AA).