### PR TITLE
Fix Janus and Scorcher tracking bombs

### DIFF
--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -736,6 +736,9 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             if unit.Dead then return end
             unit:SetBusy(false)
 
+            -- at this point salvo is always done so reset the data in case firing was interrupted
+            self.CurrentSalvoData = nil
+
             self:WaitForAndDestroyManips()
             local bp = self.Blueprint
             for _, rack in bp.RackBones do

--- a/lua/sim/weapons/uef/TIFCarpetBombWeapon.lua
+++ b/lua/sim/weapons/uef/TIFCarpetBombWeapon.lua
@@ -27,21 +27,24 @@ local DefaultProjectileWeaponCreateProjectileAtMuzzle = DefaultProjectileWeapon.
 TIFCarpetBombWeapon = ClassWeapon(DefaultProjectileWeapon) {
     FxMuzzleFlash = { '/effects/emitters/antiair_muzzle_fire_02_emit.bp', },
 
+    -- We adapt this function because it will call every time a projectile is created,
+    -- so we can retarget the weapon to where we want the projectile to go instead
+    -- of the unit AI targeting the weapon for us during that one projectile firing.
     --- This function creates the projectile, and happens when the unit is trying to fire
     --- Called from inside RackSalvoFiringState
     ---@param self TIFCarpetBombWeapon
     ---@param muzzle string
     ---@return Projectile
     CreateProjectileAtMuzzle = function(self, muzzle)
-        -- adapt this function to keep the correct target lock during carpet bombing
         local data = self.CurrentSalvoData
-        if data and data.usestore then
-            local pos = data.targetpos
-            if pos then
-                self:SetTargetGround(pos)
+        if data then -- check if we fired once
+            if data.target then
+                -- last shot we calculated where to drop bombs to hit a certain target
+                -- we don't want to keep updating this location, so remove the target.
+                data.target = nil
             end
+            self:SetTargetGround(data.targetPos)
         end
-
         return DefaultProjectileWeaponCreateProjectileAtMuzzle(self, muzzle)
     end,
 }


### PR DESCRIPTION
Resolves #2407.
Greatly improves the bomb dropping pattern of the Janus and Scorcher by making them drop their entire salvo onto one location instead of constantly tracking their target and dropping each individual bomb onto the current predicted target location.
It does change balance for both bombers.
To test, turn on NoDamage in the console, spawn 10 bombers, and spawn a Harbinger as a target for you to micro. The Harbinger turns quickly so it can show off bomb dodging but isn't so fast that the bombing attempt fails like the Spirit. Notice how the Janus doesn't leave giant fiery rings when bombing a turning target.

https://github.com/FAForever/fa/assets/82986251/e17f1c57-8a12-4f36-84a0-49dd0ab74fce

https://github.com/FAForever/fa/assets/82986251/0d2cdb82-fa63-4ba8-82ad-f0d9d0ff3a15

The old "fix" in the weapon script didn't work because `data.usestore` was never set to true. Regardless, it would've had an incorrect bomb trajectory because targetPos was not adjusted for unit speed, while the ballistic acceleration calculation was.