### PR TITLE
Fix aeon bomber getting stuck flipping

### DIFF
--- a/units/UAA0103/UAA0103_unit.bp
+++ b/units/UAA0103/UAA0103_unit.bp
@@ -178,9 +178,9 @@ UnitBlueprint{
     SelectionSizeZ = 0.45,
     SelectionThickness = 0.24,
     SizeSphere = 1.6,
-    SizeX = 2,
-    SizeY = 0.25,
-    SizeZ = 0.625,
+    SizeX = 1.4,
+    SizeY = 0.2,
+    SizeZ = 0.8,
     StrategicIconName = "icon_bomber1_directfire",
     StrategicIconSortPriority = 75,
     Transport = {


### PR DESCRIPTION
Copies sera bomber values. I noticed you have to f10 -> "restart game" to have the `SizeX/Y/Z` changes apply.
Here are two pictures with tests of ~100 bombers.
Before (all the bombers flying low are stuck flipping over trying to aim at the move waypoint):
![OldAeonBomber](https://github.com/FAForever/fa/assets/82986251/3e022411-8d3b-4c7a-9914-d0c8c977e951)
After (the bombers don't fly nearly as low nearly as often, and they correct their trajectory+height quickly):
![NewAeonBomber](https://github.com/FAForever/fa/assets/82986251/5550da83-45b9-4487-933c-ce145fdcf9a5)
