### PR TITLE
All spawn locations are now populated with spawn markers

### DIFF
--- a/lua/sim/MarkerUtilities.lua
+++ b/lua/sim/MarkerUtilities.lua
@@ -460,10 +460,11 @@ function Setup()
     -- prepare spawn markers
     local armies = table.hash(ListArmies())
     for k, marker in AllMarkers do
-        if armies[k] then
+        if string.sub(k, 1, 5) == 'ARMY_' then
             marker.Name = k
             marker.Position = marker.position
             marker.size = 50
+            marker.IsOccupied = (armies[k] and true) or false
             MarkerCache["Spawn"].Count = MarkerCache["Spawn"].Count + 1
             MarkerCache["Spawn"].Markers[MarkerCache["Spawn"].Count] = marker
         end

--- a/lua/sim/MarkerUtilities.lua
+++ b/lua/sim/MarkerUtilities.lua
@@ -463,7 +463,8 @@ function Setup()
         if string.sub(k, 1, 5) == 'ARMY_' then
             marker.Name = k
             marker.Position = marker.position
-            marker.size = 50
+            marker.size = 25
+            marker.Size = 25
             marker.IsOccupied = (armies[k] and true) or false
             MarkerCache["Spawn"].Count = MarkerCache["Spawn"].Count + 1
             MarkerCache["Spawn"].Markers[MarkerCache["Spawn"].Count] = marker


### PR DESCRIPTION
The old implementation would consider all non-occupied spawn locations as a large expansion. This was in conflict with how it worked before and existing AI logic would trip over it. All spawns are now considered as spawn locations.

When a spawn location is occupied the field `IsOccupied` is true, otherwise it is set to false.

![image](https://github.com/FAForever/fa/assets/15778155/d34845ce-cdcb-4c58-bda8-9bad11570540)

