### PR TITLE
Add more diverse debris to tactical missiles

### DIFF
--- a/effects/Entities/TacticalDebris01/TacticalDebris01_proj.bp
+++ b/effects/Entities/TacticalDebris01/TacticalDebris01_proj.bp
@@ -1,0 +1,23 @@
+ProjectileBlueprint {
+    Display = {
+        ImpactEffects = {
+            Type = 'Small01',
+            Scale = 1.0,
+        },
+        MeshBlueprint = '/meshes/projectiles/debris_misc_04_mesh.bp',
+        UniformScale = 0.23,
+    },
+    Physics = {
+        CollideEntity = false,
+        DestroyOnWater = true,
+        DirectionY = 0.75,
+        DirectionYRange = 0.5,
+        InitialSpeed = 8.5,
+        InitialSpeedRange = 6,
+        MaxSpeed = 24,
+        RotationalVelocity = 360,
+        RotationalVelocityRange = 180,
+        Lifetime = 20,
+        VelocityAlign = false,
+    },
+}

--- a/effects/Entities/TacticalDebris01/TacticalDebris01_script.lua
+++ b/effects/Entities/TacticalDebris01/TacticalDebris01_script.lua
@@ -1,0 +1,5 @@
+---@class TacticalDebris01 : GenericDebris
+TacticalDebris01 = ClassDummyProjectile(import("/lua/genericdebris.lua").GenericDebris) {
+    FxTrails = import("/lua/EffectTemplates.lua").TacticalDebrisTrails01,
+}
+TypeClass = TacticalDebris01

--- a/effects/Entities/TacticalDebris02/TacticalDebris02_proj.bp
+++ b/effects/Entities/TacticalDebris02/TacticalDebris02_proj.bp
@@ -1,0 +1,23 @@
+ProjectileBlueprint {
+    Display = {
+        ImpactEffects = {
+            Type = 'Small01',
+            Scale = 1.0,
+        },
+        MeshBlueprint = '/meshes/projectiles/debris_misc_04_mesh.bp',
+        UniformScale = 0.23,
+    },
+    Physics = {
+        CollideEntity = false,
+        DestroyOnWater = true,
+        DirectionY = 1.5,
+        DirectionYRange = 0.5,
+        InitialSpeed = 12.0,
+        InitialSpeedRange = 6,
+        MaxSpeed = 24,
+        RotationalVelocity = 360,
+        RotationalVelocityRange = 180,
+        Lifetime = 20,
+        VelocityAlign = false,
+    },
+}

--- a/effects/Entities/TacticalDebris02/TacticalDebris02_script.lua
+++ b/effects/Entities/TacticalDebris02/TacticalDebris02_script.lua
@@ -1,0 +1,18 @@
+
+local GenericDebris = import("/lua/genericdebris.lua").GenericDebris
+
+---@class TacticalDebris02 : GenericDebris
+TacticalDebris02 = ClassDummyProjectile(GenericDebris) {
+    FxTrails = import("/lua/EffectTemplates.lua").TacticalDebrisTrails02,
+
+    ---@param self BaseGenericDebris
+    ---@param targetType string
+    ---@param targetEntity Unit | Shield | Projectile
+    OnImpact = function(self, targetType, targetEntity)
+        GenericDebris.OnImpact(self, targetType, targetEntity)
+
+        DamageArea(self, self:GetPosition(), 2, 1, 'TreeFire', false, false)
+        CreateLightParticle(self, -1, self.Army, 3, 6, 'flare_lens_add_02', 'ramp_fire_13')
+    end,
+}
+TypeClass = TacticalDebris02

--- a/effects/Entities/TacticalDebris03/TacticalDebris03_proj.bp
+++ b/effects/Entities/TacticalDebris03/TacticalDebris03_proj.bp
@@ -1,0 +1,23 @@
+ProjectileBlueprint {
+    Display = {
+        ImpactEffects = {
+            Type = 'Small01',
+            Scale = 1.0,
+        },
+        MeshBlueprint = '/meshes/projectiles/debris_misc_04_mesh.bp',
+        UniformScale = 0.23,
+    },
+    Physics = {
+        CollideEntity = false,
+        DestroyOnWater = true,
+        DirectionY = 1.5,
+        DirectionYRange = 0.5,
+        InitialSpeed = 12.0,
+        InitialSpeedRange = 6,
+        MaxSpeed = 24,
+        RotationalVelocity = 360,
+        RotationalVelocityRange = 180,
+        Lifetime = 20,
+        VelocityAlign = false,
+    },
+}

