### PR TITLE
Re-Open "Make veterancy requirements equal for presets and SACUs

### DIFF
--- a/changelog/3807.md
+++ b/changelog/3807.md
@@ -6,7 +6,9 @@
 
 ## Balance
 
-<!-- Remove header when empty -->
+- (#6040) Make veterancy requirements equal for presets and normal SACUs
+
+Previously, the cost of enhancements for an SACU preset was added to the veterancy requirement of the unit, making it much harder to gain veterancy with them than manually upgraded SACUs.
 
 ## Features
 
@@ -28,7 +30,7 @@
 
 With thanks to the following people who contributed through coding:
 
-<!-- Remove when empty -->
+- lL1l1
 
 With thanks to the following people who contributed through binary patches:
 

--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -676,6 +676,12 @@ function HandleUnitWithBuildPresets(bps, all_bps)
             tempBp.Economy.BuildCostMass = preset.BuildCostMassOverride or (tempBp.Economy.BuildCostMass + m)
             tempBp.Economy.BuildTime = preset.BuildTimeOverride or (tempBp.Economy.BuildTime + t)
 
+            -- adjust veterancy so that it is as easy to vet with preset SCUs as upgraded SCUs
+            if not bp.VeteranMass then
+                -- blueprints-units.lua gives a default multiplier of 2 for SUBCOMMANDER category units.
+                tempBp.VeteranMassMult = (tempBp.VeteranMassMult or 2) * bp.Economy.BuildCostMass / tempBp.Economy.BuildCostMass
+            end
+
             -- teleport cost adjustments. Manually enhanced SCU with teleport is cheaper than a prebuild SCU because the latter has its cost
             -- adjusted (up). This code sets bp values used in the code to calculate with different base values than the unit cost.
             if preset.TeleportNoCostAdjustment ~= false then

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -482,7 +482,7 @@ function UpdateWindow(info)
                         elseif upperThreshold >= 10000 then
                             text = string.format('%.1fK/%.1fK', experience / 1000, upperThreshold / 1000)
                         else
-                            text = experience .. '/' .. upperThreshold
+                            text = experience .. '/' .. string.format('%d', upperThreshold)
                         end
                         controls.nextVet:SetText(text)
 


### PR DESCRIPTION
## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Re-opens #5730 except pointed at `fafdevelop` since `fafbeta` is no longer used, and this change wasn't explicitly denied, so I assume it got lost in that transition of no longer using `fafbeta`.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
