### PR TITLE
Pull threads out of functions

### DIFF
--- a/engine/Core.lua
+++ b/engine/Core.lua
@@ -240,6 +240,7 @@ end
 function MATH_IRound(number)
 end
 
+---@overload fun(s: number, a1: number, b1: number, a2: number, b2: number): number, number
 --- Applies linear interpolation between two values `a` and `b`
 ---@param s number Usually between 0 (returns `a`) and 1 (returns `b`)
 ---@param a number

--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -64,19 +64,21 @@ function EndOperation(success, allPrimary, allSecondary, allBonus)
 
     import("/lua/sim/matchstate.lua").CallEndGame() -- We need this here to populate the score screen
 
-    ForkThread(function()
-        WaitSeconds(3) -- Wait for the stats to be synced
-        UnlockInput()
-        EndOperationT {
-            success = success,
-            difficulty = ScenarioInfo.Options.Difficulty,
-            allPrimary = allPrimary,
-            allSecondary = allSecondary,
-            allBonus = allBonus,
-            faction = ScenarioInfo.LocalFaction,
-            opData = opData.operationData
-        }
-    end)
+    ForkThread(EndOperationThread, {
+        success = success,
+        difficulty = ScenarioInfo.Options.Difficulty,
+        allPrimary = allPrimary,
+        allSecondary = allSecondary,
+        allBonus = allBonus,
+        faction = ScenarioInfo.LocalFaction,
+        opData = opData.operationData
+    })
+end
+
+function EndOperationThread(tbl)
+    WaitSeconds(3) -- Wait for the stats to be synced
+    UnlockInput()
+    EndOperationT(tbl)
 end
 
 ---@alias FactionSelectData {Faction: "aeon" | "cybran" | "uef"}

--- a/lua/SimPing.lua
+++ b/lua/SimPing.lua
@@ -66,7 +66,10 @@ function SpawnPing(data)
             end
         end
 
-        ForkThread(function(owner) WaitSeconds(PingTimeout) PingsRemaining[owner] = PingsRemaining[owner] + 1 end, data.Owner)
+        ForkThread(function(owner)
+            WaitSeconds(PingTimeout)
+            PingsRemaining[owner] = PingsRemaining[owner] + 1
+        end, data.Owner)
     end
 end
 

--- a/lua/SimPing.lua
+++ b/lua/SimPing.lua
@@ -9,17 +9,25 @@ MaxPingMarkers = 15
 Sync.MaxPingMarkers = MaxPingMarkers
 
 ---@param entity Entity
----@param lifetime number
+---@param lifetime? number
 function AnimatePingMesh(entity, lifetime)
     local time = 0
-    while entity and lifetime > 0 do
-        entity:SetScale(MATH_Lerp(math.sin(time), -0.5, 0.5, 0.3, 0.5))
-        time = time + 0.3
-        WaitSeconds(0.1)
+    if lifetime then
+        while entity and lifetime > 0 do
+            entity:SetScale(MATH_Lerp(math.sin(time), -0.5, 0.5, 0.3, 0.5))
+            time = time + 0.3
+            WaitSeconds(0.1)
 
-        lifetime = lifetime - 0.1
+            lifetime = lifetime - 0.1
+        end
+        entity:Destroy()
+    else
+        while entity do
+            entity:SetScale(MATH_Lerp(math.sin(time), -0.5, 0.5, 0.3, 0.5))
+            time = time + 0.3
+            WaitSeconds(0.1)
+        end
     end
-    entity:Destroy()
 end
 
 function SpawnPing(data)

--- a/lua/SimPingGroup.lua
+++ b/lua/SimPingGroup.lua
@@ -54,13 +54,16 @@ function OnClickCallback(data)
 end
 
 function OnPostLoad()
