### PR TITLE
Implement alternative of `IssueBuildMobile`

### DIFF
--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -748,14 +748,24 @@ end
 function IssueBuildFactory(units, blueprintID, count)
 end
 
---- Orders a group of units to build a unit, each unit is assigned the closest building.
---- Takes some time to process (at least 3 ticks).
+--- Orders a group of units to build a unit, the nearest unit is given the order
+--- Takes some time to apply (at least 3 ticks).
 ---@param units Unit[]
 ---@param position Vector
 ---@param blueprintID string
 ---@param table number[] # A list of alternative build locations, similar to AiBrain.BuildStructure. Doesn't appear to function properly
 ---@return SimCommand
 function IssueBuildMobile(units, position, blueprintID, table)
+end
+
+--- Orders a group of units to start building another unit by blueprint id
+--- Takes some time to apply (at least 3 ticks).
+---@param units Unit[]
+---@param position Vector
+---@param blueprintID string
+---@param table number[] # A list of alternative build locations, similar to AiBrain.BuildStructure. Doesn't appear to function properly
+---@return SimCommand
+function IssueBuildAllMobile(units, position, blueprintID, table)
 end
 
 --- Orders a group of units to capture a target, usually engineers

--- a/lua/SimHooks.lua
+++ b/lua/SimHooks.lua
@@ -1,3 +1,4 @@
+---@declare-global
 
 do 
     -- can only cause issues, like remote code exploit
@@ -91,5 +92,17 @@ do
         end
 
         return oldChangeUnitArmy(unit, army)
+    end
+end
+
+do
+    -- implementation of https://github.com/FAForever/FA-Binary-Patches/pull/29
+    local oldIssueBuildMobile = _G.IssueBuildMobile
+    _G.IssueBuildMobile = function(units, position, blueprintID, table)
+        oldIssueBuildMobile(units, position, blueprintID, table, false)
+    end
+
+    _G.IssueBuildAllMobile = function(units, position, blueprintID, table)
+        oldIssueBuildMobile(units, position, blueprintID, table, true)
     end
 end

--- a/lua/sim/commands/copy-queue.lua
+++ b/lua/sim/commands/copy-queue.lua
@@ -76,11 +76,7 @@ CopyOrders = function(units, target, clearCommands, doPrint)
         local issueOrder = commandInfo.Callback
         if issueOrder then
             if commandName == 'BuildMobile' then
-                dummyUnitTable[1] = units[1]
-                issueOrder(dummyUnitTable, PopulateLocation(order, dummyVectorTable), order.blueprintId, dummyEmptyTable)
-                if unitCount > 1 then
-                    IssueGuard(units, units[1])
-                end
+                issueOrder(units, PopulateLocation(order, dummyVectorTable), order.blueprintId, dummyEmptyTable)
             else
                 issueOrder(units, order.target or PopulateLocation(order, dummyVectorTable))
             end

--- a/lua/sim/commands/ring-extractor.lua
+++ b/lua/sim/commands/ring-extractor.lua
@@ -107,10 +107,7 @@ RingExtractor = function(extractor, engineers)
         end
 
         if freeToBuild then
-            for _, engineer in engineersOfFaction do
-                engineerTable[1] = engineer
-                IssueBuildMobile(engineerTable, buildLocation, storage, emptyTable)
-            end
+            IssueBuildMobile(engineersOfFaction, buildLocation, storage, emptyTable)
         end
     end
 

--- a/lua/sim/commands/shared.lua
+++ b/lua/sim/commands/shared.lua
@@ -52,7 +52,7 @@ UnitQueueDataToCommand = {
     [7] = { Type = "BuildFactory", },
     [8] = {
         Type = "BuildMobile",
-        Callback = IssueBuildMobile,
+        Callback = IssueBuildAllMobile,
         Redundancy = 1,
     },
     [9] = {


### PR DESCRIPTION
Implements the changes of https://github.com/FAForever/FA-Binary-Patches/pull/29 and applies it to the Ring Extractor, Distribute Orders and Copy Orders features.

The assembly change fixes the performance problem where each build order would create a separate built preview. Built previews are transparent and therefore expensive on your framerate. With the assembly change we can assign 1 build order to a group of engineers, instead of assigning a separate build order to each engineer.