### PR TITLE
Annotate shield assist mechanics and max jammer blips

### DIFF
--- a/changelog/3810.md
+++ b/changelog/3810.md
@@ -97,6 +97,8 @@
 
 - (#6042) Improve annotations for `OnMotionHorzEventChange` and `OnMotionVertEventChange`
 
+- (#6109) Annotate the shield assist mechanics of `RegenAssistMult`
+
 - (#6086) Ensure that the Cooper's hitbox aligns with its model
 
 - (#6091) Count cargo for veterancy when a transport or carrier is killed

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -410,7 +410,9 @@
 --- stunning).
 --- Should not be defined with `AntiArtilleryShield`, `PersonalBubble`, or `TransportShield`.
 ---@field PersonalShield? boolean
---- an efficacy multiplier applied to units assisting the shield to regenerate its health
+--- How much buildpower is required to provide 1x of the shield's regen rate.
+--- The cost of assisting a shield is `repairCostRate / RegenAssistMult`,
+--- where repairCostRate is determined by Unit:UpdateConsumptionValues
 ---@field RegenAssistMult? number
 --- The amount of time the shield takes to come back online when its disabled due to insufficient
 --- energy. Defaults to `10` in the shield spec.
@@ -857,7 +859,9 @@
 ---@field OwnerShieldMesh string
 --- Personal shiled toggle
 ---@field PersonalShield boolean
---- an efficacy multiplier applied to units assisting the shield to regenerate its health
+--- How much buildpower is required to provide 1x of the shield's regen rate.
+--- The cost of assisting a shield is `repairCostRate / RegenAssistMult`,
+--- where repairCostRate is determined by Unit:UpdateConsumptionValues
 ---@field RegenAssistMult number
 --- The amount of time the shield takes to come back online when its disabled due to insufficient energy. Defaults to 10 in the shield spec.
 ---@field ShieldEnergyDrainRechargeTime number

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -1006,7 +1006,7 @@
 ---@field IntelDurationOnDeath? number
 --- how far we create fake blips
 ---@field JamRadius { Max: number, Min: number }
---- how many blips does a jammer produce
+--- How many blips a jammer produces. Maximum 255
 ---@field JammerBlips number
 --- used by the Soothsayer
 ---@field MaxVisionRadius? number

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1172,7 +1172,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
                     mass = (mass / siloBuildRate) * (self:GetBuildRate() or 0)
                 else
                     time, energy, mass = self:GetBuildCosts(focus:GetBlueprint())
-                    if self:IsUnitState('Repairing') and focus.isFinishedUnit then
+                    if self:IsUnitState('Repairing') and focus.isFinishedUnit then -- also applies to shield assisting
                         energy = energy * repairRatio
                         mass = mass * repairRatio
                     end


### PR DESCRIPTION
## Description of the proposed changes
Describe how shield assistance works in annotations.
Annotate that jammer blips have a max of 255. Past 255, it overflows back to 0.

## Testing done on the proposed changes
Tested modifying repair rate to change shield assist cost. Determined regen assist mechanics through looking at regen and consumption values on assisted shields tick by tick.

## Checklist

- [x] Changes are documented in the changelog for the next game version
