### PR TITLE
Fix bug that can make build queue unresponsive

### DIFF
--- a/engine/User.lua
+++ b/engine/User.lua
@@ -937,7 +937,7 @@ end
 
 ---
 ---@param unit UserUnit
----@return BuildQueue
+---@return UIBuildQueue
 function SetCurrentFactoryForQueueDisplay(unit)
 end
 

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -711,7 +711,11 @@ function OnSelectionChanged(oldSelection, newSelection, added, removed)
     import("/lua/ui/game/unitview.lua").OnSelection(newSelection)
 end
 
+---@param newQueue UIBuildQueue
 function OnQueueChanged(newQueue)
+    -- update the Lua representation of the queue
+    UpdateCurrentFactoryForQueueDisplay(newQueue)
+
     if not gameUIHidden then
         import("/lua/ui/game/construction.lua").OnQueueChanged(newQueue)
     end

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -552,8 +552,7 @@ function UpdateWindow(info)
                 end
 
                 -- show that queue
-                controls.queue.grid:UpdateQueue(SetCurrentFactoryForQueueDisplay(factory))
-                ClearCurrentFactoryForQueueDisplay()
+                controls.queue.grid:UpdateQueue(PeekCurrentFactoryForQueueDisplay(factory))
             else
                 controls.queue:Hide()
             end

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -256,11 +256,11 @@ do
     ---@field count number
     ---@field id UnitId
 
-    ---@type boolean
-    local buildQueueExists = false
+    ---@type UserUnit | nil
+    local buildQueueOfUnit = nil
 
     ---@type UIBuildQueue
-    local factoryBuildQueue = {}
+    local buildQueue = {}
 
     local OldClearCurrentFactoryForQueueDisplay = _G.ClearCurrentFactoryForQueueDisplay
     local OldSetCurrentFactoryForQueueDisplay = _G.SetCurrentFactoryForQueueDisplay
@@ -275,8 +275,8 @@ do
     ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
     _G.ClearCurrentFactoryForQueueDisplay = function()
         LOG("ClearCurrentFactoryForQueueDisplay")
-        buildQueueExists = false
-        factoryBuildQueue = {}
+        buildQueueOfUnit = nil
+        buildQueue = {}
         OldClearCurrentFactoryForQueueDisplay()
     end
 
@@ -290,9 +290,28 @@ do
     ---@return UIBuildQueue
     _G.SetCurrentFactoryForQueueDisplay = function(userUnit)
         LOG("SetCurrentFactoryForQueueDisplay")
-        buildQueueExists = true
-        factoryBuildQueue = OldSetCurrentFactoryForQueueDisplay(userUnit)
-        return factoryBuildQueue
+        buildQueueOfUnit = userUnit
+        buildQueue = OldSetCurrentFactoryForQueueDisplay(userUnit)
+        return buildQueue
+    end
+
+    --- Retrieve the build queue without changing the global state
+    ---@see DecreaseBuildCountInQueue           # To decrease the build count in the queue
+    ---@see IncreaseBuildCountInQueue           # To increase the build count in the queue
+    ---@see SetCurrentFactoryForQueueDisplay    # To set the current queue
+    ---@see GetCurrentFactoryForQueueDisplay    # To get the current queue
+    ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
+    ---@param userUnit UserUnit
+    ---@return UIBuildQueue
+    _G.PeekCurrentFactoryForQueueDisplay = function(userUnit)
+        local oldBuildQueueOfUnit = buildQueueOfUnit
+        local queue = SetCurrentFactoryForQueueDisplay(userUnit)
+
+        if oldBuildQueueOfUnit then
+            SetCurrentFactoryForQueueDisplay(oldBuildQueueOfUnit)
+        end
+
+        return queue
     end
 
     --- Update the current command queue. Does not update the internal state of the engine - do not use directly!
@@ -304,8 +323,7 @@ do
     ---@param queue UIBuildQueue
     _G.UpdateCurrentFactoryForQueueDisplay = function(queue)
         LOG("UpdateCurrentFactoryForQueueDisplay")
-        buildQueueExists = true
-        factoryBuildQueue = queue
+        buildQueue = queue
     end
 
     --- Retrieves the current build queue
