### PR TITLE
Tune Cybran albedo

### DIFF
--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -792,28 +792,28 @@ float4 PBR_UEF(NORMALMAPPED_VERTEX vertex, float teamColorFactor, uniform bool h
 {
     float3x3 rotationMatrix = float3x3(vertex.binormal, vertex.tangent, vertex.normal);
     float3 normal = ComputeNormal(normalsSampler, vertex.texcoord0.zw, rotationMatrix);
-    float4 albedo = tex2D(albedoSampler, vertex.texcoord0.xy);
+    float3 albedo = tex2D(albedoSampler, vertex.texcoord0.xy).rgb;
     float4 specular = tex2D(specularSampler, vertex.texcoord0.xy);
 
     // try to extract some ambient occlusion information from the albedo
     // unfortunately the albedos have lots of baked in lighting so
     // we have to keep the effect slight
-    float ao = .5 + logisticFn(length(albedo.rgb) / sqrt(3), .1, 40, .5, 2);
+    float ao = .5 + logisticFn(length(albedo) / sqrt(3), .1, 40, .5, 2);
 
     float teamcolor = min(pow(specular.a * 1.1, 0.6), 1);
     float metallic = max(1 - teamcolor * 2.2, 0);
 
-    albedo.rgb = lerp(albedo.rgb, albedo.rgb * 1.9, metallic);
-    albedo.rgb = lerp(albedo.rgb, vertex.color.rgb * 0.6, teamColorFactor * teamcolor);
+    albedo = lerp(albedo, albedo * 1.9, metallic);
+    albedo = lerp(albedo, vertex.color.rgb * 0.6, teamColorFactor * teamcolor);
 
     float planeCockpitMask = saturate((specular.r - 0.65) * 3);
-    albedo.rgb += planeCockpitMask;
+    albedo += planeCockpitMask;
 
     float roughness = specular.g * 0.6 + 0.35 + saturate(pow(specular.a * 3.7, 0.6)) * 0.3;
     roughness += planeCockpitMask - specular.b * 3;
     roughness = saturate(1 - roughness);
 
-    float3 color = PBR(vertex, albedo.rgb, metallic, roughness, normal, hiDefShadows, .04, ao);
+    float3 color = PBR(vertex, albedo, metallic, roughness, normal, hiDefShadows, .04, ao);
     float emission = specular.b * 0.8;
     color = ApplyWaterColor(vertex.depth.x, vertex.viewDirection, color, emission * albedo);
 
@@ -872,16 +872,16 @@ float4 PBR_Cybran(NORMALMAPPED_VERTEX vertex, float teamColorFactor, uniform boo
 
     float3x3 rotationMatrix = float3x3(vertex.binormal, vertex.tangent, vertex.normal);
     float3 normal = ComputeNormal(normalsSampler, vertex.texcoord0.zw, rotationMatrix);
-    float4 albedo = tex2D( albedoSampler, vertex.texcoord0.xy);
+    float3 albedo = tex2D( albedoSampler, vertex.texcoord0.xy).rgb;
     float4 specular = tex2D( specularSampler, vertex.texcoord0.xy);
 
     float metallic = saturate(specular.r + saturate(specular.g - 0.1) * 0.87 - specular.a * 2.2);
     float roughness = lerp(0.8 * (1 - specular.g), lerp(0.5, 0.25, specular.g), metallic);
 
-    albedo.rgb = min(lerp(albedo.rgb, albedo.rgb * 2.3, pow(metallic, 2.5)), float3(1, 1, 1));
-    albedo.rgb = lerp(albedo.rgb, vertex.color.rgb, teamColorFactor * specular.a);
+    albedo = min(lerp(albedo, albedo * 2.3, pow(metallic, 2.5)), float3(1, 1, 1));
+    albedo = lerp(albedo, vertex.color.rgb, teamColorFactor * specular.a);
 
-    float3 color = PBR(vertex, albedo.rgb, metallic, roughness, normal, hiDefShadows);
+    float3 color = PBR(vertex, albedo, metallic, roughness, normal, hiDefShadows);
     float emission = pow(max(specular.b - 0.04, 0.0), 0.5);
     color = ApplyWaterColor(vertex.depth.x, vertex.viewDirection, color, emission * albedo);
 
@@ -6241,6 +6241,7 @@ technique UEFNavy_LowFidelity
         PixelShader = compile ps_2_0 ColorMaskPS_LowFidelity();
     }
 }
+
 
 technique CybranNavy_HighFidelity
 <

--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -878,6 +878,7 @@ float4 PBR_Cybran(NORMALMAPPED_VERTEX vertex, float teamColorFactor, uniform boo
     float metallic = saturate(specular.r + saturate(specular.g - 0.1) * 0.87 - specular.a * 2.2);
     float roughness = lerp(0.8 * (1 - specular.g), lerp(0.5, 0.25, specular.g), metallic);
 
+    albedo += specular.r * 0.1;
     albedo = min(lerp(albedo, albedo * 2.3, pow(metallic, 2.5)), float3(1, 1, 1));
     albedo = lerp(albedo, vertex.color.rgb, teamColorFactor * specular.a);
 

--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -6243,7 +6243,6 @@ technique UEFNavy_LowFidelity
     }
 }
 
-
 technique CybranNavy_HighFidelity
 <
     string abstractTechnique = "CybranNavy";

--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -879,7 +879,7 @@ float4 PBR_Cybran(NORMALMAPPED_VERTEX vertex, float teamColorFactor, uniform boo
     float roughness = lerp(0.8 * (1 - specular.g), lerp(0.5, 0.25, specular.g), metallic);
 
     albedo += specular.r * 0.1;
-    albedo = min(lerp(albedo, albedo * 2.3, pow(metallic, 2.5)), float3(1, 1, 1));
+    albedo = min(lerp(albedo, albedo * 2.3, pow(metallic, 2.5)), float3(0.9, 0.9, 0.9));
     albedo = lerp(albedo, vertex.color.rgb, teamColorFactor * specular.a);
 
     float3 color = PBR(vertex, albedo, metallic, roughness, normal, hiDefShadows);


### PR DESCRIPTION
There was feedback that the cybran units look too bland. Adding a bit of the red specular channel brings back some of the albedo variation. This works because originally the specular red channel added sunreflection, essentially making the albedo brighter. We have already encountered this on the Aeon units, where adding the specular red channel to the albedo greatly homogenized their look. Here we use this trick to bring back some detail that got lost.
It also makes metal parts look brighter, which is a nice touch as they were a bit too dark before.
![Screenshot 2023-10-01 001715](https://github.com/FAForever/fa/assets/52536103/c1c6a056-49dc-4743-be46-8cfd95b82447)
![Screenshot 2023-10-01 001535](https://github.com/FAForever/fa/assets/52536103/a09b401d-019e-47b6-b895-23f2616f2895)
![Screenshot 2023-10-01 001538](https://github.com/FAForever/fa/assets/52536103/fbd7e0fa-befd-46a1-80d1-90088361b0f4)
