### PR TITLE
T2 Bomber speed nerf

### DIFF
--- a/units/DEA0202/DEA0202_unit.bp
+++ b/units/DEA0202/DEA0202_unit.bp
@@ -20,7 +20,7 @@ UnitBlueprint{
         KTurn = 1,
         KTurnDamping = 1.5,
         LiftFactor = 10,
-        MaxAirspeed = 15,
+        MaxAirspeed = 14.25,
         MinAirspeed = 10,
         PredictAheadForBombDrop = 4,
         StartTurnDistance = 5,

--- a/units/DRA0202/DRA0202_unit.bp
+++ b/units/DRA0202/DRA0202_unit.bp
@@ -20,7 +20,7 @@ UnitBlueprint{
         KTurn = 1,
         KTurnDamping = 1.5,
         LiftFactor = 7,
-        MaxAirspeed = 15,
+        MaxAirspeed = 14.25,
         MinAirspeed = 10,
         StartTurnDistance = 5,
         TightTurnMultiplier = 1.02,

--- a/units/XSA0202/XSA0202_unit.bp
+++ b/units/XSA0202/XSA0202_unit.bp
@@ -20,7 +20,7 @@ UnitBlueprint{
         KTurn = 1,
         KTurnDamping = 1.5,
         LiftFactor = 15,
-        MaxAirspeed = 15,
+        MaxAirspeed = 14.25,
         MinAirspeed = 10,
         PredictAheadForBombDrop = 3,
         StartTurnDistance = 5,


### PR DESCRIPTION
MaxAirspeed: 15 --> 14.25

T2 Bombers were as fast as their counter (interceptors) which meant that, in some scenarios, interceptors would never be able to catch them. This nerf increases the skill-cap of using T2 Bombers and enables better counter play for the defending player.

Pointed at fafdevelop.