### PR TITLE
No longer force the fire state of mobile units to ground attack

### DIFF
--- a/lua/DefaultUnits/Mobile.lua
+++ b/lua/DefaultUnits/Mobile.lua
@@ -3,7 +3,6 @@ local EffectUtil = import("/lua/effectutilities.lua")
 
 local Unit = import("/lua/sim/unit.lua").Unit
 local TreadComponent = import("/lua/defaultcomponents.lua").TreadComponent
-local FireState = import("/lua/game.lua").FireState
 
 ---@class MobileUnit : Unit, TreadComponent
 ---@field MovementEffectsBag TrashBag
@@ -16,8 +15,6 @@ MobileUnit = ClassUnit(Unit, TreadComponent) {
     OnCreate = function(self)
         Unit.OnCreate(self)
         TreadComponent.OnCreate(self)
-
-        self:SetFireState(FireState.GROUND_FIRE)
 
         self.MovementEffectsBag = TrashBag()
         self.TopSpeedEffectsBag = TrashBag()


### PR DESCRIPTION
When a unit is built by a factory it inherits the fire state of that factory. However, when a mobile unit is created the fire state was overwritten to always be the attack ground fire state

All factories default to the attack ground fire state. A user can now switch that to the return fire state or the no fire state and units will inherit that accordingly.

