### PR TITLE
Hotkey to upgrade unit you're hovering over

### DIFF
--- a/engine/Core.lua
+++ b/engine/Core.lua
@@ -101,7 +101,7 @@ end
 
 --- returns true if a unit category contains this unit
 ---@param category EntityCategory
----@param unit Unit | UserUnit
+---@param unit Unit | UserUnit | UnitId
 function EntityCategoryContains(category, unit)
 end
 

--- a/engine/User.lua
+++ b/engine/User.lua
@@ -456,7 +456,7 @@ end
 ---@param unitSet any
 ---@return string[] orders
 ---@return CommandCap[] availableToggles
----@return EntityCategory[] buildableCategories
+---@return EntityCategory buildableCategories
 function GetUnitCommandData(unitSet)
 end
 
@@ -637,12 +637,32 @@ end
 function IsObserver(playerId)
 end
 
----
----@param command string
----@param blueprintid string
+--- Issue a factory build or upgrade command to your selection
+---@param command UserUnitBlueprintCommand
+---@param blueprintid UnitId
 ---@param count number
 ---@param clear boolean? defaults to false
 function IssueBlueprintCommand(command, blueprintid, count, clear)
+end
+
+--- Issue a factory build or upgrade command to the given units
+---@see IssueBlueprintCommand
+---@param units UserUnit[]
+---@param command UserUnitBlueprintCommand
+---@param blueprintid UnitId
+---@param count number
+---@param clear boolean? defaults to false
+function IssueBlueprintCommandToUnits(units, command, blueprintid, count, clear)
+end
+
+--- Issue a factory build or upgrade command to the given unit
+---@see IssueBlueprintCommand
+---@param unit UserUnit
+---@param command UserUnitBlueprintCommand
+---@param blueprintid UnitId
+---@param count number
+---@param clear boolean? defaults to false
+function IssueBlueprintCommandToUnit(unit, command, blueprintid, count, clear)
 end
 
 ---

--- a/engine/User.lua
+++ b/engine/User.lua
@@ -322,6 +322,12 @@ end
 function GetIsPaused(units)
 end
 
+--- Returns a boolean that indicates the unit is paused
+---@param unit UserUnit[]
+---@return boolean
+function GetIsPausedOfUnit(unit)
+end
+
 --- Sees if any units in the list are submerged
 ---@param units UserUnit[]
 ---@return SubmergeStatus
@@ -452,12 +458,20 @@ end
 function GetUIControlsAlpha()
 end
 
---- Given a set of units, gets the union of orders and unit categories (for determining builds)
+--- Given a set of units, gets the union of orders and unit categories (for determining builds). You can use `GetUnitCommandFromCommandCap` to convert the toggles to unit commands
 ---@param unitSet any
 ---@return string[] orders
 ---@return CommandCap[] availableToggles
 ---@return EntityCategory buildableCategories
 function GetUnitCommandData(unitSet)
+end
+
+--- Retrieves the orders, toggles and buildable categories of the given unit. You can use `GetUnitCommandFromCommandCap` to convert the toggles to unit commands
+---@param unit any
+---@return string[] orders
+---@return CommandCap[] availableToggles
+---@return EntityCategory buildableCategories
+function GetUnitCommandDataOfUnit(unit)
 end
 
 --- Givens a `RULEUCC` type command, return the equivalent `UNITCOMMAND` command.
@@ -973,10 +987,16 @@ end
 function SetOverlayFilters(list)
 end
 
---- Pause builders in this list
----@param selection UserUnit[]
----@param paused boolean
-function SetPaused(selection, paused)
+--- Pause or unpause the given units
+---@param units UserUnit[]
+---@param pause boolean
+function SetPaused(units, pause)
+end
+
+--- Pause or unpause the given unit
+---@param unit UserUnit
+---@param pause boolean
+function SetPausedOfUnit(unit, pause)
 end
 
 ---

--- a/engine/User/UserUnit.lua
+++ b/engine/User/UserUnit.lua
@@ -5,6 +5,51 @@
 ---@field ThreadUnpauseCandidates? table<EntityId, boolean>
 local UserUnit = {}
 
