### PR TITLE
Add power generator templates for Eye and Soothsayer

### DIFF
--- a/lua/ui/game/hotkeys/context-based-templates-data.lua
+++ b/lua/ui/game/hotkeys/context-based-templates-data.lua
@@ -41,6 +41,7 @@
 CapExtractorWithStorages = import("/lua/ui/game/hotkeys/context-based-templates-data/CapExtractorWithStorages.lua").Template
 CapExtractorWithFabs = import("/lua/ui/game/hotkeys/context-based-templates-data/CapExtractorWithFabs.lua").Template
 CapRadarWithPower = import("/lua/ui/game/hotkeys/context-based-templates-data/CapRadarWithPower.lua").Template
+CapOpticsWithPower = import("/lua/ui/game/hotkeys/context-based-templates-data/CapOpticsWithPower.lua").Template
 CapT2ArtilleryWithPower = import("/lua/ui/game/hotkeys/context-based-templates-data/CapT2ArtilleryWithPower.lua").Template
 CapT3FabricatorWithStorages = import("/lua/ui/game/hotkeys/context-based-templates-data/CapT3FabricatorWithStorages.lua").Template
 CapT3ArtilleryWithPower = import("/lua/ui/game/hotkeys/context-based-templates-data/CapT3ArtilleryWithPower.lua").Template
