### PR TITLE
Allow automatically loading constructed units into constructed transports

### DIFF
--- a/lua/sim/units/AirFactoryUnit.lua
+++ b/lua/sim/units/AirFactoryUnit.lua
@@ -21,6 +21,44 @@
 --**********************************************************************************
 
 local FactoryUnit = import("/lua/sim/units/factoryunit.lua").FactoryUnit
+local IssueOrderQueue = import("/lua/sim/commands/copy-queue.lua").IssueOrderQueue
+
+local LogCommandQueue = function(unit)
+    local queue = unit:GetCommandQueue()
+    for i, command in queue do
+        LOG(reprs(command),{depth=3})
+    end
+end
+
+local LogWaitThread = function(unit)
+    WaitTicks(2)
+    LogCommandQueue(unit)
+end
+
+local AutoLoadThread = function(transport, unitToLoad)
+    WaitTicks(1)
+    if transport:IsDead() or unitToLoad:IsDead() then
+        return
+    end
+    local rallyQueue = transport:GetCommandQueue()
+    IssueClearCommands({transport, unitToLoad})
+    IssueTransportLoad({unitToLoad}, transport)
+    IssueOrderQueue({transport}, rallyQueue)
+end
 
 ---@class AirFactoryUnit : FactoryUnit
-AirFactoryUnit = ClassUnit(FactoryUnit) {}
+AirFactoryUnit = ClassUnit(FactoryUnit) {
+
+    OnStopBuild = function(self, unitBeingBuilt, order)
+        FactoryUnit.OnStopBuild(self, unitBeingBuilt, order)
+        if EntityCategoryContains(categories.TRANSPORTATION, unitBeingBuilt) then
+            local guards = EntityCategoryFilterDown(categories.MOBILE * categories.LAND - categories.ENGINEER, self:GetGuards())
+            if not table.empty(guards) then
+                local unitToBeLoaded = guards[1]
+                LOG(unitToBeLoaded:GetBlueprint().General.UnitName or 'unit to be loaded has no name')
+                ForkThread(AutoLoadThread, unitBeingBuilt, unitToBeLoaded)
+                --IssueTransportLoad({unitToBeLoaded}, unitBeingBuilt)
+            end
+        end
+    end,
+}

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -252,7 +252,8 @@ FactoryUnit = ClassUnit(StructureUnit) {
     end,
 
     ---@param self FactoryUnit
-    CalculateRollOffPoint = function(self)
+    ---@param targetPosOverride Vector -- An override for the rally position if we're doing something special
+    CalculateRollOffPoint = function(self, targetPosOverride)
         local px, py, pz = self:GetPositionXYZ()
 
         -- check if we have roll of points set
@@ -278,7 +279,9 @@ FactoryUnit = ClassUnit(StructureUnit) {
         end
 
         -- check if we have a rally point set
-        if not rally then
+        if targetPosOverride then
+            rally = targetPosOverride
+        elseif not rally then
             return 0, px, py, pz
         end
 


### PR DESCRIPTION
Demo of two backend lua widgets for autoloading units in transports. Allows (for example) infinite construction of stingers carrying mech marines.

First widget: If a land factory is assisting an air factory, any non-engineer units from the land factory will be routed to assist the air factory instead of going to the land factories rally point.

Second widget: When an air factory finishes constructing a transport, it checks for the presence of any non-engineer land unit guards. This works independently of the first element; units can be manually ordered to assist a factory and will be loaded into transports in the same manner. Prototype only loads 1 unit per transport, but additional logic can check the size of the transport and load units as appropriate.

Stretch goals: give units assisting an air fac special formations, either a basic square or a more advanced arrangement where they group up with respect the air factory's build queue. Right now they play musical chairs as more units arrive/are loaded, which is workable but distracting and carries all the usual factory assist pathfinding issues.

https://github.com/FAForever/fa/assets/7411478/df2edc70-f0f5-42e0-b008-cca1eb489d9f

See discussion here: https://discord.com/channels/197033481883222026/1144605729911738439
