### PR TITLE
Fix floating point imprecision for processors with a lot of cores

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -46,9 +46,14 @@ if SetProcessPriority and GetProcessAffinityMask and SetProcessAffinityMask then
     -- affinity values acts like a bit mask, we retrieve the mask and shift it if we think there are sufficient computing units
     local success, processAffinityMask, systemAffinityMask = GetProcessAffinityMask();
     if success then
+        -- system has 24 (logical) computing units or more, skip the first two computing units and all cores beyond the first 24. We need 
+        -- to do this because of floating point imprecision - we simply can't deduct a few digits to prevent using the first two cores
+        if systemAffinityMask >= 16777215 then
+            processAffinityMask = 16777212 -- 2 ^ 24 - 3 - 1
+
         -- system has 6 (logical) computing units or more, skip first two computing units
-        if (systemAffinityMask >= 63) and (processAffinityMask == systemAffinityMask) then
-            processAffinityMask = systemAffinityMask - 3
+        elseif (systemAffinityMask >= 63) then
+            processAffinityMask = systemAffinityMask - 4 -- 2 ^ 6 - 3 - 1
         end
 
         -- update the afinity mask
@@ -59,6 +64,8 @@ if SetProcessPriority and GetProcessAffinityMask and SetProcessAffinityMask then
             else
                 LOG("Process - Failed to adjust the process affinity, this may impact your framerate")
             end
+        else
+            LOG("Process - Failed to update the process affinity, this may impact your framerate")
         end
     else
         LOG("Process - Failed to retrieve the process affinity, this may impact your framerate")

--- a/init_faf.lua
+++ b/init_faf.lua
@@ -47,9 +47,14 @@ if SetProcessPriority and GetProcessAffinityMask and SetProcessAffinityMask then
     -- shift it if we think there are sufficient computing units
     local success, processAffinityMask, systemAffinityMask = GetProcessAffinityMask();
     if success then
+        -- system has 24 (logical) computing units or more, skip the first two computing units and all cores beyond the first 24. We need 
+        -- to do this because of floating point imprecision - we simply can't deduct a few digits to prevent using the first two cores
+        if systemAffinityMask >= 16777215 then
+            processAffinityMask = 16777212 -- 2 ^ 24 - 3 - 1
+
         -- system has 6 (logical) computing units or more, skip first two computing units
-        if (systemAffinityMask >= 63) and (processAffinityMask == systemAffinityMask) then
-            processAffinityMask = systemAffinityMask - 3
+        elseif (systemAffinityMask >= 63) then
+            processAffinityMask = systemAffinityMask - 4 -- 2 ^ 6 - 3 - 1
         end
 
         -- update the afinity mask
@@ -60,6 +65,8 @@ if SetProcessPriority and GetProcessAffinityMask and SetProcessAffinityMask then
             else
                 LOG("Process - Failed to adjust the process affinity, this may impact your framerate")
             end
+        else
+            LOG("Process - Failed to update the process affinity, this may impact your framerate")
         end
     else
         LOG("Process - Failed to retrieve the process affinity, this may impact your framerate")

--- a/init_fafbeta.lua
+++ b/init_fafbeta.lua
@@ -46,9 +46,14 @@ if SetProcessPriority and GetProcessAffinityMask and SetProcessAffinityMask then
     -- affinity values acts like a bit mask, we retrieve the mask and shift it if we think there are sufficient computing units
     local success, processAffinityMask, systemAffinityMask = GetProcessAffinityMask();
     if success then
+        -- system has 24 (logical) computing units or more, skip the first two computing units and all cores beyond the first 24. We need 
+        -- to do this because of floating point imprecision - we simply can't deduct a few digits to prevent using the first two cores
+        if systemAffinityMask >= 16777215 then
+            processAffinityMask = 16777212 -- 2 ^ 24 - 3 - 1
+
         -- system has 6 (logical) computing units or more, skip first two computing units
-        if (systemAffinityMask >= 63) and (processAffinityMask == systemAffinityMask) then
-            processAffinityMask = systemAffinityMask - 3
+        elseif (systemAffinityMask >= 63) then
+            processAffinityMask = systemAffinityMask - 4 -- 2 ^ 6 - 3 - 1
         end
 
         -- update the afinity mask
