### PR TITLE
Improve Teleport Reticle Cost Display

### DIFF
--- a/lua/shared/teleport.lua
+++ b/lua/shared/teleport.lua
@@ -43,14 +43,14 @@ TeleportCostFunction = function(unit, location)
     local pos = unit:GetPosition()
 
     -- or, if queuing commands, use the position of the last teleport/move command
-    if IsKeyDown('Shift') then
-        local queue = unit:GetCommandQueue() --[[@as (UICommandInfo[])]]
-        if table.getn(queue) > 0 then
-            for k = 1, table.getn(queue) do
-                local command = queue[k]
+    local queue = unit:GetCommandQueue() --[[@as (UICommandInfo[])]]
+    if table.getn(queue) > 0 then
+        for k = 1, table.getn(queue) do
+            local command = queue[k]
 
-                -- this if statement can only be true in the UI code
-                if command.type == 'Teleport' or command.type == 'Move' then
+            -- this if statement can only be true in the UI code, so IsKeyDown works
+            if command.type == 'Teleport' or command.type == 'Move' then
+                if IsKeyDown('Shift') then
                     pos = command.position
                 end
             end

--- a/lua/shared/teleport.lua
+++ b/lua/shared/teleport.lua
@@ -42,15 +42,17 @@ TeleportCostFunction = function(unit, location)
     -- use unit position by default
     local pos = unit:GetPosition()
 
-    -- or use the position of the last teleport/move command
-    local queue = unit:GetCommandQueue() --[[@as (UICommandInfo[])]]
-    if table.getn(queue) > 0 then
-        for k = 1, table.getn(queue) do
-            local command = queue[k]
+    -- or, if queuing commands, use the position of the last teleport/move command
+    if IsKeyDown('Shift') then
+        local queue = unit:GetCommandQueue() --[[@as (UICommandInfo[])]]
+        if table.getn(queue) > 0 then
+            for k = 1, table.getn(queue) do
+                local command = queue[k]
 
-            -- this if statement can only be true in the UI code
-            if command.type == 'Teleport' or command.type == 'Move' then
-                pos = command.position
+                -- this if statement can only be true in the UI code
+                if command.type == 'Teleport' or command.type == 'Move' then
+                    pos = command.position
+                end
             end
         end
     end

--- a/lua/ui/controls/reticles/teleport.lua
+++ b/lua/ui/controls/reticles/teleport.lua
@@ -20,6 +20,8 @@
 --** SOFTWARE.
 --******************************************************************************************************
 
+local Bitmap   = import("/lua/maui/bitmap.lua").Bitmap
+
 local UIUtil = import("/lua/ui/uiutil.lua")
 local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
 local Reticle = import('/lua/ui/controls/reticle.lua').Reticle
