### PR TITLE
Increase break off distance for Solace for better bombing runs

### DIFF
--- a/units/XAA0306/XAA0306_unit.bp
+++ b/units/XAA0306/XAA0306_unit.bp
@@ -8,7 +8,7 @@ UnitBlueprint{
         AutoLandTime = 1,
         BankFactor = 2.5,
         BankForward = false,
-        BreakOffDistance = 34,
+        BreakOffDistance = 42,
         BreakOffTrigger = 15,
         CanFly = true,
         CombatTurnSpeed = 0.8,


### PR DESCRIPTION
Closes https://github.com/FAForever/fa/issues/5539

By increasing the break off distance the solace has the space it requires to maneuver between bombing runs