### PR TITLE
Remove mass from dead trees and tree groups

### DIFF
--- a/env/Lava/Props/Trees/Dead01_s1_prop.bp
+++ b/env/Lava/Props/Trees/Dead01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/Dead01_s2_prop.bp
+++ b/env/Lava/Props/Trees/Dead01_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/Dead01_s3_prop.bp
+++ b/env/Lava/Props/Trees/Dead01_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/Groups/Dead01_Group1_prop.bp
+++ b/env/Lava/Props/Trees/Groups/Dead01_Group1_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 40,
-        ReclaimMassMax = 4,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/Groups/Dead01_Group2_prop.bp
+++ b/env/Lava/Props/Trees/Groups/Dead01_Group2_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 40,
-        ReclaimMassMax = 4,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/LV_Dead01_s1_prop.bp
+++ b/env/Lava/Props/Trees/LV_Dead01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/XDead01_s1_prop.bp
+++ b/env/Lava/Props/Trees/XDead01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/xDead01_s2_prop.bp
+++ b/env/Lava/Props/Trees/xDead01_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/xDead01_s3_prop.bp
+++ b/env/Lava/Props/Trees/xDead01_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {


### PR DESCRIPTION
This is an experimental change to allow studying the engineer behaviour when trees have no mass.
I only included the dead trees so far, these are an issue on Badlands, where they are interspersed with important rocks.
I can trivially add this change for other trees if wanted, because I had chatGPT write me a nice script to automate it.

This approach is way easier for testing than having to edit the armature as done in #6063 
This is intended to be used for testing on fafdevelop, it's not ready to be included in game patch at the moment.


## Checklist

- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
