### PR TITLE
Add IsAlly check to MobileUnit OnStartBuild

### DIFF
--- a/changelog/snippets/fix.6215.md
+++ b/changelog/snippets/fix.6215.md
@@ -1,0 +1,1 @@
+- (#6215) Fix an edge case where an engineer can assist an enemy construction task if they were given an order to build the same unit in the same location before the enemy task was started.

--- a/lua/sim/units/MobileUnit.lua
+++ b/lua/sim/units/MobileUnit.lua
@@ -126,6 +126,20 @@ MobileUnit = ClassUnit(Unit, TreadComponent) {
     end,
 
     ---@param self MobileUnit
+    ---@param built Unit
+    ---@param order string
+    ---@return boolean
+    OnStartBuild = function(self, built, order)
+        if IsAlly(self.Army, built.Army) then
+            return Unit.OnStartBuild(self, built, order)
+        else
+            self:OnFailedToBuild()
+            IssueToUnitClearCommands(self)
+            return false
+        end
+    end,
+
+    ---@param self MobileUnit
     ---@param new string
     ---@param old string
     OnLayerChange = function(self, new, old)


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

fixes #2725
## Description of the proposed changes
Prevent mobile units (engineers) from building enemy buildings. This typically happens when two engineers of the same faction are given a build order to the same resource spot.
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->


## Testing done on the proposed changes
Spawn two engineers of a given faction, give them an order to build a mex/hydro on the same spot. Previously whichever engineer arrived second would assist with constructing the enemy structure; now they clear their command queue instead.
