### PR TITLE
Remove pathing parameters that should not have been merged in

### DIFF
--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -86,10 +86,6 @@ end
 --but before any armies are created.
 function SetupSession()
 
-    ScenarioInfo.pathcap_land = 20000
-    ScenarioInfo.pathcap_sea = 20000
-    ScenarioInfo.pathcap_both = 20000
-
     import("/lua/ai/gridreclaim.lua").Setup()
 
     ScenarioInfo.TriggerManager = import("/lua/triggermanager.lua").Manager


### PR DESCRIPTION
These were found by @Hdt80bro and I was testing them while being checked out on #5525 . These three parameter changes are likely the cause of the path finding hiccups that people are experiencing. We're removing them again, so that they default back to the values defined by the engine.