### PR TITLE
Allow projectiles of strategic bombers to ignore ASF

### DIFF
--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -52,8 +52,6 @@
 --- the localised language). If the localisation part is not set, the description in tags will be
 --- used for any language, which would be "Medium Tank" for this example
 ---@field Description UnlocalizedString
---- list of categories that this unit will not collide with
----@field DoNotCollideList? CategoryName[]
 --- used by the Othuy ("lighting storm") script
 ---@field Lifetime? number
 --- used by the Othuy ("lighting storm") script
@@ -106,10 +104,6 @@
 ---@field BlueprintId UnitId
 --- auto-generated categories table based on `Categories` with each key a value in that array
 ---@field CategoriesHash table<CategoryName, true>
---- auto-generated number from `DoNotCollideList`
----@field DoNotCollideListCount number
---- auto-generated table from `DoNotCollideList`
----@field DoNotCollideListHash table<UnparsedCategory, true>
 --- auto-generated for unit blueprints generated from a unit with a preset in `EnhancementPresets`
 ---@field EnhancementPresetAssigned? UnitBlueprintAssignedEnhancementPreset
 --- auto-generated faction category from `Categories`

--- a/engine/Core/Blueprints/WeaponBlueprint.lua
+++ b/engine/Core/Blueprints/WeaponBlueprint.lua
@@ -94,9 +94,6 @@
 --- Name of the weapon. Used for lobby restrictions and for debugging:
 --- `dbg weapons` in the console shows the weapon names.
 ---@field DisplayName string
---- Use the `DoNotCollideList` in the projectile blueprint instead--this table is only used
---- by anti-artillery shields
----@field DoNotCollideList? UnparsedCategory[]
 --- number of times the Damage over Time damage will be dealt
 ---@field DoTPulses number
 --- duration that the Damage over Time will last in seconds

