### PR TITLE
Fix production queue tooltip in non-default layouts

### DIFF
--- a/changelog/snippets/fix.6243.md
+++ b/changelog/snippets/fix.6243.md
@@ -1,0 +1,1 @@
+- (#6243) Fix production queue tooltip in non-default layouts.

--- a/lua/ui/game/layouts/unitview_left.lua
+++ b/lua/ui/game/layouts/unitview_left.lua
@@ -34,6 +34,9 @@ function SetLayout()
     LayoutHelpers.AtLeftIn(controls.bg, controls.parent)
     LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
 
+    LayoutHelpers.Above(controls.queue, controls.bg, 10)
+    LayoutHelpers.AtLeftIn(controls.queue, controls.bg, 3)
+    
     controls.bracket:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_t.dds'))
     LayoutHelpers.AtLeftTopIn(controls.bracket, controls.bg, -6, 3)
 

--- a/lua/ui/game/layouts/unitview_left.lua
+++ b/lua/ui/game/layouts/unitview_left.lua
@@ -36,7 +36,7 @@ function SetLayout()
 
     LayoutHelpers.Above(controls.queue, controls.bg, 10)
     LayoutHelpers.AtLeftIn(controls.queue, controls.bg, 3)
-    controls.queue.SetThemeTextures()
+    controls.queue:SetThemeTextures()
     
     controls.bracket:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_t.dds'))
     LayoutHelpers.AtLeftTopIn(controls.bracket, controls.bg, -6, 3)

--- a/lua/ui/game/layouts/unitview_left.lua
+++ b/lua/ui/game/layouts/unitview_left.lua
@@ -36,6 +36,7 @@ function SetLayout()
 
     LayoutHelpers.Above(controls.queue, controls.bg, 10)
     LayoutHelpers.AtLeftIn(controls.queue, controls.bg, 3)
+    controls.queue.SetThemeTextures()
     
     controls.bracket:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_t.dds'))
     LayoutHelpers.AtLeftTopIn(controls.bracket, controls.bg, -6, 3)

--- a/lua/ui/game/layouts/unitview_mini.lua
+++ b/lua/ui/game/layouts/unitview_mini.lua
@@ -36,7 +36,7 @@ function SetLayout()
     
     LayoutHelpers.Above(controls.queue, controls.bg, 10)
     LayoutHelpers.AtLeftIn(controls.queue, controls.bg, 3)
-    controls.queue.SetThemeTextures()
+    controls.queue:SetThemeTextures()
 
     controls.bracket:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/bracket-unit_bmp.dds'))
     LayoutHelpers.AtLeftTopIn(controls.bracket, controls.bg, -18, -2)

--- a/lua/ui/game/layouts/unitview_mini.lua
+++ b/lua/ui/game/layouts/unitview_mini.lua
@@ -34,64 +34,8 @@ function SetLayout()
     LayoutHelpers.AtLeftIn(controls.bg, controls.parent)
     LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
     
-    controls.queue.bg:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/queue_back.dds'))
-    
-    LayoutHelpers.SetDimensions(controls.queue, 316, 48)
     LayoutHelpers.Above(controls.queue, controls.bg, 10)
     LayoutHelpers.AtLeftIn(controls.queue, controls.bg, 3)
-    
-    LayoutHelpers.FillParent(controls.queue.bg, controls.queue)
-    LayoutHelpers.FillParent(controls.queue.grid, controls.queue)
-
-    controls.queue:DisableHitTest()
-    controls.queue.grid:DisableHitTest()
-    controls.queue.bg:DisableHitTest()
-    
-	for id, item in controls.queue.grid.items do
-		if id > 1 then
-		   local before = controls.queue.grid.items[id-1]
-		   LayoutHelpers.RightOf(item, before, -6) 
-		else
-		   LayoutHelpers.AtLeftTopIn(item, controls.queue.grid, 2)
-		end
-        item:DisableHitTest()
-		item:SetTexture(UIUtil.UIFile('/game/avatar-factory-panel/avatar-s-e-f_bmp.dds'))
-        LayoutHelpers.DepthOverParent(item.icon, item)
-        LayoutHelpers.FillParentFixedBorder(item.icon, item, 8)
-        LayoutHelpers.DepthOverParent(item.text, item.icon)
-        LayoutHelpers.AtRightBottomIn(item.text, item, 4, 4)
-	end
-	
-    controls.queue.bg.leftBracket:SetTexture(UIUtil.UIFile('/game/filter-ping-panel/bracket-left_bmp.dds'))
-	
-    controls.queue.bg.leftGlowTop:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_t.dds'))
-    controls.queue.bg.leftGlowMiddle:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_m.dds'))
-    controls.queue.bg.leftGlowBottom:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_b.dds'))
-	
-    controls.queue.bg.rightGlowTop:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_t.dds'))
-    controls.queue.bg.rightGlowMiddle:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_m.dds'))
-    controls.queue.bg.rightGlowBottom:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_b.dds'))
-	
-	LayoutHelpers.AtTopIn(controls.queue.bg.leftBracket, controls.queue.bg, -4)
-    LayoutHelpers.AnchorToLeft(controls.queue.bg.leftBracket, controls.queue.bg, -6)
-	LayoutHelpers.SetHeight(controls.queue.bg.leftBracket, 54)
-	controls.queue.bg.leftBracket.Depth:Set(function() return controls.queue.bg.Depth() + 10 end)
-	
-	LayoutHelpers.AtTopIn(controls.queue.bg.leftGlowTop, controls.queue.bg, -4)
-    LayoutHelpers.AnchorToLeft(controls.queue.bg.leftGlowTop, controls.queue.bg, -10)
-    LayoutHelpers.AtBottomIn(controls.queue.bg.leftGlowBottom, controls.queue.bg, -4)
-    controls.queue.bg.leftGlowBottom.Left:Set(controls.queue.bg.leftGlowTop.Left)
-    controls.queue.bg.leftGlowMiddle.Top:Set(controls.queue.bg.leftGlowTop.Bottom)
-    controls.queue.bg.leftGlowMiddle.Bottom:Set(function() return math.max(controls.queue.bg.leftGlowTop.Bottom(), controls.queue.bg.leftGlowBottom.Top()) end)
-    controls.queue.bg.leftGlowMiddle.Left:Set(function() return controls.queue.bg.leftGlowTop.Left() end)
-	
-    LayoutHelpers.AtTopIn(controls.queue.bg.rightGlowTop, controls.queue.bg, -4)
-    LayoutHelpers.AnchorToRight(controls.queue.bg.rightGlowTop, controls.queue.bg, -8)
-    LayoutHelpers.AtBottomIn(controls.queue.bg.rightGlowBottom, controls.queue.bg, -4)
-    controls.queue.bg.rightGlowBottom.Left:Set(controls.queue.bg.rightGlowTop.Left)
-    controls.queue.bg.rightGlowMiddle.Top:Set(controls.queue.bg.rightGlowTop.Bottom)
-    controls.queue.bg.rightGlowMiddle.Bottom:Set(function() return math.max(controls.queue.bg.rightGlowTop.Bottom(), controls.queue.bg.rightGlowBottom.Top()) end)
-    controls.queue.bg.rightGlowMiddle.Right:Set(function() return controls.queue.bg.rightGlowTop.Right() end)
 
     controls.bracket:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/bracket-unit_bmp.dds'))
     LayoutHelpers.AtLeftTopIn(controls.bracket, controls.bg, -18, -2)

--- a/lua/ui/game/layouts/unitview_mini.lua
+++ b/lua/ui/game/layouts/unitview_mini.lua
@@ -36,6 +36,7 @@ function SetLayout()
     
     LayoutHelpers.Above(controls.queue, controls.bg, 10)
     LayoutHelpers.AtLeftIn(controls.queue, controls.bg, 3)
+    controls.queue.SetThemeTextures()
 
     controls.bracket:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/bracket-unit_bmp.dds'))
     LayoutHelpers.AtLeftTopIn(controls.bracket, controls.bg, -18, -2)

--- a/lua/ui/game/layouts/unitview_right.lua
+++ b/lua/ui/game/layouts/unitview_right.lua
@@ -33,6 +33,9 @@ function SetLayout()
     LayoutHelpers.AtLeftIn(controls.bg, controls.parent)
     LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
 
+    LayoutHelpers.Above(controls.queue, controls.bg, 10)
+    LayoutHelpers.AtLeftIn(controls.queue, controls.bg, 3)
+    
     controls.bracket:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/bracket-unit_bmp.dds'))
     LayoutHelpers.AtLeftTopIn(controls.bracket, controls.bg, -19, -2)
 

--- a/lua/ui/game/layouts/unitview_right.lua
+++ b/lua/ui/game/layouts/unitview_right.lua
@@ -35,7 +35,7 @@ function SetLayout()
 
     LayoutHelpers.Above(controls.queue, controls.bg, 10)
     LayoutHelpers.AtLeftIn(controls.queue, controls.bg, 3)
-    controls.queue.SetThemeTextures()
+    controls.queue:SetThemeTextures()
     
     controls.bracket:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/bracket-unit_bmp.dds'))
     LayoutHelpers.AtLeftTopIn(controls.bracket, controls.bg, -19, -2)

--- a/lua/ui/game/layouts/unitview_right.lua
+++ b/lua/ui/game/layouts/unitview_right.lua
@@ -35,6 +35,7 @@ function SetLayout()
 
     LayoutHelpers.Above(controls.queue, controls.bg, 10)
     LayoutHelpers.AtLeftIn(controls.queue, controls.bg, 3)
+    controls.queue.SetThemeTextures()
     
     controls.bracket:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/bracket-unit_bmp.dds'))
     LayoutHelpers.AtLeftTopIn(controls.bracket, controls.bg, -19, -2)

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -273,7 +273,6 @@ function CreateQueueGrid(parent)
         controls.queue.grid.items[id] = CreateGridUnitIcon(controls.queue.grid)
     end
 
-    controls.queue.bg:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/queue_back.dds'))
     LayoutHelpers.SetDimensions(controls.queue, 316, 48)
     LayoutHelpers.FillParent(controls.queue.bg, controls.queue)
     LayoutHelpers.FillParent(controls.queue.grid, controls.queue)
@@ -290,22 +289,11 @@ function CreateQueueGrid(parent)
            LayoutHelpers.AtLeftTopIn(item, controls.queue.grid, 2)
         end
         item:DisableHitTest()
-        item:SetTexture(UIUtil.UIFile('/game/avatar-factory-panel/avatar-s-e-f_bmp.dds'))
         LayoutHelpers.DepthOverParent(item.icon, item)
         LayoutHelpers.FillParentFixedBorder(item.icon, item, 8)
         LayoutHelpers.DepthOverParent(item.text, item.icon)
         LayoutHelpers.AtRightBottomIn(item.text, item, 4, 4)
     end
-    
-    controls.queue.bg.leftBracket:SetTexture(UIUtil.UIFile('/game/filter-ping-panel/bracket-left_bmp.dds'))
-    
-    controls.queue.bg.leftGlowTop:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_t.dds'))
-    controls.queue.bg.leftGlowMiddle:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_m.dds'))
-    controls.queue.bg.leftGlowBottom:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_b.dds'))
-    
-    controls.queue.bg.rightGlowTop:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_t.dds'))
-    controls.queue.bg.rightGlowMiddle:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_m.dds'))
-    controls.queue.bg.rightGlowBottom:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_b.dds'))
     
     LayoutHelpers.AtTopIn(controls.queue.bg.leftBracket, controls.queue.bg, -4)
     LayoutHelpers.AnchorToLeft(controls.queue.bg.leftBracket, controls.queue.bg, -6)
@@ -328,6 +316,22 @@ function CreateQueueGrid(parent)
     controls.queue.bg.rightGlowMiddle.Bottom:Set(function() return math.max(controls.queue.bg.rightGlowTop.Bottom(), controls.queue.bg.rightGlowBottom.Top()) end)
     controls.queue.bg.rightGlowMiddle.Right:Set(function() return controls.queue.bg.rightGlowTop.Right() end)
 
+    controls.queue.SetThemeTextures = function()
+        controls.queue.bg:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/queue_back.dds'))
+        controls.queue.bg.leftBracket:SetTexture(UIUtil.UIFile('/game/filter-ping-panel/bracket-left_bmp.dds'))
+
+        for id, item in controls.queue.grid.items do
+            item:SetTexture(UIUtil.UIFile('/game/avatar-factory-panel/avatar-s-e-f_bmp.dds'))
+        end
+    
+        controls.queue.bg.leftGlowTop:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_t.dds'))
+        controls.queue.bg.leftGlowMiddle:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_m.dds'))
+        controls.queue.bg.leftGlowBottom:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_b.dds'))
+        
+        controls.queue.bg.rightGlowTop:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_t.dds'))
+        controls.queue.bg.rightGlowMiddle:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_m.dds'))
+        controls.queue.bg.rightGlowBottom:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_b.dds'))
+    end
 
     controls.queue.grid.UpdateQueue = function(self, queue)
         if not queue then

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -273,6 +273,62 @@ function CreateQueueGrid(parent)
         controls.queue.grid.items[id] = CreateGridUnitIcon(controls.queue.grid)
     end
 
+    controls.queue.bg:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/queue_back.dds'))
+    LayoutHelpers.SetDimensions(controls.queue, 316, 48)
+    LayoutHelpers.FillParent(controls.queue.bg, controls.queue)
+    LayoutHelpers.FillParent(controls.queue.grid, controls.queue)
+
+    controls.queue:DisableHitTest()
+    controls.queue.grid:DisableHitTest()
+    controls.queue.bg:DisableHitTest()
+    
+    for id, item in controls.queue.grid.items do
+        if id > 1 then
+           local before = controls.queue.grid.items[id-1]
+           LayoutHelpers.RightOf(item, before, -6) 
+        else
+           LayoutHelpers.AtLeftTopIn(item, controls.queue.grid, 2)
+        end
+        item:DisableHitTest()
+        item:SetTexture(UIUtil.UIFile('/game/avatar-factory-panel/avatar-s-e-f_bmp.dds'))
+        LayoutHelpers.DepthOverParent(item.icon, item)
+        LayoutHelpers.FillParentFixedBorder(item.icon, item, 8)
+        LayoutHelpers.DepthOverParent(item.text, item.icon)
+        LayoutHelpers.AtRightBottomIn(item.text, item, 4, 4)
+    end
+    
+    controls.queue.bg.leftBracket:SetTexture(UIUtil.UIFile('/game/filter-ping-panel/bracket-left_bmp.dds'))
+    
+    controls.queue.bg.leftGlowTop:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_t.dds'))
+    controls.queue.bg.leftGlowMiddle:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_m.dds'))
+    controls.queue.bg.leftGlowBottom:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_b.dds'))
+    
+    controls.queue.bg.rightGlowTop:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_t.dds'))
+    controls.queue.bg.rightGlowMiddle:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_m.dds'))
+    controls.queue.bg.rightGlowBottom:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_b.dds'))
+    
+    LayoutHelpers.AtTopIn(controls.queue.bg.leftBracket, controls.queue.bg, -4)
+    LayoutHelpers.AnchorToLeft(controls.queue.bg.leftBracket, controls.queue.bg, -6)
+    LayoutHelpers.SetHeight(controls.queue.bg.leftBracket, 54)
+    controls.queue.bg.leftBracket.Depth:Set(function() return controls.queue.bg.Depth() + 10 end)
+    
+    LayoutHelpers.AtTopIn(controls.queue.bg.leftGlowTop, controls.queue.bg, -4)
+    LayoutHelpers.AnchorToLeft(controls.queue.bg.leftGlowTop, controls.queue.bg, -10)
+    LayoutHelpers.AtBottomIn(controls.queue.bg.leftGlowBottom, controls.queue.bg, -4)
+    controls.queue.bg.leftGlowBottom.Left:Set(controls.queue.bg.leftGlowTop.Left)
+    controls.queue.bg.leftGlowMiddle.Top:Set(controls.queue.bg.leftGlowTop.Bottom)
+    controls.queue.bg.leftGlowMiddle.Bottom:Set(function() return math.max(controls.queue.bg.leftGlowTop.Bottom(), controls.queue.bg.leftGlowBottom.Top()) end)
+    controls.queue.bg.leftGlowMiddle.Left:Set(function() return controls.queue.bg.leftGlowTop.Left() end)
+    
+    LayoutHelpers.AtTopIn(controls.queue.bg.rightGlowTop, controls.queue.bg, -4)
+    LayoutHelpers.AnchorToRight(controls.queue.bg.rightGlowTop, controls.queue.bg, -8)
+    LayoutHelpers.AtBottomIn(controls.queue.bg.rightGlowBottom, controls.queue.bg, -4)
+    controls.queue.bg.rightGlowBottom.Left:Set(controls.queue.bg.rightGlowTop.Left)
+    controls.queue.bg.rightGlowMiddle.Top:Set(controls.queue.bg.rightGlowTop.Bottom)
+    controls.queue.bg.rightGlowMiddle.Bottom:Set(function() return math.max(controls.queue.bg.rightGlowTop.Bottom(), controls.queue.bg.rightGlowBottom.Top()) end)
+    controls.queue.bg.rightGlowMiddle.Right:Set(function() return controls.queue.bg.rightGlowTop.Right() end)
+
+
     controls.queue.grid.UpdateQueue = function(self, queue)
         if not queue then
             controls.queue:Hide()

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -316,21 +316,23 @@ function CreateQueueGrid(parent)
     controls.queue.bg.rightGlowMiddle.Bottom:Set(function() return math.max(controls.queue.bg.rightGlowTop.Bottom(), controls.queue.bg.rightGlowBottom.Top()) end)
     controls.queue.bg.rightGlowMiddle.Right:Set(function() return controls.queue.bg.rightGlowTop.Right() end)
 
-    controls.queue.SetThemeTextures = function()
-        controls.queue.bg:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/queue_back.dds'))
-        controls.queue.bg.leftBracket:SetTexture(UIUtil.UIFile('/game/filter-ping-panel/bracket-left_bmp.dds'))
+    --- Set textures according to the current theme
+    --- @param - self queue control
+    controls.queue.SetThemeTextures = function(self)
+        self.bg:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/queue_back.dds'))
+        self.bg.leftBracket:SetTexture(UIUtil.UIFile('/game/filter-ping-panel/bracket-left_bmp.dds'))
 
-        for id, item in controls.queue.grid.items do
+        for id, item in self.grid.items do
             item:SetTexture(UIUtil.UIFile('/game/avatar-factory-panel/avatar-s-e-f_bmp.dds'))
         end
     
-        controls.queue.bg.leftGlowTop:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_t.dds'))
-        controls.queue.bg.leftGlowMiddle:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_m.dds'))
-        controls.queue.bg.leftGlowBottom:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_b.dds'))
+        self.bg.leftGlowTop:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_t.dds'))
+        self.bg.leftGlowMiddle:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_m.dds'))
+        self.bg.leftGlowBottom:SetTexture(UIUtil.UIFile('/game/bracket-left-energy/bracket_bmp_b.dds'))
         
-        controls.queue.bg.rightGlowTop:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_t.dds'))
-        controls.queue.bg.rightGlowMiddle:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_m.dds'))
-        controls.queue.bg.rightGlowBottom:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_b.dds'))
+        self.bg.rightGlowTop:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_t.dds'))
+        self.bg.rightGlowMiddle:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_m.dds'))
+        self.bg.rightGlowBottom:SetTexture(UIUtil.UIFile('/game/bracket-right-energy/bracket_bmp_b.dds'))
     end
 
     controls.queue.grid.UpdateQueue = function(self, queue)


### PR DESCRIPTION
## Description of the proposed changes
![image](https://github.com/FAForever/fa/assets/5189292/c4e0bd39-c845-4e08-834d-8625e7eaf315)

The top part of the tooltip is the queue. It can be enabled in Options->Interface->Additional Information->Show Factory Queue on Hover.

The issue is that the _left and _right layouts are missing the layouting logic for the queue.

Fix:
 * Moved code that handles internal layout/graphics of unit tooltip queue from unitview_mini.lua SetLayout() to unitview.lua CreateQueueGrid(). This leaves only the two LayoutHelper calls that "dock" the queue display to the unit tooltip itself. Even though this docking should be the same for all layouts it makes sense to duplicate them in all SetLayout() implementations from the readability standpoint.
 * Moved the code that assigns themed textures to controls.queue.SetThemeTextures(). Added a call to SetThemeTextures()
 * Duplicated the logic that docks unit tooltip queue and sets theme textures to the _left and _right layouts.

<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->


## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->

Verified the queue tooltip behaves correctly for an observer even when the layout is cycled
For each layout
 * Selected the layout
 * Restarted the game
 * Started a replay
 * Verified no lazyvar errors appear in logs

Verified the queue tooltip behaves correctly for a player
 * Set the queue tooltip in the options to "Always"
 * Cycled through layouts and everything looked good
 * Cycled through themes and found no issues except that on the _right layout if the theme is cycled after selecting a unit (regardless of whether it remains selected) in the current theme, there are lazyvar errors (see the snippet below) and it partially fails (some parts of the ui update the theme, some don't). This issue is present without the changes and it looks much worse in the log without the changes. If the theme is cycled without ever selecting a unit in the current theme, it works correctly and no lazyvar errors show up.

```
INFO: attempting to set skin to: 	aeon
WARNING: Error running console command UI_RotateSkin +: e:\workshop\coding\faf\lua\lazyvar.lua(207): attempt to call method `OnDirty' (a nil value)
         stack traceback:
         	e:\workshop\coding\faf\lua\lazyvar.lua(207): in function `SetValue'
         	e:\workshop\coding\faf\lua\lazyvar.lua(225): in function `Set'
         	e:\workshop\coding\faf\lua\ui\uiutil.lua(287): in function `SetCurrentSkin'
         	e:\workshop\coding\faf\lua\ui\uiutil.lua(385): in function <e:\workshop\coding\faf\lua\ui\uiutil.lua:350>
```

## Additional context
<!-- Add any other context about the pull request here. -->


## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
