### PR TITLE
Fix `AttackGroundTries` and Othuy Lightning Storm

### DIFF
--- a/engine/Core/Blueprints/WeaponBlueprint.lua
+++ b/engine/Core/Blueprints/WeaponBlueprint.lua
@@ -39,6 +39,8 @@
 ---@field ArtilleryShieldBlocks? boolean
 --- information about the audio files used by the weapon
 ---@field Audio WeaponBlueprintAudio
+--- How many times a unit tries to attack the ground with this weapon before moving on to the next ground attack order. Defaults to 3
+---@field AttackGroundTries?
 --- if the unit has no issued commands and has a weapon that has `AutoInitiateAttackCommand` set,
 --- then if it finds a suitable target it will issue an attack command to go after the target
 ---@field AutoInitiateAttackCommand? boolean

--- a/engine/Core/Blueprints/WeaponBlueprint.lua
+++ b/engine/Core/Blueprints/WeaponBlueprint.lua
@@ -39,7 +39,7 @@
 ---@field ArtilleryShieldBlocks? boolean
 --- information about the audio files used by the weapon
 ---@field Audio WeaponBlueprintAudio
---- How many times a unit tries to attack the ground with this weapon before moving on to the next ground attack order. Defaults to 3
+--- How many times the engine calls OnFire for the weapon when attacking ground before moving on to the next ground attack order. Defaults to 3
 ---@field AttackGroundTries?
 --- if the unit has no issued commands and has a weapon that has `AutoInitiateAttackCommand` set,
 --- then if it finds a suitable target it will issue an attack command to go after the target

--- a/engine/Core/Blueprints/WeaponBlueprint.lua
+++ b/engine/Core/Blueprints/WeaponBlueprint.lua
@@ -313,7 +313,7 @@
 ---@field ToggleWeapon? string
 --- The radius at which the weapon starts tracking the target. This does not mean that the weapon
 --- will fire. The weapon will only fire when a target enters the maxradius. This is a multiplier of
---- the weapon's `MaxRadius`.
+--- the weapon's `MaxRadius`. Weapons do not track targets within the weapon's `MinRadius`.
 ---@field TrackingRadius? number
 --- the second muzzle bone for a turret, used for arms on bots as weapons
 ---@field TurretBoneDualMuzzle? Bone

--- a/engine/Sim/CAiAttackerImpl.lua
+++ b/engine/Sim/CAiAttackerImpl.lua
@@ -1,5 +1,8 @@
 ---@meta
 
+-- The attacker implementation is unfinished, and using any of these methods freezes the sim!
+
+--- "tactical attack manager object"
 ---@class moho.CAiAttackerImpl_methods
 local CAiAttackerImpl = {}
 

--- a/engine/Sim/Unit.lua
+++ b/engine/Sim/Unit.lua
@@ -122,6 +122,7 @@ function Unit:GetArmorMult(damageTypeName)
 end
 
 --- Returns the tactical attack manager object of this unit
+--- The attacker implementation is unfinished, so using this freezes the sim!
 ---@return Attacker
 function Unit:GetAttacker()
 end

--- a/engine/Sim/UnitWeapon.lua
+++ b/engine/Sim/UnitWeapon.lua
@@ -96,8 +96,8 @@ end
 function UnitWeapon:GetCurrentTargetPos()
 end
 
---- Gets the firing clock percent, `0.0` - `1.0`
----@return number
+--- Returns the progress of the engine's firing clock determined by RateOfFire in the weapon blueprint
+---@return number # within [0.0, 1.0]
 function UnitWeapon:GetFireClockPct()
 end
 
@@ -111,8 +111,9 @@ end
 function UnitWeapon:GetProjectileBlueprint()
 end
 
----
----@param label string
+--- Returns true if the given AimManipulator is the weapon's fire control
+---@see SetFireControl
+---@param label string label that was used to create the AimManipulator
 ---@return boolean
 function UnitWeapon:IsFireControl(label)
 end
