### PR TITLE
Remove unused cost stats from Seraphim naval TML

### DIFF
--- a/projectiles/SIFLaanseTacticalMissile02/SIFLaanseTacticalMissile02_proj.bp
+++ b/projectiles/SIFLaanseTacticalMissile02/SIFLaanseTacticalMissile02_proj.bp
@@ -39,11 +39,6 @@ ProjectileBlueprint {
         StrategicIconSize = 2,
         UniformScale = 0.05,
     },
-    Economy = {
-        BuildCostEnergy = 6000,
-        BuildCostMass = 300,
-        BuildTime = 30,
-    },
     General = {
         Category = 'Missile',
         Faction = 'Seraphim',

--- a/projectiles/SIFLaanseTacticalMissile03/SIFLaanseTacticalMissile03_proj.bp
+++ b/projectiles/SIFLaanseTacticalMissile03/SIFLaanseTacticalMissile03_proj.bp
@@ -39,11 +39,6 @@ ProjectileBlueprint {
         StrategicIconSize = 2,
         UniformScale = 0.05,
     },
-    Economy = {
-        BuildCostEnergy = 6000,
-        BuildCostMass = 300,
-        BuildTime = 30,
-    },
     General = {
         Category = 'Missile',
         Faction = 'Seraphim',


### PR DESCRIPTION
They unnecessarily show up in the weapon stats.