### PR TITLE
Separate blueprint fields for an external factory

### DIFF
--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -88,6 +88,7 @@
 ---@field Defense UnitBlueprintDefense
 ---@field Display UnitBlueprintDisplay
 ---@field Economy UnitBlueprintEconomy
+---@field ExternalFactory UnitBlueprintExternalFactory
 ---@field Enhancements?  table<Enhancement, UnitBlueprintEnhancement>
 ---@field EnhancementPresets? table<string, UnitBlueprintEnhancementPreset>
 ---@field General UnitBlueprintGeneral
@@ -753,6 +754,11 @@
 --- Treated as `0.01` when absent.
 ---@field TeleportTimeMod? number
 
+---@class UnitBlueprintExternalFactory
+---@field SelectionSizeX number
+---@field SelectionSizeZ number
+---@field SelectionCenterOffsetX number
+---@field SelectionCenterOffsetZ number
 
 ---@class UnitBlueprintEnhancements : table<Enhancement, UnitBlueprintEnhancement>
 ---@field Slots table<EnhancementSlot, {name: UnlocalizedString, x: number, y: number}>

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -88,7 +88,7 @@
 ---@field Defense UnitBlueprintDefense
 ---@field Display UnitBlueprintDisplay
 ---@field Economy UnitBlueprintEconomy
----@field ExternalFactory UnitBlueprintExternalFactory
+---@field ExternalFactory? UnitBlueprintExternalFactory
 ---@field Enhancements?  table<Enhancement, UnitBlueprintEnhancement>
 ---@field EnhancementPresets? table<string, UnitBlueprintEnhancementPreset>
 ---@field General UnitBlueprintGeneral
@@ -755,10 +755,15 @@
 ---@field TeleportTimeMod? number
 
 ---@class UnitBlueprintExternalFactory
----@field SelectionSizeX number
----@field SelectionSizeZ number
----@field SelectionCenterOffsetX number
----@field SelectionCenterOffsetZ number
+---@field SelectionSizeX? number
+---@field SelectionSizeZ? number
+---@field SelectionCenterOffsetX? number
+---@field SelectionCenterOffsetY? number
+---@field SelectionCenterOffsetZ? number
+---@field SelectionMeshScaleX? number
+---@field SelectionMeshScaleY? number
+---@field SelectionMeshScaleZ? number
+---@field UniformScale? number
 
 ---@class UnitBlueprintEnhancements : table<Enhancement, UnitBlueprintEnhancement>
 ---@field Slots table<EnhancementSlot, {name: UnlocalizedString, x: number, y: number}>