@@ -64,6 +65,9 @@ AppendMassStoragesAndFabricators = import("/lua/ui/game/hotkeys/context-based-te
 AppendPowerGeneratorsToArtillery = import("/lua/ui/game/hotkeys/context-based-templates-data/AppendPowerGeneratorsToArtillery.lua").Template
 AppendPowerGeneratorsToEnergyStorage = import("/lua/ui/game/hotkeys/context-based-templates-data/AppendPowerGeneratorsToEnergyStorage.lua").Template
 AppendPowerGeneratorsToRadar = import("/lua/ui/game/hotkeys/context-based-templates-data/AppendPowerGeneratorsToRadar.lua").Template
+-- Soothsayer and Eye have different footprints so they need different appending templates.
+AppendPowerGeneratorsToSoothsayer = import("/lua/ui/game/hotkeys/context-based-templates-data/AppendPowerGeneratorsToSoothsayer.lua").Template
+AppendPowerGeneratorsToEye = import("/lua/ui/game/hotkeys/context-based-templates-data/AppendPowerGeneratorsToEye.lua").Template
 AppendPowerGeneratorsToTML = import("/lua/ui/game/hotkeys/context-based-templates-data/AppendPowerGeneratorsToTML.lua").Template
 AppendWallsToPointDefense = import("/lua/ui/game/hotkeys/context-based-templates-data/AppendWallsToPointDefense.lua").Template
 

--- a/lua/ui/game/hotkeys/context-based-templates-data/AppendPowerGeneratorsToEye.lua
+++ b/lua/ui/game/hotkeys/context-based-templates-data/AppendPowerGeneratorsToEye.lua
@@ -1,0 +1,110 @@
+--******************************************************************************************************
+--** Copyright (c) 2024  Il1I1
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
+---@type ContextBasedTemplate
+Template = {
+    Name = 'Power generators',
+    TriggersOnBuilding = categories.STRUCTURE * categories.OPTICS * categories.TECH3 * categories.AEON,
+    TemplateSortingOrder = 100,
+    TemplateData = {
+        0,
+        0,
+        {
+            'dummy',
+            2600,
+            1,
+            1
+        },
+        {
+            'uab1101',
+            2605,
+            -1,
+            5
+        },
+        {
+            'uab1101',
+            2621,
+            1,
+            5
+        },
+        {
+            'uab1101',
+            2636,
+            3,
+            5
+        },
+        {
+            'uab1101',
+            2651,
+            5,
+            3
+        },
+        {
+            'uab1101',
+            2666,
+            5,
+            1
+        },
+        {
+            'uab1101',
+            2680,
+            5,
+            -1
+        },
+        {
+            'uab1101',
+            2695,
+            3,
+            -3
+        },
+        {
+            'uab1101',
+            2710,
+            1,
+            -3
+        },
+        {
+            'uab1101',
+            2724,
+            -1,
+            -3
+        },
+        {
+            'uab1101',
+            2738,
+            -3,
+            -1
+        },
+        {
+            'uab1101',
+            2753,
+            -3,
+            1
+        },
+        {
+            'uab1101',
+            2767,
+            -3,
+            3
+        }
+    },
+}

--- a/lua/ui/game/hotkeys/context-based-templates-data/AppendPowerGeneratorsToEye.lua
+++ b/lua/ui/game/hotkeys/context-based-templates-data/AppendPowerGeneratorsToEye.lua
@@ -26,8 +26,8 @@ Template = {
     TriggersOnBuilding = categories.STRUCTURE * categories.OPTICS * categories.TECH3 * categories.AEON,
     TemplateSortingOrder = 100,
     TemplateData = {
-        0,
-        0,
+        10,
+        10,
         {
             'dummy',
             2600,

--- a/lua/ui/game/hotkeys/context-based-templates-data/AppendPowerGeneratorsToSoothsayer.lua
+++ b/lua/ui/game/hotkeys/context-based-templates-data/AppendPowerGeneratorsToSoothsayer.lua
@@ -26,8 +26,8 @@ Template = {
     TriggersOnBuilding = categories.STRUCTURE * categories.OPTICS * categories.TECH3 * categories.CYBRAN,
     TemplateSortingOrder = 100,
     TemplateData = {
-        0,
-        0,
+        10,
+        10,
         {
             'dummy',
             2600,

--- a/lua/ui/game/hotkeys/context-based-templates-data/AppendPowerGeneratorsToSoothsayer.lua
+++ b/lua/ui/game/hotkeys/context-based-templates-data/AppendPowerGeneratorsToSoothsayer.lua
@@ -1,0 +1,110 @@
+--******************************************************************************************************
+--** Copyright (c) 2024  Il1I1
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
+---@type ContextBasedTemplate
+Template = {
+    Name = 'Power generators',
+    TriggersOnBuilding = categories.STRUCTURE * categories.OPTICS * categories.TECH3 * categories.CYBRAN,
+    TemplateSortingOrder = 100,
+    TemplateData = {
+        0,
+        0,
+        {
+            'dummy',
+            2600,
+            2,
+            2
+        },
+        {
+            'uab1101',
+            2605,
+            0,
+            6
+        },
+        {
+            'uab1101',
+            2621,
+            2,
+            6
+        },
+        {
+            'uab1101',
+            2636,
+            4,
+            6
+        },
+        {
+            'uab1101',
+            2651,
+            6,
+            4
+        },
+        {
+            'uab1101',
+            2666,
+            6,
+            2
+        },
+        {
+            'uab1101',
+            2680,
+            6,
+            0
+        },
+        {
+            'uab1101',
+            2695,
+            4,
+            -2
+        },
+        {
+            'uab1101',
+            2710,
+            2,
+            -2
+        },
+        {
+            'uab1101',
+            2724,
+            0,
+            -2
+        },
+        {
+            'uab1101',
+            2738,
+            -2,
+            0
+        },
+        {
+            'uab1101',
+            2753,
+            -2,
+            2
+        },
+        {
+            'uab1101',
+            2767,
+            -2,
+            4
+        }
+    },
+}

--- a/lua/ui/game/hotkeys/context-based-templates-data/CapOpticsWithPower.lua
+++ b/lua/ui/game/hotkeys/context-based-templates-data/CapOpticsWithPower.lua
@@ -1,0 +1,104 @@
+--******************************************************************************************************
+--** Copyright (c) 2024  Il1I1
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
+---@type ContextBasedTemplate
+Template = {
+    Name = 'Power generators',
+    TriggersOnUnit = categories.STRUCTURE * categories.OPTICS * categories.TECH3,
+    TemplateSortingOrder = 100,
+    TemplateData = {
+        0,
+        0,
+        {
+            'uab1101',
+            2605,
+            -2,
+            4
+        },
+        {
+            'uab1101',
+            2621,
+            0,
+            4
+        },
+        {
+            'uab1101',
+            2636,
+            2,
+            4
+        },
+        {
+            'uab1101',
+            2651,
+            4,
+            2
+        },
+        {
+            'uab1101',
+            2666,
+            4,
+            0
+        },
+        {
+            'uab1101',
+            2680,
+            4,
+            -2
+        },
+        {
+            'uab1101',
+            2695,
+            2,
+            -4
+        },
+        {
+            'uab1101',
+            2710,
+            0,
+            -4
+        },
+        {
+            'uab1101',
+            2724,
+            -2,
+            -4
+        },
+        {
+            'uab1101',
+            2738,
+            -4,
+            -2
+        },
+        {
+            'uab1101',
+            2753,
+            -4,
+            0
+        },
+        {
+            'uab1101',
+            2767,
+            -4,
+            2
+        }
+    },
+}

--- a/units/XAB3301/XAB3301_unit.bp
+++ b/units/XAB3301/XAB3301_unit.bp
@@ -19,7 +19,6 @@ UnitBlueprint{
         "AEON",
         "BUILTBYTIER3COMMANDER",
         "BUILTBYTIER3ENGINEER",
-        "DRAGBUILD",
         "INTELLIGENCE",
         "OPTICS",
         "PRODUCTFA",


### PR DESCRIPTION
It is always a good idea to cap these structures with t1 pgens:
- 1.43x more efficient than t3 pgens at 990 energy for 900 mass.
- Volatility isn't an issue at all for eye, and soothsayer can only be hit by the top and bottom pgens' death explosions, but it has only 500 HP anyway.