@@ -59,6 +64,8 @@ if SetProcessPriority and GetProcessAffinityMask and SetProcessAffinityMask then
             else
                 LOG("Process - Failed to adjust the process affinity, this may impact your framerate")
             end
+        else
+            LOG("Process - Failed to update the process affinity, this may impact your framerate")
         end
     else
         LOG("Process - Failed to retrieve the process affinity, this may impact your framerate")

--- a/init_fafdevelop.lua
+++ b/init_fafdevelop.lua
@@ -46,9 +46,14 @@ if SetProcessPriority and GetProcessAffinityMask and SetProcessAffinityMask then
     -- affinity values acts like a bit mask, we retrieve the mask and shift it if we think there are sufficient computing units
     local success, processAffinityMask, systemAffinityMask = GetProcessAffinityMask();
     if success then
+        -- system has 24 (logical) computing units or more, skip the first two computing units and all cores beyond the first 24. We need 
+        -- to do this because of floating point imprecision - we simply can't deduct a few digits to prevent using the first two cores
+        if systemAffinityMask >= 16777215 then
+            processAffinityMask = 16777212 -- 2 ^ 24 - 3 - 1
+
         -- system has 6 (logical) computing units or more, skip first two computing units
-        if (systemAffinityMask >= 63) and (processAffinityMask == systemAffinityMask) then
-            processAffinityMask = systemAffinityMask - 3
+        elseif (systemAffinityMask >= 63) then
+            processAffinityMask = systemAffinityMask - 4 -- 2 ^ 6 - 3 - 1
         end
 
         -- update the afinity mask
@@ -59,6 +64,8 @@ if SetProcessPriority and GetProcessAffinityMask and SetProcessAffinityMask then
             else
                 LOG("Process - Failed to adjust the process affinity, this may impact your framerate")
             end
+        else
+            LOG("Process - Failed to update the process affinity, this may impact your framerate")
         end
     else
         LOG("Process - Failed to retrieve the process affinity, this may impact your framerate")

--- a/init_shared.lua
+++ b/init_shared.lua
@@ -46,9 +46,14 @@ if SetProcessPriority and GetProcessAffinityMask and SetProcessAffinityMask then
     -- affinity values acts like a bit mask, we retrieve the mask and shift it if we think there are sufficient computing units
     local success, processAffinityMask, systemAffinityMask = GetProcessAffinityMask();
     if success then
+        -- system has 24 (logical) computing units or more, skip the first two computing units and all cores beyond the first 24. We need 
+        -- to do this because of floating point imprecision - we simply can't deduct a few digits to prevent using the first two cores
+        if systemAffinityMask >= 16777215 then
+            processAffinityMask = 16777212 -- 2 ^ 24 - 3 - 1
+
         -- system has 6 (logical) computing units or more, skip first two computing units
-        if (systemAffinityMask >= 63) and (processAffinityMask == systemAffinityMask) then
-            processAffinityMask = systemAffinityMask - 3
+        elseif (systemAffinityMask >= 63) then
+            processAffinityMask = systemAffinityMask - 4 -- 2 ^ 6 - 3 - 1
         end
 
         -- update the afinity mask
@@ -59,6 +64,8 @@ if SetProcessPriority and GetProcessAffinityMask and SetProcessAffinityMask then
             else
                 LOG("Process - Failed to adjust the process affinity, this may impact your framerate")
             end
+        else
+            LOG("Process - Failed to update the process affinity, this may impact your framerate")
         end
     else
         LOG("Process - Failed to retrieve the process affinity, this may impact your framerate")


### PR DESCRIPTION
When a system has too many logical cores then we hit problems with floating point imprecision. We're simply unable to 'disable' the first two logical cores because of that. At the moment it works like this:

- When someone has 24 or more logical cores than the first 2 logical cores and any logical core starting at the 25th are disabled.
- When someone has 6 or more logical cores than the first 2 logical cores are disabled.