### PR TITLE
Assisting engineers track new construction orders

### DIFF
--- a/changelog/snippets/features.6169.md
+++ b/changelog/snippets/features.6169.md
@@ -1,0 +1,4 @@
+(#6169) Assisting engineers now track new construction
+- When an assisted engineer starts a new construction before the current one is complete, any assisting engineers will switch over immediately instead of completing the old
+- Engineers (and engineer pods) assisting UEF shoulder pods will assist with construction properly
+- Assist commands for UEF shoulder pods are "sticky"--when the shoulder pod attaches to its parent, the assist orders are transferred to the parent. When it detaches the assist orders are reapplied.

--- a/lua/sim/units/MobileUnit.lua
+++ b/lua/sim/units/MobileUnit.lua
@@ -125,6 +125,15 @@ MobileUnit = ClassUnit(Unit, TreadComponent) {
         self:OnLayerChange(layer, 'None')
     end,
 
+    -- Check for any assisting units and make sure they are assisting the new construction
+    ---@param self MobileUnit
+    ---@param unitBeingBuilt Unit
+    ---@param order string
+    OnStartBuild = function(self, unitBeingBuilt, order)
+        Unit.OnStartBuild(self, unitBeingBuilt, order)
+        self:CheckAssistersFocus()
+    end,
+
     ---@param self MobileUnit
     ---@param new string
     ---@param old string

--- a/units/UEA0001/UEA0001_script.lua
+++ b/units/UEA0001/UEA0001_script.lua
@@ -25,6 +25,21 @@ UEA0001 = ClassUnit(TConstructionUnit) {
         end
     end,
 
+    OnAttachedToTransport = function(self, transport, bone)
+        self.guardCache = self:GetGuards()
+        IssueClearCommands(self.guardCache)
+        IssueGuard(self.guardCache, self:GetParent())
+        TConstructionUnit.OnAttachedToTransport(self, transport, bone)
+    end,
+
+    OnDetachedFromTransport = function(self, transport, bone)
+        TConstructionUnit.OnDetachedFromTransport(self, transport, bone)
+        if self.guardCache then
+            IssueClearCommands(self.guardCache)
+            IssueGuard(self.guardCache, self)
+        end
+    end,
+
     SetParent = function(self, parent, podName)
         self.Parent = parent
         self.Pod = podName

--- a/units/UEA0001/UEA0001_unit.bp
+++ b/units/UEA0001/UEA0001_unit.bp
@@ -81,6 +81,7 @@ UnitBlueprint {
         'AIR',
         'TECH1',
         'POD',
+        'CONSTRUCTION',
         'REPAIR',
         'RECLAIM',
         'PATROLHELPER',
@@ -88,6 +89,7 @@ UnitBlueprint {
         'CAPTURE',
         'VISIBLETORECON',
         'RECLAIMABLE',
+        'SHOWQUEUE',
     },
     CollisionOffsetY = -0.5,
     Defense = {

--- a/units/UEA0003/UEA0003_script.lua
+++ b/units/UEA0003/UEA0003_script.lua
@@ -24,6 +24,21 @@ UEA0003 = ClassUnit(TConstructionUnit) {
         end
     end,
 
+    OnAttachedToTransport = function(self, transport, bone)
+        self.guardCache = self:GetGuards()
+        IssueClearCommands(self.guardCache)
+        IssueGuard(self.guardCache, self:GetParent())
+        TConstructionUnit.OnAttachedToTransport(self, transport, bone)
+    end,
+
+    OnDetachedFromTransport = function(self, transport, bone)
+        TConstructionUnit.OnDetachedFromTransport(self, transport, bone)
+        if self.guardCache then
+            IssueClearCommands(self.guardCache)
+            IssueGuard(self.guardCache, self)
+        end
+    end,
+
     SetParent = function(self, parent, podName)
         self.Parent = parent
         self.Pod = podName

--- a/units/UEA0003/UEA0003_unit.bp
+++ b/units/UEA0003/UEA0003_unit.bp
@@ -81,6 +81,7 @@ UnitBlueprint {
         'AIR',
         'TECH3',
         'POD',
+        'CONSTRUCTION',
         'REPAIR',
         'RECLAIM',
         'PATROLHELPER',
@@ -88,6 +89,7 @@ UnitBlueprint {
         'CAPTURE',
         'VISIBLETORECON',
         'RECLAIMABLE',
+        'SHOWQUEUE',
     },
     CollisionOffsetY = -0.5,
     Defense = {

--- a/units/UEL0001/UEL0001_script.lua
+++ b/units/UEL0001/UEL0001_script.lua
@@ -216,6 +216,12 @@ UEL0001 = ClassUnit(ACUUnit) {
     end,
 
     ---@param self UEL0001
+    ---@return Unit[] pods
+    GetPods = function(self)
+        return {self.LeftPod, self.RightPod}
+    end,
+
+    ---@param self UEL0001
     ---@param bone Bone
     ---@param attachee Unit
     OnTransportAttach = function(self, bone, attachee)

--- a/units/UEL0301/UEL0301_script.lua
+++ b/units/UEL0301/UEL0301_script.lua
@@ -84,6 +84,12 @@ UEL0301 = ClassUnit(CommandUnit) {
     end,
 
     ---@param self UEL0301
+    ---@return Unit[] pods
+    GetPods = function(self)
+        return {self.Pod}
+    end,
+
+    ---@param self UEL0301
     ---@param bone Bone
     ---@param attachee Unit
     OnTransportAttach = function(self, bone, attachee)


### PR DESCRIPTION
Additions:
1. When an engineer with assisting engineers starts a new construction in the middle of working on another, the assisting engineers will immediately switch to the new construction instead of staying on the old.
2. Engineers assisting UEF shoulder pods will now assist construction initated by the shoulder pods.
3. Assist orders for UEF shoulder pods are "sticky"--when the shoulder pod attaches to storage, the assist orders are transferred to the parent unit, and then transferred back when it detaches.
