### PR TITLE
Show the Backpack on SCU BubbleShield

### DIFF
--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -445,7 +445,7 @@ UnitBlueprint{
             BuildCostEnergy = 360800,
             BuildCostMass = 3500,
             BuildTime = 10800,
-            HideBones = { "Jetpack" },
+            ShowBones = { "Jetpack" },
             Icon = "sgf",
             ImpactEffects = "UEFShieldHit01",
             ImpactMesh = "/effects/entities/ShieldSection01/ShieldSection01_mesh",


### PR DESCRIPTION
For consistent look keeping the Backpack bone showing when the SACU has the bubble shield make sense and shouldn't be removed