### PR TITLE
Display Sera Sniper/Loyalist secondary ranges

### DIFF
--- a/units/URL0303/URL0303_unit.bp
+++ b/units/URL0303/URL0303_unit.bp
@@ -34,6 +34,7 @@ UnitBlueprint{
         "MOBILE",
         "OVERLAYDEFENSE",
         "OVERLAYDIRECTFIRE",
+        "OVERLAYINDIRECTFIRE",
         "PRODUCTSC1",
         "RECLAIMABLE",
         "SELECTABLE",
@@ -338,7 +339,7 @@ UnitBlueprint{
             RackSalvoReloadTime = 0,
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
-            RangeCategory = "UWRC_DirectFire",
+            RangeCategory = "UWRC_IndirectFire",
             RateOfFire = 2.5,
             TargetPriorities = {
                 "TECH1 MOBILE",

--- a/units/XSL0305/XSL0305_unit.bp
+++ b/units/XSL0305/XSL0305_unit.bp
@@ -20,6 +20,7 @@ UnitBlueprint{
         "LAND",
         "MOBILE",
         "OVERLAYDIRECTFIRE",
+        "OVERLAYINDIRECTFIRE",
         "PRODUCTFA",
         "RECLAIMABLE",
         "SELECTABLE",


### PR DESCRIPTION
They are shown as yellow indirect-fire rings.
Annoyingly sera snipers overlap the indirect fire ring on top of the sniper mode's direct fire ring, but only when selected; if you turn on indirect fire rings in the strategic overlay options (top left corner where the minimap/pings/player colors/eco overlay are), direct fire rings overlap on top of indirect fire rings instead.
Resolves #5400.