### PR TITLE
Fix AA formations for directfire-capable land AA

### DIFF
--- a/units/DRLK001/DRLK001_unit.bp
+++ b/units/DRLK001/DRLK001_unit.bp
@@ -15,7 +15,7 @@ UnitBlueprint{
         "BOT",
         "BUILTBYTIER3FACTORY",
         "CYBRAN",
-        "DIRECTFIRE",
+        "WEAKDIRECTFIRE",
         "LAND",
         "MOBILE",
         "OVERLAYANTIAIR",
@@ -25,7 +25,6 @@ UnitBlueprint{
         "SELECTABLE",
         "TECH3",
         "VISIBLETORECON",
-        "WEAKDIRECTFIRE",
     },
     Defense = {
         AirThreatLevel = 33,

--- a/units/DSLK004/DSLK004_unit.bp
+++ b/units/DSLK004/DSLK004_unit.bp
@@ -11,7 +11,7 @@ UnitBlueprint{
     Categories = {
         "ANTIAIR",
         "BUILTBYTIER3FACTORY",
-        "DIRECTFIRE",
+        "WEAKDIRECTFIRE",
         "LAND",
         "MOBILE",
         "OVERLAYANTIAIR",
@@ -22,7 +22,6 @@ UnitBlueprint{
         "SERAPHIM",
         "TECH3",
         "VISIBLETORECON",
-        "WEAKDIRECTFIRE",
     },
     Defense = {
         AirThreatLevel = 120,

--- a/units/URL0104/URL0104_unit.bp
+++ b/units/URL0104/URL0104_unit.bp
@@ -14,7 +14,7 @@ UnitBlueprint{
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",
         "CYBRAN",
-        "DIRECTFIRE",
+        "WEAKDIRECTFIRE",
         "LAND",
         "MOBILE",
         "OVERLAYANTIAIR",


### PR DESCRIPTION
Cybran T1 MAA was considered a T1 Tank, and Cybran/Sera T3 MAA didn't get formation categories. Now they're all properly considered as T1AA or T3AA in formations.lua.