### PR TITLE
Adjust the variable teleport costs

### DIFF
--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -946,6 +946,10 @@
 ---@field TeleportDelay? number
 --- if present, adds a flat energy cost to the "teleport" ability. Defaults to 150000 energy. Only applies when `UseVariableTeleportCosts` is true.
 ---@field TeleportFlatEnergyCost? number
+--- Only applies when `UseVariableTeleportCosts` is true. Defaults to 2.500.000 energy.
+---@field TeleportMaximumEnergyCost? number
+--- Only applies when `UseVariableTeleportCosts` is true. Defaults to 50 seconds.
+---@field TeleportMaximumDuration? number
 --- table of toggle capabilities available for this unit
 ---@field ToggleCaps table<ToggleCap, boolean>
 --- table of boolean toggles set/got with SetStatByCallback/GetStat

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -942,8 +942,10 @@
 ---@field TarmacGlowDecal? any unused
 --- defines the tech level used for display purposes
 ---@field TechLevel UnitTechLevel
---- if present, makes the "teleport" ability show up in the unit view with the delay of this value
+--- if present, makes the "teleport" ability show up in the unit view with the delay of this value. Defaults to 15 seconds.
 ---@field TeleportDelay? number
+--- if present, adds a flat energy cost to the "teleport" ability. Defaults to 150000 energy. Only applies when `UseVariableTeleportCosts` is true.
+---@field TeleportFlatEnergyCost? number
 --- table of toggle capabilities available for this unit
 ---@field ToggleCaps table<ToggleCap, boolean>
 --- table of boolean toggles set/got with SetStatByCallback/GetStat

--- a/lua/shared/teleport.lua
+++ b/lua/shared/teleport.lua
@@ -58,21 +58,15 @@ TeleportCostFunction = function(unit, location)
     end
 
     local dist = VDist3(pos, location)
-    local teleDelay = bp.General.TeleportDelay
+    local teleDelay = bp.General.TeleportDelay or 15
+    local teleportFlatEnergyCost = bp.General.TeleportFlatEnergyCost or 150000
     local bpEco = bp.Economy
     local energyCost, time
 
     if bpEco.UseVariableTeleportCosts then
-        -- New function
-        -- energy cost is dist^2
-        -- time cost is natural log of dist
-        energyCost = MathPow(dist, 1.8)
-        time = MathSqrt(dist)
+        energyCost = teleportFlatEnergyCost + dist * dist
+        time = teleDelay + (0.005 * dist) * (0.005 * dist)
 
-        -- clamp time to teleDelay
-        if teleDelay and time < teleDelay then
-            time = teleDelay
-        end
         -- make sure the teleport destination effects appear on time
         teleDelay = time * 0.4
     else

--- a/lua/shared/teleport.lua
+++ b/lua/shared/teleport.lua
@@ -59,13 +59,15 @@ TeleportCostFunction = function(unit, location)
 
     local dist = VDist3(pos, location)
     local teleDelay = bp.General.TeleportDelay or 15
-    local teleportFlatEnergyCost = bp.General.TeleportFlatEnergyCost or 150000
+    local teleportFlatEnergyCost = bp.General.TeleportFlatEnergyCost or 75000
+    local teleportMaximumEnergyCost = bp.General.TeleportMaximumEnergyCost or 2500000
+    local teleportMaximumDuration = bp.General.TeleportMaximumDuration or 50
     local bpEco = bp.Economy
     local energyCost, time
 
     if bpEco.UseVariableTeleportCosts then
-        energyCost = teleportFlatEnergyCost + dist * dist
-        time = teleDelay + (0.005 * dist) * (0.005 * dist)
+        energyCost = math.min(teleportFlatEnergyCost + dist * dist, teleportMaximumEnergyCost)
+        time = math.min(teleDelay + (0.005 * dist) * (0.005 * dist), teleportMaximumDuration)
 
         -- make sure the teleport destination effects appear on time
         teleDelay = time * 0.4

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -465,6 +465,9 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
             cursor[1], cursor[2], cursor[3], cursor[4], cursor[5] = UIUtil.GetCursor('HOVERCOMMAND')
         end
 
+        local command = GetHighlightCommand()
+        reprsl(command)
+
         self:ApplyCursor()
     end,
 

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -465,9 +465,6 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
             cursor[1], cursor[2], cursor[3], cursor[4], cursor[5] = UIUtil.GetCursor('HOVERCOMMAND')
         end
 
-        local command = GetHighlightCommand()
-        reprsl(command)
-
         self:ApplyCursor()
     end,
 

