### PR TITLE
Double the exponential absorption rate of water

### DIFF
--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -603,7 +603,8 @@ float3 ApplyWaterColor(float depth, float3 viewDirection, float3 color, float3 e
     if (surfaceElevation > 0) {
         // we need this switch to make it consistent with the terrain shader coloration
         if (IsExperimentalShader()) {
-            float scaledDepth = (-depth / (surfaceElevation - abyssElevation));
+            // We need to multiply by 2 to match the terrain shader.
+            float scaledDepth = (-depth / (surfaceElevation - abyssElevation)) * 2;
             float3 up = float3(0,1,0);
             // this is the length that the light travels underwater back to the camera
             float oneOverCosV = 1 / max(dot(up, normalize(viewDirection)), 0.0001);

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -410,7 +410,8 @@ float3 ApplyWaterColorExponentially(float3 viewDirection, float terrainHeight, f
         float oneOverCosV = 1 / max(dot(up, normalize(viewDirection)), 0.0001);
         // Light gets absorbed exponentially,
         // to simplify, we assume that the light enters vertically into the water.
-        float waterAbsorption = 1 - saturate(exp(-waterDepth * (1 + oneOverCosV)));
+        // We need to multiply by 2 to reach 98% absorption as the waterDepth can't go over 1.
+        float waterAbsorption = 1 - saturate(exp(-waterDepth * 2 * (1 + oneOverCosV)));
         // darken the color first to simulate the light absorption on the way in and out
         color *= 1 - waterAbsorption * opacity;
         // lerp in the watercolor to simulate the scattered light from the dirty water


### PR DESCRIPTION
I noticed a problem with our new fancy water: the water depth for the terrain shader is limited to 1 maximum as we read that from a texture and the texture can't provide values greater than 1. With the exponential absorption that means we are stuck with ~90% absorption, which is a problem if someone wants to create really murky water. What I did is that we simply multiply the scale by two, then we can reach ~98% absorption, which should be enough.
If a map is supposed to have pretty clear water, then the abyss depth can be set to be significantly lower than the lowest terrain.

Maps using the linear water absorption are unaffected