### PR TITLE
Fix not capturing the right click when exiting hot build

### DIFF
--- a/lua/keymap/hotbuild.lua
+++ b/lua/keymap/hotbuild.lua
@@ -262,11 +262,18 @@ function availableTemplate(allTemplates,buildable)
     return effectiveTemplates, effectiveIcons
 end
 
+--- A 'hack' to allow us to detect whether the `ButtonRelease` event was from a left-click
+factoryHotkeyLastClickWasLeft = false
+
 function factoryHotkey(units, count)
     CommandMode.StartCommandMode("build", {name = ''})
+
+    -- Another 'hack' that is, uuhh - a hack. Override the event handle of the world view. If it doesn't 
+    -- return false then the event is captured and the engine ignores it (no orders are issued when clicking, etc)
     worldview.HandleEvent = function(self, event)
-        if event.Type == 'ButtonPress' then
+        if event.Type != 'ButtonRelease' then
             if event.Modifiers.Left then
+                factoryHotkeyLastClickWasLeft = true
                 if type(units) == "string" then
                     if IsKeyDown("Shift") then
                         count = 5
@@ -282,6 +289,10 @@ function factoryHotkey(units, count)
                     end
                     StopCycleMap(self, event)
                 end
+            end
+        else
+            if factoryHotkeyLastClickWasLeft then
+                factoryHotkeyLastClickWasLeft = false
             else
                 StopCycleMap(self, event)
             end
@@ -290,7 +301,7 @@ function factoryHotkey(units, count)
 end
 
 function StopCycleMap(self, event)
-    worldview.HandleEvent = oldHandleEvent(self, event)
+    worldview.HandleEvent = oldHandleEvent
     cycleThread = ForkThread(function()
         local options = Prefs.GetFromCurrentProfile('options')
         local fadeTime = options.hotbuild_cycle_reset_time / 2000.0
@@ -494,6 +505,8 @@ function buildActionTemplate(modifier)
 end
 
 function buildActionUnit(name, modifier)
+    LOG("buildActionUnit")
+    LOG(" - " .. name)
     local values = unitkeygroups[name]
     local factoryFlag = true
 

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -885,7 +885,7 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
         end
     end,
 
-    --- Called whenever the mouse moves and clicks in the world view
+    --- Called whenever the mouse moves and clicks in the world view. If it returns false then the engine further processes the event for orders
     ---@param self WorldView
     ---@param event any
     ---@return boolean


### PR DESCRIPTION
Fixes a subtle, but very annoying bug related to using hot build to queue units in a factory. You can now reliably use the release of any non-left button of the mouse to exit the cycle preview. When exiting, the `HandleEvent` of the worldview is properly reset, previously it would be assigned the _result of the old `HandleEvent`_, which is really not what you want 😃 

It now also properly registers _any left click_. The old implementation would only register non-double clicks, but usually you'll have a lot of those as you want to quickly queue up units

When you exit the cycle preview using right-click it no longer registers it as a command issues (which is a rally point in 99.9% of the cases)
