### PR TITLE
Terrain advancements

### DIFF
--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -2618,6 +2618,8 @@ float4 Terrain301AlbedoPS ( VS_OUTPUT inV) : COLOR
     albedo = splatLerp(albedo, stratum4Albedo, stratum4Height, mask1.x);
     albedo = splatLerp(albedo, stratum5Albedo, stratum5Height, mask1.y);
     albedo = splatLerp(albedo, stratum6Albedo, stratum6Height, mask1.z);
+    float4 mapwide = tex2D(Stratum7NormalSampler, position.xy);
+    albedo.rgb = lerp(albedo.rgb, mapwide.rgb, mapwide.a);
 
     // We need to add 0.01 as the reflection disappears at 0
     float roughness = saturate(albedo.a * mask1.w * 2 + 0.01);

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -425,7 +425,7 @@ float4 CalculateLighting( float3 inNormal, float3 inViewPosition, float3 inAlbed
     float shadow = ( inShadows && ( 1 == ShadowsEnabled ) ) ? ComputeShadow( inShadow ) : 1;
     if (IsExperimentalShader()) {
         float3 position = TerrainScale * inViewPosition;
-        float mapShadow = tex2D(Stratum7AlbedoSampler, position.xy).w;
+        float mapShadow = tex2D(UpperAlbedoSampler, position.xy).w;
         shadow = shadow * mapShadow;
     }
 

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -43,7 +43,7 @@ texture        UtilityTextureB;
 // red: wave normal strength
 // green: water depth
 // blue: ???
-// ???
+// alpha: foam reduction
 texture        UtilityTextureC;
 
 // appear to be unused

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -424,7 +424,7 @@ float4 CalculateLighting( float3 inNormal, float3 inViewPosition, float3 inAlbed
     float shadow = ( inShadows && ( 1 == ShadowsEnabled ) ) ? ComputeShadow( inShadow ) : 1;
     if (IsExperimentalShader()) {
         float3 position = TerrainScale * inViewPosition;
-        float mapShadow = saturate(1 - tex2D(Stratum7AlbedoSampler, position.xy).b);
+        float mapShadow = tex2D(Stratum7AlbedoSampler, position.xy).w;
         shadow = shadow * mapShadow;
     }
 
@@ -494,7 +494,7 @@ float3 PBR(VS_OUTPUT inV, float4 position, float3 albedo, float3 n, float roughn
 
     float shadow = 1;
     if (ShadowsEnabled == 1) {
-        float mapShadow = 1 - tex2D(UpperAlbedoSampler, position.xy).w; // 1 where sun is, 0 where shadow is
+        float mapShadow = tex2D(UpperAlbedoSampler, position.xy).w; // 1 where sun is, 0 where shadow is
         shadow = tex2D(ShadowSampler, inV.mShadow.xy).g; // 1 where sun is, 0 where shadow is
         shadow *= mapShadow;
     }

--- a/effects/water2.fx
+++ b/effects/water2.fx
@@ -23,6 +23,11 @@ float3 waveCrestColor = float3( 1, 1, 1);
 
 float4x4		WorldToView;
 float4x4		Projection;
+
+// red: wave normal strength
+// green: water depth
+// blue: ???
+// alpha: foam reduction
 texture		UtilityTextureC;
 
 samplerCUBE SkySampler = sampler_state


### PR DESCRIPTION
I had to partially revert the fix that got rid of the water coloration on steep cliffs. When only checking for the terrain height we can get artifacts in shallow water when zooming out far because of the terrain tesselation. Then random segments of the water disappear. So as a compromise we only get rid of the start of the coloration. This is enough for reasonably steep cliffs while it minimizes the tesselation artifacts to a level that is not distracting.
![Screenshot 2023-10-12 234552](https://github.com/FAForever/fa/assets/52536103/30d2b444-f948-4c97-8c89-f1be6ddc47c4)


The advanced shaders now use the previously unused channel in our mapwide texture for the water depth. This enables us to put the mapwide albedo "decal" into a normal slot that was already free, but we couldn't access it because of the limit of how many different textures we can sample. Now that we got rid of the need to sample the water depth texture that the engine provides, we can sample that normal slot.

The areas underwater now get their specularity reduced instead of their roughness increased, which is more physically accurate.

According to the naming scheme in #5529 I added shaders that utilize the full mask range and I added a shader that uses the pbr workflow with roughness maps without implementing the advanced splatting, which makes it much easier to use this shader with the current map editor.

The map generator will soon provide tools to easily generate the needed mapwide and pbr texture in https://github.com/FAForever/Neroxis-Map-Generator/pull/365