--- a/effects/Entities/TacticalDebris03/TacticalDebris03_script.lua
+++ b/effects/Entities/TacticalDebris03/TacticalDebris03_script.lua
@@ -1,0 +1,8 @@
+
+local GenericDebris = import("/lua/genericdebris.lua").GenericDebris
+
+---@class TacticalDebris03 : GenericDebris
+TacticalDebris03 = ClassDummyProjectile(GenericDebris) {
+    FxTrails = import("/lua/EffectTemplates.lua").TacticalDebrisTrails03,
+}
+TypeClass = TacticalDebris03

--- a/effects/emitters/tactical_debris_distortion_01_emit.bp
+++ b/effects/emitters/tactical_debris_distortion_01_emit.bp
@@ -1,0 +1,155 @@
+-- used by trees
+EmitterBlueprint {
+	BlueprintId = 'destruction_damaged_fire_distort_01',
+	Lifetime = -1.00,
+	Repeattime = 15.00,
+	TextureFramecount = 1.00,
+	Blendmode = 5.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 200.00,
+	EmitIfVisible = true,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 10.00,
+	LowFidelity = false,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = '/textures/particles/distort_ring_02.dds',
+	RampTexture = '/textures/particles/ramp_white_premod_01.dds',
+	XDirectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.010,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.620,y=0.100,z=0.030 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=6.510,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=4.930,y=3.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=2.513,y=4.000,z=2.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=1.200,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=4.590,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=4.180,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.050,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=15.000,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.664,y=0.000,z=0.050 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=2.445,y=0.050,z=0.040 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.800,y=0.100,z=0.050 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=10.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.460,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+}

--- a/effects/emitters/tactical_debris_fire_01_emit.bp
+++ b/effects/emitters/tactical_debris_fire_01_emit.bp
@@ -1,0 +1,155 @@
+-- used by trees
+EmitterBlueprint {
+	BlueprintId = 'destruction_damaged_fire_01',
+	Lifetime = -1.00,
+	Repeattime = 15.00,
+	TextureFramecount = 1.00,
+	Blendmode = 3.00,
+	LocalVelocity = false,
+	LocalAcceleration = false,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 300.00,
+	EmitIfVisible = true,
+	CatchupEmit = false,
+	CreateIfVisible = false,
+	SnapToWaterline = false,
+	OnlyEmitOnWater = false,
+	ParticleResistance = false,
+	InterpolateEmission = true,
+	TextureStripcount = 4.00,
+	SortOrder = 10.00,
+	LowFidelity = true,
+	MedFidelity = true,
+	HighFidelity = true,
+	Texture = '/textures/particles/fire_flame_add_05.dds',
+	RampTexture = '/textures/particles/ramp_white_premod_01.dds',
+	XDirectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.010,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=6.590,y=0.020,z=0.030 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=6.510,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=4.930,y=20.000,z=0.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.580,y=3.000,z=1.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=4.590,y=0.010,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=4.180,y=0.000,z=0.000 },
+		},
+	},
+	ResistanceCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.050,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.050 },
+		},
+	},
+	YPosCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.664,y=0.000,z=0.050 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=2.445,y=0.065,z=0.080 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.800,y=0.040,z=0.020 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=35.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.460,y=2.000,z=4.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+}

--- a/effects/emitters/tactical_debris_smoke_01_emit.bp
+++ b/effects/emitters/tactical_debris_smoke_01_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+    BlueprintId = 'smoke_01',
+    Lifetime = 2.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 0.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 400.00,
+    EmitIfVisible = true,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 4.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = '/textures/particles/bluesmoke.dds',
+    RampTexture = '/textures/particles/ramp_white_21.dds',
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.020 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.005,z=0.030 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.020 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=8.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=60.000,z=20.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.500,z=1.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.250 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.500,z=0.000 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.800,z=1.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=2.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=2.000,z=4.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+}
+

