### PR TITLE
Various smaller fixes for unitviewDetail.lua

### DIFF
--- a/changelog/3807.md
+++ b/changelog/3807.md
@@ -22,7 +22,7 @@
 
 ## Other Changes
 
-- (#6018) Various smaller improvements to the additional unit details displayed when `Show Armament Detail in Build Menu` is enabled in the settings.
+- (#6037) Various smaller improvements to the additional unit details displayed when `Show Armament Detail in Build Menu` is enabled in the settings.
 
 ## Contributors
 

--- a/changelog/3807.md
+++ b/changelog/3807.md
@@ -22,13 +22,13 @@
 
 ## Other Changes
 
-<!-- Remove header when empty -->
+- (#6018) Various smaller improvements to the additional unit details displayed when `Show Armament Detail in Build Menu` is enabled in the settings.
 
 ## Contributors
 
 With thanks to the following people who contributed through coding:
 
-<!-- Remove when empty -->
+- Basilisk3
 
 With thanks to the following people who contributed through binary patches:
 

--- a/loc/US/strings_db.lua
+++ b/loc/US/strings_db.lua
@@ -6760,6 +6760,7 @@ uvd_0012="Speed: %0.1f, Reverse: %0.1f, Acceleration: %0.1f, Turning: %d"
 uvd_0013="Vision: %d, Underwater Vision: %d, Regen: %0.1f, Cap Cost: %0.1f"
 uvd_0014="Damage: %.8g - %.8g, Splash: %.3g - %.3g"
 uvd_0015="Damage: %.8g x%d, Splash: %.3g"
+uvd_0016="Enhancements: %d"
 
 uvd_DPS="(DPS: %d)"
 uvd_ManualFire="(Manual Fire)"

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -399,7 +399,7 @@ GetAbilityDesc = {
             if v.RemoveEnhancements or (not v.Slot) then continue end
             cnt = cnt + 1
         end
-        return cnt
+        return LOCF('<LOC uvd_0016>Enhancements: %d', cnt)
     end,
     ability_massive = function(bp)
         return string.format(LOC('<LOC uvd_0010>Damage: %.7g, Splash: %.3g'),
@@ -639,17 +639,25 @@ function WrapAndPlaceText(bp, builder, descID, control)
                             end
 
                             -- Avoid saying a unit fires a salvo when it in fact has a constant rate of fire
-                            if singleShot and ReloadTime == 0 then
+                            if singleShot and ReloadTime == 0 and CycleProjs > 1 then
                                 CycleTime = CycleTime / CycleProjs
                                 CycleProjs = 1
                             end
 
                             if CycleProjs > 1 then
-                                 weaponDetails2 = string.format(LOC('<LOC uvd_0015>Damage: %.8g x%d, Splash: %.3g')..', '..LOC('<LOC uvd_Range>')..', '..LOC('<LOC uvd_Reload>'),
-                                    Damage, CycleProjs, info.DamageRadius, info.MinRadius, info.MaxRadius, CycleTime)
+                                weaponDetails2 = string.format(LOC('<LOC uvd_0015>Damage: %.8g x%d, Splash: %.3g')..', '..LOC('<LOC uvd_Range>')..', '..LOC('<LOC uvd_Reload>'),
+                                Damage, CycleProjs, info.DamageRadius, info.MinRadius, info.MaxRadius, CycleTime)
+                            -- Do not display Reload stats for Kamikaze weapons
+                            elseif info.WeaponCategory == 'Kamikaze' then
+                                weaponDetails2 = string.format(LOC('<LOC uvd_0010>Damage: %.7g, Splash: %.3g')..', '..LOC('<LOC uvd_Range>'),
+                                Damage, info.DamageRadius, info.MinRadius, info.MaxRadius)
+                            -- Do not display 'Range' and Reload stats for 'Teleport in' weapons
+                            elseif info.WeaponCategory == 'Teleport' then
+                                weaponDetails2 = string.format(LOC('<LOC uvd_0010>Damage: %.7g, Splash: %.3g'),
+                                Damage, info.DamageRadius)
                             else
                                 weaponDetails2 = string.format(LOC('<LOC uvd_0010>Damage: %.7g, Splash: %.3g')..', '..LOC('<LOC uvd_Range>')..', '..LOC('<LOC uvd_Reload>'),
-                                    Damage, info.DamageRadius, info.MinRadius, info.MaxRadius, CycleTime)
+                                Damage, info.DamageRadius, info.MinRadius, info.MaxRadius, CycleTime)
                             end
 
 
@@ -658,7 +666,14 @@ function WrapAndPlaceText(bp, builder, descID, control)
                             weaponDetails1 = weaponDetails1..' x'..weapon.count
                         end
                         table.insert(blocks, {color = UIUtil.fontColor, lines = {weaponDetails1}})
-                        table.insert(blocks, {color = 'FFFFB0B0', lines = {weaponDetails2}})
+
+                        if info.DamageType == 'Overcharge' then
+                            table.insert(blocks, {color = 'FF5AB34B', lines = {weaponDetails2}}) -- Same color as auto-overcharge highlight (autocast_green.dds)
+                        elseif info.WeaponCategory == 'Kamikaze' then
+                            table.insert(blocks, {color = 'FFFF2C2C', lines = {weaponDetails2}})
+                        else
+                            table.insert(blocks, {color = 'FFFFB0B0', lines = {weaponDetails2}})
+                        end
 
                         if info.EnergyRequired > 0 and info.EnergyDrainPerSecond > 0 then
                             local weaponDetails3 = string.format('Charge Cost: -%d E (-%d E/s)', info.EnergyRequired, info.EnergyDrainPerSecond)

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -632,7 +632,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                 CycleTime = CycleTime + FiringCooldown
                             end
 
-                            if not info.ManualFire and info.WeaponCategory ~= 'Kamikaze' and info.RangeCategory ~= 'UWRC_Countermeasure' then
+                            if not info.ManualFire and info.WeaponCategory ~= 'Kamikaze' and info.WeaponCategory ~= 'Defense' then
                                 --Round DPS, or else it gets floored in string.format.
                                 local DPS = MATH_IRound(Damage * CycleProjs / CycleTime)
                                 weaponDetails1 = weaponDetails1..LOCF('<LOC uvd_DPS>', DPS)

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -632,7 +632,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                 CycleTime = CycleTime + FiringCooldown
                             end
 
-                            if not info.ManualFire and info.WeaponCategory ~= 'Kamikaze' then
+                            if not info.ManualFire and info.WeaponCategory ~= 'Kamikaze' and info.RangeCategory ~= 'UWRC_Countermeasure' then
                                 --Round DPS, or else it gets floored in string.format.
                                 local DPS = MATH_IRound(Damage * CycleProjs / CycleTime)
                                 weaponDetails1 = weaponDetails1..LOCF('<LOC uvd_DPS>', DPS)

--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -1065,6 +1065,7 @@ UnitBlueprint{
             DamageType = "Normal",
             DisplayName = "Teleport in",
             DummyWeapon = true,
+            EnabledByEnhancement = "Teleporter",
             Label = "TeleportWeapon",
             ManualFire = true,
             MaxRadius = 1,

--- a/units/UAL0301/UAL0301_unit.bp
+++ b/units/UAL0301/UAL0301_unit.bp
@@ -698,6 +698,7 @@ UnitBlueprint{
             DamageType = "Normal",
             DisplayName = "Teleport in",
             DummyWeapon = true,
+            EnabledByEnhancement = "Teleporter",
             Label = "TeleportWeapon",
             ManualFire = true,
             MaxRadius = 1,

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -1129,6 +1129,7 @@ UnitBlueprint {
             DamageType = "Normal",
             DisplayName = "Teleport in",
             DummyWeapon = true,
+            EnabledByEnhancement = "Teleporter",
             Label = "TeleportWeapon",
             ManualFire = true,
             MaxRadius = 1,

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -1053,6 +1053,7 @@ UnitBlueprint{
             DamageType = "Normal",
             DisplayName = "Teleport in",
             DummyWeapon = true,
+            EnabledByEnhancement = "Teleporter",
             Label = "TeleportWeapon",
             ManualFire = true,
             MaxRadius = 1,

--- a/units/XSL0301/XSL0301_unit.bp
+++ b/units/XSL0301/XSL0301_unit.bp
@@ -903,6 +903,7 @@ UnitBlueprint{
             DamageType = "Normal",
             DisplayName = "Teleport in",
             DummyWeapon = true,
+            EnabledByEnhancement = "Teleporter",
             Label = "TeleportWeapon",
             ManualFire = true,
             MaxRadius = 1,


### PR DESCRIPTION
## Description of the proposed changes

**1. The `Range` and `Reload` stats should not be displayed for `Teleport in` weapons, as they do not make sense here. Also remove the `Reload` stat from `Kamikaze` weapons.**

The old output for `Teleport in` weapons:

```
Teleport in (Teleport) (Manual Fire)
Damage: 100, Splash: 4, Range: 0 - 1, Reload: 1.$
```

The new output for `Teleport in` weapons:

```
Teleport in (Teleport) (Manual Fire)
Damage: 100, Splash: 4
```

**2. Move the `Teleport in` weapons of Personal Teleporters to `Upgrades`, as this form of damage is only accessible via the enhancement after the initial gate-in.**

**3. Clarify the number of available enhancements.**

**4. Change the color of the DamageType `Overcharge` to green; change the color of Kamikaze weapons to a deeper shade of red.**

**5. Exclude countermeasures like Torpedo and Missile Defenses from DPS calculations**

## Additional context

Concerning the `Teleport in` damage: Technically `Damage: 100` is wrong, it does 101 damage.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
