### PR TITLE
Fix rounding in beam damage calculation

### DIFF
--- a/changelog/snippets/fix.6115.md
+++ b/changelog/snippets/fix.6115.md
@@ -1,1 +1,1 @@
-- (#6115) Fix damage calculation in the unit view UI for beam weapons with a `BeamCollisionDelay` such as the Zapper's weapon.
+- (#6115, #6201) Fix damage calculation in the unit view UI for beam weapons with a `BeamCollisionDelay` such as the Zapper's weapon.

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -567,7 +567,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                                 Damage = math.max(Damage, info.DamageToShields)
                             end
                             if info.BeamLifetime > 0 then
-                                Damage = Damage * (1 + MathFloor(MATH_IRound(info.BeamLifetime)/(info.BeamCollisionDelay+0.1)))
+                                Damage = Damage * (1 + MathFloor(MATH_IRound(info.BeamLifetime*10)/(MATH_IRound(info.BeamCollisionDelay*10)+1)))
                             else
                                 Damage = Damage * (info.DoTPulses or 1) + (info.InitialDamage or 0)
                                 local ProjectilePhysics = __blueprints[info.ProjectileId].Physics

--- a/units/DSLK004/DSLK004_unit.bp
+++ b/units/DSLK004/DSLK004_unit.bp
@@ -249,7 +249,7 @@ UnitBlueprint{
             },
             AutoInitiateAttackCommand = false,
             BallisticArc = "RULEUBA_None",
-            BeamCollisionDelay = 0.01,
+            BeamCollisionDelay = 0,
             BeamLifetime = 0.6,
             CannotAttackGround = true,
             CollideFriendly = false,


### PR DESCRIPTION

<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
BeamLifetime is in tenths, but was being rounded to ones BeamCollisionDelay could be set to weird numbers (ex: DSLK004). Continuation of #6115


## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Check the lightning tank's damage value in the UI, it should be 1400. Zapper remains at 1 damage.

## Checklist

- [x] Changes are documented in the changelog for the next game version
