### PR TITLE
Reduce overhead of the projectile hierarchy

### DIFF
--- a/engine/Sim/Projectile.lua
+++ b/engine/Sim/Projectile.lua
@@ -28,7 +28,7 @@ function Projectile:ChangeZigZagFrequency(freq)
 end
 
 --- Creates a child projectile that inherits the speed and orientation of its parent
----@param blueprint ProjectileBlueprint
+---@param blueprint BlueprintId
 ---@return Projectile
 function Projectile:CreateChildProjectile(blueprint)
 end

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -942,7 +942,7 @@ Projectile = ClassProjectile(ProjectileMethods) {
     --#region C hooks
 
     --- Creates a child projectile that inherits the speed, orientation and launcher of its parent
-    ---@param blueprint ProjectileBlueprint
+    ---@param blueprint BlueprintId
     ---@return Projectile
     CreateChildProjectile = function(self, blueprint)
         local projectile = ProjectileMethods.CreateChildProjectile(self, blueprint)

--- a/lua/sim/projectiles/DebrisProjectile.lua
+++ b/lua/sim/projectiles/DebrisProjectile.lua
@@ -21,10 +21,13 @@
 --******************************************************************************************************
 
 local DummyProjectile = import("/lua/sim/projectile.lua").DummyProjectile
+local DummyProjectileOnCreate = DummyProjectile.OnCreate
 
 -- upvalue for performance
 local Random = Random
 local CreateEmitterOnEntity = CreateEmitterOnEntity
+local CreateEmitterAtEntity = CreateEmitterAtEntity
+
 local IEffectScaleEmitter = _G.moho.IEffect.ScaleEmitter
 
 ---@class BaseGenericDebris : DummyProjectile
@@ -36,11 +39,12 @@ BaseGenericDebris = ClassDummyProjectile(DummyProjectile) {
 
     ---@param self BaseGenericDebris
     OnCreate = function(self)
-        DummyProjectile.OnCreate(self)
+        DummyProjectileOnCreate(self)
 
         local army = self.Army
-        for k, effect in self.FxTrails do
-            CreateEmitterOnEntity(self, army, effect)
+        local fxTrails = self.FxTrails
+        for i in fxTrails do
+            CreateEmitterOnEntity(self, army, fxTrails[i])
         end
     end,
 
@@ -56,7 +60,7 @@ BaseGenericDebris = ClassDummyProjectile(DummyProjectile) {
                 local effect = CreateEmitterAtEntity(self, army, fxBlueprint)
                 IEffectScaleEmitter(effect, 0.05 + 0.15 * Random())
             end
-        -- default impact for water
+            -- default impact for water
         elseif targetType == 'Water' then
             for _, fxBlueprint in self.FxImpactWater do
                 local effect = CreateEmitterAtEntity(self, army, fxBlueprint)

--- a/lua/sim/projectiles/EmitterProjectile.lua
+++ b/lua/sim/projectiles/EmitterProjectile.lua
@@ -47,14 +47,8 @@ EmitterProjectile = ClassProjectile(Projectile) {
 
         for i in fxTrails do
             local effect = CreateEmitterOnEntity(self, army, fxTrails[i])
-
-            if fxTrailScale ~= 1 then
-                IEffectScaleEmitter(effect, fxTrailScale)
-            end
-
-            if fxTrailOffset ~= 0 then
-                IEffectOffsetEmitter(effect, 0, 0, fxTrailOffset)
-            end
+            IEffectScaleEmitter(effect, fxTrailScale)
+            IEffectOffsetEmitter(effect, 0, 0, fxTrailOffset)
         end
     end,
 }

--- a/lua/sim/projectiles/EmitterProjectile.lua
+++ b/lua/sim/projectiles/EmitterProjectile.lua
@@ -23,6 +23,8 @@
 
 local Projectile = import("/lua/sim/projectile.lua").Projectile
 
+local ProjectileOnCreate = Projectile.OnCreate
+
 -- upvalue scope for performance
 local CreateEmitterOnEntity = CreateEmitterOnEntity
 local IEffectScaleEmitter = _G.moho.IEffect.ScaleEmitter
@@ -30,27 +32,27 @@ local IEffectOffsetEmitter = _G.moho.IEffect.OffsetEmitter
 
 ---@class EmitterProjectile : Projectile
 EmitterProjectile = ClassProjectile(Projectile) {
-    FxTrails = {'/effects/emitters/missile_munition_trail_01_emit.bp',},
+    FxTrails = { '/effects/emitters/missile_munition_trail_01_emit.bp', },
     FxTrailScale = 1,
     FxTrailOffset = 0,
 
     ---@param self EmitterProjectile
     OnCreate = function(self)
-        Projectile.OnCreate(self)
+        ProjectileOnCreate(self)
 
+        local army = self.Army
+        local fxTrails = self.FxTrails
         local fxTrailScale = self.FxTrailScale
         local fxTrailOffset = self.FxTrailOffset
-        local army = self.Army
 
-        local effect
-        for i in self.FxTrails do
-            effect = CreateEmitterOnEntity(self, army, self.FxTrails[i])
+        for i in fxTrails do
+            local effect = CreateEmitterOnEntity(self, army, fxTrails[i])
 
             if fxTrailScale ~= 1 then
                 IEffectScaleEmitter(effect, fxTrailScale)
             end
 
-            if fxTrailOffset ~= 1 then
+            if fxTrailOffset ~= 0 then
                 IEffectOffsetEmitter(effect, 0, 0, fxTrailOffset)
             end
         end

--- a/lua/sim/projectiles/MultiBeamProjectile.lua
+++ b/lua/sim/projectiles/MultiBeamProjectile.lua
@@ -22,25 +22,26 @@
 
 
 local EmitterProjectile = import("/lua/sim/projectiles/emitterprojectile.lua").EmitterProjectile
-
+local EmitterProjectileOnCreate = EmitterProjectile.OnCreate
 -- upvalue scope for performance
 local CreateBeamEmitterOnEntity = CreateBeamEmitterOnEntity
 
 ---@class MultiBeamProjectile : EmitterProjectile
 MultiBeamProjectile = ClassProjectile(EmitterProjectile) {
 
-    Beams = {'/effects/emitters/default_beam_01_emit.bp',},
-    FxTrails = { },
+    Beams = { '/effects/emitters/default_beam_01_emit.bp', },
+    FxTrails = {},
 
     ---@param self MultiBeamProjectile
     OnCreate = function(self)
-        EmitterProjectile.OnCreate(self)
+        EmitterProjectileOnCreate(self)
 
         -- local scope for performance
         local army = self.Army
+        local beams = self.Beams
 
-        for k, v in self.Beams do
-            CreateBeamEmitterOnEntity(self, -1, army, v)
+        for i in beams do
+            CreateBeamEmitterOnEntity(self, -1, army, beams[i])
         end
     end,
 }

--- a/lua/sim/projectiles/MultiCompositeEmitterProjectile.lua
+++ b/lua/sim/projectiles/MultiCompositeEmitterProjectile.lua
@@ -22,6 +22,7 @@
 
 
 local MultiPolyTrailProjectile = import("/lua/sim/projectiles/multipolytrailprojectile.lua").MultiPolyTrailProjectile
+local MultiPolyTrailProjectileOnCreate = MultiPolyTrailProjectile.OnCreate
 
 -- upvalue for performance
 local CreateBeamEmitterOnEntity = CreateBeamEmitterOnEntity
@@ -29,21 +30,21 @@ local CreateBeamEmitterOnEntity = CreateBeamEmitterOnEntity
 ---@class MultiCompositeEmitterProjectile : MultiPolyTrailProjectile
 MultiCompositeEmitterProjectile = ClassProjectile(MultiPolyTrailProjectile) {
 
-    Beams = {'/effects/emitters/default_beam_01_emit.bp',},
-    PolyTrails = {'/effects/emitters/test_missile_trail_emit.bp'},
+    Beams = { '/effects/emitters/default_beam_01_emit.bp', },
+    PolyTrails = { '/effects/emitters/test_missile_trail_emit.bp' },
     PolyTrailOffset = { 0 },
     RandomPolyTrails = 0,
-    FxTrails = { },
+    FxTrails = {},
 
     ---@param self MultiCompositeEmitterProjectile
     OnCreate = function(self)
-        MultiPolyTrailProjectile.OnCreate(self)
+        MultiPolyTrailProjectileOnCreate(self)
 
         local army = self.Army
         local beams = self.Beams
 
-        for _, beamName in beams do
-            CreateBeamEmitterOnEntity(self, -1, army, beamName)
+        for i in beams do
+            CreateBeamEmitterOnEntity(self, -1, army, beams[i])
         end
     end,
 }

--- a/lua/sim/projectiles/MultiPolyTrailProjectile.lua
+++ b/lua/sim/projectiles/MultiPolyTrailProjectile.lua
@@ -55,20 +55,12 @@ MultiPolyTrailProjectile = ClassProjectile(EmitterProjectile) {
                 for i = 1, numberOfPolyTrails do
                     index = Random(1, polyTrailCount)
                     local effect = CreateTrail(self, -1, army, polyTrails[index])
-
-                    -- only do these engine calls when they matter
-                    if polyTrailOffsets[index] ~= 0 then
-                        IEffectOffsetEmitter(effect, 0, 0, polyTrailOffsets[index])
-                    end
+                    IEffectOffsetEmitter(effect, 0, 0, polyTrailOffsets[index])
                 end
             else
                 for i = 1, polyTrailCount do
                     local effect = CreateTrail(self, -1, army, polyTrails[i])
-
-                    -- only do these engine calls when they matter
-                    if polyTrailOffsets[i] ~= 0 then
-                        IEffectOffsetEmitter(effect, 0, 0, polyTrailOffsets[i])
-                    end
+                    IEffectOffsetEmitter(effect, 0, 0, polyTrailOffsets[i])
                 end
             end
         end

--- a/lua/sim/projectiles/MultiPolyTrailProjectile.lua
+++ b/lua/sim/projectiles/MultiPolyTrailProjectile.lua
@@ -21,27 +21,27 @@
 --******************************************************************************************************
 
 local EmitterProjectile = import("/lua/sim/projectiles/emitterprojectile.lua").EmitterProjectile
+local EmitterProjectileOnCreate = EmitterProjectile.OnCreate
 
 -- upvalue scope for performance
 local Random = Random
 local CreateTrail = CreateTrail
 local IEffectOffsetEmitter = _G.moho.IEffect.OffsetEmitter
-
 local TableGetn = table.getn
 
 ---@class MultiPolyTrailProjectile : EmitterProjectile
 MultiPolyTrailProjectile = ClassProjectile(EmitterProjectile) {
 
-    PolyTrails = {'/effects/emitters/test_missile_trail_emit.bp'},
+    PolyTrails = { '/effects/emitters/test_missile_trail_emit.bp' },
     PolyTrailOffset = { 0 },
-    FxTrails = { },
+    FxTrails = {},
 
     --- Count of how many are selected randomly for PolyTrail table
     RandomPolyTrails = 0,
 
     ---@param self MultiPolyTrailProjectile
     OnCreate = function(self)
-        EmitterProjectile.OnCreate(self)
+        EmitterProjectileOnCreate(self)
 
         local army = self.Army
         local polyTrails = self.PolyTrails
@@ -50,7 +50,6 @@ MultiPolyTrailProjectile = ClassProjectile(EmitterProjectile) {
 
         if polyTrails then
             local polyTrailCount = TableGetn(polyTrails)
-
             if numberOfPolyTrails ~= 0 then
                 local index
                 for i = 1, numberOfPolyTrails do
@@ -58,7 +57,7 @@ MultiPolyTrailProjectile = ClassProjectile(EmitterProjectile) {
                     local effect = CreateTrail(self, -1, army, polyTrails[index])
 
                     -- only do these engine calls when they matter
-                    if polyTrailOffsets[index] ~= 0 then 
+                    if polyTrailOffsets[index] ~= 0 then
                         IEffectOffsetEmitter(effect, 0, 0, polyTrailOffsets[index])
                     end
                 end
@@ -67,7 +66,7 @@ MultiPolyTrailProjectile = ClassProjectile(EmitterProjectile) {
                     local effect = CreateTrail(self, -1, army, polyTrails[i])
 
                     -- only do these engine calls when they matter
-                    if polyTrailOffsets[i] ~= 0 then 
+                    if polyTrailOffsets[i] ~= 0 then
                         IEffectOffsetEmitter(effect, 0, 0, polyTrailOffsets[i])
                     end
                 end

--- a/lua/sim/projectiles/NukeProjectile.lua
+++ b/lua/sim/projectiles/NukeProjectile.lua
@@ -25,13 +25,13 @@ local NullShell = import("/lua/sim/projectiles/nullprojectile.lua").NullShell
 ---@class NukeProjectile : NullShell
 NukeProjectile = ClassProjectile(NullShell) {
 
-    InitialEffects = { },
-    LaunchEffects = { },
-    ThrustEffects = { },
+    InitialEffects = {},
+    LaunchEffects = {},
+    ThrustEffects = {},
 
     ---@param self NukeProjectile
     MovementThread = function(self)
-		self.Nuke = true
+        self.Nuke = true
         self:CreateEffects(self.InitialEffects, self.Army, 1)
         self:TrackTarget(false)
         WaitTicks(26) -- Height
@@ -108,7 +108,8 @@ NukeProjectile = ClassProjectile(NullShell) {
     ---@param TargetType string
     ---@param TargetEntity Unit | Prop
     OnImpact = function(self, TargetType, TargetEntity)
-        if not TargetEntity or not EntityCategoryContains(categories.PROJECTILE * categories.ANTIMISSILE * categories.TECH3, TargetEntity) then
+        if not TargetEntity or
+            not EntityCategoryContains(categories.PROJECTILE * categories.ANTIMISSILE * categories.TECH3, TargetEntity) then
             local myBlueprint = self.Blueprint
             if myBlueprint.Audio.NukeExplosion then
                 self:PlaySound(myBlueprint.Audio.NukeExplosion)
@@ -116,7 +117,7 @@ NukeProjectile = ClassProjectile(NullShell) {
 
             self.effectEntity = self:CreateProjectile(self.effectEntityPath, 0, 0, 0, nil, nil, nil):SetCollision(false)
             self.effectEntity:ForkThread(self.effectEntity.EffectThread)
-            self.Trash:Add(ForkThread(self.ForceThread,self))
+            self.Trash:Add(ForkThread(self.ForceThread, self))
         end
         NullShell.OnImpact(self, TargetType, TargetEntity)
     end,
@@ -126,12 +127,12 @@ NukeProjectile = ClassProjectile(NullShell) {
         local launcher = self.Launcher
         if launcher and not launcher.Dead and launcher.EventCallbacks.ProjectileDamaged then
             self.ProjectileDamaged = {}
-            for k,v in launcher.EventCallbacks.ProjectileDamaged do
+            for k, v in launcher.EventCallbacks.ProjectileDamaged do
                 table.insert(self.ProjectileDamaged, v)
             end
         end
         self:SetCollisionShape('Sphere', 0, 0, 0, 2.0)
-        self.Trash:Add(ForkThread(self.MovementThread,self))
+        self.Trash:Add(ForkThread(self.MovementThread, self))
     end,
 
     ---@param self NukeProjectile
@@ -141,7 +142,7 @@ NukeProjectile = ClassProjectile(NullShell) {
     ---@param damageType DamageType
     DoTakeDamage = function(self, instigator, amount, vector, damageType)
         if self.ProjectileDamaged then
-            for k,v in self.ProjectileDamaged do
+            for k, v in self.ProjectileDamaged do
                 v(self)
             end
         end
@@ -154,11 +155,11 @@ NukeProjectile = ClassProjectile(NullShell) {
     ---@param vector Vector
     ---@param damageType DamageType
     OnDamage = function(self, instigator, amount, vector, damageType)
-		local bp = self.Blueprint.Defense.MaxHealth
-			if bp then
-			self:DoTakeDamage(instigator, amount, vector, damageType)
-		else
-			self:OnKilled(instigator, damageType)
-		end
+        local bp = self.Blueprint.Defense.MaxHealth
+        if bp then
+            self:DoTakeDamage(instigator, amount, vector, damageType)
+        else
+            self:OnKilled(instigator, damageType)
+        end
     end,
 }

--- a/lua/sim/projectiles/OnWaterEntryEmitterProjectile.lua
+++ b/lua/sim/projectiles/OnWaterEntryEmitterProjectile.lua
@@ -21,17 +21,22 @@
 --******************************************************************************************************
 
 local Projectile = import("/lua/sim/projectile.lua").Projectile
+local ProjectileOnCreate = Projectile.OnCreate
+local ProjectileOnEnterWater = Projectile.OnEnterWater
+local ProjectileOnImpact = Projectile.OnImpact
 
 -- upvalue scope for performance
 local WaitTicks = WaitTicks
 local IsDestroyed = IsDestroyed
 local CreateTrail = CreateTrail
+local GetSurfaceHeight = GetSurfaceHeight
 local CreateEmitterOnEntity = CreateEmitterOnEntity
 
 local IEffectScaleEmitter = _G.moho.IEffect.ScaleEmitter
 local IEffectOffsetEmitter = _G.moho.IEffect.OffsetEmitter
 
 ---@class OnWaterEntryEmitterProjectile : Projectile
+---@field MovementThread fun(projectile: OnWaterEntryEmitterProjectile)
 OnWaterEntryEmitterProjectile = ClassProjectile(Projectile) {
     FxTrails = { '/effects/emitters/torpedo_munition_trail_01_emit.bp', },
     FxTrailScale = 1,
@@ -50,7 +55,7 @@ OnWaterEntryEmitterProjectile = ClassProjectile(Projectile) {
     ---@param self OnWaterEntryEmitterProjectile
     ---@param inWater boolean
     OnCreate = function(self, inWater)
-        Projectile.OnCreate(self, inWater)
+        ProjectileOnCreate(self, inWater)
 
         if inWater then
 
@@ -126,7 +131,7 @@ OnWaterEntryEmitterProjectile = ClassProjectile(Projectile) {
 
     ---@param self OnWaterEntryEmitterProjectile
     OnEnterWater = function(self)
-        Projectile.OnEnterWater(self)
+        ProjectileOnEnterWater(self)
 
         self:SetVelocityAlign(true)
         self:SetStayUpright(false)
@@ -137,8 +142,9 @@ OnWaterEntryEmitterProjectile = ClassProjectile(Projectile) {
         self.Trash:Add(ForkThread(self.EnterWaterThread, self))
 
         -- adjusts the velocity / acceleration, used for torpedo bombers
-        if self.MovementThread then
-            self.Trash:Add(ForkThread(self.MovementThread, self))
+        local movementThread = self.MovementThread
+        if movementThread then
+            self.Trash:Add(ForkThread(movementThread, self))
         end
     end,
 
@@ -155,6 +161,6 @@ OnWaterEntryEmitterProjectile = ClassProjectile(Projectile) {
             end
         end
 
-        Projectile.OnImpact(self, targetType, targetEntity)
+        ProjectileOnImpact(self, targetType, targetEntity)
     end,
 }

--- a/lua/sim/projectiles/OnWaterEntryEmitterProjectile.lua
+++ b/lua/sim/projectiles/OnWaterEntryEmitterProjectile.lua
@@ -69,24 +69,13 @@ OnWaterEntryEmitterProjectile = ClassProjectile(Projectile) {
 
             for i in fxTrails do
                 local effect = CreateEmitterOnEntity(self, army, fxTrails[i])
-
-                -- only do these engine calls when they matter
-                if fxTrailScale ~= 1 then
-                    IEffectScaleEmitter(effect, fxTrailScale)
-                end
-
-                if fxTrailOffset ~= 1 then
-                    IEffectOffsetEmitter(effect, 0, 0, fxTrailOffset)
-                end
+                IEffectScaleEmitter(effect, fxTrailScale)
+                IEffectOffsetEmitter(effect, 0, 0, fxTrailOffset)
             end
 
             if polyTrail ~= '' then
                 local effect = CreateTrail(self, -1, army, polyTrail)
-
-                -- only do these engine calls when they matter
-                if polyTrailOffset ~= 0 then
-                    IEffectOffsetEmitter(effect, 0, 0, polyTrailOffset)
-                end
+                IEffectOffsetEmitter(effect, 0, 0, polyTrailOffset)
             end
         end
     end,
@@ -108,24 +97,13 @@ OnWaterEntryEmitterProjectile = ClassProjectile(Projectile) {
 
         for i in fxTrails do
             local effect = CreateEmitterOnEntity(self, army, fxTrails[i])
-
-            -- only do these engine calls when they matter
-            if fxTrailScale ~= 1 then
-                IEffectScaleEmitter(effect, fxTrailScale)
-            end
-
-            if fxTrailOffset ~= 1 then
-                IEffectOffsetEmitter(effect, 0, 0, fxTrailOffset)
-            end
+            IEffectScaleEmitter(effect, fxTrailScale)
+            IEffectOffsetEmitter(effect, 0, 0, fxTrailOffset)
         end
 
         if polyTrail ~= '' then
             local effect = CreateTrail(self, -1, army, polyTrail)
-
-            -- only do these engine calls when they matter
-            if polyTrailOffset ~= 0 then
-                IEffectOffsetEmitter(effect, 0, 0, polyTrailOffset)
-            end
+            IEffectOffsetEmitter(effect, 0, 0, polyTrailOffset)
         end
     end,
 

--- a/lua/sim/projectiles/OverchargeProjectile.lua
+++ b/lua/sim/projectiles/OverchargeProjectile.lua
@@ -57,8 +57,8 @@ OverchargeProjectile = ClassSimple {
 
         local wep = launcher:GetWeaponByLabel('OverCharge')
         if not wep then
-             return
-            end
+            return
+        end
 
         if IsDestroyed(wep) then
             return
@@ -106,7 +106,7 @@ OverchargeProjectile = ClassSimple {
             local idealDamage = targetEntity:GetHealth()
             local maxHP = self:UnitsDetection(targetType, targetEntity)
             idealDamage = maxHP or data.minDamage
-            
+
             local targetCats = targetEntity:GetBlueprint().CategoriesHash
 
             -----SHIELDS------
@@ -132,7 +132,7 @@ OverchargeProjectile = ClassSimple {
             -- prevents radars blinks if there is less than 5k e in storage when OC hits the target
             if energyAvailable < 7500 then
                 damage = energyLimitDamage
-            end   
+            end
         end
         -- Turn the final damage into energy
         local drain = self:DamageAsEnergy(damage)
@@ -148,7 +148,8 @@ OverchargeProjectile = ClassSimple {
                 OCProjectiles[self.Army] = OCProjectiles[self.Army] - 1
                 launcher.EconDrain = nil
                 -- if oc depletes a mobile shield it kills the generator, vet counted, no wreck left
-                if killShieldUnit and targetEntity and not IsDestroyed(targetEntity) and (IsDestroyed(targetEntity.MyShield) or (not targetEntity.MyShield:IsUp())) then
+                if killShieldUnit and targetEntity and not IsDestroyed(targetEntity) and
+                    (IsDestroyed(targetEntity.MyShield) or (not targetEntity.MyShield:IsUp())) then
                     targetEntity:Kill(launcher, 'Overcharge', 2)
                     launcher:OnKilledUnit(targetEntity, targetEntity:GetVeterancyValue())
                 end
@@ -175,21 +176,23 @@ OverchargeProjectile = ClassSimple {
     ---@param targetEntity Unit
     ---@return number?
     UnitsDetection = function(self, targetType, targetEntity)
-     -- looking for units around target which are in splash range
+        -- looking for units around target which are in splash range
         local launcher = self.Launcher
         local maxHP = 0
 
-        for _, unit in UnitsInSphere(launcher, self:GetPosition(), 2.7, categories.MOBILE -categories.COMMAND) or {} do
-                if unit.MyShield and unit:GetHealth() + unit.MyShield:GetHealth() > maxHP then
-                    maxHP = unit:GetHealth() + unit.MyShield:GetHealth()
-                elseif unit:GetHealth() > maxHP then
-                    maxHP = unit:GetHealth()
-                end
+        for _, unit in UnitsInSphere(launcher, self:GetPosition(), 2.7, categories.MOBILE - categories.COMMAND) or {} do
+            if unit.MyShield and unit:GetHealth() + unit.MyShield:GetHealth() > maxHP then
+                maxHP = unit:GetHealth() + unit.MyShield:GetHealth()
+            elseif unit:GetHealth() > maxHP then
+                maxHP = unit:GetHealth()
+            end
         end
 
-        for _, unit in UnitsInSphere(launcher, self:GetPosition(), 13.2, categories.EXPERIMENTAL*categories.LAND*categories.MOBILE) or {} do
+        for _, unit in UnitsInSphere(launcher, self:GetPosition(), 13.2,
+            categories.EXPERIMENTAL * categories.LAND * categories.MOBILE) or {} do
             -- Special for fatty's shield
-            if EntityCategoryContains(categories.UEF, unit) and unit.MyShield._IsUp and unit.MyShield:GetMaxHealth() > maxHP then
+            if EntityCategoryContains(categories.UEF, unit) and unit.MyShield._IsUp and
+                unit.MyShield:GetMaxHealth() > maxHP then
                 maxHP = unit.MyShield:GetMaxHealth()
             elseif unit:GetHealth() > maxHP then
                 local distance = math.min(unit:GetBlueprint().SizeX, unit:GetBlueprint().SizeZ)

--- a/lua/sim/projectiles/SingleBeamProjectile.lua
+++ b/lua/sim/projectiles/SingleBeamProjectile.lua
@@ -30,7 +30,7 @@ local CreateBeamEmitterOnEntity = CreateBeamEmitterOnEntity
 SingleBeamProjectile = ClassProjectile(EmitterProjectile) {
 
     BeamName = '/effects/emitters/default_beam_01_emit.bp',
-    FxTrails = { },
+    FxTrails = {},
 
     ---@param self SingleBeamProjectile
     OnCreate = function(self)

--- a/lua/sim/projectiles/SingleBeamProjectile.lua
+++ b/lua/sim/projectiles/SingleBeamProjectile.lua
@@ -21,6 +21,7 @@
 --******************************************************************************************************
 
 local EmitterProjectile = import("/lua/sim/projectiles/emitterprojectile.lua").EmitterProjectile
+local EmitterProjectileOnCreate = EmitterProjectile.OnCreate
 
 -- upvalue scope for performance
 local CreateBeamEmitterOnEntity = CreateBeamEmitterOnEntity
@@ -33,10 +34,12 @@ SingleBeamProjectile = ClassProjectile(EmitterProjectile) {
 
     ---@param self SingleBeamProjectile
     OnCreate = function(self)
-        EmitterProjectile.OnCreate(self)
+        EmitterProjectileOnCreate(self)
 
-        if self.BeamName then
-            CreateBeamEmitterOnEntity(self, -1, self.Army, self.BeamName)
+        local army = self.Army
+        local beamName = self.BeamName
+        if beamName ~= '' then
+            CreateBeamEmitterOnEntity(self, -1, army, beamName)
         end
     end,
 }

--- a/lua/sim/projectiles/SingleCompositeEmitterProjectile.lua
+++ b/lua/sim/projectiles/SingleCompositeEmitterProjectile.lua
@@ -21,10 +21,12 @@
 --******************************************************************************************************
 
 local SinglePolyTrailProjectile = import("/lua/sim/projectiles/singlepolytrailprojectile.lua").SinglePolyTrailProjectile
+local SinglePolyTrailProjectileOnCreate = SinglePolyTrailProjectile.OnCreate
 
 -- upvalue for performance
 local CreateBeamEmitterOnEntity = CreateBeamEmitterOnEntity
 
+---@class SingleCompositeEmitterProjectile : SinglePolyTrailProjectile
 SingleCompositeEmitterProjectile = ClassProjectile(SinglePolyTrailProjectile) {
 
     BeamName = '/effects/emitters/default_beam_01_emit.bp',
@@ -32,11 +34,10 @@ SingleCompositeEmitterProjectile = ClassProjectile(SinglePolyTrailProjectile) {
 
     ---@param self SingleCompositeEmitterProjectile
     OnCreate = function(self)
-        SinglePolyTrailProjectile.OnCreate(self)
+        SinglePolyTrailProjectileOnCreate(self)
 
         local army = self.Army
         local beamName = self.BeamName
-
         if beamName ~= '' then
             CreateBeamEmitterOnEntity(self, -1, army, beamName)
         end

--- a/lua/sim/projectiles/SingleCompositeEmitterProjectile.lua
+++ b/lua/sim/projectiles/SingleCompositeEmitterProjectile.lua
@@ -30,7 +30,7 @@ local CreateBeamEmitterOnEntity = CreateBeamEmitterOnEntity
 SingleCompositeEmitterProjectile = ClassProjectile(SinglePolyTrailProjectile) {
 
     BeamName = '/effects/emitters/default_beam_01_emit.bp',
-    FxTrails = { },
+    FxTrails = {},
 
     ---@param self SingleCompositeEmitterProjectile
     OnCreate = function(self)

--- a/lua/sim/projectiles/SinglePolyTrailProjectile.lua
+++ b/lua/sim/projectiles/SinglePolyTrailProjectile.lua
@@ -32,7 +32,7 @@ SinglePolyTrailProjectile = ClassProjectile(EmitterProjectile) {
 
     PolyTrail = '/effects/emitters/test_missile_trail_emit.bp',
     PolyTrailOffset = 0,
-    FxTrails = { },
+    FxTrails = {},
 
     ---@param self SinglePolyTrailProjectile
     OnCreate = function(self)
@@ -44,11 +44,7 @@ SinglePolyTrailProjectile = ClassProjectile(EmitterProjectile) {
 
         if polyTrail ~= '' then
             local effect = CreateTrail(self, -1, army, polyTrail)
-
-            -- only do these engine calls when they matter
-            if polyTrailOffset ~= 0 then
-                IEffectOffsetEmitter(effect, 0, 0, polyTrailOffset)
-            end
+            IEffectOffsetEmitter(effect, 0, 0, polyTrailOffset)
         end
     end,
 }

--- a/lua/sim/projectiles/SinglePolyTrailProjectile.lua
+++ b/lua/sim/projectiles/SinglePolyTrailProjectile.lua
@@ -21,6 +21,7 @@
 --******************************************************************************************************
 
 local EmitterProjectile = import("/lua/sim/projectiles/emitterprojectile.lua").EmitterProjectile
+local EmitterProjectileOnCreate = EmitterProjectile.OnCreate
 
 -- upvalue scope for performance
 local CreateTrail = CreateTrail
@@ -35,7 +36,7 @@ SinglePolyTrailProjectile = ClassProjectile(EmitterProjectile) {
 
     ---@param self SinglePolyTrailProjectile
     OnCreate = function(self)
-        EmitterProjectile.OnCreate(self)
+        EmitterProjectileOnCreate(self)
 
         local army = self.Army
         local polyTrail = self.PolyTrail

--- a/lua/sim/projectiles/components/DebrisComponent.lua
+++ b/lua/sim/projectiles/components/DebrisComponent.lua
@@ -21,6 +21,9 @@
 --** SOFTWARE.
 --**********************************************************************************
 
+-- upvalue scope for performance
+local TableRandom = table.random
+
 ---@class DebrisComponent
 DebrisComponent = ClassSimple {
 
@@ -30,7 +33,7 @@ DebrisComponent = ClassSimple {
 
     ---@param self DebrisComponent | Projectile
     CreateDebris = function(self)
-        local blueprint = table.random(self.DebrisBlueprints)
+        local blueprint = TableRandom(self.DebrisBlueprints)
         return self:CreateChildProjectile(blueprint)
     end,
 }


### PR DESCRIPTION
According to @KionX one of the most expensive operations is the `GETTABLE` operation. A recent, very obvious example of this was done by @Pokute in https://github.com/FAForever/fa/pull/5524 . In this example we apply the same idea, but at a smaller scale 😃 .

The class hierarchy relies on calling the base class. As a quick example:

```
Projectile.OnCreate(self)
(UPVALUE) ^
```

I've marked the `.` as that indicates a `GETTABLE` operator. we use it to retrieve the same function of the base class. This involves a `GETTABLE` operator at every class that overrides a given function. The reference to the `Projectile` class is stored in an upvalue. Why would we not use that upvalue to just store a reference to the function of the base class?

Previously this would not always be possible. But With thanks to https://github.com/FAForever/fa/issues/5474 we're slowing giving each class their own, separate file. Through this approach we can be guaranteed that any hooks that would apply to the base class are completely applied before we populate our own class.

By keeping a reference directly to the function we can effectively cull a `GETTABLE` operator. This can add up for functions that are called repeatedly, such as projectiles that are constantly (de)allocated as weapons fire. This pull request represents the first step in culling those table operators