### PR TITLE
Enable Soothsayer target bones

### DIFF
--- a/changelog/snippets/fix.6182.md
+++ b/changelog/snippets/fix.6182.md
@@ -1,0 +1,1 @@
+- (#6182) Enable the target bones for the Soothsayer.

--- a/units/XRB3301/XRB3301_unit.bp
+++ b/units/XRB3301/XRB3301_unit.bp
@@ -1,6 +1,10 @@
 UnitBlueprint{
     Description = "<LOC xrb3301_desc>Perimeter Monitoring System",
     AI = {
+        TargetBones = {
+            "TargetBone03",
+            "TargetBone02",
+        },
         ShowAssistRangeOnSelect = true,
         StagingPlatformScanRadius = 200,
     },


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
I noticed the skeleton had them, so I added them. There's also `TargetBone01` but that one is outside the collision box.
![image](https://github.com/FAForever/fa/assets/82986251/ea455f68-bd6c-4ba3-8627-bd6366cc2368)

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
A monkeylord given cycling stop/attack orders on the soothsayer will randomly fire at one of the bones.

## Additional Context
The Steam bp file doesn't use the bones, and we haven't added in our own new model either, so I have no idea why it isn't used on Steam.

## Checklist

- [x] Changes are documented in the changelog for the next game version
