### PR TITLE
Enable the Czar's depth charges to function again

### DIFF
--- a/changelog/snippets/fix.6232.md
+++ b/changelog/snippets/fix.6232.md
@@ -1,0 +1,1 @@
+- (#6232) Fix the Czar's depth charges by enabling them to track their target again. They were simply dropping to the bottom of the ocean previously.

--- a/projectiles/AANDepthCharge01/AANDepthCharge01_script.lua
+++ b/projectiles/AANDepthCharge01/AANDepthCharge01_script.lua
@@ -51,6 +51,7 @@ AANDepthCharge01 = ClassProjectile(ADepthChargeProjectile) {
     ---@param self AANDepthCharge01
     OnEnterWater = function(self)
         ADepthChargeProjectileOnEnterWater(self)
+        self:TrackTarget(true)
         self:SetMaxSpeed(20)
         self:SetVelocity(0)
         self:SetAcceleration(5)


### PR DESCRIPTION
## Description of the bug
Instead of homing in on their target, the depth charges simply drop to the bottom of the ocean after they hit the water. This renders them practically useless.

## Description of the proposed changes
This PR enables the Czar's depth charges to track their target again. Once they have entered the water that is.

## Checklist
- [x] Changes are documented in the changelog for the next game version
