### PR TITLE
Don't remove unit buildrate after processing external factory

### DIFF
--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -596,7 +596,6 @@ function PostProcessUnitWithExternalFactory(allBlueprints, unit)
 
         -- remove properties of the seed unit
         unit.Categories = table.unhash(unit.CategoriesHash)
-        unit.Economy.BuildRate = 0
     end
 end
 


### PR DESCRIPTION
Fixes #5724. Mousing over units in the build bar with the unit selected (not the external factory) displays correct buildrates.
![image](https://github.com/FAForever/fa/assets/82986251/b9c986ac-824b-42cf-b3ec-cacdca0676f6)

<details>
<summary> Spawn test units command: </summary>

``` CreateUnitAtMouse('urs0303ef', 0,   25.84,  -18.40, -0.00000)
   CreateUnitAtMouse('uel0401', 0,    9.09,   25.80,  1.30232)
   CreateUnitAtMouse('uel0401ef', 0,    4.39,   24.50,  1.30232)
   CreateUnitAtMouse('xab1401', 0,   -4.16,   27.02, -0.00160)
   CreateUnitAtMouse('ues0401ef', 0,  -16.66,  -21.53, -0.00000)
   CreateUnitAtMouse('ues0401', 0,  -16.66,  -12.48, -0.00000)
   CreateUnitAtMouse('uas0303', 0,   -4.16,  -11.98, -0.00000)
   CreateUnitAtMouse('urs0303', 0,   25.84,   -9.98, -0.00000)
   CreateUnitAtMouse('xss0303', 0,   11.84,  -10.98, -0.00000)
   CreateUnitAtMouse('uas0303ef', 0,   -4.16,  -21.19, -0.00000)
   CreateUnitAtMouse('uaa0310', 0,  -21.51,   20.60, -0.00000)
   CreateUnitAtMouse('uaa0310ef', 0,  -21.51,   29.83, -0.00000)
   CreateUnitAtMouse('xss0303ef', 0,   11.84,  -21.20, -0.00000)
   ```

</details>