### PR TITLE
Enable the Tech 3 Kennel to be dragged when spawning it via the Alt + F2 menu

### DIFF
--- a/units/XEB0204/XEB0204_unit.bp
+++ b/units/XEB0204/XEB0204_unit.bp
@@ -17,6 +17,7 @@ UnitBlueprint{
     BuildIconSortPriority = 200,
     Categories = {
         "CONSTRUCTION",
+        "DRAGBUILD",
         "ENGINEERSTATION",
         "OVERLAYMISC",
         "PODSTAGINGPLATFORM",


### PR DESCRIPTION
This previously only worked when the unit preview was disabled.