### PR TITLE
Fix offmapping wrecks

### DIFF
--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -2266,6 +2266,7 @@ function AntiOffMapMainThread()
         end
     end
 end
+
 -- This is for bad units who choose to go off map, shame on them
 function MoveOnMapThread(unit)
     unit.OffMapTime = 0
@@ -2293,7 +2294,16 @@ end
 --- Clears a unit's orders and issues a move order to the closest point on the map
 ---@param unit Unit
 function MoveOnMap(unit)
-    local position = unit:GetPosition()
+    local nearestPoint = GetNearestPlayablePoint( unit:GetPosition() )
+
+    IssueToUnitClearCommands(unit)
+    IssueToUnitMove(unit, nearestPoint)
+end
+
+--- Returns the closest point on the map
+---@param pos Vector
+---@return Vector
+function GetNearestPlayablePoint(position)
     local playableArea = ScenarioInfo.PlayableArea
     local nearestPoint = {position[1], position[2], position[3]}
 
@@ -2309,8 +2319,7 @@ function MoveOnMap(unit)
         nearestPoint[3] = playableArea[4] - 5
     end
 
-    IssueToUnitClearCommands(unit)
-    IssueToUnitMove(unit, nearestPoint)
+    return nearestPoint
 end
 
 --- Returns if the unit's army is human

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1704,7 +1704,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         end
 
         -- Create potentially offmap wrecks on-map. Exclude campaign maps that may do weird scripted things.
-        if IsHumanUnit(self) and not ScenarioInfo.CampaignMode then
+        if self.Brain.BrainType == 'Human' and (not ScenarioInfo.CampaignMode) then
             pos = GetNearestPlayablePoint(pos)
         end
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -39,6 +39,8 @@ local UpdateAssistersConsumptionCats = categories.REPAIR - categories.INSIGNIFIC
 
 local DefaultTerrainType = GetTerrainType(-1, -1)
 
+local GetNearestPlayablePoint = import("/lua/scenarioframework.lua").GetNearestPlayablePoint
+
 --- Structures that are reused for performance reasons
 --- Maps unit.techCategory to a number so we can do math on it for naval units
 
@@ -1700,6 +1702,11 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             energy = energy * 0.6
         end
 
+        -- Create offmap aircraft wrecks on-map.
+        if EntityCategoryContains(categories.AIR, self) then
+            pos = GetNearestPlayablePoint(pos)
+        end
+
         local halfBuilt = self:GetFractionComplete() < 1
 
         -- Make sure air / naval wrecks stick to ground / seabottom, unless they're in a factory.
@@ -1720,7 +1727,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         -- Attempt to copy our animation pose to the prop. Only works if
         -- the mesh and skeletons are the same, but will not produce an error if not.
         if self.Tractored or (layer ~= 'Air' or (layer == "Air" and halfBuilt)) then
-            TryCopyPose(self, prop, true)
+            TryCopyPose(self, prop, false)
         end
 
         -- Create some ambient wreckage smoke

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -40,7 +40,6 @@ local UpdateAssistersConsumptionCats = categories.REPAIR - categories.INSIGNIFIC
 local DefaultTerrainType = GetTerrainType(-1, -1)
 
 local GetNearestPlayablePoint = import("/lua/scenarioframework.lua").GetNearestPlayablePoint
-local IsHumanUnit = import("/lua/scenarioframework.lua").IsHumanUnit
 
 --- Structures that are reused for performance reasons
 --- Maps unit.techCategory to a number so we can do math on it for naval units

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1702,8 +1702,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             energy = energy * 0.6
         end
 
-        -- Create offmap aircraft wrecks on-map.
-        if EntityCategoryContains(categories.AIR, self) then
+        -- Create potentially offmap wrecks on-map.
+        if EntityCategoryContains(categories.AIR, self) or self.killedInTransport then
             pos = GetNearestPlayablePoint(pos)
         end
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -40,6 +40,7 @@ local UpdateAssistersConsumptionCats = categories.REPAIR - categories.INSIGNIFIC
 local DefaultTerrainType = GetTerrainType(-1, -1)
 
 local GetNearestPlayablePoint = import("/lua/scenarioframework.lua").GetNearestPlayablePoint
+local IsHumanUnit = import("/lua/scenarioframework.lua").IsHumanUnit
 
 --- Structures that are reused for performance reasons
 --- Maps unit.techCategory to a number so we can do math on it for naval units
@@ -1702,8 +1703,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
             energy = energy * 0.6
         end
 
-        -- Create potentially offmap wrecks on-map.
-        if EntityCategoryContains(categories.AIR, self) or self.killedInTransport then
+        -- Create potentially offmap wrecks on-map. Exclude campaign maps that may do weird scripted things.
+        if IsHumanUnit(self) and not ScenarioInfo.CampaignMode then
             pos = GetNearestPlayablePoint(pos)
         end
 

--- a/lua/sim/units/AirTransportUnit.lua
+++ b/lua/sim/units/AirTransportUnit.lua
@@ -164,7 +164,7 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
                 end
             end
             if not EntityCategoryContains(categories.COMMAND, unit) then
-                unit.willBeKilledByTransport = true
+                unit.killedInTransport = true
                 table.insert(self.cargo, unit)
             end
         end

