### PR TITLE
Fix a bug related to the duration and costs of capturing a unit

### DIFF
--- a/lua/game.lua
+++ b/lua/game.lua
@@ -41,8 +41,8 @@ VeteranDefault = {
 ---
 --- In order to keep backwards compatibility, there is a new option in the blueprint economy section.
 --- if DifferentialUpgradeCostCalculation is set to true, the base upgrade cost will be subtracted
----@param builder Builder
----@param targetData table
+---@param builder Unit
+---@param targetData UnitBlueprintEconomy
 ---@param upgradeBaseData UnitBlueprintEconomy
 ---@return number time
 ---@return number energy


### PR DESCRIPTION
As reported on [Discord](https://discord.com/channels/197033481883222026/1208701956697227294).

Units that are attached to a unit that you are trying to capture are taken into account when computing the total duration and energy costs. We now exclude units that are not finished, which applies to factories.