@@ -131,8 +132,8 @@ end
 function UnitWeapon:SetEnabled(enabled)
 end
 
----
----@param label string
+--- Set which AimManipulator will call OnFire for the weapon when that manipulator has finished tracking
+---@param label string label that was used to create the AimManipulator
 function UnitWeapon:SetFireControl(label)
 end
 
@@ -165,7 +166,8 @@ end
 function UnitWeapon:TransferTarget()
 end
 
----
+--- Returns true if the weapon currently has a target.
+--- This only updates at the end of a tick, so it shouldn't be used in behavior relating to OnLostTarget or OnGotTarget callbacks
 ---@return boolean
 function UnitWeapon:WeaponHasTarget()
 end

--- a/engine/Sim/UnitWeapon.lua
+++ b/engine/Sim/UnitWeapon.lua
@@ -8,7 +8,7 @@ local UnitWeapon = {}
 function UnitWeapon:BeenDestroyed()
 end
 
----
+--- Returns true if the weapon is aiming at the target as allowed by the FiringTolerance blueprint value and the target is within the weapon's range
 ---@return boolean
 function UnitWeapon:CanFire()
 end
@@ -96,7 +96,8 @@ end
 function UnitWeapon:GetCurrentTargetPos()
 end
 
---- Returns the progress of the engine's firing clock determined by RateOfFire in the weapon blueprint
+--- Returns the progress of the engine's firing clock determined by RateOfFire, usually from the blueprint
+---@see ChangeRateOfFire
 ---@return number # within [0.0, 1.0]
 function UnitWeapon:GetFireClockPct()
 end

--- a/engine/Sim/UnitWeapon.lua
+++ b/engine/Sim/UnitWeapon.lua
@@ -122,7 +122,7 @@ end
 function UnitWeapon:PlaySound(params)
 end
 
