### PR TITLE
Use tooltip class for order buttons' tooltips instead of custom code

### DIFF
--- a/changelog/snippets/other.6173.md
+++ b/changelog/snippets/other.6173.md
@@ -1,0 +1,1 @@
+- (#6173) Fix slow transparency change for the tooltips of order buttons by making them use the generic tooltip creator function.

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -116,31 +116,7 @@ function CreateMouseoverDisplay(parent, ID)
         return
     end
 
-    controls.mouseoverDisplay = Tooltip.CreateExtendedToolTip(parent, text, desc)
-    local Frame = GetFrame(0)
-    controls.mouseoverDisplay.Bottom:Set(parent.Top)
-    if (parent.Left() + (parent.Width() / 2)) - (controls.mouseoverDisplay.Width() / 2) < 0 then
-        controls.mouseoverDisplay.Left:Set(4)
-    elseif (parent.Right() - (parent.Width() / 2)) + (controls.mouseoverDisplay.Width() / 2) > Frame.Right() then
-        controls.mouseoverDisplay.Right:Set(function() return Frame.Right() - 4 end)
-    else
-        LayoutHelpers.AtHorizontalCenterIn(controls.mouseoverDisplay, parent)
-    end
-
-    local alpha = 0.0
-    controls.mouseoverDisplay:SetAlpha(alpha, true)
-    local mdThread = ForkThread(function()
-        WaitSeconds(createDelay)
-        while alpha <= 1.0 do
-            controls.mouseoverDisplay:SetAlpha(alpha, true)
-            alpha = alpha + 0.1
-            WaitSeconds(0.01)
-        end
-    end)
-
-    controls.mouseoverDisplay.OnDestroy = function(self)
-        KillThread(mdThread)
-    end
+    controls.mouseoverDisplay = Tooltip.CreateMouseoverDisplay(parent, {["text"] = text, ["body"] = desc}, nil, true)
 end
 
 local function CreateOrderButtonGrid()


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes abnormally slow alpha change of order button tooltips. Removes code duplication.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Mousing over orders creates a smooth transparency transition just like the tooltips for the construction menu buttons (tech level, templates, unit selector, construction selector, enhancements selector).

## Additional context
<!-- Add any other context about the pull request here. -->
The old code is from GPG files.

## Checklist

- [x] Changes are documented in the changelog for the next game version
