### PR TITLE
Revert change in default teleport time

### DIFF
--- a/changelog/snippets/fix.6213.md
+++ b/changelog/snippets/fix.6213.md
@@ -1,0 +1,1 @@
+- (#6213) Fix the default teleport delay being set to 15 seconds instead of 0, which caused some modded units to teleport much slower.

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -755,8 +755,9 @@
 ---@field TeleportMassMod? number
 --- Multiplied by the resulting total energy cost of the teleport to get its required time.
 --- Treated as `0.01` when absent.
+---@see TeleportDelay For an additional flat delay that also delays teleport FX showing at the destination.
 ---@field TeleportTimeMod? number
---- Whether to use the new variable teleport cost calculation method, or revert to the old
+--- Whether to use the new distance-based teleport cost calculation method, or revert to the old unit cost based method.
 ---@field UseVariableTeleportCosts? boolean
 
 ---@class UnitBlueprintExternalFactory
@@ -947,7 +948,10 @@
 ---@field TarmacGlowDecal? any unused
 --- defines the tech level used for display purposes
 ---@field TechLevel UnitTechLevel
---- if present, makes the "teleport" ability show up in the unit view with the delay of this value. Defaults to 15 seconds.
+--- Extra time taken to teleport before other teleport time calculations. Defaults to 0 seconds.
+--- If `UseVariableTeleportCosts` is false, then this also delays teleport FX appearing at the destination.
+--- If `UseVariableTeleportCosts` is true, then destination FX appear after 0.4x the total teleport time.
+---@see TeleportTimeMod For an energy-scaling teleport time that does not delay teleport FX at the destination.
 ---@field TeleportDelay? number
 --- if present, adds a flat energy cost to the "teleport" ability. Defaults to 150000 energy. Only applies when `UseVariableTeleportCosts` is true.
 ---@field TeleportFlatEnergyCost? number

--- a/lua/shared/teleport.lua
+++ b/lua/shared/teleport.lua
@@ -58,7 +58,7 @@ TeleportCostFunction = function(unit, location)
     end
 
     local dist = VDist3(pos, location)
-    local teleDelay = bp.General.TeleportDelay or 15
+    local teleDelay = bp.General.TeleportDelay or 0
     local teleportFlatEnergyCost = bp.General.TeleportFlatEnergyCost or 75000
     local teleportMaximumEnergyCost = bp.General.TeleportMaximumEnergyCost or 2500000
     local teleportMaximumDuration = bp.General.TeleportMaximumDuration or 50


### PR DESCRIPTION

<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
Reduces the default teleport delay set in #5907 from 15 seconds to 0 seconds to return old behavior for modded units. I noticed this with BlackOps ACUs, which used to have a lightning fast and very cheap 1.4 second teleport.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
After the changes, the quick teleport time is back.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
