### PR TITLE
Rework/economy cost eye

### DIFF
--- a/lua/RemoteViewing.lua
+++ b/lua/RemoteViewing.lua
@@ -47,8 +47,9 @@ function RemoteViewing(SuperClass)
         end,
 
         TargetLocationThread = function(self)
-            local Cost = CreateEconomyEvent(self, self:GetBlueprint().Economy.InitialRemoteViewingEnergyDrain, 0, 0.1)
+            local Cost = CreateEconomyEvent(self, self:GetBlueprint().Economy.InitialRemoteViewingEnergyDrain * (self.EnergyMaintAdjMod or 1), 0, 1, self.SetWorkProgress)
             WaitFor(Cost)
+            self:SetWorkProgress(0.0)
             RemoveEconomyEvent(self, Cost)
             self:RequestRefreshUI()
             self.RemoteViewingData.VisibleLocation = self.RemoteViewingData.PendingVisibleLocation

--- a/lua/RemoteViewing.lua
+++ b/lua/RemoteViewing.lua
@@ -47,9 +47,10 @@ function RemoteViewing(SuperClass)
         end,
 
         TargetLocationThread = function(self)
-            WaitFor(
-                CreateEconomyEvent(self, self:GetBlueprint().Economy.InitialRemoteViewingEnergyDrain, 0, 0.1)
-            )
+            local Cost = CreateEconomyEvent(self, self:GetBlueprint().Economy.InitialRemoteViewingEnergyDrain, 0, 0.1)
+            WaitFor(Cost)
+            RemoveEconomyEvent(self, Cost)
+            self:RequestRefreshUI()
             self.RemoteViewingData.VisibleLocation = self.RemoteViewingData.PendingVisibleLocation
             self.RemoteViewingData.PendingVisibleLocation = nil
             self:CreateVisibleEntity()

--- a/lua/RemoteViewing.lua
+++ b/lua/RemoteViewing.lua
@@ -46,23 +46,24 @@ function RemoteViewing(SuperClass)
             self:AddToggleCap('RULEUTC_IntelToggle')
         end,
 
-        OnTargetLocation = function(self, location)
-            -- Initial energy drain here - we drain resources instantly when an eye is relocated (including initial move)
-            local aiBrain = self:GetAIBrain()
-            local bp = self:GetBlueprint()
-            local have = aiBrain:GetEconomyStored('ENERGY')
-            local need = bp.Economy.InitialRemoteViewingEnergyDrain
-            if not ( have > need ) then
-                return
-            end
-
-            -- Drain economy here
-            aiBrain:TakeResource( 'ENERGY', bp.Economy.InitialRemoteViewingEnergyDrain )
-
-            self.RemoteViewingData.VisibleLocation = location
+        TargetLocationThread = function(self)
+            WaitFor(
+                CreateEconomyEvent(self, self:GetBlueprint().Economy.InitialRemoteViewingEnergyDrain, 0, 0.1)
+            )
+            self.RemoteViewingData.VisibleLocation = self.RemoteViewingData.PendingVisibleLocation
+            self.RemoteViewingData.PendingVisibleLocation = nil
             self:CreateVisibleEntity()
         end,
 
+        OnTargetLocation = function(self, location)
+            if self.RemoteViewingData.PendingVisibleLocation then
+                self.RemoteViewingData.PendingVisibleLocation = location
+            else
+                self.RemoteViewingData.PendingVisibleLocation = location
+                self:ForkThread(self.TargetLocationThread)
+            end
+        end,
+        
         CreateVisibleEntity = function(self)
             -- Only give a visible area if we have a location and intel button enabled
             if not self.RemoteViewingData.VisibleLocation then

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -598,6 +598,8 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                 ReloadTime = math.max(0.1, MATH_IRound(10 * ReloadTime) / 10)
                             end
 
+                            -- Keep track that the firing cycle has a constant rate
+                            local fireRateOnly = true
                             --OnFire is called from FireReadyState at this point, so we need to track time
                             --to know how much the fire rate cooldown has progressed during our fire cycle.
                             local SubCycleTime = 0
@@ -610,6 +612,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                     if info.MuzzleSalvoDelay == 0 then
                                         MuzzleCount = table.getsize(Rack.MuzzleBones)
                                     end
+                                    if MuzzleCount > 1 then fireRateOnly = false end
                                     CycleProjs = CycleProjs + MuzzleCount
 
                                     SubCycleTime = SubCycleTime + MuzzleCount * MuzzleDelays
