### PR TITLE
Make Percival prioritize structures over T1 units

### DIFF
--- a/units/XEL0305/XEL0305_unit.bp
+++ b/units/XEL0305/XEL0305_unit.bp
@@ -245,9 +245,8 @@ UnitBlueprint{
             TargetPriorities = {
                 "TECH3 MOBILE",
                 "TECH2 MOBILE",
-                "COMMAND",
                 "(STRUCTURE * DEFENSE - ANTIMISSILE)",
-                "TECH1 MOBILE",
+                "STRUCTURE",
                 "ALLUNITS",
             },
             TargetRestrictDisallow = "UNTARGETABLE",


### PR DESCRIPTION
- Remove `COMMAND` which it cannot use because it does not have `SNIPEMODE` category.
- Prioritize structures over T1 mobile units because of its extremely low fire rate, in the same way as snipers.