### PR TITLE
Remove Novax from air restrictions

### DIFF
--- a/lua/ui/lobby/UnitsRestrictions.lua
+++ b/lua/ui/lobby/UnitsRestrictions.lua
@@ -78,7 +78,7 @@ Expressions = {
     -- added exclusion of engineers and structures because they are restricted by other presets
     LAND        = "(LAND - ENGINEER - STRUCTURE + SUBCOMMANDER)",
     -- added restriction of air staging structures because they are not needed when all air units are restricted
-    AIR         = "(STRUCTURE * AIRSTAGINGPLATFORM) + (AIR - POD)",
+    AIR         = "(STRUCTURE * AIRSTAGINGPLATFORM) + (AIR - POD) - (SATELLITE + ORBITALSYSTEM)",
     NAVAL       = "((STRUCTURE * NAVAL * FACTORY) + (NAVAL * MOBILE - MOBILESONAR))",
     HOVER       = "(HOVER - INSIGNIFICANTUNIT - ENGINEER)",
     AMPHIBIOUS  = "(AMPHIBIOUS)",
@@ -168,7 +168,7 @@ Expressions = {
     INTEL_OPTICS = "(STRUCTURE * OPTICS)", -- "xab3301 + xrb3301",
     INTEL_SONAR  = "(STRUCTURE * SONAR) + MOBILESONAR",
     INTEL_BASE   = "(((OMNI + RADAR + SONAR) * STRUCTURE) + MOBILESONAR - DEFENSE)",
-    INTEL_AIR    = "(((OMNI + RADAR + SONAR + SCOUT) * AIR) - BOMBER - DEFENSE - GROUNDATTACK - ANTIAIR - ANTINAVY)",
+    INTEL_AIR    = "(((OMNI + RADAR + SONAR + SCOUT) * AIR) - BOMBER - DEFENSE - GROUNDATTACK - ANTIAIR - ANTINAVY - SATELLITE)",
     INTEL_LAND   = "(((OMNI + RADAR + SONAR + SCOUT) * LAND) - COMMAND - DEFENSE - SUBCOMMANDER - ANTIAIR - ANTINAVY)",
 
     STEALTH_BASE = "(STEALTHFIELD * STRUCTURE)",


### PR DESCRIPTION
Considering Novax's unique role as a support/precision artillery + intel unit, it shouldn't be covered by the air restriction. As for people who play with no air and are used to Novax being restricted, there is already a specific satellite restriction for Novax.