--- a/lua/sim/units/AirTransportUnit.lua
+++ b/lua/sim/units/AirTransportUnit.lua
@@ -165,7 +165,6 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
             end
             if not EntityCategoryContains(categories.COMMAND, unit) then
                 unit.willBeKilledByTransport = true
-                unit.killedInTransport = true
                 table.insert(self.cargo, unit)
             end
         end

--- a/lua/sim/units/AirTransportUnit.lua
+++ b/lua/sim/units/AirTransportUnit.lua
@@ -164,6 +164,7 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
                 end
             end
             if not EntityCategoryContains(categories.COMMAND, unit) then
+                unit.willBeKilledByTransport = true
                 unit.killedInTransport = true
                 table.insert(self.cargo, unit)
             end

--- a/lua/sim/units/AirUnit.lua
+++ b/lua/sim/units/AirUnit.lua
@@ -181,7 +181,9 @@ AirUnit = ClassUnit(MobileUnit) {
         -- Additional stupidity: An idle transport, bot loaded and unloaded, counts as 'Land' layer so it would die with the wreck hovering.
         -- It also wouldn't call this code, and hence the cargo destruction. Awful!
         if self:GetFractionComplete() == 1 and
-            (self.Layer == 'Air' or EntityCategoryContains(categories.TRANSPORTATION, self)) then
+            (self.Layer == 'Air' or EntityCategoryContains(categories.TRANSPORTATION, self))
+        then
+            self.Dead = true
             self:CreateUnitAirDestructionEffects(1.0)
             self:DestroyTopSpeedEffects()
             self:DestroyBeamExhaust()

--- a/lua/sim/units/AirUnit.lua
+++ b/lua/sim/units/AirUnit.lua
@@ -102,11 +102,6 @@ AirUnit = ClassUnit(MobileUnit) {
     OnImpact = function(self, with)
         if self.GroundImpacted then return end
 
-        -- Immediately destroy units outside the map
-        if not ScenarioFramework.IsUnitInPlayableArea(self) then
-            self:Destroy()
-        end
-
         -- Only call this code once
         self.GroundImpacted = true
 

--- a/lua/sim/units/MobileUnit.lua
+++ b/lua/sim/units/MobileUnit.lua
@@ -95,9 +95,8 @@ MobileUnit = ClassUnit(Unit, TreadComponent) {
     ---@param type string
     ---@param overkillRatio number
     OnKilled = function(self, instigator, type, overkillRatio)
-        -- This unit was in a transport and OnKilled will be called by the transport's OnImpact.
-        if self.killedInTransport then
-            self.killedInTransport = false
+        if self.willBeKilledByTransport then
+            self.willBeKilledByTransport = false
         else
             UnitOnKilled(self, instigator, type, overkillRatio)
         end

--- a/lua/sim/units/MobileUnit.lua
+++ b/lua/sim/units/MobileUnit.lua
@@ -95,8 +95,9 @@ MobileUnit = ClassUnit(Unit, TreadComponent) {
     ---@param type string
     ---@param overkillRatio number
     OnKilled = function(self, instigator, type, overkillRatio)
-        if self.willBeKilledByTransport then
-            self.willBeKilledByTransport = false
+        -- OnKilled will be called a second time by the transport's OnImpact
+        if self.killedInTransport then
+            self.killedInTransport = false
         else
             UnitOnKilled(self, instigator, type, overkillRatio)
         end

--- a/lua/sim/units/MobileUnit.lua
+++ b/lua/sim/units/MobileUnit.lua
@@ -95,7 +95,7 @@ MobileUnit = ClassUnit(Unit, TreadComponent) {
     ---@param type string
     ---@param overkillRatio number
     OnKilled = function(self, instigator, type, overkillRatio)
-        -- This unit was in a transport and should create a wreck on crash
+        -- This unit was in a transport and OnKilled will be called by the transport's OnImpact.
         if self.killedInTransport then
             self.killedInTransport = false
         else

--- a/projectiles/Sinker/Sinker_script.lua
+++ b/projectiles/Sinker/Sinker_script.lua
@@ -67,7 +67,7 @@ Sinker = ClassProjectile(Projectile) {
     ---@param targetType string
     ---@param targetEntity Prop|Unit
     OnImpact = function(self, targetType, targetEntity)
-        if targetType == 'Terrain' then
+        if targetType == 'Terrain' or targetType == 'Underwater' then
             self:Destroy()
             if self.callback then
                 ForkThread(self.callback)

--- a/projectiles/Sinker/Sinker_script.lua
+++ b/projectiles/Sinker/Sinker_script.lua
@@ -67,6 +67,7 @@ Sinker = ClassProjectile(Projectile) {
     ---@param targetType string
     ---@param targetEntity Prop|Unit
     OnImpact = function(self, targetType, targetEntity)
+        -- 'Underwater' is impacted when sinking off map for a long time.
         if targetType == 'Terrain' or targetType == 'Underwater' then
             self:Destroy()
             if self.callback then


### PR DESCRIPTION
If an aircraft/transported unit creates a wreck outside the playable area, the wreck position is moved back inside.

![image](https://github.com/FAForever/fa/assets/82986251/8ad3090d-ba04-4795-a05c-8302475e04ac)
