### PR TITLE
Initial setup for the new chunk template concept

### DIFF
--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -27,7 +27,7 @@
 ---@alias EnhancementSlot "Back" | "RCH" | "LCH"
 ---@alias TechCategory "TECH1" | "TECH2" | "TECH3" | "EXPERIMENTAL"
 ---@alias LayerCategory "AIR" | "LAND" | "NAVAL"
----@alias FactionCategory "UEF" | "CYBRAN" | "AEON" | "SERAPHIM"
+---@alias FactionCategory "UEF" | "CYBRAN" | "AEON" | "SERAPHIM" | "NOMADS"
 ---@alias IconBackgroundType "air" | "amph" | "land" | "sea"
 
 ---@alias UnitId BlueprintId

--- a/lua/keymap/debugKeyActions.lua
+++ b/lua/keymap/debugKeyActions.lua
@@ -285,6 +285,26 @@ local keyActionsDebugAI = {
         action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").AIPlatoonSimpleStructureBehavior()',
         category = 'ai'
     },
+    ['create_build_template_02'] = {
+        action = 'UI_Lua import("/lua/ui/game/aichunktemplates.lua").PopulateChunkTemplate(2)',
+        category = 'ai'
+    },
+    ['create_build_template_04'] = {
+        action = 'UI_Lua import("/lua/ui/game/aichunktemplates.lua").PopulateChunkTemplate(4)',
+        category = 'ai'
+    },
+    ['create_build_template_08'] = {
+        action = 'UI_Lua import("/lua/ui/game/aichunktemplates.lua").PopulateChunkTemplate(8)',
+        category = 'ai'
+    },
+    ['create_build_template_16'] = {
+        action = 'UI_Lua import("/lua/ui/game/aichunktemplates.lua").PopulateChunkTemplate(16)',
+        category = 'ai'
+    },
+    ['create_build_template_32'] = {
+        action = 'UI_Lua import("/lua/ui/game/aichunktemplates.lua").PopulateChunkTemplate(32)',
+        category = 'ai'
+    },
 }
 
 ---@type table<string, UIKeyAction>

