### PR TITLE
Score graph start end fix

### DIFF
--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -84,7 +84,6 @@ end
 
 local function ScoreHistoryThread()
     while not GameIsOver do 
-        WaitSeconds(scoreData.interval)
         local data = {}
         for index, brain in ArmyBrains do
             local Score = scoreData.current[index]
@@ -96,6 +95,7 @@ local function ScoreHistoryThread()
             data[index] = table.deepcopy(Score)
         end
         table.insert(scoreData.history, data)
+        WaitSeconds(scoreData.interval)
     end
 end
 


### PR DESCRIPTION
The end-of-game score graphs had buggy starts and ends. The start was actually the first saved datapoint at 00:30 instead of 00:00 and thus the scores never started from zero. The final graph segment between the last save datapoint and the end-of-game datapoint, which usually had a duration less than the default 30 seconds, had incorrect rendering.

Additionally the end-of-game datapoint was not taken into account when calculating the maximum values for graphs. Thus the graph could render outside the background.

Example of old graph:
![image](https://github.com/FAForever/fa/assets/5271115/d4f3888d-57e4-436a-93e9-7c7d72859f9a)

Example of fixed graph:
![image](https://github.com/FAForever/fa/assets/5271115/f5852fc6-8772-4246-b83c-444ce6055c5c)


This PR has a possible breaking change: Score history data now has an additional data point at 00:00, instead of the first one being at 00:30. If some mod uses this data, it might get confused.