@@ -317,8 +335,10 @@ do
     ---@return UIBuildQueue[]
     _G.GetCurrentFactoryForQueueDisplay = function()
         LOG("GetCurrentFactoryForQueueDisplay")
-        return factoryBuildQueue
+        return buildQueue
     end
+
+
 
     --- Decrease the count at a given location of the current build queue
     ---@see DecreaseBuildCountInQueue           # To decrease the build count in the queue
@@ -331,20 +351,24 @@ do
     _G.DecreaseBuildCountInQueue = function(index, count)
         LOG("DecreaseBuildCountInQueue")
 
-        if not buildQueueExists then
+        if not buildQueueOfUnit then
             WARN("Unable to decrease build queue count when no build queue is set")
+            return
         end
 
-        if table.empty(factoryBuildQueue) then
+        if table.empty(buildQueue) then
             WARN("Unable to decrease build queue is empty")
+            return
         end
 
         if index < 1 then
             WARN("Unable to decrease build queue count when index is smaller than 1")
+            return
         end
 
-        if index > table.getn(factoryBuildQueue) then
+        if index > table.getn(buildQueue) then
             WARN("Unable to decrease build queue count when queue index is larger than the elements in the queue")
+            return
         end
 
         return OldDecreaseBuildCountInQueue(index, count)
@@ -361,24 +385,29 @@ do
     _G.IncreaseBuildCountInQueue = function(index, count)
         LOG("IncreaseBuildCountInQueue")
 
-        if not buildQueueExists then
+        if not buildQueueOfUnit then
             WARN("Unable to increase build queue count when no build queue is set")
+            return
         end
 
-        if table.empty(factoryBuildQueue) then
+        if table.empty(buildQueue) then
             WARN("Unable to increase build queue is empty")
+            return
         end
 
-        if table.empty(factoryBuildQueue) then
+        if table.empty(buildQueue) then
             WARN("Unable to increase build queue count when no build queue is set")
+            return
         end
 
         if index < 1 then
             WARN("Unable to increase build queue count when index is smaller than 1")
+            return
         end
 
-        if index > table.getn(factoryBuildQueue) then
+        if index > table.getn(buildQueue) then
             WARN("Unable to increase build queue count when queue index is larger than the elements in the queue")
+            return
         end
 
         return OldIncreaseBuildCountInQueue(index, count)

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -274,7 +274,6 @@ do
     ---@see GetCurrentFactoryForQueueDisplay    # To get the current queue
     ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
     _G.ClearCurrentFactoryForQueueDisplay = function()
-        LOG("ClearCurrentFactoryForQueueDisplay")
         buildQueueOfUnit = nil
         buildQueue = {}
         OldClearCurrentFactoryForQueueDisplay()
@@ -289,7 +288,6 @@ do
     ---@param userUnit UserUnit
     ---@return UIBuildQueue
     _G.SetCurrentFactoryForQueueDisplay = function(userUnit)
-        LOG("SetCurrentFactoryForQueueDisplay")
         buildQueueOfUnit = userUnit
         buildQueue = OldSetCurrentFactoryForQueueDisplay(userUnit)
         return buildQueue
@@ -305,7 +303,7 @@ do
     ---@return UIBuildQueue
     _G.PeekCurrentFactoryForQueueDisplay = function(userUnit)
         if IsDestroyed(userUnit) then
-            return { }
+            return {}
         end
 
         local oldBuildQueueOfUnit = buildQueueOfUnit
@@ -326,7 +324,6 @@ do
     ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
     ---@param queue UIBuildQueue
     _G.UpdateCurrentFactoryForQueueDisplay = function(queue)
-        LOG("UpdateCurrentFactoryForQueueDisplay")
         buildQueue = queue
     end
 
@@ -338,11 +335,8 @@ do
     ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
     ---@return UIBuildQueue[]
     _G.GetCurrentFactoryForQueueDisplay = function()
-        LOG("GetCurrentFactoryForQueueDisplay")
         return buildQueue
     end
-
-
 
     --- Decrease the count at a given location of the current build queue
     ---@see DecreaseBuildCountInQueue           # To decrease the build count in the queue
@@ -353,8 +347,6 @@ do
     ---@param index number
     ---@param count number
     _G.DecreaseBuildCountInQueue = function(index, count)
