### PR TITLE
Add a workflow to periodically update `deploy/fafdevelop`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+  workflow_call:
   workflow_dispatch:
   pull_request:
   push:

--- a/.github/workflows/update-fafdevelop.yaml
+++ b/.github/workflows/update-fafdevelop.yaml
@@ -1,0 +1,49 @@
+# Copyright (c) 2024 Willem 'Jip' Wijnia
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: FA - update development deployment branch
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 21 * * 2'
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+  update:
+    name: Update FAF Develop
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout/tree/v4/
+      - name: Checkout FA repository
+        uses: actions/checkout@v4
+        with:
+            repository: FAForever/fa
+            ref: develop
+
+      # Update the deploy/fafdevelop branch, we force push here because 
+      # we're not interested in fixing conflicts
+      - name: Update deploy/fafdevelop
+        run: |
+          git push origin HEAD:deploy/fafdevelop --force
+
+

--- a/.github/workflows/update-fafdevelop.yaml
+++ b/.github/workflows/update-fafdevelop.yaml
@@ -23,7 +23,7 @@ name: FA - update development deployment branch
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 21 * * 2'
+    - cron: '0 21 * * 4'
 
 jobs:
   test:


### PR DESCRIPTION
## Description of the proposed changes

This workflow will sync `deploy/fafdevelop` with whatever is on `develop` every Thursday at 21:00.

## Additional context

Part of switching back to using `develop` as our default branch.  This workflow reduces the burden on the game team to keep `deploy/fafdevelop` in sync.