@@ -37,17 +39,19 @@ TeleportReticle = ClassUI(Reticle) {
 
     ---@param self UITeleportReticle
     SetLayout = function(self)
-        self.ePrefix = UIUtil.CreateText(self, "Eng Cost: ", 16, UIUtil.bodyFont, true)
-        self.tPrefix = UIUtil.CreateText(self, "Max Time: ", 16, UIUtil.bodyFont, true)
+        self.BuildTimeIcon = Bitmap(self)
+        self.BuildTimeIcon:SetTexture(UIUtil.UIFile('/game/unit_view_icons/time.dds'))
+
+        self.EnergyCostIcon = Bitmap(self)
+        self.EnergyCostIcon:SetTexture(UIUtil.UIFile('/game/unit_view_icons/energy.dds'))
+
         self.eText = UIUtil.CreateText(self, "eCost", 16, UIUtil.bodyFont, true)
         self.tText = UIUtil.CreateText(self, "tCost", 16, UIUtil.bodyFont, true)
-        LayoutHelpers.RightOf(self.ePrefix, self, 4)
-        LayoutHelpers.RightOf(self.eText, self.ePrefix, 0)
-        LayoutHelpers.Below(self.tPrefix, self.ePrefix, 4)
-        LayoutHelpers.RightOf(self.tText, self.tPrefix, 0)
+        LayoutHelpers.RightOf(self.EnergyCostIcon, self, 4)
+        LayoutHelpers.RightOf(self.eText, self.EnergyCostIcon, 0)
+        LayoutHelpers.Below(self.BuildTimeIcon, self.EnergyCostIcon, 4)
+        LayoutHelpers.RightOf(self.tText, self.BuildTimeIcon, 0)
 
-        self.ePrefix:SetColor('654bc2')
-        self.tPrefix:SetColor('654bc2')
         self.eText:SetColor('ffff00')
     end,
 
@@ -65,8 +69,8 @@ TeleportReticle = ClassUI(Reticle) {
                 end
             end
             -- update our text
-            self.eText:SetText(string.format('%.0f', eCost))
-            self.tText:SetText(string.format('%.2f', tCost))
+            self.eText:SetText(string.format('%.0f (-%.0f)', eCost, eCost/tCost))
+            self.tText:SetText(string.format('%.1f', tCost))
         else
             if self.changedOnMap then
                 self.eText:SetText('--')

--- a/lua/ui/controls/reticles/teleport.lua
+++ b/lua/ui/controls/reticles/teleport.lua
@@ -50,9 +50,9 @@ TeleportReticle = ClassUI(Reticle) {
         self.eText = UIUtil.CreateText(self, "eCost", 16, UIUtil.bodyFont, true)
         self.tText = UIUtil.CreateText(self, "tCost", 16, UIUtil.bodyFont, true)
         LayoutHelpers.RightOf(self.EnergyCostIcon, self, 4)
-        LayoutHelpers.RightOf(self.eText, self.EnergyCostIcon, 0)
+        LayoutHelpers.RightOf(self.eText, self.EnergyCostIcon, 2)
         LayoutHelpers.Below(self.BuildTimeIcon, self.EnergyCostIcon, 4)
-        LayoutHelpers.RightOf(self.tText, self.BuildTimeIcon, 0)
+        LayoutHelpers.RightOf(self.tText, self.BuildTimeIcon, 2)
 
         self.eText:SetColor('fff7c70f') -- from economy_mini.lua, same color as the energy stored/storage text
     end,

--- a/lua/ui/controls/reticles/teleport.lua
+++ b/lua/ui/controls/reticles/teleport.lua
@@ -41,9 +41,11 @@ TeleportReticle = ClassUI(Reticle) {
     SetLayout = function(self)
         self.BuildTimeIcon = Bitmap(self)
         self.BuildTimeIcon:SetTexture(UIUtil.UIFile('/game/unit_view_icons/time.dds'))
+        LayoutHelpers.SetDimensions(self.BuildTimeIcon, 19, 19)
 
         self.EnergyCostIcon = Bitmap(self)
         self.EnergyCostIcon:SetTexture(UIUtil.UIFile('/game/unit_view_icons/energy.dds'))
+        LayoutHelpers.SetDimensions(self.EnergyCostIcon, 19, 19)
 
         self.eText = UIUtil.CreateText(self, "eCost", 16, UIUtil.bodyFont, true)
         self.tText = UIUtil.CreateText(self, "tCost", 16, UIUtil.bodyFont, true)

--- a/lua/ui/controls/reticles/teleport.lua
+++ b/lua/ui/controls/reticles/teleport.lua
@@ -54,7 +54,7 @@ TeleportReticle = ClassUI(Reticle) {
         LayoutHelpers.Below(self.BuildTimeIcon, self.EnergyCostIcon, 4)
         LayoutHelpers.RightOf(self.tText, self.BuildTimeIcon, 0)
 
-        self.eText:SetColor('ffff00')
+        self.eText:SetColor('fff7c70f') -- from economy_mini.lua, same color as the energy stored/storage text
     end,
 
     ---@param self UITeleportReticle


### PR DESCRIPTION
- Icons instead of text
- Display Energy cost/second
- Round time to 0.1 (0.01 does not fit in game ticks)

Before <br> ![4](https://github.com/FAForever/fa/assets/82986251/3b193dfa-ab52-4179-90ea-e52a1df12381) |After <br>  ![6](https://github.com/FAForever/fa/assets/82986251/8604a4f6-b93b-4f5c-befb-336156408fda) 
|:--:|:--:|
