### PR TITLE
Resource deposit grid for AIs

### DIFF
--- a/lua/AI/GridDeposits.lua
+++ b/lua/AI/GridDeposits.lua
@@ -15,8 +15,7 @@ function DisableDebugging()
 end
 
 ---@class AIGridDepositsCell : AIGridCell
----@field MassDeposits { Marker: MarkerResource, NavAmphLayer: number }
----@field HydroDeposits { Marker: MarkerResource, NavAmphLayer: number }
+---@field Deposits { Marker: MarkerResource, NavAmphLayer: number, Type: 'Mass' | 'Hydrocarbon', Position: Vector }[]
 
 ---@class AIGridDeposits : AIGrid
 ---@field Cells AIGridDepositsCell[][]
@@ -32,13 +31,12 @@ GridDeposits = Class(Grid) {
         for k = 1, cellCount do
             for l = 1, cellCount do
                 local cell = cells[k][l]
-                cell.MassDeposits = {}
-                cell.HydroDeposits = {}
+                cell.Deposits = {}
             end
         end
 
         --self:Update()
-        --self:DebugUpdate()
+        self:DebugUpdate()
     end,
 
     --- Converts a world position to a cell
@@ -79,7 +77,8 @@ GridDeposits = Class(Grid) {
         end
 
         local cell = self:ToCellFromWorldSpace(position[1], position[3])
-        table.insert(cell.MassDeposits, { Marker = deposit })
+        table.insert(cell.Deposits, { Marker = deposit, Type = 'Mass', Position = position })
+        SPEW("Registered extractor")
     end,
 
     ---@param self AIGridDeposits
@@ -101,19 +100,133 @@ GridDeposits = Class(Grid) {
         end
 
         local cell = self:ToCellFromWorldSpace(position[1], position[3])
-        table.insert(cell.HydroDeposits, { Marker = deposit })
+        table.insert(cell.Deposits, { Marker = deposit, Type = 'Hydrocarbon', Position = position })
+        SPEW("Registered hydrocarbon plant")
     end,
 
+    --- Retrieves all resources that are within a given pathing distance to the provided position
     ---@param self AIGridDeposits
+    ---@param depositType 'Mass' | 'Hydrocarbon'
     ---@param position Vector
     ---@param distance number
-    GetResourcesWithinDistance = function(self, depositType, position, distance)
+    ---@param layer NavLayers
+    GetResourcesWithinDistance = function(self, depositType, position, distance, layer)
+        local resources = { }
+
+        local navLabel = NavUtils.GetLabel(layer, position)
+
+        local gx, gz = self:ToGridSpace(position[1], position[3])
+        local gridDistance = NavUtils.WorldDistanceToGridDistance(distance)
+        for lx = -gridDistance, gridDistance do
+            local x = gx + lx
+            for lz = -gridDistance, gridDistance do
+                local z = gz + lz
+                local cell = self.Cells[x][z]
+
+                -- cell is outside of map
+                if not cell then
+                    continue
+                end
+
+                local deposits = cell.Deposits
+                for k = 1, table.getn(deposits) do
+                    local deposit = deposits[k]
+
+                    -- wrong type of resource deposit
+                    if not deposit.Type == depositType then
+                        continue
+                    end
+
+                    local label = NavUtils.GetLabel(layer, deposit.Position)
+
+                    -- wrong type of label, we can't possibly compute a distance
+                    if navLabel != label then
+                        continue
+                    end
+
+                    local path, count, pathDistance = NavUtils.PathTo(layer, position, deposit.Position)
+
+                    -- apparently we can't reach this marker
+                    if not pathDistance then
+                        continue
+                    end
+
+                    if pathDistance <= distance then
+                        table.insert(resources, deposit.Marker)
+                    end
+                end
+            end
+        end
+
+        return resources
     end,
 
+    --- Retrieves all resources that are within a given radius, ignoring all other factors
     ---@param self AIGridDeposits
+    ---@param depositType 'Mass' | 'Hydrocarbon'
     ---@param position Vector
     ---@param distance number
     GetResourcesWithinRadius = function(self, depositType, position, distance)
+        local resources = { }
+
+        local gx, gz = self:ToGridSpace(position[1], position[3])
+        local gridDistance = NavUtils.WorldDistanceToGridDistance(distance)
+        for lx = -gridDistance, gridDistance do
+            local x = gx + lx
+            for lz = -gridDistance, gridDistance do
+                local z = gz + lz
+                local cell = self.Cells[x][z]
+
+                -- cell is outside of map
+                if not cell then
+                    continue
+                end
+
+                local deposits = cell.Deposits
+                for k = 1, table.getn(deposits) do
+                    local deposit = deposits[k]
+
+                    -- wrong type of resource deposit
+                    if not deposit.Type == depositType then
+                        continue
+                    end
+
+                    -- compute squared distance
+                    local dx = position[1] - deposit.Position[1]
+                    local dz = position[3] - deposit.Position[3]
+                    local distanceToMarker =dx * dx + dz * dz
+
+                    if distanceToMarker <= (distance * distance) then
+                        table.insert(deposit.Marker, resources)
+                    end
+                end
+            end
+        end
+
+        return resources
+    end,
+
+    ---------------------------------------------------------------------------
+    --#region Debugging
+
+    ---@param self AIGridDeposits
+    DebugUpdateThread = function(self)
+        while true do
+
+            local position = GetMouseWorldPos()
+            local resources = self:GetResourcesWithinDistance('Mass' , position, 50, 'Amphibious')
+
+            for k, resource in resources do
+                DrawLinePop(resource.Position, position, 'ffffff')
+            end
+
+            WaitTicks(1)
+        end
+    end,
+
+    ---@param self AIGridDeposits
+    DebugUpdate = function(self)
+        ForkThread(self.DebugUpdateThread, self)
     end,
 }
 

--- a/lua/AI/GridDeposits.lua
+++ b/lua/AI/GridDeposits.lua
@@ -217,7 +217,7 @@ GridDeposits = Class(Grid) {
             local resources = self:GetResourcesWithinDistance('Mass' , position, 50, 'Amphibious')
 
             for k, resource in resources do
-                DrawLinePop(resource.Position, position, 'ffffff')
+                DrawLinePop(position, resource.Position, 'ffffff')
             end
 
             WaitTicks(1)

--- a/lua/AI/GridDeposits.lua
+++ b/lua/AI/GridDeposits.lua
@@ -1,0 +1,109 @@
+local Grid = import("/lua/ai/grid.lua").Grid
+
+local WeakValue = { __mode = 'v' }
+
+local Debug = false
+function EnableDebugging()
+    if ScenarioInfo.GameHasAIs or CheatsEnabled() then
+        Debug = true
+    end
+end
+
+function DisableDebugging()
+    if ScenarioInfo.GameHasAIs or CheatsEnabled() then
+        Debug = false
+    end
+end
+
+---@class AIGridDepositsCell : AIGridCell
+---@field EngineersReclaiming table<EntityId, Unit>
+---@field AssignedScouts { LAND: table<EntityId, Unit>, AIR: table<EntityId, Unit> } 
+---@field LastScouted number
+---@field ScoutPriority number
+---@field MustScout boolean
+---@field IntelCoverage boolean
+
+---@class AIGridDeposits : AIGrid
+---@field Cells AIGridDepositsCell[][]
+GridDeposits = Class(Grid) {
+
+    ---@param self AIGridDeposits
+    __init = function(self)
+        Grid.__init(self)
+
+        local cellCount = self.CellCount
+        local cells = self.Cells
+
+        for k = 1, cellCount do
+            for l = 1, cellCount do
+                local cell = cells[k][l]
+            end
+        end
+
+        --self:Update()
+        --self:DebugUpdate()
+    end,
+
+    --- Converts a world position to a cell
+    ---@param self AIGridDeposits
+    ---@param wx number     # in world space
+    ---@param wz number     # in world space
+    ---@return AIGridDepositsCell
+    ToCellFromWorldSpace = function(self, wx, wz)
+        local gx, gz = self:ToGridSpace(wx, wz)
+        return self.Cells[gx][gz]
+    end,
+
+    --- Converts a grid position to a cell
+    ---@param self AIGridDeposits
+    ---@param gx number     # in grid space
+    ---@param gz number     # in grid space
+    ---@return AIGridDepositsCell
+    ToCellFromGridSpace = function(self, gx, gz)
+        return self.Cells[gx][gz]
+    end,
+
+    RegisterExtractorDeposit = function(self, deposit)
+
+    end,
+
+    RegisterHydrocarbonDeposit = function(self, deposit)
+
+    end,
+
+    ---@param self AIGridDeposits
+    ---@param position Vector
+    ---@param distance number
+    GetResourcesWithinDistance = function (self, depositType, position, distance)
+    end,
+
+    ---@param self AIGridDeposits
+    ---@param position Vector
+    ---@param distance number
+    GetResourcesWithinRadius = function (self, depositType, position, distance)
+    end,
+}
+
+---@type AIGridDeposits
+GridDepositsInstance = false
+
+---@return AIGridDeposits
+Setup = function()
+    if not GridDepositsInstance then
+        GridDepositsInstance = GridDeposits() --[[@as AIGridDeposits]]
+
+        local markerUtilities = import("/lua/sim/MarkerUtilities.lua")
+
+        local extractors, extractorCount = markerUtilities.GetMarkersByType('Mass')
+        for k = 1, extractorCount do
+            GridDepositsInstance:RegisterExtractorDeposit(extractors[k])
+        end
+
+        local hydrocarbons, hydrocarbonCount = markerUtilities.GetMarkersByType('Hydrocarbon')
+        for k = 1, hydrocarbonCount do
+            GridDepositsInstance:RegisterExtractorDeposit(hydrocarbons[k])
+        end
+    end
+
+    return GridDepositsInstance
+end

--- a/lua/AI/GridDeposits.lua
+++ b/lua/AI/GridDeposits.lua
@@ -15,8 +15,8 @@ function DisableDebugging()
 end
 
 ---@class AIGridDepositsCell : AIGridCell
----@field MassDeposits { Marker: MarkerResource }
----@field HydroDeposits { Marker: MarkerResource }
+---@field MassDeposits { Marker: MarkerResource, NavAmphLayer: number }
+---@field HydroDeposits { Marker: MarkerResource, NavAmphLayer: number }
 
 ---@class AIGridDeposits : AIGrid
 ---@field Cells AIGridDepositsCell[][]
@@ -122,6 +122,10 @@ GridDepositsInstance = false
 
 ---@return AIGridDeposits
 Setup = function()
+
+    -- requires the navigational mesh
+    NavUtils.Generate()
+
     if not GridDepositsInstance then
         GridDepositsInstance = GridDeposits() --[[@as AIGridDeposits]]
 

--- a/lua/AI/GridPresence.lua
+++ b/lua/AI/GridPresence.lua
@@ -1,6 +1,6 @@
 local Grid = import("/lua/ai/grid.lua").Grid
 local MarkerUtilities = import("/lua/sim/MarkerUtilities.lua")
-local NavUtils = import("/lua/sim/NavUtils.lua")
+local NavUtils = import("/lua/sim/navutils.lua")
 
 -- upvalue scope for performance
 local TableGetn = table.getn

--- a/lua/AI/GridPresence.lua
+++ b/lua/AI/GridPresence.lua
@@ -379,5 +379,9 @@ GridPresence = Class(Grid) {
 ---@param brain moho.aibrain_methods
 ---@return AIGridPresence
 Setup = function(brain)
+
+    -- requires the navigational mesh
+    NavUtils.Generate()
+
     return GridPresence(brain)
 end

--- a/lua/aibrains/base-ai.lua
+++ b/lua/aibrains/base-ai.lua
@@ -144,6 +144,7 @@ AIBrain = Class(StandardBrain) {
         -- requires these datastructures to understand the game
         self.GridReclaim = import("/lua/ai/gridreclaim.lua").Setup(self)
         self.GridBrain = import("/lua/ai/gridbrain.lua").Setup()
+        self.GridDeposits = import("/lua/ai/griddeposits.lua").Setup()
         self.GridRecon = import("/lua/ai/gridrecon.lua").Setup(self)
     end,
 

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -101,7 +101,7 @@ end
 function SizeOfCell()
     ---@type number
     local MapSize = math.max(ScenarioInfo.size[1], ScenarioInfo.size[2])
-
+    
     ---@type number
     return MapSize / LabelCompressionTreesPerAxis
 end

--- a/lua/sim/NavUtils.lua
+++ b/lua/sim/NavUtils.lua
@@ -1295,3 +1295,11 @@ end
 function IsInBuildableArea(origin)
     return IsInPlayableArea(origin, 8)
 end
+
+--- Converts a world distance into grid distance
+---@param distance number
+---@return number
+function WorldDistanceToGridDistance(distance)
+    local sizeOfCell = NavGenerator.SizeOfCell()
+    return math.ceil(distance / sizeOfCell) + 1
+end

--- a/lua/sim/NavUtils.lua
+++ b/lua/sim/NavUtils.lua
@@ -1299,7 +1299,7 @@ end
 --- Converts a world distance into grid distance
 ---@param distance number
 ---@return number
-function WorldDistanceToGridDistance(distance)
+function ToGridDistance(distance)
     local sizeOfCell = NavGenerator.SizeOfCell()
-    return math.ceil(distance / sizeOfCell) + 1
+    return math.floor(distance / sizeOfCell) + 1
 end

--- a/lua/sim/NavUtils.lua
+++ b/lua/sim/NavUtils.lua
@@ -144,6 +144,14 @@ function Generate()
     end
 end
 
+--- Converts a world distance into grid distance
+---@param distance number
+---@return number
+function ToGridDistance(distance)
+    local sizeOfCell = NavGenerator.SizeOfCell()
+    return math.floor(distance / sizeOfCell) + 1
+end
+
 ---@param layer NavLayers
 ---@return NavGrid?
 ---@return 'InvalidLayer'?
@@ -631,8 +639,7 @@ function GetPositionsInRadius(layer, position, thresholdDistance, thresholdSize,
         return nil, 'OutsideMap'
     end
 
-    local sizeOfcell = NavGenerator.SizeOfCell()
-    local distanceInCells = math.ceil(0.5 * thresholdDistance / sizeOfcell) + 1
+    local distanceInCells = ToGridDistance(thresholdDistance)
     for lz = -distanceInCells, distanceInCells do
         for lx = -distanceInCells, distanceInCells do
             local neighbor = FindRootGridspaceXZ(grid, gx + lz, gz + lx)
@@ -1296,10 +1303,3 @@ function IsInBuildableArea(origin)
     return IsInPlayableArea(origin, 8)
 end
 
---- Converts a world distance into grid distance
----@param distance number
----@return number
-function ToGridDistance(distance)
-    local sizeOfCell = NavGenerator.SizeOfCell()
-    return math.floor(distance / sizeOfCell) + 1
-end


### PR DESCRIPTION
Closes #5226 

Introduces the resource deposit grid with two queries:

- `GetResourcesWithinDistance` Returns all deposits that are within a given pathing distance to the start location
- `GetResourcesWithinRadius` Returns all deposits that are within a given radius, ignoring other conditions

Visual examples of `GetResourcesWithinDistance`:

https://github.com/FAForever/fa/assets/15778155/18e5194f-93c1-4433-9769-2463f2d37ace

https://github.com/FAForever/fa/assets/15778155/52fdc48c-e0d2-41c6-aab0-9e6895f9bc14