-        LOG("DecreaseBuildCountInQueue")
-
         if not buildQueueOfUnit then
             WARN("Unable to decrease build queue count when no build queue is set")
             return
@@ -387,8 +379,6 @@ do
     ---@param index number
     ---@param count number
     _G.IncreaseBuildCountInQueue = function(index, count)
-        LOG("IncreaseBuildCountInQueue")
-
         if not buildQueueOfUnit then
             WARN("Unable to increase build queue count when no build queue is set")
             return

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -274,7 +274,6 @@ do
     ---@see GetCurrentFactoryForQueueDisplay    # To get the current queue
     ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
     _G.ClearCurrentFactoryForQueueDisplay = function()
-        LOG("ClearCurrentFactoryForQueueDisplay")
         buildQueueOfUnit = nil
         buildQueue = {}
         OldClearCurrentFactoryForQueueDisplay()
@@ -289,7 +288,6 @@ do
     ---@param userUnit UserUnit
     ---@return UIBuildQueue
     _G.SetCurrentFactoryForQueueDisplay = function(userUnit)
-        LOG("SetCurrentFactoryForQueueDisplay")
         buildQueueOfUnit = userUnit
         buildQueue = OldSetCurrentFactoryForQueueDisplay(userUnit)
         return buildQueue
@@ -322,7 +320,6 @@ do
     ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
     ---@param queue UIBuildQueue
     _G.UpdateCurrentFactoryForQueueDisplay = function(queue)
-        LOG("UpdateCurrentFactoryForQueueDisplay")
         buildQueue = queue
     end
 
@@ -334,11 +331,8 @@ do
     ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
     ---@return UIBuildQueue[]
     _G.GetCurrentFactoryForQueueDisplay = function()
-        LOG("GetCurrentFactoryForQueueDisplay")
         return buildQueue
     end
-
-
 
     --- Decrease the count at a given location of the current build queue
     ---@see DecreaseBuildCountInQueue           # To decrease the build count in the queue
@@ -349,8 +343,6 @@ do
     ---@param index number
     ---@param count number
     _G.DecreaseBuildCountInQueue = function(index, count)
-        LOG("DecreaseBuildCountInQueue")
-
         if not buildQueueOfUnit then
             WARN("Unable to decrease build queue count when no build queue is set")
             return
@@ -383,8 +375,6 @@ do
     ---@param index number
     ---@param count number
     _G.IncreaseBuildCountInQueue = function(index, count)
-        LOG("IncreaseBuildCountInQueue")
-
         if not buildQueueOfUnit then
             WARN("Unable to increase build queue count when no build queue is set")
             return

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -274,6 +274,7 @@ do
     ---@see GetCurrentFactoryForQueueDisplay    # To get the current queue
     ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
     _G.ClearCurrentFactoryForQueueDisplay = function()
+        LOG("ClearCurrentFactoryForQueueDisplay")
         buildQueueOfUnit = nil
         buildQueue = {}
         OldClearCurrentFactoryForQueueDisplay()
@@ -288,6 +289,7 @@ do
     ---@param userUnit UserUnit
     ---@return UIBuildQueue
     _G.SetCurrentFactoryForQueueDisplay = function(userUnit)
+        LOG("SetCurrentFactoryForQueueDisplay")
         buildQueueOfUnit = userUnit
         buildQueue = OldSetCurrentFactoryForQueueDisplay(userUnit)
         return buildQueue
@@ -302,6 +304,10 @@ do
     ---@param userUnit UserUnit
     ---@return UIBuildQueue
     _G.PeekCurrentFactoryForQueueDisplay = function(userUnit)
+        if IsDestroyed(userUnit) then
+            return { }
+        end
+
         local oldBuildQueueOfUnit = buildQueueOfUnit
         local queue = SetCurrentFactoryForQueueDisplay(userUnit)
 
@@ -320,6 +326,7 @@ do
     ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
     ---@param queue UIBuildQueue
     _G.UpdateCurrentFactoryForQueueDisplay = function(queue)
+        LOG("UpdateCurrentFactoryForQueueDisplay")
         buildQueue = queue
     end
 
@@ -331,8 +338,11 @@ do
     ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
     ---@return UIBuildQueue[]
     _G.GetCurrentFactoryForQueueDisplay = function()