+---@alias UserUnitCommand 
+--- | 'UNITCOMMAND_BuildFactory' 
+--- | 'UNITCOMMAND_BuildSilo'
+--- | 'UNITCOMMAND_DestroySelf'
+--- | 'UNITCOMMAND_KillSelf'
+--- | 'UNITCOMMAND_AssistCommander'
+--- | 'UNITCOMMAND_Upgrade'
+--- | 'UNITCOMMAND_Land'
+--- | 'UNITCOMMAND_Stop'
+--- | 'UNITCOMMAND_Dive'
+--- | 'UNITCOMMAND_OverCharge'
+--- | 'UNITCOMMAND_Sacrifice'
+--- | 'UNITCOMMAND_Capture'
+--- | 'UNITCOMMAND_Dock'
+--- | 'UNITCOMMAND_Repair'
+--- | 'UNITCOMMAND_Reclaim'
+--- | 'UNITCOMMAND_Guard'
+--- | 'UNITCOMMAND_BuildMobile'
+--- | 'UNITCOMMAND_BuildAssist'
+--- | 'UNITCOMMAND_Teleport'
+--- | 'UNITCOMMAND_Ferry'
+--- | 'UNITCOMMAND_AssistMove'
+--- | 'UNITCOMMAND_DetachFromTransport'
+--- | 'UNITCOMMAND_TransportUnloadSpecificUnits'
+--- | 'UNITCOMMAND_TransportUnloadUnits'
+--- | 'UNITCOMMAND_TransportReverseLoadUnits'
+--- | 'UNITCOMMAND_TransportLoadUnits'
+--- | 'UNITCOMMAND_FormPatrol'
+--- | 'UNITCOMMAND_Patrol'
+--- | 'UNITCOMMAND_CoordinatedMove'
+--- | 'UNITCOMMAND_FormMove'
+--- | 'UNITCOMMAND_Move'
+--- | 'UNITCOMMAND_Nuke'
+--- | 'UNITCOMMAND_FormAggressiveMove'
+--- | 'UNITCOMMAND_AggressiveMove'
+--- | 'UNITCOMMAND_Script'
+--- | 'UNITCOMMAND_Tactical'
+--- | 'UNITCOMMAND_FormAttack'
+--- | 'UNITCOMMAND_Retaliate'
+--- | 'UNITCOMMAND_Attack'
+
+---@alias UserUnitBlueprintCommand
+--- | 'UNITCOMMAND_Upgrade'
+--- | 'UNITCOMMAND_BuildFactory'
+
 ---@class MissileInfo
 ---@field nukeSiloBuildCount number
 ---@field nukeSiloMaxStorageCount number

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -1691,6 +1691,16 @@ local keyactionsOrdersContextBased = {
         action = 'UI_LUA import("/lua/ui/game/hotkeys/capping.lua").CapHotkey()',
         category = 'ordersContextBased',
     },
