### PR TITLE
Fix look of cybran units on medium fidelity

### DIFF
--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -3776,7 +3776,7 @@ float4 NormalMappedInsectPS( NORMALMAPPED_VERTEX vertex, uniform bool hiDefShado
 
     albedo.rgb = lerp( vertex.color.rgb, albedo.rgb, 1 - specular.a );
 
-    float4 phongAdditive = anisoAmount * specular.g + float4( 0.5 * specular.r * environment, 0);
+    float4 phongAdditive = anisoAmount * specular.g + float4( 0.05 * specular.r * environment, 0);
   phongAdditive *= ( 1 - specular.a);
 
     float shadow = ComputeShadow( vertex.shadow, hiDefShadows);


### PR DESCRIPTION
Here comes another shader fix xD
Adjusting the red specular channel for cybran units produced the side effect that on medium fidelity (that setting that is supposed to be close to the steam fa shader) all units looked overly bright, as seen here:

![Screenshot 2023-10-01 111856](https://github.com/FAForever/fa/assets/52536103/36233797-fb52-4e0a-96c0-a5865cc51ff4)


Originally they looked like this:
![Screenshot 2023-10-01 110538](https://github.com/FAForever/fa/assets/52536103/0ebb22c2-5646-49ea-aa73-3195dd367ab1)


We can bring them in line with the original look with a small change, which leaves us with this result, which is pretty close:

![Screenshot 2023-10-01 111451](https://github.com/FAForever/fa/assets/52536103/557822f3-5241-496b-84ce-bbab128f3536)

This enables easier comparisons between the PBR shader and the original shader and preserves the original shader better for people that prefer that look. PBR shaders are unaffected by this PR.