### PR TITLE
Increase Cybran ASF stealth maintenance in accordance with previous cost increases

### DIFF
--- a/units/URA0303/URA0303_unit.bp
+++ b/units/URA0303/URA0303_unit.bp
@@ -129,7 +129,7 @@ UnitBlueprint{
         BuildCostEnergy = 51200,
         BuildCostMass = 450,
         BuildTime = 3840,
-        MaintenanceConsumptionPerSecondEnergy = 25,
+        MaintenanceConsumptionPerSecondEnergy = 32,
     },
     Footprint = {
         MaxSlope = 0.25,


### PR DESCRIPTION
#5452 increased ASF cost by ~28%, but missed the stealth maintenance cost, thus unintentionally making Cybran ASF 22% cheaper to stealth relative to their cost.