### PR TITLE
Fix small details related to the mobile factory

### DIFF
--- a/lua/DefaultUnits/ExternalFactory.lua
+++ b/lua/DefaultUnits/ExternalFactory.lua
@@ -12,7 +12,13 @@ ExternalFactoryUnit = ClassUnit(Unit) {
     ---@param self ExternalFactoryUnit
     OnCreate = function(self)
         Unit.OnCreate(self)
+
+        -- do not show the mesh
         self:HideBone(0, true)
+
+        -- do not allow the unit to be killed or to take damage
+        self.CanBeKilled = false
+        self.CanTakeDamage = false
     end,
 
     ---@param self ExternalFactoryUnit

--- a/lua/DefaultUnits/ExternalFactory.lua
+++ b/lua/DefaultUnits/ExternalFactory.lua
@@ -19,8 +19,12 @@ ExternalFactoryUnit = ClassUnit(Unit) {
         -- do not allow the unit to be killed or to take damage
         self.CanBeKilled = false
         self.CanTakeDamage = false
-        self:SetReclaimable (false)
+
+        -- is inherited by units, mimic what factories have as their default
         self:SetFireState(2)
+
+        -- do not allow the unit to be reclaimed or targeted by weapons
+        self:SetReclaimable (false)
         self:SetDoNotTarget(true)
     end,
 

--- a/lua/DefaultUnits/ExternalFactory.lua
+++ b/lua/DefaultUnits/ExternalFactory.lua
@@ -19,6 +19,9 @@ ExternalFactoryUnit = ClassUnit(Unit) {
         -- do not allow the unit to be killed or to take damage
         self.CanBeKilled = false
         self.CanTakeDamage = false
+        self:SetReclaimable (false)
+        self:SetFireState(2)
+        self:SetDoNotTarget(true)
     end,
 
     ---@param self ExternalFactoryUnit

--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -883,7 +883,7 @@ ExternalFactoryComponent = ClassSimple {
         if not IsDestroyed(self.ExternalFactory) then
             self.ExternalFactory:SetBusy(true)
             self.ExternalFactory:SetBlockCommandQueue(true)
-            self.ExternalFactory:Kill()
+            self.ExternalFactory:Destroy()
         end
     end,
 


### PR DESCRIPTION
Mobile factories can no longer self destruct (on accident). They can also no longer be reclaimed. They now also start off with the same fire state as regular factories (attack ground). 