### PR TITLE
Give more control over what orders end up being distributed

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -377,7 +377,7 @@ do
 end
 
 do
-  
+
     --- Processes the orders and re-distributes them over the units
     ---@param data any
     ---@param selection Unit[]
@@ -388,7 +388,16 @@ do
             return
         end
 
-        import("/lua/sim/commands/orders-distribute.lua").DistributeOrders(selection)
+        -- verify the target
+        local target = (data.target and GetUnitById(data.target)) --[[@as Unit]]
+        if (not target) or
+            (not target.Army) or
+            (not OkayToMessWithArmy(target.Army))
+        then
+            return
+        end
+
+        import("/lua/sim/commands/orders-distribute.lua").DistributeOrders(selection, target)
     end
 end
 

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -1580,7 +1580,6 @@ local keyActionsOrders = {
 }
 
 local keyActionsOrdersQueueBased = {
-
     ['distribute_orders'] = {
         action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").DistributeOrders()',
         category = 'ordersQueueBased',
@@ -1589,7 +1588,14 @@ local keyActionsOrdersQueueBased = {
         action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").DistributeOrders()',
         category = 'ordersQueueBased',
     },
-
+    ['distribute_orders_context'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").DistributeOrdersOfMouseContext()',
+        category = 'ordersQueueBased',
+    },
+    ['shift_distribute_orders_context'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").DistributeOrdersOfMouseContext()',
+        category = 'ordersQueueBased',
+    },
 }
 
 local keyactionsOrdersContextBased = {

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -525,7 +525,9 @@ keyDescriptions = {
     ['toggle_ai_nav_direction_to'] = 'NavUtils - Toggle to visualize output of DirectionTo',
 
     ['filter_highest_engineer_and_assist'] = '<LOC key_desc_filter_highest_engineer_and_assist>Filter the selection to the most advanced engineer, all other engineers assist that engineer',
-    ['distribute_orders'] = '<LOC key_desc_distribute_orders>Distribute orders of the selected units',
-    ['shift_distribute_orders'] = '<LOC key_desc_distribute_orders>Distribute orders of the selected units',
+    ['distribute_orders'] = '<LOC key_desc_distribute_orders>Distribute the command queue of the unit nearest to the mouse',
+    ['shift_distribute_orders'] = '<LOC key_desc_distribute_orders>Distribute the command queue of the unit nearest to the mouse',
+    ['distribute_orders_context'] = '<LOC key_desc_distribute_orders>Distribute the command queue of the unit that the mouse is hovering over',
+    ['shift_distribute_orders_context'] = '<LOC key_desc_distribute_orders>Distribute the command queue of the unit that the mouse is hovering over',
     ['cycle_context_based_templates'] = '<LOC key_desc_context_based_templates>Cycle templates based on the unit that the mouse is hovering over',
 }

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -18,7 +18,8 @@ function lockZoom()
 end
 
 function airNoTransports()
-    UISelectionByCategory("AIR + MOBILE", false, false, false, false) SelectUnits(EntityCategoryFilterDown(categories.ALLUNITS - categories.TRANSPORTATION, GetSelectedUnits()))
+    UISelectionByCategory("AIR + MOBILE", false, false, false, false)
+    SelectUnits(EntityCategoryFilterDown(categories.ALLUNITS - categories.TRANSPORTATION, GetSelectedUnits()))
 end
 
 function airTransports()
@@ -55,7 +56,7 @@ end
 -- Function to toggle things like shields etc
 -- Unit toggle rules copied from orders.lua, used for converting to the numbers needed for the togglescriptbit function
 unitToggleRules = {
-    Shield =  0,
+    Shield = 0,
     Weapon = 1,
     Jamming = 2,
     Intel = 3,
@@ -82,8 +83,8 @@ function toggleAllScript()
 end
 
 local FILTERS = {
-    Military = {"defense", "antinavy", "miscellaneous", "antiair", "directfire", "indirectfire"},
-    Intel = {"counterintel", "omni", "radar", "sonar" }
+    Military = { "defense", "antinavy", "miscellaneous", "antiair", "directfire", "indirectfire" },
+    Intel = { "counterintel", "omni", "radar", "sonar" }
 }
 
 function toggleOverlay(type)
@@ -127,7 +128,7 @@ function getGetNextFactory(factoryType)
             if currentFactoryIndex > table.getn(factoryList) then
                 currentFactoryIndex = 1
             end
-            SelectUnits({nextFac})
+            SelectUnits({ nextFac })
         end
     end
 end
@@ -229,7 +230,7 @@ function GetNearestIdleEngineerNotACU()
         end
     end
 
-    SelectUnits({idleEngineers[nearestIndex]})
+    SelectUnits({ idleEngineers[nearestIndex] })
 end
 
 function AddNearestIdleEngineersSeq()
@@ -267,10 +268,10 @@ function AddNearestIdleEngineersSeq()
         end
     end
 
-    AddSelectUnits({idleEngineers[nearestIndex]})
+    AddSelectUnits({ idleEngineers[nearestIndex] })
 end
 
-local categoryTable = {'LAND','AIR','NAVAL'}
+local categoryTable = { 'LAND', 'AIR', 'NAVAL' }
 local curFacIndex = 1
 function CycleIdleFactories()
     local idleFactories = GetIdleFactories()
@@ -300,7 +301,7 @@ function CycleIdleFactories()
     end
 
     local selection = GetSelectedUnits() or {}
-    if table.equal(selection, {factoriesList[curFacIndex]}) then
+    if table.equal(selection, { factoriesList[curFacIndex] }) then
         curFacIndex = curFacIndex + 1
         if not factoriesList[curFacIndex] then
             curFacIndex = 1
@@ -309,7 +310,7 @@ function CycleIdleFactories()
         curFacIndex = 1
     end
 
-    SelectUnits({factoriesList[curFacIndex]})
+    SelectUnits({ factoriesList[curFacIndex] })
 end
 
 local unitTypes = {
@@ -391,7 +392,8 @@ function SetWeaponPriorities(prioritiesString, name, exclusive)
         table.insert(unitIds, unit:GetEntityId())
     end
 
-    SimCallback({Func = 'WeaponPriorities', Args = {SelectedUnits = unitIds, prioritiesTable = priotable, name = name, exclusive = exclusive or false }})
+    SimCallback({ Func = 'WeaponPriorities',
+        Args = { SelectedUnits = unitIds, prioritiesTable = priotable, name = name, exclusive = exclusive or false } })
 end
 
 --- Sets selected units to target the unit (and similar units) that is hovered over
@@ -415,10 +417,10 @@ function SetDefaultWeaponPriorities()
 end
 
 local categoriesToCheck = {
-    ['tech'] = {"TECH1", "TECH2", "TECH3", "EXPERIMENTAL", 'COMMAND'},
-    ['faction'] = {"CYBRAN", "UEF", "AEON", "SERAPHIM"},
-    ['type'] = {"FACTORY", 'SCOUT', "DIRECTFIRE", 'INDIRECTFIRE', 'DEFENSE', "ANTIAIR", 'TRANSPORTATION', "ENGINEER",},
-    ['layer'] = {"NAVAL", "AIR", "LAND", "STRUCTURE"},
+    ['tech'] = { "TECH1", "TECH2", "TECH3", "EXPERIMENTAL", 'COMMAND' },
+    ['faction'] = { "CYBRAN", "UEF", "AEON", "SERAPHIM" },
+    ['type'] = { "FACTORY", 'SCOUT', "DIRECTFIRE", 'INDIRECTFIRE', 'DEFENSE', "ANTIAIR", 'TRANSPORTATION', "ENGINEER", },
+    ['layer'] = { "NAVAL", "AIR", "LAND", "STRUCTURE" },
 }
 
 --- Creates a target priority that includes the tech, faction, type, and layer of a unit
@@ -451,7 +453,8 @@ function findPriority(bpID)
             return string.format("{categories.%s}", bpID)
         end
 
-        local a = string.format("categories.%s * categories.%s * categories.%s * categories.%s", tech, faction, unitType, layer)
+        local a = string.format("categories.%s * categories.%s * categories.%s * categories.%s", tech, faction, unitType
+            , layer)
         local b = string.format("categories.%s * categories.%s * categories.%s", tech, unitType, layer)
         local c = string.format("categories.%s * categories.%s", unitType, layer)
         local d = string.format("categories.%s", layer)
@@ -476,7 +479,7 @@ function SelectAllUpgradingExtractors()
     if selection then
 
         -- try and find extractors that are upgrading
-        local upgrading = { }
+        local upgrading = {}
         for k, unit in selection do
             if unit:GetWorkProgress() > 0 then
                 table.insert(upgrading, unit)
@@ -487,7 +490,7 @@ function SelectAllUpgradingExtractors()
             SelectionUtils.EnableSelectionSound(true)
             SelectUnits(upgrading)
         end
-    else 
+    else
         SelectUnits(oldSelection)
     end
 
@@ -521,31 +524,71 @@ import("/lua/ui/game/gamemain.lua").ObserveSelection:AddObserver(
     'KeyActionHardMove'
 )
 
+--- Distributes the orders of the unit in the selection that is closest to the mouse location
 DistributeOrders = function()
-    print("Distributing orders")
-    SimCallback({Func = 'DistributeOrders', Args = { }}, true)
+    local mouse = GetMouseWorldPos()
+    local selection = GetSelectedUnits()
+    if mouse[1] and mouse[3] and selection and (not table.empty(selection)) then
+        for k, unit in selection do
+            local position = unit:GetPosition()
+            local dx = position[1] - mouse[1]
+            local dz = position[3] - mouse[3]
+            unit.DistanceToMouse = dx * dx + dz * dz
+        end
+
+        table.sort(selection,
+            function(a, b)
+                return a.DistanceToMouse < b.DistanceToMouse
+            end
+        )
+
+        local target = selection[1]
+        local orderCount = table.getn(target:GetCommandQueue())
+        if orderCount > 0 then
+            print(string.format("Distributing %d orders", orderCount))
+            SimCallback({ Func = 'DistributeOrders', Args = { target = target:GetEntityId() } }, true)
+        else
+            print("No orders to distribute")
+        end
+    else
+        print("No orders to distribute")
+    end
+end
+
+--- Distributes the orders of the unit that the mouse is hovering over
+DistributeOrdersOfMouseContext = function()
+    local target = GetRolloverInfo().userUnit
+    if target then
+        local orderCount = table.getn(target:GetCommandQueue())
+        if orderCount > 0 then
+            print(string.format("Distributing %d orders", orderCount))
+            SimCallback({ Func = 'DistributeOrders', Args = { target = target:GetEntityId() } }, true)
+        else
+            print("No orders to distribute")
+        end
+    end
 end
 
 CopyOrders = function()
     local info = GetRolloverInfo()
     if info.userUnit then
         print("Copy orders")
-        SimCallback({Func = 'CopyOrders', Args = { target = info.userUnit:GetEntityId() }}, true)
+        SimCallback({ Func = 'CopyOrders', Args = { target = info.userUnit:GetEntityId() } }, true)
     else
         print("Can not copy orders")
     end
 end
 
 AssignPlatoonBehaviorSilo = function()
-    SimCallback({Func = 'AIPlatoonSiloTacticalBehavior', Args = { Behavior = 'AIBehaviorTacticalSimple' }}, true)
+    SimCallback({ Func = 'AIPlatoonSiloTacticalBehavior', Args = { Behavior = 'AIBehaviorTacticalSimple' } }, true)
 end
 
 AIPlatoonSimpleRaidBehavior = function()
-    SimCallback({Func = 'AIPlatoonSimpleRaidBehavior', Args = {}}, true)
+    SimCallback({ Func = 'AIPlatoonSimpleRaidBehavior', Args = {} }, true)
 end
 
 AIPlatoonSimpleStructureBehavior = function()
-    SimCallback({Func = 'AIPlatoonSimpleStructureBehavior', Args = {}}, true)
+    SimCallback({ Func = 'AIPlatoonSimpleStructureBehavior', Args = {} }, true)
 end
 
 StoreCameraPosition = function()
@@ -554,11 +597,11 @@ StoreCameraPosition = function()
     Prefs.SetToCurrentProfile('DebugCameraPosition', settings)
 end
 
-RestoreCameraPosition = function ()
+RestoreCameraPosition = function()
     -- ConExecute('cam_Free 1')
     local camera = GetCamera('WorldCamera')
     local settings = Prefs.GetFromCurrentProfile('DebugCameraPosition') --[[@as UserCameraSettings]]
-    camera:MoveTo(settings.Focus, { settings.Heading, settings.Pitch, 0}, settings.Zoom, 0)
+    camera:MoveTo(settings.Focus, { settings.Heading, settings.Pitch, 0 }, settings.Zoom, 0)
 end
 
 function SelectHighestEngineerAndAssist()
@@ -571,13 +614,13 @@ function SelectHighestEngineerAndAssist()
         local sACUs = EntityCategoryFilterDown(categories.SUBCOMMANDER - categories.COMMAND, selection)
 
         if next(sACUs) then
-            SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = sACUs[1]:GetEntityId() }}, true)
+            SimCallback({ Func = 'SelectHighestEngineerAndAssist', Args = { TargetId = sACUs[1]:GetEntityId() } }, true)
             SelectUnits(sACUs)
         elseif next(tech3) then
-            SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = tech3[1]:GetEntityId() }}, true)
+            SimCallback({ Func = 'SelectHighestEngineerAndAssist', Args = { TargetId = tech3[1]:GetEntityId() } }, true)
             SelectUnits(tech3)
         elseif next(tech2) then
