### PR TITLE
Fix issues with fire rate test related to rounding tie-breaking towards evens

### DIFF
--- a/changelog/snippets/balance.6252.md
+++ b/changelog/snippets/balance.6252.md
@@ -1,0 +1,2 @@
+- (#6252) A bug fix reverts 1.2 -> 1.3 second reload time changes for the following unit weapons:
+	- Megalith proton cannons, CZAR AA missiles, Pillar cannons, and Cybran cruiser AA

--- a/changelog/snippets/balance.6252.md
+++ b/changelog/snippets/balance.6252.md
@@ -1,2 +1,2 @@
-- (#6252) A bug fix reverts 1.2 -> 1.3 second reload time changes for the following unit weapons:
+- (#6252) A bug fix reverts a 1.2 -> 1.3 second reload time increase for the following unit weapons:
 	- Megalith proton cannons, CZAR AA missiles, Pillar cannons, and Cybran cruiser AA

--- a/changelog/snippets/fix.6252.md
+++ b/changelog/snippets/fix.6252.md
@@ -1,0 +1,3 @@
+- (#6252) Fix the blueprint fire rate test not accounting for rounding tie-breaking towards even numbers, which gave incorrect suggestions for these numbers:
+	- 4.0 fire rate: suggested 3.333, correct suggestion 5.0
+	- 0.8 fire rate: suggested 0.769, correct suggestion 0.833

--- a/tests/blueprint/unit.spec.lua
+++ b/tests/blueprint/unit.spec.lua
@@ -69,7 +69,8 @@ local function rateOfFireTest(rateOfFire)
 
         if rateOfFire > 6.6666 then
             luft.expect(rateOfFire).to.be.close.to(10)
-        elseif rateOfFire > 4.0 then
+        -- the game's rounding tie-breaks towards even numbers
+        elseif rateOfFire >= 4.0 then
             luft.expect(rateOfFire).to.be.close.to(5)
         elseif rateOfFire > 2.8571 then
             luft.expect(rateOfFire).to.be.close.to(3.333)
@@ -89,7 +90,8 @@ local function rateOfFireTest(rateOfFire)
             luft.expect(rateOfFire).to.be.close.to(1.0)
         elseif rateOfFire > 0.8696 then
             luft.expect(rateOfFire).to.be.close.to(0.909)
-        elseif rateOfFire > 0.8 then
+        -- the game's rounding tie-breaks towards even numbers
+        elseif rateOfFire >= 0.8 then
             luft.expect(rateOfFire).to.be.close.to(0.833)
         elseif rateOfFire > 0.7407 then
             luft.expect(rateOfFire).to.be.close.to(0.769)

--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -325,7 +325,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_AntiAir",
-            RateOfFire = 0.769,
+            RateOfFire = 0.833,
             TargetPriorities = {
                 "(AIR * MOBILE - INTELLIGENCE)",
                 "ALLUNITS",
@@ -383,7 +383,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_AntiAir",
-            RateOfFire = 0.769,
+            RateOfFire = 0.833,
             TargetPriorities = {
                 "(AIR * MOBILE - INTELLIGENCE)",
                 "ALLUNITS",
@@ -441,7 +441,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_AntiAir",
-            RateOfFire = 0.769,
+            RateOfFire = 0.833,
             TargetPriorities = {
                 "(AIR * MOBILE - INTELLIGENCE)",
                 "ALLUNITS",
@@ -499,7 +499,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_AntiAir",
-            RateOfFire = 0.769,
+            RateOfFire = 0.833,
             TargetPriorities = {
                 "(AIR * MOBILE - INTELLIGENCE)",
                 "ALLUNITS",

--- a/units/UEB2204/UEB2204_unit.bp
+++ b/units/UEB2204/UEB2204_unit.bp
@@ -195,7 +195,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_AntiAir",
-            RateOfFire = 1.255,
+            RateOfFire = 1.25,
             SalvoSize = 2,
             TargetCheckInterval = 1.0,
             TargetPriorities = {

--- a/units/UEL0202/UEL0202_unit.bp
+++ b/units/UEL0202/UEL0202_unit.bp
@@ -192,7 +192,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = true,
             RangeCategory = "UWRC_DirectFire",
-            RateOfFire = 0.769,
+            RateOfFire = 0.833,
             TargetPriorities = {
                 "MOBILE",
                 "(STRUCTURE * DEFENSE - ANTIMISSILE)",

--- a/units/URS0202/URS0202_unit.bp
+++ b/units/URS0202/URS0202_unit.bp
@@ -325,7 +325,7 @@ UnitBlueprint {
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_AntiAir",
-            RateOfFire = 0.769,
+            RateOfFire = 0.833,
             TargetCheckInterval = 1.0,
             TargetPriorities = {
                 "AIR MOBILE TECH3 BOMBER",

--- a/units/XAA0305/XAA0305_unit.bp
+++ b/units/XAA0305/XAA0305_unit.bp
@@ -242,7 +242,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
-            RateOfFire = 1.255,
+            RateOfFire = 1.25,
             TargetPriorities = {
                 "ANTIAIR",
                 "GROUNDATTACK",

--- a/units/XRL0403/XRL0403_unit.bp
+++ b/units/XRL0403/XRL0403_unit.bp
@@ -311,7 +311,7 @@ UnitBlueprint {
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
-            RateOfFire = 0.769,
+            RateOfFire = 0.833,
             SlavedToBody = true,
             SlavedToBodyArcRange = 50,
             TargetPriorities = {
@@ -385,7 +385,7 @@ UnitBlueprint {
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
-            RateOfFire = 0.769,
+            RateOfFire = 0.833,
             SlavedToBody = true,
             SlavedToBodyArcRange = 50,
             TargetPriorities = {

--- a/units/XSA0203/XSA0203_unit.bp
+++ b/units/XSA0203/XSA0203_unit.bp
@@ -223,7 +223,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
-            RateOfFire = 1.255,
+            RateOfFire = 1.25,
             TargetPriorities = {
                 "ANTIAIR",
                 "GROUNDATTACK",
@@ -286,7 +286,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
-            RateOfFire = 1.255,
+            RateOfFire = 1.25,
             TargetPriorities = {
                 "ANTIAIR",
                 "GROUNDATTACK",


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes the fire rate test to account for banker's rounding (tie break towards even numbers), and corrects erroneous fire rate changes from #5845.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Set my ACU's fire rate to 4/0.8 and added a log statement when the projectile is created to make sure it fires every 2/12 ticks.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
