### PR TITLE
Fix Corona and Swiftwind having a tough time aiming at landed units

### DIFF
--- a/units/UAA0303/UAA0303_unit.bp
+++ b/units/UAA0303/UAA0303_unit.bp
@@ -217,7 +217,7 @@ UnitBlueprint{
                 Air = "Air|Land|Water",
                 Land = "Air|Land|Water",
             },
-            FiringTolerance = 2,
+            FiringTolerance = 0,
             Label = "AutoCannon1",
             MaxRadius = 30,
             MuzzleSalvoDelay = 0,
@@ -259,7 +259,7 @@ UnitBlueprint{
             TurretYawRange = 55,
             TurretYawSpeed = 360,
             Turreted = true,
-            UseFiringSolutionInsteadOfAimBone = false,
+            UseFiringSolutionInsteadOfAimBone = true,
             WeaponCategory = "Anti Air",
         },
         {

--- a/units/XAA0202/XAA0202_unit.bp
+++ b/units/XAA0202/XAA0202_unit.bp
@@ -252,6 +252,7 @@ UnitBlueprint{
             TurretYawRange = 55,
             TurretYawSpeed = 360,
             Turreted = true,
+            UseFiringSolutionInsteadOfAimBone = true,
             WeaponCategory = "Anti Air",
         },
         {


### PR DESCRIPTION
As reported on [Discord](https://discord.com/channels/197033481883222026/1204224371757944872), the Corona was not using the aiming solution. Therefore it would have a tough time aiming for units that are landed.

