### PR TITLE
Terrain bugfixes and small improvements

### DIFF
--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -1778,7 +1778,7 @@ float splatLerp(float t1, float t2, float t2height, float opacity, uniform float
     return (t1 * factor1 + t2 * factor2) / (factor1 + factor2);
 }
 
-float4 splatLerp(float4 t1, float4 t2, float t2height, float opacity, uniform float blurriness = 0.2) {
+float4 splatLerp(float4 t1, float4 t2, float t2height, float opacity, uniform float blurriness = 0.12) {
     float height1 = 1 + blurriness;
     float height2 = t2height + opacity;
     float ma = max(height1, height2) - blurriness;
@@ -1787,7 +1787,7 @@ float4 splatLerp(float4 t1, float4 t2, float t2height, float opacity, uniform fl
     return (t1 * factor1 + t2 * factor2) / (factor1 + factor2);
 }
 
-float3 splatBlendNormal(float3 n1, float3 n2, float t2height, float opacity, uniform float blurriness = 0.2) {
+float3 splatBlendNormal(float3 n1, float3 n2, float t2height, float opacity, uniform float blurriness = 0.12) {
     float height1 = 1 + blurriness;
     float height2 = t2height + opacity;
     float ma = max(height1, height2) - blurriness;
@@ -1796,8 +1796,8 @@ float3 splatBlendNormal(float3 n1, float3 n2, float t2height, float opacity, uni
     // These factors are to make low opacity normal maps more visible,
     // as we notice small changes to the albedo maps more easily.
     // The value of 0.5 is just eyeballed.
-    float factor1modified = pow(factor1 / (factor1 + factor2), 0.5);
-    float factor2modified = pow(factor2 / (factor1 + factor2), 0.5);
+    float factor1modified = pow(factor1 / (factor1 + factor2), 0.6);
+    float factor2modified = pow(factor2 / (factor1 + factor2), 0.6);
     // UDN blending
     return normalize(float3((n1.xy * factor1modified + n2.xy * factor2modified), n1.z));
 }

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -1770,26 +1770,26 @@ technique LowFidelityLighting
 /* # Blending techniques # */
 
 float splatLerp(float t1, float t2, float t2height, float opacity, uniform float blurriness) {
-    float height1 = 1 + blurriness;
-    float height2 = t2height + opacity;
+    float height1 = 1;
+    float height2 = t2height * (1 - 2 * blurriness) + blurriness + opacity;
     float ma = max(height1, height2) - blurriness;
     float factor1 = max(height1 - ma, 0);
     float factor2 = max(height2 - ma, 0);
     return (t1 * factor1 + t2 * factor2) / (factor1 + factor2);
 }
 
-float4 splatLerp(float4 t1, float4 t2, float t2height, float opacity, uniform float blurriness = 0.12) {
-    float height1 = 1 + blurriness;
-    float height2 = t2height + opacity;
+float4 splatLerp(float4 t1, float4 t2, float t2height, float opacity, uniform float blurriness = 0.06) {
+    float height1 = 1;
+    float height2 = t2height * (1 - 2 * blurriness) + blurriness + opacity;
     float ma = max(height1, height2) - blurriness;
     float factor1 = max(height1 - ma, 0);
     float factor2 = max(height2 - ma, 0);
     return (t1 * factor1 + t2 * factor2) / (factor1 + factor2);
 }
 
-float3 splatBlendNormal(float3 n1, float3 n2, float t2height, float opacity, uniform float blurriness = 0.12) {
-    float height1 = 1 + blurriness;
-    float height2 = t2height + opacity;
+float3 splatBlendNormal(float3 n1, float3 n2, float t2height, float opacity, uniform float blurriness = 0.06) {
+    float height1 = 1;
+    float height2 = t2height * (1 - 2 * blurriness) + blurriness + opacity;
     float ma = max(height1, height2) - blurriness;
     float factor1 = max(height1 - ma, 0);
     float factor2 = max(height2 - ma, 0);

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -958,8 +958,7 @@ float4 TerrainAlbedoXP( VS_OUTPUT pixel) : COLOR
     albedo.rgb = light * ( albedo.rgb + specular.rgb );
 
     float waterDepth = tex2Dproj(UtilitySamplerC,pixel.mTexWT*TerrainScale).g;
-    float4 water = tex1D(WaterRampSampler,waterDepth);
-    albedo.rgb = lerp(albedo.rgb,water.rgb,water.a);
+    albedo.rgb = ApplyWaterColor(pixel.mTexWT.z, waterDepth, albedo.rgb);
 
     return float4(albedo.rgb, 0.01f);
 }


### PR DESCRIPTION
The fix for the water bleeding was inadvertantly only applied to maps using the TTerrain shader, so the vast majority of maps were left out. The effect can be seen for example on project albus.


The height and roughness textures had ugly seams where the texture repeats. These are now fixed.
The calculation of the texture splatting was reworked. The bluriness can now be changed without biasing where the texture shows up.
The bluriness can now be controlled by the red value of the SpecularColor.
Also adjusts the values for blending textures as these seemed nicer to me.
Value of 0.06 for bluriness:
![Screenshot 2023-12-06 131306](https://github.com/FAForever/fa/assets/52536103/a50233fe-bf6c-4232-b0bc-58afe2c6ca66)
Value of 0.25 for bluriness:
![Screenshot 2023-12-06 152424](https://github.com/FAForever/fa/assets/52536103/4850b9fb-a524-4625-a07f-0b343131e765)


No maps use these advanced shaders so far, so there is no direct effect on the community.
I had to comment out the TerrainPBR shader as it is now over the instruction limit for ps_2_a shaders. I'll work on finding out if we can work around that at a later date.

