### PR TITLE
Change external factory categories to fix AI

### DIFF
--- a/units/ZXA0002/ZXA0002_unit.bp
+++ b/units/ZXA0002/ZXA0002_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint {
     Categories = {
-        'STRUCTURE',
+        'MOBILE',
         'TECH3',
         'FACTORY',
         'CONSTRUCTION',
@@ -8,7 +8,6 @@ UnitBlueprint {
         'UNTARGETTABLE',
         'RALLYPOINT',
         'SORTCONSTRUCTION',
-        'MOBILEFACTORY',
         'DRAGBUILD',
         'SHOWQUEUE',
         'EXTERNALFACTORYUNIT'


### PR DESCRIPTION
`STRUCTURE` category was messing with the AI.
`MOBILEFACTORY` is now obsolete, since `MOBILE * FACTORY` does the magic

It goes with https://github.com/FAForever/faf-coop-maps/pull/416