### PR TITLE
Atlantis: Increase its BackUpDistance from 15 to 30

### DIFF
--- a/projectiles/ADFQuadLaserLight01/ADFQuadLaserLight01_proj.bp
+++ b/projectiles/ADFQuadLaserLight01/ADFQuadLaserLight01_proj.bp
@@ -38,5 +38,8 @@ ProjectileBlueprint {
         InitialSpeed = 14,
         Lifetime = 1.5,
         UseGravity = false,
+        TrackTarget = true,
+        TurnRate = 15,
+        OnLostTargetLifetime = 0.5,
     },
 }

--- a/projectiles/CDFLaserDisintegrator04/CDFLaserDisintegrator04_proj.bp
+++ b/projectiles/CDFLaserDisintegrator04/CDFLaserDisintegrator04_proj.bp
@@ -45,5 +45,8 @@ ProjectileBlueprint {
         InitialSpeed = 15,
         ProjectileLifetime = 1.5,
         UseGravity = true,
+        TrackTarget = true,
+        TurnRate = 15,
+        OnLostTargetLifetime = 0.5,
     },
 }

--- a/projectiles/SDFHeavyPhasicAutogun02/SDFHeavyPhasicAutogun02_proj.bp
+++ b/projectiles/SDFHeavyPhasicAutogun02/SDFHeavyPhasicAutogun02_proj.bp
@@ -43,6 +43,9 @@ ProjectileBlueprint {
         InitialSpeedReduceDistance = 30,
         LeadTarget = false,
         TurnRate = 360,
+        TrackTarget = true,
+        TurnRate = 15,
+        OnLostTargetLifetime = 0.5,
         VelocityAlign = true,
     },
 }

--- a/projectiles/TDFPlasmaHeavy02/TDFPlasmaHeavy02_proj.bp
+++ b/projectiles/TDFPlasmaHeavy02/TDFPlasmaHeavy02_proj.bp
@@ -46,5 +46,8 @@ ProjectileBlueprint {
         LeadTarget = false,
         Lifetime = 4,
         UseGravity = false,
+        TrackTarget = true,
+        TurnRate = 15,
+        OnLostTargetLifetime = 0.5,
     },
 }

--- a/projectiles/TDFRiot01/TDFRiot01_proj.bp
+++ b/projectiles/TDFRiot01/TDFRiot01_proj.bp
@@ -44,6 +44,9 @@ ProjectileBlueprint {
         DestroyOnWater = true,
         InitialSpeed = 13,
         UseGravity = false,
+        TrackTarget = true,
+        TurnRate = 15,
+        OnLostTargetLifetime = 0.5,
         VelocityAlign = true,
     },
 }

--- a/units/UAS0102/UAS0102_unit.bp
+++ b/units/UAS0102/UAS0102_unit.bp
@@ -91,8 +91,8 @@ UnitBlueprint{
         BuildTime = 600,
     },
     Footprint = {
-        SizeX = 2,
-        SizeZ = 6,
+        SizeX = 3,
+        SizeZ = 3,
     },
     General = {
         CommandCaps = {

--- a/units/UEA0001/UEA0001_unit.bp
+++ b/units/UEA0001/UEA0001_unit.bp
@@ -150,7 +150,7 @@ UnitBlueprint {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,
             RULEUCC_Nuke = false,
-            RULEUCC_Patrol = false,
+            RULEUCC_Patrol = true,
             RULEUCC_Pause = true,
             RULEUCC_Reclaim = true,
             RULEUCC_Repair = true,

--- a/units/UEA0003/UEA0003_unit.bp
+++ b/units/UEA0003/UEA0003_unit.bp
@@ -153,7 +153,7 @@ UnitBlueprint {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,
             RULEUCC_Nuke = false,
-            RULEUCC_Patrol = false,
+            RULEUCC_Patrol = true,
             RULEUCC_Pause = true,
             RULEUCC_Reclaim = true,
             RULEUCC_Repair = true,

--- a/units/UEA0203/UEA0203_unit.bp
+++ b/units/UEA0203/UEA0203_unit.bp
@@ -208,7 +208,7 @@ UnitBlueprint{
             MaxRadius = 22,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 40,
+            MuzzleVelocity = 35,
             ProjectileId = "/projectiles/TDFRiot01/TDFRiot01_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.15,
             ProjectilesPerOnFire = 1,

--- a/units/UEA0305/UEA0305_unit.bp
+++ b/units/UEA0305/UEA0305_unit.bp
@@ -262,7 +262,7 @@ UnitBlueprint{
             MaxRadius = 25,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 40,
+            MuzzleVelocity = 35,
             ProjectileId = "/projectiles/TDFPlasmaHeavy02/TDFPlasmaHeavy02_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.15,
             RackBones = {

--- a/units/UES0401/UES0401_unit.bp
+++ b/units/UES0401/UES0401_unit.bp
@@ -247,7 +247,7 @@ UnitBlueprint{
     LifeBarOffset = 10.5,
     LifeBarSize = 6,
     Physics = {
-        BackUpDistance = 15,
+        BackUpDistance = 30,
         BankingSlope = 0,
         CatchUpAcc = 10,
         DragCoefficient = 0.2,

--- a/units/XAA0305/XAA0305_unit.bp
+++ b/units/XAA0305/XAA0305_unit.bp
@@ -175,7 +175,7 @@ UnitBlueprint{
             MaxRadius = 25,
             MuzzleSalvoDelay = 0.2,
             MuzzleSalvoSize = 4,
-            MuzzleVelocity = 40,
+            MuzzleVelocity = 35,
             ProjectileId = "/projectiles/ADFQuadLaserLight01/ADFQuadLaserLight01_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.15,
             ProjectilesPerOnFire = 4,

--- a/units/XRA0305/XRA0305_unit.bp
+++ b/units/XRA0305/XRA0305_unit.bp
@@ -229,7 +229,7 @@ UnitBlueprint{
             MinRadius = 2,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 40,
+            MuzzleVelocity = 35,
             NotExclusive = true,
             ProjectileId = "/projectiles/CDFLaserDisintegrator04/CDFLaserDisintegrator04_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.15,

--- a/units/XSA0203/XSA0203_unit.bp
+++ b/units/XSA0203/XSA0203_unit.bp
@@ -182,7 +182,7 @@ UnitBlueprint{
             MaxRadius = 22,
             MuzzleSalvoDelay = 0.2,
             MuzzleSalvoSize = 2,
-            MuzzleVelocity = 40,
+            MuzzleVelocity = 35,
             ProjectileId = "/projectiles/SDFHeavyPhasicAutogun02/SDFHeavyPhasicAutogun02_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.15,
             ProjectilesPerOnFire = 4,


### PR DESCRIPTION
*Changes:*
Atlantis: BackUpDistance 15 --> 30

The Atlantis had a rather low BackUpDistance of 15. This meant, that in order to retreat slightly, it usually had to turn by 180 degrees and then drive forwards. This made the unit feel clunky to micro.