### PR TITLE
Fix SACUs having less effective range due to low projectile lifetimes

### DIFF
--- a/units/UAL0301/UAL0301_unit.bp
+++ b/units/UAL0301/UAL0301_unit.bp
@@ -624,7 +624,7 @@ UnitBlueprint{
             MuzzleVelocity = 25,
             MuzzleVelocityReduceDistance = 5,
             ProjectileId = "/projectiles/ADFReactonCannon01/ADFReactonCannon01_proj.bp",
-            ProjectileLifetimeUsesMultiplier = 1.15,
+            ProjectileLifetimeUsesMultiplier = 1.30,
             ProjectilesPerOnFire = 1,
             RackBones = {
                 {

--- a/units/UAL0301/UAL0301_unit.bp
+++ b/units/UAL0301/UAL0301_unit.bp
@@ -624,7 +624,7 @@ UnitBlueprint{
             MuzzleVelocity = 25,
             MuzzleVelocityReduceDistance = 5,
             ProjectileId = "/projectiles/ADFReactonCannon01/ADFReactonCannon01_proj.bp",
-            ProjectileLifetimeUsesMultiplier = 1.30,
+            ProjectileLifetimeUsesMultiplier = 1.3,
             ProjectilesPerOnFire = 1,
             RackBones = {
                 {

--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -633,7 +633,7 @@ UnitBlueprint{
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 25,
             ProjectileId = "/projectiles/TDFPlasmaHeavy03/TDFPlasmaHeavy03_proj.bp",
-            ProjectileLifetimeUsesMultiplier = 1.15,
+            ProjectileLifetimeUsesMultiplier = 1.30,
             ProjectilesPerOnFire = 1,
             RackBones = {
                 {

--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -633,7 +633,7 @@ UnitBlueprint{
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 25,
             ProjectileId = "/projectiles/TDFPlasmaHeavy03/TDFPlasmaHeavy03_proj.bp",
-            ProjectileLifetimeUsesMultiplier = 1.30,
+            ProjectileLifetimeUsesMultiplier = 1.3,
             ProjectilesPerOnFire = 1,
             RackBones = {
                 {

--- a/units/URL0301/URL0301_unit.bp
+++ b/units/URL0301/URL0301_unit.bp
@@ -627,7 +627,7 @@ UnitBlueprint{
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 18,
             ProjectileId = "/projectiles/CDFLaserDisintegrator03/CDFLaserDisintegrator03_proj.bp",
-            ProjectileLifetimeUsesMultiplier = 2.4,
+            ProjectileLifetimeUsesMultiplier = 1.5,
             ProjectilesPerOnFire = 1,
             RackBones = {
                 {

--- a/units/URL0301/URL0301_unit.bp
+++ b/units/URL0301/URL0301_unit.bp
@@ -627,7 +627,7 @@ UnitBlueprint{
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 18,
             ProjectileId = "/projectiles/CDFLaserDisintegrator03/CDFLaserDisintegrator03_proj.bp",
-            ProjectileLifetimeUsesMultiplier = 1.5,
+            ProjectileLifetimeUsesMultiplier = 1.4,
             ProjectilesPerOnFire = 1,
             RackBones = {
                 {

--- a/units/XSL0301/XSL0301_unit.bp
+++ b/units/XSL0301/XSL0301_unit.bp
@@ -616,7 +616,7 @@ UnitBlueprint{
             MuzzleVelocity = 25,
             MuzzleVelocityReduceDistance = 5,
             ProjectileId = "/projectiles/SDFLightChronatronCannon01/SDFLightChronatronCannon01_proj.bp",
-            ProjectileLifetimeUsesMultiplier = 1.15,
+            ProjectileLifetimeUsesMultiplier = 1.30,
             ProjectilesPerOnFire = 1,
             RackBones = {
                 {

--- a/units/XSL0301/XSL0301_unit.bp
+++ b/units/XSL0301/XSL0301_unit.bp
@@ -616,7 +616,7 @@ UnitBlueprint{
             MuzzleVelocity = 25,
             MuzzleVelocityReduceDistance = 5,
             ProjectileId = "/projectiles/SDFLightChronatronCannon01/SDFLightChronatronCannon01_proj.bp",
-            ProjectileLifetimeUsesMultiplier = 1.30,
+            ProjectileLifetimeUsesMultiplier = 1.3,
             ProjectilesPerOnFire = 1,
             RackBones = {
                 {


### PR DESCRIPTION
In the current branch, the projectile lifetime of three of the four SACUs is extremely low. This means, that at the edge of their effective ranges, their shots disappear in front of units before they can hit them. This is especially bad for the Seraphim SACU, as that one does not have an AOE upgrade (ignoring OC). The projectile lifetime for the Cybran SACU was excessive, so I reduced it to be more reasonable.

**Changes:**
ProjectileLifetimeUsesMultiplier: 1.15 --> 1.3 (Aeon; Seraphim; UEF)
ProjectileLifetimeUsesMultiplier: 2.4 --> 1.4 (Cybran) 

A higher multiplier is required for the Cybran SACU, as its projectile's muzzle velocity is lower.

Only relevant with the respective range-increasing upgrades. 