### PR TITLE
Fix achievements JsonStats message

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1523,6 +1523,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     ---@param unitKilled Unit
     ---@param experience number | nil
     OnKilledUnit = function (self, unitKilled, experience)
+        ArmyBrains[self.Army]:AddUnitStat(unitKilled.UnitId, "kills", 1)
+        
         if experience then
             VeterancyComponent.OnKilledUnit(self, unitKilled, experience)
         end

--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -8,13 +8,101 @@ local scoreOption = ScenarioInfo.Options.Score or "no"
 scoreData = {interval = historyInterval, current = ArmyScore, history = {}, focusArmyIndex = 0}
 
 -- Some of these values pre-existed and are used in other places, that's why their naming is not consistent
+-- The 'kills', 'built', and 'loss' stats for each category are updated for each army during the game and synced to 'Sync.Score'
 local categoriesToCollect = {
     land = categories.LAND,
     air = categories.AIR,
     naval = categories.NAVAL,
     cdr = categories.COMMAND,
     experimental = categories.EXPERIMENTAL,
-    structures = categories.STRUCTURE
+    structures = categories.STRUCTURE,
+}
+
+-- The 'kills', 'built', and 'loss' stats for each category are checked for each army at the end of the game
+-- Format specifications and required categories for achievements: https://github.com/FAForever/fa/issues/5813
+local categoriesForAchievements = {
+    tech1 = categories.TECH1,
+    tech2 = categories.TECH2,
+    tech3 = categories.TECH3,
+    engineer = categories.ENGINEER,
+    transportation = categories.TRANSPORTATION, 
+    sacu = categories.SUBCOMMANDER,
+}
+
+-- The stats for these units are checked for each army at the end of the game.
+-- They can have custom stats on top of the 3 standard ones.
+-- Unit IDs used for achievements: https://github.com/FAForever/server/blob/develop/server/stats/unit.py
+local unitIdsForAchievements = {
+    -- ACUs
+    -- lowest_health custom stat
+    'ual0001', -- AEON_ACU
+    'url0001', -- CYBRAN_ACU
+    'uel0001', -- UEF_ACU
+    'xsl0001', -- SERAPHIM_ACU
+
+    -- ASFs
+    'uaa0303', -- CORONA
+    'ura0303', -- GEMINI
+    'uea0303', -- WASP
+    'xsa0303', -- IAZYNE
+
+    -- Experimentals
+    -- Aeon
+    'xab1401', -- PARAGON
+    'uaa0310', -- CZAR
+    'ual0401', -- GALACTIC_COLOSSUS
+    'uas0401', -- TEMPEST
+    'xab2307', -- SALVATION
+    -- UEF
+    'ueb2401', -- MAVOR
+    'uel0401', -- FATBOY
+    'xeb2402', -- NOVAX_CENTER
+    'ues0401', -- ATLANTIS
+    -- Cybran
+    'ura0401', -- SOUL_RIPPER
+    'url0401', -- SCATHIS
+    'url0402', -- MONKEYLORD
+    'xrl0403', -- MEGALITH
+    -- Sera
+    'xsb2401', -- YOLONA_OSS
+    'xsa0402', -- AHWASSA
+    'xsl0401', -- YTHOTHA
+
+    -- Transporters
+    'uaa0107', -- CHARIOT
+    'uaa0104', -- ALUMINAR
+    'ura0107', -- SKYHOOK
+    'ura0104', -- DRAGON_FLY
+    'uea0107', -- C6_COURIER
+    'uea0104', -- C14_STAR_LIFTER
+    'xea0306', -- CONTINENTAL
+    'xsa0107', -- VISH
+    'xsa0104', -- VISHALA
+
+    -- SACUs
+    'ual0301', -- AEON_SACU
+    'url0301', -- CYBRAN_SACU
+    'uel0301', -- UEF_SACU
+    'xsl0301', -- SERAPHIM_SACU
+
+    -- Engineers
+    'ual0105', -- AEON_T1_ENGINEER
+    'ual0208', -- AEON_T2_ENGINEER
+    'ual0309', -- AEON_T3_ENGINEER
+    'url0105', -- CYBRAN_T1_ENGINEER
+    'url0208', -- CYBRAN_T2_ENGINEER
+    'url0309', -- CYBRAN_T3_ENGINEER
+    'uel0105', -- UEF_T1_ENGINEER
+    'uel0208', -- UEF_T2_ENGINEER
+    'xel0209', -- UEF_T2_FIELD_ENGINEER
+    'uel0309', -- UEF_T3_ENGINEER
+    'xsl0105', -- SERAPHIM_T1_ENGINEER
+    'xsl0208', -- SERAPHIM_T2_ENGINEER
+    'xsl0309', -- SERAPHIM_T3_ENGINEER
+
+    -- Other units
+    'daa0206', -- MERCY
+    'xrl0302', -- FIRE_BEETLE
 }
 
 ---@param brain AIBrain
@@ -250,10 +338,39 @@ local function ScoreThread()
     end
 end
 
