### PR TITLE
Rework the FPS counter to be less obstructive and more modern

### DIFF
--- a/lua/debug/uidebug.lua
+++ b/lua/debug/uidebug.lua
@@ -10,25 +10,31 @@ function ShowFPS()
         return
     end
     
-    fps = UIUtil.CreateText(GetFrame(0), '', 30)
-    fps:SetColor('ffffffff')
+    fps = UIUtil.CreateText(GetFrame(0), '', 12)
+    fps:SetColor('ffffff')
+    fps:SetFont(UIUtil.fixedFont, 12)
     fps:SetDropShadow(true)
     fps:DisableHitTest()
     fps.Depth:Set(GetFrame(0):GetTopmostDepth() + 1)
-    LayoutHelpers.AtLeftTopIn(fps, GetFrame(0))
+    LayoutHelpers.AtRightTopIn(fps, GetFrame(0), 425, 0)
     
     fps:SetNeedsFrameUpdate(true)
     fps.OnFrame = function(self, deltatime)
-        for key, val in __EngineStats.Children do
-            if val.Name == 'Frame' then
-                for childKey, childVal in val.Children do
-                    if childVal.Name == 'FPS' then
-                        self:SetText(string.format("%2.1f", childVal.Value))
-                        break
+        if not self.timer or self.timer > 0.4 then
+            for key, val in __EngineStats.Children do
+                if val.Name == 'Frame' then
+                    for childKey, childVal in val.Children do
+                        if childVal.Name == 'FPS' then
+                            self:SetText(string.format("FPS: %.0f", childVal.Value))
+                            break
+                        end
                     end
+                    break
                 end
-                break
             end
+            self.timer = 0
+        else
+            self.timer = self.timer + deltatime
         end
     end
 end

--- a/lua/debug/uidebug.lua
+++ b/lua/debug/uidebug.lua
@@ -36,7 +36,9 @@ end
 function ShowFPS()
     if fps then
         fps:Destroy()
+        stdPanel:Destroy()
         fps = false
+        showFPS = false
         return
     end
 
@@ -56,8 +58,18 @@ function ShowFPS()
 	stdPanel.Depth:Set(GetFrame(0):GetTopmostDepth() + 1)
 	LayoutHelpers.AtRightTopIn(stdPanel, GetFrame(0), 425, 0)
 
+    local updateTimer = 0
+    local updateInterval = 0.25
+
     fps:SetNeedsFrameUpdate(true)
     fps.OnFrame = function(self, deltatime)
+        updateTimer = updateTimer + deltatime
+        if updateTimer < updateInterval then
+			return
+		end
+
+        updateTimer = updateTimer - updateInterval
+
         for key, val in __EngineStats.Children do
             if val.Name == 'Frame' then
                 for childKey, childVal in val.Children do

--- a/lua/debug/uidebug.lua
+++ b/lua/debug/uidebug.lua
@@ -1,7 +1,37 @@
+--******************************************************************************************************
+--** Copyright (c) 2024  FAForever
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
 local UIUtil = import("/lua/ui/uiutil.lua")
 local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
+local Statistics = import("/lua/shared/statistics.lua")
 
 local fps = false
+
+local framerateCurrent = 1
+local framerateMax = 30
+local framerates = {}
+for k = 1, framerateMax do
+    framerates[k] = 0
+end
 
 function ShowFPS()
     if fps then
@@ -9,7 +39,7 @@ function ShowFPS()
         fps = false
         return
     end
-    
+
     fps = UIUtil.CreateText(GetFrame(0), '', 12)
     fps:SetColor('ffffff')
     fps:SetFont(UIUtil.fixedFont, 12)
@@ -17,24 +47,36 @@ function ShowFPS()
     fps:DisableHitTest()
     fps.Depth:Set(GetFrame(0):GetTopmostDepth() + 1)
     LayoutHelpers.AtRightTopIn(fps, GetFrame(0), 425, 0)
-    
+
     fps:SetNeedsFrameUpdate(true)
     fps.OnFrame = function(self, deltatime)
-        if not self.timer or self.timer > 0.4 then
-            for key, val in __EngineStats.Children do
-                if val.Name == 'Frame' then
-                    for childKey, childVal in val.Children do
-                        if childVal.Name == 'FPS' then
-                            self:SetText(string.format("FPS: %.0f", childVal.Value))
-                            break
+        for key, val in __EngineStats.Children do
+            if val.Name == 'Frame' then
+                for childKey, childVal in val.Children do
+                    if childVal.Name == 'FPS' then
+
+                        framerates[framerateCurrent] = childVal.Value
+                        framerateCurrent = framerateCurrent + 1
+                        if framerateCurrent > framerateMax then
+                            framerateCurrent = 1
                         end
+
+                        local mean = Statistics.Mean(framerates, framerateMax)
+                        local std = Statistics.Deviation(framerates, framerateMax, mean)
+
+                        self:SetText(string.format("FPS: %03.0f (σ %0.03f)", mean, std))
+                        break
                     end