--- a/effects/emitters/tactical_debris_smoke_02_emit.bp
+++ b/effects/emitters/tactical_debris_smoke_02_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+    BlueprintId = 'smoke_01',
+    Lifetime = 4.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 0.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 350.00,
+    EmitIfVisible = true,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 4.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = '/textures/particles/bluesmoke.dds',
+    RampTexture = '/textures/particles/ramp_white_27.dds',
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.020 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.005,z=0.030 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.020 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=8.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=60.000,z=20.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=1.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.250 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.500,z=0.000 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.800,z=1.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=2.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=2.000,z=4.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+}
+

--- a/effects/emitters/tactical_debris_smoke_03_emit.bp
+++ b/effects/emitters/tactical_debris_smoke_03_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+    BlueprintId = 'smoke_01',
+    Lifetime = 2.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 0.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 400.00,
+    EmitIfVisible = true,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 4.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = '/textures/particles/bluesmoke.dds',
+    RampTexture = '/textures/particles/ramp_white_21.dds',
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.020 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.005,z=0.030 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.020 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=8.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=40.000,z=20.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.800,z=1.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.250 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.500,z=0.000 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.800,z=1.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=2.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=2.000,z=4.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+}
+

--- a/effects/emitters/tactical_debris_smoke_04_emit.bp
+++ b/effects/emitters/tactical_debris_smoke_04_emit.bp
@@ -1,0 +1,155 @@
+EmitterBlueprint {
+    BlueprintId = 'smoke_01',
+    Lifetime = 4.00,
+    Repeattime = 50.00,
+    TextureFramecount = 1.00,
+    Blendmode = 0.00,
+    LocalVelocity = false,
+    LocalAcceleration = false,
+    Gravity = false,
+    AlignRotation = false,
+    AlignToBone = false,
+    Flat = false,
+    LODCutoff = 350.00,
+    EmitIfVisible = true,
+    CatchupEmit = false,
+    CreateIfVisible = false,
+    SnapToWaterline = false,
+    OnlyEmitOnWater = false,
+    ParticleResistance = false,
+    InterpolateEmission = true,
+    TextureStripcount = 4.00,
+    SortOrder = 0.00,
+    LowFidelity = true,
+    MedFidelity = true,
+    HighFidelity = true,
+    Texture = '/textures/particles/bluesmoke.dds',
+    RampTexture = '/textures/particles/ramp_white_27.dds',
+    XDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.020 },
+        },
+    },
+    YDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.005,z=0.030 },
+        },
+    },
+    ZDirectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.020 },
+        },
+    },
+    EmitRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=8.000,z=0.000 },
+        },
+    },
+    LifetimeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=40.000,z=20.000 },
+        },
+    },
+    VelocityCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    XAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ZAccelCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    ResistanceCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    SizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.600,z=1.000 },
+        },
+    },
+    XPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    YPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.250 },
+        },
+    },
+    ZPosCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+    StartSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.500,z=0.000 },
+        },
+    },
+    EndSizeCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.800,z=1.000 },
+        },
+    },
+    InitialRotationCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=180.000,z=360.000 },
+        },
+    },
+    RotationRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=2.000 },
+        },
+    },
+    FrameRateCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=1.000,z=0.000 },
+        },
+    },
+    TextureSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=2.000,z=4.000 },
+        },
+    },
+    RampSelectionCurve = {
+        XRange = 50.00,
+        Keys = {
+            { x=25.000,y=0.000,z=0.000 },
+        },
+    },
+}
+

