### PR TITLE
Evaluate and rework the categories of UEF air units

### DIFF
--- a/units/UEA0103/UEA0103_unit.bp
+++ b/units/UEA0103/UEA0103_unit.bp
@@ -54,6 +54,7 @@ UnitBlueprint{
         "PRODUCTSC1",
         "RECLAIMABLE",
         "SELECTABLE",
+        "SHOWATTACKRETICLE",
         "SNIPEMODE",
         "TECH1",
         "UEF",

--- a/units/UEA0104/UEA0104_unit.bp
+++ b/units/UEA0104/UEA0104_unit.bp
@@ -61,6 +61,8 @@ UnitBlueprint {
         "TRANSPORTFOCUS",
         "UEF",
         "VISIBLETORECON",
+        "WEAKANTIAIR",
+        "WEAKDIRECTFIRE",
     },
     Defense = {
         AirThreatLevel = 5.5,

--- a/units/UEA0304/UEA0304_unit.bp
+++ b/units/UEA0304/UEA0304_unit.bp
@@ -47,7 +47,6 @@ UnitBlueprint{
         "BUILTBYTIER3FACTORY",
         "HIGHALTAIR",
         "MOBILE",
-        "NUKE",
         "OVERLAYANTIAIR",
         "OVERLAYRADAR",
         "PRODUCTSC1",
@@ -59,6 +58,7 @@ UnitBlueprint{
         "TECH3",
         "UEF",
         "VISIBLETORECON",
+        "WEAKANTIAIR",
     },
     Defense = {
         AirThreatLevel = 5.5,

--- a/units/UEA0305/UEA0305_unit.bp
+++ b/units/UEA0305/UEA0305_unit.bp
@@ -51,6 +51,7 @@ UnitBlueprint {
         "TECH3",
         "UEF",
         "VISIBLETORECON",
+        "WEAKANTIAIR",
     },
     Defense = {
         AirThreatLevel = 1,


### PR DESCRIPTION
Related to #5919 

Introduces the `WEAK...` categories to various units. Also removes the `NUKE` category from the strategic bomber as it is... not a strategic unit. 

~~What I found interesting is that there's very little to no distinction between regular bombers and torpedo bombers. I was thinking of introducing a `TORPEDO` category to the torpedo bomber to make it more distinguishable. Now, of course - mods that are unmaintained will not follow this practice and therefore it would only apply to units we ship with FAForever directly.~~

edit: apparently the `ANTINAVY` category means 'something that fires torpedo's according to torpedo weapons and the categories of naval units, as seen in https://github.com/FAForever/fa/pull/5929. As a result, introducing `TORPEDO` is not necessary because `ANTINAVY` essentially means that.
