### PR TITLE
Change depth indicator to multiple dots again and update description

### DIFF
--- a/lua/ui/game/cursor/depth.lua
+++ b/lua/ui/game/cursor/depth.lua
@@ -6,7 +6,8 @@ local meshSphere = '/env/Common/Props/sphere_lod0.scm'
 
 local MeshOnTerrain = nil
 local MeshOnTerrainRed = nil
-local MeshInBetween = nil
+local MeshesInBetween = { }
+local MaxMeshesInbetweenCount = 5
 local MeshFadeDistance = 300
 
 local Trash = TrashBag()
@@ -123,16 +124,31 @@ local function DepthScanningThread()
     Trash:Add(MeshOnTerrain)
     Trash:Add(MeshOnTerrainRed)
 
-    -- allocate intermediate mesh
-    MeshInBetween = WorldMesh()
-        MeshInBetween:SetMesh({
-            MeshName = meshSphere,
-            TextureName = '/meshes/game/Assist_albedo.dds',
-            ShaderName = 'FakeRings',
-            UniformScale = 0.15,
-            LODCutoff = MeshFadeDistance
+    -- allocate intermediate bits
+    for k = 1, MaxMeshesInbetweenCount do
+
+        local bit = WorldMesh()
+        if k == 2 then
+            bit:SetMesh({
+                MeshName = meshSphere,
+                TextureName = '/meshes/game/map-border_squ_cybran_a_SpecTeam.dds',
+                ShaderName = 'FakeRings',
+                UniformScale = 0.15,
+                LODCutoff = MeshFadeDistance
             })
-        Trash:Add(MeshInBetween)
+        else
+            bit:SetMesh({
+                MeshName = meshSphere,
+                TextureName = '/meshes/game/Assist_albedo.dds',
+                ShaderName = 'FakeRings',
+                UniformScale = 0.15,
+                LODCutoff = MeshFadeDistance
+            })
+        end
+        
+        MeshesInBetween[k] = bit
+        Trash:Add(bit)
+    end
 
     -- pre-allocate all locals for performance
     local camera, position, cursor, elevation, transparency, location, info
@@ -182,21 +198,26 @@ local function DepthScanningThread()
             end
 
             -- update visiblity intermediate dots
-            location[2] = position[2] - 1.5
+            for k = 1, MaxMeshesInbetweenCount do
+                local bit = MeshesInBetween[k]
+                location[2] = position[2] - k*0.5 - (k-1)*0.5 - (k-1)*(k-2) * 0.05 * (position[2] - elevation) -- 1:0.5, 2:1.5, 3-5: scaled based on elevation
 
-            transparency = ComputeTransparency(camera, MeshFadeDistance, elevation, position[2])
-            if transparency > 0.05 then
-                MeshInBetween:SetHidden(false)
-                MeshInBetween:SetStance(location)
-                MeshInBetween:SetFractionCompleteParameter(transparency)
-            else
-                MeshInBetween:SetHidden(true)
+                transparency = ComputeTransparency(camera, MeshFadeDistance, elevation, position[2])
+                if transparency > 0.05 then
+                    bit:SetHidden(false)
+                    bit:SetStance(location)
+                    bit:SetFractionCompleteParameter(transparency)
+                else
+                    bit:SetHidden(true)
+                end
             end
         else
             -- hide them
             MeshOnTerrain:SetHidden(true)
             MeshOnTerrainRed:SetHidden(true)
-            MeshInBetween:SetHidden(true)
+            for k = 1, MaxMeshesInbetweenCount do
+                MeshesInBetween[k]:SetHidden(true)
+            end
         end
 
         WaitFrames(1)

--- a/lua/ui/help/tooltips.lua
+++ b/lua/ui/help/tooltips.lua
@@ -1033,7 +1033,7 @@ Tooltips = {
     },
     options_cursor_hover_scanning = {
         title = "<LOC PLANE_HEIGHT_ASSISTANCE_TITLE>Plane height indication",
-        description = "<LOC WATER_DEPTH_ASSISTANCE_DESCRIPTION>When enabled, adds visual elements to visualize the offset between the terrain surface and the (expected) height of the selected air unit at the position of the cursor. \r\nIs only applied when you have one unit selected.",
+        description = "<LOC PLANE_HEIGHT_ASSISTANCE_DESCRIPTION>When enabled, adds visual elements to visualize the offset between the terrain surface and the (expected) height of the selected air unit at the position of the cursor. \r\nIs only applied when you have one unit selected.",
     },
     options_share_mouse = {
         title = '<LOC OPTIONS_0305>Show Player Cursor Locations for Observers',

--- a/lua/ui/help/tooltips.lua
+++ b/lua/ui/help/tooltips.lua
@@ -1029,7 +1029,7 @@ Tooltips = {
     },
     options_cursor_depth_scanning = {
         title = "<LOC WATER_DEPTH_ASSISTANCE_TITLE>Water depth indication",
-        description = "<LOC WATER_DEPTH_ASSISTANCE_DESCRIPTION>When enabled, adds visual elements to visualize the offset between the water surface and the ocean floor at the position of the cursor.",
+        description = "<LOC WATER_DEPTH_ASSISTANCE_DESCRIPTION>When enabled, adds visual elements to visualize the water depth at the cursor, glowing red if too shallow for navy.",
     },
     options_cursor_hover_scanning = {
         title = "<LOC PLANE_HEIGHT_ASSISTANCE_TITLE>Plane height indication",

--- a/lua/ui/help/tooltips.lua
+++ b/lua/ui/help/tooltips.lua
@@ -1029,7 +1029,7 @@ Tooltips = {
     },
     options_cursor_depth_scanning = {
         title = "<LOC WATER_DEPTH_ASSISTANCE_TITLE>Water depth indication",
-        description = "<LOC WATER_DEPTH_ASSISTANCE_DESCRIPTION>When enabled, adds visual elements to visualize the water depth at the cursor, glowing red if too shallow for navy.",
+        description = "<LOC WATER_DEPTH_ASSISTANCE_DESCRIPTION>When enabled, adds visual elements to visualize the offset between the water surface and the ocean floor at the position of the cursor. A separate indicator turns red when naval units are guaranteed to not be able to path at the location due to lack of depth.",
     },
     options_cursor_hover_scanning = {
         title = "<LOC PLANE_HEIGHT_ASSISTANCE_TITLE>Plane height indication",


### PR DESCRIPTION
new look
![image](https://github.com/FAForever/fa/assets/7266458/4b43cde8-0d57-4a1c-a7ad-a06e5b223214)
First two dots are at fixed depth (0.5 and 1.5) up to 3 dots appear afterwards and their distance scales based on water depth.
New description
![image](https://github.com/FAForever/fa/assets/7266458/70448489-38c3-401e-85f9-3a1022b13688)
