### PR TITLE
Adjust t1 bomb max speeds.

### DIFF
--- a/projectiles/AIFBombGraviton01/AIFBombGraviton01_proj.bp
+++ b/projectiles/AIFBombGraviton01/AIFBombGraviton01_proj.bp
@@ -49,7 +49,7 @@ ProjectileBlueprint {
     },
     Physics = {
         DestroyOnWater = true,
-        MaxSpeed = 40,
+        MaxSpeed = 17,
         RealisticOrdinance = true,
         TrackTarget = false,
         VelocityAlign = true,

--- a/projectiles/CIFNeutronClusterBomb01/CIFNeutronClusterBomb01_proj.bp
+++ b/projectiles/CIFNeutronClusterBomb01/CIFNeutronClusterBomb01_proj.bp
@@ -56,7 +56,7 @@ ProjectileBlueprint {
     },
     Physics = {
         DestroyOnWater = true,
-        MaxSpeed = 25,
+        MaxSpeed = 20,
         RealisticOrdinance = true,
         TrackTarget = false,
         TurnRate = 30,

--- a/projectiles/SBOOtheTacticalBomb01/SBOOtheTacticalBomb01_proj.bp
+++ b/projectiles/SBOOtheTacticalBomb01/SBOOtheTacticalBomb01_proj.bp
@@ -40,7 +40,7 @@ ProjectileBlueprint {
     },
     Physics = {
         DestroyOnWater = true,
-        MaxSpeed = 40,
+        MaxSpeed = 17,
         RealisticOrdinance = true,
         TrackTarget = false,
         VelocityAlign = true,

--- a/projectiles/TIFNapalmCarpetBomb01/TIFNapalmCarpetBomb01_proj.bp
+++ b/projectiles/TIFNapalmCarpetBomb01/TIFNapalmCarpetBomb01_proj.bp
@@ -50,7 +50,7 @@ ProjectileBlueprint {
     },
     Physics = {
         DestroyOnWater = true,
-        MaxSpeed = 20,
+        MaxSpeed = 25,
         RealisticOrdinance = true,
         RotationalVelocityRange = 0.25,
         TrackTarget = false,


### PR DESCRIPTION
### The Problem
Currently it's possible to boost sera and aeon bomber bomb velocity so they drop 3x faster than normal and make it practically impossible for engis to dodge them, and that is achievable with some sandbox practice using the plane height indicator game setting and groundfiring 1-2.5 units in front of the bomber. It is also a bit too effective to be fair compared to cybran and uef bombers.
### Aeon/Sera t1 bomb max speed 40 -> 17
As the main change, this fixes super speedy bomb drops.
*I mostly tested sera, because aeon has practically the same weapon but gets stuck randomly.*
Approximate drop times in seconds for sera bomber:

| type of drop | before nerf | after nerf |
| --------------- | ------------ | ---------- |
| best case| 0.5 | 0.9 |
| good skill | 0.6-0.7 | 1.0-1.1 |
| improving skill | 0.8-0.9 | 1.2 |
| basic skill | 1-1.3 | 1.3 |
| normal hover bombs | 1.5-2.0 | 1.5-2.0 |
| flat ground bombing run | ~2.7 | ~2.7 |

### Cyb/UEF t1 bomb max speed 25/20 -> 20/25 respectively
As a secondary change, this balances bomber AoE effectiveness vs drop speed. 
- Aeon and Sera are the slowest because of their consistent damage, instant shot, and large splash radius. 
- Cybran and UEF are faster because of their inconsistent damage, 0.2 delay between bombs salvo, and smaller splash radius.
- Cybran has slightly larger AoE in testing and doesn't rely on damage over time, so I switched UEF and cybran max speeds.
The AoE tests were done by *hover* bombing a line of t1 engis: UEF 6-7 direct kills 7-8 with napalm per bomb, cyb 7-8 kills per bomb, sera 8-9 kills per bomb.

The third bomb is the one that can kill engis, and it is affected by +0.4 salvo delay and the automatic attack-run movement of the bomber, so it can reach 0.5-0.8 drop time with these changes.