### PR TITLE
Annotation fixes

### DIFF
--- a/engine/Patches.lua
+++ b/engine/Patches.lua
@@ -1,3 +1,4 @@
+---@diagnostic disable: undefined-global
 -- Info about exe patches and new lua<->engine functions
 
 -- sim version of GetStat(). Awesome function as it already sends a string, integer and unit object to engine +

--- a/engine/Sim/CAiBrain.lua
+++ b/engine/Sim/CAiBrain.lua
@@ -45,7 +45,7 @@ end
 ---@param builder Unit
 ---@param blueprintID UnitId
 ---@param buildLocation Vector
----@param buildRelative boolean if true, the location is used as an offset to the builders current location
+---@param buildRelative? boolean if true, the location is used as an offset to the builders current location
 function CAiBrain:BuildStructure(builder, blueprintID, buildLocation, buildRelative)
 end
 
@@ -138,7 +138,7 @@ end
 --- points in the template are used.
 ---
 ---@param type          string
----@param structureName filename # blueprint file
+---@param structureName FileName # blueprint file
 ---@param buildingTypes BuildingTemplate[]
 ---@param relative      boolean
 ---@param builder       Unit
@@ -289,8 +289,8 @@ end
 --- ..........   ....xxx...
 --- ..........   ..........
 ---@param restriction boolean
----@param threatType BrainThreatType
----@param armyIndex number defaults to use all enemy armies.
+---@param threatType? BrainThreatType
+---@param armyIndex? number defaults to use all enemy armies.
 ---@return Vector
 ---@return number
 function CAiBrain:GetHighestThreatPosition(ring, restriction, threatType, armyIndex)
@@ -356,7 +356,7 @@ end
 ---@param position Vector
 ---@param radius number in game units
 ---@param restriction boolean
----@param threatType BrainThreatType
+---@param threatType? BrainThreatType
 ---@param armyIndex? number defaults to this brain's index
 ---@return number
 function CAiBrain:GetThreatAtPosition(position, radius, restriction, threatType, armyIndex)

--- a/engine/Sim/CPlatoon.lua
+++ b/engine/Sim/CPlatoon.lua
@@ -20,7 +20,7 @@ end
 --- Orders platoon to attack mote to target position..
 -- If squad is specified, attack moves only with the squad.
 ---@param position Vector Table with position {x, y, z}.
----@param squad PlatoonSquadType?
+---@param squad? PlatoonSquadType
 ---@return PlatoonCommand
 function CPlatoon:AggressiveMoveToLocation(position, squad)
 end
@@ -252,7 +252,7 @@ end
 --- Orders platoon to patrol at target position.
 -- If squad is specified, patrols only with the squad.
 ---@param position Vector Table with position {x, y, z}.
----@param squad PlatoonSquadType
+---@param squad? PlatoonSquadType
 ---@return PlatoonCommand
 function CPlatoon:Patrol(position, squad)
 end

--- a/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
+++ b/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
@@ -755,7 +755,7 @@ function ExpansionEngineer(platoon)
     end
 end
 
---- Guts of the build thing
+---@param brain AIBrain
 ---@param platoon Platoon
 function ExpansionPlatoonDestroyed(brain, platoon)
     local aiBrain = platoon:GetBrain()

--- a/lua/AI/OpAI/BomberEscort_EditorFunctions.lua
+++ b/lua/AI/OpAI/BomberEscort_EditorFunctions.lua
@@ -82,7 +82,7 @@ end
 ---@param platoon Platoon
 function BomberEscortAI(platoon)
     local aiBrain = platoon:GetBrain()
-    local target = false
+    local target
     --local cmd = false
     while aiBrain:PlatoonExists(platoon) do
         target = false

--- a/lua/AI/OpAI/ReactiveAI.lua
+++ b/lua/AI/OpAI/ReactiveAI.lua
@@ -44,9 +44,11 @@ TrackingCategories = {
 }
 
 ---@class ReactiveAI : OpAI
