### PR TITLE
Broadsword and Continental: Fix, so they no longer miss low height units 

### DIFF
--- a/projectiles/TDFPlasmaHeavy02/TDFPlasmaHeavy02_proj.bp
+++ b/projectiles/TDFPlasmaHeavy02/TDFPlasmaHeavy02_proj.bp
@@ -46,5 +46,8 @@ ProjectileBlueprint {
         LeadTarget = false,
         Lifetime = 4,
         UseGravity = false,
+        TrackTarget = true,
+        TurnRate = 15,
+        OnLostTargetLifetime = 0.5,
     },
 }

--- a/units/UEA0305/UEA0305_unit.bp
+++ b/units/UEA0305/UEA0305_unit.bp
@@ -262,7 +262,7 @@ UnitBlueprint{
             MaxRadius = 25,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 40,
+            MuzzleVelocity = 35,
             ProjectileId = "/projectiles/TDFPlasmaHeavy02/TDFPlasmaHeavy02_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.15,
             RackBones = {


### PR DESCRIPTION
**Changes:**
Added a slight amount of homing to the Broadsword's and Continental's air to ground weapons
MuzzleVelocity 40 --> 35 to prevent the unit from missing low height units (Broadsword only)