### PR TITLE
Draft implementation to test `GetFractionComplete`

### DIFF
--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -210,6 +210,15 @@ StructureUnit = ClassUnit(Unit) {
             self:RotateTowardsEnemy()
         end
 
+        self.WorkProgressThread = ForkThread(
+            function()
+                while not IsDestroyed(self) do
+                    self:SetWorkProgress(self:GetFractionComplete())
+                    WaitTicks(1)
+                end
+            end
+        )
+
         -- procedure to remove props that do not obstruct the building
         local blueprint = self.Blueprint
         if 
@@ -270,6 +279,9 @@ StructureUnit = ClassUnit(Unit) {
     ---@param layer Layer
     OnStopBeingBuilt = function(self, builder, layer)
         Unit.OnStopBeingBuilt(self, builder, layer)
+
+        self:SetWorkProgress(-1);
+        KillThread(self.WorkProgressThread)
 
         -- tarmac is made once seraphim animation is complete
         if self.Blueprint.General.FactionName == "Seraphim" then

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -568,9 +568,9 @@ function UpdateWindow(info)
             else
                 controls.actionIcon:SetTexture('/textures/ui/common/game/unit_view_icons/unidentified.dds')
             end
-            if info.focus.health and info.focus.maxHealth then
+            if info.focus.health and info.focus.maxHealth and info.focus.userUnit then
                 controls.actionText:SetFont(UIUtil.bodyFont, 14)
-                controls.actionText:SetText(string.format('%d%%', (info.focus.health / info.focus.maxHealth) * 100))
+                controls.actionText:SetText(string.format('%d%%', info.focus.userUnit:GetFractionComplete() * 100))
             elseif queueTextures[unitQueue[1].type] then
                 controls.actionText:SetFont(UIUtil.bodyFont, 10)
                 controls.actionText:SetText(LOC(queueTextures[unitQueue[1].type].text))


### PR DESCRIPTION
Requires the following binary patch: https://github.com/FAForever/FA-Binary-Patches/pull/40

The UI can now retrieve the build fraction that a unit that is being constructed is at. Previously the fraction was based on the hit points of the unit. This works, as long as the unit is not being damaged during construction.

Separately, also updates the work progress of the unit in question with the build fraction. This adds another layer of information to the player.

![image](https://github.com/FAForever/fa/assets/15778155/dc1af012-c306-422d-8cb7-c1a59881cec5)
