### PR TITLE
Remove several unused fields from various blueprints

### DIFF
--- a/units/OPC1001/OPC1001_unit.bp
+++ b/units/OPC1001/OPC1001_unit.bp
@@ -47,7 +47,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Cybran',
-        TechLevel = 'RULEUTL_Basic',
     },
     Intel = {
         VisionRadius = 16,

--- a/units/OPC1001/OPC1001_unit.bp
+++ b/units/OPC1001/OPC1001_unit.bp
@@ -31,7 +31,6 @@ UnitBlueprint {
         BuildCostMass = 0,
     },
     General = {
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPC1002/OPC1002_unit.bp
+++ b/units/OPC1002/OPC1002_unit.bp
@@ -71,7 +71,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Research Truck',
-        Classification = 'RULEUC_MilitaryVehicle',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/OPC1002/OPC1002_unit.bp
+++ b/units/OPC1002/OPC1002_unit.bp
@@ -85,7 +85,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Cybran',
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 18,

--- a/units/OPC1002/OPC1002_unit.bp
+++ b/units/OPC1002/OPC1002_unit.bp
@@ -70,7 +70,6 @@ UnitBlueprint {
         BuildCostMass = 158,
     },
     General = {
-        Category = 'Research Truck',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/OPC1002/OPC1002_unit.bp
+++ b/units/OPC1002/OPC1002_unit.bp
@@ -87,7 +87,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Cybran',
-        TechLevel = 'RULEUTL_Advanced',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/OPC2001/OPC2001_unit.bp
+++ b/units/OPC2001/OPC2001_unit.bp
@@ -48,7 +48,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Cybran',
-        TechLevel = 'RULEUTL_Basic',
     },
     Interface = {
         HelpText = '<LOC opc2001_help>OpC2 Temple',

--- a/units/OPC2001/OPC2001_unit.bp
+++ b/units/OPC2001/OPC2001_unit.bp
@@ -32,7 +32,6 @@ UnitBlueprint {
         BuildCostMass = 0,
     },
     General = {
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPC2002/OPC2002_unit.bp
+++ b/units/OPC2002/OPC2002_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Aeon',
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 20,

--- a/units/OPC5007/OPC5007_unit.bp
+++ b/units/OPC5007/OPC5007_unit.bp
@@ -63,7 +63,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'UEF',
-        TechLevel = 'RULEUTL_Basic',
         UnitName = '<LOC opc5007_name>',
         UnitWeight = 1,
     },

--- a/units/OPC5007/OPC5007_unit.bp
+++ b/units/OPC5007/OPC5007_unit.bp
@@ -47,7 +47,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPC5007/OPC5007_unit.bp
+++ b/units/OPC5007/OPC5007_unit.bp
@@ -62,7 +62,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         UnitName = '<LOC opc5007_name>',
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC oopc5007_help>UEF Research Facility',

--- a/units/OPC5007/OPC5007_unit.bp
+++ b/units/OPC5007/OPC5007_unit.bp
@@ -46,7 +46,6 @@ UnitBlueprint {
         BuildTime = 50,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPC5008/OPC5008_unit.bp
+++ b/units/OPC5008/OPC5008_unit.bp
@@ -62,7 +62,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         UnitName = '<LOC opc5008_name>',
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC oopc5008_help>UEF Prison Facility',

--- a/units/OPC5008/OPC5008_unit.bp
+++ b/units/OPC5008/OPC5008_unit.bp
@@ -47,7 +47,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPC5008/OPC5008_unit.bp
+++ b/units/OPC5008/OPC5008_unit.bp
@@ -63,7 +63,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'UEF',
-        TechLevel = 'RULEUTL_Basic',
         UnitName = '<LOC opc5008_name>',
         UnitWeight = 1,
     },

--- a/units/OPC5008/OPC5008_unit.bp
+++ b/units/OPC5008/OPC5008_unit.bp
@@ -46,7 +46,6 @@ UnitBlueprint {
         BuildTime = 50,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPE2001/OPE2001_unit.bp
+++ b/units/OPE2001/OPE2001_unit.bp
@@ -47,7 +47,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPE2001/OPE2001_unit.bp
+++ b/units/OPE2001/OPE2001_unit.bp
@@ -63,7 +63,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'UEF',
-        TechLevel = 'RULEUTL_Basic',
         UnitName = '<LOC ope2001_name>UEF Civilian Center',
         UnitWeight = 1,
     },

--- a/units/OPE2001/OPE2001_unit.bp
+++ b/units/OPE2001/OPE2001_unit.bp
@@ -62,7 +62,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         UnitName = '<LOC ope2001_name>UEF Civilian Center',
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC ope2001_help>UEF Civilian Center',

--- a/units/OPE2001/OPE2001_unit.bp
+++ b/units/OPE2001/OPE2001_unit.bp
@@ -46,7 +46,6 @@ UnitBlueprint {
         BuildTime = 50,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPE3001/OPE3001_unit.bp
+++ b/units/OPE3001/OPE3001_unit.bp
@@ -46,7 +46,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPE3001/OPE3001_unit.bp
+++ b/units/OPE3001/OPE3001_unit.bp
@@ -62,7 +62,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'UEF',
-        TechLevel = 'RULEUTL_Basic',
         UnitName = '<LOC ope3001_name>Arnold\'s Black Box',
         UnitWeight = 1,
     },

--- a/units/OPE3001/OPE3001_unit.bp
+++ b/units/OPE3001/OPE3001_unit.bp
@@ -45,7 +45,6 @@ UnitBlueprint {
         BuildTime = 50,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPE3001/OPE3001_unit.bp
+++ b/units/OPE3001/OPE3001_unit.bp
@@ -61,7 +61,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         UnitName = '<LOC ope3001_name>Arnold\'s Black Box',
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 2,

--- a/units/OPE6001/OPE6001_unit.bp
+++ b/units/OPE6001/OPE6001_unit.bp
@@ -64,7 +64,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Cybran',
-        TechLevel = 'RULEUTL_Basic',
     },
     Interface = {
         HelpText = '<LOC ope6001_help>Black Sun Control Center',

--- a/units/OPE6001/OPE6001_unit.bp
+++ b/units/OPE6001/OPE6001_unit.bp
@@ -48,7 +48,6 @@ UnitBlueprint {
         BuildCostMass = 0,
     },
     General = {
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPE6002/OPE6002_unit.bp
+++ b/units/OPE6002/OPE6002_unit.bp
@@ -47,7 +47,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Cybran',
-        TechLevel = 'RULEUTL_Basic',
     },
     Interface = {
         HelpText = '<LOC ope6002_help>Black Sun Cannon',

--- a/units/OPE6002/OPE6002_unit.bp
+++ b/units/OPE6002/OPE6002_unit.bp
@@ -31,7 +31,6 @@ UnitBlueprint {
         BuildCostMass = 0,
     },
     General = {
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPE6003/OPE6003_unit.bp
+++ b/units/OPE6003/OPE6003_unit.bp
@@ -117,7 +117,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'UEF',
-        TechLevel = 'RULEUTL_Advanced',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/OPE6003/OPE6003_unit.bp
+++ b/units/OPE6003/OPE6003_unit.bp
@@ -115,7 +115,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'UEF',
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 18,

--- a/units/OPE6003/OPE6003_unit.bp
+++ b/units/OPE6003/OPE6003_unit.bp
@@ -101,7 +101,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Civilian Truck',
-        Classification = 'RULEUC_MilitaryVehicle',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/OPE6003/OPE6003_unit.bp
+++ b/units/OPE6003/OPE6003_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         BuildCostMass = 158,
     },
     General = {
-        Category = 'Civilian Truck',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/OPE6004/OPE6004_unit.bp
+++ b/units/OPE6004/OPE6004_unit.bp
@@ -47,7 +47,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Cybran',
-        TechLevel = 'RULEUTL_Basic',
     },
     Interface = {
         HelpText = '<LOC ope6004_help>Black Sun Power',

--- a/units/OPE6004/OPE6004_unit.bp
+++ b/units/OPE6004/OPE6004_unit.bp
@@ -31,7 +31,6 @@ UnitBlueprint {
         BuildCostMass = 0,
     },
     General = {
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPE6005/OPE6005_unit.bp
+++ b/units/OPE6005/OPE6005_unit.bp
@@ -47,7 +47,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Cybran',
-        TechLevel = 'RULEUTL_Basic',
     },
     Interface = {
         HelpText = '<LOC ope6005_help>Black Sun Building',

--- a/units/OPE6005/OPE6005_unit.bp
+++ b/units/OPE6005/OPE6005_unit.bp
@@ -31,7 +31,6 @@ UnitBlueprint {
         BuildCostMass = 0,
     },
     General = {
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPE6006/ope6006_unit.bp
+++ b/units/OPE6006/ope6006_unit.bp
@@ -68,7 +68,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPE6006/ope6006_unit.bp
+++ b/units/OPE6006/ope6006_unit.bp
@@ -67,7 +67,6 @@ UnitBlueprint {
         SizeZ = 20,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/OPE6006/ope6006_unit.bp
+++ b/units/OPE6006/ope6006_unit.bp
@@ -86,7 +86,6 @@ UnitBlueprint {
             RULEUTC_SpecialToggle = true,
         },
         UnitName = '<LOC uec1901_name>UEF Black Sun',
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uec1901_help>UEF Black Sun',

--- a/units/OPE6006/ope6006_unit.bp
+++ b/units/OPE6006/ope6006_unit.bp
@@ -84,7 +84,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'UEF',
-        TechLevel = 'RULEUTL_Basic',
         ToggleCaps = {
             RULEUTC_SpecialToggle = true,
         },

--- a/units/UAC1101/UAC1101_unit.bp
+++ b/units/UAC1101/UAC1101_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UAC1101/UAC1101_unit.bp
+++ b/units/UAC1101/UAC1101_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uac1101_help>Aeon Civilian Structure',

--- a/units/UAC1101/UAC1101_unit.bp
+++ b/units/UAC1101/UAC1101_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UAC1101/UAC1101_unit.bp
+++ b/units/UAC1101/UAC1101_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UAC1201/UAC1201_unit.bp
+++ b/units/UAC1201/UAC1201_unit.bp
@@ -124,7 +124,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uac1201_help>Aeon Civilian Structure',

--- a/units/UAC1201/UAC1201_unit.bp
+++ b/units/UAC1201/UAC1201_unit.bp
@@ -108,7 +108,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UAC1201/UAC1201_unit.bp
+++ b/units/UAC1201/UAC1201_unit.bp
@@ -126,7 +126,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UAC1201/UAC1201_unit.bp
+++ b/units/UAC1201/UAC1201_unit.bp
@@ -109,7 +109,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UAC1301/UAC1301_unit.bp
+++ b/units/UAC1301/UAC1301_unit.bp
@@ -136,7 +136,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uac1301_help>Aeon Civilian Structure',

--- a/units/UAC1301/UAC1301_unit.bp
+++ b/units/UAC1301/UAC1301_unit.bp
@@ -121,7 +121,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UAC1301/UAC1301_unit.bp
+++ b/units/UAC1301/UAC1301_unit.bp
@@ -120,7 +120,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UAC1301/UAC1301_unit.bp
+++ b/units/UAC1301/UAC1301_unit.bp
@@ -138,7 +138,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UAC1401/UAC1401_unit.bp
+++ b/units/UAC1401/UAC1401_unit.bp
@@ -127,7 +127,6 @@ UnitBlueprint {
         Icon = 'land',
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UAC1401/UAC1401_unit.bp
+++ b/units/UAC1401/UAC1401_unit.bp
@@ -125,7 +125,6 @@ UnitBlueprint {
         Icon = 'land',
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uac1401_help>Aeon Civilian Structure',

--- a/units/UAC1401/UAC1401_unit.bp
+++ b/units/UAC1401/UAC1401_unit.bp
@@ -108,7 +108,6 @@ UnitBlueprint {
         SizeZ = 5,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UAC1401/UAC1401_unit.bp
+++ b/units/UAC1401/UAC1401_unit.bp
@@ -109,7 +109,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UAC1501/UAC1501_unit.bp
+++ b/units/UAC1501/UAC1501_unit.bp
@@ -124,7 +124,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uac1501_help>Aeon Civilian Structure',

--- a/units/UAC1501/UAC1501_unit.bp
+++ b/units/UAC1501/UAC1501_unit.bp
@@ -108,7 +108,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UAC1501/UAC1501_unit.bp
+++ b/units/UAC1501/UAC1501_unit.bp
@@ -126,7 +126,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UAC1501/UAC1501_unit.bp
+++ b/units/UAC1501/UAC1501_unit.bp
@@ -109,7 +109,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UAC1901/UAC1901_unit.bp
+++ b/units/UAC1901/UAC1901_unit.bp
@@ -108,7 +108,6 @@ UnitBlueprint {
         SizeZ = 5,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UAC1901/UAC1901_unit.bp
+++ b/units/UAC1901/UAC1901_unit.bp
@@ -126,7 +126,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UAC1901/UAC1901_unit.bp
+++ b/units/UAC1901/UAC1901_unit.bp
@@ -109,7 +109,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UAC1901/UAC1901_unit.bp
+++ b/units/UAC1901/UAC1901_unit.bp
@@ -124,7 +124,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uac1901_help>Seraphim Ruins',

--- a/units/UAC1902/UAC1902_unit.bp
+++ b/units/UAC1902/UAC1902_unit.bp
@@ -121,7 +121,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uac1902_help>Aeon Civilian Structure',

--- a/units/UAC1902/UAC1902_unit.bp
+++ b/units/UAC1902/UAC1902_unit.bp
@@ -123,7 +123,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UAC1902/UAC1902_unit.bp
+++ b/units/UAC1902/UAC1902_unit.bp
@@ -106,7 +106,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UAC1902/UAC1902_unit.bp
+++ b/units/UAC1902/UAC1902_unit.bp
@@ -105,7 +105,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEA0001/UEA0001_unit.bp
+++ b/units/UEA0001/UEA0001_unit.bp
@@ -173,7 +173,6 @@ UnitBlueprint {
             RULEUTC_WeaponToggle = true,
         },
         UnitName = '<LOC uea0001_name>C-D1 "Rover"',
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 12,

--- a/units/UEA0001/UEA0001_unit.bp
+++ b/units/UEA0001/UEA0001_unit.bp
@@ -141,7 +141,6 @@ UnitBlueprint {
             },
         },
         CapCost = 0,
-        Category = 'Utility',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/UEA0001/UEA0001_unit.bp
+++ b/units/UEA0001/UEA0001_unit.bp
@@ -142,7 +142,6 @@ UnitBlueprint {
         },
         CapCost = 0,
         Category = 'Utility',
-        Classification = 'RULEUC_MilitaryAircraft',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/UEA0001/UEA0001_unit.bp
+++ b/units/UEA0001/UEA0001_unit.bp
@@ -171,7 +171,6 @@ UnitBlueprint {
             },
         },
         SelectionPriority = 6,
-        TechLevel = 'RULEUTL_Basic',
         ToggleCaps = {
             RULEUTC_WeaponToggle = true,
         },

--- a/units/UEA0003/UEA0003_unit.bp
+++ b/units/UEA0003/UEA0003_unit.bp
@@ -174,7 +174,6 @@ UnitBlueprint {
             },
         },
         SelectionPriority = 6,
-        TechLevel = 'RULEUTL_Basic',
         ToggleCaps = {
             RULEUTC_WeaponToggle = true,
         },

--- a/units/UEA0003/UEA0003_unit.bp
+++ b/units/UEA0003/UEA0003_unit.bp
@@ -176,7 +176,6 @@ UnitBlueprint {
             RULEUTC_WeaponToggle = true,
         },
         UnitName = '<LOC uea0003_name>C-D3 "Rover-3"',
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 12,

--- a/units/UEA0003/UEA0003_unit.bp
+++ b/units/UEA0003/UEA0003_unit.bp
@@ -144,7 +144,6 @@ UnitBlueprint {
             },
         },
         CapCost = 0,
-        Category = 'Utility',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/UEA0003/UEA0003_unit.bp
+++ b/units/UEA0003/UEA0003_unit.bp
@@ -145,7 +145,6 @@ UnitBlueprint {
         },
         CapCost = 0,
         Category = 'Utility',
-        Classification = 'RULEUC_MilitaryAircraft',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/UEC0001/UEC0001_unit.bp
+++ b/units/UEC0001/UEC0001_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         BuildCostMass = 158,
     },
     General = {
-        Category = 'Civilian Truck',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/UEC0001/UEC0001_unit.bp
+++ b/units/UEC0001/UEC0001_unit.bp
@@ -116,7 +116,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Advanced',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/UEC0001/UEC0001_unit.bp
+++ b/units/UEC0001/UEC0001_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 18,

--- a/units/UEC0001/UEC0001_unit.bp
+++ b/units/UEC0001/UEC0001_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Civilian Truck',
-        Classification = 'RULEUC_MilitaryVehicle',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/UEC1101/UEC1101_unit.bp
+++ b/units/UEC1101/UEC1101_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UEC1101/UEC1101_unit.bp
+++ b/units/UEC1101/UEC1101_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uec1101_help>UEF Residential Building',

--- a/units/UEC1101/UEC1101_unit.bp
+++ b/units/UEC1101/UEC1101_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1101/UEC1101_unit.bp
+++ b/units/UEC1101/UEC1101_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1201/UEC1201_unit.bp
+++ b/units/UEC1201/UEC1201_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UEC1201/UEC1201_unit.bp
+++ b/units/UEC1201/UEC1201_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uec1201_help>UEF Science Lab',

--- a/units/UEC1201/UEC1201_unit.bp
+++ b/units/UEC1201/UEC1201_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1201/UEC1201_unit.bp
+++ b/units/UEC1201/UEC1201_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1301/UEC1301_unit.bp
+++ b/units/UEC1301/UEC1301_unit.bp
@@ -126,7 +126,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UEC1301/UEC1301_unit.bp
+++ b/units/UEC1301/UEC1301_unit.bp
@@ -124,7 +124,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uec1301_help>UEF Administrative Building',

--- a/units/UEC1301/UEC1301_unit.bp
+++ b/units/UEC1301/UEC1301_unit.bp
@@ -108,7 +108,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1301/UEC1301_unit.bp
+++ b/units/UEC1301/UEC1301_unit.bp
@@ -109,7 +109,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1401/UEC1401_unit.bp
+++ b/units/UEC1401/UEC1401_unit.bp
@@ -126,7 +126,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UEC1401/UEC1401_unit.bp
+++ b/units/UEC1401/UEC1401_unit.bp
@@ -124,7 +124,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uec1401_help>UEF Agricultural Center',

--- a/units/UEC1401/UEC1401_unit.bp
+++ b/units/UEC1401/UEC1401_unit.bp
@@ -108,7 +108,6 @@ UnitBlueprint {
         SizeZ = 5,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1401/UEC1401_unit.bp
+++ b/units/UEC1401/UEC1401_unit.bp
@@ -109,7 +109,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1501/UEC1501_unit.bp
+++ b/units/UEC1501/UEC1501_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1501/UEC1501_unit.bp
+++ b/units/UEC1501/UEC1501_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uec1501_help>UEF Manufacturing Facility',

--- a/units/UEC1501/UEC1501_unit.bp
+++ b/units/UEC1501/UEC1501_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1501/UEC1501_unit.bp
+++ b/units/UEC1501/UEC1501_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UEC1901/UEC1901_unit.bp
+++ b/units/UEC1901/UEC1901_unit.bp
@@ -152,7 +152,6 @@ UnitBlueprint {
         ToggleCaps = {
             RULEUTC_SpecialToggle = true,
         },
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uec1901_help>UEF Black Sun',

--- a/units/UEC1901/UEC1901_unit.bp
+++ b/units/UEC1901/UEC1901_unit.bp
@@ -134,7 +134,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1901/UEC1901_unit.bp
+++ b/units/UEC1901/UEC1901_unit.bp
@@ -151,7 +151,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         ToggleCaps = {
             RULEUTC_SpecialToggle = true,
         },

--- a/units/UEC1901/UEC1901_unit.bp
+++ b/units/UEC1901/UEC1901_unit.bp
@@ -133,7 +133,6 @@ UnitBlueprint {
         SizeZ = 20,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1902/UEC1902_unit.bp
+++ b/units/UEC1902/UEC1902_unit.bp
@@ -120,7 +120,6 @@ UnitBlueprint {
         FactionName = 'UEF',
         Icon = 'land',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UEC1902/UEC1902_unit.bp
+++ b/units/UEC1902/UEC1902_unit.bp
@@ -118,7 +118,6 @@ UnitBlueprint {
         FactionName = 'UEF',
         Icon = 'land',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uec1902_help>UEF Black Sun Control Center',

--- a/units/UEC1902/UEC1902_unit.bp
+++ b/units/UEC1902/UEC1902_unit.bp
@@ -101,7 +101,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1902/UEC1902_unit.bp
+++ b/units/UEC1902/UEC1902_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1903/UEC1903_unit.bp
+++ b/units/UEC1903/UEC1903_unit.bp
@@ -86,7 +86,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1903/UEC1903_unit.bp
+++ b/units/UEC1903/UEC1903_unit.bp
@@ -85,7 +85,6 @@ UnitBlueprint {
         SizeZ = 5,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1903/UEC1903_unit.bp
+++ b/units/UEC1903/UEC1903_unit.bp
@@ -103,7 +103,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UEC1903/UEC1903_unit.bp
+++ b/units/UEC1903/UEC1903_unit.bp
@@ -101,7 +101,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uec1903_help>UEF Black Sun Support',

--- a/units/UEC1904/UEC1904_unit.bp
+++ b/units/UEC1904/UEC1904_unit.bp
@@ -86,7 +86,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1904/UEC1904_unit.bp
+++ b/units/UEC1904/UEC1904_unit.bp
@@ -85,7 +85,6 @@ UnitBlueprint {
         SizeZ = 6,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1904/UEC1904_unit.bp
+++ b/units/UEC1904/UEC1904_unit.bp
@@ -103,7 +103,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UEC1904/UEC1904_unit.bp
+++ b/units/UEC1904/UEC1904_unit.bp
@@ -101,7 +101,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uec1904_help>UEF Black Sun Tower',

--- a/units/UEC1905/UEC1905_unit.bp
+++ b/units/UEC1905/UEC1905_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uec1905_help>UEF Black Sun Crane',

--- a/units/UEC1905/UEC1905_unit.bp
+++ b/units/UEC1905/UEC1905_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1905/UEC1905_unit.bp
+++ b/units/UEC1905/UEC1905_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UEC1905/UEC1905_unit.bp
+++ b/units/UEC1905/UEC1905_unit.bp
@@ -80,7 +80,6 @@ UnitBlueprint {
         SizeZ = 4,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1906/UEC1906_unit.bp
+++ b/units/UEC1906/UEC1906_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uec1906_help>UEF Black Sun Crane',

--- a/units/UEC1906/UEC1906_unit.bp
+++ b/units/UEC1906/UEC1906_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1906/UEC1906_unit.bp
+++ b/units/UEC1906/UEC1906_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UEC1906/UEC1906_unit.bp
+++ b/units/UEC1906/UEC1906_unit.bp
@@ -80,7 +80,6 @@ UnitBlueprint {
         SizeZ = 4,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1907/UEC1907_unit.bp
+++ b/units/UEC1907/UEC1907_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC uec1907_help>UEF Black Sun Building',

--- a/units/UEC1907/UEC1907_unit.bp
+++ b/units/UEC1907/UEC1907_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/UEC1907/UEC1907_unit.bp
+++ b/units/UEC1907/UEC1907_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/UEC1907/UEC1907_unit.bp
+++ b/units/UEC1907/UEC1907_unit.bp
@@ -80,7 +80,6 @@ UnitBlueprint {
         SizeZ = 4,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URA0001/URA0001_unit.bp
+++ b/units/URA0001/URA0001_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'air',
         SelectionPriority = 3,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/URA0001/URA0001_unit.bp
+++ b/units/URA0001/URA0001_unit.bp
@@ -80,7 +80,6 @@ UnitBlueprint {
     General = {
         CapCost = 0,
         Category = 'Construction',
-        Classification = 'RULEUC_Engineer',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/URA0001/URA0001_unit.bp
+++ b/units/URA0001/URA0001_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'air',
         SelectionPriority = 3,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/URA0001/URA0001_unit.bp
+++ b/units/URA0001/URA0001_unit.bp
@@ -79,7 +79,6 @@ UnitBlueprint {
     },
     General = {
         CapCost = 0,
-        Category = 'Construction',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/URB5206/URB5206_unit.bp
+++ b/units/URB5206/URB5206_unit.bp
@@ -44,7 +44,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'land',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/URB5206/URB5206_unit.bp
+++ b/units/URB5206/URB5206_unit.bp
@@ -26,7 +26,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Intelligence',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URB5206/URB5206_unit.bp
+++ b/units/URB5206/URB5206_unit.bp
@@ -25,7 +25,6 @@ UnitBlueprint {
         },
     },
     General = {
-        Category = 'Intelligence',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URB5206/URB5206_unit.bp
+++ b/units/URB5206/URB5206_unit.bp
@@ -42,7 +42,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'land',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/URC0001/URC0001_unit.bp
+++ b/units/URC0001/URC0001_unit.bp
@@ -115,7 +115,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Advanced',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/URC0001/URC0001_unit.bp
+++ b/units/URC0001/URC0001_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 18,

--- a/units/URC0001/URC0001_unit.bp
+++ b/units/URC0001/URC0001_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Civilian Truck',
-        Classification = 'RULEUC_MilitaryVehicle',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/URC0001/URC0001_unit.bp
+++ b/units/URC0001/URC0001_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         BuildCostMass = 158,
     },
     General = {
-        Category = 'Civilian Truck',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/URC1101/URC1101_unit.bp
+++ b/units/URC1101/URC1101_unit.bp
@@ -118,7 +118,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC urc1101_help>Cybran Civilian Structure',

--- a/units/URC1101/URC1101_unit.bp
+++ b/units/URC1101/URC1101_unit.bp
@@ -103,7 +103,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1101/URC1101_unit.bp
+++ b/units/URC1101/URC1101_unit.bp
@@ -120,7 +120,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/URC1101/URC1101_unit.bp
+++ b/units/URC1101/URC1101_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1201/URC1201_unit.bp
+++ b/units/URC1201/URC1201_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC urc1201_help>Cybran Civilian Structure',

--- a/units/URC1201/URC1201_unit.bp
+++ b/units/URC1201/URC1201_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/URC1201/URC1201_unit.bp
+++ b/units/URC1201/URC1201_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1201/URC1201_unit.bp
+++ b/units/URC1201/URC1201_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1301/URC1301_unit.bp
+++ b/units/URC1301/URC1301_unit.bp
@@ -103,7 +103,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1301/URC1301_unit.bp
+++ b/units/URC1301/URC1301_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1301/URC1301_unit.bp
+++ b/units/URC1301/URC1301_unit.bp
@@ -121,7 +121,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'land',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/URC1301/URC1301_unit.bp
+++ b/units/URC1301/URC1301_unit.bp
@@ -119,7 +119,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'land',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC urc1301_help>Cybran Civilian Structure',

--- a/units/URC1302/URC1302_unit.bp
+++ b/units/URC1302/URC1302_unit.bp
@@ -103,7 +103,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1302/URC1302_unit.bp
+++ b/units/URC1302/URC1302_unit.bp
@@ -120,7 +120,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/URC1302/URC1302_unit.bp
+++ b/units/URC1302/URC1302_unit.bp
@@ -118,7 +118,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC urc1302_help>Cybran Communication Station',

--- a/units/URC1302/URC1302_unit.bp
+++ b/units/URC1302/URC1302_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1401/URC1401_unit.bp
+++ b/units/URC1401/URC1401_unit.bp
@@ -103,7 +103,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1401/URC1401_unit.bp
+++ b/units/URC1401/URC1401_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         SizeZ = 5,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1401/URC1401_unit.bp
+++ b/units/URC1401/URC1401_unit.bp
@@ -120,7 +120,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/URC1401/URC1401_unit.bp
+++ b/units/URC1401/URC1401_unit.bp
@@ -118,7 +118,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC urc1401_help>Cybran Civilian Structure',

--- a/units/URC1501/URC1501_unit.bp
+++ b/units/URC1501/URC1501_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1501/URC1501_unit.bp
+++ b/units/URC1501/URC1501_unit.bp
@@ -101,7 +101,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'land',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/URC1501/URC1501_unit.bp
+++ b/units/URC1501/URC1501_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1501/URC1501_unit.bp
+++ b/units/URC1501/URC1501_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'land',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC urc1501_help>Cybran Civilian Structure',

--- a/units/URC1901/URC1901_unit.bp
+++ b/units/URC1901/URC1901_unit.bp
@@ -103,7 +103,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1901/URC1901_unit.bp
+++ b/units/URC1901/URC1901_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         SizeZ = 5,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1901/URC1901_unit.bp
+++ b/units/URC1901/URC1901_unit.bp
@@ -120,7 +120,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/URC1901/URC1901_unit.bp
+++ b/units/URC1901/URC1901_unit.bp
@@ -118,7 +118,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC urc1901_help>Cybran Civilian Structure',

--- a/units/URC1902/URC1902_unit.bp
+++ b/units/URC1902/URC1902_unit.bp
@@ -103,7 +103,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1902/URC1902_unit.bp
+++ b/units/URC1902/URC1902_unit.bp
@@ -120,7 +120,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/URC1902/URC1902_unit.bp
+++ b/units/URC1902/URC1902_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/URC1902/URC1902_unit.bp
+++ b/units/URC1902/URC1902_unit.bp
@@ -118,7 +118,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC urc1902_help>Cybran Civilian Structure',

--- a/units/XAC0101/XAC0101_unit.bp
+++ b/units/XAC0101/XAC0101_unit.bp
@@ -105,7 +105,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xac0101_help>Aeon Boat',

--- a/units/XAC0101/XAC0101_unit.bp
+++ b/units/XAC0101/XAC0101_unit.bp
@@ -107,7 +107,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XAC0101/XAC0101_unit.bp
+++ b/units/XAC0101/XAC0101_unit.bp
@@ -90,7 +90,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC0101/XAC0101_unit.bp
+++ b/units/XAC0101/XAC0101_unit.bp
@@ -89,7 +89,6 @@ UnitBlueprint {
         BuildTime = 50,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC1101/XAC1101_unit.bp
+++ b/units/XAC1101/XAC1101_unit.bp
@@ -115,7 +115,6 @@ UnitBlueprint {
         FactionName = 'UEF',
         Icon = 'land',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XAC1101/XAC1101_unit.bp
+++ b/units/XAC1101/XAC1101_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
         FactionName = 'UEF',
         Icon = 'land',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xac1101_help>Aeon Prison Building',

--- a/units/XAC1101/XAC1101_unit.bp
+++ b/units/XAC1101/XAC1101_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC1101/XAC1101_unit.bp
+++ b/units/XAC1101/XAC1101_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC1401/XAC1401_unit.bp
+++ b/units/XAC1401/XAC1401_unit.bp
@@ -127,7 +127,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XAC1401/XAC1401_unit.bp
+++ b/units/XAC1401/XAC1401_unit.bp
@@ -110,7 +110,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC1401/XAC1401_unit.bp
+++ b/units/XAC1401/XAC1401_unit.bp
@@ -109,7 +109,6 @@ UnitBlueprint {
         SizeZ = 5,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC1401/XAC1401_unit.bp
+++ b/units/XAC1401/XAC1401_unit.bp
@@ -125,7 +125,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xac1401_help>Aeon Civilian Structure',

--- a/units/XAC2101/XAC2101_unit.bp
+++ b/units/XAC2101/XAC2101_unit.bp
@@ -163,7 +163,6 @@ UnitBlueprint {
         },
         FactionName = 'Aeon',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         ToggleCaps = {
             RULEUTC_ShieldToggle = true,
         },

--- a/units/XAC2101/XAC2101_unit.bp
+++ b/units/XAC2101/XAC2101_unit.bp
@@ -164,7 +164,6 @@ UnitBlueprint {
         ToggleCaps = {
             RULEUTC_ShieldToggle = true,
         },
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 20,

--- a/units/XAC2101/XAC2101_unit.bp
+++ b/units/XAC2101/XAC2101_unit.bp
@@ -138,7 +138,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC2101/XAC2101_unit.bp
+++ b/units/XAC2101/XAC2101_unit.bp
@@ -139,7 +139,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC2201/XAC2201_unit.bp
+++ b/units/XAC2201/XAC2201_unit.bp
@@ -94,7 +94,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC2201/XAC2201_unit.bp
+++ b/units/XAC2201/XAC2201_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XAC2201/XAC2201_unit.bp
+++ b/units/XAC2201/XAC2201_unit.bp
@@ -95,7 +95,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC2201/XAC2201_unit.bp
+++ b/units/XAC2201/XAC2201_unit.bp
@@ -110,7 +110,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xac2201_help>Aeon Temple',

--- a/units/XAC2301/XAC2301_unit.bp
+++ b/units/XAC2301/XAC2301_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XAC2301/XAC2301_unit.bp
+++ b/units/XAC2301/XAC2301_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC2301/XAC2301_unit.bp
+++ b/units/XAC2301/XAC2301_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC2301/XAC2301_unit.bp
+++ b/units/XAC2301/XAC2301_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xac2301_help>Aeon Loyalist Supply Depot',

--- a/units/XAC8001/XAC8001_unit.bp
+++ b/units/XAC8001/XAC8001_unit.bp
@@ -115,7 +115,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XAC8001/XAC8001_unit.bp
+++ b/units/XAC8001/XAC8001_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xac8001_help>Aeon Wall Segment',

--- a/units/XAC8001/XAC8001_unit.bp
+++ b/units/XAC8001/XAC8001_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC8001/XAC8001_unit.bp
+++ b/units/XAC8001/XAC8001_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC8002/XAC8002_unit.bp
+++ b/units/XAC8002/XAC8002_unit.bp
@@ -115,7 +115,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XAC8002/XAC8002_unit.bp
+++ b/units/XAC8002/XAC8002_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xac8002_help>Aeon Wall Segment',

--- a/units/XAC8002/XAC8002_unit.bp
+++ b/units/XAC8002/XAC8002_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC8002/XAC8002_unit.bp
+++ b/units/XAC8002/XAC8002_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC8003/XAC8003_unit.bp
+++ b/units/XAC8003/XAC8003_unit.bp
@@ -115,7 +115,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XAC8003/XAC8003_unit.bp
+++ b/units/XAC8003/XAC8003_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xac8003_help>Aeon Wall Segment',

--- a/units/XAC8003/XAC8003_unit.bp
+++ b/units/XAC8003/XAC8003_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC8003/XAC8003_unit.bp
+++ b/units/XAC8003/XAC8003_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC8101/XAC8101_unit.bp
+++ b/units/XAC8101/XAC8101_unit.bp
@@ -115,7 +115,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XAC8101/XAC8101_unit.bp
+++ b/units/XAC8101/XAC8101_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xac8101_help>Aeon Palace Wall Segment',

--- a/units/XAC8101/XAC8101_unit.bp
+++ b/units/XAC8101/XAC8101_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC8101/XAC8101_unit.bp
+++ b/units/XAC8101/XAC8101_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC8102/XAC8102_unit.bp
+++ b/units/XAC8102/XAC8102_unit.bp
@@ -115,7 +115,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XAC8102/XAC8102_unit.bp
+++ b/units/XAC8102/XAC8102_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xac8102_help>Aeon Palace Wall Segment',

--- a/units/XAC8102/XAC8102_unit.bp
+++ b/units/XAC8102/XAC8102_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC8102/XAC8102_unit.bp
+++ b/units/XAC8102/XAC8102_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC8103/XAC8103_unit.bp
+++ b/units/XAC8103/XAC8103_unit.bp
@@ -115,7 +115,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XAC8103/XAC8103_unit.bp
+++ b/units/XAC8103/XAC8103_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xac8103_help>Aeon Palace Wall Segment',

--- a/units/XAC8103/XAC8103_unit.bp
+++ b/units/XAC8103/XAC8103_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XAC8103/XAC8103_unit.bp
+++ b/units/XAC8103/XAC8103_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC1301/XEC1301_unit.bp
+++ b/units/XEC1301/XEC1301_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XEC1301/XEC1301_unit.bp
+++ b/units/XEC1301/XEC1301_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xec1301_help>UEF Administration Building',

--- a/units/XEC1301/XEC1301_unit.bp
+++ b/units/XEC1301/XEC1301_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC1301/XEC1301_unit.bp
+++ b/units/XEC1301/XEC1301_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC1401/XEC1401_unit.bp
+++ b/units/XEC1401/XEC1401_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XEC1401/XEC1401_unit.bp
+++ b/units/XEC1401/XEC1401_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xec1401_help>UEF High Command Building',

--- a/units/XEC1401/XEC1401_unit.bp
+++ b/units/XEC1401/XEC1401_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC1401/XEC1401_unit.bp
+++ b/units/XEC1401/XEC1401_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC1501/XEC1501_unit.bp
+++ b/units/XEC1501/XEC1501_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XEC1501/XEC1501_unit.bp
+++ b/units/XEC1501/XEC1501_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xec1501_help>UEF Samantha Clarke Statue',

--- a/units/XEC1501/XEC1501_unit.bp
+++ b/units/XEC1501/XEC1501_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC1501/XEC1501_unit.bp
+++ b/units/XEC1501/XEC1501_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC1908/XEC1908_unit.bp
+++ b/units/XEC1908/XEC1908_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XEC1908/XEC1908_unit.bp
+++ b/units/XEC1908/XEC1908_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xec1908_help>UEF Blacksun Remains --1',

--- a/units/XEC1908/XEC1908_unit.bp
+++ b/units/XEC1908/XEC1908_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC1908/XEC1908_unit.bp
+++ b/units/XEC1908/XEC1908_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC1909/XEC1909_unit.bp
+++ b/units/XEC1909/XEC1909_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XEC1909/XEC1909_unit.bp
+++ b/units/XEC1909/XEC1909_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xec1909_help>UEF Blacksun Remains --2',

--- a/units/XEC1909/XEC1909_unit.bp
+++ b/units/XEC1909/XEC1909_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC1909/XEC1909_unit.bp
+++ b/units/XEC1909/XEC1909_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8001/XEC8001_unit.bp
+++ b/units/XEC8001/XEC8001_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8001/XEC8001_unit.bp
+++ b/units/XEC8001/XEC8001_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8001/XEC8001_unit.bp
+++ b/units/XEC8001/XEC8001_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8001/XEC8001_unit.bp
+++ b/units/XEC8001/XEC8001_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8002/XEC8002_unit.bp
+++ b/units/XEC8002/XEC8002_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8002/XEC8002_unit.bp
+++ b/units/XEC8002/XEC8002_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8002/XEC8002_unit.bp
+++ b/units/XEC8002/XEC8002_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8002/XEC8002_unit.bp
+++ b/units/XEC8002/XEC8002_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8003/XEC8003_unit.bp
+++ b/units/XEC8003/XEC8003_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8003/XEC8003_unit.bp
+++ b/units/XEC8003/XEC8003_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8003/XEC8003_unit.bp
+++ b/units/XEC8003/XEC8003_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8003/XEC8003_unit.bp
+++ b/units/XEC8003/XEC8003_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8004/XEC8004_unit.bp
+++ b/units/XEC8004/XEC8004_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8004/XEC8004_unit.bp
+++ b/units/XEC8004/XEC8004_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8004/XEC8004_unit.bp
+++ b/units/XEC8004/XEC8004_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8004/XEC8004_unit.bp
+++ b/units/XEC8004/XEC8004_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8005/XEC8005_unit.bp
+++ b/units/XEC8005/XEC8005_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8005/XEC8005_unit.bp
+++ b/units/XEC8005/XEC8005_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8005/XEC8005_unit.bp
+++ b/units/XEC8005/XEC8005_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8005/XEC8005_unit.bp
+++ b/units/XEC8005/XEC8005_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8006/XEC8006_unit.bp
+++ b/units/XEC8006/XEC8006_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8006/XEC8006_unit.bp
+++ b/units/XEC8006/XEC8006_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8006/XEC8006_unit.bp
+++ b/units/XEC8006/XEC8006_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8006/XEC8006_unit.bp
+++ b/units/XEC8006/XEC8006_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8007/XEC8007_unit.bp
+++ b/units/XEC8007/XEC8007_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8007/XEC8007_unit.bp
+++ b/units/XEC8007/XEC8007_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8007/XEC8007_unit.bp
+++ b/units/XEC8007/XEC8007_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8007/XEC8007_unit.bp
+++ b/units/XEC8007/XEC8007_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8008/XEC8008_unit.bp
+++ b/units/XEC8008/XEC8008_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8008/XEC8008_unit.bp
+++ b/units/XEC8008/XEC8008_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8008/XEC8008_unit.bp
+++ b/units/XEC8008/XEC8008_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8008/XEC8008_unit.bp
+++ b/units/XEC8008/XEC8008_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8009/XEC8009_unit.bp
+++ b/units/XEC8009/XEC8009_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8009/XEC8009_unit.bp
+++ b/units/XEC8009/XEC8009_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8009/XEC8009_unit.bp
+++ b/units/XEC8009/XEC8009_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8009/XEC8009_unit.bp
+++ b/units/XEC8009/XEC8009_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8010/XEC8010_unit.bp
+++ b/units/XEC8010/XEC8010_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8010/XEC8010_unit.bp
+++ b/units/XEC8010/XEC8010_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8010/XEC8010_unit.bp
+++ b/units/XEC8010/XEC8010_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8010/XEC8010_unit.bp
+++ b/units/XEC8010/XEC8010_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8011/XEC8011_unit.bp
+++ b/units/XEC8011/XEC8011_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8011/XEC8011_unit.bp
+++ b/units/XEC8011/XEC8011_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8011/XEC8011_unit.bp
+++ b/units/XEC8011/XEC8011_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8011/XEC8011_unit.bp
+++ b/units/XEC8011/XEC8011_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8012/XEC8012_unit.bp
+++ b/units/XEC8012/XEC8012_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8012/XEC8012_unit.bp
+++ b/units/XEC8012/XEC8012_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8012/XEC8012_unit.bp
+++ b/units/XEC8012/XEC8012_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8012/XEC8012_unit.bp
+++ b/units/XEC8012/XEC8012_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8013/XEC8013_unit.bp
+++ b/units/XEC8013/XEC8013_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8013/XEC8013_unit.bp
+++ b/units/XEC8013/XEC8013_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8013/XEC8013_unit.bp
+++ b/units/XEC8013/XEC8013_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8013/XEC8013_unit.bp
+++ b/units/XEC8013/XEC8013_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8014/XEC8014_unit.bp
+++ b/units/XEC8014/XEC8014_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8014/XEC8014_unit.bp
+++ b/units/XEC8014/XEC8014_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8014/XEC8014_unit.bp
+++ b/units/XEC8014/XEC8014_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8014/XEC8014_unit.bp
+++ b/units/XEC8014/XEC8014_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8015/XEC8015_unit.bp
+++ b/units/XEC8015/XEC8015_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8015/XEC8015_unit.bp
+++ b/units/XEC8015/XEC8015_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8015/XEC8015_unit.bp
+++ b/units/XEC8015/XEC8015_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8015/XEC8015_unit.bp
+++ b/units/XEC8015/XEC8015_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8016/XEC8016_unit.bp
+++ b/units/XEC8016/XEC8016_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8016/XEC8016_unit.bp
+++ b/units/XEC8016/XEC8016_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8016/XEC8016_unit.bp
+++ b/units/XEC8016/XEC8016_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8016/XEC8016_unit.bp
+++ b/units/XEC8016/XEC8016_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8017/XEC8017_unit.bp
+++ b/units/XEC8017/XEC8017_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8017/XEC8017_unit.bp
+++ b/units/XEC8017/XEC8017_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8017/XEC8017_unit.bp
+++ b/units/XEC8017/XEC8017_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8017/XEC8017_unit.bp
+++ b/units/XEC8017/XEC8017_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8018/XEC8018_unit.bp
+++ b/units/XEC8018/XEC8018_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8018/XEC8018_unit.bp
+++ b/units/XEC8018/XEC8018_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8018/XEC8018_unit.bp
+++ b/units/XEC8018/XEC8018_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8018/XEC8018_unit.bp
+++ b/units/XEC8018/XEC8018_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8019/XEC8019_unit.bp
+++ b/units/XEC8019/XEC8019_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8019/XEC8019_unit.bp
+++ b/units/XEC8019/XEC8019_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8019/XEC8019_unit.bp
+++ b/units/XEC8019/XEC8019_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8019/XEC8019_unit.bp
+++ b/units/XEC8019/XEC8019_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8020/XEC8020_unit.bp
+++ b/units/XEC8020/XEC8020_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC8020/XEC8020_unit.bp
+++ b/units/XEC8020/XEC8020_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC8020/XEC8020_unit.bp
+++ b/units/XEC8020/XEC8020_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC8020/XEC8020_unit.bp
+++ b/units/XEC8020/XEC8020_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9001/XEC9001_unit.bp
+++ b/units/XEC9001/XEC9001_unit.bp
@@ -104,7 +104,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC9001/XEC9001_unit.bp
+++ b/units/XEC9001/XEC9001_unit.bp
@@ -87,7 +87,6 @@ UnitBlueprint {
     General = {
         CapCost = 0,
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9001/XEC9001_unit.bp
+++ b/units/XEC9001/XEC9001_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC9001/XEC9001_unit.bp
+++ b/units/XEC9001/XEC9001_unit.bp
@@ -86,7 +86,6 @@ UnitBlueprint {
     },
     General = {
         CapCost = 0,
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9002/XEC9002_unit.bp
+++ b/units/XEC9002/XEC9002_unit.bp
@@ -84,7 +84,6 @@ UnitBlueprint {
     General = {
         CapCost = 0,
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9002/XEC9002_unit.bp
+++ b/units/XEC9002/XEC9002_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC9002/XEC9002_unit.bp
+++ b/units/XEC9002/XEC9002_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         CapCost = 0,
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9002/XEC9002_unit.bp
+++ b/units/XEC9002/XEC9002_unit.bp
@@ -101,7 +101,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC9003/XEC9003_unit.bp
+++ b/units/XEC9003/XEC9003_unit.bp
@@ -104,7 +104,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC9003/XEC9003_unit.bp
+++ b/units/XEC9003/XEC9003_unit.bp
@@ -87,7 +87,6 @@ UnitBlueprint {
     General = {
         CapCost = 0,
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9003/XEC9003_unit.bp
+++ b/units/XEC9003/XEC9003_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC9003/XEC9003_unit.bp
+++ b/units/XEC9003/XEC9003_unit.bp
@@ -86,7 +86,6 @@ UnitBlueprint {
     },
     General = {
         CapCost = 0,
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9004/XEC9004_unit.bp
+++ b/units/XEC9004/XEC9004_unit.bp
@@ -104,7 +104,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC9004/XEC9004_unit.bp
+++ b/units/XEC9004/XEC9004_unit.bp
@@ -87,7 +87,6 @@ UnitBlueprint {
     General = {
         CapCost = 0,
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9004/XEC9004_unit.bp
+++ b/units/XEC9004/XEC9004_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC9004/XEC9004_unit.bp
+++ b/units/XEC9004/XEC9004_unit.bp
@@ -86,7 +86,6 @@ UnitBlueprint {
     },
     General = {
         CapCost = 0,
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9005/XEC9005_unit.bp
+++ b/units/XEC9005/XEC9005_unit.bp
@@ -104,7 +104,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC9005/XEC9005_unit.bp
+++ b/units/XEC9005/XEC9005_unit.bp
@@ -87,7 +87,6 @@ UnitBlueprint {
     General = {
         CapCost = 0,
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9005/XEC9005_unit.bp
+++ b/units/XEC9005/XEC9005_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC9005/XEC9005_unit.bp
+++ b/units/XEC9005/XEC9005_unit.bp
@@ -86,7 +86,6 @@ UnitBlueprint {
     },
     General = {
         CapCost = 0,
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9006/XEC9006_unit.bp
+++ b/units/XEC9006/XEC9006_unit.bp
@@ -104,7 +104,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC9006/XEC9006_unit.bp
+++ b/units/XEC9006/XEC9006_unit.bp
@@ -87,7 +87,6 @@ UnitBlueprint {
     General = {
         CapCost = 0,
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9006/XEC9006_unit.bp
+++ b/units/XEC9006/XEC9006_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC9006/XEC9006_unit.bp
+++ b/units/XEC9006/XEC9006_unit.bp
@@ -86,7 +86,6 @@ UnitBlueprint {
     },
     General = {
         CapCost = 0,
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9007/XEC9007_unit.bp
+++ b/units/XEC9007/XEC9007_unit.bp
@@ -104,7 +104,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC9007/XEC9007_unit.bp
+++ b/units/XEC9007/XEC9007_unit.bp
@@ -87,7 +87,6 @@ UnitBlueprint {
     General = {
         CapCost = 0,
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9007/XEC9007_unit.bp
+++ b/units/XEC9007/XEC9007_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC9007/XEC9007_unit.bp
+++ b/units/XEC9007/XEC9007_unit.bp
@@ -86,7 +86,6 @@ UnitBlueprint {
     },
     General = {
         CapCost = 0,
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9008/XEC9008_unit.bp
+++ b/units/XEC9008/XEC9008_unit.bp
@@ -104,7 +104,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC9008/XEC9008_unit.bp
+++ b/units/XEC9008/XEC9008_unit.bp
@@ -87,7 +87,6 @@ UnitBlueprint {
     General = {
         CapCost = 0,
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9008/XEC9008_unit.bp
+++ b/units/XEC9008/XEC9008_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC9008/XEC9008_unit.bp
+++ b/units/XEC9008/XEC9008_unit.bp
@@ -86,7 +86,6 @@ UnitBlueprint {
     },
     General = {
         CapCost = 0,
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9009/XEC9009_unit.bp
+++ b/units/XEC9009/XEC9009_unit.bp
@@ -104,7 +104,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC9009/XEC9009_unit.bp
+++ b/units/XEC9009/XEC9009_unit.bp
@@ -87,7 +87,6 @@ UnitBlueprint {
     General = {
         CapCost = 0,
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9009/XEC9009_unit.bp
+++ b/units/XEC9009/XEC9009_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC9009/XEC9009_unit.bp
+++ b/units/XEC9009/XEC9009_unit.bp
@@ -86,7 +86,6 @@ UnitBlueprint {
     },
     General = {
         CapCost = 0,
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9010/XEC9010_unit.bp
+++ b/units/XEC9010/XEC9010_unit.bp
@@ -104,7 +104,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC9010/XEC9010_unit.bp
+++ b/units/XEC9010/XEC9010_unit.bp
@@ -87,7 +87,6 @@ UnitBlueprint {
     General = {
         CapCost = 0,
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9010/XEC9010_unit.bp
+++ b/units/XEC9010/XEC9010_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC9010/XEC9010_unit.bp
+++ b/units/XEC9010/XEC9010_unit.bp
@@ -86,7 +86,6 @@ UnitBlueprint {
     },
     General = {
         CapCost = 0,
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9011/XEC9011_unit.bp
+++ b/units/XEC9011/XEC9011_unit.bp
@@ -104,7 +104,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XEC9011/XEC9011_unit.bp
+++ b/units/XEC9011/XEC9011_unit.bp
@@ -87,7 +87,6 @@ UnitBlueprint {
     General = {
         CapCost = 0,
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XEC9011/XEC9011_unit.bp
+++ b/units/XEC9011/XEC9011_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XEC9011/XEC9011_unit.bp
+++ b/units/XEC9011/XEC9011_unit.bp
@@ -86,7 +86,6 @@ UnitBlueprint {
     },
     General = {
         CapCost = 0,
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC1101/XRC1101_unit.bp
+++ b/units/XRC1101/XRC1101_unit.bp
@@ -107,7 +107,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC1101/XRC1101_unit.bp
+++ b/units/XRC1101/XRC1101_unit.bp
@@ -125,7 +125,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XRC1101/XRC1101_unit.bp
+++ b/units/XRC1101/XRC1101_unit.bp
@@ -123,7 +123,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xrc1101_help>QAI Jamming Station',

--- a/units/XRC1101/XRC1101_unit.bp
+++ b/units/XRC1101/XRC1101_unit.bp
@@ -108,7 +108,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC1502/XRC1502_unit.bp
+++ b/units/XRC1502/XRC1502_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC1502/XRC1502_unit.bp
+++ b/units/XRC1502/XRC1502_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'land',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xrc1502_help>Cybran Civilian Structure',

--- a/units/XRC1502/XRC1502_unit.bp
+++ b/units/XRC1502/XRC1502_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'land',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XRC1502/XRC1502_unit.bp
+++ b/units/XRC1502/XRC1502_unit.bp
@@ -84,7 +84,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC2101/XRC2101_unit.bp
+++ b/units/XRC2101/XRC2101_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XRC2101/XRC2101_unit.bp
+++ b/units/XRC2101/XRC2101_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xrc2101_help>QAI Prison Building',

--- a/units/XRC2101/XRC2101_unit.bp
+++ b/units/XRC2101/XRC2101_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC2101/XRC2101_unit.bp
+++ b/units/XRC2101/XRC2101_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC2201/XRC2201_unit.bp
+++ b/units/XRC2201/XRC2201_unit.bp
@@ -103,7 +103,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC2201/XRC2201_unit.bp
+++ b/units/XRC2201/XRC2201_unit.bp
@@ -120,7 +120,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XRC2201/XRC2201_unit.bp
+++ b/units/XRC2201/XRC2201_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC2201/XRC2201_unit.bp
+++ b/units/XRC2201/XRC2201_unit.bp
@@ -118,7 +118,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xrc2201_help>QAI Mainframe',

--- a/units/XRC2301/XRC2301_unit.bp
+++ b/units/XRC2301/XRC2301_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XRC2301/XRC2301_unit.bp
+++ b/units/XRC2301/XRC2301_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xrc2301_help>QAI Node',

--- a/units/XRC2301/XRC2301_unit.bp
+++ b/units/XRC2301/XRC2301_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC2301/XRC2301_unit.bp
+++ b/units/XRC2301/XRC2301_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC2401/XRC2401_unit.bp
+++ b/units/XRC2401/XRC2401_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XRC2401/XRC2401_unit.bp
+++ b/units/XRC2401/XRC2401_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xrc2401_help>QAI Spire Node',

--- a/units/XRC2401/XRC2401_unit.bp
+++ b/units/XRC2401/XRC2401_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC2401/XRC2401_unit.bp
+++ b/units/XRC2401/XRC2401_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8001/XRC8001_unit.bp
+++ b/units/XRC8001/XRC8001_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8001/XRC8001_unit.bp
+++ b/units/XRC8001/XRC8001_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8001/XRC8001_unit.bp
+++ b/units/XRC8001/XRC8001_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8001/XRC8001_unit.bp
+++ b/units/XRC8001/XRC8001_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8002/XRC8002_unit.bp
+++ b/units/XRC8002/XRC8002_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8002/XRC8002_unit.bp
+++ b/units/XRC8002/XRC8002_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8002/XRC8002_unit.bp
+++ b/units/XRC8002/XRC8002_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8002/XRC8002_unit.bp
+++ b/units/XRC8002/XRC8002_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8003/XRC8003_unit.bp
+++ b/units/XRC8003/XRC8003_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8003/XRC8003_unit.bp
+++ b/units/XRC8003/XRC8003_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8003/XRC8003_unit.bp
+++ b/units/XRC8003/XRC8003_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8003/XRC8003_unit.bp
+++ b/units/XRC8003/XRC8003_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8004/XRC8004_unit.bp
+++ b/units/XRC8004/XRC8004_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8004/XRC8004_unit.bp
+++ b/units/XRC8004/XRC8004_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8004/XRC8004_unit.bp
+++ b/units/XRC8004/XRC8004_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8004/XRC8004_unit.bp
+++ b/units/XRC8004/XRC8004_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8005/XRC8005_unit.bp
+++ b/units/XRC8005/XRC8005_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8005/XRC8005_unit.bp
+++ b/units/XRC8005/XRC8005_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8005/XRC8005_unit.bp
+++ b/units/XRC8005/XRC8005_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8005/XRC8005_unit.bp
+++ b/units/XRC8005/XRC8005_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8006/XRC8006_unit.bp
+++ b/units/XRC8006/XRC8006_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8006/XRC8006_unit.bp
+++ b/units/XRC8006/XRC8006_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8006/XRC8006_unit.bp
+++ b/units/XRC8006/XRC8006_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8006/XRC8006_unit.bp
+++ b/units/XRC8006/XRC8006_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8007/XRC8007_unit.bp
+++ b/units/XRC8007/XRC8007_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8007/XRC8007_unit.bp
+++ b/units/XRC8007/XRC8007_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8007/XRC8007_unit.bp
+++ b/units/XRC8007/XRC8007_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8007/XRC8007_unit.bp
+++ b/units/XRC8007/XRC8007_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8008/XRC8008_unit.bp
+++ b/units/XRC8008/XRC8008_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8008/XRC8008_unit.bp
+++ b/units/XRC8008/XRC8008_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8008/XRC8008_unit.bp
+++ b/units/XRC8008/XRC8008_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8008/XRC8008_unit.bp
+++ b/units/XRC8008/XRC8008_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8009/XRC8009_unit.bp
+++ b/units/XRC8009/XRC8009_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8009/XRC8009_unit.bp
+++ b/units/XRC8009/XRC8009_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8009/XRC8009_unit.bp
+++ b/units/XRC8009/XRC8009_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8009/XRC8009_unit.bp
+++ b/units/XRC8009/XRC8009_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8010/XRC8010_unit.bp
+++ b/units/XRC8010/XRC8010_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8010/XRC8010_unit.bp
+++ b/units/XRC8010/XRC8010_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8010/XRC8010_unit.bp
+++ b/units/XRC8010/XRC8010_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8010/XRC8010_unit.bp
+++ b/units/XRC8010/XRC8010_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8011/XRC8011_unit.bp
+++ b/units/XRC8011/XRC8011_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8011/XRC8011_unit.bp
+++ b/units/XRC8011/XRC8011_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8011/XRC8011_unit.bp
+++ b/units/XRC8011/XRC8011_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8011/XRC8011_unit.bp
+++ b/units/XRC8011/XRC8011_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8012/XRC8012_unit.bp
+++ b/units/XRC8012/XRC8012_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8012/XRC8012_unit.bp
+++ b/units/XRC8012/XRC8012_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8012/XRC8012_unit.bp
+++ b/units/XRC8012/XRC8012_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8012/XRC8012_unit.bp
+++ b/units/XRC8012/XRC8012_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8013/XRC8013_unit.bp
+++ b/units/XRC8013/XRC8013_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8013/XRC8013_unit.bp
+++ b/units/XRC8013/XRC8013_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8013/XRC8013_unit.bp
+++ b/units/XRC8013/XRC8013_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8013/XRC8013_unit.bp
+++ b/units/XRC8013/XRC8013_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8014/XRC8014_unit.bp
+++ b/units/XRC8014/XRC8014_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8014/XRC8014_unit.bp
+++ b/units/XRC8014/XRC8014_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8014/XRC8014_unit.bp
+++ b/units/XRC8014/XRC8014_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8014/XRC8014_unit.bp
+++ b/units/XRC8014/XRC8014_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8015/XRC8015_unit.bp
+++ b/units/XRC8015/XRC8015_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8015/XRC8015_unit.bp
+++ b/units/XRC8015/XRC8015_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8015/XRC8015_unit.bp
+++ b/units/XRC8015/XRC8015_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8015/XRC8015_unit.bp
+++ b/units/XRC8015/XRC8015_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8016/XRC8016_unit.bp
+++ b/units/XRC8016/XRC8016_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8016/XRC8016_unit.bp
+++ b/units/XRC8016/XRC8016_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8016/XRC8016_unit.bp
+++ b/units/XRC8016/XRC8016_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8016/XRC8016_unit.bp
+++ b/units/XRC8016/XRC8016_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8017/XRC8017_unit.bp
+++ b/units/XRC8017/XRC8017_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8017/XRC8017_unit.bp
+++ b/units/XRC8017/XRC8017_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8017/XRC8017_unit.bp
+++ b/units/XRC8017/XRC8017_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8017/XRC8017_unit.bp
+++ b/units/XRC8017/XRC8017_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8018/XRC8018_unit.bp
+++ b/units/XRC8018/XRC8018_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8018/XRC8018_unit.bp
+++ b/units/XRC8018/XRC8018_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8018/XRC8018_unit.bp
+++ b/units/XRC8018/XRC8018_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8018/XRC8018_unit.bp
+++ b/units/XRC8018/XRC8018_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8019/XRC8019_unit.bp
+++ b/units/XRC8019/XRC8019_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8019/XRC8019_unit.bp
+++ b/units/XRC8019/XRC8019_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8019/XRC8019_unit.bp
+++ b/units/XRC8019/XRC8019_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8019/XRC8019_unit.bp
+++ b/units/XRC8019/XRC8019_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8020/XRC8020_unit.bp
+++ b/units/XRC8020/XRC8020_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8020/XRC8020_unit.bp
+++ b/units/XRC8020/XRC8020_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8020/XRC8020_unit.bp
+++ b/units/XRC8020/XRC8020_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8020/XRC8020_unit.bp
+++ b/units/XRC8020/XRC8020_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8101/XRC8101_unit.bp
+++ b/units/XRC8101/XRC8101_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8101/XRC8101_unit.bp
+++ b/units/XRC8101/XRC8101_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8101/XRC8101_unit.bp
+++ b/units/XRC8101/XRC8101_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8101/XRC8101_unit.bp
+++ b/units/XRC8101/XRC8101_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8102/XRC8102_unit.bp
+++ b/units/XRC8102/XRC8102_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8102/XRC8102_unit.bp
+++ b/units/XRC8102/XRC8102_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8102/XRC8102_unit.bp
+++ b/units/XRC8102/XRC8102_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8102/XRC8102_unit.bp
+++ b/units/XRC8102/XRC8102_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8103/XRC8103_unit.bp
+++ b/units/XRC8103/XRC8103_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8103/XRC8103_unit.bp
+++ b/units/XRC8103/XRC8103_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8103/XRC8103_unit.bp
+++ b/units/XRC8103/XRC8103_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8103/XRC8103_unit.bp
+++ b/units/XRC8103/XRC8103_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8104/XRC8104_unit.bp
+++ b/units/XRC8104/XRC8104_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8104/XRC8104_unit.bp
+++ b/units/XRC8104/XRC8104_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8104/XRC8104_unit.bp
+++ b/units/XRC8104/XRC8104_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8104/XRC8104_unit.bp
+++ b/units/XRC8104/XRC8104_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8105/XRC8105_unit.bp
+++ b/units/XRC8105/XRC8105_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8105/XRC8105_unit.bp
+++ b/units/XRC8105/XRC8105_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8105/XRC8105_unit.bp
+++ b/units/XRC8105/XRC8105_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8105/XRC8105_unit.bp
+++ b/units/XRC8105/XRC8105_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8106/XRC8106_unit.bp
+++ b/units/XRC8106/XRC8106_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8106/XRC8106_unit.bp
+++ b/units/XRC8106/XRC8106_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8106/XRC8106_unit.bp
+++ b/units/XRC8106/XRC8106_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8106/XRC8106_unit.bp
+++ b/units/XRC8106/XRC8106_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8107/XRC8107_unit.bp
+++ b/units/XRC8107/XRC8107_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8107/XRC8107_unit.bp
+++ b/units/XRC8107/XRC8107_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8107/XRC8107_unit.bp
+++ b/units/XRC8107/XRC8107_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8107/XRC8107_unit.bp
+++ b/units/XRC8107/XRC8107_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8108/XRC8108_unit.bp
+++ b/units/XRC8108/XRC8108_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8108/XRC8108_unit.bp
+++ b/units/XRC8108/XRC8108_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8108/XRC8108_unit.bp
+++ b/units/XRC8108/XRC8108_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8108/XRC8108_unit.bp
+++ b/units/XRC8108/XRC8108_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8109/XRC8109_unit.bp
+++ b/units/XRC8109/XRC8109_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8109/XRC8109_unit.bp
+++ b/units/XRC8109/XRC8109_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8109/XRC8109_unit.bp
+++ b/units/XRC8109/XRC8109_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8109/XRC8109_unit.bp
+++ b/units/XRC8109/XRC8109_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8110/XRC8110_unit.bp
+++ b/units/XRC8110/XRC8110_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8110/XRC8110_unit.bp
+++ b/units/XRC8110/XRC8110_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8110/XRC8110_unit.bp
+++ b/units/XRC8110/XRC8110_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8110/XRC8110_unit.bp
+++ b/units/XRC8110/XRC8110_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8111/XRC8111_unit.bp
+++ b/units/XRC8111/XRC8111_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8111/XRC8111_unit.bp
+++ b/units/XRC8111/XRC8111_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8111/XRC8111_unit.bp
+++ b/units/XRC8111/XRC8111_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8111/XRC8111_unit.bp
+++ b/units/XRC8111/XRC8111_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8112/XRC8112_unit.bp
+++ b/units/XRC8112/XRC8112_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8112/XRC8112_unit.bp
+++ b/units/XRC8112/XRC8112_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8112/XRC8112_unit.bp
+++ b/units/XRC8112/XRC8112_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8112/XRC8112_unit.bp
+++ b/units/XRC8112/XRC8112_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8113/XRC8113_unit.bp
+++ b/units/XRC8113/XRC8113_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8113/XRC8113_unit.bp
+++ b/units/XRC8113/XRC8113_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8113/XRC8113_unit.bp
+++ b/units/XRC8113/XRC8113_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8113/XRC8113_unit.bp
+++ b/units/XRC8113/XRC8113_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8114/XRC8114_unit.bp
+++ b/units/XRC8114/XRC8114_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8114/XRC8114_unit.bp
+++ b/units/XRC8114/XRC8114_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8114/XRC8114_unit.bp
+++ b/units/XRC8114/XRC8114_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8114/XRC8114_unit.bp
+++ b/units/XRC8114/XRC8114_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8115/XRC8115_unit.bp
+++ b/units/XRC8115/XRC8115_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8115/XRC8115_unit.bp
+++ b/units/XRC8115/XRC8115_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8115/XRC8115_unit.bp
+++ b/units/XRC8115/XRC8115_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8115/XRC8115_unit.bp
+++ b/units/XRC8115/XRC8115_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8116/XRC8116_unit.bp
+++ b/units/XRC8116/XRC8116_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8116/XRC8116_unit.bp
+++ b/units/XRC8116/XRC8116_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8116/XRC8116_unit.bp
+++ b/units/XRC8116/XRC8116_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8116/XRC8116_unit.bp
+++ b/units/XRC8116/XRC8116_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8117/XRC8117_unit.bp
+++ b/units/XRC8117/XRC8117_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8117/XRC8117_unit.bp
+++ b/units/XRC8117/XRC8117_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8117/XRC8117_unit.bp
+++ b/units/XRC8117/XRC8117_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8117/XRC8117_unit.bp
+++ b/units/XRC8117/XRC8117_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8118/XRC8118_unit.bp
+++ b/units/XRC8118/XRC8118_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8118/XRC8118_unit.bp
+++ b/units/XRC8118/XRC8118_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8118/XRC8118_unit.bp
+++ b/units/XRC8118/XRC8118_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8118/XRC8118_unit.bp
+++ b/units/XRC8118/XRC8118_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8119/XRC8119_unit.bp
+++ b/units/XRC8119/XRC8119_unit.bp
@@ -80,7 +80,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8119/XRC8119_unit.bp
+++ b/units/XRC8119/XRC8119_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8119/XRC8119_unit.bp
+++ b/units/XRC8119/XRC8119_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8119/XRC8119_unit.bp
+++ b/units/XRC8119/XRC8119_unit.bp
@@ -96,7 +96,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8120/XRC8120_unit.bp
+++ b/units/XRC8120/XRC8120_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XRC8120/XRC8120_unit.bp
+++ b/units/XRC8120/XRC8120_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'Cybran',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XRC8120/XRC8120_unit.bp
+++ b/units/XRC8120/XRC8120_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRC8120/XRC8120_unit.bp
+++ b/units/XRC8120/XRC8120_unit.bp
@@ -81,7 +81,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XRL0305/XRL0305_unit.bp
+++ b/units/XRL0305/XRL0305_unit.bp
@@ -106,7 +106,6 @@ UnitBlueprint{
         TeleportTimeMod = 0.01,
     },
     General = {
-        Classification = "RULEUMT_Amphibious",
         CommandCaps = {
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = true,

--- a/units/XSC0001/XSC0001_unit.bp
+++ b/units/XSC0001/XSC0001_unit.bp
@@ -62,7 +62,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = false,

--- a/units/XSC0001/XSC0001_unit.bp
+++ b/units/XSC0001/XSC0001_unit.bp
@@ -79,7 +79,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Seraphim',
-        TechLevel = 'RULEUTL_Basic',
         UnitName = '<LOC xsc0001>Seraphim Test Unit',
         UnitWeight = 1,
     },

--- a/units/XSC0001/XSC0001_unit.bp
+++ b/units/XSC0001/XSC0001_unit.bp
@@ -63,7 +63,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MilitaryVehicle',
         CommandCaps = {
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = false,

--- a/units/XSC0001/XSC0001_unit.bp
+++ b/units/XSC0001/XSC0001_unit.bp
@@ -78,7 +78,6 @@ UnitBlueprint {
         },
         FactionName = 'Seraphim',
         UnitName = '<LOC xsc0001>Seraphim Test Unit',
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc0001_help>Seraphim Test Unit',

--- a/units/XSC1101/XSC1101_unit.bp
+++ b/units/XSC1101/XSC1101_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1101/XSC1101_unit.bp
+++ b/units/XSC1101/XSC1101_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Seraphim',
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc1101_help>Seraphim Civilian Structure',

--- a/units/XSC1101/XSC1101_unit.bp
+++ b/units/XSC1101/XSC1101_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Seraphim',
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC1101/XSC1101_unit.bp
+++ b/units/XSC1101/XSC1101_unit.bp
@@ -84,7 +84,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1201/XSC1201_unit.bp
+++ b/units/XSC1201/XSC1201_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Seraphim',
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc1201_help>Seraphim Science Facility',

--- a/units/XSC1201/XSC1201_unit.bp
+++ b/units/XSC1201/XSC1201_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1201/XSC1201_unit.bp
+++ b/units/XSC1201/XSC1201_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1201/XSC1201_unit.bp
+++ b/units/XSC1201/XSC1201_unit.bp
@@ -115,7 +115,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Seraphim',
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC1301/XSC1301_unit.bp
+++ b/units/XSC1301/XSC1301_unit.bp
@@ -107,7 +107,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1301/XSC1301_unit.bp
+++ b/units/XSC1301/XSC1301_unit.bp
@@ -124,7 +124,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Seraphim',
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC1301/XSC1301_unit.bp
+++ b/units/XSC1301/XSC1301_unit.bp
@@ -122,7 +122,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Seraphim',
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc1301_help>Seraphim Administrative Building',

--- a/units/XSC1301/XSC1301_unit.bp
+++ b/units/XSC1301/XSC1301_unit.bp
@@ -108,7 +108,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1401/XSC1401_unit.bp
+++ b/units/XSC1401/XSC1401_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Seraphim',
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc1401_help>Seraphim Research Station',

--- a/units/XSC1401/XSC1401_unit.bp
+++ b/units/XSC1401/XSC1401_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1401/XSC1401_unit.bp
+++ b/units/XSC1401/XSC1401_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1401/XSC1401_unit.bp
+++ b/units/XSC1401/XSC1401_unit.bp
@@ -115,7 +115,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Seraphim',
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC1501/XSC1501_unit.bp
+++ b/units/XSC1501/XSC1501_unit.bp
@@ -107,7 +107,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1501/XSC1501_unit.bp
+++ b/units/XSC1501/XSC1501_unit.bp
@@ -121,7 +121,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Seraphim',
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc1501_help>Seraphim Manufacturing Building',

--- a/units/XSC1501/XSC1501_unit.bp
+++ b/units/XSC1501/XSC1501_unit.bp
@@ -106,7 +106,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1501/XSC1501_unit.bp
+++ b/units/XSC1501/XSC1501_unit.bp
@@ -123,7 +123,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Seraphim',
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC1601/XSC1601_unit.bp
+++ b/units/XSC1601/XSC1601_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Seraphim',
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc1601_help>Seraphim Hydroponics Bay',

--- a/units/XSC1601/XSC1601_unit.bp
+++ b/units/XSC1601/XSC1601_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1601/XSC1601_unit.bp
+++ b/units/XSC1601/XSC1601_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1601/XSC1601_unit.bp
+++ b/units/XSC1601/XSC1601_unit.bp
@@ -115,7 +115,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'Seraphim',
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC1701/XSC1701_unit.bp
+++ b/units/XSC1701/XSC1701_unit.bp
@@ -115,7 +115,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'UEF',
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC1701/XSC1701_unit.bp
+++ b/units/XSC1701/XSC1701_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'UEF',
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc1701_help>Seraphim Barracks',

--- a/units/XSC1701/XSC1701_unit.bp
+++ b/units/XSC1701/XSC1701_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1701/XSC1701_unit.bp
+++ b/units/XSC1701/XSC1701_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1901/XSC1901_unit.bp
+++ b/units/XSC1901/XSC1901_unit.bp
@@ -128,7 +128,6 @@ UnitBlueprint {
         },
         FactionName = 'Seraphim',
         Icon = 'land',
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC1901/XSC1901_unit.bp
+++ b/units/XSC1901/XSC1901_unit.bp
@@ -111,7 +111,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1901/XSC1901_unit.bp
+++ b/units/XSC1901/XSC1901_unit.bp
@@ -126,7 +126,6 @@ UnitBlueprint {
         },
         FactionName = 'Seraphim',
         Icon = 'land',
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc1901_help>Seraphim Quantum Rift Archway',

--- a/units/XSC1901/XSC1901_unit.bp
+++ b/units/XSC1901/XSC1901_unit.bp
@@ -110,7 +110,6 @@ UnitBlueprint {
         SizeZ = 6,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1902/XSC1902_unit.bp
+++ b/units/XSC1902/XSC1902_unit.bp
@@ -123,7 +123,6 @@ UnitBlueprint {
         },
         FactionName = 'Seraphim',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC1902/XSC1902_unit.bp
+++ b/units/XSC1902/XSC1902_unit.bp
@@ -106,7 +106,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC1902/XSC1902_unit.bp
+++ b/units/XSC1902/XSC1902_unit.bp
@@ -121,7 +121,6 @@ UnitBlueprint {
         },
         FactionName = 'Seraphim',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc1902_help>Seraphim Civilian Structure',

--- a/units/XSC1902/XSC1902_unit.bp
+++ b/units/XSC1902/XSC1902_unit.bp
@@ -105,7 +105,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC2201/XSC2201_unit.bp
+++ b/units/XSC2201/XSC2201_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         FactionName = 'Seraphim',
         Icon = 'land',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc2201_help>Seraphim Rift Support Structures',

--- a/units/XSC2201/XSC2201_unit.bp
+++ b/units/XSC2201/XSC2201_unit.bp
@@ -116,7 +116,6 @@ UnitBlueprint {
         FactionName = 'Seraphim',
         Icon = 'land',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC2201/XSC2201_unit.bp
+++ b/units/XSC2201/XSC2201_unit.bp
@@ -97,7 +97,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC2201/XSC2201_unit.bp
+++ b/units/XSC2201/XSC2201_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8001/XSC8001_unit.bp
+++ b/units/XSC8001/XSC8001_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8001/XSC8001_unit.bp
+++ b/units/XSC8001/XSC8001_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XSC8001/XSC8001_unit.bp
+++ b/units/XSC8001/XSC8001_unit.bp
@@ -84,7 +84,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8001/XSC8001_unit.bp
+++ b/units/XSC8001/XSC8001_unit.bp
@@ -101,7 +101,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC8002/XSC8002_unit.bp
+++ b/units/XSC8002/XSC8002_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8002/XSC8002_unit.bp
+++ b/units/XSC8002/XSC8002_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC8002/XSC8002_unit.bp
+++ b/units/XSC8002/XSC8002_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8002/XSC8002_unit.bp
+++ b/units/XSC8002/XSC8002_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XSC8003/XSC8003_unit.bp
+++ b/units/XSC8003/XSC8003_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8003/XSC8003_unit.bp
+++ b/units/XSC8003/XSC8003_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC8003/XSC8003_unit.bp
+++ b/units/XSC8003/XSC8003_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8003/XSC8003_unit.bp
+++ b/units/XSC8003/XSC8003_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XSC8004/XSC8004_unit.bp
+++ b/units/XSC8004/XSC8004_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8004/XSC8004_unit.bp
+++ b/units/XSC8004/XSC8004_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC8004/XSC8004_unit.bp
+++ b/units/XSC8004/XSC8004_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8004/XSC8004_unit.bp
+++ b/units/XSC8004/XSC8004_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XSC8005/XSC8005_unit.bp
+++ b/units/XSC8005/XSC8005_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8005/XSC8005_unit.bp
+++ b/units/XSC8005/XSC8005_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC8005/XSC8005_unit.bp
+++ b/units/XSC8005/XSC8005_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8005/XSC8005_unit.bp
+++ b/units/XSC8005/XSC8005_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XSC8006/XSC8006_unit.bp
+++ b/units/XSC8006/XSC8006_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8006/XSC8006_unit.bp
+++ b/units/XSC8006/XSC8006_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC8006/XSC8006_unit.bp
+++ b/units/XSC8006/XSC8006_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8006/XSC8006_unit.bp
+++ b/units/XSC8006/XSC8006_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XSC8007/XSC8007_unit.bp
+++ b/units/XSC8007/XSC8007_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8007/XSC8007_unit.bp
+++ b/units/XSC8007/XSC8007_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC8007/XSC8007_unit.bp
+++ b/units/XSC8007/XSC8007_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8007/XSC8007_unit.bp
+++ b/units/XSC8007/XSC8007_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XSC8008/XSC8008_unit.bp
+++ b/units/XSC8008/XSC8008_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8008/XSC8008_unit.bp
+++ b/units/XSC8008/XSC8008_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC8008/XSC8008_unit.bp
+++ b/units/XSC8008/XSC8008_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8008/XSC8008_unit.bp
+++ b/units/XSC8008/XSC8008_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XSC8009/XSC8009_unit.bp
+++ b/units/XSC8009/XSC8009_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8009/XSC8009_unit.bp
+++ b/units/XSC8009/XSC8009_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC8009/XSC8009_unit.bp
+++ b/units/XSC8009/XSC8009_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8009/XSC8009_unit.bp
+++ b/units/XSC8009/XSC8009_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XSC8010/XSC8010_unit.bp
+++ b/units/XSC8010/XSC8010_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8010/XSC8010_unit.bp
+++ b/units/XSC8010/XSC8010_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC8010/XSC8010_unit.bp
+++ b/units/XSC8010/XSC8010_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8010/XSC8010_unit.bp
+++ b/units/XSC8010/XSC8010_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XSC8011/XSC8011_unit.bp
+++ b/units/XSC8011/XSC8011_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8011/XSC8011_unit.bp
+++ b/units/XSC8011/XSC8011_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC8011/XSC8011_unit.bp
+++ b/units/XSC8011/XSC8011_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8011/XSC8011_unit.bp
+++ b/units/XSC8011/XSC8011_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XSC8012/XSC8012_unit.bp
+++ b/units/XSC8012/XSC8012_unit.bp
@@ -82,7 +82,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8012/XSC8012_unit.bp
+++ b/units/XSC8012/XSC8012_unit.bp
@@ -100,7 +100,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC8012/XSC8012_unit.bp
+++ b/units/XSC8012/XSC8012_unit.bp
@@ -83,7 +83,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8012/XSC8012_unit.bp
+++ b/units/XSC8012/XSC8012_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/XSC8013/XSC8013_unit.bp
+++ b/units/XSC8013/XSC8013_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc8013_help>Seraphim Wall Segment',

--- a/units/XSC8013/XSC8013_unit.bp
+++ b/units/XSC8013/XSC8013_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8013/XSC8013_unit.bp
+++ b/units/XSC8013/XSC8013_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8013/XSC8013_unit.bp
+++ b/units/XSC8013/XSC8013_unit.bp
@@ -116,7 +116,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC8014/XSC8014_unit.bp
+++ b/units/XSC8014/XSC8014_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc8014_help>Seraphim Wall Segment',

--- a/units/XSC8014/XSC8014_unit.bp
+++ b/units/XSC8014/XSC8014_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8014/XSC8014_unit.bp
+++ b/units/XSC8014/XSC8014_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8014/XSC8014_unit.bp
+++ b/units/XSC8014/XSC8014_unit.bp
@@ -116,7 +116,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC8015/XSC8015_unit.bp
+++ b/units/XSC8015/XSC8015_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8015/XSC8015_unit.bp
+++ b/units/XSC8015/XSC8015_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8015/XSC8015_unit.bp
+++ b/units/XSC8015/XSC8015_unit.bp
@@ -116,7 +116,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC8015/XSC8015_unit.bp
+++ b/units/XSC8015/XSC8015_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc8015_help>Seraphim Wall Segment',

--- a/units/XSC8016/XSC8016_unit.bp
+++ b/units/XSC8016/XSC8016_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc8016_help>Seraphim Wall Segment',

--- a/units/XSC8016/XSC8016_unit.bp
+++ b/units/XSC8016/XSC8016_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8016/XSC8016_unit.bp
+++ b/units/XSC8016/XSC8016_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8016/XSC8016_unit.bp
+++ b/units/XSC8016/XSC8016_unit.bp
@@ -116,7 +116,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC8017/XSC8017_unit.bp
+++ b/units/XSC8017/XSC8017_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc8017_help>Seraphim Wall Segment',

--- a/units/XSC8017/XSC8017_unit.bp
+++ b/units/XSC8017/XSC8017_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8017/XSC8017_unit.bp
+++ b/units/XSC8017/XSC8017_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8017/XSC8017_unit.bp
+++ b/units/XSC8017/XSC8017_unit.bp
@@ -116,7 +116,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC8018/XSC8018_unit.bp
+++ b/units/XSC8018/XSC8018_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8018/XSC8018_unit.bp
+++ b/units/XSC8018/XSC8018_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc8018_help>Seraphim Wall Segment',

--- a/units/XSC8018/XSC8018_unit.bp
+++ b/units/XSC8018/XSC8018_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8018/XSC8018_unit.bp
+++ b/units/XSC8018/XSC8018_unit.bp
@@ -116,7 +116,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC8019/XSC8019_unit.bp
+++ b/units/XSC8019/XSC8019_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc8019_help>Seraphim Wall Segment',

--- a/units/XSC8019/XSC8019_unit.bp
+++ b/units/XSC8019/XSC8019_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8019/XSC8019_unit.bp
+++ b/units/XSC8019/XSC8019_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8019/XSC8019_unit.bp
+++ b/units/XSC8019/XSC8019_unit.bp
@@ -116,7 +116,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC8020/XSC8020_unit.bp
+++ b/units/XSC8020/XSC8020_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC xsc8020_help>Seraphim Wall Segment',

--- a/units/XSC8020/XSC8020_unit.bp
+++ b/units/XSC8020/XSC8020_unit.bp
@@ -98,7 +98,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8020/XSC8020_unit.bp
+++ b/units/XSC8020/XSC8020_unit.bp
@@ -99,7 +99,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/XSC8020/XSC8020_unit.bp
+++ b/units/XSC8020/XSC8020_unit.bp
@@ -116,7 +116,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Interface = {

--- a/units/XSC9002/XSC9002_unit.bp
+++ b/units/XSC9002/XSC9002_unit.bp
@@ -61,7 +61,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MilitaryVehicle',
         CommandCaps = {
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = false,

--- a/units/XSC9002/XSC9002_unit.bp
+++ b/units/XSC9002/XSC9002_unit.bp
@@ -76,7 +76,6 @@ UnitBlueprint {
         },
         FactionName = 'Seraphim',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         JamRadius = {

--- a/units/XSC9002/XSC9002_unit.bp
+++ b/units/XSC9002/XSC9002_unit.bp
@@ -60,7 +60,6 @@ UnitBlueprint {
         SizeZ = 3,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = false,

--- a/units/XSC9002/XSC9002_unit.bp
+++ b/units/XSC9002/XSC9002_unit.bp
@@ -78,7 +78,6 @@ UnitBlueprint {
         },
         FactionName = 'Seraphim',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC9010/XSC9010_unit.bp
+++ b/units/XSC9010/XSC9010_unit.bp
@@ -78,7 +78,6 @@ UnitBlueprint {
         FactionName = 'Seraphim',
         Icon = 'land',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         JamRadius = {

--- a/units/XSC9010/XSC9010_unit.bp
+++ b/units/XSC9010/XSC9010_unit.bp
@@ -61,7 +61,6 @@ UnitBlueprint {
         SizeZ = 0,
     },
     General = {
-        Category = 'Direct Fire',
         CommandCaps = {
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = false,

--- a/units/XSC9010/XSC9010_unit.bp
+++ b/units/XSC9010/XSC9010_unit.bp
@@ -62,7 +62,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Direct Fire',
-        Classification = 'RULEUC_MilitaryVehicle',
         CommandCaps = {
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = false,

--- a/units/XSC9010/XSC9010_unit.bp
+++ b/units/XSC9010/XSC9010_unit.bp
@@ -80,7 +80,6 @@ UnitBlueprint {
         FactionName = 'Seraphim',
         Icon = 'land',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC9011/XSC9011_unit.bp
+++ b/units/XSC9011/XSC9011_unit.bp
@@ -85,7 +85,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Utility',
-        Classification = 'RULEUC_MilitaryAircraft',
         CommandCaps = {
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = true,

--- a/units/XSC9011/XSC9011_unit.bp
+++ b/units/XSC9011/XSC9011_unit.bp
@@ -84,7 +84,6 @@ UnitBlueprint {
         BuildTime = 320,
     },
     General = {
-        Category = 'Utility',
         CommandCaps = {
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = true,

--- a/units/XSC9011/XSC9011_unit.bp
+++ b/units/XSC9011/XSC9011_unit.bp
@@ -104,7 +104,6 @@ UnitBlueprint {
         FactionName = 'Seraphim',
         Icon = 'air',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Basic',
         UnitWeight = 1,
     },
     Intel = {

--- a/units/XSC9011/XSC9011_unit.bp
+++ b/units/XSC9011/XSC9011_unit.bp
@@ -102,7 +102,6 @@ UnitBlueprint {
         FactionName = 'Seraphim',
         Icon = 'air',
         SelectionPriority = 5,
-        UnitWeight = 1,
     },
     Intel = {
         JamRadius = {

--- a/units/ZAB9502/ZAB9502_unit.bp
+++ b/units/ZAB9502/ZAB9502_unit.bp
@@ -143,7 +143,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZAB9502/ZAB9502_unit.bp
+++ b/units/ZAB9502/ZAB9502_unit.bp
@@ -161,7 +161,6 @@ UnitBlueprint {
         FactionName = 'Aeon',
         Icon = 'air',
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFrom = 'uab0102',
         UpgradesFromBase = 'uab0102',
         UpgradesTo = 'zab9602',

--- a/units/ZAB9502/ZAB9502_unit.bp
+++ b/units/ZAB9502/ZAB9502_unit.bp
@@ -163,7 +163,6 @@ UnitBlueprint {
         FactionName = 'Aeon',
         Icon = 'air',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Advanced',
         UnitWeight = 1,
         UpgradesFrom = 'uab0102',
         UpgradesFromBase = 'uab0102',

--- a/units/ZAB9502/ZAB9502_unit.bp
+++ b/units/ZAB9502/ZAB9502_unit.bp
@@ -142,7 +142,6 @@ UnitBlueprint {
                 'Turret_Muzzle_02',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZAB9503/ZAB9503_unit.bp
+++ b/units/ZAB9503/ZAB9503_unit.bp
@@ -159,7 +159,6 @@ UnitBlueprint {
         FactionName = 'Aeon',
         Icon = 'sea',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Advanced',
         UnitWeight = 1,
         UpgradesFrom = 'uab0103',
         UpgradesFromBase = 'uab0103',

--- a/units/ZAB9503/ZAB9503_unit.bp
+++ b/units/ZAB9503/ZAB9503_unit.bp
@@ -157,7 +157,6 @@ UnitBlueprint {
         FactionName = 'Aeon',
         Icon = 'sea',
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFrom = 'uab0103',
         UpgradesFromBase = 'uab0103',
         UpgradesTo = 'zab9603',

--- a/units/ZAB9503/ZAB9503_unit.bp
+++ b/units/ZAB9503/ZAB9503_unit.bp
@@ -139,7 +139,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZAB9503/ZAB9503_unit.bp
+++ b/units/ZAB9503/ZAB9503_unit.bp
@@ -138,7 +138,6 @@ UnitBlueprint {
                 'Turret_Muzzle_02',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZAB9602/ZAB9602_unit.bp
+++ b/units/ZAB9602/ZAB9602_unit.bp
@@ -158,7 +158,6 @@ UnitBlueprint {
         FactionName = 'Aeon',
         Icon = 'air',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Secret',
         UnitWeight = 1,
         UpgradesFromBase = 'uab0102',
         UpgradesFrom = 'zab9502',

--- a/units/ZAB9602/ZAB9602_unit.bp
+++ b/units/ZAB9602/ZAB9602_unit.bp
@@ -138,7 +138,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZAB9602/ZAB9602_unit.bp
+++ b/units/ZAB9602/ZAB9602_unit.bp
@@ -137,7 +137,6 @@ UnitBlueprint {
                 'Turret_Muzzle_03',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZAB9602/ZAB9602_unit.bp
+++ b/units/ZAB9602/ZAB9602_unit.bp
@@ -156,7 +156,6 @@ UnitBlueprint {
         FactionName = 'Aeon',
         Icon = 'air',
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFromBase = 'uab0102',
         UpgradesFrom = 'zab9502',
     },

--- a/units/ZAB9603/ZAB9603_unit.bp
+++ b/units/ZAB9603/ZAB9603_unit.bp
@@ -123,7 +123,6 @@ UnitBlueprint {
         FactionName = 'Aeon',
         Icon = 'sea',
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFrom = 'zab9503',
         UpgradesFromBase = 'uab0103',
     },

--- a/units/ZAB9603/ZAB9603_unit.bp
+++ b/units/ZAB9603/ZAB9603_unit.bp
@@ -125,7 +125,6 @@ UnitBlueprint {
         FactionName = 'Aeon',
         Icon = 'sea',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Secret',
         UnitWeight = 1,
         UpgradesFrom = 'zab9503',
         UpgradesFromBase = 'uab0103',

--- a/units/ZAB9603/ZAB9603_unit.bp
+++ b/units/ZAB9603/ZAB9603_unit.bp
@@ -104,7 +104,6 @@ UnitBlueprint {
                 'Turret_Muzzle_03',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZAB9603/ZAB9603_unit.bp
+++ b/units/ZAB9603/ZAB9603_unit.bp
@@ -105,7 +105,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZEB9501/ZEB9501_unit.bp
+++ b/units/ZEB9501/ZEB9501_unit.bp
@@ -125,7 +125,6 @@ UnitBlueprint {
         FactionName = "UEF",
         Icon = "land",
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFrom = "ueb0101",
         UpgradesFromBase = "ueb0101",
         UpgradesTo = "zeb9601",

--- a/units/ZEB9501/ZEB9501_unit.bp
+++ b/units/ZEB9501/ZEB9501_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
                 "Muzzle03",
             },
         },
-        Category = "Factory",
         CommandCaps = {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,

--- a/units/ZEB9501/ZEB9501_unit.bp
+++ b/units/ZEB9501/ZEB9501_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
             },
         },
         Category = "Factory",
-        Classification = "RULEUC_Factory",
         CommandCaps = {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,
@@ -127,7 +126,6 @@ UnitBlueprint {
         FactionName = "UEF",
         Icon = "land",
         SelectionPriority = 5,
-        TechLevel = "RULEUTL_Advanced",
         UnitWeight = 1,
         UpgradesFrom = "ueb0101",
         UpgradesFromBase = "ueb0101",

--- a/units/ZEB9502/ZEB9502_unit.bp
+++ b/units/ZEB9502/ZEB9502_unit.bp
@@ -168,7 +168,6 @@ UnitBlueprint {
         FactionName = 'UEF',
         Icon = 'air',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Advanced',
         UnitWeight = 1,
         UpgradesFrom = 'ueb0102',
         UpgradesFromBase = 'ueb0102',

--- a/units/ZEB9502/ZEB9502_unit.bp
+++ b/units/ZEB9502/ZEB9502_unit.bp
@@ -166,7 +166,6 @@ UnitBlueprint {
         FactionName = 'UEF',
         Icon = 'air',
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFrom = 'ueb0102',
         UpgradesFromBase = 'ueb0102',
         UpgradesTo = 'zeb9602',

--- a/units/ZEB9502/ZEB9502_unit.bp
+++ b/units/ZEB9502/ZEB9502_unit.bp
@@ -147,7 +147,6 @@ UnitBlueprint {
                 'Muzzle02',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZEB9502/ZEB9502_unit.bp
+++ b/units/ZEB9502/ZEB9502_unit.bp
@@ -148,7 +148,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZEB9503/ZEB9503_unit.bp
+++ b/units/ZEB9503/ZEB9503_unit.bp
@@ -167,7 +167,6 @@ UnitBlueprint {
         FactionName = 'UEF',
         Icon = 'sea',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Advanced',
         UnitWeight = 1,
         UpgradesFrom = 'ueb0103',
         UpgradesFromBase = 'ueb0103',

--- a/units/ZEB9503/ZEB9503_unit.bp
+++ b/units/ZEB9503/ZEB9503_unit.bp
@@ -147,7 +147,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZEB9503/ZEB9503_unit.bp
+++ b/units/ZEB9503/ZEB9503_unit.bp
@@ -165,7 +165,6 @@ UnitBlueprint {
         FactionName = 'UEF',
         Icon = 'sea',
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFrom = 'ueb0103',
         UpgradesFromBase = 'ueb0103',
         UpgradesTo = 'zeb9603',

--- a/units/ZEB9503/ZEB9503_unit.bp
+++ b/units/ZEB9503/ZEB9503_unit.bp
@@ -146,7 +146,6 @@ UnitBlueprint {
                 'Center_Exhaust',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZEB9601/ZEB9601_unit.bp
+++ b/units/ZEB9601/ZEB9601_unit.bp
@@ -125,7 +125,6 @@ UnitBlueprint {
         FactionName = "UEF",
         Icon = "land",
         SelectionPriority = 5,
-        TechLevel = "RULEUTL_Secret",
         UnitWeight = 1,
         UpgradesFrom = "zeb9501",
         UpgradesFromBase = "ueb0101",

--- a/units/ZEB9601/ZEB9601_unit.bp
+++ b/units/ZEB9601/ZEB9601_unit.bp
@@ -111,7 +111,6 @@ UnitBlueprint {
                 "Muzzle03",
             },
         },
-        Category = "Factory",
         CommandCaps = {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,

--- a/units/ZEB9601/ZEB9601_unit.bp
+++ b/units/ZEB9601/ZEB9601_unit.bp
@@ -123,7 +123,6 @@ UnitBlueprint {
         FactionName = "UEF",
         Icon = "land",
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFrom = "zeb9501",
         UpgradesFromBase = "ueb0101",
     },

--- a/units/ZEB9601/ZEB9601_unit.bp
+++ b/units/ZEB9601/ZEB9601_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
             },
         },
         Category = "Factory",
-        Classification = "RULEUC_Factory",
         CommandCaps = {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,

--- a/units/ZEB9602/ZEB9602_unit.bp
+++ b/units/ZEB9602/ZEB9602_unit.bp
@@ -142,7 +142,6 @@ UnitBlueprint {
                 'Muzzle03',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZEB9602/ZEB9602_unit.bp
+++ b/units/ZEB9602/ZEB9602_unit.bp
@@ -143,7 +143,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZEB9602/ZEB9602_unit.bp
+++ b/units/ZEB9602/ZEB9602_unit.bp
@@ -161,7 +161,6 @@ UnitBlueprint {
         FactionName = 'UEF',
         Icon = 'air',
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFrom = 'zeb9502',
         UpgradesFromBase = 'ueb0102',
     },

--- a/units/ZEB9602/ZEB9602_unit.bp
+++ b/units/ZEB9602/ZEB9602_unit.bp
@@ -163,7 +163,6 @@ UnitBlueprint {
         FactionName = 'UEF',
         Icon = 'air',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Secret',
         UnitWeight = 1,
         UpgradesFrom = 'zeb9502',
         UpgradesFromBase = 'ueb0102',

--- a/units/ZEB9603/ZEB9603_unit.bp
+++ b/units/ZEB9603/ZEB9603_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZEB9603/ZEB9603_unit.bp
+++ b/units/ZEB9603/ZEB9603_unit.bp
@@ -133,7 +133,6 @@ UnitBlueprint {
         FactionName = 'UEF',
         Icon = 'sea',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Secret',
         UnitWeight = 1,
         UpgradesFrom = 'zeb9503',
         UpgradesFromBase = 'ueb0103',

--- a/units/ZEB9603/ZEB9603_unit.bp
+++ b/units/ZEB9603/ZEB9603_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
                 'Left_Exhaust',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZEB9603/ZEB9603_unit.bp
+++ b/units/ZEB9603/ZEB9603_unit.bp
@@ -131,7 +131,6 @@ UnitBlueprint {
         FactionName = 'UEF',
         Icon = 'sea',
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFrom = 'zeb9503',
         UpgradesFromBase = 'ueb0103',
     },

--- a/units/ZRB9501/ZRB9501_unit.bp
+++ b/units/ZRB9501/ZRB9501_unit.bp
@@ -113,7 +113,6 @@ UnitBlueprint {
                 'Arm03_Muzzle',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,

--- a/units/ZRB9501/ZRB9501_unit.bp
+++ b/units/ZRB9501/ZRB9501_unit.bp
@@ -125,7 +125,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'land',
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFrom = 'urb0101',
         UpgradesFromBase = 'urb0101',
         UpgradesTo = 'zrb9601',

--- a/units/ZRB9501/ZRB9501_unit.bp
+++ b/units/ZRB9501/ZRB9501_unit.bp
@@ -127,7 +127,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'land',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Advanced',
         UnitWeight = 1,
         UpgradesFrom = 'urb0101',
         UpgradesFromBase = 'urb0101',

--- a/units/ZRB9501/ZRB9501_unit.bp
+++ b/units/ZRB9501/ZRB9501_unit.bp
@@ -114,7 +114,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,

--- a/units/ZRB9502/ZRB9502_unit.bp
+++ b/units/ZRB9502/ZRB9502_unit.bp
@@ -174,7 +174,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'air',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Advanced',
         UnitWeight = 1,
         UpgradesFrom = 'urb0102',
         UpgradesFromBase = 'urb0102',

--- a/units/ZRB9502/ZRB9502_unit.bp
+++ b/units/ZRB9502/ZRB9502_unit.bp
@@ -172,7 +172,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'air',
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFrom = 'urb0102',
         UpgradesFromBase = 'urb0102',
         UpgradesTo = 'zrb9602',

--- a/units/ZRB9502/ZRB9502_unit.bp
+++ b/units/ZRB9502/ZRB9502_unit.bp
@@ -154,7 +154,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZRB9502/ZRB9502_unit.bp
+++ b/units/ZRB9502/ZRB9502_unit.bp
@@ -153,7 +153,6 @@ UnitBlueprint {
                 'Arm04_Muzzle',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZRB9503/ZRB9503_unit.bp
+++ b/units/ZRB9503/ZRB9503_unit.bp
@@ -168,7 +168,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'sea',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Advanced',
         UnitWeight = 1,
         UpgradesFrom = 'urb0103',
         UpgradesFromBase = 'urb0103',

--- a/units/ZRB9503/ZRB9503_unit.bp
+++ b/units/ZRB9503/ZRB9503_unit.bp
@@ -166,7 +166,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'sea',
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFrom = 'urb0103',
         UpgradesFromBase = 'urb0103',
         UpgradesTo = 'zrb9603',

--- a/units/ZRB9503/ZRB9503_unit.bp
+++ b/units/ZRB9503/ZRB9503_unit.bp
@@ -148,7 +148,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZRB9503/ZRB9503_unit.bp
+++ b/units/ZRB9503/ZRB9503_unit.bp
@@ -147,7 +147,6 @@ UnitBlueprint {
                 'Right_Exhaust02',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZRB9601/ZRB9601_unit.bp
+++ b/units/ZRB9601/ZRB9601_unit.bp
@@ -111,7 +111,6 @@ UnitBlueprint {
                 'Arm06_Muzzle',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,

--- a/units/ZRB9601/ZRB9601_unit.bp
+++ b/units/ZRB9601/ZRB9601_unit.bp
@@ -124,7 +124,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'land',
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFromBase = 'urb0101',
         UpgradesFrom = 'zrb9501',
     },

--- a/units/ZRB9601/ZRB9601_unit.bp
+++ b/units/ZRB9601/ZRB9601_unit.bp
@@ -126,7 +126,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'land',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Secret',
         UnitWeight = 1,
         UpgradesFromBase = 'urb0101',
         UpgradesFrom = 'zrb9501',

--- a/units/ZRB9601/ZRB9601_unit.bp
+++ b/units/ZRB9601/ZRB9601_unit.bp
@@ -112,7 +112,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,

--- a/units/ZRB9602/ZRB9602_unit.bp
+++ b/units/ZRB9602/ZRB9602_unit.bp
@@ -150,7 +150,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZRB9602/ZRB9602_unit.bp
+++ b/units/ZRB9602/ZRB9602_unit.bp
@@ -170,7 +170,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'air',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Secret',
         UnitWeight = 1,
         UpgradesFromBase = 'urb0102',
         UpgradesFrom = 'zrb9502',

--- a/units/ZRB9602/ZRB9602_unit.bp
+++ b/units/ZRB9602/ZRB9602_unit.bp
@@ -149,7 +149,6 @@ UnitBlueprint {
                 'Arm06_Muzzle',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZRB9602/ZRB9602_unit.bp
+++ b/units/ZRB9602/ZRB9602_unit.bp
@@ -168,7 +168,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'air',
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFromBase = 'urb0102',
         UpgradesFrom = 'zrb9502',
     },

--- a/units/ZRB9603/ZRB9603_unit.bp
+++ b/units/ZRB9603/ZRB9603_unit.bp
@@ -162,7 +162,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'sea',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Secret',
         UnitWeight = 1,
         UpgradesFromBase = 'urb0103',
         UpgradesFrom = 'zrb9503',

--- a/units/ZRB9603/ZRB9603_unit.bp
+++ b/units/ZRB9603/ZRB9603_unit.bp
@@ -142,7 +142,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZRB9603/ZRB9603_unit.bp
+++ b/units/ZRB9603/ZRB9603_unit.bp
@@ -160,7 +160,6 @@ UnitBlueprint {
         FactionName = 'Cybran',
         Icon = 'sea',
         SelectionPriority = 5,
-        UnitWeight = 1,
         UpgradesFromBase = 'urb0103',
         UpgradesFrom = 'zrb9503',
     },

--- a/units/ZRB9603/ZRB9603_unit.bp
+++ b/units/ZRB9603/ZRB9603_unit.bp
@@ -141,7 +141,6 @@ UnitBlueprint {
                 'Right_Exhaust03',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZSB9501/ZSB9501_unit.bp
+++ b/units/ZSB9501/ZSB9501_unit.bp
@@ -136,7 +136,6 @@ UnitBlueprint {
         FactionName = 'Seraphim',
         Icon = 'land',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Advanced',
         UnitName = '<LOC zsb9501_name>Hethiya',
         UnitWeight = 1,
         UpgradesFrom = 'xsb0101',

--- a/units/ZSB9501/ZSB9501_unit.bp
+++ b/units/ZSB9501/ZSB9501_unit.bp
@@ -122,7 +122,6 @@ UnitBlueprint {
                 'Muzzle02',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,

--- a/units/ZSB9501/ZSB9501_unit.bp
+++ b/units/ZSB9501/ZSB9501_unit.bp
@@ -123,7 +123,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,

--- a/units/ZSB9501/ZSB9501_unit.bp
+++ b/units/ZSB9501/ZSB9501_unit.bp
@@ -135,7 +135,6 @@ UnitBlueprint {
         Icon = 'land',
         SelectionPriority = 5,
         UnitName = '<LOC zsb9501_name>Hethiya',
-        UnitWeight = 1,
         UpgradesFrom = 'xsb0101',
         UpgradesFromBase = 'xsb0101',
         UpgradesTo = 'zsb9601',

--- a/units/ZSB9502/ZSB9502_unit.bp
+++ b/units/ZSB9502/ZSB9502_unit.bp
@@ -155,7 +155,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZSB9502/ZSB9502_unit.bp
+++ b/units/ZSB9502/ZSB9502_unit.bp
@@ -174,7 +174,6 @@ UnitBlueprint {
         Icon = 'air',
         SelectionPriority = 5,
         UnitName = '<LOC zsb9502_name>Ia-iya',
-        UnitWeight = 1,
         UpgradesFrom = 'xsb0102',
         UpgradesFromBase = 'xsb0102',
         UpgradesTo = 'zsb9602',

--- a/units/ZSB9502/ZSB9502_unit.bp
+++ b/units/ZSB9502/ZSB9502_unit.bp
@@ -154,7 +154,6 @@ UnitBlueprint {
                 'Muzzle02',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZSB9502/ZSB9502_unit.bp
+++ b/units/ZSB9502/ZSB9502_unit.bp
@@ -175,7 +175,6 @@ UnitBlueprint {
         FactionName = 'Seraphim',
         Icon = 'air',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Advanced',
         UnitName = '<LOC zsb9502_name>Ia-iya',
         UnitWeight = 1,
         UpgradesFrom = 'xsb0102',

--- a/units/ZSB9503/ZSB9503_unit.bp
+++ b/units/ZSB9503/ZSB9503_unit.bp
@@ -155,7 +155,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZSB9503/ZSB9503_unit.bp
+++ b/units/ZSB9503/ZSB9503_unit.bp
@@ -174,7 +174,6 @@ UnitBlueprint {
         Icon = 'sea',
         SelectionPriority = 5,
         UnitName = '<LOC zsb9503_name>Uosiya',
-        UnitWeight = 1,
         UpgradesFrom = 'xsb0103',
         UpgradesFromBase = 'xsb0103',
         UpgradesTo = 'zsb9603',

--- a/units/ZSB9503/ZSB9503_unit.bp
+++ b/units/ZSB9503/ZSB9503_unit.bp
@@ -154,7 +154,6 @@ UnitBlueprint {
                 'Muzzle02',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZSB9503/ZSB9503_unit.bp
+++ b/units/ZSB9503/ZSB9503_unit.bp
@@ -175,7 +175,6 @@ UnitBlueprint {
         FactionName = 'Seraphim',
         Icon = 'sea',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Advanced',
         UnitName = '<LOC zsb9503_name>Uosiya',
         UnitWeight = 1,
         UpgradesFrom = 'xsb0103',

--- a/units/ZSB9601/ZSB9601_unit.bp
+++ b/units/ZSB9601/ZSB9601_unit.bp
@@ -122,7 +122,6 @@ UnitBlueprint {
                 'Muzzle03',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,

--- a/units/ZSB9601/ZSB9601_unit.bp
+++ b/units/ZSB9601/ZSB9601_unit.bp
@@ -123,7 +123,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,

--- a/units/ZSB9601/ZSB9601_unit.bp
+++ b/units/ZSB9601/ZSB9601_unit.bp
@@ -135,7 +135,6 @@ UnitBlueprint {
         Icon = 'land',
         SelectionPriority = 5,
         UnitName = '<LOC zsb9601_name>Hethiya',
-        UnitWeight = 1,
         UpgradesFrom = 'zsb9501',
         UpgradesFromBase = 'xsb0101',
     },

--- a/units/ZSB9601/ZSB9601_unit.bp
+++ b/units/ZSB9601/ZSB9601_unit.bp
@@ -136,7 +136,6 @@ UnitBlueprint {
         FactionName = 'Seraphim',
         Icon = 'land',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Secret',
         UnitName = '<LOC zsb9601_name>Hethiya',
         UnitWeight = 1,
         UpgradesFrom = 'zsb9501',

--- a/units/ZSB9602/ZSB9602_unit.bp
+++ b/units/ZSB9602/ZSB9602_unit.bp
@@ -170,7 +170,6 @@ UnitBlueprint {
         FactionName = 'Seraphim',
         Icon = 'air',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Secret',
         UnitName = '<LOC zsb9602_name>Ia-iya',
         UnitWeight = 1,
         UpgradesFrom = 'zsb9502',

--- a/units/ZSB9602/ZSB9602_unit.bp
+++ b/units/ZSB9602/ZSB9602_unit.bp
@@ -169,7 +169,6 @@ UnitBlueprint {
         Icon = 'air',
         SelectionPriority = 5,
         UnitName = '<LOC zsb9602_name>Ia-iya',
-        UnitWeight = 1,
         UpgradesFrom = 'zsb9502',
         UpgradesFromBase = 'xsb0102',
     },

--- a/units/ZSB9602/ZSB9602_unit.bp
+++ b/units/ZSB9602/ZSB9602_unit.bp
@@ -150,7 +150,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZSB9602/ZSB9602_unit.bp
+++ b/units/ZSB9602/ZSB9602_unit.bp
@@ -149,7 +149,6 @@ UnitBlueprint {
                 'Muzzle03',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZSB9603/ZSB9603_unit.bp
+++ b/units/ZSB9603/ZSB9603_unit.bp
@@ -168,7 +168,6 @@ UnitBlueprint {
         FactionName = 'Seraphim',
         Icon = 'sea',
         SelectionPriority = 5,
-        TechLevel = 'RULEUTL_Secret',
         UnitName = '<LOC zsb9603_name>Uosiya',
         UnitWeight = 1,
         UpgradesFromBase = 'xsb0103',

--- a/units/ZSB9603/ZSB9603_unit.bp
+++ b/units/ZSB9603/ZSB9603_unit.bp
@@ -167,7 +167,6 @@ UnitBlueprint {
         Icon = 'sea',
         SelectionPriority = 5,
         UnitName = '<LOC zsb9603_name>Uosiya',
-        UnitWeight = 1,
         UpgradesFromBase = 'xsb0103',
         UpgradesFrom = 'zsb9503',
     },

--- a/units/ZSB9603/ZSB9603_unit.bp
+++ b/units/ZSB9603/ZSB9603_unit.bp
@@ -148,7 +148,6 @@ UnitBlueprint {
             },
         },
         Category = 'Factory',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZSB9603/ZSB9603_unit.bp
+++ b/units/ZSB9603/ZSB9603_unit.bp
@@ -147,7 +147,6 @@ UnitBlueprint {
                 'Muzzle03',
             },
         },
-        Category = 'Factory',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZXA0001/ZXA0001_unit.bp
+++ b/units/ZXA0001/ZXA0001_unit.bp
@@ -92,7 +92,6 @@ UnitBlueprint {
             },
         },
         SelectionPriority = 6,
-        TechLevel = 'RULEUTL_Basic',
         ToggleCaps = {
             RULEUTC_WeaponToggle = false,
         },

--- a/units/ZXA0001/ZXA0001_unit.bp
+++ b/units/ZXA0001/ZXA0001_unit.bp
@@ -63,7 +63,6 @@ UnitBlueprint {
     General = {
         CapCost = 0,
         Category = 'Utility',
-        Classification = 'RULEUC_MilitaryAircraft',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZXA0001/ZXA0001_unit.bp
+++ b/units/ZXA0001/ZXA0001_unit.bp
@@ -62,7 +62,6 @@ UnitBlueprint {
     },
     General = {
         CapCost = 0,
-        Category = 'Utility',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ZXA0001/ZXA0001_unit.bp
+++ b/units/ZXA0001/ZXA0001_unit.bp
@@ -94,7 +94,6 @@ UnitBlueprint {
             RULEUTC_WeaponToggle = false,
         },
         UnitName = 'zxa0001 dummy drone',
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/ZXA0002/ZXA0002_unit.bp
+++ b/units/ZXA0002/ZXA0002_unit.bp
@@ -43,7 +43,6 @@ UnitBlueprint {
     },
     General = {
         CapCost = 0,
-        Category = '',
         CommandCaps = {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,

--- a/units/ZXA0002/ZXA0002_unit.bp
+++ b/units/ZXA0002/ZXA0002_unit.bp
@@ -44,7 +44,6 @@ UnitBlueprint {
     General = {
         CapCost = 0,
         Category = '',
-        Classification = 'RULEUC_Factory',
         CommandCaps = {
             RULEUCC_Guard = true,
             RULEUCC_Move = true,

--- a/units/ZXA0002/ZXA0002_unit.bp
+++ b/units/ZXA0002/ZXA0002_unit.bp
@@ -78,13 +78,11 @@ UnitBlueprint {
         SizeX = 0,
         SizeZ = 0,
     },
-
     SelectionMeshScaleX = 1.0,
     SelectionMeshScaleY = 3.0,
     SelectionMeshScaleZ = 1.0,
     SelectionMeshUseTopAmount  = 0.0,
     SelectionYOffset  = 0,
-
     SelectionSizeX = 3.6,
     SelectionSizeY = 0,
     SelectionSizeZ = 1.8,

--- a/units/ZXA0002/ZXA0002_unit.bp
+++ b/units/ZXA0002/ZXA0002_unit.bp
@@ -54,7 +54,6 @@ UnitBlueprint {
             RULEUCC_Stop = true,
         },
         SelectionPriority = 6,
-        TechLevel = 'RULEUTL_Experimental',
         UnitName = 'Mobile Factory',
         UnitWeight = 1,
     },

--- a/units/ZXA0002/ZXA0002_unit.bp
+++ b/units/ZXA0002/ZXA0002_unit.bp
@@ -53,7 +53,6 @@ UnitBlueprint {
         },
         SelectionPriority = 6,
         UnitName = 'Mobile Factory',
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 0,

--- a/units/ope2002/OPE2002_unit.bp
+++ b/units/ope2002/OPE2002_unit.bp
@@ -47,7 +47,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Defense',
-        Classification = 'RULEUC_MiscSupport',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ope2002/OPE2002_unit.bp
+++ b/units/ope2002/OPE2002_unit.bp
@@ -62,7 +62,6 @@ UnitBlueprint {
         },
         FactionName = 'UEF',
         UnitName = '<LOC ope2002_name>UEF Research Facility',
-        UnitWeight = 1,
     },
     Interface = {
         HelpText = '<LOC ope2002_help>UEF Research Facility',

--- a/units/ope2002/OPE2002_unit.bp
+++ b/units/ope2002/OPE2002_unit.bp
@@ -63,7 +63,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'UEF',
-        TechLevel = 'RULEUTL_Basic',
         UnitName = '<LOC ope2002_name>UEF Research Facility',
         UnitWeight = 1,
     },

--- a/units/ope2002/OPE2002_unit.bp
+++ b/units/ope2002/OPE2002_unit.bp
@@ -46,7 +46,6 @@ UnitBlueprint {
         BuildTime = 50,
     },
     General = {
-        Category = 'Defense',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = false,

--- a/units/ope2003/OPE2003_unit.bp
+++ b/units/ope2003/OPE2003_unit.bp
@@ -55,7 +55,6 @@ UnitBlueprint {
     },
     General = {
         Category = 'Civilian Truck',
-        Classification = 'RULEUC_MilitaryVehicle',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/ope2003/OPE2003_unit.bp
+++ b/units/ope2003/OPE2003_unit.bp
@@ -54,7 +54,6 @@ UnitBlueprint {
         BuildCostMass = 158,
     },
     General = {
-        Category = 'Civilian Truck',
         CommandCaps = {
             RULEUCC_Attack = false,
             RULEUCC_CallTransport = true,

--- a/units/ope2003/OPE2003_unit.bp
+++ b/units/ope2003/OPE2003_unit.bp
@@ -69,7 +69,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'UEF',
-        UnitWeight = 1,
     },
     Intel = {
         VisionRadius = 18,

--- a/units/ope2003/OPE2003_unit.bp
+++ b/units/ope2003/OPE2003_unit.bp
@@ -71,7 +71,6 @@ UnitBlueprint {
             RULEUCC_Transport = false,
         },
         FactionName = 'UEF',
-        TechLevel = 'RULEUTL_Advanced',
         UnitWeight = 1,
     },
     Intel = {


### PR DESCRIPTION
## Description of the proposed changes
This PR removes the following fields from various blueprints:
`bp.General.TechLevel`
`bp.General.Classification`
`bp.General.Category`
`bp.General.UnitWeight`

## Testing done on the proposed changes
All units I tested still functioned normally.

## Additional context
According to an older Discord post by @The-Balthazar, these fields can be removed safely. 

## Checklist
- [x] Changes are documented in the changelog for the next game version (in #6149).
