### PR TITLE
Allow Chrono Dampener to fire underwater

### DIFF
--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -959,8 +959,8 @@ UnitBlueprint{
             WeaponUnpacks = false,
         },
         {
-            AboveWaterFireOnly = true,
-            AboveWaterTargetsOnly = true,
+            AboveWaterFireOnly = false,
+            AboveWaterTargetsOnly = false,
             BallisticArc = "RULEUBA_None",
             Buffs = {
                 {
@@ -982,9 +982,9 @@ UnitBlueprint{
             EnergyDrainPerSecond = 200,
             EnergyRequired = 200,
             FireTargetLayerCapsTable = {
-                Land = "Land|Water|Seabed",
-                Seabed = "Land|Water|Seabed",
-                Water = "Land|Water|Seabed",
+                Land = "Land|Water|Sub|Seabed",
+                Seabed = "Land|Water|Sub|Seabed",
+                Water = "Land|Water|Sub|Seabed",
             },
             FiringTolerance = 360,
             Label = "ChronoDampener",


### PR DESCRIPTION
Opened because #5883 removes this ability, #2410 makes it sound like an intentional design, and it can still stun submerged units. 
There is also an annoying trait that despite the muzzle being located on the head, Chrono won't fire until the entire ACU exits the water, unlike the main gun.