### PR TITLE
Increases size of mongoose grenade strategic icon

### DIFF
--- a/projectiles/TDFFragmentationGrenade01/TDFFragmentationGrenade01_proj.bp
+++ b/projectiles/TDFFragmentationGrenade01/TDFFragmentationGrenade01_proj.bp
@@ -27,7 +27,7 @@ ProjectileBlueprint {
             Type = 'Medium02',
         },
         MeshBlueprint = '/projectiles/TIFMortar01/TIFMortar01_mesh.bp',
-        StrategicIconSize = 1,
+        StrategicIconSize = 2,
         UniformScale = 0.05,
     },
     General = {


### PR DESCRIPTION
Microfix that allows the grenades to be distinguished from the gatling gun bullets in strategic view.

![image](https://github.com/FAForever/fa/assets/7411478/c9447649-e82a-4130-bbed-73d3b8a4cff1)
