### PR TITLE
Make veterancy requirements equal for presets and SACUs

### DIFF
--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -676,6 +676,12 @@ function HandleUnitWithBuildPresets(bps, all_bps)
             tempBp.Economy.BuildCostMass = preset.BuildCostMassOverride or (tempBp.Economy.BuildCostMass + m)
             tempBp.Economy.BuildTime = preset.BuildTimeOverride or (tempBp.Economy.BuildTime + t)
 
+            -- adjust veterancy so that it is as easy to vet with preset SCUs as upgraded SCUs
+            if not bp.VeteranMass then
+                -- blueprints-units.lua gives a default multiplier of 2 for SUBCOMMANDER category units.
+                tempBp.VeteranMassMult = (tempBp.VeteranMassMult or 2) * bp.Economy.BuildCostMass / tempBp.Economy.BuildCostMass
+            end
+
             -- teleport cost adjustments. Manually enhanced SCU with teleport is cheaper than a prebuild SCU because the latter has its cost
             -- adjusted (up). This code sets bp values used in the code to calculate with different base values than the unit cost.
             if preset.TeleportNoCostAdjustment ~= false then

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -482,7 +482,7 @@ function UpdateWindow(info)
                         elseif upperThreshold >= 10000 then
                             text = string.format('%.1fK/%.1fK', experience / 1000, upperThreshold / 1000)
                         else
-                            text = experience .. '/' .. upperThreshold
+                            text = experience .. '/' .. string.format('%d', upperThreshold)
                         end
                         controls.nextVet:SetText(text)
 


### PR DESCRIPTION
Resolves #3446. Makes veterancy requirements equal for presets and SACUs.
There was a rounding error with some Cybran presets, so the UI had to be adjusted too.