### PR TITLE
Rework UnitsTooltip to use Layouter to fix its UI scaling

### DIFF
--- a/changelog/snippets/fix.6175.md
+++ b/changelog/snippets/fix.6175.md
@@ -1,0 +1,4 @@
+- (#6175) Rework the unit manager's unit tooltips using the Layouter with various fixes:
+  - Fix UI Scaling for unit tooltips in the unit manager.
+  - Display buildtime in ticks instead of MM:SS in the unit manager.
+  - Fix empty names appearing as empty parentheses in the unit manager.

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -70,6 +70,9 @@ function Create(parent, bp)
 
     Destroy()
 
+    -- This looks like a border for the entire tooltip when the other backgrounds on top fill it in.
+    tooltipUI = Layouter(Bitmap(parent)):Color(UIUtil.tooltipBorderColor):Over(parent, 10000):Width(tooltipWidth):Height(tooltipHeight):End()
+
     local title = ''
 
     if bp.Description then
@@ -80,11 +83,6 @@ function Create(parent, bp)
     if bp.General.UnitName and not bp.CategoriesHash['SUBCOMMANDER'] then
         title = title .. ' (' .. LOCF(bp.General.UnitName) .. ')'
     end
-
-    tooltipUI = Bitmap(parent)
-    tooltipUI:SetSolidColor(UIUtil.tooltipBorderColor)
-    tooltipUI.Depth:Set(function() return parent.Depth() + 10000 end)
-    LayoutHelpers.SetDimensions(tooltipUI, tooltipWidth, tooltipHeight)
 
     tooltipUI.title = UIUtil.CreateText(tooltipUI, title, fontTextSize, UIUtil.bodyFont)
     LayoutHelpers.AtLeftTopIn(tooltipUI.title, tooltipUI, 2, 2)

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -89,14 +89,9 @@ function Create(parent, bp)
     local title = Layouter(UIUtil.CreateText(tooltipUI, titleString, fontTextSize, UIUtil.bodyFont)):AtLeftTopIn(tooltipUI, 2, 2):End()
     tooltipUI.title = title
 
-    tooltipUI.titleBg = Bitmap(tooltipUI)
-    tooltipUI.titleBg:SetSolidColor(UIUtil.tooltipTitleColor)
-    tooltipUI.titleBg.Depth:Set(function() return tooltipUI.title.Depth() - 1 end)
-    tooltipUI.titleBg.Top:Set(tooltipUI.title.Top)
-    LayoutHelpers.AtBottomIn(tooltipUI.titleBg, tooltipUI.title, -2)
-
-    tooltipUI.titleBg.Left:Set(function() return tooltipUI.title.Left() end)
-    LayoutHelpers.AnchorToLeft(tooltipUI.titleBg, tooltipUI.title, - tooltipWidth + 4)
+    -- AtBottomIn -2 offset for parantheses to appear centered
+    local titleBg = Layouter(Bitmap(tooltipUI)):Color(UIUtil.tooltipTitleColor):Under(title):AtTopIn(title):AtBottomIn(title, -2):AtLeftIn(tooltipUI, 2):AtRightIn(tooltipUI, 2):End()
+    tooltipUI.titleBg = titleBg
 
     local titleHeight = math.max(tooltipUI.title.Height(), 1) + 4
     local top  = titleHeight

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -137,8 +137,9 @@ function Create(parent, bp)
     value = LOC(UnitDescriptions[id]) or LOC(bp.Interface.Help.HelpText)
 
     -- defaulting to description of base units for preset support commanders
-    if not value and bp.CategoriesHash['SUBCOMMANDER'] and string.find(id, "_") then
-        local baseID = StringSplit(id, '_')[1]
+    local underscoreIndex = string.find(id, "_")
+    if not value and bp.CategoriesHash['SUBCOMMANDER'] and underscoreIndex then
+        local baseID = string.sub(id, 1, underscoreIndex - 1)
         value = LOC(UnitDescriptions[baseID])
     end
 

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -93,16 +93,15 @@ function Create(parent, bp)
     local titleBg = Layouter(Bitmap(tooltipUI)):Color(UIUtil.tooltipTitleColor):Under(title):AtTopIn(title):AtBottomIn(title, -2):AtLeftIn(tooltipUI, 2):AtRightIn(tooltipUI, 2):End()
     tooltipUI.titleBg = titleBg
 
-    local titleHeight = math.max(tooltipUI.title.Height(), 1) + 4
+    local titleHeight = math.max(tooltipUI.title.Height(), 1) + 4 -- 2 border + title height + 2 titleBg bottom negative padding
     local top  = titleHeight
     local left = 7
 
-    tooltipUI.body = Bitmap(tooltipUI)
-    tooltipUI.body:SetSolidColor('FF080808') ----FF080808
-    LayoutHelpers.SetDimensions(tooltipUI.body, tooltipWidth-4, 300)
-    LayoutHelpers.AtLeftTopIn(tooltipUI.body, tooltipUI, 2, top)
+    -- Serves as the black background of the body of the tooltip
+    local body = Layouter(Bitmap(tooltipUI)):Color('FF080808'):AtLeftIn(tooltipUI, 2):AtRightIn(tooltipUI, 2):Height(300):AnchorToBottom(titleBg):End()
+    tooltipUI.body = body
 
-    top = top + 2
+    top = top + 2 -- + 2 body padding
 
     local column1 = left
     local column2 = tooltipWidth - 100 + left -- damage

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -47,14 +47,6 @@ local colorMod     = 'FFCB59F7' -- --FFCB59F7
 
 local debugging = false
 
--- convert time in ticks to a string with MM:SS format
-local function stringTime(time)
-    time = time / 60
-    local timeMM =  math.floor(time / 60)
-    local timeSS =  math.floor(math.mod(time, 60))
-    return string.format("%02d:%02d", timeMM, timeSS)
-end
-
 -- initializes value to zero if it is nil
 local function init(value)
     return value > 1 and value or 0
@@ -227,7 +219,7 @@ function Create(parent, bp)
 
     top = top + EnergyCostText.Height() + 2 -- row 3 text height + 2 padding
 
-    value = stringTime(math.floor(eco.BuildTime)) .. ' '
+    value = math.floor(eco.BuildTime)
     BuildTimeText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
     BuildTimeText:SetColor(colorBuild) ----FFD9D9D9
     LayoutHelpers.AtRightTopIn(BuildTimeText, tooltipUI, column2, top)

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -117,20 +117,16 @@ function Create(parent, bp)
     tooltipHeight = math.max(tooltipUI.title.Height(), 1)
 
     -- showing bp.Categories because they are more accurate than bp.Display.Abilities
-    local cats = UnitsAnalyzer.GetUnitsCategories(bp, false)
-    value = table.concat(cats, ', ')
-    --table.print(bp.Display.Abilities, 'Abilities')
-    tooltipUI.Categories = TextArea(tooltipUI, LayoutHelpers.ScaleNumber(tooltipWidth), 30)
-    tooltipUI.Categories:SetText(value)
-    tooltipUI.Categories:SetFont(fontTextName, fontTextSize-1)
-    tooltipUI.Categories:SetColors('FFFC9038', '00000000', UIUtil.fontColor, '00000000') ----FFFC9038
-    local wrapped = Text.WrapText(value, LayoutHelpers.ScaleNumber(tooltipWidth-10), function(value) return tooltipUI.Categories:GetStringAdvance(value) end)
-    local wrappedHeight = (table.getsize(wrapped) or 1) * tooltipHeight
-    tooltipUI.Categories.Height:Set(wrappedHeight)
-    LayoutHelpers.AtLeftTopIn(tooltipUI.Categories, tooltipUI, left, top)
+    local categoriesText = TextArea(tooltipUI, LayoutHelpers.ScaleNumber(tooltipWidth), 30)
+    categoriesText:SetText( table.concat(UnitsAnalyzer.GetUnitsCategories(bp, false), ', ') )
+    categoriesText:SetFont(fontTextName, fontTextSize - 1)
+    categoriesText:SetColors('FFFC9038', nil, nil, nil) -- Only the foreground color will be changed, the rest will remain as defaults
+    local textAreaHeight = categoriesText:GetRowHeight() * categoriesText:GetItemCount()
+    Layouter(categoriesText):Height(textAreaHeight):AtLeftIn(tooltipUI, 7):AtTopIn(body, 2):End()
+    tooltipUI.Categories = categoriesText
 
     top = top + tooltipUI.Categories.Height()
-    top = top + 8
+    top = top + 8 -- + categories height + 8 padding
 
     local id = bp.ID
     if bp.Type == "UPGRADE" and bp.Icon and bp.SourceID then

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -73,19 +73,19 @@ function Create(parent, bp)
     -- This looks like a border for the entire tooltip when the other backgrounds on top fill it in.
     tooltipUI = Layouter(Bitmap(parent)):Color(UIUtil.tooltipBorderColor):Over(parent, 10000):Width(tooltipWidth):Height(tooltipHeight):End()
 
-    local title = ''
+    local titleString = ''
 
     if bp.Description then
-        title = ' ' .. bp.Tech .. ' ' .. LOCF(bp.Description)
+        titleString = ' ' .. bp.Tech .. ' ' .. LOCF(bp.Description)
     elseif bp.Name  then
-        title = ' ' .. LOCF(bp.Name)
+        titleString = ' ' .. LOCF(bp.Name)
     end
     if bp.General.UnitName and not bp.CategoriesHash['SUBCOMMANDER'] then
-        title = title .. ' (' .. LOCF(bp.General.UnitName) .. ')'
+        titleString = titleString .. ' (' .. LOCF(bp.General.UnitName) .. ')'
     end
 
-    tooltipUI.title = UIUtil.CreateText(tooltipUI, title, fontTextSize, UIUtil.bodyFont)
-    LayoutHelpers.AtLeftTopIn(tooltipUI.title, tooltipUI, 2, 2)
+    local title = Layouter(UIUtil.CreateText(tooltipUI, titleString, fontTextSize, UIUtil.bodyFont)):AtLeftTopIn(tooltipUI, 2, 2):End()
+    tooltipUI.title = title
 
     tooltipUI.titleBg = Bitmap(tooltipUI)
     tooltipUI.titleBg:SetSolidColor(UIUtil.tooltipTitleColor)

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -107,13 +107,6 @@ function Create(parent, bp)
 
     top = top + 2 -- + 2 body padding
 
-    local column1 = left
-    local column2 = tooltipWidth - 100 + left -- damage
-    local column3 = column2 - 100 -- dps
-    local column4 = column3 - 90  -- dpm
-    local column5 = column4 - 90  -- range
-    local column6 = column5 - 10
-
     -- Reusable string value
     local value = ''
 
@@ -163,6 +156,12 @@ function Create(parent, bp)
         top  = top + tooltipUI.Descr.Height()
         top  = top + 12 -- + categories height + 12 padding
     end
+
+    -- the columns give the right margin of the text so that the numbers can grow leftwards freely
+    local column2 = tooltipWidth - 100 + left -- cost/damage            -- 327  -- 420 - 327 = 93
+    local column3 = column2 - 100 -- production/dps                     -- 227  -- 420 - 227 = 193
+    local column4 = column3 - 90  -- defense/range                      -- 137  -- 420 - 137 = 283
+    local column5 = column4 - 90  -- per mass                           -- 47   -- 420 - 47  = 373
 
     local costLabel = Layouter(UIUtil.CreateText(tooltipUI, 'BUILD COST ', fontTextSize-2, fontTextName)):Color(colorText)
         :AtRightIn(tooltipUI, column2-iconSize-5):AnchorToBottom(description or categoriesText, 12):End()
@@ -396,6 +395,7 @@ function Create(parent, bp)
     end
 
     --NOTE UI for debugging
+    --local column1 = left
     --BlueprintText = UIUtil.CreateText(tooltipUI, bp.Source or '', fontValueSize, fontValueName)
     --BlueprintText:SetColor('FFE4BF0C') ----FFE4BF0C
     --LayoutHelpers.AtRightTopIn(BlueprintText, tooltipUI, column1, top)

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -15,6 +15,7 @@ local Text     = import("/lua/maui/text.lua")
 local TextArea = import("/lua/ui/controls/textarea.lua").TextArea
 
 local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
+local PixelScaleFactor = LayoutHelpers.GetPixelScaleFactor()
 local Layouter = LayoutHelpers.ReusedLayoutFor
 
 local UnitsAnalyzer   = import("/lua/ui/lobby/unitsanalyzer.lua")
@@ -73,6 +74,9 @@ function Create(parent, bp)
     -- This looks like a border for the entire tooltip when the other backgrounds on top fill it in.
     tooltipUI = Layouter(Bitmap(parent)):Color(UIUtil.tooltipBorderColor):Over(parent, 10000):Width(tooltipWidth):Height(tooltipHeight):End()
 
+    -- left text margin; leftwards offset from the tooltip border's left edge
+    local left = 7
+
     local titleString = ''
 
     if bp.Description then
@@ -87,7 +91,7 @@ function Create(parent, bp)
     end
 
     -- 2px top/left border, 7px left offset
-    local title = Layouter(UIUtil.CreateText(tooltipUI, titleString, fontTextSize, UIUtil.bodyFont)):AtLeftTopIn(tooltipUI, 9, 2):End()
+    local title = Layouter(UIUtil.CreateText(tooltipUI, titleString, fontTextSize, UIUtil.bodyFont)):AtLeftTopIn(tooltipUI, 2 + left, 2):End()
     tooltipUI.title = title
 
     -- AtBottomIn -2 offset for parantheses to appear centered
@@ -96,7 +100,6 @@ function Create(parent, bp)
 
     local titleHeight = math.max(tooltipUI.title.Height(), 1) + 4 -- 2 border + title height + 2 titleBg bottom negative padding
     local top  = titleHeight
-    local left = 7
 
     -- Serves as the black background of the body of the tooltip
     local body = Layouter(Bitmap(tooltipUI)):Color('FF080808'):AtLeftIn(tooltipUI, 2):AtRightIn(tooltipUI, 2):Height(300):AnchorToBottom(titleBg):End()
@@ -117,12 +120,12 @@ function Create(parent, bp)
     tooltipHeight = math.max(tooltipUI.title.Height(), 1)
 
     -- showing bp.Categories because they are more accurate than bp.Display.Abilities
-    local categoriesText = TextArea(tooltipUI, LayoutHelpers.ScaleNumber(tooltipWidth), 30)
+    local categoriesText = TextArea(tooltipUI, tooltipWidth - 2 * left, 30)
     categoriesText:SetText( table.concat(UnitsAnalyzer.GetUnitsCategories(bp, false), ', ') )
     categoriesText:SetFont(fontTextName, fontTextSize - 1)
     categoriesText:SetColors('FFFC9038', nil, nil, nil) -- Only the foreground color will be changed, the rest will remain as defaults
-    local textAreaHeight = categoriesText:GetRowHeight() * categoriesText:GetItemCount()
-    Layouter(categoriesText):Height(textAreaHeight):AtLeftIn(tooltipUI, 7):AtTopIn(body, 2):End()
+    local textAreaHeight = categoriesText:GetItemCount() * (fontTextSize + PixelScaleFactor) -- +1 px for the text to fit in
+    Layouter(categoriesText):Height(textAreaHeight):AtLeftIn(tooltipUI, left):AtTopIn(body, 2):End()
     tooltipUI.Categories = categoriesText
 
     top = top + tooltipUI.Categories.Height()

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -203,47 +203,29 @@ function Create(parent, bp)
 
     top  = top + MassCostText.Height() + 2 -- row 2 text height + 2 padding
 
-    local shieldValue = init(bp.ShieldMaxHealth or bp.Defense.Shield.ShieldMaxHealth)
-    local shieldString = StringComma(math.floor(shieldValue)) .. ' '
-    ShieldText = UIUtil.CreateText(tooltipUI, shieldString, fontValueSize, fontValueName)
-    ShieldText:SetColor(colorDefense) ----FF0BACF7
-    LayoutHelpers.AtRightTopIn(ShieldText, tooltipUI, column4, top)
-    ShieldIcon = Bitmap(tooltipUI)
-    ShieldIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/defense-shields.dds')
-    LayoutHelpers.SetDimensions(ShieldIcon, iconSize, iconSize)
-    LayoutHelpers.AtLeftTopIn(ShieldIcon, tooltipUI, tooltipWidth-column4, top+2)
-
-    local shieldValue = (shieldValue / eco.BuildCostMass)
-    local shieldString = string.format("%0.2f",shieldValue) .. ' '
-    ShieldPerMassText = UIUtil.CreateText(tooltipUI, shieldString, fontValueSize, fontValueName)
-    ShieldPerMassText:SetColor(colorDefense) ----FF0BACF7
-    LayoutHelpers.AtRightTopIn(ShieldPerMassText, tooltipUI, column5, top)
-    ShieldPerMassIcon = Bitmap(tooltipUI)
-    ShieldPerMassIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/defense-shields.dds')
-    LayoutHelpers.SetDimensions(ShieldPerMassIcon, iconSize, iconSize)
-    LayoutHelpers.AtLeftTopIn(ShieldPerMassIcon, tooltipUI, tooltipWidth-column5, top+2)
+    value = StringComma(math.ceil(eco.BuildCostEnergy))
+    local EnergyCostIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/energy.dds'):Width(iconSize):Height(iconSize)
+        :AtRightIn(MassCostIcon):AnchorToBottom(MassCostText, 3):End()
+    local EnergyCostText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorEnergy):LeftOf(EnergyCostIcon, 4):AnchorToBottom(MassCostText, 2):End()
 
     value = eco.YieldEnergy
