### PR TITLE
Formations: Fix the Tech 3 Sub Hunter not being defined as “SubNaval”

### DIFF
--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -449,7 +449,7 @@ local GrowthChevronBlock = {
 
 local LightAttackNaval = categories.LIGHTBOAT
 local FrigateNaval = categories.FRIGATE
-local SubNaval = categories.T1SUBMARINE + categories.T2SUBMARINE + (categories.NUKESUB * categories.ANTINAVY - categories.NUKE)
+local SubNaval = categories.T1SUBMARINE + categories.T2SUBMARINE + (categories.SERAPHIM * categories.TECH3 * categories.SUBMERSIBLE)
 local DestroyerNaval = categories.DESTROYER
 local CruiserNaval = categories.CRUISER
 local BattleshipNaval = categories.BATTLESHIP


### PR DESCRIPTION
This is a problem because the following line gets spammed into the log hundreds, even thousands of times:

`INFO: *FORMATION DEBUG: Unit xss0304 does not match any Naval categories.`

This dilutes the log and makes it less readable. Additionally, I cannot image this is good for the performance of the game. The more Sub Hunters you have, the more lines are printed into the log. 

**How to reproduce the issue:**
- Open the Moho Log and deselect everything except “Info”
- Clear the log
- Spawn in a number of Tech 3 Sub Hunters
- Select the Sub Hunters you spawned in and give them a move order
- Select a portion of the Sub Hunters and give them another move order
- You will now see that the log gets spammed by the above message

