### PR TITLE
Improve details of warnings when map files are missing

### DIFF
--- a/changelog/snippets/fix.6245.md
+++ b/changelog/snippets/fix.6245.md
@@ -1,0 +1,1 @@
+- (#6245) Improve details of warnings when a map's scenario file specifies invalid map/save/script files.

--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -415,19 +415,32 @@ function PreloadMap(row)
     local scen = scenarios[scenarioKeymap[row+1]]
 
     selectedScenario = scen
+
+    advOptions = scen.options
+    MapUtil.ValidateScenarioOptions(advOptions)
+    RefreshOptions(false)
+    SetDescription(scen)
+
     local mapfile = scen.map
-    if DiskGetFileInfo(mapfile) then
-        advOptions = scen.options
-        MapUtil.ValidateScenarioOptions(advOptions)
-        RefreshOptions(false)
+    if not DiskGetFileInfo(mapfile) then
+        WARN(string.format('Scenario file "%s" expected map file "%s" but it could not be found.', scen.file, mapfile))
+        description:AddItem('WARNING: Map file is missing!')
+        selectButton:Disable()
+    end
+
+    local saveFile = scen.save
+    if DiskGetFileInfo(saveFile) then
         preview:SetScenario(scen)
-        SetDescription(scen)
     else
-        WARN("No scenario map file defined")
-        description:DeleteAllItems()
-        description:AddItem(LOC("<LOC MAPSEL_0000>No description available."))
-        mapplayers:SetText(LOCF("<LOC map_select_0002>NO START SPOTS DEFINED"))
-        mapsize:SetText(LOCF("<LOC map_select_0003>NO MAP SIZE INFORMATION"))
+        WARN(string.format('Scenario file "%s" expected save file "%s" but it could not be found.', scen.file, saveFile))
+        description:AddItem('WARNING: Save file is missing!')
+        selectButton:Disable()
+    end
+
+    local scriptFile = scen.script
+    if not DiskGetFileInfo(scriptFile) then
+        WARN(string.format('Scenario file "%s" expected script file "%s" but it could not be found.', scen.file, scriptFile))
+        description:AddItem('WARNING: Script file is missing!')
         selectButton:Disable()
     end
 end

--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -23,15 +23,10 @@ local scenarios = nil
 local selectedScenario = nil
 local isSinglePlayer = nil
 local description = nil
-local descText = nil
-local posGroup = nil
 local mapList = nil
 local filters = {}
 local filterTitle = nil
 local mapListTitle = nil
-local mapsize = nil
-local mapplayers = nil
-local mapInfo = nil
 local preview = nil
 local selectButton = nil
 

--- a/lua/ui/dialogs/mapselect.lua
+++ b/lua/ui/dialogs/mapselect.lua
@@ -406,7 +406,9 @@ function LoadScenarios(force)
     return scenarios
 end
 
+---@param row number
 function PreloadMap(row)
+    -- ScenarioInfo in the _Scenario file
     local scen = scenarios[scenarioKeymap[row+1]]
 
     selectedScenario = scen
@@ -424,6 +426,7 @@ function PreloadMap(row)
     end
 
     local saveFile = scen.save
+    -- preview requires save file for marker data
     if DiskGetFileInfo(saveFile) then
         preview:SetScenario(scen)
     else


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Makes the warning that you get when a map's scenario file has incorrect map/save/script files defined more clear.
Also fixes the error when that part of the code runs and tries to call non-existent methods with `mapplayers` and `mappsize`, which aren't used anywhere in the file.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Message before:
```
warning: No scenario map file defined
warning: Error running OnRelease script in <deleted object>: ...\fa\lua\ui\dialogs\mapselect.lua(429): attempt to call method `SetText' (a nil value)
         stack traceback:
         	...\fa\lua\ui\dialogs\mapselect.lua(429): in function `PreloadMap'
         	...\fa\lua\ui\dialogs\mapselect.lua(438): in function `OnClick'
         	...\fa\lua\ui\dialogs\mapselect.lua(491): in function `OnClick'
         	...\fa\lua\maui\button.lua(118): in function <...\fa\lua\maui\button.lua:112>
```
New message:
```
warning: Scenario file "/maps/adaptive_project_albus.v0001/project_albus_scenario.lua" expected map file "/maps/Project_Albus.v0002/Project_Albus.scmap" but it could not be found.
warning: Scenario file "/maps/adaptive_project_albus.v0001/project_albus_scenario.lua" expected save file "/maps/Project_Albus.v0002/Project_Albus_save.lua" but it could not be found.
warning: Scenario file "/maps/adaptive_project_albus.v0001/project_albus_scenario.lua" expected script file "/maps/Project_Albus.v0002/Project_Albus_script.lua" but it could not be found.
```

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