-            SimCallback({Func= 'SelectHighestEngineerAndAssist', Args = { TargetId = tech2[1]:GetEntityId() }}, true)
+            SimCallback({ Func = 'SelectHighestEngineerAndAssist', Args = { TargetId = tech2[1]:GetEntityId() } }, true)
             SelectUnits(tech2)
         else
             -- do nothing
@@ -586,11 +629,11 @@ function SelectHighestEngineerAndAssist()
 end
 
 local function SeparateDiveStatus(units)
-    local dummyUnitTable = { }
+    local dummyUnitTable = {}
     local categoriesSubmersible = categories.SUBMERSIBLE
 
-    local submergedUnits = { }
-    local surfacedUnits = { }
+    local submergedUnits = {}
+    local surfacedUnits = {}
 
     for k, unit in units do
         dummyUnitTable[1] = unit
@@ -644,7 +687,7 @@ SelectAllBuildingEngineers = function(onscreen)
 
     -- remove empty entries
     for k = unitSelectedHead, unitCount do
-        units[k] =  nil
+        units[k] = nil
     end
 
     SelectUnits(units)

--- a/lua/sim/commands/orders-distribute.lua
+++ b/lua/sim/commands/orders-distribute.lua
@@ -37,7 +37,8 @@ local PopulateLocation = import("/lua/sim/commands/orders-shared.lua").PopulateL
 --- Processes the orders and re-distributes them over the units. Assumes that all units in the
 --- selection to have the same command queue. If that is not the case then orders are lost
 ---@param units Unit[]
-DistributeOrders = function(units)
+---@param target Unit
+DistributeOrders = function(units, target)
 
     local start = GetSystemTimeSecondsOnlyForProfileUse()
 
@@ -57,7 +58,8 @@ DistributeOrders = function(units)
     local groups = { {} }
 
     ---@type UnitCommand[]
-    local orders = units[1]:GetCommandQueue()
+    local orders = target:GetCommandQueue()
+
     for k, order in orders do
 
         -- find the first order that represents a position


### PR DESCRIPTION
The default distribute orders hotkey now takes the command queue of the unit that is nearest to the mouse location. This allows you (as a player) to have some control over what queue is being distributed.

Introduces a new hotkey that allows you to distribute the queue of the unit you're hovering over.

https://github.com/FAForever/fa/assets/15778155/7c8374aa-7f78-4c2c-bf98-afbd8471687f

