### PR TITLE
Reduce memory allocations when ringing structures

### DIFF
--- a/engine/Sim/CAiBrain.lua
+++ b/engine/Sim/CAiBrain.lua
@@ -58,7 +58,7 @@ end
 function CAiBrain:CanBuildPlatoon(template, factories)
 end
 
---- Returns true if the structure can be built at the given location
+--- Returns true if the structure can be built at the given location. May return false positives
 ---@param blueprintID string As an example: `ueb0101`
 ---@param location Vector
 function CAiBrain:CanBuildStructureAt(blueprintID, location)

--- a/lua/sim/commands/ring-with-storages.lua
+++ b/lua/sim/commands/ring-with-storages.lua
@@ -23,20 +23,31 @@
 
 local SortUnitsByTech = import("/lua/sim/commands/shared.lua").SortUnitsByTech
 local FindNearestUnit = import("/lua/sim/commands/shared.lua").FindNearestUnit
+local FindBuildingSkirts = import("/lua/sim/commands/shared.lua").FindBuildingSkirts
 local SortOffsetsByDistanceToPoint = import("/lua/sim/commands/shared.lua").SortOffsetsByDistanceToPoint
-
-local BuildOffsets = { { 2, 0 }, { 0, 2 }, { -2, 0 }, { 0, -2 } }
 
 -- upvalue scope for performance
 local IssueGuard = IssueGuard
-local GetUnitsInRect = GetUnitsInRect
 local GetTerrainHeight = GetTerrainHeight
 local EntityCategoryFilterDown = EntityCategoryFilterDown
 local IssueBuildAllMobile = IssueBuildAllMobile
 
+-- cached for performance
+local CacheX1 = { }
+local CacheZ1 = { }
+local CacheX2 = { }
+local CacheZ2 = { }
+
+local BuildLocation = { }
+local EmptyTable = { }
+
+local BuildOffsets = { { 2, 0 }, { 0, 2 }, { -2, 0 }, { 0, -2 } }
+
 ---@param extractor Unit
 ---@param engineers Unit[]
 RingExtractor = function(extractor, engineers)
+
+    local start = GetSystemTimeSecondsOnlyForProfileUse()
 
     ---------------------------------------------------------------------------
     -- defensive programming
@@ -61,38 +72,7 @@ RingExtractor = function(extractor, engineers)
     local blueprint = extractor:GetBlueprint()
     local skirtSize = blueprint.Physics.SkirtSizeX
     local cx, _, cz = extractor:GetPositionXYZ()
-
-    -- we manually scan for build skirts in the surrounding area. The function brain:CanBuildStructureAt(...) does
-    -- not always return correct results: it may end up returning true after factories upgraded
-
-    local x1 = cx - (skirtSize + 10)
-    local z1 = cz - (skirtSize + 10)
-    local x2 = cx + (skirtSize + 10)
-    local z2 = cz + (skirtSize + 10)
-
-    -- find all units that may prevent us from building
-    local structures = GetUnitsInRect(x1, z1, x2, z2)
-    if not structures then
-        return
-    end
-
-    structures = EntityCategoryFilterDown(categories.STRUCTURE + categories.EXPERIMENTAL, structures)
-
-    -- populate the skirts to check
-    local skirts = {}
-    for k, unit in structures do
-        local blueprint = unit:GetBlueprint()
-        local px, _, pz = unit:GetPositionXYZ()
-        local sx, sz = 0.5 * blueprint.Physics.SkirtSizeX, 0.5 * blueprint.Physics.SkirtSizeZ
-        local rect = {
-            px - sx, -- top left
-            pz - sz, -- top left
-            px + sx, -- bottom right
-            pz + sz -- bottom right
-        }
-
-        skirts[k] = rect
-    end
+    local cx1, cz1, cx2, cz2, buildingSkirtCount = FindBuildingSkirts(cx, cz, skirtSize, CacheX1, CacheZ1, CacheX2, CacheZ2)
 
     ---------------------------------------------------------------------------
     -- filter engineers and sort offsets
@@ -111,19 +91,18 @@ RingExtractor = function(extractor, engineers)
     ---------------------------------------------------------------------------
     -- issue the build orders
 
-    local buildLocation = {}
-    local emptyTable = {}
+    local buildLocation = BuildLocation
+    local emptyTable = EmptyTable
 
-    -- loop over build locations in given layer
-    for k, location in BuildOffsets do
-        buildLocation[1] = cx + location[1]
-        buildLocation[3] = cz + location[2]
-        buildLocation[2] = GetTerrainHeight(buildLocation[1], buildLocation[3])
+    for k, offset in offsets do
+        local bx = cx + offset[1]
+        local bz = cz + offset[2]
 
+        -- determine if location is free to build
         local freeToBuild = true
-        for _, skirt in skirts do
-            if buildLocation[1] > skirt[1] and buildLocation[1] < skirt[3] then
-                if buildLocation[3] > skirt[2] and buildLocation[3] < skirt[4] then
+        for k = 1, buildingSkirtCount do
+            if bx > cx1[k] and bx < cx2[k] then
+                if bz > cz1[k] and bz < cz2[k] then
                     freeToBuild = false
                     break
                 end
