### PR TITLE
Fix crash when cybran build bots assist a silo

### DIFF
--- a/lua/sim/units/cybran/CBuildBotUnit.lua
+++ b/lua/sim/units/cybran/CBuildBotUnit.lua
@@ -50,6 +50,14 @@ CBuildBotUnit = ClassDummyUnit(DummyUnit) {
     end,
 
     ---@param self CBuildBotUnit
+    OnCreate = function(self)
+        DummyUnit.OnCreate(self)
+
+        -- prevent drone from consuming anything
+        UnitSetConsumptionActive(self, false)
+    end,
+
+    ---@param self CBuildBotUnit
     OnDestroy = function(self)
         TrashBagDestroy(self.Trash)
 


### PR DESCRIPTION
Was caused by #5672. I copy-pasted the missing `OnCreate` function for build bots, and now they work. I found the issue independently, but it was also reported earlier on discord.
We both have a similar crash log from the debugger, this is my log:
```
ACCESS_VIOLATION: Read from 0x00000008
Stacktrace: 0x005F5D3E 0x005F5B8A 0x005F9CD9 0x00958CE2 0x005947A2 0x006FE171 0x0040A8C5 0x0040A8C5
.?AVUnit@Moho@@
.?AVCUnitRepairTask@Moho@@
.?AVRUnitBlueprint@Moho@@
.?AVCArmyStats@Moho@@
.?AVCArmyImpl@Moho@@
MiniDump:
From 0x005F5CFE to 0x005F5D7E
C3740583C0FCEB0233C08B108BC88B423C6A2DFFD084C00F84050600008B45083BC3740583C0FCEB0233C03998580500000F84A80600008B4D008B8134050000
8B5008F30F1044241C895424248B400CF30F104C2424894424288B45083BC3F30F59C8F30F114C2424F30F104C2428F30F59C8F30F114C2428740583C0FCEB02
```
