### PR TITLE
AI - State Machine implementation

### DIFF
--- a/lua/AI/AIBuilders/AIDefenseBuilders.lua
+++ b/lua/AI/AIBuilders/AIDefenseBuilders.lua
@@ -39,7 +39,7 @@ BuilderGroup {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 10, categories.DEFENSE}},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 1, categories.DEFENSE } },
             { UCBC, 'UnitCapCheckLess', { .9 } },
         },
@@ -93,7 +93,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 6, categories.DEFENSE * categories.TECH2 }},
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, categories.ENERGYPRODUCTION * categories.TECH2 }},
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 1, categories.DEFENSE } },
@@ -192,7 +192,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 2, categories.ARTILLERY * categories.TECH2 * categories.STRUCTURE }},
             { UCBC, 'CheckUnitRange', { 'LocationType', 'T2Artillery', categories.STRUCTURE + (categories.LAND * (categories.TECH2 + categories.TECH3)) } },
             { UCBC, 'UnitCapCheckLess', { .8 } },
@@ -214,7 +214,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiency', { 0.9, 1.2}},
+            { EBC, 'GreaterThanEconEfficiency', { 1.05, 1.2}},
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 1, categories.TACTICALMISSILEPLATFORM}},
             { UCBC, 'CheckUnitRange', { 'LocationType', 'T2StrategicMissile', categories.STRUCTURE + (categories.LAND * (categories.TECH2 + categories.TECH3)) } },
         },
@@ -262,7 +262,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.1 }}, --DUNCAN - was 0.9, 1.2
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.1 }}, --DUNCAN - was 0.9, 1.2
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 10, categories.DEFENSE * categories.TECH3 * categories.ANTIAIR * categories.STRUCTURE}},
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, categories.ENERGYPRODUCTION * categories.TECH3 } },
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 1, categories.DEFENSE * categories.TECH3 * categories.ANTIAIR * categories.STRUCTURE } },
@@ -291,7 +291,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, categories.ENERGYPRODUCTION * categories.TECH3 } },
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 2, categories.DEFENSE * categories.TECH3 * categories.DIRECTFIRE }},
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 1, categories.DEFENSE } },
@@ -316,7 +316,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiency', { 0.9, 1.2}},
+            { EBC, 'GreaterThanEconEfficiency', { 1.05, 1.2}},
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 2, categories.TACTICALMISSILEPLATFORM}},
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, categories.ENERGYPRODUCTION * categories.TECH3 } },
         },
@@ -344,7 +344,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 20, categories.DEFENSE * categories.TECH1}},
         },
         BuilderType = 'Any',
@@ -374,7 +374,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 30, categories.DEFENSE * categories.TECH2}},
         },
         BuilderType = 'Any',
@@ -406,7 +406,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 30, categories.DEFENSE * categories.TECH3}},
         },
         BuilderType = 'Any',
@@ -438,7 +438,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'DefensivePointNeedsStructure', { 'LocationType', 150, 'DEFENSE', 20,        5,     0,   1,   2, 'AntiSurface' } },
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 2, categories.DEFENSE } },
             { UCBC, 'UnitCapCheckLess', { .75 } },
@@ -479,7 +479,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'DefensivePointNeedsStructure', { 'LocationType', 150, 'DEFENSE TECH2, DEFENSE TECH3', 20, 5, 0, 1, 2, 'AntiSurface' } },
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 2, categories.DEFENSE } },
             { UCBC, 'UnitCapCheckLess', { .75 } },
@@ -520,7 +520,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'DefensivePointNeedsStructure', { 'LocationType', 150, 'DEFENSE TECH3 DIRECTFIRE', 20, 2, 0, 1, 2, 'AntiSurface' } },
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 2, categories.DEFENSE } },
             { UCBC, 'UnitCapCheckLess', { .75 } },
@@ -560,7 +560,7 @@ BuilderGroup {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
             { UCBC, 'DefensivePointNeedsStructure', { 'LocationType', 150, 'DEFENSE', 20,        3,     0,   1,   2, 'AntiSurface' } },
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 2, categories.DEFENSE } },
             { UCBC, 'UnitCapCheckLess', { .8 } },
         },
@@ -600,7 +600,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
             { UCBC, 'DefensivePointNeedsStructure', { 'LocationType', 150, 'DEFENSE TECH2, DEFENSE TECH3', 20, 3, 0, 1, 2, 'AntiSurface' } },
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 2, categories.DEFENSE } },
             { UCBC, 'UnitCapCheckLess', { .8 } },
@@ -681,7 +681,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 2, categories.DEFENSE * categories.TECH1 * categories.ANTINAVY }},
             { UCBC, 'NavalDefensivePointNeedsStructure', { 'LocationType', 75, 'DEFENSE TECH1 ANTINAVY', 20, 2, 0, 1, 2, 'AntiSurface' } },
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 1, categories.DEFENSE } },
@@ -716,7 +716,7 @@ BuilderGroup {
             { TBC, 'EnemyThreatGreaterThanValueAtBase', { 'LocationType', 5, 'Air' } },
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'NavalDefensivePointNeedsStructure', { 'LocationType', 75, 'DEFENSE TECH1 ANTIAIR', 20, 2, 0, 1, 2, 'AntiSurface' } },
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 1, categories.DEFENSE } },
             { UCBC, 'UnitCapCheckLess', { .7 } },
@@ -754,7 +754,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 2, categories.DEFENSE * categories.TECH2 * categories.ANTINAVY }},
             { UCBC, 'NavalDefensivePointNeedsStructure', { 'LocationType', 75, 'DEFENSE TECH2 ANTINAVY', 20, 2, 0, 1, 2, 'AntiSurface' } },
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 1, categories.DEFENSE } },
@@ -789,7 +789,7 @@ BuilderGroup {
             { TBC, 'EnemyThreatGreaterThanValueAtBase', { 'LocationType', 5, 'Air' } },
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'NavalDefensivePointNeedsStructure', { 'LocationType', 75, 'DEFENSE TECH2 ANTIAIR', 20, 2, 0, 1, 2, 'AntiSurface' } },
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 1, categories.DEFENSE } },
             { UCBC, 'UnitCapCheckLess', { .7 } },
@@ -827,7 +827,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 1, categories.DEFENSE * categories.TECH3 * categories.ANTINAVY }},
             { UCBC, 'NavalDefensivePointNeedsStructure', { 'LocationType', 75, 'DEFENSE TECH3 ANTIAIR', 20, 2, 0, 1, 2, 'AntiSurface' } },
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 1, categories.DEFENSE } },
@@ -862,7 +862,7 @@ BuilderGroup {
             { TBC, 'EnemyThreatGreaterThanValueAtBase', { 'LocationType', 5, 'Air' } },
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.05, 1.2 }},
             { UCBC, 'NavalDefensivePointNeedsStructure', { 'LocationType', 75, 'DEFENSE TECH3 ANTIAIR', 20, 2, 0, 1, 2, 'AntiSurface' } },
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 1, categories.DEFENSE } },
             { UCBC, 'UnitCapCheckLess', { .7 } },
@@ -901,7 +901,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
-            { EBC, 'GreaterThanEconEfficiency', { 0.8, 1.4 } },
+            { EBC, 'GreaterThanEconEfficiency', { 0.85, 1.4 } },
             { UCBC, 'HaveLessThanUnitsWithCategory', { 7, categories.SHIELD * categories.STRUCTURE}}, --DUNCAN - Added Sructure
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 0, categories.DEFENSE * categories.TECH2}}, --DUNCAN - Added
             { UCBC, 'LocationEngineersBuildingLess', { 'LocationType', 1, categories.SHIELD } },
@@ -1016,7 +1016,7 @@ BuilderGroup {
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 4, categories.ENGINEER * categories.TECH3}}, --DUNCAN - was 8
             { UCBC, 'UnitsLessAtLocation', { 'LocationType', 8, categories.SHIELD * categories.STRUCTURE}}, --DUNCAN - Added Sructure
             { MIBC, 'FactionIndex', {1, 2, 4}},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.1 }}, --DUNCAN - was 0.9, 1.4
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.85, 1.1 }}, --DUNCAN - was 0.9, 1.4
             { IBC, 'BrainNotLowPowerMode', {} },
             --{ UCBC, 'UnitCapCheckLess', { .8 } },
         },
@@ -1051,7 +1051,7 @@ BuilderGroup {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanMassStorageCurrent', { 150 }},
             { EBC, 'GreaterThanEconIncomeOverTime', { 2.5, 100}},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.9, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 1.0, 1.2 }},
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 1, categories.ANTIMISSILE * categories.TECH3}}, --DUNCAN - Added
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 5, categories.ENGINEER * categories.TECH3}},
             { UCBC, 'HaveGreaterThanUnitsWithCategory', { 1, categories.ENERGYPRODUCTION * categories.TECH3 } }, --DUNCAN - Added

