### PR TITLE
Fix AI rating for sub-1.0 ratings

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -493,14 +493,7 @@ function ComputeAIRating(gameOptions, aiLobbyProperties)
     local cheatBuildMultiplier = (tonumber(gameOptions.BuildMult) or 1.0) - 1.0
     local cheatResourceMultiplier = (tonumber(gameOptions.CheatMult) or 1.0) - 1.0
 
-    -- if they're smaller than 1.0 then the AI doesn't get better; it gets worse!
-    if cheatBuildMultiplier < 0 then
-        cheatBuildMultiplier = 1 / cheatBuildMultiplier
-    end
-
-    if cheatResourceMultiplier < 0 then
-        cheatResourceMultiplier = 1 / cheatResourceMultiplier
-    end
+    
 
     -- compute the rating
     local cheatBuildValue = (aiLobbyProperties.ratingBuildMultiplier or 0.0) * cheatBuildMultiplier


### PR DESCRIPTION
##Issue
If a sub-1.0 AiX modifier is chosen, the rating impact was modified by 1 / (AiX - 1) previously.  So for example, a 0.9 rating modifier would have 10 times the normal modifier applied as a negative amount, wheras a 0.6 modifier would have 4 times the normal modifier applied as a negative amount.  In other words, a 0.9 AiX would have a far worse rating than a 0.6 AiX.

## Description of the proposed changes
This removes the code applying this - there is no need for such a modification.


## Testing done on the proposed changes
Created a lobby and used 0.9 and 0.6 AiX modifiers.

For example, with this change, M28's ratings are (on a 5km map):
0.9 AiX: 521 rating
0.6 AiX: 156 rating

Without this change, M28's ratings are:
0.9 AiX: -3279 rating
0.6 AiX: -595 rating