### PR TITLE
Expand the assist-to functionality

### DIFF
--- a/changelog/3779.md
+++ b/changelog/3779.md
@@ -44,7 +44,7 @@ The collision shape of air units is relatively large in comparison to the size o
 
 - (#5785) Fix various projectiles being unable to impact the water surface.
 
-Most notable the UEF tech 2 Destroyer and various tactical missiles would not impact on the water surface.
+Most notable projectiles of the UEF tech 2 Destroyer and various tactical missiles would not impact with the water surface.
 
 ## Bug Fixes
 

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -234,6 +234,22 @@ Callbacks.OnPlayerQueryResult = SimPlayerQuery.OnPlayerQueryResult
 
 Callbacks.PingGroupClick = import("/lua/simpinggroup.lua").OnClickCallback
 
+---@param unit Unit
+---@param target? Unit
+---@return boolean
+function IsInvalidAssist(unit, target)
+    if target and target.EntityId == unit.EntityId then
+        return true
+    elseif not target or not target:GetGuardedUnit() then
+        return false
+    else
+        return IsInvalidAssist(unit, target:GetGuardedUnit())
+    end
+end
+
+--- Detect and fix a simulation freeze by clearing the command queue of all factories that take part in a cycle
+---@param data { target: EntityId}
+---@param units any
 Callbacks.ValidateAssist = function(data, units)
     units = SecureUnits(units)
     local target = GetEntityById(data.target)
@@ -244,16 +260,6 @@ Callbacks.ValidateAssist = function(data, units)
                 return
             end
         end
-    end
-end
-
-function IsInvalidAssist(unit, target)
-    if target and target.EntityId == unit.EntityId then
-        return true
-    elseif not target or not target:GetGuardedUnit() then
-        return false
-    else
-        return IsInvalidAssist(unit, target:GetGuardedUnit())
     end
 end
 

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -490,7 +490,8 @@ options = {
                     states = {
                         { text = "<LOC _Off>", key = 'Off' },
                         { text = "<LOC ASSIST_TO_UPGRADE_MASS_TECH1>Tech 1 extractors", key = 'Tech1Extractors' },
-                        { text = "<LOC ASSIST_TO_UPGRADE_MASS_TECH1>Tech 1 and tech 2 extractors", key = 'Tech1Tech2Extractors' },
+                        { text = "<LOC ASSIST_TO_UPGRADE_MASS_TECH1>Tech 1 and tech 2 extractors",
+                            key = 'Tech1Tech2Extractors' },
                     },
                 },
             },
@@ -536,19 +537,6 @@ options = {
                             key = 'OnlyEngineers' },
                         { text = "<LOC _ASSIST_TO_COPY_ENGINEERS_ADD>Engineers and add to the selection",
                             key = 'OnlyEngineersAddToSelection' },
-                    },
-                },
-            },
-
-            {
-                title = "<LOC OPTIONS_0287>Factories Default to Repeat Build",
-                key = 'repeatbuild',
-                type = 'toggle',
-                default = 'Off',
-                custom = {
-                    states = {
-                        { text = "<LOC _Off>", key = 'Off' },
-                        { text = "<LOC _On>", key = 'On' },
                     },
                 },
             },
