### PR TITLE
Improve Bulwark UI and give it a dummy weapon

### DIFF
--- a/units/XES0205/XES0205_script.lua
+++ b/units/XES0205/XES0205_script.lua
@@ -9,9 +9,13 @@
 ----****************************************************************************
 local TShieldSeaUnit = import("/lua/terranunits.lua").TShieldSeaUnit
 local ShieldEffectsComponent = import("/lua/defaultcomponents.lua").ShieldEffectsComponent
+local DefaultProjectileWeapon = import("/lua/sim/defaultweapons.lua").DefaultProjectileWeapon
 
 ---@class XES0205 : TShieldSeaUnit
 XES0205 = ClassUnit(TShieldSeaUnit, ShieldEffectsComponent) {
+    Weapons = {
+        TargetPointer = ClassWeapon(DefaultProjectileWeapon) {},
+    },
     ShieldEffects = {
         '/effects/emitters/terran_shield_generator_shipmobile_01_emit.bp',
         '/effects/emitters/terran_shield_generator_shipmobile_02_emit.bp',

--- a/units/XES0205/XES0205_unit.bp
+++ b/units/XES0205/XES0205_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         "BUILTBYTIER3FACTORY",
         "DEFENSE",
         "DEFENSIVEBOAT",
+        "DUMMYGSRWEAPON",
         "MOBILE",
         "NAVAL",
         "PRODUCTFA",
@@ -25,6 +26,7 @@ UnitBlueprint{
         "TECH2",
         "UEF",
         "VISIBLETORECON",
+        "OVERLAYDIRECTFIRE",
     },
     Defense = {
         AirThreatLevel = 0,
@@ -198,9 +200,28 @@ UnitBlueprint{
     Weapon = {
         {
             Damage = 0,
+            DamageFriendly = false,
+            FireTargetLayerCapsTable = {
+                Land = "Land|Water",
+                Water = "Land|Water",
+            },
+            MaxRadius = 54,
+            RackBones = {
+                {
+                    MuzzleBones = { "XES0205" },
+                    RackBone = "XES0205",
+                },
+            },
+            RateOfFire = 0.5,
+            SlavedToBody = false,
+            TargetPriorities = { "ALLUNITS" },
+            TargetRestrictDisallow = "UNTARGETABLE",
+            Turreted = false,
+        },
+        {
+            Damage = 0,
             MaxRadius = 34,
             RangeCategory = "UWRC_DirectFire",
-            WeaponCategory = "Direct Fire Naval",
         },
     },
 }


### PR DESCRIPTION
- Fix the ls_ weapon appearing in the armament details. Dummy weapons should not have a WeaponCategory.
- Re-add the range ring that weapon is meant to display to represent the shield range on the water surface.
- Adds a dummy weapon so it doesn't drive into the enemy when on attack move. The range of the weapon is set up so that the shield should be 5 units in front of frigates that are within firing range.

With frigates, destroyers, and bulwarks on attack  move you should get a setup somewhat like this:
![image](https://github.com/FAForever/fa/assets/82986251/3a15138c-e4bd-4890-b9ec-3ab201515d40)