### PR TITLE
Fix teleport effects not appearing at short ranges with variable cost

### DIFF
--- a/lua/shared/teleport.lua
+++ b/lua/shared/teleport.lua
@@ -73,6 +73,8 @@ TeleportCostFunction = function(unit, location)
         if teleDelay and time < teleDelay then
             time = teleDelay
         end
+        -- make sure the teleport destination effects appear on time
+        teleDelay = time * 0.4
     else
         -- original cost function
         if bpEco then


### PR DESCRIPTION
Teleport destination effects specifically. 0.4 is 10/25, based off the old 10 delay/25 total teleport time.