### PR TITLE
Downgrade ps_3_0 shader

### DIFF
--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -2013,7 +2013,7 @@ technique TerrainPBRNormals
         DepthState( Depth_Enable )
 
         VertexShader = compile vs_1_1 TerrainVS(false);
-        PixelShader = compile ps_3_0 TerrainPBRNormalsPS();
+        PixelShader = compile ps_2_a TerrainPBRNormalsPS();
     }
 }
 


### PR DESCRIPTION
One thechnique is still using ps_3_0, which is unnecessary and possibly increasing loading times, so we fix that