### PR TITLE
Make unbuilt structures and experimentals not spawn a wreck

### DIFF
--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1667,7 +1667,9 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         if overkillRatio and overkillRatio > 1.0 then
             return
         end
-        if self:GetFractionComplete() < 0.5 then
+        local bp = self.Blueprint
+        local fractionComplete = self:GetFractionComplete()
+        if fractionComplete < 0.5 or (bp.TechCategory == 'EXPERIMENTAL' or bp.CategoriesHash["STRUCTURE"] and fractionComplete < 1) then
             return
         end
         return self:CreateWreckageProp(overkillRatio)


### PR DESCRIPTION
Resolves #5837. T1-T3 units in factories still spawn a wreck above 50% completion progress.