### PR TITLE
Working prototype of an alternative way for units to crash to the ground

### DIFF
--- a/effects/Entities/CrashProjectile/CrashAirProjectile_proj.bp
+++ b/effects/Entities/CrashProjectile/CrashAirProjectile_proj.bp
@@ -1,0 +1,12 @@
+ProjectileBlueprint {
+    Physics = {
+        CollideSurface = true,
+        CollideEntity = true,
+        DestroyOnWater = false,
+        RotationalVelocity = 60,
+        RotationalVelocityRange = 120,
+        UseGravity = true,
+        Lifetime = 100,
+        VelocityAlign = true,
+    },
+}

--- a/effects/Entities/CrashProjectile/CrashAirProjectile_script.lua
+++ b/effects/Entities/CrashProjectile/CrashAirProjectile_script.lua
@@ -1,0 +1,51 @@
+--**********************************************************************************
+--** Copyright (c) 2023 FAForever
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--**********************************************************************************
+
+local DummyProjectile = import("/lua/sim/Projectile.lua").DummyProjectile
+
+---@class CrashAirProjectile : DummyProjectile
+CrashAirProjectile = ClassDummyProjectile(DummyProjectile) {
+    ---@param self CrashAirProjectile
+    OnEnterWater = function(self)
+        LOG("OnEnterWater")
+        local crashingUnit = self:GetLauncher() --[[@as Unit]]
+        crashingUnit:OnCrashIntoWater(self)
+    end,
+
+    ---@param self CrashAirProjectile
+    ---@param impactType ProjectileImpactType
+    ---@param impactEntity ProjectileImpactEntity
+    OnImpact = function(self, impactType, impactEntity)
+        LOG("OnImpact - CrashAirProjectile", impactType)
+        local crashingUnit = self:GetLauncher() --[[@as Unit]]
+
+        if impactType == 'Terrain' then
+            crashingUnit:OnCrashIntoTerrain(self, false)
+        elseif impactType == 'Shield' then
+            crashingUnit:OnCrashIntoShield(self, impactEntity, false)
+        elseif impactType == 'Water' then
+            crashingUnit:OnCrashIntoWater(self)
+        end
+    end,
+}
+
+TypeClass = CrashAirProjectile

--- a/effects/Entities/CrashProjectile/CrashWaterProjectile_proj.bp
+++ b/effects/Entities/CrashProjectile/CrashWaterProjectile_proj.bp
@@ -1,0 +1,13 @@
+ProjectileBlueprint {
+    Physics = {
+        CollideSurface = true,
+        CollideEntity = false,
+        DestroyOnWater = false,
+        UseGravity = true,
+        RotationalVelocity = 10,
+        Lifetime = 100,
+        MaxSpeed = 2,
+        MaxSpeedRange = 0.1,
+        VelocityAlign = true,
+    },
+}

--- a/effects/Entities/CrashProjectile/CrashWaterProjectile_script.lua
+++ b/effects/Entities/CrashProjectile/CrashWaterProjectile_script.lua
@@ -1,0 +1,43 @@
+--**********************************************************************************
+--** Copyright (c) 2023 FAForever
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--**********************************************************************************
+
+local DummyProjectile = import("/lua/sim/Projectile.lua").DummyProjectile
+
+---@class CrashWaterProjectile : DummyProjectile
+CrashWaterProjectile = ClassDummyProjectile(DummyProjectile) {
+    ---@param self CrashWaterProjectile
+    ---@param impactType ProjectileImpactType
+    ---@param impactEntity ProjectileImpactEntity
+    OnImpact = function(self, impactType, impactEntity)
+        LOG("OnImpact")
+        LOG(impactType)
+        local crashingUnit = self:GetLauncher() --[[@as Unit]]
+
+        if impactType == 'Terrain' then
+            crashingUnit:OnCrashIntoTerrain(self, true)
+        elseif impactType == 'Shield' then
+            crashingUnit:OnCrashIntoShield(self, true)
+        end
+    end,
+}
+
+TypeClass = CrashWaterProjectile

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -40,6 +40,10 @@
 ---@field BuildBotTotal? number
 --- set to an integer that describes the unit's position in the list of build icons
 ---@field BuildIconSortPriority integer
+--- 
+---@field CrashWatchBone Bone
+--- 
+---@field CrashRadius number
 --- the collision x offset used when `SizeSphere` is defined
 ---@field CollisionSphereOffsetX? number
 --- the collision y offset used when `SizeSphere` is defined

