### PR TITLE
Small UI Fixes for Cybran Stealth

### DIFF
--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -1503,7 +1503,7 @@ local function CreateAltOrders(availableOrders, availableToggles, units)
                         end
                     end
                     if not foundFreeSlot then
-                        WARN("No free slot for order: " .. item)
+                        SPEW("No free slot for order: " .. item)
                         -- Could break here, but don't, then you'll know how many extra orders you have
                     end
                 end

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -1600,8 +1600,7 @@ function ApplyOverrides(standardOrdersTable, newSelection)
                 if override then
                     for key, value in override do
                         if orderDiffs[orderKey][key] ~= nil and (orderDiffs[orderKey][key] ~= value) then
-                            -- Found order diff already, so mark it false so it gets ignored when applying to table
-                            orderDiffs[orderKey] = false
+                            -- Found order diff we already have
                             break
                         else
                             orderDiffs[orderKey] = orderDiffs[orderKey] or {}

--- a/units/URL0001/URL0001_script.lua
+++ b/units/URL0001/URL0001_script.lua
@@ -118,7 +118,7 @@ URL0001 = ClassUnit(ACUUnit, CCommandUnit) {
             RemoveUnitEnhancement(self, 'TeleporterRemove')
             self:RemoveCommandCap('RULEUCC_Teleport')
         elseif enh == 'StealthGenerator' then
-            self:AddToggleCap('RULEUTC_CloakToggle')
+            self:AddToggleCap('RULEUTC_StealthToggle')
             self.StealthEnh = true
             self:EnableUnitIntel('Enhancement', 'RadarStealth')
             self:EnableUnitIntel('Enhancement', 'SonarStealth')
@@ -145,7 +145,7 @@ URL0001 = ClassUnit(ACUUnit, CCommandUnit) {
                 Buff.ApplyBuff(self, 'CybranACUStealthBonus')
             end
         elseif enh == 'StealthGeneratorRemove' then
-            self:RemoveToggleCap('RULEUTC_CloakToggle')
+            self:RemoveToggleCap('RULEUTC_StealthToggle')
             self:DisableUnitIntel('Enhancement', 'RadarStealth')
             self:DisableUnitIntel('Enhancement', 'SonarStealth')
             self.StealthEnh = nil
@@ -177,7 +177,7 @@ URL0001 = ClassUnit(ACUUnit, CCommandUnit) {
             end
         elseif enh == 'FAF_SelfRepairSystemRemove' then
             -- remove prerequisites
-            self:RemoveToggleCap('RULEUTC_CloakToggle')
+            self:RemoveToggleCap('RULEUTC_StealthToggle')
             self:DisableUnitIntel('Enhancement', 'RadarStealth')
             self:DisableUnitIntel('Enhancement', 'SonarStealth')
             self.StealthEnh = nil
@@ -191,6 +191,8 @@ URL0001 = ClassUnit(ACUUnit, CCommandUnit) {
             end
         elseif enh == 'CloakingGenerator' then
             if not bp then return end
+            self:RemoveToggleCap('RULEUTC_StealthToggle')
+            self:AddToggleCap('RULEUTC_CloakToggle')
             self.StealthEnh = nil
             self.CloakEnh = true
             self:EnableUnitIntel('Enhancement', 'Cloak')

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -583,6 +583,13 @@ UnitBlueprint{
         },
         FactionName = "Cybran",
         Icon = "amph",
+        OrderOverrides = {
+            RULEUTC_StealthToggle = {
+                bitmapId = "stealth-personal",
+                helpText = "toggle_stealth_personal",
+            },
+        },
+
         QuickSelectPriority = 1,
         SelectionPriority = 3,
         TeleportDelay = 10,

--- a/units/URL0301/URL0301_script.lua
+++ b/units/URL0301/URL0301_script.lua
@@ -78,6 +78,8 @@ URL0301 = ClassUnit(CCommandUnit) {
         local bp = self.Blueprint.Enhancements[enh]
         if not bp then return end
         if enh == 'CloakingGenerator' then
+            self:RemoveToggleCap('RULEUTC_StealthToggle')
+            self:AddToggleCap('RULEUTC_CloakToggle')
             self.StealthEnh = false
             self.CloakEnh = true
             self:EnableUnitIntel('Enhancement', 'Cloak')
@@ -109,7 +111,7 @@ URL0301 = ClassUnit(CCommandUnit) {
                 Buff.RemoveBuff(self, 'CybranSCUCloakBonus')
             end
         elseif enh == 'StealthGenerator' then
-            self:AddToggleCap('RULEUTC_CloakToggle')
+            self:AddToggleCap('RULEUTC_StealthToggle')
             if self.IntelEffectsBag then
                 EffectUtil.CleanupEffectBag(self, 'IntelEffectsBag')
                 self.IntelEffectsBag = nil
@@ -119,7 +121,7 @@ URL0301 = ClassUnit(CCommandUnit) {
             self:EnableUnitIntel('Enhancement', 'RadarStealth')
             self:EnableUnitIntel('Enhancement', 'SonarStealth')
         elseif enh == 'StealthGeneratorRemove' then
-            self:RemoveToggleCap('RULEUTC_CloakToggle')
+            self:RemoveToggleCap('RULEUTC_StealthToggle')
             self:DisableUnitIntel('Enhancement', 'RadarStealth')
             self:DisableUnitIntel('Enhancement', 'SonarStealth')
             self.StealthEnh = false

--- a/units/URL0301/URL0301_unit.bp
+++ b/units/URL0301/URL0301_unit.bp
@@ -492,6 +492,12 @@ UnitBlueprint{
         ConstructionBar = true,
         FactionName = "Cybran",
         Icon = "amph",
+        OrderOverrides = {
+            RULEUTC_StealthToggle = {
+                bitmapId = "stealth-personal",
+                helpText = "toggle_stealth_personal",
+            },
+        },
         SelectionPriority = 3,
     },
     Intel = {


### PR DESCRIPTION
- Fixes the toggle stealth button disappearing when you select a deceiver and a different stealth unit. Same issue occurs when selecting a personal shield unit with a shield structure.
- Stealth and cloak upgrades for ACU/SACU use separate togglecaps so they can be separately toggled.
- Stealth and cloak upgrades for ACU/SACU now use appropriate icons and help texts instead of only cloak:
Cloaking icon:
![image](https://github.com/FAForever/fa/assets/82986251/d683b88d-9199-4a41-9b23-e48474755ced)
Personal stealth icon:
![image](https://github.com/FAForever/fa/assets/82986251/cb61f189-59bd-45e9-bace-6112bec24a2a)
- Changes frequent warn to spew.
