### PR TITLE
Raised Platform visualisation for cheat spawn menu

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -647,6 +647,29 @@ local function SetWorldCameraToUnitIconAngle(location, zoom)
     })
 end
 
+local function ShowRaisedPlatforms(self)
+    local plats = self:GetBlueprint().Physics.RaisedPlatforms
+    if not plats then return end
+    local pos = self:GetPosition()
+    local entities = {}
+    for i=1, (table.getn(plats)/12) do
+        entities[i]={}
+        for b=1,4 do
+            entities[i][b] = import('/lua/sim/Entity.lua').Entity{Owner = self}
+            self.Trash:Add(entities[i][b])
+            entities[i][b]:SetPosition(Vector(
+                pos[1]+plats[((i-1)*12)+(b*3)-2],
+                pos[2]+plats[((i-1)*12)+(b*3)],
+                pos[3]+plats[((i-1)*12)+(b*3)-1]
+            ), true)
+        end
+        self.Trash:Add(AttachBeamEntityToEntity(entities[i][1], -2, entities[i][2], -2, self:GetArmy(), '/effects/emitters/build_beam_01_emit.bp'))
+        self.Trash:Add(AttachBeamEntityToEntity(entities[i][1], -2, entities[i][3], -2, self:GetArmy(), '/effects/emitters/build_beam_01_emit.bp'))
+        self.Trash:Add(AttachBeamEntityToEntity(entities[i][4], -2, entities[i][2], -2, self:GetArmy(), '/effects/emitters/build_beam_01_emit.bp'))
+        self.Trash:Add(AttachBeamEntityToEntity(entities[i][4], -2, entities[i][3], -2, self:GetArmy(), '/effects/emitters/build_beam_01_emit.bp'))
+    end
+end
+
 Callbacks.ClearSpawnedMeshes = function()
     if not PassesAntiCheatCheck() then
         return
@@ -715,6 +738,9 @@ Callbacks.CheatSpawnUnit = function(data)
             end
             if data.veterancy and data.veterancy ~= 0 and unit.SetVeterancy then
                 unit:SetVeterancy(data.veterancy)
+            end
+            if data.ShowRaisedPlatforms then
+                ShowRaisedPlatforms(unit)
             end
         end
     end

--- a/lua/ui/dialogs/createunit.lua
+++ b/lua/ui/dialogs/createunit.lua
@@ -1052,6 +1052,7 @@ function CreateDialog()
             rand = dialogData.inputRand and dialogData.inputRand:GetValue() or 0,
             CreateTarmac = options.spawn_menu_tarmacs_enabled,
             MeshOnly = options.spawn_menu_mesh_only,
+            ShowRaisedPlatforms = options.spawn_menu_show_raised_platforms,
             UnitIconCameraMode = options.spawn_menu_unit_icon_camera,
 
             selection = selection,
@@ -1893,6 +1894,7 @@ function CreateDebugConfig()
         {style = 'toggle',       name = 'Clear spawned entity meshes', activate = function() SimCallback{Func = 'ClearSpawnedMeshes'} end },
         {style = 'configtoggle', name = 'Position camera for build icon on spawn',    prefid = 'spawn_menu_unit_icon_camera' },
         {style = 'configtoggle', name = 'Ignore terrain blocking (disables preview)', prefid = 'spawn_menu_force_dummy_spawn'},
+        {style = 'configtoggle', name = 'Show raised platforms',                      prefid = 'spawn_menu_show_raised_platforms', },
 
         {style = 'title',        name = 'Unit spawn filter settings:' },
         {style = 'configtoggle', name = 'Include build-menu filters',     refresh = true, prefid = 'spawn_menu_filter_build_menu', check = function() return options.spawn_menu_filter_build_menu ~= false end },

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -271,6 +271,7 @@ local function CheatSpawn(command, data)
             veterancy = data.vet,
             CreateTarmac = data.CreateTarmac,
             MeshOnly = data.MeshOnly,
+            ShowRaisedPlatforms = data.ShowRaisedPlatforms,
             UnitIconCameraMode = data.UnitIconCameraMode,
         }
     }, true)


### PR DESCRIPTION
Since the `ShowRaisedPlatforms` command appears to do nothing, this adds a toggle option to the cheat spawn menu to outline raised platforms with beams.
![image](https://github.com/FAForever/fa/assets/11473693/150e527c-7e2b-4f83-9382-8f252a9223ab)