--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -668,7 +668,7 @@ UnitBlueprint{
         QuickSelectPriority = 1,
         SelectionPriority = 3,
         TeleportDelay = 15,
-        TeleportFlatEnergyCost = 150000,
+        TeleportFlatEnergyCost = 75000,
     },
     Intel = {
         FreeIntel = true,

--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -667,7 +667,8 @@ UnitBlueprint{
         },
         QuickSelectPriority = 1,
         SelectionPriority = 3,
-        TeleportDelay = 10,
+        TeleportDelay = 15,
+        TeleportFlatEnergyCost = 150000,
     },
     Intel = {
         FreeIntel = true,

--- a/units/UAL0301/UAL0301_unit.bp
+++ b/units/UAL0301/UAL0301_unit.bp
@@ -538,7 +538,8 @@ UnitBlueprint{
             },
         },
         SelectionPriority = 3,
-        TeleportDelay = 10,
+        TeleportDelay = 15,
+        TeleportFlatEnergyCost = 150000,
     },
     Intel = {
         FreeIntel = true,

--- a/units/UAL0301/UAL0301_unit.bp
+++ b/units/UAL0301/UAL0301_unit.bp
@@ -539,7 +539,7 @@ UnitBlueprint{
         },
         SelectionPriority = 3,
         TeleportDelay = 15,
-        TeleportFlatEnergyCost = 150000,
+        TeleportFlatEnergyCost = 75000,
     },
     Intel = {
         FreeIntel = true,

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -668,7 +668,7 @@ UnitBlueprint {
         QuickSelectPriority = 1,
         SelectionPriority = 3,
         TeleportDelay = 15,
-        TeleportFlatEnergyCost = 150000,
+        TeleportFlatEnergyCost = 75000,
     },
     Intel = {
         FreeIntel = true,

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -667,7 +667,8 @@ UnitBlueprint {
         },
         QuickSelectPriority = 1,
         SelectionPriority = 3,
-        TeleportDelay = 10,
+        TeleportDelay = 15,
+        TeleportFlatEnergyCost = 150000,
     },
     Intel = {
         FreeIntel = true,

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -594,7 +594,7 @@ UnitBlueprint{
         QuickSelectPriority = 1,
         SelectionPriority = 3,
         TeleportDelay = 15,
-        TeleportFlatEnergyCost = 150000,
+        TeleportFlatEnergyCost = 75000,
     },
     Intel = {
         ActiveIntel = { Omni = true },

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -593,7 +593,8 @@ UnitBlueprint{
 
         QuickSelectPriority = 1,
         SelectionPriority = 3,
-        TeleportDelay = 10,
+        TeleportDelay = 15,
+        TeleportFlatEnergyCost = 150000,
     },
     Intel = {
         ActiveIntel = { Omni = true },

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -659,7 +659,8 @@ UnitBlueprint{
         Icon = "amph",
         QuickSelectPriority = 1,
         SelectionPriority = 3,
-        TeleportDelay = 10,
+        TeleportDelay = 15,
+        TeleportFlatEnergyCost = 150000,
     },
     Intel = {
         FreeIntel = true,

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -660,7 +660,7 @@ UnitBlueprint{
         QuickSelectPriority = 1,
         SelectionPriority = 3,
         TeleportDelay = 15,
-        TeleportFlatEnergyCost = 150000,
+        TeleportFlatEnergyCost = 75000,
     },
     Intel = {
         FreeIntel = true,

--- a/units/XSL0301/XSL0301_unit.bp
+++ b/units/XSL0301/XSL0301_unit.bp
@@ -533,7 +533,7 @@ UnitBlueprint{
         },
         SelectionPriority = 3,
         TeleportDelay = 15,
-        TeleportFlatEnergyCost = 150000,
+        TeleportFlatEnergyCost = 75000,
     },
     Intel = {
         FreeIntel = true,

--- a/units/XSL0301/XSL0301_unit.bp
+++ b/units/XSL0301/XSL0301_unit.bp
@@ -532,7 +532,8 @@ UnitBlueprint{
             },
         },
         SelectionPriority = 3,
-        TeleportDelay = 10,
+        TeleportDelay = 15,
+        TeleportFlatEnergyCost = 150000,
     },
     Intel = {
         FreeIntel = true,


### PR DESCRIPTION
Adjusts the costs so that all teleports will take at least 15 seconds and consume at least 10k energy per second.


https://github.com/FAForever/fa/assets/15778155/85ee3767-bd4e-4375-84e0-cddd059c1711

