### PR TITLE
Reduce Scathis selection priority to structure level

### DIFF
--- a/units/URL0401/URL0401_unit.bp
+++ b/units/URL0401/URL0401_unit.bp
@@ -140,6 +140,7 @@ UnitBlueprint{
         },
         FactionName = "Cybran",
         Icon = "amph",
+        SelectionPriority = 5,
         UnitName = "<LOC url0401_name>Scathis",
     },
     Intel = {


### PR DESCRIPTION
Prevents Scathis being selected instead of engineers or alongside combat units.
Resolves #4892.