### PR TITLE
Let Suthanus fire backwards

### DIFF
--- a/units/XSL0304/XSL0304_unit.bp
+++ b/units/XSL0304/XSL0304_unit.bp
@@ -247,7 +247,7 @@ UnitBlueprint{
             TurretBoneYaw = "Turret",
             TurretDualManipulators = false,
             TurretPitch = 30,
-            TurretPitchRange = 40,
+            TurretPitchRange = 50,
             TurretPitchSpeed = 20,
             TurretYaw = 0,
             TurretYawRange = 180,


### PR DESCRIPTION
Fixes #4889.
As for animations, the weapon clips into the body when firing backwards regardless of 40 or 50 pitch range, so it's not an issue.