### PR TITLE
Fix Novax and CZAR beam end/startpoint fx being swapped

### DIFF
--- a/changelog/3810.md
+++ b/changelog/3810.md
@@ -100,7 +100,7 @@
 
 - (#5668, #6066) Rework Seraphim weapon modules
   
-- (#6065) Refactor collision beam modules
+- (#6065, #6116) Refactor collision beam modules
 
 - (#6067) Fix a performance issue related to AIs and their transport logic
 

--- a/lua/sim/collisionBeams/OrbitalDeathLaserCollisionBeam.lua
+++ b/lua/sim/collisionBeams/OrbitalDeathLaserCollisionBeam.lua
@@ -10,9 +10,9 @@ OrbitalDeathLaserCollisionBeam = Class(SCCollisionBeam) {
     TerrainImpactType = 'LargeBeam02',
     TerrainImpactScale = 1,
 
+    FxBeamStartPoint = EffectTemplate.TOrbitalDeathLaserMuzzleFlash01,
     FxBeam = EffectTemplate.TOrbitalDeathLaserBeam,
-    FxBeamEndPoint = EffectTemplate.TOrbitalDeathLaserMuzzleFlash01,
-    FxBeamStartPoint = EffectTemplate.TOrbitalDeathLaserHit01,
+    FxBeamEndPoint = EffectTemplate.TOrbitalDeathLaserHit01,
 
     SplatTexture = 'czar_mark01_albedo',
     ScorchSplatDropTime = 0.5,

--- a/lua/sim/collisionBeams/QuantumBeamGeneratorCollisionBeam.lua
+++ b/lua/sim/collisionBeams/QuantumBeamGeneratorCollisionBeam.lua
@@ -10,9 +10,9 @@ QuantumBeamGeneratorCollisionBeam = Class(SCCollisionBeam) {
     TerrainImpactType = 'LargeBeam02',
     TerrainImpactScale = 1,
 
+    FxBeamStartPoint = EffectTemplate.AQuantumBeamGeneratorMuzzleFlash01,
     FxBeam =  EffectTemplate.AQuantumBeamGeneratorBeam,
-    FxBeamEndPoint = EffectTemplate.AQuantumBeamGeneratorMuzzleFlash01,
-    FxBeamStartPoint = EffectTemplate.AQuantumBeamGeneratorHit01,
+    FxBeamEndPoint = EffectTemplate.AQuantumBeamGeneratorHit01,
 
     SplatTexture = 'czar_mark01_albedo',
     ScorchSplatDropTime = 0.5,


### PR DESCRIPTION
## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Swaps them back to the right fields.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Groundfire novax and czar. I also checked the files of all the other beams to make sure I didn't repeat that mistake anywhere else.

## Additional context
Caused by #6065.


## Checklist

- [x] Changes are documented in the changelog for the next game version
