### PR TITLE
Inherit all damage data in Ahwassa bomb script

### DIFF
--- a/changelog/3810.md
+++ b/changelog/3810.md
@@ -2,7 +2,7 @@
 
 ## Bug Fixes
 
-<!-- Remove header when empty -->
+- (#6102) Fix Ahwassa's bomb dealing full damage to ASF.
 
 ## Balance
 

--- a/projectiles/SBOOhwalliStrategicBomb01/SBOOhwalliStrategicBomb01_script.lua
+++ b/projectiles/SBOOhwalliStrategicBomb01/SBOOhwalliStrategicBomb01_script.lua
@@ -44,8 +44,11 @@ SBOOhwalliStategicBomb01 = ClassProjectile(SOhwalliStrategicBombProjectile) {
         local data = self.DamageData
         local damage = data.DamageAmount
         local radius = data.DamageRadius or 0
+        local damageType = data.DamageType
+        local damageFriendly = data.DamageFriendly
+        local damageSelf = data.DamageSelf or false
         local instigator = self.Launcher or self
-        ForkThread(self.DamageThread, self, position, instigator, damage, radius)
+        ForkThread(self.DamageThread, self, position, instigator, damage, radius, damageType, damageFriendly, damageSelf)
 
         self:Destroy()
     end,
@@ -55,25 +58,25 @@ SBOOhwalliStategicBomb01 = ClassProjectile(SOhwalliStrategicBombProjectile) {
     ---@param instigator? Unit | Projectile
     ---@param damage number
     ---@param radius number
-    DamageThread = function(self, position, instigator, damage, radius)
+    DamageThread = function(self, position, instigator, damage, radius, damageType, damageFriendly, damageSelf)
         -- knock over trees
         DamageArea(instigator, position, 0.75 * radius, 1, 'TreeForce', true, true)
         DamageArea(instigator, position, 0.75 * radius, 1, 'TreeForce', true, true)
 
         -- initial damage
-        DamageArea(instigator, position, radius, 0.1 * damage, 'Normal', true, true)
+        DamageArea(instigator, position, radius, 0.1 * damage, damageType, damageFriendly, damageSelf)
         DamageArea(instigator, position, 0.9 * radius, 1, 'TreeFire', true, true)
 
         -- wait for the full explosion and then deal the remaining damage
         WaitTicks(26)
         DamageArea(instigator, position, 0.2 * radius, 1, 'Disintegrate', true, true)
-        DamageArea(instigator, position, radius, 0.3 * damage, 'Normal', true, true)
+        DamageArea(instigator, position, radius, 0.3 * damage, damageType, damageFriendly, damageSelf)
         WaitTicks(1)
         DamageArea(instigator, position, 0.3 * radius, 1, 'Disintegrate', true, true)
-        DamageArea(instigator, position, radius, 0.3 * damage, 'Normal', true, true)
+        DamageArea(instigator, position, radius, 0.3 * damage, damageType, damageFriendly, damageSelf)
         WaitTicks(1)
         DamageArea(instigator, position, 0.4 * radius, 1, 'Disintegrate', true, true)
-        DamageArea(instigator, position, radius, 0.3 * damage, 'Normal', true, true)
+        DamageArea(instigator, position, radius, 0.3 * damage, damageType, damageFriendly, damageSelf)
     end,
 }
 TypeClass = SBOOhwalliStategicBomb01


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes #6074.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spawn an Ahwassa and a friendly ASF. Groundfiring the bomb at the ASF deals 1101 damage (10% of 11000).


## Checklist

- [x] Changes are documented in the changelog for the next game version
