### PR TITLE
Increase the Chariot's hitbox to fix interceptors missing it

### DIFF
--- a/units/UAA0107/UAA0107_unit.bp
+++ b/units/UAA0107/UAA0107_unit.bp
@@ -162,9 +162,9 @@ UnitBlueprint{
     SelectionThickness = 0.43,
     CollisionOffsetY = -0.25,
     CollisionOffsetZ = 0,
-    SizeX = 1.8,
-    SizeY = 0.9,
-    SizeZ = 1.8,
+    SizeX = 2.2,
+    SizeY = 1.3,
+    SizeZ = 2.2,
     StrategicIconName = "icon_gunship1_transport",
     StrategicIconSortPriority = 65,
     Transport = {


### PR DESCRIPTION
**Changes**
SizeX: 1.8 --> 2.2
SizeY: 0.9 --> 1.3
SizeZ: 1.8 --> 2.2

This attempts to fix the bug where interceptors shoot in front of the Chariot and miss it. In my tests, these changes fixed this in most cases. They can still miss it when it starts and lands, even with the increased Y-size, although this is reduced with these values. Let me know if the increase in Y-size is too much in your opinion.

Pointed at fafbeta, because technically this is a balance change.