### PR TITLE
Process the balance changes to walls

### DIFF
--- a/units/UAB5101/UAB5101_unit.bp
+++ b/units/UAB5101/UAB5101_unit.bp
@@ -27,8 +27,8 @@ UnitBlueprint{
         AirThreatLevel = 0,
         ArmorType = "Structure",
         EconomyThreatLevel = 0,
-        Health = 2000,
-        MaxHealth = 2000,
+        Health = 500,
+        MaxHealth = 500,
         RegenRate = 0,
         SubThreatLevel = 0,
         SurfaceThreatLevel = 0,
@@ -57,9 +57,9 @@ UnitBlueprint{
         UniformScale = 0.122,
     },
     Economy = {
-        BuildCostEnergy = 10,
-        BuildCostMass = 2,
-        BuildTime = 20,
+        BuildCostEnergy = 20,
+        BuildCostMass = 3,
+        BuildTime = 15,
         RebuildBonusIds = { "uab5101" },
     },
     General = {

--- a/units/UEB5101/UEB5101_unit.bp
+++ b/units/UEB5101/UEB5101_unit.bp
@@ -28,8 +28,8 @@ UnitBlueprint{
         AirThreatLevel = 0,
         ArmorType = "Structure",
         EconomyThreatLevel = 0,
-        Health = 3000,
-        MaxHealth = 3000,
+        Health = 500,
+        MaxHealth = 500,
         RegenRate = 0,
         SubThreatLevel = 0,
         SurfaceThreatLevel = 0,
@@ -55,9 +55,9 @@ UnitBlueprint{
         UniformScale = 0.129,
     },
     Economy = {
-        BuildCostEnergy = 10,
-        BuildCostMass = 2,
-        BuildTime = 20,
+        BuildCostEnergy = 20,
+        BuildCostMass = 3,
+        BuildTime = 15,
         RebuildBonusIds = { "ueb5101" },
     },
     General = {

--- a/units/URB5101/URB5101_unit.bp
+++ b/units/URB5101/URB5101_unit.bp
@@ -28,8 +28,8 @@ UnitBlueprint{
         AirThreatLevel = 0,
         ArmorType = "Structure",
         EconomyThreatLevel = 0,
-        Health = 1500,
-        MaxHealth = 1500,
+        Health = 500,
+        MaxHealth = 500,
         RegenRate = 6,
         SubThreatLevel = 0,
         SurfaceThreatLevel = 0,
@@ -54,9 +54,9 @@ UnitBlueprint{
         UniformScale = 0.14,
     },
     Economy = {
-        BuildCostEnergy = 10,
-        BuildCostMass = 2,
-        BuildTime = 20,
+        BuildCostEnergy = 20,
+        BuildCostMass = 3,
+        BuildTime = 15,
         RebuildBonusIds = { "urb5101" },
     },
     General = {

--- a/units/XSB5101/XSB5101_unit.bp
+++ b/units/XSB5101/XSB5101_unit.bp
@@ -29,8 +29,8 @@ UnitBlueprint{
         AirThreatLevel = 0,
         ArmorType = "Structure",
         EconomyThreatLevel = 0,
-        Health = 2500,
-        MaxHealth = 2500,
+        Health = 500,
+        MaxHealth = 500,
         RegenRate = 0,
         SubThreatLevel = 0,
         SurfaceThreatLevel = 0,
@@ -69,9 +69,9 @@ UnitBlueprint{
         UniformScale = 0.136,
     },
     Economy = {
-        BuildCostEnergy = 10,
-        BuildCostMass = 2,
-        BuildTime = 20,
+        BuildCostEnergy = 20,
+        BuildCostMass = 3,
+        BuildTime = 15,
         RebuildBonusIds = { "xsb5101" },
     },
     General = {


### PR DESCRIPTION
In addition to https://github.com/FAForever/fa/issues/5514 and because of https://github.com/FAForever/FA-Binary-Patches/pull/48 where we tackled the order of collisions for projectiles.

For all walls:

- Hitpoints: Reduced from `X` to `500`
- Energy cost: Increased from `10` to `20`
- Mass cost: Increased from `2` to `3`
- Build time: Reduced from `20` to `15`

