### PR TITLE
Make shields absorb full overcharge damage

### DIFF
--- a/changelog/snippets/fix.6258.md
+++ b/changelog/snippets/fix.6258.md
@@ -1,0 +1,1 @@
+- (#6258) Fix overcharge hitting units standing at the edge of a shield.

--- a/lua/ShieldAbsorptionValues.lua
+++ b/lua/ShieldAbsorptionValues.lua
@@ -28,6 +28,7 @@
 ---@type table<AbsorptionType, table<DamageType, number>>
 shieldAbsorptionValues = {
 	["Default"] = {
-		["Deathnuke"] = 1.0
+		["Deathnuke"] = 1.0,
+		["Overcharge"] = 1.0,
 	},
 }

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -510,13 +510,13 @@ Shield = ClassShield(moho.shield_methods, Entity) {
         local tick = GetGameTick()
 
         -- damage correction for overcharge
-        -- These preset damages deal `2 * dmg * absorbMult or armorMult`, currently absorption multiplier is 1x so nothing needs to be done
+        -- These preset damages deal `2 * dmg * absorbMult or armorMult`, currently absorption multiplier is 1x so we need to divide by 2
         if dmgType == 'Overcharge' then
             local wep = instigator:GetWeaponByLabel('OverCharge')
             if self.StaticShield then -- fixed damage for static shields
-                amount = wep:GetBlueprint().Overcharge.structureDamage
+                amount = wep:GetBlueprint().Overcharge.structureDamage / 2
             elseif self.CommandShield then -- fixed damage for UEF bubble shield
-                amount = wep:GetBlueprint().Overcharge.commandDamage
+                amount = wep:GetBlueprint().Overcharge.commandDamage / 2
             end
         end
 

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -454,6 +454,9 @@ Shield = ClassShield(moho.shield_methods, Entity) {
     ---@param type DamageType
     ---@return number damageAbsorbed If not all damage is absorbed, the remainder passes to targets under the shield.
     OnGetDamageAbsorption = function(self, instigator, amount, type)
+        if type == "TreeForce" or type == "TreeFire" then
+            return
+        end
         -- Allow decoupling the shield from the owner's armor multiplier
         local absorptionMulti = self.AbsorptionTypeDamageTypeToMulti[type] or self.Owner:GetArmorMult(type)
 

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -507,13 +507,12 @@ Shield = ClassShield(moho.shield_methods, Entity) {
         local tick = GetGameTick()
 
         -- damage correction for overcharge
-
+        -- These preset damages deal `2 * dmg * absorbMult or armorMult`, currently absorption multiplier is 1x so nothing needs to be done
         if dmgType == 'Overcharge' then
             local wep = instigator:GetWeaponByLabel('OverCharge')
             if self.StaticShield then -- fixed damage for static shields
-                amount = wep:GetBlueprint().Overcharge.structureDamage * 2
-                -- Static shields absorbing 50% OC damage somehow, I don't want to change anything anywhere so just *2.
-            elseif self.CommandShield then --fixed damage for all ACU shields
+                amount = wep:GetBlueprint().Overcharge.structureDamage
+            elseif self.CommandShield then -- fixed damage for UEF bubble shield
                 amount = wep:GetBlueprint().Overcharge.commandDamage
             end
         end


### PR DESCRIPTION
## Description of the proposed changes:
Sets shield absorption of overcharge damage type to 1.0 by default. So that units do not take damage from OC when standing at the edge of a shield.

## Testing done on the proposed changes:
Shoot a UEF bubble shield or any static shield and they take 400/800 damage without letting through any damage to nearby units underneath.

## Additional Context
Cherry picked from #6257, further details on the armor multiplier comment there.

## Checklist
- [x] Changes are annotated
- [x] Changes are in the changelog for the next version