--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -196,7 +196,7 @@ end
 --- Creates a collision detection manipulator, calling the function
 --- `self:OnAnimTerrainCollision(bone, x, y, z)`
 --- when a bone that is being watched collides with the terrain
----@param unit Unit
+---@param unit moho.unit_methods
 ---@return moho.CollisionManipulator
 function CreateCollisionDetector(unit)
 end

--- a/engine/Sim/CCollisionManipulator.lua
+++ b/engine/Sim/CCollisionManipulator.lua
@@ -3,21 +3,23 @@
 ---@class moho.CollisionManipulator : moho.manipulator_methods
 local CCollisionManipulator = {}
 
+--- Enables the manipulator. Events trigger the `OnAnimTerrainCollision` function of the unit
 function CCollisionManipulator:Enable()
 end
 
+--- Disables the manipulator. It is disabled by default
 function CCollisionManipulator:Disable()
 end
 
----
---  Make manipulator check for terrain height intersection
-function CCollisionManipulator:EnableTerrainCheck()
+--- Enables checking for the terrain. Events trigger the `OnAnimTerrainCollision` function of the unit
+---@param checked boolean # Enables or disables the terrain check
+function CCollisionManipulator:EnableTerrainCheck(checked)
 end
 
 ---
---  CollisionDetector:WatchBone(bone) -- add the given bone to those watched by this manipulator
+--- Specify the bones to keep track of.Events trigger the `OnAnimTerrainCollision` function of the unit
+---@param bone Bone
 function CCollisionManipulator:WatchBone(bone)
 end
 
 return CCollisionManipulator
-

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -5,6 +5,20 @@
 --  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 ------------------------------------------------------------------
 
+---@alias ProjectileImpactType 
+--- | 'Terrain' 
+--- | 'Shield' 
+--- | 'Water' 
+--- | 'Unit' 
+--- | 'UnitAir' 
+--- | 'Air'
+--- | 'Projectile'
+--- | 'ProjectileUnderwater'
+--- | 'Underwater'
+--- | 'Prop'
+
+---@alias ProjectileImpactEntity Unit | Prop | Projectile | nil
+
 local ProjectileMethods = moho.projectile_methods
 local DefaultDamage = import("/lua/sim/defaultdamage.lua")
 local Flare = import("/lua/defaultantiprojectile.lua").Flare
