### PR TITLE
Fix presets giving double veterancy

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1210,8 +1210,12 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
                 local presetEnhancements = bp.EnhancementPresetAssigned.Enhancements
                 for _, enhName in activeEnhancements do
                     -- don't add enhancement costs built into the unit cost
-                    if presetEnhancements and presetEnhancements[enhName] then
-                        continue
+                    if presetEnhancements then
+                        for _, v in presetEnhancements do
+                            if v == enhName then
+                                continue
+                            end
+                        end
                     end
                     -- add up the enhancement AND all of its prerequisites
                     repeat


### PR DESCRIPTION
Currently presets give experience from their enhancements' mass twice. This fixes that bug.
It was caused by addressing an array with a key instead of traversing it and looking for the required value.