### PR TITLE
Remove redundant thread creations for gauss-like projectiles

### DIFF
--- a/projectiles/TDFGauss01/TDFGauss01_proj.bp
+++ b/projectiles/TDFGauss01/TDFGauss01_proj.bp
@@ -46,7 +46,7 @@ ProjectileBlueprint {
     },
     Physics = {
         Acceleration = 0,
-        DestroyOnWater = false,
+        DestroyOnWater = true,
         InitialSpeed = 12,
         InitialSpeedRange = 0,
         InitialSpeedReduceDistance = 0,

--- a/projectiles/TDFGauss01/TDFGauss01_script.lua
+++ b/projectiles/TDFGauss01/TDFGauss01_script.lua
@@ -1,25 +1,28 @@
+--******************************************************************************************************
+--** Copyright (c) 2023 FAForever
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
 local TDFGaussCannonProjectile = import("/lua/terranprojectiles.lua").TDFGaussCannonProjectile
 
 -- Terran Gauss Cannon Projectile
 ---@class TDFGauss01: TDFGaussCannonProjectile
-TDFGauss01 = ClassProjectile(TDFGaussCannonProjectile) {
-
-    ---@param self TDFGauss01
-    ---@param inWater boolean
-    OnCreate = function(self, inWater)
-        TDFGaussCannonProjectile.OnCreate(self, inWater)
-        if not inWater then
-            self:SetDestroyOnWater(true)
-        else
-            self.Trash:Add(ForkThread(self.DestroyOnWaterThread,self))
-        end
-    end,
-
-    ---@param self TDFGauss01
-    DestroyOnWaterThread = function(self)
-        WaitTicks(3)
-        self:SetDestroyOnWater(true)
-    end,
-}
+TDFGauss01 = ClassProjectile(TDFGaussCannonProjectile) {}
 TypeClass = TDFGauss01
-

--- a/projectiles/TDFGauss02/TDFGauss02_proj.bp
+++ b/projectiles/TDFGauss02/TDFGauss02_proj.bp
@@ -31,11 +31,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'UEF',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'UEF',
         Weapon = 'Gauss Cannon',
     },

--- a/projectiles/TDFGauss02/TDFGauss02_script.lua
+++ b/projectiles/TDFGauss02/TDFGauss02_script.lua
@@ -1,8 +1,30 @@
+--******************************************************************************************************
+--** Copyright (c) 2023 FAForever
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
 local TDFGaussCannonProjectile = import("/lua/terranprojectiles.lua").TDFMediumLandGaussCannonProjectile
 
 -- Terran Gauss Cannon Projectile
 ---@class TDFGauss02: TDFMediumLandGaussCannonProjectile
 TDFGauss02 = ClassProjectile(TDFGaussCannonProjectile) {
-    FxTrails = {'/effects/emitters/gauss_cannon_munition_trail_03_emit.bp',},
+    FxTrails = { '/effects/emitters/gauss_cannon_munition_trail_03_emit.bp', },
 }
 TypeClass = TDFGauss02

--- a/projectiles/TDFGauss03/TDFGauss03_proj.bp
+++ b/projectiles/TDFGauss03/TDFGauss03_proj.bp
@@ -32,11 +32,6 @@ ProjectileBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        EntityCategory = {
-            'UEF',
-            'PROJECTILE',
-            'DIRECTFIRE',
-        },
         Faction = 'UEF',
         Weapon = 'Gauss Cannon',
     },

--- a/projectiles/TDFGauss03/TDFGauss03_script.lua
+++ b/projectiles/TDFGauss03/TDFGauss03_script.lua
@@ -1,9 +1,31 @@
+--******************************************************************************************************
+--** Copyright (c) 2023 FAForever
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
 local TDFGaussCannonProjectile = import("/lua/terranprojectiles.lua").TDFBigShipGaussCannonProjectile
 
 --- Terran Gauss Cannon Projectile (UES0302) UEF Battleship
 ---@class TDFGauss03: TDFBigShipGaussCannonProjectile
 TDFGauss03 = ClassProjectile(TDFGaussCannonProjectile) {
-    FxTrails = {'/effects/emitters/gauss_cannon_munition_trail_03_emit.bp',},
+    FxTrails = { '/effects/emitters/gauss_cannon_munition_trail_03_emit.bp', },
     FxLandHitScale = 1.5,
 }
 TypeClass = TDFGauss03

--- a/projectiles/TDFGauss04/TDFGauss04_proj.bp
+++ b/projectiles/TDFGauss04/TDFGauss04_proj.bp
@@ -38,7 +38,7 @@ ProjectileBlueprint {
     },
     Physics = {
         Acceleration = 0,
-        DestroyOnWater = false,
+        DestroyOnWater = true,
         InitialSpeed = 12,
         InitialSpeedRange = 0,
         InitialSpeedReduceDistance = 0,

--- a/projectiles/TDFGauss04/TDFGauss04_script.lua
+++ b/projectiles/TDFGauss04/TDFGauss04_script.lua
@@ -1,28 +1,31 @@
+--******************************************************************************************************
+--** Copyright (c) 2023 FAForever
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
 local TDFGaussCannonProjectile = import("/lua/terranprojectiles.lua").TDFBigLandGaussCannonProjectile
 
 --- Terran Gauss Cannon Projectile (UEL0401) Fatboy
 ---@class TDFGauss04: TDFBigLandGaussCannonProjectile
 TDFGauss04 = ClassProjectile(TDFGaussCannonProjectile) {
-
     FxUnitHitScale = 0.9,
     FxLandHitScale = 0.9,
-
-    ---@param self TDFGauss04
-    ---@param inWater boolean
-    OnCreate = function(self, inWater)
-        TDFGaussCannonProjectile.OnCreate(self, inWater)
-        if not inWater then
-            self:SetDestroyOnWater(true)
-        else
-            self.Trash:Add(ForkThread(self.DestroyOnWaterThread,self))
-        end
-    end,
-
-    ---@param self TDFGauss04
-    DestroyOnWaterThread = function(self)
-        WaitTicks(3)
-        self:SetDestroyOnWater(true)
-    end,
 }
 TypeClass = TDFGauss04
-

--- a/projectiles/TDFGauss05/TDFGauss05_script.lua
+++ b/projectiles/TDFGauss05/TDFGauss05_script.lua
@@ -1,28 +1,31 @@
+--******************************************************************************************************
+--** Copyright (c) 2023 FAForever
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
 local TDFGaussCannonProjectile = import("/lua/terranprojectiles.lua").TDFMediumShipGaussCannonProjectile
 
 --- Terran Gauss Cannon Projectile
 ---@class TDFGauss05: TDFMediumShipGaussCannonProjectile
 TDFGauss05 = ClassProjectile(TDFGaussCannonProjectile) {
-
     FxUnitHitScale = 1.6,
     FxLandHitScale = 1.6,
-
-    ---@param self TDFGauss05
-    ---@param inWater boolean
-    OnCreate = function(self, inWater)
-        TDFGaussCannonProjectile.OnCreate(self, inWater)
-        if not inWater then
-            self:SetDestroyOnWater(true)
-        else
-            self.Trash:Add(ForkThread(self.DestroyOnWaterThread,self))
-        end
-    end,
-
-    ---@param self TDFGauss05
-    DestroyOnWaterThread = function(self)
-        WaitTicks(3)
-        self:SetDestroyOnWater(true)
-    end,
 }
 TypeClass = TDFGauss05
-


### PR DESCRIPTION
I have no idea why some did and others did not have these threads running for each projectile they create. It appears entirely redundant.