@@ -642,6 +630,19 @@ options = {
                     states = {
                         { text = "<LOC _Off>Off", key = "off" },
                         { text = "<LOC _On>On", key = "on" },
+                    },
+                },
+            },
+
+            {
+                title = "<LOC OPTIONS_0287>Factories Default to Repeat Build",
+                key = 'repeatbuild',
+                type = 'toggle',
+                default = 'Off',
+                custom = {
+                    states = {
+                        { text = "<LOC _Off>", key = 'Off' },
+                        { text = "<LOC _On>", key = 'On' },
                     },
                 },
             },

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -490,7 +490,7 @@ options = {
                     states = {
                         { text = "<LOC _Off>", key = 'Off' },
                         { text = "<LOC ASSIST_TO_UPGRADE_MASS_TECH1>Tech 1 extractors", key = 'Tech1Extractors' },
-                        { text = "<LOC ASSIST_TO_UPGRADE_MASS_TECH1>Tech 1 and tech 2 extractors",
+                        { text = "<LOC ASSIST_TO_UPGRADE_MASS_TECH1_TECH2>Tech 1 and tech 2 extractors",
                             key = 'Tech1Tech2Extractors' },
                     },
                 },
@@ -504,8 +504,8 @@ options = {
                 custom = {
                     states = {
                         { text = "<LOC _Off>", key = 'Off' },
-                        { text = "<LOC ASSIST_TO_UPGRADE_MASS_TECH1>Only tech 1 radars", key = 'Tech1Radars' },
-                        { text = "<LOC ASSIST_TO_UPGRADE_MASS_TECH1>Tech 1 and tech 2 radars", key = 'Tech1Tech2Radars' },
+                        { text = "<LOC ASSIST_TO_UPGRADE_RADAR_TECH1>Only tech 1 radars", key = 'Tech1Radars' },
+                        { text = "<LOC ASSIST_TO_UPGRADE_RADAR_TECH1_TECH2>Tech 1 and tech 2 radars", key = 'Tech1Tech2Radars' },
                     },
                 },
             },

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -482,14 +482,29 @@ options = {
             -- },
 
             {
-                title = "<LOC ASSIST_TO_UPGRADE>Assist to upgrade",
+                title = "<LOC ASSIST_TO_UPGRADE>Assist to upgrade mass extractors",
                 key = 'assist_to_upgrade',
                 type = 'toggle',
                 default = 'Off',
                 custom = {
                     states = {
                         { text = "<LOC _Off>", key = 'Off' },
-                        { text = "<LOC ASSIST_TO_UPGRADE_MASS_TECH1>Only tech 1 extractors", key = 'Tech1Extractors' },
+                        { text = "<LOC ASSIST_TO_UPGRADE_MASS_TECH1>Tech 1 extractors", key = 'Tech1Extractors' },
+                        { text = "<LOC ASSIST_TO_UPGRADE_MASS_TECH1>Tech 1 and tech 2 extractors", key = 'Tech1Tech2Extractors' },
+                    },
+                },
+            },
+
+            {
+                title = "<LOC ASSIST_TO_UPGRADE>Assist to upgrade radars",
+                key = 'assist_to_upgrade_radar',
+                type = 'toggle',
+                default = 'Off',
+                custom = {
+                    states = {
+                        { text = "<LOC _Off>", key = 'Off' },
+                        { text = "<LOC ASSIST_TO_UPGRADE_MASS_TECH1>Only tech 1 radars", key = 'Tech1Radars' },
+                        { text = "<LOC ASSIST_TO_UPGRADE_MASS_TECH1>Tech 1 and tech 2 radars", key = 'Tech1Tech2Radars' },
                     },
                 },
             },
@@ -517,8 +532,10 @@ options = {
                 custom = {
                     states = {
                         { text = "<LOC _Off>Off", key = 'Off' },
-                        { text = "<LOC _ASSIST_TO_COPY_ENGINEERS>Only engineers",
+                        { text = "<LOC _ASSIST_TO_COPY_ENGINEERS>Engineers",
                             key = 'OnlyEngineers' },
+                        { text = "<LOC _ASSIST_TO_COPY_ENGINEERS_ADD>Engineers and add to the selection",
+                            key = 'OnlyEngineersAddToSelection' },
                     },
                 },
             },

--- a/lua/sim/commands/shared.lua
+++ b/lua/sim/commands/shared.lua
@@ -243,7 +243,7 @@ function SortUnitsByDistanceToPoint(units, px, pz)
     end
 
     -- sort the units
-    TableSort(units,SortByDistance)
+    TableSort(units, SortByDistance)
 
     -- remove distance field
     for _, unit in units do
@@ -261,7 +261,7 @@ end
 --- Sorts the units in-place by tech
 ---@param units Unit[]
 function SortUnitsByTech(units)
-    TableSort(units,SortBytech)
+    TableSort(units, SortBytech)
 end
 
 ---@param offsets {[1]: number, [2]: number}
@@ -332,15 +332,14 @@ end
 ---@param degrees number
 ---@return Vector
 function PointOnUnitCircle(px, pz, radius, degrees)
-    local cx = px + radius * math.cos( (degrees + 90) * 3.14 / 180 );
-    local cz = pz + radius * math.sin( (degrees + 90) * 3.14 / 180 );
+    local cx = px + radius * math.cos((degrees + 90) * 3.14 / 180);
+    local cz = pz + radius * math.sin((degrees + 90) * 3.14 / 180);
     return {
         cx,
         GetSurfaceHeight(cx, cz),
         cz
     }
 end
-
 
 ---@param units Unit[]
 ---@param px number

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -32,8 +32,51 @@ local TableGetN = table.getn
 local MathPi = math.pi
 local MathAtan = math.atan
 
----@class UserCommand
+---@alias UserCommandType
+--- | 'None' # by-product of other commands
+--- | 'Stop'
+--- | 'Reclaim'
+--- | 'Move'
+--- | 'Attack'
+--- | 'Guard'
+--- | 'AggressiveMove'
+--- | 'Upgrade'
+--- | 'Build'
+--- | 'BuildMobile'
+--- | 'Tactical'
+--- | 'Nuke'
+--- | 'TransportReverseLoadUnits' # when you right click a transport
+--- | 'TransportLoadUnits' # when you right click a unit with a transport in your selection
+--- | 'TransportUnloadUnits'
+--- | 'TransportUnloadSpecificUnits' # when you click to unload specific units
+--- | 'Ferry'
+--- | 'AssistMove' # by-product of other commands
+--- | 'Script' # as an example: enhancements
+--- | 'Capture'
+--- | 'FormMove'
+--- | 'FormAggressiveMove'
+--- | 'OverCharge'
+--- | 'FormAttack'
+--- | 'Teleport'
+--- | 'Patrol'
+--- | 'FormPatrol'
+--- | 'Sacrifice'
+--- | 'Pause'
+--- | 'Dock'
+--- | 'DetachFromTransport'
 
+---@class UserCommandTarget
+---@field EntityId? EntityId
+---@field Position Vector
+---@field Type 'Position' | 'Entity' | 'None'
+
+---@class UserCommand
+---@field Blueprint UnitId
+---@field Clear boolean
+---@field CommandType UserCommandType
+---@field LuaParams table
+---@field Target UserCommandTarget
+---@field Units UserUnit[]
 
 ---@class MeshInfo
 ---@field Position Vector
@@ -282,37 +325,91 @@ local categoriesFactories = categories.STRUCTURE * categories.FACTORY
 local categoriesShields = categories.MOBILE * categories.SHIELD
 local categoriesStructure = categories.STRUCTURE
 
---- Upgrades a tech 1 extractor that is being assisted
 ---@param unit UserUnit
-local function OnGuardUpgrade(guardees, unit)
-    if EntityCategoryContains(categories.MASSEXTRACTION * categories.TECH1, unit) and
-        Prefs.GetFromCurrentProfile('options.assist_to_upgrade') == 'Tech1Extractors'
+local function UpgradeUnit(unit)
+    LOG("UpgradeUnit")
+    if unit:GetFocus() then
+        return
+    end
+
+    ---@type UserUnit[]
+    local units = { unit }
+
+    -- paused units do not start upgrades
+    if GetIsPaused(units) then
+        SetPaused(units, false)
+        WaitTicks(5)
+    end
+
+    -- check if unit still exists
+    if IsDestroyed(unit) then
+        return
+    end
+
+    -- issue the upgrade
+    IssueBlueprintCommandToUnit(
+        unit, "UNITCOMMAND_Upgrade",
+        unit:GetBlueprint().General.UpgradesTo,
+        1, true
+    )
+
+    -- inform the user
+    print("Upgrade unit")
+
+    -- pause it
+    WaitTicks(5)
+    if IsDestroyed(unit) then
+        return
+    end
+
+    SetPaused(units, true)
+end
+
+---@param command UserCommand
+---@param guardees UserUnit[]
+---@param unit UserUnit
+local function OnGuardUpgrade(command, guardees, unit)
+    local unitBlueprint = unit:GetBlueprint()
+
+    -- check for radars
+    local upgradeRadar = Prefs.GetFromCurrentProfile('options.assist_to_upgrade_radar')
+    local upgradeRadarTech1 = upgradeRadar == 'Tech1Radars' or upgradeRadar == 'Tech1Tech2Radars'
+    local upgradeRadarTech2 = upgradeRadar == 'Tech1Tech2Radars'
+    if upgradeRadarTech1 and
+        EntityCategoryContains(categories.STRUCTURE * categories.RADAR * categories.TECH1, unit)
     then
-        ForkThread(
-            function()
-                ---@type UserUnit
-                local units = { unit }
-                if not IsDestroyed(unit) and not unit:GetFocus() then
-                    import("/lua/ui/game/selection.lua").Hidden(
-                        function()
-                            SelectUnits(units)
-                            IssueBlueprintCommand("UNITCOMMAND_Upgrade", unit:GetBlueprint().General.UpgradesTo, 1, true)
-                        end
-                    )
+        ForkThread(UpgradeUnit, unit)
+    end
 
-                    WaitSeconds(0.5)
+    if upgradeRadarTech2 and
+        EntityCategoryContains(categories.STRUCTURE * categories.RADAR * categories.TECH2, unit) and
+        unitBlueprint.Economy.ConsumptionPerSecondEnergy > unit:GetEconData().energyConsumed -- check for any adjacency
+    then
+        ForkThread(UpgradeUnit, unit)
+    end
 
-                    SetPaused(units, true)
-                end
-            end
-        )
+    -- check for mass extractors
+    local upgradeExtractor = Prefs.GetFromCurrentProfile('options.assist_to_upgrade')
+    local upgradeExtractorTech1 = upgradeExtractor == 'Tech1Extractors' or upgradeExtractor == 'Tech1Tech2Extractors'
+    local upgradeExtractorTech2 = upgradeExtractor == 'Tech1Tech2Extractors'
+    if upgradeExtractorTech1 and
+        EntityCategoryContains(categories.STRUCTURE * categories.MASSEXTRACTION * categories.TECH1, unit)
+    then
+        ForkThread(UpgradeUnit, unit)
+    end
+
+    if upgradeExtractorTech2 and
+        EntityCategoryContains(categories.STRUCTURE * categories.MASSEXTRACTION * categories.TECH2, unit) and
+        unitBlueprint.Economy.ProductionPerSecondMass < unit:GetEconData().massProduced -- check for any adjacency
+    then
+        ForkThread(UpgradeUnit, unit)
     end
 end
 
---- Unpauses a
+---@param command UserCommand
 ---@param guardees UserUnit[]
 ---@param target UserUnit
-local function OnGuardUnpause(guardees, target)
+local function OnGuardUnpause(command, guardees, target)
     local prefs = Prefs.GetFromCurrentProfile('options.assist_to_unpause')
     if prefs == 'On' or
         (
@@ -351,7 +448,7 @@ local function OnGuardUnpause(guardees, target)
                             target.ThreadUnpauseCandidates = nil
                             target.ThreadUnpause = nil
                             break
-                            ; end
+                        end
 
                         WaitSeconds(1.0)
                         target = GetUnitById(id)
@@ -368,29 +465,35 @@ local function OnGuardUnpause(guardees, target)
     end
 end
 
+---@param command UserCommand
 ---@param guardees UserUnit[]
 ---@param unit UserUnit
-local function OnGuardCopy(guardees, unit)
+local function OnGuardCopy(command, guardees, unit)
     local prefs = Prefs.GetFromCurrentProfile('options.assist_to_copy_command_queue')
     local engineers = EntityCategoryFilterDown(categories.ENGINEER, guardees)
     if table.getn(engineers) > 0 and
-        (prefs == 'OnlyEngineers') and
+        (prefs == 'OnlyEngineers' or prefs == 'OnlyEngineersAddToSelection') and
         EntityCategoryContains(categories.ENGINEER, unit)
     then
         if IsKeyDown('Control') then
             SimCallback({ Func = 'CopyOrders', Args = { Target = unit:GetEntityId(), ClearCommands = true } }, true)
+
+            if prefs == 'OnlyEngineersAddToSelection' then
+                AddSelectUnits({ unit })
+            end
         end
     end
 end
 
 --- Is called when a unit receies a guard / assist order
+---@param command UserCommand
 ---@param guardees UserUnit[]
 ---@param unit UserUnit
-local function OnGuard(guardees, unit)
+local function OnGuard(command, guardees, unit)
     if unit:GetArmy() == GetFocusArmy() then
-        OnGuardUpgrade(guardees, unit)
-        OnGuardUnpause(guardees, unit)
-        OnGuardCopy(guardees, unit)
+        OnGuardUpgrade(command, guardees, unit)
+        OnGuardUnpause(command, guardees, unit)
+        OnGuardCopy(command, guardees, unit)
     end
 end
 
@@ -433,9 +536,9 @@ function OnCommandIssued(command)
     if command.CommandType == 'Guard' and command.Target.EntityId then
 
         local unit = GetUnitById(command.Target.EntityId)
-        OnGuard(command.Units, unit)
+        OnGuard(command, command.Units, unit)
 
-        -- validate factories assisting other factories
+        -- Detect and fix a simulation freeze by clearing the command queue of all factories that take part in a cycle
         if EntityCategoryContains(categoriesFactories, command.Blueprint) then
             local factories = EntityCategoryFilterDown(categoriesFactories, command.Units) or {}
             if factories[1] then

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -327,7 +327,7 @@ local categoriesStructure = categories.STRUCTURE
 
 ---@param unit UserUnit
 local function UpgradeUnit(unit)
-    LOG("UpgradeUnit")
+    -- do not upgrade units that are already upgrading
     if unit:GetFocus() then
         return
     end

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -365,10 +365,9 @@ local function UpgradeUnit(unit)
     SetPaused(units, true)
 end
 
----@param command UserCommand
 ---@param guardees UserUnit[]
 ---@param unit UserUnit
-local function OnGuardUpgrade(command, guardees, unit)
+local function OnGuardUpgrade(guardees, unit)
     local unitBlueprint = unit:GetBlueprint()
 
     -- check for radars
@@ -406,10 +405,9 @@ local function OnGuardUpgrade(command, guardees, unit)
     end
 end
 
----@param command UserCommand
 ---@param guardees UserUnit[]
 ---@param target UserUnit
-local function OnGuardUnpause(command, guardees, target)
+local function OnGuardUnpause(guardees, target)
     local prefs = Prefs.GetFromCurrentProfile('options.assist_to_unpause')
     if prefs == 'On' or
         (
@@ -465,10 +463,9 @@ local function OnGuardUnpause(command, guardees, target)
     end
 end
 
----@param command UserCommand
 ---@param guardees UserUnit[]
 ---@param unit UserUnit
-local function OnGuardCopy(command, guardees, unit)
+local function OnGuardCopy(guardees, unit)
     local prefs = Prefs.GetFromCurrentProfile('options.assist_to_copy_command_queue')
     local engineers = EntityCategoryFilterDown(categories.ENGINEER, guardees)
     if table.getn(engineers) > 0 and
@@ -486,14 +483,13 @@ local function OnGuardCopy(command, guardees, unit)
 end
 
 --- Is called when a unit receies a guard / assist order
----@param command UserCommand
 ---@param guardees UserUnit[]
 ---@param unit UserUnit
-local function OnGuard(command, guardees, unit)
+local function OnGuard(guardees, unit)
     if unit:GetArmy() == GetFocusArmy() then
-        OnGuardUpgrade(command, guardees, unit)
-        OnGuardUnpause(command, guardees, unit)
-        OnGuardCopy(command, guardees, unit)
+        OnGuardUpgrade(guardees, unit)
+        OnGuardUnpause(guardees, unit)
+        OnGuardCopy(guardees, unit)
     end
 end
 
@@ -536,7 +532,7 @@ function OnCommandIssued(command)
     if command.CommandType == 'Guard' and command.Target.EntityId then
 
         local unit = GetUnitById(command.Target.EntityId)
-        OnGuard(command, command.Units, unit)
+        OnGuard(command.Units, unit)
 
         -- Detect and fix a simulation freeze by clearing the command queue of all factories that take part in a cycle
         if EntityCategoryContains(categoriesFactories, command.Blueprint) then

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -65,12 +65,16 @@ function WaitSeconds(n)
     end
 end
 
---- Waits the given number of ticks. Always waits at least four frames
+--- Waits the given number of ticks. Always waits at least two frames
 ---@param ticks any
 function WaitTicks(ticks)
+    -- local scope for performance
+    local GameTick = GameTick
+    local WaitFrames = WaitFrames
+
     local start = GameTick()
     repeat
-        WaitFrames(4)
+        WaitFrames(2)
     until (start + ticks) <= GameTick()
 end
 


### PR DESCRIPTION
Extends the ability to assist-to upgrade tech 1 extractors to also apply to tech 2 extractors. Adds the ability to assist-to upgrade radars tech 1 and tech 2 radars. Tech 2 extractors and radars only trigger when they receive _some_ adjacency bonus.

Fixes a bug where the unit would not be paused due to network lag.

Fixes a bug where the unit would be paused before the upgrade is applied, and therefore effectively not upgrade.

Adds various annotations to the user commands data structures.