### PR TITLE
Fix lasers missing the Aurora, Thaam and Striker

### DIFF
--- a/units/UAL0201/UAL0201_unit.bp
+++ b/units/UAL0201/UAL0201_unit.bp
@@ -155,7 +155,7 @@ UnitBlueprint{
     SelectionThickness = 0.58,
     SizeX = 0.7,
     SizeY = 0.5,
-    SizeZ = 1.0,
+    SizeZ = 1.1,
     StrategicIconName = "icon_land1_directfire",
     StrategicIconSortPriority = 135,
     Veteran = {

--- a/units/UEL0201/UEL0201_unit.bp
+++ b/units/UEL0201/UEL0201_unit.bp
@@ -142,7 +142,7 @@ UnitBlueprint{
     SelectionThickness = 0.7,
     SizeX = 0.7,
     SizeY = 0.5,
-    SizeZ = 1.0,
+    SizeZ = 1.1,
     StrategicIconName = "icon_land1_directfire",
     StrategicIconSortPriority = 135,
     Veteran = {

--- a/units/XSL0201/XSL0201_unit.bp
+++ b/units/XSL0201/XSL0201_unit.bp
@@ -142,7 +142,7 @@ UnitBlueprint{
     CollisionOffsetZ = 0.1,
     SizeX = 0.7,
     SizeY = 0.5,
-    SizeZ = 0.9,
+    SizeZ = 1.1,
     StrategicIconName = "icon_land1_directfire",
     StrategicIconSortPriority = 125,
     Transport = { TransportClass = 1 },


### PR DESCRIPTION
At 1.0, this still happened.

**Changes:**

Striker and Aurora: 
SizeZ: 1.0 --> 1.1

Thaam:
SizeZ = 0.9 --> 1.1