### PR TITLE
Remove the 'BUILTBYEXPERIMENTALSUB' category from various units

### DIFF
--- a/changelog/3804.md
+++ b/changelog/3804.md
@@ -30,7 +30,7 @@
 
 - (#6004) Add missing categories to the CZAR
 
-- (#6004) Remove the `BUILTBYEXPERIMENTALSUB` category from all units that have it. This category was unused, the Tempest is not affected by this change in any way.
+- (#6005) Remove the `BUILTBYEXPERIMENTALSUB` category from all units that have it. This category was unused, the Tempest is not affected by this change in any way.
 
 - (#6008) Remove unecessary category from the Brick
 

--- a/changelog/3804.md
+++ b/changelog/3804.md
@@ -30,6 +30,8 @@
 
 - (#6004) Add missing categories to the CZAR
 
+- (#6004) Remove the `BUILTBYEXPERIMENTALSUB` category from all units that have it. This category was unused, the Tempest is not affected by this.
+
 - (#6008) Remove unecessary category from the Brick
 
 ## Contributors

--- a/changelog/3804.md
+++ b/changelog/3804.md
@@ -30,7 +30,7 @@
 
 - (#6004) Add missing categories to the CZAR
 
-- (#6005) Remove the `BUILTBYEXPERIMENTALSUB` category from all units that have it. This category was unused, the Tempest is not affected by this change in any way.
+- (#6005) Remove the `BUILTBYEXPERIMENTALSUB` category from all units that previously had it. As this category was unused, the Tempest still functions as you would expect.
 
 - (#6008) Remove unecessary category from the Brick
 

--- a/changelog/3804.md
+++ b/changelog/3804.md
@@ -30,7 +30,7 @@
 
 - (#6004) Add missing categories to the CZAR
 
-- (#6004) Remove the `BUILTBYEXPERIMENTALSUB` category from all units that have it. This category was unused, the Tempest is not affected by this.
+- (#6004) Remove the `BUILTBYEXPERIMENTALSUB` category from all units that have it. This category was unused, the Tempest is not affected by this change in any way.
 
 - (#6008) Remove unecessary category from the Brick
 

--- a/units/UAS0102/UAS0102_unit.bp
+++ b/units/UAS0102/UAS0102_unit.bp
@@ -12,7 +12,6 @@ UnitBlueprint{
     Categories = {
         "AEON",
         "ANTIAIR",
-        "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER1FACTORY",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",

--- a/units/UAS0103/UAS0103_unit.bp
+++ b/units/UAS0103/UAS0103_unit.bp
@@ -15,7 +15,6 @@ UnitBlueprint{
     BuildIconSortPriority = 40,
     Categories = {
         "AEON",
-        "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER1FACTORY",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",

--- a/units/UAS0201/UAS0201_unit.bp
+++ b/units/UAS0201/UAS0201_unit.bp
@@ -13,7 +13,6 @@ UnitBlueprint{
         "AEON",
         "ANTINAVY",
         "ANTISUB",
-        "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",
         "DESTROYER",

--- a/units/UAS0202/UAS0202_unit.bp
+++ b/units/UAS0202/UAS0202_unit.bp
@@ -13,7 +13,6 @@ UnitBlueprint{
         "AEON",
         "ANTIAIR",
         "ANTIMISSILE",
-        "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",
         "CRUISER",

--- a/units/UAS0203/UAS0203_unit.bp
+++ b/units/UAS0203/UAS0203_unit.bp
@@ -19,7 +19,6 @@ UnitBlueprint{
     Categories = {
         "AEON",
         "ANTINAVY",
-        "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER1FACTORY",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",

--- a/units/XAS0204/XAS0204_unit.bp
+++ b/units/XAS0204/XAS0204_unit.bp
@@ -17,7 +17,6 @@ UnitBlueprint{
     Categories = {
         "AEON",
         "ANTINAVY",
-        "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",
         "MOBILE",

--- a/units/XES0102/XES0102_unit.bp
+++ b/units/XES0102/XES0102_unit.bp
@@ -11,7 +11,6 @@ UnitBlueprint{
     BuildIconSortPriority = 20,
     Categories = {
         "ANTINAVY",
-        "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",
         "LIGHTBOAT",

--- a/units/XRS0205/XRS0205_unit.bp
+++ b/units/XRS0205/XRS0205_unit.bp
@@ -18,7 +18,6 @@ UnitBlueprint{
     },
     BuildIconSortPriority = 40,
     Categories = {
-        "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",
         "COUNTERINTELLIGENCE",

--- a/units/XSS0201/XSS0201_unit.bp
+++ b/units/XSS0201/XSS0201_unit.bp
@@ -19,7 +19,6 @@ UnitBlueprint{
     BuildIconSortPriority = 30,
     Categories = {
         "ANTINAVY",
-        "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",
         "DESTROYER",

--- a/units/XSS0202/XSS0202_unit.bp
+++ b/units/XSS0202/XSS0202_unit.bp
@@ -12,7 +12,6 @@ UnitBlueprint{
     Categories = {
         "ANTIAIR",
         "ANTIMISSILE",
-        "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER2FACTORY",
         "BUILTBYTIER3FACTORY",
         "CRUISER",

--- a/units/XSS0304/XSS0304_unit.bp
+++ b/units/XSS0304/XSS0304_unit.bp
@@ -19,7 +19,6 @@ UnitBlueprint{
     Categories = {
         "ANTIAIR",
         "ANTINAVY",
-        "BUILTBYEXPERIMENTALSUB",
         "BUILTBYTIER3FACTORY",
         "MOBILE",
         "NAVAL",


### PR DESCRIPTION
## Description of the proposed changes

Removes the `BUILTBYEXPERIMENTALSUB` category from various units.

## Testing done on the proposed changes

The Tempest can still build these units just fine. Except units like the Seraphim cruiser of course, interestingly enough, this unit also had the category.

## Additional context

According to @The-Balthazar on Discord, this category is unused. 

## Checklist

- [x] Changes are documented in the changelog for the next game version