-    value = value > 0 and '+' .. value or value
-    value = StringComma(value) .. ' '
-    EnergyProdText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-    EnergyProdText:SetColor(colorEnergy) ----FFF7B00B
-    LayoutHelpers.AtRightTopIn(EnergyProdText, tooltipUI, column3, top)
-    EnergyProdIcon = Bitmap(tooltipUI)
-    EnergyProdIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/energy.dds')
-    LayoutHelpers.SetDimensions(EnergyProdIcon, iconSize, iconSize)
-    LayoutHelpers.AtLeftTopIn(EnergyProdIcon, tooltipUI, tooltipWidth-column3, top+2)
+    value = StringComma(value > 0 and '+' .. value or value)
+    local EnergyProdIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/energy.dds'):Width(iconSize):Height(iconSize)
+        :AtRightIn(MassProdIcon):AnchorToBottom(MassProdText, 3):End()
+    local EnergyProdText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorEnergy):LeftOf(EnergyProdIcon, 4):AnchorToBottom(MassProdText, 2):End()
 
-    value = StringComma(math.ceil(eco.BuildCostEnergy)) .. ' '
-    EnergyCostText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-    EnergyCostText:SetColor(colorEnergy) ----FFF7B00B
-    LayoutHelpers.AtRightTopIn(EnergyCostText, tooltipUI, column2, top)
-    EnergyCostIcon = Bitmap(tooltipUI)
-    EnergyCostIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/energy.dds')
-    LayoutHelpers.SetDimensions(EnergyCostIcon, iconSize, iconSize)
-    LayoutHelpers.AtLeftTopIn(EnergyCostIcon, tooltipUI, tooltipWidth-column2, top+2)
+    local shieldValue = init(bp.ShieldMaxHealth or bp.Defense.Shield.ShieldMaxHealth)
+    value = StringComma(math.floor(shieldValue))
+    local ShieldIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/defense-shields.dds'):Width(iconSize):Height(iconSize)
+        :AtRightIn(HealthIcon):AnchorToBottom(HealthText, 3):End()
+    local ShieldText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorDefense):LeftOf(ShieldIcon, 4):AnchorToBottom(HealthText, 2):End()
 
