### PR TITLE
Fix units not rebuilding on army transfer

### DIFF
--- a/changelog/3810.md
+++ b/changelog/3810.md
@@ -4,6 +4,8 @@
 
 - (#6102) Fix Ahwassa's bomb dealing full damage to ASF.
 
+- (#6106) Fix partially built units not transferring properly in Full Share.
+
 ## Balance
 
 - (#6060) Make shields absorb ACU explosions.

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1094,7 +1094,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     ---@param self Unit
     GetBuildRate = function(self)
         local buildrate = cUnitGetBuildRate(self)
-        if buildrate < 0 then
+        if buildrate <= 0 then
             buildrate = 0.00001
         end
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1094,6 +1094,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
     ---@param self Unit
     GetBuildRate = function(self)
         local buildrate = cUnitGetBuildRate(self)
+        -- prevent division by zero
         if buildrate <= 0 then
             buildrate = 0.00001
         end


### PR DESCRIPTION
## Description of the proposed changes
Fixes units not being rebuilt after being transferred.

## Testing done on the proposed changes
Spawn a bunch of RAS presets, start building a T4 unit. Then run this console command to transfer the unbuilt T4 to yourself:
```lua
SimLua 
local tu = import('/lua/SimUtils.lua').TransferUnfinishedUnitsAfterDeath
local b = ArmyBrains[GetFocusArmy()]
local units = b:GetListOfUnits(categories.EXPERIMENTAL)
ForkThread(tu, units, {b:GetArmyIndex()})
```
It should return to you at the same HP/progress you partially built it at.

## Additional context
Caused by a change to `Unit:GetBuildRate` (lua, not engine function) in #5932 unrelated to the reclaim costs. Instead of returning 0.0001 for 0 buildrate, it returned 0 which did not allow the rebuilder unit (`zxa0001`) to build.

This means that an alternative fix is to give the rebuilder 1 buildrate, and fixing this: https://github.com/FAForever/fa/commit/efdfc5e5a1ee68d45246df075fa864f6fdf558bd in a different way (we at least divide by buildrate in `GetReclaimCosts` and `GiveNukeSiloBlocks`).

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
