### PR TITLE
Fix incorrect property being set on BaseTypes

### DIFF
--- a/lua/aibrains/adaptive-ai.lua
+++ b/lua/aibrains/adaptive-ai.lua
@@ -524,7 +524,7 @@ AIBrain = Class(StandardBrain, EconomyComponent) {
             EngineerManager = EngineerManager.CreateEngineerManager(self, baseName, position, radius),
             BuilderHandles = {},
             Position = position,
-            BaseType = MarkerUtilities.GetMarker(baseName).Name or 'Main',
+            BaseType = MarkerUtilities.GetMarker(baseName).Type or 'MAIN',
             Layer = baseLayer,
         }
 

--- a/lua/aibrains/medium-ai.lua
+++ b/lua/aibrains/medium-ai.lua
@@ -524,7 +524,7 @@ AIBrain = Class(StandardBrain, EconomyComponent) {
             EngineerManager = EngineerManager.CreateEngineerManager(self, baseName, position, radius),
             BuilderHandles = {},
             Position = position,
-            BaseType = MarkerUtilities.GetMarker(baseName).Name or 'Main',
+            BaseType = MarkerUtilities.GetMarker(baseName).Type or 'MAIN',
             Layer = baseLayer,
         }
 

--- a/lua/aibrains/rush-ai.lua
+++ b/lua/aibrains/rush-ai.lua
@@ -524,7 +524,7 @@ AIBrain = Class(StandardBrain, EconomyComponent) {
             EngineerManager = EngineerManager.CreateEngineerManager(self, baseName, position, radius),
             BuilderHandles = {},
             Position = position,
-            BaseType = MarkerUtilities.GetMarker(baseName).Name or 'Main',
+            BaseType = MarkerUtilities.GetMarker(baseName).Type or 'MAIN',
             Layer = baseLayer,
         }
 

--- a/lua/aibrains/tech-ai.lua
+++ b/lua/aibrains/tech-ai.lua
@@ -524,7 +524,7 @@ AIBrain = Class(StandardBrain, EconomyComponent) {
             EngineerManager = EngineerManager.CreateEngineerManager(self, baseName, position, radius),
             BuilderHandles = {},
             Position = position,
-            BaseType = MarkerUtilities.GetMarker(baseName).Name or 'Main',
+            BaseType = MarkerUtilities.GetMarker(baseName).Type or 'MAIN',
             Layer = baseLayer,
         }
 

--- a/lua/aibrains/turtle-ai.lua
+++ b/lua/aibrains/turtle-ai.lua
@@ -524,7 +524,7 @@ AIBrain = Class(StandardBrain, EconomyComponent) {
             EngineerManager = EngineerManager.CreateEngineerManager(self, baseName, position, radius),
             BuilderHandles = {},
             Position = position,
-            BaseType = MarkerUtilities.GetMarker(baseName).Name or 'Main',
+            BaseType = MarkerUtilities.GetMarker(baseName).Type or 'MAIN',
             Layer = baseLayer,
         }
 


### PR DESCRIPTION
This PR fixes an issue with the BaseType that is set on AI bases when they are created.

Due to the marker name being used instead of the type the AI could never understand that it already had Naval bases which caused it to constantly make new ones. On naval maps this results in too many naval expansions being created.

This will have also caused issues with some of the UnitCountBuildConditions that also relied on this property being a specific string rather than a marker name.

This was deceptively hard to track down :)

The ramification of this change is that the AI's naval expansion will be weaker now as its not tuned correctly. It won't ruin its economy and cause the game slow downs on naval maps.
