### PR TITLE
Command Queue Annotations

### DIFF
--- a/engine/Sim/Unit.lua
+++ b/engine/Sim/Unit.lua
@@ -52,6 +52,16 @@ local Unit = {}
 ---| "HoldingPattern"
 ---| "SiloBuildingAmmo"
 
+---@class UnitCommand
+---@field _c_object userdata
+---@field blueprintId? string -- For build commands
+---@field commandType integer -- Integer representation of CommandType, see UnitQueueDataToCommand for details
+---@field target? Prop|Unit|Entity -- For commands that target an entity
+---@field targetId? EntityId
+---@field x number -- X coordinate of command target
+---@field y number -- Y coordinate of command target
+---@field z number -- Z coordinate of command target
+
 --- Adds a command cap to the unit
 ---@param category moho.EntityCategory
 function Unit:AddBuildRestriction(category)
@@ -146,7 +156,7 @@ function Unit:GetCargo()
 end
 
 --- Returns table of commands queued up for this unit
----@return { }
+---@return UnitCommand[]
 function Unit:GetCommandQueue()
 end
 

--- a/engine/User.lua
+++ b/engine/User.lua
@@ -235,9 +235,11 @@ end
 function DecreaseBuildCountInQueue(queueIndex, count)
 end
 
----
----@param id unknown
-function DeleteCommand(id)
+---Deletes a command from the player command queue.
+---Each player has an array that holds all commands for all units, the commandID indexes to this array.
+---Note: this function doesn't receive any units as arguments--you will have to retrieve the commandId by UserUnit:GetCommandQueue()[commandIndex].ID
+---@param commandId number commandId, from UserUnit:GetCommandQueue()[commandIndex].ID
+function DeleteCommand(commandId)
 end
 
 ---

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -96,14 +96,6 @@ SyncMeta = {
 ---@field AdjEnergyMod? number
 ---@field AdjRoFMod? number
 
----@class UnitCommand
----@field x number
----@field y number
----@field z number
----@field targetId? EntityId
----@field target? Entity
----@field commandType string 
-
 ---@class AIUnitProperties
 ---@field AIPlatoonReference AIPlatoon
 ---@field AIBaseManager LocationType


### PR DESCRIPTION
1. Adds annotations + description for user side `DeleteCommand` (novel!)
2. Add missing fields + moves class annotation definition of `UnitCommand` (table element returned by (`Unit:GetCommandQueue`) to file where the `GetCommandQueue` reference is defined.