### PR TITLE
Fix the invalid replacement of `TrailEmitterBlueprint` into `return`

### DIFF
--- a/effects/emitters/_phalanx_munition_polytrail_01_emit.bp
+++ b/effects/emitters/_phalanx_munition_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_cannon_trail_emit.bp
+++ b/effects/emitters/aeon_cannon_trail_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_commander_overcharge_trail_01_emit.bp
+++ b/effects/emitters/aeon_commander_overcharge_trail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_dualquantum_cannon_projectile_trail_emit.bp
+++ b/effects/emitters/aeon_dualquantum_cannon_projectile_trail_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_heavydisruptor_cannon_projectile_trail_emit.bp
+++ b/effects/emitters/aeon_heavydisruptor_cannon_projectile_trail_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_laser_trail_01_emit.bp
+++ b/effects/emitters/aeon_laser_trail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_laser_trail_02_emit.bp
+++ b/effects/emitters/aeon_laser_trail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_light_displacement_missile_polytrail_01_emit.bp
+++ b/effects/emitters/aeon_light_displacement_missile_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 300,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_light_displacement_missile_polytrail_02_emit.bp
+++ b/effects/emitters/aeon_light_displacement_missile_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 300,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_mercy_missile_polytrail_01_emit.bp
+++ b/effects/emitters/aeon_mercy_missile_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 200,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_missile_trail_01_emit.bp
+++ b/effects/emitters/aeon_missile_trail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_missile_trail_02_emit.bp
+++ b/effects/emitters/aeon_missile_trail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_missile_trail_03_emit.bp
+++ b/effects/emitters/aeon_missile_trail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_mortar02_polytrail_01_emit.bp
+++ b/effects/emitters/aeon_mortar02_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3.0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_mortar02_polytrail_02_emit.bp
+++ b/effects/emitters/aeon_mortar02_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3.0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_nuke_trail_emit.bp
+++ b/effects/emitters/aeon_nuke_trail_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_quantic_cluster_polytrail_01_emit.bp
+++ b/effects/emitters/aeon_quantic_cluster_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_quantic_cluster_polytrail_02_emit.bp
+++ b/effects/emitters/aeon_quantic_cluster_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_quantic_cluster_polytrail_03_emit.bp
+++ b/effects/emitters/aeon_quantic_cluster_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_quasar_antitorpedo_polytrail_01_emit.bp
+++ b/effects/emitters/aeon_quasar_antitorpedo_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 300,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_quasar_antitorpedo_polytrail_02_emit.bp
+++ b/effects/emitters/aeon_quasar_antitorpedo_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 300,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_sonicgun_trail_emit.bp
+++ b/effects/emitters/aeon_sonicgun_trail_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/aeon_torpedocluster_polytrail_01_emit.bp
+++ b/effects/emitters/aeon_torpedocluster_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3.0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/antimatter_polytrail_01_emit.bp
+++ b/effects/emitters/antimatter_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 500,
     Lifetime = -1.0,

--- a/effects/emitters/auto_cannon_trail_01_emit.bp
+++ b/effects/emitters/auto_cannon_trail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/caamissilenanite01_polytrail_01_emit.bp
+++ b/effects/emitters/caamissilenanite01_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/caamissilenanite01_polytrail_02_emit.bp
+++ b/effects/emitters/caamissilenanite01_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/cannon_polytrail_01_emit.bp
+++ b/effects/emitters/cannon_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/contrail_polytrail_01_emit.bp
+++ b/effects/emitters/contrail_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     HighFidelity = true,
     LODCutoff = 160,

--- a/effects/emitters/contrail_polytrail_02_emit.bp
+++ b/effects/emitters/contrail_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0.0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/contrail_polytrail_03_emit.bp
+++ b/effects/emitters/contrail_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0.0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/contrail_ser_ohw_polytrail_01_emit.bp
+++ b/effects/emitters/contrail_ser_ohw_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 500,
     Lifetime = -1.0,

