### PR TITLE
Remove `ANTIMISSILE` category from Brick

### DIFF
--- a/changelog/3804.md
+++ b/changelog/3804.md
@@ -28,6 +28,8 @@
 
 - (#6004) Add missing categories to the CZAR
 
+- (#6008) Remove unecessary category from the Brick
+
 ## Contributors
 
 With thanks to the following people who contributed through coding:

--- a/units/XRL0305/XRL0305_unit.bp
+++ b/units/XRL0305/XRL0305_unit.bp
@@ -10,7 +10,6 @@ UnitBlueprint{
     BuildIconSortPriority = 20,
     Categories = {
         "AMPHIBIOUS",
-        "ANTIMISSILE",
         "ANTINAVY",
         "ANTITORPEDO", 
         "BOT",


### PR DESCRIPTION
## Description of the proposed changes
The incorrect category I guess is from either copy-pasting the loyalist when GPG made the unit or a misunderstanding of how the torpedo defense should be categorized.

## Checklist

- [x] Changes are documented in the changelog for the next game version