+        LOG("GetCurrentFactoryForQueueDisplay")
         return buildQueue
     end
+
+
 
     --- Decrease the count at a given location of the current build queue
     ---@see DecreaseBuildCountInQueue           # To decrease the build count in the queue
@@ -343,6 +353,8 @@ do
     ---@param index number
     ---@param count number
     _G.DecreaseBuildCountInQueue = function(index, count)
+        LOG("DecreaseBuildCountInQueue")
+
         if not buildQueueOfUnit then
             WARN("Unable to decrease build queue count when no build queue is set")
             return
@@ -375,6 +387,8 @@ do
     ---@param index number
     ---@param count number
     _G.IncreaseBuildCountInQueue = function(index, count)
+        LOG("IncreaseBuildCountInQueue")
+
         if not buildQueueOfUnit then
             WARN("Unable to increase build queue count when no build queue is set")
             return

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -248,3 +248,139 @@ do
         IssueBlueprintCommandToUnits(UnitsCache, command, blueprintid, count, clear)
     end
 end
+
+do
+    ---@alias UIBuildQueue UIBuildQueueItem[]
+
+    ---@class UIBuildQueueItem
+    ---@field count number
+    ---@field id UnitId
+
+    ---@type boolean
+    local buildQueueExists = false
+
+    ---@type UIBuildQueue
+    local factoryBuildQueue = {}
+
+    local OldClearCurrentFactoryForQueueDisplay = _G.ClearCurrentFactoryForQueueDisplay
+    local OldSetCurrentFactoryForQueueDisplay = _G.SetCurrentFactoryForQueueDisplay
+    local OldDecreaseBuildCountInQueue = _G.DecreaseBuildCountInQueue
+    local OldIncreaseBuildCountInQueue = _G.IncreaseBuildCountInQueue
+
+    --- Clears the current build queue
+    ---@see DecreaseBuildCountInQueue           # To decrease the build count in the queue
+    ---@see IncreaseBuildCountInQueue           # To increase the build count in the queue
+    ---@see SetCurrentFactoryForQueueDisplay    # To set the current queue
+    ---@see GetCurrentFactoryForQueueDisplay    # To get the current queue
+    ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
+    _G.ClearCurrentFactoryForQueueDisplay = function()
+        LOG("ClearCurrentFactoryForQueueDisplay")
+        buildQueueExists = false
+        factoryBuildQueue = {}
+        OldClearCurrentFactoryForQueueDisplay()
+    end
+
+    --- Defines the current build queue
+    ---@see DecreaseBuildCountInQueue           # To decrease the build count in the queue
+    ---@see IncreaseBuildCountInQueue           # To increase the build count in the queue
+    ---@see SetCurrentFactoryForQueueDisplay    # To set the current queue
+    ---@see GetCurrentFactoryForQueueDisplay    # To get the current queue
+    ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
+    ---@param userUnit UserUnit
+    ---@return UIBuildQueue
+    _G.SetCurrentFactoryForQueueDisplay = function(userUnit)
+        LOG("SetCurrentFactoryForQueueDisplay")
+        buildQueueExists = true
+        factoryBuildQueue = OldSetCurrentFactoryForQueueDisplay(userUnit)
+        return factoryBuildQueue
+    end
+
+    --- Update the current command queue. Does not update the internal state of the engine - do not use directly!
+    ---@see DecreaseBuildCountInQueue           # To decrease the build count in the queue
+    ---@see IncreaseBuildCountInQueue           # To increase the build count in the queue
+    ---@see SetCurrentFactoryForQueueDisplay    # To set the current queue
+    ---@see GetCurrentFactoryForQueueDisplay    # To get the current queue
+    ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
+    ---@param queue UIBuildQueue
+    _G.UpdateCurrentFactoryForQueueDisplay = function(queue)
+        LOG("UpdateCurrentFactoryForQueueDisplay")
+        buildQueueExists = true
+        factoryBuildQueue = queue
+    end
+
+    --- Retrieves the current build queue
+    ---@see DecreaseBuildCountInQueue           # To decrease the build count in the queue
+    ---@see IncreaseBuildCountInQueue           # To increase the build count in the queue
+    ---@see SetCurrentFactoryForQueueDisplay    # To set the current queue
+    ---@see GetCurrentFactoryForQueueDisplay    # To get the current queue
+    ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
+    ---@return UIBuildQueue[]
+    _G.GetCurrentFactoryForQueueDisplay = function()
+        LOG("GetCurrentFactoryForQueueDisplay")
+        return factoryBuildQueue
+    end
+
+    --- Decrease the count at a given location of the current build queue
+    ---@see DecreaseBuildCountInQueue           # To decrease the build count in the queue
+    ---@see IncreaseBuildCountInQueue           # To increase the build count in the queue
+    ---@see SetCurrentFactoryForQueueDisplay    # To set the current queue
+    ---@see GetCurrentFactoryForQueueDisplay    # To get the current queue
+    ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
+    ---@param index number
+    ---@param count number
+    _G.DecreaseBuildCountInQueue = function(index, count)
+        LOG("DecreaseBuildCountInQueue")
+
+        if not buildQueueExists then
+            WARN("Unable to decrease build queue count when no build queue is set")
+        end
+
+        if table.empty(factoryBuildQueue) then
+            WARN("Unable to decrease build queue is empty")
+        end
+
+        if index < 1 then
+            WARN("Unable to decrease build queue count when index is smaller than 1")
+        end
+
+        if index > table.getn(factoryBuildQueue) then
+            WARN("Unable to decrease build queue count when queue index is larger than the elements in the queue")
+        end
+
+        return OldDecreaseBuildCountInQueue(index, count)
+    end
+
+    --- Increase the count at a given location of the current build queue
+    ---@see DecreaseBuildCountInQueue           # To decrease the build count in the queue
+    ---@see IncreaseBuildCountInQueue           # To increase the build count in the queue
+    ---@see SetCurrentFactoryForQueueDisplay    # To set the current queue
+    ---@see GetCurrentFactoryForQueueDisplay    # To get the current queue
+    ---@see ClearCurrentFactoryForQueueDisplay  # To clear the current queue
+    ---@param index number
+    ---@param count number
+    _G.IncreaseBuildCountInQueue = function(index, count)
+        LOG("IncreaseBuildCountInQueue")
+
+        if not buildQueueExists then
+            WARN("Unable to increase build queue count when no build queue is set")
+        end
+
+        if table.empty(factoryBuildQueue) then
+            WARN("Unable to increase build queue is empty")
+        end
+
+        if table.empty(factoryBuildQueue) then
+            WARN("Unable to increase build queue count when no build queue is set")
+        end
+
+        if index < 1 then
+            WARN("Unable to increase build queue count when index is smaller than 1")
+        end
+
+        if index > table.getn(factoryBuildQueue) then
+            WARN("Unable to increase build queue count when queue index is larger than the elements in the queue")
+        end
+
+        return OldIncreaseBuildCountInQueue(index, count)
+    end
+end


