### PR TITLE
Fix lingering build queue icons

### DIFF
--- a/changelog/3806.md
+++ b/changelog/3806.md
@@ -2,7 +2,11 @@
 
 ## Bug Fixes
 
-- (#6022) Fix a bug, which made Seraphim Air Factories harder to place than other Air Factories.
+- (#6022) Fix a bug where the Seraphim Air Factories are more sensitive to the terrain than the air factories of other factions.
+
+- (#6026) Fix a bug where the build icons of the build queues of units would randomly pop up on screen when observing and/or watching a replay.
+
+- ([#73](https://github.com/FAForever/FA-Binary-Patches/pull/73)) Fix a memory leak where weak tables are not being garbage collected
 
 ## Balance
 
@@ -29,10 +33,11 @@
 With thanks to the following people who contributed through coding:
 
 - Basilisk3
+- Jip
 
 With thanks to the following people who contributed through binary patches:
 
-<!-- Remove when empty -->
+- 4z0t
 
 With thanks to the following individuals who contributed through model, texture, and effect changes:
 

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -468,6 +468,8 @@ do
 
         if oldBuildQueueOfUnit then
             SetCurrentFactoryForQueueDisplay(oldBuildQueueOfUnit)
+        else
+            ClearCurrentFactoryForQueueDisplay()
         end
 
         return queue


### PR DESCRIPTION
## Description of the proposed changes

When you observe a game and/or run a replay the unit to watch the build queue of would not be cleared out properly. As a result you'd randomly see build icons pop up where the construction menu is.

Introduced by: #5761

## Testing done on the proposed changes

Run a game as an observer, see if `construction.lua/SetSecondaryDisplay` is called or not. It should not be called when you're an observer and your focus army is -1.

## Checklist

- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
