### PR TITLE
Add tracking to the Vulthoo + small fix

### DIFF
--- a/projectiles/SDFHeavyPhasicAutogun02/SDFHeavyPhasicAutogun02_proj.bp
+++ b/projectiles/SDFHeavyPhasicAutogun02/SDFHeavyPhasicAutogun02_proj.bp
@@ -43,6 +43,9 @@ ProjectileBlueprint {
         InitialSpeedReduceDistance = 30,
         LeadTarget = false,
         TurnRate = 360,
+        TrackTarget = true,
+        TurnRate = 15,
+        OnLostTargetLifetime = 0.5,
         VelocityAlign = true,
     },
 }

--- a/units/XSA0203/XSA0203_unit.bp
+++ b/units/XSA0203/XSA0203_unit.bp
@@ -182,7 +182,7 @@ UnitBlueprint{
             MaxRadius = 22,
             MuzzleSalvoDelay = 0.2,
             MuzzleSalvoSize = 2,
-            MuzzleVelocity = 40,
+            MuzzleVelocity = 35,
             ProjectileId = "/projectiles/SDFHeavyPhasicAutogun02/SDFHeavyPhasicAutogun02_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.15,
             ProjectilesPerOnFire = 4,


### PR DESCRIPTION
**Changes:**
Added a slight amount of homing to the Vulthoo 
MuzzleVelocity 40 --> 35 to prevent the unit from missing low height units

Tries to fix the Vulthoo missing units it really shouldn't miss.