### PR TITLE
Salvation Undershoot Fix

### DIFF
--- a/changelog/snippets/fix.6185.md
+++ b/changelog/snippets/fix.6185.md
@@ -1,0 +1,1 @@
+(#6185) Fix Salvation Undershooting - reworks Salvation projectile code to not drop short and use blueprint values for speed and fragment spread

--- a/engine/Core/Blueprints/ProjectileBlueprint.lua
+++ b/engine/Core/Blueprints/ProjectileBlueprint.lua
@@ -137,4 +137,6 @@
 ---@field RealisticOrdinance boolean
 --- bombs that always drop stright down
 ---@field StraightDownOrdinance boolean
+--- for projectiles that spawn spreads of sub-projectiles, how large the impact radius should be
+---@field FragmentRadius number
 ---@field OnLostTargetLifetime? number

--- a/engine/Sim/Projectile.lua
+++ b/engine/Sim/Projectile.lua
@@ -170,6 +170,7 @@ end
 ---@param velX number
 ---@param velY? number
 ---@param velZ? number
+---@return Projectile
 function Projectile:SetVelocity(velX, velY, velZ)
 end
 

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -401,7 +401,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                 end
                 self.EconDrain = CreateEconomyEvent(self.unit, nrgReq, 0, time)
                 self.FirstShot = true
-                self.unit:ForkThread(self.EconomyDrainThread)
+                ForkThread(self.EconomyDrainThread, self)
             end
         end
     end,

--- a/projectiles/AIFFragmentationSensorShell01/AIFFragmentationSensorShell01_proj.bp
+++ b/projectiles/AIFFragmentationSensorShell01/AIFFragmentationSensorShell01_proj.bp
@@ -39,7 +39,7 @@ ProjectileBlueprint {
     Physics = {
         DestroyOnWater = true,
         DetonateBelowHeight = 45,
-        InitialSpeed = 14.6,
+        InitialSpeed = 16,
         InitialSpeedRange = 3,
         InitialSpeedReduceDistance = 30,
         LeadTarget = false,

--- a/projectiles/AIFFragmentationSensorShell01/AIFFragmentationSensorShell01_proj.bp
+++ b/projectiles/AIFFragmentationSensorShell01/AIFFragmentationSensorShell01_proj.bp
@@ -47,6 +47,6 @@ ProjectileBlueprint {
         VelocityAlign = true,
         Fragments = 6,
         FragmentId = '/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_proj.bp',
-        FragmentRadius = 10,
+        FragmentRadius = 7,
     },
 }

--- a/projectiles/AIFFragmentationSensorShell01/AIFFragmentationSensorShell01_proj.bp
+++ b/projectiles/AIFFragmentationSensorShell01/AIFFragmentationSensorShell01_proj.bp
@@ -46,6 +46,7 @@ ProjectileBlueprint {
         TurnRate = 360,
         VelocityAlign = true,
         Fragments = 6,
-        FragmentId = '/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_proj.bp'
+        FragmentId = '/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_proj.bp',
+        FragmentRadius = 10,
     },
 }

--- a/projectiles/AIFFragmentationSensorShell01/AIFFragmentationSensorShell01_script.lua
+++ b/projectiles/AIFFragmentationSensorShell01/AIFFragmentationSensorShell01_script.lua
@@ -7,6 +7,7 @@
 local EffectTemplate = import("/lua/effecttemplates.lua")
 local AArtilleryFragmentationSensorShellProjectile = import("/lua/aeonprojectiles.lua").AArtilleryFragmentationSensorShellProjectile
 local RandomFloat = import("/lua/utilities.lua").GetRandomFloat
+local MathPow = math.pow
 
 ---@class AIFFragmentationSensorShell01 : AArtilleryFragmentationSensorShellProjectile
 AIFFragmentationSensorShell01 = ClassProjectile(AArtilleryFragmentationSensorShellProjectile) {
@@ -24,10 +25,27 @@ AIFFragmentationSensorShell01 = ClassProjectile(AArtilleryFragmentationSensorShe
         end
 
         local vx, vy, vz = self:GetVelocity()
-        local velocity = 16
+        LOG('vx: '..vx..' vy: '..vy..' vz: '..vz)
+        LOG('Current speed: '..self:GetCurrentSpeed())
+        LOG('DetonateBelowHeight: '..bp.DetonateBelowHeight)
+        local vMult = bp.InitialSpeed/(self:GetCurrentSpeed()*10)
+        LOG('vMult: '..vMult)
+
+        -- We'll implicitly calculate our remaining horizontal distance on
+        -- the assumption that our initial trajectory was accurate, then
+        -- calculate our new desired ballistic acceleration to reach the target.
+        local rangeToTarget = math.sqrt(4.75/(2*bp.DetonateBelowHeight)) * VDist2(0,0,vx*10,vz*10)
+        LOG('Range to target: '..rangeToTarget)
+        local newTimeToImpact = rangeToTarget / VDist2(0,0,vx*vMult,vz*vMult)
+        LOG('New time to impact: '..newTimeToImpact)
+        LOG('New vertical speed: '..vy*vMult)
+        local newBallisticAcceleration = - (2 * (bp.DetonateBelowHeight + vy*vMult*10)) / MathPow(newTimeToImpact, 2)
+        LOG('New ballistic acceleration: '..newBallisticAcceleration)
 
 		-- One initial projectile following same directional path as the original
-        self:CreateChildProjectile(bp.FragmentId):SetVelocity(vx,0.8*vy, vz):SetVelocity(velocity):PassDamageData(self.DamageData)
+        self:CreateChildProjectile(bp.FragmentId)
+            :SetVelocity(vx*vMult*10, vy*vMult*10, vz*vMult*10)
+            :SetBallisticAcceleration(newBallisticAcceleration).DamageData = self.DamageData
 
 		-- Create several other projectiles in a dispersal pattern
         local numProjectiles = bp.Fragments - 1
@@ -38,18 +56,16 @@ AIFFragmentationSensorShell01 = ClassProjectile(AArtilleryFragmentationSensorShe
         local angleVariation = angle * 8 -- Adjusts angle variance spread
         local spreadMul = 0.8 -- Adjusts the width of the dispersal        
 
-        local xVec = 0 
-        local yVec = vy*0.8
-        local zVec = 0
+        local xVec
+        local zVec
 
         -- Launch projectiles at semi-random angles away from split location
         for i = 0, numProjectiles - 1 do
             xVec = vx + (math.sin(angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation))) * spreadMul
             zVec = vz + (math.cos(angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation))) * spreadMul
-            local proj = self:CreateChildProjectile(bp.FragmentId)
-            proj:SetVelocity(xVec,yVec,zVec)
-            proj:SetVelocity(velocity)
-            proj.DamageData = self.DamageData
+            self:CreateChildProjectile(bp.FragmentId)
+                :SetVelocity(xVec*vMult, vy*vMult, zVec*vMult)
+                :SetBallisticAcceleration(newBallisticAcceleration).DamageData = self.DamageData
         end
 
         self:Destroy()

--- a/projectiles/AIFFragmentationSensorShell01/AIFFragmentationSensorShell01_script.lua
+++ b/projectiles/AIFFragmentationSensorShell01/AIFFragmentationSensorShell01_script.lua
@@ -7,8 +7,12 @@
 local EffectTemplate = import("/lua/effecttemplates.lua")
 local AArtilleryFragmentationSensorShellProjectile = import("/lua/aeonprojectiles.lua").AArtilleryFragmentationSensorShellProjectile
 local RandomFloat = import("/lua/utilities.lua").GetRandomFloat
-local MathPow = math.pow
+
 local MathSqrt = math.sqrt
+local MathPow = math.pow
+local MathPi = math.pi
+local MathSin = math.sin
+local MathCos = math.cos
 
 -- Gravitational constant
 local g = -4.9
@@ -50,7 +54,7 @@ AIFFragmentationSensorShell01 = ClassProjectile(AArtilleryFragmentationSensorShe
 
 		-- Create several other projectiles in a dispersal pattern
         local numProjectiles = bp.Fragments - 1
-        local angle = (2 * math.pi) / numProjectiles
+        local angle = (2 * MathPi) / numProjectiles
         local angleInitial = RandomFloat( 0, angle )
 
         -- Randomization of the spread
@@ -66,8 +70,8 @@ AIFFragmentationSensorShell01 = ClassProjectile(AArtilleryFragmentationSensorShe
         for i = 0, numProjectiles - 1 do
             offsetAngle = angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation)
             magnitudeVariation = RandomFloat(0.9, 1.1)
-            xVec = vx + math.sin(offsetAngle) * spreadMagnitude * magnitudeVariation
-            zVec = vz + math.cos(offsetAngle) * spreadMagnitude * magnitudeVariation
+            xVec = vx + MathSin(offsetAngle) * spreadMagnitude * magnitudeVariation
+            zVec = vz + MathCos(offsetAngle) * spreadMagnitude * magnitudeVariation
             self:CreateChildProjectile(bp.FragmentId)
                 :SetVelocity(xVec, vy, zVec)
                 :SetVelocity(bp.InitialSpeed + RandomFloat(-bp.InitialSpeedRange, bp.InitialSpeedRange))

--- a/projectiles/AIFFragmentationSensorShell01/AIFFragmentationSensorShell01_script.lua
+++ b/projectiles/AIFFragmentationSensorShell01/AIFFragmentationSensorShell01_script.lua
@@ -60,12 +60,14 @@ AIFFragmentationSensorShell01 = ClassProjectile(AArtilleryFragmentationSensorShe
         local xVec
         local zVec
         local offsetAngle
-
+        local magnitudeVariation
+	
         -- Launch projectiles at semi-random angles away from split location
         for i = 0, numProjectiles - 1 do
             offsetAngle = angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation)
-            xVec = vx + math.sin(offsetAngle) * spreadMagnitude
-            zVec = vz + math.cos(offsetAngle) * spreadMagnitude
+            magnitudeVariation = RandomFloat(0.9, 1.1)
+            xVec = vx + math.sin(offsetAngle) * spreadMagnitude * magnitudeVariation
+            zVec = vz + math.cos(offsetAngle) * spreadMagnitude * magnitudeVariation
             self:CreateChildProjectile(bp.FragmentId)
                 :SetVelocity(xVec, vy, zVec)
                 :SetVelocity(bp.InitialSpeed + RandomFloat(-bp.InitialSpeedRange, bp.InitialSpeedRange))

--- a/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_proj.bp
+++ b/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_proj.bp
@@ -47,6 +47,6 @@ ProjectileBlueprint {
         VelocityAlign = true,
         Fragments = 6,
         FragmentId = '/projectiles/AIFFragmentationSensorShell03/AIFFragmentationSensorShell03_proj.bp',
-        FragmentRadius = 2,
+        FragmentRadius = 4,
     },
 }

--- a/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_proj.bp
+++ b/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_proj.bp
@@ -39,7 +39,7 @@ ProjectileBlueprint {
     Physics = {
         DestroyOnWater = true,
         DetonateBelowHeight = 24,
-        InitialSpeed = 14.6,
+        InitialSpeed = 12,
         InitialSpeedRange = 3,
         InitialSpeedReduceDistance = 30,
         LeadTarget = false,

--- a/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_proj.bp
+++ b/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_proj.bp
@@ -46,6 +46,7 @@ ProjectileBlueprint {
         TurnRate = 360,
         VelocityAlign = true,
         Fragments = 6,
-        FragmentId = '/projectiles/AIFFragmentationSensorShell03/AIFFragmentationSensorShell03_proj.bp'
+        FragmentId = '/projectiles/AIFFragmentationSensorShell03/AIFFragmentationSensorShell03_proj.bp',
+        FragmentRadius = 2,
     },
 }

--- a/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_proj.bp
+++ b/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_proj.bp
@@ -43,10 +43,8 @@ ProjectileBlueprint {
         InitialSpeedRange = 3,
         InitialSpeedReduceDistance = 30,
         LeadTarget = false,
-        MaxZigZag = 0,
         TurnRate = 360,
         VelocityAlign = true,
-        ZigZagFrequency = 0,
         Fragments = 6,
         FragmentId = '/projectiles/AIFFragmentationSensorShell03/AIFFragmentationSensorShell03_proj.bp'
     },

--- a/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_script.lua
+++ b/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_script.lua
@@ -53,16 +53,18 @@ AIFFragmentationSensorShell02 = ClassProjectile(AArtilleryFragmentationSensorShe
 				local timeToImpact = ((-vy - MathSqrt(MathPow(vy,2) - 2*g*detonationHeight))/g) / vMult
 
 				-- Calculate the new ballistic acceleration
-				ballisticAcceleration = -2 * (bp.DetonateBelowHeight + vy*vMult * timeToImpact) / MathPow(timeToImpact, 2)
+				ballisticAcceleration = -2 * (detonationHeight + vy*vMult * timeToImpact) / MathPow(timeToImpact, 2)
 				spreadMagnitude = bp.FragmentRadius / timeToImpact
 			end
 
 			-- Update our velocity values
-			vx, vy, vz = vx*vMult, vy*vMult, vz*vMult
+			-- There appears to be inevitable decay with child projectiles, so we give a slight vertical lift to compensate
+			vx, vy, vz = vx*vMult, vy*vMult + 2, vz*vMult
 
 			-- One initial projectile following same directional path as the original
 			self:CreateChildProjectile(bp.FragmentId)
 				:SetVelocity(vx, vy, vz)
+				:SetVelocity(bp.InitialSpeed)
 				:SetBallisticAcceleration(ballisticAcceleration).DamageData = self.DamageData
 
 			-- Create several other projectiles in a dispersal pattern
@@ -75,12 +77,14 @@ AIFFragmentationSensorShell02 = ClassProjectile(AArtilleryFragmentationSensorShe
 			local xVec
 			local zVec
 			local offsetAngle
+			local magnitudeVariation
 	
 			-- Launch projectiles at semi-random angles away from split location
 			for i = 0, numProjectiles - 1 do
 				offsetAngle = angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation)
-				xVec = vx + math.sin(offsetAngle) * spreadMagnitude
-				zVec = vz + math.cos(offsetAngle) * spreadMagnitude
+				magnitudeVariation = RandomFloat(0.9, 1.1)
+				xVec = vx + math.sin(offsetAngle) * spreadMagnitude * magnitudeVariation
+				zVec = vz + math.cos(offsetAngle) * spreadMagnitude * magnitudeVariation
 				self:CreateChildProjectile(bp.FragmentId)
 					:SetVelocity(xVec, vy, zVec)
 					:SetVelocity(bp.InitialSpeed + RandomFloat(-bp.InitialSpeedRange, bp.InitialSpeedRange))

--- a/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_script.lua
+++ b/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_script.lua
@@ -7,6 +7,7 @@
 local EffectTemplate = import("/lua/effecttemplates.lua")
 local AArtilleryFragmentationSensorShellProjectile = import("/lua/aeonprojectiles.lua").AArtilleryFragmentationSensorShellProjectile02
 local RandomFloat = import("/lua/utilities.lua").GetRandomFloat
+
 local MathSqrt = math.sqrt
 local MathPow = math.pow
 local MathPi = math.pi
@@ -83,8 +84,8 @@ AIFFragmentationSensorShell02 = ClassProjectile(AArtilleryFragmentationSensorShe
 			for i = 0, numProjectiles - 1 do
 				offsetAngle = angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation)
 				magnitudeVariation = RandomFloat(0.9, 1.1)
-				xVec = vx + math.sin(offsetAngle) * spreadMagnitude * magnitudeVariation
-				zVec = vz + math.cos(offsetAngle) * spreadMagnitude * magnitudeVariation
+				xVec = vx + MathSin(offsetAngle) * spreadMagnitude * magnitudeVariation
+				zVec = vz + MathCos(offsetAngle) * spreadMagnitude * magnitudeVariation
 				self:CreateChildProjectile(bp.FragmentId)
 					:SetVelocity(xVec, vy, zVec)
 					:SetVelocity(bp.InitialSpeed + RandomFloat(-bp.InitialSpeedRange, bp.InitialSpeedRange))

--- a/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_script.lua
+++ b/projectiles/AIFFragmentationSensorShell02/AIFFragmentationSensorShell02_script.lua
@@ -7,6 +7,21 @@
 local EffectTemplate = import("/lua/effecttemplates.lua")
 local AArtilleryFragmentationSensorShellProjectile = import("/lua/aeonprojectiles.lua").AArtilleryFragmentationSensorShellProjectile02
 local RandomFloat = import("/lua/utilities.lua").GetRandomFloat
+local MathSqrt = math.sqrt
+local MathPow = math.pow
+local MathPi = math.pi
+local MathSin = math.sin
+local MathCos = math.cos
+
+-- We'll update our ballistic parameters so we still hit the target, but only need
+-- to do it once for the subprojectiles, because the velocity delta will be very similar
+-- and these won't change much/at all.
+local ballisticAcceleration
+local vMult
+local spreadMagnitude
+
+-- Gravitational constant
+local g = -4.9
 
 --- Aeon Quantic Cluster Fragmentation Sensor shell script , Child Projectile after 1st split - XAB2307
 ---@class AIFFragmentationSensorShell02 : AArtilleryFragmentationSensorShellProjectile02
@@ -25,35 +40,55 @@ AIFFragmentationSensorShell02 = ClassProjectile(AArtilleryFragmentationSensorShe
 	        end
 
 			local vx, vy, vz = self:GetVelocity()
-	        local velocity = 12
+			-- Normalize our velocity to ogrids/second
+			vx, vy, vz = vx*10, vy*10, vz*10
+
+			-- If we haven't already calculated our ballistic acceleration, do so now
+			-- This shouldn't change much between subprojectiles, so we only need to do it once
+			if not ballisticAcceleration then
+				local detonationHeight = bp.DetonateBelowHeight
+				vMult = bp.InitialSpeed/(10 * self:GetCurrentSpeed())
+
+				-- Time to impact (with our reduced speed) is calculated using the quadratic formula and vMult.
+				local timeToImpact = ((-vy - MathSqrt(MathPow(vy,2) - 2*g*detonationHeight))/g) / vMult
+
+				-- Calculate the new ballistic acceleration
+				ballisticAcceleration = -2 * (bp.DetonateBelowHeight + vy*vMult * timeToImpact) / MathPow(timeToImpact, 2)
+				spreadMagnitude = bp.FragmentRadius / timeToImpact
+			end
+
+			-- Update our velocity values
+			vx, vy, vz = vx*vMult, vy*vMult, vz*vMult
 
 			-- One initial projectile following same directional path as the original
-            self:CreateChildProjectile(bp.FragmentId):SetVelocity(vx,0.8*vy, vz):SetVelocity(velocity):PassDamageData(self.DamageData)
+			self:CreateChildProjectile(bp.FragmentId)
+				:SetVelocity(vx, vy, vz)
+				:SetBallisticAcceleration(ballisticAcceleration).DamageData = self.DamageData
 
 			-- Create several other projectiles in a dispersal pattern
             local numProjectiles = bp.Fragments - 1
-            local angle = (2 * math.pi) / numProjectiles
+            local angle = (2 * MathPi) / numProjectiles
             local angleInitial = RandomFloat( 0, angle )
 
             -- Randomization of the spread
             local angleVariation = angle * 13 -- Adjusts angle variance spread
-            local spreadMul = 0.4 -- Adjusts the width of the dispersal        
-	        local xVec = 0 
-	        local yVec = vy*0.8
-	        local zVec = 0
-
-	        -- Launch projectiles at semi-random angles away from split location
-	        for i = 0, numProjectiles - 1 do
-	            xVec = vx + (math.sin(angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation))) * spreadMul
-	            zVec = vz + (math.cos(angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation))) * spreadMul 
-                local proj = self:CreateChildProjectile(bp.FragmentId)
-	            proj:SetVelocity(xVec,yVec,zVec)
-	            proj:SetVelocity(velocity)
-	            proj.DamageData = self.DamageData
-	        end
+			local xVec
+			local zVec
+			local offsetAngle
+	
+			-- Launch projectiles at semi-random angles away from split location
+			for i = 0, numProjectiles - 1 do
+				offsetAngle = angleInitial + (i*angle) + RandomFloat(-angleVariation, angleVariation)
+				xVec = vx + math.sin(offsetAngle) * spreadMagnitude
+				zVec = vz + math.cos(offsetAngle) * spreadMagnitude
+				self:CreateChildProjectile(bp.FragmentId)
+					:SetVelocity(xVec, vy, zVec)
+					:SetVelocity(bp.InitialSpeed + RandomFloat(-bp.InitialSpeedRange, bp.InitialSpeedRange))
+					:SetBallisticAcceleration(ballisticAcceleration).DamageData = self.DamageData
+			end
 	        self:Destroy()
 		else
-	        self:DoDamage( self, self.DamageData, TargetEntity)
+	        self:DoDamage(self, self.DamageData, TargetEntity)
 	        self:OnImpactDestroy(TargetType, TargetEntity)
         end
     end,


### PR DESCRIPTION
Issue:
Salvation undershoots, sub-fragment and sub-sub-fragment code is generally brittle and not blueprint dependent.

Fixes:
1. Adds a `FragmentRadius` blueprint value to the AIFFragmentationSensor projectile blueprints, and links the fragment initial velocity to the blueprint `InitialSpeed` value.
2. Calculates the ballistic acceleration of the (progressively slower) sub-fragments so they don't fall short of the target.

Tangentially related fixes:
- Fixes an error where the wrong reference was passed to the Econ thread in `DefaultProjectileWeapon.lua`