### PR TITLE
Annotate auto assist in `InitialAutoMode` and `SetAutoMode`

### DIFF
--- a/changelog/snippets/other.6218.md
+++ b/changelog/snippets/other.6218.md
@@ -1,0 +1,1 @@
+- (#6218) Annotate auto-assist toggling in `InitialAutoMode` and `SetAutoMode`.

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -141,7 +141,8 @@
 ---@field GuardReturnRadius number
 --- guard range for the unit, automatically added if absent
 ---@field GuardScanRadius number
---- initial auto mode behaviour for the unit
+--- initial toggle of automatic behaviors (silo building and auto-assist)
+---@see SetAutoMode
 ---@field InitialAutoMode boolean
 --- unit should unpack before firing weapon
 ---@field NeedUnpack boolean

--- a/engine/Sim/Unit.lua
+++ b/engine/Sim/Unit.lua
@@ -479,7 +479,7 @@ end
 function Unit:SetAccMult(accelMult)
 end
 
---- sets silo auto-build mode
+--- enable silo auto-build or unit auto-assist
 ---@param mode boolean
 function Unit:SetAutoMode(mode)
 end

--- a/engine/User.lua
+++ b/engine/User.lua
@@ -1057,7 +1057,7 @@ end
 function SetActiveBuildTemplate(template)
 end
 
---- Set if anyone in the list is auto building
+--- Set if anyone in the list is auto building or auto assisting
 ---@param units UserUnit[]
 ---@param mode boolean
 function SetAutoMode(units, mode)

--- a/units/UAL0111/UAL0111_unit.bp
+++ b/units/UAL0111/UAL0111_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint{
     Description = "<LOC ual0111_desc>Mobile Missile Launcher",
-    AI = { InitialAutoMode = true },
+    AI = { },
     Audio = {
         AmbientMove = Sound { Bank = 'UAL',        Cue = 'UAL0111_Move_Loop',   LodCutoff = 'UnitMove_LodCutoff' },
         Destroyed   = Sound { Bank = 'UALDestroy', Cue = 'UAL_Destroy_Land',    LodCutoff = 'UnitMove_LodCutoff' },

--- a/units/UEA0001/UEA0001_unit.bp
+++ b/units/UEA0001/UEA0001_unit.bp
@@ -1,4 +1,5 @@
 UnitBlueprint {
+    Description = '<LOC uea0001_desc>Engineering Drone',
     AI = {
         InitialAutoMode = true,
     },
@@ -100,7 +101,6 @@ UnitBlueprint {
         SubThreatLevel = 0,
         SurfaceThreatLevel = 0,
     },
-    Description = '<LOC uea0001_desc>Engineering Drone',
     Display = {
         Abilities = {
             '<LOC ability_engineeringsuite>Engineering Suite',

--- a/units/UEA0003/UEA0003_unit.bp
+++ b/units/UEA0003/UEA0003_unit.bp
@@ -1,4 +1,5 @@
 UnitBlueprint {
+    Description = '<LOC uea0003_desc>Engineering Drone',
     AI = {
         InitialAutoMode = true,
     },
@@ -100,7 +101,6 @@ UnitBlueprint {
         SubThreatLevel = 0,
         SurfaceThreatLevel = 0,
     },
-    Description = '<LOC uea0003_desc>Engineering Drone',
     Display = {
         Abilities = {
             '<LOC ability_engineeringsuite>Engineering Suite',

--- a/units/UEL0111/UEL0111_unit.bp
+++ b/units/UEL0111/UEL0111_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint{
     Description = "<LOC uel0111_desc>Mobile Missile Launcher",
-    AI = { InitialAutoMode = true },
+    AI = { },
     Audio = {
         AmbientMove = Sound { Bank = 'UEL',        Cue = 'UEL0111_Move_Loop',    LodCutoff = 'UnitMove_LodCutoff' },
         Destroyed   = Sound { Bank = 'UELDestroy', Cue = 'UEL_Destroy_Med_Land', LodCutoff = 'UnitMove_LodCutoff' },

--- a/units/UES0202/UES0202_unit.bp
+++ b/units/UES0202/UES0202_unit.bp
@@ -3,7 +3,6 @@ UnitBlueprint{
     AI = {
         AttackAngle = 90,
         GuardReturnRadius = 30,
-        InitialAutoMode = true,
         TargetBones = {
             "UES0202",
             "Back_Wake",

--- a/units/URL0111/URL0111_unit.bp
+++ b/units/URL0111/URL0111_unit.bp
@@ -1,7 +1,6 @@
 UnitBlueprint{
     Description = "<LOC url0111_desc>Mobile Missile Launcher",
     AI = {
-        InitialAutoMode = true,
         TargetBones = { "Launcher" },
     },
     Audio = {

--- a/units/XEL0306/XEL0306_unit.bp
+++ b/units/XEL0306/XEL0306_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint{
     Description = "<LOC xel0306_desc>Mobile Missile Platform",
-    AI = { InitialAutoMode = true },
+    AI = { },
     Audio = {
         AmbientMove = Sound { Bank = 'XEL',        Cue = 'XEL0306_Move_Loop',    LodCutoff = 'UnitMove_LodCutoff' },
         Destroyed   = Sound { Bank = 'UELDestroy', Cue = 'UEL_Destroy_Med_Land', LodCutoff = 'UnitMove_LodCutoff' },

--- a/units/XSL0111/XSL0111_unit.bp
+++ b/units/XSL0111/XSL0111_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint{
     Description = "<LOC xsl0111_desc>Mobile Missile Launcher",
-    AI = { InitialAutoMode = true },
+    AI = { },
     Audio = {
         AmbientMove = Sound { Bank = 'XSL',            Cue = 'XSL0111_Move_Loop',    LodCutoff = 'UnitMove_LodCutoff' },
         Destroyed   = Sound { Bank = 'XSL_Destroy',    Cue = 'XSL_Destroy_Land_Med', LodCutoff = 'UnitMove_LodCutoff' },


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
- Toggling off `InitialAutoMode` for hives disables their automatic assistance. Weirdly enough the production toggle on hives doesn't actually toggle auto mode (through SetAutoMode), but it toggles whether auto mode can act or not.
- Toggling off `InitialAutoMode` for drones and the base station simultaneously toggles off automatic assistance.
- It's already known that auto mode toggles automatic silo building.

## Other
I'm not sure what the exact requirements for a unit to be able to automatically assist are. The unit also only auto assists within its `GuardScanRadius`. The `ENGINEERSTATION` `STATIONASSISTPOD` `PODSTAGINGPLATFORM` categories seem important. Mainly `STATIONASSISTPOD` since it is on kennel drones and hives.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
