### PR TITLE
Fix a bug and extend the context based templates feature

### DIFF
--- a/changelog/3804.md
+++ b/changelog/3804.md
@@ -6,13 +6,17 @@
 
 - (#6007) Fix Siren uselessly trying to repair units when assisting them
 
+- (#6015) Fix a bug with capping extractors via the context-based templates feature
+
 ## Balance
 
 <!-- Remove header when empty -->
 
 ## Features
 
-<!-- Remove header when empty -->
+- (#6015) Extend the context-based templates feature
+
+When you hover over a unit the first 'template' is always just the 'best fit' that represents that unit. As an example, if you hover over a point defense then it will pick the or a similar point defense that your current selection can build.
 
 ## Graphics
 

--- a/lua/ui/game/hotkeys/context-based-templates.lua
+++ b/lua/ui/game/hotkeys/context-based-templates.lua
@@ -60,6 +60,8 @@ end
 
 -- convert all known templates
 
+local SingletonTemplate = { TemplateData = { 0, 0, { 'dummy', 0, 0, 0 } }}
+
 ---@type table
 local RawTemplates = import("/lua/ui/game/hotkeys/context-based-templates-data.lua")
 
@@ -98,10 +100,35 @@ CommandMode.AddEndBehavior(
         if not table.empty(ContextBasedTemplates) then
             ContextBasedTemplates = {}
             ContextBasedTemplateStep = 0
+            ClearBuildTemplates()
         end
     end,
     'ContextBasedTemplates'
 )
+
+--- Converts the blueprint id to the preferred faction
+---@param blueprintId BlueprintId
+---@param prefix 'ua' | 'ue' | 'ur' | 'xs' | 'xn'
+---@return BlueprintId
+local function ConvertBlueprintId(blueprintId, prefix)
+    local templateUnitBlueprintId = prefix .. blueprintId:sub(3)
+
+    -- because the support factories originate from mods they do not adhere to the
+    -- standard blueprint convention for factions; very annoying ^^
+    local isSupportFactory = blueprintId:sub(1, 1) == 'z'
+    if isSupportFactory then
+        templateUnitBlueprintId = 'z' .. prefix:sub(2, 2) .. blueprintId:sub(3)
+    end
+
+    -- same here but then for units that are part of the Forged Alliance expansion; they
+    -- do not adhere to blueprint standards
+    local isExpansion = blueprintId:sub(1, 1) == 'x' and blueprintId:sub(1, 2) ~= 'xs'
+    if isExpansion then
+        templateUnitBlueprintId = 'x' .. prefix:sub(2, 2) .. blueprintId:sub(3)
+    end
+
+    return templateUnitBlueprintId
+end
 
 --- Validates the template in-place, returns whether the process succeeded
 ---@param template ContextBasedTemplate
@@ -114,27 +141,20 @@ local function ValidateTemplate(template, buildableUnits, prefix)
 
     for l = 3, TableGetn(template.TemplateData) do
         local templateUnit = template.TemplateData[l]
-        local templateUnitBlueprintId = prefix .. templateUnit[1]:sub(3)
+        local templateUnitBlueprintId = ConvertBlueprintId(templateUnit[1], prefix)
 
-        -- because the support factories originate from mods they do not adhere to the
-        -- standard blueprint convention for factions; very annoying ^^
-        local isSupportFactory = templateUnit[1]:sub(1, 1) == 'z'
-        if isSupportFactory then
-            templateUnitBlueprintId = 'z' .. prefix:sub(2, 2) .. templateUnit[1]:sub(3)
-        end
-
-        -- same here but then for units that are part of the Forged Alliance expansion; they
-        -- do not adhere to blueprint standards
-        local isExpansion = templateUnit[1]:sub(1, 1) == 'x' and templateUnit[1]:sub(1, 2) ~= 'xs'
-        if isExpansion then
-            templateUnitBlueprintId = 'x' .. prefix:sub(2, 2) .. templateUnit[1]:sub(3)
-        end
-
-        -- proceed as usual
+        -- proceed as usual, try and find a template
+        ---@type UnitBlueprint
         local templateUnitBlueprint = __blueprints[templateUnitBlueprintId]
+        local templateUnitBlueprintFromId = templateUnitBlueprint.General.UpgradesFrom
+        local templateUnitBlueprintBaseId = templateUnitBlueprint.General.UpgradesFromBase
         if templateUnitBlueprint then
             if buildableUnits[templateUnitBlueprintId] then
                 templateUnit[1] = templateUnitBlueprintId
+            elseif templateUnitBlueprintFromId and buildableUnits[templateUnitBlueprintFromId] then
+                templateUnit[1] = templateUnitBlueprintFromId
+            elseif templateUnitBlueprintBaseId and buildableUnits[templateUnitBlueprintBaseId] then
+                templateUnit[1] = templateUnitBlueprintBaseId
             else
                 allUnitsBuildable = false
             end
@@ -212,7 +232,8 @@ local function FilterTemplatesByUnitContext(buildableUnits, prefix)
     -- try and retrieve blueprint id from highlight command
     if not blueprintId then
         local highlightCommand = GetHighlightCommand()
-        if highlightCommand.blueprintId then
+        reprsl(highlightCommand)
+        if highlightCommand and highlightCommand.blueprintId then
             blueprintId = highlightCommand.blueprintId
         end
     end
@@ -220,7 +241,9 @@ local function FilterTemplatesByUnitContext(buildableUnits, prefix)
     -- try and retrieve blueprint id from rollover info
     if not blueprintId then
         local info = GetRolloverInfo()
-        blueprintId = info.blueprintId
+        if info.userUnit then
+            blueprintId = info.blueprintId
+        end
     end
 
     -- if still not available then give up and bail out
@@ -242,6 +265,32 @@ local function FilterTemplatesByUnitContext(buildableUnits, prefix)
                 TableInsert(ContextBasedTemplates, template)
                 ContextBasedTemplateCount = ContextBasedTemplateCount + 1
             end
+        end
+    end
+
+    -- act like a color picker but then for units, see if there's something useful that we can build
+    if ContextBasedTemplateCount == 0 then
+        local convertedBlueprintId = ConvertBlueprintId(blueprintId, prefix)
+        local convertedBlueprint = __blueprints[convertedBlueprintId]
+        local templateUnitBlueprintFromId = convertedBlueprint.General.UpgradesFrom
+        local templateUnitBlueprintBaseId = convertedBlueprint.General.UpgradesFromBase
+
+        local validBlueprintId
+        if convertedBlueprint then
+            if buildableUnits[convertedBlueprintId] then
+                validBlueprintId = convertedBlueprintId
+            elseif templateUnitBlueprintFromId and buildableUnits[templateUnitBlueprintFromId] then
+                validBlueprintId = templateUnitBlueprintFromId
+            elseif templateUnitBlueprintBaseId and buildableUnits[templateUnitBlueprintBaseId] then
+                validBlueprintId = templateUnitBlueprintBaseId
+            end
+        end
+
+        if validBlueprintId then
+            SingletonTemplate.Name = LOC(__blueprints[validBlueprintId].Description)
+            SingletonTemplate.TemplateData[3][1] = validBlueprintId
+            TableInsert(ContextBasedTemplates, SingletonTemplate)
+            ContextBasedTemplateCount = ContextBasedTemplateCount + 1
         end
     end
 
@@ -329,7 +378,7 @@ Cycle = function()
                 ClearBuildTemplates()
             end
 
-            print(StringFormat("(%d/%d) %s", index, ContextBasedTemplateCount, template.Name))
+            print(StringFormat("(%d/%d) %s", index, ContextBasedTemplateCount, tostring(template.Name)))
         end
 
         ContextBasedTemplateStep = ContextBasedTemplateStep + 1

--- a/lua/ui/game/hotkeys/context-based-templates.lua
+++ b/lua/ui/game/hotkeys/context-based-templates.lua
@@ -250,7 +250,31 @@ local function FilterTemplatesByUnitContext(buildableUnits, prefix)
         return false
     end
 
-    -- see if any templates match the blueprint id
+    -- add the blueprint id that we're hovering over
+    local convertedBlueprintId = ConvertBlueprintId(blueprintId, prefix)
+    local convertedBlueprint = __blueprints[convertedBlueprintId]
+    local templateUnitBlueprintFromId = convertedBlueprint.General.UpgradesFrom
+    local templateUnitBlueprintBaseId = convertedBlueprint.General.UpgradesFromBase
+
+    local validBlueprintId
+    if convertedBlueprint then
+        if buildableUnits[convertedBlueprintId] then
+            validBlueprintId = convertedBlueprintId
+        elseif templateUnitBlueprintFromId and buildableUnits[templateUnitBlueprintFromId] then
+            validBlueprintId = templateUnitBlueprintFromId
+        elseif templateUnitBlueprintBaseId and buildableUnits[templateUnitBlueprintBaseId] then
+            validBlueprintId = templateUnitBlueprintBaseId
+        end
+    end
+
+    if validBlueprintId then
+        SingletonTemplate.Name = LOC(__blueprints[validBlueprintId].Description)
+        SingletonTemplate.TemplateData[3][1] = validBlueprintId
+        TableInsert(ContextBasedTemplates, SingletonTemplate)
+        ContextBasedTemplateCount = ContextBasedTemplateCount + 1
+    end
+
+    -- add templates that match the unit that we're hovering over
     for k = 1, TableGetn(Templates) do
         local template = Templates[k]
         local trigger = template.TriggersOnUnit or template.TriggersOnBuilding
@@ -264,32 +288,6 @@ local function FilterTemplatesByUnitContext(buildableUnits, prefix)
                 TableInsert(ContextBasedTemplates, template)
                 ContextBasedTemplateCount = ContextBasedTemplateCount + 1
             end
-        end
-    end
-
-    -- act like a color picker but then for units, see if there's something useful that we can build
-    if ContextBasedTemplateCount == 0 then
-        local convertedBlueprintId = ConvertBlueprintId(blueprintId, prefix)
-        local convertedBlueprint = __blueprints[convertedBlueprintId]
-        local templateUnitBlueprintFromId = convertedBlueprint.General.UpgradesFrom
-        local templateUnitBlueprintBaseId = convertedBlueprint.General.UpgradesFromBase
-
-        local validBlueprintId
-        if convertedBlueprint then
-            if buildableUnits[convertedBlueprintId] then
-                validBlueprintId = convertedBlueprintId
-            elseif templateUnitBlueprintFromId and buildableUnits[templateUnitBlueprintFromId] then
-                validBlueprintId = templateUnitBlueprintFromId
-            elseif templateUnitBlueprintBaseId and buildableUnits[templateUnitBlueprintBaseId] then
-                validBlueprintId = templateUnitBlueprintBaseId
-            end
-        end
-
-        if validBlueprintId then
-            SingletonTemplate.Name = LOC(__blueprints[validBlueprintId].Description)
-            SingletonTemplate.TemplateData[3][1] = validBlueprintId
-            TableInsert(ContextBasedTemplates, SingletonTemplate)
-            ContextBasedTemplateCount = ContextBasedTemplateCount + 1
         end
     end
 

--- a/lua/ui/game/hotkeys/context-based-templates.lua
+++ b/lua/ui/game/hotkeys/context-based-templates.lua
@@ -232,7 +232,6 @@ local function FilterTemplatesByUnitContext(buildableUnits, prefix)
     -- try and retrieve blueprint id from highlight command
     if not blueprintId then
         local highlightCommand = GetHighlightCommand()
-        reprsl(highlightCommand)
         if highlightCommand and highlightCommand.blueprintId then
             blueprintId = highlightCommand.blueprintId
         end

--- a/units/XEB0204/XEB0204_unit.bp
+++ b/units/XEB0204/XEB0204_unit.bp
@@ -139,6 +139,7 @@ UnitBlueprint{
         SelectionPriority = 5,
         UnitName = "<LOC xeb0204_name>The Kennel",
         UpgradesFrom = "xeb0104",
+        UpgradesFromBase = "xeb0104",
     },
     Intel = { VisionRadius = 14 },
     LifeBarHeight = 0.075,

--- a/units/XRB0204/XRB0204_unit.bp
+++ b/units/XRB0204/XRB0204_unit.bp
@@ -139,6 +139,7 @@ UnitBlueprint{
         ToggleCaps = { RULEUTC_ProductionToggle = true },
         UnitName = "<LOC xrb0204_name>The Hive",
         UpgradesFrom = "xrb0104",
+        UpgradesFromBase = "xrb0104",
         UpgradesTo = "xrb0304",
     },
     Intel = { VisionRadius = 14 },

--- a/units/XRB0304/XRB0304_unit.bp
+++ b/units/XRB0304/XRB0304_unit.bp
@@ -136,6 +136,7 @@ UnitBlueprint{
         ToggleCaps = { RULEUTC_ProductionToggle = true },
         UnitName = "<LOC xrb0304_name>The Hive",
         UpgradesFrom = "xrb0204",
+        UpgradesFromBase = "xrb0104",
     },
     Intel = { VisionRadius = 14 },
     LifeBarHeight = 0.075,


### PR DESCRIPTION
## Description of the proposed changes

Related to [this bug report on Discord](https://discord.com/channels/197033481883222026/1219563479581720577). The bug was that a tech 1 engineer can not create the storage template when trying to cap a tech 2 extractor because the tech 2 extractor would block the template as a tech 1 engineer can't build it. We fix that by trying to build the unit it upgrades from, or by trying to build the unit it originates from.

Next to that we extend the feature by allowing it to act like a color picker - if we're hovering over a unit or a build order and we can't find matching templates then we'll try to enter command mode with a build order for the given unit and/or blueprint order. This is inspired by the featured of @4z0t mentioned on the [forums](https://forum.faforever.com/topic/7351/ctrl-ui-mod).

https://github.com/FAForever/fa/assets/15778155/1b3270b0-dc49-4626-9e9e-b8f6d2efaab9

## Testing done on the proposed changes

Spawning in structures and triggering the hotkey in various conditions.

## Checklist

- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
