### PR TITLE
Add a moderator message when pings are created

### DIFF
--- a/changelog/3802.md
+++ b/changelog/3802.md
@@ -26,6 +26,10 @@
 
 <!-- Remove header when empty -->
 
+- (#5995) Adds an event message when a player self destructs units
+
+The chat message is also visible in the game log that is shown in the client, which is useful for moderators.
+
 ## Contributors
 
 With thanks to the following people who contributed through coding:

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -52,7 +52,6 @@ local Callbacks = {}
 ---@param data table
 ---@param units? Unit[]
 function DoCallback(name, data, units)
-    LOG(name, repru(data))
     local start = GetSystemTimeSecondsOnlyForProfileUse()
     local fn = Callbacks[name];
     if fn then

--- a/lua/ui/game/ping.lua
+++ b/lua/ui/game/ping.lua
@@ -16,10 +16,10 @@ MaxMarkers = false
 -- Table of ping types
 -- All of this data is sent to the sim and back to the UI for display on the world views
 PingTypes = {
-    alert = {Lifetime = 6, Mesh = 'alert_marker', Ring = '/game/marker/ring_yellow02-blur.dds', ArrowColor = 'yellow', Sound = 'UEF_Select_Radar'},
-    move = {Lifetime = 6, Mesh = 'move', Ring = '/game/marker/ring_blue02-blur.dds', ArrowColor = 'blue', Sound = 'Cybran_Select_Radar'},
-    attack = {Lifetime = 6, Mesh = 'attack_marker', Ring = '/game/marker/ring_red02-blur.dds', ArrowColor = 'red', Sound = 'Aeon_Select_Radar'},
-    marker = {Lifetime = 5, Ring = '/game/marker/ring_yellow02-blur.dds', ArrowColor = 'yellow', Sound = 'UI_Main_IG_Click', Marker = true},
+    alert = {Type = 'Alert', Lifetime = 6, Mesh = 'alert_marker', Ring = '/game/marker/ring_yellow02-blur.dds', ArrowColor = 'yellow', Sound = 'UEF_Select_Radar'},
+    move = {Type = 'Move', Lifetime = 6, Mesh = 'move', Ring = '/game/marker/ring_blue02-blur.dds', ArrowColor = 'blue', Sound = 'Cybran_Select_Radar'},
+    attack = {Type = 'Attack', Lifetime = 6, Mesh = 'attack_marker', Ring = '/game/marker/ring_red02-blur.dds', ArrowColor = 'red', Sound = 'Aeon_Select_Radar'},
+    marker = {Type = 'Marker', Lifetime = 5, Ring = '/game/marker/ring_yellow02-blur.dds', ArrowColor = 'yellow', Sound = 'UI_Main_IG_Click', Marker = true},
 }
 
 --- The original army that this player represents. Is populated else where during initialisation of the game.

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -142,6 +142,16 @@ do
             return
         end
 
+        -- inform allies about self-destructed units
+        if find(lower, 'killselectedunits') then
+            local selectedUnits = GetSelectedUnits()
+            SessionSendChatMessage(import('/lua/ui/game/clientutils.lua').GetAllies(), {
+                to = 'allies',
+                text = string.format('Self-destructed %d units', TableGetn(selectedUnits)),
+                Chat = true,
+            })
+        end
+
         -- do a basic check
         if find(lower, 'setfocusarmy') then
             if not SessionIsReplay() then
@@ -225,6 +235,16 @@ do
             return
         end
 
+        -- inform allies about self-destructed units
+        if find(lower, 'killselectedunits') then
+            local selectedUnits = GetSelectedUnits()
+            SessionSendChatMessage(import('/lua/ui/game/clientutils.lua').GetAllies(), {
+                to = 'allies',
+                text = string.format('Self-destructed %d units', TableGetn(selectedUnits)),
+                Chat = true,
+            })
+        end
+
         -- do a basic check
         if find(lower, 'setfocusarmy') then
             if not SessionIsReplay() then
@@ -293,6 +313,24 @@ do
         end
 
         oldConExecuteSave(command)
+    end
+
+    local oldSimCallback = SimCallback
+
+    ---@param callback SimCallback
+    ---@param addUnitSelection boolean
+    _G.SimCallback = function(callback, addUnitSelection)
+        -- inform allies about self-destructed units
+        if callback.Func == 'ToggleSelfDestruct' then
+            local selectedUnits = GetSelectedUnits()
+            SessionSendChatMessage(import('/lua/ui/game/clientutils.lua').GetAllies(), {
+                to = 'allies',
+                text = string.format('Self-destructed %d units', TableGetn(selectedUnits)),
+                Chat = true,
+            })
+        end
+
+        oldSimCallback(callback, addUnitSelection or false)
     end
 
     --- Retrieves the terrain elevation, can be compared with the y coordinate of `GetMouseWorldPos` to determine if the mouse is above water

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -320,6 +320,16 @@ do
     ---@param callback SimCallback
     ---@param addUnitSelection boolean
     _G.SimCallback = function(callback, addUnitSelection)
+        local clients = GetSessionClients()
+        local localClient = nil
+        for k = 1, TableGetn(clients) do
+            if clients[k]["local"] then
+                localClient = clients[k]
+                break
+            end
+        end
+        local currentFocusArmy = GetFocusArmy()
+
         -- inform allies about self-destructed units
         if callback.Func == 'ToggleSelfDestruct' then
             local selectedUnits = GetSelectedUnits()
@@ -328,6 +338,41 @@ do
                 text = string.format('Self-destructed %d units', TableGetn(selectedUnits)),
                 Chat = true,
             })
+        end
+
+        -- inform moderators about pings
+        if callback.Func == 'SpawnPing' then
+            if callback.Args.Marker then
+                SimCallback(
+                    {
+                        Func="GiveResourcesToPlayer",
+                        Args= {
+                            From=currentFocusArmy,
+                            To=currentFocusArmy,
+                            Mass=0,
+                            Energy=0,
+                            Sender=localClient.name,
+                            Msg={ to='moderators', text = string.format("Created a marker with the text: '%s'", tostring(callback.Args.Name)) }
+                        },
+                    },
+                    true
+                )
+            else
+                SimCallback(
+                    {
+                        Func="GiveResourcesToPlayer",
+                        Args= {
+                            From=currentFocusArmy,
+                            To=currentFocusArmy,
+                            Mass=0,
+                            Energy=0,
+                            Sender=localClient.name,
+                            Msg={ to='moderators', text = string.format("Created a ping of type '%s'", tostring(callback.Args.Type)) }
+                        },
+                    },
+                    true
+                )
+            end
         end
 
         oldSimCallback(callback, addUnitSelection or false)


### PR DESCRIPTION
## Description of the proposed changes

Adds a hidden chat message when a player creates a ping. The chat message is visible in the game log that is shown in the client, which is useful for moderators.

## Testing done on the proposed changes

Create various pings and review the created sim callbacks.

## Checklist

- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
