### PR TITLE
Make it easier to start building extractors while zoomed out

### DIFF
--- a/lua/ui/game/hotkeys/context-based-templates.lua
+++ b/lua/ui/game/hotkeys/context-based-templates.lua
@@ -175,7 +175,7 @@ Cycle = function()
         end
 
         local massDeposits = TableGetn(GetDepositsAroundPoint(position[1], position[3], radius, 1))
-        local hydroDeposits = TableGetn(GetDepositsAroundPoint(position[1], position[3], 2 * radius, 2))
+        local hydroDeposits = TableGetn(GetDepositsAroundPoint(position[1], position[3], 2 + radius, 2))
         local noDeposits = (massDeposits == 0) and (hydroDeposits == 0)
         local onLand = elevation + 0.1 >= position[2]
 

--- a/lua/ui/game/hotkeys/context-based-templates.lua
+++ b/lua/ui/game/hotkeys/context-based-templates.lua
@@ -164,8 +164,18 @@ Cycle = function()
         -- a bit of a hack to retrieve the faction prefix
         local prefix = selectedUnits[1]:GetBlueprint().BlueprintId:sub(1, 2)
 
-        local massDeposits = TableGetn(GetDepositsAroundPoint(position[1], position[3], 1.5, 1))
-        local hydroDeposits = TableGetn(GetDepositsAroundPoint(position[1], position[3], 3.0, 2))
+        -- deposit scan radius depending on zoom level to make it easier to place extractors while zoomed out
+        local radius = 2
+        local camera = GetCamera('WorldCamera')
+        if camera then
+            local zoom = camera:GetZoom()
+            if zoom > 200 then
+                radius = radius * zoom * 0.005
+            end
+        end
+
+        local massDeposits = TableGetn(GetDepositsAroundPoint(position[1], position[3], radius, 1))
+        local hydroDeposits = TableGetn(GetDepositsAroundPoint(position[1], position[3], 2 * radius, 2))
         local noDeposits = (massDeposits == 0) and (hydroDeposits == 0)
         local onLand = elevation + 0.1 >= position[2]
 


### PR DESCRIPTION
When using context based templates you can start creating extractors by hovering over a deposit. The radius used to be fixed to 1.5 (extractors) and 3.0 (hydrocarbon plants). It now includes a factor based on the zoom of your camera. This makes it easier to cycle through extractors and / or a hydrocarbon plant based templates while zoomed out.