### PR TITLE
Limit target check interval of weapons that can retarget

### DIFF
--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -528,8 +528,7 @@ Projectile = ClassProjectile(ProjectileMethods) {
     ---@param self Projectile
     RetargetThread = function (self)
         local createdByWeapon = self.CreatedByWeapon
-
-        for k = 1, 5 do
+        if createdByWeapon then
             WaitTicks(0.2)
 
             if IsDestroyed(self) then

--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -979,7 +979,7 @@ function PostModBlueprints(all_bps)
     SetUnitThreatValues(all_bps.Unit)
     BlueprintLoaderUpdateProgress()
 
-    ProcessWeapons(all_bps.Unit)
+    ProcessWeapons(all_bps, all_bps.Unit)
     BlueprintLoaderUpdateProgress()
 
     -- re-computes all the LODs of various entities to match the LOD with the size of the entity


### PR DESCRIPTION
By limiting the target check interval we make it easier for projectiles to find new targets