### PR TITLE
Tactical Missile Component Rework

### DIFF
--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -296,8 +296,10 @@ TacticalMissileComponent = ClassSimple(SemiBallisticComponent) {
 
         -- wait until we've allegedly hit our target, then turn tracking off
         -- (in case we miss, so we don't fly in circles forever)
-        WaitTicks(glideTime * 10)
-        self:TrackTarget(false)
+        WaitTicks((glideTime+1) * 10)
+        if not self:BeenDestroyed() then
+            self:TrackTarget(false)
+        end
     end,
 
 }

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -127,10 +127,21 @@ SemiBallisticComponent = ClassSimple {
         return ballisticAcceleration, timeToImpact
     end,
 
+    TurnRateFromDistance = function(self)
+        local dist = self:DistanceToTarget()
+        local targetVector = VDiff(self:GetCurrentTargetPosition(), self:GetPosition())
+        local ux, uy, uz = self:GetVelocity()
+        local velocityVector = Vector(ux, uy, uz)
+        local speed = self:GetCurrentSpeed() * 10
+        local theta = math.acos(VDot(targetVector, velocityVector) / (speed * dist))
+        local degreesPerSecond = 2 * math.sin(theta) * 360 * self:GetBlueprint().Physics.MaxSpeed / dist
+        return degreesPerSecond
+    end,
+
     DistanceToTarget = function(self)
         local tpos = self:GetCurrentTargetPosition()
         local mpos = self:GetPosition()
-        return VDist2(tpos, mpos)
+        return VDist3(tpos, mpos)
     end,
 
     HorizontalDistanceToTarget = function(self)
@@ -144,7 +155,11 @@ SemiBallisticComponent = ClassSimple {
         local vh = VDist2(vx, vz, 0, 0)
         if vh == 0 then
             -- can't divide by zero, so just return 90 degrees
-            return math.pi/2
+            if vy >= 0 then
+                return math.pi/2
+            else
+                return -math.pi/2
+            end
         end
         return math.atan(vy / vh)
     end,

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -20,8 +20,15 @@ local CreateTrail = CreateTrail
 local CreateEmitterOnEntity = CreateEmitterOnEntity
 local CreateBeamEmitterOnEntity = CreateBeamEmitterOnEntity
 local VDist2 = VDist2
+local VDist3 = VDist3
 local MathPow = math.pow
 local MathSqrt = math.sqrt
+local MathAbs = math.abs
+local MathSin = math.sin
+local MathCos = math.cos
+local MathAcos = math.acos
+local MathAtan = math.atan
+local MathPi = math.pi
 
 local TableGetn = table.getn
 
@@ -128,7 +135,7 @@ SemiBallisticComponent = ClassSimple {
     --- Used for the initial part of a trajectory
     TurnRateFromAngleAndHeight = function(self)
 
-        local targetAngle = self.FinalBoostAngle * math.pi/180
+        local targetAngle = self.FinalBoostAngle * MathPi/180
         local currentAngle = self:ElevationAngle()
         local deltaY = self:OptimalMaxHeight() - self:GetPosition()[2]
         if deltaY < self.MinHeight then
@@ -136,7 +143,7 @@ SemiBallisticComponent = ClassSimple {
         end
         local turnTime = deltaY/self:AverageVerticalVelocityThroughTurn(targetAngle, currentAngle)
 
-        local degreesPerSecond = math.abs(targetAngle - currentAngle)/turnTime * 180/math.pi
+        local degreesPerSecond = MathAbs(targetAngle - currentAngle)/turnTime * 180/MathPi
         return degreesPerSecond, turnTime
     end,
 
@@ -150,9 +157,9 @@ SemiBallisticComponent = ClassSimple {
         local velocityVector = Vector(ux, uy, uz)
         local speed = self:GetCurrentSpeed()
 
-        local theta = math.acos(VDot(targetVector, velocityVector) / (speed * dist))
-        --local radius = dist/(2 * math.sin(theta))
-        local arcLength = 2 * theta * dist/(2 * math.sin(theta))
+        local theta = MathAcos(VDot(targetVector, velocityVector) / (speed * dist))
+        --local radius = dist/(2 * MathSin(theta))
+        local arcLength = 2 * theta * dist/(2 * MathSin(theta))
 
         local averageSpeed
         if speed*10 < self:GetBlueprint().Physics.MaxSpeed * 0.95 then
@@ -164,7 +171,7 @@ SemiBallisticComponent = ClassSimple {
 
         local arcTime = arcLength / averageSpeed
 
-        local degreesPerSecond = 2 * theta / arcTime * ( 180 / math.pi )
+        local degreesPerSecond = 2 * theta / arcTime * ( 180 / MathPi )
         LOG('theta: ', theta)
         LOG('dist: ', dist)
         LOG('arcLength: ', arcLength)
@@ -205,7 +212,7 @@ SemiBallisticComponent = ClassSimple {
     -- what will our average vertical velocity be?
     -- (we can use that number to calculate how long the turn should take, and therefore the turn rate)
     AverageVerticalVelocityThroughTurn = function(self, targetAngle, currentAngle)
-        local averageVerticalVelocity = 1/(targetAngle-currentAngle) * (math.cos(currentAngle) - math.cos(targetAngle))
+        local averageVerticalVelocity = 1/(targetAngle-currentAngle) * (MathCos(currentAngle) - MathCos(targetAngle))
         averageVerticalVelocity = averageVerticalVelocity * self:GetBlueprint().Physics.MaxSpeed
         return averageVerticalVelocity
     end,
@@ -233,12 +240,12 @@ SemiBallisticComponent = ClassSimple {
         local vh = VDist2(vx, vz, 0, 0)
         if vh == 0 then
             if vy >= 0 then
-                return math.pi/2
+                return MathPi/2
             else
-                return -math.pi/2
+                return -MathPi/2
             end
         end
-        return math.atan(vy / vh)
+        return MathAtan(vy / vh)
     end,
 
     -- optimal highest point of the trajectory based on the heightDistanceFactor

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -128,11 +128,11 @@ SemiBallisticComponent = ClassSimple {
     --- Used for the initial part of a trajectory
     TurnRateFromAngleAndHeight = function(self)
 
-        local targetAngle = self.finalBoostAngle * math.pi/180
+        local targetAngle = self.FinalBoostAngle * math.pi/180
         local currentAngle = self:ElevationAngle()
         local deltaY = self:OptimalMaxHeight() - self:GetPosition()[2]
-        if deltaY < self.minHeight then
-            deltaY = self.minHeight
+        if deltaY < self.MinHeight then
+            deltaY = self.MinHeight
         end
         local turnTime = deltaY/self:AverageVerticalVelocityThroughTurn(targetAngle, currentAngle)
 
@@ -245,7 +245,7 @@ SemiBallisticComponent = ClassSimple {
     OptimalMaxHeight = function(self)
         local horizDist = self:HorizontalDistanceToTarget()
         local targetHeight = self:GetCurrentTargetPosition()[2]
-        local maxHeight = targetHeight + horizDist/self.heightDistanceFactor
+        local maxHeight = targetHeight + horizDist/self.HeightDistanceFactor
         return maxHeight
     end,
 
@@ -282,8 +282,8 @@ TacticalMissileComponent = ClassSimple(SemiBallisticComponent) {
     MovementThread = function(self)
 
         -- launch
-        self:SetTurnRate(self.launchTurnRate)
-        WaitTicks(self.launchTicks)
+        self:SetTurnRate(self.LaunchTurnRate)
+        WaitTicks(self.LaunchTicks)
 
         -- boost
         local boostTurnRate, boostTime = self:TurnRateFromAngleAndHeight()

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -169,41 +169,26 @@ SemiBallisticComponent = ClassSimple {
         end
 
         local arcTime = arcLength / averageSpeed
-
         local degreesPerSecond = 2 * theta / arcTime * ( 180 / MathPi )
-        LOG('theta: ', theta)
-        LOG('dist: ', dist)
-        LOG('arcLength: ', arcLength)
-        LOG('arcTime: ', arcTime)
-        LOG('degreesPerSecond: ', degreesPerSecond)
         return degreesPerSecond, arcTime
     end,
 
     -- Gives an average speed over a given distance (arc or straight)
     -- Used for a projectile that has not yet reached max speed
     AverageSpeedOverDistance = function(self, dist, acceleration)
-        LOG('')
         local speed = self:GetCurrentSpeed()*10
         local maxSpeed = self:GetBlueprint().Physics.MaxSpeed
         local accelerationDistance = (MathPow(maxSpeed,2) - MathPow(speed,2)) / (2 * acceleration)
         local averageSpeed
-        LOG('Speed: ', speed)
-        LOG('Acceleration distance: ', accelerationDistance)
         if dist < accelerationDistance then
             -- we'll never reach max speed
-            LOG('We will never reach max speed')
             local speedFinal = MathSqrt(2 * acceleration * dist + MathPow(speed,2))
-            LOG('Final speed: ', speedFinal)
             averageSpeed = (speed + speedFinal) / 2
         else
             -- we'll reach max speed
-            LOG('We will reach max speed')
             local remainingDistance = dist - accelerationDistance
             averageSpeed = ((maxSpeed + speed)/2 * accelerationDistance + maxSpeed * remainingDistance) / dist
-            LOG('Distance at max speed: ', remainingDistance)
         end
-        LOG('AverageSpeed: ', averageSpeed)
-        LOG('')
         return averageSpeed
     end,
 
@@ -262,28 +247,18 @@ SemiBallisticComponent = ClassSimple {
 TacticalMissileComponent = ClassSimple(SemiBallisticComponent) {
 
     -- TacticalMissileComponent Trajectory Parameters
-
-    -- LaunchTicks: how long we spend in the launch phase
-    -- LaunchTicks = 8,
-
-    -- LaunchTurnRate: inital launch phase turn rate, gives a little turnover coming out of the tube
-    -- LaunchTurnRate = 6,
-
-    -- HeightDistanceFactor: each missile calculates an optimal highest point of its trajectory,
+    --- LaunchTicks: how long we spend in the launch phase
+    --- LaunchTurnRate: inital launch phase turn rate, gives a little turnover coming out of the tube
+    --- HeightDistanceFactor: each missile calculates an optimal highest point of its trajectory,
     -- based on its distance to the target.
     -- This is the factor that determines how high above the target that point is, in relation to the horizontal distance.
     -- a higher number will result in a lower trajectory
     -- 5-8 is a decent value
-    -- HeightDistanceFactor = 5,
-
-    -- MinHeight: minimum height of the highest point of the trajectory
+    --- MinHeight: minimum height of the highest point of the trajectory
     -- measured from the position of the missile at the end of the launch phase
     -- minRadius/2 or so is a decent value
-    -- MinHeight = 7,
-
-    -- FinalBoostAngle: angle in degrees that we'll aim to be at the end of the boost phase
+    --- FinalBoostAngle: angle in degrees that we'll aim to be at the end of the boost phase
     -- 90 is vertical, 0 is horizontal
-    -- FinalBoostAngle = 0,
 
     maxZigZagThreshold = 1,
 
@@ -313,7 +288,6 @@ TacticalMissileComponent = ClassSimple(SemiBallisticComponent) {
             -- wait until we're just short of our target (just short of the normal glide time is a good number)
             -- then up the turn rate so we can actually get close to hitting something
             WaitTicks((glideTime-1) * 10)
-            LOG('Terminal zigzag guidance')
             self:SetTurnRate(100)
         else
             self:SetTurnRate(glideTurnRate)
@@ -326,6 +300,7 @@ TacticalMissileComponent = ClassSimple(SemiBallisticComponent) {
         end
     end,
 }
+
 --- Nukes
 ---@class NukeProjectile : NullShell
 NukeProjectile = ClassProjectile(NullShell) {

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -292,7 +292,6 @@ TacticalMissileComponent = ClassSimple(SemiBallisticComponent) {
 
         -- are we a wiggler?
         local zigZagger = false
-        
         if self:GetBlueprint().Physics.MaxZigZag and
            self:GetBlueprint().Physics.MaxZigZag > self.maxZigZagThreshold then
             zigZagger = true
@@ -311,9 +310,9 @@ TacticalMissileComponent = ClassSimple(SemiBallisticComponent) {
         local glideTurnRate, glideTime = self:TurnRateFromDistance()
         if zigZagger then
             self:SetTurnRate(75)
-            -- wait until we're just short of our target (normal glide time is a good number)
+            -- wait until we're just short of our target (just short of the normal glide time is a good number)
             -- then up the turn rate so we can actually get close to hitting something
-            WaitTicks(glideTime * 10)
+            WaitTicks((glideTime-1) * 10)
             LOG('Terminal zigzag guidance')
             self:SetTurnRate(100)
         else
@@ -325,12 +324,7 @@ TacticalMissileComponent = ClassSimple(SemiBallisticComponent) {
                 self:TrackTarget(false)
             end
         end
-
-
-
-
     end,
-
 }
 --- Nukes
 ---@class NukeProjectile : NullShell

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -255,26 +255,27 @@ SemiBallisticComponent = ClassSimple {
 ---@class TacticalMissileProjectile : NullShell
 TacticalMissileComponent = ClassSimple(SemiBallisticComponent) {
 
-    -- default trajectory parameters
+    -- TacticalMissileComponent Trajectory Parameters
 
-    -- how long we spend in the launch phase
-    -- LaunchTicks = 2,
+    -- LaunchTicks: how long we spend in the launch phase
+    -- LaunchTicks = 8,
 
-    -- inital launch phase turn rate, gives a little turnover coming out of the tube
+    -- LaunchTurnRate: inital launch phase turn rate, gives a little turnover coming out of the tube
     -- LaunchTurnRate = 6,
 
-    -- each missile calculates an optimal highest point of its trajectory based on its distance to the target
-    -- this is the factor that determines how high above the target that point is, in relation to the horizontal distance
+    -- HeightDistanceFactor: each missile calculates an optimal highest point of its trajectory,
+    -- based on its distance to the target.
+    -- This is the factor that determines how high above the target that point is, in relation to the horizontal distance.
     -- a higher number will result in a lower trajectory
     -- 5-8 is a decent value
     -- HeightDistanceFactor = 5,
 
-    -- minimum height of the high point of the trajectory
+    -- MinHeight: minimum height of the highest point of the trajectory
     -- measured from the position of the missile at the end of the launch phase
-    -- minimum range/3 is not a bad number
-    -- MinHeight = 2,
+    -- minRadius/2 or so is a decent value
+    -- MinHeight = 7,
 
-    -- angle in degrees that we'll aim to be at the end of the boost phase
+    -- FinalBoostAngle: angle in degrees that we'll aim to be at the end of the boost phase
     -- 90 is vertical, 0 is horizontal
     -- FinalBoostAngle = 0,
 

--- a/projectiles/AIFMissileSerpentine01/AIFMissileSerpentine01_script.lua
+++ b/projectiles/AIFMissileSerpentine01/AIFMissileSerpentine01_script.lua
@@ -1,52 +1,20 @@
 -- Aeon Serpentine Missile
 
 local AMissileSerpentineProjectile = import("/lua/aeonprojectiles.lua").AMissileSerpentineProjectile
-AIFMissileSerpentine01 = ClassProjectile(AMissileSerpentineProjectile) {
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
+
+AIFMissileSerpentine01 = ClassProjectile(AMissileSerpentineProjectile, TacticalMissileComponent) {
+
+    LaunchTicks = 2,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 2,
+    FinalBoostAngle = 0,
+    
     OnCreate = function(self)
         AMissileSerpentineProjectile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2)
         self.MoveThread = self.Trash:Add(ForkThread(self.MovementThread, self))
-    end,
-
-    MovementThread = function(self)
-        self.Distance = self:GetDistanceToTarget()
-        self:SetTurnRate(8)
-        WaitTicks(4)
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(2)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        if dist > 50 then
-            -- Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(21)
-            self:SetTurnRate(8)
-        elseif dist > 35 and dist <= 70 then
-            -- Increase check intervals
-            self:SetTurnRate(12)
-            WaitTicks(16)
-            self:SetTurnRate(45)
-        elseif dist > 20 and dist <= 35 then
-            -- Further increase check intervals
-            WaitTicks(4)
-            self:SetTurnRate(60)
-        elseif dist > 5 and dist <= 20 then
-            -- Further increase check intervals
-            self:SetTurnRate(100)
-        elseif dist > 0 and dist <= 5 then
-            self:SetTurnRate(150)
-            KillThread(self.MoveThread)
-        end
-    end,
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
 }
 TypeClass = AIFMissileSerpentine01

--- a/projectiles/AIFMissileSerpentine02/AIFMissileSerpentine02_script.lua
+++ b/projectiles/AIFMissileSerpentine02/AIFMissileSerpentine02_script.lua
@@ -2,8 +2,15 @@
 -- Aeon Serpentine Missile
 --
 local AMissileSerpentineProjectile = import("/lua/aeonprojectiles.lua").AMissileSerpentineProjectile
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
 
-AIFMissileSerpentine02 = ClassProjectile(AMissileSerpentineProjectile) {
+AIFMissileSerpentine02 = ClassProjectile(AMissileSerpentineProjectile, TacticalMissileComponent) {
+
+    LaunchTicks = 6,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 5,
+    FinalBoostAngle = 0,
 
     FxWaterHitScale = 1.65,
 
@@ -11,45 +18,6 @@ AIFMissileSerpentine02 = ClassProjectile(AMissileSerpentineProjectile) {
         AMissileSerpentineProjectile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2.0)
         self:ForkThread( self.MovementThread )
-    end,
-
-    MovementThread = function(self)        
-        self:SetTurnRate(8)
-        WaitSeconds(0.3)        
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(1)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        --Get the nuke as close to 90 deg as possible
-        if dist > 50 then        
-            --Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitSeconds(2)
-            self:SetTurnRate(20)
-        elseif dist > 64 and dist <= 107 then
-						-- Increase check intervals
-						self:SetTurnRate(30)
-						WaitSeconds(1.5)
-            self:SetTurnRate(30)
-        elseif dist > 21 and dist <= 53 then
-						-- Further increase check intervals
-            WaitSeconds(0.3)
-            self:SetTurnRate(50)
-				elseif dist > 0 and dist <= 21 then
-						-- Further increase check intervals            
-            self:SetTurnRate(100)   
-            KillThread(self.MoveThread)         
-        end
-    end,        
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
     
     OnExitWater = function(self)

--- a/projectiles/AIFMissileSerpentine03/AIFMissileSerpentine03_Script.lua
+++ b/projectiles/AIFMissileSerpentine03/AIFMissileSerpentine03_Script.lua
@@ -1,52 +1,20 @@
 -- Serpentine Missile 03
 
 local AMissileSerpentine02Projectile = import("/lua/aeonprojectiles.lua").AMissileSerpentine02Projectile
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
 
-AIFMissileTactical02 = ClassProjectile(AMissileSerpentine02Projectile) {
+AIFMissileTactical02 = ClassProjectile(AMissileSerpentine02Projectile, TacticalMissileComponent) {
+
+    LaunchTicks = 6,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 3,
+    MinHeight = 5,
+    FinalBoostAngle = 0,
 
     OnCreate = function(self)
         AMissileSerpentine02Projectile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2.0)
         self.Trash:Add(ForkThread( self.MovementThread,self))
-    end,
-
-    MovementThread = function(self)
-        self:SetTurnRate(3)
-        WaitTicks(21)
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(1)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        --Get the nuke as close to 90 deg as possible
-        if dist > 100 then
-            --Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(21)
-            self:SetTurnRate(20)
-        elseif dist > 64 and dist <= 107 then
-						-- Increase check intervals
-						self:SetTurnRate(30)
-						WaitTicks(16)
-            self:SetTurnRate(30)
-        elseif dist > 21 and dist <= 53 then
-						-- Further increase check intervals
-            WaitTicks(4)
-            self:SetTurnRate(50)
-				elseif dist > 0 and dist <= 21 then
-						-- Further increase check intervals            
-            self:SetTurnRate(100)
-            KillThread(self.MoveThread)
-        end
-    end,
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
 }
 TypeClass = AIFMissileTactical02

--- a/projectiles/AIFMissileTactical01/AIFMissileTactical01_Script.lua
+++ b/projectiles/AIFMissileTactical01/AIFMissileTactical01_Script.lua
@@ -2,52 +2,20 @@
 -- Aeon Land-Based Tactical Missile
 --
 local AMissileSerpentineProjectile = import("/lua/aeonprojectiles.lua").AMissileSerpentineProjectile
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
 
-AIFMissileTactical01 = ClassProjectile(AMissileSerpentineProjectile) {
+AIFMissileTactical01 = ClassProjectile(AMissileSerpentineProjectile, TacticalMissileComponent) {
+
+    LaunchTicks = 6,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 5,
+    FinalBoostAngle = 0,
 
     OnCreate = function(self)
         AMissileSerpentineProjectile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2.0)
         self.Trash:Add(ForkThread( self.MovementThread,self ))
-    end,
-
-    MovementThread = function(self)
-        self:SetTurnRate(8)
-        WaitTicks(4)
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(2)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        --Get the nuke as close to 90 deg as possible
-        if dist > 50 then
-            --Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(21)
-            self:SetTurnRate(20)
-        elseif dist > 128 and dist <= 213 then
-						-- Increase check intervals
-						self:SetTurnRate(30)
-						WaitTicks(16)
-            self:SetTurnRate(30)
-        elseif dist > 43 and dist <= 107 then
-						-- Further increase check intervals
-            WaitTicks(4)
-            self:SetTurnRate(50)
-				elseif dist > 0 and dist <= 43 then
-						-- Further increase check intervals            
-            self:SetTurnRate(100)
-            KillThread(self.MoveThread)
-        end
-    end,
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
 }
 TypeClass = AIFMissileTactical01

--- a/projectiles/AIFMissileTactical02/AIFMissileTactical02_Script.lua
+++ b/projectiles/AIFMissileTactical02/AIFMissileTactical02_Script.lua
@@ -1,50 +1,19 @@
 -- Aeon Land-Based Tactical Missile
 
 local AMissileSerpentineProjectile = import("/lua/aeonprojectiles.lua").AMissileSerpentineProjectile
-AIFMissileTactical02 = ClassProjectile(AMissileSerpentineProjectile) {
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
+AIFMissileTactical02 = ClassProjectile(AMissileSerpentineProjectile, TacticalMissileComponent) {
+
+    LaunchTicks = 6,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 5,
+    FinalBoostAngle = 0,
+    
     OnCreate = function(self)
         AMissileSerpentineProjectile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2.0)
         self.Trash:Add(ForkThread( self.MovementThread,self ))
-    end,
-
-    MovementThread = function(self)
-        self:TrackTarget(false)
-        self:SetCollision(true)
-        WaitTicks(21)
-        self:SetTurnRate(5)
-        WaitTicks(6)
-        self:TrackTarget(true)
-        self:SetTurnRate(10)
-        WaitTicks(6)
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(6)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        if dist > 125 and self.MovementTurnLevel < 2 then
-            self:SetTurnRate(30)
-            self.MovementTurnLevel = 1
-        elseif dist > 85 and dist <= 125 and self.MovementTurnLevel < 3 then
-            self:SetTurnRate(40)
-            self.MovementTurnLevel = 2
-        elseif dist > 40 and dist <= 85 and self.MovementTurnLevel < 4 then
-            self:SetTurnRate(50)
-            self.MovementTurnLevel = 3
-        elseif dist < 40 then
-            self:SetTurnRate(85)
-            self.MovementTurnLevel = 4
-        end
-    end,
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
 }
 TypeClass = AIFMissileTactical02

--- a/projectiles/CIFMissileTactical01/CIFMissileTactical01_Script.lua
+++ b/projectiles/CIFMissileTactical01/CIFMissileTactical01_Script.lua
@@ -3,64 +3,22 @@
 -- Splits into child projectile if it takes enough damage.
 
 local CLOATacticalMissileProjectile = import("/lua/cybranprojectiles.lua").CLOATacticalMissileProjectile
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
 
-CIFMissileTactical01 = ClassProjectile(CLOATacticalMissileProjectile) {
+CIFMissileTactical01 = ClassProjectile(CLOATacticalMissileProjectile, TacticalMissileComponent) {
     NumChildMissiles = 3,
+    
+    LaunchTicks = 2,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 2,
+    FinalBoostAngle = 0,
+
     OnCreate = function(self)
         CLOATacticalMissileProjectile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2)
         self.Split = false
         self.MoveThread = self.Trash:Add(ForkThread(self.MovementThread,self))
-    end,
-
-    MovementThread = function(self)
-        self.Distance = self:GetDistanceToTarget()
-        self:SetTurnRate(8)
-        WaitTicks(4)
-
-
-        
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(2)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        if dist > self.Distance then
-            self:SetTurnRate(75)
-            WaitTicks(31)
-            self:SetTurnRate(8)
-            self.Distance = self:GetDistanceToTarget()
-        end
-        if dist > 50 then        
-            -- Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(13)
-            self:SetTurnRate(14)
-        elseif dist > 30 and dist <= 50 then
-						-- Increase check intervals
-						self:SetTurnRate(18)
-						WaitTicks(8)
-            self:SetTurnRate(34)
-        elseif dist > 10 and dist <= 25 then
-						-- Further increase check intervals
-                        WaitTicks(2)
-            self:SetTurnRate(68)
-				elseif dist > 5 and dist <= 10 then
-						-- Further increase check intervals            
-            self:SetTurnRate(100)  
-                elseif dist>0 and dist <=5 then
-                    self:SetTurnRate(150)
-            KillThread(self.MoveThread)         
-        end
-    end,
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
 
     OnImpact = function(self, targetType, targetEntity)       

--- a/projectiles/CIFMissileTactical02/CIFMissileTactical02_Script.lua
+++ b/projectiles/CIFMissileTactical02/CIFMissileTactical02_Script.lua
@@ -5,11 +5,18 @@
 -- if it takes enough damage.
 -- 
 local CLOATacticalMissileProjectile = import("/lua/cybranprojectiles.lua").CLOATacticalMissileProjectile
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
 
-CIFMissileTactical02 = ClassProjectile(CLOATacticalMissileProjectile) {
+CIFMissileTactical02 = ClassProjectile(CLOATacticalMissileProjectile, TacticalMissileComponent) {
 
     NumChildMissiles = 3,
     FxWaterHitScale = 1.65,
+
+    LaunchTicks = 6,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 5,
+    FinalBoostAngle = 0,
 
     OnCreate = function(self)
         CLOATacticalMissileProjectile.OnCreate(self)
@@ -53,45 +60,6 @@ CIFMissileTactical02 = ClassProjectile(CLOATacticalMissileProjectile) {
             end
         end
         CLOATacticalMissileProjectile.OnDamage(self, instigator, amount, vector, damageType)
-    end,
-
-    MovementThread = function(self)
-        self:SetTurnRate(8)
-        WaitTicks(4)
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(2)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        -- Get the nuke as close to 90 deg as possible
-        if dist > 50 then
-            -- Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(21)
-            self:SetTurnRate(20)
-        elseif dist > 64 and dist <= 107 then
-            -- Increase check intervals
-            self:SetTurnRate(30)
-            WaitTicks(16)
-            self:SetTurnRate(30)
-        elseif dist > 21 and dist <= 64 then
-            -- Further increase check intervals
-            WaitTicks(4)
-            self:SetTurnRate(50)
-        elseif dist > 0 and dist <= 21 then
-            -- Further increase check intervals            
-            self:SetTurnRate(100)
-            KillThread(self.MoveThread)
-        end
-    end,        
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
 
     OnExitWater = function(self)

--- a/projectiles/CIFMissileTactical03/CIFMissileTactical03_Script.lua
+++ b/projectiles/CIFMissileTactical03/CIFMissileTactical03_Script.lua
@@ -5,9 +5,16 @@
 -- if it takes enough damage.
 -- 
 local CLOATacticalMissileProjectile = import("/lua/cybranprojectiles.lua").CLOATacticalMissileProjectile
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
 
-CIFMissileTactical03 = ClassProjectile(CLOATacticalMissileProjectile) {
+CIFMissileTactical03 = ClassProjectile(CLOATacticalMissileProjectile, TacticalMissileComponent) {
     NumChildMissiles = 3,
+
+    LaunchTicks = 6,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 5,
+    FinalBoostAngle = 0,
 
     OnCreate = function(self)
         CLOATacticalMissileProjectile.OnCreate(self)
@@ -43,45 +50,6 @@ CIFMissileTactical03 = ClassProjectile(CLOATacticalMissileProjectile) {
             end
         end
         CLOATacticalMissileProjectile.OnDamage(self, instigator, amount, vector, damageType)
-    end,
-
-    MovementThread = function(self)
-        self:SetTurnRate(8)
-        WaitTicks(4)
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(2)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        -- Get the nuke as close to 90 deg as possible
-        if dist > 50 then
-            -- Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(21)
-            self:SetTurnRate(20)
-        elseif dist > 128 and dist <= 213 then
-            -- Increase check intervals
-            self:SetTurnRate(30)
-            WaitTicks(16)
-            self:SetTurnRate(30)
-        elseif dist > 43 and dist <= 128 then
-            -- Further increase check intervals
-            WaitTicks(4)
-            self:SetTurnRate(50)
-        elseif dist > 0 and dist <= 43 then
-            -- Further increase check intervals            
-            self:SetTurnRate(100)
-            KillThread(self.MoveThread)
-        end
-    end,
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
 }
 TypeClass = CIFMissileTactical03

--- a/projectiles/SIFLaanseTacticalMissile01/SIFLaanseTacticalMissile01_Script.lua
+++ b/projectiles/SIFLaanseTacticalMissile01/SIFLaanseTacticalMissile01_Script.lua
@@ -4,57 +4,20 @@
 -- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 ---------------------------------------------------------------------------------------------------
 local SLaanseTacticalMissile = import("/lua/seraphimprojectiles.lua").SLaanseTacticalMissile
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
 
-SIFLaanseTacticalMissile01 = ClassProjectile(SLaanseTacticalMissile) {
+SIFLaanseTacticalMissile01 = ClassProjectile(SLaanseTacticalMissile, TacticalMissileComponent) {
+
+    LaunchTicks = 2,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 2,
+    FinalBoostAngle = 0,
+    
     OnCreate = function(self)
         SLaanseTacticalMissile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2)
         self.MoveThread = self:ForkThread(self.MovementThread)
-    end,
-
-    MovementThread = function(self)
-        self.Distance = self:GetDistanceToTarget()
-        self:SetTurnRate(8)
-        WaitTicks(4)        
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(2)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        if dist > self.Distance then
-        	self:SetTurnRate(75)
-        	WaitTicks(31)
-        	self:SetTurnRate(8)
-        	self.Distance = self:GetDistanceToTarget()
-        end
-        if dist > 50 then        
-            -- Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(13)
-            self:SetTurnRate(14)
-        elseif dist > 30 and dist <= 50 then
-						-- Increase check intervals
-						self:SetTurnRate(18)
-						WaitTicks(8)
-            self:SetTurnRate(18)
-        elseif dist > 10 and dist <= 25 then
-						-- Further increase check intervals
-                        WaitTicks(2)
-            self:SetTurnRate(68)
-				elseif dist > 0 and dist <= 10 then
-						-- Further increase check intervals            
-            self:SetTurnRate(150)   
-            KillThread(self.MoveThread)         
-        end
-    end,        
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
 }
 TypeClass = SIFLaanseTacticalMissile01

--- a/projectiles/SIFLaanseTacticalMissile02/SIFLaanseTacticalMissile02_Script.lua
+++ b/projectiles/SIFLaanseTacticalMissile02/SIFLaanseTacticalMissile02_Script.lua
@@ -4,52 +4,20 @@
 -- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 --------------------------------------------------------------------------------------------------
 local SLaanseTacticalMissile = import("/lua/seraphimprojectiles.lua").SLaanseTacticalMissile
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
 
-SIFLaanseTacticalMissile02 = ClassProjectile(SLaanseTacticalMissile) {
+SIFLaanseTacticalMissile02 = ClassProjectile(SLaanseTacticalMissile, TacticalMissileComponent) {
+
+    LaunchTicks = 6,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 5,
+    FinalBoostAngle = 0,
 
     OnCreate = function(self)
         SLaanseTacticalMissile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2.0)
         self.Trash:Add(ForkThread( self.MovementThread,self ))
-    end,
-
-    MovementThread = function(self)
-        self:SetTurnRate(8)
-        WaitTicks(4)
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(2)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        --Get the nuke as close to 90 deg as possible
-        if dist > 50 then        
-            --Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(21)
-            self:SetTurnRate(20)
-        elseif dist > 64 and dist <= 107 then
-						-- Increase check intervals
-						self:SetTurnRate(30)
-						WaitTicks(16)
-            self:SetTurnRate(30)
-        elseif dist > 21 and dist <= 53 then
-						-- Further increase check intervals
-                        WaitTicks(4)
-            self:SetTurnRate(50)
-				elseif dist > 0 and dist <= 21 then
-						-- Further increase check intervals            
-            self:SetTurnRate(100)
-            KillThread(self.MoveThread)
-        end
-    end,
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
 }
 TypeClass = SIFLaanseTacticalMissile02

--- a/projectiles/SIFLaanseTacticalMissile03/SIFLaanseTacticalMissile03_Script.lua
+++ b/projectiles/SIFLaanseTacticalMissile03/SIFLaanseTacticalMissile03_Script.lua
@@ -4,50 +4,19 @@
 -- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 ---------------------------------------------------------------------------------------------------
 local SLaanseTacticalMissile = import("/lua/seraphimprojectiles.lua").SLaanseTacticalMissile
-SIFLaanseTacticalMissile03 = ClassProjectile(SLaanseTacticalMissile) {
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
+SIFLaanseTacticalMissile03 = ClassProjectile(SLaanseTacticalMissile, TacticalMissileComponent) {
+
+    LaunchTicks = 6,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 5,
+    FinalBoostAngle = 0,
+
     OnCreate = function(self)
         SLaanseTacticalMissile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2.0)
         self.Trash:Add(ForkThread( self.MovementThread,self ))
-    end,
-
-    MovementThread = function(self)
-        self:SetTurnRate(8)
-        WaitTicks(4)
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(2)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        --Get the nuke as close to 90 deg as possible
-        if dist > 50 then        
-            --Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(21)
-            self:SetTurnRate(20)
-        elseif dist > 64 and dist <= 107 then
-						-- Increase check intervals
-						self:SetTurnRate(30)
-						WaitTicks(16)
-            self:SetTurnRate(30)
-        elseif dist > 21 and dist <= 53 then
-						-- Further increase check intervals
-                        WaitTicks(4)
-            self:SetTurnRate(50)
-				elseif dist > 0 and dist <= 21 then
-						-- Further increase check intervals            
-            self:SetTurnRate(100)
-            KillThread(self.MoveThread)
-        end
-    end,
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
 }
 TypeClass = SIFLaanseTacticalMissile03

--- a/projectiles/SIFLaanseTacticalMissileCDR/SIFLaanseTacticalMissileCDR_script.lua
+++ b/projectiles/SIFLaanseTacticalMissileCDR/SIFLaanseTacticalMissileCDR_script.lua
@@ -4,51 +4,19 @@
 -- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 ---------------------------------------------------------------------------------------------------
 local SLaanseTacticalMissile = import("/lua/seraphimprojectiles.lua").SLaanseTacticalMissile
-SIFLaanseTacticalMissileCDR = ClassProjectile(SLaanseTacticalMissile) {
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
+SIFLaanseTacticalMissileCDR = ClassProjectile(SLaanseTacticalMissile, TacticalMissileComponent) {
+
+    LaunchTicks = 6,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 5,
+    FinalBoostAngle = 0,
+
     OnCreate = function(self)
         SLaanseTacticalMissile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2)
         self.MoveThread = self.Trash:Add(ForkThread(self.MovementThread,self))
-    end,
-
-    MovementThread = function(self)
-        self:SetTurnRate(8)
-        WaitTicks(4)
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            self:SetDestroyOnWater(true)
-            WaitTicks(2)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        --Get the nuke as close to 90 deg as possible
-        if dist > 50 then
-            --Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(21)
-            self:SetTurnRate(20)
-        elseif dist > 30 and dist <= 150 then
-            -- Increase check intervals
-            self:SetTurnRate(30)
-            WaitTicks(16)
-            self:SetTurnRate(30)
-        elseif dist > 10 and dist <= 30 then
-            -- Further increase check intervals
-            WaitTicks(4)
-            self:SetTurnRate(50)
-        elseif dist > 0 and dist <= 10 then
-            -- Further increase check intervals
-            self:SetTurnRate(100)
-            KillThread(self.MoveThread)
-        end
-    end,
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
 }
 TypeClass = SIFLaanseTacticalMissileCDR

--- a/projectiles/SIFLaanseTacticalMissileSCU/SIFLaanseTacticalMissileSCU_script.lua
+++ b/projectiles/SIFLaanseTacticalMissileSCU/SIFLaanseTacticalMissileSCU_script.lua
@@ -4,51 +4,19 @@
 -- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------------------------------------------
 local SLaanseTacticalMissile = import("/lua/seraphimprojectiles.lua").SLaanseTacticalMissile
-SIFLaanseTacticalMissile01 = ClassProjectile(SLaanseTacticalMissile) {
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
+SIFLaanseTacticalMissile01 = ClassProjectile(SLaanseTacticalMissile, TacticalMissileComponent) {
+
+    LaunchTicks = 6,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 5,
+    FinalBoostAngle = 0,
+
     OnCreate = function(self)
         SLaanseTacticalMissile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2)
         self.MoveThread = self.Trash:Add(ForkThread(self.MovementThread, self))
-    end,
-
-    MovementThread = function(self)
-        self:SetTurnRate(8)
-        WaitTicks(4)
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            self:SetDestroyOnWater(true)
-            WaitTicks(2)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        --Get the nuke as close to 90 deg as possible
-        if dist > 50 then
-            --Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(21)
-            self:SetTurnRate(20)
-        elseif dist > 30 and dist <= 150 then
-            -- Increase check intervals
-            self:SetTurnRate(30)
-            WaitTicks(16)
-            self:SetTurnRate(30)
-        elseif dist > 10 and dist <= 30 then
-            -- Further increase check intervals
-            WaitTicks(4)
-            self:SetTurnRate(50)
-        elseif dist > 0 and dist <= 10 then
-            -- Further increase check intervals
-            self:SetTurnRate(100)
-            KillThread(self.MoveThread)
-        end
-    end,
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
 }
 TypeClass = SIFLaanseTacticalMissile01

--- a/projectiles/TIFMissileCruise01/TIFMissileCruise01_Script.lua
+++ b/projectiles/TIFMissileCruise01/TIFMissileCruise01_Script.lua
@@ -25,7 +25,7 @@ TIFMissileCruise01 = ClassProjectile(TMissileCruiseProjectile, TacticalMissileCo
     -- TacticalMissileComponent Trajectory Parameters
 
     -- LaunchTicks: how long we spend in the launch phase
-    LaunchTicks = 8,
+    LaunchTicks = 6,
 
     -- LaunchTurnRate: inital launch phase turn rate, gives a little turnover coming out of the tube
     LaunchTurnRate = 6,
@@ -40,7 +40,7 @@ TIFMissileCruise01 = ClassProjectile(TMissileCruiseProjectile, TacticalMissileCo
     -- MinHeight: minimum height of the highest point of the trajectory
     -- measured from the position of the missile at the end of the launch phase
     -- minRadius/2 or so is a decent value
-    MinHeight = 7,
+    MinHeight = 5,
 
     -- FinalBoostAngle: angle in degrees that we'll aim to be at the end of the boost phase
     -- 90 is vertical, 0 is horizontal

--- a/projectiles/TIFMissileCruise01/TIFMissileCruise01_Script.lua
+++ b/projectiles/TIFMissileCruise01/TIFMissileCruise01_Script.lua
@@ -2,9 +2,10 @@
 -- Terran Land-Based Cruise Missile
 --
 local TMissileCruiseProjectile = import("/lua/terranprojectiles.lua").TMissileCruiseProjectile02
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
 local EffectTemplate = import("/lua/effecttemplates.lua")
 
-TIFMissileCruise01 = ClassProjectile(TMissileCruiseProjectile) {
+TIFMissileCruise01 = ClassProjectile(TMissileCruiseProjectile, TacticalMissileComponent) {
 
 	FxAirUnitHitScale = 1.65,
     FxLandHitScale = 1.65,
@@ -26,43 +27,5 @@ TIFMissileCruise01 = ClassProjectile(TMissileCruiseProjectile) {
         self.Trash:Add(ForkThread( self.MovementThread,self ))
     end,
     
-    MovementThread = function(self)
-        self:SetTurnRate(8)
-        WaitTicks(4)
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(2)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        --Get the nuke as close to 90 deg as possible
-        if dist > 50 then        
-            --Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(21)
-            self:SetTurnRate(20)
-        elseif dist > 128 and dist <= 213 then
-						-- Increase check intervals
-						self:SetTurnRate(30)
-						WaitTicks(16)
-            self:SetTurnRate(30)
-        elseif dist > 43 and dist <= 107 then
-						-- Further increase check intervals
-                        WaitTicks(4)
-            self:SetTurnRate(50)
-				elseif dist > 0 and dist <= 43 then
-						-- Further increase check intervals            
-            self:SetTurnRate(100)   
-            KillThread(self.MoveThread)         
-        end
-    end,        
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
-    end,
 }
 TypeClass = TIFMissileCruise01

--- a/projectiles/TIFMissileCruise01/TIFMissileCruise01_Script.lua
+++ b/projectiles/TIFMissileCruise01/TIFMissileCruise01_Script.lua
@@ -21,6 +21,31 @@ TIFMissileCruise01 = ClassProjectile(TMissileCruiseProjectile, TacticalMissileCo
 
     FxTrails = EffectTemplate.TMissileExhaust01,
 
+
+    -- TacticalMissileComponent Trajectory Parameters
+
+    -- LaunchTicks: how long we spend in the launch phase
+    LaunchTicks = 8,
+
+    -- LaunchTurnRate: inital launch phase turn rate, gives a little turnover coming out of the tube
+    LaunchTurnRate = 6,
+
+    -- HeightDistanceFactor: each missile calculates an optimal highest point of its trajectory,
+    -- based on its distance to the target.
+    -- This is the factor that determines how high above the target that point is, in relation to the horizontal distance.
+    -- a higher number will result in a lower trajectory
+    -- 5-8 is a decent value
+    HeightDistanceFactor = 5,
+
+    -- MinHeight: minimum height of the highest point of the trajectory
+    -- measured from the position of the missile at the end of the launch phase
+    -- minRadius/2 or so is a decent value
+    MinHeight = 7,
+
+    -- FinalBoostAngle: angle in degrees that we'll aim to be at the end of the boost phase
+    -- 90 is vertical, 0 is horizontal
+    FinalBoostAngle = 0,
+
     OnCreate = function(self)
         TMissileCruiseProjectile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2.0)

--- a/projectiles/TIFMissileCruise02/TIFMissileCruise02_script.lua
+++ b/projectiles/TIFMissileCruise02/TIFMissileCruise02_script.lua
@@ -2,8 +2,9 @@
 -- Terran Sub-Launched Cruise Missile
 --
 local TMissileCruiseSubProjectile = import("/lua/terranprojectiles.lua").TMissileCruiseSubProjectile
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
 
-TIFMissileCruise02 = ClassProjectile(TMissileCruiseSubProjectile) {
+TIFMissileCruise02 = ClassProjectile(TMissileCruiseSubProjectile, TacticalMissileComponent) {
 
 	FxAirUnitHitScale = 1.65,
     FxLandHitScale = 1.65,
@@ -17,49 +18,16 @@ TIFMissileCruise02 = ClassProjectile(TMissileCruiseSubProjectile) {
     FxWaterHitScale = 1.65,
     FxOnKilledScale = 1.65,
 
+    LaunchTicks = 6,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 5,
+    FinalBoostAngle = 0,
+
     OnCreate = function(self)
         TMissileCruiseSubProjectile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2.0)
         self.Trash:Add(ForkThread( self.MovementThread,self ))
-    end,
-
-    MovementThread = function(self)        
-        self:SetTurnRate(8)
-        WaitTicks(4)        
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(2)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        --Get the nuke as close to 90 deg as possible
-        if dist > 50 then        
-            --Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(21)
-            self:SetTurnRate(20)
-        elseif dist > 64 and dist <= 107 then
-						-- Increase check intervals
-						self:SetTurnRate(30)
-						WaitTicks(16)
-            self:SetTurnRate(30)
-        elseif dist > 21 and dist <= 53 then
-						-- Further increase check intervals
-                        WaitTicks(4)
-            self:SetTurnRate(50)
-				elseif dist > 0 and dist <= 21 then
-						-- Further increase check intervals            
-            self:SetTurnRate(100)   
-            KillThread(self.MoveThread)         
-        end
-    end,        
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
     
     OnExitWater = function(self)

--- a/projectiles/TIFMissileCruise03/TIFMissileCruise03_Script.lua
+++ b/projectiles/TIFMissileCruise03/TIFMissileCruise03_Script.lua
@@ -3,9 +3,10 @@
 --
 
 local TMissileCruiseProjectile = import("/lua/terranprojectiles.lua").TMissileCruiseProjectile
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
 local EffectTemplate = import("/lua/effecttemplates.lua")
 
-TIFMissileCruise03 = ClassProjectile(TMissileCruiseProjectile) {
+TIFMissileCruise03 = ClassProjectile(TMissileCruiseProjectile, TacticalMissileComponent) {
 
     FxTrails = EffectTemplate.TMissileExhaust01,
     FxTrailOffset = -0.85,
@@ -28,53 +29,7 @@ TIFMissileCruise03 = ClassProjectile(TMissileCruiseProjectile) {
         self.MoveThread = self.Trash:Add(ForkThread(self.MovementThread,self))
     end,
 
-    MovementThread = function(self)        
-        self.Distance = self:GetDistanceToTarget()
-        self:SetTurnRate(8)
-        WaitTicks(4)        
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(2)
-        end
-    end,
 
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        if dist > self.Distance then
-        	self:SetTurnRate(75)
-        	WaitTicks(31)
-        	self:SetTurnRate(10)
-        	self.Distance = self:GetDistanceToTarget()
-        end
-        --Get the nuke as close to 90 deg as possible
-        if dist > 50 then        
-            -- Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(13)
-            self:SetTurnRate(14)
-        elseif dist > 30 and dist <= 50 then
-						-- Increase check intervals
-						self:SetTurnRate(20)
-						WaitTicks(8)
-            self:SetTurnRate(18)
-        elseif dist > 15 and dist <= 25 then
-						-- Further increase check intervals
-                        WaitTicks(2)
-            self:SetTurnRate(40)
-		elseif dist > 5 and dist <= 15 then
-						-- Further increase check intervals            
-                        self:SetTurnRate(100)
-        elseif dist > 0 and dist<= 5 then
-                        self:SetTurnRate(150)   
-            KillThread(self.MoveThread)         
-        end
-    end,        
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
-    end,
 }
 TypeClass = TIFMissileCruise03
 

--- a/projectiles/TIFMissileCruise03/TIFMissileCruise03_Script.lua
+++ b/projectiles/TIFMissileCruise03/TIFMissileCruise03_Script.lua
@@ -23,6 +23,31 @@ TIFMissileCruise03 = ClassProjectile(TMissileCruiseProjectile, TacticalMissileCo
     FxWaterHitScale = 0.65,
     FxOnKilledScale = 0.65,
     
+
+    -- TacticalMissileComponent Trajectory Parameters
+
+    -- LaunchTicks: how long we spend in the launch phase
+    LaunchTicks = 2,
+
+    -- LaunchTurnRate: inital launch phase turn rate, gives a little turnover coming out of the tube
+    LaunchTurnRate = 6,
+
+    -- HeightDistanceFactor: each missile calculates an optimal highest point of its trajectory,
+    -- based on its distance to the target.
+    -- This is the factor that determines how high above the target that point is, in relation to the horizontal distance.
+    -- a higher number will result in a lower trajectory
+    -- 5-8 is a decent value
+    HeightDistanceFactor = 5,
+
+    -- MinHeight: minimum height of the highest point of the trajectory
+    -- measured from the position of the missile at the end of the launch phase
+    -- minRadius/2 or so is a decent value
+    MinHeight = 2,
+
+    -- FinalBoostAngle: angle in degrees that we'll aim to be at the end of the boost phase
+    -- 90 is vertical, 0 is horizontal
+    FinalBoostAngle = 0,
+
     OnCreate = function(self)
         TMissileCruiseProjectile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2)        

--- a/projectiles/TIFMissileCruise04/TIFMissileCruise04_Script.lua
+++ b/projectiles/TIFMissileCruise04/TIFMissileCruise04_Script.lua
@@ -1,8 +1,9 @@
 -- Terran Land-Based Cruise Missile : UES0202 (UEF cruiser)
 
 local TMissileCruiseProjectile = import("/lua/terranprojectiles.lua").TMissileCruiseProjectile
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
 
-TIFMissileCruise04 = ClassProjectile(TMissileCruiseProjectile) {
+TIFMissileCruise04 = ClassProjectile(TMissileCruiseProjectile, TacticalMissileComponent) {
 
     FxAirUnitHitScale = 1.5,
     FxLandHitScale = 1.5,
@@ -16,49 +17,16 @@ TIFMissileCruise04 = ClassProjectile(TMissileCruiseProjectile) {
     FxWaterHitScale = 1.5,
     FxOnKilledScale = 1.5,
 
+    LaunchTicks = 6,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 5,
+    FinalBoostAngle = 0,
+
     OnCreate = function(self)
         TMissileCruiseProjectile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2.0)
         self.Trash:Add(ForkThread( self.MovementThread,self ))
-    end,
-
-    MovementThread = function(self)        
-        self:SetTurnRate(8)
-        WaitTicks(4)
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(2)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        -- Get the nuke as close to 90 deg as possible
-        if dist > 50 then        
-            -- Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(21)
-            self:SetTurnRate(20)
-        elseif dist > 64 and dist <= 107 then
-						-- Increase check intervals
-						self:SetTurnRate(30)
-						WaitTicks(16)
-            self:SetTurnRate(30)
-        elseif dist > 21 and dist <= 53 then
-						-- Further increase check intervals
-                        WaitTicks(4)
-            self:SetTurnRate(50)
-				elseif dist > 0 and dist <= 21 then
-						-- Further increase check intervals            
-            self:SetTurnRate(100)   
-            KillThread(self.MoveThread)         
-        end
-    end,        
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
 }
 TypeClass = TIFMissileCruise04

--- a/projectiles/TIFMissileCruise05/TIFMissileCruise05_Script.lua
+++ b/projectiles/TIFMissileCruise05/TIFMissileCruise05_Script.lua
@@ -5,7 +5,7 @@
 local TMissileCruiseProjectile = import("/lua/terranprojectiles.lua").TMissileCruiseProjectile
 local EffectTemplate = import("/lua/effecttemplates.lua")
 
-TIFMissileCruise05 = ClassProjectile(TMissileCruiseProjectile) {
+TIFMissileCruise05 = ClassProjectile(TMissileCruiseProjectile, TacticalMissileComponent) {
 
     FxTrails = EffectTemplate.TMissileExhaust01,
     FxTrailOffset = -0.85,
@@ -22,52 +22,38 @@ TIFMissileCruise05 = ClassProjectile(TMissileCruiseProjectile) {
     FxWaterHitScale = 0.65,
     FxOnKilledScale = 0.65,
     
+
+    -- TacticalMissileComponent Trajectory Parameters
+
+    -- LaunchTicks: how long we spend in the launch phase
+    LaunchTicks = 2,
+
+    -- LaunchTurnRate: inital launch phase turn rate, gives a little turnover coming out of the tube
+    LaunchTurnRate = 6,
+
+    -- HeightDistanceFactor: each missile calculates an optimal highest point of its trajectory,
+    -- based on its distance to the target.
+    -- This is the factor that determines how high above the target that point is, in relation to the horizontal distance.
+    -- a higher number will result in a lower trajectory
+    -- 5-8 is a decent value
+    HeightDistanceFactor = 5,
+
+    -- MinHeight: minimum height of the highest point of the trajectory
+    -- measured from the position of the missile at the end of the launch phase
+    -- minRadius/2 or so is a decent value
+    MinHeight = 2,
+
+    -- FinalBoostAngle: angle in degrees that we'll aim to be at the end of the boost phase
+    -- 90 is vertical, 0 is horizontal
+    FinalBoostAngle = 0,
+    
     OnCreate = function(self)
         TMissileCruiseProjectile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2)
         self.MoveThread = self.Trash:Add(ForkThread(self.MovementThread,self))
     end,
 
-    MovementThread = function(self)        
-        self.Distance = self:GetDistanceToTarget()
-        self:SetTurnRate(8)
-        WaitTicks(4)        
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(2)
-        end
-    end,
 
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        if dist > 50 then        
-            -- Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(13)
-            self:SetTurnRate(14)
-        elseif dist > 30 and dist <= 50 then
-						-- Increase check intervals
-						self:SetTurnRate(18)
-						WaitTicks(8)
-            self:SetTurnRate(18)
-        elseif dist > 10 and dist <= 25 then
-						-- Further increase check intervals
-                        WaitTicks(2)
-            self:SetTurnRate(68)
-				elseif dist > 5 and dist <= 10 then
-						-- Further increase check intervals            
-            self:SetTurnRate(100)
-                elseif dist >0 and dist <=2 then
-                    self:SetTurnRate(150)   
-            KillThread(self.MoveThread)         
-        end
-    end,        
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
-    end,
 }
 TypeClass = TIFMissileCruise05
 

--- a/projectiles/TIFMissileCruise05/TIFMissileCruise05_Script.lua
+++ b/projectiles/TIFMissileCruise05/TIFMissileCruise05_Script.lua
@@ -3,6 +3,7 @@
 --
 
 local TMissileCruiseProjectile = import("/lua/terranprojectiles.lua").TMissileCruiseProjectile
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
 local EffectTemplate = import("/lua/effecttemplates.lua")
 
 TIFMissileCruise05 = ClassProjectile(TMissileCruiseProjectile, TacticalMissileComponent) {
@@ -46,7 +47,7 @@ TIFMissileCruise05 = ClassProjectile(TMissileCruiseProjectile, TacticalMissileCo
     -- FinalBoostAngle: angle in degrees that we'll aim to be at the end of the boost phase
     -- 90 is vertical, 0 is horizontal
     FinalBoostAngle = 0,
-    
+
     OnCreate = function(self)
         TMissileCruiseProjectile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2)

--- a/projectiles/TIFMissileCruiseCDR/TIFMissileCruiseCDR_Script.lua
+++ b/projectiles/TIFMissileCruiseCDR/TIFMissileCruiseCDR_Script.lua
@@ -2,10 +2,11 @@
 -- Terran Land-Based Cruise Missile
 --
 local TMissileCruiseProjectile = import("/lua/terranprojectiles.lua").TMissileCruiseProjectile02
+local TacticalMissileComponent = import('/lua/sim/DefaultProjectiles.lua').TacticalMissileComponent
 local Explosion = import("/lua/defaultexplosions.lua")
 local EffectTemplate = import("/lua/effecttemplates.lua")
 
-TIFMissileCruiseCDR = ClassProjectile(TMissileCruiseProjectile) {
+TIFMissileCruiseCDR = ClassProjectile(TMissileCruiseProjectile, TacticalMissileComponent) {
 
     FxAirUnitHitScale = 1.65,
     FxLandHitScale = 1.65,
@@ -21,49 +22,16 @@ TIFMissileCruiseCDR = ClassProjectile(TMissileCruiseProjectile) {
 
     FxTrails = EffectTemplate.TMissileExhaust01,
 
+    LaunchTicks = 6,
+    LaunchTurnRate = 6,
+    HeightDistanceFactor = 5,
+    MinHeight = 5,
+    FinalBoostAngle = 0,
+
     OnCreate = function(self)
         TMissileCruiseProjectile.OnCreate(self)
         self:SetCollisionShape('Sphere', 0, 0, 0, 2)
         self.MoveThread = self.Trash:Add(ForkThread(self.MovementThread,self))
-    end,
-
-    MovementThread = function(self)
-        self:SetTurnRate(8)
-        WaitTicks(4)
-        while not self:BeenDestroyed() do
-            self:SetTurnRateByDist()
-            WaitTicks(2)
-        end
-    end,
-
-    SetTurnRateByDist = function(self)
-        local dist = self:GetDistanceToTarget()
-        --Get the nuke as close to 90 deg as possible
-        if dist > 50 then
-            --Freeze the turn rate as to prevent steep angles at long distance targets
-            WaitTicks(21)
-            self:SetTurnRate(20)
-        elseif dist > 30 and dist <= 150 then
-            -- Increase check intervals
-            self:SetTurnRate(30)
-            WaitTicks(16)
-            self:SetTurnRate(30)
-        elseif dist > 10 and dist <= 30 then
-            -- Further increase check intervals
-            WaitTicks(4)
-            self:SetTurnRate(50)
-        elseif dist > 0 and dist <= 10 then
-            -- Further increase check intervals
-            self:SetTurnRate(100)
-            KillThread(self.MoveThread)
-        end
-    end,
-
-    GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
-        return dist
     end,
 
     OnEnterWater = function(self)

--- a/units/UAL0111/UAL0111_unit.bp
+++ b/units/UAL0111/UAL0111_unit.bp
@@ -178,6 +178,8 @@ UnitBlueprint{
                 Water = "Land|Water|Seabed",
             },
             FiringTolerance = 5,
+            HeadingArcCenter = 0,
+            HeadingArcRange = 60,
             Label = "MissileRack",
             MaxRadius = 60,
             MinRadius = 3,

--- a/units/UEL0111/UEL0111_unit.bp
+++ b/units/UEL0111/UEL0111_unit.bp
@@ -178,6 +178,8 @@ UnitBlueprint{
                 Water = "Land|Water|Seabed",
             },
             FiringTolerance = 5,
+            HeadingArcCenter = 0,
+            HeadingArcRange = 60,
             Label = "MissileWeapon",
             MaxRadius = 60,
             MinRadius = 5,

--- a/units/URL0111/URL0111_unit.bp
+++ b/units/URL0111/URL0111_unit.bp
@@ -177,6 +177,8 @@ UnitBlueprint{
                 Water = "Land|Water|Seabed",
             },
             FiringTolerance = 2,
+            HeadingArcCenter = 0,
+            HeadingArcRange = 60,
             Label = "MissileRack",
             MaxRadius = 60,
             MinRadius = 4,

--- a/units/XSL0111/XSL0111_unit.bp
+++ b/units/XSL0111/XSL0111_unit.bp
@@ -176,6 +176,8 @@ UnitBlueprint{
                 Water = "Land|Water|Seabed",
             },
             FiringTolerance = 5,
+            HeadingArcCenter = 0,
+            HeadingArcRange = 60,
             Label = "MissileRack",
             MaxRadius = 60,
             MinRadius = 4,


### PR DESCRIPTION
Parameterizes and componentizes tactical missiles. Currently limited to the following projectiles for testing:
Aloha
Flapjack
Spearhead

Flight parameters are now:

- `LaunchTicks`: how many ticks we'll spend in a low-turn-rate launch phase. 2 for mobile launchers, 6-8 for vertical launched projectiles.
- `LaunchTurnRate`: turn rate in aforementioned phase. Set to a low value (6-8) to prevent jerkiness as soon as the projectile is created.
- `HeightDistanceFactor`: Range to the target will be divided by this number when calculating the maximum height of the trajectory. Set to a higher number for a flatter flight path. ~5 is a decent number.
- `MinHeight`: If the calculated highest point of the trajectory is lower than this number, it will be bumped up to reach this altitude above the launch point. Prevents low angle trajectory weirdness. Minimum range/2 is a decent starting point.
- `FinalBoostAngle`: Angle in degrees the missile will aim to be at when it reaches the highest point of its trajectory. 0 degrees (horizontal) is a reasonable choice, can be tweaked to achieve a more parabolic-esque flight path.

The new SemiBallisticComponent in DefaultProjectiles.lua is not terribly well optimized yet in terms of redundant information gathering function calls (target:GetPosition, projectile:GetVelocity, etc.). This can be addressed with an update function at the beginning of each flight phase, when the time comes.