----
+--- Force the weapon to recheck its targets. Also resets the counter for AttackGroundTries
 function UnitWeapon:ResetTarget()
 end
 

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -334,6 +334,7 @@ Weapon = ClassWeapon(WeaponMethods) {
 
     ---@param self Weapon
     OnLostTarget = function(self)
+        LOG("weapon.lua:losttarget")
         local animator = self.unit.Animator
         if self.DisabledFiringBones and animator then
             for _, value in self.DisabledFiringBones do

--- a/lua/sim/weapons/DefaultBeamWeapon.lua
+++ b/lua/sim/weapons/DefaultBeamWeapon.lua
@@ -108,12 +108,12 @@ DefaultBeamWeapon = ClassWeapon(DefaultProjectileWeapon) {
         -- enable the beam
         beam:Enable()
 
-        -- non-continious beams that just end
+        -- non-continuous beams that just end
         if bp.BeamLifetime > 0 then
             self:ForkThread(self.BeamLifetimeThread, beam, bp.BeamLifetime or 1)
         end
 
-        -- continious beams
+        -- continuous beams
         if bp.BeamLifetime == 0 then
             self.HoldFireThread = self:ForkThread(self.WatchForHoldFire, beam)
         end

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -1107,8 +1107,6 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                 unit.Trash:Add(ForkThread(self.DisabledWhileReloadingThread, self, 1 / rof))
             end
 
-            local hasTarget = self:WeaponHasTarget()
-
             -- Deal with the rack firing sequence
             if self.CurrentRackSalvoNumber > rackBoneCount then
                 self.CurrentRackSalvoNumber = 1
@@ -1116,7 +1114,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                     ChangeState(self, self.RackSalvoReloadState)
                 elseif bp.RackSalvoChargeTime > 0 then
                     ChangeState(self, self.IdleState)
-                elseif countedProjectile or not hasTarget then
+                elseif countedProjectile then
                     if bp.WeaponUnpacks then
                         ChangeState(self, self.WeaponPackingState)
                     else
@@ -1125,7 +1123,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                 else
                     ChangeState(self, self.RackSalvoFireReadyState)
                 end
-            elseif countedProjectile or not hasTarget then
+            elseif countedProjectile then
                 if bp.WeaponUnpacks then
                     ChangeState(self, self.WeaponPackingState)
                 else

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -881,6 +881,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                 ChangeState(self, self.RackSalvoFiringState)
             end
 
+            -- Bombers should not have their targets reset since they take a large path much longer than their reload time.
             if not (IsDestroyed(unit) or IsDestroyed(self)) and not bp.NeedToComputeBombDrop then
                 if bp.TargetResetWhenReady then
 
@@ -893,13 +894,13 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                     self:ResetTarget()
                 else
 
-                    -- attempts to fix units being stuck on targets that are outside their current attack radius, but inside
-                    -- the tracking radius. This happens when the unit is trying to fire, but it is never actually firing and
+                    -- attempts to fix weapons being stuck on targets that are outside their current attack radius, but inside
+                    -- the tracking radius. This happens when the weapon acquires a target, but never actually fires and
                     -- therefore the thread of this state is not destroyed
 
-                    -- wait reload time + 2 seconds, then force the weapon to recheck its target
+                    -- wait reload time + 3 seconds, then force the weapon to recheck its target
                     WaitSeconds((1 / self.Blueprint.RateOfFire) + 3)
-                    self:ResetTarget() -- this breaks AttackGroundTries for bombers
+                    self:ResetTarget()
                 end
             end
         end,

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -899,7 +899,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
 
                     -- wait reload time + 2 seconds, then force the weapon to recheck its target
                     WaitSeconds((1 / self.Blueprint.RateOfFire) + 3)
-                    self:ResetTarget()
+                    self:ResetTarget() -- this breaks AttackGroundTries for bombers
                 end
             end
         end,

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -13,6 +13,7 @@ local UnitGetVelocity = UnitMethods.GetVelocity
 local UnitGetTargetEntity = UnitMethods.GetTargetEntity
 
 local MathClamp = math.clamp
+local MATH_IRound = MATH_IRound
 
 function LOGWeapon(self, string)
     LOG(("T: %d WeaponId: %s %s"):format(GetGameTick(), tostring(self), string))
@@ -982,7 +983,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             -- is the more aggressive variant of `TargetResetWhenReady` as it completely disables the weapon. Should only be used
             -- for weapons that do not visually track, such as torpedo defenses
 
-            local reloadTime = math.floor(10 * rateOfFire) - 1
+            local reloadTime = MATH_IRound(1 / self:GetWeaponRoF()) - 1
             if reloadTime > 4 then
                 if IsDestroyed(self) then
                     return

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -22,8 +22,8 @@ local MathClamp = math.clamp
 -- Most weapons derive from this class, including beam weapons later in this file
 ---@class DefaultProjectileWeapon : Weapon
 ---@field RecoilManipulators? TrashBag
----@field CurrentSalvoNumber number
----@field CurrentRackSalvoNumber number
+---@field CurrentSalvoNumber number         # Current shot we are on in the current rack
+---@field CurrentRackSalvoNumber number     # Current rack we are on in the current salvo
 ---@field CurrentSalvoData? WeaponSalvoData
 ---@field AdjustedSalvoDelay? number if the weapon blueprint requests a trajectory fix, this is set to the effective duration of the salvo in ticks used to calculate projectile spread
 ---@field DropBombShortRatio? number if the weapon blueprint requests a trajectory fix, this is set to the ratio of the distance to the target that the projectile is launched short to

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -151,7 +151,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             while not self:BeenDestroyed() do
                 local cond = self:CanFire()
                 if cond ~= lastCond then
-                    LOGWeapon(self, "changed CanFire: " .. tostring(cond))
+                    LOGWeapon(self, "changed CanFire to " .. tostring(cond))
                     lastCond = cond
                 end
                 WaitTicks(1)
@@ -1089,7 +1089,11 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                     end
 
                     local proj = self:CreateProjectileAtMuzzle(muzzle)
-                    LOGWeapon(self, string.format("Fired! Shot #%d Rack #%d", self.CurrentSalvoNumber or -1, self.CurrentRackSalvoNumber or -1) )
+                    LOGWeapon(self, string.format("Fired! Shot #%d Rack #%d"
+                        , self.CurrentSalvoNumber or -1
+                        , self.CurrentRackSalvoNumber or -1
+                        )
+                    )
 
                     -- Decrement the ammo if they are a counted projectile
                     if proj and not proj:BeenDestroyed() and countedProjectile then
@@ -1181,6 +1185,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             if baseOnLostTarget ~= DefaultProjectileWeapon.OnLostTarget then
                 baseOnLostTarget(self)
             else
+                LOGWeapon(self, "FiringState OnLostTarget")
                 Weapon.OnLostTarget(self)
 
                 -- it's usually okay for a salvo to continue firing unless MuzzleVelocityReduceDistance is present, which requires a target to always exist
@@ -1196,7 +1201,21 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             end
         end,
 
-        -- Set a bool so we won't fire if the target reticle is moved
+        OnGotTarget = function(self)
+            self.__base.OnGotTarget(self)
+            LOGWeapon(self, "FiringState OnGotTarget")
+        end,
+
+        OnStartTracking = function(self)
+            self.__base.OnStartTracking(self)
+            LOGWeapon(self, "FiringState OnStartTracking")
+        end,
+
+        OnStopTracking = function(self)
+            self.__base.OnStopTracking(self)
+            LOGWeapon(self, "FiringState OnStopTracking")
+        end,
+
         OnHaltFire = function(self)
             self.HaltFireOrdered = true
         end,

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -1135,7 +1135,15 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         end,
 
         OnLostTarget = function(self)
-            self.HaltFireOrdered = true
+            local baseOnLostTarget = self.__base.OnLostTarget
+            if baseOnLostTarget ~= DefaultProjectileWeapon.OnLostTarget then
+                baseOnLostTarget(self)
+            else
+                Weapon.OnLostTarget(self)
+                if self.Blueprint.WeaponUnpacks then
+                    ChangeState(self, self.WeaponPackingState)
+                end
+            end
         end,
 
         -- Set a bool so we won't fire if the target reticle is moved

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -965,6 +965,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             local unit = self.unit
             local clockTime = math.round(10 * rateOfFire)
             local totalTime = clockTime
+            clockTime = (1 - self:GetFireClockPct()) * totalTime
             while clockTime >= 0 and
                 not self:BeenDestroyed() and
                 not unit.Dead do

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -1146,7 +1146,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                 -- it's usually okay for a salvo to continue firing unless MuzzleVelocityReduceDistance is present, which requires a target to always exist
                 -- or else the projectile will fire at a very high speed, so we need to pack up/idle in that case
                 local bp = self.Blueprint
-                if bp.MuzzleVelocityReduceDistance then
+                if bp.MuzzleVelocityReduceDistance > 0 then
                     if bp.WeaponUnpacks then
                         ChangeState(self, self.WeaponPackingState)
                     else

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -1192,6 +1192,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         end,
 
         OnLostTarget = function(self)
+            -- Override default OnLostTarget to prevent bypassing reload time by switching to idle state immediately
         end,
     },
 

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -881,7 +881,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                 ChangeState(self, self.RackSalvoFiringState)
             end
 
-            if not (IsDestroyed(unit) or IsDestroyed(self)) then
+            if not (IsDestroyed(unit) or IsDestroyed(self)) and not bp.NeedToComputeBombDrop then
                 if bp.TargetResetWhenReady then
 
                     -- attempts to fix weapons that intercept projectiles to being stuck on a projectile while reloading, preventing

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -1041,11 +1041,9 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         -- Render the fire recharge bar
         ---@param self DefaultProjectileWeapon
         ---@param rateOfFire number
-        RenderClockThread = function(self, rateOfFire)
-            local unit = self.unit
-            local clockTime = math.round(10 * rateOfFire)
-            local totalTime = clockTime
-            clockTime = (1 - self:GetFireClockPct()) * totalTime
+        RenderClockThread = function(self)
+            local totalTime = MATH_IRound(1 / self:GetWeaponRoF())
+            clockTime = self:GetFireClockRemainingSeconds()
             while clockTime >= 0 and
                 not self:BeenDestroyed() and
                 not unit.Dead do
@@ -1106,8 +1104,8 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             -- Fork timer counter thread carefully
             if not self:BeenDestroyed() and
                 not unit.Dead then
-                if bp.RenderFireClock and rof > 0 then
-                    self:ForkThread(self.RenderClockThread, 1 / rof)
+                if bp.RenderFireClock then
+                    self:ForkThread(self.RenderClockThread)
                 end
             end
 

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -651,6 +651,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
     -- Includes the manual selection of a new target, and the issuing of a move order
     ---@param self DefaultProjectileWeapon
     OnLostTarget = function(self)
+        LOG("Default OnLostTarget")
         -- Issue 43
         -- Tell the owner this weapon has lost the target
         local unit = self.unit

--- a/lua/sim/weapons/uef/TIFCarpetBombWeapon.lua
+++ b/lua/sim/weapons/uef/TIFCarpetBombWeapon.lua
@@ -43,6 +43,7 @@ TIFCarpetBombWeapon = ClassWeapon(DefaultProjectileWeapon) {
                 -- we don't want to keep updating this location, so remove the target.
                 data.target = nil
             end
+            -- every shot the target position has to be updated to a fixed position so that the bomb projectile bp's `RealisticOrdinance = true` doesn't track the target unit
             self:SetTargetGround(data.targetPos)
         end
         return DefaultProjectileWeaponCreateProjectileAtMuzzle(self, muzzle)

--- a/lua/system/class.lua
+++ b/lua/system/class.lua
@@ -785,6 +785,14 @@ EffectFactory = {
 ---@param instance table The current instance we want to switch states for
 ---@param newState State the state we want to insert between the instance and its base class
 function ChangeState(instance, newState)
+    LOG(string.format("T:%d %s changing state: %s (%s) -> %s (%s)\n"
+        , GetGameTick()
+        , tostring(instance)
+        , instance.StateName or 'unnamed', tostring(instance.__StateIdentifier)
+        , newState.StateName or 'unnamed', tostring(newState.__StateIdentifier)
+    ))
+    local dbg = debug.getinfo(2, 'Sl')
+    LOG(string.format('%10s:%s', dbg.short_src, dbg.currentline))
 
     -- call on-exit function
     if instance.OnExitState then

--- a/units/URB2301/URB2301_Script.lua
+++ b/units/URB2301/URB2301_Script.lua
@@ -11,14 +11,12 @@
 local CStructureUnit = import("/lua/cybranunits.lua").CStructureUnit
 local CDFLaserHeavyWeapon = import("/lua/cybranweapons.lua").CDFLaserHeavyWeapon
 
-
 ---@class URB2301 : CStructureUnit
 URB2301 = ClassUnit(CStructureUnit) {
-
     Weapons = {
         MainGun = ClassWeapon(CDFLaserHeavyWeapon) {
-        FxMuzzleFlash = {'/effects/emitters/particle_cannon_muzzle_02_emit.bp'},
-    }
+        	FxMuzzleFlash = {'/effects/emitters/particle_cannon_muzzle_02_emit.bp'},
+    	},
     },
 }
 

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -978,7 +978,6 @@ UnitBlueprint{
             DamageType = "Normal",
             DisplayName = "Heavy Microwave Laser",
             EnabledByEnhancement = "MicrowaveLaserGenerator",
-            EnergyChargeForFirstShot = false,
             FireTargetLayerCapsTable = {
                 Land = "Land|Water|Seabed",
                 Seabed = "Land|Water|Seabed",


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes the ability of `AttackGroundTries` for bombers and fixes an off by one issue for other units. Annotates the field.
As a bonus, fixes lightning storm spawned from Ythotha too (cheat menu spawn and Ythotha spawn act differently).

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->

## Checklist

- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
