### PR TITLE
Navigational mesh - Rectangle maps

### DIFF
--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -1433,7 +1433,7 @@ function Generate()
     NavLayerData = Shared.CreateEmptyNavLayerData()
 
     ---@type number
-    local MapSize = ScenarioInfo.size[1]
+    local MapSize = math.max(ScenarioInfo.size[1], ScenarioInfo.size[2])
 
     ---@type number
     local CompressionTreeSize = MapSize / LabelCompressionTreesPerAxis


### PR DESCRIPTION
Fixes issue where navmesh wouldnt generate properly for non-square maps, like M2 of the Seraphim campaign

Previously the navigational mesh would compress locations based on the map size, but was only taking the x map size.  On a rectangular map where x is smaller than y (i.e. the actual map size, not just the playable area), this would lead to labels being generated for only part of the map.

The following is what the land grid looked like on M2 of the Seraphim campaign (which is a rectangular map):

![image](https://github.com/FAForever/fa/assets/95254039/31c845b3-f3d0-4119-b9c7-83168adc9657)


This is the result after this change on the same map/replay:
![image](https://github.com/FAForever/fa/assets/95254039/63522ffb-c899-4c52-b859-7a1d16534b41)


Testing on a couple of other maps (using different colouring for different plateaus) it still looks ok.
#
![image](https://github.com/FAForever/fa/assets/95254039/27d8a19e-d389-4ed4-8fe6-1bc7a288c960)

![image](https://github.com/FAForever/fa/assets/95254039/dfda7812-4df6-4184-972a-880b360f3520)

One issue to note on dual gap is it's still seeing locations outside the playable area as pathable (I'd thought the issue had been patched out a while ago), but checking on the current FAF develop it has the same issue so isn't caused by these changes.