--- a/effects/emitters/contrail_ser_polytrail_01_emit.bp
+++ b/effects/emitters/contrail_ser_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/cybran_brackman_crab_peg_polytrail_01_emit.bp
+++ b/effects/emitters/cybran_brackman_crab_peg_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 300,
     Lifetime = -1.0,

--- a/effects/emitters/cybran_brackman_crab_pegpod_polytrail_01_emit.bp
+++ b/effects/emitters/cybran_brackman_crab_pegpod_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 300,
     Lifetime = -1.0,

--- a/effects/emitters/cybran_brackman_hacking_qai_polytrail_01_emit.bp
+++ b/effects/emitters/cybran_brackman_hacking_qai_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 300,
     Lifetime = -1.0,

--- a/effects/emitters/cybran_brackman_hacking_qai_polytrail_02_emit.bp
+++ b/effects/emitters/cybran_brackman_hacking_qai_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 300,
     Lifetime = -1.0,

--- a/effects/emitters/cybran_corsair_missile_polytrail_01_emit.bp
+++ b/effects/emitters/cybran_corsair_missile_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 300,
     Lifetime = -1.0,

--- a/effects/emitters/cybran_iridium_missile_polytrail_01_emit.bp
+++ b/effects/emitters/cybran_iridium_missile_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 300,
     Lifetime = -1.0,

--- a/effects/emitters/cybran_laser_trail_01_emit.bp
+++ b/effects/emitters/cybran_laser_trail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/cybran_laser_trail_02_emit.bp
+++ b/effects/emitters/cybran_laser_trail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/cybran_nano_dart_polytrail_01_emit.bp
+++ b/effects/emitters/cybran_nano_dart_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 200,
     Lifetime = -1.0,

--- a/effects/emitters/cybran_nano_dart_polytrail_02_emit.bp
+++ b/effects/emitters/cybran_nano_dart_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 200,
     Lifetime = -1.0,

--- a/effects/emitters/default_polytrail_01_emit.bp
+++ b/effects/emitters/default_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = -1,
     Lifetime = -1.0,

--- a/effects/emitters/default_polytrail_02_emit.bp
+++ b/effects/emitters/default_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/default_polytrail_03_emit.bp
+++ b/effects/emitters/default_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/default_polytrail_04_emit.bp
+++ b/effects/emitters/default_polytrail_04_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/default_polytrail_05_emit.bp
+++ b/effects/emitters/default_polytrail_05_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/default_polytrail_06_emit.bp
+++ b/effects/emitters/default_polytrail_06_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/default_polytrail_07_emit.bp
+++ b/effects/emitters/default_polytrail_07_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0,
     LODCutoff = -1,
     Lifetime = -1.0,

--- a/effects/emitters/disintegrator_polytrail_01_emit.bp
+++ b/effects/emitters/disintegrator_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/disintegrator_polytrail_02_emit.bp
+++ b/effects/emitters/disintegrator_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/disintegrator_polytrail_03_emit.bp
+++ b/effects/emitters/disintegrator_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/disintegrator_polytrail_04_emit.bp
+++ b/effects/emitters/disintegrator_polytrail_04_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/disintegrator_polytrail_05_emit.bp
+++ b/effects/emitters/disintegrator_polytrail_05_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/disruptor_cannon_polytrail_01_emit.bp
+++ b/effects/emitters/disruptor_cannon_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3.0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/electron_bolter_trail_01_emit.bp
+++ b/effects/emitters/electron_bolter_trail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 4,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/electron_bolter_trail_02_emit.bp
+++ b/effects/emitters/electron_bolter_trail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/gauss_cannon_polytrail_01_emit.bp
+++ b/effects/emitters/gauss_cannon_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 70,
     Lifetime = -1.0,

