### PR TITLE
Fix strategic icon scale not applying correctly

### DIFF
--- a/engine/User.lua
+++ b/engine/User.lua
@@ -247,7 +247,7 @@ function GetCommandLineArg(option, maxArgs)
 end
 
 --- Returns 'splash', 'frontend', or 'game' depending on the current state of the UI
----@return 'splash' | 'frontend' | 'game'
+---@return 'splash' | 'frontend' | 'game' | 'none'
 function GetCurrentUIState()
 end
 

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -917,9 +917,7 @@ options = {
                 type = 'toggle',
                 default = 1.0,
                 set = function(key, value, startup)
-                    if GetCurrentUIState() == 'game' then
-                        ConExecute("ui_StrategicIconScale " .. value)
-                    end
+                    ConExecute("ui_StrategicIconScale " .. value)
                 end,
                 custom = {
                     states = {


### PR DESCRIPTION
Closes https://github.com/FAForever/fa/issues/5793

I thought that the `set` function was run when a new game starts. But apparently it does not 😃 