### PR TITLE
Draft setup for persistent tree groups

### DIFF
--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -2899,6 +2899,16 @@ float4 NormalMappedPS( NORMALMAPPED_VERTEX vertex,
     return float4( color.rgb, alpha );
 }
 
+/// InvisiblePS
+///
+/// Lighting using normal maps.
+/// Used by some props, mostly trees
+float4 InvisiblePS( NORMALMAPPED_VERTEX vertex) : COLOR0
+{
+    clip(1);
+    return float4(0, 0, 0, 0);
+}
+
 /// MapImagerPS0
 ///
 ///
@@ -5065,6 +5075,71 @@ technique UndulatingNormalMappedAlpha_LowFidelity
 
         VertexShader = compile vs_1_1 VertexNormalVS();
         PixelShader = compile ps_2_0 VertexNormalPS_LowFidelity( true, d3d_Greater, 0x80 );
+    }
+}
+
+/// Invisible
+///
+/// Normal mapped with alpha test.  No color mask or glow.
+technique Invisible_HighFidelity
+<
+    int fidelity = FIDELITY_HIGH;
+
+    string abstractTechnique = "Invisible";
+    string cartographicTechnique = "CartographicFeature";
+    int parameter = PARAM_FRACTIONCOMPLETE;
+>
+{
+    pass P0
+    {
+        AlphaState( AlphaBlend_Disable_Write_RGBA )
+        RasterizerState( Rasterizer_Cull_CW )
+        DepthState( Depth_Enable )
+
+        VertexShader = compile vs_1_1 VertexNormalVS();
+        PixelShader = compile ps_2_a InvisiblePS();
+    }
+}
+
+technique Invisible_MedFidelity
+<
+    int fidelity = FIDELITY_MEDIUM;
+
+    string abstractTechnique = "Invisible";
+    string cartographicTechnique = "CartographicFeature";
+    int parameter = PARAM_FRACTIONCOMPLETE;
+>
+{
+    pass P0
+    {
+        AlphaState( AlphaBlend_Disable )
+        RasterizerState( Rasterizer_Cull_CW )
+        DepthState( Depth_Enable )
+
+        VertexShader = compile vs_1_1 VertexNormalVS();
+        PixelShader = compile ps_2_a InvisiblePS();
+    }
+}
+
+technique Invisible_LowFidelity
+<
+    int fidelity = FIDELITY_LOW;
+
+    string abstractTechnique = "Invisible";
+    string cartographicTechnique = "CartographicFeature";
+
+    int renderStage = STAGE_DEPTH + STAGE_PREWATER + STAGE_PREEFFECT;
+    int parameter = PARAM_FRACTIONCOMPLETE;
+>
+{
+    pass P0
+    {
+        AlphaState( AlphaBlend_Disable )
+        RasterizerState( Rasterizer_Cull_CW )
+        DepthState( Depth_Enable )
+
+        VertexShader = compile vs_1_1 VertexNormalVS();
+        PixelShader = compile ps_2_0 InvisiblePS();
     }
 }
 

--- a/engine/Core/Blueprints/PropBlueprint.lua
+++ b/engine/Core/Blueprints/PropBlueprint.lua
@@ -7,8 +7,10 @@
 ---@field Display PropBlueprintDisplay
 ---@field Economy PropBlueprintEconomy
 ---@field Physics PropBlueprintPhysics
+---@field SingleTreeDir? string
 ---@field ScriptClass PropType Class name for this prop
 ---@field ScriptModule FileName File to find class in
+
 
 ---@class PropBlueprintDefense
 --- max health value for the prop
@@ -19,6 +21,8 @@
 ---@class PropBlueprintDisplay
 --- Name of mesh blueprint to use. Leave blank to use default mesh.
 ---@field MeshBlueprint string
+---@field MeshBlueprintWreck string
+---@field MeshBlueprintInvisible string
 
 ---@class PropBlueprintEconomy
 --- maximum reclaimable mass in this prop (taking damage removes some)

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -299,7 +299,7 @@ Prop = Class(moho.prop_methods) {
     --- You can pass an optional 'dirprefix' arg saying where to look for the child props.
     --- If not given, it defaults to one directory up from this prop's blueprint location.
     ---@param self Prop
-    ---@param dirprefix string
+    ---@param dirprefix? string
     ---@return table
     SplitOnBonesByName = function(self, dirprefix)
 
@@ -337,20 +337,19 @@ Prop = Class(moho.prop_methods) {
 
             -- determine prop name (removing _01, _02 from bone name)
             trimmedBoneName = StringGsub(bone, "_?[0-9]+$", "")
-            blueprint = dirprefix .. trimmedBoneName .. "_prop.bp"
+            blueprint = dirprefix .. trimmedBoneName .. "_prop_generated.bp"
 
             -- attempt to make the prop
             ok, out = pcall(self.CreatePropAtBone, self, ibone, blueprint)
             if ok then
                 out:SetMaxReclaimValues(time, mass, energy)
-                props[ibone] = out
+                TableInsert(props, out)
             else
                 WARN("Unable to split a prop: " .. self.Blueprint.BlueprintId .. " -> " .. blueprint)
                 WARN(out)
             end
         end
 
-        self:Destroy()
         return props
     end,
 

--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -993,7 +993,7 @@ function PostModBlueprints(all_bps)
     -- post process units and projectiles for easier access to information and sanitizing some fields
     PostProcessProjectiles(all_bps.Projectile)
     PostProcessUnits(all_bps, all_bps.Unit)
-    PostProcessProps(all_bps.Prop)
+    PostProcessProps(all_bps, all_bps.Prop)
 end
 
 --- Loads all blueprints with optional parameters  

--- a/lua/system/repr.lua
+++ b/lua/system/repr.lua
@@ -65,9 +65,6 @@ end
 ---@param str string
 ---@return string
 local function smartQuote(str)
-    if match(str, '"') and not match(str, "'") then
-        return "'" .. str .. "'"
-    end
     return '"' .. gsub(str, '"', '\\"') .. '"'
 end
 


### PR DESCRIPTION
## Description of the proposed changes

This is based on a suggestion of @clyfordv where when a tree group breaks (because of a collision, damage, etc) we do not delete the group and instead spawn in individual trees that are not reclaimable. That way we can still reclaim the tree group as a whole, and instead reduce the mass value as individual trees are destroyed.

## Testing done on the proposed changes

<todo>


## Additional context

Ran into a strange bug where I am unable to change the mesh of a tree group after creating it. 

When the tree group 'breaks' we want to hide the mesh of the tree group itself. This allows the individual trees to take over, which in turn allows for interactions with units and damage.

Attempts:

- (1) Hide the mesh - this is not possible. Units are able to do this, but those are unit-specific functions.
- (2) Scale the mesh to 0 - this is not possible. The rendering bounding box appears to be used to determine if we're hovering over a tree (group). As a result if we reduce the scale to 0 then the tree group becomes unclickable.
- (3) Change the mesh - this appears to be buggy and is where I am now. I can change the mesh to a version with a shader that doesn't render any pixels on screen but only in the tick the prop is created. When I try it at a later moment it simply does not work and the game does not tell me why. I suspect it may be because of batching of the props, but then why does it work for individual trees as they take (fire) damage?

## Checklist

- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
