### PR TITLE
add antinavy category to CZAR UAA0310

### DIFF
--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -51,6 +51,7 @@ UnitBlueprint{
         "AIR",
         "AIRSTAGINGPLATFORM",
         "ANTIAIR",
+        "ANTINAVY",
         "BUILTBYTIER3COMMANDER",
         "BUILTBYTIER3ENGINEER",
         "CANNOTUSEAIRSTAGING",


### PR DESCRIPTION
## Description of the proposed changes

This PR adds the ANTINAVY category to the CZAR to match its sub threat capabilities.

## Testing done on the proposed changes

Validation of not causing obvious issues

## Additional context

@Garanas I'm not sure if this can cause issues with existing formation logic etc. The default AI already excluded experimentals for its air based antinavy platoon templates so there are no issues there. 

fixes #5988

## Additional Information

This issue came about when creating an improved state machines for air based experimentals, it was found that the czar could not detect its anti naval capabilities using unit categories when flying over water so it could not be determined to attack naval units should it want to.