### PR TITLE
Re-introduce the Seraphim-specific scorch splats

### DIFF
--- a/engine/Core/Blueprints/ProjectileBlueprint.lua
+++ b/engine/Core/Blueprints/ProjectileBlueprint.lua
@@ -34,6 +34,8 @@
 ---@field CameraFollowTimeout number
 --- how large is the strategic icon square for the projectile
 ---@field StrategicIconSize number
+--- flag to not use generic scorch splats
+---@field NoGenericScorchSplats? boolean
 
 ---@class ProjectileBlueprintEconomy
 --- energy cost to build this projectile

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -388,38 +388,29 @@ Projectile = ClassProjectile(ProjectileMethods) {
                 false-- damage friendly flag
             )
 
-            -- try and spawn in a splat
-            if -- if we flat out hit the terrain
-            targetType == "Terrain" or
-
-                -- if we hit a unit that is on land
-                (targetEntity and targetEntity.Layer == "Land")
+            if (-- see if we need to spawn a splat
+                targetType == "Terrain" or
+                    targetEntity and targetEntity.Layer == "Land"
+                ) and (not blueprintDisplay.NoGenericScorchSplats)
             then
-                -- choose a splat to spawn
-                local splat = blueprintDisplay.ScorchSplat
-                if not splat then
-                    splat = ScorchSplatTextures[ ScorchSplatTexturesLookup[ScorchSplatTexturesLookupIndex] ]
-                    ScorchSplatTexturesLookupIndex = ScorchSplatTexturesLookupIndex + 1
-                    if ScorchSplatTexturesLookupIndex > ScorchSplatTexturesLookupCount then
-                        ScorchSplatTexturesLookupIndex = 1
-                    end
+                -- choose a splat
+                local splat = ScorchSplatTextures[ ScorchSplatTexturesLookup[ScorchSplatTexturesLookupIndex] ]
+                ScorchSplatTexturesLookupIndex = ScorchSplatTexturesLookupIndex + 1
+                if ScorchSplatTexturesLookupIndex > ScorchSplatTexturesLookupCount then
+                    ScorchSplatTexturesLookupIndex = 1
                 end
 
-                -- choose our radius to use
-                local altRadius = blueprintDisplay.ScorchSplatSize
-                if not altRadius then
-                    local damageMultiplier = (0.01 * damageData.DamageAmount)
-                    if damageMultiplier > 1 then
-                        damageMultiplier = 1
-                    end
-                    altRadius = damageMultiplier * radius
+                -- determine radius
+                local damageMultiplier = (0.01 * damageData.DamageAmount)
+                if damageMultiplier > 1 then
+                    damageMultiplier = 1
                 end
+                local altRadius = damageMultiplier * radius
 
                 -- radius, lod and lifetime share the same rng adjustment
                 local rngRadius = altRadius * Random()
 
                 CreateSplat(
-                -- position, orientation and the splat
                     vc, -- position
                     6.28 * Random(), -- heading
                     splat, -- splat

--- a/projectiles/SBOOhwalliStrategicBomb01/SBOOhwalliStrategicBomb01_proj.bp
+++ b/projectiles/SBOOhwalliStrategicBomb01/SBOOhwalliStrategicBomb01_proj.bp
@@ -28,6 +28,7 @@ ProjectileBlueprint {
             Type = 'Small01',
         },
         StrategicIconSize = 3,
+        NoGenericScorchSplats = true
     },
     General = {
         Category = 'Bomb',

--- a/projectiles/SBOZhanaseeBomb01/SBOZhanaseeBomb01_proj.bp
+++ b/projectiles/SBOZhanaseeBomb01/SBOZhanaseeBomb01_proj.bp
@@ -29,6 +29,7 @@ ProjectileBlueprint {
             Type = 'Small01',
         },
         StrategicIconSize = 2,
+        NoGenericScorchSplats = true
     },
     General = {
         Category = 'Bomb',

--- a/projectiles/SBOZhanaseeBomb01/SBOZhanaseeBomb01_script.lua
+++ b/projectiles/SBOZhanaseeBomb01/SBOZhanaseeBomb01_script.lua
@@ -8,7 +8,12 @@ local SZhanaseeBombProjectile = import("/lua/seraphimprojectiles.lua").SZhanasee
 SBOZhanaseeBombProjectile01 = ClassProjectile(SZhanaseeBombProjectile){
     OnImpact = function(self, targetType, targetEntity)        
 		SZhanaseeBombProjectile.OnImpact(self, targetType, targetEntity) 
-        CreateLightParticle(self, -1, self.Army, 26, 5, 'sparkle_white_add_08', 'ramp_white_24' )
+        local army = self.Army
+        CreateLightParticle(self, -1, army, 26, 5, 'sparkle_white_add_08', 'ramp_white_24' )
+
+        if targetType == 'Terrain' then
+            CreateDecal( self:GetPosition(), Random() * 6.28, 'Scorch_012_albedo', '', 'Albedo', 40, 40, 300, 200, army)
+        end
 
         -- One initial projectile following same directional path as the original
         self:CreateProjectile('/effects/entities/SBOZhanaseeBombEffect01/SBOZhanaseeBombEffect01_proj.bp', 0, 0, 0, 0, 10.0, 0):SetCollision(false):SetVelocity(0,10.0, 0)


### PR DESCRIPTION
Closes https://github.com/FAForever/fa/issues/4404

Re-introduces the Seraphim-specific scorch splats for the Seraphim tech 3 bomber. Introduces a new projectile blueprint field that you can use to ignore the default scorch splats