--- a/lua/DefaultUnits/Air.lua
+++ b/lua/DefaultUnits/Air.lua
@@ -223,9 +223,17 @@ AirUnit = ClassUnit(MobileUnit) {
             return false
         end
 
+        local selfBlueprintCategoriesHashed = self.Blueprint.CategoriesHash
+        local otherBlueprintCategoriesHashed = other.Blueprint.CategoriesHash
+
         -- allow regular air units to be destroyed by the projectiles of SMDs and SMLs
-        if other.Blueprint.CategoriesHash["KILLAIRONCOLLISION"] and not self.Blueprint.CategoriesHash.EXPERIMENTAL then
+        if otherBlueprintCategoriesHashed["KILLAIRONCOLLISION"] and (not selfBlueprintCategoriesHashed["EXPERIMENTAL"]) then
             self:Kill()
+            return false
+        end
+
+        -- disallow ASF to intercept certain projectiles
+        if otherBlueprintCategoriesHashed["IGNOREASFONCOLLISION"] and selfBlueprintCategoriesHashed["ASF"] then
             return false
         end
 

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -1288,17 +1288,11 @@ AntiArtilleryShield = ClassShield(Shield) {
                 return false
             end
         end
-        -- Check DNC list
-        if bp.DoNotCollideList then
-            for k, v in pairs(bp.DoNotCollideList) do
-                if EntityCategoryContains(ParseEntityCategory(v), self) then
-                    return false
-                end
-            end
-        end
+
         if bp.ArtilleryShieldBlocks then
             return true
         end
+
         return false
     end,
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1518,8 +1518,6 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         end
     end,
 
-    
-
     --- Called when a unit collides with a projectile to check if the collision is valid
     ---@param self Unit The unit we're checking the collision for
     ---@param other Projectile The projectile we're checking the collision with
@@ -1531,23 +1529,12 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             return false
         end
 
+        local selfArmy = self.Army
+        local otherArmy = other.Army
+
         -- if we're allied, check if we allow allied collisions
-        if self.Army == other.Army or IsAlly(self.Army, other.Army) then
+        if selfArmy == otherArmy or IsAlly(selfArmy, otherArmy) then
             return other.CollideFriendly
-        end
-
-        -- check for exclusions from projectile perspective
-        for k = 1, other.Blueprint.DoNotCollideListCount do
-            if self.Blueprint.CategoriesHash[other.Blueprint.DoNotCollideList[k]] then
-                return false 
-            end
-        end
-
-        -- check for exclusions from unit perspective
-        for k = 1, self.Blueprint.DoNotCollideListCount do
-            if other.Blueprint.CategoriesHash[self.Blueprint.DoNotCollideList[k]] then
-                return false
-            end
         end
 
         return true
@@ -1564,8 +1551,11 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             return false
         end
 
+        local selfArmy = self.Army
+        local otherArmy = firingWeapon.Army
+
         -- if we're allied, check if we allow allied collisions
-        if self.Army == firingWeapon.Army or IsAlly(self.Army, firingWeapon.Army) then
+        if selfArmy == otherArmy or IsAlly(selfArmy, otherArmy) then
             return firingWeapon.Blueprint.CollideFriendly
         end
 

--- a/lua/system/blueprints-projectiles.lua
+++ b/lua/system/blueprints-projectiles.lua
@@ -10,9 +10,6 @@
 --      Description = STRING,           -- default
 --      Display = { },                  -- default
 --      Economy = { },                  -- default
---      DoNotCollideList = { },         -- default
---      DoNotCollideListCount = NUMBER, -- generated
---      DoNotCollideListHash = { },     -- generated
 --      General = { },                  -- default
 --      Interface = { },                -- default
 --      Physics = { },                  -- default
@@ -32,16 +29,6 @@ local function PostProcessProjectile(projectile)
     end
 
     projectile.CategoriesHash[projectile.BlueprintId] = true
-
-    -- create hash tables for quick lookup
-    projectile.DoNotCollideListCount = 0
-    projectile.DoNotCollideListHash = {}
-    if projectile.DoNotCollideList then
-        projectile.DoNotCollideListCount = table.getn(projectile.DoNotCollideList)
-        for _, category in projectile.DoNotCollideList do
-            projectile.DoNotCollideListHash[category] = true
-        end
-    end
 
     -- fix desired shooter cap for missiles
     if (projectile.CategoriesHash['MISSILE'] and (not projectile.CategoriesHash['STRATEGIC'])) or projectile.CategoriesHash["TORPEDO"] then

--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -130,16 +130,6 @@ local function PostProcessUnit(unit)
 
     unit.CategoriesHash[unit.BlueprintId] = true
 
-    -- create hash tables for quick lookup
-    unit.DoNotCollideListCount = 0
-    unit.DoNotCollideListHash = {}
-    if unit.DoNotCollideList then
-        unit.DoNotCollideListCount = table.getn(unit.DoNotCollideList)
-        for _, category in unit.DoNotCollideList do
-            unit.DoNotCollideListHash[category] = true
-        end
-    end
-
     -- sanitize guard scan radius
 
     -- The guard scan radius is used when:

--- a/projectiles/AANDepthCharge01/AANDepthCharge01_proj.bp
+++ b/projectiles/AANDepthCharge01/AANDepthCharge01_proj.bp
@@ -38,9 +38,6 @@ ProjectileBlueprint {
         StrategicIconSize = 1,
         UniformScale = 0.45,
     },
-    DoNotCollideList = {
-        'TORPEDO',
-    },
     General = {
         Category = 'Anti Navy',
         Faction = 'Aeon',

--- a/projectiles/AANDepthCharge02/AANDepthCharge02_proj.bp
+++ b/projectiles/AANDepthCharge02/AANDepthCharge02_proj.bp
@@ -41,9 +41,6 @@ ProjectileBlueprint {
     Interface = {
         HelpText = 0,
     },
-    DoNotCollideList = {
-        'TORPEDO',
-    },
     Physics = {
         Acceleration = 0,
         DestroyOnWater = false,

--- a/projectiles/AANDepthCharge03/AANDepthCharge03_proj.bp
+++ b/projectiles/AANDepthCharge03/AANDepthCharge03_proj.bp
@@ -41,9 +41,6 @@ ProjectileBlueprint {
         StrategicIconSize = 1,
         UniformScale = 0.45,
     },
-    DoNotCollideList = {
-        'TORPEDO',
-    },
     General = {
         Category = 'Anti Navy',
         Faction = 'Aeon',

--- a/projectiles/AIFBombQuark01/AIFBombQuark01_proj.bp
+++ b/projectiles/AIFBombQuark01/AIFBombQuark01_proj.bp
@@ -20,6 +20,7 @@ ProjectileBlueprint {
         'AEON',
         'PROJECTILE',
         'INDIRECTFIRE',
+        'IGNOREASFONCOLLISION',
     },
     Display = {
         CameraFollowsProjectile = true,
@@ -30,9 +31,6 @@ ProjectileBlueprint {
 
         -- MeshBlueprint = '/meshes/projectiles/bomb_default_mesh.bp',
         UniformScale = 0.3,
-    },
-    DoNotCollideList = {
-        'ASF',
     },
     General = {
         Category = 'Bomb',

--- a/projectiles/CIFProtonBomb01/CIFProtonBomb01_proj.bp
+++ b/projectiles/CIFProtonBomb01/CIFProtonBomb01_proj.bp
@@ -20,6 +20,7 @@ ProjectileBlueprint {
         'CYBRAN',
         'PROJECTILE',
         'INDIRECTFIRE',
+        'IGNOREASFONCOLLISION',
     },
     Display = {
         CameraFollowTimeout = 2,
@@ -38,9 +39,6 @@ ProjectileBlueprint {
         },
         StrategicIconSize = 2,
         UniformScale = 0.25,
-    },
-    DoNotCollideList = {
-        'ASF',
     },
     General = {
         Category = 'Bomb',

--- a/projectiles/SANHeavyCavitationTorpedo01/SANHeavyCavitationTorpedo01_proj.bp
+++ b/projectiles/SANHeavyCavitationTorpedo01/SANHeavyCavitationTorpedo01_proj.bp
@@ -32,10 +32,6 @@ ProjectileBlueprint {
         },
         StrategicIconSize = 1,
     },
-    DoNotCollideList = {
-        'PROJECTILE',
-        'TORPEDO',
-    },
     General = {
         Category = 'Anti Navy',
         Faction = 'Seraphim',

--- a/projectiles/SBOZhanaseeBomb01/SBOZhanaseeBomb01_proj.bp
+++ b/projectiles/SBOZhanaseeBomb01/SBOZhanaseeBomb01_proj.bp
@@ -20,6 +20,7 @@ ProjectileBlueprint {
         'SERAPHIM',
         'PROJECTILE',
         'INDIRECTFIRE',
+        'IGNOREASFONCOLLISION',
     },
     Display = {
         CameraFollowTimeout = 2,
@@ -28,9 +29,6 @@ ProjectileBlueprint {
             Type = 'Small01',
         },
         StrategicIconSize = 2,
-    },
-    DoNotCollideList = {
-        'ASF',
     },
     General = {
         Category = 'Bomb',

--- a/projectiles/TIFSmallYieldNuclearBomb01/TIFSmallYieldNuclearBomb01_proj.bp
+++ b/projectiles/TIFSmallYieldNuclearBomb01/TIFSmallYieldNuclearBomb01_proj.bp
@@ -20,6 +20,7 @@ ProjectileBlueprint {
         'UEF',
         'PROJECTILE',
         'INDIRECTFIRE',
+        'IGNOREASFONCOLLISION',
     },
     Display = {
         CameraFollowTimeout = 2,
@@ -37,9 +38,6 @@ ProjectileBlueprint {
         },
         StrategicIconSize = 2,
         UniformScale = 0.125,
-    },
-    DoNotCollideList = {
-        'ASF',
     },
     General = {
         Category = 'Bomb',


### PR DESCRIPTION
Removes the `DoNotCollideList` and generated fields from the unit and projectile blueprints. It is a bit silly in the nature of a physics simulation to begin with, but due to https://github.com/FAForever/FA-Binary-Patches/pull/48 collisions can trigger quite a bit more often. Therefore a generic solution with a complexity of `O(n)` is not desirable as the `OnCollisionCheck` is now a critical path for performance

The second step towards making collision detection less expensive due to https://github.com/FAForever/FA-Binary-Patches/pull/48