### PR TITLE
Fix reclaiming unbuilt units not giving back resources

### DIFF
--- a/changelog/snippets/fix.6234.md
+++ b/changelog/snippets/fix.6234.md
@@ -1,0 +1,1 @@
+- (#6234) Fix unbuilt units not giving back resources when reclaimed.

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -3950,8 +3950,9 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent) {
                 duration = 1
             end
 
-            -- for units the energy and mass fields are ignored but they do need to exist or the engine burps
-            return duration, 0, 0
+            -- duration determines both unbuilt and built unit reclaim speed
+            -- energy and mass fields needed for unbuilt units to give back resources when reclaimed
+            return duration, buildEnergyCosts, buildMassCosts
         end
 
         return 0, 0, 0


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes a [bug reported on discord](https://discord.com/channels/197033481883222026/1234260183719608392). Caused by 97cb6ecfab.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Partially building a unit and reclaiming it returns all the resources used.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
