### PR TITLE
Fix the Campaign AI's PBM automatically grabbing Mobile Factories

### DIFF
--- a/lua/aibrains/campaign-ai.lua
+++ b/lua/aibrains/campaign-ai.lua
@@ -487,13 +487,13 @@ AIBrain = Class(StandardBrain) {
             local seaFactories = {}
             local gates = {}
             for ek, ev in factories do
-                if EntityCategoryContains(categories.FACTORY * categories.AIR, ev) and self:PBMFactoryLocationCheck(ev, v) then
+                if EntityCategoryContains(categories.FACTORY * categories.AIR - categories.EXTERNALFACTORYUNIT, ev) and self:PBMFactoryLocationCheck(ev, v) then
                     table.insert(airFactories, ev)
-                elseif EntityCategoryContains(categories.FACTORY * categories.LAND, ev) and self:PBMFactoryLocationCheck(ev, v) then
+                elseif EntityCategoryContains(categories.FACTORY * categories.LAND - categories.EXTERNALFACTORYUNIT, ev) and self:PBMFactoryLocationCheck(ev, v) then
                     table.insert(landFactories, ev)
-                elseif EntityCategoryContains(categories.FACTORY * categories.NAVAL, ev) and self:PBMFactoryLocationCheck(ev, v) then
+                elseif EntityCategoryContains(categories.FACTORY * categories.NAVAL - categories.EXTERNALFACTORYUNIT, ev) and self:PBMFactoryLocationCheck(ev, v) then
                     table.insert(seaFactories, ev)
-                elseif EntityCategoryContains(categories.FACTORY * categories.GATE, ev) and self:PBMFactoryLocationCheck(ev, v) then
+                elseif EntityCategoryContains(categories.FACTORY * categories.GATE - categories.EXTERNALFACTORYUNIT, ev) and self:PBMFactoryLocationCheck(ev, v) then
                     table.insert(gates, ev)
                 end
             end


### PR DESCRIPTION
The issue was raised in the Coop Discord.

The campaign AI's PBM automatically grabs factories in range of a build location to build units, this includes the external factory component of mobile factory units. This breaks a lot of missions where units like Tempests, and Fatboys are built inside bases, and weren't meant to produce units by the mission makers.

This pull request is meant to fix that, by simply excluding the `EXTERNALFACTORYUNIT` category when the AI is assigning its factories to make use of them. Quantum Gates included, just to be sure.

Both the issue, and fix can be tested in any mission, by simply spawning in a Fatboy or such inside an AI base, and observing if its factory component is assigned any orders by the AI.