### PR TITLE
Remove the dive button for units that do no not need it

### DIFF
--- a/lua/sim/units/SubUnit.lua
+++ b/lua/sim/units/SubUnit.lua
@@ -1,4 +1,3 @@
-
 local EffectTemplate = import("/lua/effecttemplates.lua")
 
 local Entity = import("/lua/sim/entity.lua").Entity
@@ -39,8 +38,10 @@ SubUnit = ClassUnit(MobileUnit) {
         end
 
         if new == 'Top' or new == 'Bottom' then
-            self:AddCommandCap("RULEUCC_Dive")
-            self:RequestRefreshUI()
+			if bp.General.CommandCaps.RULEUCC_Dive then
+				self:AddCommandCap("RULEUCC_Dive")
+				self:RequestRefreshUI()
+			end
         end
     end,
 }

--- a/lua/sim/units/SubUnit.lua
+++ b/lua/sim/units/SubUnit.lua
@@ -23,7 +23,7 @@ SubUnit = ClassUnit(MobileUnit) {
         self.SoundEntity = Entity()
         self.Trash:Add(self.SoundEntity)
         Warp(self.SoundEntity, self:GetPosition())
-        self.SoundEntity:AttachTo(self,-1)
+        self.SoundEntity:AttachTo(self, -1)
     end,
 
     ---@param self Unit
@@ -32,16 +32,17 @@ SubUnit = ClassUnit(MobileUnit) {
     OnMotionVertEventChange = function(self, new, old)
         MobileUnit.OnMotionVertEventChange(self, new, old)
 
-        if new == 'Up' or new == 'Down' then
-            self:RemoveCommandCap("RULEUCC_Dive")
-            self:RequestRefreshUI()
-        end
+        -- only temporarily remove/add dive command if the submarine should have a dive command
+        if self.Blueprint.General.CommandCaps.RULEUCC_Dive then
+            if new == 'Up' or new == 'Down' then
+                self:RemoveCommandCap("RULEUCC_Dive")
+                self:RequestRefreshUI()
+            end
 
-        if new == 'Top' or new == 'Bottom' then
-			if bp.General.CommandCaps.RULEUCC_Dive then
-				self:AddCommandCap("RULEUCC_Dive")
-				self:RequestRefreshUI()
-			end
+            if new == 'Top' or new == 'Bottom' then
+                self:AddCommandCap("RULEUCC_Dive")
+                self:RequestRefreshUI()
+            end
         end
     end,
 }

--- a/units/UAS0203/UAS0203_unit.bp
+++ b/units/UAS0203/UAS0203_unit.bp
@@ -167,7 +167,7 @@ UnitBlueprint{
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = false,
             RULEUCC_Capture = false,
-            RULEUCC_Dive = true,
+            RULEUCC_Dive = false,
             RULEUCC_Guard = true,
             RULEUCC_Move = true,
             RULEUCC_Nuke = false,

--- a/units/UAS0304/UAS0304_unit.bp
+++ b/units/UAS0304/UAS0304_unit.bp
@@ -175,7 +175,7 @@ UnitBlueprint{
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = false,
             RULEUCC_Capture = false,
-            RULEUCC_Dive = true,
+            RULEUCC_Dive = false,
             RULEUCC_Guard = true,
             RULEUCC_Move = true,
             RULEUCC_Nuke = true,

--- a/units/UES0304/UES0304_unit.bp
+++ b/units/UES0304/UES0304_unit.bp
@@ -163,7 +163,7 @@ UnitBlueprint{
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = false,
             RULEUCC_Capture = false,
-            RULEUCC_Dive = true,
+            RULEUCC_Dive = false,
             RULEUCC_Guard = true,
             RULEUCC_Move = true,
             RULEUCC_Nuke = true,

--- a/units/URS0304/URS0304_unit.bp
+++ b/units/URS0304/URS0304_unit.bp
@@ -198,7 +198,7 @@ UnitBlueprint{
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = false,
             RULEUCC_Capture = false,
-            RULEUCC_Dive = true,
+            RULEUCC_Dive = false,
             RULEUCC_Guard = true,
             RULEUCC_Move = true,
             RULEUCC_Nuke = true,

--- a/units/XAS0204/XAS0204_unit.bp
+++ b/units/XAS0204/XAS0204_unit.bp
@@ -157,7 +157,7 @@ UnitBlueprint{
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = false,
             RULEUCC_Capture = false,
-            RULEUCC_Dive = true,
+            RULEUCC_Dive = false,
             RULEUCC_Guard = true,
             RULEUCC_Move = true,
             RULEUCC_Nuke = false,

--- a/units/XRS0204/XRS0204_unit.bp
+++ b/units/XRS0204/XRS0204_unit.bp
@@ -157,7 +157,7 @@ UnitBlueprint{
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = false,
             RULEUCC_Capture = false,
-            RULEUCC_Dive = true,
+            RULEUCC_Dive = false,
             RULEUCC_Guard = true,
             RULEUCC_Move = true,
             RULEUCC_Nuke = false,


### PR DESCRIPTION
A lot of submarines do not have a deck-gun, which makes surfacing them detrimental and a noob-trap. This PR removes the dive button for these units. Note, that Strategic Missile Submarines can launch missiles while submerged, surfacing them is not necessary.