### PR TITLE
Jester: Fix, so it no longer misses low height units

### DIFF
--- a/units/XRA0105/XRA0105_unit.bp
+++ b/units/XRA0105/XRA0105_unit.bp
@@ -197,7 +197,7 @@ UnitBlueprint{
             MaxRadius = 20,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 55,
+            MuzzleVelocity = 35,
             ProjectileId = "/projectiles/CDFLaserHeavy03/CDFLaserHeavy03_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.15,
             ProjectilesPerOnFire = 1,


### PR DESCRIPTION
**Changes**
MuzzleVelocity 55 --> 35 

High values make units miss/shoot through low height units. It is especially bad with the Jester, it misses a Fervor more than it manages to hit it.

Pointed at fafdevelop, as it is relatively urgent and has little implications balance wise (it has homing).