### PR TITLE
Remove friendly fire from Ravager

### DIFF
--- a/units/XEB2306/XEB2306_unit.bp
+++ b/units/XEB2306/XEB2306_unit.bp
@@ -149,6 +149,7 @@ UnitBlueprint{
             BallisticArc = "RULEUBA_None",
             CollideFriendly = false,
             Damage = 175,
+            DamageFriendly = false,
             DamageRadius = 1,
             DamageType = "Normal",
             DisplayName = "Heavy Plasma Gatling Cannon",


### PR DESCRIPTION
Point defenses usually don't friendly fire to allow them to be used as teleport defense/base defense in general. Ravager counterintuitively does allow friendly fire, which can cause a disheartening situation where your own Ravagers kill your SMD or game ender.