### PR TITLE
Re-use the old spread attack key identifiers

### DIFF
--- a/lua/keymap/alternativeKeyMap.lua
+++ b/lua/keymap/alternativeKeyMap.lua
@@ -108,7 +108,7 @@ defaultKeyMap = {
     ['I']                   = 'assist',
     ['T']                   = 'repair',
     ['R']                   = 'attack',
-    ['Alt-R']               = 'distribute_orders',
+    ['Alt-R']               = 'spreadattack',
     ['E']                   = 'overcharge',
     ['Tilde']               = 'toggle_repeat_build',
 
@@ -119,7 +119,7 @@ defaultKeyMap = {
     ['Shift-I']             = 'shift_assist',
     ['Shift-T']             = 'shift_repair',
     ['Shift-R']             = 'shift_attack',
-    ['Shift-Alt-R']         = 'shift_distribute_orders',
+    ['Shift-Alt-R']         = 'shift_spreadattack',
     ['Shift-E']             = 'shift_overcharge',
 
     ['Z']                   = 'alt_builders',

--- a/lua/keymap/defaultKeyMap.lua
+++ b/lua/keymap/defaultKeyMap.lua
@@ -117,7 +117,7 @@ defaultKeyMap = {
     ['O']                   = 'overcharge',
     ['M']                   = 'move',
     ['N']                   = 'nuke',
-    ['G']                   = 'distribute_orders',
+    ['G']                   = 'spreadattack',
 
     ['Shift-R']             = 'shift_repair',
     ['Shift-E']             = 'shift_reclaim',
@@ -133,7 +133,7 @@ defaultKeyMap = {
     ['Shift-O']             = 'shift_overcharge',
     ['Shift-M']             = 'shift_move',
     ['Shift-N']             = 'shift_nuke',
-    ['Shift-G']             = 'shift_distribute_orders',
+    ['Shift-G']             = 'shift_spreadattack',
 
     ['B']                   = 'toggle_build_mode',
     ['Alt-R']               = 'toggle_reclaim_labels',

--- a/lua/keymap/hotbuildKeyMap.lua
+++ b/lua/keymap/hotbuildKeyMap.lua
@@ -112,7 +112,7 @@ defaultKeyMap = {
     ['Shift-Q']             = 'shift_patrol',
     ['Shift-I']             = 'shift_guard',
     ['Shift-O']             = 'shift_overcharge',
-    ['Shift-Z']             = 'shift_distribute_orders',
+    ['Shift-Z']             = 'shift_spreadattack',
 
     ['W']                   = 'builders',
     ['E']                   = 'sensors',

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -1621,22 +1621,22 @@ local keyActionsOrdersAdvanced = {
 }
 
 local keyActionsOrdersQueueBased = {
-    ['distribute_orders'] = {
+    ['spreadattack'] = {
         action = 'UI_Lua import("/lua/ui/game/hotkeys/distribute-queue.lua").DistributeOrders(true)',
         category = 'ordersQueueBased',
         wikiURL = 'Play/Game/Hotkeys/OrdersQueueManipulation#distribute-orders'
     },
-    ['shift_distribute_orders'] = {
+    ['shift_spreadattack'] = {
         action = 'UI_Lua import("/lua/ui/game/hotkeys/distribute-queue.lua").DistributeOrders(true)',
         category = 'ordersQueueBased',
         wikiURL = 'Play/Game/Hotkeys/OrdersQueueManipulation#distribute-orders'
     },
-    ['distribute_orders_context'] = {
+    ['spreadattack_context'] = {
         action = 'UI_Lua import("/lua/ui/game/hotkeys/distribute-queue.lua").DistributeOrdersOfMouseContext(true)',
         category = 'ordersQueueBased',
         wikiURL = 'Play/Game/Hotkeys/OrdersQueueManipulation#distribute-orders'
     },
-    ['shift_distribute_orders_context'] = {
+    ['shift_spreadattack_context'] = {
         action = 'UI_Lua import("/lua/ui/game/hotkeys/distribute-queue.lua").DistributeOrdersOfMouseContext(true)',
         category = 'ordersQueueBased',
         wikiURL = 'Play/Game/Hotkeys/OrdersQueueManipulation#distribute-orders'

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -528,10 +528,10 @@ keyDescriptions = {
 
     ['filter_highest_engineer_and_assist'] = '<LOC key_desc_filter_highest_engineer_and_assist>Filter engineers',
     ['shift_filter_highest_engineer_and_assist'] = '<LOC key_desc_shift_filter_highest_engineer_and_assist>Filter engineers',
-    ['distribute_orders'] = '<LOC key_desc_distribute_orders>Distribute orders',
-    ['shift_distribute_orders'] = '<LOC key_desc_shift_distribute_orders>Distribute orders',
-    ['distribute_orders_context'] = '<LOC key_desc_distribute_orders>Distribute orders from the unit beneath the mouse cursor',
-    ['shift_distribute_orders_context'] = '<LOC key_desc_shift_distribute_orders>Distribute orders from the unit beneath the mouse cursor',
+    ['spreadattack'] = '<LOC key_desc_distribute_orders>Distribute orders',
+    ['shift_spreadattack'] = '<LOC key_desc_shift_distribute_orders>Distribute orders',
+    ['spreadattack_context'] = '<LOC key_desc_distribute_orders>Distribute orders from the unit beneath the mouse cursor',
+    ['shift_spreadattack_context'] = '<LOC key_desc_shift_distribute_orders>Distribute orders from the unit beneath the mouse cursor',
     ['cycle_context_based_templates'] = '<LOC key_desc_context_based_templates>Cycle templates',
     ['shift_cycle_context_based_templates'] = '<LOC key_desc_shift_context_based_templates>Cycle templates',
 

--- a/lua/sim/NavUtils.lua
+++ b/lua/sim/NavUtils.lua
@@ -237,7 +237,12 @@ local function TracePath(destination)
         path[head - k] = temp
     end
 
-    return path, head - 1, distance
+    -- include destination into path
+    local px = destination.px
+    local pz = destination.pz
+    path[head] = { px, GetSurfaceHeight(px, pz), pz }
+
+    return path, head, distance
 end
 
 --- Returns true when you can path from the origin to the destination


### PR DESCRIPTION
In an attempt to make it easier to migrate to the new implementation