### PR TITLE
Tree mass reclaim

### DIFF
--- a/env/Evergreen/Props/Trees/Brch01_prop.bp
+++ b/env/Evergreen/Props/Trees/Brch01_prop.bp
@@ -51,7 +51,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 3.3,
-        ReclaimMassMax = 0.66,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Brch01_s1_prop.bp
+++ b/env/Evergreen/Props/Trees/Brch01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 3.3,
-        ReclaimMassMax = 0.66,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Brch01_s2_prop.bp
+++ b/env/Evergreen/Props/Trees/Brch01_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 3.3,
-        ReclaimMassMax = 0.66,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Brch01_s3_prop.bp
+++ b/env/Evergreen/Props/Trees/Brch01_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 3.3,
-        ReclaimMassMax = 0.66,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/DC01_s1_prop.bp
+++ b/env/Evergreen/Props/Trees/DC01_s1_prop.bp
@@ -54,7 +54,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 10,
-        ReclaimMassMax = 1.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/DC01_s2_prop.bp
+++ b/env/Evergreen/Props/Trees/DC01_s2_prop.bp
@@ -54,7 +54,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 10,
-        ReclaimMassMax = 1.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/DC01_s3_prop.bp
+++ b/env/Evergreen/Props/Trees/DC01_s3_prop.bp
@@ -54,7 +54,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 10,
-        ReclaimMassMax = 1.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Groups/Brch01_Group01_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Brch01_Group01_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 40,
-        ReclaimMassMax = 8,
+        ReclaimMassMax = 0,
         ReclaimTime = 60,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Groups/Brch01_Group02_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Brch01_Group02_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 40,
-        ReclaimMassMax = 8,
+        ReclaimMassMax = 0,
         ReclaimTime = 60,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Groups/DC01_Group1_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/DC01_Group1_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 80,
-        ReclaimMassMax = 12,
+        ReclaimMassMax = 0,
         ReclaimTime = 40,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Groups/DC01_Group2_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/DC01_Group2_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 50,
-        ReclaimMassMax = 7.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 25,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Groups/Oak01_Group1_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Oak01_Group1_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 64,
-        ReclaimMassMax = 6.4,
+        ReclaimMassMax = 0,
         ReclaimTime = 40,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Groups/Oak01_Group2_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Oak01_Group2_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 80,
-        ReclaimMassMax = 8,
+        ReclaimMassMax = 0,
         ReclaimTime = 50,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Groups/Pine06_Big_GroupA_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Pine06_Big_GroupA_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 80,
-        ReclaimMassMax = 8,
+        ReclaimMassMax = 0,
         ReclaimTime = 100,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Groups/Pine06_Big_GroupB_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Pine06_Big_GroupB_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 80,
-        ReclaimMassMax = 8,
+        ReclaimMassMax = 0,
         ReclaimTime = 100,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Groups/Pine06_GroupA_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Pine06_GroupA_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 68.4,
-        ReclaimMassMax = 6,
+        ReclaimMassMax = 0,
         ReclaimTime = 100,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Groups/Pine06_GroupB_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Pine06_GroupB_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 62.7,
-        ReclaimMassMax = 6.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 100,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Groups/Pine07_GroupA_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Pine07_GroupA_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 40,
-        ReclaimMassMax = 8,
+        ReclaimMassMax = 0,
         ReclaimTime = 40,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Groups/Pine07_GroupB_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Pine07_GroupB_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 25,
-        ReclaimMassMax = 5,
+        ReclaimMassMax = 0,
         ReclaimTime = 25,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Oak01_s1_prop.bp
