### PR TITLE
Filter all whitespace from UI weapon priority strings

### DIFF
--- a/lua/WeaponPriorities.lua
+++ b/lua/WeaponPriorities.lua
@@ -23,7 +23,7 @@ function ParseTableOfCategories(inputString)
                 local clean = category
                 clean = string.gsub(clean, '{', '')
                 clean = string.gsub(clean, '}', '')
-                clean = string.gsub(clean, ' ', '')
+                clean = string.gsub(clean, '%s', '')
                 clean = string.gsub(clean, 'categories.', '')
                 categories[k] = clean
             end


### PR DESCRIPTION
Writing a weapon priorities string in a readable format currently requires
```lua
priorityString = "COMMAND, STRATEGIC, MASSFABRICATION, " ..
"ENERGYPRODUCTION, MASSEXTRACTION, " .. 
"INTELLIGENCE"
```
which is clunky with all the concatenations. This PR makes it possible to write it much simpler as:
```lua
priorityString = [[COMMAND, STRATEGIC, MASSFABRICATION,
ENERGYPRODUCTION, MASSEXTRACTION,
INTELLIGENCE]]
```