-    top = top + EnergyCostText.Height() + 2
+    value = string.format("%0.2f",(shieldValue / eco.BuildCostMass))
+    local ShieldPerMassIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/defense-shields.dds'):Width(iconSize):Height(iconSize)
+        :AtRightIn(HealthPerMassIcon):AnchorToBottom(HealthPerMassText, 3):End()
+    local ShieldPerMassText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorDefense):LeftOf(ShieldPerMassIcon, 4):AnchorToBottom(HealthPerMassText, 2):End()
+
+    top = top + EnergyCostText.Height() + 2 -- row 3 text height + 2 padding
 
     value = stringTime(math.floor(eco.BuildTime)) .. ' '
     BuildTimeText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -231,13 +231,13 @@ function Create(parent, bp)
 
     top  = top + BuildTimeText.Height() + 10 -- row 4 text height + 10 padding
 
-    local furthestDownControl
+    local furthestDownControl = BuildRateText
     local weapons = UnitsAnalyzer.GetWeaponsStats(bp)
     for i, weapon in weapons or {} do
         top = top + 1 -- + 1 padding
 
         local weaponText = Layouter(UIUtil.CreateText(tooltipUI, weapon.Info, fontTextSize-1, fontTextName)):Color(colorText):AtLeftIn(tooltipUI, left)
