### PR TITLE
Use the internal unit statistics

### DIFF
--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -325,15 +325,24 @@ local function GameOverScore()
             Score.units[categoryName]['built'] = brain:GetBlueprintStat("Units_History", category)
             Score.units[categoryName]['lost'] = brain:GetBlueprintStat("Units_Killed", category)
         end
-        
+
         Score.blueprints = {}
         local allStats = brain:GetUnitStats()
         for _, unitId in unitIdsForAchievements do
+
+
+
             local unitStats = allStats[unitId]
             if unitStats then
-                if not unitStats['kills'] then unitStats['kills'] = 0 end
-                if not unitStats['built'] then unitStats['built'] = 0 end
-                if not unitStats['lost'] then unitStats['lost'] = 0 end
+                LOG(index, unitId, brain:GetBlueprintStat("Enemies_Killed", categories[unitId]), '->', unitStats['kills'])
+                LOG(index, unitId, brain:GetBlueprintStat("Units_History", categories[unitId]), '->', unitStats['built'])
+                LOG(index, unitId, brain:GetBlueprintStat("Units_History", categories[unitId]) - brain:GetBlueprintStat("Units_Active", categories[unitId]), '->', unitStats['lost'])
+
+                -- track the statistics for these specific units
+                unitStats['kills'] = brain:GetBlueprintStat("Enemies_Killed", categories[unitId])
+                unitStats['built'] = brain:GetBlueprintStat("Units_History", categories[unitId])
+                unitStats['lost'] = brain:GetBlueprintStat("Units_History", categories[unitId]) - brain:GetBlueprintStat("Units_Active", categories[unitId])
+
                 Score.blueprints[unitId] = unitStats
             end
         end

--- a/lua/sim/score.lua
+++ b/lua/sim/score.lua
@@ -330,14 +330,12 @@ local function GameOverScore()
         local allStats = brain:GetUnitStats()
         for _, unitId in unitIdsForAchievements do
 
-
+            LOG(index, unitId, brain:GetBlueprintStat("Enemies_Killed", categories[unitId]), '->', allStats[unitId]['kills'])
+            LOG(index, unitId, brain:GetBlueprintStat("Units_History", categories[unitId]), '->', allStats[unitId]['built'])
+            LOG(index, unitId, brain:GetBlueprintStat("Units_History", categories[unitId]) - brain:GetBlueprintStat("Units_Active", categories[unitId]), '->', allStats[unitId]['lost'])
 
             local unitStats = allStats[unitId]
             if unitStats then
-                LOG(index, unitId, brain:GetBlueprintStat("Enemies_Killed", categories[unitId]), '->', unitStats['kills'])
-                LOG(index, unitId, brain:GetBlueprintStat("Units_History", categories[unitId]), '->', unitStats['built'])
-                LOG(index, unitId, brain:GetBlueprintStat("Units_History", categories[unitId]) - brain:GetBlueprintStat("Units_Active", categories[unitId]), '->', unitStats['lost'])
-
                 -- track the statistics for these specific units
                 unitStats['kills'] = brain:GetBlueprintStat("Enemies_Killed", categories[unitId])
                 unitStats['built'] = brain:GetBlueprintStat("Units_History", categories[unitId])


### PR DESCRIPTION
## Description of the proposed changes

Remove the tracking of unit statistics. They are unnecessary as the engine tracks the same information. 

## Testing done on the proposed changes

Launch a game using 2badd4141ef4ee7a26dd6a8a8356311b25ffaffe and compare the results when you exit. You should see something like this in your logs:

```
INFO: 1	uel0001	0	->	nil -- killed
INFO: 1	uel0001	1	->	nil -- created
INFO: 1	uel0001	1	->	1   -- still alive
INFO: 1	uea0303	0	->	nil
INFO: 1	uea0303	8	->	8
INFO: 1	uea0303	3	->	3
INFO: 1	uel0401	0	->	nil
INFO: 1	uel0401	1	->	1
INFO: 1	uel0401	0	->	nil
INFO: 2	ual0001	0	->	nil
INFO: 2	ual0001	1	->	nil
INFO: 2	ual0001	1	->	1
INFO: 2	uel0001	1	->	1
INFO: 2	uel0001	0	->	nil
INFO: 2	uel0001	0	->	nil
INFO: 2	uea0303	1	->	1
INFO: 2	uea0303	0	->	nil
INFO: 2	uea0303	0	->	nil
INFO: 3	ual0001	1	->	1
INFO: 3	ual0001	0	->	nil
INFO: 3	ual0001	0	->	nil
INFO: 3	xsl0001	1	->	1
INFO: 3	xsl0001	0	->	nil
INFO: 3	xsl0001	0	->	nil
INFO: 3	ura0303	0	->	nil
INFO: 3	ura0303	7	->	7
INFO: 3	ura0303	2	->	2
INFO: 3	xsa0303	7	->	7
INFO: 3	xsa0303	0	->	nil
INFO: 3	xsa0303	0	->	nil
INFO: 3	url0402	0	->	nil
INFO: 3	url0402	1	->	1
INFO: 3	url0402	0	->	nil
INFO: 3	xrl0403	0	->	nil
INFO: 3	xrl0403	1	->	1
INFO: 3	xrl0403	0	->	nil
INFO: 3	xsl0401	2	->	2
INFO: 3	xsl0401	0	->	nil
INFO: 3	xsl0401	0	->	nil
INFO: 4	xsl0001	0	->	nil
INFO: 4	xsl0001	1	->	nil
INFO: 4	xsl0001	1	->	1
INFO: 4	ura0303	2	->	2
INFO: 4	ura0303	0	->	nil
INFO: 4	ura0303	0	->	nil
INFO: 4	uea0303	2	->	2
INFO: 4	uea0303	0	->	nil
INFO: 4	uea0303	0	->	nil
INFO: 4	xsa0303	0	->	2
INFO: 4	xsa0303	6	->	6
INFO: 4	xsa0303	6	->	9
INFO: 4	xsl0401	0	->	nil
INFO: 4	xsl0401	0	->	nil
INFO: 4	xsl0401	0	->	2
```

## Additional context

This was introduced 8 years ago in https://github.com/FAForever/fa/commit/06690e0bf6a6e0bc8ec5d3c48ae8b96a2fa09612. The use of JSON instead of XML is fine, but it appears the introduction of this logic to track the status quo of units was not necessary.

## Checklist

- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
- [ ] Keep support for the 'lowest health' ACU achievement
