### PR TITLE
Fix unit tooltip docking for non-startup layouts

### DIFF
--- a/changelog/snippets/fix.6216.md
+++ b/changelog/snippets/fix.6216.md
@@ -1,1 +1,1 @@
-- (#6162) Fix incorrect unit tooltip docking after switching layout in-game (default alt-up/alt-down).
+- (#6216) Fix incorrect unit tooltip docking after switching layout in-game (default alt-up/alt-down).

--- a/changelog/snippets/fix.6216.md
+++ b/changelog/snippets/fix.6216.md
@@ -1,0 +1,1 @@
+- (#6162) Fix incorrect unit tooltip docking after switching layout in-game (default alt-up/alt-down).

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -19,7 +19,7 @@ local Prefs = import("/lua/user/prefs.lua")
 local EnhancementCommon = import("/lua/enhancementcommon.lua")
 local options = Prefs.GetFromCurrentProfile('options')
 local GetUnitRolloverInfo = import("/lua/keymap/selectedinfo.lua").GetUnitRolloverInfo
-local unitViewLayout = import(UIUtil.GetLayoutFilename('unitview'))
+local unitViewLayout = nil -- Holds the current layout, updated by SetLayout().
 local unitviewDetail = import("/lua/ui/game/unitviewdetail.lua")
 local Grid = import("/lua/maui/grid.lua").Grid
 local Construction = import("/lua/ui/game/construction.lua")
@@ -739,12 +739,14 @@ function ShowROBox()
 end
 
 function SetLayout(layout)
+    unitViewLayout = import(UIUtil.GetLayoutFilename('unitview'))
     unitViewLayout.SetLayout()
 end
 
 function SetupUnitViewLayout(mapGroup, orderControl)
     controls.parent = mapGroup
     controls.orderPanel = orderControl
+    unitViewLayout = import(UIUtil.GetLayoutFilename('unitview')) -- SetLayout() will set this too but let's make sure CreateUI() does not use nil, even though it only sets up an OnFrame function.
     CreateUI()
     SetLayout(UIUtil.currentLayout)
 end


### PR DESCRIPTION
## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->

### Issue

Non-startup layouts (when you change the layout with alt-up or alt-down) don't dock unit tooltip correctly, here the tooltip has sunk beneath the construction control:

![DockingGlitch](https://github.com/FAForever/fa/assets/5189292/66d84f4a-90fb-45f0-9a7e-48880b9f071a)

### Root cause

Unlike other controls, unitview.lua does not fetch the current layout every time it uses it. Instead, https://github.com/FAForever/fa/commit/241c13cf4198d6aa81f70251eae615627a934451 introduced an optimization to only load the layout on startup into a variable and then call its methods through the variable. The optimization was motivated by the fact that unitview calls the layout methods in an OnFrame function and fetching it on each frame would be expensive.

### Fix:
The main fix is to update the layout variable in SetLayout().
In addition to that:
 * Set the initial value of the variable to nil since we don't depend on whatever the current layout might be when the file is loaded. It seems to work for the startup layout but it's not obvious why.
 * Update the current value in SetupUnitViewLayout() before CreateUI(). CreateUI() creates the OnFrame function that calls layout methods through the variable, so it's a better form to have the variable initialized. It's not required because the OnFrame function would only fire later and SetupUnitViewLayout() calls SetLayout() next, but that's the sort of intricacy I would rather not explain in code comments. We won't lose any measurable performance by doing this since SetupUnitViewLayout() is called only once.


## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->

* For each layout
   * Selected the layout
   * Restarted the game
   * Verified the unit tooltip docks correctly for all layouts
   * Checked the logs and found no lazyvar issues.

## Additional context
<!-- Add any other context about the pull request here. -->
There is still this glitch in the left layout when you switch to it (regardless of whether it was the startup layout), but it is a pre-existing issue:
![Non-startup-left-production-glitch](https://github.com/FAForever/fa/assets/5189292/9f4fdcd3-f270-44d4-963b-fbbdf56b9a7f)


## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
What's the process around this? Make a draft PR and add a snippet to changelog/snippets based on the PR number and the nature of the change?
