### PR TITLE
Speed up death animations of structures

### DIFF
--- a/lua/defaultexplosions.lua
+++ b/lua/defaultexplosions.lua
@@ -454,14 +454,14 @@ function CreateTimedStuctureUnitExplosion(obj, deathAnimation)
         while deathAnimation:GetAnimationFraction() < 1 do
             CreateDefaultHitExplosionOffset(obj, 1.0, unpack({GetRandomOffset(x, y, z, 0.8)}))
             obj:PlayUnitSound('DeathExplosion')
-            WaitSeconds(GetRandomFloat(0.2, 0.5))
+            WaitSeconds(GetRandomFloat(0.1, 0.2))
         end
     -- do generic destruction effect
     else
         for i = 0, numExplosions do
             CreateDefaultHitExplosionOffset(obj, 1.0, unpack({GetRandomOffset(x, y, z, 0.8)}))
             obj:PlayUnitSound('DeathExplosion')
-            WaitSeconds(GetRandomFloat(0.2, 0.5))
+            WaitSeconds(GetRandomFloat(0.1, 0.2))
         end
     end
 end

--- a/units/XSB1103/XSB1103_unit.bp
+++ b/units/XSB1103/XSB1103_unit.bp
@@ -52,14 +52,6 @@ UnitBlueprint{
             "<LOC ability_amphibious>Amphibious",
         },
         AnimationActivate = "/units/XSB1103/XSB1103_apump.sca",
-        AnimationDeath = {
-            {
-                Animation = "/units/xsb1103/xsb1103_ADeath.sca",
-                AnimationRateMax = 1,
-                AnimationRateMin = 1,
-                Weight = 100,
-            },
-        },
         Mesh = {
             IconFadeInZoom = 130,
             LODs = {

--- a/units/XSB1202/XSB1202_unit.bp
+++ b/units/XSB1202/XSB1202_unit.bp
@@ -45,14 +45,6 @@ UnitBlueprint{
             "<LOC ability_amphibious>Amphibious",
         },
         AnimationActivate = "/units/XSB1202/XSB1202_apump.sca",
-        AnimationDeath = {
-            {
-                Animation = "/units/xsb1202/xsb1202_ADeath.sca",
-                AnimationRateMax = 1,
-                AnimationRateMin = 1,
-                Weight = 100,
-            },
-        },
         Mesh = {
             IconFadeInZoom = 130,
             LODs = {

--- a/units/XSB1302/XSB1302_script.lua
+++ b/units/XSB1302/XSB1302_script.lua
@@ -7,6 +7,8 @@ local SMassCollectionUnit = import("/lua/seraphimunits.lua").SMassCollectionUnit
 
 ---@class XSB1302 : SMassCollectionUnit
 XSB1302 = ClassUnit(SMassCollectionUnit) {
+
+    ---@param self SMassCollectionUnit
     PlayActiveAnimation = function(self)
         SMassCollectionUnit.PlayActiveAnimation(self)
         if not self.AnimationManipulator then
@@ -16,12 +18,14 @@ XSB1302 = ClassUnit(SMassCollectionUnit) {
         self.AnimationManipulator:PlayAnim(self.Blueprint.Display.AnimationActivate, true)
     end,
 
+    ---@param self SMassCollectionUnit
     OnProductionPaused = function(self)
         SMassCollectionUnit.OnProductionPaused(self)
         if not self.AnimationManipulator then return end
         self.AnimationManipulator:SetRate(0)
     end,
 
+    ---@param self SMassCollectionUnit
     OnProductionUnpaused = function(self)
         SMassCollectionUnit.OnProductionUnpaused(self)
         if not self.AnimationManipulator then return end

--- a/units/XSB1302/XSB1302_unit.bp
+++ b/units/XSB1302/XSB1302_unit.bp
@@ -38,14 +38,6 @@ UnitBlueprint{
     Display = {
         Abilities = { "<LOC ability_amphibious>Amphibious" },
         AnimationActivate = "/units/XSB1302/XSB1302_Apump.sca",
-        AnimationDeath = {
-            {
-                Animation = "/units/xsb1302/xsb1302_ADeath.sca",
-                AnimationRateMax = 1,
-                AnimationRateMin = 1,
-                Weight = 100,
-            },
-        },
         Mesh = {
             IconFadeInZoom = 130,
             LODs = {


### PR DESCRIPTION
In general speed up the (generic) death animations of structures. Removes the death animation of Seraphim extractors. That way all extractors that are killed are turned into a wreck at a similar (or the same) rate.

A consequence is that the wreck may contain flying / hovering parts. But it is barely noticeable from the 'usual' camera angle and if you do turn the camera then just remind yourself that wrecks of hover units are flying / hovering too 😃 