-        if not furthestDownControl then
+        if furthestDownControl == BuildRateText then
             weaponText = weaponText:AnchorToBottom(BuildTimeText, 11):End()
         else
             weaponText = weaponText:AnchorToBottom(furthestDownControl, 1):End()
@@ -320,25 +320,25 @@ function Create(parent, bp)
         end
     end
 
-    LayoutHelpers.SetHeight(tooltipUI.body, top)
+    body = Layouter(body):AtBottomIn(furthestDownControl, -8):End()
 
-    local tooltipHeight = titleHeight
-    tooltipHeight = tooltipHeight + math.max(top, 1) + 2
-    LayoutHelpers.SetDimensions(tooltipUI, tooltipWidth, tooltipHeight)
-    tooltipUI:DisableHitTest(true)
 
-    local frame = GetFrame(0)
-    if parent.Top() - tooltipUI.Height() < 0 then
-        tooltipUI.Top:Set(function() return parent.Bottom() end)
+    tooltipUI = Layouter(tooltipUI):AtBottomIn(body, -2):Top(0):ResetHeight():Height(tooltipUI.Height()/PixelScaleFactor):ResetTop()
+
+    -- Keep the tooltip on screen
+    if parent.Top() - tooltipUI:Get().Height() < 0 then
+        tooltipUI:Top(parent.Bottom)
     else
-        tooltipUI.Bottom:Set(parent.Top)
+        tooltipUI:Bottom(parent.Top)
     end
 
-    if parent.Left() - tooltipUI.Width() < 0 then
-        tooltipUI.Left:Set(function() return parent.Right() end)
+    if parent.Left() - tooltipUI:Get().Width() < 0 then
+        tooltipUI:Left(parent.Right)
     else
-        tooltipUI.Right:Set(parent.Left)
+        tooltipUI:Right(parent.Left)
     end
+
+    tooltipUI = tooltipUI:DisableHitTest(true):End()
 
     -- NOTE keep this code in case of adding tooltip animation
     --if not Prefs.GetOption('tooltips') then return end

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -111,7 +111,7 @@ function Create(parent, bp)
     local column5 = column4 - 90  -- range
     local column6 = column5 - 10
 
-    local text = nil
+    -- Reusable string value
     local value = ''
 
     tooltipHeight = math.max(tooltipUI.title.Height(), 1)

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -231,51 +231,43 @@ function Create(parent, bp)
 
     top  = top + BuildTimeText.Height() + 10 -- row 4 text height + 10 padding
 
+    local furthestDownControl
     local weapons = UnitsAnalyzer.GetWeaponsStats(bp)
     for i, weapon in weapons or {} do
-        top  = top + 1
-        local weaponText = UIUtil.CreateText(tooltipUI, weapon.Info, fontTextSize-1, fontTextName)
-        weaponText:SetColor('FFE1DFDF') ----FFE1DFDF
-        LayoutHelpers.AtLeftTopIn(weaponText, tooltipUI, left, top)
-        top  = top + weaponText.Height()  + 1
+        top = top + 1 -- + 1 padding
 
-        value = StringComma(weapon.Range) .. ' ' --RANGE
-        local rangeText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-        rangeText:SetColor('FFF70B0B') ----FFF70B0B
-        LayoutHelpers.AtRightTopIn(rangeText, tooltipUI, column4, top)
-        local rangeIcon = Bitmap(tooltipUI)
-        rangeIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/damage-range.dds')
-        LayoutHelpers.SetDimensions(rangeIcon, iconSize, iconSize)
-        LayoutHelpers.AtLeftTopIn(rangeIcon, tooltipUI, tooltipWidth-column4, top+1)
+        local weaponText = Layouter(UIUtil.CreateText(tooltipUI, weapon.Info, fontTextSize-1, fontTextName)):Color(colorText):AtLeftIn(tooltipUI, left)
+        if not furthestDownControl then
+            weaponText = weaponText:AnchorToBottom(BuildTimeText, 11):End()
+        else
+            weaponText = weaponText:AnchorToBottom(furthestDownControl, 1):End()
+        end
 
-        value = string.format("%0.2f",weapon.DPM) .. ' '
-        local dpmText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-        dpmText:SetColor('FFF70B0B') ----FFF70B0B
-        LayoutHelpers.AtRightTopIn(dpmText, tooltipUI, column5, top)
-        local dpmIcon = Bitmap(tooltipUI)
-        dpmIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/damage-per-mass.dds')
-        LayoutHelpers.SetDimensions(dpmIcon, iconSize, iconSize)
-        LayoutHelpers.AtLeftTopIn(dpmIcon, tooltipUI, tooltipWidth-column5, top+1)
+        top = top + weaponText.Height()  + 1 -- + weapon title text height + 1 padding
+        
+        value = StringComma(weapon.Damage)
+        local dmgIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/damage.dds'):Width(iconSize):Height(iconSize)
+            :AtRightIn(EnergyCostIcon):AnchorToBottom(weaponText, 2):End()
+        local dmgText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorDamage):LeftOf(dmgIcon, 4):AnchorToBottom(weaponText, 1):End()
 
-        value = StringComma(weapon.DPS) .. ' '
-        local dpsText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-        dpsText:SetColor('FFF70B0B') ----FFF70B0B
-        LayoutHelpers.AtRightTopIn(dpsText, tooltipUI, column3, top)
-        local dpsIcon = Bitmap(tooltipUI)
-        dpsIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/damage-per-second.dds')
-        LayoutHelpers.SetDimensions(dpsIcon, iconSize, iconSize)
-        LayoutHelpers.AtLeftTopIn(dpsIcon, tooltipUI, tooltipWidth-column3, top+1)
+        furthestDownControl = dmgText
 
-        value = StringComma(weapon.Damage) .. ' '
-        local dmgText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-        dmgText:SetColor('FFF70B0B') ----FFF70B0B
-        LayoutHelpers.AtRightTopIn(dmgText, tooltipUI, column2, top)
-        local dmgIcon = Bitmap(tooltipUI)
-        dmgIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/damage.dds')
-        LayoutHelpers.SetDimensions(dmgIcon, iconSize, iconSize)
-        LayoutHelpers.AtLeftTopIn(dmgIcon, tooltipUI, tooltipWidth-column2, top+1)
+        value = StringComma(weapon.DPS)
+        local dpsIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/damage-per-second.dds'):Width(iconSize):Height(iconSize)
+            :AtRightIn(EnergyProdIcon):AnchorToBottom(weaponText, 2):End()
+        local dpsText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorDamage):LeftOf(dpsIcon, 4):AnchorToBottom(weaponText, 1):End()
+        
+        value = StringComma(weapon.Range)
+        local rangeIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/damage-range.dds'):Width(iconSize):Height(iconSize)
+            :AtRightIn(ShieldIcon):AnchorToBottom(weaponText, 2):End()
+        local rangeText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorDamage):LeftOf(rangeIcon, 4):AnchorToBottom(weaponText, 1):End()
+        
+        value = string.format("%0.2f", weapon.DPM)
+        local dpmIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/damage-per-mass.dds'):Width(iconSize):Height(iconSize)
+            :AtRightIn(ShieldPerMassIcon):AnchorToBottom(weaponText, 2):End()
+        local dpmText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorDamage):LeftOf(dpmIcon, 4):AnchorToBottom(weaponText, 1):End()
 
