### PR TITLE
Fix a typo in the script file of the Seraphim Tech 3 Mass Fabricator

### DIFF
--- a/changelog/3810.md
+++ b/changelog/3810.md
@@ -2,7 +2,7 @@
 
 ## Bug Fixes
 
-<!-- Remove header when empty -->
+- (#6105) Fix a typo in the script file of the Seraphim Tech 3 Mass Fabricator.
 
 ## Balance
 

--- a/changelog/3810.md
+++ b/changelog/3810.md
@@ -8,6 +8,8 @@
 
 - (#6105) Fix a typo in the script file of the Seraphim Tech 3 Mass Fabricator.
 
+- (#6105) Fix the Seraphim Tech 3 Mass Fabricator's rotators not spinning down when production is disabled.
+
 ## Balance
 
 - (#6060) Make shields absorb ACU explosions.

--- a/units/XSB1303/XSB1303_script.lua
+++ b/units/XSB1303/XSB1303_script.lua
@@ -15,11 +15,11 @@ XSB1303 = ClassUnit(SMassFabricationUnit) {
 
     OnStopBeingBuilt = function(self, builder, layer)
         SMassFabricationUnit.OnStopBeingBuilt(self, builder, layer)
-        self.RingManip1 = CreateRotator(self, 'Blades01', 'y', nil, 0, 15, -30)
+        self.RingManip1 = CreateRotator(self, 'Blades01', '-y', nil, 0, 15, 30)
         self.Trash:Add(self.RingManip1)
         self.RingManip2 = CreateRotator(self, 'Blades02', 'y', nil, 0, 15, 45)
         self.Trash:Add(self.RingManip2)
-        self.RingManip3 = CreateRotator(self, 'Blades03', 'y', nil, 0, 15, -60)
+        self.RingManip3 = CreateRotator(self, 'Blades03', '-y', nil, 0, 15, 60)
         self.Trash:Add(self.RingManip3)
     end,
 

--- a/units/XSB1303/XSB1303_script.lua
+++ b/units/XSB1303/XSB1303_script.lua
@@ -1,9 +1,9 @@
 --****************************************************************************
 --**
---**  File     :  /cdimage/units/UAB1303/UAB1303_script.lua
+--**  File     :  /units/XSB1303/XSB1303_script.lua
 --**  Author(s):  Jessica St. Croix, David Tomandl, John Comes
 --**
---**  Summary  :  Aeon T3 Mass Fabricator
+--**  Summary  :  Seraphim T3 Mass Fabricator
 --**
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
@@ -15,6 +15,7 @@ XSB1303 = ClassUnit(SMassFabricationUnit) {
 
     OnStopBeingBuilt = function(self, builder, layer)
         SMassFabricationUnit.OnStopBeingBuilt(self, builder, layer)
+        -- 1: Bottom, 2: Middle, 3: Top
         self.RingManip1 = CreateRotator(self, 'Blades01', '-y', nil, 0, 15, 30)
         self.Trash:Add(self.RingManip1)
         self.RingManip2 = CreateRotator(self, 'Blades02', 'y', nil, 0, 15, 45)

--- a/units/XSB1303/XSB1303_script.lua
+++ b/units/XSB1303/XSB1303_script.lua
@@ -35,7 +35,7 @@ XSB1303 = ClassUnit(SMassFabricationUnit) {
         self.RingManip1:SetSpinDown(false)
         self.RingManip2:SetSpinDown(false)
         self.RingManip3:SetSpinDown(false)
-    end,false
+    end,
 }
 
 TypeClass = XSB1303


### PR DESCRIPTION
## Description of the proposed changes
Hopefully this also fixes this warning I sometimes see in replays, but I cannot promise it:

```warning: ToggleEnergyExcessUnitsThread: ...\gamedata\units.nx2\units\xsb1303\xsb1303_script.lua(35): attempt to call method `SetSpinDown' (a nil value)```

## Checklist
- [x] Changes are documented in the changelog for the next game version