### PR TITLE
Table allocation free versions of sim commands

### DIFF
--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -773,7 +773,7 @@ end
 function IssueCapture(units, target)
 end
 
---- Clears out all commands issued on the group of units, this happens immediately
+--- Clears out all commands issued on the group of units, this happens immediately. See `IssueToUnitClearCommands` when you want to computationally efficiently apply it to a single unit 
 ---@param units Unit[]
 ---@return SimCommand
 function IssueClearCommands(units)

--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -884,7 +884,9 @@ end
 function IssueMoveOffFactory(units, position)
 end
 
---- Orders a unit to move off a factory build site. This global is not compatible with the Steam version of the game. See `IssueMoveOffFactory` when you want to apply the order to a group of units
+--- Orders a unit to move off a factory build site. See `IssueMoveOffFactory` when you want to apply the order to a group of units.
+---
+--- This use of this function is **not** compatible with the Steam version of the game.
 ---@param units Unit[]
 ---@param position Vector
 ---@return SimCommand

--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -870,14 +870,14 @@ end
 function IssueKillSelf(units)
 end
 
---- Orders a group of units to move to a position
+--- Orders a group of units to move to a position.  See `IssueToUnitMove` when you want to computationally efficiently apply it to a single unit 
 ---@param units Unit[]
 ---@param position Vector
 ---@return SimCommand
 function IssueMove(units, position)
 end
 
---- Orders a group of units to move off a factory build site. See `IssueToUnitMoveOffFactory` when you want to apply it to a single unit efficiently
+--- Orders a group of units to move off a factory build site. See `IssueToUnitMoveOffFactory` when you want to computationally efficiently apply it to a single unit
 ---@param units Unit[]
 ---@param position Vector
 ---@return SimCommand

--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -877,14 +877,14 @@ end
 function IssueMove(units, position)
 end
 
---- Orders a group of units to move off a factory build site. See `IssueMoveOffFactoryToUnit` for a single unit
+--- Orders a group of units to move off a factory build site. See `IssueMoveOffFactoryToUnit` when you want to apply it to a single unit efficiently
 ---@param units Unit[]
 ---@param position Vector
 ---@return SimCommand
 function IssueMoveOffFactory(units, position)
 end
 
---- Orders a unit to move off a factory build site. See `IssueMoveOffFactory` for a group of units
+--- Orders a unit to move off a factory build site. This global is not compatible with the Steam version of the game. See `IssueMoveOffFactory` when you want to apply the order to a group of units
 ---@param units Unit[]
 ---@param position Vector
 ---@return SimCommand

--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -877,7 +877,7 @@ end
 function IssueMove(units, position)
 end
 
---- Orders a group of units to move off a factory build site. See `IssueMoveOffFactoryToUnit` when you want to apply it to a single unit efficiently
+--- Orders a group of units to move off a factory build site. See `IssueToUnitMoveOffFactory` when you want to apply it to a single unit efficiently
 ---@param units Unit[]
 ---@param position Vector
 ---@return SimCommand

--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -877,11 +877,18 @@ end
 function IssueMove(units, position)
 end
 
---- Orders a group of units to move off a factory build site
+--- Orders a group of units to move off a factory build site. See `IssueMoveOffFactoryToUnit` for a single unit
 ---@param units Unit[]
 ---@param position Vector
 ---@return SimCommand
 function IssueMoveOffFactory(units, position)
+end
+
+--- Orders a unit to move off a factory build site. See `IssueMoveOffFactory` for a group of units
+---@param units Unit[]
+---@param position Vector
+---@return SimCommand
+function IssueMoveOffFactoryToUnit(units, position)
 end
 
 --- Orders a group of units to launch a strategic missile at a position

--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -884,15 +884,6 @@ end
 function IssueMoveOffFactory(units, position)
 end
 
---- Orders a unit to move off a factory build site. See `IssueMoveOffFactory` when you want to apply the order to a group of units.
----
---- This use of this function is **not** compatible with the Steam version of the game.
----@param units Unit[]
----@param position Vector
----@return SimCommand
-function IssueMoveOffFactoryToUnit(units, position)
-end
-
 --- Orders a group of units to launch a strategic missile at a position
 ---@see IssueTactical() # for tactical missiles
 ---@param units Unit[]

--- a/lua/AI/AIBehaviors.lua
+++ b/lua/AI/AIBehaviors.lua
@@ -194,8 +194,8 @@ function CDROverCharge(aiBrain, cdr)
                         IssueOverCharge({cdr}, target)
                     elseif target and not target.Dead then -- Commander attacks even if not enough energy for overcharge
                         IssueClearCommands({cdr})
-                        IssueMove({cdr}, targetPos)
-                        IssueMove({cdr}, cdr.CDRHome)
+                        IssueToUnitMove(cdr, targetPos)
+                        IssueToUnitMove(cdr, cdr.CDRHome)
                     end
                 elseif distressLoc then
                     enemyThreat = aiBrain:GetThreatAtPosition(distressLoc, 1, true, 'AntiSurface')
@@ -206,8 +206,8 @@ function CDROverCharge(aiBrain, cdr)
                     end
                     if distressLoc and (Utilities.XZDistanceTwoVectors(distressLoc, cdrPos) < distressRange) then
                         IssueClearCommands({cdr})
-                        IssueMove({cdr}, distressLoc)
-                        IssueMove({cdr}, cdr.CDRHome)
+                        IssueToUnitMove(cdr, distressLoc)
+                        IssueToUnitMove(cdr, cdr.CDRHome)
                     end
                 end
             end
@@ -269,7 +269,7 @@ function CDRReturnHome(aiBrain, cdr)
                 return
             end
             IssueStop({cdr})
-            IssueMove({cdr}, loc)
+            IssueToUnitMove(cdr, loc)
             cdr.GoingHome = true
             WaitSeconds(7)
         until cdr.Dead or VDist2Sq(cdrPos[1], cdrPos[3], loc[1], loc[3]) <= distSqAway
@@ -891,7 +891,7 @@ function FatBoyBehavior(self)
 
             local useMove = InWaterCheck(self)
             if useMove then
-                IssueMove({experimental}, targetUnit:GetPosition())
+                IssueToUnitMove(experimental, targetUnit:GetPosition())
             else
                 IssueAttack({experimental}, targetUnit)
             end
@@ -1125,7 +1125,7 @@ function TempestBuiltUnitMoveOut(unit, platoon, position, heading)
     local counter = 0
     repeat
         IssueClearCommands({unit})
-        IssueMove({unit}, position)
+        IssueToUnitMove(unit, position)
         WaitSeconds(5)
         if unit.Dead then
             return
@@ -1159,12 +1159,12 @@ CzarBehavior = function(self)
 
             -- Move to the target without attacking. This will get it out of your base without the beam on.
             if targetUnit and VDist3(targetUnit:GetPosition(), experimental:GetPosition()) > 50 then
-                IssueMove({experimental}, targetUnit:GetPosition())
+                IssueToUnitMove(experimental, targetUnit:GetPosition())
             else
                 IssueAttack({experimental}, experimental:GetPosition())
                 WaitTicks(5)
 
-                IssueMove({experimental}, targetUnit:GetPosition())
+                IssueToUnitMove(experimental, targetUnit:GetPosition())
             end
         end
 
@@ -1178,7 +1178,7 @@ CzarBehavior = function(self)
                 IssueAttack({experimental}, experimental:GetPosition())
                 WaitTicks(5)
 
-                IssueMove({experimental}, nearCommander:GetPosition())
+                IssueToUnitMove(experimental, nearCommander:GetPosition())
                 targetUnit = nearCommander
             end
             WaitSeconds(1)
@@ -1397,14 +1397,14 @@ function CDRHideBehavior(aiBrain, cdr)
         if category then
             runPos = AIUtils.AIFindDefensiveAreaSorian(aiBrain, cdr, category, 100, runShield)
             IssueClearCommands({cdr})
-            IssueMove({cdr}, runPos)
+            IssueToUnitMove(cdr, runPos)
         end
 
         if not category or not runPos then
             local x, z = aiBrain:GetArmyStartPos()
             runPos = AIUtils.RandomLocation(x, z)
             IssueClearCommands({cdr})
-            IssueMove({cdr}, runPos)
+            IssueToUnitMove(cdr, runPos)
         end
     end
 end

--- a/lua/AI/AIBehaviors.lua
+++ b/lua/AI/AIBehaviors.lua
@@ -994,13 +994,13 @@ function FatboyChildBehavior(self, parent, base)
         local units = self:GetPlatoonUnits()
         if not base then
             -- Wrecked base. Kill AI thread
