### PR TITLE
Rework sera sniper mode logic

### DIFF
--- a/units/XSL0305/XSL0305_script.lua
+++ b/units/XSL0305/XSL0305_script.lua
@@ -52,7 +52,6 @@ XSL0305 = ClassUnit(SLandUnit) {
     ---@param mode boolean
     ScheduleMovementChange = function(self, delaySeconds, mode)
         if self.isSniperMoveMode == mode then return end
-        LOG("sniper move mode " .. tostring(self.isSniperMoveMode) .. "   changing mode " .. tostring(self.isChangingMoveMode))
         local switchToMode = function(mode)
             local speedMult = self.Blueprint.Physics.LandSpeedMultiplier or 1 -- left for compatability
             self.isSniperMoveMode = mode

--- a/units/XSL0305/XSL0305_script.lua
+++ b/units/XSL0305/XSL0305_script.lua
@@ -17,37 +17,7 @@ local SDFSihEnergyRifleSniperMode = SeraphimWeapons.SDFSniperShotSniperMode
 XSL0305 = ClassUnit(SLandUnit) {
     Weapons = {
         -- used for both modes of operation
-        MainGun = ClassWeapon(SDFSihEnergyRifleNormalMode) {
-            -- used to determine the reload time after a shot (the next shot's RoF should be used)
-            ---@param self SDFSniperShotNormalMode
-            GetWeaponRoF = function(self)
-                local baseRoF = self.NextBlueprint.RateOfFire or self.Blueprint.RateOfFire
-                return baseRoF / (self.AdjRoFMod or 1)
-            end,
-
-            RackSalvoFireReadyState = State(SDFSihEnergyRifleNormalMode.RackSalvoFireReadyState) {
-                Main = function(self)
-                    -- it will keep looping through this state - we only want to check the first
-                    -- time (immediately after a shot)
-                    if self.FiredAShot then
-                        self.FiredAShot = nil
-                        local scheduledMode = self.unit.ScheduledForSniperMode
-                        if scheduledMode ~= nil then
-                            self.unit:SetSniperMode(scheduledMode)
-                            self.unit.ScheduledForSniperMode = nil
-                        end
-                    end
-                    SDFSihEnergyRifleNormalMode.RackSalvoFireReadyState.Main(self)
-                end,
-            },
-
-            RackSalvoFiringState = State(SDFSihEnergyRifleNormalMode.RackSalvoFiringState) {
-                Main = function(self)
-                    self.FiredAShot = true
-                    SDFSihEnergyRifleNormalMode.RackSalvoFiringState.Main(self)
-                end,
-            },
-        },
+        MainGun = ClassWeapon(SDFSihEnergyRifleNormalMode) {},
         -- kind of a dummy weapon that carries the data of the sniper mode for the main gun
         SniperGun = ClassWeapon(SDFSihEnergyRifleSniperMode) {},
     },
@@ -64,7 +34,7 @@ XSL0305 = ClassUnit(SLandUnit) {
     OnScriptBitSet = function(self, bit)
         SLandUnit.OnScriptBitSet(self, bit)
         if bit == 1 then
-            self:ScheduleSniperMode(true)
+            self:SetSniperMode(true)
         end
     end,
 
@@ -73,62 +43,64 @@ XSL0305 = ClassUnit(SLandUnit) {
     OnScriptBitClear = function(self, bit)
         SLandUnit.OnScriptBitClear(self, bit)
         if bit == 1 then
-            self:ScheduleSniperMode(false)
+            self:SetSniperMode(false)
         end
     end,
 
     ---@param self XSL0305
+    ---@param delaySeconds number
     ---@param mode boolean
-    ScheduleSniperMode = function(self, mode)
-        local weapon = self:GetWeaponByLabel("MainGun")
-        -- The engine needs the next rate of fire set before the projectile launches and there
-        -- doesn't seem to be any other time we get before that happens to set it.
-        local nextBp
-        if mode then
-            nextBp = self:GetWeaponByLabel("SniperGun").Blueprint
-        else
-            nextBp = weapon:GetBlueprint()
-        end
-        weapon:ChangeRateOfFire(nextBp.RateOfFire)
-        weapon.NextBlueprint = nextBp -- keep around to properly get the RoF of the next shot
-
-        if weapon:GetFireClockPct() == 1 then -- idle, ready to switch now
-            self:SetSniperMode(mode)
-        else
-            if self.ScheduledForSniperMode ~= nil and self.ScheduledForSniperMode ~= mode then
-                self.ScheduledForSniperMode = nil -- cancel a double toggle
-                weapon.NextBlueprint = nil
+    ScheduleMovementChange = function(self, delaySeconds, mode)
+        if self.isSniperMoveMode == mode then return end
+        LOG("sniper move mode " .. tostring(self.isSniperMoveMode) .. "   changing mode " .. tostring(self.isChangingMoveMode))
+        local switchToMode = function(mode)
+            local speedMult = self.Blueprint.Physics.LandSpeedMultiplier or 1 -- left for compatability
+            self.isSniperMoveMode = mode
+            if mode then
+                speedMult = speedMult * (self.Blueprint.Physics.SniperModeSpeedMultiplier or 0.75)
+                self:SetSpeedMult(speedMult)
+                if not self.TrashSniperFx[1] then
+                    self.TrashSniperFx:Add(CreateAttachedEmitter(self, "XSL0305", self.Army,
+                            "/effects/emitters/seraphim_being_built_ambient_01_emit.bp"))
+                end
             else
-                self.ScheduledForSniperMode = mode
+                self:SetSpeedMult(speedMult)
+                self.TrashSniperFx:Destroy()
             end
+        end
+
+        if delaySeconds == 0 then
+            switchToMode(mode)
+        elseif self.isChangingMoveMode == nil then 
+            self.Trash:Add(ForkThread(function()
+                self.isChangingMoveMode = true
+                WaitSeconds(delaySeconds)
+                switchToMode(mode)
+                self.isChangingMoveMode = nil
+                end))
         end
     end,
 
     ---@param self XSL0305
     ---@param mode boolean
     SetSniperMode = function(self, mode)
-        local speedMult = self.Blueprint.Physics.LandSpeedMultiplier or 1 -- left for compatability
         local label
         if mode then
             label = "SniperGun"
-            speedMult = speedMult * (self.Blueprint.Physics.SniperModeSpeedMultiplier or 0.75)
-            if not self.TrashSniperFx[1] then
-                self.TrashSniperFx:Add(CreateAttachedEmitter(self, "XSL0305", self.Army,
-                        "/effects/emitters/seraphim_being_built_ambient_01_emit.bp"))
-            end
         else
             label = "MainGun"
-            self.TrashSniperFx:Destroy()
         end
-
-        self:SetSpeedMult(speedMult)
-
+        
         local weapon = self:GetWeaponByLabel("MainGun")
-        local bp = weapon.NextBlueprint or self:GetWeaponByLabel(label):GetBlueprint()
+
+        -- We will reload 0.1 seconds this current tick.
+        local reloadTimeLeft = math.max(0, (1 - weapon:GetFireClockPct()) / (weapon:GetWeaponRoF()) - 0.1)
+        self.ScheduleMovementChange(self, reloadTimeLeft, mode)
+        
+        local bp = self:GetWeaponByLabel(label):GetBlueprint()
         -- a lot of the firing sequence relies on the stored blueprint - we'll store the current
         -- weapon blueprint so that it works
         weapon.Blueprint = bp
-        weapon.NextBlueprint = nil
         weapon.FxMuzzleFlash = self.Weapons[label].FxMuzzleFlash
         weapon.damageTableCache = false
         weapon:ChangeProjectileBlueprint(bp.ProjectileId)


### PR DESCRIPTION
Now it is more responsive and logical, resolving #5399, and reworking #5196.
Previously it saved the next firing mode's BP and immediately applied only its fire rate to the weapon, and only switched the rest of the stats immediately after firing or if the switch modes button was pressed when the weapon was fully reloaded. This lead to unexpected behavior from the player's point of view.
Now it switches stats immediately, except for movement speed which is synced with the reload time, since the reload and movement reduction are both drawbacks of sniper mode shots, and without syncing you could ignore the movement penalty by toggling snipe mode off then on in between every shot.
In addition, it is easily possible to reduce micro needed to use sniper mode by moving the `ScheduleMovementChange` function from `SetSniperMode` to the MainGun's `RackSalvoFiringState Main` function, so that there is no need to micro sniper mode snipers out of combat for movement speed (the movement penalty would only apply during the long reload).