-        top  = top + dmgText.Height()
+        top  = top + dmgText.Height() -- + dmgtext Height
     end
 
     local total = UnitsAnalyzer.GetWeaponsTotal(weapons)

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -272,50 +272,36 @@ function Create(parent, bp)
 
     local total = UnitsAnalyzer.GetWeaponsTotal(weapons)
     if total.Count > 1 then
-        top  = top + 10
+        top  = top + 10 -- + 10 padding (don't forget dmgtext from before)
 
-        local weaponText = UIUtil.CreateText(tooltipUI, total.Info, fontTextSize, fontTextName)
-        weaponText:SetColor('FFE1DFDF') ----FFE1DFDF
-        LayoutHelpers.AtLeftTopIn(weaponText, tooltipUI, left, top)
-        top  = top + weaponText.Height() + 1
+        local weaponText = Layouter(UIUtil.CreateText(tooltipUI, total.Info, fontTextSize-1, fontTextName)):Color(colorText):AtLeftIn(tooltipUI, left)
+            :AnchorToBottom(furthestDownControl, 10):End()
 
-        value = StringComma(total.Range) .. ' ' --RANGE
-        local rangeText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-        rangeText:SetColor('FFF70B0B') ----FFF70B0B
-        LayoutHelpers.AtRightTopIn(rangeText, tooltipUI, column4, top)
-        local rangeIcon = Bitmap(tooltipUI)
-        rangeIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/damage-range.dds')
-        LayoutHelpers.SetDimensions(rangeIcon, iconSize, iconSize)
-        LayoutHelpers.AtLeftTopIn(rangeIcon, tooltipUI, tooltipWidth-column4, top+1)
+        top  = top + weaponText.Height() + 1 -- all weapons title text + 1 padding
 
-        value = string.format("%0.2f",total.DPM) .. ' '
-        local dpmText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-        dpmText:SetColor('FFF70B0B') ----FFF70B0B
-        LayoutHelpers.AtRightTopIn(dpmText, tooltipUI, column5, top)
-        local dpmIcon = Bitmap(tooltipUI)
-        dpmIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/damage-per-mass.dds')
-        LayoutHelpers.SetDimensions(dpmIcon, iconSize, iconSize)
-        LayoutHelpers.AtLeftTopIn(dpmIcon, tooltipUI, tooltipWidth-column5, top+1)
+        value = StringComma(total.Damage)
+        local dmgIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/damage.dds'):Width(iconSize):Height(iconSize)
+            :AtRightIn(EnergyCostIcon):AnchorToBottom(weaponText, 2):End()
+        local dmgText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorDamage):LeftOf(dmgIcon, 4):AnchorToBottom(weaponText, 1):End()
 
-        value = StringComma(total.DPS) .. ' '
-        local dpsText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-        dpsText:SetColor('FFF70B0B') ----FFF70B0B
-        LayoutHelpers.AtRightTopIn(dpsText, tooltipUI, column3, top)
-        local dpsIcon = Bitmap(tooltipUI)
-        dpsIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/damage-per-second.dds')
-        LayoutHelpers.SetDimensions(dpsIcon, iconSize, iconSize)
-        LayoutHelpers.AtLeftTopIn(dpsIcon, tooltipUI, tooltipWidth-column3, top+1)
+        furthestDownControl = dmgText
 
-        value = StringComma(total.Damage) .. ' '
-        local dmgText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-        dmgText:SetColor('FFF70B0B') ----FFF70B0B
-        LayoutHelpers.AtRightTopIn(dmgText, tooltipUI, column2, top)
-        local dmgIcon = Bitmap(tooltipUI)
-        dmgIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/damage.dds')
-        LayoutHelpers.SetDimensions(dmgIcon, iconSize, iconSize)
-        LayoutHelpers.AtLeftTopIn(dmgIcon, tooltipUI, tooltipWidth-column2, top+1)
+        value = StringComma(total.DPS)
+        local dpsIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/damage-per-second.dds'):Width(iconSize):Height(iconSize)
+            :AtRightIn(EnergyProdIcon):AnchorToBottom(weaponText, 2):End()
+        local dpsText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorDamage):LeftOf(dpsIcon, 4):AnchorToBottom(weaponText, 1):End()
+        
+        value = StringComma(total.Range)
+        local rangeIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/damage-range.dds'):Width(iconSize):Height(iconSize)
+            :AtRightIn(ShieldIcon):AnchorToBottom(weaponText, 2):End()
+        local rangeText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorDamage):LeftOf(rangeIcon, 4):AnchorToBottom(weaponText, 1):End()
+        
+        value = string.format("%0.2f", total.DPM)
+        local dpmIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/damage-per-mass.dds'):Width(iconSize):Height(iconSize)
+            :AtRightIn(ShieldPerMassIcon):AnchorToBottom(weaponText, 2):End()
+        local dpmText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorDamage):LeftOf(dpmIcon, 4):AnchorToBottom(weaponText, 1):End()
 
-        top  = top + dmgText.Height()
+        top  = top + dmgText.Height() -- + dmgtext height
     end
 
     if bp.Mod then

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -15,6 +15,7 @@ local Text     = import("/lua/maui/text.lua")
 local TextArea = import("/lua/ui/controls/textarea.lua").TextArea
 
 local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
+local Layouter = LayoutHelpers.ReusedLayoutFor
 
 local UnitsAnalyzer   = import("/lua/ui/lobby/unitsanalyzer.lua")
 local UnitDescriptions = import("/lua/ui/help/unitdescription.lua").Description

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -146,12 +146,13 @@ function Create(parent, bp)
         value = LOC(UnitDescriptions[baseID])
     end
 
+    local description
     if not value then
         if not bp.Mod then -- show warnings only for not modded units
             WARN('UnitsTooltip cannot find unit description for ' .. bp.ID .. ' blueprint')
         end
     else
-        local description = TextArea(tooltipUI, tooltipWidth-14, 30)
+        description = TextArea(tooltipUI, tooltipWidth-14, 30)
         description:SetText(value)
         description:SetFont(fontTextName, fontTextSize-1)
         description:SetColors(colorText, nil, nil, nil)
@@ -163,23 +164,19 @@ function Create(parent, bp)
         top  = top + 12 -- + categories height + 12 padding
     end
 
-    local perMassLabel = UIUtil.CreateText(tooltipUI, 'PER MASS ', fontTextSize-2, fontTextName)
-    perMassLabel:SetColor(colorText)
-    LayoutHelpers.AtRightTopIn(perMassLabel, tooltipUI, column5-iconSize-5, top)
+    local costLabel = Layouter(UIUtil.CreateText(tooltipUI, 'BUILD COST ', fontTextSize-2, fontTextName)):Color(colorText)
+        :AtRightIn(tooltipUI, column2-iconSize-5):AnchorToBottom(description or categoriesText, 12):End()
 
