### PR TITLE
Fix log spam from spawn dummies when reloading blueprints

### DIFF
--- a/changelog/snippets/fix.6209.md
+++ b/changelog/snippets/fix.6209.md
@@ -1,0 +1,1 @@
+- (#6209) Fix log warning spam from spawn dummies every time blueprints are reloaded.

--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -901,6 +901,9 @@ local function SpawnMenuDummyChanges(all_bps)
                         UniformScale = 0,
                         HideLifebars = true,
                     },
+                    Intel = {
+                        WaterVisionRadius = 0,
+                    },
                     Physics = {
                         SkirtOffsetX = SOffsetX,
                         SkirtOffsetZ = SOffsetZ,


### PR DESCRIPTION

<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Water vision defaults to 10, which causes intel size warnings in the log every time blueprints are reloaded. For example:
```
warning: Intel radius of spawn_dummy_24_0-1_22 (= 10) for WaterVisionRadius does not match intel grid (4 ogrids), should be either 8 or 12
```

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Reloading a blueprint no longer causes 40 lines of warnings about spawn dummy water vision not matching intel grid resolution.

## Checklist

- [ ] Changes are documented in the changelog for the next game version
