### PR TITLE
Add MassValueKilled stat for access by the UI

### DIFF
--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -609,10 +609,12 @@ VeterancyComponent = ClassSimple {
 
         -- optionally, these fields are defined too to inform UI of our veterancy status
         if blueprint.VetEnabled then
-            self:UpdateStat('VetLevel', 0)
             self:UpdateStat('VetExperience', 0)
+            self:UpdateStat('VetLevel', 0)
+            self:UpdateStat('MassValueKilled', 0)
             self.VetExperience = 0
             self.VetLevel = 0
+            self.MassValueKilled = 0
         end
     end,
 
@@ -662,6 +664,11 @@ VeterancyComponent = ClassSimple {
         if not blueprint.VetEnabled then
             return
         end
+
+        -- Update a mass value killed stat, not used
+        -- by veterancy but potentially useful to the player
+        self.MassValueKilled = self.MassValueKilled + experience
+        self:UpdateStat('MassValueKilled', self.MassValueKilled)
 
         local currExperience = self.VetExperience
         local currLevel = self.VetLevel


### PR DESCRIPTION
Unlike veterancy, which is capped at 1 level/kill, MassValueKilled is a straight sum of the mass exp a unit would have gained with no level cap. Let me know if this a go, and I'll add it to https://github.com/FAForever/fa/pull/6110.