### PR TITLE
Fix Aeon T1 and Seraphim T1/T2 transports blocking construction

### DIFF
--- a/units/UAA0107/UAA0107_unit.bp
+++ b/units/UAA0107/UAA0107_unit.bp
@@ -111,8 +111,8 @@ UnitBlueprint{
     },
     Footprint = {
         MaxSlope = 0.25,
-        SizeX = 1,
-        SizeZ = 4,
+        SizeX = 2,
+        SizeZ = 2,
     },
     General = {
         CommandCaps = {

--- a/units/XSA0104/XSA0104_unit.bp
+++ b/units/XSA0104/XSA0104_unit.bp
@@ -138,8 +138,8 @@ UnitBlueprint{
     },
     Footprint = {
         MaxSlope = 0.25,
-        SizeX = 3,
-        SizeZ = 5,
+        SizeX = 4,
+        SizeZ = 6,
     },
     General = {
         CommandCaps = {

--- a/units/XSA0107/XSA0107_unit.bp
+++ b/units/XSA0107/XSA0107_unit.bp
@@ -129,8 +129,8 @@ UnitBlueprint{
     },
     Footprint = {
         MaxSlope = 0.25,
-        SizeX = 1,
-        SizeZ = 4,
+        SizeX = 4,
+        SizeZ = 6,
     },
     General = {
         CommandCaps = {


### PR DESCRIPTION
Fixes #2037.
Their footprints were much smaller than their hitboxes, so they wouldn't move far enough from the construction site, and would repeatedly lift off and land back in the same exact place until the construction order gave up.