### PR TITLE
Fix a bug with zappers intersecting the wrong missile

### DIFF
--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -184,7 +184,6 @@ Projectile = ClassProjectile(ProjectileMethods) {
     ---@param other Projectile The projectile we're checking the collision with
     ---@return boolean
     OnCollisionCheck = function(self, other)
-
         -- we can't hit our own
         if self.Army == other.Army then
             return false
@@ -237,7 +236,7 @@ Projectile = ClassProjectile(ProjectileMethods) {
         -- check for projectile types that require a defensive weapon to intercept
         if selfHashedCategories['TACTICAL'] or selfHashedCategories['STRATEGIC'] or selfHashedCategories['TORPEDO'] then
             if firingWeapon.Blueprint.WeaponCategory == 'Defense' then
-                return alliedCheck
+                return firingWeapon:GetCurrentTarget() == self
             else
                 return false
             end

--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -1074,7 +1074,6 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             -- for weapons that do not visually track, such as torpedo defenses
 
             if bp.DisableWhileReloading then
-                DrawCircle(unit:GetPosition(), 10, 'ffffff')
                 local reloadTime = math.floor(10 / self.Blueprint.RateOfFire) - 1
                 if reloadTime > 4 then
                     self:SetEnabled(false)

--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -1074,6 +1074,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             -- for weapons that do not visually track, such as torpedo defenses
 
             if bp.DisableWhileReloading then
+                DrawCircle(unit:GetPosition(), 10, 'ffffff')
                 local reloadTime = math.floor(10 / self.Blueprint.RateOfFire) - 1
                 if reloadTime > 4 then
                     self:SetEnabled(false)


### PR DESCRIPTION
As reported on [Discord](https://discord.com/channels/197033481883222026/1168238017572511865).

The problem was that the beam could hit multiple missiles at once. It would then be able to intercept the 'wrong' missile