### PR TITLE
Link enhancement descriptions to bp stats

### DIFF
--- a/loc/US/strings_db.lua
+++ b/loc/US/strings_db.lua
@@ -1754,7 +1754,7 @@ Unit_Description_0157="Creates a Quantum Stasis Field around the ACU. Immobilize
 Unit_Description_0158="Increases the range of the ACU's main cannon and that of Overcharge.\n\n+8 Main cannon range"
 Unit_Description_0159="Grants the ACU a long range omni Sensor and increased optical range.\n\n+54 Vision Radius\n+54 Omni Radius"
 Unit_Description_0160="Grants Tech 3 and Experimental schematic access and further increases the ACU's build speed and maximum health.\n\n+58 Buildpower\n+1000 Health\n+10 Regen"
-Unit_Description_0161="Doubles the main cannon's rate of fire.\n\n+100% Rate of fire"
+Unit_Description_0161="Doubles the main cannon's rate of fire.\n\n<VAR NewRateOfFire> Rate of fire"
 Unit_Description_0162="Increases ACU's resource generation to 19 mass per second and 1720 energy per second."
 Unit_Description_0163="Increases ACU's resource generation to 37 mass per second and 3420 energy per second."
 Unit_Description_0164="Creates a rapidly-recharging, protective Personal Shield around the ACU. Requires energy to run.\n\nShield Regen Rate = 30 HP/s\nShield Recharge Time = 75 seconds"

--- a/lua/maui/text.lua
+++ b/lua/maui/text.lua
@@ -188,7 +188,7 @@ function WrapText(text, lineWidth, advanceFunction)
                 -- find the next line feed
                 lfStartIndex = string.find(packedWord, "\n", curIndex)
                 -- pick up any trailing word
-                if not lfStartIndex and curIndex < bytes then
+                if not lfStartIndex and curIndex <= bytes then
                     table.insert(words, string.sub(packedWord, curIndex, bytes))
                 end
             end


### PR DESCRIPTION
This PR aims to create a VAR function to add bp stats into descriptions similar to the LOC format. Currently it uses `<VAR EnhancementStatName>`
I'm creating this as a draft to get opinions on what syntax to use for formatting the variable itself, because there are some bp stats that need some math to be done before being written down such as 
- `NewRateOfFire` (2 and 1.82), `RegenPerSecond` (0.035; used by regen aura) - needs to be formatted to percents.
- `NewMaxRadius` (30, 35, 40) - choose between hard coding subtraction of the specific unit's gun range or creating a way to reference the unit bp from the VAR function.
- `ShieldRegenRate`, `ShieldRechargeTime` - add a syntax for choosing to not use the prerequisite's stats, or else the aeon heavy shield will say +2 Regen +85 Recharge Time.

FYI LOC already uses the curly brackets `{}` for op codes so those aren't available.