### PR TITLE
Create workflows to update unit viewers

### DIFF
--- a/.github/workflows/spookydb-update.yaml
+++ b/.github/workflows/spookydb-update.yaml
@@ -27,5 +27,60 @@ on:
     #   - deploy/faf
 
 jobs:
-  update:
-    uses: FAForever/spooky-db/.github/workflows/deploy.yaml@master
+  build:
+    uses: FAForever/spooky-db/.github/workflows/build.yaml@master
+  deploy:
+    name: Deploy the SpookyDB
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/marketplace/actions/webfactory-ssh-agent
+      # https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys
+      - uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SPOOKYDB_DEPLOYMENT_KEY }}
+
+      # https://github.com/actions/checkout/tree/v4/
+      - name: Checkout spooky db code
+        uses: actions/checkout@v4
+        with:
+            repository: FAForever/spooky-db
+            path: gh-pages
+            ref: gh-pages  
+    
+      - name: Download recent unit information
+        uses: actions/download-artifact@v4
+        with:
+            name: spookydb-dist
+            path: dist
+
+      - name: Copy
+        run: |
+            # remove old files that have a hash in the name
+            rm -r gh-pages/css/*
+            rm -r gh-pages/data/*
+            rm -r gh-pages/img/*
+            rm -r gh-pages/js/*
+            rm -r gh-pages/views/*
+
+            # copy over new files
+            cp -r dist/* gh-pages/
+
+      - name: Deploy
+        working-directory: gh-pages
+        run: |
+            # Check for any differences between the working directory and the latest commit
+            if git diff --quiet; then
+                echo "No changes to deploy"
+                exit 0
+            fi
+
+            # Configure git
+            git config user.email "administrator@faforever.com"
+            git config user.name "FAForever"
+
+            # Stage, commit and push the changes
+            git stage .
+            git commit -m 'Automated deployment of spooky db'
+            git push origin HEAD:gh-pages
+
+

--- a/.github/workflows/spookydb-update.yaml
+++ b/.github/workflows/spookydb-update.yaml
@@ -23,8 +23,8 @@ name: SpookyDB - update unit information
 on:
   workflow_dispatch:
   push:
-    # branches:
-    #   - deploy/faf
+    branches:
+      - deploy/faf
 
 jobs:
   build:
@@ -34,12 +34,6 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      # # https://github.com/marketplace/actions/webfactory-ssh-agent
-      # # https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys
-      # - uses: webfactory/ssh-agent@v0.9.0
-      #   with:
-      #     ssh-private-key: ${{ secrets.SPOOKYDB_DEPLOYMENT_KEY }}
-
       # https://github.com/actions/checkout/tree/v4/
       - name: Checkout spooky db code
         uses: actions/checkout@v4
@@ -49,12 +43,17 @@ jobs:
             ref: gh-pages  
             ssh-key: ${{ secrets.SPOOKYDB_DEPLOYMENT_KEY }}
     
+      # https://github.com/actions/download-artifact/tree/v4/
       - name: Download recent unit information
         uses: actions/download-artifact@v4
         with:
             name: spookydb-dist
             path: dist
 
+      # Each file is given a (random) hash pre-pended to the filename to prevent caching
+      # issues. Because of that we first need to remove all existing hashed files as otherwise
+      # they will keep accumulating forever. As much as this fits the narrative of the community
+      # (Forged Alliance >Forever<) it's not what we want here.
       - name: Copy
         run: |
             # remove old files that have a hash in the name
@@ -67,6 +66,10 @@ jobs:
             # copy over new files
             cp -r dist/* gh-pages/
 
+      # By pushing the changes to the gh-pages branch, the changes will be deployed to the
+      # website. The website is hosted on GitHub Pages and is (at the moment of writing) 
+      # available at:
+      # - https://faforever.github.io/spooky-db/
       - name: Deploy
         working-directory: gh-pages
         run: |

--- a/.github/workflows/spookydb-update.yaml
+++ b/.github/workflows/spookydb-update.yaml
@@ -29,5 +29,3 @@ on:
 jobs:
   update:
     uses: FAForever/spooky-db/.github/workflows/deploy.yaml@master
-    
-    

--- a/.github/workflows/spookydb-update.yaml
+++ b/.github/workflows/spookydb-update.yaml
@@ -29,3 +29,4 @@ on:
 jobs:
   update:
     uses: FAForever/spooky-db/.github/workflows/deploy.yaml@master
+    

--- a/.github/workflows/spookydb-update.yaml
+++ b/.github/workflows/spookydb-update.yaml
@@ -34,11 +34,11 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      # https://github.com/marketplace/actions/webfactory-ssh-agent
-      # https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys
-      - uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SPOOKYDB_DEPLOYMENT_KEY }}
+      # # https://github.com/marketplace/actions/webfactory-ssh-agent
+      # # https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys
+      # - uses: webfactory/ssh-agent@v0.9.0
+      #   with:
+      #     ssh-private-key: ${{ secrets.SPOOKYDB_DEPLOYMENT_KEY }}
 
       # https://github.com/actions/checkout/tree/v4/
       - name: Checkout spooky db code
@@ -47,6 +47,7 @@ jobs:
             repository: FAForever/spooky-db
             path: gh-pages
             ref: gh-pages  
+            ssh-key: ${{ secrets.SPOOKYDB_DEPLOYMENT_KEY }}
     
       - name: Download recent unit information
         uses: actions/download-artifact@v4

--- a/.github/workflows/spookydb-update.yaml
+++ b/.github/workflows/spookydb-update.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2024 Willem 'Jip' Wijnia
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: SpookyDB - update unit information
+
+on:
+  workflow_dispatch:
+  push:
+    # branches:
+    #   - deploy/faf
+
+jobs:
+  update:
+    uses: FAForever/spooky-db/.github/workflows/deploy.yaml@master

--- a/.github/workflows/spookydb-update.yaml
+++ b/.github/workflows/spookydb-update.yaml
@@ -31,6 +31,7 @@ jobs:
     uses: FAForever/spooky-db/.github/workflows/build.yaml@master
   deploy:
     name: Deploy the SpookyDB
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       # https://github.com/marketplace/actions/webfactory-ssh-agent

--- a/.github/workflows/spookydb-update.yaml
+++ b/.github/workflows/spookydb-update.yaml
@@ -30,3 +30,4 @@ jobs:
   update:
     uses: FAForever/spooky-db/.github/workflows/deploy.yaml@master
     
+    

--- a/.github/workflows/spookydb-update.yaml
+++ b/.github/workflows/spookydb-update.yaml
@@ -84,4 +84,3 @@ jobs:
             git commit -m 'Automated deployment of spooky db'
             git push origin HEAD:gh-pages
 
-

--- a/.github/workflows/unitdb-update.yaml
+++ b/.github/workflows/unitdb-update.yaml
@@ -23,14 +23,16 @@ name: UnitDB - update unit information
 on:
   workflow_dispatch:
   push:
-    # branches:
-    #   - deploy/faf
+    branches:
+      - deploy/faf
 
 jobs:
   deploy:
     name: Update the UnitDB
     runs-on: ubuntu-latest
     steps:
+        # When using two or more query parameters the URL needs to be enclosed in double quotes, see also:
+        # - https://stackoverflow.com/questions/59749561/how-to-pass-several-parameters-through-curl-in-get-request
       - name: Send request to server to update
         run: |
           curl -v -X GET "https://unitdb.faforever.com/update.php?token=${{secrets.UNITDB_UPGRADE_SECRET}}&version=deploy%2Ffaf"

--- a/.github/workflows/unitdb-update.yaml
+++ b/.github/workflows/unitdb-update.yaml
@@ -33,4 +33,4 @@ jobs:
     steps:
       - name: Send request to server to update
         run: |
-          curl -v -X GET https://unitdb.faforever.com/update.php?token=${{secrets.UNITDB_UPGRADE_SECRET}}
+          curl -v -X GET "https://unitdb.faforever.com/update.php?token=${{secrets.UNITDB_UPGRADE_SECRET}}&version=deploy%2Ffaf"

--- a/.github/workflows/unitdb-update.yaml
+++ b/.github/workflows/unitdb-update.yaml
@@ -33,4 +33,4 @@ jobs:
     steps:
       - name: Send request to server to update
         run: |
-          curl --fail-with-body -v -X GET https://unitdb.faforever.com/update.php?token=${{secrets.UNITDB_UPGRADE_SECRET}}&version=deploy/faf
+          curl -v -X GET https://unitdb.faforever.com/update.php?token=${{secrets.UNITDB_UPGRADE_SECRET}}

--- a/.github/workflows/unitdb-update.yaml
+++ b/.github/workflows/unitdb-update.yaml
@@ -33,4 +33,4 @@ jobs:
     steps:
       - name: Send request to server to update
         run: |
-          curl --fail-with-body -v -X POST https://unitdb.faforever.com/update.php?token=${{secrets.UNITDB_UPGRADE_SECRET}}&version=deploy/faf
+          curl --fail-with-body -v -X GET https://unitdb.faforever.com/update.php?token=${{secrets.UNITDB_UPGRADE_SECRET}}&version=deploy/faf

--- a/.github/workflows/unitdb-update.yaml
+++ b/.github/workflows/unitdb-update.yaml
@@ -33,5 +33,5 @@ jobs:
     steps:
       - name: Send post request to the server
         run: |
-            curl --fail-with-body -v -X POST https://unitdb.faforever.com/update.php?version=deploy/faf&token=${{secrets.UNITDB_UPGRADE_SECRET}}
+            curl --fail-with-body -v -X POST https://unitdb.faforever.com/update.php?version=deploy%2Ffaf&token=${{secrets.UNITDB_UPGRADE_SECRET}}
     

--- a/.github/workflows/unitdb-update.yaml
+++ b/.github/workflows/unitdb-update.yaml
@@ -33,5 +33,5 @@ jobs:
     steps:
       - name: Send post request to the server
         run: |
-            curl -X POST https://unitdb.faforever.com/update.php?version=deploy/faf&token=${{secrets.UNITDB_UPGRADE_SECRET}}
+            curl -X POST https://unitdb.faforever.com/update.php?version=deploy/faf&token=${{secrets.UNITDB_UPGRADE_SECRET}} --fail-early -v
     

--- a/.github/workflows/unitdb-update.yaml
+++ b/.github/workflows/unitdb-update.yaml
@@ -33,5 +33,5 @@ jobs:
     steps:
       - name: Send post request to the server
         run: |
-            curl -X POST https://unitdb.faforever.com/update.php?version=deploy/faf&token=${{secrets.UNITDB_UPGRADE_SECRET}} -f -v
+            curl --fail-with-body -v -X POST https://unitdb.faforever.com/update.php?version=deploy/faf&token=${{secrets.UNITDB_UPGRADE_SECRET}}
     

--- a/.github/workflows/unitdb-update.yaml
+++ b/.github/workflows/unitdb-update.yaml
@@ -33,4 +33,4 @@ jobs:
     steps:
       - name: Send request to server to update
         run: |
-          curl -v -X GET https://unitdb.faforever.com/update.php?token=${{secrets.UNITDB_UPGRADE_SECRET}}&version=deploy%2Ffaf
+          curl -v -X GET https://unitdb.faforever.com/update.php?token=${{secrets.UNITDB_UPGRADE_SECRET}}

--- a/.github/workflows/unitdb-update.yaml
+++ b/.github/workflows/unitdb-update.yaml
@@ -1,0 +1,37 @@
+# Copyright (c) 2024 Willem 'Jip' Wijnia
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: UnitDB - update unit information
+
+on:
+  workflow_dispatch:
+  push:
+    # branches:
+    #   - deploy/faf
+
+jobs:
+  deploy:
+    name: Update the UnitDB
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send post request to the server
+        run: |
+            curl -X POST https://unitdb.faforever.com/update.php?version=deploy/faf&token=${{secrets.UNITDB_UPGRADE_SECRET}}
+    

--- a/.github/workflows/unitdb-update.yaml
+++ b/.github/workflows/unitdb-update.yaml
@@ -33,5 +33,5 @@ jobs:
     steps:
       - name: Send post request to the server
         run: |
-            curl -X POST https://unitdb.faforever.com/update.php?version=deploy/faf&token=${{secrets.UNITDB_UPGRADE_SECRET}} --fail-early -v
+            curl -X POST https://unitdb.faforever.com/update.php?version=deploy/faf&token=${{secrets.UNITDB_UPGRADE_SECRET}} -f -v
     

--- a/.github/workflows/unitdb-update.yaml
+++ b/.github/workflows/unitdb-update.yaml
@@ -33,4 +33,4 @@ jobs:
     steps:
       - name: Send request to server to update
         run: |
-          curl -v -X GET https://unitdb.faforever.com/update.php?token=${{secrets.UNITDB_UPGRADE_SECRET}}
+          curl -v -X GET https://unitdb.faforever.com/update.php?token=${{secrets.UNITDB_UPGRADE_SECRET}}&version=deploy%2Ffaf

--- a/.github/workflows/unitdb-update.yaml
+++ b/.github/workflows/unitdb-update.yaml
@@ -31,7 +31,6 @@ jobs:
     name: Update the UnitDB
     runs-on: ubuntu-latest
     steps:
-      - name: Send post request to the server
+      - name: Send request to server to update
         run: |
-            curl --fail-with-body -v -X POST https://unitdb.faforever.com/update.php?version=deploy%2Ffaf&token=${{secrets.UNITDB_UPGRADE_SECRET}}
-    
+          curl --fail-with-body -v -X POST https://unitdb.faforever.com/update.php?token=${{secrets.UNITDB_UPGRADE_SECRET}}&version=deploy/faf

--- a/.github/workflows/unitdb-update.yaml
+++ b/.github/workflows/unitdb-update.yaml
@@ -31,6 +31,9 @@ jobs:
     name: Update the UnitDB
     runs-on: ubuntu-latest
     steps:
+        # All we need to do is send a request to the server to update the blueprint information. You can find the server code here:
+        # - https://github.com/FAForever/UnitDB/blob/master/www/update.php
+
         # When using two or more query parameters the URL needs to be enclosed in double quotes, see also:
         # - https://stackoverflow.com/questions/59749561/how-to-pass-several-parameters-through-curl-in-get-request
       - name: Send request to server to update

--- a/changelog/snippets/other.6223.md
+++ b/changelog/snippets/other.6223.md
@@ -1,0 +1,3 @@
+- (#6223) Create Github Action workflows to automatically update unit databases
+
+The SpookyDB and UnitDB unit viewers are now automatically updated as we push content to the `deploy/faf` branch, which represents the production branch.


### PR DESCRIPTION
## Description of the proposed changes

Adds two workflows to automatically update the unit viewers when content is pushed to `deploy/faf`

- [SpookyDB](https://faforever.github.io/spooky-db/#/)
- [UnitDB](https://unitdb.faforever.com/)

## Testing done on the proposed changes

Run the workflows and review the actions.

- Action that correctly updates SpookyDB: https://github.com/FAForever/fa/actions/runs/9331392303
- Action that correctly updates UnitDB: https://github.com/FAForever/fa/actions/runs/9331576973

## Additional context

With thanks to @Sheikah45, @relent0r and @MrRowey for their time and effort to related contributions and pair programming!

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