### PR DESCRIPTION
There are four cfunctions that allow you to interact with the build queue:

- (1) `ClearCurrentFactoryForQueueDisplay(): nil`: clear the internal build queue
- (2) `SetCurrentFactoryForQueueDisplay(userUnit) : UIBuildQueue`: define the internal build queue 
- (3) `DecreaseBuildCountInQueue(index, count):nil`: decrease count at index of internal build queue
- (4) `IncreaseBuildCountInQueue(index, count):nil`: increase count at index of internal build queue

The first problem is that they interact with some global object that is defined with (2). The functions (3) and (4) rely on that global object. With (1) the global object is reset. The jargon for this is 'global state' and it is considered a [bad practice](https://softwareengineering.stackexchange.com/questions/148108/why-is-global-state-so-evil).

The second problem is that (3) and (4) lack error handling. For example, the situation where you first call (1) and then (3) or (4) throws no errors. The jargon for this is a 'silent error' and it can be quite frustrating to work with.

The third problem is that you are unable to retrieve the current global state. There is no 'get' function.

The fourth problem is that you are unable to retrieve the build queue of a unit without also messing with the global state. There is no 'peek' function.

With the hooks as defined in `lua/userInit.lua` I try to help fix some of these problems. There is still a global object, but at least there are now safe to use functions that allow you to retrieve the global object and peek at the build queue of a given unit.