### PR TITLE
Atlantis: Increase its BackUpDistance from 15 to 30

### DIFF
--- a/units/UES0401/UES0401_unit.bp
+++ b/units/UES0401/UES0401_unit.bp
@@ -255,7 +255,7 @@ UnitBlueprint{
     LifeBarOffset = 10.5,
     LifeBarSize = 6,
     Physics = {
-        BackUpDistance = 15,
+        BackUpDistance = 30,
         BankingSlope = 0,
         BuildOnLayerCaps = {
             LAYER_Air = false,


### PR DESCRIPTION
**Changes:**
Atlantis: BackUpDistance 15 --> 30

The Atlantis had a rather low BackUpDistance of 15. This meant, that in order to retreat slightly, it usually had to turn by 180 degrees and then drive forwards. This made the unit feel clunky to micro.
