### PR TITLE
Assist to copy the command queue of an engineer

### DIFF
--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -510,6 +510,20 @@ options = {
             },
 
             {
+                title = "<LOC ASSIST_TO_COPY_COMMAND_QUEUE>Assist to copy command queue",
+                key = 'assist_to_copy_command_queue',
+                type = 'toggle',
+                default = 'Off',
+                custom = {
+                    states = {
+                        { text = "<LOC _Off>Off", key = 'Off' },
+                        { text = "<LOC _ASSIST_TO_COPY_ENGINEERS>Only engineers",
+                            key = 'OnlyEngineers' },
+                    },
+                },
+            },
+
+            {
                 title = "<LOC OPTIONS_0287>Factories Default to Repeat Build",
                 key = 'repeatbuild',
                 type = 'toggle',

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -378,7 +378,7 @@ local function OnGuardCopy(guardees, unit)
         EntityCategoryContains(categories.ENGINEER, unit)
     then
         if IsKeyDown('Control') then
-            SimCallback({ Func = 'CopyOrders', Args = { Target = unit:GetEntityId(), ClearCommands = false } }, true)
+            SimCallback({ Func = 'CopyOrders', Args = { Target = unit:GetEntityId(), ClearCommands = true } }, true)
         end
     end
 end

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -351,7 +351,7 @@ local function OnGuardUnpause(guardees, target)
                             target.ThreadUnpauseCandidates = nil
                             target.ThreadUnpause = nil
                             break
-                            ;end
+                            ; end
 
                         WaitSeconds(1.0)
                         target = GetUnitById(id)
@@ -368,6 +368,21 @@ local function OnGuardUnpause(guardees, target)
     end
 end
 
+---@param guardees UserUnit[]
+---@param unit UserUnit
+local function OnGuardCopy(guardees, unit)
+    local prefs = Prefs.GetFromCurrentProfile('options.assist_to_copy_command_queue')
+    local engineers = EntityCategoryFilterDown(categories.ENGINEER, guardees)
+    if table.getn(engineers) > 0 and
+        (prefs == 'OnlyEngineers') and
+        EntityCategoryContains(categories.ENGINEER, unit)
+    then
+        if IsKeyDown('Control') then
+            SimCallback({ Func = 'CopyOrders', Args = { Target = unit:GetEntityId(), ClearCommands = false } }, true)
+        end
+    end
+end
+
 --- Is called when a unit receies a guard / assist order
 ---@param guardees UserUnit[]
 ---@param unit UserUnit
@@ -375,6 +390,7 @@ local function OnGuard(guardees, unit)
     if unit:GetArmy() == GetFocusArmy() then
         OnGuardUpgrade(guardees, unit)
         OnGuardUnpause(guardees, unit)
+        OnGuardCopy(guardees, unit)
     end
 end
 

--- a/lua/ui/help/tooltips.lua
+++ b/lua/ui/help/tooltips.lua
@@ -652,6 +652,12 @@ Tooltips = {
         title = "<LOC ASSIST_TO_UNPAUSE_TITLE>Assist to Unpause",
         description = "<LOC ASSIST_TO_UNPAUSE_DESCRIPTION>When enabled structures automatically unpause as engineers start assisting it.",
     },
+
+    options_assist_to_copy_command_queue = {
+        title = "<LOC ASSIST_TO_UNPAUSE_TITLE>Assist to copy command queue",
+        description = "<LOC ASSIST_TO_UNPAUSE_DESCRIPTION>When enabled, engineers in the selection will try to copy the command queue of the engineer you issue an assist order for. \r\n\r\nRequires you to hold 'Control'",
+    },
+
     options_mp_taunt_head = {
         title = "<LOC OPTIONS_0119>MP Taunt Head",
         description = "<LOC OPTIONS_0120>Select which 3D head is displayed when taunts are used in multiplayer",


### PR DESCRIPTION
A small feature for the list of the 'assist to' features. With this change you can assist an engineer but instead of applying an assist order you copy and apply the command queue of that engineer to your selection.

This is similar to the [Copy orders](https://wiki.faforever.com/en/Play/Game/Hotkeys/OrdersQueueManipulation#copy-orders) feature except that this does not require a hotkey 😃 