--- a/lua/shared/aichunktemplates.lua
+++ b/lua/shared/aichunktemplates.lua
@@ -1,0 +1,128 @@
+
+---@class AIChunkOffset
+---@field [1] number
+---@field [2] number
+
+---@class AIChunks
+---@field [1] AIChunkOffset[]    # 01 ogrid : units such as walls and tech 1 anti air and point defense
+---@field [2] AIChunkOffset[]    # 02 ogrids: units such as radars, extractors, and storages
+---@field [3] AIChunkOffset[]    # 03 ogrids: units such as a strategic missile defense
+---@field [4] AIChunkOffset[]    # 04 ogrids: exists for mods
+---@field [5] AIChunkOffset[]    # 05 ogrids: exists for mods
+---@field [6] AIChunkOffset[]    # 06 ogrids: units such as tech 2 power generators, stealth field and shield generators
+---@field [7] AIChunkOffset[]    # 07 ogrids: exists for mods
+---@field [8] AIChunkOffset[]    # 08 ogrids: units such as factories
+---@field [9] AIChunkOffset[]    # 09 ogrids: units such as the novax center
+---@field [10] AIChunkOffset[]   # 10 ogrids: units such as the paragon
+---@field [11] AIChunkOffset[]   # 11 ogrids: exists for mods
+---@field [12] AIChunkOffset[]   # 12 ogrids: exists for mods
+---@field [13] AIChunkOffset[]   # 13 ogrids: exists for mods
+---@field [14] AIChunkOffset[]   # 14 ogrids: exists for mods
+---@field [15] AIChunkOffset[]   # 15 ogrids: exists for mods
+---@field [16] AIChunkOffset[]   # 16 ogrids: exists for mods
+
+---@class AIChunkTemplate
+---@field Size number
+---@field BuildAreas AIChunkOffset[][]
+---@field Faction FactionCategory
+
+--- Verifies the chunk so that it 
+---@param template AIChunkTemplate
+function VerifyChunkTemplate(template)
+    if not template.Faction then
+        WARN("AIChunkTemplates - missing 'Faction' field")
+        return false
+    end
+
+    if not template.Size then
+        WARN("AIChunkTemplates - missing 'Size' field")
+        return false
+    end
+
+    if not template.BuildAreas then
+        WARN("AIChunkTemplates - missing 'BuildAreas' field")
+        return false
+    end
+
+    local count = table.getn(template.BuildAreas)
+    if count < 16 then
+        WARN("AIChunkTemplates - not sufficient offsets in the 'BuildAreas' field: should be at least 16")
+        return false
+    end
+
+    for k = 1, table.getn(template.BuildAreas) do
+        local offsets = template.BuildAreas[k]
+        for i = 1, table.getn(offsets) do
+            local offset = offsets[i]
+
+            if not (offset[1] or offset[2]) then
+                WARN(string.format("AIChunkTemplates - invalid offset at size %d at index %d: %s ", k, i, repru(offset)))
+            end
+        end
+    end
+
+    return true
+end
+
+---@param faction FactionCategory
+---@param size number
+---@return AIChunkTemplate?
+function CreateChunkTemplate(size, faction)
+
+    if size < 1 then
+        WARN(string.format("AIChunkTemplates - size is too small: %s", tostring(size)))
+        return nil
+    end
+
+    if size > 256 then
+        WARN(string.format("AIChunkTemplates - size is too large: %s", tostring(size)))
+        return nil
+    end
+
+    ---@type AIChunkTemplate
+    local template = {
+        Faction = faction,
+        BuildAreas = { },
+        Size = size,
+    }
+
+    -- pre-pupulate the first 16 tables
+    for k = 1, 16 do
+        template.BuildAreas[k] = {}
+    end
+
+    VerifyChunkTemplate(template)
+
+    return template
+end
+
+--- Copies the template 
+---@param template AIChunkTemplate
+function CopyChunkTemplate(template)
+
+end
+
+--- Turns the template into a stringified Lua table
+---@param template AIChunkTemplate
+function StringifyChunkTemplate(template)
+
+    local lines = { }
+
+    table.insert(lines, "{\r\n")
+    table.insert(lines, string.format("  Faction = %s, \r\n", tostring(template.Faction)))
+    table.insert(lines, string.format("  Size = %d, \r\n", tostring(template.Size)))
+    table.insert(lines, string.format("  BuildAreas = { \r\n", tostring(template.Size)))
+    for k = 1, table.getn(template.BuildAreas) do
+        local buildOffsets = template.BuildAreas[k]
+        local content = { }
+        for l = 1, table.getn(buildOffsets) do
+            local offset = buildOffsets[l]
+            content[l] = string.format("{ %.2f, %.2f }, ", offset[1], offset[2])
+        end
+        table.insert(lines, string.format("    { %s }, \r\n", table.concat(content, "")))
+    end
+    table.insert(lines, "  }, \r\n")
+    table.insert(lines, "} \r\n")
+
+    return table.concat(lines, "")
+end

