### PR TITLE
Fix the Cybran T3 and the Seraphim T2 Sonars being able to evade beam weapons

### DIFF
--- a/units/URS0305/URS0305_unit.bp
+++ b/units/URS0305/URS0305_unit.bp
@@ -169,9 +169,9 @@ UnitBlueprint{
     SelectionSizeZ = 0.5,
     SelectionThickness = 0.78,
     CollisionOffsetY = -0.25,
-    SizeX = 0.8,
+    SizeX = 0.9,
     SizeY = 1.2,
-    SizeZ = 0.8,
+    SizeZ = 0.9,
     StrategicIconName = "icon_structure3_intel",
     StrategicIconSortPriority = 230,
     Wreckage = {

--- a/units/URS0305/URS0305_unit.bp
+++ b/units/URS0305/URS0305_unit.bp
@@ -169,9 +169,9 @@ UnitBlueprint{
     SelectionSizeZ = 0.5,
     SelectionThickness = 0.78,
     CollisionOffsetY = -0.25,
-    SizeX = 0.9,
+    SizeX = 0.8,
     SizeY = 1.2,
-    SizeZ = 0.9,
+    SizeZ = 0.8,
     StrategicIconName = "icon_structure3_intel",
     StrategicIconSortPriority = 230,
     Wreckage = {

--- a/units/XSB3202/XSB3202_unit.bp
+++ b/units/XSB3202/XSB3202_unit.bp
@@ -26,7 +26,6 @@ UnitBlueprint{
         "RECLAIMABLE",
         "SELECTABLE",
         "SERAPHIM",
-        "SHOWQUEUE",
         "SONAR",
         "SORTINTEL",
         "SUBMERSIBLE",

--- a/units/XSB3202/XSB3202_unit.bp
+++ b/units/XSB3202/XSB3202_unit.bp
@@ -172,7 +172,7 @@ UnitBlueprint{
     CollisionOffsetY = -0.25,
     SizeX = 0.9,
     SizeY = 1,
-    SizeZ = 0.7,
+    SizeZ = 0.95,
     StrategicIconName = "icon_structure2_intel",
     StrategicIconSortPriority = 230,
     Wreckage = {

--- a/units/XSB3202/XSB3202_unit.bp
+++ b/units/XSB3202/XSB3202_unit.bp
@@ -169,9 +169,9 @@ UnitBlueprint{
     SelectionSizeZ = 0.6,
     SelectionThickness = 0.66,
     CollisionOffsetY = -0.25,
-    SizeX = 0.9,
+    SizeX = 1.2,
     SizeY = 1,
-    SizeZ = 0.95,
+    SizeZ = 1,
     StrategicIconName = "icon_structure2_intel",
     StrategicIconSortPriority = 230,
     Wreckage = {


### PR DESCRIPTION
**Flood XR:**
SizeX: 0.8 --> 0.9
SizeZ: 0.8 --> 0.9

**Shou-esel**
SizeX: 0.9 --> 1.2
SizeZ: 0.7 --> 1
Removed the `SHOWQUEUE` category