+---@field ReactionData table
+---@field GetBuilderType function
 ReactiveAI = Class(OpAI) {
 
-    ---@param self OpAI
+    ---@param self ReactiveAI
     ---@param brain AIBrain
     ---@param location Vector
     ---@param triggeringEventType any
@@ -188,7 +190,7 @@ ReactiveAI = Class(OpAI) {
     GetBuilderData = function( self, builderData, typeData, builderType, triggeringEventType, reactionType )
     end,
 
-    ---@param self OpAI
+    ---@param self ReactiveAI
     ---@param triggeringEventType any
     ---@param reactionType any
     ---@return any

--- a/lua/AI/aiutilities.lua
+++ b/lua/AI/aiutilities.lua
@@ -889,7 +889,7 @@ end
 ---@param markerType MarkerType
 ---@param startX Vector
 ---@param startZ Vector
----@param extraTypes string
+---@param extraTypes? string
 ---@return unknown
 ---@return unknown
 function AIGetClosestMarkerLocation(aiBrain, markerType, startX, startZ, extraTypes)
@@ -1306,13 +1306,13 @@ function GetUnitBaseStructureVector(unit)
 end
 
 ---@param aiBrain AIBrain
----@param category string
+---@param category EntityCategory
 ---@param location Vector
 ---@param radius number
----@param min number
----@param max number
----@param rings number
----@param tType string
+---@param min? number
+---@param max? number
+---@param rings? number
+---@param tType? string
 ---@return table
 function GetOwnUnitsAroundPoint(aiBrain, category, location, radius, min, max, rings, tType)
     local units = aiBrain:GetUnitsAroundPoint(category, location, radius, 'Ally')
@@ -1748,7 +1748,7 @@ end
 ---@param units Unit[]
 ---@param transports AirUnit[]
 ---@param location Vector
----@param transportPlatoon Platoon
+---@param transportPlatoon? Platoon
 ---@return boolean
 function UseTransports(units, transports, location, transportPlatoon)
     local aiBrain

--- a/lua/AI/sorianutilities.lua
+++ b/lua/AI/sorianutilities.lua
@@ -712,7 +712,7 @@ end
 ---     - Launch Time: ~3 seconds
 ---@param platoon Platoon
 ---@param target Unit
----@return boolean
+---@return Vector
 function LeadTarget(platoon, target)
     -- Get launcher and target position
     local LauncherPos = platoon:GetPlatoonPosition()
@@ -822,7 +822,7 @@ function LeadTarget(platoon, target)
         return false
     end
     -- return extrapolated target position / missile impact coordinates
-    return {MissileImpactX, Target2SecPos[2], MissileImpactY}
+    return Vector(MissileImpactX, Target2SecPos[2], MissileImpactY)
 end
 
 --- Checks to see if there is terrain blocking a unit from hiting a target.

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -25,6 +25,7 @@ local CoroutineYield = coroutine.yield
 ---@field TargetAIBrain AIBrain
 
 ---@class PlatoonTable
+---@field PlatoonTemplate string
 ---@alias AIResult "defeat" | "draw" | "victor"
 ---@alias HqTech "TECH2" | "TECH3"
 ---@alias HqLayer "AIR" | "LAND" | "NAVY"
@@ -547,6 +548,13 @@ local CategoriesDummyUnit = categories.DUMMYUNIT
 ---@field UnitBuiltTriggerList table
 ---@field PingCallbackList { CallbackFunction: fun(pingData: any), PingType: string }[]
 ---@field BrainType 'Human' | 'AI'
+---@field BaseTemplates table
+---@field BaseManagers table
+---@field AttackData table
+---@field AttackManager table
+---@field BuilderManagers table
+---@field IntelData table
+---@field PBM table
 AIBrain = Class(AIBrainHQComponent, AIBrainStatisticsComponent, AIBrainJammerComponent, AIBrainEnergyComponent,
     moho.aibrain_methods) {
 

--- a/lua/aibrains/campaign-ai.lua
+++ b/lua/aibrains/campaign-ai.lua
@@ -13,6 +13,12 @@ local StandardBrain = import("/lua/aibrain.lua").AIBrain
 --- brain is a 'blunt' copy of the functionality that is required to run various campaign maps.
 ---@class CampaignAIBrain: AIBrain
 ---@field PBM AiPlatoonBuildManager
+---@field AIPlansList table
+---@field LayerPref string
+---@field ConstantEval boolean
+---@field CurrentPlan string
+---@field RepeatExecution boolean
+---@field CurrentPlanScript table
 AIBrain = Class(StandardBrain) {
 
     --- Called after `SetupSession` but before `BeginSession` - no initial units, props or resources exist at this point
@@ -45,7 +51,7 @@ AIBrain = Class(StandardBrain) {
 
     --- Called after `SetupSession` but before `BeginSession` - no initial units, props or resources exist at this point
     ---@param self CampaignAIBrain
-    ---@param planName string
+    ---@param planName FileName
     CreateBrainShared = function(self, planName)
         StandardBrain.CreateBrainShared(self, planName)
 
@@ -902,7 +908,7 @@ AIBrain = Class(StandardBrain) {
     --- IF either is nil, then it will do the other.
     --- This way you can remove all of one type or all of one rectangle
     ---@param self CampaignAIBrain
-    ---@param loc Vector
+    ---@param loc? Vector
     ---@param locType string
     PBMRemoveBuildLocation = function(self, loc, locType)
         for k, v in self.PBM.Locations do

--- a/lua/editor/BaseManagerBuildConditions.lua
+++ b/lua/editor/BaseManagerBuildConditions.lua
@@ -258,7 +258,7 @@ end
 
 ---@param aiBrain AIBrain
 ---@param baseName string
----@param catTable string
+---@param catTable table
 ---@return boolean
 function CategoriesBeingBuilt(aiBrain, baseName, catTable)
     if not aiBrain.BaseManagers[baseName] then

--- a/lua/sim/CategoryUtils.lua
+++ b/lua/sim/CategoryUtils.lua
@@ -23,12 +23,18 @@ function ParseEntityCategoryProperly(categoryExpression)
 
     -- Map operator tokens to their corresponding functions: used for building the category set.
     local OPERATOR_FUNCTIONS = {
+        ---@param a EntityCategory
+        ---@param b EntityCategory
         ["-"] = function(a, b)
             return a - b
         end,
+        ---@param a EntityCategory
+        ---@param b EntityCategory
         ["+"] = function(a, b)
             return a + b
         end,
+        ---@param a EntityCategory
+        ---@param b EntityCategory
         ["*"] = function(a, b)
             return a * b
         end,
@@ -95,6 +101,7 @@ function ParseEntityCategoryProperly(categoryExpression)
 
     --- Given two categories and an operator token, return the result of applying the operator to
     -- the two categories (in the order given)
+    ---@return EntityCategory | nil
     local function mergeCategories(currentCategory, newCategory, operator)
         -- Initialization case.
         if not operator and not currentCategory then
@@ -111,6 +118,7 @@ function ParseEntityCategoryProperly(categoryExpression)
 
     -- Parsing time. Since Lua-operators on category objects work correctly, we simply have to
     -- translate the expression we have into those as we go along.
+    ---@return EntityCategory | nil
     local function _parseSubexpression(start, finish)
         local currentCategory = nil
 

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -1069,8 +1069,8 @@ end
 ---Creates the specified group in game.
 ---@param strArmy string
 ---@param strGroup string
----@param wreckage Wreckage
----@param balance number
+---@param wreckage? boolean
+---@param balance? number
 ---@return Unit[]|nil
 ---@return table|nil
 ---@return Platoon[]|nil

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -113,6 +113,7 @@ local cUnitGetBuildRate = cUnit.GetBuildRate
 ---@field Brain AIBrain
 ---@field buildBots? Unit[]
 ---@field Blueprint UnitBlueprint
+---@field UnitName string
 ---@field BuildEffectsBag TrashBag
 ---@field BuildArmManipulator? moho.BuilderArmManipulator
 ---@field Trash TrashBag
@@ -138,6 +139,9 @@ local cUnitGetBuildRate = cUnit.GetBuildRate
 ---@field SiloProjectile? ProjectileBlueprint
 ---@field ReclaimTimeMultiplier? number
 ---@field CaptureTimeMultiplier? number
+---@field BaseName string
+---@field CDRData table
+---@field PlatoonData table
 Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
 
     IsUnit = true,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -113,7 +113,7 @@ local cUnitGetBuildRate = cUnit.GetBuildRate
 ---@field Brain AIBrain
 ---@field buildBots? Unit[]
 ---@field Blueprint UnitBlueprint
----@field UnitName string
+---@field UnitName? string
 ---@field BuildEffectsBag TrashBag
 ---@field BuildArmManipulator? moho.BuilderArmManipulator
 ---@field Trash TrashBag
@@ -139,9 +139,9 @@ local cUnitGetBuildRate = cUnit.GetBuildRate
 ---@field SiloProjectile? ProjectileBlueprint
 ---@field ReclaimTimeMultiplier? number
 ---@field CaptureTimeMultiplier? number
----@field BaseName string
----@field CDRData table
----@field PlatoonData table
+---@field BaseName? string
+---@field CDRData? table
+---@field PlatoonData? table
 Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
 
     IsUnit = true,


### PR DESCRIPTION
Goal: It would be nice for the warnings given by the lua language server to be more limited and useful, instead of everywhere, all the time.

This is a test run for eliminating warnings through annotation fixes. In some cases functions have been moved around, or nil checks have been added. Logic has otherwise not been modified.

For the largest commit (for eliminating warnings in the BaseManager files), the other modified files contained functions or classes where annotation fixes have eliminated warnings.

The warnings that are left are (in theory) the real ones--deprecated functions, junky code, etc. I want to make sure I'm on the right track before chiseling away at this more.