### PR TITLE
Introduce a wall overspill mechanic

### DIFF
--- a/lua/armordefinition.lua
+++ b/lua/armordefinition.lua
@@ -28,6 +28,7 @@
 ---| "TacticalMissile"
 ---| "TreeFire"
 ---| "TreeForce"
+---| "WallOverspill"
 
 ---@alias ArmorType
 ---| "ASF"

--- a/lua/sim/DefaultUnits/StructureUnit.lua
+++ b/lua/sim/DefaultUnits/StructureUnit.lua
@@ -729,18 +729,18 @@ StructureUnit = ClassUnit(Unit) {
             return
         end
 
-        -- make sure we have adjacency buffs to apply
-        local adjBuffs = self.Blueprint.Adjacency
-        if not adjBuffs then
-            return
-        end
-
         -- keep track of who is adjacent to who
         self.AdjacentUnits = self.AdjacentUnits or { }
         adjacentUnit.AdjacentUnits = adjacentUnit.AdjacentUnits or { }
 
         self.AdjacentUnits[adjacentUnit.EntityId] = adjacentUnit
         adjacentUnit.AdjacentUnits[self.EntityId] = self
+
+        -- make sure we have adjacency buffs to apply
+        local adjBuffs = self.Blueprint.Adjacency
+        if not adjBuffs then
+            return
+        end
 
         -- apply the buffs
         local buffApplied = false
@@ -785,6 +785,10 @@ StructureUnit = ClassUnit(Unit) {
             return
         end
 
+        -- keep track of who is adjacent to who
+        self.AdjacentUnits[adjacentUnit.EntityId] = nil
+        adjacentUnit.AdjacentUnits[self.EntityId] = nil
+
         -- make sure we have buffs to remove
         local adjBuffs = self.Blueprint.Adjacency
         if not adjBuffs then
@@ -822,10 +826,6 @@ StructureUnit = ClassUnit(Unit) {
 
         -- clean up effects
         self:DestroyAdjacentEffects(adjacentUnit)
-
-        -- keep track of who is adjacent to who
-        self.AdjacentUnits[adjacentUnit.EntityId] = nil
-        adjacentUnit.AdjacentUnits[self.EntityId] = nil
 
         -- refresh the UI
         adjacentUnit:RequestRefreshUI()

--- a/lua/sim/DefaultUnits/WallStructureUnit.lua
+++ b/lua/sim/DefaultUnits/WallStructureUnit.lua
@@ -1,5 +1,32 @@
 
 local StructureUnit = import("/lua/sim/defaultunits/structureunit.lua").StructureUnit
 
+local StructureUnitOnDamage = StructureUnit.OnDamage
+
 ---@class WallStructureUnit : StructureUnit
-WallStructureUnit = ClassUnit(StructureUnit) { }
+WallStructureUnit = ClassUnit(StructureUnit) {
+
+    IsWall = true,
+    WallOverspillFactor = 0.2,
+
+    ---@param self WallStructureUnit
+    ---@param instigator Unit
+    ---@param amount number
+    ---@param vector Vector
+    ---@param damageType DamageType
+    OnDamage = function(self, instigator, amount, vector, damageType)
+        StructureUnitOnDamage(self, instigator, amount, vector, damageType)
+
+        if damageType != 'WallOverspill' then
+            local adjacentUnits = self.AdjacentUnits
+            if adjacentUnits then
+                local wallOverspillFactor = self.WallOverspillFactor
+                for id, adjacentUnit in adjacentUnits do
+                    if adjacentUnit.IsWall then
+                        adjacentUnit:OnDamage(instigator, wallOverspillFactor * amount, vector, 'WallOverspill')
+                    end
+                end
+            end
+        end
+    end,
+}

--- a/lua/sim/DefaultUnits/WallStructureUnit.lua
+++ b/lua/sim/DefaultUnits/WallStructureUnit.lua
@@ -1,12 +1,16 @@
 
 local StructureUnit = import("/lua/sim/defaultunits/structureunit.lua").StructureUnit
 
+-- upvalue scope for performance
+local EntityCategoryContains = EntityCategoryContains
+
 local StructureUnitOnDamage = StructureUnit.OnDamage
+
+local CategoriesWall = categories.WALL
 
 ---@class WallStructureUnit : StructureUnit
 WallStructureUnit = ClassUnit(StructureUnit) {
 
-    IsWall = true,
     WallOverspillFactor = 0.2,
 
     ---@param self WallStructureUnit
@@ -22,7 +26,7 @@ WallStructureUnit = ClassUnit(StructureUnit) {
             if adjacentUnits then
                 local wallOverspillFactor = self.WallOverspillFactor
                 for id, adjacentUnit in adjacentUnits do
-                    if adjacentUnit.IsWall then
+                    if EntityCategoryContains(CategoriesWall, adjacentUnit) then
                         adjacentUnit:OnDamage(instigator, wallOverspillFactor * amount, vector, 'WallOverspill')
                     end
                 end

--- a/units/UAB5101/UAB5101_unit.bp
+++ b/units/UAB5101/UAB5101_unit.bp
@@ -121,7 +121,7 @@ UnitBlueprint{
     SelectionSizeZ = 0.6,
     SelectionThickness = 0.66,
     SizeX = 1,
-    SizeY = 0.4,
+    SizeY = 0.5,
     SizeZ = 1,
     StrategicIconName = "icon_structure_wall",
     StrategicIconSortPriority = 210,

--- a/units/UEB5101/UEB5101_unit.bp
+++ b/units/UEB5101/UEB5101_unit.bp
@@ -114,7 +114,7 @@ UnitBlueprint{
     SelectionSizeZ = 0.6,
     SelectionThickness = 0.66,
     SizeX = 1,
-    SizeY = 0.4,
+    SizeY = 0.5,
     SizeZ = 1,
     StrategicIconName = "icon_structure_wall",
     StrategicIconSortPriority = 210,

--- a/units/URB5101/URB5101_unit.bp
+++ b/units/URB5101/URB5101_unit.bp
@@ -109,7 +109,7 @@ UnitBlueprint{
     SelectionSizeZ = 0.6,
     SelectionThickness = 0.66,
     SizeX = 1,
-    SizeY = 0.4,
+    SizeY = 0.5,
     SizeZ = 1,
     StrategicIconName = "icon_structure_wall",
     StrategicIconSortPriority = 210,

--- a/units/XSB5101/XSB5101_unit.bp
+++ b/units/XSB5101/XSB5101_unit.bp
@@ -128,7 +128,7 @@ UnitBlueprint{
     SelectionSizeZ = 0.6,
     SelectionThickness = 0.66,
     SizeX = 1,
-    SizeY = 0.4,
+    SizeY = 0.5,
     SizeZ = 1,
     StrategicIconName = "icon_structure_wall",
     StrategicIconSortPriority = 210,


### PR DESCRIPTION
With thanks to https://github.com/FAForever/FA-Binary-Patches/pull/48 walls can now properly block projectiles. With this pull request we double-down on that by introducing a wall overspill mechanic in combination with a 0.1 ogrid increase of height for the walls. On flat ground a pitbox now reliably blocks projectiles of any tech 1 medium tank.