--- a/effects/emitters/tactical_debris_trail_01_emit.bp
+++ b/effects/emitters/tactical_debris_trail_01_emit.bp
@@ -1,0 +1,146 @@
+EmitterBlueprint {
+	BlueprintId = 'destruction_explosion_debris_trail_01',
+	Lifetime = 25.00,
+	Repeattime = 15.00,
+	TextureFramecount = 1.00,
+	Blendmode = 0.00,
+	LocalVelocity = true,
+	LocalAcceleration = true,
+	Gravity = false,
+	AlignRotation = false,
+	AlignToBone = false,
+	Flat = false,
+	LODCutoff = 300.00,
+	EmitIfVisible = true,
+	CatchupEmit = true,
+	CreateIfVisible = false,
+	SnapToWaterline = true,
+	OnlyEmitOnWater = false,
+	InterpolateEmission = true,
+	TextureStripcount = 1.00,
+	SortOrder = 1.00,
+	Texture = '/textures/particles/cloud_smoke_alpha_10.dds',
+	RampTexture = '/textures/particles/ramp_fire_smoke_01.dds',
+	XDirectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+	YDirectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.410,y=0.000,z=0.000 },
+		},
+	},
+	ZDirectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+	EmitRateCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=0.040,y=8.140,z=2.000 },
+			{ x=14.800,y=1.630,z=2.000 },
+		},
+	},
+	LifetimeCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.590,y=20.000,z=0.000 },
+		},
+	},
+	VelocityCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=1.000,z=0.000 },
+		},
+	},
+	XAccelCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+	YAccelCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+	ZAccelCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+	SizeCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=6.960,y=0.000,z=0.000 },
+		},
+	},
+	XPosCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+	YPosCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.440,y=0.000,z=0.000 },
+		},
+	},
+	ZPosCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.650,y=0.000,z=0.000 },
+		},
+	},
+	StartSizeCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.650,y=0.065,z=0.050 },
+		},
+	},
+	EndSizeCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=8.292,y=0.065,z=0.050 },
+		},
+	},
+	InitialRotationCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=180.000,z=360.000 },
+		},
+	},
+	RotationRateCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=20.000 },
+		},
+	},
+	FrameRateCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=1.000,z=0.000 },
+		},
+	},
+	TextureSelectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+	RampSelectionCurve = {
+		XRange = 15.00,
+		Keys = {
+			{ x=7.500,y=0.000,z=0.000 },
+		},
+	},
+}
+

--- a/lua/EffectTemplates.lua
+++ b/lua/EffectTemplates.lua
@@ -252,6 +252,25 @@ GenericDebrisTrails01 = {
     EmtBpPath .. 'destruction_explosion_debris_trail_01_emit.bp',
 }
 
