### PR TITLE
Clarify hotbuild keybind collision warning

### DIFF
--- a/changelog/snippets/other.6217.md
+++ b/changelog/snippets/other.6217.md
@@ -1,0 +1,1 @@
+- (#6217) Clarify warning when Hotbuild hotkeys collide with other hotkeys.

--- a/lua/keymap/keymapper.lua
+++ b/lua/keymap/keymapper.lua
@@ -291,22 +291,19 @@ function GenerateHotbuildModifiers()
                 local altModKey = "Alt-" .. key
                 local shiftModBinding = keyDetails[shiftModKey]
                 local altModBinding = keyDetails[altModKey]
-                if not shiftModBinding and not altModBinding then
-                    modifiers[shiftModKey] =  info.action
-                    modifiers[altModKey] =  info.action
-                elseif not shiftModBinding then
-                    modifiers[shiftModKey] =  info.action
-                    WARN(string.format('Alt modifier for Hotbuild action "%s" (%s)  is already bound to action "%s" (%s)\nThe Alt modifier of the Hotbuild action will not work!'
-                        , info.name, key, altModBinding.name, altModKey))
-                elseif not altModBinding then
-                    modifiers[altModKey] =  info.action
+
+                if shiftModBinding then
                     WARN(string.format('Shift modifier for Hotbuild action "%s" (%s)  is already bound to action "%s" (%s)\nThe Shift modifier of the Hotbuild action will not work!'
                         , info.name, key, shiftModBinding.name, shiftModKey))
                 else
+                    modifiers[shiftModKey] = info.action
+                end
+
+                if altModBinding then
                     WARN(string.format('Alt modifier for Hotbuild action "%s" (%s)  is already bound to action "%s" (%s)\nThe Alt modifier of the Hotbuild action will not work!'
                         , info.name, key, altModBinding.name, altModKey))
-                    WARN(string.format('Shift modifier for Hotbuild action "%s" (%s)  is already bound to action "%s" (%s)\nThe Shift modifier of the Hotbuild action will not work!'
-                        , info.name, key, shiftModBinding.name, shiftModKey))
+                else
+                    modifiers[altModKey] =  info.action
                 end
             end
         end

--- a/lua/keymap/keymapper.lua
+++ b/lua/keymap/keymapper.lua
@@ -296,13 +296,17 @@ function GenerateHotbuildModifiers()
                     modifiers[altModKey] =  info.action
                 elseif not shiftModBinding then
                     modifiers[shiftModKey] =  info.action
-                    WARN('Hotbuild key '..altModKey..' is already bound to action "'..altModBinding.name..'" under "'..altModBinding.category..'" category')
+                    WARN(string.format('Alt modifier for Hotbuild action "%s" (%s)  is already bound to action "%s" (%s)\nThe Alt modifier of the Hotbuild action will not work!'
+                        , info.name, key, altModBinding.name, altModKey))
                 elseif not altModBinding then
                     modifiers[altModKey] =  info.action
-                    WARN('Hotbuild key '..shiftModKey..' is already bound to action "'..shiftModBinding.name..'" under "'..shiftModBinding.category..'" category')
+                    WARN(string.format('Shift modifier for Hotbuild action "%s" (%s)  is already bound to action "%s" (%s)\nThe Shift modifier of the Hotbuild action will not work!'
+                        , info.name, key, shiftModBinding.name, shiftModKey))
                 else
-                    WARN('Hotbuild key '..shiftModKey..' is already bound to action "'..shiftModBinding.name..'" under "'..shiftModBinding.category..'" category')
-                    WARN('Hotbuild key '..altModKey..' is already bound to action "'..altModBinding.name..'" under "'..altModBinding.category..'" category')
+                    WARN(string.format('Alt modifier for Hotbuild action "%s" (%s)  is already bound to action "%s" (%s)\nThe Alt modifier of the Hotbuild action will not work!'
+                        , info.name, key, altModBinding.name, altModKey))
+                    WARN(string.format('Shift modifier for Hotbuild action "%s" (%s)  is already bound to action "%s" (%s)\nThe Shift modifier of the Hotbuild action will not work!'
+                        , info.name, key, shiftModBinding.name, shiftModKey))
                 end
             end
         end


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
## Issue
Hotbuild automatically assigns shift and alt modifiers for its hotbuild actions, and gives warnings if another action is already bound to that key. The warning is hard to understand because it didn't specify what hotbuild key the autogenerated modifier came from.
```
WARNING: Hotbuild key Alt-H is already bound to action "Toggle intel and shield" under "ORDERS" category
```

## Description of the proposed changes
Add the other side of the key collision to the warning, and the resolution of the collision.
``` 
WARNING: Alt modifier for Hotbuild action "build shields + mobiles Shields & shield disruptors + shield boat" (H)  is already bound to action "Toggle intel and shield" (Alt-H)
WARNING: The Alt modifier of the Hotbuild action will not work!
```

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Checked for errors in log when closing the keybindings menu (this is when the keybindings are auto generated).

## Checklist

- [x] Changes are documented in the changelog for the next game version
