### PR TITLE
Fix flak acting like a gattling cannon

### DIFF
--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -772,15 +772,16 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         end,
 
         OnFire = function(self)
+
             local bp = self.Blueprint
-            if bp.WeaponUnpacks then
+            if bp.WeaponUnpacks and self.WeaponPackState ~= 'Unpacked' then
                 ChangeState(self, self.WeaponUnpackingState)
             else
                 if bp.RackSalvoChargeTime and bp.RackSalvoChargeTime > 0 then
                     ChangeState(self, self.RackSalvoChargeState)
 
                     -- SkipReadyState used for Janus and Corsair
-                elseif bp.SkipReadyState and bp.SkipReadyState then
+                elseif bp.SkipReadyState then
                     ChangeState(self, self.RackSalvoFiringState)
                 else
                     ChangeState(self, self.RackSalvoFireReadyState)
@@ -1140,11 +1141,8 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
 
             self:WaitForAndDestroyManips()
 
-            if notExclusive then
-                unit:SetBusy(true)
-            end
             local hasTarget = self:WeaponHasTarget()
-            local canFire = self.WeaponCanFire
+            local canFire = self:CanFire()
 
             if hasTarget and bp.RackSalvoChargeTime > 0 and canFire then
                 ChangeState(self, self.RackSalvoChargeState)

--- a/units/XEL0306/XEL0306_unit.bp
+++ b/units/XEL0306/XEL0306_unit.bp
@@ -195,13 +195,15 @@ UnitBlueprint{
             RackRecoilDistance = 0,
             RackReloadTimeout = 6,
             RackSalvoChargeTime = 0,
-            RackSalvoReloadTime = 6,
+            RackSalvoReloadTime = 10,
+
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_IndirectFire",
             RateOfFire = 0.1,
             RenderFireClock = true,
             SlavedToBody = true,
+            SkipReadyState = true,
             TargetPriorities = {
                 "STRUCTURE DEFENSE",
                 "TECH3 MOBILE",


### PR DESCRIPTION
Not properly checking and confirming that a weapon can fire has some clear consequences. It was fun while it lasted 😃 . 

Fixes a bug where the Spearhead would skip an attack cycle by default by using the packing state of a weapon. If a weapon is already unpacked then it won't try to unpack again.