### PR TITLE
Allow up to 6 bytes in the clan name

### DIFF
--- a/changelog/snippets/fix.6157.md
+++ b/changelog/snippets/fix.6157.md
@@ -1,0 +1,3 @@
+- (#6157) Allow for clan names up to 6 bytes
+
+The existing limit would specifically prevent Yudi from joining lobbies.

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5250,6 +5250,7 @@ local MessageHandlers = {
                     return false
                 end
 
+                -- note: there are strange clan names that use more than 1 byte per character
                 if string.len(data.PlayerOptions.PlayerClan) > 6 then
                     return false
                 end

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -5250,7 +5250,7 @@ local MessageHandlers = {
                     return false
                 end
 
-                if string.len(data.PlayerOptions.PlayerClan) > 3 then
+                if string.len(data.PlayerOptions.PlayerClan) > 6 then
                     return false
                 end
             end


### PR DESCRIPTION
## Description of the proposed changes

The function `string.len` computes the number of bytes, not the number of characters. Therefore one can have a relative long name even though it's only three characters. As a few examples that are in the database at this moment:

```
♂
☾⋆⁺
™¶€
•••
ФБК
еба
ΔLT
ΐ1
ƒ
Æ
º*º
±
©
J¢p
```

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
