### PR TITLE
Adjust SACU preset selectionpriority for combat

### DIFF
--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -700,6 +700,7 @@ function HandleUnitWithBuildPresets(bps, all_bps)
             tempBp.BaseBlueprintId = tempBp.BlueprintId
             tempBp.BlueprintId = string.lower(tempBp.BlueprintId .. '_' .. name)
             tempBp.BuildIconSortPriority = preset.BuildIconSortPriority or tempBp.BuildIconSortPriority or 0
+            tempBp.General.SelectionPriority = preset.SelectionPriority or tempBp.General.SelectionPriority or 1
             tempBp.General.UnitName = preset.UnitName or tempBp.General.UnitName
             tempBp.Interface = tempBp.Interface or { }
             tempBp.Interface.HelpText = preset.HelpText or tempBp.Interface.HelpText

--- a/units/UAL0301/UAL0301_script.lua
+++ b/units/UAL0301/UAL0301_script.lua
@@ -72,7 +72,7 @@ UAL0301 = ClassUnit(CommandUnit) {
             self:SetMaintenanceConsumptionInactive()
             self:RemoveToggleCap('RULEUTC_ShieldToggle')
         elseif enh == 'ShieldHeavy' then
-            self.Trash:Add(ForkThread(self.CreateHeavyShield, bp,self))
+            self.Trash:Add(ForkThread(self.CreateHeavyShield, self, bp))
         elseif enh == 'ShieldHeavyRemove' then
             self:DestroyShield()
             self:SetMaintenanceConsumptionInactive()

--- a/units/UAL0301/UAL0301_unit.bp
+++ b/units/UAL0301/UAL0301_unit.bp
@@ -223,6 +223,7 @@ UnitBlueprint{
             HelpText = "<LOC ual0301_NanoCombat_help>Support Armored Command Unit. Enhanced during construction with the reacton refractor and nano-repair system enhancements.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC ual0301_NanoCombat_name>SACU (Nano Combatant preset)",
+            SelectionPriority = 1,
         },
         RAS = {
             Description = "<LOC ual0301_RAS_desc>SACU (RAS preset)",
@@ -243,6 +244,7 @@ UnitBlueprint{
             HelpText = "<LOC ual0301_Rambo_help>Support Armored Command Unit. Enhanced during construction with a personal shield and the reacton refractor enhancements.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC ual0301_Rambo_name>SACU (Rambo preset)",
+            SelectionPriority = 1,
         },
         ShieldCombat = {
             Description = "<LOC ual0301_ShieldCombat_desc>SACU (Shield Combatant preset)",
@@ -254,6 +256,7 @@ UnitBlueprint{
             HelpText = "<LOC ual0301_ShieldCombat_help>Support Armored Command Unit. Enhanced during construction with a personal shield and the reacton refractor enhancements.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC ual0301_ShieldCombat_name>SACU (Shield Combatant preset)",
+            SelectionPriority = 1,
         },
         SimpleCombat = {
             Description = "<LOC ual0301_SimpleCombat_desc>SACU (Combatant preset)",
@@ -262,6 +265,7 @@ UnitBlueprint{
             HelpText = "<LOC ual0301_SimpleCombat_help>Support Armored Command Unit. Enhanced during construction with the reacton refractor enhancement.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC ual0301_SimpleCombat_name>SACU (Combatant preset)",
+            SelectionPriority = 1,
         },
     },
     Enhancements = {

--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -201,6 +201,7 @@ UnitBlueprint{
             HelpText = "<LOC uel0301_BubbleShield_help>Support Armored Command Unit. Enhanced during construction with the bubble shield generator enhancement.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC uel0301_BubbleShield_name>SACU (Shield preset)",
+            SelectionPriority = 1,
         },
         Combat = {
             Description = "<LOC uel0301_Combat_desc>SACU (Combatant preset)",
@@ -212,6 +213,7 @@ UnitBlueprint{
             HelpText = "<LOC uel0301_Combat_help>Support Armored Command Unit. Enhanced during construction with the energy accelerator and heavy plasma refractor enhancements.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC uel0301_Combat_name>SACU (Combatant preset)",
+            SelectionPriority = 1,
         },
         Engineer = {
             Description = "<LOC uel0301_Engineer_desc>SACU (Engineer preset)",
@@ -251,6 +253,7 @@ UnitBlueprint{
             HelpText = "<LOC uel0301_Rambo_help>Support Armored Command Unit. Enhanced during construction with a personal shield, energy accelerator and heavy plasma refractor enhancements.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC uel0301_Rambo_name>SACU (Rambo preset)",
+            SelectionPriority = 1,
         },
     },
     Enhancements = {

--- a/units/URL0301/URL0301_unit.bp
+++ b/units/URL0301/URL0301_unit.bp
@@ -199,6 +199,7 @@ UnitBlueprint{
             HelpText = "<LOC url0301_AntiAir_help>Support Armored Command Unit. Enhanced during construction with the nanite missile system enhancement.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC url0301_AntiAir_name>SACU (Anti-Air preset)",
+            SelectionPriority = 1,
         },
         Cloak = {
             Description = "<LOC url0301_Cloak_desc>SACU (Cloak preset)",
@@ -211,6 +212,7 @@ UnitBlueprint{
             HelpText = "<LOC url0301_Cloak_help>Support Armored Command Unit. Enhanced during construction with the personal cloaking generator and disintegrator amplifier enhancements.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC url0301_Cloak_name>SACU (Cloak preset)",
+            SelectionPriority = 1,
         },
         Combat = {
             Description = "<LOC url0301_Combat_desc>SACU (Combatant preset)",
@@ -222,6 +224,7 @@ UnitBlueprint{
             HelpText = "<LOC url0301_Combat_help>Support Armored Command Unit. Enhanced during construction with the EMP burst and disintegrator amplifier enhancements.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC url0301_Combat_name>SACU (Combatant preset)",
+            SelectionPriority = 1,
         },
         Engineer = {
             Description = "<LOC url0301_Engineer_desc>SACU (Engineer preset)",
@@ -250,6 +253,7 @@ UnitBlueprint{
             HelpText = "<LOC url0301_Rambo_help>Support Armored Command Unit. Enhanced during construction with the EMP burst, disintegrator amplifier and nano-repair system enhancements.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC url0301_Rambo_name>SACU (Rambo preset)",
+            SelectionPriority = 1,
         },
         Stealth = {
             Description = "<LOC url0301_Stealth_desc>SACU (Stealth preset)",
@@ -258,6 +262,7 @@ UnitBlueprint{
             HelpText = "<LOC url0301_Stealth_help>Support Armored Command Unit. Enhanced during construction with the personal stealth generator enhancement.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC url0301_Stealth_name>SACU (Stealth preset)",
+            SelectionPriority = 1,
         },
     },
     Enhancements = {

--- a/units/XSL0301/XSL0301_unit.bp
+++ b/units/XSL0301/XSL0301_unit.bp
@@ -223,6 +223,7 @@ UnitBlueprint{
             HelpText = "<LOC xsl0301_AdvancedCombat_help>Support Armored Command Unit. Enhanced during construction with the enhanced sensor system, nano-repair system and overcharge enhancements.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC xsl0301_AdvancedCombat_name>SACU (Advanced Combatant preset)",
+            SelectionPriority = 1,
         },
         Combat = {
             Description = "<LOC xsl0301_Combat_desc>SACU (Combatant preset)",
@@ -231,6 +232,7 @@ UnitBlueprint{
             HelpText = "<LOC xsl0301_Combat_help>Support Armored Command Unit. Enhanced during construction with the enhanced sensor system enhancement.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC xsl0301_Combat_name>SACU (Combatant preset)",
+            SelectionPriority = 1,
         },
         Engineer = {
             Description = "<LOC xsl0301_Engineer_desc>SACU (Engineer preset)",
@@ -261,6 +263,7 @@ UnitBlueprint{
             HelpText = "<LOC xsl0301_NanoCombat_help>Support Armored Command Unit. Enhanced during construction with the enhanced sensor system and nano-repair system enhancements.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC xsl0301_NanoCombat_name>SACU (Nano Combatant preset)",
+            SelectionPriority = 1,
         },
         Rambo = {
             Description = "<LOC xsl0301_Rambo_desc>SACU (Rambo preset)",
@@ -273,6 +276,7 @@ UnitBlueprint{
             HelpText = "<LOC xsl0301_Rambo_help>Support Armored Command Unit. Enhanced during construction with the personal shield generator, nano-repair system and overcharge enhancements.",
             SortCategory = "SORTOTHER",
             UnitName = "<LOC xsl0301_Rambo_name>SACU (Rambo preset)",
+            SelectionPriority = 1,
         },
     },
     Enhancements = {


### PR DESCRIPTION
Presets that are made for fighting now have the same selection priority as combat units and can be selected together with them even when not holding shift.
SACU presets that are not made to be used like other combat units are left unchanged.

Presets adjusted to be selectable like combat units: 
UEF: BubbleShield, Combat, Rambo
AEON: NanoCombat, Rambo, ShieldCombat, SimpleCombat
CYBRAN: AntiAir, Cloak, Combat, Rambo, Stealth
SERA: AdvancedCombat, Combat, NanoCombat, Rambo

Presets unchanged and still selectable like default SACUs and engies: 
UEF: Engineer, IntelJammer, RAS
AEON: Engineer, RAS
CYBRAN: Engineer, RAS
SERA: Engineer, Missile