--- a/effects/emitters/gauss_cannon_polytrail_02_emit.bp
+++ b/effects/emitters/gauss_cannon_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/heavy_plasma_gatling_cannon_laser_polytrail_01_emit.bp
+++ b/effects/emitters/heavy_plasma_gatling_cannon_laser_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -4.0,

--- a/effects/emitters/hiro_laser_cannon_polytrail_01_emit.bp
+++ b/effects/emitters/hiro_laser_cannon_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/hrailgunsd_polytrail_01_emit.bp
+++ b/effects/emitters/hrailgunsd_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     EmitIfVisible = true,
     LODCutoff = 300.0,

--- a/effects/emitters/hvyproton_cannon_polytrail_01_emit.bp
+++ b/effects/emitters/hvyproton_cannon_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/ionized_plasma_gatling_cannon_laser_polytrail_01_emit.bp
+++ b/effects/emitters/ionized_plasma_gatling_cannon_laser_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/laserturret_munition_trail_01_emit.bp
+++ b/effects/emitters/laserturret_munition_trail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/machinegun_polytrail_01_emit.bp
+++ b/effects/emitters/machinegun_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/meson_rocket_missile_trail_01_emit.bp
+++ b/effects/emitters/meson_rocket_missile_trail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/missile_smoke_polytrail_01_emit.bp
+++ b/effects/emitters/missile_smoke_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/phalanx_munition_polytrail_01_emit.bp
+++ b/effects/emitters/phalanx_munition_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/plasma_cannon_polytrail_01_emit.bp
+++ b/effects/emitters/plasma_cannon_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3.0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/plasma_cannon_polytrail_02_emit.bp
+++ b/effects/emitters/plasma_cannon_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/plasma_cannon_polytrail_03_emit.bp
+++ b/effects/emitters/plasma_cannon_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3.0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/plasma_cannon_polytrail_04_emit.bp
+++ b/effects/emitters/plasma_cannon_polytrail_04_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3.0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/proton_artillery_polytrail_01_emit.bp
+++ b/effects/emitters/proton_artillery_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0.0,
     LODCutoff = -1,
     Lifetime = -1.0,

--- a/effects/emitters/proton_cannon_polytrail_01_emit.bp
+++ b/effects/emitters/proton_cannon_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/proton_cannon_polytrail_02_emit.bp
+++ b/effects/emitters/proton_cannon_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/proton_cannon_trail_01_emit.bp
+++ b/effects/emitters/proton_cannon_trail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/quantum_cannon_polytrail_01_emit.bp
+++ b/effects/emitters/quantum_cannon_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/quantum_displacement_cannon_polytrail_01_emit.bp
+++ b/effects/emitters/quantum_displacement_cannon_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/railgun_polytrail_01_emit.bp
+++ b/effects/emitters/railgun_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 100,
     Lifetime = -1.0,

