### PR TITLE
Add additional deployment workflows and documentation

### DIFF
--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -10,4 +10,17 @@ All three branches originate from the `develop` branch, which is the default bra
 
 ## Automated deployments
 
-As of [#6225](https://github.com/FAForever/fa/pull/6225) the branch `deploy/fafdevelop` is updated on a weekly basis by pushing `develop` to it. 
+There are three workflows to help with deployment:
+
+- [FAF game type](./workflows/deploy-faf.yaml)
+- [FAF Beta Balance game type](./workflows/deploy-faf.yaml)
+- [FAF Develop game type](./workflows/deploy-faf.yaml)
+
+The workflows for Beta Balance and Develop trigger periodically. You can review when by evaluating the [cron expression](https://crontab.cronhub.io/). The [API of FAForever](https://github.com/FAForever/faf-java-api/blob/develop/src/main/java/com/faforever/api/deployment/GitHubDeploymentService.java) registers the push to a deployment branch via a webhook. The server creates (and updates) a [deployment status](https://github.com/FAForever/fa/deployments). During that process the server retrieves the game related files, processes it and when everything is fine the new game version will be available in roughly 5 to 10 minutes.
+
+## Related deployments
+
+A push to `deploy/faf` will also trigger secondary deployments:
+
+- [Spooky DB](./workflows/spookydb-update.yaml)
+- [Unit DB](./workflows//unitdb-update.yaml)

--- a/.github/workflows/deploy-faf.yaml
+++ b/.github/workflows/deploy-faf.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) 2024 Willem 'Jip' Wijnia
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: Deploy to FAF
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+  update:
+    name: Update FAF Develop
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout/tree/v4/
+      - name: Checkout FA repository
+        uses: actions/checkout@v4
+        with:
+            repository: FAForever/fa
+            ref: develop
+
+      # Update the deploy/faf branch, we force push here because 
+      # we're not interested in fixing conflicts
+      - name: Update deploy/faf
+        run: |
+          git push origin HEAD:deploy/faf --force
+
+

--- a/.github/workflows/deploy-faf.yaml
+++ b/.github/workflows/deploy-faf.yaml
@@ -31,7 +31,7 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
   update:
-    name: Update FAF Develop
+    name: Update FAF
     needs: [test]
     runs-on: ubuntu-latest
     environment: deploy/faf

--- a/.github/workflows/deploy-faf.yaml
+++ b/.github/workflows/deploy-faf.yaml
@@ -20,6 +20,10 @@
 
 name: Deploy to FAF
 
+concurrency:
+  cancel-in-progress: true
+  group: deploy/faf
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/deploy-faf.yaml
+++ b/.github/workflows/deploy-faf.yaml
@@ -34,6 +34,7 @@ jobs:
     name: Update FAF Develop
     needs: [test]
     runs-on: ubuntu-latest
+    environment: deploy/faf
     steps:
       # https://github.com/actions/checkout/tree/v4/
       - name: Checkout FA repository

--- a/.github/workflows/deploy-fafbeta.yaml
+++ b/.github/workflows/deploy-fafbeta.yaml
@@ -33,7 +33,7 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
   update:
-    name: Update FAF Beta
+    name: Update FAF Beta Balance
     needs: [test]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-fafbeta.yaml
+++ b/.github/workflows/deploy-fafbeta.yaml
@@ -1,0 +1,49 @@
+# Copyright (c) 2024 Willem 'Jip' Wijnia
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: Deploy to FAF Beta Balance
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 21 1 * *'
+
+jobs:
+  test:
+    uses: ./.github/workflows/test.yaml
+  update:
+    name: Update FAF Beta
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout/tree/v4/
+      - name: Checkout FA repository
+        uses: actions/checkout@v4
+        with:
+            repository: FAForever/fa
+            ref: develop
+
+      # Update the deploy/fafbeta branch, we force push here because 
+      # we're not interested in fixing conflicts
+      - name: Update deploy/fafbeta
+        run: |
+          git push origin HEAD:deploy/fafbeta --force
+
+

--- a/.github/workflows/deploy-fafbeta.yaml
+++ b/.github/workflows/deploy-fafbeta.yaml
@@ -20,6 +20,10 @@
 
 name: Deploy to FAF Beta Balance
 
+concurrency:
+  cancel-in-progress: true
+  group: deploy/fafbeta
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/deploy-fafdevelop.yaml
+++ b/.github/workflows/deploy-fafdevelop.yaml
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-name: FA - update development deployment branch
+name: Deploy to FAF Develop
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-fafdevelop.yaml
+++ b/.github/workflows/deploy-fafdevelop.yaml
@@ -20,6 +20,10 @@
 
 name: Deploy to FAF Develop
 
+concurrency:
+  cancel-in-progress: true
+  group: deploy/fafdevelop
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Adds additional workflows to manage the deployments to the various deployment branches. All maintainers can trigger these workflows, ideally the workflow to `deploy/faf` requires an approval of at least one different maintainer.

To deploy to the FAF game type should require approvals from at least a different maintainer that triggered the deployment.