### PR TITLE
Mute scoreboard background ambient if music is off

### DIFF
--- a/lua/ui/dialogs/score.lua
+++ b/lua/ui/dialogs/score.lua
@@ -422,9 +422,9 @@ function CreateSkirmishScreen(victory, showCampaign, operationVictoryTable)
 
     -- No way to set ambient sound volumes, so let's at least turn it off if music is off.
     if (GetVolume("Music") > 0) then
-    local ambientSounds = PlaySound(Sound({Cue = "AMB_SER_OP_Briefing", Bank = "AmbientTest",}))
-    dialog.OnDestroy = function(self)
-        StopSound(ambientSounds)
+        local ambientSounds = PlaySound(Sound({Cue = "AMB_SER_OP_Briefing", Bank = "AmbientTest",}))
+        dialog.OnDestroy = function(self)
+            StopSound(ambientSounds)
         end
     end
 

--- a/lua/ui/dialogs/score.lua
+++ b/lua/ui/dialogs/score.lua
@@ -420,9 +420,12 @@ function CreateSkirmishScreen(victory, showCampaign, operationVictoryTable)
         self:SetNeedsFrameUpdate(false)
     end
 
+    -- No way to set ambient sound volumes, so let's at least turn it off if music is off.
+    if (GetVolume("Music") > 0) then
     local ambientSounds = PlaySound(Sound({Cue = "AMB_SER_OP_Briefing", Bank = "AmbientTest",}))
     dialog.OnDestroy = function(self)
         StopSound(ambientSounds)
+        end
     end
 
     movieBG = Movie(dialog, '/movies/menu_background.sfd')


### PR DESCRIPTION
Currently there is no way to set volume for ambient sounds. (I did try `SetVolume("Ambient"/"AmbientTest", 0)`). Now at least won't play the ambient sound in scoreboard if music is off.