### PR TITLE
Add a message when units are self-destructed

### DIFF
--- a/changelog/3802.md
+++ b/changelog/3802.md
@@ -26,6 +26,10 @@
 
 <!-- Remove header when empty -->
 
+- (#5995) Adds an event message when a player self destructs units
+
+The chat message is also visible in the game log that is shown in the client, which is useful for moderators.
+
 ## Contributors
 
 With thanks to the following people who contributed through coding:

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -142,6 +142,16 @@ do
             return
         end
 
+        -- inform allies about self-destructed units
+        if find(lower, 'killselectedunits') then
+            local selectedUnits = GetSelectedUnits()
+            SessionSendChatMessage(import('/lua/ui/game/clientutils.lua').GetAllies(), {
+                to = 'allies',
+                text = string.format('Self-destructed %d units', TableGetn(selectedUnits)),
+                Chat = true,
+            })
+        end
+
         -- do a basic check
         if find(lower, 'setfocusarmy') then
             if not SessionIsReplay() then
@@ -225,6 +235,16 @@ do
             return
         end
 
+        -- inform allies about self-destructed units
+        if find(lower, 'killselectedunits') then
+            local selectedUnits = GetSelectedUnits()
+            SessionSendChatMessage(import('/lua/ui/game/clientutils.lua').GetAllies(), {
+                to = 'allies',
+                text = string.format('Self-destructed %d units', TableGetn(selectedUnits)),
+                Chat = true,
+            })
+        end
+
         -- do a basic check
         if find(lower, 'setfocusarmy') then
             if not SessionIsReplay() then
@@ -293,6 +313,24 @@ do
         end
 
         oldConExecuteSave(command)
+    end
+
+    local oldSimCallback = SimCallback
+
+    ---@param callback SimCallback
+    ---@param addUnitSelection boolean
+    _G.SimCallback = function(callback, addUnitSelection)
+        -- inform allies about self-destructed units
+        if callback.Func == 'ToggleSelfDestruct' then
+            local selectedUnits = GetSelectedUnits()
+            SessionSendChatMessage(import('/lua/ui/game/clientutils.lua').GetAllies(), {
+                to = 'allies',
+                text = string.format('Self-destructed %d units', TableGetn(selectedUnits)),
+                Chat = true,
+            })
+        end
+
+        oldSimCallback(callback, addUnitSelection or false)
     end
 
     --- Retrieves the terrain elevation, can be compared with the y coordinate of `GetMouseWorldPos` to determine if the mouse is above water


### PR DESCRIPTION
## Description of the proposed changes

Adds a chat message send to all allies when a player self-destructs units. The chat message is also visible in the game log that is shown in the client, which is useful for moderators.

## Testing done on the proposed changes

Spawn in and self destruct the units.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
