### PR TITLE
Log re-added achievement values at end of game only

### DIFF
--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -7,34 +7,34 @@ local ArmyScore = {}
 local scoreOption = ScenarioInfo.Options.Score or "no"
 scoreData = {interval = historyInterval, current = ArmyScore, history = {}, focusArmyIndex = 0}
 
--- Some of these values pre-existed and are used in other places, that's why their naming is not consistent
--- The 'kills', 'built', and 'loss' stats for each category are updated for each army during the game and synced to 'Sync.Score'
+-- Some of these values pre-existed and are used in other places, that's why their naming is not consistent. Mainly in `hotstats.lua` `info_dialog` table
+-- The 'kills', 'built', and 'loss' stats for each category are updated for each human army during the game
+-- and synced to 'Sync.Score' if the user is an observer, in a replay, or score is enabled.
 local categoriesToCollect = {
     land = categories.LAND,
     air = categories.AIR,
     naval = categories.NAVAL,
     cdr = categories.COMMAND,
+    experimental = categories.EXPERIMENTAL,
+    structures = categories.STRUCTURE,
+}
+
+-- Format specifications for achievements: https://github.com/FAForever/fa/issues/5813
+-- Unit categories used in achievements: `def _category_stats` in https://github.com/FAForever/server/blob/develop/server/stats/game_stats_service.py
+-- Unit IDs used for unit categories: https://github.com/FAForever/server/blob/develop/server/stats/unit.py
+
+-- The 'kills', 'built', and 'loss' stats for each category are checked for each army at the end of the game
+local categoriesForAchievements = {
+    transportation = categories.TRANSPORTATION, 
     sacu = categories.SUBCOMMANDER,
+    -- Tracked by FAF server events but doesn't increment any achievements
     engineer = categories.ENGINEER,
     tech1 = categories.TECH1,
     tech2 = categories.TECH2,
     tech3 = categories.TECH3,
-    experimental = categories.EXPERIMENTAL,
-    structures = categories.STRUCTURE,
-    transportation = categories.TRANSPORTATION
 }
 
--- Format specifications for achievements: https://github.com/FAForever/fa/issues/5813
--- Unit categories used in achievements: https://github.com/FAForever/server/blob/develop/server/stats/game_stats_service.py
--- Unit IDs used for unit categories: https://github.com/FAForever/server/blob/develop/server/stats/unit.py
-
--- The 'kills', 'built', and 'loss' stats for each category are checked for each army at the end of the game_stats_service
-local categoriesForAchievements = {
-    transportation = categories.TRANSPORTATION, 
-    sacu = categories.SUBCOMMANDER,
-}
-
--- The stats for these units are checked for each army at the end of the game.
+-- The stats for these units are checked for each army at the end of the game
 -- They can have custom stats on top of the 3 standard ones.
 local unitIdsForAchievements = {
     -- ACUs

--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -20,6 +20,7 @@ local categoriesToCollect = {
 }
 
 -- Format specifications for achievements: https://github.com/FAForever/fa/issues/5813
+-- Example JSON with all the expected fields: https://github.com/FAForever/server/blob/665454a5d8a2d97a1b512f89bcadef7a25343e6a/tests/data/game_stats_simple_win.json#L38
 -- Unit categories used in achievements: `def _category_stats` in https://github.com/FAForever/server/blob/develop/server/stats/game_stats_service.py
 -- Unit IDs used for unit categories: https://github.com/FAForever/server/blob/develop/server/stats/unit.py
 -- The 'kills', 'built', and 'loss' stats for each category are checked for each army at the end of the game

--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -22,12 +22,13 @@ local categoriesToCollect = {
 -- Format specifications for achievements: https://github.com/FAForever/fa/issues/5813
 -- Unit categories used in achievements: `def _category_stats` in https://github.com/FAForever/server/blob/develop/server/stats/game_stats_service.py
 -- Unit IDs used for unit categories: https://github.com/FAForever/server/blob/develop/server/stats/unit.py
-
 -- The 'kills', 'built', and 'loss' stats for each category are checked for each army at the end of the game
 local categoriesForAchievements = {
     transportation = categories.TRANSPORTATION, 
     sacu = categories.SUBCOMMANDER,
-    -- Tracked by FAF server events but doesn't increment any achievements
+
+    -- Tracked by FAF server events but doesn't increment any achievements. We do need to include them
+    -- or the achievements do not update as a whole.
     engineer = categories.ENGINEER,
     tech1 = categories.TECH1,
     tech2 = categories.TECH2,


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Resolves https://github.com/FAForever/fa/commit/a1327004af5faf998a96c63f41261ece16de0f2d#commitcomment-140697683
Only log the re-added achievement categories at the end of the game.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Add `LOG(repr(ArmyScore))` after `GameOverScore` https://github.com/FAForever/fa/blob/0944ed698af1e8187afe2f5a0cec0b2cb4aac491/lua/sim/score.lua#L344-L347

Spawn SACUs, build an air factory, and build some tech 1 and tech 2 transports from it. Press end game in the main menu. The log should show how many SACU were spawned, how many transports were built, how many engineers there are (SACUs + 1 ACU), and the number of units for each tech tier.

## Checklist

- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
