### PR TITLE
Fix the status of the minimap's pin feature not being saved into the game.prefs file

### DIFF
--- a/lua/ui/game/minimap.lua
+++ b/lua/ui/game/minimap.lua
@@ -131,12 +131,19 @@ function CreateMinimap(parent)
         end
         frameCount = frameCount + 1
     end
-    controls.displayGroup.OnPinCheck = function(control, checked)
-        control:SetSizeLock(checked)
-        control:SetPositionLock(checked)
-        -- add save pin in prefs
-    end
+	controls.displayGroup.OnPinCheck = function(control, checked)
+		control:SetSizeLock(checked)
+		control:SetPositionLock(checked)
+		Prefs.SetToCurrentProfile('minimapPin', checked)
+		Prefs.SavePreferences()
+	end
     Tooltip.AddCheckboxTooltip(controls.displayGroup._pinBtn, 'minimap_pin')
+
+    local minimapPin = Prefs.GetFromCurrentProfile('minimapPin')
+
+	if minimapPin ~= nil then
+		controls.displayGroup._pinBtn:SetCheck(minimapPin)
+	end
 
     controls.displayGroup.resetBtn = Button(controls.displayGroup.TitleGroup,
         UIUtil.SkinnableFile('/game/menu-btns/default_btn_up.dds'),

--- a/lua/ui/game/minimap.lua
+++ b/lua/ui/game/minimap.lua
@@ -135,7 +135,6 @@ function CreateMinimap(parent)
 		control:SetSizeLock(checked)
 		control:SetPositionLock(checked)
 		Prefs.SetToCurrentProfile('minimapPin', checked)
-		Prefs.SavePreferences()
 	end
     Tooltip.AddCheckboxTooltip(controls.displayGroup._pinBtn, 'minimap_pin')
 


### PR DESCRIPTION
Before this PR, you had to re-pin the minimap every game, as its pin-status would not be saved into your game.prefs file.