--- a/lua/ui/game/aichunktemplates.lua
+++ b/lua/ui/game/aichunktemplates.lua
@@ -1,0 +1,97 @@
+
+local UserDecal = import("/lua/user/userdecal.lua").UserDecal
+local CreateChunkTemplate = import("/lua/shared/aichunktemplates.lua").CreateChunkTemplate
+local VerifyChunkTemplate = import("/lua/shared/aichunktemplates.lua").VerifyChunkTemplate
+local StringifyChunkTemplate = import("/lua/shared/aichunktemplates.lua").StringifyChunkTemplate
+
+---@param size number
+function PopulateChunkTemplate (size)
+    -- sanity check
+    local template = CreateChunkTemplate(size, 'UEF')
+    if not template then
+        return
+    end
+
+    -- sanity check
+    local selection = GetSelectedUnits()
+    if not selection or table.empty(selection) then
+        return
+    end
+
+    local buildAreas = template.BuildAreas
+
+    -- for debugging
+    local decals = { }
+    ForkThread(
+        function()
+            WaitSeconds(10)
+            for k, v in decals do
+                v:Destroy()
+            end
+        end
+    )
+
+    local c = table.getn(selection)
+    local cx, cz = 0, 0
+    for k = 1, c do
+        -- compute center
+        local unit = selection[k]
+        local position = unit:GetPosition()
+        cx = cx + position[1]
+        cz = cz + position[3]
+
+        -- determine skirt size
+        local blueprint = unit:GetBlueprint()
+
+        ---@type string | number
+        -- local id = "Walls"
+        -- if not EntityCategoryContains(categories.WALL, unit) then
+            id = math.min(math.max(blueprint.Physics.SkirtSizeX, blueprint.Physics.SkirtSizeZ), 16)
+        -- end
+
+        table.insert(buildAreas[id], unit)
+    end
+
+    cx = math.floor((cx / c) / size) * size + 0.5 * size
+    cz = math.floor((cz / c) / size) * size + 0.5 * size
+
+    for k = 1, table.getn(buildAreas) do
+        local buildOffsets = buildAreas[k]
+        for u = 1, table.getn(buildOffsets) do
+            local unit = buildOffsets[u] --[[@as UserUnit]]
+            local position = unit:GetPosition()
+            buildOffsets[u] = {
+                position[1] - cx,
+                position[3] - cz
+            }
+        end
+    end
+
+    --#region debugging
+
+    local decal = UserDecal()
+    decal:SetTexture("/textures/ui/common/game/AreaTargetDecal/nuke_icon_inner.dds")
+    decal:SetScale({ 20, 1, 20 })
+    decal:SetPosition({cx, 0, cz})
+    table.insert(decals, decal)
+
+    for k = 1, table.getn(buildAreas) do
+        local buildOffsets = buildAreas[k]
+        for u = 1, table.getn(buildOffsets) do
+            local offset = buildOffsets[u]
+
+            local decal = UserDecal()
+            decal:SetTexture("/textures/ui/common/game/AreaTargetDecal/nuke_icon_inner.dds")
+            decal:SetScale({ 1, 1, 1 })
+            decal:SetPosition({ cx + offset[1], 0, cz + offset[2] })
+            table.insert(decals, decal)
+        end
+    end
+
+    --#endregion
+
+    LOG(StringifyChunkTemplate(template))
+    VerifyChunkTemplate(template)
+
+    return template
+end


### PR DESCRIPTION
The chunk templates will eventually replace the base templates. It is similar, if not equal, to the templates used by the LOUD community. 

We use the navigational mesh to divide a map into squares. These 'chunks' templates represent what an AI could populate (in terms of structures) in one of those squares.

![image](https://github.com/FAForever/fa/assets/15778155/f2868a6b-128e-4f17-91e2-e94d3a33b62f)

We can then create templates that are similar to build templates that fit in exactly one of those squares. As an example:

![image](https://github.com/FAForever/fa/assets/15778155/fc2e9d6b-73ca-4097-bd9d-529abe25688c)

Each of those squares represents a chunk. A chunk of an AI base. We can create many variations of each size of a chunk to make sure one base is unlike the other. 

The idea is that the AI will claim additional chunks as it tries to build structures. This way the AI can expand the base and gain more ground.

We need chunks to prevent the AI from exhaustively searching for a place to build. An example are the current [base templates](https://github.com/FAForever/fa/blob/deploy/fafdevelop/lua/basetemplates.lua). These are gigantic files with gigantic tables that the AI can use to find a build location that is 'nearby' of the intended build location. On average there will be a lot of negative tests before a valid build location is found.