### PR TITLE
Fix Mantis build power display

### DIFF
--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -522,6 +522,12 @@ local function PostProcessUnit(unit)
     end
 
     --#endregion
+
+    -- Override the default 1 build rate given to units
+    -- so that rollover unit view can work with Mantis.
+    if unit.Economy and not unit.Economy.BuildRate then
+        unit.Economy.BuildRate = 0
+    end
 end
 
 ---@param allBlueprints BlueprintsTable

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -237,7 +237,7 @@ local statFuncs = {
         if options.gui_detailed_unitview == 0 then
             return false
         end
-        if info.userUnit ~= nil and info.userUnit:GetBuildRate() >= 2 then
+        if info.userUnit ~= nil and info.userUnit:GetBuildRate() >= 1 then
             return string.format("%d", math.floor(info.userUnit:GetBuildRate()))
         end
         return false


### PR DESCRIPTION
Resolves #5379.
![image](https://github.com/FAForever/fa/assets/82986251/be9e1b4c-affa-4ea9-99d3-91b7f6e15eb5)
The mantis should have buildpower, the thaam shouldn't. Test:
```
   CreateUnitAtMouse('xsl0201', 0,   -1.50,    0.00, -0.00030)
   CreateUnitAtMouse('url0107', 0,    1.50,    0.00,  0.00013)
```

