### PR TITLE
Remove full redundancy from reclaim commands

### DIFF
--- a/changelog/3802.md
+++ b/changelog/3802.md
@@ -6,6 +6,10 @@
 
 - (#5986) Fix a bug where experimental units leave no wreckage
 
+- (#5997) Fix losing reclaim orders when distributing a large number of reclaim orders
+
+Reclaim orders are now distributed in a similar fashion as move and build orders are. Each reclaim order is assigned to a single engineer. There is no redundancy anymore.
+
 ## Balance
 
 <!-- Remove header when empty -->
@@ -30,7 +34,7 @@
 
 With thanks to the following people who contributed through coding:
 
-<!-- Remove when empty -->
+- Jip
 
 With thanks to the following people who contributed through binary patches:
 
@@ -42,4 +46,7 @@ With thanks to the following individuals who contributed through model, texture,
 
 And, last but certainly not least - with thanks to those that took part in constructive discussions:
 
-<!-- Remove when empty -->
+- Fichom
+- Sheikah
+- Prohibitorum
+- Maudlin27

--- a/lua/sim/commands/shared.lua
+++ b/lua/sim/commands/shared.lua
@@ -113,7 +113,6 @@ UnitQueueDataToCommand = {
             pcall(IssueReclaim, units, positionOrEntity)
         end,
         BatchOrders = true,
-        FullRedundancy = true,
     },
     [20] = {
         Type = "Repair",


### PR DESCRIPTION
## Description of the proposed changes

Reclaim orders are now applied similar to move orders are, there is no redundancy anymore. For a large chain of orders the full redundancy may cause a loss of orders.

https://github.com/FAForever/fa/assets/15778155/7e53be5d-dd4b-40c6-8dc8-b82911e6eaa0

## Additional context

As reported by Fichom on [Discord](https://discord.com/channels/197033481883222026/1212473389688823870)

## Checklist

- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
