### PR TITLE
Increase the muzzle velocity of the Hoplite's rockets

### DIFF
--- a/changelog/3810.md
+++ b/changelog/3810.md
@@ -90,10 +90,6 @@
         - VisionRadius while stealthed/cloaked: 0.6 --> 0.8
         - RadarRadius while stealthed/cloaked: 0.6 --> 0.8
 
-- (#6141) Slightly buff the currently underused Hoplite by increasing the muzzle velocity of its rockets.
-    - Hoplite: T2 Rocket Bot (DRL0204):
-        - MuzzleVelocity: 20 --> 25
-
 ## Features
 
 - (#6079) Make various structures easier to place to help with base building.

--- a/changelog/3810.md
+++ b/changelog/3810.md
@@ -90,6 +90,10 @@
         - VisionRadius while stealthed/cloaked: 0.6 --> 0.8
         - RadarRadius while stealthed/cloaked: 0.6 --> 0.8
 
+- (#6141) Slightly buff the currently underused Hoplite by increasing the muzzle velocity of its rockets.
+    - Hoplite: T2 Rocket Bot (DRL0204):
+        - MuzzleVelocity: 20 --> 25
+
 ## Features
 
 - (#6079) Make various structures easier to place to help with base building.

--- a/changelog/snippets/balance.6141.md
+++ b/changelog/snippets/balance.6141.md
@@ -1,0 +1,3 @@
+- (#6141) Slightly buff the currently underused Hoplite by increasing the muzzle velocity of its rockets.
+    - Hoplite: T2 Rocket Bot (DRL0204):
+        - MuzzleVelocity: 20 --> 25

--- a/units/DRL0204/DRL0204_unit.bp
+++ b/units/DRL0204/DRL0204_unit.bp
@@ -216,7 +216,7 @@ UnitBlueprint{
             MaxRadius = 37,
             MuzzleSalvoDelay = 0.1,
             MuzzleSalvoSize = 3,
-            MuzzleVelocity = 20,
+            MuzzleVelocity = 25,
             ProjectileId = "/projectiles/CDFRocketIridium02/CDFRocketIridium02_proj.bp",
             ProjectileLifetime = 5,
             ProjectilesPerOnFire = 3,


### PR DESCRIPTION
## Description of the proposed changes
**Hoplite: T2 Rocket Bot**
MuzzleVelocity: 20 --> 25

As discussed with the balance team.

## Checklist
- [x] Changes are documented in the changelog for the next game version