-            IssueToUnitClearCommands(nits
+            IssueClearCommands(units)
             IssueGuard(units, parent)
             return
         end
 
         if targetUnit then
-            IssueToUnitClearCommands(nits
+            IssueClearCommands(units)
             IssueAggressiveMove(units, targetUnit)
         end
 

--- a/lua/AI/AIBehaviors.lua
+++ b/lua/AI/AIBehaviors.lua
@@ -67,7 +67,7 @@ function CDRRunAway(aiBrain, cdr)
                 end
             until cdr.Dead or (nmeAir < 2 and nmeLand < 2 and nmeHardcore == 0) or cdr:GetHealthPercent() > 0.7
 
-            IssueClearCommands({cdr})
+            IssueToUnitClearCommands(cdr)
         end
     end
 end
@@ -190,10 +190,10 @@ function CDROverCharge(aiBrain, cdr)
 
                     if aiBrain:GetEconomyStored('ENERGY') >= weapon.EnergyRequired and target and not target.Dead then
                         overCharging = true
-                        IssueClearCommands({cdr})
+                        IssueToUnitClearCommands(cdr)
                         IssueOverCharge({cdr}, target)
                     elseif target and not target.Dead then -- Commander attacks even if not enough energy for overcharge
-                        IssueClearCommands({cdr})
+                        IssueToUnitClearCommands(cdr)
                         IssueToUnitMove(cdr, targetPos)
                         IssueToUnitMove(cdr, cdr.CDRHome)
                     end
@@ -205,7 +205,7 @@ function CDROverCharge(aiBrain, cdr)
                         break
                     end
                     if distressLoc and (Utilities.XZDistanceTwoVectors(distressLoc, cdrPos) < distressRange) then
-                        IssueClearCommands({cdr})
+                        IssueToUnitClearCommands(cdr)
                         IssueToUnitMove(cdr, distressLoc)
                         IssueToUnitMove(cdr, cdr.CDRHome)
                     end
@@ -239,7 +239,7 @@ function CDROverCharge(aiBrain, cdr)
         if cdr.Initializing then
             cdr.Initializing = false
         end
-        IssueClearCommands({cdr})
+        IssueToUnitClearCommands(cdr)
     end
 end
 
@@ -276,7 +276,7 @@ function CDRReturnHome(aiBrain, cdr)
 
         cdr.Combat = false
         cdr.GoingHome = false
-        IssueClearCommands({cdr})
+        IssueToUnitClearCommands(cdr)
     end
     if not cdr.Dead and cdr.Combat and VDist2Sq(cdrPos[1], cdrPos[3], loc[1], loc[3]) < distSqAway then
         cdr.Combat = false
@@ -452,7 +452,7 @@ function AirUnitRefitThread(unit, plan, data)
                         local plat = aiBrain:MakePlatoon('', '')
                         aiBrain:AssignUnitsToPlatoon(plat, {unit}, 'Attack', 'None')
                         IssueStop({unit})
-                        IssueClearCommands({unit})
+                        IssueToUnitClearCommands(unit)
                         IssueTransportLoad({unit}, closest)
                         if EntityCategoryContains(categories.AIRSTAGINGPLATFORM, closest) and not closest.AirStaging then
                             closest.AirStaging = closest:ForkThread(AirStagingThread)
@@ -486,7 +486,7 @@ function AirStagingThread(unit)
         end
         if ready and numUnits > 0 then
             local pos = unit:GetPosition()
-            IssueClearCommands({unit})
+            IssueToUnitClearCommands(unit)
             IssueTransportUnload({unit}, {pos[1] + 5, pos[2], pos[3] + 5})
             WaitSeconds(2)
             for _, v in unit.Refueling do
@@ -760,7 +760,7 @@ function BehemothBehavior(self)
         end
 
         if targetUnit then
-            IssueClearCommands({experimental})
+            IssueToUnitClearCommands(experimental)
             IssueAttack({experimental}, targetUnit)
         end
 
@@ -768,7 +768,7 @@ function BehemothBehavior(self)
         while not experimental.Dead and not experimental:IsIdleState() do
             local nearCommander = CommanderOverrideCheck(self)
             if nearCommander and nearCommander ~= targetUnit then
-                IssueClearCommands({experimental})
+                IssueToUnitClearCommands(experimental)
                 IssueAttack({experimental}, nearCommander)
                 targetUnit = nearCommander
             end
@@ -785,7 +785,7 @@ function BehemothBehavior(self)
 
             -- Kill shields loop
             while closestBlockingShield do
-                IssueClearCommands({experimental})
+                IssueToUnitClearCommands(experimental)
                 IssueAttack({experimental}, closestBlockingShield)
 
                 -- Wait for shield to die loop
@@ -887,7 +887,7 @@ function FatBoyBehavior(self)
     while experimental and not experimental.Dead do
         targetUnit, lastBase = FindExperimentalTarget(self)
         if targetUnit then
-            IssueClearCommands({experimental})
+            IssueToUnitClearCommands(experimental)
 
             local useMove = InWaterCheck(self)
             if useMove then
@@ -903,7 +903,7 @@ function FatBoyBehavior(self)
                     WaitSeconds(5)
             end
 
-            IssueClearCommands({experimental})
+            IssueToUnitClearCommands(experimental)
 
             -- Send our homies to wreck this base
             local goodList = {}
@@ -972,7 +972,7 @@ function FatBoyBuildCheck(self)
 
     if unitBeingBuilt and not unitBeingBuilt.Dead then
         aiBrain:AssignUnitsToPlatoon(experimental.NewPlatoon, {unitBeingBuilt}, 'Attack', 'NoFormation')
-        IssueClearCommands({unitBeingBuilt})
+        IssueToUnitClearCommands(unitBeingBuilt)
         IssueGuard({unitBeingBuilt}, experimental)
     end
 end
@@ -994,13 +994,13 @@ function FatboyChildBehavior(self, parent, base)
         local units = self:GetPlatoonUnits()
         if not base then
             -- Wrecked base. Kill AI thread
-            IssueClearCommands(units)
+            IssueToUnitClearCommands(nits
             IssueGuard(units, parent)
             return
         end
 
         if targetUnit then
-            IssueClearCommands(units)
+            IssueToUnitClearCommands(nits
             IssueAggressiveMove(units, targetUnit)
         end
 
@@ -1060,7 +1060,7 @@ TempestBehavior = function(self)
 
             if unitToBuild then
                 IssueStop({unit})
-                IssueClearCommands({unit})
+                IssueToUnitClearCommands(unit)
                 aiBrain:BuildUnit(unit, unitToBuild, 1)
             end
 
@@ -1084,7 +1084,7 @@ TempestBehavior = function(self)
                 unit.BuiltUnitCount = unit.BuiltUnitCount + 1
                 ScenarioFramework.CreateUnitDestroyedTrigger(TempestUnitDeath, unitBeingBuilt)
                 aiBrain:AssignUnitsToPlatoon(self, {unitBeingBuilt}, 'Attack', 'GrowthFormation')
-                IssueClearCommands({unitBeingBuilt})
+                IssueToUnitClearCommands(unitBeingBuilt)
                 unitBeingBuilt:ForkThread(TempestBuiltUnitMoveOut, position, testHeading)
             end
             self.BreakOff = false
@@ -1124,7 +1124,7 @@ function TempestBuiltUnitMoveOut(unit, platoon, position, heading)
 
     local counter = 0
     repeat
-        IssueClearCommands({unit})
+        IssueToUnitClearCommands(unit)
         IssueToUnitMove(unit, position)
         WaitSeconds(5)
         if unit.Dead then
@@ -1154,7 +1154,7 @@ CzarBehavior = function(self)
     local oldTargetUnit = nil
     while not experimental.Dead do
         if targetUnit and targetUnit ~= oldTargetUnit then
-            IssueClearCommands({experimental})
+            IssueToUnitClearCommands(experimental)
             WaitTicks(5)
 
             -- Move to the target without attacking. This will get it out of your base without the beam on.
@@ -1172,7 +1172,7 @@ CzarBehavior = function(self)
         local oldCommander = nil
         while nearCommander and not experimental.Dead and not experimental:IsIdleState() do
             if nearCommander and nearCommander ~= oldCommander and nearCommander ~= targetUnit then
-                IssueClearCommands({experimental})
+                IssueToUnitClearCommands(experimental)
                 WaitTicks(5)
 
                 IssueAttack({experimental}, experimental:GetPosition())
@@ -1213,7 +1213,7 @@ AhwassaBehavior = function(self)
     local oldTargetLocation = nil
     while not experimental.Dead do
         if targetLocation and targetLocation ~= oldTargetLocation then
-            IssueClearCommands({experimental})
+            IssueToUnitClearCommands(experimental)
             IssueAttack({experimental}, targetLocation)
             WaitSeconds(25)
         end
@@ -1244,7 +1244,7 @@ TickBehavior = function(self)
     local oldTargetLocation = nil
     while not experimental.Dead do
         if targetLocation and targetLocation ~= oldTargetLocation then
-            IssueClearCommands({experimental})
+            IssueToUnitClearCommands(experimental)
             IssueAggressiveMove({experimental}, targetLocation)
             WaitSeconds(25)
         end
@@ -1349,7 +1349,7 @@ end
 ---@param cdr CommandUnit
 function CDRFinishUnit(cdr)
     if cdr.UnitBeingBuiltBehavior and (not cdr.UnitBeingBuiltBehavior:BeenDestroyed()) then
-        IssueClearCommands({cdr})
+        IssueToUnitClearCommands(cdr)
         IssueRepair({cdr}, cdr.UnitBeingBuiltBehavior)
         repeat
             WaitSeconds(1)
@@ -1358,7 +1358,7 @@ function CDRFinishUnit(cdr)
             end
         until cdr:IsIdleState()
 
-        IssueClearCommands({cdr})
+        IssueToUnitClearCommands(cdr)
         if cdr.UnitBeingBuiltBehavior and (not cdr.UnitBeingBuiltBehavior:BeenDestroyed()) then
             if cdr.UnitBeingBuiltBehavior:GetFractionComplete() == 1 then
                 cdr.UnitBeingBuiltBehavior = false
@@ -1396,14 +1396,14 @@ function CDRHideBehavior(aiBrain, cdr)
 
         if category then
             runPos = AIUtils.AIFindDefensiveAreaSorian(aiBrain, cdr, category, 100, runShield)
-            IssueClearCommands({cdr})
+            IssueToUnitClearCommands(cdr)
             IssueToUnitMove(cdr, runPos)
         end
 
         if not category or not runPos then
             local x, z = aiBrain:GetArmyStartPos()
             runPos = AIUtils.RandomLocation(x, z)
-            IssueClearCommands({cdr})
+            IssueToUnitClearCommands(cdr)
             IssueToUnitMove(cdr, runPos)
         end
     end

--- a/lua/AI/OpAI/BaseManager.lua
+++ b/lua/AI/OpAI/BaseManager.lua
@@ -1244,7 +1244,7 @@ BaseManager = ClassSimple {
         local armyIndex = aiBrain:GetArmyIndex()
         local upgradeID = aiBrain:FindUpgradeBP(unit.UnitId, UpgradeTemplates.StructureUpgradeTemplates[factionIndex])
         if upgradeID then
-            IssueClearCommands({ unit })
+            IssueToUnitClearCommands(unit)
             IssueUpgrade({ unit }, upgradeID)
         end
 

--- a/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
+++ b/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
@@ -358,7 +358,7 @@ function AssistConditionalBuild(singleEngineerPlatoon)
     bManager.ConditionalBuildData.IncrementAssisting()
 
     -- Give orders to repair the unit
-    IssueClearCommands({engineer})
+    IssueToUnitClearCommands(engineer)
     IssueRepair({engineer}, bManager.ConditionalBuildData.Unit)
 
     -- Super loop
@@ -370,7 +370,7 @@ function AssistConditionalBuild(singleEngineerPlatoon)
         end
     end
 
-    IssueClearCommands({engineer})
+    IssueToUnitClearCommands(engineer)
     TriggerFile.RemoveUnitTrigger(engineer, ConditionalBuilderDead)
 end
 
@@ -411,7 +411,7 @@ function DoConditionalBuild(singleEngineerPlatoon)
     TriggerFile.CreateUnitDestroyedTrigger(ConditionalBuilderDead, engineer)
 
     -- Issue build orders
-    IssueClearCommands({engineer})
+    IssueToUnitClearCommands(engineer)
     local result = aiBrain:BuildStructure(engineer, unitToBuild.type, {unitToBuild.Position[1], unitToBuild.Position[3], 0})
 
     -- Enter build monitoring loop
@@ -450,7 +450,7 @@ function DoConditionalBuild(singleEngineerPlatoon)
         end
         WaitTicks(Random(7, 13))
     end
-    IssueClearCommands({engineer})
+    IssueToUnitClearCommands(engineer)
     TriggerFile.RemoveUnitTrigger(engineer, ConditionalBuilderDead)
 end
 
@@ -801,7 +801,7 @@ function BaseManagerEngineerThread(platoon)
             if not eng then
                 eng = v
             else
-                IssueClearCommands({v})
+                IssueToUnitClearCommands(v)
                 IssueGuard({v}, eng)
             end
         end
@@ -938,7 +938,7 @@ function BuildBaseManagerStructure(aiBrain, eng, baseManager, levelName, buildin
                     -- Removed transport call as the pathing check was creating problems with base manager rebuilding
                     -- TODO: develop system where base managers more easily rebuild in far away or hard to reach locations
                     -- and TransportUnitsToLocation(platoon, {closest[1], 0, closest[2]}) then
-                    IssueClearCommands({eng})
+                    IssueToUnitClearCommands(eng)
                     aiBrain:BuildStructure(eng, category, closest, false)
 
                     local unitName = false
@@ -988,7 +988,7 @@ function BuildUnfinishedStructures(platoon)
             if ScenarioInfo.UnitNames[armyIndex][unitName] and not ScenarioInfo.UnitNames[armyIndex][unitName].Dead then
                 if not beingBuiltList[unitName] then
                     unfinishedBuildings = true
-                    IssueClearCommands({eng})
+                    IssueToUnitClearCommands(eng)
                     IssueRepair({eng}, ScenarioInfo.UnitNames[armyIndex][unitName])
                     repeat
                         WaitSeconds(3)
@@ -1248,7 +1248,7 @@ function BaseManagerNukeAI(platoon)
 			if nukePos then
 				IssueNuke({unit}, nukePos)
 				WaitSeconds(15)
-				IssueClearCommands({unit})
+				IssueToUnitClearCommands(unit)
 			end
 		end
 		WaitSeconds(10)
@@ -1379,7 +1379,7 @@ function UnitUpgradeThread(unit)
                     Enhancement = upgradeName
                 }
                 IssueStop({unit})
-                IssueClearCommands({unit})
+                IssueToUnitClearCommands(unit)
                 IssueScript({unit}, order)
 
                 repeat

--- a/lua/AI/OpAI/OpBehaviors.lua
+++ b/lua/AI/OpAI/OpBehaviors.lua
@@ -81,11 +81,11 @@ function CDROverChargeThread( cdr )
                         if target then
                             if aiBrain:GetEconomyStored('ENERGY') >= weapon.EnergyRequired and target and not target:IsDead() then
                                 overCharging = true
-                                IssueClearCommands({cdr})
+                                IssueToUnitClearCommands(cdr)
                                 IssueOverCharge( {cdr}, target )
                             elseif not target:IsDead() then
                                 local tarPos = target:GetPosition()
-                                IssueClearCommands( {cdr} )
+                                IssueToUnitClearCommands(cdr)
                                 IssueToUnitMove(cdr, tarPos )
                                 if cdr.CDRData and cdr.CDRData.LeashPosition then
                                     local tempPos = ScenarioUtils.MarkerToPosition(cdr.CDRData.LeashPosition)
@@ -139,7 +139,7 @@ end
 function CDRRepairBuildingUnit( cdr, plat )
     local aiBrain = cdr:GetAIBrain()
     if cdr.UnitBeingBuiltBehavior and not cdr.UnitBeingBuiltBehavior:BeenDestroyed() then
-        IssueClearCommands( {cdr} )
+        IssueToUnitClearCommands(cdr)
         IssueRepair( {cdr}, cdr.UnitBeingBuiltBehavior )
         repeat
             WaitTicks(11)

--- a/lua/AI/OpAI/OpBehaviors.lua
+++ b/lua/AI/OpAI/OpBehaviors.lua
@@ -86,13 +86,13 @@ function CDROverChargeThread( cdr )
                             elseif not target:IsDead() then
                                 local tarPos = target:GetPosition()
                                 IssueClearCommands( {cdr} )
-                                IssueMove( {cdr}, tarPos )
+                                IssueToUnitMove(cdr, tarPos )
                                 if cdr.CDRData and cdr.CDRData.LeashPosition then
                                     local tempPos = ScenarioUtils.MarkerToPosition(cdr.CDRData.LeashPosition)
                                     startX = tempPos[1]
                                     startZ = tempPos[3]
                                 end
-                                IssueMove( {cdr}, {startX, 0, startZ} )
+                                IssueToUnitMove(cdr, {startX, 0, startZ} )
                             end
                         end
                     end
@@ -121,7 +121,7 @@ function CDROverChargeThread( cdr )
                     end
                     cdr.Fighting = false
                     if overCharging then
-                        IssueMove( {cdr}, {startX, 0, startZ} )
+                        IssueToUnitMove(cdr, {startX, 0, startZ} )
                     end
                 end
                 --LOG('*AI DEBUG: ARMY ', repr(aiBrain:GetArmyIndex()),  ': CDR AI DEACTIVATE - Nothing to see here!')

--- a/lua/AI/Transportutilities.lua
+++ b/lua/AI/Transportutilities.lua
@@ -668,7 +668,7 @@ function GetTransports( platoon, aiBrain)
                 
 				AssignUnitsToPlatoon( aiBrain, transportplatoon, {transport}, 'Support', 'BlockFormation')
 				IssueClearCommands({transport})
-				IssueMove( {transport}, location )
+				IssueToUnitMove(transport, location )
 
                 while neededTable.Large >= 1 and AvailableSlots.Large >= 1 do
                     neededTable.Large = neededTable.Large - 1.0
@@ -856,17 +856,17 @@ function ReturnTransportsToPool( aiBrain, units, move )
                         end
                         -- use path
                         for _,p in safePath do
-                            IssueMove( {v}, p )
+                            IssueToUnitMove(v, p )
                         end
                     else
                         if TransportDialog then
                             LOG("*AI DEBUG "..aiBrain.Nickname.." "..returnpool.BuilderName.." Transport "..v.EntityId.." no safe path for RTB -- home -- after drop - going direct")
                         end
                         -- go direct -- possibly bad
-                        IssueMove( {v}, baseposition )
+                        IssueToUnitMove(v, baseposition )
                     end
                 else
-                    IssueMove( {v}, baseposition)
+                    IssueToUnitMove(v, baseposition)
                 end
 
 				-- move the unit to the correct pool - pure transports to Transport Pool
@@ -1775,7 +1775,7 @@ function WatchUnitLoading( transport, units, aiBrain, UnitPlatoon)
 	
     -- At this point we really should safepath to the position
     -- and we should probably use a movement thread 
-	IssueMove( {transport}, GetPosition(units[1]) )
+	IssueToUnitMove(transport, GetPosition(units[1]) )
 	WaitTicks(5)
 	
 	for _,u in newunits do
@@ -2004,7 +2004,7 @@ function WatchTransportTravel( transport, destination, aiBrain, UnitPlatoon )
 				end
 
 				IssueClearCommands( {transport} )
-				IssueMove( {transport}, destination )
+				IssueToUnitMove(transport, destination )
 			end
 		
 			-- this needs some examination -- it should signal the entire transport platoon - not just itself --

--- a/lua/AI/Transportutilities.lua
+++ b/lua/AI/Transportutilities.lua
@@ -90,7 +90,7 @@ function AssignTransportToPool( unit, aiBrain )
         if TransportDialog then
             LOG("*AI DEBUG TRANSPORT "..repr(unit.PlatoonHandle.BuilderName).." Transport "..unit.EntityId.." starts assigning to Transport Pool" )
         end
-		IssueClearCommands( {unit} )
+		IssueToUnitClearCommands(unit)
 		-- if not in need of repair or fuel -- 
 		if not ProcessAirUnits( unit, aiBrain ) then
             if aiBrain.TransportPool then
@@ -153,7 +153,7 @@ function CheckTransportPool( aiBrain )
 				--	continue
 				--end
 			end
-			IssueClearCommands( {v} )
+			IssueToUnitClearCommands(v)
 			if v.WatchLoadingThread then
                 if TransportDialog then
                     LOG("*AI DEBUG "..aiBrain.Nickname.." Killing Watch Loading thread - transport "..v.EntityId.." in CheckTransportPool")
@@ -667,7 +667,7 @@ function GetTransports( platoon, aiBrain)
                 end
                 
 				AssignUnitsToPlatoon( aiBrain, transportplatoon, {transport}, 'Support', 'BlockFormation')
-				IssueClearCommands({transport})
+				IssueToUnitClearCommands(transport)
 				IssueToUnitMove(transport, location )
 
                 while neededTable.Large >= 1 and AvailableSlots.Large >= 1 do
@@ -846,7 +846,7 @@ function ReturnTransportsToPool( aiBrain, units, move )
                     return
                 end
                 baseposition = RandomLocation(x,z)
-                IssueClearCommands( {v} )
+                IssueToUnitClearCommands(v)
                 if VDist3( baseposition, unitposition ) > 100 then
                     -- this requests a path for the transport with a threat allowance of 20 - which is kinda steep sometimes
 					local safePath, reason = NavUtils.PathToWithThreatThreshold('Air', unitposition, baseposition, aiBrain, NavUtils.ThreatFunctions.AntiAir, 50, aiBrain.IMAPConfig.Rings)
@@ -907,7 +907,7 @@ function ReturnUnloadedUnitToPool( aiBrain, unit )
 	local attached = true
 	
 	if not unit.Dead then
-		IssueClearCommands( {unit} )
+		IssueToUnitClearCommands(unit)
 		local ident = Random(1,999999)
 		local returnpool = aiBrain:MakePlatoon('ReturnToPool'..tostring(ident), 'none')
 		AssignUnitsToPlatoon( aiBrain, returnpool, {unit}, 'Unassigned', 'None' )
@@ -1453,7 +1453,7 @@ function UseTransports( aiBrain, transports, location, UnitPlatoon, IsEngineer )
 		-- send any leftovers to RTB --
 		if currLeftovers[1] then
 			for _,v in currLeftovers do
-				IssueClearCommands({v})
+				IssueToUnitClearCommands(v)
 			end
 			local ident = Random(1,999999)
 			local returnpool = aiBrain:MakePlatoon('RTB - Excess in SortingOnTransport'..tostring(ident), 'none')
@@ -1584,7 +1584,7 @@ function UseTransports( aiBrain, transports, location, UnitPlatoon, IsEngineer )
 							returnpool.BuilderName = UnitPlatoon.BuilderName
 						end
 					end
-					IssueClearCommands( {v} )
+					IssueToUnitClearCommands(v)
 					AssignUnitsToPlatoon( aiBrain, returnpool, {v}, 'Attack', 'None' )
 				end
 			end
@@ -2003,7 +2003,7 @@ function WatchTransportTravel( transport, destination, aiBrain, UnitPlatoon )
 					transport.StuckCount = 0
 				end
 
-				IssueClearCommands( {transport} )
+				IssueToUnitClearCommands(transport)
 				IssueToUnitMove(transport, destination )
 			end
 		
@@ -2022,7 +2022,7 @@ function WatchTransportTravel( transport, destination, aiBrain, UnitPlatoon )
 	end
 
 	if not transport.Dead then
-		IssueClearCommands( {transport} )
+		IssueToUnitClearCommands(transport)
 		if not transport.Dead then
             if TransportDialog then
                 LOG("*AI DEBUG "..aiBrain.Nickname.." "..UnitPlatoon.BuilderName.." "..transport.PlatoonHandle.BuilderName.." Transport "..transport.EntityId.." ends travelwatch ")

--- a/lua/AI/aibuildstructures.lua
+++ b/lua/AI/aibuildstructures.lua
@@ -836,7 +836,7 @@ function AIMaintainBuildList(aiBrain, builder, buildingTemplate, brainBaseTempla
                             if m > 1 then
                                 if aiBrain:CanBuildStructureAt(v.StructureCategory, BuildToNormalLocation(location)) then
                                     IssueStop({builder})
-                                    IssueClearCommands({builder})
+                                    IssueToUnitClearCommands(builder)
                                     aiBrain:BuildStructure(builder, v.StructureCategory, location, false)
                                     return true
                                 end
@@ -846,7 +846,7 @@ function AIMaintainBuildList(aiBrain, builder, buildingTemplate, brainBaseTempla
                 end
             elseif aiBrain:FindPlaceToBuild(v.StructureType, v.StructureCategory,  brainBaseTemplate.Template, false, v.CloseToBuilder) then
                 IssueStop({builder})
-                IssueClearCommands({builder})
+                IssueToUnitClearCommands(builder)
                 if AIExecuteBuildStructure(aiBrain, builder, v.StructureType , v.CloseToBuilder, false, buildingTemplate, brainBaseTemplate.Template) then
                     return true
                 end

--- a/lua/AI/aiutilities.lua
+++ b/lua/AI/aiutilities.lua
@@ -2020,10 +2020,10 @@ function ReturnTransportsToPool(units, move)
             if move then
                 if safePath then
                     for _, p in safePath do
-                        IssueMove({unit}, p)
+                        IssueToUnitMove(unit, p)
                     end
                 else
-                    IssueMove({unit}, position)
+                    IssueToUnitMove(unit, position)
                 end
             end
         end
@@ -2114,7 +2114,7 @@ function EngineerMoveWithSafePath(aiBrain, unit, destination)
             -- Move to way points (but not to destination... leave that for the final command)
             for widx, waypointPath in path do
                 if pathSize ~= widx then
-                    IssueMove({unit}, waypointPath)
+                    IssueToUnitMove(unit, waypointPath)
                 end
             end
         end
@@ -3206,7 +3206,7 @@ function EngAvoidLocalDanger(aiBrain, eng)
                 end
             else
                 IssueClearCommands({eng})
-                IssueMove({eng}, ShiftPosition(enemyUnitPos, engPos, 50, false))
+                IssueToUnitMove(eng, ShiftPosition(enemyUnitPos, engPos, 50, false))
                 coroutine.yield(60)
                 action = true
             end

--- a/lua/AI/aiutilities.lua
+++ b/lua/AI/aiutilities.lua
@@ -3187,7 +3187,7 @@ function EngAvoidLocalDanger(aiBrain, eng)
             if VDist2Sq(engPos[1], engPos[3], enemyUnitPos[1], enemyUnitPos[3]) < 144 then
                 if unit and not IsDestroyed(unit) and unit:GetFractionComplete() == 1 then
                     if VDist2Sq(engPos[1], engPos[3], enemyUnitPos[1], enemyUnitPos[3]) < 156 then
-                        IssueClearCommands({eng})
+                        IssueToUnitClearCommands(eng)
                         IssueReclaim({eng}, unit)
                         action = true
                         break
@@ -3198,14 +3198,14 @@ function EngAvoidLocalDanger(aiBrain, eng)
             if VDist2Sq(engPos[1], engPos[3], enemyUnitPos[1], enemyUnitPos[3]) < 81 then
                 if unit and not IsDestroyed(unit) and unit:GetFractionComplete() == 1 then
                     if VDist2Sq(engPos[1], engPos[3], enemyUnitPos[1], enemyUnitPos[3]) < 156 then
-                        IssueClearCommands({eng})
+                        IssueToUnitClearCommands(eng)
                         IssueReclaim({eng}, unit)
                         action = true
                         break
                     end
                 end
             else
-                IssueClearCommands({eng})
+                IssueToUnitClearCommands(eng)
                 IssueToUnitMove(eng, ShiftPosition(enemyUnitPos, engPos, 50, false))
                 coroutine.yield(60)
                 action = true
@@ -3225,7 +3225,7 @@ function EngLocalExtractorBuild(aiBrain, eng)
     local action = false
     local bool,markers=CanBuildOnLocalMassPoints(aiBrain, eng:GetPosition(), 25)
     if bool then
-        IssueClearCommands({eng})
+        IssueToUnitClearCommands(eng)
         local factionIndex = aiBrain:GetFactionIndex()
         local buildingTmplFile = import('/lua/BuildingTemplates.lua')
         local buildingTmpl = buildingTmplFile[('BuildingTemplates')][factionIndex]
@@ -3310,7 +3310,7 @@ function EngPerformReclaim(eng, minimumReclaim)
             end
         end
         if table.getn(closeReclaim) > 0 then
-            IssueClearCommands({eng})
+            IssueToUnitClearCommands(eng)
             for _, rec in closeReclaim do
                 IssueReclaim({eng}, rec)
             end

--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -2310,7 +2310,7 @@ function MoveOnMap(unit)
     end
 
     IssueClearCommands({unit})
-    IssueMove({unit}, nearestPoint)
+    IssueToUnitMove(unit, nearestPoint)
 end
 
 --- Returns if the unit's army is human

--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -188,7 +188,7 @@ function OverrideDoDamage(self, instigator, amount, vector, damageType)
             if excess < 0 and maxHealth > 0 then
                 excessDamageRatio = -excess / maxHealth
             end
-            IssueClearCommands({self})
+            IssueToUnitClearCommands(self)
             ForkThread(UnlockAndKillUnitThread, self, instigator, damageType, excessDamageRatio)
         end
     end
@@ -915,7 +915,7 @@ end
 ---@param killUnit? boolean
 function FakeTeleportUnit(unit, killUnit)
     IssueStop({unit})
-    IssueClearCommands({unit})
+    IssueToUnitClearCommands(unit)
     unit.CanBeKilled = false
 
     unit:PlayTeleportChargeEffects(unit:GetPosition(), unit:GetOrientation())
@@ -1034,7 +1034,7 @@ end
 function UpgradeUnit(unit)
     local upgradeBP = unit:GetBlueprint().General.UpgradesTo
     IssueStop({unit})
-    IssueClearCommands({unit})
+    IssueToUnitClearCommands(unit)
     IssueUpgrade({unit}, upgradeBP)
 end
 
@@ -2309,7 +2309,7 @@ function MoveOnMap(unit)
         nearestPoint[3] = playableArea[4] - 5
     end
 
-    IssueClearCommands({unit})
+    IssueToUnitClearCommands(unit)
     IssueToUnitMove(unit, nearestPoint)
 end
 

--- a/lua/ScenarioPlatoonAI.lua
+++ b/lua/ScenarioPlatoonAI.lua
@@ -1653,7 +1653,7 @@ function ReorganizeEngineers(platoon, engTable)
                                 brainFacData.NumEngs = brainFacData.NumEngs + 1
                             end
                         end
-                        IssueToUnitClearCommands({moveEng})
+                        IssueToUnitClearCommands(moveEng)
                         IssueGuard({moveEng}, facLowData.Factory)
                         break
                     end

--- a/lua/ScenarioPlatoonAI.lua
+++ b/lua/ScenarioPlatoonAI.lua
@@ -1380,7 +1380,7 @@ end
 --- Utility Function
 --- Has an engineer build a certain type of structure using a base template
 ---@param aiBrain AIBrain
----@param builder Builder
+---@param builder Unit
 ---@param building StructureUnit
 ---@param brainBaseTemplate any
 ---@param buildingTemplate any
@@ -1403,7 +1403,7 @@ function EngineerBuildStructure(aiBrain, builder, building, brainBaseTemplate, b
                     if m > 1 then
                         if aiBrain:CanBuildStructureAt(structureCategory, {location[1], 0, location[2]}) then
                             IssueStop({builder})
-                            IssueToUnitClearCommands(euider})
+                            IssueToUnitClearCommands(builder)
                             local result = aiBrain:BuildStructure(builder, structureCategory, location, false)
                             if result then
                                 return true
@@ -1416,7 +1416,7 @@ function EngineerBuildStructure(aiBrain, builder, building, brainBaseTemplate, b
     else
         if aiBrain:FindPlaceToBuild(building, structureCategory, brainBaseTemplate, false, nil) then
             IssueStop({builder})
-            IssueToUnitClearCommands(euider})
+            IssueToUnitClearCommands(builder)
             if AIBuildStructures.AIExecuteBuildStructure(aiBrain, builder, building, builder, false,
                                                          buildingTemplate, brainBaseTemplate) then
                 return true

--- a/lua/ScenarioPlatoonAI.lua
+++ b/lua/ScenarioPlatoonAI.lua
@@ -624,7 +624,7 @@ function EngineersBuildPlatoon(platoon)
             for strName, tblData in unitGroup do
                 if eng and aiBrain:CanBuildStructureAt(tblData.type, tblData.Position) then
                     IssueStop({eng})
-                    IssueClearCommands({eng})
+                    IssueToUnitClearCommands(eng)
                     local result = aiBrain:BuildStructure(eng, tblData.type, {tblData.Position[1], tblData.Position[3], 0}, false)
                     unitBeingBuilt = false
 
@@ -1067,7 +1067,7 @@ function StartBaseBuildUnits(eng, engTable, data, aiBrain)
             if unit then
                 if aiBrain:CanBuildStructureAt(unit.type, unit.Position) then
                     IssueStop({eng})
-                    IssueClearCommands({eng})
+                    IssueToUnitClearCommands(eng)
                     local result = aiBrain:BuildStructure(eng, unit.type, {unit.Position[1], unit.Position[3], 0}, false)
                     if result then
                         unitBeingBuilt = eng.UnitBeingBuilt
@@ -1113,7 +1113,7 @@ function StartBaseGroupOnceBuild(eng, engTable, data, aiBrain)
         for _, v in buildGroup do
             if aiBrain:CanBuildStructureAt(v.type, v.Position) then
                 IssueStop({eng})
-                IssueClearCommands({eng})
+                IssueToUnitClearCommands(eng)
                 local result = aiBrain:BuildStructure(eng, v.type, {v.Position[1], v.Position[3], 0}, false)
                 if result then
                     unitBeingBuilt = eng.UnitBeingBuilt
@@ -1403,7 +1403,7 @@ function EngineerBuildStructure(aiBrain, builder, building, brainBaseTemplate, b
                     if m > 1 then
                         if aiBrain:CanBuildStructureAt(structureCategory, {location[1], 0, location[2]}) then
                             IssueStop({builder})
-                            IssueClearCommands({builder})
+                            IssueToUnitClearCommands(euider})
                             local result = aiBrain:BuildStructure(builder, structureCategory, location, false)
                             if result then
                                 return true
@@ -1416,7 +1416,7 @@ function EngineerBuildStructure(aiBrain, builder, building, brainBaseTemplate, b
     else
         if aiBrain:FindPlaceToBuild(building, structureCategory, brainBaseTemplate, false, nil) then
             IssueStop({builder})
-            IssueClearCommands({builder})
+            IssueToUnitClearCommands(euider})
             if AIBuildStructures.AIExecuteBuildStructure(aiBrain, builder, building, builder, false,
                                                          buildingTemplate, brainBaseTemplate) then
                 return true
@@ -1653,7 +1653,7 @@ function ReorganizeEngineers(platoon, engTable)
                                 brainFacData.NumEngs = brainFacData.NumEngs + 1
                             end
                         end
-                        IssueClearCommands({moveEng})
+                        IssueToUnitClearCommands(eovEng})
                         IssueGuard({moveEng}, facLowData.Factory)
                         break
                     end
@@ -1692,7 +1692,7 @@ function EngAssist(platoon, engTable)
                         break
                     end
                 end
-                IssueClearCommands({eng})
+                IssueToUnitClearCommands(eng)
                 IssueGuard({eng}, lowFac.Factory)
                 table.remove(engTable, engNum)
             else

--- a/lua/ScenarioPlatoonAI.lua
+++ b/lua/ScenarioPlatoonAI.lua
@@ -1653,7 +1653,7 @@ function ReorganizeEngineers(platoon, engTable)
                                 brainFacData.NumEngs = brainFacData.NumEngs + 1
                             end
                         end
-                        IssueToUnitClearCommands(eovEng})
+                        IssueToUnitClearCommands({moveEng})
                         IssueGuard({moveEng}, facLowData.Factory)
                         break
                     end

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -224,7 +224,7 @@ Callbacks.ValidateAssist = function(data, units)
     if units and target then
         for k, u in units do
             if IsEntity(u) and u.Army == target.Army and IsInvalidAssist(u, target) then
-                IssueClearCommands({ target })
+                IssueToUnitClearCommands(target)
                 return
             end
         end

--- a/lua/SimHooks.lua
+++ b/lua/SimHooks.lua
@@ -111,10 +111,13 @@ end
 ---@type { [1]: Unit }
 local UnitsCache = {}
 
+--- Orders a unit to move to a location. See `IssueMove` when you want to apply the order to a group of units.
+---
+--- This use of this function is **not** compatible with the Steam version of the game.
 ---@param unit Unit
 ---@param position Vector
 ---@return SimCommand
-IssueMoveToUnit = function(unit, position)
+IssueToUnitMove = function(unit, position)
     UnitsCache[1] = unit
     return IssueMove(UnitsCache, position)
 end
@@ -125,7 +128,7 @@ end
 ---@param unit Unit
 ---@param position Vector
 ---@return SimCommand
-IssueMoveOffFactoryToUnit = function(unit, position)
+IssueToUnitMoveOffFactory = function(unit, position)
     UnitsCache[1] = unit
     return IssueMoveOffFactory(UnitsCache, position)
 end

--- a/lua/SimHooks.lua
+++ b/lua/SimHooks.lua
@@ -106,3 +106,24 @@ do
         oldIssueBuildMobile(units, position, blueprintID, table, true)
     end
 end
+
+do
+    ---@type { [1]: Unit }
+    local UnitsCache = {}
+
+    ---@param unit Unit
+    ---@param position Vector
+    ---@return SimCommand
+    _G.IssueMoveToUnit = function(unit, position)
+        UnitsCache[1] = unit
+        return IssueMove(UnitsCache, position)
+    end
+
+    ---@param unit Unit
+    ---@param position Vector
+    ---@return SimCommand
+    _G.IssueMoveOffFactoryToUnit = function(unit, position)
+        UnitsCache[1] = unit
+        return IssueMoveOffFactory(UnitsCache, position)
+    end
+end

--- a/lua/SimHooks.lua
+++ b/lua/SimHooks.lua
@@ -132,3 +132,8 @@ IssueToUnitMoveOffFactory = function(unit, position)
     UnitsCache[1] = unit
     return IssueMoveOffFactory(UnitsCache, position)
 end
+
+IssueToUnitClearCommands = function(unit)
+    UnitsCache[1] = unit
+    return IssueClearCommands(UnitsCache)
+end

--- a/lua/SimHooks.lua
+++ b/lua/SimHooks.lua
@@ -1,6 +1,6 @@
 ---@declare-global
 
-do 
+do
     -- can only cause issues, like remote code exploit
     _G.loadstring = nil
 end
@@ -23,15 +23,15 @@ do
     _G.GetUnitsInRect = function(rtlx, tlz, brx, brz)
 
         -- try and retrieve units
-        local units 
-        if brx then 
+        local units
+        if brx then
             units = oldGetUnitsInRect(rtlx, tlz, brx, brz)
         else
             units = oldGetUnitsInRect(rtlx)
         end
 
         -- as it can return nil, check if we have any units
-        if units then 
+        if units then
             units = EntityCategoryFilterDown(CategoriesNoDummyUnits, units)
         end
 
@@ -107,23 +107,25 @@ do
     end
 end
 
-do
-    ---@type { [1]: Unit }
-    local UnitsCache = {}
 
-    ---@param unit Unit
-    ---@param position Vector
-    ---@return SimCommand
-    _G.IssueMoveToUnit = function(unit, position)
-        UnitsCache[1] = unit
-        return IssueMove(UnitsCache, position)
-    end
+---@type { [1]: Unit }
+local UnitsCache = {}
 
-    ---@param unit Unit
-    ---@param position Vector
-    ---@return SimCommand
-    _G.IssueMoveOffFactoryToUnit = function(unit, position)
-        UnitsCache[1] = unit
-        return IssueMoveOffFactory(UnitsCache, position)
-    end
+---@param unit Unit
+---@param position Vector
+---@return SimCommand
+IssueMoveToUnit = function(unit, position)
+    UnitsCache[1] = unit
+    return IssueMove(UnitsCache, position)
+end
+
+--- Orders a unit to move off a factory build site. See `IssueMoveOffFactory` when you want to apply the order to a group of units.
+---
+--- This use of this function is **not** compatible with the Steam version of the game.
+---@param unit Unit
+---@param position Vector
+---@return SimCommand
+IssueMoveOffFactoryToUnit = function(unit, position)
+    UnitsCache[1] = unit
+    return IssueMoveOffFactory(UnitsCache, position)
 end

--- a/lua/SimHooks.lua
+++ b/lua/SimHooks.lua
@@ -133,6 +133,11 @@ IssueToUnitMoveOffFactory = function(unit, position)
     return IssueMoveOffFactory(UnitsCache, position)
 end
 
+--- Clears out all commands issued on the unit, this happens immediately. See `IssueClearCommands` when you want to apply the order to a group of units.
+---
+--- This use of this function is **not** compatible with the Steam version of the game.
+---@param unit Unit
+---@return SimCommand
 IssueToUnitClearCommands = function(unit)
     UnitsCache[1] = unit
     return IssueClearCommands(UnitsCache)

--- a/lua/aeonweapons.lua
+++ b/lua/aeonweapons.lua
@@ -205,7 +205,7 @@ ADFTractorClaw = ClassWeapon(Weapon) {
             self:MakeImmune(target)
 
             -- make it stop what it was doing
-            IssueClearCommands({target})
+            IssueToUnitClearCommands(target)
 
             local velocity = self.SliderVelocity[target.Blueprint.TechCategory] or 13
 

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -1129,7 +1129,7 @@ AIBrain = Class(AIBrainHQComponent, AIBrainStatisticsComponent, AIBrainJammerCom
                             unit.PlatoonHandle:PlatoonDisbandNoAssign()
                         end
                         IssueStop({ unit })
-                        IssueClearCommands({ unit })
+                        IssueToUnitClearCommands(unit)
                     end
                 end
             end

--- a/lua/aibrains/campaign-ai.lua
+++ b/lua/aibrains/campaign-ai.lua
@@ -554,7 +554,7 @@ AIBrain = Class(StandardBrain) {
             if not v.Dead and not (v:IsUnitState('Building') or v:IsUnitState('Upgrading')) then
                 local guarded = v:GetGuardedUnit()
                 if not guarded or guarded.EntityId ~= primary.EntityId then
-                    IssueClearCommands({v})
+                    IssueToUnitClearCommands(v)
                     IssueFactoryAssist({v}, primary)
                 end
             end

--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -887,7 +887,7 @@ ExternalFactoryComponent = ClassSimple {
                 self.ExternalFactory:AddBuildRestriction(categories.ALLUNITS)
                 self.ExternalFactory:RequestRefreshUI()
 
-                IssueClearCommands({self.ExternalFactory})
+                IssueToUnitClearCommands(self.ExternalFactory)
             end
         end
     end,

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -591,7 +591,7 @@ StructureUnit = ClassUnit(Unit) {
                 local guards = self:GetGuards()
                 for k, guard in guards do
                     if table.getn(guard:GetCommandQueue()) == 1 then
-                        IssueClearCommands({guard})
+                        IssueToUnitClearCommands(guard)
                         IssueGuard({guard}, self)
                     end
                 end

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -281,7 +281,7 @@ Platoon = Class(moho.platoon_methods) {
             end
             if not v.Dead then
                 IssueStop({v})
-                IssueClearCommands({v})
+                IssueToUnitClearCommands(v)
             end
         end
         if self.AIThread then
@@ -371,7 +371,7 @@ Platoon = Class(moho.platoon_methods) {
         end
         if unit then
             IssueStop({unit})
-            IssueClearCommands({unit})
+            IssueToUnitClearCommands(unit)
             for k,v in data.Enhancement do
                 if not unit:HasEnhancement(v) then
                     local order = {
@@ -507,7 +507,7 @@ Platoon = Class(moho.platoon_methods) {
                 if nukePos then
                    IssueNuke({unit}, nukePos)
                    WaitSeconds(12)
-                   IssueClearCommands({unit})
+                   IssueToUnitClearCommands(unit)
                 end
                 WaitSeconds(1)
             end
@@ -2170,7 +2170,7 @@ Platoon = Class(moho.platoon_methods) {
         local eng
         for k, v in platoonUnits do
             if not v.Dead and EntityCategoryContains(categories.ENGINEER - categories.STATIONASSISTPOD, v) then --DUNCAN - was construction
-                IssueClearCommands({v})
+                IssueToUnitClearCommands(v)
                 if not eng then
                     eng = v
                 else
@@ -3662,7 +3662,7 @@ Platoon = Class(moho.platoon_methods) {
         end
 
         eng.ProcessBuildDone = false
-        IssueClearCommands({eng})
+        IssueToUnitClearCommands(eng)
         local commandDone = false
         local PlatoonPos
         local whatToBuild
@@ -4342,7 +4342,7 @@ Platoon = Class(moho.platoon_methods) {
         eng.Combat = true
         while aiBrain:PlatoonExists(self) do
             WaitTicks(10)
-            IssueClearCommands({eng})
+            IssueToUnitClearCommands(eng)
             -- Find a cell we want to reclaim from
             local reclaimTargetX, reclaimTargetZ = AIUtils.EngFindReclaimCell(aiBrain, eng, self.MovementLayer, searchType)
             if reclaimTargetX and reclaimTargetZ then
@@ -4400,7 +4400,7 @@ Platoon = Class(moho.platoon_methods) {
                 if dist <= gridSize then
                     -- Statemachine switch to reclaiming state
                     local time = 0
-                    IssueClearCommands({eng})
+                    IssueToUnitClearCommands(eng)
                     while time < 30 do
                         IssueAggressiveMove({eng}, moveLocation)
                         time = time + 1
@@ -4421,7 +4421,7 @@ Platoon = Class(moho.platoon_methods) {
                             for _, v in reclaimGridInstance.Cells[reclaimTargetX][reclaimTargetZ].Reclaim do
                                 if IsProp(v) and v.MaxMassReclaim > 0 then
                                     moveLocation = v:GetPosition()
-                                    IssueClearCommands({eng})
+                                    IssueToUnitClearCommands(eng)
                                     break
                                 end
                             end
@@ -4467,7 +4467,7 @@ Platoon = Class(moho.platoon_methods) {
         local eng
         for _, v in platoonUnits do
             if not v.Dead and EntityCategoryContains(categories.ENGINEER, v) then
-                IssueClearCommands({v})
+                IssueToUnitClearCommands(v)
                 if not eng then
                     eng = v
                 end
@@ -4571,7 +4571,7 @@ Platoon = Class(moho.platoon_methods) {
                         break
                     end
                 end
-                IssueClearCommands({eng})
+                IssueToUnitClearCommands(eng)
                 if v.position[1] - playableArea[1] <= 8 or v.position[1] >= playableArea[3] - 8 or v.position[3] - playableArea[2] <= 8 or v.position[3] >= playableArea[4] - 8 then
                     borderWarning = true
                 end
@@ -4697,7 +4697,7 @@ Platoon = Class(moho.platoon_methods) {
                                 break
                             end
                         end
-                        IssueClearCommands({eng})
+                        IssueToUnitClearCommands(eng)
                         if v.position[1] - playableArea[1] <= 8 or v.position[1] >= playableArea[3] - 8 or v.position[3] - playableArea[2] <= 8 or v.position[3] >= playableArea[4] - 8 then
                             borderWarning = true
                         end
@@ -4749,7 +4749,7 @@ Platoon = Class(moho.platoon_methods) {
         end
         local energyCount = 3
         if not hydroPresent then
-            IssueClearCommands({eng})
+            IssueToUnitClearCommands(eng)
             if closeMarkers > 0 then
                 if closeMarkers < 4 then
                     if closeMarkers < 4 and distantMarkers > 1 then
@@ -4823,7 +4823,7 @@ Platoon = Class(moho.platoon_methods) {
                     end
                 end
             end
-            IssueClearCommands({eng})
+            IssueToUnitClearCommands(eng)
             local assistList = AIUtils.GetAssistees(aiBrain, 'MAIN', 'Engineer', categories.HYDROCARBON, categories.ALLUNITS)
             local assistee = false
             local assistListCount = 0
@@ -4853,7 +4853,7 @@ Platoon = Class(moho.platoon_methods) {
                 assistee = bestUnit
             end
             if assistee  then
-                IssueClearCommands({eng})
+                IssueToUnitClearCommands(eng)
                 eng.UnitBeingAssist = assistee.UnitBeingBuilt or assistee.UnitBeingAssist or assistee
                 IssueGuard({eng}, eng.UnitBeingAssist)
                 coroutine.yield(30)
@@ -4863,7 +4863,7 @@ Platoon = Class(moho.platoon_methods) {
                     end
                     -- stop if our target is finished
                     if eng.UnitBeingAssist:GetFractionComplete() == 1 and not eng.UnitBeingAssist:IsUnitState('Upgrading') then
-                        IssueClearCommands({eng})
+                        IssueToUnitClearCommands(eng)
                         break
                     end
                     coroutine.yield(30)

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -4351,7 +4351,7 @@ Platoon = Class(moho.platoon_methods) {
                 eng.CellAssigned = {reclaimTargetX, reclaimTargetZ}
                 brainGridInstance:AddReclaimingEngineer(brainCell, eng)
                 local moveLocation = reclaimGridInstance:ToWorldSpace(reclaimTargetX, reclaimTargetZ)
-                IssueMove({eng}, moveLocation)
+                IssueToUnitMove(eng, moveLocation)
                 local engStuckCount = 0
                 local Lastdist
                 local dist = VDist3Sq(eng:GetPosition(), moveLocation)
@@ -4364,7 +4364,7 @@ Platoon = Class(moho.platoon_methods) {
                         local actionTaken = AIUtils.EngAvoidLocalDanger(aiBrain, eng)
                         if actionTaken then
                             -- Statemachine switch to evaluating next action to take
-                            IssueMove({eng}, moveLocation)
+                            IssueToUnitMove(eng, moveLocation)
                         end
                     else
                         -- Jip discussed potentially getting navmesh to return mass points along the path rather than this.
@@ -4374,13 +4374,13 @@ Platoon = Class(moho.platoon_methods) {
                             if reclaimAction then
                                 WaitTicks(45)
                                 -- Statemachine switch to evaluating next action to take
-                                IssueMove({eng}, moveLocation)
+                                IssueToUnitMove(eng, moveLocation)
                             end
                         end
                         local extractorAction = AIUtils.EngLocalExtractorBuild(aiBrain, eng)
                         if extractorAction then
                             -- Statemachine switch to evaluating next action to take
-                            IssueMove({eng}, moveLocation)
+                            IssueToUnitMove(eng, moveLocation)
                         end
                     end
                     dist = VDist3Sq(eng:GetPosition(), moveLocation)
@@ -4563,7 +4563,7 @@ Platoon = Class(moho.platoon_methods) {
         elseif next(buildMassDistantPoints) then
             whatToBuild = aiBrain:DecideWhatToBuild(eng, 'T1Resource', buildingTmpl)
             for k, v in buildMassDistantPoints do
-                IssueMove({eng}, v.position )
+                IssueToUnitMove(eng, v.position )
                 while VDist2Sq(engPos[1],engPos[3],v.position[1],v.position[3]) > 165 do
                     coroutine.yield(5)
                     engPos = eng:GetPosition()
@@ -4689,7 +4689,7 @@ Platoon = Class(moho.platoon_methods) {
             if table.getn(buildMassDistantPoints) < 3 then
                 for k, v in buildMassDistantPoints do
                     if aiBrain:CanBuildStructureAt('ueb1103', v.position) then
-                        IssueMove({eng}, v.position )
+                        IssueToUnitMove(eng, v.position )
                         while VDist2Sq(engPos[1],engPos[3],v.position[1],v.position[3]) > 165 do
                             coroutine.yield(5)
                             engPos = eng:GetPosition()
@@ -4814,7 +4814,7 @@ Platoon = Class(moho.platoon_methods) {
         if hydroPresent and (closeMarkers > 0 or distantMarkers > 0) then
             engPos = eng:GetPosition()
             if VDist3Sq(engPos,closestHydro.Position) > 144 then
-                IssueMove({eng}, closestHydro.Position )
+                IssueToUnitMove(eng, closestHydro.Position )
                 while VDist3Sq(engPos,closestHydro.Position) > 100 do
                     coroutine.yield(5)
                     engPos = eng:GetPosition()

--- a/lua/seraphimunits.lua
+++ b/lua/seraphimunits.lua
@@ -572,7 +572,7 @@ SEnergyBallUnit = ClassUnit(SHoverLandUnit) {
             -- Queue up random moves
             local x, y,z = unpack(self:GetPosition())
             for i = 1, 100 do
-                IssueMove({self}, {x + Random(-bp.MaxMoveRange, bp.MaxMoveRange), y, z + Random(-bp.MaxMoveRange, bp.MaxMoveRange)})
+                IssueToUnitMove(self, {x + Random(-bp.MaxMoveRange, bp.MaxMoveRange), y, z + Random(-bp.MaxMoveRange, bp.MaxMoveRange)})
             end
 
             -- Weapon information

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -295,26 +295,6 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         -- Flags for scripts
         self.IsCivilian = armies[self.Army] == "NEUTRAL_CIVILIAN" or nil
 
-
-        local start = GetSystemTimeSecondsOnlyForProfileUse()
-
-        for k = 1, 1000 do
-            local arr = {self}
-        end
-
-        local diff = (GetSystemTimeSecondsOnlyForProfileUse() - start) * 1000
-        LOG("New table: " .. tostring(diff))
-
-        local start = GetSystemTimeSecondsOnlyForProfileUse()
-
-        local cached = { } 
-        for k = 1, 1000 do
-            cached[1] = self
-        end
-
-        local diff = (GetSystemTimeSecondsOnlyForProfileUse() - start) * 1000
-        LOG("Reused table: " .. tostring(diff))
-
         VeterancyComponent.OnCreate(self)
     end,
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -295,6 +295,26 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         -- Flags for scripts
         self.IsCivilian = armies[self.Army] == "NEUTRAL_CIVILIAN" or nil
 
+
+        local start = GetSystemTimeSecondsOnlyForProfileUse()
+
+        for k = 1, 1000 do
+            local arr = {self}
+        end
+
+        local diff = (GetSystemTimeSecondsOnlyForProfileUse() - start) * 1000
+        LOG("New table: " .. tostring(diff))
+
+        local start = GetSystemTimeSecondsOnlyForProfileUse()
+
+        local cached = { } 
+        for k = 1, 1000 do
+            cached[1] = self
+        end
+
+        local diff = (GetSystemTimeSecondsOnlyForProfileUse() - start) * 1000
+        LOG("Reused table: " .. tostring(diff))
+
         VeterancyComponent.OnCreate(self)
     end,
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -798,7 +798,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         -- Force me to move on to the guard properly when done
         local guard = self:GetGuardedUnit()
         if guard then
-            IssueClearCommands({self})
+            IssueToUnitClearCommands(self)
             IssueReclaim({self}, target)
             IssueGuard({self}, guard)
         end
@@ -2661,7 +2661,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             end
 
             if cmd then
-                IssueClearCommands({self})
+                IssueToUnitClearCommands(self)
                 cmd({self}, focus)
                 IssueGuard({self}, guarded)
             end
@@ -2692,7 +2692,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             WARN('Unit.OnStartBuild() Army ' ..self.Army.. ' cannot build restricted unit: ' .. (bp.Description or id))
             self:OnFailedToBuild() -- Don't use: self:OnStopBuild()
             IssueClearFactoryCommands({self})
-            IssueClearCommands({self})
+            IssueToUnitClearCommands(self)
             return false -- Report failure of OnStartBuild
         end
 
@@ -4388,7 +4388,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         local slot = transport.slots[bone]
         if slot then
             self:GetAIBrain():OnTransportFull()
-            IssueClearCommands({self})
+            IssueToUnitClearCommands(self)
             return
         end
 
@@ -4661,7 +4661,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             Warp(self, location, orientation)
             self:PlayTeleportInEffects()
         else
-            IssueClearCommands({self})
+            IssueToUnitClearCommands(self)
         end
 
         self:SetWorkProgress(0.0)

--- a/units/UAA0310/UAA0310_script.lua
+++ b/units/UAA0310/UAA0310_script.lua
@@ -131,7 +131,7 @@ UAA0310 = ClassUnit(AirTransport) {
                 self:AddUnitToStorage(unitBuilding)
             else
                 local worldPos = self:CalculateWorldPositionFromRelative({ 0, 0, -20 })
-                IssueMoveOffFactoryToUnit(unitBuilding, worldPos)
+                IssueToUnitMoveOffFactory(unitBuilding, worldPos)
                 unitBuilding:ShowBone(0, true)
             end
             self:RequestRefreshUI()

--- a/units/UAA0310/UAA0310_script.lua
+++ b/units/UAA0310/UAA0310_script.lua
@@ -131,7 +131,7 @@ UAA0310 = ClassUnit(AirTransport) {
                 self:AddUnitToStorage(unitBuilding)
             else
                 local worldPos = self:CalculateWorldPositionFromRelative({ 0, 0, -20 })
-                IssueMoveOffFactory({ unitBuilding }, worldPos)
+                IssueMoveOffFactoryToUnit(unitBuilding, worldPos)
                 unitBuilding:ShowBone(0, true)
             end
             self:RequestRefreshUI()

--- a/units/UAS0303/UAS0303_script.lua
+++ b/units/UAS0303/UAS0303_script.lua
@@ -96,7 +96,7 @@ UAS0303 = ClassUnit(AircraftCarrier, ExternalFactoryComponent) {
                 self:AddUnitToStorage(unitBuilding)
             else
                 local worldPos = self:CalculateWorldPositionFromRelative({ 0, 0, -20 })
-                IssueMoveOffFactory({ unitBuilding }, worldPos)
+                IssueMoveOffFactoryToUnit(unitBuilding, worldPos)
                 unitBuilding:ShowBone(0, true)
             end
             self:SetBusy(false)

--- a/units/UAS0303/UAS0303_script.lua
+++ b/units/UAS0303/UAS0303_script.lua
@@ -96,7 +96,7 @@ UAS0303 = ClassUnit(AircraftCarrier, ExternalFactoryComponent) {
                 self:AddUnitToStorage(unitBuilding)
             else
                 local worldPos = self:CalculateWorldPositionFromRelative({ 0, 0, -20 })
-                IssueMoveOffFactoryToUnit(unitBuilding, worldPos)
+                IssueToUnitMoveOffFactory(unitBuilding, worldPos)
                 unitBuilding:ShowBone(0, true)
             end
             self:SetBusy(false)

--- a/units/UAS0401/UAS0401_script.lua
+++ b/units/UAS0401/UAS0401_script.lua
@@ -205,7 +205,7 @@ UAS0401 = ClassUnit(ASeaUnit, ExternalFactoryComponent) {
             local blueprint = unitBeingBuilt.Blueprint
             local distance = math.max(blueprint.SizeX, blueprint.SizeZ, 6)
             local worldPos = self:CalculateWorldPositionFromRelative({0, 0, - 2 * distance})
-            IssueMoveOffFactoryToUnit(unitBeingBuilt, worldPos)
+            IssueToUnitMoveOffFactory(unitBeingBuilt, worldPos)
             ChangeState(self, self.RollingOffState)
         end,
     },

--- a/units/UAS0401/UAS0401_script.lua
+++ b/units/UAS0401/UAS0401_script.lua
@@ -205,7 +205,7 @@ UAS0401 = ClassUnit(ASeaUnit, ExternalFactoryComponent) {
             local blueprint = unitBeingBuilt.Blueprint
             local distance = math.max(blueprint.SizeX, blueprint.SizeZ, 6)
             local worldPos = self:CalculateWorldPositionFromRelative({0, 0, - 2 * distance})
-            IssueMoveOffFactory({unitBeingBuilt}, worldPos)
+            IssueMoveOffFactoryToUnit(unitBeingBuilt, worldPos)
             ChangeState(self, self.RollingOffState)
         end,
     },

--- a/units/UES0401/UES0401_script.lua
+++ b/units/UES0401/UES0401_script.lua
@@ -183,7 +183,7 @@ UES0401 = ClassUnit(AircraftCarrier, ExternalFactoryComponent) {
                 self:AddUnitToStorage(unitBuilding)
             else
                 local worldPos = self:CalculateWorldPositionFromRelative({0, 0, -20})
-                IssueMoveOffFactoryToUnit(unitBuilding, worldPos)
+                IssueToUnitMoveOffFactory(unitBuilding, worldPos)
                 unitBuilding:ShowBone(0,true)
             end
 

--- a/units/UES0401/UES0401_script.lua
+++ b/units/UES0401/UES0401_script.lua
@@ -183,7 +183,7 @@ UES0401 = ClassUnit(AircraftCarrier, ExternalFactoryComponent) {
                 self:AddUnitToStorage(unitBuilding)
             else
                 local worldPos = self:CalculateWorldPositionFromRelative({0, 0, -20})
-                IssueMoveOffFactory({unitBuilding}, worldPos)
+                IssueMoveOffFactoryToUnit(unitBuilding, worldPos)
                 unitBuilding:ShowBone(0,true)
             end
 

--- a/units/URA0001/URA0001_script.lua
+++ b/units/URA0001/URA0001_script.lua
@@ -88,7 +88,7 @@ URA0001 = ClassUnit(CAirUnit) {
 
     IdleState = State {
         Main = function(self)
-            IssueClearCommands({self})
+            IssueToUnitClearCommands(self)
             IssueToUnitMove(self, self:GetPosition())
             WaitSeconds(0.5)
             IssueToUnitMove(self, self.spawnedBy:GetPosition())
@@ -120,7 +120,7 @@ URA0001 = ClassUnit(CAirUnit) {
                 ChangeState(self, self.IdleState)
             end
 
-            IssueClearCommands({self})
+            IssueToUnitClearCommands(self)
             IssueGuard({self}, focus)
         end,
     },

--- a/units/URA0001/URA0001_script.lua
+++ b/units/URA0001/URA0001_script.lua
@@ -89,9 +89,9 @@ URA0001 = ClassUnit(CAirUnit) {
     IdleState = State {
         Main = function(self)
             IssueClearCommands({self})
-            IssueMove({self}, self:GetPosition())
+            IssueToUnitMove(self, self:GetPosition())
             WaitSeconds(0.5)
-            IssueMove({self}, self.spawnedBy:GetPosition())
+            IssueToUnitMove(self, self.spawnedBy:GetPosition())
 
             local delay = 0.1
             local wait = 0

--- a/units/URS0303/URS0303_script.lua
+++ b/units/URS0303/URS0303_script.lua
@@ -100,7 +100,7 @@ URS0303 = ClassUnit(AircraftCarrier, ExternalFactoryComponent) {
                 self:AddUnitToStorage(unitBuilding)
             else
                 local worldPos = self:CalculateWorldPositionFromRelative({ 0, 0, -20 })
-                IssueMoveOffFactoryToUnit(unitBuilding, worldPos)
+                IssueToUnitMoveOffFactory(unitBuilding, worldPos)
                 unitBuilding:ShowBone(0, true)
             end
             self:SetBusy(false)

--- a/units/URS0303/URS0303_script.lua
+++ b/units/URS0303/URS0303_script.lua
@@ -100,7 +100,7 @@ URS0303 = ClassUnit(AircraftCarrier, ExternalFactoryComponent) {
                 self:AddUnitToStorage(unitBuilding)
             else
                 local worldPos = self:CalculateWorldPositionFromRelative({ 0, 0, -20 })
-                IssueMoveOffFactory({ unitBuilding }, worldPos)
+                IssueMoveOffFactoryToUnit(unitBuilding, worldPos)
                 unitBuilding:ShowBone(0, true)
             end
             self:SetBusy(false)

--- a/units/XEB2402/XEB2402_Script.lua
+++ b/units/XEB2402/XEB2402_Script.lua
@@ -89,7 +89,7 @@ XEB2402 = ClassUnit(TAirFactoryUnit) {
 
                 -- Release unit
                 self.Satellite:DetachFrom()
-                IssueMove({self.Satellite}, self:GetRallyPoint())
+                IssueToUnitMove(self.Satellite, self:GetRallyPoint())
                 self.Satellite:Open()
 
                 self.waitingForLaunch = false

--- a/units/XEB2402/XEB2402_Script.lua
+++ b/units/XEB2402/XEB2402_Script.lua
@@ -95,7 +95,7 @@ XEB2402 = ClassUnit(TAirFactoryUnit) {
                 self.waitingForLaunch = false
                 self:Retract()
 
-                IssueClearCommands({self})
+                IssueToUnitClearCommands(self)
             end
 
             ChangeState(self, self.IdleState)
@@ -106,7 +106,7 @@ XEB2402 = ClassUnit(TAirFactoryUnit) {
     OnStartBuild = function(self, unitBeingBuilt, order)
         if self.Satellite or self.waitingForLaunch then
             IssueStop({self})
-            IssueClearCommands({self}) -- This clears the State launch procedure for some reason, leading to the following hack
+            IssueToUnitClearCommands(self) -- This clears the State launch procedure for some reason, leading to the following hack
 
             -- This is ugly but necessary. It will keep resetting the launch procedure if the player spams to build a Satellite before initial launch
             -- It looks bad, but it's better than that player not getting a Satellite at all

--- a/units/XSS0303/XSS0303_script.lua
+++ b/units/XSS0303/XSS0303_script.lua
@@ -100,7 +100,7 @@ XSS0303 = ClassUnit(AircraftCarrier, ExternalFactoryComponent) {
                 self:AddUnitToStorage(unitBuilding)
             else
                 local worldPos = self:CalculateWorldPositionFromRelative({0, 0, -20})
-                IssueMoveOffFactory({unitBuilding}, worldPos)
+                IssueMoveOffFactoryToUnit(unitBuilding, worldPos)
                 unitBuilding:ShowBone(0,true)
             end
             self:SetBusy(false)

--- a/units/XSS0303/XSS0303_script.lua
+++ b/units/XSS0303/XSS0303_script.lua
@@ -100,7 +100,7 @@ XSS0303 = ClassUnit(AircraftCarrier, ExternalFactoryComponent) {
                 self:AddUnitToStorage(unitBuilding)
             else
                 local worldPos = self:CalculateWorldPositionFromRelative({0, 0, -20})
-                IssueMoveOffFactoryToUnit(unitBuilding, worldPos)
+                IssueToUnitMoveOffFactory(unitBuilding, worldPos)
                 unitBuilding:ShowBone(0,true)
             end
             self:SetBusy(false)


### PR DESCRIPTION
This idea started with https://github.com/FAForever/fa/issues/5398 where we introduce alternatives to global functions that work for just a single unit, instead of a group of units. The goal is to prevent the allocation of a table with a single array entry in it when we need to apply the function to a single unit.

We can apply the same approach to the simulation. We introduce alternatives that work on a single unit and re-use a single table to efficiently manage memory without the developer being aware of it.