--- a/effects/emitters/reacton_cannon_polytrail_01_emit.bp
+++ b/effects/emitters/reacton_cannon_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/riot_gun_polytrail_01_emit.bp
+++ b/effects/emitters/riot_gun_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/riot_gun_polytrail_02_emit.bp
+++ b/effects/emitters/riot_gun_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/riot_gun_polytrail_03_emit.bp
+++ b/effects/emitters/riot_gun_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/riot_gun_polytrail_engi_01_emit.bp
+++ b/effects/emitters/riot_gun_polytrail_engi_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/riot_gun_polytrail_engi_02_emit.bp
+++ b/effects/emitters/riot_gun_polytrail_engi_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/riot_gun_polytrail_engi_03_emit.bp
+++ b/effects/emitters/riot_gun_polytrail_engi_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/riot_gun_polytrail_tank_01_emit.bp
+++ b/effects/emitters/riot_gun_polytrail_tank_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/riot_gun_polytrail_tank_02_emit.bp
+++ b/effects/emitters/riot_gun_polytrail_tank_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/riot_gun_polytrail_tank_03_emit.bp
+++ b/effects/emitters/riot_gun_polytrail_tank_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_aero_bolter_projectile_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_aero_bolter_projectile_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_aero_bolter_projectile_polytrail_02_emit.bp
+++ b/effects/emitters/seraphim_aero_bolter_projectile_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_aero_bolter_projectile_polytrail_03_emit.bp
+++ b/effects/emitters/seraphim_aero_bolter_projectile_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 1,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_aireau_autocannon_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_aireau_autocannon_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_aireau_autocannon_polytrail_02_emit.bp
+++ b/effects/emitters/seraphim_aireau_autocannon_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_aireau_autocannon_polytrail_03_emit.bp
+++ b/effects/emitters/seraphim_aireau_autocannon_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_ajellu_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_ajellu_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_ajellu_polytrail_02_emit.bp
+++ b/effects/emitters/seraphim_ajellu_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_ammit_torpedo_projectile_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_ammit_torpedo_projectile_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_ammit_torpedo_projectile_polytrail_02_emit.bp
+++ b/effects/emitters/seraphim_ammit_torpedo_projectile_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 1,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_blazar_cannon_projectile_emit.bp
+++ b/effects/emitters/seraphim_blazar_cannon_projectile_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_blazar_cannon_projectile_emit_02.bp
+++ b/effects/emitters/seraphim_blazar_cannon_projectile_emit_02.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_blazar_cannon_projectile_emit_03.bp
+++ b/effects/emitters/seraphim_blazar_cannon_projectile_emit_03.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_blazar_cannon_projectile_emit_04.bp
+++ b/effects/emitters/seraphim_blazar_cannon_projectile_emit_04.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_chromatic_beam_generator_trail_emit.bp
+++ b/effects/emitters/seraphim_chromatic_beam_generator_trail_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_01_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_02_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_overcharge_projectile_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_chronotron_cannon_projectile_01_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_projectile_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_chronotron_cannon_projectile_02_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_projectile_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_chronotron_cannon_projectile_emit.bp
+++ b/effects/emitters/seraphim_chronotron_cannon_projectile_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_cleo_cannon_projectile_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_cleo_cannon_projectile_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_cleo_cannon_projectile_polytrail_02_emit.bp
+++ b/effects/emitters/seraphim_cleo_cannon_projectile_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_cleo_cannon_projectile_polytrail_03_emit.bp
+++ b/effects/emitters/seraphim_cleo_cannon_projectile_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_cleo_cannon_projectile_polytrail_04_emit.bp
+++ b/effects/emitters/seraphim_cleo_cannon_projectile_polytrail_04_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_cleo_cannon_projectile_polytrail_05_emit.bp
+++ b/effects/emitters/seraphim_cleo_cannon_projectile_polytrail_05_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_cleo_cannon_projectile_polytrail_06_emit.bp
+++ b/effects/emitters/seraphim_cleo_cannon_projectile_polytrail_06_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_cleo_cannon_projectile_trail_01_emit.bp
+++ b/effects/emitters/seraphim_cleo_cannon_projectile_trail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_electrum_missile_defense_projectile_emit.bp
+++ b/effects/emitters/seraphim_electrum_missile_defense_projectile_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_electrum_missile_defense_projectile_emit_02.bp
+++ b/effects/emitters/seraphim_electrum_missile_defense_projectile_emit_02.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_expirimental_laser_trail_emit.bp
+++ b/effects/emitters/seraphim_expirimental_laser_trail_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_expirimental_unstable_laser_trail_emit.bp
+++ b/effects/emitters/seraphim_expirimental_unstable_laser_trail_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_expnuke_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_expnuke_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 500,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_expnuke_polytrail_02_emit.bp
+++ b/effects/emitters/seraphim_expnuke_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 500,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_expnuke_polytrail_03_emit.bp
+++ b/effects/emitters/seraphim_expnuke_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 500,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_heavy_phasic_autogun_projectile_emit.bp
+++ b/effects/emitters/seraphim_heavy_phasic_autogun_projectile_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 1,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_heavy_phasic_autogun_projectile_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_heavy_phasic_autogun_projectile_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 1,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_heavy_phasic_autogun_projectile_polytrail_02_emit.bp
+++ b/effects/emitters/seraphim_heavy_phasic_autogun_projectile_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_heavy_phasic_autogun_projectile_polytrail_03_emit.bp
+++ b/effects/emitters/seraphim_heavy_phasic_autogun_projectile_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_heavyquarnon_cannon_projectile_trail_01_emit.bp
+++ b/effects/emitters/seraphim_heavyquarnon_cannon_projectile_trail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 300,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_heavyquarnon_cannon_projectile_trail_02_emit.bp
+++ b/effects/emitters/seraphim_heavyquarnon_cannon_projectile_trail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 300,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_heavyquarnon_cannon_projectile_trail_03_emit.bp
+++ b/effects/emitters/seraphim_heavyquarnon_cannon_projectile_trail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 300,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_heayvcavitation_torpedo_projectile_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_heayvcavitation_torpedo_projectile_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_heayvcavitation_torpedo_projectile_polytrail_02_emit.bp
+++ b/effects/emitters/seraphim_heayvcavitation_torpedo_projectile_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_khamaseen_bombhitspiral_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_khamaseen_bombhitspiral_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 300,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_khu_anti_nuke_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_khu_anti_nuke_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_lancer_missile_exhaust_polytrail_01.bp
+++ b/effects/emitters/seraphim_lancer_missile_exhaust_polytrail_01.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 1,
     LODCutoff = 200,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_light_chronotron_cannon_overcharge_projectile_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_overcharge_projectile_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_light_chronotron_cannon_projectile_01_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_projectile_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_light_chronotron_cannon_projectile_02_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_projectile_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_light_chronotron_cannon_projectile_emit.bp