+local function GameOverScore()
+    for index, brain in ArmyBrains do
+
+        if ArmyIsCivilian(index) then continue end
+
+        local Score = ArmyScore[index]
+
+        for categoryName, category in categoriesForAchievements do
+            Score.units[categoryName] = {kills = 0, built = 0, lost = 0}
+            Score.units[categoryName]['kills'] = brain:GetBlueprintStat("Enemies_Killed", category)
+            Score.units[categoryName]['built'] = brain:GetBlueprintStat("Units_History", category)
+            Score.units[categoryName]['lost'] = brain:GetBlueprintStat("Units_Killed", category)
+        end
+        
+        Score.blueprints = {}
+        local allStats = brain:GetUnitStats()
+        for _, unitId in unitIdsForAchievements do
+            local unitStats = allStats[unitId]
+            if unitStats then
+                if not unitStats['kills'] then unitStats['kills'] = 0 end
+                if not unitStats['built'] then unitStats['built'] = 0 end
+                if not unitStats['lost'] then unitStats['lost'] = 0 end
+                Score.blueprints[unitId] = unitStats
+            end
+        end
+    end
+end
+
 function init()
     ForkThread(ScoreThread)
     table.insert(GameOverListeners, function()
         GameIsOver = true
+        GameOverScore()
         Sync.ScoreAccum = scoreData
         Sync.StatsToSend = ArmyScore
     end)

--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -18,20 +18,18 @@ local categoriesToCollect = {
     structures = categories.STRUCTURE,
 }
 
--- The 'kills', 'built', and 'loss' stats for each category are checked for each army at the end of the game
--- Format specifications and required categories for achievements: https://github.com/FAForever/fa/issues/5813
+-- Format specifications for achievements: https://github.com/FAForever/fa/issues/5813
+-- Unit categories used in achievements: https://github.com/FAForever/server/blob/develop/server/stats/game_stats_service.py
+-- Unit IDs used for unit categories: https://github.com/FAForever/server/blob/develop/server/stats/unit.py
+
+-- The 'kills', 'built', and 'loss' stats for each category are checked for each army at the end of the game_stats_service
 local categoriesForAchievements = {
-    tech1 = categories.TECH1,
-    tech2 = categories.TECH2,
-    tech3 = categories.TECH3,
-    engineer = categories.ENGINEER,
     transportation = categories.TRANSPORTATION, 
     sacu = categories.SUBCOMMANDER,
 }
 
 -- The stats for these units are checked for each army at the end of the game.
 -- They can have custom stats on top of the 3 standard ones.
--- Unit IDs used for achievements: https://github.com/FAForever/server/blob/develop/server/stats/unit.py
 local unitIdsForAchievements = {
     -- ACUs
     -- lowest_health custom stat
@@ -67,38 +65,6 @@ local unitIdsForAchievements = {
     'xsb2401', -- YOLONA_OSS
     'xsa0402', -- AHWASSA
     'xsl0401', -- YTHOTHA
-
-    -- Transporters
-    'uaa0107', -- CHARIOT
-    'uaa0104', -- ALUMINAR
-    'ura0107', -- SKYHOOK
-    'ura0104', -- DRAGON_FLY
-    'uea0107', -- C6_COURIER
-    'uea0104', -- C14_STAR_LIFTER
-    'xea0306', -- CONTINENTAL
-    'xsa0107', -- VISH
-    'xsa0104', -- VISHALA
-
-    -- SACUs
-    'ual0301', -- AEON_SACU
-    'url0301', -- CYBRAN_SACU
-    'uel0301', -- UEF_SACU
-    'xsl0301', -- SERAPHIM_SACU
-
-    -- Engineers
-    'ual0105', -- AEON_T1_ENGINEER
-    'ual0208', -- AEON_T2_ENGINEER
-    'ual0309', -- AEON_T3_ENGINEER
-    'url0105', -- CYBRAN_T1_ENGINEER
-    'url0208', -- CYBRAN_T2_ENGINEER
-    'url0309', -- CYBRAN_T3_ENGINEER
-    'uel0105', -- UEF_T1_ENGINEER
-    'uel0208', -- UEF_T2_ENGINEER
-    'xel0209', -- UEF_T2_FIELD_ENGINEER
-    'uel0309', -- UEF_T3_ENGINEER
-    'xsl0105', -- SERAPHIM_T1_ENGINEER
-    'xsl0208', -- SERAPHIM_T2_ENGINEER
-    'xsl0309', -- SERAPHIM_T3_ENGINEER
 
     -- Other units
     'daa0206', -- MERCY

--- a/lua/sim/units/AirUnit.lua
+++ b/lua/sim/units/AirUnit.lua
@@ -214,6 +214,18 @@ AirUnit = ClassUnit(MobileUnit) {
             self.Trash:Add(proj)
 
             self:VeterancyDispersal()
+
+            local army = self.Army
+            -- awareness for traitor game mode and game statistics
+            ArmyBrains[army].LastUnitKilledBy = (instigator or self).Army
+            ArmyBrains[army]:AddUnitStat(self.UnitId, "lost", 1)
+
+            -- awareness of instigator that it killed a unit, but it can also be a projectile or nil
+            if instigator and instigator.OnKilledUnit then
+                instigator:OnKilledUnit(self)
+            end
+
+            self.Brain:OnUnitKilled(self, instigator, type, overkillRatio)
         else
             MobileUnit.OnKilled(self, instigator, type, overkillRatio)
         end

--- a/lua/system/dkson.lua
+++ b/lua/system/dkson.lua
@@ -161,7 +161,8 @@ end
 updatedecpoint()
 
 local function num2str (num)
-    return replace(fsub(tostring(num), numfilter, ""), decpoint, ".")
+    -- An overflowing number will return "1.#INF", so we need to get rid of the trailing period.
+    return replace(fsub(fsub(tostring(num), numfilter, ""), ".$", ""), decpoint, ".")
 end
 
 local function str2num (str)


### PR DESCRIPTION
Fixes #5813. Caused by #4466.
The data is only collected at the end of the game as suggested in #4466.

@Askaholic do you want all the extra unit data? I noticed that transports, engineers, and SACU blueprint data can be interpreted, but it isn't used for anything. Also SACU presets have a different blueprint ID from the base SACU so they wouldn't work anyway. The transport and SACU achievements are done with the category data instead of blueprint data.