### PR TITLE
Improve Fatboy attack angle and give it a longer projectile lifetime

### DIFF
--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -377,7 +377,7 @@ UnitBlueprint{
             MuzzleVelocity = 25,
             MuzzleVelocityReduceDistance = 90,
             ProjectileId = "/projectiles/TDFGauss04/TDFGauss04_proj.bp",
-            ProjectileLifetimeUsesMultiplier = 1.15,
+            ProjectileLifetimeUsesMultiplier = 1.6,
             ProjectilesPerOnFire = 3,
             RackBones = {
                 {
@@ -455,7 +455,7 @@ UnitBlueprint{
             MuzzleVelocityReduceDistance = 90,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = "/projectiles/TDFGauss04/TDFGauss04_proj.bp",
-            ProjectileLifetimeUsesMultiplier = 1.15,
+            ProjectileLifetimeUsesMultiplier = 1.6,
             ProjectilesPerOnFire = 3,
             RackBones = {
                 {
@@ -531,7 +531,7 @@ UnitBlueprint{
             MuzzleVelocityReduceDistance = 90,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = "/projectiles/TDFGauss04/TDFGauss04_proj.bp",
-            ProjectileLifetimeUsesMultiplier = 1.15,
+            ProjectileLifetimeUsesMultiplier = 1.6,
             ProjectilesPerOnFire = 3,
             RackBones = {
                 {
@@ -609,7 +609,7 @@ UnitBlueprint{
             MuzzleVelocityReduceDistance = 90,
             PrefersPrimaryWeaponTarget = true,
             ProjectileId = "/projectiles/TDFGauss04/TDFGauss04_proj.bp",
-            ProjectileLifetimeUsesMultiplier = 1.15,
+            ProjectileLifetimeUsesMultiplier = 1.6,
             ProjectilesPerOnFire = 3,
             RackBones = {
                 {

--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint{
     Description = "<LOC uel0401_desc>Experimental Mobile Factory",
     AI = {
-        AttackAngle = 10,
+        AttackAngle = 20,
         RefuelingMultiplier = 75,
         RefuelingRepairAmount = 500,
         RepairConsumeEnergy = 30,


### PR DESCRIPTION
An `AttackAngle` of 10 allows 3 weapons to fire only if the target is stationary. An in-game example of weapons not firing because of this would be a galactic colossus moving perpendicular to and towards the Fatboy at long range, which causes the back weapon to not fire. 20 angle is in the middle of the angle limits, so it should more often allow 3 cannons to fire, depending on unit speed/distance. It does solve the example with the GC.

https://github.com/FAForever/fa/assets/82986251/ed25d07d-00f6-480e-ae7c-7ad530f633cf

<details> <summary>Angle limits math image</summary>
Bone yaw + turret yaw + turret yaw range = actual yaw range. Then intersect all the ranges. The `HeadingArcRange` values are greater than the yaw ranges, so they have no effect and I didn't include them in this image.

![image](https://github.com/FAForever/fa/assets/82986251/f5221ca8-4bf8-4d8a-9c86-6eac43a165eb)

</details>

I noticed that while shooting a GC or groundfiring up a tall plateau the projectiles that miss above the target would time out and be unable to hit the ground, so I increased the projectile lifetime significantly.

Setting `SlaveToBody = true` for the weapons makes it automatically turn towards the target at `AttackAngle`, just like battleships, but it makes it annoying to micro with how often it would turn + how fragile it is, so I decided against making that change. For now you have to right click the enemy to get the optimal angle.
Ideally we could have a rear version of `AttackAngle` that it could choose as a second option, then it would always try for max single target DPS while not constantly turning 160 degrees (5.3x2 seconds) towards the enemy after you order it to retreat. Alternatively we could compute how it needs to turn to hit its target similar to Nomads' [Akimbo](https://github.com/FAForever/nomads/blob/25ce334371bbe0ae6d7c8a56f3598e94d4b8fabd/lua/nomadsutils.lua#L447) feature?