### PR TITLE
Add `ANTITORPEDO` category to all units with antitorp weapons

### DIFF
--- a/units/UAS0103/UAS0103_unit.bp
+++ b/units/UAS0103/UAS0103_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
     BuildIconSortPriority = 40,
     Categories = {
         "AEON",
+        "ANTITORPEDO",
         "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER1FACTORY",
         "BUILTBYTIER2FACTORY",

--- a/units/UAS0201/UAS0201_unit.bp
+++ b/units/UAS0201/UAS0201_unit.bp
@@ -11,6 +11,7 @@ UnitBlueprint{
     BuildIconSortPriority = 30,
     Categories = {
         "AEON",
+        "ANTITORPEDO",
         "ANTINAVY",
         "ANTISUB",
         "BUILTBYEXPERIMENTALSUB",

--- a/units/UAS0305/UAS0305_unit.bp
+++ b/units/UAS0305/UAS0305_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
     BuildIconSortPriority = 190,
     Categories = {
         "AEON",
+        "ANTITORPEDO",
         "BUILTBYTIER3COMMANDER",
         "BUILTBYTIER3ENGINEER",
         "CQUEMOV",

--- a/units/UAS0401/UAS0401_unit.bp
+++ b/units/UAS0401/UAS0401_unit.bp
@@ -31,6 +31,7 @@ UnitBlueprint{
     BuildIconSortPriority = 120,
     Categories = {
         "AEON",
+        "ANTITORPEDO",
         "ANTINAVY",
         "BATTLESHIP",
         "BUILTBYTIER3COMMANDER",

--- a/units/UES0201/UES0201_unit.bp
+++ b/units/UES0201/UES0201_unit.bp
@@ -19,6 +19,7 @@ UnitBlueprint{
     BuildIconSortPriority = 30,
     Categories = {
         "ANTINAVY",
+        "ANTITORPEDO",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",
         "DESTROYER",

--- a/units/XAS0204/XAS0204_unit.bp
+++ b/units/XAS0204/XAS0204_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
     BuildIconSortPriority = 15,
     Categories = {
         "AEON",
+        "ANTITORPEDO",
         "ANTINAVY",
         "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER2FACTORY",

--- a/units/XAS0306/XAS0306_unit.bp
+++ b/units/XAS0306/XAS0306_unit.bp
@@ -18,6 +18,7 @@ UnitBlueprint{
     BuildIconSortPriority = 20,
     Categories = {
         "AEON",
+        "ANTITORPEDO",
         "ANTIMISSILE",
         "BATTLESHIP",
         "BUILTBYTIER3FACTORY",

--- a/units/XES0102/XES0102_unit.bp
+++ b/units/XES0102/XES0102_unit.bp
@@ -11,6 +11,7 @@ UnitBlueprint{
     BuildIconSortPriority = 20,
     Categories = {
         "ANTINAVY",
+        "ANTITORPEDO",
         "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",

--- a/units/XES0307/XES0307_unit.bp
+++ b/units/XES0307/XES0307_unit.bp
@@ -20,6 +20,7 @@ UnitBlueprint{
     Categories = {
         "ANTIMISSILE",
         "ANTINAVY",
+        "ANTITORPEDO",
         "BATTLESHIP",
         "BUILTBYTIER3FACTORY",
         "DIRECTFIRE",

--- a/units/XRL0403/XRL0403_unit.bp
+++ b/units/XRL0403/XRL0403_unit.bp
@@ -29,6 +29,7 @@ UnitBlueprint {
     BuildBotTotal = 12,
     BuildIconSortPriority = 30,
     Categories = {
+        "ANTITORPEDO",
         "AMPHIBIOUS",
         "BOT",
         "BUILTBYTIER3COMMANDER",

--- a/units/XRS0205/XRS0205_unit.bp
+++ b/units/XRS0205/XRS0205_unit.bp
@@ -18,6 +18,7 @@ UnitBlueprint{
     },
     BuildIconSortPriority = 40,
     Categories = {
+        "ANTITORPEDO",
         "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",

--- a/units/XSB2205/XSB2205_unit.bp
+++ b/units/XSB2205/XSB2205_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
     BuildIconSortPriority = 130,
     Categories = {
         "ANTINAVY",
+        "ANTITORPEDO",
         "BUILTBYTIER2COMMANDER",
         "BUILTBYTIER2ENGINEER",
         "BUILTBYTIER3COMMANDER",

--- a/units/XSS0201/XSS0201_unit.bp
+++ b/units/XSS0201/XSS0201_unit.bp
@@ -19,6 +19,7 @@ UnitBlueprint{
     BuildIconSortPriority = 30,
     Categories = {
         "ANTINAVY",
+        "ANTITORPEDO",
         "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",

--- a/units/XSS0203/XSS0203_unit.bp
+++ b/units/XSS0203/XSS0203_unit.bp
@@ -18,6 +18,7 @@ UnitBlueprint{
     BuildIconSortPriority = 30,
     Categories = {
         "ANTINAVY",
+        "ANTITORPEDO",
         "BUILTBYTIER1FACTORY",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",

--- a/units/XSS0304/XSS0304_unit.bp
+++ b/units/XSS0304/XSS0304_unit.bp
@@ -19,6 +19,7 @@ UnitBlueprint{
     Categories = {
         "ANTIAIR",
         "ANTINAVY",
+        "ANTITORPEDO",
         "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER3FACTORY",
         "MOBILE",


### PR DESCRIPTION
## Description of the proposed changes
Adds `ANTITORPEDO` to units with antitorpedo weapons. Cherry picks #5990 #5991 #5992 to consolidate into one PR.
The regex string used to find antitorp weapons was: `ProjectileId ?= ?.*Antitorpedo`.

## Testing done on the proposed changes
I didn't find any mentions of the ANTITORPEDO unit categories in the repository (only mentioned for projectile categories), M28AI, M27AI, RNGAI, or AI-Uveso. The category changes should just improve the consistent application of the category, making it useful for AI developers. For example, `M28UnitInfo.lua` uses
```lua
if oCurWeapon.RangeCategory == 'UWRC_Countermeasure' then
  --Target restriction should catch all cases, have but the most common labels as redundancy as well (doesnt cover mega? and fatboy? torpedo defence which have antitorpedoleft, left1, left2, right, etc. labels)
  if oCurWeapon.TargetRestrictOnlyAllow == "TORPEDO" or oCurWeapon.Label == 'AntiTorpedo' or oCurWeapon.Label == 'AntiTorpedo01' or oCurWeapon.Label == 'AntiTorpedoF' then
    oUnit[refbHasTorpedoDefence] = true
  else
```
which can be simplified and improved thanks to theses category changes. @maudlin27 

## Checklist

- [ ] Changes are annotated, including comments where useful

The category is already annotated in `categories.lua`.

- [ ] Changes are documented in the changelog for the next game version
