### PR TITLE
Revert "Remove mass from dead trees and tree groups"

### DIFF
--- a/env/Lava/Props/Trees/Dead01_s1_prop.bp
+++ b/env/Lava/Props/Trees/Dead01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0,
+        ReclaimMassMax = 0.5,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/Dead01_s2_prop.bp
+++ b/env/Lava/Props/Trees/Dead01_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0,
+        ReclaimMassMax = 0.5,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/Dead01_s3_prop.bp
+++ b/env/Lava/Props/Trees/Dead01_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0,
+        ReclaimMassMax = 0.5,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/Groups/Dead01_Group1_prop.bp
+++ b/env/Lava/Props/Trees/Groups/Dead01_Group1_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 40,
-        ReclaimMassMax = 0,
+        ReclaimMassMax = 4,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/Groups/Dead01_Group2_prop.bp
+++ b/env/Lava/Props/Trees/Groups/Dead01_Group2_prop.bp
@@ -37,7 +37,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 40,
-        ReclaimMassMax = 0,
+        ReclaimMassMax = 4,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/LV_Dead01_s1_prop.bp
+++ b/env/Lava/Props/Trees/LV_Dead01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0,
+        ReclaimMassMax = 0.5,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/XDead01_s1_prop.bp
+++ b/env/Lava/Props/Trees/XDead01_s1_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0,
+        ReclaimMassMax = 0.5,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/xDead01_s2_prop.bp
+++ b/env/Lava/Props/Trees/xDead01_s2_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0,
+        ReclaimMassMax = 0.5,
         ReclaimTime = 5,
     },
     Interface = {

--- a/env/Lava/Props/Trees/xDead01_s3_prop.bp
+++ b/env/Lava/Props/Trees/xDead01_s3_prop.bp
@@ -53,7 +53,7 @@ PropBlueprint {
     },
     Economy = {
         ReclaimEnergyMax = 5,
-        ReclaimMassMax = 0,
+        ReclaimMassMax = 0.5,
         ReclaimTime = 5,
     },
     Interface = {


### PR DESCRIPTION
Reverts FAForever/fa#6087 because this is already done with a mod in the vault.
Also it's "based on a misunderstanding and is not needed."
> BlackYps commented https://github.com/FAForever/fa/pull/6096#issuecomment-2066216851
I pinged you in discord, but actually keep this closed. It was based on a misunderstanding and is not needed