### PR TITLE
Projectiles that retarget autonomously

### DIFF
--- a/engine/Core/Blueprints/ProjectileBlueprint.lua
+++ b/engine/Core/Blueprints/ProjectileBlueprint.lua
@@ -129,3 +129,4 @@
 ---@field RealisticOrdinance boolean
 --- bombs that always drop stright down
 ---@field StraightDownOrdinance boolean
+---@field OnLostTargetLifetime? number

--- a/engine/Sim/Projectile.lua
+++ b/engine/Sim/Projectile.lua
@@ -109,7 +109,7 @@ function Projectile:SetMaxSpeed(speed)
 end
 
 ---
----@param object Entity | Unit | Projectile
+---@param object Blip | Entity | Unit | Projectile
 function Projectile:SetNewTarget(object)
 end
 

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -527,6 +527,8 @@ Projectile = ClassProjectile(ProjectileMethods) {
 
     ---@param self Projectile
     RetargetThread = function (self)
+        local createdByWeapon = self.CreatedByWeapon
+
         for k = 1, 5 do
             WaitTicks(0.2)
 
@@ -534,11 +536,11 @@ Projectile = ClassProjectile(ProjectileMethods) {
                 return
             end
 
-            if IsDestroyed(self.CreatedByWeapon) then
+            if IsDestroyed(createdByWeapon) then
                 return
             end
 
-            local target = self.CreatedByWeapon:GetCurrentTarget()
+            local target = createdByWeapon:GetCurrentTarget()
             if target then
                 self:SetNewTarget(target)
                 self:TrackTarget(true)

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -72,12 +72,13 @@ local ForkThread = ForkThread
 local CategoriesDoNotCollide = categories.TORPEDO + categories.MISSILE + categories.DIRECTFIRE
 local OnImpactDestroyCategories = categories.ANTIMISSILE * categories.ALLPROJECTILES
 
----@class Projectile : moho.projectile_methods
+---@class Projectile : moho.projectile_methods, InternalObject
 ---@field Blueprint ProjectileBlueprint
 ---@field Army number
 ---@field Trash TrashBag
 ---@field Launcher Unit
 ---@field DamageData table
+---@field CreatedByWeapon Weapon
 Projectile = ClassProjectile(ProjectileMethods) {
     IsProjectile = true,
     DestroyOnImpact = true,
@@ -512,14 +513,45 @@ Projectile = ClassProjectile(ProjectileMethods) {
     OnLostTarget = function(self)
         local bp = self.Blueprint.Physics
         local trackTarget = bp.TrackTarget
-        local onLostTargetLifetime = bp.OnLostTargetLifetime or 0.5
         if trackTarget then
-            self:SetLifetime(onLostTargetLifetime)
+            self.Trash:Add(ForkThread(self.RetargetThread, self))
         end
 
         local originalTarget = self.OriginalTarget
         if originalTarget and not (originalTarget.Dead or IsDestroyed(originalTarget)) then
             self:SetNewTarget(originalTarget)
+        end
+    end,
+
+    -- Lua functionality
+
+    ---@param self Projectile
+    RetargetThread = function (self)
+        for k = 1, 5 do
+            WaitTicks(0.2)
+
+            if IsDestroyed(self) then
+                return
+            end
+
+            if IsDestroyed(self.CreatedByWeapon) then
+                return
+            end
+
+            local target = self.CreatedByWeapon:GetCurrentTarget()
+            if target then
+                self:SetNewTarget(target)
+                self:TrackTarget(true)
+                return
+            end
+        end
+
+        -- we couldn't find a new target, take us out
+        local bp = self.Blueprint.Physics
+        if bp.OnLostTargetLifetime then
+            self:SetLifetime(bp.OnLostTargetLifetime)
+        else
+            self:SetLifetime(0.5)
         end
     end,
 

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -47,7 +47,7 @@ end
 
 local WeaponMethods = moho.weapon_methods
 
----@class Weapon : moho.weapon_methods
+---@class Weapon : moho.weapon_methods, InternalObject
 ---@field AimControl? moho.AimManipulator
 ---@field AimLeft? moho.AimManipulator
 ---@field AimRight? moho.AimManipulator
@@ -455,7 +455,10 @@ Weapon = ClassWeapon(WeaponMethods) {
     CreateProjectileForWeapon = function(self, bone)
         local proj = self:CreateProjectile(bone)
 
-        -- store the original target, can be nil if ground firing
+        -- used for the retargeting feature
+        proj.CreatedByWeapon = self
+
+        -- used for tactical / strategic defenses to ignore all other collisions
         proj.OriginalTarget = self:GetCurrentTarget()
         if proj.OriginalTarget.GetSource then
             proj.OriginalTarget = proj.OriginalTarget:GetSource()

--- a/units/UAB2204/UAB2204_unit.bp
+++ b/units/UAB2204/UAB2204_unit.bp
@@ -198,6 +198,7 @@ UnitBlueprint{
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_AntiAir",
             RateOfFire = 1,
+            TargetCheckInterval = 1.0,
             TargetPriorities = {
                 "(AIR * MOBILE * EXPERIMENTAL - BOMBER)",
                 "AIR MOBILE GROUNDATTACK",

--- a/units/UAS0202/UAS0202_unit.bp
+++ b/units/UAS0202/UAS0202_unit.bp
@@ -269,6 +269,7 @@ UnitBlueprint{
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_AntiAir",
             RateOfFire = 1,
+            TargetCheckInterval = 1.0,
             TargetPriorities = {
                 "AIR MOBILE TECH3 BOMBER",
                 "AIR MOBILE BOMBER",

--- a/units/UEB2204/UEB2204_unit.bp
+++ b/units/UEB2204/UEB2204_unit.bp
@@ -202,6 +202,7 @@ UnitBlueprint{
             RangeCategory = "UWRC_AntiAir",
             RateOfFire = 1.25,
             SalvoSize = 2,
+            TargetCheckInterval = 1.0,
             TargetPriorities = {
                 "(AIR * MOBILE * EXPERIMENTAL - BOMBER)",
                 "AIR MOBILE GROUNDATTACK",

--- a/units/UES0202/UES0202_unit.bp
+++ b/units/UES0202/UES0202_unit.bp
@@ -396,6 +396,7 @@ UnitBlueprint{
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_AntiAir",
             RateOfFire = 0.5,
+            TargetCheckInterval = 1.0,
             TargetPriorities = {
                 "EXPERIMENTAL",
                 "AIR MOBILE TECH3 BOMBER",

--- a/units/URB2204/URB2204_unit.bp
+++ b/units/URB2204/URB2204_unit.bp
@@ -206,6 +206,7 @@ UnitBlueprint{
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_AntiAir",
             RateOfFire = 2,
+            TargetCheckInterval = 1.0,
             TargetPriorities = {
                 "(AIR * MOBILE * EXPERIMENTAL - BOMBER)",
                 "AIR MOBILE GROUNDATTACK",

--- a/units/URS0202/URS0202_unit.bp
+++ b/units/URS0202/URS0202_unit.bp
@@ -328,6 +328,7 @@ UnitBlueprint{
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_AntiAir",
             RateOfFire = 0.8,
+            TargetCheckInterval = 1.0,
             TargetPriorities = {
                 "AIR MOBILE TECH3 BOMBER",
                 "AIR MOBILE BOMBER",

--- a/units/XSB2204/XSB2204_unit.bp
+++ b/units/XSB2204/XSB2204_unit.bp
@@ -210,6 +210,7 @@ UnitBlueprint{
             RackSlavedToTurret = true,
             RangeCategory = "UWRC_AntiAir",
             RateOfFire = 1.5,
+            TargetCheckInterval = 1.0,
             TargetPriorities = {
                 "(AIR * MOBILE * EXPERIMENTAL - BOMBER)",
                 "AIR MOBILE GROUNDATTACK",


### PR DESCRIPTION
All projectiles that track (usually, SAM-like weapons and torpedo's) can now retarget after they lost a target. The projectile retargets to the new target of the weapon it is launched from. This guarantees that the target is valid category wise and that the target is in range of the weapon

The target check interval for certain units is relatively low. But in order for projectiles to reliably find a new target the check interval needs to be at least a second

Features for another pull request:

- Limit the number of times that a projectile can retarget before self-destructing
- Look into target check interval of units with projectiles that retarget