@@ -296,8 +310,8 @@ Projectile = ClassProjectile(ProjectileMethods) {
 
     --- Called by the engine when the projectile impacts something
     ---@param self Projectile
-    ---@param targetType string
-    ---@param targetEntity Unit | Prop
+    ---@param targetType ProjectileImpactType
+    ---@param targetEntity ProjectileImpactEntity
     OnImpact = function(self, targetType, targetEntity)
 
         -- localize information for performance

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -21,6 +21,7 @@ local PersonalShield = import("/lua/shield.lua").PersonalShield
 local Shield = import("/lua/shield.lua").Shield
 local TransportShield = import("/lua/shield.lua").TransportShield
 local Weapon = import("/lua/sim/weapon.lua").Weapon
+local CrashComponent = import("/lua/sim/units/components/CrashComponent.lua").CrashComponent
 local IntelComponent = import('/lua/defaultcomponents.lua').IntelComponent
 local VeterancyComponent = import('/lua/defaultcomponents.lua').VeterancyComponent
 
@@ -104,7 +105,7 @@ SyncMeta = {
 ---@field Combat? boolean
 
 local cUnit = moho.unit_methods
----@class Unit : moho.unit_methods, InternalObject, IntelComponent, VeterancyComponent, AIUnitProperties
+---@class Unit : moho.unit_methods, InternalObject, IntelComponent, VeterancyComponent, AIUnitProperties, CrashComponent
 ---@field AIManagerIdentifier? string
 ---@field Repairers table<EntityId, Unit>
 ---@field Brain AIBrain
@@ -133,7 +134,8 @@ local cUnit = moho.unit_methods
 ---@field IdleEffectsBag TrashBag
 ---@field SiloWeapon? Weapon
 ---@field SiloProjectile? ProjectileBlueprint
-Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
+---@field TopSpeedEffectsBag TrashBag
+Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, CrashComponent) {
 
     IsUnit = true,
     Weapons = {},
@@ -271,7 +273,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             BuffTable = {},
             Affects = {},
         }
-        
+
         self:ShowPresetEnhancementBones()
 
         local bpDeathAnim = bp.Display.AnimationDeath
@@ -1508,7 +1510,10 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
 
         self:DisableShield()
         self:DisableUnitIntel('Killed')
-        self:ForkThread(self.DeathThread, overkillRatio , instigator)
+        -- self:ForkThread(self.DeathThread, overkillRatio , instigator)
+        self:Crash()
+
+
 
         -- awareness for traitor game mode and game statistics
         ArmyBrains[army].LastUnitKilledBy = (instigator or self).Army
@@ -1849,17 +1854,18 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         -- add flag to identify a unit died but is sinking before it is destroyed
         self.Sinking = true 
 
-        local bp = self.Blueprint
-        local scale = (((bp.SizeX or 0) + (bp.SizeZ or 0)) * 0.5)
-        local bone = 0
+        self.SinkThreadInstance = self.Trash:Add(ForkThread(self.SinkThread, self))
+        -- local bp = self.Blueprint
+        -- local scale = (((bp.SizeX or 0) + (bp.SizeZ or 0)) * 0.5)
+        -- local bone = 0
 
-        -- Create sinker projectile
-        local proj = self:CreateProjectileAtBone('/projectiles/Sinker/Sinker_proj.bp', bone)
+        -- -- Create sinker projectile
+        -- local proj = self:CreateProjectileAtBone('/projectiles/Sinker/Sinker_proj.bp', bone)
 
-        -- Start the sinking after a delay of the given number of seconds, attaching to a given bone
-        -- and entity.
-        proj:Start(4 * math.max(2, math.min(7, scale)), self, bone, callback)
-        self.Trash:Add(proj)
+        -- -- Start the sinking after a delay of the given number of seconds, attaching to a given bone
+        -- -- and entity.
+        -- proj:Start(4 * math.max(2, math.min(7, scale)), self, bone, callback)
+        -- self.Trash:Add(proj)
     end,
 
     ---@param self Unit
@@ -1958,7 +1964,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         self:CreateWreckage(overkillRatio or self.overkillRatio)
 
         -- wait at least 1 tick before destroying unit
-        WaitSeconds(math.max(0.1, self.DeathThreadDestructionWaitTime))
+        -- WaitSeconds(math.max(0.1, self.DeathThreadDestructionWaitTime))
 
         -- do not play sound after sinking
         if not self.Sinking then 
@@ -3750,12 +3756,18 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
 
     ---@param self Unit
     DestroyTopSpeedEffects = function(self)
-        TrashDestroy(self.TopSpeedEffectsBag)
+        local topSpeedEffectsBag = self.TopSpeedEffectsBag
+        if topSpeedEffectsBag then
+        TrashDestroy(topSpeedEffectsBag)
+        end
     end,
 
     ---@param self Unit
     DestroyIdleEffects = function(self)
-        TrashDestroy(self.IdleEffectsBag)
+        local idleEffectsBag = self.IdleEffectsBag
+        if idleEffectsBag then
+            TrashDestroy(idleEffectsBag)
+        end
     end,
 
     ---@param self Unit

--- a/lua/sim/units/components/CrashComponent.lua
+++ b/lua/sim/units/components/CrashComponent.lua
@@ -1,0 +1,219 @@
+--**********************************************************************************
+--** Copyright (c) 2023 FAForever
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--**********************************************************************************
+
+---@class CrashComponent : moho.unit_methods
+---@field CrashThreadInstance? thread
+CrashComponent = ClassSimple {
+
+    -- There's a couple of things that you wish worked, but don't work:
+    -- - We can't use manipulators (such as sliders) as they move the mesh but not the collision shape
+    -- - We can't use a collision detector as it detects the water surface but not the terrain below it
+    --
+    -- Therefore we rely on a dummy projectile to pass these events to the unit.
+
+    ---@param self Unit
+    Crash = function(self)
+        -- local scope for performance
+        local trash = self.Trash
+        local blueprint = self.Blueprint
+        local crashWatchBone = blueprint.CrashWatchBone
+        local crashRadius = blueprint.CrashRadius
+        local px, py, pz = self:GetPositionXYZ(crashWatchBone)
+        local inWater = GetSurfaceHeight(px, pz) > py
+
+        -- multiply velocity with tick rate
+        local uvx, uvy, uvz = self:GetVelocity()
+        uvx = 10 * uvx
+        uvy = 10 * uvy
+        uvz = 10 * uvz
+
+        -- create air or wter projectile
+        local crashProjectile
+        if inWater then
+            crashProjectile = self:CreateProjectileAtBone(
+                '/effects/Entities/CrashProjectile/CrashWaterProjectile_proj.bp',
+                crashWatchBone
+            ) --[[@as DummyProjectile]]
+
+            self.CrashThreadInstance = trash:Add(
+                ForkThread(
+                    self.CrashWaterBehaviorThread,
+                    self,
+                    crashProjectile, uvx, uvy, uvz
+                )
+            )
+        else
+            crashProjectile = self:CreateProjectileAtBone(
+                '/effects/Entities/CrashProjectile/CrashAirProjectile_proj.bp',
+                crashWatchBone
+            ) --[[@as DummyProjectile]]
+
+            self.CrashThreadInstance = trash:Add(
+                ForkThread(
+                    self.CrashAirBehaviorThread,
+                    self,
+                    crashProjectile, uvx, uvy, uvz
+                )
+            )
+        end
+
+        -- attach the unit to the projectile
+        self:AttachBoneTo(crashWatchBone, crashProjectile, -2)
+
+        -- inherit the unit velocity
+        crashProjectile:SetVelocity(uvx, uvy, uvz)
+        crashProjectile:ChangeDetonateBelowHeight(crashRadius)
+
+        -- clear out the movement effects
+        self:DestroyMovementEffects()
+        self:DestroyTopSpeedEffects()
+        self:DestroyBeamExhaust()
+    end,
+
+    ---@param self Unit
+    ---@param crashProjectile CrashAirProjectile | CrashWaterProjectile
+    ---@param uvx number
+    ---@param uvy number
+    ---@param uvz number
+    CrashAirBehaviorThread = function(self, crashProjectile, uvx, uvy, uvz)
+    end,
+
+    ---@param self Unit
+    ---@param crashProjectile CrashAirProjectile | CrashWaterProjectile
+    ---@param uvx number
+    ---@param uvy number
+    ---@param uvz number
+    CrashWaterBehaviorThread = function(self, crashProjectile, uvx, uvy, uvz)
+        crashProjectile:SetMaxSpeed(0.4)
+        WaitTicks(3)
+        crashProjectile:SetMaxSpeed(0.8)
+        WaitTicks(3)
+        crashProjectile:SetMaxSpeed(1.2)
+    end,
+
+    --- Called when the dummy projectile impacts with the terrain
+    ---@param self Unit
+    ---@param crashProjectile CrashAirProjectile | CrashWaterProjectile
+    ---@param inWater boolean
+    OnCrashIntoTerrain = function(self, crashProjectile, inWater)
+        KillThread(self.CrashThreadInstance)
+        crashProjectile:Destroy()
+
+        -- create debris?
+        ForkThread(self.DestroyUnit, self, 0)
+    end,
+
+    --- Called when the dummy projectile impacts with a shield
+    ---@param self Unit
+    ---@param crashProjectile CrashAirProjectile | CrashWaterProjectile
+    ---@param shield Unit
+    ---@param inWater any
+    OnCrashIntoShield = function(self, crashProjectile, shield, inWater)
+        if not inWater then
+            self:CrashReflect(crashProjectile, shield)
+        end
+
+        crashProjectile:SetCollideEntity(false)
+    end,
+
+    --- Called when the dummy projectile impacts with the water surface
+    ---@param self Unit
+    ---@param crashProjectile CrashAirProjectile | CrashWaterProjectile
+    OnCrashIntoWater = function(self, crashProjectile)
+        local trash = self.Trash
+        local blueprint = self.Blueprint
+        local crashWatchBone = blueprint.CrashWatchBone
+        local crashRadius = blueprint.CrashRadius
+
+        -- match velocity of the projectile with the velocity of the unit when it died
+        local uvx, uvy, uvz = self:GetVelocity()
+        uvx = 10 * uvx
+        uvy = 10 * uvy
+        uvz = 10 * uvz
+
+        -- apply water crash behavior
+        KillThread(self.CrashThreadInstance)
+        self.CrashThreadInstance = trash:Add(
+            ForkThread(
+                self.CrashWaterBehaviorThread,
+                self,
+                crashProjectile,
+                uvx, uvy, uvz
+            )
+        )
+
+        crashProjectile:SetMaxSpeed(0.2)
+    end,
+
+    ---@param self Unit
+    ---@param crashProjectile CrashAirProjectile | CrashWaterProjectile
+    ---@param shield Unit
+    CrashReflect = function(self, crashProjectile, shield)
+
+        -- https://gamedev.stackexchange.com/questions/150322/how-to-find-collision-reflection-vector-on-a-sphere
+        -- https://3dkingdoms.com/weekly/weekly.php?a=2
+
+        local cpx, cpy, cpz = crashProjectile:GetPositionXYZ()
+        local cvx, cvy, cvz = crashProjectile:GetVelocity()
+        local spx, spy, spz = shield:GetPositionXYZ()
+
+        -- from velocity/tick to velocity/second
+        cvx = 10 * cvx
+        cvy = 10 * cvy
+        cvz = 10 * cvz
+
+        -- compute normal
+        local nx = cpx - spx
+        local ny = cpy - spy
+        local nz = cpz - spz
+        local nl = math.sqrt(nx * nx + ny * ny + nz * nz)
+        nx = nx / nl
+        ny = ny / nl
+        nz = nz / nl
+
+        -- compute dot product
+        local d = nx * cvx + ny * cvy + nz * cvz
+
+        -- compute reflection
+        local rvx = -2 * d * nx + cvx
+        local rvy = -2 * d * ny + cvy
+        local rvz = -2 * d * nz + cvz
+
+        -- local factor = 25
+        -- DrawCircle({ cpx, cpy, cpz }, 0.5, 'ffffff')
+        -- DrawLine({ cpx, cpy, cpz }, { cpx + factor * nx, cpy + factor * ny, cpz + factor * nz }, 'ffffff')
+        -- DrawCircle({ cpx + factor * nx, cpy + factor * ny, cpz + factor * nz }, 0.5, 'ffffff')
+        -- DrawLine({ cpx, cpy, cpz }, { cpx + factor * rvx, cpy + factor * rvy, cpz + factor * rvz }, '00ff00')
+        -- DrawCircle({ cpx + factor * rvx, cpy + factor * rvy, cpz + factor * rvz }, 0.5, '00ff00')
+        -- DrawLine({ cpx, cpy, cpz }, { cpx - factor * cvx, cpy - factor * cvy, cpz - factor * cvz }, '0000ff')
+        -- DrawCircle({ cpx - factor * cvx, cpy - factor * cvy, cpz - factor * cvz }, 0.5, '0000ff')
+
+        -- LOG("velocity", cvx, cvy, cvz)
+        -- LOG("normal ", nx, ny, nz)
+        -- LOG("reflection", rvx, rvy, rvz)
+
+        -- update velocity
+        local damping = 0.5
+        crashProjectile:SetVelocity(damping * rvx, damping * rvy, damping * rvz)
+        crashProjectile:SetPosition({ cpx + 0.1 * nx, cpy + 0.1 * ny, cpz + 0.1 * nz }, true)
+    end,
+}

--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -528,6 +528,14 @@ local function PostProcessUnit(unit)
     if unit.Economy and not unit.Economy.BuildRate then
         unit.Economy.BuildRate = 0
     end
+
+    ---------------------------------------------------------------------------
+    --#region Air crash behavior
+
+    unit.CrashWatchBone = unit.CrashWatchBone or 0
+    unit.CrashRadius = unit.CrashRadius or 0
+
+    --#endregion
 end
 
 ---@param allBlueprints BlueprintsTable


### PR DESCRIPTION
_This is very much a draft at this moment_

How units crash is a bit of a web at the moment. There's the sinker projectile and the shield collider projectile. And then there's units with death animations. And all of that comes together with a lot of overhead, such as closures and threads and a lot of table operations.

I've been wondering: could we do this different? And the answer is: yes we can!

Features:

- [x] (1) A generic crash component
- [x] (2) A generic crash projectile
- [x] (3) All units that are ballistic can now bounce off shields
- [x] (4) All units can now technically crash
- [x] (5) All crashing units inherit their velocity when they start crashing

Fixes:

- [x] Hover units create wrecks that are on the ground now

Todo:

- [ ] (1) Integrate with death animations
- [ ] (2) Add functionality to create explosions
- [ ] (3) Add functionality to create debris
- [ ] (4) Apply death weapon damage to shields that it bounces off
- [ ] (4) Adapt the functionality of (2) and (3) so that you can customize it on a per-unit basis
- [ ] (5) Add functionality to manipulate the fall direction based on damage taken

Problems:

- [ ] What to do with units attached to a transport and the transport died?