### PR TITLE
Lobby: Change the default UnitCap to 1500

### DIFF
--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -268,7 +268,7 @@ globalOpts = {
         },
     },
     {
-        default = 8,
+        default = 10,
         label = "<LOC lobui_0102>Unit Cap",
         help = "<LOC lobui_0103>Set the maximum number of units that can be in play",
         key = 'UnitCap',


### PR DESCRIPTION
With the game running much faster now, I think we can finally increase the default UnitCap to 1500. A default UnitCap of 1000 can cause problems, especially when the host forgets to change it to 1500 on large maps. It is an artificial limitation, that is not required to this extent anymore. If a lower UnitCap is desired, it can still be selected in the settings.