### PR TITLE
Reduce radius of area reclaim commands

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -730,7 +730,6 @@ do
         local queue = unit:GetCommandQueue()
         local lastCommand = queue[table.getn(queue)]
 
-        reprsl(lastCommand)
         if not (lastCommand and lastCommand.commandType == 19 and lastCommand.target) then
             return
         end

--- a/lua/sim/commands/area-reclaim-order.lua
+++ b/lua/sim/commands/area-reclaim-order.lua
@@ -86,11 +86,7 @@ end
 ---@param target Prop
 ---@param doPrint boolean
 local function ReclaimNearbyProps (units, target, doPrint)
-    local radius = 1.5
-    if target.IsTreeGroup then
-        radius = 0.1
-    end
-
+    local radius = 1.0
     local px, _, pz = target:GetPositionXYZ()
     local adjacentReclaim = GetReclaimablesInRect(px - radius, pz - radius, px + radius, pz + radius)
     local processed = 0
@@ -98,7 +94,12 @@ local function ReclaimNearbyProps (units, target, doPrint)
     if adjacentReclaim then
         for k = 1, TableGetn(adjacentReclaim) do
             local entity = adjacentReclaim[k] --[[@as Prop]]
-            if target != entity and IsProp(entity) and entity.MaxMassReclaim > 0 and (entity.IsTree == target.IsTree) then
+            local ex, _, ez = entity:GetPositionXYZ()
+            if target != entity and IsProp(entity) and
+                entity.MaxMassReclaim > 0 and
+                entity.IsTree == target.IsTree and
+                VDist2(px, pz, ex, ez) <= radius
+            then
                 IssueReclaim(units, entity)
                 processed = processed + 1
             end


### PR DESCRIPTION
## Description of the proposed changes

Extension of https://github.com/FAForever/fa/pull/6049

Units have a maximum command queue of 501 commands. By reducing the area we can drastically limit the number of commands issued and therefore increase the amount of clicks required to reach the limit.

## Checklist

- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
