### PR TITLE
Introduce `Deathnuke` armor for ASFs

### DIFF
--- a/changelog/3806.md
+++ b/changelog/3806.md
@@ -2,7 +2,7 @@
 
 ## Bug Fixes
 
-<!-- Remove header when empty -->
+- (#6022) Fix a bug, which made Seraphim Air Factories harder to place than other Air Factories.
 
 ## Balance
 
@@ -28,7 +28,7 @@
 
 With thanks to the following people who contributed through coding:
 
-<!-- Remove when empty -->
+- Basilisk3
 
 With thanks to the following people who contributed through binary patches:
 

--- a/changelog/3806.md
+++ b/changelog/3806.md
@@ -1,0 +1,43 @@
+# Game Version 3806 
+
+## Bug Fixes
+
+<!-- Remove header when empty -->
+
+## Balance
+
+<!-- Remove header when empty -->
+
+## Features
+
+<!-- Remove header when empty -->
+
+## Graphics
+
+<!-- Remove header when empty -->
+
+## AI
+
+<!-- Remove header when empty -->
+
+## Other Changes
+
+<!-- Remove header when empty -->
+
+## Contributors
+
+With thanks to the following people who contributed through coding:
+
+<!-- Remove when empty -->
+
+With thanks to the following people who contributed through binary patches:
+
+<!-- Remove when empty -->
+
+With thanks to the following individuals who contributed through model, texture, and effect changes:
+
+<!-- Remove when empty -->
+
+And, last but certainly not least - with thanks to those that took part in constructive discussions:
+
+<!-- Remove when empty -->

--- a/lua/armordefinition.lua
+++ b/lua/armordefinition.lua
@@ -101,6 +101,7 @@ armordefinition = {
         'Normal 1.0',
         'CzarBeam 0.25',
         'OtheTacticalBomb 0.1',
+        'Deathnuke 0.75',
     },
     {
         -- Armor Type name

--- a/lua/system/dkson.lua
+++ b/lua/system/dkson.lua
@@ -161,9 +161,7 @@ end
 updatedecpoint()
 
 local function num2str (num)
-    return string.format("%.17g", num)
-    -- An overflowing number will return "1.#INF", so we need to get rid of the trailing period.
-    -- return replace(fsub(fsub(tostring(num), numfilter, ""), ".$", ""), decpoint, ".")
+    return replace(fsub(tostring(num), numfilter, ""), decpoint, ".")
 end
 
 local function str2num (str)

--- a/lua/system/dkson.lua
+++ b/lua/system/dkson.lua
@@ -161,7 +161,7 @@ end
 updatedecpoint()
 
 local function num2str (num)
-    return replace(fsub(tostring(num), numfilter, ""), decpoint, ".")
+    return replace(fsub(tostring(num), numfilter, ""), decpoint, ".0")
 end
 
 local function str2num (str)

--- a/lua/version.lua
+++ b/lua/version.lua
@@ -1,7 +1,7 @@
 
-local Version = "3805"
----@alias PATCH "3805"
----@alias VERSION "1.5.3805"
+local Version = "3806"
+---@alias PATCH "3806"
+---@alias VERSION "1.5.3806"
 ---@return PATCH
 function GetVersion()
     LOG('Supreme Commander: Forged Alliance version ' .. Version)

--- a/mod_info.lua
+++ b/mod_info.lua
@@ -3,7 +3,7 @@
 -- Documentation for the extended FAF mod_info.lua format can be found here:
 -- https://github.com/FAForever/fa/wiki/mod_info.lua-documentation
 name = "Forged Alliance Forever"
-version = 3805
+version = 3806
 _faf_modname='faf'
 copyright = "Forged Alliance Forever Community"
 description = "Forged Alliance Forever extends Forged Alliance, bringing new patches, game modes, units, ladder, and much more!"

--- a/units/XSB0102/XSB0102_unit.bp
+++ b/units/XSB0102/XSB0102_unit.bp
@@ -157,7 +157,7 @@ UnitBlueprint{
             LAYER_Water = false,
         },
         DragCoefficient = 0.2,
-        FlattenSkirt = false,
+        FlattenSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 4.25,
         MeshExtentsY = 2.5,

--- a/units/XSB0202/XSB0202_unit.bp
+++ b/units/XSB0202/XSB0202_unit.bp
@@ -154,7 +154,7 @@ UnitBlueprint{
             LAYER_Water = false,
         },
         DragCoefficient = 0.2,
-        FlattenSkirt = false,
+        FlattenSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 5.5,
         MeshExtentsY = 3,

--- a/units/XSB0302/XSB0302_unit.bp
+++ b/units/XSB0302/XSB0302_unit.bp
@@ -158,7 +158,7 @@ UnitBlueprint{
             LAYER_Water = false,
         },
         DragCoefficient = 0.2,
-        FlattenSkirt = false,
+        FlattenSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 6,
         MeshExtentsY = 4,

--- a/units/ZSB9502/ZSB9502_unit.bp
+++ b/units/ZSB9502/ZSB9502_unit.bp
@@ -202,7 +202,7 @@ UnitBlueprint {
             LAYER_Water = false,
         },
         DragCoefficient = 0.2,
-        FlattenSkirt = false,
+        FlattenSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 5.5,
         MeshExtentsY = 3,

--- a/units/ZSB9602/ZSB9602_unit.bp
+++ b/units/ZSB9602/ZSB9602_unit.bp
@@ -196,7 +196,7 @@ UnitBlueprint {
             LAYER_Water = false,
         },
         DragCoefficient = 0.2,
-        FlattenSkirt = false,
+        FlattenSkirt = true,
         MaxSteerForce = 0,
         MeshExtentsX = 6,
         MeshExtentsY = 4,


### PR DESCRIPTION
## Description of the proposed changes

All ASFs: `Deathnuke` armor introduced (ASFs take 25% less damage from ACU explosions)

## Additional context
Due to #5465, bombing ASFs with ACU explosions has become even more powerful, as they are now more expensive but remain under the threshold of 2500 hit points to survive the explosion.

## Checklist

- [ ] Changes are documented in the changelog for the next game version
