### PR TITLE
add semitransparent background for unit counter

### DIFF
--- a/lua/maui/text.lua
+++ b/lua/maui/text.lua
@@ -91,6 +91,13 @@ Text = ClassUI(moho.text_methods, Control) {
         end
     end,
 
+    --- creates semitransprent shadow behind this text control with optional styling parameters
+    --- this improves visibility of the displayed tex and it works better than SetDropShadow(true) function
+    SetColorShadow = function(self, color, left, top, right, bottom, targetDepth, shadowDepth)
+        self.Shadow = import('/lua/ui/uiutil.lua').CreateBackground(self, color, left, top, right, bottom, targetDepth, shadowDepth)
+        return self.Shadow
+    end,
+
     OnDestroy = function(self)
         if self._font then
             if self._font._family then

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -684,7 +684,9 @@ function CommonLogic()
 
         btn.Count = UIUtil.CreateText(btn.Icon, '', 20, UIUtil.bodyFont)
         btn.Count:SetColor('ffffffff')
-        btn.Count:SetDropShadow(true)
+        -- creating shadow background behind the text box for better visibility of unit count
+        -- this is similar to existing styling of keybinding displayed in contruction menu
+        btn.Count:SetColorShadow('88060606')
         btn.Count:DisableHitTest()
         LayoutHelpers.AtBottomIn(btn.Count, btn, 4)
         LayoutHelpers.AtRightIn(btn.Count, btn, 3)
@@ -720,10 +722,13 @@ function CommonLogic()
 
         btn.Count = UIUtil.CreateText(btn.Icon, '', 20, UIUtil.bodyFont)
         btn.Count:SetColor('ffffffff')
-        btn.Count:SetDropShadow(true)
+        -- creating shadow background behind the text box for better visibility of unit count
+        -- this is similar to existing styling of keybinding displayed in contruction menu
+        btn.Count:SetColorShadow('88060606')
         btn.Count:DisableHitTest()
         LayoutHelpers.AtBottomIn(btn.Count, btn)
         LayoutHelpers.AtRightIn(btn.Count, btn)
+
         btn.LowFuel = Bitmap(btn)
         btn.LowFuel:SetSolidColor('ffff0000')
         btn.LowFuel:DisableHitTest()

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -552,6 +552,29 @@ function CreateText(parent, label, pointSize, font, dropshadow)
     return text
 end
 
+--- Returns background bitmap behind specified target control with optional styling parameters
+--- for example creating semitransparent background behind text control or an icon
+---@param target Control
+---@param color? LazyVarColor
+---@param left? number
+---@param top? number
+---@param right? number
+---@param bottom? number
+---@param targetDepth? number
+---@param bitmapDepth? number
+---@return Bitmap
+function CreateBackground(target, color, left, top, right, bottom, targetDepth, bitmapDepth)
+    local bitmap = Bitmap(target)
+    bitmap:DisableHitTest()
+    bitmap:SetSolidColor(color or '88060606')
+    bitmap.Depth:Set(function() return bitmapDepth or (target:GetParent().Depth() + 1) end)
+    target.Depth:Set(function() return targetDepth or (target:GetParent().Depth() + 2) end)
+    -- by default, offseting the bitmap outside (negative values) on left and right side
+    -- and not offsetting on top and bottom becaause text already has small margin on top/bottom
+    LayoutHelpers.OffsetIn(bitmap, target, left or -1, top or 0, right or -1, bottom or 0)
+    return bitmap
+end
+
 ---@param parent Control
 ---@param filename FileName
 ---@param border? number


### PR DESCRIPTION
Adds semitransparent background for unit counter to improve visibility of displaying text which fixes  issue #2854

The new SetColorShadow() works better than internal SetDropShadow() for displaying text, e.g. white unit count over bright blue background of air units

Units counter with new semitransparent background:
![image](https://github.com/FAForever/fa/assets/11665978/e37354cf-1da4-4b07-9d74-e92444c7457e)

this work similar to existing semitransparent background used in displaying keybinding in construction menu:
![image](https://github.com/FAForever/fa/assets/11665978/84d1b482-527f-4405-a17b-7fb2202cf3e6)

Note above screenshots where taken with a mod that increase size of strategic icons so this is why they appear to overlap with unit counter. @Garanas should we add an option to configure placement of strategic icons on left/right side of the unit icon? Also, I could add options to configure color of unit counter and background if you want?
