### PR TITLE
Fix the Cybran ACU's teleport weapon being displayed under 'Basics' in uvd

### DIFF
--- a/changelog/snippets/fix.6224.md
+++ b/changelog/snippets/fix.6224.md
@@ -1,0 +1,1 @@
+- (#6224) Adds `EnabledByEnhancement = "Teleporter",` to the teleport weapon of the Cybran ACU, so it is displayed under 'Upgrades' and not 'Basics' when `Show Armament Detail in Build Menu` is enabled in the settings.

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -1090,6 +1090,7 @@ UnitBlueprint{
             DamageType = "Normal",
             DisplayName = "Teleport in",
             DummyWeapon = true,
+            EnabledByEnhancement = "Teleporter",
             Label = "TeleportWeapon",
             ManualFire = true,
             MaxRadius = 1,


### PR DESCRIPTION
## Description of the proposed changes

Adds `EnabledByEnhancement = "Teleporter",` to the teleport weapon of the Cybran ACU, so it is displayed under 'Upgrades' and not 'Basics' when `Show Armament Detail in Build Menu` is enabled in the settings.

This is already the case for the other ACUs.

## Checklist
- [x] Changes are documented in the changelog for the next game version
