### PR TITLE
Fix Seraphim Air Factories being harder to place than other factories

### DIFF
--- a/changelog/3806.md
+++ b/changelog/3806.md
@@ -2,7 +2,7 @@
 
 ## Bug Fixes
 
-<!-- Remove header when empty -->
+- (#6022) Fix a bug, which made Seraphim Air Factories harder to place than other Air Factories.
 
 ## Balance
 
@@ -28,7 +28,7 @@
 
 With thanks to the following people who contributed through coding:
 
-<!-- Remove when empty -->
+- Basilisk3
 
 With thanks to the following people who contributed through binary patches:
 

--- a/units/XSB0102/XSB0102_unit.bp
+++ b/units/XSB0102/XSB0102_unit.bp
@@ -157,7 +157,7 @@ UnitBlueprint{
             LAYER_Water = false,
         },
         DragCoefficient = 0.2,
-        FlattenSkirt = false,
+        FlattenSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 4.25,
         MeshExtentsY = 2.5,

--- a/units/XSB0202/XSB0202_unit.bp
+++ b/units/XSB0202/XSB0202_unit.bp
@@ -154,7 +154,7 @@ UnitBlueprint{
             LAYER_Water = false,
         },
         DragCoefficient = 0.2,
-        FlattenSkirt = false,
+        FlattenSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 5.5,
         MeshExtentsY = 3,

--- a/units/XSB0302/XSB0302_unit.bp
+++ b/units/XSB0302/XSB0302_unit.bp
@@ -158,7 +158,7 @@ UnitBlueprint{
             LAYER_Water = false,
         },
         DragCoefficient = 0.2,
-        FlattenSkirt = false,
+        FlattenSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 6,
         MeshExtentsY = 4,

--- a/units/ZSB9502/ZSB9502_unit.bp
+++ b/units/ZSB9502/ZSB9502_unit.bp
@@ -202,7 +202,7 @@ UnitBlueprint {
             LAYER_Water = false,
         },
         DragCoefficient = 0.2,
-        FlattenSkirt = false,
+        FlattenSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 5.5,
         MeshExtentsY = 3,

--- a/units/ZSB9602/ZSB9602_unit.bp
+++ b/units/ZSB9602/ZSB9602_unit.bp
@@ -196,7 +196,7 @@ UnitBlueprint {
             LAYER_Water = false,
         },
         DragCoefficient = 0.2,
-        FlattenSkirt = false,
+        FlattenSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 6,
         MeshExtentsY = 4,


### PR DESCRIPTION
## Description of the proposed changes

`FlattenSkirt` needs to be set to `true`, as it is for all other Air Factories. Resolves #5460.

## Additinal Context

#4584 set this value to `false`.

## Checklist

- [x] Changes are documented in the changelog for the next game version
