### PR TITLE
Add missing emission on maps without water

### DIFF
--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -622,7 +622,9 @@ float3 ApplyWaterColor(float depth, float3 viewDirection, float3 color, float3 e
             color = lerp(color, waterColor.rgb, waterColor.w);
             color += emission;
         }
-    } 
+    } else {
+        color += emission;
+    }
     return color;
 }
 


### PR DESCRIPTION
I forgot that we still need to add the emission, even if we don't do any water processing. This lead to inadvertantly turning of the emission on maps without water.

![Screenshot 2023-10-01 000509](https://github.com/FAForever/fa/assets/52536103/7edf26a4-28a3-43d5-ac16-7b9107b4d6e5)

![Screenshot 2023-10-01 000653](https://github.com/FAForever/fa/assets/52536103/87ee47b2-70dd-4027-bcea-c87bfbd03076)
