### PR TITLE
Improve Ythotha targeting

### DIFF
--- a/units/XSL0401/XSL0401_unit.bp
+++ b/units/XSL0401/XSL0401_unit.bp
@@ -1,6 +1,7 @@
 UnitBlueprint{
     Description = "<LOC xsl0401_desc>Experimental Assault Bot",
     AI = {
+        AttackAngle = 1,
         TargetBones = {
             "pelvis",
             "Torso",
@@ -296,7 +297,6 @@ UnitBlueprint{
             SlavedToBody = true,
             SlavedToBodyArcRange = 135,
             TargetPriorities = {
-                "COMMAND",
                 "EXPERIMENTAL",
                 "SUBCOMMANDER",
                 "TECH3 MOBILE",
@@ -512,10 +512,12 @@ UnitBlueprint{
             RangeCategory = "UWRC_AntiAir",
             RateOfFire = 3,
             TargetPriorities = {
-                "AIR MOBILE TECH3 BOMBER",
-                "AIR MOBILE BOMBER",
+                "(AIR * MOBILE * EXPERIMENTAL - BOMBER)",
                 "AIR MOBILE GROUNDATTACK",
+                "AIR MOBILE TECH2 BOMBER",
+                "AIR MOBILE TECH1 BOMBER",
                 "AIR MOBILE TRANSPORTATION",
+                "AIR MOBILE BOMBER",
                 "AIR MOBILE",
                 "ALLUNITS",
             },
@@ -583,10 +585,12 @@ UnitBlueprint{
             RangeCategory = "UWRC_AntiAir",
             RateOfFire = 3,
             TargetPriorities = {
-                "AIR MOBILE TECH3 BOMBER",
-                "AIR MOBILE BOMBER",
+                "(AIR * MOBILE * EXPERIMENTAL - BOMBER)",
                 "AIR MOBILE GROUNDATTACK",
+                "AIR MOBILE TECH2 BOMBER",
+                "AIR MOBILE TECH1 BOMBER",
                 "AIR MOBILE TRANSPORTATION",
+                "AIR MOBILE BOMBER",
                 "AIR MOBILE",
                 "ALLUNITS",
             },


### PR DESCRIPTION
- Now faces towards its target when attacking to prevent the common situation of only one arm shooting at the target.
- Remove ACU priority from the Phason Beam Generator (the death-ball-shooting eye weapon) so that it doesn't waste its 1200 DPS on ACUs in experimental battles.
- Use flak priorities instead of T1 AA priorities on the secondary AA.