### PR TITLE
Remove Siren `REPAIR` category

### DIFF
--- a/changelog/3804.md
+++ b/changelog/3804.md
@@ -4,6 +4,8 @@
 
 - (#6002) Fix a bug where the map would not reveal at the end of the game
 
+- (#6007) Fix Siren uselessly trying to repair units when assisting them
+
 ## Balance
 
 <!-- Remove header when empty -->
@@ -33,6 +35,7 @@ With thanks to the following people who contributed through coding:
 - Jip
 - ll1ll
 - Relent0r
+- Hdt80bro
 
 With thanks to the following people who contributed through binary patches:
 
@@ -44,4 +47,4 @@ With thanks to the following individuals who contributed through model, texture,
 
 And, last but certainly not least - with thanks to those that took part in constructive discussions:
 
-<!-- Remove when empty -->
+- Basilisk3

--- a/units/URS0202/URS0202_unit.bp
+++ b/units/URS0202/URS0202_unit.bp
@@ -42,7 +42,6 @@ UnitBlueprint {
         "OVERLAYSONAR",
         "PRODUCTSC1",
         "RECLAIMABLE",
-        "REPAIR",
         "SELECTABLE",
         "SNIPEMODE",
         "TECH2",


### PR DESCRIPTION
Currently, the Siren Class cruiser has the `REPAIR` category - presumably because it's an air staging platform that can repair aircraft. What this actually does is let it repair other units like an engineer, despite having no visual indication or defined build rate - it defaults to 1 and is incredibly slow. If this was intended, it would have been more clear with an appreciable build rate and effect (maybe even an animation, unit description line, or unit ability), but given the context, it appears to be a simple oversight.

![image](https://github.com/FAForever/fa/assets/37224614/aa9cefc0-8e17-4398-83a3-564dc9a2e412)
*Notice the orange progress bar and 1 power drain - the damaged cruiser used to be at 30% health but is now at 32%*
