### PR TITLE
Wailer: Fix, so it no longer misses low height units

### DIFF
--- a/projectiles/CDFLaserDisintegrator04/CDFLaserDisintegrator04_proj.bp
+++ b/projectiles/CDFLaserDisintegrator04/CDFLaserDisintegrator04_proj.bp
@@ -45,5 +45,8 @@ ProjectileBlueprint {
         InitialSpeed = 15,
         ProjectileLifetime = 1.5,
         UseGravity = true,
+        TrackTarget = true,
+        TurnRate = 15,
+        OnLostTargetLifetime = 0.5,
     },
 }

--- a/units/XRA0305/XRA0305_unit.bp
+++ b/units/XRA0305/XRA0305_unit.bp
@@ -229,7 +229,7 @@ UnitBlueprint{
             MinRadius = 2,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 40,
+            MuzzleVelocity = 35,
             NotExclusive = true,
             ProjectileId = "/projectiles/CDFLaserDisintegrator04/CDFLaserDisintegrator04_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.15,


### PR DESCRIPTION
**Changes:**
Added a slight amount of homing to the Wailer's air to ground weapon
MuzzleVelocity 40 --> 35 to prevent the unit from missing low height units