### PR TITLE
fix submarines surfacing at start of navalforceai 

### DIFF
--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -2938,17 +2938,11 @@ Platoon = Class(moho.platoon_methods) {
         local PlatoonFormation = self.PlatoonData.UseFormation or 'NoFormation'
         self:SetPlatoonFormationOverride(PlatoonFormation)
 
-        for k,v in self:GetPlatoonUnits() do
-            if v.Dead then
-                continue
-            end
-
-            if v.Layer != 'Sub' then
-                continue
-            end
-
-            if v:TestCommandCaps('RULEUCC_Dive') then
-                IssueDive({v})
+        for _,v in platoonUnits do
+            if not v.Dead then
+                if v.Layer ~= 'Sub' and v:TestCommandCaps('RULEUCC_Dive') then
+                    IssueDive({v})
+                end
             end
         end
 


### PR DESCRIPTION
This PR fixes an issue with the NavalForceAI platoon where it would make submarines surface when they were already submerged due to the IssueDive command acting as a toggle.