### PR TITLE
Fix: Enable the Sparky to be buffed by the RegenAura-upgrades

### DIFF
--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -284,7 +284,7 @@ UnitBlueprint{
             RegenFloor = 15,
             RegenPerSecond = 0.035,
             Slot = "LCH",
-            UnitCategory = "BUILTBYTIER3FACTORY, BUILTBYQUANTUMGATE, NEEDMOBILEBUILD, TRANSPORTATION",
+            UnitCategory = "BUILTBYTIER3FACTORY, BUILTBYQUANTUMGATE, NEEDMOBILEBUILD, TRANSPORTATION, FIELDENGINEER",
             UpgradeEffectBones = {
                 "Left_Upgrade",
                 "Left_Turret_Muzzle",
@@ -470,7 +470,7 @@ UnitBlueprint{
             RegenPerSecond = 0.02,
             ShowBones = { "Left_Upgrade" },
             Slot = "LCH",
-            UnitCategory = "BUILTBYTIER3FACTORY, BUILTBYQUANTUMGATE, NEEDMOBILEBUILD,TRANSPORTATION",
+            UnitCategory = "BUILTBYTIER3FACTORY, BUILTBYQUANTUMGATE, NEEDMOBILEBUILD, TRANSPORTATION, FIELDENGINEER",
             UpgradeEffectBones = {
                 "Left_Upgrade",
                 "Left_Turret_Muzzle",


### PR DESCRIPTION
This was not the case previously.