### PR TITLE
Automate Sera sniper mode micro

### DIFF
--- a/units/XSL0305/XSL0305_script.lua
+++ b/units/XSL0305/XSL0305_script.lua
@@ -15,7 +15,6 @@ local SDFSihEnergyRifleSniperMode = SeraphimWeapons.SDFSniperShotSniperMode
 ---@class XSL0305 : SLandUnit
 ---@field TrashSniperFx TrashBag
 ---@field isSniperFiringMode boolean -- Whether the sniper mode is active for next shot
----@field isSniperMoveMode boolean -- Whether the sniper mode speed slowdown is active. Is active during sniper mode shot cooldown.
 XSL0305 = ClassUnit(SLandUnit) {
     Weapons = {
         -- used for both modes of operation
@@ -63,10 +62,8 @@ XSL0305 = ClassUnit(SLandUnit) {
     ---@param delaySeconds number
     ---@param mode boolean
     ScheduleMovementChange = function(self, delaySeconds, mode)
-        if self.isSniperMoveMode == mode then return end
         local switchToMoveMode = function(mode)
             local speedMult = self.Blueprint.Physics.LandSpeedMultiplier or 1 -- left for compatability
-            self.isSniperMoveMode = mode
             if mode then
                 speedMult = speedMult * (self.Blueprint.Physics.SniperModeSpeedMultiplier or 0.75)
                 self:SetSpeedMult(speedMult)

--- a/units/XSL0305/XSL0305_script.lua
+++ b/units/XSL0305/XSL0305_script.lua
@@ -15,11 +15,21 @@ local SDFSihEnergyRifleSniperMode = SeraphimWeapons.SDFSniperShotSniperMode
 ---@class XSL0305 : SLandUnit
 ---@field TrashSniperFx TrashBag
 ---@field isSniperFiringMode boolean -- Whether the sniper mode is active for next shot
----@field isSniperMoveMode boolean -- Whether the sniper mode speed slowdown is active. Is active during sniper mode.
+---@field isSniperMoveMode boolean -- Whether the sniper mode speed slowdown is active. Is active during sniper mode shot cooldown.
 XSL0305 = ClassUnit(SLandUnit) {
     Weapons = {
         -- used for both modes of operation
-        MainGun = ClassWeapon(SDFSihEnergyRifleNormalMode) {},
+        MainGun = ClassWeapon(SDFSihEnergyRifleNormalMode) {
+            RackSalvoFiringState = State(SDFSihEnergyRifleNormalMode.RackSalvoFiringState) {
+                Main = function(self)
+                    if self.unit.isSniperFiringMode ~= nil then
+                        self.unit:ScheduleMovementChange(0, true)
+                        self.unit:ScheduleMovementChange(1 / self:GetWeaponRoF(), false)
+                    end
+                    SDFSihEnergyRifleNormalMode.RackSalvoFiringState.Main(self)
+                end,
+            }
+        },
         -- kind of a dummy weapon that carries the data of the sniper mode for the main gun
         SniperGun = ClassWeapon(SDFSihEnergyRifleSniperMode) {},
     },
@@ -76,7 +86,7 @@ XSL0305 = ClassUnit(SLandUnit) {
             self.Trash:Add(ForkThread(function()
                 self.isChangingMoveMode = true
                 WaitSeconds(delaySeconds)
-                switchToMoveMode(self.isSniperFiringMode)
+                switchToMoveMode(mode)
                 self.isChangingMoveMode = nil
                 end))
         end
@@ -89,16 +99,13 @@ XSL0305 = ClassUnit(SLandUnit) {
         self.isSniperFiringMode = mode
         if mode then
             label = "SniperGun"
+            self.isSniperFiringMode = true
         else
             label = "MainGun"
+            self.isSniperFiringMode = nil
         end
         
         local weapon = self:GetWeaponByLabel("MainGun")
-
-        -- We will reload 0.1 seconds this current tick.
-        local reloadTimeLeft = math.max(0, (1 - weapon:GetFireClockPct()) / (weapon:GetWeaponRoF()) - 0.1)
-        self.ScheduleMovementChange(self, reloadTimeLeft, mode)
-        
         local bp = self:GetWeaponByLabel(label):GetBlueprint()
         -- a lot of the firing sequence relies on the stored blueprint - we'll store the current
         -- weapon blueprint so that it works

--- a/units/XSL0305/XSL0305_script.lua
+++ b/units/XSL0305/XSL0305_script.lua
@@ -60,7 +60,7 @@ XSL0305 = ClassUnit(SLandUnit) {
 
     ---@param self XSL0305
     ---@param delaySeconds number
-    ---@param mode boolean
+    ---@param mode boolean -- true activates the slowdown, false deactivates it.
     ScheduleMovementChange = function(self, delaySeconds, mode)
         local switchToMoveMode = function(mode)
             local speedMult = self.Blueprint.Physics.LandSpeedMultiplier or 1 -- left for compatability


### PR DESCRIPTION
This change makes the sniper mode slowdown only trigger during the reload, which is already possible manually by changing mode after the sniper shot.
#### Pros: 

- It's in theme with Supcom's design to remove tedious micro: clicking the sniper button back and forth when in range and after shooting isn't fun or in-depth like other micro tricks kept in the game.
- It would be much easier for all players to get full capabilities out of the unit.

#### Cons: 
- This allows bands of snipers roaming at max speed, but then shooting a very high damage volley whenever they spot anything, entirely without player attention. But that inattention can still be punished by abusing the overkill the snipers will inflict on fodder like land scouts or single targets.