### PR TITLE
Add the `UpgradesFromBase` field to the tech 2 mass extractors

### DIFF
--- a/changelog/3805.md
+++ b/changelog/3805.md
@@ -1,0 +1,31 @@
+# Game Version 3805 
+
+## Bug Fixes
+
+- (#6017) Fix a bug that prevents you from upgrading tech 2 mass extractors to tech 3 mass extractors
+
+## Balance
+
+<!-- Remove header when empty -->
+
+## Features
+
+<!-- Remove header when empty -->
+
+## Graphics
+
+<!-- Remove header when empty -->
+
+## AI
+
+<!-- Remove header when empty -->
+
+## Other Changes
+
+<!-- Remove header when empty -->
+
+## Contributors
+
+With thanks to the following people who contributed through coding:
+
+Jip

--- a/changelog/3805.md
+++ b/changelog/3805.md
@@ -1,28 +1,14 @@
 # Game Version 3805 
 
+Fixes various issues that were introduced in the past game versions.
+
+With gratitude to all those who took the time to report issues,
+
+Jip
+
 ## Bug Fixes
 
 - (#6017) Fix a bug that prevents you from upgrading tech 2 mass extractors to tech 3 mass extractors
-
-## Balance
-
-<!-- Remove header when empty -->
-
-## Features
-
-<!-- Remove header when empty -->
-
-## Graphics
-
-<!-- Remove header when empty -->
-
-## AI
-
-<!-- Remove header when empty -->
-
-## Other Changes
-
-<!-- Remove header when empty -->
 
 ## Contributors
 

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -961,7 +961,7 @@
 ---@field UpgradesFrom? UnitId
 --- what unit, if any, this unit can be upgraded to
 ---@field UpgradesTo? UnitId
---- the base unit from which all units in this upgrade chain can be upgraded from
+--- the base unit from which all units in this upgrade chain can be upgraded from. If this field is lacking then the unit may refuse to upgrade even when `UpgradesFrom` and `UpgradesTo` are set
 ---@field UpgradesFromBase? UnitId
 ---
 --- auto-generated field from `CommandCaps`

--- a/lua/ui/game/hotkeys/context-based-templates-data/AppendExtractorWithStorages.lua
+++ b/lua/ui/game/hotkeys/context-based-templates-data/AppendExtractorWithStorages.lua
@@ -23,7 +23,7 @@
 ---@type ContextBasedTemplate
 Template = {
     Name = 'Storages',
-    TriggersOnUnit = (categories.TECH2 + categories.TECH3) * categories.MASSEXTRACTION,
+    TriggersOnUnit = categories.MASSEXTRACTION,
     TemplateSortingOrder = 100,
     TemplateData = {
         6,

--- a/lua/ui/lobby/changelogData.lua
+++ b/lua/ui/lobby/changelogData.lua
@@ -1,8 +1,22 @@
 ---@type number
-last_version = 3804
+last_version = 3805
 
 ---@type PatchNotes[]
 gamePatches = {
+    {
+        version = 3805,
+        name = "Hotfix",
+        hasPrettyGithubRelease = true,
+        description = {
+            "# Game Version 3805 (24th of March, 2024)",
+            "",
+            "Fixes various issues that were introduced in the past game versions.",
+            "",
+            "With gratitude to all those who took the time to report issues,",
+            "",
+            "Jip",
+        }
+    },
     {
         version = 3804,
         name = "Hotfix",

--- a/lua/version.lua
+++ b/lua/version.lua
@@ -1,7 +1,7 @@
 
-local Version = "3804"
----@alias PATCH "3804"
----@alias VERSION "1.5.3804"
+local Version = "3805"
+---@alias PATCH "3805"
+---@alias VERSION "1.5.3805"
 ---@return PATCH
 function GetVersion()
     LOG('Supreme Commander: Forged Alliance version ' .. Version)

--- a/mod_info.lua
+++ b/mod_info.lua
@@ -3,7 +3,7 @@
 -- Documentation for the extended FAF mod_info.lua format can be found here:
 -- https://github.com/FAForever/fa/wiki/mod_info.lua-documentation
 name = "Forged Alliance Forever"
-version = 3804
+version = 3805
 _faf_modname='faf'
 copyright = "Forged Alliance Forever Community"
 description = "Forged Alliance Forever extends Forged Alliance, bringing new patches, game modes, units, ladder, and much more!"

--- a/units/UAB1202/UAB1202_unit.bp
+++ b/units/UAB1202/UAB1202_unit.bp
@@ -105,6 +105,7 @@ UnitBlueprint{
         ToggleCaps = { RULEUTC_ProductionToggle = true },
         UpgradesFrom = "uab1103",
         UpgradesTo = "uab1302",
+        UpgradesFromBase = "uab1103",
     },
     Intel = { VisionRadius = 20 },
     LifeBarHeight = 0.075,

--- a/units/UEB1202/UEB1202_unit.bp
+++ b/units/UEB1202/UEB1202_unit.bp
@@ -107,6 +107,7 @@ UnitBlueprint{
         UnitName = "<LOC ueb1202_name>Mass Pump 2",
         UpgradesFrom = "ueb1103",
         UpgradesTo = "ueb1302",
+        UpgradesFromBase = "ueb1103",
     },
     Intel = { VisionRadius = 20 },
     LifeBarHeight = 0.075,

--- a/units/URB1202/URB1202_unit.bp
+++ b/units/URB1202/URB1202_unit.bp
@@ -103,6 +103,7 @@ UnitBlueprint{
         ToggleCaps = { RULEUTC_ProductionToggle = true },
         UpgradesFrom = "urb1103",
         UpgradesTo = "urb1302",
+        UpgradesFromBase = "urb1103",
     },
     Intel = { VisionRadius = 20 },
     LifeBarHeight = 0.075,

--- a/units/XSB1202/XSB1202_unit.bp
+++ b/units/XSB1202/XSB1202_unit.bp
@@ -110,6 +110,7 @@ UnitBlueprint{
         UnitName = "<LOC xsb1202_name>Hyalatoh",
         UpgradesFrom = "xsb1103",
         UpgradesTo = "xsb1302",
+        UpgradesFromBase = "xsb1103",
     },
     Intel = { VisionRadius = 20 },
     LifeBarHeight = 0.075,


### PR DESCRIPTION
## Description of the proposed changes

Apparently the `UpgradesFromBase` is not just a field that is only read by Lua. It is also read by the engine and it can cancel an upgrade in the simulation. All intermediate units need the same field, which is what was lacking for tech 2 mass extractors because of https://github.com/FAForever/fa/commit/d0009a9b3cd7a71fb487859954a9fd331e105507 .

## Testing done on the proposed changes

Spawn in and/or build extractors and try to upgrade them.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
