### PR TITLE
Add feature to hide player names locally

### DIFF
--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -901,7 +901,7 @@ options = {
                 title = "<LOC options_show_player_names_title>Show Player Names",
                 key = 'options_show_player_names',
                 type = 'toggle',
-                default = 0,
+                default = 'on',
                 set = function(key, value, startup)
                     if GetCurrentUIState() == 'game' then
                         import("/lua/ui/override/SessionClients.lua").OptionShowPlayerNames = value

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -898,6 +898,26 @@ options = {
             },
 
             {
+                title = "<LOC options_show_player_names_title>Show Player Names",
+                key = 'options_show_player_names',
+                type = 'toggle',
+                default = 0,
+                set = function(key, value, startup)
+                    if GetCurrentUIState() == 'game' then
+                        import("/lua/ui/override/SessionClients.lua").OptionShowPlayerNames = value
+                        import("/lua/ui/override/ArmiesTable.lua").OptionShowPlayerNames = value
+                    end
+                end,
+                custom = {
+                    states = {
+                        { text = "<LOC _On>", key = 'on' },
+                        { text = "<LOC options_show_player_names_allies_only>Allies only", key = 'allies-only' },
+                        { text = "<LOC _Off>Allies only", key = 'off' },
+                    },
+                },
+            },
+
+            {
                 title = "<LOC OPTIONS_0242>Always Show Custom Names",
                 key = 'gui_render_custom_names',
                 type = 'toggle',

--- a/lua/ui/game/score.lua
+++ b/lua/ui/game/score.lua
@@ -635,10 +635,10 @@ function _OnBeat()
         for index, scoreData in currentScores do
             for _, line in controls.armyLines do
                 if line.armyID == index then
-                    if scoreData.name then
-                        line.name:SetText(scoreData.name)
-                        updatePlayerName(line)
-                    end
+                    -- if scoreData.name then
+                    --     line.name:SetText(scoreData.name)
+                    --     updatePlayerName(line)
+                    -- end
                     if scoreData.general.score >= 0 then
                         line.score:SetText(fmtnum(scoreData.general.score))
                     end

--- a/lua/ui/override/ArmiesTable.lua
+++ b/lua/ui/override/ArmiesTable.lua
@@ -1,3 +1,25 @@
+--******************************************************************************************************
+--** Copyright (c) 2024  FAForever
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
 ---@class ArmiesTable
 ---@field armiesTable ArmyInfo[]
 ---@field numArmies number
@@ -14,11 +36,40 @@
 ---@field outOfGame boolean
 ---@field showScore boolean
 
+local Prefs = import("/lua/user/prefs.lua")
+
+---@type 'on' | 'allies-only' | 'off'
+OptionShowPlayerNames = Prefs.GetFromCurrentProfile('options.options_show_player_names')
+
+---@param armiesTable ArmiesTable
+---@return ArmiesTable
+local function PostprocessArmiesTable(armiesTable)
+    local focusArmy = GetFocusArmy()
+
+    if OptionShowPlayerNames == 'off' then
+        for i, client in ipairs(armiesTable.armiesTable) do
+            if (not client.civilian) then
+                client.nickname = string.format('Player %d', i)
+            end
+        end
+    elseif OptionShowPlayerNames == 'allies-only' then
+        for i, client in ipairs(armiesTable.armiesTable) do
+            if (not client.civilian) then
+                if (focusArmy > 0 and IsEnemy(i, focusArmy)) then
+                    client.nickname = string.format('Player %d', i)
+                end
+            end
+        end
+    end
+
+    return armiesTable
+end
+
 -- keep a reference to the actual function
 local GlobalGetArmiesTable = _G.GetArmiesTable
 
 --- Allows UI elements to be updated when the cache is updated by adding a callback via Observable:AddObserver()
-local Cached = GlobalGetArmiesTable()
+local Cached = PostprocessArmiesTable(GlobalGetArmiesTable())
 Observable = import("/lua/shared/observable.lua").Create()
 Observable:Set(Cached)
 
@@ -32,7 +83,7 @@ local TickIntervalResetCounter = 0
 
 --- A simple tick thread that updates the cache
 local function TickThread()
-    while true do 
+    while true do
         -- allows us to be more responsive on tick interval changes
         WaitSeconds(0.5 * TickInterval)
         WaitSeconds(0.5 * TickInterval)
@@ -40,7 +91,7 @@ local function TickThread()
         WaitSeconds(0.5 * TickInterval)
 
         -- update the cache and inform observers
-        Cached = GlobalGetArmiesTable()
+        Cached = PostprocessArmiesTable(GlobalGetArmiesTable())
         Observable:Set(Cached)
     end
 end
@@ -64,7 +115,7 @@ end
 --- Resets the interval to every 2.0 seconds or a framerate of 0.5.
 function ResetInterval()
     TickIntervalResetCounter = TickIntervalResetCounter - 1
-    if TickIntervalResetCounter == 0 then 
+    if TickIntervalResetCounter == 0 then
         TickInterval = 2.0
     end
 end

--- a/lua/ui/override/SessionClients.lua
+++ b/lua/ui/override/SessionClients.lua
@@ -1,3 +1,24 @@
+--******************************************************************************************************
+--** Copyright (c) 2024  FAForever
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
 
 ---@class Client
 ---@field authorizedCommandSources number[]
@@ -9,12 +30,40 @@
 ---@field quiet number
 ---@field uid string
 
+local Prefs = import("/lua/user/prefs.lua")
+
+---@type 'on' | 'allies-only' | 'off'
+OptionShowPlayerNames = Prefs.GetFromCurrentProfile('options.options_show_player_names')
+
+---@param clients Client[]
+---@return Client[]
+local function PostprocessClients(clients)
+    local focusArmy = GetFocusArmy()
+
+    if OptionShowPlayerNames == 'off' then
+        for i, client in ipairs(clients) do
+            if (i != focusArmy) then
+                client.name = string.format('Player %d', i)
+            end
+        end
+    elseif OptionShowPlayerNames == 'allies-only' then
+        for i, client in ipairs(clients) do
+            if i != focusArmy and (focusArmy > 0 and IsEnemy(i, focusArmy)) then
+                client.name = string.format('Player %d', i)
+            end
+        end
+    end
+
+    return clients
+end
 
 -- keep a reference to the actual function
 local GlobalGetSessionClients = _G.GetSessionClients
 
 --- Allows UI elements to be updated when the cache is updated by adding a callback via Observable:AddObserver()
-local Cached = GlobalGetSessionClients()
+---@type Client[]
+local Cached = PostprocessClients(GlobalGetSessionClients())
+
 Observable = import("/lua/shared/observable.lua").Create()
 Observable:Set(Cached)
 
@@ -28,7 +77,7 @@ local TickIntervalResetCounter = 0
 
 --- A simple tick thread that updates the cache
 local function TickThread()
-    while true do 
+    while true do
         -- allows us to be more responsive on tick interval changes
         WaitSeconds(0.5 * TickInterval)
         WaitSeconds(0.5 * TickInterval)
@@ -36,7 +85,7 @@ local function TickThread()
         WaitSeconds(0.5 * TickInterval)
 
         -- update the cache and inform observers
-        Cached = GlobalGetSessionClients()
+        Cached = PostprocessClients(GlobalGetSessionClients())
         Observable:Set(Cached)
     end
 end
@@ -61,7 +110,7 @@ end
 --- Resets the interval to every 2.0 seconds or a framerate of 0.5.
 function ResetInterval()
     TickIntervalResetCounter = TickIntervalResetCounter - 1
-    if TickIntervalResetCounter == 0 then 
+    if TickIntervalResetCounter == 0 then
         TickInterval = 2.0
     end
 end

--- a/lua/user/prefs.lua
+++ b/lua/user/prefs.lua
@@ -78,6 +78,7 @@ function GetCurrentProfile()
 end
 
 -- Get the map last requested by the player
+---@return any
 function GetFromCurrentProfile(fieldName)
     local current = GetPreference('profile.current')
     if not current then return nil end


### PR DESCRIPTION
Allows you to hide player names in the game. This is a local change, the client and/or other players are not aware of it and will see/show the actual player names.

![image](https://github.com/FAForever/fa/assets/15778155/cc49cba5-1735-48c0-b532-992e48575679)