-                    break
                 end
+                break
             end
-            self.timer = 0
-        else
-            self.timer = self.timer + deltatime
         end
+    end
+end
+
+--- Called by the module manager when this module is dirty due to a disk change
+function __moduleinfo.OnDirty()
+    if fps then
+        fps:Destroy()
     end
 end

--- a/lua/debug/uidebug.lua
+++ b/lua/debug/uidebug.lua
@@ -34,7 +34,7 @@ local stdPanel = false
 local framerateCurrent = 1
 
 ---@type number
-local framerateMax = 30
+local framerateMax = 60
 
 ---@type number[]
 local framerates = {}

--- a/lua/debug/uidebug.lua
+++ b/lua/debug/uidebug.lua
@@ -46,7 +46,15 @@ function ShowFPS()
     fps:SetDropShadow(true)
     fps:DisableHitTest()
     fps.Depth:Set(GetFrame(0):GetTopmostDepth() + 1)
-    LayoutHelpers.AtRightTopIn(fps, GetFrame(0), 425, 0)
+    LayoutHelpers.AtRightTopIn(fps, GetFrame(0), 495, 0)
+
+    stdPanel = UIUtil.CreateText(GetFrame(0), '', 12)
+	stdPanel:SetColor('ffffff')
+	stdPanel:SetFont(UIUtil.fixedFont, 12)
+	stdPanel:SetDropShadow(true)
+	stdPanel:DisableHitTest()
+	stdPanel.Depth:Set(GetFrame(0):GetTopmostDepth() + 1)
+	LayoutHelpers.AtRightTopIn(stdPanel, GetFrame(0), 425, 0)
 
     fps:SetNeedsFrameUpdate(true)
     fps.OnFrame = function(self, deltatime)
@@ -64,7 +72,8 @@ function ShowFPS()
                         local mean = Statistics.Mean(framerates, framerateMax)
                         local std = Statistics.Deviation(framerates, framerateMax, mean)
 
-                        self:SetText(string.format("FPS: %03.0f (σ %0.03f)", mean, std))
+                        self:SetText(string.format("FPS: %03.0f", mean))
+                        stdPanel:SetText(string.format("(σ %07.02f)", std))
                         break
                     end
                 end

--- a/lua/shared/statistics.lua
+++ b/lua/shared/statistics.lua
@@ -1,15 +1,37 @@
+--******************************************************************************************************
+--** Copyright (c) 2024  FAForever
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
 
 local TableGetn = table.getn
 
 --- Computes the sum of an array of values
--- @param t Table to compute values over, only array elements are used.
--- @param n Number of elements, defaults to table.getn(t)
+---@param t number[] Array to compute values over, only array elements are used.
+---@param n number Count of elements, defaults to table.getn(t)
+---@return number
 function Sum(t, n)
     -- allow for optionals
     n = n or TableGetn(t)
 
     local sum = 0
-    for k = 1, n do 
+    for k = 1, n do
         sum = sum + t[k]
     end
 
@@ -17,28 +39,28 @@ function Sum(t, n)
 end
 
 --- Computes the mean of an array of values
--- @param t Table to compute values over, only array elements are used.
--- @param n Number of elements, defaults to table.getn(t)
+---@param t number[] Array to compute values over, only array elements are used.
+---@param n number Count of elements, defaults to table.getn(t)
+---@return number
 function Mean(t, n)
-
     -- allow for optionals
     n = n or TableGetn(t)
 
     -- compute mean
     local mean = 0
-    for k = 1, n do 
+    for k = 1, n do
         mean = mean + t[k]
     end
 
     return mean * (1 / n)
 end
 
---- Computes the deviation of an array of values
--- @param t Table to compute values over, only array elements are used.
--- @param n Number of elements, defaults to table.getn(t)
--- @param m Mean of table, defaults to Mean(t, n)
+--- Computes the standard deviation of an array of values
+---@param t number[] Array to compute values over, only array elements are used.
+---@param n number Count of elements, defaults to table.getn(t)
+---@param m number Mean of table, defaults to Mean(t, n)
+---@return number
 function Deviation(t, n, m)
-
     -- allow for optionals
     n = n or TableGetn(t)
     m = m or Mean(t, n)
@@ -46,7 +68,7 @@ function Deviation(t, n, m)
     -- compute deviation
     local i = 0
     local deviation = 0
-    for k = 1, n do 
+    for k = 1, n do
         i = t[k] - m
         deviation = deviation + i * i
     end


### PR DESCRIPTION
This PR orients itself on other, modern FPS counters, like the one Steam provides.

- The counter now takes up much less screen space
- The numbers do not constantly jump around anymore, as fixedFont is used instead of bodyFont
- Unnecessary decimal places have been removed
- The counter does not obstruct other UI-elements anymore

To access the FPS counter in-game, go to: Key Bindings --> Debug --> "Toggle the display of frames rendered per second"