-    local defenseLabel = UIUtil.CreateText(tooltipUI, 'DEFENSE ', fontTextSize-2, fontTextName)
-    defenseLabel:SetColor(colorText)
-    LayoutHelpers.AtRightTopIn(defenseLabel, tooltipUI, column4-iconSize-5, top)
+    local prodLabel = Layouter(UIUtil.CreateText(tooltipUI, 'PRODUCTION ', fontTextSize-2, fontTextName)):Color(colorText)
+        :AtRightIn(tooltipUI, column3-iconSize-5):AnchorToBottom(description or categoriesText, 12):End()
 
-    local prodLabel = UIUtil.CreateText(tooltipUI, 'PRODUCTION ', fontTextSize-2, fontTextName)
-    prodLabel:SetColor(colorText)
-    LayoutHelpers.AtRightTopIn(prodLabel, tooltipUI, column3-iconSize-5, top)
+    local defenseLabel = Layouter(UIUtil.CreateText(tooltipUI, 'DEFENSE ', fontTextSize-2, fontTextName)):Color(colorText)
+        :AtRightIn(tooltipUI, column4-iconSize-5):AnchorToBottom(description or categoriesText, 12):End()
 
-    local costLabel = UIUtil.CreateText(tooltipUI, 'BUILD COST ', fontTextSize-2, fontTextName)
-    costLabel:SetColor(colorText)
-    LayoutHelpers.AtRightTopIn(costLabel, tooltipUI, column2-iconSize-5, top)
+    local perMassLabel = Layouter(UIUtil.CreateText(tooltipUI, 'PER MASS ', fontTextSize-2, fontTextName)):Color(colorText)
+        :AtRightIn(tooltipUI, column5-iconSize-5):AnchorToBottom(description or categoriesText, 12):End()
 
-    top  = top + costLabel.Height()  + 1
+    top  = top + costLabel.Height()  + 1 -- + row 1 height + 1 padding
 
     local eco = UnitsAnalyzer.GetEconomyStats(bp)
 

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -179,47 +179,29 @@ function Create(parent, bp)
 
     local eco = UnitsAnalyzer.GetEconomyStats(bp)
 
-    value = StringComma(eco.BuildCostMass) .. ' '
-    MassCostText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-    MassCostText:SetColor(colorMass) -- --FF2DEC28
-    LayoutHelpers.AtRightTopIn(MassCostText, tooltipUI, column2, top)
-    MassCostIcon = Bitmap(tooltipUI)
-    MassCostIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/mass.dds')
-    LayoutHelpers.SetDimensions(MassCostIcon, iconSize, iconSize)
-    LayoutHelpers.AtLeftTopIn(MassCostIcon, tooltipUI, tooltipWidth-column2, top+2)
+    value = StringComma(eco.BuildCostMass)
+    local MassCostIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/mass.dds'):Width(iconSize):Height(iconSize)
+        :AtRightIn(costLabel, 5):AnchorToBottom(costLabel, 2):End()
+    local MassCostText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorMass):LeftOf(MassCostIcon, 4):AnchorToBottom(costLabel, 1):End()
 
     value = eco.YieldMass
-    value = value > 0 and '+' .. value or value
-    value = StringComma(value) .. ' '
-    MassProdText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-    MassProdText:SetColor(colorMass)  -- --FF2DEC28
-    LayoutHelpers.AtRightTopIn(MassProdText, tooltipUI, column3, top)
-    MassProdIcon = Bitmap(tooltipUI)
-    MassProdIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/mass.dds')
-    LayoutHelpers.SetDimensions(MassProdIcon, iconSize, iconSize)
-    LayoutHelpers.AtLeftTopIn(MassProdIcon, tooltipUI, tooltipWidth-column3, top+2)
+    value = StringComma(value > 0 and '+' .. value or value)
+    local MassProdIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/mass.dds'):Width(iconSize):Height(iconSize)
+        :AtRightIn(prodLabel, 5):AnchorToBottom(prodLabel, 2):End()
+    local MassProdText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorMass):LeftOf(MassProdIcon, 4):AnchorToBottom(prodLabel, 1):End()
 
-    local healthValue = init(bp.NewHealth or bp.Defense.Health)
-    local healthString = StringComma(math.floor(healthValue)) .. ' '
-    HealthText = UIUtil.CreateText(tooltipUI, healthString, fontValueSize, fontValueName)
-    HealthText:SetColor(colorDefense) ----FF0BACF7
-    LayoutHelpers.AtRightTopIn(HealthText, tooltipUI, column4, top)
-    HealthIcon = Bitmap(tooltipUI)
-    HealthIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/defense-health.dds')
-    LayoutHelpers.SetDimensions(HealthIcon, iconSize, iconSize)
-    LayoutHelpers.AtLeftTopIn(HealthIcon, tooltipUI, tooltipWidth-column4, top+2)
+    local healthValue = init(bp.Defense.Health or bp.NewHealth) -- NewHealth is used by enhancements
+    value = StringComma(math.floor(healthValue))
+    local HealthIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/defense-health.dds'):Width(iconSize):Height(iconSize)
+        :AtRightIn(defenseLabel, 5):AnchorToBottom(defenseLabel, 2):End()
+    local HealthText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorDefense):LeftOf(HealthIcon, 4):AnchorToBottom(defenseLabel, 1):End()
 
-    local healthValue = (healthValue / eco.BuildCostMass)
-    local healthString = string.format("%0.2f ",healthValue)
-    HealthPerMassText = UIUtil.CreateText(tooltipUI, healthString, fontValueSize, fontValueName)
-    HealthPerMassText:SetColor(colorDefense) ----FF0BACF7
-    LayoutHelpers.AtRightTopIn(HealthPerMassText, tooltipUI, column5, top)
-    HealthPerMassIcon = Bitmap(tooltipUI)
-    HealthPerMassIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/defense-health.dds')
-    LayoutHelpers.SetDimensions(HealthPerMassIcon, iconSize, iconSize)
-    LayoutHelpers.AtLeftTopIn(HealthPerMassIcon, tooltipUI, tooltipWidth-column5, top+2)
+    value = string.format("%0.2f ", (healthValue / eco.BuildCostMass))
+    local HealthPerMassIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/defense-health.dds'):Width(iconSize):Height(iconSize)
+        :AtRightIn(perMassLabel, 5):AnchorToBottom(perMassLabel, 2):End()
+    local HealthPerMassText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorDefense):LeftOf(HealthPerMassIcon, 4):AnchorToBottom(perMassLabel, 1):End()
 
-    top  = top + MassCostText.Height() + 2
+    top  = top + MassCostText.Height() + 2 -- row 2 text height + 2 padding
 
     local shieldValue = init(bp.ShieldMaxHealth or bp.Defense.Shield.ShieldMaxHealth)
     local shieldString = StringComma(math.floor(shieldValue)) .. ' '

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -76,9 +76,9 @@ function Create(parent, bp)
     local titleString = ''
 
     if bp.Description then
-        titleString = ' ' .. bp.Tech .. ' ' .. LOC(bp.Description)
+        titleString = bp.Tech .. ' ' .. LOC(bp.Description)
     elseif bp.Name then
