### PR TITLE
Introduce `Deathnuke` armor for ASFs

### DIFF
--- a/lua/armordefinition.lua
+++ b/lua/armordefinition.lua
@@ -101,6 +101,7 @@ armordefinition = {
         'Normal 1.0',
         'CzarBeam 0.25',
         'OtheTacticalBomb 0.1',
+        'Deathnuke 0.75',
     },
     {
         -- Armor Type name


### PR DESCRIPTION
## Description of the proposed changes

All ASFs: `Deathnuke` armor introduced (ASFs take 25% less damage from ACU explosions)

## Additional context
Due to #5465, bombing ASFs with ACU explosions has become even more powerful, as they are now more expensive but remain under the threshold of 2500 hit points to survive the explosion.

## Checklist

- [ ] Changes are documented in the changelog for the next game version