@@ -625,6 +628,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                             end
                             if FiringCooldown <= (SubCycleTime + ChargeTime + ReloadTime) then
                                 CycleTime = CycleTime + SubCycleTime + ReloadTime + ChargeTime + math.max(0.1, FiringCooldown - SubCycleTime - ChargeTime - ReloadTime)
+                                fireRateOnly = false
                             else
                                 CycleTime = CycleTime + FiringCooldown
                             end
@@ -633,6 +637,12 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                 --Round DPS, or else it gets floored in string.format.
                                 local DPS = MATH_IRound(Damage * CycleProjs / CycleTime)
                                 weaponDetails1 = weaponDetails1..LOCF('<LOC uvd_DPS>', DPS)
+                            end
+
+                            -- Avoid saying a unit fires a salvo when it in fact has a constant rate of fire
+                            if fireRateOnly then
+                                CycleTime = CycleTime / CycleProjs
+                                CycleProjs = 1
                             end
 
                             if CycleProjs > 1 then

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -599,7 +599,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                             end
 
                             -- Keep track that the firing cycle has a constant rate
-                            local fireRateOnly = true
+                            local singleShot = true
                             --OnFire is called from FireReadyState at this point, so we need to track time
                             --to know how much the fire rate cooldown has progressed during our fire cycle.
                             local SubCycleTime = 0
@@ -612,7 +612,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                     if info.MuzzleSalvoDelay == 0 then
                                         MuzzleCount = table.getsize(Rack.MuzzleBones)
                                     end
-                                    if MuzzleCount > 1 then fireRateOnly = false end
+                                    if MuzzleCount > 1 then singleShot = false end
                                     CycleProjs = CycleProjs + MuzzleCount
 
                                     SubCycleTime = SubCycleTime + MuzzleCount * MuzzleDelays
@@ -628,7 +628,6 @@ function WrapAndPlaceText(bp, builder, descID, control)
                             end
                             if FiringCooldown <= (SubCycleTime + ChargeTime + ReloadTime) then
                                 CycleTime = CycleTime + SubCycleTime + ReloadTime + ChargeTime + math.max(0.1, FiringCooldown - SubCycleTime - ChargeTime - ReloadTime)
-                                fireRateOnly = false
                             else
                                 CycleTime = CycleTime + FiringCooldown
                             end
@@ -640,7 +639,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                             end
 
                             -- Avoid saying a unit fires a salvo when it in fact has a constant rate of fire
-                            if fireRateOnly then
+                            if singleShot and ReloadTime == 0 then
                                 CycleTime = CycleTime / CycleProjs
                                 CycleProjs = 1
                             end

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -598,9 +598,6 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                 ReloadTime = math.max(0.1, MATH_IRound(10 * ReloadTime) / 10)
                             end
 
-                            --Upon acquiring a target
-                            CycleTime = CycleTime + ChargeTime
-
                             --OnFire is called from FireReadyState at this point, so we need to track time
                             --to know how much the fire rate cooldown has progressed during our fire cycle.
                             local SubCycleTime = 0
@@ -627,7 +624,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                 end
                             end
                             if FiringCooldown <= (SubCycleTime + ChargeTime + ReloadTime) then
-                                CycleTime = CycleTime + SubCycleTime + ReloadTime + math.max(0.1, FiringCooldown - SubCycleTime - ChargeTime - ReloadTime)
+                                CycleTime = CycleTime + SubCycleTime + ReloadTime + ChargeTime + math.max(0.1, FiringCooldown - SubCycleTime - ChargeTime - ReloadTime)
                             else
                                 CycleTime = CycleTime + FiringCooldown
                             end

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -617,8 +617,8 @@ function WrapAndPlaceText(bp, builder, descID, control)
 
                                     SubCycleTime = SubCycleTime + MuzzleCount * MuzzleDelays
                                     if not info.RackFireTogether and index ~= RackCount then
-                                        if FiringCooldown <= SubCycleTime then
-                                            CycleTime = CycleTime + SubCycleTime + math.max(0.1, FiringCooldown - SubCycleTime)
+                                        if FiringCooldown <= SubCycleTime + ChargeTime then
+                                            CycleTime = CycleTime + SubCycleTime + ChargeTime + math.max(0.1, FiringCooldown - SubCycleTime - ChargeTime)
                                         else
                                             CycleTime = CycleTime + FiringCooldown
                                         end


### PR DESCRIPTION
_continuation of #5743_

The remote viewing script as a whole is a bit of a mess, but this attempts to address the clunky UX of trying to activate the ability when you have less than 10k energy in storage by being a drain event and a wait instead of a check and a take event.

~~Current issue with it though, is that this breaks the UI for the maintenance drain. (At least on the Steam version; the drain still happens, but it doesn't show on the unit.)~~