### PR TITLE
Fix experimental wrecks disappearing

### DIFF
--- a/changelog/3802.md
+++ b/changelog/3802.md
@@ -4,6 +4,8 @@
 
 <!-- Remove header when empty -->
 
+- (#5986) Fix a bug where experimental units would leave no wreckage
+
 ## Balance
 
 <!-- Remove header when empty -->

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1669,7 +1669,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         end
         local bp = self.Blueprint
         local fractionComplete = self:GetFractionComplete()
-        if fractionComplete < 0.5 or (bp.TechCategory == 'EXPERIMENTAL' or bp.CategoriesHash["STRUCTURE"] and fractionComplete < 1) then
+        if fractionComplete < 0.5 or ((bp.TechCategory == 'EXPERIMENTAL' or bp.CategoriesHash["STRUCTURE"]) and fractionComplete < 1) then
             return
         end
         return self:CreateWreckageProp(overkillRatio)


### PR DESCRIPTION
## Description of the proposed changes

Fix for a bug where all experimental units have no wrecks.

## Testing done on the proposed changes

Spawned in an experimental units and self-destructing them.

## Additional context

Related to: https://github.com/FAForever/fa/pull/5947

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
