### PR TITLE
Fix Billy dealing wrong outer ring damage

### DIFF
--- a/changelog/snippets/fix.6256.md
+++ b/changelog/snippets/fix.6256.md
@@ -1,0 +1,1 @@
+- (#6256) Fix billy nuke dealing 25 outer damage instead of 250.

--- a/projectiles/TIFMissileNukeCDR/TIFMissileNukeCDR_Script.lua
+++ b/projectiles/TIFMissileNukeCDR/TIFMissileNukeCDR_Script.lua
@@ -155,7 +155,7 @@ TIFMissileNukeCDR = ClassProjectile(TIFTacticalNuke) {
         local InnerRing = self.InnerRing
         local OuterRing = self.OuterRing
         DamageArea(instigator, cachedPosition, InnerRing.Radius, InnerRing.Damage, 'Normal', true, true)
-        DamageArea(instigator, cachedPosition, OuterRing.Radius, OuterRing.Radius, 'Normal', true, true)
+        DamageArea(instigator, cachedPosition, OuterRing.Radius, OuterRing.Damage, 'Normal', true, true)
     end,
 }
 TypeClass = TIFMissileNukeCDR


### PR DESCRIPTION
## Description of Changes
Fixes a typo that made Billy nuke deal 25 damage on the outer radius instead of 250.

## Testing Done on the proposed changes
Units on the outer range take 250 damage.

- [x] Changes are in the changelog for the next game version