### PR TITLE
Fix custom data in game.prefs breaking Notify management window

### DIFF
--- a/changelog/3807.md
+++ b/changelog/3807.md
@@ -2,7 +2,7 @@
 
 ## Bug Fixes
 
-<!-- Remove header when empty -->
+- (#6044) Fix Seraphim experimentals not appearing in the Notify settings window in normal games after having played Nomads.
 
 ## Balance
 

--- a/lua/ui/notify/customiser.lua
+++ b/lua/ui/notify/customiser.lua
@@ -827,6 +827,7 @@ function FormatData()
             LineGroups[category].collapsed = linesCollapsed
 
             for source, message in data do
+                if not clarityTable[source] then continue end
                 local messageLine = {
                     source = source,
                     category = category,

--- a/lua/ui/notify/customiser.lua
+++ b/lua/ui/notify/customiser.lua
@@ -827,7 +827,9 @@ function FormatData()
             LineGroups[category].collapsed = linesCollapsed
 
             for source, message in data do
+                -- Will break customiser if alias from `clarityTable` is nil
                 if not clarityTable[source] then continue end
+
                 local messageLine = {
                     source = source,
                     category = category,


### PR DESCRIPTION
## Description of the proposed changes
Fixes a Discord bug report [(Notify menu missing Seraphim T4)](https://discord.com/channels/197033481883222026/1224605381116956762) by adding a nil check.
### Cause: 
Nomads makes Notify save the following data in `game.prefs`:
```lua
Notify_Messages_ESC = {
  ...
  experimentals = {
    ...
    xnl0401 = '\\u41\\u74\\u6C\\u61\\u73',
    xna0403 = '\\u43\\u72\\u61\\u77\\u6C\\u65\\u72',
    xnl0402 = '\\u42\\u65\\u61\\u6D\\u65\\u72',
  },
  ...
},
```
When back in FA, Notify fails to create the setting lines past the Novax line for the experimentals tab in the "Notify Management" window because it fails to find an alias for the Nomads blueprint ids from ClarityTable. This could be solved by adding the data to the `defaultmessages.lua` file (Nomads does), but then the Nomads experimentals would appear as options despite the units not being in the current session, so I opted for a nil check instead.

## Testing done on the proposed changes
Add the data into my game.prefs, and go to the in-game menu -> Notify Management -> Experimentals window. All the FA experimentals display correctly and you can scroll down if you open more tabs.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