+TacticalDebrisTrails01 = {
+    EmtBpPath .. 'tactical_debris_smoke_01_emit.bp',
+    EmtBpPath .. 'tactical_debris_smoke_02_emit.bp',
+    EmtBpPath .. 'tactical_debris_trail_01.bp',
+}
+
+TacticalDebrisTrails02 = {
+    EmtBpPath .. 'tactical_debris_fire_01_emit.bp',
+    EmtBpPath .. 'tactical_debris_distortion_01_emit.bp',
+    EmtBpPath .. 'tactical_debris_trail_01.bp',
+}
+
+TacticalDebrisTrails03 = {
+    EmtBpPath .. 'tactical_debris_smoke_03_emit.bp',
+    EmtBpPath .. 'tactical_debris_smoke_04_emit.bp',
+    EmtBpPath .. 'tactical_debris_trail_01.bp',
+}
+
+
 UnitHitShrapnel01 = { EmtBpPath .. 'destruction_unit_hit_shrapnel_01_emit.bp',}
 
 WaterSplash01 = {
@@ -2564,6 +2583,7 @@ TMissileHit01 = {
 TMissileKilled01 = {
     EmtBpPath .. 'terran_missile_hit_01_emit.bp',
     EmtBpPath .. 'terran_missile_hit_02_emit.bp',
+    EmtBpPath .. 'tactical_debris_smoke_01_emit.bp',
     -- EmtBpPath .. 'terran_missile_hit_03_emit.bp',
     -- EmtBpPath .. 'terran_missile_hit_04_emit.bp',
 }

--- a/lua/EffectTemplates.lua
+++ b/lua/EffectTemplates.lua
@@ -255,19 +255,19 @@ GenericDebrisTrails01 = {
 TacticalDebrisTrails01 = {
     EmtBpPath .. 'tactical_debris_smoke_01_emit.bp',
     EmtBpPath .. 'tactical_debris_smoke_02_emit.bp',
-    EmtBpPath .. 'tactical_debris_trail_01.bp',
+    EmtBpPath .. 'tactical_debris_trail_01_emit.bp',
 }
 
 TacticalDebrisTrails02 = {
     EmtBpPath .. 'tactical_debris_fire_01_emit.bp',
     EmtBpPath .. 'tactical_debris_distortion_01_emit.bp',
-    EmtBpPath .. 'tactical_debris_trail_01.bp',
+    EmtBpPath .. 'tactical_debris_trail_01_emit.bp',
 }
 
 TacticalDebrisTrails03 = {
     EmtBpPath .. 'tactical_debris_smoke_03_emit.bp',
     EmtBpPath .. 'tactical_debris_smoke_04_emit.bp',
-    EmtBpPath .. 'tactical_debris_trail_01.bp',
+    EmtBpPath .. 'tactical_debris_trail_01_emit.bp',
 }
 
 

--- a/lua/aeonprojectiles.lua
+++ b/lua/aeonprojectiles.lua
@@ -324,6 +324,12 @@ AMissileSerpentineProjectile = ClassProjectile(SingleCompositeEmitterProjectile,
     MinHeight = 2,
     FinalBoostAngle = 20,
 
+    DebrisBlueprints = {
+        '/effects/Entities/TacticalDebris01/TacticalDebris01_proj.bp',
+        '/effects/Entities/TacticalDebris01/TacticalDebris01_proj.bp',
+        '/effects/Entities/TacticalDebris02/TacticalDebris02_proj.bp',
+    },
+
     ---@param self AMissileSerpentineProjectile
     OnCreate = function(self)
         SingleCompositeEmitterProjectile.OnCreate(self)

--- a/lua/aeonprojectiles.lua
+++ b/lua/aeonprojectiles.lua
@@ -353,7 +353,7 @@ AMissileSerpentineProjectile = ClassProjectile(SingleCompositeEmitterProjectile,
     OnImpact = function(self, targetType, targetEntity)
         SingleCompositeEmitterProjectile.OnImpact(self, targetType, targetEntity)
 
-        if targetType == 'None' then
+        if targetType == 'None' or targetType == 'Air' then
             self:CreateDebris()
         end
 

--- a/lua/cybranprojectiles.lua
+++ b/lua/cybranprojectiles.lua
@@ -562,10 +562,10 @@ CLOATacticalMissileProjectile = ClassProjectile(SingleBeamProjectile, TacticalMi
     FxImpactLand = EffectTemplate.CMissileLOAHit01,
     FxImpactProp = EffectTemplate.CMissileLOAHit01,
 
-    FxImpactNone = EffectTemplate.CMissileLOAHit01,
+    FxImpactNone = EffectTemplate.TMissileKilled01,
     FxNoneHitScale = 0.6,
 
-    FxOnKilled = EffectTemplate.CMissileLOAHit01,
+    FxOnKilled = EffectTemplate.TMissileKilled01,
     FxOnKilledScale = 0.6,
 
     LaunchTicks = 2,
@@ -578,7 +578,9 @@ CLOATacticalMissileProjectile = ClassProjectile(SingleBeamProjectile, TacticalMi
     ChildProjectileBlueprint = '/projectiles/CIFMissileTacticalSplit01/CIFMissileTacticalSplit01_proj.bp',
 
     DebrisBlueprints = {
-        '/effects/entities/DebrisMisc04/DebrisMisc04_proj.bp'
+        '/effects/Entities/TacticalDebris01/TacticalDebris01_proj.bp',
+        '/effects/Entities/TacticalDebris01/TacticalDebris01_proj.bp',
+        '/effects/Entities/TacticalDebris02/TacticalDebris02_proj.bp',
     },
 
     ---@param self CLOATacticalMissileProjectile
@@ -629,8 +631,8 @@ CLOATacticalMissileProjectile = ClassProjectile(SingleBeamProjectile, TacticalMi
 }
 
 ---  CYBRAN ROCKET PROJECILES
----@class CLOATacticalChildMissileProjectile : SingleBeamProjectile, TacticalMissileComponent
-CLOATacticalChildMissileProjectile = ClassProjectile(SingleBeamProjectile, TacticalMissileComponent) {
+---@class CLOATacticalChildMissileProjectile : SingleBeamProjectile, TacticalMissileComponent, DebrisComponent
+CLOATacticalChildMissileProjectile = ClassProjectile(SingleBeamProjectile, TacticalMissileComponent, DebrisComponent) {
     BeamName = '/effects/emitters/missile_loa_munition_exhaust_beam_02_emit.bp',
     FxTrails = {'/effects/emitters/missile_cruise_munition_trail_03_emit.bp',},
     FxTrailOffset = -0.5,
@@ -638,15 +640,18 @@ CLOATacticalChildMissileProjectile = ClassProjectile(SingleBeamProjectile, Tacti
     FxImpactUnit = EffectTemplate.CMissileLOAHit01,
     FxImpactLand = EffectTemplate.CMissileLOAHit01,
     FxImpactProp = EffectTemplate.CMissileLOAHit01,
-    FxImpactNone = EffectTemplate.CMissileLOAHit01,
     FxAirUnitHitScale = 0.375,
     FxLandHitScale = 0.375,
-    FxNoneHitScale = 0.375,
     FxPropHitScale = 0.375,
     FxProjectileHitScale = 0.375,
     FxShieldHitScale = 0.375,
     FxUnitHitScale = 0.375,
     FxWaterHitScale = 0.375,
+
+    FxImpactNone = EffectTemplate.TMissileKilled01,
+    FxNoneHitScale = 0.375,
+
+    FxOnKilled = EffectTemplate.TMissileKilled01,
     FxOnKilledScale = 0.375,
 
     LaunchTicks = 2,
@@ -654,6 +659,10 @@ CLOATacticalChildMissileProjectile = ClassProjectile(SingleBeamProjectile, Tacti
     HeightDistanceFactor = 5,
     MinHeight = 2,
     FinalBoostAngle = 0,
+
+    DebrisBlueprints = {
+        '/effects/Entities/TacticalDebris03/TacticalDebris03_proj.bp',
+    },
 
     ---@param self CLOATacticalChildMissileProjectile
     OnCreate = function(self)
@@ -682,11 +691,6 @@ CLOATacticalChildMissileProjectile = ClassProjectile(SingleBeamProjectile, Tacti
         if targetType == 'None' then
             self:CreateDebris()
         end
-    end,
-
-    ---@param self TMissileProjectile
-    CreateDebris = function(self)
-        self:CreateChildProjectile('/effects/entities/DebrisMisc04/DebrisMisc04_proj.bp')
     end,
 }
 

--- a/lua/cybranprojectiles.lua
+++ b/lua/cybranprojectiles.lua
@@ -624,7 +624,7 @@ CLOATacticalMissileProjectile = ClassProjectile(SingleBeamProjectile, TacticalMi
         SingleBeamProjectile.OnImpact(self, targetType, targetEntity)
 
         CreateLightParticle(self, -1, self.Army, 3, 6, 'flare_lens_add_02', 'ramp_fire_11')
-        if targetType == 'None' then
+        if targetType == 'None' or targetType == 'Air' then
             self:CreateDebris()
         end
     end,

--- a/lua/terranprojectiles.lua
+++ b/lua/terranprojectiles.lua
@@ -356,7 +356,8 @@ TMissileProjectile = ClassProjectile(SingleBeamProjectile, TacticalMissileCompon
     OnImpact = function(self, targetType, targetEntity)
         SingleBeamProjectile.OnImpact(self, targetType, targetEntity)
 
-        if targetType == 'None' then
+        LOG(targetType)
+        if targetType == 'None' or targetType == 'Air' then
             self:CreateDebris()
         end
 

--- a/lua/terranprojectiles.lua
+++ b/lua/terranprojectiles.lua
@@ -329,7 +329,9 @@ TMissileProjectile = ClassProjectile(SingleBeamProjectile, TacticalMissileCompon
     FinalBoostAngleRange = 5,
 
     DebrisBlueprints = {
-        '/effects/entities/DebrisMisc04/DebrisMisc04_proj.bp'
+        '/effects/Entities/TacticalDebris01/TacticalDebris01_proj.bp',
+        '/effects/Entities/TacticalDebris01/TacticalDebris01_proj.bp',
+        '/effects/Entities/TacticalDebris02/TacticalDebris02_proj.bp',
     },
 
     OnCreate = function(self)


### PR DESCRIPTION
Adds more types of debris to tactical missiles that end up being intercepted. Involves trails that are especially good looking on Cybran tactical missiles. The debris that is on fire can set trees ablaze. Because of faction diversity; Seraphim missiles do not leave any type of debris when intercepted

https://github.com/FAForever/fa/assets/15778155/6b829b15-731c-411f-91c8-6c906f0edddf

https://github.com/FAForever/fa/assets/15778155/39429fa0-908a-4fea-92eb-ed9e02c0727c

https://github.com/FAForever/fa/assets/15778155/759f40eb-ed3b-4f12-9416-3f74b94cb24f

https://github.com/FAForever/fa/assets/15778155/e4fbb4e4-c9da-4c39-af1a-913e33ea3988