+++ b/env/Evergreen/Props/Trees/Oak01_s1_prop.bp
@@ -54,7 +54,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 8,
-        ReclaimMassMax = 0.8,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Oak01_s2_prop.bp
+++ b/env/Evergreen/Props/Trees/Oak01_s2_prop.bp
@@ -54,7 +54,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 8,
-        ReclaimMassMax = 0.8,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Oak01_s3_prop.bp
+++ b/env/Evergreen/Props/Trees/Oak01_s3_prop.bp
@@ -54,7 +54,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 8,
-        ReclaimMassMax = 0.8,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_Big_V1_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_Big_V1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_Big_V1_s2_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_Big_V1_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_Big_V1_s3_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_Big_V1_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_Big_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_Big_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_Big_s2_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_Big_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_Big_s3_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_Big_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_V1_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_V1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_V1_s2_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_V1_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_V1_s3_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_V1_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_V2_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_V2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_V2_s2_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_V2_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_V2_s3_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_V2_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_s2_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine06_s3_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine06_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 2.85,
-        ReclaimMassMax = 0.27,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine07_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine07_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 1,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine07_s2_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine07_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 1,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Evergreen/Props/Trees/Pine07_s3_prop.bp
+++ b/env/Evergreen/Props/Trees/Pine07_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 1,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/Dead01_s1_prop.bp
+++ b/env/Lava/Props/Trees/Dead01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/Dead01_s2_prop.bp
+++ b/env/Lava/Props/Trees/Dead01_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/Dead01_s3_prop.bp
+++ b/env/Lava/Props/Trees/Dead01_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/Groups/Dead01_Group1_prop.bp
+++ b/env/Lava/Props/Trees/Groups/Dead01_Group1_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 40,
-        ReclaimMassMax = 4,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/Groups/Dead01_Group2_prop.bp
+++ b/env/Lava/Props/Trees/Groups/Dead01_Group2_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 40,
-        ReclaimMassMax = 4,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/LV_Dead01_s1_prop.bp
+++ b/env/Lava/Props/Trees/LV_Dead01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/XDead01_s1_prop.bp
+++ b/env/Lava/Props/Trees/XDead01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/xDead01_s2_prop.bp
+++ b/env/Lava/Props/Trees/xDead01_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/xDead01_s3_prop.bp
+++ b/env/Lava/Props/Trees/xDead01_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/RedRocks/Props/Trees/Carotenoid01_s1_prop.bp
+++ b/env/RedRocks/Props/Trees/Carotenoid01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 3.3,
-        ReclaimMassMax = 0.55,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/RedRocks/Props/Trees/Carotenoid01_s2_prop.bp
+++ b/env/RedRocks/Props/Trees/Carotenoid01_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 3.3,
-        ReclaimMassMax = 0.55,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/RedRocks/Props/Trees/Carotenoid01_s3_prop.bp
+++ b/env/RedRocks/Props/Trees/Carotenoid01_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 3.3,
-        ReclaimMassMax = 0.55,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/RedRocks/Props/Trees/Groups/Carotenoid01_Group1_prop.bp
+++ b/env/RedRocks/Props/Trees/Groups/Carotenoid01_Group1_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 42,
-        ReclaimMassMax = 7.7,
+        ReclaimMassMax = 0,
         ReclaimTime = 60,
     },
     Interface = {

--- a/env/RedRocks/Props/Trees/Groups/Carotenoid01_Group2_prop.bp
+++ b/env/RedRocks/Props/Trees/Groups/Carotenoid01_Group2_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 60,
-        ReclaimMassMax = 10,
+        ReclaimMassMax = 0,
         ReclaimTime = 80,
     },
     Interface = {

--- a/env/RedRocks/Props/Trees/Groups/RedTree01_Group1_prop.bp
+++ b/env/RedRocks/Props/Trees/Groups/RedTree01_Group1_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 24,
-        ReclaimMassMax = 6.4,
+        ReclaimMassMax = 0,
         ReclaimTime = 80,
     },
     Interface = {

--- a/env/RedRocks/Props/Trees/Groups/RedTree01_Group2_prop.bp
+++ b/env/RedRocks/Props/Trees/Groups/RedTree01_Group2_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 30,
-        ReclaimMassMax = 8,
+        ReclaimMassMax = 0,
         ReclaimTime = 100,
     },
     Interface = {

--- a/env/RedRocks/Props/Trees/RedTree01_s1_prop.bp
+++ b/env/RedRocks/Props/Trees/RedTree01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 1.5,
-        ReclaimMassMax = 0.4,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/RedRocks/Props/Trees/RedTree01_s2_prop.bp
+++ b/env/RedRocks/Props/Trees/RedTree01_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 1.5,
-        ReclaimMassMax = 0.4,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/RedRocks/Props/Trees/RedTree01_s3_prop.bp
+++ b/env/RedRocks/Props/Trees/RedTree01_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 1.5,
-        ReclaimMassMax = 0.4,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Swamp/Props/Trees/Groups/cypress01_Group1_prop.bp
+++ b/env/Swamp/Props/Trees/Groups/cypress01_Group1_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 150,
-        ReclaimMassMax = 8,
+        ReclaimMassMax = 0,
         ReclaimTime = 75,
     },
     Interface = {

--- a/env/Swamp/Props/Trees/Groups/cypress01_Group2_prop.bp
+++ b/env/Swamp/Props/Trees/Groups/cypress01_Group2_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 150,
-        ReclaimMassMax = 8,
+        ReclaimMassMax = 0,
         ReclaimTime = 75,
     },
     Interface = {

--- a/env/Swamp/Props/Trees/cypress01_s1_prop.bp
+++ b/env/Swamp/Props/Trees/cypress01_s1_prop.bp
@@ -54,7 +54,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 10,
-        ReclaimMassMax = 0.53,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Swamp/Props/Trees/cypress01_s2_prop.bp
+++ b/env/Swamp/Props/Trees/cypress01_s2_prop.bp
@@ -54,7 +54,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 10,
-        ReclaimMassMax = 0.53,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Swamp/Props/Trees/cypress01_s3_prop.bp
+++ b/env/Swamp/Props/Trees/cypress01_s3_prop.bp
@@ -54,7 +54,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 10,
-        ReclaimMassMax = 0.53,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Ficus01_s1_prop.bp
+++ b/env/Tropical/Props/Trees/Ficus01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5.7,
-        ReclaimMassMax = 0.7,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Ficus01_s2_prop.bp
+++ b/env/Tropical/Props/Trees/Ficus01_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5.7,
-        ReclaimMassMax = 0.7,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Ficus01_s3_prop.bp
+++ b/env/Tropical/Props/Trees/Ficus01_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5.7,
-        ReclaimMassMax = 0.7,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Ficus02_s1_prop.bp
+++ b/env/Tropical/Props/Trees/Ficus02_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 4.7,
-        ReclaimMassMax = 0.6,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Ficus02_s2_prop.bp
+++ b/env/Tropical/Props/Trees/Ficus02_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 4.7,
-        ReclaimMassMax = 0.6,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Ficus02_s3_prop.bp
+++ b/env/Tropical/Props/Trees/Ficus02_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 4.7,
-        ReclaimMassMax = 0.6,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Groups/Ficus01_Group1_prop.bp
+++ b/env/Tropical/Props/Trees/Groups/Ficus01_Group1_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 57,
-        ReclaimMassMax = 8.4,
+        ReclaimMassMax = 0,
         ReclaimTime = 50,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Groups/Ficus01_Group2_prop.bp
+++ b/env/Tropical/Props/Trees/Groups/Ficus01_Group2_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 80,
-        ReclaimMassMax = 10,
+        ReclaimMassMax = 0,
         ReclaimTime = 60,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Groups/Ficus01_Group3_prop.bp
+++ b/env/Tropical/Props/Trees/Groups/Ficus01_Group3_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 51,
-        ReclaimMassMax = 6.3,
+        ReclaimMassMax = 0,
         ReclaimTime = 45,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Groups/Ficus02_Group1_prop.bp
+++ b/env/Tropical/Props/Trees/Groups/Ficus02_Group1_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 47,
-        ReclaimMassMax = 6,
+        ReclaimMassMax = 0,
         ReclaimTime = 50,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Groups/Ficus02_Group2_prop.bp
+++ b/env/Tropical/Props/Trees/Groups/Ficus02_Group2_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 80,
-        ReclaimMassMax = 10,
+        ReclaimMassMax = 0,
         ReclaimTime = 80,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Groups/Ficus02_Group3_prop.bp
+++ b/env/Tropical/Props/Trees/Groups/Ficus02_Group3_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 47,
-        ReclaimMassMax = 6,
+        ReclaimMassMax = 0,
         ReclaimTime = 50,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Groups/Palm01_Group1_prop.bp
+++ b/env/Tropical/Props/Trees/Groups/Palm01_Group1_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 33,
-        ReclaimMassMax = 6.6,
+        ReclaimMassMax = 0,
         ReclaimTime = 100,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Groups/Palm01_Group2_prop.bp
+++ b/env/Tropical/Props/Trees/Groups/Palm01_Group2_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 40,
-        ReclaimMassMax = 8,
+        ReclaimMassMax = 0,
         ReclaimTime = 100,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Groups/Palm01_Group3_prop.bp
+++ b/env/Tropical/Props/Trees/Groups/Palm01_Group3_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 16,
-        ReclaimMassMax = 3.3,
+        ReclaimMassMax = 0,
         ReclaimTime = 50,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Groups/Palm01_Group4_prop.bp
+++ b/env/Tropical/Props/Trees/Groups/Palm01_Group4_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 16,
-        ReclaimMassMax = 3.3,
+        ReclaimMassMax = 0,
         ReclaimTime = 50,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Groups/Palm02_Group1_prop.bp
+++ b/env/Tropical/Props/Trees/Groups/Palm02_Group1_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 22,
-        ReclaimMassMax = 8,
+        ReclaimMassMax = 0,
         ReclaimTime = 70,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Groups/Palm02_Group2_prop.bp
+++ b/env/Tropical/Props/Trees/Groups/Palm02_Group2_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 34,
-        ReclaimMassMax = 7,
+        ReclaimMassMax = 0,
         ReclaimTime = 100,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Groups/Palm02_Group3_prop.bp
+++ b/env/Tropical/Props/Trees/Groups/Palm02_Group3_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 11.5,
-        ReclaimMassMax = 2.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 40,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Groups/Palm02_Group4_prop.bp
+++ b/env/Tropical/Props/Trees/Groups/Palm02_Group4_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 17,
-        ReclaimMassMax = 3.5,
+        ReclaimMassMax = 0,
         ReclaimTime = 50,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Palm01_s1_prop.bp
+++ b/env/Tropical/Props/Trees/Palm01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 1.66,
-        ReclaimMassMax = 0.33,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Palm01_s2_prop.bp
+++ b/env/Tropical/Props/Trees/Palm01_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 1.66,
-        ReclaimMassMax = 0.33,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Palm01_s3_prop.bp
+++ b/env/Tropical/Props/Trees/Palm01_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 1.66,
-        ReclaimMassMax = 0.33,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Palm01_s4_prop.bp
+++ b/env/Tropical/Props/Trees/Palm01_s4_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 1.66,
-        ReclaimMassMax = 0.33,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Palm01_s5_prop.bp
+++ b/env/Tropical/Props/Trees/Palm01_s5_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 1.66,
-        ReclaimMassMax = 0.33,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Palm02_s1_prop.bp
+++ b/env/Tropical/Props/Trees/Palm02_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 1.42,
-        ReclaimMassMax = 0.29,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Palm02_s2_prop.bp
+++ b/env/Tropical/Props/Trees/Palm02_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 1.42,
-        ReclaimMassMax = 0.29,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Palm02_s3_prop.bp
+++ b/env/Tropical/Props/Trees/Palm02_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 1.42,
-        ReclaimMassMax = 0.29,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Palm02_s4_prop.bp
+++ b/env/Tropical/Props/Trees/Palm02_s4_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 1.42,
-        ReclaimMassMax = 0.29,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tropical/Props/Trees/Palm02_s5_prop.bp
+++ b/env/Tropical/Props/Trees/Palm02_s5_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 1.42,
-        ReclaimMassMax = 0.29,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tundra/Props/Trees/Groups/Tund_Pine01_Group1_prop.bp
+++ b/env/Tundra/Props/Trees/Groups/Tund_Pine01_Group1_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 80,
-        ReclaimMassMax = 10,
+        ReclaimMassMax = 0,
         ReclaimTime = 50,
     },
     Interface = {

--- a/env/Tundra/Props/Trees/Groups/Tund_Pine01_Group2_prop.bp
+++ b/env/Tundra/Props/Trees/Groups/Tund_Pine01_Group2_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 80,
-        ReclaimMassMax = 10,
+        ReclaimMassMax = 0,
         ReclaimTime = 50,
     },
     Interface = {

--- a/env/Tundra/Props/Trees/Tund_Pine01_s1_prop.bp
+++ b/env/Tundra/Props/Trees/Tund_Pine01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 8,
-        ReclaimMassMax = 0.8,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tundra/Props/Trees/Tund_Pine01_s2_prop.bp
+++ b/env/Tundra/Props/Trees/Tund_Pine01_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 8,
-        ReclaimMassMax = 0.8,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Tundra/Props/Trees/Tund_Pine01_s3_prop.bp
+++ b/env/Tundra/Props/Trees/Tund_Pine01_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 8,
-        ReclaimMassMax = 0.8,
+        ReclaimMassMax = 0,
         ReclaimTime = 5,
     },
     Interface = {


### PR DESCRIPTION
Farms said that only dead trees having no mass is not enough to properly test it, as team game maps with relevant forests often feature green trees, so I extended the change to all trees for testing purposes.

Btw, I don't really understand what "Changes are annotated" in the checklist is supposed to be...

## Checklist

- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
