### PR TITLE
Marr (Aeon stationary flak) buff

### DIFF
--- a/units/UAB2204/UAB2204_unit.bp
+++ b/units/UAB2204/UAB2204_unit.bp
@@ -178,7 +178,7 @@ UnitBlueprint{
             MaxRadius = 50,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 35,
+            MuzzleVelocity = 40,
             ProjectileId = "/projectiles/AAAFizz01/AAAFizz01_proj.bp",
             ProjectileLifetimeUsesMultiplier = 1.25,
             ProjectilesPerOnFire = 1,


### PR DESCRIPTION
MuzzleVelocity: 35 --> 40

This unit has always been much worse than the other stationary flaks. Essentially it is a worse version of the Air Cleaner, as it has a much worse firing cycle, lower AOE, lower DPS and lower HP. In exchange for these disadvantages, it only gets 0.5 less FiringRandomnes, which does not help the unit much.

This PR aims to buff the unit, while also making it more unique, in line with the theme of its faction. With this change it still has the disadvantage of having low damage, but is now able to hit fast moving targets more reliably and at a greater range, than other flaks.

Pointed at fafdevelop.