--- a/lua/AI/AIBuilders/AIEconomicBuilders.lua
+++ b/lua/AI/AIBuilders/AIEconomicBuilders.lua
@@ -595,7 +595,7 @@ BuilderGroup {
         Priority = 875,
         BuilderConditions = {
             { EBC, 'GreaterThanEconEfficiencyCombined', { 0.5, 0.5 }}, --DUNCAN - was 0.8 mass check
-            { EBC, 'LessThanEconEfficiencyOverTime', { 2.0, 1.3 }},
+            { EBC, 'LessThanEnergyTrendOverTime', { 10.0 } },
             { UCBC, 'EngineerLessAtLocation', { 'LocationType', 1, categories.ENGINEER * ( categories.TECH2 + categories.TECH3 ) } },
         },
         BuilderType = 'Any',
@@ -1327,7 +1327,7 @@ BuilderGroup {
     },
     Builder {
         BuilderName = 'T1 Engineer Reclaim',
-        PlatoonTemplate = 'T1EngineerGridReclaimer',
+        PlatoonTemplate = 'StateMachineEngineerT1',
         Priority = 1000,
         InstanceCount = 2,
         BuilderConditions = {
@@ -1337,12 +1337,13 @@ BuilderGroup {
         BuilderData = {
             LocationType = 'LocationType',
             SearchType   = 'MAIN',
+            StateMachine = 'AIPlatoonAdaptiveReclaimBehavior',
         },
         BuilderType = 'Any',
     },
     Builder {
         BuilderName = 'T1 Engineer Reclaim Excess',
-        PlatoonTemplate = 'T1EngineerGridReclaimer',
+        PlatoonTemplate = 'StateMachineEngineerT1',
         Priority = 3, --DUNCAN - was 1
         InstanceCount = 10,
         BuilderConditions = {
@@ -1351,6 +1352,7 @@ BuilderGroup {
             },
         BuilderData = {
             LocationType = 'LocationType',
+            StateMachine = 'AIPlatoonAdaptiveReclaimBehavior',
         },
         BuilderType = 'Any',
     },
@@ -1607,16 +1609,17 @@ BuilderGroup {
     },
     Builder {
         BuilderName = 'T2 Engineer Reclaim Excess',
-        PlatoonTemplate = 'T2EngineerGridReclaimer',
+        PlatoonTemplate = 'StateMachineEngineerT2',
         Priority = 2, --DUNCAN - was 1
         InstanceCount = 10,
         BuilderConditions = {
-                { EBC, 'LessThanEconStorageRatio', { 0.75, 2.0}},
+                { EBC, 'LessThanEconStorageRatio', { 0.50, 2.0}},
                 { MIBC, 'ReclaimAvailableInGrid', { 'LocationType', true}},
             },
         BuilderData = {
             LocationType = 'LocationType',
             ReclaimTime = 30,
+            StateMachine = 'AIPlatoonAdaptiveReclaimBehavior',
         },
         BuilderType = 'Any',
     },
@@ -1761,16 +1764,17 @@ BuilderGroup {
     -- =========================
     Builder {
         BuilderName = 'T3 Engineer Reclaim Excess',
-        PlatoonTemplate = 'T3EngineerGridReclaimer',
+        PlatoonTemplate = 'StateMachineEngineerT3',
         Priority = 0, --DUNCAN - was 1
         InstanceCount = 2, --DUNCAN - was 10
         BuilderConditions = {
-            { EBC, 'LessThanEconStorageRatio', { 0.75, 2.0}},
+            { EBC, 'LessThanEconStorageRatio', { 0.35, 2.0}},
             { MIBC, 'ReclaimAvailableInGrid', { 'LocationType', true}},
         },
         BuilderData = {
             LocationType = 'LocationType',
             ReclaimTime = 10,
+            StateMachine = 'AIPlatoonAdaptiveReclaimBehavior',
         },
         BuilderType = 'Any',
     },
@@ -2554,7 +2558,7 @@ BuilderGroup {
         InstanceCount = 1,
         BuilderConditions = {
             { EBC, 'GreaterThanEconEfficiencyCombined', { 0.6, 0.1 }},
-            { EBC, 'LessThanEnergyTrendOverTime', { 10.0 } },
+            { EBC, 'LessThanEnergyTrendOverTime', { 15.0 } },
             { UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.ENERGYPRODUCTION * (categories.TECH2 + categories.TECH3) }},
         },
         BuilderType = 'Any',
@@ -2573,7 +2577,7 @@ BuilderGroup {
         Priority = 1000,
         InstanceCount = 1,
         BuilderConditions = {
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.7, 0.1 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.75, 0.1 }},
             { EBC, 'LessThanEnergyTrendOverTime', { 25.0 } },
             { UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.ENERGYPRODUCTION * (categories.TECH2 + categories.TECH3) }},
         },

--- a/lua/AI/AIBuilders/AIEconomyUpgradeBuilders.lua
+++ b/lua/AI/AIBuilders/AIEconomyUpgradeBuilders.lua
@@ -129,12 +129,12 @@ BuilderGroup {
     Builder {
         BuilderName = 'T2 Mass Extractor Upgrade Timeless Multiple Expansion',
         PlatoonTemplate = 'T2MassExtractorUpgrade',
-        InstanceCount = 4,
+        InstanceCount = 3,
         Priority = 200,
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanEconIncomeOverTime',  { 35, 10}},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.6, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.2 }},
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 3, categories.MASSEXTRACTION } },
             { UCBC, 'UnitsGreaterAtLocation', { 'MAIN', 3, categories.MASSEXTRACTION * categories.TECH3 } },
         },
@@ -184,7 +184,7 @@ BuilderGroup {
         BuilderConditions = {
             { IBC, 'BrainNotLowPowerMode', {} },
             { EBC, 'GreaterThanEconIncomeOverTime',  { 15, 10}},
-            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.6, 1.2 }},
+            { EBC, 'GreaterThanEconEfficiencyCombined', { 0.8, 1.2 }},
             { UCBC, 'HaveLessThanUnitsInCategoryBeingBuilt', { 4, categories.MASSEXTRACTION } },
         },
         FormRadius = 10000,

--- a/lua/AI/AIBuilders/AILandAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AILandAttackBuilders.lua
@@ -120,7 +120,7 @@ BuilderGroup {
     Builder {
         BuilderName = 'T1 Mortar',
         PlatoonTemplate = 'T1LandArtillery',
-        Priority = 830,
+        Priority = 825,
         BuilderConditions = {
             { UCBC, 'HaveLessThanUnitsWithCategory', { 150, categories.MOBILE * categories.LAND * categories.TECH1 - categories.ENGINEER - categories.ANTIAIR } },
             --{ UCBC, 'LocationFactoriesBuildingLess', { 'LocationType', 1, 'INDIRECTFIRE LAND MOBILE' } },
@@ -807,7 +807,7 @@ BuilderGroup {
     -- Hunts for mass locations with Economic threat value of no more than 2 mass extractors
     Builder {
         BuilderName = 'Mass Hunter Early Game',
-        PlatoonTemplate = 'T1MassHuntersCategory',
+        PlatoonTemplate = 'StateMachinePlatoon',
         -- Commented out as the platoon doesn't exist in AILandAttackBuilders.lua
         --PlatoonTemplate = 'EarlyGameMassHuntersCategory',
         Priority = 950,
@@ -817,6 +817,7 @@ BuilderGroup {
                 --{ UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.TECH2 * categories.MOBILE * categories.LAND - categories.ENGINEER } },
             },
         BuilderData = {
+            StateMachine = 'AIPlatoonAdaptiveRaidBehavior',
             MarkerType = 'Mass',
             MoveFirst = 'Random',
             MoveNext = 'Threat',
@@ -838,7 +839,7 @@ BuilderGroup {
     -- Used after 10, goes after mass locations of no max threat
     Builder {
         BuilderName = 'Mass Hunter Mid Game',
-        PlatoonTemplate = 'T2MassHuntersCategory',
+        PlatoonTemplate = 'StateMachinePlatoon',
         Priority = 950,
         BuilderConditions = {
                 { MIBC, 'MapCheck', { 'Seton\'s Clutch', false } },
@@ -846,6 +847,7 @@ BuilderGroup {
                 --{ UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.TECH2 * categories.MOBILE * categories.LAND - categories.ENGINEER } },
             },
         BuilderData = {
+            StateMachine = 'AIPlatoonAdaptiveRaidBehavior',
             MarkerType = 'Mass',
             MoveFirst = 'Random',
             MoveNext = 'Threat',
@@ -870,7 +872,7 @@ BuilderGroup {
     -- Also the platoon carries an engineer with it
     Builder {
         BuilderName = 'Start Location Attack',
-        PlatoonTemplate = 'StartLocationAttack',
+        PlatoonTemplate = 'StateMachinePlatoon',
         Priority = 1000, --DUNCAN - was 960
         BuilderConditions = {
                 { MIBC, 'MapCheck', { 'Seton\'s Clutch', false } },
@@ -879,6 +881,7 @@ BuilderGroup {
                 --{ UCBC, 'HaveLessThanUnitsWithCategory', { 1, categories.TECH2 * categories.MOBILE * categories.LAND - categories.ENGINEER } },
             },
         BuilderData = {
+            StateMachine = 'AIPlatoonAdaptiveRaidBehavior',
             MarkerType = 'Start Location',
             MoveFirst = 'Closest',
             MoveNext = 'None', --DUNCAN - was guard base
@@ -959,17 +962,14 @@ BuilderGroup {
     -- Seek and destroy
     Builder {
         BuilderName = 'T1 Hunters',
-        PlatoonTemplate = 'HuntAttackSmall',
+        PlatoonTemplate = 'StateMachinePlatoon',
         Priority = 990,
         InstanceCount = 2,
         BuilderType = 'Any',
         BuilderData = {
             NeverGuardBases = true,
             NeverGuardEngineers = true,
-            --UseFormation = 'AttackFormation',
-            ThreatWeights = {
-                IgnoreStrongerTargetsRatio = 100.0,
-            },
+            StateMachine = 'AIPlatoonAdaptiveAttackBehavior',
         },
         BuilderConditions = {
             { MIBC, 'IsIsland', { false } }, --DUNCAN - added to stop units bunching on island maps
@@ -981,39 +981,33 @@ BuilderGroup {
     -- Seek and destroy
     Builder {
         BuilderName = 'T2 Hunters',
-        PlatoonTemplate = 'HuntAttackMedium',
+        PlatoonTemplate = 'StateMachinePlatoon',
         Priority = 990,
         InstanceCount = 2,
         BuilderType = 'Any',
         BuilderData = {
             NeverGuardBases = true,
             NeverGuardEngineers = true,
-            --UseFormation = 'AttackFormation',
-            ThreatWeights = {
-                IgnoreStrongerTargetsRatio = 100.0,
-            },
+            StateMachine = 'AIPlatoonAdaptiveAttackBehavior',
         },
         BuilderConditions = {
             { MIBC, 'IsIsland', { false } }, --DUNCAN - added to stop units bunching on island maps
             { UCBC, 'PoolLessAtLocation', { 'LocationType', 1, categories.MOBILE * categories.LAND - categories.ENGINEER - categories.TECH1 } },
-            { LandAttackCondition, { 'LocationType', 15 } },
+            { LandAttackCondition, { 'LocationType', 20 } },
         },
     },
 
     -- Seek and destroy
     Builder {
         BuilderName = 'T1 LAB Hunters',
-        PlatoonTemplate = 'LABAttack',
+        PlatoonTemplate = 'StateMachinePlatoon',
         Priority = 1000,
         InstanceCount = 4,
         BuilderType = 'Any',
         BuilderData = {
             NeverGuardBases = true,
             NeverGuardEngineers = true,
-            --UseFormation = 'AttackFormation',
-            ThreatWeights = {
-                IgnoreStrongerTargetsRatio = 100.0,
-            },
+            StateMachine = 'AIPlatoonAdaptiveAttackBehavior',
         },
         BuilderConditions = {
             { MIBC, 'IsIsland', { false } }, --DUNCAN - added to stop units bunching on island maps

--- a/lua/AI/PlatoonTemplates/EngineerPlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/EngineerPlatoonTemplates.lua
@@ -154,6 +154,30 @@ PlatoonTemplate {
     },
 }
 
+PlatoonTemplate {
+    Name = 'StateMachineEngineerT1',
+    Plan = 'StateMachineAI',
+    GlobalSquads = {
+        { categories.ENGINEER * categories.TECH1 - categories.COMMAND, 1, 1, 'support', 'None' },
+    },
+}
+
+PlatoonTemplate {
+    Name = 'StateMachineEngineerT2',
+    Plan = 'StateMachineAI',
+    GlobalSquads = {
+        { categories.ENGINEER * categories.TECH2 - categories.COMMAND, 1, 1, 'support', 'None' },
+    },
+}
+
+PlatoonTemplate {
+    Name = 'StateMachineEngineerT3',
+    Plan = 'StateMachineAI',
+    GlobalSquads = {
+        { categories.ENGINEER * categories.TECH3 - categories.COMMAND, 1, 1, 'support', 'None' },
+    },
+}
+
 -- Factory built Engineers below
 
 PlatoonTemplate {

--- a/lua/AI/PlatoonTemplates/LandPlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/LandPlatoonTemplates.lua
@@ -184,7 +184,15 @@ PlatoonTemplate {
     },
 }
 
+PlatoonTemplate {
+    Name = 'StateMachinePlatoon',
+    Plan = 'StateMachineAI',
+    GlobalSquads = {
+        { categories.DIRECTFIRE * categories.LAND * categories.MOBILE - categories.SCOUT - categories.ENGINEER, 2, 15, 'Attack', 'None' },
+        { categories.LAND * categories.MOBILE * categories.SCOUT, 1, 2, 'Scout', 'None' }
+    },
 
+}
 -- ==== Factional Templates ==== --
 
 -- T1

--- a/lua/AI/Transportutilities.lua
+++ b/lua/AI/Transportutilities.lua
@@ -1196,6 +1196,9 @@ function SendPlatoonWithTransports(aiBrain, platoon, destination, attempts, bSki
 		-- we stay in this function until we load, move and arrive or die
 		-- we'll get a false return if then entire unit platoon cannot be transported
 		-- note how we pass the IsEngineer flag -- alters the behaviour of the transport
+		if platoon.LogDebug then
+			platoon:LogDebug(string.format('Raid Platoon using transports'))
+		end
 		bUsedTransports = UseTransports( aiBrain, transportplatoon, transportLocation, platoon, IsEngineer )
 
 		-- if platoon died or we couldn't use transports -- exit
@@ -1224,7 +1227,11 @@ function SendPlatoonWithTransports(aiBrain, platoon, destination, attempts, bSki
 				v:MarkWeaponsOnTransport(v, false)
 			end
 		end
-		
+
+		if platoon.LogDebug then
+			platoon:LogDebug(string.format('Raid Platoon getting commands post drop off'))
+		end
+
 		-- set path to destination if we landed anywhere else but the destination
 		-- All platoons except engineers (which move themselves) get this behavior
 		if (not IsEngineer) and GetPlatoonPosition(platoon) != destination then
@@ -1245,7 +1252,9 @@ function SendPlatoonWithTransports(aiBrain, platoon, destination, attempts, bSki
 			end
 		end
 	end
-    
+    if platoon.LogDebug then
+		platoon:LogDebug(string.format('Raid Platoon existing transport function'))
+	end
 	return PlatoonExists( aiBrain, platoon )
     
 end

--- a/lua/AI/aiattackutilities.lua
+++ b/lua/AI/aiattackutilities.lua
@@ -1521,6 +1521,31 @@ function AIFindUnitRadiusThreat(aiBrain, alliance, priTable, position, radius, t
     end
 end
 
+GetSurfaceThreatAtPosition = function(aiBrain, position, range )
+                
+    local IMAPblocks = aiBrain.IMAPConfig.Rings or 1
+    local TESTUNITS = categories.ALLUNITS - categories.FACTORY - categories.ECONOMIC - categories.SHIELD - categories.WALL
+    local sfake = aiBrain:GetThreatAtPosition(position, IMAPblocks, true, 'AntiSurface' )
+    surthreat = 0
+    local eunits = aiBrain:GetUnitsAroundPoint(TESTUNITS, position, range,  'Enemy')
+    if eunits then
+        for _,u in eunits do
+            if not u.Dead then
+                Defense = u.Blueprint.Defense
+                surthreat = surthreat + Defense.SurfaceThreatLevel
+            end
+        end
+    end
+    
+    -- if there is IMAP threat and it's greater than what we actually see
+    -- use the sum of both * .5
+    if sfake > 0 and sfake > surthreat then
+        surthreat = (surthreat + sfake) * .5
+    end
+    
+    return surthreat
+end
+
 --------------------------------------------------------------------------------------------------------------------------------------------------
 ----Below this line are Sorian AI exclusive functions added for sorian AI
 --------------------------------------------------------------------------------------------------------------------------------------------------

--- a/lua/AI/aiutilities.lua
+++ b/lua/AI/aiutilities.lua
@@ -3281,6 +3281,47 @@ function CanBuildOnLocalMassPoints(aiBrain, engPos, distance)
     end
 end
 
+---@param aiBrain AIBrain
+---@param engPos table
+---@param distance number
+---@return boolean
+---@return table
+function CanBuildOnGridMassPoints(aiBrain, engPos, distance, layer)
+    -- Checks if an engineer can build on mass points close to its location
+    -- will return a bool if it found anything and if it did then a table of mass markers
+    -- the BorderWarning is used to tell the AI that the mass marker is too close to the map border
+    local pointDistance = distance * distance
+    local depositsGrid = aiBrain.GridDeposits
+    if not depositsGrid then
+        WARN('GridDeposits class is not setup for AI')
+        return
+    end
+    local massMarkers = depositsGrid:GetResourcesWithinDistance('Mass', engPos, distance, layer)
+    local NavUtils = import("/lua/sim/navutils.lua")
+    local validMassMarkers = {}
+    for _, v in massMarkers do
+        if v.type == 'Mass' then
+            local massBorderWarn = false
+            if v.position[1] <= 8 or v.position[1] >= ScenarioInfo.size[1] - 8 or v.position[3] <= 8 or v.position[3] >= ScenarioInfo.size[2] - 8 then
+                massBorderWarn = true
+            end 
+            local mexDistance = VDist2Sq( v.position[1],v.position[3], engPos[1], engPos[3] )
+            if mexDistance < pointDistance and aiBrain:CanBuildStructureAt('ueb1103', v.position) and NavUtils.CanPathTo('Amphibious', engPos, v.position) then
+                table.insert(validMassMarkers, {Position = v.position, Distance = mexDistance , MassSpot = v, BorderWarning = massBorderWarn})
+            end
+        end
+    end
+    if table.getn(validMassMarkers) > 0 then
+        LOG('Close mass markers '..repr(validMassMarkers))
+    end
+    table.sort(validMassMarkers, function(a,b) return a.Distance < b.Distance end)
+    if table.getn(validMassMarkers) > 0 then
+        return true, validMassMarkers
+    else
+        return false
+    end
+end
+
 ---@param eng Unit
 ---@param minimumReclaim number
 ---@return boolean

--- a/lua/aibrains/adaptive-ai.lua
+++ b/lua/aibrains/adaptive-ai.lua
@@ -145,6 +145,7 @@ AIBrain = Class(StandardBrain, EconomyComponent) {
         self.GridReclaim = import("/lua/ai/gridreclaim.lua").Setup(self)
         self.GridBrain = import("/lua/ai/gridbrain.lua").Setup()
         self.GridRecon = import("/lua/ai/gridrecon.lua").Setup(self)
+        self.GridDeposits = import("/lua/ai/griddeposits.lua").Setup()
         self.GridPresence = import("/lua/AI/GridPresence.lua").Setup(self)
     end,
 

--- a/lua/aibrains/adaptive-ai.lua
+++ b/lua/aibrains/adaptive-ai.lua
@@ -1,0 +1,1624 @@
+local StandardBrain = import("/lua/aibrain.lua").AIBrain
+local EconomyComponent = import("/lua/aibrains/components/economy.lua").AIBrainEconomyComponent
+
+local AIUtils = import("/lua/ai/aiutilities.lua")
+
+local Utilities = import("/lua/utilities.lua")
+local ScenarioUtils = import("/lua/sim/scenarioutilities.lua")
+
+local FactoryManager = import("/lua/sim/factorybuildermanager.lua")
+local PlatoonFormManager = import("/lua/sim/platoonformmanager.lua")
+local BrainConditionsMonitor = import("/lua/sim/brainconditionsmonitor.lua")
+local EngineerManager = import("/lua/sim/engineermanager.lua")
+
+local SUtils = import("/lua/ai/sorianutilities.lua")
+
+local TableGetn = table.getn
+
+---@class EasyAIBrainManagers
+---@field FactoryManager AIFactoryManager
+---@field EngineerManager AIEngineerManager
+---@field StructureManager AIStructureManager
+
+---@class TriggerSpec
+---@field Callback function
+---@field ReconTypes ReconTypes
+---@field Blip boolean
+---@field Value boolean
+---@field Category EntityCategory
+---@field OnceOnly boolean
+---@field TargetAIBrain AIBrain
+
+---@class EasyAIBrain: AIBrain, AIBrainEconomyComponent
+---@field GridReclaim AIGridReclaim
+---@field GridBrain AIGridBrain
+---@field GridRecon AIGridRecon
+---@field BuilderManagers table<LocationType, AIBase>
+
+---@class AIBrainAdaptive : AIBrain, AIBrainEconomyComponent
+---@field Army number
+---@field AIPlansList string[][]
+---@field AirAttackPoints? table
+---@field AttackData AttackManager
+---@field AttackManager AttackManager
+---@field AttackPoints? table
+---@field BaseMonitor AiBaseMonitor
+---@field BrainType BrainType
+---@field BuilderManagers table<string, table>
+---@field ConditionsMonitor BrainConditionsMonitor
+---@field CurrentPlan string lua file which contains plan
+---@field CurrentPlanScript table
+---@field EconomyCurrentTick number
+---@field EconomyData {EnergyIncome: number, EnergyRequested: number, MassIncome: number, MassRequested: number}[]
+---@field EnergyExcessThread thread
+---@field EnergyExcessUnitsEnabled table<EntityId, MassFabricationUnit>
+---@field EnergyExcessUnitsDisabled table<EntityId, MassFabricationUnit>
+---@field EnergyDependingUnits table<EntityId, Unit | Shield>
+---@field EnergyDepleted boolean
+---@field EconomyTicksMonitor number
+---@field HasPlatoonList boolean
+---@field IntelData? table<string, number>
+---@field IntelTriggerList table
+---@field LayerPref "LAND" | "AIR"
+---@field Name string
+---@field Radars table<string, Unit[]>
+---@field Result? AIResult
+---@field Sorian boolean
+---@field T4ThreatFound? table
+---@field TacticalBases? table
+---@field targetoveride boolean
+---@field GridReclaim AIGridReclaim
+---@field GridBrain AIGridBrain
+---@field Team number The team this brain's army belongs to. Note that games with unlocked teams behave like free-for-alls.
+---@field DelayEqualBuildPlattons table<string, number>     # Used to delay builders, the key is the builder name and the number is the game time in seconds that the builder remains delayed
+AIBrain = Class(StandardBrain, EconomyComponent) {
+
+    SkirmishSystems = true,
+
+    --- Called after `SetupSession` but before `BeginSession` - no initial units, props or resources exist at this point
+    ---@param self AIBrainAdaptive
+    ---@param planName string
+    OnCreateAI = function(self, planName)
+        EconomyComponent.OnCreateAI(self)
+        StandardBrain.OnCreateAI(self, planName)
+
+        local personality = ScenarioInfo.ArmySetup[self.Name].AIPersonality
+
+        local cheatPos = string.find(personality, 'cheat')
+        if cheatPos then
+            AIUtils.SetupCheat(self, true)
+            ScenarioInfo.ArmySetup[self.Name].AIPersonality = string.sub(personality, 1, cheatPos - 1)
+        end
+
+        LOG('* OnCreateAI: AIPersonality: ('..personality..')')
+
+        self.CurrentPlan = self.AIPlansList[self:GetFactionIndex()][1]
+        self.RepeatExecution = true
+        self:ForkThread(self.InitialAIThread)
+        self.IntelData = {
+            ScoutCounter = 0,
+        }
+
+        -- Flag enemy starting locations with threat?
+        if ScenarioInfo.type == 'skirmish' then
+            self:AddInitialEnemyThreat(200, 0.005)
+        end
+
+        self.UnitBuiltTriggerList = {}
+        self.FactoryAssistList = {}
+        self.DelayEqualBuildPlattons = {}
+
+        self:ForkThread(self.GetPlatoonDebugInfoThread)
+    end,
+
+    --- Called after `SetupSession` but before `BeginSession` - no initial units, props or resources exist at this point
+    ---@param self AIBrainAdaptive
+    ---@param planName string
+    CreateBrainShared = function(self, planName)
+        StandardBrain.CreateBrainShared(self, planName)
+
+        local aiScenarioPlans = self:ImportScenarioArmyPlans(planName)
+        if aiScenarioPlans then
+            self.AIPlansList = aiScenarioPlans
+        else
+            self.DefaultPlan = true
+            self.AIPlansList = import("/lua/aibrainplans.lua").AIPlansList
+        end
+
+        self.RepeatExecution = false
+        self.ConstantEval = true
+    end,
+
+    --- Called after `BeginSession`, at this point all props, resources and initial units exist in the map
+    ---@param self AIBrainAdaptive
+    OnBeginSession = function(self)
+        StandardBrain.OnBeginSession(self)
+
+        -- requires navigational mesh
+        import("/lua/sim/NavUtils.lua").Generate()
+
+        -- requires these markers to exist
+        import("/lua/sim/MarkerUtilities.lua").GenerateExpansionMarkers()
+        import("/lua/sim/MarkerUtilities.lua").GenerateRallyPointMarkers()
+
+        -- requires these datastructures to understand the game
+        self.GridReclaim = import("/lua/ai/gridreclaim.lua").Setup(self)
+        self.GridBrain = import("/lua/ai/gridbrain.lua").Setup()
+        self.GridRecon = import("/lua/ai/gridrecon.lua").Setup(self)
+        self.GridPresence = import("/lua/AI/GridPresence.lua").Setup(self)
+    end,
+
+    ---@param self AIBrainAdaptive
+    OnDestroy = function(self)
+        StandardBrain.OnDestroy(self)
+
+        if self.BuilderManagers then
+            self.ConditionsMonitor:Destroy()
+            for _, v in self.BuilderManagers do
+
+                v.EngineerManager:SetEnabled(false)
+                v.FactoryManager:SetEnabled(false)
+                v.PlatoonFormManager:SetEnabled(false)
+                v.FactoryManager:Destroy()
+                v.PlatoonFormManager:Destroy()
+                v.EngineerManager:Destroy()
+            end
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param planName FileName
+    ---@return string[]|nil
+    ImportScenarioArmyPlans = function(self, planName)
+        if planName and planName ~= '' then
+            return import(planName).AIPlansList
+        else
+            return nil
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    InitialAIThread = function(self)
+        -- delay the AI so it can't reclaim the start area before it's cleared from the ACU landing blast.
+        WaitTicks(30)
+        self.EvaluateThread = self:ForkThread(self.EvaluateAIThread)
+        self.ExecuteThread = self:ForkThread(self.ExecuteAIThread)
+    end,
+
+    ---@param self AIBrainAdaptive
+    EvaluateAIThread = function(self)
+        local personality = self:GetPersonality()
+        local factionIndex = self:GetFactionIndex()
+
+        if not self.LayerPref then
+            self:CalculateLayerPreference()
+        end
+
+        while self.ConstantEval do
+            self:EvaluateAIPlanList()
+            local delay = personality:AdjustDelay(100, 2)
+            WaitTicks(delay)
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    EvaluateAIPlanList = function(self)
+        local factionIndex = self:GetFactionIndex()
+        local bestPlan = nil
+        local bestValue = 0
+        for _, v in self.AIPlansList[factionIndex] do
+            local value = self:EvaluatePlan(v)
+            if value > bestValue then
+                bestPlan = v
+                bestValue = value
+            end
+        end
+        if bestPlan then
+            self:SetCurrentPlan(bestPlan)
+            local bPlan = import(bestPlan)
+            if bPlan ~= self.CurrentPlanScript then
+                self.CurrentPlanScript = import(bestPlan)
+                self:SetRepeatExecution(true)
+                self:ExecutePlan(self.CurrentPlan)
+            end
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ExecuteAIThread = function(self)
+        local personality = self:GetPersonality()
+
+        while true do
+            if self.CurrentPlan and self.RepeatExecution then
+                self:ExecutePlan(self.CurrentPlan)
+            end
+            local delay = personality:AdjustDelay(20, 4)
+            WaitTicks(delay)
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param planName FileName
+    ---@return number
+    EvaluatePlan = function(self, planName)
+        local plan = import(planName)
+        if plan then
+            return plan.EvaluatePlan(self)
+        else
+            LOG('*WARNING: TRIED TO IMPORT PLAN NAME ', repr(planName), ' BUT IT ERRORED OUT IN THE AI BRAIN.')
+            return 0
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ExecutePlan = function(self)
+        self.CurrentPlanScript.ExecutePlan(self)
+    end,
+
+    ---@param self AIBrainAdaptive
+    SetRepeatExecution = function(self, repeatEx)
+        self.RepeatExecution = repeatEx
+    end,
+
+    ---@param self AIBrainAdaptive
+    GetCurrentPlanScript = function(self)
+        return self.CurrentPlanScript
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param bestPlan string
+    SetCurrentPlan = function(self, bestPlan)
+        if not bestPlan then
+            self.CurrentPlan = self.AIPlansList[self:GetFactionIndex()][1]
+        else
+            self.CurrentPlan = bestPlan
+        end
+        if not self.CurrentPlan then
+            error('*AI ERROR: Invalid plan list for army - '..self.Name, 2)
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    CalculateLayerPreference = function(self)
+        local personality = self:GetPersonality()
+        local factionIndex = self:GetFactionIndex()
+
+        -- SET WHAT THE AI'S LAYER PREFERENCE IS
+        local airpref = personality:GetAirUnitsEmphasis() * 100
+        local tankpref = personality:GetTankUnitsEmphasis() * 100
+        local botpref = personality:GetBotUnitsEmphasis() * 100
+        local seapref = personality:GetSeaUnitsEmphasis() * 100
+        local landpref = tankpref
+        if tankpref < botpref then
+            landpref = botpref
+        end
+
+        -- SEA PREF COMMENTED OUT FOR NOW
+        local totalpref = landpref + airpref  + seapref
+        totalpref = totalpref
+        local random = Random(0, totalpref)
+        if random < landpref then
+            self.LayerPref = 'LAND'
+        elseif random < (landpref + airpref) then
+            self.LayerPref = 'AIR'
+        else
+            self.LayerPref = 'LAND'
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param loc Vector
+    ---@return Vector | false
+    PBMGetLocationCoords = function(self, loc)
+        if not loc then
+            return false
+        end
+        if self.HasPlatoonList then
+            for _, v in self.PBM.Locations do
+                if v.LocationType == loc then
+                    local height = GetTerrainHeight(v.Location[1], v.Location[3])
+                    if GetSurfaceHeight(v.Location[1], v.Location[3]) > height then
+                        height = GetSurfaceHeight(v.Location[1], v.Location[3])
+                    end
+                    return {v.Location[1], height, v.Location[3]}
+                end
+            end
+        elseif self.BuilderManagers[loc] then
+            return self.BuilderManagers[loc].FactoryManager:GetLocationCoords()
+        end
+        return false
+    end,
+
+    ---SKIRMISH AI HELPER SYSTEMS
+    ---@param self AIBrainAdaptive
+    InitializeSkirmishSystems = function(self)
+        -- Make sure we don't do anything for the human player!!!
+        if self.BrainType == 'Human' then
+            return
+        end
+        LOG('Initialize Skirmish for '..self.Nickname)
+
+        -- TURNING OFF AI POOL PLATOON, I MAY JUST REMOVE THAT PLATOON FUNCTIONALITY LATER
+        local poolPlatoon = self:GetPlatoonUniquelyNamed('ArmyPool')
+        if poolPlatoon then
+            poolPlatoon.ArmyPool = true
+            poolPlatoon:TurnOffPoolAI()
+        end
+
+        -- Stores handles to all builders for quick iteration and updates to all
+        self.BuilderHandles = {}
+
+        -- Condition monitor for the whole brain
+        self.ConditionsMonitor = BrainConditionsMonitor.CreateConditionsMonitor(self)
+
+        -- Economy monitor for new skirmish - stores out econ over time to get trend over 10 seconds
+        self.LowEnergyMode = false
+
+        -- Add default main location and setup the builder managers
+        self.NumBases = 0 -- AddBuilderManagers will increase the number
+        
+        -- Set the map center point
+        self.MapCenterPoint = { (ScenarioInfo.size[1] / 2), GetSurfaceHeight((ScenarioInfo.size[1] / 2), (ScenarioInfo.size[2] / 2)) ,(ScenarioInfo.size[2] / 2) }
+
+        self.BuilderManagers = {}
+        SUtils.AddCustomUnitSupport(self)
+        self:AddBuilderManagers(self:GetStartVector3f(), 100, 'MAIN', false)
+
+        -- Begin the base monitor process
+        self:BaseMonitorInitialization()
+        local plat = self:GetPlatoonUniquelyNamed('ArmyPool')
+        plat:ForkThread(plat.BaseManagersDistressAI)
+        self.DeadBaseThread = self:ForkThread(self.DeadBaseMonitor)
+        self.EnemyPickerThread = self:ForkThread(self.PickEnemy)
+
+        
+        self.IMAPConfig = {
+            OgridRadius = 0,
+            IMAPSize = 0,
+            Rings = 0,
+        }
+
+        self:IMAPConfiguration()
+        self:ForkThread(self.MapAnalysis)
+    end,
+
+    ---Removes bases that have no engineers or factories.  This is a sorian AI function
+    ---Helps reduce the load on the game.
+    ---@param self AIBrainAdaptive
+    DeadBaseMonitor = function(self)
+        while true do
+            WaitSeconds(5)
+            local needSort = false
+            for k, v in self.BuilderManagers do
+                if k ~= 'MAIN' and v.EngineerManager:GetNumCategoryUnits('Engineers', categories.ALLUNITS) <= 0 and v.FactoryManager:GetNumCategoryFactories(categories.ALLUNITS) <= 0 then
+                    v.EngineerManager:SetEnabled(false)
+                    v.EngineerManager:Destroy()
+                    v.FactoryManager:SetEnabled(false)
+                    v.FactoryManager:Destroy()
+                    v.PlatoonFormManager:SetEnabled(false)
+                    v.PlatoonFormManager:Destroy()
+                    self.BuilderManagers[k] = nil
+                    self.NumBases = self.NumBases - 1
+                    needSort = true
+                end
+            end
+            if needSort then
+                self.BuilderManagers = self:RebuildTable(self.BuilderManagers)
+            end
+        end
+    end,
+
+    ---Used to get rid of nil table entries. Sorian ai function
+    ---@param self AIBrainAdaptive
+    ---@param oldtable table
+    ---@return table
+    RebuildTable = function(self, oldtable)
+        local temptable = {}
+        for k, v in oldtable do
+            if v ~= nil then
+                if type(k) == 'string' then
+                    temptable[k] = v
+                else
+                    table.insert(temptable, v)
+                end
+            end
+        end
+        return temptable
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param locationType string
+    ---@return boolean
+    GetLocationPosition = function(self, locationType)
+        if not self.BuilderManagers[locationType] then
+            WARN('*AI ERROR: Invalid location type - ' .. locationType)
+            return false
+        end
+        return self.BuilderManagers[locationType].Position
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param position Vector
+    ---@return Vector
+    FindClosestBuilderManagerPosition = function(self, position)
+        local distance, closest
+        for k, v in self.BuilderManagers do
+            if v.EngineerManager and v.EngineerManager:GetNumCategoryUnits('Engineers', categories.ALLUNITS) > 0
+            and v.FactoryManager and v.FactoryManager:GetNumCategoryFactories(categories.ALLUNITS) > 0 then
+                if position and v.Position then
+                    if not closest then
+                        distance = VDist3(position, v.Position)
+                        closest = v.Position
+                    else
+                        local tempDist = VDist3(position, v.Position)
+                        if tempDist < distance then
+                            distance = tempDist
+                            closest = v.Position
+                        end
+                    end
+                end
+            end
+        end
+        return closest
+    end,
+
+    ---@param self AIBrainAdaptive
+    ForceManagerSort = function(self)
+        for _, v in self.BuilderManagers do
+            v.EngineerManager:SortBuilderList('Any')
+            v.FactoryManager:SortBuilderList('Land')
+            v.FactoryManager:SortBuilderList('Air')
+            v.FactoryManager:SortBuilderList('Sea')
+            v.PlatoonFormManager:SortBuilderList('Any')
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param type string
+    ---@return integer
+    GetManagerCount = function(self, type)
+        local count = 0
+        for k, v in self.BuilderManagers do
+            if not v.BaseType then
+                continue
+            end
+            if type then
+                if type == 'Start Location' and v.BaseType ~= 'MAIN' and v.BaseType ~= 'Blank Marker' then
+                    continue
+                elseif type == 'Naval Area' and v.BaseType ~= 'Naval Area' then
+                    continue
+                elseif type == 'Expansion Area' and v.BaseType ~= 'Expansion Area' and v.BaseType ~= 'Large Expansion Area' then
+                    continue
+                end
+            end
+
+            if v.EngineerManager:GetNumCategoryUnits('Engineers', categories.ALLUNITS) <= 0 and v.FactoryManager:GetNumCategoryFactories(categories.ALLUNITS) <= 0 then
+                continue
+            end
+
+            count = count + 1
+        end
+        return count
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param position Vector
+    ---@param radius number
+    ---@param baseName string
+    ---@param useCenter boolean
+    AddBuilderManagers = function(self, position, radius, baseName, useCenter)
+
+        local baseLayer = 'Land'
+        position[2] = GetTerrainHeight( position[1], position[3] )
+        if GetSurfaceHeight( position[1], position[3] ) > position[2] then
+            position[2] = GetSurfaceHeight( position[1], position[3] )
+            baseLayer = 'Water'
+        end
+
+        self.BuilderManagers[baseName] = {
+            FactoryManager = FactoryManager.CreateFactoryBuilderManager(self, baseName, position, radius, useCenter),
+            PlatoonFormManager = PlatoonFormManager.CreatePlatoonFormManager(self, baseName, position, radius, useCenter),
+            EngineerManager = EngineerManager.CreateEngineerManager(self, baseName, position, radius),
+            BuilderHandles = {},
+            Position = position,
+            BaseType = Scenario.MasterChain._MASTERCHAIN_.Markers[baseName].type or 'MAIN',
+            Layer = baseLayer,
+        }
+        self.NumBases = self.NumBases + 1
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param category EntityCategory
+    ---@return integer
+    GetEngineerManagerUnitsBeingBuilt = function(self, category)
+        local unitCount = 0
+        for k, v in self.BuilderManagers do
+            unitCount = unitCount + TableGetn(v.EngineerManager:GetEngineersBuildingCategory(category, categories.ALLUNITS))
+        end
+        return unitCount
+    end,
+
+    ---@param self AIBrainAdaptive
+    GetStartVector3f = function(self)
+        local startX, startZ = self:GetArmyStartPos()
+        return {startX, 0, startZ}
+    end,
+
+    ---# BASE MONITORING SYSTEM
+    ---@param self AIBrainAdaptive
+    ---@param spec any
+    BaseMonitorInitialization = function(self, spec)
+        ---@class AiBaseMonitor
+        self.BaseMonitor = {
+            BaseMonitorStatus = 'ACTIVE',
+            BaseMonitorPoints = {},
+            AlertSounded = false,
+            AlertsTable = {},
+            AlertLocation = false,
+            AlertSoundedThreat = 0,
+            ActiveAlerts = 0,
+
+            PoolDistressRange = 75,
+            PoolReactionTime = 7,
+
+            -- Variables for checking a radius for enemy units
+            UnitRadiusThreshold = spec.UnitRadiusThreshold or 3,
+            UnitCategoryCheck = spec.UnitCategoryCheck or (categories.MOBILE - (categories.SCOUT + categories.ENGINEER)),
+            UnitCheckRadius = spec.UnitCheckRadius or 40,
+
+            -- Threat level must be greater than this number to sound a base alert
+            AlertLevel = spec.AlertLevel or 0,
+            -- Delay time for checking base
+            BaseMonitorTime = spec.BaseMonitorTime or 11,
+            -- Default distance a platoon will travel to help around the base
+            DefaultDistressRange = spec.DefaultDistressRange or 75,
+            -- Default how often platoons will check if the base is under duress
+            PlatoonDefaultReactionTime = spec.PlatoonDefaultReactionTime or 5,
+            -- Default duration for an alert to time out
+            DefaultAlertTimeout = spec.DefaultAlertTimeout or 10,
+
+            PoolDistressThreshold = 1,
+
+            -- Monitor platoons for help
+            PlatoonDistressTable = {},
+            PlatoonDistressThread = false,
+            PlatoonAlertSounded = false,
+        }
+        self:ForkThread(self.BaseMonitorThread)
+        self:ForkThread(self.CanPathToCurrentEnemy)
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param platoon Platoon
+    ---@param threat number
+    BaseMonitorPlatoonDistress = function(self, platoon, threat)
+        if not self.BaseMonitor then
+            return
+        end
+
+        local found = false
+        for k, v in self.BaseMonitor.PlatoonDistressTable do
+            -- If already calling for help, don't add another distress call
+            if v.Platoon == platoon then
+                found = true
+                break
+            end
+        end
+        if not found then
+            -- Add platoon to list desiring aid
+            table.insert(self.BaseMonitor.PlatoonDistressTable, {Platoon = platoon, Threat = threat})
+        end
+        -- Create the distress call if it doesn't exist
+        if not self.BaseMonitor.PlatoonDistressThread then
+            self.BaseMonitor.PlatoonDistressThread = self:ForkThread(self.BaseMonitorPlatoonDistressThread)
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    BaseMonitorPlatoonDistressThread = function(self)
+        self.BaseMonitor.PlatoonAlertSounded = true
+        while true do
+            local numPlatoons = 0
+            for k, v in self.BaseMonitor.PlatoonDistressTable do
+                if self:PlatoonExists(v.Platoon) then
+                    local threat = self:GetThreatAtPosition(v.Platoon:GetPlatoonPosition(), 0, true, 'AntiSurface')
+                    local myThreat = self:GetThreatAtPosition(v.Platoon:GetPlatoonPosition(), 0, true, 'Overall', self:GetArmyIndex())
+                    -- Platoons still threatened
+                if threat and threat > (myThreat * 1.5) then
+                        v.Threat = threat
+                        numPlatoons = numPlatoons + 1
+                    -- Platoon not threatened
+                    else
+                        self.BaseMonitor.PlatoonDistressTable[k] = nil
+                        v.Platoon.DistressCall = false
+                    end
+                else
+                    self.BaseMonitor.PlatoonDistressTable[k] = nil
+                end
+            end
+
+            -- If any platoons still want help; continue sounding
+            if numPlatoons > 0 then
+                self.BaseMonitor.PlatoonAlertSounded = true
+            else
+                self.BaseMonitor.PlatoonAlertSounded = false
+            end
+            WaitSeconds(self.BaseMonitor.BaseMonitorTime)
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param position Vector
+    ---@param radius number
+    ---@param threshold number
+    ---@return boolean|table
+    BaseMonitorDistressLocation = function(self, position, radius, threshold)
+        local returnPos = false
+        local highThreat = false
+        local distance
+        if self.BaseMonitor.CDRDistress
+                and Utilities.XZDistanceTwoVectors(self.BaseMonitor.CDRDistress, position) < radius
+                and self.BaseMonitor.CDRThreatLevel > threshold then
+            -- Commander scared and nearby; help it
+            return self.BaseMonitor.CDRDistress
+        end
+        if self.BaseMonitor.AlertSounded then
+            for k, v in self.BaseMonitor.AlertsTable do
+                local tempDist = Utilities.XZDistanceTwoVectors(position, v.Position)
+
+                -- Too far away
+                if tempDist > radius then
+                    continue
+                end
+
+                -- Not enough threat in location
+                if v.Threat < threshold then
+                    continue
+                end
+
+                -- Threat lower than or equal to a threat we already have
+                if v.Threat <= highThreat then
+                    continue
+                end
+
+                -- Get real height
+                local height = GetTerrainHeight(v.Position[1], v.Position[3])
+                local surfHeight = GetSurfaceHeight(v.Position[1], v.Position[3])
+                if surfHeight > height then
+                    height = surfHeight
+                end
+
+                -- currently our winner in high threat
+                returnPos = {v.Position[1], height, v.Position[3]}
+                distance = tempDist
+            end
+        end
+        if self.BaseMonitor.PlatoonAlertSounded then
+            for k, v in self.BaseMonitor.PlatoonDistressTable do
+                if self:PlatoonExists(v.Platoon) then
+                    local platPos = v.Platoon:GetPlatoonPosition()
+                    local tempDist = Utilities.XZDistanceTwoVectors(position, platPos)
+
+                    -- Platoon too far away to help
+                    if tempDist > radius then
+                        continue
+                    end
+
+                    -- Area not scary enough
+                    if v.Threat < threshold then
+                        continue
+                    end
+
+                    -- Further away than another call for help
+                    if tempDist > distance then
+                        continue
+                    end
+
+                    -- Our current winners
+                    returnPos = platPos
+                    distance = tempDist
+                end
+            end
+        end
+        return returnPos
+    end,
+
+    ---@param self AIBrainAdaptive
+    BaseMonitorThread = function(self)
+        while true do
+            if self.BaseMonitor.BaseMonitorStatus == 'ACTIVE' then
+                self:BaseMonitorCheck()
+            end
+            WaitSeconds(self.BaseMonitor.BaseMonitorTime)
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param pos Vector
+    ---@param threattype string
+    BaseMonitorAlertTimeout = function(self, pos, threattype)
+        local timeout = self.BaseMonitor.DefaultAlertTimeout
+        local threat
+        local threshold = self.BaseMonitor.AlertLevel
+        local myThreat
+        repeat
+            WaitSeconds(timeout)
+            threat = self:GetThreatAtPosition(pos, 0, true, threattype or 'AntiSurface')
+            myThreat = self:GetThreatAtPosition(pos, 0, true, 'Overall', self:GetArmyIndex())
+            if threat - myThreat < 1 then
+                local eEngies = self:GetNumUnitsAroundPoint(categories.ENGINEER, pos, 10, 'Enemy')
+                if eEngies > 0 then
+                    threat = threat + (eEngies * 10)
+                end
+            end
+        until threat - myThreat <= threshold
+
+        for k, v in self.BaseMonitor.AlertsTable do
+            if pos[1] == v.Position[1] and pos[3] == v.Position[3] then
+                table.remove(self.BaseMonitor.AlertsTable, k)
+                break
+            end
+        end
+
+        for k, v in self.BaseMonitor.BaseMonitorPoints do
+            if pos[1] == v.Position[1] and pos[3] == v.Position[3] then
+                v.Alert = false
+                break
+            end
+        end
+
+        self.BaseMonitor.ActiveAlerts = self.BaseMonitor.ActiveAlerts - 1
+        if self.BaseMonitor.ActiveAlerts == 0 then
+            self.BaseMonitor.AlertSounded = false
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    BaseMonitorCheck = function(self)
+        local vecs = self:GetStructureVectors()
+        if not table.empty(vecs) then
+            -- Find new points to monitor
+            for k, v in vecs do
+                local found = false
+                for subk, subv in self.BaseMonitor.BaseMonitorPoints do
+                    if v[1] == subv.Position[1] and v[3] == subv.Position[3] then
+                        found = true
+                        -- if we found this point already stored, we don't need to continue searching the rest
+                        break
+                    end
+                end
+                if not found then
+                    table.insert(self.BaseMonitor.BaseMonitorPoints,
+                        {
+                            Position = v,
+                            Threat = self:GetThreatAtPosition(v, 0, true, 'Overall'),
+                            Alert = false
+                        }
+                    )
+                end
+            end
+            -- Remove any points that we dont monitor anymore
+            for k, v in self.BaseMonitor.BaseMonitorPoints do
+                local found = false
+                for subk, subv in vecs do
+                    if v.Position[1] == subv[1] and v.Position[3] == subv[3] then
+                        found = true
+                        break
+                    end
+                end
+                -- If point not in list and the num units around the point is small
+                if not found and self:GetNumUnitsAroundPoint(categories.STRUCTURE, v.Position, 16, 'Ally') <= 1 then
+                    table.remove(self.BaseMonitor.BaseMonitorPoints, k)
+                end
+            end
+            -- Check monitor points for change
+            local alertThreat = self.BaseMonitor.AlertLevel
+            for k, v in self.BaseMonitor.BaseMonitorPoints do
+                if not v.Alert then
+                    v.Threat = self:GetThreatAtPosition(v.Position, 0, true, 'Overall')
+                    if v.Threat > alertThreat then
+                        v.Alert = true
+                        table.insert(self.BaseMonitor.AlertsTable,
+                            {
+                                Position = v.Position,
+                                Threat = v.Threat,
+                            }
+                        )
+                        self.BaseMonitor.AlertSounded = true
+                        self:ForkThread(self.BaseMonitorAlertTimeout, v.Position)
+                        self.BaseMonitor.ActiveAlerts = self.BaseMonitor.ActiveAlerts + 1
+                    end
+                end
+            end
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param threattypes string
+    T4ThreatMonitorTimeout = function(self, threattypes)
+        WaitSeconds(180)
+        for _, v in threattypes do
+            self.T4ThreatFound[v] = false
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@return Vector[]
+    GetBaseVectors = function(self)
+        local enemy = self:GetCurrentEnemy()
+        local index = self:GetArmyIndex()
+        self:SetCurrentEnemy(self)
+        self:SetUpAttackVectorsToArmy(categories.STRUCTURE - (categories.MASSEXTRACTION))
+        self:SetCurrentEnemy(enemy)
+        if enemy then
+            self:SetUpAttackVectorsToArmy()
+        end
+
+        local vecs = self:GetAttackVectors()
+        local returnPoints = {}
+        if vecs then
+            for _, v in vecs do
+                local loc = {v.px, v.py, v.pz}
+                local found = false
+                for subk, subv in returnPoints do
+                    if subv[1] == loc[1] and subv[3] == loc[3] then
+                        found = true
+                        break
+                    end
+                end
+                if not found then
+                    table.insert(returnPoints, loc)
+                end
+            end
+        end
+        return returnPoints
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@return table
+    GetStructureVectors = function(self)
+        local structures = self:GetListOfUnits(categories.STRUCTURE - categories.WALL, false)
+        -- Add all points around location
+        local tempGridPoints = {}
+        local indexChecker = {}
+
+        for k, v in structures do
+            if not v.Dead then
+                local pos = AIUtils.GetUnitBaseStructureVector(v)
+                if pos then
+                    if not indexChecker[pos[1]] then
+                        indexChecker[pos[1]] = {}
+                    end
+                    if not indexChecker[pos[1]][pos[3]] then
+                        indexChecker[pos[1]][pos[3]] = true
+                        table.insert(tempGridPoints, pos)
+                    end
+                end
+            end
+        end
+
+        return tempGridPoints
+    end,
+
+    -- ENEMY PICKER AI
+    ---@param self AIBrainAdaptive
+    PickEnemy = function(self)
+        while true do
+            self:PickEnemyLogic()
+            WaitSeconds(120)
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param strengthTable table
+    ---@return boolean
+    GetAllianceEnemy = function(self, strengthTable)
+        local returnEnemy = false
+        local myIndex = self:GetArmyIndex()
+        local highStrength = strengthTable[myIndex].Strength
+        for k, v in strengthTable do
+            -- It's an enemy, ignore
+            if k ~= myIndex and not v.Enemy and not ArmyIsCivilian(k) and not v.Brain:IsDefeated() then
+                -- Ally too weak
+                if v.Strength < highStrength then
+                    continue
+                end
+                -- If the brain has an enemy, it's our new enemy
+                local enemy = v.Brain:GetCurrentEnemy()
+                if enemy then
+                    highStrength = v.Strength
+                    returnEnemy = v.Brain:GetCurrentEnemy()
+                end
+            end
+        end
+        return returnEnemy
+    end,
+
+    ---@param self AIBrainAdaptive
+    PickEnemyLogic = function(self)
+        local armyStrengthTable = {}
+        local selfIndex = self:GetArmyIndex()
+        for _, v in ArmyBrains do
+            local insertTable = {
+                Enemy = true,
+                Strength = 0,
+                Position = false,
+                Brain = v,
+            }
+            local armyIndex = v:GetArmyIndex()
+            -- Share resources with friends but don't regard their strength
+            if IsAlly(selfIndex, armyIndex) then
+                self:SetResourceSharing(true)
+                insertTable.Enemy = false
+            elseif not IsEnemy(selfIndex, armyIndex) then
+                insertTable.Enemy = false
+            end
+
+            if insertTable.Enemy then
+                insertTable.Position, insertTable.Strength = self:GetHighestThreatPosition(self.IMAPConfig.Rings, true, 'Structures', armyIndex)
+            else
+                local startX, startZ = v:GetArmyStartPos()
+                local ecoStructures = self:GetUnitsAroundPoint(categories.STRUCTURE * (categories.MASSEXTRACTION + categories.MASSPRODUCTION), {startX, 0 ,startZ}, 120, 'Ally')
+                local ecoThreat = 0
+                for _, v in ecoStructures do
+                    ecoThreat = ecoThreat + v.Blueprint.Defense.EconomyThreatLevel
+                end
+                insertTable.Position = {startX, 0, startZ}
+                insertTable.Strength = ecoThreat
+            end
+            armyStrengthTable[armyIndex] = insertTable
+        end
+
+        local allyEnemy = self:GetAllianceEnemy(armyStrengthTable)
+        if allyEnemy  then
+            self:SetCurrentEnemy(allyEnemy)
+        else
+            local findEnemy = false
+            if not self:GetCurrentEnemy() then
+                findEnemy = true
+            else
+                local cIndex = self:GetCurrentEnemy():GetArmyIndex()
+                -- If our enemy has been defeated or has less than 20 strength, we need a new enemy
+                if self:GetCurrentEnemy():IsDefeated() or armyStrengthTable[cIndex].Strength < 20 then
+                    findEnemy = true
+                end
+            end
+            if findEnemy then
+                local enemyStrength = false
+                local enemy = false
+
+                for k, v in armyStrengthTable do
+                    -- Dont' target self and ignore allies
+                    if k ~= selfIndex and v.Enemy and not v.Brain:IsDefeated() then
+                        
+                        -- If we have a better candidate; ignore really weak enemies
+                        if enemy and v.Strength < 20 then
+                            continue
+                        end
+
+                        -- The closer targets are worth more because then we get their mass spots
+                        local distanceWeight = 0.1
+                        local distance = VDist3(self:GetStartVector3f(), v.Position)
+                        local threatWeight = (1 / (distance * distanceWeight)) * v.Strength
+
+                        if not enemy or threatWeight > enemyStrength then
+                            enemy = v.Brain
+                        end
+                    end
+                end
+
+                if enemy then
+                    self:SetCurrentEnemy(enemy)
+                end
+            end
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    GetNewAttackVectors = function(self)
+        if not self.AttackVectorsThread then
+            self.AttackVectorsThread = self:ForkThread(self.SetupAttackVectorsThread)
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    SetupAttackVectorsThread = function(self)
+        self.AttackVectorUpdate = 0
+        while true do
+            self:SetUpAttackVectorsToArmy(categories.STRUCTURE - (categories.MASSEXTRACTION))
+            while self.AttackVectorUpdate < 30 do
+                WaitSeconds(1)
+                self.AttackVectorUpdate = self.AttackVectorUpdate + 1
+            end
+            self.AttackVectorUpdate = 0
+        end
+    end,
+
+    -- Skirmish expansion help
+    ---@param self AIBrainAdaptive
+    ---@param eng Unit
+    ---@param reference string
+    ExpansionHelp = function(self, eng, reference)
+        self:ForkThread(self.ExpansionHelpThread, eng, reference)
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param eng Unit
+    ---@param reference string
+    ExpansionHelpThread = function(self, eng, reference)
+        local pool = self:GetPlatoonUniquelyNamed('ArmyPool')
+        local landHelp = {}
+        local val = 0
+        for _, v in pool:GetPlatoonUnits() do
+            if val == 0 and EntityCategoryContains((categories.LAND * categories.MOBILE) - categories.CONSTRUCTION, v) then
+                table.insert(landHelp, v)
+            end
+
+            val = val + 1
+            if val == 4 then
+                val = 0
+            end
+        end
+        self:ForkThread(self.GroupHelpThread, landHelp, reference)
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param units Unit
+    ---@param reference string
+    GroupHelpThread = function(self, units, reference)
+        local plat = self:MakePlatoon('', '')
+        self:AssignUnitsToPlatoon(plat, units, 'Attack', 'GrowthFormation')
+        local cmd = plat:MoveToLocation(reference, false)
+        while self:PlatoonExists(plat) and plat:IsCommandsActive(cmd) do
+            WaitSeconds(5)
+        end
+        WaitSeconds(30)
+
+        if self:PlatoonExists(plat) then
+            local x, z = self:GetArmyStartPos()
+            plat:MoveToLocation({x, 0, z}, false)
+            self:DisbandPlatoon(plat)
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    AbandonedByPlayer = function(self)
+        if not IsGameOver() then
+            if ScenarioInfo.Options.AIReplacement == 'On' then
+                ForkThread(function()
+                    local oldName = ArmyBrains[self:GetArmyIndex()].Nickname
+
+                    WaitSeconds(1)
+
+                    SUtils.AISendChat('all', ArmyBrains[self:GetArmyIndex()].Nickname, 'takingcontrol')
+
+                    -- Reassign all Army attributes to better suit the AI.
+                    self.BrainType = 'AI'
+
+                    if self.EnergyExcessThread then 
+                        KillThread(self.EnergyExcessThread)
+                    end
+
+                    self.ConditionsMonitor = BrainConditionsMonitor.CreateConditionsMonitor(self)
+                    self.NumBases = 0 -- AddBuilderManagers will increase the number
+                    self.BuilderManagers = {}
+                    self:AddBuilderManagers(self:GetStartVector3f(), 100, 'MAIN', false)
+                    SUtils.AddCustomUnitSupport(self)
+
+                    ArmyBrains[self:GetArmyIndex()].Nickname = 'CMDR Sorian..(was '..oldName..')'
+                    ScenarioInfo.ArmySetup[self.Name].AIPersonality = 'sorianadaptive'
+
+                    local cmdUnits = self:GetListOfUnits(categories.COMMAND, true)
+                    if cmdUnits then
+                        cmdUnits[1]:SetCustomName(ArmyBrains[self:GetArmyIndex()].Nickname)
+                    end
+
+                    self:InitializeSkirmishSystems()
+                    self:OnCreateAI()
+                end)
+            else -- If ScenarioInfo.Options.AIReplacement return nil or any other value, make sure the ACU explodes.
+                self:OnDefeat()
+            end
+        end
+    end,
+
+    ---## Scouting help...
+    --- Creates an influence map threat at enemy bases so the AI will start sending attacks before scouting gets up.
+    ---@param self AIBrainAdaptive
+    ---@param amount number amount of threat to add to each enemy start area
+    ---@param decay number rate that the threat should decay
+    ---@return nil
+    AddInitialEnemyThreat = function(self, amount, decay)
+        local aiBrain = self
+        local myArmy = ScenarioInfo.ArmySetup[self.Name]
+
+        if ScenarioInfo.Options.TeamSpawn == 'fixed' then
+            -- Spawn locations were fixed. We know exactly where our opponents are.
+            for i = 1, 16 do
+                local token = 'ARMY_' .. i
+                local army = ScenarioInfo.ArmySetup[token]
+
+                if army then
+                    if army.ArmyIndex ~= myArmy.ArmyIndex and (army.Team ~= myArmy.Team or army.Team == 1) then
+                        local startPos = ScenarioUtils.GetMarker('ARMY_' .. i).position
+                        if startPos then
+                          self:AssignThreatAtPosition(startPos, amount, decay)
+                        end
+                    end
+                end
+            end
+        end
+    end,
+
+    ---##  Function: ParseIntelThread
+    ---Once per second, checks imap for enemy expansion bases.
+    ---@param self AIBrainAdaptive
+    ---@return nil  #loops forever
+    ParseIntelThread = function(self)
+        if not self.InterestList or not self.InterestList.MustScout then
+            error('Scouting areas must be initialized before calling AIBrain:ParseIntelThread.', 2)
+        end
+
+        while true do
+            local structures = self:GetThreatsAroundPosition(self.BuilderManagers.MAIN.Position, 16, true, 'StructuresNotMex')
+            for _, struct in structures do
+                local dupe = false
+                local newPos = {struct[1], 0, struct[2]}
+
+                for _, loc in self.InterestList.HighPriority do
+                    if VDist2Sq(newPos[1], newPos[3], loc.Position[1], loc.Position[3]) < 10000 then
+                        dupe = true
+                        break
+                    end
+                end
+
+                if not dupe then
+                    -- Is it in the low priority list?
+                    for i = 1, TableGetn(self.InterestList.LowPriority) do
+                        local loc = self.InterestList.LowPriority[i]
+                        if VDist2Sq(newPos[1], newPos[3], loc.Position[1], loc.Position[3]) < 10000 then
+                            -- Found it in the low pri list. Remove it so we can add it to the high priority list.
+                            table.remove(self.InterestList.LowPriority, i)
+                            break
+                        end
+                    end
+
+                    table.insert(self.InterestList.HighPriority,
+                        {
+                            Position = newPos,
+                            LastScouted = GetGameTimeSeconds(),
+                        }
+                    )
+
+                    -- Sort the list based on low long it has been since it was scouted
+                    table.sort(self.InterestList.HighPriority, function(a, b)
+                        if a.LastScouted == b.LastScouted then
+                            local MainPos = self.BuilderManagers.MAIN.Position
+                            local distA = VDist2(MainPos[1], MainPos[3], a.Position[1], a.Position[3])
+                            local distB = VDist2(MainPos[1], MainPos[3], b.Position[1], b.Position[3])
+
+                            return distA < distB
+                        else
+                            return a.LastScouted < b.LastScouted
+                        end
+                    end)
+                end
+            end
+
+            WaitSeconds(5)
+        end
+    end,
+
+    ---## Function: GetUntaggedMustScoutArea
+    --- Gets an area that has been flagged with the AddScoutArea function that does not have a unit heading to scout it already.
+    ---@param self AIBrainAdaptive
+    ---@return Vector location
+    ---@return number index
+    GetUntaggedMustScoutArea = function(self)
+        -- If any locations have been specifically tagged for scouting
+        if not self.InterestList or not self.InterestList.MustScout then
+            error('Scouting areas must be initialized before calling AIBrain:GetUntaggedMustScoutArea.', 2)
+        end
+
+        for idx, loc in self.InterestList.MustScout do
+            if not loc.TaggedBy or loc.TaggedBy.Dead then
+                return loc, idx
+            end
+        end
+    end,
+
+    ---## Function: AddScoutArea
+    --- Sets an area to be scouted once by air scouts at the next opportunity.
+    ---@param self AIBrainAdaptive
+    ---@param location Vector
+    ---@return nil
+    AddScoutArea = function(self, location)
+        if not self.InterestList or not self.InterestList.MustScout then
+            error('Scouting areas must be initialized before calling AIBrain:AddScoutArea.', 2)
+        end
+
+        -- If there's already a location to scout within 20 ogrids of this one, don't add it.
+        for _, loc in self.InterestList.MustScout do
+            if VDist2Sq(loc.Position[1], loc.Position[3], location[1], location[3]) < 400 then
+                return
+            end
+        end
+
+        table.insert(self.InterestList.MustScout,
+            {
+                Position = location,
+                TaggedBy = false,
+            }
+        )
+    end,
+
+    ---##  Function: BuildScoutLocations
+    ---  Sets up the initial low-priority scouting areas. If playing with fixed starting locations,
+    ---  also sets up high-priority scouting areas. This function may be called multiple times, but only
+    ---  has an effect the first time it is called per brain.
+    ---@param self AIBrainAdaptive
+    ---@return nil
+    BuildScoutLocations = function(self)
+        local aiBrain = self
+        local opponentStarts = {}
+        local allyStarts = {}
+
+        if not aiBrain.InterestList then
+            aiBrain.InterestList = {}
+            aiBrain.IntelData.HiPriScouts = 0
+            aiBrain.IntelData.AirHiPriScouts = 0
+            aiBrain.IntelData.AirLowPriScouts = 0
+
+            -- Add each enemy's start location to the InterestList as a new sub table
+            aiBrain.InterestList.HighPriority = {}
+            aiBrain.InterestList.LowPriority = {}
+            aiBrain.InterestList.MustScout = {}
+
+            local myArmy = ScenarioInfo.ArmySetup[self.Name]
+
+            if ScenarioInfo.Options.TeamSpawn == 'fixed' then
+                -- Spawn locations were fixed. We know exactly where our opponents are.
+                -- Don't scout areas owned by us or our allies.
+                local numOpponents = 0
+                for i = 1, 16 do
+                    local army = ScenarioInfo.ArmySetup['ARMY_' .. i]
+                    local startPos = ScenarioUtils.GetMarker('ARMY_' .. i).position
+                    if army and startPos then
+                        if army.ArmyIndex ~= myArmy.ArmyIndex and (army.Team ~= myArmy.Team or army.Team == 1) then
+                        -- Add the army start location to the list of interesting spots.
+                        opponentStarts['ARMY_' .. i] = startPos
+                        numOpponents = numOpponents + 1
+                        table.insert(aiBrain.InterestList.HighPriority,
+                            {
+                                Position = startPos,
+                                LastScouted = 0,
+                            }
+                        )
+                        else
+                            allyStarts['ARMY_' .. i] = startPos
+                        end
+                    end
+                end
+
+                aiBrain.NumOpponents = numOpponents
+
+                -- For each vacant starting location, check if it is closer to allied or enemy start locations (within 100 ogrids)
+                -- If it is closer to enemy territory, flag it as high priority to scout.
+                local starts = AIUtils.AIGetMarkerLocations(aiBrain, 'Start Location')
+                for _, loc in starts do
+                    -- If vacant
+                    if not opponentStarts[loc.Name] and not allyStarts[loc.Name] then
+                        local closestDistSq = 999999999
+                        local closeToEnemy = false
+
+                        for _, pos in opponentStarts do
+                            local distSq = VDist2Sq(pos[1], pos[3], loc.Position[1], loc.Position[3])
+                            -- Make sure to scout for bases that are near equidistant by giving the enemies 100 ogrids
+                            if distSq-10000 < closestDistSq then
+                                closestDistSq = distSq-10000
+                                closeToEnemy = true
+                            end
+                        end
+
+                        for _, pos in allyStarts do
+                            local distSq = VDist2Sq(pos[1], pos[3], loc.Position[1], loc.Position[3])
+                            if distSq < closestDistSq then
+                                closestDistSq = distSq
+                                closeToEnemy = false
+                                break
+                            end
+                        end
+
+                        if closeToEnemy then
+                            table.insert(aiBrain.InterestList.LowPriority,
+                                {
+                                    Position = loc.Position,
+                                    LastScouted = 0,
+                                }
+                            )
+                        end
+                    end
+                end
+
+            else -- Spawn locations were random. We don't know where our opponents are. Add all non-ally start locations to the scout list
+                local numOpponents = 0
+                for i = 1, 16 do
+                    local army = ScenarioInfo.ArmySetup['ARMY_' .. i]
+                    local startPos = ScenarioUtils.GetMarker('ARMY_' .. i).position
+
+                    if army and startPos then
+                        if army.ArmyIndex == myArmy.ArmyIndex or (army.Team == myArmy.Team and army.Team ~= 1) then
+                            allyStarts['ARMY_' .. i] = startPos
+                        else
+                            numOpponents = numOpponents + 1
+                        end
+                    end
+                end
+
+                aiBrain.NumOpponents = numOpponents
+
+                -- If the start location is not ours or an ally's, it is suspicious
+                local starts = AIUtils.AIGetMarkerLocations(aiBrain, 'Start Location')
+                for _, loc in starts do
+                    -- If vacant
+                    if not allyStarts[loc.Name] then
+                        table.insert(aiBrain.InterestList.LowPriority,
+                            {
+                                Position = loc.Position,
+                                LastScouted = 0,
+                            }
+                        )
+                    end
+                end
+            end
+            aiBrain:ForkThread(self.ParseIntelThread)
+        end
+    end,
+
+    ---## Function: SortScoutingAreas
+    --- Sorts the brain's list of scouting areas by time since scouted, and then distance from main base.
+    ---@param self AIBrainAdaptive
+    ---@param list table
+    ---@return nil
+    SortScoutingAreas = function(self, list)
+        table.sort(list, function(a, b)
+            if a.LastScouted == b.LastScouted then
+                local MainPos = self.BuilderManagers.MAIN.Position
+                local distA = VDist2(MainPos[1], MainPos[3], a.Position[1], a.Position[3])
+                local distB = VDist2(MainPos[1], MainPos[3], b.Position[1], b.Position[3])
+
+                return distA < distB
+            else
+                return a.LastScouted < b.LastScouted
+            end
+        end)
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param pingData table
+    DoAIPing = function(self, pingData)
+        if self.Sorian then
+            if pingData.Type then
+                SUtils.AIHandlePing(self, pingData)
+            end
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param pos Vector
+    AttackPointsTimeout = function(self, pos)
+        WaitSeconds(300)
+        for k, v in self.AttackPoints do
+            if pos[1] == v.Position[1] and pos[3] == v.Position[3] then
+                self.AttackPoints[k] = nil
+                break
+            end
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param pos Vector
+    ---@param enemy Army
+    AirAttackPointsTimeout = function(self, pos, enemy)
+        local threat
+        local myThreat
+        local overallThreat
+        repeat
+            WaitSeconds(30)
+            myThreat = 0
+            threat = self:GetThreatAtPosition(pos, 1, true, 'AntiAir', enemy:GetArmyIndex())
+            overallThreat = self:GetThreatAtPosition(pos, 1, true, 'Overall', enemy:GetArmyIndex())
+            local bombers = AIUtils.GetOwnUnitsAroundPoint(self, categories.AIR * (categories.BOMBER + categories.GROUNDATTACK), pos, 10000)
+            for _, unit in bombers do
+                myThreat = myThreat + unit:GetBlueprint().Defense.SurfaceThreatLevel
+            end
+        until threat > myThreat or overallThreat <= 0
+
+        for k, v in self.AirAttackPoints do
+            if pos[1] == v.Position[1] and pos[3] == v.Position[3] then
+                self.AirAttackPoints[k] = nil
+                break
+            end
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@return CommandUnit | nil
+    GetCommander = function(self)
+        local cdr = self.CDR
+        if cdr and cdr:IsDead() then
+            cdr = nil
+        end
+        if not cdr then
+            local commanders = self:GetListOfUnits(categories.COMMANDER, false)
+            table.shuffle(commanders)
+            for _, commander in commanders do
+                if not commander:IsDead() then
+                    cdr = commander
+                    break
+                end
+            end
+        end
+        return cdr
+    end,
+
+    --- Monitors pathing from each AI base to the current enemy start position. Used for determining which movement layers can attack an enemy.
+    ---@param self AIBrainAdaptive
+    CanPathToCurrentEnemy = function(self)
+        -- Validate Pathing to enemies based on navmesh queries
+        -- Removed from build conditions so it can run on a slower loop
+        -- added amphib vs air results so we can tell when we are trapped on a plateu
+        WaitTicks(Random(5,20))
+        local NavUtils = import("/lua/sim/navutils.lua")
+        if not self.CanPathToEnemy then
+            self.CanPathToEnemy = {}
+        end
+
+        while true do
+            --We are getting the current base position rather than the start position so we can use this for expansions.
+            for k, v in self.BuilderManagers do
+                local locPos = v.Position 
+                -- added this incase the position came back nil
+                local enemyX, enemyZ
+                if self:GetCurrentEnemy() then
+                    enemyX, enemyZ = self:GetCurrentEnemy():GetArmyStartPos()
+                    -- if we don't have an enemy position then we can't search for a path. Return until we have an enemy position
+                    if not enemyX then
+                        WaitTicks(30)
+                        break
+                    end
+                else
+                    WaitTicks(30)
+                    break
+                end
+
+                -- Get the armyindex from the enemy
+                local EnemyIndex = self:GetCurrentEnemy():GetArmyIndex()
+                local OwnIndex = self:GetArmyIndex()
+                -- create a table for the enemy index in case it's nil
+                self.CanPathToEnemy[OwnIndex] = self.CanPathToEnemy[OwnIndex] or {}
+                self.CanPathToEnemy[OwnIndex][EnemyIndex] = self.CanPathToEnemy[OwnIndex][EnemyIndex] or {}
+                -- Check if we have already done a path search to the current enemy
+                if self.CanPathToEnemy[OwnIndex][EnemyIndex][k] == 'Land' then
+                    WaitTicks(5)
+                    continue
+                elseif self.CanPathToEnemy[OwnIndex][EnemyIndex][k] == 'Amphibious' then
+                    WaitTicks(5)
+                    continue
+                elseif self.CanPathToEnemy[OwnIndex][EnemyIndex][k] == 'Air' then
+                    WaitTicks(5)
+                    continue
+                end
+                -- Check land path to current enemy
+                local path, reason = NavUtils.CanPathTo('Land', locPos, {enemyX,0,enemyZ})
+                
+                -- if we have a true path from the nav mesh....
+                if path then
+                    self.CanPathToEnemy[OwnIndex][EnemyIndex][k] = 'Land'
+                else
+                    -- we have no path from the nav mesh....
+                    local amphibPath, amphibReason = NavUtils.CanPathTo('Amphibious', locPos, {enemyX,0,enemyZ})
+                    if not amphibPath then
+                        -- No land or amphib path, we are likely on a plateu and cant go anywhere without transports.
+                        self.CanPathToEnemy[OwnIndex][EnemyIndex][k] = 'Air'
+                    else
+                        self.CanPathToEnemy[OwnIndex][EnemyIndex][k] = 'Amphibious'
+                    end
+                end
+                WaitTicks(5)
+            end
+            WaitTicks(100)
+        end
+    end,
+
+    MapAnalysis = function(self)
+        -- This function will provide various means of the AI populating intel data
+        -- Due to it potentially influencing buider/base template decisions it needs to run before the AI creates its first buildermanager
+        WaitTicks(10)
+        self.IntelData.MapWaterRatio = self:GetMapWaterRatio()
+        local AIAttackUtils = import("/lua/ai/aiattackutilities.lua")
+        AIAttackUtils.NavalAttackCheck(self)
+
+    end,
+
+    IMAPConfiguration = function(self)
+        -- Used to configure imap values, used for setting threat ring sizes depending on map size to try and get a somewhat decent radius
+        local maxmapdimension = math.max(ScenarioInfo.size[1], ScenarioInfo.size[2])
+
+        self.IMAPConfig = {
+            OgridRadius = 0,
+            IMAPSize = 0,
+            Rings = 0,
+        }
+
+        if maxmapdimension == 256 then
+            self.IMAPConfig.OgridRadius = 22.5
+            self.IMAPConfig.IMAPSize = 32
+            self.IMAPConfig.Rings = 2
+        elseif maxmapdimension == 512 then
+            self.IMAPConfig.OgridRadius = 22.5
+            self.IMAPConfig.IMAPSize = 32
+            self.IMAPConfig.Rings = 2
+        elseif maxmapdimension == 1024 then
+            self.IMAPConfig.OgridRadius = 45.0
+            self.IMAPConfig.IMAPSize = 64
+            self.IMAPConfig.Rings = 1
+        elseif maxmapdimension == 2048 then
+            self.IMAPConfig.OgridRadius = 89.5
+            self.IMAPConfig.IMAPSize = 128
+            self.IMAPConfig.Rings = 0
+        else
+            self.IMAPConfig.OgridRadius = 180.0
+            self.IMAPConfig.IMAPSize = 256
+            self.IMAPConfig.Rings = 0
+        end
+    end,
+
+    ---@param self AIBrainAdaptive
+    ---@param loc Vector
+    ---@return boolean
+    PBMGetLocationRadius = function(self, loc)
+        if not loc then
+            return false
+        end
+        if self.HasPlatoonList then
+            for k, v in self.PBM.Locations do
+                if v.LocationType == loc then
+                   return v.Radius
+                end
+            end
+        elseif self.BuilderManagers[loc] then
+            return self.BuilderManagers[loc].FactoryManager.Radius
+        end
+        return false
+    end,
+
+    ---------------------------------------------------------------------------
+    --#region Debug functionality
+
+    ---@param self EasyAIBrain
+    ---@return AIBaseDebugInfo
+    GetPlatoonDebugInfoThread = function(self)
+        while true do
+            if GetFocusArmy() == self:GetArmyIndex() then
+                local units = DebugGetSelection()
+                if units and units[1] then
+                    local unit = units[1]
+                    if unit.AIPlatoonReference then
+                        Sync.AIPlatoonInfo = {
+                            PlatoonInfo = unit.AIPlatoonReference:GetDebugInfo(),
+                            EntityId = unit.EntityId,
+                            BlueprintId = unit.Blueprint.BlueprintId,
+                            Position = unit:GetPosition(),
+                        }
+                    end
+                end
+            end
+
+            WaitTicks(10)
+        end
+    end,
+
+    --#endregion
+
+}

--- a/lua/aibrains/easy-ai.lua
+++ b/lua/aibrains/easy-ai.lua
@@ -323,9 +323,10 @@ AIBrain = Class(StandardBrain, EconomyComponent) {
 
     ---------------------------------------------------------------------------
     --#region Legacy functionality
-    --- All functions below solely exist because the code is too tightly coupled. We can't
-    --- remove them without drastically changing how the code base works. We can't do that
-    --- because it would break mod compatibility
+    
+    -- All functions below solely exist because the code is too tightly coupled. We can't
+    -- remove them without drastically changing how the code base works. We can't do that
+    -- because it would break mod compatibility
 
     ---@deprecated
     ---@param self AIBrain

--- a/lua/aibrains/index.lua
+++ b/lua/aibrains/index.lua
@@ -13,13 +13,13 @@ keyToBrain = {
     rush = import("/lua/aibrains/base-ai.lua").AIBrain,
     easy = import("/lua/aibrains/base-ai.lua").AIBrain,
     medium = import("/lua/aibrains/base-ai.lua").AIBrain,
-    adaptive = import("/lua/aibrains/base-ai.lua").AIBrain,
+    adaptive = import("/lua/aibrains/adaptive-ai.lua").AIBrain,
     random = import("/lua/aibrains/base-ai.lua").AIBrain,
 
     -- base AIX
     techcheat = import("/lua/aibrains/base-ai.lua").AIBrain,
     turtlecheat = import("/lua/aibrains/base-ai.lua").AIBrain,
     rushcheat = import("/lua/aibrains/base-ai.lua").AIBrain,
-    adaptivecheat = import("/lua/aibrains/base-ai.lua").AIBrain,
+    adaptivecheat = import("/lua/aibrains/adaptive-ai.lua").AIBrain,
     randomcheat = import("/lua/aibrains/base-ai.lua").AIBrain,
 }

--- a/lua/aibrains/platoons/platoon-adaptive-attack.lua
+++ b/lua/aibrains/platoons/platoon-adaptive-attack.lua
@@ -1,6 +1,9 @@
+
 local AIPlatoon = import("/lua/aibrains/platoons/platoon-base.lua").AIPlatoon
 local NavUtils = import("/lua/sim/navutils.lua")
 local MarkerUtils = import("/lua/sim/markerutilities.lua")
+local TransportUtils = import("/lua/ai/transportutilities.lua")
+local AIAttackUtils = import("/lua/ai/aiattackutilities.lua")
 
 -- upvalue scope for performance
 local Random = Random
@@ -12,21 +15,21 @@ local TableEmpty = table.empty
 -- constants
 local NavigateDistanceThresholdSquared = 20 * 20
 
----@class AIPlatoonSimpleRaidBehavior : AIPlatoon
----@field RetreatCount number
+---@class AIPlatoonAdaptiveAttackBehavior : AIPlatoon
+---@field RetreatCount number 
 ---@field ThreatToEvade Vector | nil
----@field LocationToRaid Vector | nil
----@field OpportunityToRaid Vector | nil
-AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
+---@field LocationToAttack Vector | nil
+---@field OpportunityToAttack Vector | nil
+AIPlatoonAdaptiveAttackBehavior = Class(AIPlatoon) {
 
-    PlatoonName = 'SimpleRaidBehavior',
+    PlatoonName = 'AdaptiveAttackBehavior',
 
     Start = State {
 
         StateName = 'Start',
 
         --- Initial state of any state machine
-        ---@param self AIPlatoonSimpleRaidBehavior
+        ---@param self AIPlatoonAdaptiveAttackBehavior
         Main = function(self)
             -- requires expansion markers
             if not import("/lua/sim/markerutilities/expansions.lua").IsGenerated() then
@@ -42,6 +45,9 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
                 return
             end
 
+            -- Set the movement layer for pathing, included for mods where water or air based engineers may exist
+            self.MovementLayer = self:GetNavigationalLayer()
+
             self:ChangeState(self.Searching)
             return
         end,
@@ -52,10 +58,10 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
         StateName = 'Searching',
 
         --- The platoon searches for a target
-        ---@param self AIPlatoonSimpleRaidBehavior
+        ---@param self AIPlatoonAdaptiveAttackBehavior
         Main = function(self)
             -- reset state
-            self.LocationToRaid = nil
+            self.LocationToAttack = nil
             self.OpportunityToRaid = nil
             self.ThreatToEvade = nil
             self.RetreatCount = 0
@@ -71,42 +77,16 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
             local label, error = NavUtils.GetLabel('Land', position)
 
             if label then
-
-                -- TODO
-                -- this should be cached, part of the marker utilities
-                local expansions, count = MarkerUtils.GetMarkersByType('Expansion Area')
-                ---@type MarkerData[]
-                local candidates = {}
-                local candidateCount = 0
-                for k = 1, count do
-                    local expansion = expansions[k]
-                    if expansion.NavLabel == label then
-                        candidates[candidateCount + 1] = expansion
-                        candidateCount = candidateCount + 1
-                    end
-                end
-                -- END OF TODO
-
-                -- something odd happened: there are no expansions with a matching label
-                if candidateCount == 0 then
-                    self:LogWarning(string.format('no expansions found on label %d', label))
-                    self:ChangeState(self.Error)
-                    return
-                end
-
-                -- pick random expansion that we can Navigating to
-                local selectionNumber = Random(1, candidateCount)
-                local expansion = candidates[selectionNumber]
-                self.LocationToRaid = expansion.position
-                if self.LocationToRaid then
-                    LOG('Location to raid is '..repr(self.LocationToRaid))
+                local target = self:FindClosestUnit('Attack', 'Enemy', true, categories.ALLUNITS - categories.WALL - categories.AIR)
+                if target then
+                    self.TargetToAttack = target
+                    self.LocationToAttack = table.copy(target:GetPosition())
+                    IssueClearCommands(units)
+                    self:ChangeState(self.Navigating)
                 else
-                    LOG('Location to raid is nil')
-                    LOG(repr(expansion))
-                    LOG('Selection was '..selectionNumber)
-                    LOG('candidates '..repr(candidates))
+                    WaitTicks(50)
+                    self:ChangeState(self.Searching)
                 end
-                self:ChangeState(self.Navigating)
                 return
             else
                 -- something odd happened: try again with another unit
@@ -122,14 +102,14 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
         StateName = 'Navigating',
 
         --- The platoon navigates towards a target, picking up oppertunities as it finds them
-        ---@param self AIPlatoonSimpleRaidBehavior
+        ---@param self AIPlatoonAdaptiveAttackBehavior
         Main = function(self)
             -- reset state
             self.OpportunityToRaid = nil
             self.ThreatToEvade = nil
 
             -- sanity check
-            local destination = self.LocationToRaid
+            local destination = self.LocationToAttack
             if not destination then
                 self:LogWarning(string.format('no destination to navigate to'))
                 self:ChangeState(self.Searching)
@@ -142,6 +122,12 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
             local brain = self:GetBrain()
             if not brain.GridPresence then
                 WARN('GridPresence does not exist, unable to detect conflict line')
+            end
+
+            if not NavUtils.CanPathToCell(self.MovementLayer, self:GetPlatoonPosition(), destination) then
+                self:LogDebug(string.format('Attack platoon is going to use transport'))
+                self:ChangeState(self.Transporting)
+                return
             end
 
             while not IsDestroyed(self) do
@@ -164,17 +150,18 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
                     return
                 end
 
-                -- we're near the destination, better start raiding it!
+                -- we're near the destination, better start attacking it!
                 if waypoint == destination then
-                    self:ChangeState(self.RaidingTarget)
+                    self:ChangeState(self.AttackingTarget)
                     return
                 end
 
-                -- navigate towards waypoint
-                local dx = origin[1] - waypoint[1]
-                local dz = origin[3] - waypoint[3]
-                local d = math.sqrt(dx * dx + dz * dz)
-                self:IssueFormMoveToWaypoint(units, origin, waypoint)
+                -- navigate towards waypoint 
+                --local dx = origin[1] - waypoint[1]
+                --local dz = origin[3] - waypoint[3]
+                --local d = math.sqrt(dx * dx + dz * dz)
+                --self:IssueFormMoveToWaypoint(units, origin, waypoint)
+                self:AggressiveMoveToLocation(waypoint)
 
                 -- check for opportunities
                 local wx = waypoint[1]
@@ -195,16 +182,17 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
                         local threatTable = brain:GetThreatsAroundPosition(position, 1, true, 'AntiSurface')
                         local platoonThreat = self:CalculatePlatoonThreatAroundPosition('Surface', categories.MOBILE * categories.DIRECTFIRE - categories.SCOUT, position, 30)
                         local positionStatus = brain.GridPresence:GetInferredStatus(position)
-                        if positionStatus != 'Allied' or platoonThreat * 2 < threat then
+                        if platoonThreat * 2 < threat then
                             if threatTable and not TableEmpty(threatTable) then
                                 local info = threatTable[Random(1, TableGetn(threatTable))]
                                 self.ThreatToEvade = { info[1], GetSurfaceHeight(info[1], info[2]), info[2] }
                                 DrawCircle(self.ThreatToEvade, 5, 'ff0000')
+                                self:LogDebug(string.format('We are going to retreat, enemy threat '..threat..' our threat '..platoonThreat..' position status '..positionStatus))
                                 self:ChangeState(self.Retreating)
                                 return
                             end
-                        else
-                            LOG('Threat and we need to attack then since it is allied, status '..positionStatus)
+                        elseif positionStatus then
+                            self:LogDebug(string.format('We are going to attack, enemy threat '..threat..' our threat '..platoonThreat..' position status '..positionStatus))
                         end
                     end
 
@@ -237,19 +225,39 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
         end,
     },
 
-    RaidingTarget = State {
+    Transporting = State {
 
-        StateName = 'RaidingTarget',
+        StateName = 'Transporting',
 
-        --- The platoon raids the target
-        ---@param self AIPlatoonSimpleRaidBehavior
+        --- The platoon avoids danger or attempts to reclaim if they are too close to avoid
+        ---@param self AIPlatoonAdaptiveAttackBehavior
+        Main = function(self)
+            local brain = self:GetBrain()
+            local usedTransports = TransportUtils.SendPlatoonWithTransports(brain, self, self.LocationToAttack, 1, false)
+            if usedTransports then
+                self:LogDebug(string.format('Attack Platoon used transports'))
+                self:ChangeState(self.Navigating)
+            else
+                self:LogDebug(string.format('Attack Platoon didnt use transports'))
+                self:ChangeState(self.Searching)
+            end
+            return
+        end,
+    },
+
+    AttackingTarget = State {
+
+        StateName = 'AttackingTarget',
+
+        --- The platoon attacks the target
+        ---@param self AIPlatoonAdaptiveAttackBehavior
         Main = function(self)
             local brain = self:GetBrain()
 
             -- sanity check
-            local location = self.LocationToRaid
+            local location = self.LocationToAttack
             if not location then
-                self:LogWarning(string.format('no location to raid'))
+                self:LogWarning(string.format('no location to attack'))
                 self:ChangeState(self.Searching)
                 return
             end
@@ -259,9 +267,8 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
 
             while not IsDestroyed(self) do
 
-                -- check if there is something to raid
-                local opportunity = brain:GetThreatAtPosition(location, 0, true, 'Economy')
-                if opportunity == 0 then
+                -- check if there is something to attack
+                if not self.TargetToAttack or IsDestroyed(self.TargetToAttack) then
                     self:ChangeState(self.Searching)
                     return
                 end
@@ -271,17 +278,24 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
                 local threat = brain:GetThreatAtPosition(position, 1, true, 'AntiSurface')
                 if threat > 0 then
                     local threatTable = brain:GetThreatsAroundPosition(position, 1, true, 'AntiSurface')
-                    if threatTable and not TableEmpty(threatTable) then
-                        local info = threatTable[Random(1, TableGetn(threatTable))]
-                        self.ThreatToEvade = { info[1], GetSurfaceHeight(info[1], info[2]), info[2] }
-                        self:ChangeState(self.Retreating)
-                        return
+                    local platoonThreat = self:CalculatePlatoonThreatAroundPosition('Surface', categories.MOBILE * categories.DIRECTFIRE - categories.SCOUT, position, 30)
+                    local positionStatus = brain.GridPresence:GetInferredStatus(position)
+                    if platoonThreat * 2 < threat then
+                        if threatTable and not TableEmpty(threatTable) then
+                            local info = threatTable[Random(1, TableGetn(threatTable))]
+                            self.ThreatToEvade = { info[1], GetSurfaceHeight(info[1], info[2]), info[2] }
+                            DrawCircle(self.ThreatToEvade, 5, 'ff0000')
+                            self:ChangeState(self.Retreating)
+                            return
+                        end
+                    else
+                        self:LogDebug(string.format('Threat and we need to attack then since it is allied, status '..positionStatus))
                     end
                 end
 
                 -- check if our command is still going
                 if not self:IsCommandsActive(command) then
-
+                    self:ChangeState(self.Searching)
                     return
                 end
 
@@ -295,7 +309,7 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
         StateName = 'RaidingOpportunity',
 
         --- The platoon raids the opportunity it walked into
-        ---@param self AIPlatoonSimpleRaidBehavior
+        ---@param self AIPlatoonAdaptiveAttackBehavior
         Main = function(self)
             local brain = self:GetBrain()
 
@@ -311,7 +325,7 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
 
             -- tell attack units to attack
             local attackCommand
-            local attackOffset, error = NavUtils.RandomDirectionFrom('Land', location, 32, 4) -- TODO: remove magic numbers'
+            local attackOffset, error = NavUtils.RandomDirectionFrom('Land', location, 32, 4)       -- TODO: remove magic numbers'
             if not attackOffset then
                 attackCommand = self:AggressiveMoveToLocation(location, 'Attack')
             else
@@ -319,7 +333,7 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
             end
 
             -- tell scout units to patrol for threats
-            local scoutOffsets, countOrError = NavUtils.DirectionsFrom('Land', location, 32, 4) -- TODO: remove magic numbers
+            local scoutOffsets, countOrError = NavUtils.DirectionsFrom('Land', location, 32, 4)    -- TODO: remove magic numbers
             if not scoutOffsets then
                 self:Patrol(location, 'Scout')
             else
@@ -343,18 +357,25 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
                 local threat = brain:GetThreatAtPosition(position, 1, true, 'AntiSurface')
                 if threat > 0 then
                     local threatTable = brain:GetThreatsAroundPosition(position, 1, true, 'AntiSurface')
-                    if threatTable and not TableEmpty(threatTable) then
-                        local info = threatTable[Random(1, TableGetn(threatTable))]
-                        self.ThreatToEvade = { info[1], GetSurfaceHeight(info[1], info[2]), info[2] }
-                        self:ChangeState(self.Retreating)
-                        return
+                    local platoonThreat = self:CalculatePlatoonThreatAroundPosition('Surface', categories.MOBILE * categories.DIRECTFIRE - categories.SCOUT, position, 30)
+                    local positionStatus = brain.GridPresence:GetInferredStatus(position)
+                    if positionStatus != 'Allied' or platoonThreat * 2 < threat then
+                        if threatTable and not TableEmpty(threatTable) then
+                            local info = threatTable[Random(1, TableGetn(threatTable))]
+                            self.ThreatToEvade = { info[1], GetSurfaceHeight(info[1], info[2]), info[2] }
+                            DrawCircle(self.ThreatToEvade, 5, 'ff0000')
+                            self:ChangeState(self.Retreating)
+                            return
+                        end
+                    else
+                        self:LogDebug(string.format('Threat and we need to attack then since it is allied, status '..positionStatus))
                     end
                 end
 
                 -- check if our command is still going
                 if not self:IsCommandsActive(attackCommand) then
                     -- setup attack units
-                    local attackOffset, error = NavUtils.RandomDirectionFrom('Land', location, 10, 8) -- TODO: remove magic numbers
+                    local attackOffset, error = NavUtils.RandomDirectionFrom('Land', location, 10, 8)       -- TODO: remove magic numbers
                     if not attackOffset then
                         self:LogWarning(string.format('no alternative directions found to evade'))
                         self:ChangeState(self.Error)
@@ -374,7 +395,7 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
         StateName = "Retreating",
 
         --- The platoon retreats from a threat
-        ---@param self AIPlatoonSimpleRaidBehavior
+        ---@param self AIPlatoonAdaptiveAttackBehavior
         Main = function(self)
             local brain = self:GetBrain()
 
@@ -463,26 +484,24 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
             end
         end
 
-        for k, scout in units do
+        for k, scout in units do 
             scout:SetFireState(1)
         end
     end,
 }
 
----@param data { Behavior: 'AIBehaviorTacticalSimple' }
+---@param data { Behavior: 'AIPlatoonAdaptiveAttackBehavior' }
 ---@param units Unit[]
 DebugAssignToUnits = function(data, units)
     if units and not TableEmpty(units) then
-        LOG('Assigning Units to new platoon')
 
         -- meet platoon requirements
         import("/lua/sim/navutils.lua").Generate()
-        import("/lua/sim/markerutilities.lua").GenerateExpansionMarkers()
 
         -- create the platoon
         local brain = units[1].Brain
-        local platoon = brain:MakePlatoon('', '') --[[@as AIPlatoonSimpleRaidBehavior]]
-        setmetatable(platoon, AIPlatoonSimpleRaidBehavior)
+        local platoon = brain:MakePlatoon('', '') --[[@as AIPlatoonAdaptiveAttackBehavior]]
+        setmetatable(platoon, AIPlatoonAdaptiveAttackBehavior)
 
         -- assign units to squads
         local scouts = EntityCategoryFilterDown(categories.SCOUT, units)
@@ -495,15 +514,15 @@ DebugAssignToUnits = function(data, units)
     end
 end
 
----@param data { Behavior: 'AIBehaviorTacticalSimple' }
+---@param data { Behavior: 'AIPlatoonAdaptiveAttackBehavior' }
 ---@param units Unit[]
 AssignToUnitsMachine = function(data, platoon, units)
     if units and not TableEmpty(units) then
+
         -- meet platoon requirements
         import("/lua/sim/navutils.lua").Generate()
-        import("/lua/sim/markerutilities.lua").GenerateExpansionMarkers()
         -- create the platoon
-        setmetatable(platoon, AIPlatoonSimpleRaidBehavior)
+        setmetatable(platoon, AIPlatoonAdaptiveAttackBehavior)
         local count = TableGetn(platoon:GetSquadUnits('Attack'))
         local scouts = platoon:GetSquadUnits('Scout')
         if scouts then
@@ -513,7 +532,13 @@ AssignToUnitsMachine = function(data, platoon, units)
             end
         end
 
+        -- TODO: to be removed until we have a better system to populate the platoons
+        platoon:OnUnitsAddedToPlatoon()
+
         -- start the behavior
         ChangeState(platoon, platoon.Start)
     end
 end
+
+
+

--- a/lua/aibrains/platoons/platoon-adaptive-raid.lua
+++ b/lua/aibrains/platoons/platoon-adaptive-raid.lua
@@ -44,6 +44,22 @@ AIPlatoonAdaptiveRaidBehavior = Class(AIPlatoon) {
                 self:ChangeState(self.Error)
                 return
             end
+            local aiBrain = self:GetBrain()
+            if not aiBrain.GridPresence then
+                self:LogWarning('requires grid presence class setup')
+                self:ChangeState(self.Error)
+                return
+            end
+            if not aiBrain.GridPresence then
+                self:LogWarning('requires GridPresence class setup')
+                self:ChangeState(self.Error)
+                return
+            end
+            if not aiBrain.GridDeposits then
+                self:LogWarning('requires GridDeposits class setup')
+                self:ChangeState(self.Error)
+                return
+            end
 
             -- Set the movement layer for pathing, included for mods where water or air based engineers may exist
             self.MovementLayer = self:GetNavigationalLayer()
@@ -65,6 +81,7 @@ AIPlatoonAdaptiveRaidBehavior = Class(AIPlatoon) {
             self.OpportunityToRaid = nil
             self.ThreatToEvade = nil
             self.RetreatCount = 0
+            local aiBrain = self:GetBrain()
 
             self:Stop()
 
@@ -89,11 +106,15 @@ AIPlatoonAdaptiveRaidBehavior = Class(AIPlatoon) {
                 for k = 1, count do
                     local expansion = expansions[k]
                     if expansion.NavLabel == label then
-                        candidates[candidateCount + 1] = expansion
-                        candidateCount = candidateCount + 1
+                        if aiBrain.GridPresence:GetInferredStatus(position) ~= 'Allied' then
+                            candidates[candidateCount + 1] = expansion
+                            candidateCount = candidateCount + 1
+                        end
                     elseif not NavUtils.CanPathTo(self.MovementLayer, position, expansion.position) then
-                        unpathableCandidates[unpathableCandidateCount + 1] = expansion
-                        unpathableCandidateCount = unpathableCandidateCount + 1
+                        if aiBrain.GridPresence:GetInferredStatus(position) ~= 'Allied' then
+                            unpathableCandidates[unpathableCandidateCount + 1] = expansion
+                            unpathableCandidateCount = unpathableCandidateCount + 1
+                        end
                     end
                 end
                 -- END OF TODO

--- a/lua/aibrains/platoons/platoon-adaptive-raid.lua
+++ b/lua/aibrains/platoons/platoon-adaptive-raid.lua
@@ -1,6 +1,9 @@
+
 local AIPlatoon = import("/lua/aibrains/platoons/platoon-base.lua").AIPlatoon
 local NavUtils = import("/lua/sim/navutils.lua")
 local MarkerUtils = import("/lua/sim/markerutilities.lua")
+local TransportUtils = import("/lua/ai/transportutilities.lua")
+local AIAttackUtils = import("/lua/ai/aiattackutilities.lua")
 
 -- upvalue scope for performance
 local Random = Random
@@ -12,21 +15,21 @@ local TableEmpty = table.empty
 -- constants
 local NavigateDistanceThresholdSquared = 20 * 20
 
----@class AIPlatoonSimpleRaidBehavior : AIPlatoon
----@field RetreatCount number
+---@class AIPlatoonAdaptiveRaidBehavior : AIPlatoon
+---@field RetreatCount number 
 ---@field ThreatToEvade Vector | nil
 ---@field LocationToRaid Vector | nil
 ---@field OpportunityToRaid Vector | nil
-AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
+AIPlatoonAdaptiveRaidBehavior = Class(AIPlatoon) {
 
-    PlatoonName = 'SimpleRaidBehavior',
+    PlatoonName = 'AdaptiveRaidBehavior',
 
     Start = State {
 
         StateName = 'Start',
 
         --- Initial state of any state machine
-        ---@param self AIPlatoonSimpleRaidBehavior
+        ---@param self AIPlatoonAdaptiveRaidBehavior
         Main = function(self)
             -- requires expansion markers
             if not import("/lua/sim/markerutilities/expansions.lua").IsGenerated() then
@@ -42,6 +45,9 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
                 return
             end
 
+            -- Set the movement layer for pathing, included for mods where water or air based engineers may exist
+            self.MovementLayer = self:GetNavigationalLayer()
+
             self:ChangeState(self.Searching)
             return
         end,
@@ -52,7 +58,7 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
         StateName = 'Searching',
 
         --- The platoon searches for a target
-        ---@param self AIPlatoonSimpleRaidBehavior
+        ---@param self AIPlatoonAdaptiveRaidBehavior
         Main = function(self)
             -- reset state
             self.LocationToRaid = nil
@@ -71,40 +77,53 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
             local label, error = NavUtils.GetLabel('Land', position)
 
             if label then
-
+                
                 -- TODO
                 -- this should be cached, part of the marker utilities
                 local expansions, count = MarkerUtils.GetMarkersByType('Expansion Area')
                 ---@type MarkerData[]
-                local candidates = {}
+                local candidates = { }
+                local unpathableCandidates = { }
                 local candidateCount = 0
+                local unpathableCandidateCount = 0
                 for k = 1, count do
                     local expansion = expansions[k]
                     if expansion.NavLabel == label then
                         candidates[candidateCount + 1] = expansion
                         candidateCount = candidateCount + 1
+                    elseif not NavUtils.CanPathTo(self.MovementLayer, position, expansion.position) then
+                        unpathableCandidates[unpathableCandidateCount + 1] = expansion
+                        unpathableCandidateCount = unpathableCandidateCount + 1
                     end
                 end
                 -- END OF TODO
 
                 -- something odd happened: there are no expansions with a matching label
-                if candidateCount == 0 then
+                if candidateCount == 0 and unpathableCandidateCount == 0 then
                     self:LogWarning(string.format('no expansions found on label %d', label))
                     self:ChangeState(self.Error)
                     return
                 end
 
                 -- pick random expansion that we can Navigating to
-                local selectionNumber = Random(1, candidateCount)
-                local expansion = candidates[selectionNumber]
+                local selectionNumber
+                local expansion
+                if candidateCount > 0 then
+                    selectionNumber = Random(1, candidateCount)
+                    expansion = candidates[selectionNumber]
+                elseif unpathableCandidateCount > 0 then
+                    selectionNumber = Random(1, unpathableCandidateCount)
+                    expansion = unpathableCandidates[selectionNumber]
+                end
+                if unpathableCandidateCount > 0 then
+                    self:LogDebug(string.format('unpathableCandidateCount '..unpathableCandidateCount))
+                    self:LogDebug(string.format('Current raid position is '..repr(expansion.position)))
+                end
                 self.LocationToRaid = expansion.position
                 if self.LocationToRaid then
-                    LOG('Location to raid is '..repr(self.LocationToRaid))
+                    self:LogDebug(string.format('Location to raid is '..repr(self.LocationToRaid)))
                 else
-                    LOG('Location to raid is nil')
-                    LOG(repr(expansion))
-                    LOG('Selection was '..selectionNumber)
-                    LOG('candidates '..repr(candidates))
+                    self:LogDebug(string.format('Location to raid is nil'))
                 end
                 self:ChangeState(self.Navigating)
                 return
@@ -122,7 +141,7 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
         StateName = 'Navigating',
 
         --- The platoon navigates towards a target, picking up oppertunities as it finds them
-        ---@param self AIPlatoonSimpleRaidBehavior
+        ---@param self AIPlatoonAdaptiveRaidBehavior
         Main = function(self)
             -- reset state
             self.OpportunityToRaid = nil
@@ -142,6 +161,12 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
             local brain = self:GetBrain()
             if not brain.GridPresence then
                 WARN('GridPresence does not exist, unable to detect conflict line')
+            end
+
+            if not NavUtils.CanPathToCell(self.MovementLayer, self:GetPlatoonPosition(), destination) then
+                self:LogDebug(string.format('Raid platoon is going to use transport'))
+                self:ChangeState(self.Transporting)
+                return
             end
 
             while not IsDestroyed(self) do
@@ -170,7 +195,7 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
                     return
                 end
 
-                -- navigate towards waypoint
+                -- navigate towards waypoint 
                 local dx = origin[1] - waypoint[1]
                 local dz = origin[3] - waypoint[3]
                 local d = math.sqrt(dx * dx + dz * dz)
@@ -200,11 +225,12 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
                                 local info = threatTable[Random(1, TableGetn(threatTable))]
                                 self.ThreatToEvade = { info[1], GetSurfaceHeight(info[1], info[2]), info[2] }
                                 DrawCircle(self.ThreatToEvade, 5, 'ff0000')
+                                self:LogDebug(string.format('We are going to retreat, enemy threat '..threat..' our threat '..platoonThreat..' position status '..positionStatus))
                                 self:ChangeState(self.Retreating)
                                 return
                             end
-                        else
-                            LOG('Threat and we need to attack then since it is allied, status '..positionStatus)
+                        elseif positionStatus then
+                            self:LogDebug(string.format('We are going to attack, enemy threat '..threat..' our threat '..platoonThreat..' position status '..positionStatus))
                         end
                     end
 
@@ -237,12 +263,32 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
         end,
     },
 
+    Transporting = State {
+
+        StateName = 'Transporting',
+
+        --- The platoon avoids danger or attempts to reclaim if they are too close to avoid
+        ---@param self AIPlatoonAdaptiveRaidBehavior
+        Main = function(self)
+            local brain = self:GetBrain()
+            local usedTransports = TransportUtils.SendPlatoonWithTransports(brain, self, self.LocationToRaid, 1, false)
+            if usedTransports then
+                self:LogDebug(string.format('Raid Platoon used transports'))
+                self:ChangeState(self.Navigating)
+            else
+                self:LogDebug(string.format('Raid Platoon didnt use transports'))
+                self:ChangeState(self.Searching)
+            end
+            return
+        end,
+    },
+
     RaidingTarget = State {
 
         StateName = 'RaidingTarget',
 
         --- The platoon raids the target
-        ---@param self AIPlatoonSimpleRaidBehavior
+        ---@param self AIPlatoonAdaptiveRaidBehavior
         Main = function(self)
             local brain = self:GetBrain()
 
@@ -281,7 +327,7 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
 
                 -- check if our command is still going
                 if not self:IsCommandsActive(command) then
-
+                    self:ChangeState(self.Searching)
                     return
                 end
 
@@ -295,7 +341,7 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
         StateName = 'RaidingOpportunity',
 
         --- The platoon raids the opportunity it walked into
-        ---@param self AIPlatoonSimpleRaidBehavior
+        ---@param self AIPlatoonAdaptiveRaidBehavior
         Main = function(self)
             local brain = self:GetBrain()
 
@@ -311,7 +357,7 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
 
             -- tell attack units to attack
             local attackCommand
-            local attackOffset, error = NavUtils.RandomDirectionFrom('Land', location, 32, 4) -- TODO: remove magic numbers'
+            local attackOffset, error = NavUtils.RandomDirectionFrom('Land', location, 32, 4)       -- TODO: remove magic numbers'
             if not attackOffset then
                 attackCommand = self:AggressiveMoveToLocation(location, 'Attack')
             else
@@ -319,7 +365,7 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
             end
 
             -- tell scout units to patrol for threats
-            local scoutOffsets, countOrError = NavUtils.DirectionsFrom('Land', location, 32, 4) -- TODO: remove magic numbers
+            local scoutOffsets, countOrError = NavUtils.DirectionsFrom('Land', location, 32, 4)    -- TODO: remove magic numbers
             if not scoutOffsets then
                 self:Patrol(location, 'Scout')
             else
@@ -343,18 +389,25 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
                 local threat = brain:GetThreatAtPosition(position, 1, true, 'AntiSurface')
                 if threat > 0 then
                     local threatTable = brain:GetThreatsAroundPosition(position, 1, true, 'AntiSurface')
-                    if threatTable and not TableEmpty(threatTable) then
-                        local info = threatTable[Random(1, TableGetn(threatTable))]
-                        self.ThreatToEvade = { info[1], GetSurfaceHeight(info[1], info[2]), info[2] }
-                        self:ChangeState(self.Retreating)
-                        return
+                    local platoonThreat = self:CalculatePlatoonThreatAroundPosition('Surface', categories.MOBILE * categories.DIRECTFIRE - categories.SCOUT, position, 30)
+                    local positionStatus = brain.GridPresence:GetInferredStatus(position)
+                    if positionStatus != 'Allied' or platoonThreat * 2 < threat then
+                        if threatTable and not TableEmpty(threatTable) then
+                            local info = threatTable[Random(1, TableGetn(threatTable))]
+                            self.ThreatToEvade = { info[1], GetSurfaceHeight(info[1], info[2]), info[2] }
+                            DrawCircle(self.ThreatToEvade, 5, 'ff0000')
+                            self:ChangeState(self.Retreating)
+                            return
+                        end
+                    else
+                        self:LogDebug(string.format('Threat and we need to attack then since it is allied, status '..positionStatus))
                     end
                 end
 
                 -- check if our command is still going
                 if not self:IsCommandsActive(attackCommand) then
                     -- setup attack units
-                    local attackOffset, error = NavUtils.RandomDirectionFrom('Land', location, 10, 8) -- TODO: remove magic numbers
+                    local attackOffset, error = NavUtils.RandomDirectionFrom('Land', location, 10, 8)       -- TODO: remove magic numbers
                     if not attackOffset then
                         self:LogWarning(string.format('no alternative directions found to evade'))
                         self:ChangeState(self.Error)
@@ -374,7 +427,7 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
         StateName = "Retreating",
 
         --- The platoon retreats from a threat
-        ---@param self AIPlatoonSimpleRaidBehavior
+        ---@param self AIPlatoonAdaptiveRaidBehavior
         Main = function(self)
             local brain = self:GetBrain()
 
@@ -463,17 +516,16 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
             end
         end
 
-        for k, scout in units do
+        for k, scout in units do 
             scout:SetFireState(1)
         end
     end,
 }
 
----@param data { Behavior: 'AIBehaviorTacticalSimple' }
+---@param data { Behavior: 'AIPlatoonAdaptiveRaidBehavior' }
 ---@param units Unit[]
 DebugAssignToUnits = function(data, units)
     if units and not TableEmpty(units) then
-        LOG('Assigning Units to new platoon')
 
         -- meet platoon requirements
         import("/lua/sim/navutils.lua").Generate()
@@ -481,8 +533,8 @@ DebugAssignToUnits = function(data, units)
 
         -- create the platoon
         local brain = units[1].Brain
-        local platoon = brain:MakePlatoon('', '') --[[@as AIPlatoonSimpleRaidBehavior]]
-        setmetatable(platoon, AIPlatoonSimpleRaidBehavior)
+        local platoon = brain:MakePlatoon('', '') --[[@as AIPlatoonAdaptiveRaidBehavior]]
+        setmetatable(platoon, AIPlatoonAdaptiveRaidBehavior)
 
         -- assign units to squads
         local scouts = EntityCategoryFilterDown(categories.SCOUT, units)
@@ -495,15 +547,16 @@ DebugAssignToUnits = function(data, units)
     end
 end
 
----@param data { Behavior: 'AIBehaviorTacticalSimple' }
+---@param data { Behavior: 'AIPlatoonAdaptiveRaidBehavior' }
 ---@param units Unit[]
 AssignToUnitsMachine = function(data, platoon, units)
     if units and not TableEmpty(units) then
+
         -- meet platoon requirements
         import("/lua/sim/navutils.lua").Generate()
         import("/lua/sim/markerutilities.lua").GenerateExpansionMarkers()
         -- create the platoon
-        setmetatable(platoon, AIPlatoonSimpleRaidBehavior)
+        setmetatable(platoon, AIPlatoonAdaptiveRaidBehavior)
         local count = TableGetn(platoon:GetSquadUnits('Attack'))
         local scouts = platoon:GetSquadUnits('Scout')
         if scouts then
@@ -513,7 +566,13 @@ AssignToUnitsMachine = function(data, platoon, units)
             end
         end
 
+        -- TODO: to be removed until we have a better system to populate the platoons
+        platoon:OnUnitsAddedToPlatoon()
+
         -- start the behavior
         ChangeState(platoon, platoon.Start)
     end
 end
+
+
+

--- a/lua/aibrains/platoons/platoon-adaptive-reclaim.lua
+++ b/lua/aibrains/platoons/platoon-adaptive-reclaim.lua
@@ -1,0 +1,493 @@
+local AIPlatoon = import("/lua/aibrains/platoons/platoon-base.lua").AIPlatoon
+local NavUtils = import("/lua/sim/navutils.lua")
+local MarkerUtils = import("/lua/sim/markerutilities.lua")
+local TransportUtils = import("/lua/ai/transportutilities.lua")
+local AIUtils = import("/lua/ai/aiutilities.lua")
+
+local IsDestroyed = IsDestroyed
+
+local TableGetn = table.getn
+local TableEmpty = table.empty
+local TableInsert = table.insert
+
+-- I'm up to navigating. Specifically the reclaim check.
+
+---@class AIPlatoonAdaptiveReclaimBehavior : AIPlatoon
+---@field ThreatToEvade Vector | nil
+---@field LocationToReclaim Vector | nil
+AIPlatoonAdaptiveReclaimBehavior = Class(AIPlatoon) {
+
+    PlatoonName = 'AdaptiveReclaimBehavior',
+
+    Start = State {
+
+        StateName = 'Start',
+
+        --- Initial state of any state machine
+        ---@param self AIPlatoonAdaptiveReclaimBehavior
+        Main = function(self)
+            local brain = self:GetBrain()
+
+            if not self.SearchRadius then
+                local maxMapDimension = math.max(ScenarioInfo.size[1], ScenarioInfo.size[2])
+                if maxMapDimension == 256 then
+                    self.SearchRadius = 8
+                else
+                    self.SearchRadius = 16
+                end
+            end
+
+            if not brain.GridReclaim then
+                self:LogWarning('requires reclaim grid to be generated and running')
+                self:ChangeState(self.Error)
+                return
+            end
+
+            self.CellSize = brain.GridReclaim.CellSize * brain.GridReclaim.CellSize
+
+            -- requires navigational mesh
+            if not NavUtils.IsGenerated() then
+                self:LogWarning('requires generated navigational mesh')
+                self:ChangeState(self.Error)
+                return
+            end
+
+            -- Set the movement layer for pathing, included for mods where water or air based engineers may exist
+            self.MovementLayer = self:GetNavigationalLayer()
+
+            self:ChangeState(self.Searching)
+            return
+        end,
+    },
+
+    Searching = State {
+
+        StateName = 'Searching',
+
+        --- The platoon searches for a target
+        ---@param self AIPlatoonAdaptiveReclaimBehavior
+        Main = function(self)
+            -- reset state
+            self.LocationToReclaim = nil
+            self.ThreatToEvade = nil
+
+            self:Stop()
+            local brain = self:GetBrain()
+            local reclaimGridInstance = brain.GridReclaim
+            local brainGridInstance = brain.GridBrain
+            local searchRadius = self.SearchRadius
+            local eng = self:GetPlatoonUnits()[1]
+            local searchLoop = 0
+            local reclaimTargetX, reclaimTargetZ
+            local engPos = eng:GetPosition()
+            local gx, gz = reclaimGridInstance:ToGridSpace(engPos[1], engPos[3])
+            local imapRadius = brain.IMAPConfig.Rings or 0
+            local pathFailTable = {}
+            while searchLoop < searchRadius and (not (reclaimTargetX and reclaimTargetZ)) do
+                WaitTicks(1)
+
+                -- retrieve a list of cells with some mass value
+                local cells, count = reclaimGridInstance:FilterAndSortInRadius(gx, gz, searchRadius, 10)
+                -- find out if we can path to the center of the cell and check engineer maximums
+                for k = 1, count do
+                    local cell = cells[k] --[[@as AIGridReclaimCell]]
+                    local centerOfCell = reclaimGridInstance:ToWorldSpace(cell.X, cell.Z)
+                    local maxEngineers = math.min(math.ceil(cell.TotalMass / 500), 8)
+
+                    -- make sure we can path to it and it doesnt have high threat e.g Point Defense
+                    if NavUtils.CanPathToCell(self.MovementLayer, engPos, centerOfCell) 
+                        and brain:GetThreatAtPosition(centerOfCell, imapRadius, true, 'AntiSurface') < 10 then
+
+                        local brainCell = brainGridInstance:ToCellFromGridSpace(cell.X, cell.Z)
+                        local engineersInCell = brainGridInstance:CountReclaimingEngineers(brainCell)
+                        if engineersInCell < maxEngineers then
+                            reclaimTargetX, reclaimTargetZ = cell.X, cell.Z
+                            break
+                        end
+                    elseif brain:GetThreatAtPosition(centerOfCell, imapRadius, true, 'AntiSurface') < 10 then
+                        TableInsert(pathFailTable, { center = centerOfCell, x = cell.X, z = cell.Z })
+                    end
+                end
+
+                searchLoop = searchLoop + 1
+                if searchLoop == searchRadius and (not (reclaimTargetX and reclaimTargetZ)) and TableGetn(pathFailTable) > 0 then
+                    self:LogDebug(string.format('Loop failed and we have unpathable reclaim'))
+                    local closestReclaimDistance
+                    local closestReclaim
+                    for _, v in pathFailTable do
+                        local distance = VDist3Sq(engPos, v.center)
+                        if not closestReclaim or distance < closestReclaimDistance then
+                            closestReclaim = v
+                            closestReclaimDistance = distance
+                            reclaimTargetX, reclaimTargetZ = v.x, v.z
+                        end
+                    end
+                end
+                self:LogDebug('Search loop is ' .. searchLoop .. ' out of a possible ' .. searchRadius)
+            end
+            if reclaimTargetX and reclaimTargetZ then
+                local brainCell = brainGridInstance:ToCellFromGridSpace(reclaimTargetX, reclaimTargetZ)
+                -- Assign engineer to cell
+                self.CellAssigned = { reclaimTargetX, reclaimTargetZ }
+                brainGridInstance:AddReclaimingEngineer(brainCell, eng)
+                self.LocationToReclaim = reclaimGridInstance:ToWorldSpace(reclaimTargetX, reclaimTargetZ)
+                self:ChangeState(self.Navigating)
+                return
+            else
+                if self.SearchRadius < 8 then
+                    self.SearchRadius = 8
+                    self:LogDebug(string.format('No reclaim found, extending search range to 8'))
+                    self:ChangeState(self.Searching)
+                    return
+                end
+                self:LogWarning(string.format('no reclaim target found'))
+                local closestManager 
+                local returnPos
+                if eng.BuilderManagerData.EngineerManager.Location then
+                    returnPos = eng.BuilderManagerData.EngineerManager.Location
+                end
+                if not returnPos then
+                    for _,v in brain.BuilderManagers do
+                        local basePos = v.EngineerManager:GetLocationCoords()
+                        if not closestManager or (VDist3Sq(engPos, basePos) < closestManager and NavUtils.CanPathTo('Amphibious', engPos, basePos)) then
+                            returnPos = basePos
+                        end
+                    end
+                end
+                if returnPos and VDist3Sq(engPos, returnPos) < 6400 then
+                    self:ExitStateMachine()
+                elseif returnPos then
+                    self.LocationToReclaim = returnPos
+                    self:ChangeState(self.Navigating)
+                else
+                    self:ChangeState(self.Error)
+                end
+                return
+            end
+        end,
+
+    },
+
+    Navigating = State {
+
+        StateName = 'Navigating',
+
+        --- The platoon navigates towards a target, picking up oppertunities as it finds them
+        ---@param self AIPlatoonAdaptiveReclaimBehavior
+        Main = function(self)
+            -- reset state
+            self.ThreatToEvade = nil
+
+            -- sanity check
+            local destination = self.LocationToReclaim
+            if not destination then
+                self:LogWarning(string.format('no destination to navigate to'))
+                self:ChangeState(self.Searching)
+                return
+            end
+            local brain = self:GetBrain()
+            self:Stop()
+            local eng = self:GetPlatoonUnits()[1]
+            local cache = { 0, 0, 0 }
+
+            if not brain.GridPresence then
+                WARN('GridPresence does not exist, unable to detect conflict line')
+            end
+            if not NavUtils.CanPathToCell(self.MovementLayer, eng:GetPosition(), destination) then
+                self:LogDebug(string.format('Reclaim engineer is going to use transport'))
+                self:ChangeState(self.Transporting)
+                return
+            end
+
+            while not IsDestroyed(self) do
+                local origin = eng:GetPosition()
+
+                -- generate a direction
+                local waypoint, length = NavUtils.DirectionTo('Land', origin, destination, 60)
+
+                -- something odd happened: no direction found
+                if not waypoint then
+                    self:LogWarning(string.format('no path found'))
+                    self:ChangeState(self.Searching)
+                    return
+                end
+
+                -- we're near the destination, better start raiding it!
+                if waypoint == destination then
+                    self:ChangeState(self.ReclaimCell)
+                    return
+                end
+
+
+                IssueMove({ eng }, waypoint)
+                local engStuckCount = 0
+                local Lastdist
+                local dist = VDist3Sq(eng:GetPosition(), destination)
+                local cellSize = self.CellSize
+
+                -- Statemachine switch for engineer moving to location
+                while not IsDestroyed(eng) and dist > cellSize do
+                    WaitTicks(25)
+                    if brain:GetNumUnitsAroundPoint(categories.LAND * categories.MOBILE, eng:GetPosition(), 45, 'Enemy')
+                        > 0 then
+                        -- Statemachine switch to avoiding/reclaiming danger
+                        self:ChangeState(self.Retreating)
+                        return
+                    else
+                        -- Jip discussed potentially getting navmesh to return mass points along the path rather than this.
+                        -- Potential Statemachine switch to building extractors
+                        if not IsDestroyed(eng) and not eng:IsUnitState('Reclaiming') then
+                            local reclaimAction = AIUtils.EngPerformReclaim(eng, 10)
+                            if reclaimAction then
+                                WaitTicks(45)
+                                -- Statemachine switch to evaluating next action to take
+                                IssueMove({ eng }, waypoint)
+                            end
+                        end
+                        if not IsDestroyed(eng) then
+                            local bool, markers = AIUtils.CanBuildOnLocalMassPoints(brain, eng:GetPosition(), 25)
+                            if bool then
+                                self.MassPointTable = markers
+                                self:ChangeState(self.BuilderStructure)
+                                return
+                            end
+                        end
+                    end
+                    dist = VDist3Sq(eng:GetPosition(), waypoint)
+                    if Lastdist ~= dist then
+                        engStuckCount = 0
+                        Lastdist = dist
+                    elseif not eng:IsUnitState('Reclaiming') then
+                        engStuckCount = engStuckCount + 1
+                        if engStuckCount > 15 then
+                            break
+                        end
+                    end
+                end
+                if IsDestroyed(eng) then
+                    return
+                end
+                if dist <= cellSize then
+                    -- Statemachine switch to reclaiming state
+                    self:ChangeState(self.ReclaimCell)
+                    return
+                end
+
+                -- always wait
+                WaitTicks(1)
+            end
+        end,
+    },
+
+    BuilderStructure = State {
+
+        StateName = 'BuilderStructure',
+
+        --- The platoon avoids danger or attempts to reclaim if they are too close to avoid
+        ---@param self AIPlatoonAdaptiveReclaimBehavior
+        Main = function(self)
+            if not self.MassPointTable then
+                self:ChangeState(self.Error)
+                return
+            end
+
+            self:LogDebug('Attempting to build a mass point or two')
+            local eng = self:GetPlatoonUnits()[1]
+            local brain = self:GetBrain()
+            IssueClearCommands({ eng })
+            local factionIndex = brain:GetFactionIndex()
+            local buildingTmplFile = import('/lua/BuildingTemplates.lua')
+            local buildingTmpl = buildingTmplFile[('BuildingTemplates')][factionIndex]
+            local whatToBuild = brain:DecideWhatToBuild(eng, 'T1Resource', buildingTmpl)
+            for _, massMarker in self.MassPointTable do
+                AIUtils.EngineerTryReclaimCaptureArea(brain, eng, massMarker.Position, 2)
+                AIUtils.EngineerTryRepair(brain, eng, whatToBuild, massMarker.Position)
+                if massMarker.BorderWarning then
+                    IssueBuildMobile({ eng }, massMarker.Position, whatToBuild, {})
+                else
+                    brain:BuildStructure(eng, whatToBuild, { massMarker.Position[1], massMarker.Position[3], 0 }, false)
+                end
+            end
+            while eng and not eng.Dead and
+                (0 < table.getn(eng:GetCommandQueue()) or eng:IsUnitState('Building') or eng:IsUnitState("Moving")) do
+                coroutine.yield(20)
+            end
+            self.MassPointTable = nil
+            self:ChangeState(self.Searching)
+            return
+        end,
+    },
+
+    Retreating = State {
+
+        StateName = 'Retreating',
+
+        --- The platoon avoids danger or attempts to reclaim if they are too close to avoid
+        ---@param self AIPlatoonAdaptiveReclaimBehavior
+        Main = function(self)
+            local eng = self:GetPlatoonUnits()[1]
+            local brain = self:GetBrain()
+
+            local engPos = eng:GetPosition()
+            local enemyUnits = brain:GetUnitsAroundPoint(categories.LAND * categories.MOBILE, engPos, 45, 'Enemy')
+            local action = false
+            for _, unit in enemyUnits do
+                local enemyUnitPos = unit:GetPosition()
+                if EntityCategoryContains(categories.SCOUT + categories.ENGINEER * (categories.TECH1 + categories.TECH2)
+                    - categories.COMMAND, unit) then
+                    if VDist2Sq(engPos[1], engPos[3], enemyUnitPos[1], enemyUnitPos[3]) < 144 then
+                        if unit and not IsDestroyed(unit) and unit:GetFractionComplete() == 1 then
+                            if VDist2Sq(engPos[1], engPos[3], enemyUnitPos[1], enemyUnitPos[3]) < 156 then
+                                IssueClearCommands({ eng })
+                                IssueReclaim({ eng }, unit)
+                                action = true
+                                break
+                            end
+                        end
+                    end
+                elseif EntityCategoryContains(categories.LAND * categories.MOBILE - categories.SCOUT, unit) then
+                    if VDist2Sq(engPos[1], engPos[3], enemyUnitPos[1], enemyUnitPos[3]) < 81 then
+                        if unit and not IsDestroyed(unit) and unit:GetFractionComplete() == 1 then
+                            if VDist2Sq(engPos[1], engPos[3], enemyUnitPos[1], enemyUnitPos[3]) < 156 then
+                                IssueClearCommands({ eng })
+                                IssueReclaim({ eng }, unit)
+                                action = true
+                                break
+                            end
+                        end
+                    else
+                        IssueClearCommands({ eng })
+                        IssueMove({ eng }, AIUtils.ShiftPosition(enemyUnitPos, engPos, 50, false))
+                        coroutine.yield(60)
+                        action = true
+                    end
+                end
+            end
+            self:ChangeState(self.Searching)
+            return
+        end,
+    },
+
+    ReclaimCell = State {
+
+        StateName = 'ReclaimCell',
+
+        --- The platoon avoids danger or attempts to reclaim if they are too close to avoid
+        ---@param self AIPlatoonAdaptiveReclaimBehavior
+        Main = function(self)
+            local eng = self:GetPlatoonUnits()[1]
+            local brain = self:GetBrain()
+            local reclaimGridInstance = brain.GridReclaim
+            local reclaimTargetX = self.CellAssigned[1]
+            local reclaimTargetZ = self.CellAssigned[2]
+            local reclaimPos = self.LocationToReclaim
+            local action = false
+            local time = 0
+            IssueClearCommands({ eng })
+            while time < 30 do
+                IssueAggressiveMove({ eng }, reclaimPos)
+                time = time + 1
+                WaitTicks(50)
+                local engPos = eng:GetPosition()
+                if brain:GetNumUnitsAroundPoint(categories.LAND * categories.MOBILE, engPos, 45, 'Enemy') > 0 then
+                    -- Statemachine switch to avoiding/reclaiming danger
+                    local actionTaken = AIUtils.EngAvoidLocalDanger(brain, eng)
+                    if actionTaken then
+                        -- Statemachine switch to evaluating next action to take
+                        IssueAggressiveMove({ eng }, reclaimPos)
+                    end
+                end
+                if reclaimGridInstance.Cells[reclaimTargetX][reclaimTargetZ].TotalMass < 10 or
+                    brain:GetEconomyStoredRatio('MASS') > 0.95 then
+                    break
+                end
+                if VDist3Sq(engPos, reclaimPos) < 4 and
+                    reclaimGridInstance.Cells[reclaimTargetX][reclaimTargetZ].TotalMass > 5 then
+                    for _, v in reclaimGridInstance.Cells[reclaimTargetX][reclaimTargetZ].Reclaim do
+                        if IsProp(v) and v.MaxMassReclaim > 0 then
+                            reclaimPos = v:GetPosition()
+                            IssueClearCommands({ eng })
+                            break
+                        end
+                    end
+                end
+            end
+
+            self:ChangeState(self.Searching)
+            return
+        end,
+    },
+
+    Transporting = State {
+
+        StateName = 'Transporting',
+
+        --- The platoon avoids danger or attempts to reclaim if they are too close to avoid
+        ---@param self AIPlatoonAdaptiveReclaimBehavior
+        Main = function(self)
+            local brain = self:GetBrain()
+            local usedTransports = TransportUtils.SendPlatoonWithTransports(brain, self, self.LocationToReclaim, 3, false)
+            if usedTransports then
+                self:LogDebug(string.format('Engineer used transports'))
+                self:ChangeState(self.Navigating)
+            else
+                self:LogDebug(string.format('Engineer tried but didnt use transports'))
+                self:ChangeState(self.Searching)
+            end
+            return
+        end,
+    },
+
+
+}
+
+---@param data { Behavior: 'AIPlatoonAdaptiveReclaimBehavior' }
+---@param units Unit[]
+AssignToUnitsMachine = function(data, platoon, units)
+    if units and not TableEmpty(units) then
+
+        -- meet platoon requirements
+        import("/lua/sim/navutils.lua").Generate()
+        import("/lua/sim/markerutilities.lua").GenerateExpansionMarkers()
+        -- create the platoon
+        setmetatable(platoon, AIPlatoonAdaptiveReclaimBehavior)
+        local count = TableGetn(platoon:GetPlatoonUnits())
+        local engineers = platoon:GetPlatoonUnits()
+        if engineers then
+            local platoonCount = 0
+            for _, eng in engineers do
+                platoonCount = platoonCount + 1
+                if platoonCount > 1 then
+                    eng.PlatoonHandle = nil
+                    eng.AssistSet = nil
+                    eng.AssistPlatoon = nil
+                    eng.UnitBeingAssist = nil
+                    eng.ReclaimInProgress = nil
+                    eng.CaptureInProgress = nil
+                    if eng:IsPaused() then
+                        eng:SetPaused(false)
+                    end
+                    if not eng.Dead and eng.BuilderManagerData then
+                        if eng.BuilderManagerData.EngineerManager then
+                            eng.BuilderManagerData.EngineerManager:TaskFinished(eng)
+                        end
+                    end
+                    if not eng.Dead then
+                        IssueStop({ eng })
+                        IssueClearCommands({ eng })
+                    end
+                end
+            end
+        end
+
+        if platoon.PlatoonData.SearchType == 'MAIN' then
+            platoon.SearchRadius = platoon:GetBrain().IMAPConfig.Rings
+        end
+
+        -- TODO: to be removed until we have a better system to populate the platoons
+        platoon:OnUnitsAddedToPlatoon()
+
+        -- start the behavior
+        ChangeState(platoon, platoon.Start)
+    end
+end

--- a/lua/aibrains/platoons/platoon-adaptive-silo.lua
+++ b/lua/aibrains/platoons/platoon-adaptive-silo.lua
@@ -1,0 +1,286 @@
+local AIPlatoon = import("/lua/aibrains/platoons/platoon-base.lua").AIPlatoon
+local NavUtils = import("/lua/sim/navutils.lua")
+local MarkerUtils = import("/lua/sim/markerutilities.lua")
+
+-- upvalue scope for performance
+local Random = Random
+local IsDestroyed = IsDestroyed
+
+local TableGetn = table.getn
+local TableEmpty = table.empty
+local TableInsert = table.insert
+
+--- Table of stringified categories to help determine
+local UnitTypeOrder = {
+    'TACTICALMISSILEPLATFORM',
+    'NUKE',
+}
+
+---@class AIPlatoonAdaptiveSilo : AIPlatoon
+---@field Base AIBase
+---@field Brain EasyAIBrain
+---@field BuilderType 'TACTICALMISSILEPLATFORM' | 'NUKE'
+---@field Builder AIBuilder | nil
+AIPlatoonAdaptiveSilo = Class(AIPlatoon) {
+
+    PlatoonName = 'AdaptiveSiloBehavior',
+
+    Start = State {
+
+        StateName = 'Start',
+
+        --- Initial state of any state machine
+        ---@param self AIPlatoonAdaptiveSilo
+        Main = function(self)
+            if not self.Base then
+                self:LogWarning("requires a base reference")
+                self:ChangeState(self.Error)
+            end
+
+            if not self.Brain then
+                self:LogWarning("requires a brain reference")
+                self:ChangeState(self.Error)
+            end
+
+            local units, count = self:GetPlatoonUnits()
+            local maxRadius
+            for _, v in units do
+                local weaponRadius = v.Blueprint.Weapon[1].MaxRadius
+                if not maxRadius and weaponRadius and v.Blueprint.Weapon[1].MaxRadius > maxRadius then
+                    self.MaxRadius = weaponRadius
+                end
+            end
+
+            -- determine unit type
+            local categoriesHashed = units[1].Blueprint.CategoriesHash
+            for k, category in UnitTypeOrder do
+                if categoriesHashed[category] then
+                    self.BuilderType = category
+                    break
+                end
+            end
+
+            self:ChangeState(self.SearchingForTarget)
+            return
+        end,
+    },
+
+    SearchingForTarget = State {
+
+        StateName = 'SearchingForTarget',
+
+        --- The platoon searches for a target
+        ---@param self AIPlatoonAdaptiveSilo
+        Main = function(self)
+            local units, count = self:GetPlatoonUnits()
+            if count < 1 then
+                self:LogWarning("multiple units is not supported")
+                self:ChangeState(self.Error)
+                return
+            end
+            local readyTmlLaunchers = {}
+            local missileCount = 0
+            for _, v in units do
+                missileCount = v:GetTacticalSiloAmmoCount()
+                if missileCount > 0 then
+                    totalMissileCount = totalMissileCount + missileCount
+                    TableInsert(readyTmlLaunchers, v)
+                end
+                
+            end
+            local atkPri = {
+                categories.MASSEXTRACTION * categories.STRUCTURE * ( categories.TECH2 + categories.TECH3 ),
+                categories.COMMAND,
+                categories.STRUCTURE * categories.ENERGYPRODUCTION * ( categories.TECH2 + categories.TECH3 ),
+                categories.MOBILE * categories.LAND * categories.EXPERIMENTAL,
+                categories.STRUCTURE * categories.DEFENSE * categories.TACTICALMISSILEPLATFORM,
+                categories.STRUCTURE * categories.DEFENSE * ( categories.TECH2 + categories.TECH3 ),
+                categories.MOBILE * categories.NAVAL * ( categories.TECH2 + categories.TECH3 ),
+                categories.STRUCTURE * categories.FACTORY * ( categories.TECH2 + categories.TECH3 ),
+                categories.STRUCTURE * categories.RADAR * (categories.TECH2 + categories.TECH3)
+            }
+
+            local targetUnits = self.Brain:GetUnitsAroundPoint(categories.ALLUNITS, self.CenterPosition, 235, 'Enemy')
+            local targetPosition
+
+            for _, v in atkPri do
+                for num, unit in targetUnits do
+                    if not unit.Dead and EntityCategoryContains(v, unit) and self:CanAttackTarget('attack', unit) then
+                        targetPosition = unit:GetPosition()
+                        if not GetTerrainHeight(targetPosition[1], targetPosition[3]) < GetSurfaceHeight(targetPosition[1], targetPosition[3]) then
+                            -- 6000 damage for TML
+                            if EntityCategoryContains(categories.COMMAND, unit) then
+                                local armorHealth = unit:GetHealth()
+                                local shieldHealth
+                                if unit.MyShield then
+                                    shieldHealth = unit.MyShield:GetHealth()
+                                else
+                                    shieldHealth = 0
+                                end
+                                targetHealth = armorHealth + shieldHealth
+                            else
+                                targetHealth = unit:GetHealth()
+                            end
+                            
+                            --RNGLOG('Target Health is '..targetHealth)
+                            local missilesRequired = math.ceil(targetHealth / 6000)
+                            local shieldMissilesRequired = 0
+                            --RNGLOG('Missiles Required = '..missilesRequired)
+                            --RNGLOG('Total Missiles '..totalMissileCount)
+                            if (totalMissileCount >= missilesRequired and not EntityCategoryContains(categories.COMMAND, unit)) or (readyTmlLauncherCount >= missilesRequired) then
+                                target = unit
+                                
+                                --enemyTMD = GetUnitsAroundPoint(aiBrain, categories.STRUCTURE * categories.DEFENSE * categories.ANTIMISSILE * categories.TECH2, targetPosition, 25, 'Enemy')
+                                enemyTmdCount = AIAttackUtils.AIFindNumberOfUnitsBetweenPointsRNG( aiBrain, self.CenterPosition, targetPosition, categories.STRUCTURE * categories.DEFENSE * categories.ANTIMISSILE * categories.TECH2, 30, 'Enemy')
+                                enemyShield = GetUnitsAroundPoint(aiBrain, categories.STRUCTURE * categories.DEFENSE * categories.SHIELD, targetPosition, 25, 'Enemy')
+                                if RNGGETN(enemyShield) > 0 then
+                                    local enemyShieldHealth = 0
+                                    --RNGLOG('There are '..RNGGETN(enemyShield)..'shields')
+                                    for k, shield in enemyShield do
+                                        if not shield or shield.Dead or not shield.MyShield then continue end
+                                        enemyShieldHealth = enemyShieldHealth + shield.MyShield:GetHealth()
+                                    end
+                                    shieldMissilesRequired = math.ceil(enemyShieldHealth / 6000)
+                                end
+
+                                --RNGLOG('Enemy Unit has '..enemyTmdCount.. 'TMD along path')
+                                --RNGLOG('Enemy Unit has '..RNGGETN(enemyShield).. 'Shields around it with a total health of '..enemyShieldHealth)
+                                --RNGLOG('Missiles Required for Shield Penetration '..shieldMissilesRequired)
+
+                                if enemyTmdCount >= readyTmlLauncherCount then
+                                    --RNGLOG('Target is too protected')
+                                    --Set flag for more TML or ping attack position with air/land
+                                    target = false
+                                    continue
+                                else
+                                    --RNGLOG('Target does not have enough defense')
+                                    for k, tml in readyTmlLaunchers do
+                                        local missileCount = tml:GetTacticalSiloAmmoCount()
+                                        --RNGLOG('Missile Count in Launcher is '..missileCount)
+                                        local tmlMaxRange = __blueprints[tml.UnitId].Weapon[1].MaxRadius
+                                        --RNGLOG('TML Max Range is '..tmlMaxRange)
+                                        local tmlPosition = tml:GetPosition()
+                                        if missileCount > 0 and VDist2Sq(tmlPosition[1], tmlPosition[3], targetPosition[1], targetPosition[3]) < tmlMaxRange * tmlMaxRange then
+                                            if (missileCount >= missilesRequired) and (enemyTmdCount < 1) and (shieldMissilesRequired < 1) and missilesRequired == 1 then
+                                                --RNGLOG('Only 1 missile required')
+                                                if tml.TargetBlackList then
+                                                    if tml.TargetBlackList[targetPosition[1]][targetPosition[3]] then
+                                                        --RNGLOG('TargetPos found in blacklist, skip')
+                                                        continue
+                                                    end
+                                                end
+                                                RNGINSERT(inRangeTmlLaunchers, tml)
+                                                break
+                                            else
+                                                if tml.TargetBlackList then
+                                                    if tml.TargetBlackList[targetPosition[1]][targetPosition[3]] then
+                                                        --RNGLOG('TargetPos found in blacklist, skip')
+                                                        continue
+                                                    end
+                                                end
+                                                RNGINSERT(inRangeTmlLaunchers, tml)
+                                                local readyTML = RNGGETN(inRangeTmlLaunchers)
+                                                if (readyTML >= missilesRequired) and (readyTML > enemyTmdCount + shieldMissilesRequired) then
+                                                    --RNGLOG('inRangeTmlLaunchers table number is enough for kill')
+                                                    break
+                                                end
+                                            end
+                                        end
+                                    end
+                                    --RNGLOG('Have Target and number of in range ready launchers is '..RNGGETN(inRangeTmlLaunchers))
+                                    break
+                                end
+                            else
+                                --RNGLOG('Not Enough Missiles Available')
+                                target = false
+                                self:ChangeState(self.Idling)
+                            end
+                        end
+                        coroutine.yield(1)
+                    end
+                end
+                if target then
+                    --RNGLOG('We have target and can fire, breaking loop')
+                    break
+                end
+            end
+        end,
+    },
+
+    Waiting = State {
+
+        StateName = 'Waiting',
+
+        ---@param self AIPlatoonAdaptiveSilo
+        Main = function(self)
+            WaitTicks(40)
+            self:ChangeState(self.SearchingForTask)
+        end,
+    },
+
+    Idling = State {
+        ---@param self AIPlatoonAdaptiveSilo
+        Main = function(self)
+        end,
+    }
+
+    -----------------------------------------------------------------
+    -- brain events
+}
+
+---@param data { }
+---@param units Unit[]
+DebugAssignToUnits = function(data, units)
+    if units and not TableEmpty(units) then
+        -- trigger the on stop being built event of the brain
+        for k = 1, table.getn(units) do
+            local unit = units[k]
+            unit.Brain:OnUnitStopBeingBuilt(unit, nil, unit.Layer)
+        end
+    end
+end
+
+---@param data { Behavior: 'AIPlatoonAdaptiveSiloBehavior' }
+---@param units Unit[]
+AssignToUnitsMachine = function(data, platoon, units)
+    if units and not TableEmpty(units) then
+
+        -- create the platoon
+        setmetatable(platoon, AIPlatoonAdaptiveSiloBehavior)
+
+        for _, silo in units do
+            -- Disband if dead launchers. Will reform platoon on next PFM cycle
+            if not silo or silo.Dead or silo:BeenDestroyed() then
+                platoon:PlatoonDisbandNoAssign()
+                return
+            end
+            if not platoon.Brain then
+                platoon.Brain = silo.Brain
+            end
+            -- Add the terrain hit callback
+            if not silo.terraincallbackset then
+                silo:AddMissileImpactTerrainCallback(
+                    function(unit, targetPos, impactPos)
+                        if unit and not unit.Dead and targetPos then
+                            if not unit.TargetBlackList then
+                                unit.TargetBlackList = {}
+                            end
+                            unit.TargetBlackList[targetPos[1]] = {}
+                            unit.TargetBlackList[targetPos[1]][targetPos[3]] = true
+                            return true, "target position added to tml blacklist"
+                        end
+                    end
+                )
+                silo.terraincallbackset = true
+            end
+            silo:SetAutoMode(true)
+            IssueClearCommands({silo})
+        end
+
+        -- TODO: to be removed until we have a better system to populate the platoons
+        platoon:OnUnitsAddedToPlatoon()
+
+        -- start the behavior
+        ChangeState(platoon, platoon.Start)
+    end
+end

--- a/lua/keymap/debugKeyActions.lua
+++ b/lua/keymap/debugKeyActions.lua
@@ -221,10 +221,6 @@ local keyActionsDebug = {
         action = 'UI_ToggleGamePanels',
         category = 'debug',
     },
-    ['debug_performance_metrics'] = {
-        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").TogglePerformanceMetricsWindow()',
-        category = 'debug',
-    },
 }
 
 ---@type table<string, UIKeyAction>
@@ -255,6 +251,10 @@ local keyActionsDebugAI = {
     },
     ['toggle_ai_base_ui'] = {
         action = 'UI_Lua import("/lua/ui/game/aibaseinfo.lua").OpenWindow()',
+        category = 'ai'
+    },
+    ['toggle_ai_platoon_ui'] = {
+        action = 'UI_Lua import("/lua/ui/game/aiplatooninfo.lua").OpenWindow()',
         category = 'ai'
     },
     ['toggle_ai_reclaim_grid_ui'] = {

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -4917,6 +4917,24 @@ Platoon = Class(moho.platoon_methods) {
         eng.Initializing = false
         self:PlatoonDisband()
     end,
+
+    StateMachineAI = function(self)
+        local machineType = self.PlatoonData.StateMachine
+
+        if machineType == 'AIPlatoonAdaptiveRaidBehavior' then
+            LOG('Starting State Raid')
+            import("/lua/aibrains/platoons/platoon-adaptive-raid.lua").AssignToUnitsMachine({ }, self, self:GetPlatoonUnits())
+        elseif machineType == 'AIPlatoonAdaptiveReclaimBehavior' then
+            LOG('Starting State Reclaim')
+            import("/lua/aibrains/platoons/platoon-adaptive-reclaim.lua").AssignToUnitsMachine({ }, self, self:GetPlatoonUnits())
+        elseif machineType == 'AIPlatoonAdaptiveAttackBehavior' then
+            LOG('Starting State Attack')
+            import("/lua/aibrains/platoons/platoon-adaptive-attack.lua").AssignToUnitsMachine({ }, self, self:GetPlatoonUnits())
+        end
+
+        WaitTicks(50)
+
+    end,
 }
 
 -- backwards compatibility with mods

--- a/lua/sim/NavUtils.lua
+++ b/lua/sim/NavUtils.lua
@@ -204,6 +204,13 @@ local function FindLeaf(grid, position)
     return leaf
 end
 
+---@param grid NavGrid
+---@param position Vector A position in world space
+---@return CompressedLabelTreeRoot?
+local FindRoot = function(grid, position)
+    return grid:FindRootXZ(position[1], position[3])
+end
+
 ---@param destination CompressedLabelTreeLeaf 
 ---@return Vector[]
 ---@return number   # Number of points in path

--- a/lua/ui/game/AIPlatoonInfo.lua
+++ b/lua/ui/game/AIPlatoonInfo.lua
@@ -1,0 +1,223 @@
+local UIUtil = import("/lua/ui/uiutil.lua")
+local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
+
+local Window = import("/lua/maui/window.lua").Window
+local Group = import("/lua/maui/group.lua").Group
+
+local Root = false
+
+---@class AIPlatoonInfoUI : Window
+---@field Data AIPlatoonDebugInfo
+---@field List Scrollbar
+---@field Structures { Tech1: Button, Tech2: Button, Tech3: Button, Experimental: Button }
+---@field First number
+---@field NumberOfElements number
+---@field NumberOfUIElements number
+---@field UIElements Text[]
+AIPlatoonInfoUI = ClassUI(Window) {
+
+    ---@param self AIPlatoonInfoUI
+    ---@param parent Control
+    __init = function(self, parent)
+        Window.__init(self, parent, "AI Platoon information", false, true, true, true, false, "AIPlatoonInfo2", {
+            Left = 10,
+            Top = 300,
+            Right = 310,
+            Bottom = 525
+        })
+
+        self.List = UIUtil.CreateLobbyVertScrollbar(self, 0, 0, 0)
+        self.First = 0
+        self.NumberOfElements = 0
+        self.NumberOfUIElements = 12
+        self.UIElements = {}
+
+        for k = 1, self.NumberOfUIElements do
+            local text = UIUtil.CreateText(self, '', 12, UIUtil.bodyFont)
+            self.UIElements[k] = text
+        end
+
+        AddOnSyncHashedCallback(
+        ---@param data AIPlatoonDebugInfo
+            function(data)
+                if not IsDestroyed(self) then
+                    self.Data = data
+                    self.NumberOfElements = table.getn(data.PlatoonInfo.DebugMessages)
+                    self:CalcVisible()
+                end
+            end, 'AIPlatoonInfo', 'AIPlatoonInfo.lua'
+        )
+
+        AddOnSyncHashedCallback(
+            function(data)
+                if Root then
+                    if not IsDestroyed(self) then
+                        self.Data = nil
+                        self.NumberOfElements = 0
+                        self:CalcVisible()
+                    end
+                end
+            end, 'FocusArmyChanged', 'AIPlatoonInfo.lua'
+        )
+    end,
+
+    ---@param self AIPlatoonInfoUI
+    __post_init = function(self, parent)
+
+        -- position the first one
+        local last = self.UIElements[1]
+        LayoutHelpers.LayoutFor(last)
+            :Over(self, 5)
+            :AtLeftTopIn(self, 10, 30)
+            :End()
+
+        -- position all others
+        for k = 2, self.NumberOfUIElements do
+            LayoutHelpers.LayoutFor(self.UIElements[k])
+                :Over(self, 5)
+                :Below(last, 4)
+                :End()
+
+            last = self.UIElements[k]
+        end
+
+        LayoutHelpers.LayoutFor(self)
+            :AtBottomIn(last, -20)
+            :End()
+    end,
+
+    ---@param self AIPlatoonInfoUI
+    Update = function(self)
+    end,
+
+    ---@param self AIPlatoonInfoUI
+    OnClose = function(self)
+        self:Hide()
+    end,
+
+    ---@param self AIPlatoonInfoUI
+    ---@param rotation number
+    OnMouseWheel = function(self, rotation)
+        if rotation > 0 then
+            self:ScrollLines(nil, -1)
+        else
+            self:ScrollLines(nil, 1)
+        end
+    end,
+
+    ---@param self AIPlatoonInfoUI
+    OnConfigClick = function(self)
+        if self.Data then
+            reprsl(self.Data)
+        end
+    end,
+
+    ---@param self AIPlatoonInfoUI
+    OnPinCheck = function(self)
+        if self.Data then
+            local camera = GetCamera('WorldCamera')
+
+            local rect = Rect(
+                self.Data.Position[1] - 20,
+                self.Data.Position[3] - 20,
+                self.Data.Position[1] + 20,
+                self.Data.Position[3] + 20
+            )
+
+            camera:MoveToRegion(rect, 1)
+        end
+    end,
+
+    ---@param self AIPlatoonInfoUI
+    ---@return number
+    ---@return number
+    ---@return number
+    ---@return number
+    GetScrollValues = function(self)
+        return 0, self.NumberOfElements, self.First,
+            math.min(self.First + self.NumberOfUIElements, self.NumberOfElements)
+    end,
+
+    ---@param self AIPlatoonInfoUI
+    ---@param axis any
+    ---@param delta number
+    ScrollLines = function(self, axis, delta)
+        self:ScrollSetTop(axis, self.First + math.floor(delta))
+    end,
+
+    ---@param self AIPlatoonInfoUI
+    ---@param axis any
+    ---@param delta number
+    ScrollPages = function(self, axis, delta)
+        self:ScrollSetTop(axis, self.First + math.floor(delta) * self.NumberOfUIElements)
+    end,
+
+    ---@param self AIPlatoonInfoUI
+    ---@param axis any
+    ---@param top number
+    ScrollSetTop = function(self, axis, top)
+
+        -- compute where we end up
+        local size = self.NumberOfElements
+        local first = math.max(math.min(size - self.NumberOfUIElements, math.floor(top)), 0)
+
+        -- check if it is different
+        if first == self.First then
+            return
+        end
+
+        -- if so, store it and compute what is visible
+        self.First = first
+        self:CalcVisible()
+    end,
+
+    IsScrollable = function(self, axis)
+        return true
+    end,
+
+    ---@param self AIPlatoonInfoUI
+    CalcVisible = function(self)
+        for k = 1, self.NumberOfUIElements do
+            local index = k + self.First
+            if index <= self.NumberOfElements then
+                self.UIElements[k]:SetText(self.Data.PlatoonInfo.DebugMessages[index])
+            else
+                self.UIElements[k]:SetText('')
+            end
+        end
+    end,
+
+    ---@param self AIPlatoonInfoUI
+    HandleEvent = function(self, event)
+        if event.Type == 'WheelRotation' then
+            if event.WheelRotation > 0 then
+                self:ScrollLines(nil, -1)
+            else
+                self:ScrollLines(nil, 1)
+            end
+        end
+    end,
+}
+
+function OpenWindow()
+    if Root then
+        Root:Show()
+    else
+        Root = AIPlatoonInfoUI(GetFrame(0))
+        Root:Show()
+    end
+end
+
+function CloseWindow()
+    if Root then
+        Root:Hide()
+    end
+end
+
+--- Called by the module manager when this module is dirty due to a disk change
+function __moduleinfo.OnDirty()
+    if Root then
+        Root:Destroy()
+        Root = false
+    end
+end


### PR DESCRIPTION
Description of changes
This PR converts introduces an adaptive raiding state machine and engineer reclaim state machine. (replaces a previous pr that I messed up)

It adds an inject function into the platoon.lua starting line 4901. This is temporary pending @Garanas doing something better.
Adds platoon templates for state machines and updates builders.
Adds an adaptive specific brain lua and updates the index.lua file.
Adds a utility function for checking threat then units to get correct threat number. Note does not get a position of said threat, may be temporary.

TODO:

- [ ]  Rewrite platoon inject method.
- [ ]  Add transport support for state machines
- [ ]  flesh out state machines further
- [x]  Fix economy metrics on the brain (errors right now)
- [ ]  Expand state machine usage for reclaiming to all reclaim builders once validated.
- [ ] Testing
- [x]  Add platoon ui debug elements

Run some AI games using the adaptive AI across various map types and validate that the platoons / units are running correctly. Currently alot of logging is included to show state machine switching and error states.