### PR TITLE
Reduce log spam from mod loading

### DIFF
--- a/lua/SessionInit.lua
+++ b/lua/SessionInit.lua
@@ -13,6 +13,9 @@ for i,m in ipairs(import("/lua/mods.lua").GetUiMods()) do
     table.insert(__active_mods, m)
 end
 
-LOG('Active mods in session: ',repr(__active_mods))
+LOG('Active mods in session:')
+for _, mod in __active_mods do
+    LOG(string.format('\t"%-30s v%02d (%-37s by %s', mod.name..'"', mod.version, mod.uid..')', mod.author))
+end
 
 doscript '/lua/UserSync.lua'


### PR DESCRIPTION
From #5946.
It avoids arbitrary output from longer fields like the description. I have noticed a 1-2 second lag spike because of the large amount of text printed to the log, especially with mods including changelog fields in their mod.info (supreme scoreboard).
Example output:
```
INFO: Active mods in session:
INFO:         "Selection Deprioritizer"       v06 (bc7731b6-1416-11ea-8d71-362b9e155667) by partytime, changes by CodingSquirrel and Myxir
INFO:         "ZeP_MiniMapZoom"               v02 (5F593E02-FEF3-487C-916F-D6020903054B) by Ze_PilOt
INFO:         "Penguin's Icon Mod"            v02 (3ccc4eca-0cb1-11ec-ac65-a37599393411-02) by Emperor_Penguin
INFO:         "Ranges"                        v11 (71a26460-ec4e-11ea-adc1-0242ac120003) by Myxir, Anihilnine, BlackYps, Prophet
INFO:         "Better chat"                   v14 (better-chat-4z0t-v14)                 by 4z0t
INFO:         "Advanced Target Priorities Tweaked" v05 (afc472ed-ab3b-4c0a-a05d-e0ce966d08ee) by Strogo, Nomander
INFO:         "Notifications v5.2"            v05 (0faf3443-1122-633s-ya-V00000005002)   by Myxir
INFO:         "Share Condition Popup"         v01 (casdb00a-0ca5-11ec-bf8a-346f5a12eff26) by Emperor_Penguin
INFO:         "UI Party"                      v15 (022E3DB4-9C00-5ED7-9876-4866D316E015) by Anihilnine, with contributions (technical help / ideas / I stole their code) from Zock, Domino, Myxir, yorick, Sir Prize, Crotalus, Coding Squirrel, Morax, Speed2, Hotbuild, camelCase, HUSAR_PL, MaCielPL, tatsu, sheeo, icedreamer, JoonasTo, Heaven, Fast-Thick-Pants
INFO:         "Common Mod Tools"              v01 (zcbf6277-24e3-437a-b968-Common-v1)    by Crotalus
INFO:         "Supreme Score Board2"          v18 (RIGOMATE-a1e2-c4t4-scfa-ssbmod-v0180) by HUSSAR
```