### PR TITLE
Fix Deceiver Range Buff

### DIFF
--- a/units/URL0306/URL0306_unit.bp
+++ b/units/URL0306/URL0306_unit.bp
@@ -117,8 +117,8 @@ UnitBlueprint{
     Intel = {
         RadarStealth = true,
         RadarStealthField = true,
-        RadarStealthFieldRadius = 23,
-        SonarStealthFieldRadius = 23,
+        RadarStealthFieldRadius = 24,
+        SonarStealthFieldRadius = 24,
         VisionRadius = 16,
     },
     LifeBarHeight = 0.075,


### PR DESCRIPTION
#5142 has no effect because the radar intel grid has a resolution of 4x4. This increases the range to 24, which is divisible by 4 so it has an effect.