### PR TITLE
Add a guard before applying the reclaim order

### DIFF
--- a/lua/sim/commands/shared.lua
+++ b/lua/sim/commands/shared.lua
@@ -105,7 +105,13 @@ UnitQueueDataToCommand = {
     },
     [19] = {
         Type = "Reclaim",
-        Callback = function(units, positionOrEntity) pcall(IssueReclaim, units, positionOrEntity) end,
+        Callback = function(units, positionOrEntity)
+            if IsDestroyed(positionOrEntity) then
+                return
+            end
+
+            pcall(IssueReclaim, units, positionOrEntity)
+        end,
         BatchOrders = true,
         FullRedundancy = true,
     },


### PR DESCRIPTION
Adds a guard to check if the entity / prop / unit still exists before trying to issue a reclaim order to it.

```
Main thread
@c:\programdata\faforever\gamedata\lua.nx2\lua\simcallbacks.lua 52
"DistributeOrders", Table, Table, 2292.209717, Func:@c:\programdata\faforever\gamedata\lua.nx2\lua\simcallbacks.lua 505
@c:\programdata\faforever\gamedata\lua.nx2\lua\simcallbacks.lua 56
Table, Table, CObject:.?AVUnit@Moho@@ ID:6291915 BpName:xsl0309
@c:\programdata\faforever\gamedata\lua.nx2\lua\simcallbacks.lua 521
Table, CObject:.?AVUnit@Moho@@ ID:6291915 BpName:xsl0309, true, true, CObject:.?AVCAiBrain@Moho@@, Table, 61.5, 695.5, Table, Table, nil, Table, Table, Table, Table, Table, 12, 9, CFunc, Table, 1, Table, 4, Table, "Reclaim", Func:@c:\programdata\faforever\gamedata\lua.nx2\lua\sim\commands\shared.lua 108, 1, true, true, 8, Table, 4, CFunc, Table, 4, 2, -1, 1, 4, 1, 1, Table, Table, Table
@c:\programdata\faforever\gamedata\lua.nx2\lua\sim\commands\distribute-queue.lua 324
Table, Table
@c:\programdata\faforever\gamedata\lua.nx2\lua\sim\commands\shared.lua 108
@CFunc: 0x0090F5B0
Table, Table, "Expected a game object. (Did you call with '.' instead of ':'?)
stack traceback:
	[C]: in function `IssueReclaim'
	[C]: in function `pcall'
	...forever\gamedata\lua.nx2\lua\sim\commands\shared.lua(108): in function `issueOrder'
	...medata\lua.nx2\lua\sim\commands\distribute-queue.lua(324): in function `DistributeOrders'
	...data\faforever\gamedata\lua.nx2\lua\simcallbacks.lua(521): in function `fn'
	...data\faforever\gamedata\lua.nx2\lua\simcallbacks.lua(56): in function <...data\faforever\gamedata\lua.nx2\lua\simcallbacks.lua:52>"
```