### PR TITLE
AI - Remove blueprint threat rounding

### DIFF
--- a/lua/system/blueprints-ai.lua
+++ b/lua/system/blueprints-ai.lua
@@ -269,16 +269,6 @@ function SetUnitThreatValues(unitBPs)
             end
         end
 
-        -- Sanitise the table
-        for i, v in cache do
-            -- Round appropriately
-            if v < 1 then
-                cache[i] = 0
-            else
-                cache[i] = MathFloor(v + 0.5)
-            end
-        end
-
         -- transfer information to blueprint table
         for k, v in cache do
             bp.Defense[k] = v


### PR DESCRIPTION
Description of changes

This PR removes the threat rounding within the blueprints-ai.lua file. It was found to have two issues. One is that any unit that produced a less than 1 threat value would get set to zero. It would drop unit threat for some units and increase for others causing increased variation for units with slight differences in threat levels depending on if that were below or above 0.5.

Testing method
Use the AI blueprint utility window to verify threat numbers that are being generated.