-    ForkThread(function()
-        WaitSeconds(5)
-        if not Sync.AddPingGroups then 
-            Sync.AddPingGroups = {}
-        end
-        for _, PingGroup in PingGroups do
-            table.insert(Sync.AddPingGroups, {ID = PingGroup._id, Name = PingGroup.Name, BlueprintID = PingGroup.BlueprintID, Type = PingGroup.Type})
-        end
-    end)
+    ForkThread(OnPostLoadThread)
+end
+
+function OnPostLoadThread()
+    WaitSeconds(5)
+
+    if not Sync.AddPingGroups then
+        Sync.AddPingGroups = {}
+    end
+    for _, PingGroup in PingGroups do
+        table.insert(Sync.AddPingGroups, {ID = PingGroup._id, Name = PingGroup.Name, BlueprintID = PingGroup.BlueprintID, Type = PingGroup.Type})
+    end
 end

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -765,14 +765,18 @@ AIBrain = Class(AIBrainHQComponent, AIBrainStatisticsComponent, AIBrainJammerCom
             return
         end
 
-        self.VOTable[string] = true
-        import('/lua/SimSyncUtils.lua').SyncVoice({ Cue = cue, Bank = bank })
+        ForkThread(self.PlayVOSoundThread, self, string, bank, cue)
+    end,
 
-        local timeout = VO['timeout']
-        ForkThread(function()
-            WaitSeconds(timeout)
-            self.VOTable[string] = nil
-        end)
+    PlayVOSoundThread = function(self, key, bank, cue)
+        self.VOTable[key] = true
+        import("/lua/SimSyncUtils.lua").SyncVoice {
+            Cue = cue,
+            Bank = bank
+        }
+        WaitSeconds(self.VOSounds["timeout"])
+
+        self.VOTable[key] = nil
     end,
 
     --- Triggers based on an AiBrain

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -765,15 +765,15 @@ AIBrain = Class(AIBrainHQComponent, AIBrainStatisticsComponent, AIBrainJammerCom
             return
         end
 
-        ForkThread(self.PlayVOSoundThread, self, string, bank, cue)
-    end,
-
-    PlayVOSoundThread = function(self, key, bank, cue)
-        self.VOTable[key] = true
-        import("/lua/SimSyncUtils.lua").SyncVoice {
+        self.VOTable[string] = true
+        ForkThread(self.PlayVOSoundThread, self, string, {
             Cue = cue,
             Bank = bank
-        }
+        })
+    end,
+
+    PlayVOSoundThread = function(self, key, data)
+        import("/lua/SimSyncUtils.lua").SyncVoice(data)
         WaitSeconds(self.VOSounds["timeout"])
 
         self.VOTable[key] = nil

--- a/lua/defaultantiprojectile.lua
+++ b/lua/defaultantiprojectile.lua
@@ -236,15 +236,13 @@ MissileRedirect = Class(Entity) {
 
             if not self.EnemyProj:BeenDestroyed() then
                 local proj = self.EnemyProj
-                local enemy = self.Enemy
-                local enemyPos = enemy and enemy:GetPosition()
 
                 if proj.MoveThread then
                     KillThread(proj.MoveThread)
                     proj.MoveThread = nil
                 end
 
-                proj:ForkThread(self.RedirectionThread)
+                ForkThread(self.RedirectionThread, self, proj, self.Enemy)
             end
 
             WaitSeconds(1 / self.RedirectRateOfFire)
@@ -255,11 +253,14 @@ MissileRedirect = Class(Entity) {
             ChangeState(self, self.WaitingState)
         end,
 
-        RedirectionThread = function(proj)
+        RedirectionThread = function(self, proj, enemy)
+            local enemyPos = enemy and enemy:GetPosition()
             local projPos = proj:GetPosition()
-            local above = { projPos[1] + GetRandomFloat(-2, 2), projPos[2] + GetRandomFloat(4, 6),
-                projPos[3] + GetRandomFloat(-2, 2) }
-
+            local above = {
+                projPos[1] + GetRandomFloat(-2, 2),
+                projPos[2] + GetRandomFloat(4, 6),
+                projPos[3] + GetRandomFloat(-2, 2)
+            }
             proj:SetLifetime(30)
             proj:SetCollideSurface(true)
             proj:SetTurnRate(160)
@@ -267,12 +268,15 @@ MissileRedirect = Class(Entity) {
             proj:TrackTarget(true)
             WaitSeconds(1)
 
-            if proj:BeenDestroyed() then return end
+            if proj:BeenDestroyed() then
+                return
+            end
             if not enemy then
-                proj:DoTakeDamage(self.Owner, 30, Vector(0, 1, 0), 'Fire')
+                proj:DoTakeDamage(self.Owner, 30, Vector(0, 1, 0), "Fire")
             elseif not enemy:BeenDestroyed() then
                 proj:SetNewTarget(enemy)
                 WaitSeconds(2)
+
                 enemyPos = enemy:GetPosition()
             end
 

--- a/lua/defaultantiprojectile.lua
+++ b/lua/defaultantiprojectile.lua
@@ -244,34 +244,7 @@ MissileRedirect = Class(Entity) {
                     proj.MoveThread = nil
                 end
 
-                proj:ForkThread(function()
-                    local projPos = proj:GetPosition()
-                    local above = { projPos[1] + GetRandomFloat(-2, 2), projPos[2] + GetRandomFloat(4, 6),
-                        projPos[3] + GetRandomFloat(-2, 2) }
-
-                    proj:SetLifetime(30)
-                    proj:SetCollideSurface(true)
-                    proj:SetTurnRate(160)
-                    proj:SetNewTargetGround(above)
-                    proj:TrackTarget(true)
-                    WaitSeconds(1)
-
-                    if proj:BeenDestroyed() then return end
-                    if not enemy then
-                        proj:DoTakeDamage(self.Owner, 30, Vector(0, 1, 0), 'Fire')
-                    elseif not enemy:BeenDestroyed() then
-                        proj:SetNewTarget(enemy)
-                        WaitSeconds(2)
-                        enemyPos = enemy:GetPosition()
-                    end
-
-                    -- aim at right below surface if unit is submerged
-                    enemyPos = enemyPos or projPos
-                    local surfaceHeight = GetSurfaceHeight(enemyPos[1], enemyPos[3]) - 0.02
-                    enemyPos[2] = math.max(surfaceHeight, enemyPos[2])
-
-                    proj:SetNewTargetGround(enemyPos)
-                end)
+                proj:ForkThread(self.RedirectionThread)
             end
 
             WaitSeconds(1 / self.RedirectRateOfFire)
@@ -280,6 +253,35 @@ MissileRedirect = Class(Entity) {
             end
 
             ChangeState(self, self.WaitingState)
+        end,
+
+        RedirectionThread = function(proj)
+            local projPos = proj:GetPosition()
+            local above = { projPos[1] + GetRandomFloat(-2, 2), projPos[2] + GetRandomFloat(4, 6),
+                projPos[3] + GetRandomFloat(-2, 2) }
+
+            proj:SetLifetime(30)
+            proj:SetCollideSurface(true)
+            proj:SetTurnRate(160)
+            proj:SetNewTargetGround(above)
+            proj:TrackTarget(true)
+            WaitSeconds(1)
+
+            if proj:BeenDestroyed() then return end
+            if not enemy then
+                proj:DoTakeDamage(self.Owner, 30, Vector(0, 1, 0), 'Fire')
+            elseif not enemy:BeenDestroyed() then
+                proj:SetNewTarget(enemy)
+                WaitSeconds(2)
+                enemyPos = enemy:GetPosition()
+            end
+
+            -- aim at right below surface if unit is submerged
+            enemyPos = enemyPos or projPos
+            local surfaceHeight = GetSurfaceHeight(enemyPos[1], enemyPos[3]) - 0.02
+            enemyPos[2] = math.max(surfaceHeight, enemyPos[2])
+
+            proj:SetNewTargetGround(enemyPos)
         end,
 
         OnCollisionCheck = function(self, other)

--- a/lua/defaultantiprojectile.lua
+++ b/lua/defaultantiprojectile.lua
@@ -242,7 +242,9 @@ MissileRedirect = Class(Entity) {
                     proj.MoveThread = nil
                 end
 
-                ForkThread(self.RedirectionThread, self, proj, self.Enemy)
+                local enemy = self.Enemy
+                local enemyPos = enemy and enemy:GetPosition()
+                proj.Trash:Add(ForkThread(self.RedirectionThread, self, proj, enemy, enemyPos))
             end
 
             WaitSeconds(1 / self.RedirectRateOfFire)
@@ -253,8 +255,7 @@ MissileRedirect = Class(Entity) {
             ChangeState(self, self.WaitingState)
         end,
 
-        RedirectionThread = function(self, proj, enemy)
-            local enemyPos = enemy and enemy:GetPosition()
+        RedirectionThread = function(self, proj, enemy, enemyPos)
             local projPos = proj:GetPosition()
             local above = {
                 projPos[1] + GetRandomFloat(-2, 2),

--- a/lua/sim/MatchState.lua
+++ b/lua/sim/MatchState.lua
@@ -12,16 +12,21 @@ local Conditions = {
 
 --- Ends the game, processing all events including sending score and statistics to the UI
 function CallEndGame()
-    ForkThread(function()
-        WaitSeconds(2.9)
-        for _, v in GameOverListeners do
-            v()
-        end
-        Sync.GameEnded = true
-        WaitSeconds(0.1)
-        EndGame()
-    end)
+    ForkThread(CallEndGameThread)
 end
+
+function CallEndGameThread()
+    WaitSeconds(2.9)
+
+    for _, v in GameOverListeners do
+        v()
+    end
+    Sync.GameEnded = true
+    WaitSeconds(0.1)
+
+    EndGame()
+end
+
 
 --- Finds and collectors the brains that are defeated
 ---@param aliveBrains AIBrain[]         # Table of brains that are relevant to check for defeat

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -30,29 +30,30 @@ function EnableLoadBalance(enabled, unitThreshold)
     if enabled then
         ScenarioInfo.LoadBalance.UnitThreshold = unitThreshold or 50
     else
-        ForkThread(function()
-            --local timePerGroup = ScenarioInfo.DistributeTime/table.getn(ScenarioInfo.LoadBalance.SpawnGroups)
-
-            --Get time
-            local time = GetSystemTimeSecondsOnlyForProfileUse()
-
-            --Spawn bases
-            while not table.empty(ScenarioInfo.LoadBalance.SpawnGroups) do
-                local base, name, uncapturable = unpack(table.remove(ScenarioInfo.LoadBalance.SpawnGroups, 1))
-                base:SpawnGroup(name, uncapturable, true)
-            end
-
-            --Spawn units
-            while not table.empty(ScenarioInfo.LoadBalance.PlatoonGroups) do
-                local strArmy, strGroup, formation, callback = unpack(table.remove(ScenarioInfo.LoadBalance.PlatoonGroups
-                    , 1))
-                CreateArmyGroupAsPlatoonBalanced(strArmy, strGroup, formation, callback)
-            end
-
-            --Report time taken
-            LOG("Time to spawn: " .. (GetSystemTimeSecondsOnlyForProfileUse() - time))
-        end)
+        ForkThread(LoadBalanceThread)
     end
+end
+
+function LoadBalanceThread()
+    --local timePerGroup = ScenarioInfo.DistributeTime/table.getn(ScenarioInfo.LoadBalance.SpawnGroups)
+
+    --Get time
+    local time = GetSystemTimeSecondsOnlyForProfileUse()
+
+    --Spawn bases
+    while not table.empty(ScenarioInfo.LoadBalance.SpawnGroups) do
+        local base, name, uncapturable = unpack(table.remove(ScenarioInfo.LoadBalance.SpawnGroups, 1))
+        base:SpawnGroup(name, uncapturable, true)
+    end
+
+    --Spawn units
+    while not table.empty(ScenarioInfo.LoadBalance.PlatoonGroups) do
+        local strArmy, strGroup, formation, callback = unpack(table.remove(ScenarioInfo.LoadBalance.PlatoonGroups, 1))
+        CreateArmyGroupAsPlatoonBalanced(strArmy, strGroup, formation, callback)
+    end
+
+    --Report time taken
+    LOG("Time to spawn: " .. (GetSystemTimeSecondsOnlyForProfileUse() - time))
 end
 
 ---@deprecated # use marker utilities instead

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -722,17 +722,19 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
         self.Captors[captor.EntityId] = captor
 
         if not self.CaptureThread then
-            self.CaptureThread = self:ForkThread(function()
-                local captors = self.Captors or {}
-                while not table.empty(captors) do
-                    for _, c in captors do
-                        self:CheckCaptor(c)
-                    end
+            self.CaptureThread = self:ForkThread(self.BeingCapturedThread)
+        end
+    end,
 
-                    WaitTicks(1)
-                    captors = self.Captors or {}
-                end
-            end)
+    BeingCapturedThread = function(self)
+        local captors = self.Captors or {}
+        while not table.empty(captors) do
+            for _, c in captors do
+                self:CheckCaptor(c)
+            end
+            WaitTicks(1)
+
+            captors = self.Captors or {}
         end
     end,
 

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -401,13 +401,16 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                 end
                 self.EconDrain = CreateEconomyEvent(self.unit, nrgReq, 0, time)
                 self.FirstShot = true
-                self.unit:ForkThread(function()
-                    WaitFor(self.EconDrain)
-                    RemoveEconomyEvent(self.unit, self.EconDrain)
-                    self.EconDrain = nil
-                end)
+                self.unit:ForkThread(self.EconomyDrainThread)
             end
         end
+    end,
+
+    ---@param self DefaultProjectileWeapon
+    EconomyDrainThread = function(self)
+        WaitFor(self.EconDrain)
+        RemoveEconomyEvent(self.unit, self.EconDrain)
+        self.EconDrain = nil
     end,
 
     -- Determine how much Energy is required to fire

--- a/lua/sim/weapons/OverchargeWeapon.lua
+++ b/lua/sim/weapons/OverchargeWeapon.lua
@@ -173,15 +173,17 @@ OverchargeWeapon = ClassWeapon(DefaultProjectileWeapon) {
             if self:CanOvercharge() then
                 DefaultProjectileWeapon.IdleState.OnGotTarget(self)
             else
-                self:ForkThread(function()
-                    while self.enabled and not self:CanOvercharge() do
-                        WaitSeconds(0.1)
-                    end
+                ForkThread(self.WaitUntilCanOCThread, self)
+            end
+        end,
 
-                    if self.enabled then
-                        self:OnGotTarget()
-                    end
-                end)
+        WaitUntilCanOCThread = function(self)
+            while self.enabled and not self:CanOvercharge() do
+                WaitSeconds(0.1)
+            end
+
+            if self.enabled then
+                self:OnGotTarget()
             end
         end,
 

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -491,33 +491,38 @@ function BeginSessionCommonArmy(teams)
                 ArmyBrains[i2].Status = 'Defeat'
                 SetArmyOutOfGame(i2)
                 local Units = ArmyBrains[i2]:GetListOfUnits(categories.COMMAND, false, true)
-                ForkThread(function(i, i2, comm)
-                    while true do
-                        if comm then
-                            WaitTicks(1)
-                            if comm:IsUnitState('Busy') then continue end
-                            if comm:IsUnitState('UnSelectable') then continue end
-                            if comm:IsUnitState('BlockCommandQueue') then continue end
-                        end
-                        SetCommandSource(i2 - 1, IsHuman[i2], false)
-                        SetCommandSource(i - 1, IsHuman[i2], true)
-                        SetArmyUnitCap(i, GetArmyUnitCap(i) + GetArmyUnitCap(i2))
-                        Units = ArmyBrains[i2]:GetListOfUnits(categories.ALLUNITS, false, true)
-                        for _, unit in Units do
-                            ChangeUnitArmy(unit, i, true)
-                        end
-                        local v1 = ArmyBrains[i]:GetEconomyStored('MASS') + ArmyBrains[i2]:GetEconomyStored('MASS')
-                        local v2 = ArmyBrains[i]:GetEconomyStored('ENERGY') + ArmyBrains[i2]:GetEconomyStored('ENERGY')
-                        SetArmyEconomy(i, v1, v2)
-                        if i2 == GetFocusArmy() then
-                            SetFocusArmy(i - 1)
-                        end
-                        break
-                    end
-                end, i, i2, Units[1])
+                ForkThread(MergeArmyPair, i, i2, Units[1], IsHuman[i2])
             end
             break
         end
+    end
+end
+
+---@param into integer
+---@param from integer
+---@param comm Unit
+---@param humanIndex integer
+function MergeArmyPair(into, from, comm, humanIndex)
+    if comm then
+        repeat
+            WaitTicks(1)
+        until
+            not comm:IsUnitState("Busy") and
+            not comm:IsUnitState("UnSelectable") and
+            not comm:IsUnitState("BlockCommandQueue")
+    end
+    SetCommandSource(from - 1, humanIndex, false)
+    SetCommandSource(into - 1, humanIndex, true)
+    SetArmyUnitCap(into, GetArmyUnitCap(into) + GetArmyUnitCap(from))
+    Units = ArmyBrains[from]:GetListOfUnits(categories.ALLUNITS, false, true)
+    for _, unit in Units do
+        ChangeUnitArmy(unit, into, true)
+    end
+    local v1 = ArmyBrains[into]:GetEconomyStored("MASS") + ArmyBrains[from]:GetEconomyStored("MASS")
+    local v2 = ArmyBrains[into]:GetEconomyStored("ENERGY") + ArmyBrains[from]:GetEconomyStored("ENERGY")
+    SetArmyEconomy(into, v1, v2)
+    if from == GetFocusArmy() then
+        SetFocusArmy(into - 1)
     end
 end
 

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -333,14 +333,7 @@ function BeginSession()
     end
 
     -- add on game over callbacks
-    ForkThread(function()
-        while not IsGameOver() do
-            WaitTicks(1)
-        end
-        for _, v in GameOverListeners do
-            v()
-        end
-    end)
+    ForkThread(GameOverListenerThread)
 
     -- log game time
     ForkThread(GameTimeLogger)
@@ -351,6 +344,15 @@ function BeginSession()
     -- trigger event for brains
     for k, brain in ArmyBrains do
         brain:OnBeginSession()
+    end
+end
+
+function GameOverListenerThread()
+    while not IsGameOver() do
+        WaitTicks(1)
+    end
+    for _, v in GameOverListeners do
+        v()
     end
 end
 

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -973,39 +973,44 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
         end
     end,
 
+    ---@param self WorldView
+    ---@param ownerIndex integer
+    FlashScoreboardIcon = function(self, ownerIndex)
+        local scoreBoardControls = import("/lua/ui/game/score.lua").controls
+        if not scoreBoardControls.armyLines then
+            return
+        end
+        for _, line in scoreBoardControls.armyLines do
+            if line.armyID == ownerIndex then
+                ForkThread(self.FlashScoreboardIconThread, self, line.faction, 8, 0.4)
+                break
+            end
+        end
+    end,
+
+    ---@param self WorldView
+    ---@param toFlash Control
+    ---@param flashesRemaining integer
+    ---@param flashInterval number
+    FlashScoreboardIconThread = function(self, toFlash, flashesRemaining, flashInterval)
+        -- Flash the icon the appropriate number of times.
+        while flashesRemaining > 0 do
+            toFlash:Hide()
+            WaitSeconds(flashInterval)
+
+            toFlash:Show()
+            WaitSeconds(flashInterval)
+
+            flashesRemaining = flashesRemaining - 1
+        end
+    end,
+
+    ---@param self WorldView
+    ---@param pingData table
     DisplayPing = function(self, pingData)
         -- Flash the scoreboard faction icon for the ping owner to indicate the source.
         if not pingData.Marker and not pingData.Renew then
-            -- Zero-based indices FTW...
-            local pingOwnerIndex = pingData.Owner + 1
-
-            -- The faction icon for the pingOwner.
-            local toFlash
-
-            -- Find the UI element we need to flash.
-            local scoreBoardControls = import("/lua/ui/game/score.lua").controls
-            for _, line in scoreBoardControls.armyLines or {} do
-                if line.armyID == pingOwnerIndex then
-                    toFlash = line.faction
-                    break
-                end
-            end
-
-            if toFlash then
-                local flashesRemaining = 8
-                local flashInterval = 0.4
-                ForkThread(function()
-                    -- Flash the icon the appropriate number of times.
-                    while flashesRemaining > 0 do
-                        toFlash:Hide()
-                        WaitSeconds(flashInterval)
-                        toFlash:Show()
-                        WaitSeconds(flashInterval)
-
-                        flashesRemaining = flashesRemaining - 1
-                    end
-                end)
-            end
+            self:FlashScoreboardIcon(pingData.Owner + 1) -- zero-based to one-based
         end
 
         if not self:IsHidden() and pingData.Location then

--- a/lua/ui/dialogs/saveload.lua
+++ b/lua/ui/dialogs/saveload.lua
@@ -98,10 +98,8 @@ local function CreateDialog(over, isLoad, callback, exitBehavior, fileType)
         end
     end
 
-    local filePicker = FilePicker(panel, fileType, ((not isLoad) or (fileType == "CampaignSave")) , function(control, fileInfo)
-        ForkThread(function()
-            callback(fileInfo, panel, KillDialog)
-        end)
+    local filePicker = FilePicker(panel, fileType, not isLoad or fileType == "CampaignSave", function(control, fileInfo)
+        ForkThread(callback, fileInfo, panel, KillDialog)
     end)
     LayoutHelpers.AtLeftTopIn(filePicker, panel, 43, 118)
     LayoutHelpers.SetDimensions(filePicker, 595, 362)

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -789,7 +789,7 @@ end
 
 function ChatPageUp(mod)
     if GUI.bg:IsHidden() then
-        ForkThread(function() ToggleChat() end)
+        ForkThread(ToggleChat)
     else
         local newTop = GUI.chatContainer.top - mod
         GUI.chatContainer:ScrollSetTop(nil, newTop)
@@ -801,7 +801,7 @@ function ChatPageDown(mod)
     local newTop = GUI.chatContainer.top + mod
     GUI.chatContainer:ScrollSetTop(nil, newTop)
     if GUI.bg:IsHidden() or oldTop == GUI.chatContainer.top then
-        ForkThread(function() ToggleChat() end)
+        ForkThread(ToggleChat)
     end
 end
 

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -1179,21 +1179,22 @@ function watchForQueueChange(unit)
     if watchingUnit == unit then
         return
     end
+    ForkThread(QueueChangeWatchThread, unit)
+end
 
+function QueueChangeWatchThread(unit)
     updateQueue = false
     watchingUnit = unit
-    ForkThread(function()
-        local threadWatchingUnit = watchingUnit
-        while unit:GetCommandQueue()[1].type ~= 'Script' do
-            WaitSeconds(0.2)
-        end
+    local threadWatchingUnit = watchingUnit
+    while unit:GetCommandQueue()[1].type ~= 'Script' do
+        WaitSeconds(0.2)
+    end
 
-        local selection = GetSelectedUnits() or {}
-        if lastDisplayType and table.getn(selection) == 1 and threadWatchingUnit == watchingUnit and selection[1] == threadWatchingUnit then
-            SetSecondaryDisplay(lastDisplayType)
-        end
-        watchingUnit = nil
-    end)
+    local selection = GetSelectedUnits() or {}
+    if lastDisplayType and table.getn(selection) == 1 and threadWatchingUnit == watchingUnit and selection[1] == threadWatchingUnit then
+        SetSecondaryDisplay(lastDisplayType)
+    end
+    watchingUnit = nil
 end
 
 function checkBadClean(unit)

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -1175,16 +1175,18 @@ function OnRolloverHandler(button, state)
     end
 end
 
+---@param unit UserUnit
 function watchForQueueChange(unit)
     if watchingUnit == unit then
         return
     end
+    updateQueue = false
+    watchingUnit = unit
     ForkThread(QueueChangeWatchThread, unit)
 end
 
+---@param unit UserUnit
 function QueueChangeWatchThread(unit)
-    updateQueue = false
-    watchingUnit = unit
     local threadWatchingUnit = watchingUnit
     while unit:GetCommandQueue()[1].type ~= 'Script' do
         WaitSeconds(0.2)

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -629,7 +629,9 @@ function OnSelectionChanged(oldSelection, newSelection, added, removed)
         newSelection, changed = DeselectSelens(newSelection)
 
         if changed then
-            ForkThread(SelectUnits, newSelection)
+            ForkThread(function()
+                SelectUnits(newSelection) -- cannot fork cfunction directly
+            end)
             return
         end
 

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -102,7 +102,7 @@ function OnFirstUpdate()
     local armiesInfo = GetArmiesTable()
     local focusArmy = armiesInfo.focusArmy
     local playerArmy = armiesInfo.armiesTable[focusArmy]
-    if avatars and  avatars[1]:IsInCategory("COMMAND") then
+    if avatars and avatars[1]:IsInCategory("COMMAND") then
         avatars[1]:SetCustomName(playerArmy.nickname)
         ForkThread(StartupSequence, avatars)
     end

--- a/lua/ui/game/multifunction.lua
+++ b/lua/ui/game/multifunction.lua
@@ -1403,11 +1403,17 @@ function TeamColorHandler(self, modifiers)
     end
 end
 
-if teamColorSettings.autoEnable then
-    ForkThread(function() 
-        WaitSeconds(0.5) 
-        TeamColorMode(calculateTeamColors()) 
-        TeamColorMode(true) 
-        GetButton('teamcolor'):ToggleCheck() 
-    end)
+ForkThread(function()
+    -- some mandatory wait time to let the global function be defined (or redefined in a hook)
+    WaitSeconds(0.1)
+    TeamColorSettingStartup()
+end)
+
+function TeamColorSettingStartup()
+    WaitSeconds(0.5 - --[[has already occured]]0.1)
+    if teamColorSettings.autoEnable then
+        TeamColorMode(calculateTeamColors())
+        TeamColorMode(true)
+        GetButton('teamcolor'):ToggleCheck()
+    end
 end

--- a/lua/ui/game/reclaim.lua
+++ b/lua/ui/game/reclaim.lua
@@ -660,19 +660,21 @@ function OnCommandGraphShow(bool)
 
     CommandGraphActive = bool
     if CommandGraphActive then
-        ForkThread(function()
-            local keydown
-            while CommandGraphActive do
-                keydown = IsKeyDown('Control')
-                if keydown ~= view.ShowingReclaim then -- state has changed
-                    ShowReclaim(keydown)
-                end
-                WaitSeconds(.1)
-            end
-
-            ShowReclaim(false)
-        end)
+        ForkThread(OnCommandGraphShowThread, view)
     else
         CommandGraphActive = false -- above coroutine runs until now
     end
+end
+
+function OnCommandGraphShowThread(view)
+    local keydown
+    while CommandGraphActive do
+        keydown = IsKeyDown('Control')
+        if keydown ~= view.ShowingReclaim then -- state has changed
+            ShowReclaim(keydown)
+        end
+        WaitSeconds(0.1)
+    end
+
+    ShowReclaim(false)
 end

--- a/lua/victory.lua
+++ b/lua/victory.lua
@@ -41,15 +41,19 @@ end
 
 function CallEndGame()
     gameOver = true
-    ForkThread(function()
-        WaitSeconds(2.9)
-        for _, v in GameOverListeners do
-            v()
-        end
-        Sync.GameEnded = true
-        WaitSeconds(0.1)
-        EndGame()
-    end)
+    ForkThread(CallEndGameThread)
+end
+
+function CallEndGameThread()
+    WaitSeconds(2.9)
+
+    for _, v in GameOverListeners do
+        v()
+    end
+    Sync.GameEnded = true
+    WaitSeconds(0.1)
+
+    EndGame()
 end
 
 function CheckVictory(scenarioInfo)


### PR DESCRIPTION
Several functions define anonymous thread functions like `ForkThread(function() ... end)` which are low-hanging fruit to adding customization points by naming them. These threads are something that, were a mod were to want to change, would require replacing the entire function in addition to the thread function. This is unnecessary on our part, and increases such a mod's stiffness - which I have seen cause at least some parts of one mod to cease to function. While this won't help with anything already written, it is possible to prevent future bit rot.