### PR TITLE
Multiple pod orders

### DIFF
--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -636,7 +636,7 @@ local function DroneInit(self, selection)
     local lastMode = nil
     if self._pod and next(self._pod) then
         for _, pod in self._pod do
-            if not lastMode then
+            if lastMode == nil then
                 lastMode = pod:IsAutoMode()
             elseif lastMode ~= pod:IsAutoMode() then
                 mixed = true
@@ -1046,8 +1046,8 @@ local defaultOrdersTable = {
     RULEUCC_Repair = {              helpText = "repair",            bitmapId = 'repair',                preferredSlot = 14, behavior = StandardOrderBehavior},
     RULEUCC_Dock = {                helpText = "dock",              bitmapId = 'dock',                  preferredSlot = 14, behavior = DockOrderBehavior},
 
-    DroneL = {                      helpText = "drone",             bitmapId = 'unload02',              preferredSlot = 13, behavior = DroneBehavior,               initialStateFunc = DroneInit},
-    DroneR = {                      helpText = "drone",             bitmapId = 'unload02',              preferredSlot = 13, behavior = DroneBehavior,               initialStateFunc = DroneInit},
+    DroneL = {                      helpText = "drone",             bitmapId = 'unload02',              preferredSlot = 10, behavior = DroneBehavior,               initialStateFunc = DroneInit},
+    DroneR = {                      helpText = "drone",             bitmapId = 'unload02',              preferredSlot = 11, behavior = DroneBehavior,               initialStateFunc = DroneInit},
 
     -- Unit toggle rules
     RULEUTC_ShieldToggle = {        helpText = "toggle_shield",     bitmapId = 'shield',                preferredSlot = 8,  behavior = ScriptButtonOrderBehavior,   initialStateFunc = ScriptButtonInitFunction, extraInfo = 0},
@@ -1296,9 +1296,21 @@ local function CreateAltOrders(availableOrders, availableToggles, units)
             podUnits['DroneL'] = assistingUnits
         end
 
+        
         if next(assistingUnits) then
-            table.insert(availableOrders, 'DroneL')
-            assistingUnitList['DroneL'] = assistingUnits
+            if table.getn(PodStagingPlatforms) == 1 and not next(Pods) then
+                table.insert(availableOrders, 'DroneL')
+                assistingUnitList['DroneL'] = {assistingUnits[1]}
+                if table.getn(assistingUnits) > 1 then
+                    table.insert(availableOrders, 'DroneR')
+                    assistingUnitList['DroneR'] = {assistingUnits[2]}
+                    podUnits['DroneL'] = {assistingUnits[1]}
+                    podUnits['DroneR'] = {assistingUnits[2]}
+                end
+            else
+                table.insert(availableOrders, 'DroneL')
+                assistingUnitList['DroneL'] = assistingUnits
+            end
         end
     end
 

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -1282,23 +1282,23 @@ local function CreateAltOrders(availableOrders, availableToggles, units)
 
     local assistingUnitList = {}
     local podUnits = {}
-    if not table.empty(units) and (next(EntityCategoryFilterDown(categories.PODSTAGINGPLATFORM, units)) or next(EntityCategoryFilterDown(categories.POD, units))) then
-        local PodStagingPlatforms = EntityCategoryFilterDown(categories.PODSTAGINGPLATFORM, units)
-        local Pods = EntityCategoryFilterDown(categories.POD, units)
+    local PodStagingPlatforms = EntityCategoryFilterDown(categories.PODSTAGINGPLATFORM, units)
+    local Pods = EntityCategoryFilterDown(categories.POD, units)
+    if not table.empty(units) and (not table.empty(PodStagingPlatforms) or not table.empty(Pods)) then
         local assistingUnits = {}
-        if next(Pods) then
+        if not table.empty(Pods) then
             for _, pod in Pods do
                 table.insert(assistingUnits, pod:GetCreator())
             end
             podUnits['DroneL'] = Pods
-        elseif next(PodStagingPlatforms) then
+        elseif not table.empty(PodStagingPlatforms) then
             assistingUnits = GetAssistingUnitsList(PodStagingPlatforms)
             podUnits['DroneL'] = assistingUnits
         end
 
         
-        if next(assistingUnits) then
-            if table.getn(PodStagingPlatforms) == 1 and not next(Pods) then
+        if not table.empty(assistingUnits) then
+            if table.getn(PodStagingPlatforms) == 1 and table.empty(Pods) then
                 table.insert(availableOrders, 'DroneL')
                 assistingUnitList['DroneL'] = {assistingUnits[1]}
                 if table.getn(assistingUnits) > 1 then

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -608,22 +608,51 @@ end
 
 local function DroneBehavior(self, modifiers)
     if modifiers.Left then
-        SelectUnits({self._unit})
+        SelectUnits(self._unit)
     end
 
     if modifiers.Right then
+        if self._mixedIcon then
+            self._mixedIcon:Destroy()
+            self._mixedIcon = nil
+        end
         if self:IsChecked() then
-            self._pod:ProcessInfo('SetAutoMode', 'false')
+            for _, pod in self._pod do
+                pod:ProcessInfo('SetAutoMode', 'false')
+            end
             self:SetCheck(false)
         else
-            self._pod:ProcessInfo('SetAutoMode', 'true')
+            for _, pod in self._pod do
+                pod:ProcessInfo('SetAutoMode', 'true')
+            end
             self:SetCheck(true)
         end
     end
 end
 
 local function DroneInit(self, selection)
-    self:SetCheck(self._pod:IsAutoMode())
+
+    local mixed = false
+    local lastMode = nil
+    if self._pod and next(self._pod) then
+        for _, pod in self._pod do
+            if not lastMode then
+                lastMode = pod:IsAutoMode()
+            elseif lastMode ~= pod:IsAutoMode() then
+                mixed = true
+                break
+            end
+        end
+    end
+
+    if mixed then
+        self:SetCheck(false)
+        self._mixedIcon = Bitmap(self, UIUtil.UIFile('/game/orders-panel/question-mark_bmp.dds'))
+        LayoutHelpers.AtRightTopIn(self._mixedIcon, self, -2, 2)
+    else
+        self:SetCheck(lastMode)
+    end
+
 end
 
 -- Retaliate button specific behvior
@@ -1251,28 +1280,25 @@ local function CreateAltOrders(availableOrders, availableToggles, units)
     -- to determine where they go by using preferred slots
     AddAbilityButtons(standardOrdersTable, availableOrders, units)
 
-    local assitingUnitList = {}
+    local assistingUnitList = {}
     local podUnits = {}
-    if not table.empty(units) and (EntityCategoryFilterDown(categories.PODSTAGINGPLATFORM, units) or EntityCategoryFilterDown(categories.POD, units)) then
+    if not table.empty(units) and (next(EntityCategoryFilterDown(categories.PODSTAGINGPLATFORM, units)) or next(EntityCategoryFilterDown(categories.POD, units))) then
         local PodStagingPlatforms = EntityCategoryFilterDown(categories.PODSTAGINGPLATFORM, units)
         local Pods = EntityCategoryFilterDown(categories.POD, units)
         local assistingUnits = {}
-        if table.empty(PodStagingPlatforms) and table.getn(Pods) == 1 then
-            assistingUnits[1] = Pods[1]:GetCreator()
-            podUnits['DroneL'] = Pods[1]
-            podUnits['DroneR'] = Pods[2]
-        elseif table.getn(PodStagingPlatforms) == 1 then
+        if next(Pods) then
+            for _, pod in Pods do
+                table.insert(assistingUnits, pod:GetCreator())
+            end
+            podUnits['DroneL'] = Pods
+        elseif next(PodStagingPlatforms) then
             assistingUnits = GetAssistingUnitsList(PodStagingPlatforms)
-            podUnits['DroneL'] = assistingUnits[1]
-            podUnits['DroneR'] = assistingUnits[2]
+            podUnits['DroneL'] = assistingUnits
         end
-        if assistingUnits[1] then
+
+        if next(assistingUnits) then
             table.insert(availableOrders, 'DroneL')
-            assitingUnitList['DroneL'] = assistingUnits[1]
-        end
-        if assistingUnits[2] then
-            table.insert(availableOrders, 'DroneR')
-            assitingUnitList['DroneR'] = assistingUnits[2]
+            assistingUnitList['DroneL'] = assistingUnits
         end
     end
 
@@ -1372,8 +1398,8 @@ local function CreateAltOrders(availableOrders, availableToggles, units)
                 orderCheckbox._cursor = standardOrdersTable[availOrder].cursor
             end
 
-            if assitingUnitList[availOrder] then
-                orderCheckbox._unit = assitingUnitList[availOrder]
+            if assistingUnitList[availOrder] then
+                orderCheckbox._unit = assistingUnitList[availOrder]
             end
 
             if podUnits[availOrder] then
@@ -1400,8 +1426,8 @@ local function CreateAltOrders(availableOrders, availableToggles, units)
                 orderCheckbox._script = standardOrdersTable[availToggle].script
             end
 
-            if assitingUnitList[availToggle] then
-                orderCheckbox._unit = assitingUnitList[availToggle]
+            if assistingUnitList[availToggle] then
+                orderCheckbox._unit = assistingUnitList[availToggle]
             end
 
             if orderInfo.initialStateFunc then

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -1282,23 +1282,23 @@ local function CreateAltOrders(availableOrders, availableToggles, units)
 
     local assistingUnitList = {}
     local podUnits = {}
-    local PodStagingPlatforms = EntityCategoryFilterDown(categories.PODSTAGINGPLATFORM, units)
-    local Pods = EntityCategoryFilterDown(categories.POD, units)
-    if not table.empty(units) and (not table.empty(PodStagingPlatforms) or not table.empty(Pods)) then
+    local podStagingPlatforms = EntityCategoryFilterDown(categories.PODSTAGINGPLATFORM, units)
+    local pods = EntityCategoryFilterDown(categories.POD, units)
+    if not table.empty(units) and (not table.empty(podStagingPlatforms) or not table.empty(pods)) then
         local assistingUnits = {}
-        if not table.empty(Pods) then
-            for _, pod in Pods do
+        if not table.empty(pods) then
+            for _, pod in pods do
                 table.insert(assistingUnits, pod:GetCreator())
             end
-            podUnits['DroneL'] = Pods
-        elseif not table.empty(PodStagingPlatforms) then
-            assistingUnits = GetAssistingUnitsList(PodStagingPlatforms)
+            podUnits['DroneL'] = pods
+        elseif not table.empty(podStagingPlatforms) then
+            assistingUnits = GetAssistingUnitsList(podStagingPlatforms)
             podUnits['DroneL'] = assistingUnits
         end
 
         
         if not table.empty(assistingUnits) then
-            if table.getn(PodStagingPlatforms) == 1 and table.empty(Pods) then
+            if table.getn(podStagingPlatforms) == 1 and table.empty(pods) then
                 table.insert(availableOrders, 'DroneL')
                 assistingUnitList['DroneL'] = {assistingUnits[1]}
                 if table.getn(assistingUnits) > 1 then


### PR DESCRIPTION
Can select multiple pods/pod platforms when multiples of their counterpart is selected. Stock behavior remains unchanged.