### PR TITLE
Correctly make Ythotha turn towards its target

### DIFF
--- a/engine/Core/Blueprints/WeaponBlueprint.lua
+++ b/engine/Core/Blueprints/WeaponBlueprint.lua
@@ -287,7 +287,8 @@
 ---@field SkipReadyState? boolean
 --- if the weapon is "slaved" to the unit's body, thus requiring it to face its target to fire
 ---@field SlavedToBody? boolean
---- range of arc to be considered "slaved" to a target
+--- Range of arc in both directions to be considered "slaved" to a target. With multiple weapons, 
+--- the first weapon in the blueprint that currently has a target is used for turning.
 ---@field SlavedToBodyArcRange? number
 --- flag to specify to not make the weapon active if the primary weapon has a current target
 ---@field StopOnPrimaryWeaponBusy? boolean

--- a/units/XSL0401/XSL0401_unit.bp
+++ b/units/XSL0401/XSL0401_unit.bp
@@ -1,7 +1,6 @@
 UnitBlueprint{
     Description = "<LOC xsl0401_desc>Experimental Assault Bot",
     AI = {
-        AttackAngle = 1,
         TargetBones = {
             "pelvis",
             "Torso",
@@ -295,7 +294,7 @@ UnitBlueprint{
             RangeCategory = "UWRC_DirectFire",
             RateOfFire = 0.2,
             SlavedToBody = true,
-            SlavedToBodyArcRange = 135,
+            SlavedToBodyArcRange = 32,
             TargetPriorities = {
                 "EXPERIMENTAL",
                 "SUBCOMMANDER",


### PR DESCRIPTION
Reverts #5916 because AttackAngle caused Ythotha to constantly rotate, which looked ugly. Instead, uses a reduced `SlavedToBodyArcRange` to turn towards the enemy for all weapons to fire, while not constantly turning to maintain an exact angle. 32 arc range instead of 45 to give weapons plenty of space to lead their target.
AttackAngle is more for weapons that can't all fire forwards, like Fatboy and battleships, so using it for Ythotha was incorrect in the first place.