+
+    ['upgrade_structure'] = { 
+        action = 'UI_LUA import("/lua/ui/game/hotkeys/upgrade-structure.lua").UpgradeStructure()',
+        category = 'ordersContextBased',
+    },
+
+    ['shift_upgrade_structure'] = { 
+        action = 'UI_LUA import("/lua/ui/game/hotkeys/upgrade-structure.lua").UpgradeStructure()',
+        category = 'ordersContextBased',
+    }
 }
 
 ---@type table<string, UIKeyAction>

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -1700,6 +1700,16 @@ local keyactionsOrdersContextBased = {
     ['shift_upgrade_structure'] = { 
         action = 'UI_LUA import("/lua/ui/game/hotkeys/upgrade-structure.lua").UpgradeStructure()',
         category = 'ordersContextBased',
+    },
+
+    ['upgrade_structure_pause'] = { 
+        action = 'UI_LUA import("/lua/ui/game/hotkeys/upgrade-structure.lua").UpgradeStructure(true)',
+        category = 'ordersContextBased',
+    },
+
+    ['shift_upgrade_structure_pause'] = { 
+        action = 'UI_LUA import("/lua/ui/game/hotkeys/upgrade-structure.lua").UpgradeStructure(true)',
+        category = 'ordersContextBased',
     }
 }
 

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -513,8 +513,11 @@ keyDescriptions = {
     ['cap'] = '<LOC key_desc_cap>Cap the unit depending on the game options',
     ['shift_cap'] = '<LOC key_desc_cap>Cap the unit depending on the game options',
 
-    ['upgrade_structure'] = '<LOC key_desc_upgrade_structure>Issue an upgrade order',
-    ['shift_upgrade_structure'] = '<LOC key_desc_shift_upgrade_structure>Issue an upgrade order',
+    ['upgrade_structure'] = '<LOC key_desc_upgrade_structure>Upgrade a structure',
+    ['shift_upgrade_structure'] = '<LOC key_desc_shift_upgrade_structure>Upgrade a structure',
+
+    ['upgrade_structure_pause'] = '<LOC key_desc_upgrade_structure_pause>Upgrade a structure and immediately pause it',
+    ['shift_upgrade_structure_pause'] = '<LOC key_desc_shift_upgrade_structure_pause>Upgrade a structure and immediately pause it',
 
     ['toggle_navui'] = 'Toggle the debugging UI for the navigational mesh',
     ['toggle_ai_reclaim_grid_ui'] = 'Toggle the debugging UI for the reclaim grid',

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -513,6 +513,9 @@ keyDescriptions = {
     ['cap'] = '<LOC key_desc_cap>Cap the unit depending on the game options',
     ['shift_cap'] = '<LOC key_desc_cap>Cap the unit depending on the game options',
 
+    ['upgrade_structure'] = '<LOC key_desc_upgrade_structure>Issue an upgrade order',
+    ['shift_upgrade_structure'] = '<LOC key_desc_shift_upgrade_structure>Issue an upgrade order',
+
     ['toggle_navui'] = 'Toggle the debugging UI for the navigational mesh',
     ['toggle_ai_reclaim_grid_ui'] = 'Toggle the debugging UI for the reclaim grid',
     ['toggle_ai_recon_grid_ui'] = 'Toggle the debugging UI for the recon grid',

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -516,8 +516,8 @@ keyDescriptions = {
     ['upgrade_structure'] = '<LOC key_desc_upgrade_structure>Upgrade a structure',
     ['shift_upgrade_structure'] = '<LOC key_desc_shift_upgrade_structure>Upgrade a structure',
 
-    ['upgrade_structure_pause'] = '<LOC key_desc_upgrade_structure_pause>Upgrade a structure and immediately pause it',
-    ['shift_upgrade_structure_pause'] = '<LOC key_desc_shift_upgrade_structure_pause>Upgrade a structure and immediately pause it',
+    ['upgrade_structure_pause'] = '<LOC key_desc_upgrade_structure_pause>Upgrade a structure and pause it',
+    ['shift_upgrade_structure_pause'] = '<LOC key_desc_shift_upgrade_structure_pause>Upgrade a structure and pause it',
 
     ['toggle_navui'] = 'Toggle the debugging UI for the navigational mesh',
     ['toggle_ai_reclaim_grid_ui'] = 'Toggle the debugging UI for the reclaim grid',

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -118,7 +118,7 @@ end
 ---@param newCommandMode CommandMode
 ---@param data CommandModeData
 function StartCommandMode(newCommandMode, data)
-
+    LOG("StartCommandMode")
     -- clean up previous command mode
     if commandMode then
         EndCommandMode(true)
@@ -137,7 +137,8 @@ end
 --- Called when the command mode ends and deconstructs all the data.
 ---@param isCancel boolean set when we're at the end of (a sequence of) order(s), is usually always true
 function EndCommandMode(isCancel)
-
+    LOG("EndCommandMode")
+    reprsl(debug.traceback())
     if ignoreSelection then
         return
     end
@@ -182,8 +183,12 @@ function CacheAndClearCommandMode()
 end
 
 --- Restores the cached command mode
-function RestoreCommandMode()
+---@param ignorePreviousCommands? boolean when set resets the command mode as if no commands were issued
+function RestoreCommandMode(ignorePreviousCommands)
     if cachedCommandMode and cachedModeData then
+        if ignorePreviousCommands then
+            issuedOneCommand = false
+        end
         StartCommandMode(cachedCommandMode, cachedModeData)
     end
 end

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -118,7 +118,6 @@ end
 ---@param newCommandMode CommandMode
 ---@param data CommandModeData
 function StartCommandMode(newCommandMode, data)
-    LOG("StartCommandMode")
     -- clean up previous command mode
     if commandMode then
         EndCommandMode(true)
@@ -137,8 +136,6 @@ end
 --- Called when the command mode ends and deconstructs all the data.
 ---@param isCancel boolean set when we're at the end of (a sequence of) order(s), is usually always true
 function EndCommandMode(isCancel)
-    LOG("EndCommandMode")
-    reprsl(debug.traceback())
     if ignoreSelection then
         return
     end

--- a/lua/ui/game/hotkeys/upgrade-structure.lua
+++ b/lua/ui/game/hotkeys/upgrade-structure.lua
@@ -85,7 +85,7 @@ function UpgradeStructure(pause)
             )
 
             -- paused units do not start upgrading, temporarily unpause
-            if GetIsPausedOfUnit(unit) or pause then
+            if (GetIsPausedOfUnit(unit) or pause) and (not unit:GetFocus()) then
                 SetPausedOfUnit(unit, false)
                 ForkThread(UpgradePauseThread, unit)
             end

--- a/lua/ui/game/hotkeys/upgrade-structure.lua
+++ b/lua/ui/game/hotkeys/upgrade-structure.lua
@@ -43,7 +43,7 @@ local TechCategoryToReadable = {
 
 ---@param unit UserUnit
 local function UpgradePauseThread(unit)
-    WaitTicks(5)
+    WaitTicks(2)
     if not IsDestroyed(unit) and unit:GetArmy() == GetFocusArmy() then
         SetPausedOfUnit(unit, true)
     end

--- a/lua/ui/game/hotkeys/upgrade-structure.lua
+++ b/lua/ui/game/hotkeys/upgrade-structure.lua
@@ -1,0 +1,88 @@
+--******************************************************************************************************
+--** Copyright (c) 2022  Willem 'Jip' Wijnia
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
+-- upvalue for performance
+local TablEmpty = table.empty
+local TableGetn = table.getn
+local StringFormat = string.format
+
+local LOC = LOC
+local print = print
+local tostring = tostring
+local GetRolloverInfo = GetRolloverInfo
+local GetUnitCommandData = GetUnitCommandData
+local EntityCategoryGetUnitList = EntityCategoryGetUnitList
+local IssueBlueprintCommandToUnit = IssueBlueprintCommandToUnit
+
+local TechCategoryToReadable = {
+    TECH1 = '(Tech 1)',
+    TECH2 = '(Tech 2)',
+    TECH3 = '(Tech 3)',
+    EXPERIMENTAL = '(Experimental)'
+}
+
+---@type { [1]: UserUnit }
+local UnitCache = { }
+
+--- Retrieves a list of buildable upgrades for the given unit
+---@param unit UserUnit
+---@return UnitId[]
+function GetUpgradesOfUnit(unit)
+    UnitCache[1] = unit
+    local _, _, buildableCategories = GetUnitCommandData(UnitCache)
+    local buildableStructures = EntityCategoryGetUnitList(buildableCategories * categories.STRUCTURE)
+    return buildableStructures
+end
+
+--- Attempts to issue an upgrade order to the unit we're hovering over. Favors upgrading to support factories when possible
+function UpgradeStructure()
+    local unit = GetRolloverInfo().userUnit
+    if unit then
+        local buildableStructures = GetUpgradesOfUnit(unit)
+        if buildableStructures and not TablEmpty(buildableStructures) then
+            local targetBlueprint = buildableStructures[1]
+
+            -- try and build support factories when possible
+            if unit:IsInCategory('FACTORY') then
+                if TableGetn(buildableStructures) > 1 then
+                    targetBlueprint = buildableStructures[2]
+                end
+            end
+
+            -- issue the upgrade and inform the user
+            local otherBlueprint = __blueprints[targetBlueprint] --[[@as UnitBlueprint]]
+            IssueBlueprintCommandToUnit(unit, 'UNITCOMMAND_Upgrade', targetBlueprint, 1, false)
+            print(
+                StringFormat(
+                    "Upgrading to %s %s",
+                    LOC(tostring(otherBlueprint.Description)),
+                    tostring(TechCategoryToReadable[otherBlueprint.TechCategory] or "")
+                )
+            )
+        else
+            local blueprint = unit:GetBlueprint()
+            print(StringFormat("Unable to upgrade %s", LOC(tostring(blueprint.Description))))
+        end
+    else
+        print("No structure to upgrade")
+    end
+end

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -174,3 +174,39 @@ do
         )
     end
 end
+
+do
+    ---@param units UserUnit[]
+    ---@param command UserUnitBlueprintCommand
+    ---@param blueprintid UnitId
+    ---@param count number
+    ---@param clear boolean? defaults to false
+    _G.IssueBlueprintCommandToUnits = function(units, command, blueprintid, count, clear)
+        local gameMain = import("/lua/ui/game/gamemain.lua")
+        local commandMode = import("/lua/ui/game/commandmode.lua")
+
+        -- prevents losing command mode
+        gameMain.SetIgnoreSelection(true)
+        commandMode.CacheAndClearCommandMode()
+        local oldSelection = GetSelectedUnits()
+        SelectUnits(units)
+        IssueBlueprintCommand(command, blueprintid, count, clear)
+        SelectUnits(oldSelection)
+        commandMode.RestoreCommandMode()
+        gameMain.SetIgnoreSelection(false)
+    end
+
+    ---@type { [1]: UserUnit }
+    local UnitsCache = { }
+
+    ---@param unit UserUnit[]
+    ---@param command UserUnitBlueprintCommand
+    ---@param blueprintid UnitId
+    ---@param count number
+    ---@param clear boolean? defaults to false
+    _G.IssueBlueprintCommandToUnit = function(unit, command, blueprintid, count, clear)
+        UnitsCache[1] = unit
+        IssueBlueprintCommandToUnits(UnitsCache, command, blueprintid, count, clear)
+    end
+
+end

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -46,6 +46,7 @@ end
 local AvgFPS = 10
 WaitFrames = coroutine.yield
 
+--- Waits the given number of seconds. Always waits at least one frame
 function WaitSeconds(n)
     local start = CurrentTime()
     local elapsed_frames = 0
@@ -62,6 +63,12 @@ function WaitSeconds(n)
     if elapsed_time >= 3 then
         AvgFPS = math.max(10, math.min(200, math.ceil(elapsed_frames / elapsed_time)))
     end
+end
+
+--- Waits the given number of ticks. Always waits at least one frame
+---@param ticks any
+function WaitTicks(ticks)
+    WaitSeconds (0.1 * ticks)
 end
 
 -- a table designed to allow communication from different user states to the front end lua state
@@ -176,6 +183,33 @@ do
 end
 
 do
+
+    ---@type { [1]: UserUnit }
+    local UnitsCache = { }
+
+    ---@param unit UserUnit
+    ---@param pause boolean
+    _G.SetPausedOfUnit = function(unit, pause)
+        UnitsCache[1] = unit
+        return SetPaused(UnitsCache, pause)
+    end
+
+    ---@param unit UserUnit
+    ---@return boolean
+    _G.GetIsPausedOfUnit = function(unit)
+        UnitsCache[1] = unit
+        return GetIsPaused(UnitsCache)
+    end
+
+    ---@param unit UserUnit
+    ---@return string[] orders
+    ---@return CommandCap[] availableToggles
+    ---@return EntityCategory buildableCategories
+    _G.GetUnitCommandDataOfUnit = function(unit)
+        UnitsCache[1] = unit
+        return GetUnitCommandData(UnitsCache)
+    end
+
     ---@param units UserUnit[]
     ---@param command UserUnitBlueprintCommand
     ---@param blueprintid UnitId
@@ -196,9 +230,6 @@ do
         gameMain.SetIgnoreSelection(false)
     end
 
-    ---@type { [1]: UserUnit }
-    local UnitsCache = { }
-
     ---@param unit UserUnit[]
     ---@param command UserUnitBlueprintCommand
     ---@param blueprintid UnitId
@@ -208,5 +239,4 @@ do
         UnitsCache[1] = unit
         IssueBlueprintCommandToUnits(UnitsCache, command, blueprintid, count, clear)
     end
-
 end

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -65,10 +65,13 @@ function WaitSeconds(n)
     end
 end
 
---- Waits the given number of ticks. Always waits at least one frame
+--- Waits the given number of ticks. Always waits at least four frames
 ---@param ticks any
 function WaitTicks(ticks)
-    WaitSeconds (0.1 * ticks)
+    local start = GameTick()
+    repeat
+        WaitFrames(4)
+    until (start + ticks) <= GameTick()
 end
 
 -- a table designed to allow communication from different user states to the front end lua state

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -220,14 +220,14 @@ do
         local commandMode = import("/lua/ui/game/commandmode.lua")
 
         -- prevents losing command mode
-        gameMain.SetIgnoreSelection(true)
         commandMode.CacheAndClearCommandMode()
+        gameMain.SetIgnoreSelection(true)
         local oldSelection = GetSelectedUnits()
         SelectUnits(units)
         IssueBlueprintCommand(command, blueprintid, count, clear)
         SelectUnits(oldSelection)
-        commandMode.RestoreCommandMode()
         gameMain.SetIgnoreSelection(false)
+        commandMode.RestoreCommandMode(true)
     end
 
     ---@param unit UserUnit[]


### PR DESCRIPTION
A mouse-context sensitive hotkey that allows you to issue upgrades to structure without selecting them. When you upgrade a factory with multiple upgrades (hq or support) then it prefers to upgrade to a support factory.

https://github.com/FAForever/fa/assets/15778155/7f7c62ca-00ec-4013-aa6c-4e7738d4172f

![image](https://github.com/FAForever/fa/assets/15778155/11187b3d-0850-4647-a9ca-51d7d11caacc)
