### PR TITLE
Fix toggle intel hotkey label not appearing for toggle scry

### DIFF
--- a/lua/keymap/hotkeylabels.lua
+++ b/lua/keymap/hotkeylabels.lua
@@ -78,7 +78,7 @@ local orderDelegations = {
     toggle_all =            {"toggle_shield","toggle_shield_dome","toggle_radar","toggle_sonar","toggle_omni",
                                 "toggle_cloak","toggle_jamming","toggle_stealth_field","toggle_scrying"},
 
-    toggle_intelshield =    {"toggle_shield","toggle_shield_dome","toggle_radar","toggle_sonar","toggle_omni"},
+    toggle_intelshield =    {"toggle_shield","toggle_shield_dome","toggle_radar","toggle_sonar","toggle_omni","toggle_scrying"},
     toggle_shield =         {"toggle_shield"},
     toggle_shield_dome =    {"toggle_shield_dome"},
 
@@ -89,7 +89,7 @@ local orderDelegations = {
 
     mode =                  {"mode"},
 
-    toggle_intel =          {"toggle_radar", "toggle_sonar", "toggle_omni"},
+    toggle_intel =          {"toggle_radar", "toggle_sonar", "toggle_omni","toggle_scrying"},
     toggle_scrying =        {"toggle_scrying"},
     scry_target =           {"scry_target"},
 }


### PR DESCRIPTION
The toggle intel hotkeys work on toggling scrying, so I added the label.
The hotkey label requires a game setting to be turned on and looks like this:
![image](https://github.com/FAForever/fa/assets/82986251/d87134da-ea3e-457d-9abe-e350606013bd)