+++ b/effects/emitters/seraphim_light_chronotron_cannon_projectile_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_losaare_cannon_projectile_emit.bp
+++ b/effects/emitters/seraphim_losaare_cannon_projectile_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_losaare_cannon_projectile_emit_02.bp
+++ b/effects/emitters/seraphim_losaare_cannon_projectile_emit_02.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_losaare_cannon_projectile_emit_03.bp
+++ b/effects/emitters/seraphim_losaare_cannon_projectile_emit_03.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_losaare_cannon_projectile_emit_04.bp
+++ b/effects/emitters/seraphim_losaare_cannon_projectile_emit_04.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_polytrails_01_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_polytrails_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_ohwalli_strategic_bomb_polytrails_02_emit.bp
+++ b/effects/emitters/seraphim_ohwalli_strategic_bomb_polytrails_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_othe_bomb_projectile_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_othe_bomb_projectile_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 1,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_phasic_autogun_projectile_02_emit.bp
+++ b/effects/emitters/seraphim_phasic_autogun_projectile_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 1,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_phasic_autogun_projectile_emit.bp
+++ b/effects/emitters/seraphim_phasic_autogun_projectile_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_polarix_cannon_projectile_02_emit.bp
+++ b/effects/emitters/seraphim_polarix_cannon_projectile_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 1,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_polarix_cannon_projectile_emit.bp
+++ b/effects/emitters/seraphim_polarix_cannon_projectile_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 1,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_reviler_artillery_projectile_polytrail_02_emit.bp
+++ b/effects/emitters/seraphim_reviler_artillery_projectile_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 1,
     LODCutoff = 200,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_reviler_artillery_projectile_polytrail_emit.bp
