### PR TITLE
Rationalize the economy stats of various Shield Generators

### DIFF
--- a/changelog/3809.md
+++ b/changelog/3809.md
@@ -58,6 +58,15 @@
         - BuildTime: 750 --> 1200
         - BuildTime: 900 --> 1400 (Cybran)
 
+- (#6082) The `BuildRate` and `BuildTime` stats of several Shield Generators are updated to be more streamlined. The Seraphim Tech 2 Shield Generator gains build power, as it previously had a very low amount. The Aeon Tech 2 Shield Generator loses its build power, as it cannot be upgraded.
+    - Tech 2 Shield Generators
+        - BuildRate: 13.66 --> 0 (Aeon)
+        - BuildRate: 12.98 --> 20 (Seraphim)
+        - BuildRate: 19.95 --> 20 (UEF)
+    - Tech 3 Shield Generators
+        - BuildTime: 5841 --> 5800 (Seraphim)
+        - BuildTime: 4988 --> 5000 (UEF)
+
 ## Features
 
 <!-- Remove header when empty -->

--- a/units/UAB4202/UAB4202_unit.bp
+++ b/units/UAB4202/UAB4202_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint{
     Economy = {
         BuildCostEnergy = 5760,
         BuildCostMass = 480,
-        BuildRate = 13.66,
         BuildTime = 950,
         MaintenanceConsumptionPerSecondEnergy = 150,
         RebuildBonusIds = {

--- a/units/UEB4202/UEB4202_unit.bp
+++ b/units/UEB4202/UEB4202_unit.bp
@@ -92,7 +92,7 @@ UnitBlueprint{
     Economy = {
         BuildCostEnergy = 6000,
         BuildCostMass = 600,
-        BuildRate = 19.95,
+        BuildRate = 20,
         BuildTime = 1150,
         BuildableCategory = { "ueb4301" },
         MaintenanceConsumptionPerSecondEnergy = 200,

--- a/units/UEB4301/UEB4301_unit.bp
+++ b/units/UEB4301/UEB4301_unit.bp
@@ -85,7 +85,7 @@ UnitBlueprint{
     Economy = {
         BuildCostEnergy = 55000,
         BuildCostMass = 3300,
-        BuildTime = 4988,
+        BuildTime = 5000,
         MaintenanceConsumptionPerSecondEnergy = 400,
         RebuildBonusIds = { "ueb4301" },
     },

--- a/units/XSB4202/XSB4202_unit.bp
+++ b/units/XSB4202/XSB4202_unit.bp
@@ -102,7 +102,7 @@ UnitBlueprint{
     Economy = {
         BuildCostEnergy = 7000,
         BuildCostMass = 700,
-        BuildRate = 12.98,
+        BuildRate = 20,
         BuildTime = 1250,
         BuildableCategory = { "xsb4301" },
         MaintenanceConsumptionPerSecondEnergy = 250,

--- a/units/XSB4301/XSB4301_unit.bp
+++ b/units/XSB4301/XSB4301_unit.bp
@@ -97,7 +97,7 @@ UnitBlueprint{
     Economy = {
         BuildCostEnergy = 60000,
         BuildCostMass = 3600,
-        BuildTime = 5841,
+        BuildTime = 5800,
         MaintenanceConsumptionPerSecondEnergy = 500,
         RebuildBonusIds = { "xsb4301" },
     },


### PR DESCRIPTION
## Description of the proposed changes

**Tech 2 Shield Generators**
BuildRate: 13.66 --> 0 (Aeon) 
BuildRate: 12.98 --> 20 (Seraphim)
BuildRate: 19.95 --> 20 (UEF)

**Tech 3 Shield Generators**
BuildTime: 5841 --> 5800 (Seraphim)
BuildTime: 4988 --> 5000 (UEF)

## Results

- Time to upgrade a Seraphim Tech 2 Shield Generator: 04:50 (from 07:30).
- Time to upgrade a UEF Tech 2 Shield Generator: 04:10 (unchanged).
- The Aeon Shield Generator loses its BuildRate, as it cannot upgrade.

## Checklist

- [x] Changes are documented in the changelog for the next game version
