### PR TITLE
Restorer: Fix, so it no longer misses low height units

### DIFF
--- a/projectiles/ADFQuadLaserLight01/ADFQuadLaserLight01_proj.bp
+++ b/projectiles/ADFQuadLaserLight01/ADFQuadLaserLight01_proj.bp
@@ -38,5 +38,8 @@ ProjectileBlueprint {
         InitialSpeed = 14,
         Lifetime = 1.5,
         UseGravity = false,
+        TrackTarget = true,
+        TurnRate = 15,
+        OnLostTargetLifetime = 0.5,
     },
 }

--- a/units/XAA0305/XAA0305_unit.bp
+++ b/units/XAA0305/XAA0305_unit.bp
@@ -175,7 +175,7 @@ UnitBlueprint{
             MaxRadius = 25,
             MuzzleSalvoDelay = 0.2,
             MuzzleSalvoSize = 4,
-            MuzzleVelocity = 40,
+            MuzzleVelocity = 35,
             ProjectileId = "/projectiles/ADFQuadLaserLight01/ADFQuadLaserLight01_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.15,
             ProjectilesPerOnFire = 4,


### PR DESCRIPTION
**Changes:**
Added a slight amount of homing to the Restorer's air to ground weapon
MuzzleVelocity 40 --> 35 to prevent the unit from missing low height units