--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -828,6 +828,10 @@ ExternalFactoryComponent = ClassSimple {
             error(string.format("%s is not setup for an external factory: the unit does not have a field 'FactoryAttachBone'", blueprint.BlueprintId))
         end
 
+        if self.BuildAttachBone and self.BuildAttachBone == self.FactoryAttachBone then
+            error(string.format("%s is not setup for an external factory: the 'FactoryAttachBone' can not be the same as the 'BuildAttachBone'", blueprint.BlueprintId))
+        end
+
         if not blueprint.CategoriesHash['EXTERNALFACTORY'] then
             error(string.format("%s is not setup for an external factory: the unit does not have a 'EXTERNALFACTORY' category", blueprint.BlueprintId))
         end

--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -544,9 +544,10 @@ function PostProcessUnitWithExternalFactory(allBlueprints, unit)
         efBlueprint.CategoriesHash[unit.FactionCategory] = true
         efBlueprint.CategoriesHash[unit.LayerCategory] = true
         efBlueprint.Categories = table.unhash(efBlueprint.CategoriesHash)
-        efBlueprint.SelectionSizeX = 0.95 * unit.SelectionSizeX
-        efBlueprint.SelectionSizeZ = 0.25 * unit.SelectionSizeZ
-        efBlueprint.SelectionCenterOffsetZ = 0.35 * unit.SelectionSizeZ
+        efBlueprint.SelectionSizeX = unit.ExternalFactory.SelectionSizeX or (0.95 * unit.SelectionSizeX)
+        efBlueprint.SelectionSizeZ = unit.ExternalFactory.SelectionSizeZ or (0.25 * unit.SelectionSizeZ)
+        efBlueprint.SelectionCenterOffsetX = unit.ExternalFactory.SelectionCenterOffsetX or (0)
+        efBlueprint.SelectionCenterOffsetZ = unit.ExternalFactory.SelectionCenterOffsetZ or (0.35 * unit.SelectionSizeZ)
 
         -- add order overrides to carriers
         if unit.CategoriesHash['CARRIER'] then
@@ -556,7 +557,7 @@ function PostProcessUnitWithExternalFactory(allBlueprints, unit)
             if not unit.General.OrderOverrides then
                 unit.General.OrderOverrides = {}
             end
-            
+
             unit.General.OrderOverrides.RULEUCC_Transport = {
                 bitmapId = 'deploy',
                 helpText = 'auto_deploy',
@@ -564,7 +565,7 @@ function PostProcessUnitWithExternalFactory(allBlueprints, unit)
                 initialStateFunc = 'AutoDeployInit',
                 extraInfo = 1,
             }
-            
+
             -- add the toggle so it can be flipped to begin with
             -- but add an order override to remove it from our orders table
             if not unit.General.ToggleCaps then

--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -546,8 +546,13 @@ function PostProcessUnitWithExternalFactory(allBlueprints, unit)
         efBlueprint.Categories = table.unhash(efBlueprint.CategoriesHash)
         efBlueprint.SelectionSizeX = unit.ExternalFactory.SelectionSizeX or (0.95 * unit.SelectionSizeX)
         efBlueprint.SelectionSizeZ = unit.ExternalFactory.SelectionSizeZ or (0.25 * unit.SelectionSizeZ)
-        efBlueprint.SelectionCenterOffsetX = unit.ExternalFactory.SelectionCenterOffsetX or (0)
+        efBlueprint.SelectionCenterOffsetX = unit.ExternalFactory.SelectionCenterOffsetX or 0
+        efBlueprint.SelectionCenterOffsetY = unit.ExternalFactory.SelectionCenterOffsetY or 0
         efBlueprint.SelectionCenterOffsetZ = unit.ExternalFactory.SelectionCenterOffsetZ or (0.35 * unit.SelectionSizeZ)
+        efBlueprint.SelectionMeshScaleX = unit.ExternalFactory.SelectionMeshScaleX or 1
+        efBlueprint.SelectionMeshScaleY = unit.ExternalFactory.SelectionMeshScaleY or 3
+        efBlueprint.SelectionMeshScaleZ = unit.ExternalFactory.SelectionMeshScaleZ or 1
+        efBlueprint.Display.UniformScale = unit.ExternalFactory.UniformScale or 1.6
 
         -- add order overrides to carriers
         if unit.CategoriesHash['CARRIER'] then

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5499,6 +5499,7 @@ function InitLobbyComm(protocol, localPort, desiredPlayerName, localPlayerUID, n
 
     lobbyComm.DataReceived = function(self, data)
 
+        
         -- Decide if we should just drop the packet. Violations here are usually people using a
         -- modified lobby.lua to try to do stupid shit.
         if not MessageHandlers[data.Type] then

--- a/units/UAA0310/UAA0310_script.lua
+++ b/units/UAA0310/UAA0310_script.lua
@@ -21,7 +21,7 @@ local ExternalFactoryComponent = import("/lua/defaultcomponents.lua").ExternalFa
 UAA0310 = ClassUnit(AirTransport, ExternalFactoryComponent) {
     DestroyNoFallRandomChance = 1.1,
     BuildAttachBone = 'Attachpoint01',
-    FactoryAttachBone = 'Attachpoint01',
+    FactoryAttachBone = 'Attachpoint02',
 
     Weapons = {
         QuantumBeamGeneratorWeapon = ClassWeapon(AQuantumBeamGenerator) {},
@@ -112,6 +112,7 @@ UAA0310 = ClassUnit(AirTransport, ExternalFactoryComponent) {
             self:DetachAll(self.BuildAttachBone)
             self:SetBusy(false)
             self:OnIdle()
+            LOG("OnIdle")
         end,
 
         OnStartBuild = function(self, unitBuilding, order)

--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -140,6 +140,12 @@ UnitBlueprint{
         BuildableCategory = { "BUILTBYTIER3FACTORY AEON MOBILE AIR" },
         MaintenanceConsumptionPerSecondEnergy = 500,
     },
+    ExternalFactory = {
+        SelectionSizeX = 4,
+        SelectionSizeZ = 4,
+        SelectionCenterOffsetX = 4,
+        SelectionCenterOffsetZ = 0,
+    },
     Footprint = {
         MaxSlope = 0.25,
         SizeX = 20,

--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -143,8 +143,8 @@ UnitBlueprint{
     ExternalFactory = {
         SelectionSizeX = 4,
         SelectionSizeZ = 4,
-        SelectionCenterOffsetX = 4,
-        SelectionCenterOffsetZ = 0,
+        SelectionCenterOffsetX = 0,
+        SelectionCenterOffsetZ = 4,
     },
     Footprint = {
         MaxSlope = 0.25,

--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -144,7 +144,8 @@ UnitBlueprint{
         SelectionSizeX = 4,
         SelectionSizeZ = 4,
         SelectionCenterOffsetX = 0,
-        SelectionCenterOffsetZ = 4,
+        SelectionCenterOffsetY = 2.7,
+        SelectionCenterOffsetZ = -2,
     },
     Footprint = {
         MaxSlope = 0.25,

--- a/units/UAS0303/UAS0303_unit.bp
+++ b/units/UAS0303/UAS0303_unit.bp
@@ -130,6 +130,12 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY AEON MOBILE AIR ANTIGROUND",
         },
     },
+    ExternalFactory = {
+        SelectionSizeX = 4,
+        SelectionSizeZ = 2,
+        SelectionCenterOffsetX = 0,
+        SelectionCenterOffsetZ = 8.5,
+    },
     Footprint = {
         SizeX = 5,
         SizeZ = 17,

--- a/units/UAS0401/UAS0401_unit.bp
+++ b/units/UAS0401/UAS0401_unit.bp
@@ -184,6 +184,13 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY AEON MOBILE NAVAL",
         },
     },
+    ExternalFactory = {
+        SelectionSizeX = 3,
+        SelectionSizeZ = 3,
+        SelectionCenterOffsetX = 0,
+        SelectionCenterOffsetY = 2.0,
+        SelectionCenterOffsetZ = 3,
+    },
     General = {
         CommandCaps = {
             RULEUCC_Attack = true,

--- a/units/UAS0401/UAS0401_unit.bp
+++ b/units/UAS0401/UAS0401_unit.bp
@@ -189,7 +189,7 @@ UnitBlueprint{
         SelectionSizeZ = 3,
         SelectionCenterOffsetX = 0,
         SelectionCenterOffsetY = 2.0,
-        SelectionCenterOffsetZ = 3,
+        SelectionCenterOffsetZ = 4,
     },
     General = {
         CommandCaps = {

--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -233,6 +233,13 @@ UnitBlueprint{
         StorageEnergy = 1000,
         StorageMass = 200,
     },
+    ExternalFactory = {
+        SelectionSizeX = 2,
+        SelectionSizeZ = 2,
+        SelectionCenterOffsetX = 0,
+        SelectionCenterOffsetY = 1.5,
+        SelectionCenterOffsetZ = 2.5,
+    },
     General = {
         BuildBones = {
             BuildEffectBones = {

--- a/units/UES0401/UES0401_unit.bp
+++ b/units/UES0401/UES0401_unit.bp
@@ -215,6 +215,13 @@ UnitBlueprint{
         BuildTime = 20500,
         BuildableCategory = { "BUILTBYTIER3FACTORY UEF MOBILE AIR" },
     },
+    ExternalFactory = {
+        SelectionSizeX = 1,
+        SelectionSizeZ = 4.5,
+        SelectionCenterOffsetX = 0,
+        SelectionCenterOffsetY = 1.0,
+        SelectionCenterOffsetZ = 8,
+    },
     Footprint = {
         SizeX = 6,
         SizeZ = 22,

--- a/units/URS0303/URS0303_unit.bp
+++ b/units/URS0303/URS0303_unit.bp
@@ -135,6 +135,12 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY CYBRAN MOBILE AIR ANTIGROUND",
         },
     },
+    ExternalFactory = {
+        SelectionSizeX = 2,
+        SelectionSizeZ = 4,
+        SelectionCenterOffsetX = 0,
+        SelectionCenterOffsetZ = 12,
+    },
     Footprint = {
         SizeX = 5,
         SizeZ = 17,

--- a/units/XSS0303/XSS0303_unit.bp
+++ b/units/XSS0303/XSS0303_unit.bp
@@ -132,6 +132,12 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY SERAPHIM MOBILE AIR ANTIGROUND",
         },
     },
+    ExternalFactory = {
+        SelectionSizeX = 2.8,
+        SelectionSizeZ = 3.2,
+        SelectionCenterOffsetX = 0,
+        SelectionCenterOffsetZ = 9.1,
+    },
     Footprint = {
         SizeX = 5,
         SizeZ = 17,


### PR DESCRIPTION
Introduces a separate field in the blueprint to pass blueprint fields to the external factory. The fields supported at the moment are related to the selection size and location. 