### PR TITLE
fixed unit scripts if blueprints are missing values

### DIFF
--- a/units/URL0303/URL0303_Script.lua
+++ b/units/URL0303/URL0303_Script.lua
@@ -63,8 +63,8 @@ URL0303 = ClassUnit(CWalkingLandUnit) {
         WaitSeconds(blueprint.SecondsBeforeChargeKicksIn)
 
         self.ChargingInProgress = true
-        self:SetAccMult(blueprint.Physics.ChargeAccMult)
-        self:SetSpeedMult(blueprint.Physics.ChargeSpeedMult)
+        self:SetAccMult(blueprint.Physics.ChargeAccMult or 1)
+        self:SetSpeedMult(blueprint.Physics.ChargeSpeedMult or 1)
 
         local bufffx1 = CreateAttachedEmitter(self, 0, army, '/effects/emitters/cybran_loyalist_charge_01_emit.bp')
         local bufffx2 = CreateAttachedEmitter(self, 0, army, '/effects/emitters/cybran_loyalist_charge_02_emit.bp')

--- a/units/URS0201/URS0201_script.lua
+++ b/units/URS0201/URS0201_script.lua
@@ -56,7 +56,7 @@ URS0201 = ClassUnit(CSeaUnit) {
         local bp = self.Blueprint or self:GetBlueprint()
         if new == 'Land' then
             self:DisableUnitIntel('Layer', 'Sonar')
-            self:SetSpeedMult(bp.Physics.LandSpeedMultiplier)
+            self:SetSpeedMult(bp.Physics.LandSpeedMultiplier or 1)
         elseif new == 'Water' then
             self:EnableUnitIntel('Layer', 'Sonar')
             self:SetSpeedMult(1)

--- a/units/XRL0403/XRL0403_script.lua
+++ b/units/XRL0403/XRL0403_script.lua
@@ -156,7 +156,7 @@ XRL0403 = ClassUnit(CWalkingLandUnit, CConstructionTemplate) {
             self:SetSpeedMult(1)
         elseif new == 'Seabed' then
             self:EnableUnitIntel('Layer', 'Sonar')
-            self:SetSpeedMult(self.Blueprint.Physics.WaterSpeedMultiplier)
+            self:SetSpeedMult(self.Blueprint.Physics.WaterSpeedMultiplier or 1)
         end
     end,
 

--- a/units/XSB3202/XSB3202_script.lua
+++ b/units/XSB3202/XSB3202_script.lua
@@ -34,7 +34,7 @@ XSB3202 = ClassUnit(SSubUnit) {
     end,
 
     OnMotionVertEventChange = function(self, new, old)
-        local mult = self.Blueprint.Physics.SubSpeedMultiplier
+        local mult = self.Blueprint.Physics.SubSpeedMultiplier or 1
         SSubUnit.OnMotionVertEventChange(self, new, old)
         if new == 'Top' then
             self:SetSpeedMult(1)


### PR DESCRIPTION
fixed warnings caused by unit scripts when nil values are loaded from blueprints 