-        titleString = ' ' .. LOC(bp.Name)
+        titleString = LOC(bp.Name)
     end
 
     local generalUnitName = LOC(bp.General.UnitName)
@@ -86,7 +86,8 @@ function Create(parent, bp)
         titleString = titleString .. ' (' .. generalUnitName .. ')'
     end
 
-    local title = Layouter(UIUtil.CreateText(tooltipUI, titleString, fontTextSize, UIUtil.bodyFont)):AtLeftTopIn(tooltipUI, 2, 2):End()
+    -- 2px top/left border, 7px left offset
+    local title = Layouter(UIUtil.CreateText(tooltipUI, titleString, fontTextSize, UIUtil.bodyFont)):AtLeftTopIn(tooltipUI, 9, 2):End()
     tooltipUI.title = title
 
     -- AtBottomIn -2 offset for parantheses to appear centered

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -305,26 +305,20 @@ function Create(parent, bp)
     end
 
     if bp.Mod then
-        top  = top + 10
+        top  = top + 10 -- + 10 padding
+
         value = 'MOD: ' .. bp.Mod.name
-        local mod = UIUtil.CreateText(tooltipUI, value, fontTextSize, fontTextName)
-        mod:SetColor(colorMod) ----FFC905DC
-        LayoutHelpers.AtLeftTopIn(mod, tooltipUI, left, top)
-        top  = top + mod.Height()
+        local mod = Layouter(UIUtil.CreateText(tooltipUI, value, fontTextSize, fontTextName)):Color(colorMod):AtLeftIn(tooltipUI, left):AnchorToBottom(furthestDownControl, 10):End()
+        furthestDownControl = mod
+
+        top  = top + mod.Height() -- + mod height
+
         if debugging and bp.Source then
             value = '' .. bp.Source
-            local source = UIUtil.CreateText(tooltipUI, value, fontTextSize, fontTextName)
-            source:SetColor(colorMod) ----FFC905DC
-            LayoutHelpers.AtLeftTopIn(source, tooltipUI, left, top)
-            top  = top + source.Height()
+            local source = Layouter(UIUtil.CreateText(tooltipUI, value, fontTextSize, fontTextName)):Color(colorMod):AtLeftIn(tooltipUI, left):AnchorToBottom(mod):End()
+            furthestDownControl = source
         end
     end
-
-    --NOTE UI for debugging
-    --local column1 = left
-    --BlueprintText = UIUtil.CreateText(tooltipUI, bp.Source or '', fontValueSize, fontValueName)
-    --BlueprintText:SetColor('FFE4BF0C') ----FFE4BF0C
-    --LayoutHelpers.AtRightTopIn(BlueprintText, tooltipUI, column1, top)
 
     LayoutHelpers.SetHeight(tooltipUI.body, top)
 

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -151,17 +151,16 @@ function Create(parent, bp)
             WARN('UnitsTooltip cannot find unit description for ' .. bp.ID .. ' blueprint')
         end
     else
-        tooltipUI.Descr = TextArea(tooltipUI, LayoutHelpers.ScaleNumber(tooltipWidth-10), 30)
-        tooltipUI.Descr:SetText(value)
-        tooltipUI.Descr:SetFont(fontTextName, fontTextSize-1)
-        tooltipUI.Descr:SetColors(colorText, '00000000', UIUtil.fontColor, '00000000')
-        local wrapped = Text.WrapText(value, LayoutHelpers.ScaleNumber(tooltipWidth-10), function(value) return tooltipUI.Descr:GetStringAdvance(value) end)
-        local wrappedHeight = (table.getsize(wrapped) or 1) * tooltipHeight
-        tooltipUI.Descr.Height:Set(wrappedHeight)
-        LayoutHelpers.AtLeftTopIn(tooltipUI.Descr, tooltipUI, left, top)
+        local description = TextArea(tooltipUI, tooltipWidth-14, 30)
+        description:SetText(value)
+        description:SetFont(fontTextName, fontTextSize-1)
+        description:SetColors(colorText, nil, nil, nil)
+        local textAreaHeight = description:GetItemCount() * (fontTextSize + PixelScaleFactor)
+        Layouter(description):Height(textAreaHeight):AtLeftIn(tooltipUI, 7):AnchorToBottom(categoriesText):End()
+        tooltipUI.Descr = description
 
         top  = top + tooltipUI.Descr.Height()
-        top  = top + 12
+        top  = top + 12 -- + categories height + 12 padding
     end
 
     local perMassLabel = UIUtil.CreateText(tooltipUI, 'PER MASS ', fontTextSize-2, fontTextName)

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -180,6 +180,26 @@ function Create(parent, bp)
 
     local eco = UnitsAnalyzer.GetEconomyStats(bp)
 
+    value = StringComma(eco.BuildCostMass) .. ' '
+    MassCostText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
+    MassCostText:SetColor(colorMass) -- --FF2DEC28
+    LayoutHelpers.AtRightTopIn(MassCostText, tooltipUI, column2, top)
+    MassCostIcon = Bitmap(tooltipUI)
+    MassCostIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/mass.dds')
+    LayoutHelpers.SetDimensions(MassCostIcon, iconSize, iconSize)
+    LayoutHelpers.AtLeftTopIn(MassCostIcon, tooltipUI, tooltipWidth-column2, top+2)
+
+    value = eco.YieldMass
+    value = value > 0 and '+' .. value or value
+    value = StringComma(value) .. ' '
+    MassProdText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
+    MassProdText:SetColor(colorMass)  -- --FF2DEC28
+    LayoutHelpers.AtRightTopIn(MassProdText, tooltipUI, column3, top)
+    MassProdIcon = Bitmap(tooltipUI)
+    MassProdIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/mass.dds')
+    LayoutHelpers.SetDimensions(MassProdIcon, iconSize, iconSize)
+    LayoutHelpers.AtLeftTopIn(MassProdIcon, tooltipUI, tooltipWidth-column3, top+2)
+
     local healthValue = init(bp.NewHealth or bp.Defense.Health)
     local healthString = StringComma(math.floor(healthValue)) .. ' '
     HealthText = UIUtil.CreateText(tooltipUI, healthString, fontValueSize, fontValueName)
@@ -199,26 +219,6 @@ function Create(parent, bp)
     HealthPerMassIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/defense-health.dds')
     LayoutHelpers.SetDimensions(HealthPerMassIcon, iconSize, iconSize)
     LayoutHelpers.AtLeftTopIn(HealthPerMassIcon, tooltipUI, tooltipWidth-column5, top+2)