+++ b/effects/emitters/seraphim_reviler_artillery_projectile_polytrail_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 200,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_rifter_mobileartillery_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_rifter_mobileartillery_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = -1.0,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_shleo_cannon_projectile_trail_01_emit.bp
+++ b/effects/emitters/seraphim_shleo_cannon_projectile_trail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_shrieker_cannon_projectile_emit.bp
+++ b/effects/emitters/seraphim_shrieker_cannon_projectile_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_shrieker_cannon_projectile_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_shrieker_cannon_projectile_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_shrieker_cannon_projectile_polytrail_02_emit.bp
+++ b/effects/emitters/seraphim_shrieker_cannon_projectile_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_shrieker_cannon_projectile_polytrail_03_emit.bp
+++ b/effects/emitters/seraphim_shrieker_cannon_projectile_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_sih_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_sih_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3.0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_sih_polytrail_02_emit.bp
+++ b/effects/emitters/seraphim_sih_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3.0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_sih_polytrail_03_emit.bp
+++ b/effects/emitters/seraphim_sih_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3.0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_sih_polytrail_04_emit.bp
+++ b/effects/emitters/seraphim_sih_polytrail_04_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3.0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_spectra_cannon_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_spectra_cannon_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_spectra_cannon_polytrail_02_emit.bp
+++ b/effects/emitters/seraphim_spectra_cannon_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 1,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_spectra_cannon_polytrail_03_emit.bp
+++ b/effects/emitters/seraphim_spectra_cannon_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_spectra_cannon_polytrail_04_emit.bp
+++ b/effects/emitters/seraphim_spectra_cannon_polytrail_04_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 1,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_tau_cannon_projectile_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_tau_cannon_projectile_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_tau_cannon_projectile_polytrail_02_emit.bp
+++ b/effects/emitters/seraphim_tau_cannon_projectile_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 1,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_thunderstorm_artillery_projectile_trail_01_emit.bp
+++ b/effects/emitters/seraphim_thunderstorm_artillery_projectile_trail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_thunderstorm_artillery_projectile_trail_02_emit.bp
+++ b/effects/emitters/seraphim_thunderstorm_artillery_projectile_trail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/seraphim_uall_torpedo_projectile_polytrail_01_emit.bp
+++ b/effects/emitters/seraphim_uall_torpedo_projectile_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/serpentine_missile_trail_emit.bp
+++ b/effects/emitters/serpentine_missile_trail_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/sonic_pulse_munition_polytrail_01_emit.bp
+++ b/effects/emitters/sonic_pulse_munition_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 4,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/sonic_pulse_munition_polytrail_02_emit.bp
+++ b/effects/emitters/sonic_pulse_munition_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 4,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/terran_commander_cannon_polytrail_01_emit.bp
+++ b/effects/emitters/terran_commander_cannon_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/terran_commander_cannon_polytrail_02_emit.bp
+++ b/effects/emitters/terran_commander_cannon_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/terran_gatling_plasma_cannon_polytrail_01_emit.bp
+++ b/effects/emitters/terran_gatling_plasma_cannon_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/terran_gatling_plasma_cannon_polytrail_02_emit.bp
+++ b/effects/emitters/terran_gatling_plasma_cannon_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/terran_gatling_plasma_cannon_polytrail_03_emit.bp
+++ b/effects/emitters/terran_gatling_plasma_cannon_polytrail_03_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/test_missile_trail_emit.bp
+++ b/effects/emitters/test_missile_trail_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/test_polytrail_01_emit.bp
+++ b/effects/emitters/test_polytrail_01_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 0.0,
     LODCutoff = 160,
     Lifetime = -1.0,

--- a/effects/emitters/test_polytrail_02_emit.bp
+++ b/effects/emitters/test_polytrail_02_emit.bp
@@ -1,4 +1,4 @@
-return {
+TrailEmitterBlueprint {
     BlendMode = 3,
     LODCutoff = 160,
     Lifetime = -1.0,


### PR DESCRIPTION
Bug originates from https://github.com/FAForever/fa/pull/6272 , with thanks to @lL1l1 for spotting the mistake.

Also turned it into an issue: https://github.com/The-Balthazar/BrewWikiGen/issues/3