### PR TITLE
Fix weapons that fire after charging skipping fire rate

### DIFF
--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -1177,7 +1177,9 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             self:WaitForAndDestroyManips()
 
             local hasTarget = self:WeaponHasTarget()
-            local autoFire = not bp.ManualFire
+            -- Weapons that fire after charging will ignore the fire rate if we don't send them to the idle state
+            -- and if we send them to the fire ready state instead, they will ignore charge effects
+            local autoFire = not bp.ManualFire and not bp.RackSalvoFiresAfterCharge
 
             if hasTarget and bp.RackSalvoChargeTime > 0 and autoFire then
                 ChangeState(self, self.RackSalvoChargeState)


### PR DESCRIPTION
Fixes #5771, caused by #5717. The bug is similar to #5555. Even though #5772 shows that it can be fixed through bps (and some refactoring of effects, which is not included there), this fixes the weapon behavior for mod compatibility as mentioned on discord by @The-Balthazar.