-
-    value = eco.YieldMass
-    value = value > 0 and '+' .. value or value
-    value = StringComma(value) .. ' '
-    MassProdText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-    MassProdText:SetColor(colorMass)  -- --FF2DEC28
-    LayoutHelpers.AtRightTopIn(MassProdText, tooltipUI, column3, top)
-    MassProdIcon = Bitmap(tooltipUI)
-    MassProdIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/mass.dds')
-    LayoutHelpers.SetDimensions(MassProdIcon, iconSize, iconSize)
-    LayoutHelpers.AtLeftTopIn(MassProdIcon, tooltipUI, tooltipWidth-column3, top+2)
-
-    value = StringComma(eco.BuildCostMass) .. ' '
-    MassCostText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-    MassCostText:SetColor(colorMass) -- --FF2DEC28
-    LayoutHelpers.AtRightTopIn(MassCostText, tooltipUI, column2, top)
-    MassCostIcon = Bitmap(tooltipUI)
-    MassCostIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/mass.dds')
-    LayoutHelpers.SetDimensions(MassCostIcon, iconSize, iconSize)
-    LayoutHelpers.AtLeftTopIn(MassCostIcon, tooltipUI, tooltipWidth-column2, top+2)
 
     top  = top + MassCostText.Height() + 2
 

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -102,7 +102,7 @@ function Create(parent, bp)
     categoriesText:SetText( table.concat(UnitsAnalyzer.GetUnitsCategories(bp, false), ', ') )
     categoriesText:SetFont(fontTextName, fontTextSize - 1)
     categoriesText:SetColors('FFFC9038', nil, nil, nil) -- Only the foreground color will be changed, the rest will remain as defaults
-    local textAreaHeight = categoriesText:GetItemCount() * (fontTextSize + PixelScaleFactor) -- +1 px for the text to fit in
+    local textAreaHeight = categoriesText:GetItemCount() * (fontTextSize + 2 /PixelScaleFactor)
     Layouter(categoriesText):Height(textAreaHeight):AtLeftIn(tooltipUI, left):AtTopIn(body, 2):End()
     tooltipUI.Categories = categoriesText
 
@@ -131,7 +131,7 @@ function Create(parent, bp)
         description:SetText(value)
         description:SetFont(fontTextName, fontTextSize-1)
         description:SetColors(colorText, nil, nil, nil)
-        local textAreaHeight = description:GetItemCount() * (fontTextSize + PixelScaleFactor)
+        local textAreaHeight = description:GetItemCount() * (fontTextSize + 2 /PixelScaleFactor)
         Layouter(description):Height(textAreaHeight):AtLeftIn(tooltipUI, 7):AnchorToBottom(categoriesText):End()
         tooltipUI.Descr = description
     end

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -76,12 +76,14 @@ function Create(parent, bp)
     local titleString = ''
 
     if bp.Description then
-        titleString = ' ' .. bp.Tech .. ' ' .. LOCF(bp.Description)
-    elseif bp.Name  then
-        titleString = ' ' .. LOCF(bp.Name)
+        titleString = ' ' .. bp.Tech .. ' ' .. LOC(bp.Description)
+    elseif bp.Name then
+        titleString = ' ' .. LOC(bp.Name)
     end
-    if bp.General.UnitName and not bp.CategoriesHash['SUBCOMMANDER'] then
-        titleString = titleString .. ' (' .. LOCF(bp.General.UnitName) .. ')'
+
+    local generalUnitName = LOC(bp.General.UnitName)
+    if generalUnitName and generalUnitName ~= '' and not bp.CategoriesHash['SUBCOMMANDER'] then
+        titleString = titleString .. ' (' .. generalUnitName .. ')'
     end
 
     local title = Layouter(UIUtil.CreateText(tooltipUI, titleString, fontTextSize, UIUtil.bodyFont)):AtLeftTopIn(tooltipUI, 2, 2):End()

--- a/lua/ui/lobby/UnitsTooltip.lua
+++ b/lua/ui/lobby/UnitsTooltip.lua
@@ -219,25 +219,17 @@ function Create(parent, bp)
 
     top = top + EnergyCostText.Height() + 2 -- row 3 text height + 2 padding
 
-    value = math.floor(eco.BuildTime)
-    BuildTimeText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-    BuildTimeText:SetColor(colorBuild) ----FFD9D9D9
-    LayoutHelpers.AtRightTopIn(BuildTimeText, tooltipUI, column2, top)
-    BuildTimeIcon = Bitmap(tooltipUI)
-    BuildTimeIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/build-time.dds')
-    LayoutHelpers.SetDimensions(BuildTimeIcon, iconSize, iconSize)
-    LayoutHelpers.AtLeftTopIn(BuildTimeIcon, tooltipUI, tooltipWidth-column2, top+2)
+    value = StringComma(math.floor(eco.BuildTime))
+    local BuildTimeIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/build-time.dds'):Width(iconSize):Height(iconSize)
+        :AtRightIn(EnergyCostIcon):AnchorToBottom(EnergyCostText, 3):End()
+    local BuildTimeText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorBuild):LeftOf(BuildTimeIcon, 4):AnchorToBottom(EnergyCostText, 2):End()
 
-    value = StringComma(eco.BuildRate).. ' '
-    BuildRateText = UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)
-    BuildRateText:SetColor(colorBuild) ----FFD9D9D9
-    LayoutHelpers.AtRightTopIn(BuildRateText, tooltipUI, column3, top)
-    BuildRateIcon = Bitmap(tooltipUI)
-    BuildRateIcon:SetTexture('/textures/ui/common/game/unit-build-over-panel/build-rate.dds')
-    LayoutHelpers.SetDimensions(BuildRateIcon, iconSize, iconSize)
-    LayoutHelpers.AtLeftTopIn(BuildRateIcon, tooltipUI, tooltipWidth-column3, top+2)
+    value = StringComma(eco.BuildRate)
+    local BuildRateIcon = Layouter(Bitmap(tooltipUI)):Texture('/textures/ui/common/game/unit-build-over-panel/build-rate.dds'):Width(iconSize):Height(iconSize)
+        :AtRightIn(EnergyProdIcon):AnchorToBottom(EnergyProdText, 3):End()
+    local BuildRateText = Layouter(UIUtil.CreateText(tooltipUI, value, fontValueSize, fontValueName)):Color(colorBuild):LeftOf(BuildRateIcon, 4):AnchorToBottom(EnergyProdText, 2):End()
 
-    top  = top + BuildTimeText.Height() + 10
+    top  = top + BuildTimeText.Height() + 10 -- row 4 text height + 10 padding
 
     local weapons = UnitsAnalyzer.GetWeaponsStats(bp)
     for i, weapon in weapons or {} do


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes #5424 by rewriting unit tooltips using the Layouter. In addition, fixes localized empty strings appearing as empty parentheses in unit names (for example UEF mex in RU/US were "T3 Mass Exctractor ()"), and changes the buildtime display to just buildtime ticks instead of a convoluted MM:SS format.
100%: 
![image](https://github.com/FAForever/fa/assets/82986251/c8a5832f-2443-4480-9a1f-51660ffcc1df)
80%: 
![image](https://github.com/FAForever/fa/assets/82986251/e92ca0dd-0129-4cf9-8470-094b9a53aeb2)
150%:
![image](https://github.com/FAForever/fa/assets/82986251/8ccd5bb0-e4a5-4838-849b-04474e811c47)


## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Go to options -> interface -> UI Scale -> 150% and then open a skirmish -> options -> restrictions and mouse over the units in a circle to make sure all 4 variants of the tooltip work as expected (variants that move which corner of the tooltip is attached as to avoid going off the screen). Repeat for 80% and 100% scale.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
