### PR TITLE
Introduce additional lobby guards

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5236,7 +5236,8 @@ local MessageHandlers = {
                 return false
             end
 
-            if string.len(data.PlayerOptions.PlayerName) > 32 then
+            local charactersInPlayerName = string.len(data.PlayerOptions.PlayerName)
+            if charactersInPlayerName < 3 or charactersInPlayerName > 32 then
                 return false
             end
 

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5210,7 +5210,7 @@ local MessageHandlers = {
     },
 
     AddPlayer = {
-        
+
         ---@class LobbyAddPlayerData
         ---@field PlayerOptions PlayerData
         ---@field SenderId number
@@ -5236,9 +5236,20 @@ local MessageHandlers = {
                 return false
             end
 
-            if string.len(data.PlayerOptions.PlayerName) > 40 then
+            if string.len(data.PlayerOptions.PlayerName) > 32 then
                 return false
             end
+
+            if data.PlayerOptions.PlayerClan then
+                if type(data.PlayerOptions.PlayerClan) != 'string' then
+                    return false
+                end
+
+                if string.len(data.PlayerOptions.PlayerClan) > 3 then
+                    return false
+                end
+            end
+
 
             if not data.PlayerOptions.OwnerID then
                 return false

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5210,11 +5210,49 @@ local MessageHandlers = {
     },
 
     AddPlayer = {
+        
+        ---@class LobbyAddPlayerData
+        ---@field PlayerOptions PlayerData
+        ---@field SenderId number
+        ---@field SenderName string
+        ---@field Type string
+
+        ---@param data LobbyAddPlayerData
         Accept = function(data)
-            return data.PlayerOptions.OwnerID and 
-                data.PlayerOptions.OwnerID == data.SenderID and
-                not FindNameForID(data.SenderID) and
-                lobbyComm:IsHost()
+            -- we need to do quite a bit of checks to prevent malicious values
+            if type(data.PlayerOptions.MEAN) != 'number' then
+                return false
+            end
+
+            if type (data.PlayerOptions.NG) != 'number' then
+                return false
+            end
+
+            if type(data.PlayerOptions.Faction) != 'number' then
+                return false
+            end
+
+            if type(data.PlayerOptions.PlayerName) != 'string' then
+                return false
+            end
+
+            if string.len(data.PlayerOptions.PlayerName) > 40 then
+                return false
+            end
+
+            if not data.PlayerOptions.OwnerID then
+                return false
+            end
+
+            if not (data.PlayerOptions.OwnerID == data.SenderID) then
+                return false
+            end
+
+            if FindNameForID(data.SenderID) then
+                return false
+            end
+            
+            return lobbyComm:IsHost()
         end,
         Reject = function(data)
             lobbyComm:EjectPeer(data.SenderID, "Invalid player data.")


### PR DESCRIPTION
An attempt to combat the following situation where a lobby is crashed by embedding (a large amount of) characters into afield that is supposed to be used for the number of games:

![image](https://github.com/FAForever/fa/assets/15778155/4e94bbd7-acac-45d8-8c63-86cd73c9cc8b)
