### PR TITLE
Further tweaks to weapon details

### DIFF
--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -598,6 +598,8 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                 ReloadTime = math.max(0.1, MATH_IRound(10 * ReloadTime) / 10)
                             end
 
+                            -- Keep track that the firing cycle has a constant rate
+                            local fireRateOnly = true
                             --OnFire is called from FireReadyState at this point, so we need to track time
                             --to know how much the fire rate cooldown has progressed during our fire cycle.
                             local SubCycleTime = 0
@@ -610,6 +612,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                     if info.MuzzleSalvoDelay == 0 then
                                         MuzzleCount = table.getsize(Rack.MuzzleBones)
                                     end
+                                    if MuzzleCount > 1 then fireRateOnly = false end
                                     CycleProjs = CycleProjs + MuzzleCount
 
                                     SubCycleTime = SubCycleTime + MuzzleCount * MuzzleDelays
@@ -625,6 +628,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                             end
                             if FiringCooldown <= (SubCycleTime + ChargeTime + ReloadTime) then
                                 CycleTime = CycleTime + SubCycleTime + ReloadTime + ChargeTime + math.max(0.1, FiringCooldown - SubCycleTime - ChargeTime - ReloadTime)
+                                fireRateOnly = false
                             else
                                 CycleTime = CycleTime + FiringCooldown
                             end
@@ -633,6 +637,12 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                 --Round DPS, or else it gets floored in string.format.
                                 local DPS = MATH_IRound(Damage * CycleProjs / CycleTime)
                                 weaponDetails1 = weaponDetails1..LOCF('<LOC uvd_DPS>', DPS)
+                            end
+
+                            -- Avoid saying a unit fires a salvo when it in fact has a constant rate of fire
+                            if fireRateOnly then
+                                CycleTime = CycleTime / CycleProjs
+                                CycleProjs = 1
                             end
 
                             if CycleProjs > 1 then

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -599,7 +599,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                             end
 
                             -- Keep track that the firing cycle has a constant rate
-                            local fireRateOnly = true
+                            local singleShot = true
                             --OnFire is called from FireReadyState at this point, so we need to track time
                             --to know how much the fire rate cooldown has progressed during our fire cycle.
                             local SubCycleTime = 0
@@ -612,7 +612,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                     if info.MuzzleSalvoDelay == 0 then
                                         MuzzleCount = table.getsize(Rack.MuzzleBones)
                                     end
-                                    if MuzzleCount > 1 then fireRateOnly = false end
+                                    if MuzzleCount > 1 then singleShot = false end
                                     CycleProjs = CycleProjs + MuzzleCount
 
                                     SubCycleTime = SubCycleTime + MuzzleCount * MuzzleDelays
@@ -628,7 +628,6 @@ function WrapAndPlaceText(bp, builder, descID, control)
                             end
                             if FiringCooldown <= (SubCycleTime + ChargeTime + ReloadTime) then
                                 CycleTime = CycleTime + SubCycleTime + ReloadTime + ChargeTime + math.max(0.1, FiringCooldown - SubCycleTime - ChargeTime - ReloadTime)
-                                fireRateOnly = false
                             else
                                 CycleTime = CycleTime + FiringCooldown
                             end
@@ -640,7 +639,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                             end
 
                             -- Avoid saying a unit fires a salvo when it in fact has a constant rate of fire
-                            if fireRateOnly then
+                            if singleShot and ReloadTime == 0 then
                                 CycleTime = CycleTime / CycleProjs
                                 CycleProjs = 1
                             end

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -598,9 +598,6 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                 ReloadTime = math.max(0.1, MATH_IRound(10 * ReloadTime) / 10)
                             end
 
-                            --Upon acquiring a target
-                            CycleTime = CycleTime + ChargeTime
-
                             --OnFire is called from FireReadyState at this point, so we need to track time
                             --to know how much the fire rate cooldown has progressed during our fire cycle.
                             local SubCycleTime = 0
@@ -627,7 +624,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                 end
                             end
                             if FiringCooldown <= (SubCycleTime + ChargeTime + ReloadTime) then
-                                CycleTime = CycleTime + SubCycleTime + ReloadTime + math.max(0.1, FiringCooldown - SubCycleTime - ChargeTime - ReloadTime)
+                                CycleTime = CycleTime + SubCycleTime + ReloadTime + ChargeTime + math.max(0.1, FiringCooldown - SubCycleTime - ChargeTime - ReloadTime)
                             else
                                 CycleTime = CycleTime + FiringCooldown
                             end

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -617,8 +617,8 @@ function WrapAndPlaceText(bp, builder, descID, control)
 
                                     SubCycleTime = SubCycleTime + MuzzleCount * MuzzleDelays
                                     if not info.RackFireTogether and index ~= RackCount then
-                                        if FiringCooldown <= SubCycleTime then
-                                            CycleTime = CycleTime + SubCycleTime + math.max(0.1, FiringCooldown - SubCycleTime)
+                                        if FiringCooldown <= SubCycleTime + ChargeTime then
+                                            CycleTime = CycleTime + SubCycleTime + ChargeTime + math.max(0.1, FiringCooldown - SubCycleTime - ChargeTime)
                                         else
                                             CycleTime = CycleTime + FiringCooldown
                                         end


### PR DESCRIPTION
_Continuation of #5779_

- Charge time was being counted even if it was less than the fire rate cooldown. This image is of the Ascendant (aeon mobile flak). It should be 0.5 reload time.
![image](https://github.com/FAForever/fa/assets/82986251/d7fc35e2-3eb5-4436-ab30-1f6810fd29aa)
- Charge time should also be counted every rack firing, for example the cybran TML was saying it had 6.0 reload time, but in reality it is 10.0. Now it says 9.9, because inexplicably, after reloading, it waits 2 ticks from idle to idle.onfire instead of 1 tick.
- Avoid incorrectly saying a unit fires a salvo for units like mantis and blaze who have multiple racks but are only controlled by fire rate. Mantis showing a salvo:
![image](https://github.com/FAForever/fa/assets/82986251/ceddf178-6806-4167-bbec-a97cb0710e64)