@@ -131,6 +110,9 @@ RingExtractor = function(extractor, engineers)
         end
 
         if freeToBuild then
+            buildLocation[1] = bx
+            buildLocation[3] = bz
+            buildLocation[2] = GetTerrainHeight(bx, bz)
             IssueBuildAllMobile(engineersOfFaction, buildLocation, storage, emptyTable)
         end
     end
@@ -139,4 +121,6 @@ RingExtractor = function(extractor, engineers)
     -- issue assist orders for remaining engineers
 
     IssueGuard(engineersOther, engineersOfFaction[1])
+
+    LOG("Time taken: " .. tostring(GetSystemTimeSecondsOnlyForProfileUse() - start))
 end

--- a/lua/sim/commands/ring-with-storages.lua
+++ b/lua/sim/commands/ring-with-storages.lua
@@ -47,8 +47,6 @@ local BuildOffsets = { { 2, 0 }, { 0, 2 }, { -2, 0 }, { 0, -2 } }
 ---@param engineers Unit[]
 RingExtractor = function(extractor, engineers)
 
-    local start = GetSystemTimeSecondsOnlyForProfileUse()
-
     ---------------------------------------------------------------------------
     -- defensive programming
 

--- a/lua/sim/commands/shared.lua
+++ b/lua/sim/commands/shared.lua
@@ -357,3 +357,56 @@ function FindNearestUnit(units, px, pz)
 
     return nearest
 end
+
+-- Scan and gather build skirts in the surrounding area. This is used as an alternative 
+-- to relying on `brain:CanBuildStructureAt(...)` as it returns false positives.
+---@param cx number
+---@param cz number
+---@param skirtSize number
+---@param cx1 number[]  # re-useable array
+---@param cz1 number[]  # re-useable array
+---@param cx2 number[]  # re-useable array
+---@param cz2 number[]  # re-useable array
+---@return number[]
+---@return number[]
+---@return number[]
+---@return number[]
+---@return number
+function FindBuildingSkirts(cx, cz, skirtSize, cx1, cz1, cx2, cz2)
+
+    local x1 = cx - (skirtSize + 10)
+    local z1 = cz - (skirtSize + 10)
+    local x2 = cx + (skirtSize + 10)
+    local z2 = cz + (skirtSize + 10)
+
+    -- clear out the cache
+    for k = 1, table.getn(cx1) do
+        cx1[k] = nil
+        cz1[k] = nil
+        cx2[k] = nil
+        cz2[k] = nil
+    end
+
+    -- find all units that may prevent us from building
+    local structures = GetUnitsInRect(x1, z1, x2, z2)
+    if not structures then
+        return cx1, cz1, cx2, cz2, 0
+    end
+
+    structures = EntityCategoryFilterDown(categories.STRUCTURE + categories.EXPERIMENTAL, structures)
+
+    -- populate the skirts to check
+    local buildingSkirtCount = 0
+    for k, unit in structures do
+        local blueprint = unit:GetBlueprint()
+        local px, _, pz = unit:GetPositionXYZ()
+        local sx, sz = 0.5 * blueprint.Physics.SkirtSizeX, 0.5 * blueprint.Physics.SkirtSizeZ
+        cx1[k] = px - sx
+        cz1[k] = pz - sz
+        cx2[k] = px + sz
+        cz2[k] = pz + sz
+        buildingSkirtCount = buildingSkirtCount + 1
+    end
+
+    return cx1, cz1, cx2, cz2, buildingSkirtCount
+end

--- a/lua/sim/commands/shared.lua
+++ b/lua/sim/commands/shared.lua
@@ -298,6 +298,7 @@ end
 
 --- Computes the average x / z coordinates of a table of units
 ---@param units Unit[]
+---@return Vector
 function AveragePositionOfUnits(units)
     local unitCount = table.getn(units)
 
@@ -319,6 +320,11 @@ function AveragePositionOfUnits(units)
     }
 end
 
+---@param px number
+---@param pz number
+---@param radius number
+---@param degrees number
+---@return Vector
 function PointOnUnitCircle(px, pz, radius, degrees)
     local cx = px + radius * math.cos( (degrees + 90) * 3.14 / 180 );
     local cz = pz + radius * math.sin( (degrees + 90) * 3.14 / 180 );
@@ -327,4 +333,27 @@ function PointOnUnitCircle(px, pz, radius, degrees)
         GetSurfaceHeight(cx, cz),
         cz
     }
+end
+
+
+---@param units Unit[]
+---@param px number
+---@param pz number
+---@return Unit | nil
+function FindNearestUnit(units, px, pz)
+    local nearest = units[1]
+    local distance = 4193 * 4193
+    for k = 1, table.getn(units) do
+        local unit = units[k]
+        local ux, _, uz = unit:GetPositionXYZ()
+        local dx = px - ux
+        local dz = pz - uz
+        local d = dx * dx + dz * dz
+        if d < distance then
+            nearest = unit
+            distance = d
+        end
+    end
+
+    return nearest
 end


### PR DESCRIPTION
Applies a similar cache pattern that is used by the distribute orders feature. Moves the data structure for build skirts from array of structures to structure of arrays, see also:

- https://en.wikipedia.org/wiki/AoS_and_SoA