### PR TITLE
Fix not being able to kick observers in team games

### DIFF
--- a/changelog/snippets/fix.6222.md
+++ b/changelog/snippets/fix.6222.md
@@ -1,0 +1,1 @@
+- (#6222) Fix not being able to kick observers in team games that are not using the "Fixed" spawn setting.

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -4365,7 +4365,7 @@ function CreateUI(maxPlayers)
             ---@see refreshObserverList
             if gameInfo.GameOptions['TeamSpawn'] == 'fixed' then
                 if numTeams < 3 then
-                obsIndex = obsIndex - numTeams
+                    obsIndex = obsIndex - numTeams
                 else
                     -- 3+ teams has ratings at the end of the list, don't allow kicking when clicking those rating rows
                     maxObsIndex = maxObsIndex - numTeams


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes #6219. Also fixes being able to try to kick the team rating row when there are 3+ teams.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Open two instances of the game. Host multiplayer LAN on a specific port, and connect to localhost:thatport on the other instance (automatic port and discovery doesn't seem to work). Move the second player to observer, and add AIs to change the team sizes (set auto teams to None). Test being able to pop up the kick dialogue only when clicking the observer in all combinations of spawns fixed/not fixed and having 0-3 teams.

## Checklist

- [x] Changes are documented in the changelog for the next game version
