### PR TITLE
CZAR categories - remove antinavy and add weakantinavy

### DIFF
--- a/changelog/3804.md
+++ b/changelog/3804.md
@@ -28,7 +28,7 @@
 
 - (#6001) Add missing categories to units with Anti-Torpedo defenses
 
-- (#6004) Add missing categories to the CZAR
+- (#6012) Add missing categories to the CZAR
 
 - (#6008) Remove unecessary category from the Brick
 

--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -51,7 +51,6 @@ UnitBlueprint{
         "AIR",
         "AIRSTAGINGPLATFORM",
         "ANTIAIR",
-        "ANTINAVY",
         "BUILTBYTIER3COMMANDER",
         "BUILTBYTIER3ENGINEER",
         "CANNOTUSEAIRSTAGING",
@@ -78,6 +77,7 @@ UnitBlueprint{
         "SNIPEMODE",
         "TARGETCHASER",
         "VISIBLETORECON",
+        "WEAKANTINAVY",
         "EXTERNALFACTORY"
     },
     Defense = {


### PR DESCRIPTION
## Description of the proposed changes

This PR changes the previously added category of ANTINAVY to WEAKANTINAVY.

After some discussion I realised that non primary weapon types for units should have the weak variant of the category.



