### PR TITLE
Eye of R-word target location cost rework

### DIFF
--- a/lua/RemoteViewing.lua
+++ b/lua/RemoteViewing.lua
@@ -47,8 +47,9 @@ function RemoteViewing(SuperClass)
         end,
 
         TargetLocationThread = function(self)
-            local Cost = CreateEconomyEvent(self, self:GetBlueprint().Economy.InitialRemoteViewingEnergyDrain, 0, 0.1)
+            local Cost = CreateEconomyEvent(self, self:GetBlueprint().Economy.InitialRemoteViewingEnergyDrain * (self.EnergyMaintAdjMod or 1), 0, 1, self.SetWorkProgress)
             WaitFor(Cost)
+            self:SetWorkProgress(0.0)
             RemoveEconomyEvent(self, Cost)
             self:RequestRefreshUI()
             self.RemoteViewingData.VisibleLocation = self.RemoteViewingData.PendingVisibleLocation

--- a/lua/RemoteViewing.lua
+++ b/lua/RemoteViewing.lua
@@ -47,9 +47,10 @@ function RemoteViewing(SuperClass)
         end,
 
         TargetLocationThread = function(self)
-            WaitFor(
-                CreateEconomyEvent(self, self:GetBlueprint().Economy.InitialRemoteViewingEnergyDrain, 0, 0.1)
-            )
+            local Cost = CreateEconomyEvent(self, self:GetBlueprint().Economy.InitialRemoteViewingEnergyDrain, 0, 0.1)
+            WaitFor(Cost)
+            RemoveEconomyEvent(self, Cost)
+            self:RequestRefreshUI()
             self.RemoteViewingData.VisibleLocation = self.RemoteViewingData.PendingVisibleLocation
             self.RemoteViewingData.PendingVisibleLocation = nil
             self:CreateVisibleEntity()

--- a/lua/RemoteViewing.lua
+++ b/lua/RemoteViewing.lua
@@ -46,23 +46,24 @@ function RemoteViewing(SuperClass)
             self:AddToggleCap('RULEUTC_IntelToggle')
         end,
 
-        OnTargetLocation = function(self, location)
-            -- Initial energy drain here - we drain resources instantly when an eye is relocated (including initial move)
-            local aiBrain = self:GetAIBrain()
-            local bp = self:GetBlueprint()
-            local have = aiBrain:GetEconomyStored('ENERGY')
-            local need = bp.Economy.InitialRemoteViewingEnergyDrain
-            if not ( have > need ) then
-                return
-            end
-
-            -- Drain economy here
-            aiBrain:TakeResource( 'ENERGY', bp.Economy.InitialRemoteViewingEnergyDrain )
-
-            self.RemoteViewingData.VisibleLocation = location
+        TargetLocationThread = function(self)
+            WaitFor(
+                CreateEconomyEvent(self, self:GetBlueprint().Economy.InitialRemoteViewingEnergyDrain, 0, 0.1)
+            )
+            self.RemoteViewingData.VisibleLocation = self.RemoteViewingData.PendingVisibleLocation
+            self.RemoteViewingData.PendingVisibleLocation = nil
             self:CreateVisibleEntity()
         end,
 
+        OnTargetLocation = function(self, location)
+            if self.RemoteViewingData.PendingVisibleLocation then
+                self.RemoteViewingData.PendingVisibleLocation = location
+            else
+                self.RemoteViewingData.PendingVisibleLocation = location
+                self:ForkThread(self.TargetLocationThread)
+            end
+        end,
+        
         CreateVisibleEntity = function(self)
             -- Only give a visible area if we have a location and intel button enabled
             if not self.RemoteViewingData.VisibleLocation then


### PR DESCRIPTION
_continuation of #5743_

The remote viewing script as a whole is a bit of a mess, but this attempts to address the clunky UX of trying to activate the ability when you have less than 10k energy in storage by being a drain event and a wait instead of a check and a take event.

~~Current issue with it though, is that this breaks the UI for the maintenance drain. (At least on the Steam version; the drain still happens, but it doesn't show on the unit.)~~