### PR TITLE
Buff/fix the Wailer's AA-missiles

### DIFF
--- a/changelog/snippets/balance.6211.md
+++ b/changelog/snippets/balance.6211.md
@@ -1,0 +1,4 @@
+- (#6211) Increase the velocity and lifetime of the Wailer's AA-missiles, since they often expired before they were able to reach their target.
+    - Wailer: T3 Heavy Gunship (XRA0305):
+        - MuzzleVelocity: 13 --> 22
+        - ProjectileLifetime: 2.0 --> 2.4

--- a/units/XRA0305/XRA0305_unit.bp
+++ b/units/XRA0305/XRA0305_unit.bp
@@ -323,10 +323,10 @@ UnitBlueprint{
             MaxRadius = 38,
             MuzzleSalvoDelay = 0.2,
             MuzzleSalvoSize = 3,
-            MuzzleVelocity = 13,
+            MuzzleVelocity = 22,
             NotExclusive = true,
             ProjectileId = "/projectiles/CAAMissileNanite03/CAAMissileNanite03_proj.bp",
-            ProjectileLifetime = 2,
+            ProjectileLifetime = 2.4,
             ProjectilesPerOnFire = 3,
             RackBones = {
                 {


### PR DESCRIPTION
## Description of the proposed changes
It is very common for the Wailer's AA-missiles to expire before they are able to reach their target. This is because their MuzzleVelocity is extremely low (`13`) and their ProjectileLifetime (`2`) is not long enough for the acceleration stat of the projectile (see below) to have a meaningful impact. 

This PR gives them a higher lifetime, so the missiles have more time to reach a higher velocity. Their MuzzleVelocity is also increased, to slightly increase their effectiveness.

**Changes:**
MuzzleVelocity: 13 --> 22
ProjectileLifetime: 2.0 --> 2.4

## Testing done on the proposed changes
The Wailer's AA-solution can now hit other air units more reliably. The missiles deal very low damage, so the balance impact of this is almost non-existent.

## Additional context
Relevant physics stats of the projectile (CAAMissileNanite03_proj; unchanged):
```
Acceleration = 5,
InitialSpeed = 30,
Lifetime = 3,
MaxSpeed = 35,
OnLostTargetLifetime = 0.7,
```

## Checklist
- [x] Changes are documented in the changelog for the next game version
