### PR TITLE
Galactic colossus hitbox#4470

### DIFF
--- a/units/UAL0401/UAL0401_Script.lua
+++ b/units/UAL0401/UAL0401_Script.lua
@@ -89,7 +89,7 @@ UAL0401 = ClassUnit(AWalkingLandUnit) {
         AWalkingLandUnit.StartBeingBuiltEffects(self, builder, layer)
         CreateAeonColossusBuildingEffects(self)
         -- adjust collision box due to build animation
-        self:SetCollisionShape('Box',0.3,3.25,-0.55,self.Blueprint.SizeX * 0.5, self.Blueprint.SizeY * 0.5, (self.Blueprint.SizeZ * 0.7))
+        self:SetCollisionShape('Box',0.3,3.25,-0.65,self.Blueprint.SizeX * 0.5, self.Blueprint.SizeY * 0.5, (self.Blueprint.SizeZ * 0.7))
     end,
 
     OnStopBeingBuilt = function(self,builder,layer)

--- a/units/UAL0401/UAL0401_Script.lua
+++ b/units/UAL0401/UAL0401_Script.lua
@@ -88,6 +88,14 @@ UAL0401 = ClassUnit(AWalkingLandUnit) {
     StartBeingBuiltEffects = function(self, builder, layer)
         AWalkingLandUnit.StartBeingBuiltEffects(self, builder, layer)
         CreateAeonColossusBuildingEffects(self)
+        -- adjust collision box due to build animation
+        self:SetCollisionShape('Box',0.3,3.25,-0.55,self.Blueprint.SizeX * 0.5, self.Blueprint.SizeY * 0.5, (self.Blueprint.SizeZ * 0.7))
+    end,
+
+    OnStopBeingBuilt = function(self,builder,layer)
+        AWalkingLandUnit.OnStopBeingBuilt(self,builder,layer)
+        -- adjust collision box due to build animation
+        self:RevertCollisionShape()
     end,
 
     OnKilled = function(self, instigator, type, overkillRatio)


### PR DESCRIPTION
fixes #4470 

took me almost a year but i was pretty busy with studying, so kinda late but here we go.
I adjusted the Collisionshape of the gc when building and reset it when the unit is finished.

To test this just spawn in some t3 engineers and build a gc, you can see the hitbox extending over all target Bones now,
when the building is finished it returns to the original Colisionshape. 

![1](https://github.com/FAForever/fa/assets/85015209/dd99e471-1aea-4d43-a689-470150792fd1)
