### PR TITLE
Evaluate and rework the categories of UEF naval units

### DIFF
--- a/engine/Core/Categories.lua
+++ b/engine/Core/Categories.lua
@@ -13,12 +13,19 @@ categories = {
     ALLPROJECTILES = categoryValue,
     ALLUNITS = categoryValue,
     AMPHIBIOUS = categoryValue,
+    --- Used for units that can target air units
     ANTIAIR = categoryValue,
+    --- Used by support commander presets
     ANTIAIRPRESET = categoryValue,
+    --- Used for units that can target missiles
     ANTIMISSILE = categoryValue,
+    --- Used for units that can target submarines (torpedoes and depth charges)
     ANTINAVY = categoryValue,
+    --- Used for units that are specifically designed to target shields
     ANTISHIELD = categoryValue,
+    --- Unused, see `ANTINAVY` instead
     ANTISUB = categoryValue,
+    --- Used for units that can target torpedoes
     ANTITORPEDO = categoryValue,
     ARTILLERY = categoryValue,
     ASF = categoryValue,

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -12,6 +12,9 @@
 
 ---@alias UnitFormations 'AttackFormation' | 'GrowthFormation' | 'NoFormation' | 'None' | 'none'
 
+local af = 0
+local gf = 0
+local gf2 = 0
 
 SurfaceFormations = {
     'AttackFormation',
@@ -36,6 +39,7 @@ local MaxCacheSize = 30
 ---@param formationType UnitFormations
 ---@return boolean
 function GetCachedResults(formationUnits, formationType)
+
     local cache = FormationCache[formationType]
     if not cache then
         return false
@@ -706,6 +710,11 @@ end
 ---@param formationUnits Unit[]
 ---@return table
 function AttackFormation(formationUnits)
+    af = af + 1
+    if math.mod(af, 100) == 0 then
+        LOG('AttackFormation calls: '..af)
+    end
+
     local cachedResults = GetCachedResults(formationUnits, 'AttackFormation')
     if cachedResults then
         return cachedResults
@@ -764,6 +773,11 @@ end
 ---@param formationUnits Unit[]
 ---@return table
 function GrowthFormation(formationUnits)
+    gf = gf + 1
+    if math.mod(gf, 100) == 0 then
+        LOG('GrowthFormation calls: '..gf)
+    end
+
     local cachedResults = GetCachedResults(formationUnits, 'GrowthFormation')
     if cachedResults then
         return cachedResults
@@ -840,6 +854,12 @@ end
 ---@param formationUnits Unit[]
 ---@return table
 function GuardFormation(formationUnits)
+    gf2 = gf2 + 1
+    if math.mod(gf2, 100) == 0 then
+        LOG('GuardFormation calls: '..gf2)
+    end
+
+
     -- Not worth caching GuardFormation because it's almost never called repeatedly with the same units.
     local FormationPos = {}
 

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -12,9 +12,6 @@
 
 ---@alias UnitFormations 'AttackFormation' | 'GrowthFormation' | 'NoFormation' | 'None' | 'none'
 
-local af = 0
-local gf = 0
-local gf2 = 0
 
 SurfaceFormations = {
     'AttackFormation',
@@ -39,7 +36,6 @@ local MaxCacheSize = 30
 ---@param formationType UnitFormations
 ---@return boolean
 function GetCachedResults(formationUnits, formationType)
-
     local cache = FormationCache[formationType]
     if not cache then
         return false
@@ -710,11 +706,6 @@ end
 ---@param formationUnits Unit[]
 ---@return table
 function AttackFormation(formationUnits)
-    af = af + 1
-    if math.mod(af, 100) == 0 then
-        LOG('AttackFormation calls: '..af)
-    end
-
     local cachedResults = GetCachedResults(formationUnits, 'AttackFormation')
     if cachedResults then
         return cachedResults
@@ -773,11 +764,6 @@ end
 ---@param formationUnits Unit[]
 ---@return table
 function GrowthFormation(formationUnits)
-    gf = gf + 1
-    if math.mod(gf, 100) == 0 then
-        LOG('GrowthFormation calls: '..gf)
-    end
-
     local cachedResults = GetCachedResults(formationUnits, 'GrowthFormation')
     if cachedResults then
         return cachedResults
@@ -854,12 +840,6 @@ end
 ---@param formationUnits Unit[]
 ---@return table
 function GuardFormation(formationUnits)
-    gf2 = gf2 + 1
-    if math.mod(gf2, 100) == 0 then
-        LOG('GuardFormation calls: '..gf2)
-    end
-
-
     -- Not worth caching GuardFormation because it's almost never called repeatedly with the same units.
     local FormationPos = {}
 

--- a/units/UES0103/UES0103_unit.bp
+++ b/units/UES0103/UES0103_unit.bp
@@ -40,6 +40,7 @@ UnitBlueprint{
         "TECH1",
         "UEF",
         "VISIBLETORECON",
+        "WEAKANTIAIR",
     },
     Defense = {
         AirThreatLevel = 1,

--- a/units/UES0103/UES0103_unit.bp
+++ b/units/UES0103/UES0103_unit.bp
@@ -36,6 +36,7 @@ UnitBlueprint{
         "RECLAIMABLE",
         "SELECTABLE",
         "SNIPEMODE",
+        "SHOWATTACKRETICLE",
         "SONAR",
         "TECH1",
         "UEF",

--- a/units/UES0201/UES0201_unit.bp
+++ b/units/UES0201/UES0201_unit.bp
@@ -18,7 +18,6 @@ UnitBlueprint{
     },
     BuildIconSortPriority = 30,
     Categories = {
-        "ANTINAVY",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",
         "DESTROYER",
@@ -37,6 +36,8 @@ UnitBlueprint{
         "TECH2",
         "UEF",
         "VISIBLETORECON",
+        "WEAKANTIAIR",
+        "WEAKANTINAVY",
     },
     Defense = {
         AirThreatLevel = 1,

--- a/units/UES0201/UES0201_unit.bp
+++ b/units/UES0201/UES0201_unit.bp
@@ -18,6 +18,7 @@ UnitBlueprint{
     },
     BuildIconSortPriority = 30,
     Categories = {
+        "ANTINAVY",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",
         "DESTROYER",

--- a/units/UES0201/UES0201_unit.bp
+++ b/units/UES0201/UES0201_unit.bp
@@ -32,6 +32,7 @@ UnitBlueprint{
         "PRODUCTSC1",
         "RECLAIMABLE",
         "SELECTABLE",
+        "SHOWATTACKRETICLE",
         "SNIPEMODE",
         "TECH2",
         "UEF",

--- a/units/UES0202/UES0202_unit.bp
+++ b/units/UES0202/UES0202_unit.bp
@@ -43,6 +43,7 @@ UnitBlueprint{
         "TECH2",
         "UEF",
         "VISIBLETORECON",
+        "WEAKDIRECTFIRE",
     },
     Defense = {
         AirThreatLevel = 50,

--- a/units/UES0203/UES0203_unit.bp
+++ b/units/UES0203/UES0203_unit.bp
@@ -36,6 +36,7 @@ UnitBlueprint{
         "TECH1",
         "UEF",
         "VISIBLETORECON",
+        "WEAKDIRECTFIRE"
     },
     Defense = {
         AirThreatLevel = 0,

--- a/units/UES0302/UES0302_unit.bp
+++ b/units/UES0302/UES0302_unit.bp
@@ -44,6 +44,7 @@ UnitBlueprint{
         "TECH3",
         "UEF",
         "VISIBLETORECON",
+        "WEAKANTIAIR",
     },
     Defense = {
         AirThreatLevel = 6,

--- a/units/UES0305/UES0305_unit.bp
+++ b/units/UES0305/UES0305_unit.bp
@@ -35,6 +35,7 @@ UnitBlueprint{
         "TECH3",
         "UEF",
         "VISIBLETORECON",
+        "WEAKANTINAVY"
     },
     Defense = {
         AirThreatLevel = 0,

--- a/units/XES0307/XES0307_unit.bp
+++ b/units/XES0307/XES0307_unit.bp
@@ -19,6 +19,7 @@ UnitBlueprint{
     BuildIconSortPriority = 20,
     Categories = {
         "ANTIMISSILE",
+        "ANTINAVY",
         "BATTLESHIP",
         "BUILTBYTIER3FACTORY",
         "DIRECTFIRE",

--- a/units/XES0307/XES0307_unit.bp
+++ b/units/XES0307/XES0307_unit.bp
@@ -19,7 +19,6 @@ UnitBlueprint{
     BuildIconSortPriority = 20,
     Categories = {
         "ANTIMISSILE",
-        "ANTINAVY",
         "BATTLESHIP",
         "BUILTBYTIER3FACTORY",
         "DIRECTFIRE",
@@ -37,6 +36,7 @@ UnitBlueprint{
         "TECH3",
         "UEF",
         "VISIBLETORECON",
+        "WEAKANTINAVY",
     },
     Defense = {
         AirThreatLevel = 0,


### PR DESCRIPTION
Related to https://github.com/FAForever/fa/issues/5919

Introduces the WEAK... categories to various units. Also removes the NUKE category from the strategic bomber as it is... not a strategic unit.

What I found interesting is that the `ANTINAVY` category actually means `anti submarine`. Weapons that are anti navy are torpedo-like weapons.