### PR TITLE
Fix Salem's main gun being able to shoot underwater in close range

### DIFF
--- a/projectiles/CDFProtonCannon01/CDFProtonCannon01_proj.bp
+++ b/projectiles/CDFProtonCannon01/CDFProtonCannon01_proj.bp
@@ -43,7 +43,7 @@ ProjectileBlueprint {
     },
     Physics = {
         Acceleration = 0,
-        DestroyOnWater = false,
+        DestroyOnWater = true,
         InitialSpeed = 19,
         InitialSpeedRange = 0,
         MaxSpeed = 0,

--- a/projectiles/CDFProtonCannon01/CDFProtonCannon01_script.lua
+++ b/projectiles/CDFProtonCannon01/CDFProtonCannon01_script.lua
@@ -2,18 +2,5 @@ local CDFProtonCannonProjectile = import("/lua/cybranprojectiles.lua").CDFProton
 
 --- Cybran Proton Cannon
 ---@class CDFProtonCannon01 : CDFProtonCannonProjectile
-CDFProtonCannon01 = ClassProjectile(CDFProtonCannonProjectile) {
-
-    ---@param self CDFProtonCannon01
-    OnCreate = function(self)
-        CDFProtonCannonProjectile.OnCreate(self)
-        self.Trash:Add(ForkThread(self.ImpactWaterThread, self))
-    end,
-
-    ---@param self CDFProtonCannon01
-    ImpactWaterThread = function(self)
-        WaitTicks(4)
-        self:SetDestroyOnWater(true)
-    end,
-}
+CDFProtonCannon01 = ClassProjectile(CDFProtonCannonProjectile) {}
 TypeClass = CDFProtonCannon01


### PR DESCRIPTION
This was included in the steam version of the game too, maybe GPG wanted destroyers to be able to shoot slightly underwater, which is why Valiant's projectiles aren't destroyed on water in GPG? Exodus can hit non-strategic subs with its 1.4 splash after all, while all other factions (including Sera's lasers) have only 1 splash, so they can't hit subs.