### PR TITLE
Introduce a coarse navigational grid

### DIFF
--- a/engine/Sim/CPlatoon.lua
+++ b/engine/Sim/CPlatoon.lua
@@ -3,7 +3,7 @@
 
 ---@class PlatoonCommand : userdata
 
----@class moho.platoon_methods
+---@class moho.platoon_methods : InternalObject
 local CPlatoon = {}
 
 ---@alias PlatoonSquadType 'Attack' | 'Artillery' | 'Guard' | 'None' | 'Scout' | 'Support'
@@ -153,8 +153,8 @@ end
 function CPlatoon:GetPlatoonLifetimeStats()
 end
 
---- Computes the average platoon position, returns {0,0,0} if the platoon has no units
----@return Vector
+--- Computes the average platoon position, returns nil if the platoon has no units
+---@return Vector?
 function CPlatoon:GetPlatoonPosition()
 end
 

--- a/lua/aibrains/platoons/platoon-adaptive-attack.lua
+++ b/lua/aibrains/platoons/platoon-adaptive-attack.lua
@@ -215,16 +215,16 @@ AIPlatoonAdaptiveAttackBehavior = Class(AIPlatoon) {
                             local threatTable = brain:GetThreatsAroundPosition(position, 1, true, 'AntiSurface')
                             local platoonThreat = self:CalculatePlatoonThreatAroundPosition('Surface', categories.MOBILE * categories.DIRECTFIRE - categories.SCOUT, position, 30)
                             local positionStatus = brain.GridPresence:GetInferredStatus(position)
-                            if positionStatus != 'Allied' or platoonThreat < threat then
+                            if positionStatus != 'Allied' and platoonThreat < threat then
                                 if threatTable and not TableEmpty(threatTable) then
                                     local info = threatTable[Random(1, TableGetn(threatTable))]
                                     self.ThreatToEvade = { info[1], GetSurfaceHeight(info[1], info[2]), info[2] }
-                                    self:LogDebug(string.format('We are going to retreat, enemy threat '..threat..' our threat '..platoonThreat..' position status '..positionStatus))
+                                    self:LogDebug(string.format('We are going to retreat, enemy threat '..threat..' our threat '..platoonThreat..' position status '.. tostring(positionStatus)))
                                     self:ChangeState(self.Retreating)
                                     return
                                 end
                             elseif positionStatus then
-                                self:LogDebug(string.format('We are going to attack, enemy threat '..threat..' our threat '..platoonThreat..' position status '..positionStatus))
+                                self:LogDebug(string.format('We are going to attack, enemy threat '..threat..' our threat '..platoonThreat..' position status '.. tostring(positionStatus)))
                             end
                         end
                     end
@@ -420,7 +420,7 @@ AIPlatoonAdaptiveAttackBehavior = Class(AIPlatoon) {
                     local threatTable = brain:GetThreatsAroundPosition(position, 1, true, 'AntiSurface')
                     local platoonThreat = self:CalculatePlatoonThreatAroundPosition('Surface', categories.MOBILE * categories.DIRECTFIRE - categories.SCOUT, position, 30)
                     local positionStatus = brain.GridPresence:GetInferredStatus(position)
-                    if positionStatus != 'Allied' or platoonThreat * 2 < threat then
+                    if positionStatus != 'Allied' and platoonThreat * 2 < threat then
                         if threatTable and not TableEmpty(threatTable) then
                             local info = threatTable[Random(1, TableGetn(threatTable))]
                             self.ThreatToEvade = { info[1], GetSurfaceHeight(info[1], info[2]), info[2] }
@@ -428,7 +428,7 @@ AIPlatoonAdaptiveAttackBehavior = Class(AIPlatoon) {
                             return
                         end
                     else
-                        self:LogDebug(string.format('Threat and we need to attack then since it is allied, status '..positionStatus))
+                        self:LogDebug(string.format('Threat and we need to attack then since it is allied, status '.. tostring(positionStatus)))
                     end
                 end
 

--- a/lua/aibrains/platoons/platoon-adaptive-attack.lua
+++ b/lua/aibrains/platoons/platoon-adaptive-attack.lua
@@ -82,6 +82,11 @@ AIPlatoonAdaptiveAttackBehavior = Class(AIPlatoon) {
             local units, unitCount = self:GetPlatoonUnits()
             local unit = units[Random(1, unitCount)]
 
+            if not unit then
+                LOG("No unit!")
+                reprsl(units)
+            end
+
             -- determine navigational label of that unit
             local position = unit:GetPosition()
             local label, error = NavUtils.GetLabel('Land', position)
@@ -122,7 +127,7 @@ AIPlatoonAdaptiveAttackBehavior = Class(AIPlatoon) {
         StateName = 'Navigating',
 
         --- The platoon retreats from a threat
-        ---@param self AIPlatoonLandAssaultBehavior
+        ---@param self AIPlatoonAdaptiveAttackBehavior
         Main = function(self)
             self:LogDebug('Navigating')
             if IsDestroyed(self) then
@@ -163,7 +168,7 @@ AIPlatoonAdaptiveAttackBehavior = Class(AIPlatoon) {
             local pathNodesCount = TableGetn(path)
             local attackFormation = false
             for i=1, pathNodesCount do
-                if self.Dead then
+                if IsDestroyed(self) then
                     return
                 end
                 local distEnd
@@ -198,10 +203,10 @@ AIPlatoonAdaptiveAttackBehavior = Class(AIPlatoon) {
                 local Stuck = 0
                 while not IsDestroyed(self) do
                     coroutine.yield(1)
-                    if self.Dead then
+                    if IsDestroyed(self) then
                         return
                     end
-                    
+
                     local position
                     units = self:GetPlatoonUnits()
                     for _, v in units do
@@ -210,6 +215,11 @@ AIPlatoonAdaptiveAttackBehavior = Class(AIPlatoon) {
                             break
                         end
                     end
+
+                    if not position then
+                        return
+                    end
+
                     local threat = brain:GetThreatAtPosition(position, 1, true, 'AntiSurface')
                     if threat > 0 then
                         local homeBasePosition = brain.BuilderManagers[self.LocationType].Position or brain.BuilderManagers['MAIN'].Position
@@ -346,7 +356,7 @@ AIPlatoonAdaptiveAttackBehavior = Class(AIPlatoon) {
                             return
                         end
                     else
-                        self:LogDebug(string.format('Threat and we need to attack then since it is allied, status '..positionStatus))
+                        self:LogDebug(string.format('Threat and we need to attack then since it is allied, status '.. tostring(positionStatus)))
                     end
                 end
 
@@ -411,6 +421,11 @@ AIPlatoonAdaptiveAttackBehavior = Class(AIPlatoon) {
 
                 -- check for threats
                 local position = self:GetPlatoonPosition()
+                if not position then
+                    return
+                end
+
+
                 local threat = brain:GetThreatAtPosition(position, 1, true, 'AntiSurface')
                 if threat > 0 then
                     local threatTable = brain:GetThreatsAroundPosition(position, 1, true, 'AntiSurface')
@@ -485,6 +500,9 @@ AIPlatoonAdaptiveAttackBehavior = Class(AIPlatoon) {
 
                 while not IsDestroyed(self) do
                     local position = self:GetPlatoonPosition()
+                    if not position then
+                        return
+                    end
 
                     -- check if we're near our retreat point
                     local dx = position[1] - wx

--- a/lua/aibrains/platoons/platoon-adaptive-guard.lua
+++ b/lua/aibrains/platoons/platoon-adaptive-guard.lua
@@ -75,12 +75,12 @@ AIPlatoonAdaptiveGuardBehavior = Class(AIPlatoon) {
 
             self:Stop()
 
-            -- pick random unit
-            local units, unitCount = self:GetPlatoonUnits()
-            local unit = units[Random(1, unitCount)]
-
             -- determine navigational label of that unit
-            local position = unit:GetPosition()
+            local position = self:GetPlatoonPosition()
+            if not position then
+                return
+            end
+
             local label, error = NavUtils.GetLabel('Land', position)
 
             if label then
@@ -129,6 +129,11 @@ AIPlatoonAdaptiveGuardBehavior = Class(AIPlatoon) {
                     if bestBase and bestDefense < threshold then
                         self.LocationToGuard = bestBase.Position
                         local platPos = self:GetPlatoonPosition()
+                        if not platPos then
+                            return
+                        end
+
+
                         local guardPos = unitToGuard:GetPosition()
                         local dx = platPos[1] - guardPos[1]
                         local dz = platPos[3] - guardPos[3]
@@ -160,6 +165,10 @@ AIPlatoonAdaptiveGuardBehavior = Class(AIPlatoon) {
         
                     if unitToGuard and not unitToGuard.Dead then
                         local platPos = self:GetPlatoonPosition()
+                        if not platPos then
+                            return
+                        end
+
                         local guardPos = unitToGuard:GetPosition()
                         local dx = platPos[1] - guardPos[1]
                         local dz = platPos[3] - guardPos[3]
@@ -204,27 +213,28 @@ AIPlatoonAdaptiveGuardBehavior = Class(AIPlatoon) {
 
             self:Stop()
 
-            local cache = { 0, 0, 0 }
             local brain = self:GetBrain()
             if not brain.GridPresence then
                 WARN('GridPresence does not exist, unable to detect conflict line')
             end
 
-            if not NavUtils.CanPathToCell(self.MovementLayer, self:GetPlatoonPosition(), destination) then
+            local position = self:GetPlatoonPosition()
+            if not position then
+                return
+            end
+
+            if not NavUtils.CanPathToCell(self.MovementLayer, position, destination) then
                 self:LogDebug(string.format('Attack platoon is going to use transport'))
                 self:ChangeState(self.Transporting)
                 return
             end
 
             while not IsDestroyed(self) do
-                -- pick random unit for a position on the grid
-                local units, unitCount = self:GetPlatoonUnits()
-                local origin
-                for _, v in units do
-                    if v and not v.Dead then
-                        origin = v:GetPosition()
-                    end
+                local origin = self:GetPlatoonPosition()
+                if not origin then
+                    return
                 end
+
                 if unitToGuard and not IsDestroyed(unitToGuard) then
                     destination = unitToGuard:GetPosition()
                 end
@@ -252,6 +262,9 @@ AIPlatoonAdaptiveGuardBehavior = Class(AIPlatoon) {
                 local wz = waypoint[3]
                 while not IsDestroyed(self) do
                     local position = self:GetPlatoonPosition()
+                    if not position then
+                        return
+                    end
 
                     -- check if we're near our current waypoint
                     local dx = position[1] - wx
@@ -509,6 +522,10 @@ AIPlatoonAdaptiveGuardBehavior = Class(AIPlatoon) {
             while not IsDestroyed(self) do
 
                 local position = self:GetPlatoonPosition()
+                if not position then
+                    return
+                end
+
                 local waypoint, error = NavUtils.RetreatDirectionFrom('Land', position, location, 40)
 
                 if not waypoint then
@@ -523,6 +540,9 @@ AIPlatoonAdaptiveGuardBehavior = Class(AIPlatoon) {
 
                 while not IsDestroyed(self) do
                     local position = self:GetPlatoonPosition()
+                    if not position then
+                        return
+                    end
 
                     -- check if we're near our retreat point
                     local dx = position[1] - wx

--- a/lua/aibrains/platoons/platoon-adaptive-raid.lua
+++ b/lua/aibrains/platoons/platoon-adaptive-raid.lua
@@ -296,16 +296,16 @@ AIPlatoonAdaptiveRaidBehavior = Class(AIPlatoon) {
                             local threatTable = brain:GetThreatsAroundPosition(position, 1, true, 'AntiSurface')
                             local platoonThreat = self:CalculatePlatoonThreatAroundPosition('Surface', categories.MOBILE * categories.DIRECTFIRE - categories.SCOUT, position, 30)
                             local positionStatus = brain.GridPresence:GetInferredStatus(position)
-                            if positionStatus != 'Allied' or platoonThreat * 1.5 < threat then
+                            if positionStatus != 'Allied' and platoonThreat * 1.5 < threat then
                                 if threatTable and not TableEmpty(threatTable) then
                                     local info = threatTable[Random(1, TableGetn(threatTable))]
                                     self.ThreatToEvade = { info[1], GetSurfaceHeight(info[1], info[2]), info[2] }
-                                    self:LogDebug(string.format('We are going to retreat, enemy threat '..threat..' our threat '..platoonThreat..' position status '..positionStatus))
+                                    self:LogDebug(string.format('We are going to retreat, enemy threat '..threat..' our threat '..platoonThreat..' position status '.. tostring(positionStatus)))
                                     self:ChangeState(self.Retreating)
                                     return
                                 end
                             elseif positionStatus then
-                                self:LogDebug(string.format('We are going to attack, enemy threat '..threat..' our threat '..platoonThreat..' position status '..positionStatus))
+                                self:LogDebug(string.format('We are going to attack, enemy threat '..threat..' our threat '..platoonThreat..' position status '.. tostring(positionStatus)))
                             end
                         end
                     end
@@ -496,7 +496,7 @@ AIPlatoonAdaptiveRaidBehavior = Class(AIPlatoon) {
                     local threatTable = brain:GetThreatsAroundPosition(position, 1, true, 'AntiSurface')
                     local platoonThreat = self:CalculatePlatoonThreatAroundPosition('Surface', categories.MOBILE * categories.DIRECTFIRE - categories.SCOUT, position, 30)
                     local positionStatus = brain.GridPresence:GetInferredStatus(position)
-                    if positionStatus != 'Allied' or platoonThreat * 2 < threat then
+                    if positionStatus != 'Allied' and platoonThreat * 2 < threat then
                         if threatTable and not TableEmpty(threatTable) then
                             local info = threatTable[Random(1, TableGetn(threatTable))]
                             self.ThreatToEvade = { info[1], GetSurfaceHeight(info[1], info[2]), info[2] }
@@ -504,7 +504,7 @@ AIPlatoonAdaptiveRaidBehavior = Class(AIPlatoon) {
                             return
                         end
                     else
-                        self:LogDebug(string.format('Threat and we need to attack then since it is allied, status '..positionStatus))
+                        self:LogDebug(string.format('Threat and we need to attack then since it is allied, status '.. tostring(positionStatus)))
                     end
                 end
 

--- a/lua/aibrains/platoons/platoon-adaptive-raid.lua
+++ b/lua/aibrains/platoons/platoon-adaptive-raid.lua
@@ -94,12 +94,12 @@ AIPlatoonAdaptiveRaidBehavior = Class(AIPlatoon) {
 
             self:Stop()
 
-            -- pick random unit
-            local units, unitCount = self:GetPlatoonUnits()
-            local unit = units[Random(1, unitCount)]
+            local position = self:GetPlatoonPosition()
+            if not position then
+                return
+            end
 
-            -- determine navigational label of that unit
-            local position = unit:GetPosition()
+            local units, unitCount = self:GetPlatoonUnits()
             local label, error = NavUtils.GetLabel(self.MovementLayer, position)
 
             if label then
@@ -224,14 +224,11 @@ AIPlatoonAdaptiveRaidBehavior = Class(AIPlatoon) {
             if not self.CurrentPlatoonThreat then
                 self.CurrentPlatoonThreat = self:CalculatePlatoonThreat('Surface', categories.ALLUNITS)
             end
-            local units = self:GetPlatoonUnits()
-            local origin
-            for _, v in units do
-                if v and not v.Dead then
-                    origin = v:GetPosition()
-                    break
-                end
+            local origin = self:GetPlatoonPosition()
+            if not origin then
+                return
             end
+
             local brain = self:GetBrain()
             local path, reason =  NavUtils.PathToWithThreatThreshold(self.MovementLayer, origin, destination, brain, NavUtils.ThreatFunctions.AntiSurface, 200, brain.IMAPConfig.Rings)
             if not path then
@@ -279,12 +276,15 @@ AIPlatoonAdaptiveRaidBehavior = Class(AIPlatoon) {
                 local dist
                 local Stuck = 0
                 while not IsDestroyed(self) do
-                    coroutine.yield(1)
                     if IsDestroyed(self) then
                         return
                     end
                     
                     local position = self:GetPlatoonPosition()
+                    if not position then
+                        return
+                    end
+
                     units = self:GetPlatoonUnits()
 
                     local threat = brain:GetThreatAtPosition(position, 1, true, 'AntiSurface')
@@ -487,6 +487,10 @@ AIPlatoonAdaptiveRaidBehavior = Class(AIPlatoon) {
 
                 -- check for threats
                 local position = self:GetPlatoonPosition()
+                if not position then
+                    return
+                end
+
                 local threat = brain:GetThreatAtPosition(position, 1, true, 'AntiSurface')
                 if threat > 0 then
                     local threatTable = brain:GetThreatsAroundPosition(position, 1, true, 'AntiSurface')
@@ -547,6 +551,10 @@ AIPlatoonAdaptiveRaidBehavior = Class(AIPlatoon) {
             while not IsDestroyed(self) do
 
                 local position = self:GetPlatoonPosition()
+                if not position then
+                    return
+                end
+
                 local waypoint, error = NavUtils.RetreatDirectionFrom('Land', position, location, 40)
 
                 if not waypoint then
@@ -561,6 +569,9 @@ AIPlatoonAdaptiveRaidBehavior = Class(AIPlatoon) {
 
                 while not IsDestroyed(self) do
                     local position = self:GetPlatoonPosition()
+                    if not position then
+                        return
+                    end
 
                     -- check if we're near our retreat point
                     local dx = position[1] - wx

--- a/lua/aibrains/platoons/platoon-adaptive-raid.lua
+++ b/lua/aibrains/platoons/platoon-adaptive-raid.lua
@@ -98,12 +98,6 @@ AIPlatoonAdaptiveRaidBehavior = Class(AIPlatoon) {
             local units, unitCount = self:GetPlatoonUnits()
             local unit = units[Random(1, unitCount)]
 
-            if not unit then
-                LOG("No unit!")
-                reprsl(units)
-                return
-            end
-
             -- determine navigational label of that unit
             local position = unit:GetPosition()
             local label, error = NavUtils.GetLabel(self.MovementLayer, position)

--- a/lua/aibrains/platoons/platoon-adaptive-returntobase.lua
+++ b/lua/aibrains/platoons/platoon-adaptive-returntobase.lua
@@ -84,6 +84,10 @@ AIPlatoonAdaptiveReturnToBaseBehavior = Class(AIPlatoon) {
 
             if bestBase then
                 local platPos = self:GetPlatoonPosition()
+                if not platPos then
+                    return
+                end
+
                 local dx = platPos[1] - bestBase.Position[1]
                 local dz = platPos[3] - bestBase.Position[3]
                 if dx * dx + dz * dz > 3600 then
@@ -121,13 +125,11 @@ AIPlatoonAdaptiveReturnToBaseBehavior = Class(AIPlatoon) {
                 self.CurrentPlatoonThreat = self:CalculatePlatoonThreat('Surface', categories.ALLUNITS)
             end
             local units = self:GetPlatoonUnits()
-            local origin
-            for _, v in units do
-                if v and not v.Dead then
-                    origin = v:GetPosition()
-                    break
-                end
+            local origin = self:GetPlatoonPosition()
+            if not origin then
+                return
             end
+
             local brain = self:GetBrain()
             local path, reason =  NavUtils.PathToWithThreatThreshold(self.MovementLayer, origin, destination, brain, NavUtils.ThreatFunctions.AntiSurface, 200, brain.IMAPConfig.Rings)
             if not path then
@@ -152,14 +154,13 @@ AIPlatoonAdaptiveReturnToBaseBehavior = Class(AIPlatoon) {
                     if self.Dead then
                         return
                     end
-                    local position
-                    units = self:GetPlatoonUnits()
-                    for _, v in units do
-                        if v and not v.Dead then
-                            position = v:GetPosition()
-                            break
-                        end
+                    local position = self:GetPlatoonPosition()
+                    if not position then
+                        return
                     end
+
+                    units = self:GetPlatoonUnits()
+
                     -- check for opportunities
                     distEnd = VDist2Sq(path[pathNodesCount][1], path[pathNodesCount][3], position[1], position[3] )
                     if not attackFormation and distEnd < 6400 then
@@ -188,14 +189,12 @@ AIPlatoonAdaptiveReturnToBaseBehavior = Class(AIPlatoon) {
                     coroutine.yield(15)
                 end
             end
-            local position
-            units = self:GetPlatoonUnits()
-            for _, v in units do
-                if v and not v.Dead then
-                    position = v:GetPosition()
-                    break
-                end
+            local position = self:GetPlatoonPosition()
+            if not position then
+                return
             end
+
+            units = self:GetPlatoonUnits()
             local hx = position[1] - destination[1]
             local hz = position[3] - destination[3]
             if hx * hx + hz * hz < 3600 then
@@ -293,6 +292,10 @@ AIPlatoonAdaptiveReturnToBaseBehavior = Class(AIPlatoon) {
             while not IsDestroyed(self) do
 
                 local position = self:GetPlatoonPosition()
+                if not position then
+                    return
+                end
+
                 local waypoint, error = NavUtils.RetreatDirectionFrom('Land', position, location, 40)
 
                 if not waypoint then
@@ -306,6 +309,9 @@ AIPlatoonAdaptiveReturnToBaseBehavior = Class(AIPlatoon) {
 
                 while not IsDestroyed(self) do
                     local position = self:GetPlatoonPosition()
+                    if not position then
+                        return
+                    end
 
                     -- check if we're near our retreat point
                     local dx = position[1] - wx

--- a/lua/aibrains/platoons/platoon-adaptive-returntobase.lua
+++ b/lua/aibrains/platoons/platoon-adaptive-returntobase.lua
@@ -63,12 +63,11 @@ AIPlatoonAdaptiveReturnToBaseBehavior = Class(AIPlatoon) {
 
             self:Stop()
 
-            -- pick random unit
-            local units, unitCount = self:GetPlatoonUnits()
-            local unit = units[Random(1, unitCount)]
-
             -- determine navigational label of that unit
-            local position = unit:GetPosition()
+            local position = self:GetPlatoonPosition()
+            if not position then
+                return
+            end
 
             --Guard the closest least-defended base
             local bestBase = false

--- a/lua/aibrains/platoons/platoon-base.lua
+++ b/lua/aibrains/platoons/platoon-base.lua
@@ -421,7 +421,7 @@ AIPlatoon = Class(moho.platoon_methods) {
 
         -- populate the cache
         local head = 1
-        for k, unit in units do
+        for _, unit in units do
             if not IsDestroyed(unit) then
                 units[head] = unit
                 head = head + 1
@@ -501,6 +501,11 @@ AIPlatoon = Class(moho.platoon_methods) {
         info.PlatoonName = self.PlatoonName
         info.StateName = self.StateName
         info.DebugMessages = self.DebugMessages
+        table.sort(self.DebugMessages,
+            function (a, b)
+                return a > b
+            end
+        )
 
         return info
     end,

--- a/lua/aibrains/platoons/platoon-base.lua
+++ b/lua/aibrains/platoons/platoon-base.lua
@@ -439,6 +439,48 @@ AIPlatoon = Class(moho.platoon_methods) {
         return units, head - 1
     end,
 
+    ---@param self AIPlatoon
+    ---@return Vector?
+    GetPlatoonPosition = function(self)
+        if IsDestroyed(self) then
+            return nil
+        end
+
+        -- retrieve average position
+        local position = AIPlatoonMoho.GetPlatoonPosition(self)
+        if not position then
+            return nil
+        end
+
+        -- retrieve units
+        local units, unitCount = self:GetPlatoonUnits()
+        if unitCount == 0 then
+            return nil
+        end
+
+        local px = position[1]
+        local pz = position[3]
+
+        -- try to find the unit closest to the center
+        local nx, ny, nz, distance
+        for k = 1, unitCount do
+            local unit = units[k]
+            local ux, uy, uz = unit:GetPositionXYZ()
+            local dx = ux - px
+            local dz = uz - pz
+            local d = dx * dx + dz * dz
+
+            if (not distance) or d < distance then
+                nx = ux
+                ny = uy
+                nz = uz
+                distance = d
+            end
+        end
+
+        return { nx, ny, nz }
+    end,
+
 
     --- This disbands the state machine platoon and sets engineers back to a manager.
     ---@param self AIPlatoon

--- a/lua/aibrains/platoons/platoon-base.lua
+++ b/lua/aibrains/platoons/platoon-base.lua
@@ -439,6 +439,7 @@ AIPlatoon = Class(moho.platoon_methods) {
         return units, head - 1
     end,
 
+    --- Returns the position of the unit that is nearest to the center of the platoon.
     ---@param self AIPlatoon
     ---@return Vector?
     GetPlatoonPosition = function(self)
@@ -485,6 +486,10 @@ AIPlatoon = Class(moho.platoon_methods) {
     --- This disbands the state machine platoon and sets engineers back to a manager.
     ---@param self AIPlatoon
     ExitStateMachine = function(self)
+        if IsDestroyed(self) then
+            return
+        end
+
         local brain = self:GetBrain()
         local platUnits = self:GetPlatoonUnits()
         if platUnits then

--- a/lua/aibrains/platoons/platoon-simple-raid.lua
+++ b/lua/aibrains/platoons/platoon-simple-raid.lua
@@ -62,12 +62,11 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
 
             self:Stop()
 
-            -- pick random unit
-            local units, unitCount = self:GetPlatoonUnits()
-            local unit = units[Random(1, unitCount)]
+            local position = self:GetPlatoonPosition()
+            if not position then
+                return
+            end
 
-            -- determine navigational label of that unit
-            local position = unit:GetPosition()
             local label, error = NavUtils.GetLabel('Land', position)
 
             if label then
@@ -139,13 +138,11 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
             while not IsDestroyed(self) do
                 -- pick random unit for a position on the grid
                 local units, unitCount = self:GetPlatoonUnits()
-                local origin
-                for _, v in units do
-                    if v and not v.Dead then
-                        origin = v:GetPosition()
-                    end
+                local origin = self:GetPlatoonPosition()
+                if not origin then
+                    return
                 end
-
+                
                 -- generate a direction
                 local waypoint, length = NavUtils.DirectionTo('Land', origin, destination, 60)
 
@@ -173,6 +170,9 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
                 local wz = waypoint[3]
                 while not IsDestroyed(self) do
                     local position = self:GetPlatoonPosition()
+                    if not position then
+                        return
+                    end
 
                     -- check if we're near our current waypoint
                     local dx = position[1] - wx
@@ -257,6 +257,10 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
 
                 -- check for threats
                 local position = self:GetPlatoonPosition()
+                if not position then
+                    return
+                end
+
                 local threat = brain:GetThreatAtPosition(position, 1, true, 'AntiSurface')
                 if threat > 0 then
                     local threatTable = brain:GetThreatsAroundPosition(position, 1, true, 'AntiSurface')
@@ -329,6 +333,10 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
 
                 -- check for threats
                 local position = self:GetPlatoonPosition()
+                if not position then
+                    return
+                end
+
                 local threat = brain:GetThreatAtPosition(position, 1, true, 'AntiSurface')
                 if threat > 0 then
                     local threatTable = brain:GetThreatsAroundPosition(position, 1, true, 'AntiSurface')
@@ -382,6 +390,10 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
             while not IsDestroyed(self) do
 
                 local position = self:GetPlatoonPosition()
+                if not position then
+                    return
+                end
+
                 local waypoint, error = NavUtils.RetreatDirectionFrom('Land', position, location, 40)
 
                 if not waypoint then
@@ -396,6 +408,9 @@ AIPlatoonSimpleRaidBehavior = Class(AIPlatoon) {
 
                 while not IsDestroyed(self) do
                     local position = self:GetPlatoonPosition()
+                    if not position then
+                        return
+                    end
 
                     -- check if we're near our retreat point
                     local dx = position[1] - wx

--- a/lua/sim/NavDatastructures.lua
+++ b/lua/sim/NavDatastructures.lua
@@ -104,6 +104,8 @@ NavHeap = ClassSimple {
         -- fix its position.
         self:Heapify()
 
+        -- DrawCircle(value.Center, 5, '9999ff')
+
         return value
     end,
 
@@ -178,5 +180,8 @@ NavHeap = ClassSimple {
         self.HeapSize = self.HeapSize + 1
         self.Heap[self.HeapSize] = element
         self:Rootify()
+
+        -- DrawCircle(element.Center, 5, '999999')
+
     end,
 }

--- a/lua/sim/NavDatastructures.lua
+++ b/lua/sim/NavDatastructures.lua
@@ -61,7 +61,7 @@ Stack = ClassSimple {
 }
 
 ---@class NavHeap
----@field Heap NavLeaf[]
+---@field Heap NavSection[]
 ---@field HeapSize number
 NavHeap = ClassSimple {
 
@@ -83,7 +83,7 @@ NavHeap = ClassSimple {
     end,
 
     ---@param self NavHeap
-    ---@return NavLeaf?
+    ---@return NavSection?
     ExtractMin = function(self)
         local heap = self.Heap
         local heapSize = self.HeapSize
@@ -124,13 +124,13 @@ NavHeap = ClassSimple {
 
             -- if there is a right child, compare its value with the left one
             -- if right is smaller, then assign min = right. Else, keep min on left.
-            if right <= heapSize and (heap[right].TotalCosts < heap[left].TotalCosts) then
+            if right <= heapSize and (heap[right].HeapTotalCosts < heap[left].HeapTotalCosts) then
                 min = right
             end
 
             -- if min has higher value than the index it means we restored heap properties
             -- and can break the loop
-            if heap[min].TotalCosts > heap[index].TotalCosts then
+            if heap[min].HeapTotalCosts > heap[index].HeapTotalCosts then
                 return
             end
 
@@ -156,7 +156,7 @@ NavHeap = ClassSimple {
         while parent >= 1 do
 
             -- if parent value is smaller than index value it means we restored correct order of the elements
-            if heap[parent].TotalCosts < heap[index].TotalCosts then
+            if heap[parent].HeapTotalCosts < heap[index].HeapTotalCosts then
                 return
             end
 
@@ -173,7 +173,7 @@ NavHeap = ClassSimple {
     end,
 
     ---@param self NavHeap
-    ---@param element NavLeaf
+    ---@param element NavSection
     Insert = function(self, element)
         self.HeapSize = self.HeapSize + 1
         self.Heap[self.HeapSize] = element

--- a/lua/sim/NavDebug.lua
+++ b/lua/sim/NavDebug.lua
@@ -129,7 +129,7 @@ function ScanOver(mouse, layer)
         local over = navGrid:FindLeaf(mouse)
         if over then
             if over.Label then
-                local color = Shared.LabelToColor(over.Label)
+                local color = Shared.LayerColors[navGrid.Layer]
                 local size = over.Size
                 local h = 0.5 * size
                 NavGenerator.DrawSquare(over.px - h, over.pz - h, size, color, 0.1)
@@ -140,7 +140,6 @@ function ScanOver(mouse, layer)
                     local neighbor = NavGenerator.NavLeaves[over[k]]
                     local size = neighbor.Size
                     local h = 0.5 * size
-                    local color = Shared.LabelToColor(neighbor.Label)
                     NavGenerator.DrawSquare(neighbor.px - h, neighbor.pz - h, size, color, 0.1)
                 end
             else

--- a/lua/sim/NavDebug.lua
+++ b/lua/sim/NavDebug.lua
@@ -137,7 +137,7 @@ function ScanOver(mouse, layer)
                 NavGenerator.DrawSquare(over.px - h, over.pz - h, size, color, 0.2)
 
                 for k = 1, table.getn(over) do
-                    local neighbor = NavGenerator.NavCells[over[k]]
+                    local neighbor = NavGenerator.NavLeaves[over[k]]
                     local size = neighbor.Size
                     local h = 0.5 * size
                     local color = Shared.LabelToColor(neighbor.Label)

--- a/lua/sim/NavDebug/DirectionTo.lua
+++ b/lua/sim/NavDebug/DirectionTo.lua
@@ -57,7 +57,9 @@ function DebugThread()
             local distance = State.Distance
             local destination = State.Destination
             if layer and origin and distance and destination then
+                local start = GetSystemTimeSecondsOnlyForProfileUse()
                 local direction, error = NavUtils.DirectionTo(layer, origin, destination, distance)
+                LOG(string.format("NavDirectionTo - %f", GetSystemTimeSecondsOnlyForProfileUse() - start))
                 DrawCircle(destination, 2, '0000FF')
                 if direction then
                     DrawCircle(origin, 2, 'ffffff')

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -335,9 +335,6 @@ NavGrid = ClassNavGrid {
     --- Draws all trees with the correct layer color
     ---@param self NavGrid
     Draw = function(self)
-
-        local count = 10
-
         for z = 0, LabelCompressionTreesPerAxis - 1 do
             for x = 0, LabelCompressionTreesPerAxis - 1 do
                 local tree = self.Trees[z][x]
@@ -1775,17 +1772,15 @@ local function ComputeTreeInformation(mapHasWater)
 
                 -- find neighbors for each section
                 local section = sections[s] --[[@as (NavSection)]]
-                if section.Area > thresholdArea then
-                    for l = 1, TableGetn(section.Leaves) do
-                        local leaf = section.Leaves[l]
+                for l = 1, TableGetn(section.Leaves) do
+                    local leaf = section.Leaves[l]
 
-                        for n = 1, TableGetn(leaf) do
-                            local neighbor = NavLeaves[leaf[n]]
-                            local neighborTree = neighbor.Root --[[@as NavTree]]
-                            local neighborSection = NavSections[neighbor.Section] --[[@as NavSection]]
-                            if (neighbor.Label > 0) and (neighborTree ~= tree) and (neighborSection.Area > thresholdArea) then
-                                section.Neighbors[neighborSection.Identifier] = true
-                            end
+                    for n = 1, TableGetn(leaf) do
+                        local neighbor = NavLeaves[leaf[n]]
+                        local neighborTree = neighbor.Root --[[@as NavTree]]
+                        local neighborSection = NavSections[neighbor.Section] --[[@as NavSection]]
+                        if (neighbor.Label > 0) and (neighborTree ~= tree) and (neighborSection.Area > thresholdArea) then
+                            section.Neighbors[neighborSection.Identifier] = true
                         end
                     end
                 end

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -1063,8 +1063,6 @@ end
 ---@param pzCache NavVerticalPathCache
 ---@param pCache NavPathCache
 ---@param bCache NavTerrainBlockCache
----@return number   # minimum depth
----@return number   # maximum depth
 function PopulateCaches(tCache, dCache, daCache, pxCache, pzCache, pCache, bCache, bx, bz, c)
     local MathAbs = MathAbs
     local GetTerrainHeight = GetTerrainHeight
@@ -1167,6 +1165,8 @@ end
 ---@param bCache NavTerrainBlockCache
 ---@param pCache NavPathCache
 ---@param rCache NavLabelCache
+---@return boolean # all blocking
+---@return boolean # all pathable
 function ComputeLandPathingMatrix(size, daCache, pCache, bCache, rCache)
     local allBlocking = true
     local allPathable = true
@@ -1200,6 +1200,8 @@ end
 ---@param bCache NavTerrainBlockCache
 ---@param pCache NavPathCache
 ---@param rCache NavLabelCache
+---@return boolean # all blocking
+---@return boolean # all pathable
 function ComputeHoverPathingMatrix(size, daCache, pCache, bCache, rCache)
     local allBlocking = true
     local allPathable = true
@@ -1234,6 +1236,8 @@ end
 ---@param bCache NavTerrainBlockCache
 ---@param pCache NavPathCache
 ---@param rCache NavLabelCache
+---@return boolean # all blocking
+---@return boolean # all pathable
 function ComputeNavalPathingMatrix(size, daCache, pCache, bCache, rCache)
     local allBlocking = true
     local allPathable = true
@@ -1266,6 +1270,8 @@ end
 ---@param bCache NavTerrainBlockCache
 ---@param pCache NavPathCache
 ---@param rCache NavLabelCache
+---@return boolean # all blocking
+---@return boolean # all pathable
 function ComputeAmphPathingMatrix(size, daCache, pCache, bCache, rCache)
     local allBlocking = true
     local allPathable = true
@@ -1298,6 +1304,7 @@ end
 --- Generates the compression grids based on the heightmap
 ---@param size number (square) size of each cell of the compression grid
 ---@param threshold number (square) size of the smallest acceptable leafs, used for culling
+---@param mapHasWater boolean
 local function GenerateCompressionGrids(size, threshold, mapHasWater)
 
     local navAir = NavGrids['Air'] --[[@as NavGrid]]
@@ -1370,6 +1377,7 @@ local function GenerateCompressionGrids(size, threshold, mapHasWater)
 end
 
 --- Generates graphs that we can traverse, based on the compression grids
+---@param mapHasWater boolean
 local function GenerateGraphs(mapHasWater)
     local navLand = NavGrids['Land'] --[[@as NavGrid]]
     local navWater = NavGrids['Water'] --[[@as NavGrid]]
@@ -1435,6 +1443,7 @@ local function GenerateCullLabels()
 end
 
 --- Generates metadata for markers for quick access
+---@param mapHasWater boolean
 local function GenerateMarkerMetadata(mapHasWater)
     local navLabels = NavLabels
 
@@ -1484,7 +1493,8 @@ local function GenerateMarkerMetadata(mapHasWater)
 end
 
 --- Computes various fields for the root nodes
-local function GenerateRootInformation(mapHasWater)
+---@param mapHasWater boolean
+local function ComputeTreeInformation(mapHasWater)
 
     local cache = {}
     local size = ScenarioInfo.size[1] / LabelCompressionTreesPerAxis
@@ -1591,7 +1601,7 @@ function Generate()
     local infoMessage = string.format("cleaning up generated data: %f", GetSystemTimeSecondsOnlyForProfileUse() - start)
     SPEW(infoMessage)
 
-    GenerateRootInformation(mapHasWater)
+    ComputeTreeInformation(mapHasWater)
     local infoMessage = string.format("generated tree information: %f", GetSystemTimeSecondsOnlyForProfileUse() - start)
     SPEW(infoMessage)
 

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -393,9 +393,14 @@ end
 ---@field Area number
 ---@field Center Vector
 ---@field Identifier NavSectionIdentifier
+---@field Label NavLabelIdentifier
 ---@field Leaves NavLeaf[]
 ---@field Neighbors NavSectionIdentifier[]
 ---@field Tree NavTreeIdentifier
+---@field HeapFrom NavSectionIdentifier
+---@field HeapIdentifier number
+---@field HeapAcquiredCosts number
+---@field HeapTotalCosts number
 
 ---@class NavLeaf 
 ---@field Root NavTree
@@ -406,8 +411,8 @@ end
 ---@field px number                 # x-coordinate of center in world space
 ---@field pz number                 # z-coordinate of center in world space
 ---@field From? NavLeaf             # Populated during path finding
----@field AcquiredCosts? number     # Populated during path finding
----@field TotalCosts? number        # Populated during path finding
+---@field HeapAcquiredCosts? number     # Populated during path finding
+---@field HeapTotalCosts? number        # Populated during path finding
 ---@field Seen? number              # Populated during path finding
 
 --- A simplified quad tree that acts as a compression of the pathing capabilities of a section of the heightmap
@@ -1661,6 +1666,7 @@ local function ComputeTreeInformation(mapHasWater)
                     ---@type NavSection
                     local section = {
                         Identifier = identifier,
+                        Label = leaf.Label,
                         Neighbors = { },
                         Leaves = { },
                         Tree = tree.Identifier,

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -76,11 +76,22 @@ NavGrids = {}
 ---@field ExtractorMarkers MarkerResource[]
 ---@field HydrocarbonMarkers MarkerResource[]
 
----@type table<number, NavLabelMetadata>
+---@alias NavTreeIdentifier number
+---@alias NavLeafIdentifier number
+---@alias NavSectionIdentifier number 
+---@alias NavLabelIdentifier number
+
+---@type table<NavLabelIdentifier, NavLabelMetadata>
 NavLabels = {}
 
----@type table<number, NavTree | NavLeaf>
-NavCells = {}
+---@type table<NavLeafIdentifier, NavLeaf>
+NavLeaves = {}
+
+---@type table<NavTreeIdentifier, NavTree>
+NavTrees = {}
+
+---@type table<NavSectionIdentifier, NavSection>
+NavSections = {}
 
 local Generated = false
 ---@return boolean
@@ -93,6 +104,20 @@ local CellIdentifier = 0
 local function GenerateCellIdentifier()
     CellIdentifier = CellIdentifier + 1
     return CellIdentifier
+end
+
+local SectionIdentifier = 0
+---@return number
+local function GenerateSectionIdentifier()
+    SectionIdentifier = SectionIdentifier + 1
+    return SectionIdentifier
+end
+
+local TreeIdentifier = 0
+---@return number
+local function GenerateTreeIdentifier()
+    TreeIdentifier = TreeIdentifier + 1
+    return TreeIdentifier
 end
 
 local LabelIdentifier = 0
@@ -181,6 +206,11 @@ NavGrid = ClassNavGrid {
     ---@param labelTree NavTree
     AddTree = function(self, z, x, labelTree)
         self.Trees[z][x] = labelTree
+
+        local treeSize = self.TreeSize
+        local cx = (x + 0.5) * treeSize
+        local cz = (z + 0.5) * treeSize
+        labelTree.Center = {cx, GetSurfaceHeight(cx, cz), cz}
     end,
 
     ---@param self NavGrid
@@ -305,10 +335,27 @@ NavGrid = ClassNavGrid {
     --- Draws all trees with the correct layer color
     ---@param self NavGrid
     Draw = function(self)
-        local size = self.TreeSize
+
+        local count = 10
+
         for z = 0, LabelCompressionTreesPerAxis - 1 do
             for x = 0, LabelCompressionTreesPerAxis - 1 do
-                self.Trees[z][x]:Draw(Shared.LayerColors[self.Layer])
+                local tree = self.Trees[z][x]
+                tree:Draw(Shared.LayerColors[self.Layer])
+
+                -- draw connections
+                for label, sections in tree.Sections do
+                    for s = 1, TableGetn(sections) do
+                        local section = sections[s] --[[@as (NavSection)]]
+                        local neighbors = section.Neighbors
+    
+                        local color = Shared.LabelToColor(label)
+                        for k = 1, TableGetn(neighbors) do
+                            local neighbor = NavSections[neighbors[k]]
+                            DrawLine(section.Center, neighbor.Center, color)
+                        end
+                    end
+                end
             end
         end
     end,
@@ -316,10 +363,10 @@ NavGrid = ClassNavGrid {
     --- Draws all trees with their corresponding labels
     ---@param self NavGrid
     DrawLabels = function(self, inset)
-        local size = self.TreeSize
         for z = 0, LabelCompressionTreesPerAxis - 1 do
             for x = 0, LabelCompressionTreesPerAxis - 1 do
-                self.Trees[z][x]:DrawLabels(inset)
+                local tree = self.Trees[z][x]
+                tree:DrawLabels(inset)
             end
         end
     end,
@@ -327,7 +374,10 @@ NavGrid = ClassNavGrid {
 
 local FactoryCompressedLabelTree = {
     __call = function(self)
-        return setmetatable({}, self)
+        local instance = {}
+        setmetatable(instance, self)
+        instance:OnCreate()
+        return instance
     end
 }
 
@@ -339,10 +389,20 @@ local ClassCompressedLabelTree = function(specs)
     return setmetatable(specs, FactoryCompressedLabelTree)
 end
 
+---@class NavSection
+---@field Area number
+---@field Center Vector
+---@field Identifier NavSectionIdentifier
+---@field Leaves NavLeaf[]
+---@field Neighbors NavSectionIdentifier[]
+---@field Tree NavTreeIdentifier
+
 ---@class NavLeaf 
+---@field Root NavTree
 ---@field Identifier number
 ---@field Size number               # Element count starting at { bx + ox, bz + oz }, used as a parameter during path finding to determine if a unit can pass
 ---@field Label number              # Label for efficient `CanPathTo` check
+---@field Section number            
 ---@field px number                 # x-coordinate of center in world space
 ---@field pz number                 # z-coordinate of center in world space
 ---@field From? NavLeaf             # Populated during path finding
@@ -352,10 +412,21 @@ end
 
 --- A simplified quad tree that acts as a compression of the pathing capabilities of a section of the heightmap
 ---@class NavTree: table<number, NavLeaf | number>
----@field Labels table<number, number>      # Table that tells us which labels are part of this compression tree. The key represents as the label, the value represents as the fractional area that the label consumes. A value of 1 means the label tree entirely consists of one value.
+---@field Identifier number
+---@field Center Vector
+---@field Labels table<number, number>      # Maps a label to the ratio of area that it occupies in this tree
+---@field Leaves table <number, NavLeaf[]>  # Maps a label to the leaves that represent that label, sorted from largest to smallest
+---@field Sections table <number, table<number, NavLeaf[]>>
 ---@field Seen number | nil                 # Used during navigating
 ---@field Threat number | nil               # Used during navigating
 CompressedLabelTree = ClassCompressedLabelTree {
+
+    ---@param self NavTree
+    OnCreate = function(self)
+        local identifier = GenerateTreeIdentifier()
+        self.Identifier = identifier
+        NavTrees[identifier] = self
+    end,
 
     ---------------------------------------------------------------------------
     --#region Generation
@@ -407,7 +478,7 @@ CompressedLabelTree = ClassCompressedLabelTree {
         }
 
         -- required for navigation
-        NavCells[identifier] = instance
+        NavLeaves[identifier] = instance
 
         return instance
     end,
@@ -784,7 +855,7 @@ CompressedLabelTree = ClassCompressedLabelTree {
 
                 -- add our pathable neighbors to the stack
                 for k = 1, TableGetn(instance) do
-                    local neighbor = NavCells[ instance[k] ]
+                    local neighbor = NavLeaves[ instance[k] ]
                     if neighbor.Label == 0 then
                         stack[free] = neighbor
                         free = free + 1
@@ -808,7 +879,7 @@ CompressedLabelTree = ClassCompressedLabelTree {
 
                     -- add unlabelled neighbors
                     for k = 1, TableGetn(other) do
-                        local neighbor = NavCells[ other[k] ]
+                        local neighbor = NavLeaves[ other[k] ]
                         if neighbor.Label == 0 then
                             stack[free] = neighbor
                             free = free + 1
@@ -828,6 +899,7 @@ CompressedLabelTree = ClassCompressedLabelTree {
 
     --- Returns all leaves in a table
     ---@param self NavTree
+    ---@param cache? NavLeaf[]
     ---@return NavLeaf[]
     ---@return number
     FindLeaves = function(self, cache)
@@ -853,10 +925,11 @@ CompressedLabelTree = ClassCompressedLabelTree {
     end,
 
     --- Returns all traversable leaves in a table
-    ---@param self NavTree | NavLeaf | NavTree
+    ---@param self NavTree
+    ---@param cache? NavLeaf[]
     ---@return NavLeaf[]
     ---@return number
-    FindTraversableLeaves = function(self, thresholdSize, cache, cacheQueue)
+    FindTraversableLeaves = function(self, cache)
         local head = 1
         cache = cache or {}
 
@@ -865,7 +938,7 @@ CompressedLabelTree = ClassCompressedLabelTree {
             local instance = self[k]
             local isLeaf = type(instance) == "table"
             if isLeaf then
-                if instance.Label > 0 then
+                if instance.Label >= 0 then
                     cache[head] = instance
                     head = head + 1
                 end
@@ -878,6 +951,27 @@ CompressedLabelTree = ClassCompressedLabelTree {
         end
 
         return cache, head - 1
+    end,
+
+    ---@param self NavTree
+    ---@return NavLeaf?
+    FindLeafOfLabel = function(self, label)
+
+        if not self.Labels[label] then
+            return nil
+        end
+
+        -- gather all the leaves
+        for k = 1, TableGetn(self) do
+            local instance = self[k]
+            local isLeaf = type(instance) == "table"
+            if isLeaf then
+                if instance.Label >= 0 then
+                    cache[head] = instance
+                    head = head + 1
+                end
+            end
+        end
     end,
 
     --- Returns the leaf that encompasses the position, or nil if no leaf does
@@ -971,7 +1065,7 @@ CompressedLabelTree = ClassCompressedLabelTree {
                 -- DrawCircle({ px, GetSurfaceHeight(px, pz), pz }, 0.5, 'ffffff')
 
                 if instance.Label >= 0 then
-                    DrawSquare(px - 0.5 * size, pz - 0.5 * size, size, color, inset)
+                    -- DrawSquare(px - 0.5 * size, pz - 0.5 * size, size, color, inset)
                 else
                     DrawSquare(px - 0.5 * size, pz - 0.5 * size, size, 'ff0000', inset)
                 end
@@ -1511,33 +1605,214 @@ local function ComputeTreeInformation(mapHasWater)
         TableInsert(grids, NavGrids['Hover'])
     end
 
+    ---@param a NavLeaf
+    ---@param b NavLeaf
+    local function SortLeaves(a, b)
+        return a.Size > b.Size
+    end
+
+    ---@param tree NavTree
+    ---@param leaves NavLeaf[]
+    ---@param count number
+    local function ComputeSections(tree, leaves, count)
+        ---@type table <number, NavLeaf[]>
+        local output = { }
+
+        -- gather all the leaves
+        for k = 1, count do
+            local leaf = leaves[k]
+            local label = leaf.Label
+            if label > 0 then
+                if not output[label] then
+                    output[label] = { leaf }
+                else
+                    table.insert(output[label], leaf)
+                end
+            end
+        end
+
+        -- sort the leaves on size, largest to smallest
+        for _, leaves in output do
+            table.sort(leaves, SortLeaves)
+        end
+
+        ---@type NavLeaf[]
+        local stack = { }
+
+        local sections = { }
+        for label, leaves in output do
+
+            sections[label] = { }
+
+            -- start creating a section of leaves
+
+            local sHead = 1
+            for k = 1, TableGetn(leaves) do
+
+                -- for each traversable leaf
+                local leaf = leaves[k]
+
+                -- that isn't already part of a section
+                if not leaf.Section then
+
+                    -- we create a new section
+                    local identifier = GenerateSectionIdentifier()
+
+                    ---@type NavSection
+                    local section = {
+                        Identifier = identifier,
+                        Neighbors = { },
+                        Leaves = { },
+                        Tree = tree.Identifier,
+                        Center = { 0, 0, 0 }
+                    } 
+
+                    NavSections[identifier] = section
+
+                    -- and gather all neighbors of the same tree that share the same label
+                    local head = 2
+                    stack[1] = leaf
+                    while head > 1 do
+                        head = head - 1
+                        local other = stack[head]
+
+                        if not other.Section then
+                            other.Section = identifier
+                            TableInsert(section.Leaves, other)
+                            for k = 1, TableGetn(other) do
+                                local neighbor = NavLeaves[other[k]]
+                                if (neighbor.Label == leaf.Label) and (neighbor.Root == tree) and (not neighbor.Section) then
+                                    stack[head] = neighbor
+                                    head = head + 1
+                                end
+                            end
+                        end
+                    end
+
+                    -- sort it from large to small again
+                    table.sort(section.Leaves, SortLeaves)
+
+                    local center = section.Leaves[1]
+                    local cx = center.px * center.Size
+                    local cz = center.pz * center.Size
+                    local av = center.Size
+
+                    for k = 1, TableGetn(center) do
+                        local neighbor = NavLeaves[center[k]]
+                        if neighbor.Root == center.Root and neighbor.Section == center.Section then
+                            cx = cx + neighbor.px * neighbor.Size
+                            cz = cz + neighbor.pz * neighbor.Size
+                            av = av + neighbor.Size
+                        end
+                    end
+
+                    cx = cx / av
+                    cz = cz / av
+
+                    section.Center = { cx, GetSurfaceHeight(cx, cz), cz }
+
+                    if av > 1 then
+                        DrawCircle(section.Center, 10, 'ffffff')
+                    end
+
+                    sections[label][sHead] = section
+
+                    -- proceed with processing the next section
+                    sHead = sHead + 1
+                end
+            end
+        end
+
+        tree.Sections = sections
+        tree.Leaves = output
+    end
+
+    ---@param tree NavTree
+    local function ComputeLabelArea(tree)
+        -- sum up the area for the tree as a whole
+        local labels = {}
+        for label, leaves in tree.Leaves do
+            local treeArea = 0
+            for k = 1, TableGetn(leaves) do
+                local leaf = leaves[k]
+                local areaOfLeaf = ((0.01 * leaf.Size) * (0.01 * leaf.Size))
+                treeArea = treeArea + areaOfLeaf
+            end
+
+            labels[label] = treeArea / area
+        end
+        tree.Labels = labels
+
+        -- sum up the area for each section of the tree
+        for label, sections in tree.Sections do
+            for s = 1, TableGetn(sections) do
+                local section = sections[s] --[[@as (NavSection)]]
+                local sectionArea = 0
+                for k = 1, TableGetn(section.Leaves) do
+                    local leaf = section.Leaves[k]
+                    local areaOfLeaf = ((0.01 * leaf.Size) * (0.01 * leaf.Size))
+                    sectionArea = sectionArea + areaOfLeaf
+                end
+
+                section.Area = sectionArea / area
+            end
+        end
+    end
+
+    ---@param tree NavTree
+    local function ComputeNeighbors(tree)
+
+        local thresholdArea = 0.05
+
+        for label, sections in tree.Sections do
+            for s = 1, TableGetn(sections) do
+
+                -- find neighbors for each section
+                local section = sections[s] --[[@as (NavSection)]]
+                if section.Area > thresholdArea then
+                    for l = 1, TableGetn(section.Leaves) do
+                        local leaf = section.Leaves[l]
+
+                        for n = 1, TableGetn(leaf) do
+                            local neighbor = NavLeaves[leaf[n]]
+                            local neighborTree = neighbor.Root --[[@as NavTree]]
+                            local neighborSection = NavSections[neighbor.Section] --[[@as NavSection]]
+                            if (neighbor.Label > 0) and (neighborTree ~= tree) and (neighborSection.Area > thresholdArea) then
+                                section.Neighbors[neighborSection.Identifier] = true
+                            end
+                        end
+                    end
+                end
+
+                section.Neighbors = table.unhash(section.Neighbors)
+            end
+        end
+    end
+
+    -- phase 1
+
     for _, grid in grids do
         for z = 0, LabelCompressionTreesPerAxis - 1 do
             for x = 0, LabelCompressionTreesPerAxis - 1 do
                 ---@type NavTree
                 local tree = grid.Trees[z][x]
 
-                if not tree.Labels then
-                    local leaves, count = tree:FindLeaves(cache)
+                local allLeaves, allCount = tree:FindLeaves(cache)
+                ComputeSections(tree, allLeaves, allCount)
+                ComputeLabelArea(tree)
 
-                    -- sum up area
-                    local labels = {}
-                    for k = 1, count do
-                        local leaf = leaves[k]
-                        local label = leaf.Label
-                        if label > 0 then
-                            local areaOfLeaf = ((0.01 * leaf.Size) * (0.01 * leaf.Size))
-                            labels[label] = (labels[label] or 0) + areaOfLeaf
-                        end
-                    end
+            end
+        end
+    end
 
-                    -- compute ratio of total area for each label
-                    for label, areaOfLabel in labels do
-                        labels[label] = areaOfLabel / area
-                    end
+    -- phase 2
 
-                    tree.Labels = labels
-                end
+    for _, grid in grids do
+        for z = 0, LabelCompressionTreesPerAxis - 1 do
+            for x = 0, LabelCompressionTreesPerAxis - 1 do
+                ---@type NavTree
+                local tree = grid.Trees[z][x]
+                ComputeNeighbors(tree)
             end
         end
     end

--- a/lua/sim/NavUtils.lua
+++ b/lua/sim/NavUtils.lua
@@ -185,7 +185,7 @@ local function FindLeaf(grid, position)
 
         -- try and find nearest valid neighbor
         for k = 1, TableGetn(leaf) do
-            local neighbor = NavGenerator.NavCells[leaf[k]]
+            local neighbor = NavGenerator.NavLeaves[leaf[k]]
             if neighbor.Label > 0 then
                 local size = 2 * neighbor.Size
                 size = size * size
@@ -441,7 +441,7 @@ function PathTo(layer, origin, destination)
 
         -- continue state
         for k = 1, TableGetn(leaf) do
-            local neighbor = NavGenerator.NavCells[leaf[k]]
+            local neighbor = NavGenerator.NavLeaves[leaf[k]]
             if neighbor.Label > 0 and neighbor.Seen != seenIdentifier then
                 local preferLargeNeighbor = 0
                 if leaf.Size > neighbor.Size then
@@ -532,7 +532,7 @@ function PathToWithThreatThreshold(layer, origin, destination, aibrain, threatFu
 
         -- search through neighbors
         for k = 1, TableGetn(leaf) do
-            local neighbor = NavGenerator.NavCells[leaf[k]]
+            local neighbor = NavGenerator.NavLeaves[leaf[k]]
             if neighbor.Label > 0 and neighbor.Seen != seenIdentifier then
                 local preferLargeNeighbor = 0
                 if leaf.Size > neighbor.Size then
@@ -878,7 +878,7 @@ function DirectionsFrom(layer, origin, distance, sizeThreshold)
 
         -- search neighbors for more leafs
         for k = 1, TableGetn(leaf) do
-            local neighbor = NavGenerator.NavCells[leaf[k]]
+            local neighbor = NavGenerator.NavLeaves[leaf[k]]
             if neighbor.Label > 0 and neighbor.Seen != seenIdentifier then
                 neighbor.From = leaf
                 neighbor.Seen = seenIdentifier
@@ -1000,7 +1000,7 @@ function RandomDirectionFrom(layer, origin, distance, sizeThreshold)
 
         -- search neighbors for more leafs
         for k = 1, TableGetn(leaf) do
-            local neighbor = NavGenerator.NavCells[leaf[k]]
+            local neighbor = NavGenerator.NavLeaves[leaf[k]]
             if neighbor.Label > 0 and neighbor.Seen != seenIdentifier then
                 neighbor.From = leaf
                 neighbor.Seen = seenIdentifier
@@ -1105,7 +1105,7 @@ function RetreatDirectionFrom(layer, origin, threat, distance)
         -- add neighbors of leaf that is too close to the origin
         if leaf.AcquiredCosts < distance then
             for k = 1, TableGetn(leaf) do
-                local neighbor = NavGenerator.NavCells[leaf[k]]
+                local neighbor = NavGenerator.NavLeaves[leaf[k]]
                 if neighbor.Label > 0 and neighbor.Seen != seenIdentifier then
 
                     px = neighbor.px
@@ -1246,7 +1246,7 @@ function DirectionTo(layer, origin, destination, distance)
 
         -- continue state
         for k = 1, TableGetn(leaf) do
-            local neighbor = NavGenerator.NavCells[leaf[k]]
+            local neighbor = NavGenerator.NavLeaves[leaf[k]]
             if neighbor.Label > 0 and neighbor.Seen != seenIdentifier then
                 local preferLargeNeighbor = 0
                 if leaf.Size > neighbor.Size then

--- a/tests/test_NavDatastructures.lua
+++ b/tests/test_NavDatastructures.lua
@@ -8,7 +8,7 @@ require "../lua/sim/NavDatastructures.lua"
 ---@param cost number
 local function AsLeaf(cost)
     -- Heap computes value of current node using this value
-    return { TotalCosts = cost }
+    return { HeapTotalCosts = cost }
 end
 
 luft.describe("NavDatastructures", function()


### PR DESCRIPTION
As an extension of #5574 we can now generate a coarse grid of the navigational mesh that we can use to navigate. The navigational mesh still exists - the coarse grid is generated on top of it.

For the average 10x10 map the setup generates in less than 0.4 seconds. For the average 20x20 map the setup generates in roughly 1.2 to 1.5 seconds. We can now use the coarse grid for navigation to speed up computations