### PR TITLE
Populate the blueprint field `AverageDensity` of units

### DIFF
--- a/engine/Core/Blueprints/EntityBlueprint.lua
+++ b/engine/Core/Blueprints/EntityBlueprint.lua
@@ -3,7 +3,7 @@
 ---@class EntityBlueprint : HitBox, Blueprint
 --- alternate Unit footprint
 ---@field AltFootprint? FootprintBlueprint
---- unit average density in tons / m^3 (default is 0.49)
+--- unit average density in tons / m^3 (default is 0.49). Affects the behavior of units when they bump into each other. Units with more weight push units with less weight.
 ---@field AverageDensity? number
 --- list of category names that this entity belongs to
 ---@field Categories CategoryName[]

--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -737,6 +737,29 @@ function VerifyBlinkingLights(unit)
     end
 end
 
+--- Feature: Unit weight based on the maximum health of a unit
+---
+--- Affects the behavior of units when they bump into each other. Units 
+--- with more weight push units with less weight. As a result units with
+--- more health will receive less to no pushback from units with less health.
+---@param unit UnitBlueprint
+local function ProcessUnitDensity(unit)
+    local averageDensity = 10
+    if unit.Defense and unit.Defense.MaxHealth then
+        averageDensity = unit.Defense.MaxHealth
+
+        if unit.Physics and unit.Physics.MotionType == "RULEUMT_Hover" then
+            averageDensity = 0.50 * averageDensity
+        end
+    end
+
+    if averageDensity ~= unit.AverageDensity then
+        WARN(string.format("Overwriting the average density of %s from %s to %s", tostring(unit.BlueprintId), unit.AverageDensity, averageDensity))
+    end
+
+    unit.AverageDensity = averageDensity
+end
+
 --- Post-processes all units
 ---@param allBlueprints BlueprintsTable
 ---@param units UnitBlueprint[]
@@ -754,6 +777,18 @@ function PostProcessUnits(allBlueprints, units)
     for _, unit in pairs(units) do
         if unit.CategoriesHash['EXTERNALFACTORY'] then
             PostProcessUnitWithExternalFactory(allBlueprints, unit)
+        end
+    end
+end
+
+--- Batch process all units
+---@param blueprints BlueprintsTable
+function BatchProcessUnits(blueprints)
+    LOG("Batch processing units")
+    if blueprints.Unit then
+        for _, unit in pairs(blueprints.Unit) do
+            ProcessCanLandOnWater(unit)
+            ProcessUnitDensity(unit)
         end
     end
 end

--- a/units/DAA0206/DAA0206_unit.bp
+++ b/units/DAA0206/DAA0206_unit.bp
@@ -32,6 +32,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UAA',        Cue = 'UAA0204_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 90,
     BuildIconSortPriority = 35,
     Categories = {
         "AEON",

--- a/units/DAL0310/DAL0310_unit.bp
+++ b/units/DAL0310/DAL0310_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UAL',        Cue = 'UAL0304_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Tank',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 400.0,
     BuildIconSortPriority = 40,
     Categories = {
         "AEON",

--- a/units/DALK003/DALK003_unit.bp
+++ b/units/DALK003/DALK003_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         StopMove      = Sound { Bank = 'UAL',        Cue = 'UAL0303_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection   = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Bot',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1700,
     BuildIconSortPriority = 25,
     Categories = {
         "AEON",

--- a/units/DEA0202/DEA0202_unit.bp
+++ b/units/DEA0202/DEA0202_unit.bp
@@ -40,6 +40,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UEA',        Cue = 'UEA0304_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1200,
     BuildIconSortPriority = 18,
     Categories = {
         "AIR",

--- a/units/DEL0204/DEL0204_unit.bp
+++ b/units/DEL0204/DEL0204_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UEL',       Cue = 'UEL0107_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface', Cue = 'UEF_Select_Bot',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 650,
     BuildIconSortPriority = 18,
     Categories = {
         "BOT",

--- a/units/DELK002/DELK002_unit.bp
+++ b/units/DELK002/DELK002_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UEL',        Cue = 'UEL0202_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Vehicle',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1900,
     BuildIconSortPriority = 25,
     Categories = {
         "ANTIAIR",

--- a/units/DRA0202/DRA0202_unit.bp
+++ b/units/DRA0202/DRA0202_unit.bp
@@ -39,6 +39,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'URA',        Cue = 'URA0204_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Air',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1100,
     BuildIconSortPriority = 15,
     Categories = {
         "AIR",

--- a/units/DRL0204/DRL0204_unit.bp
+++ b/units/DRL0204/DRL0204_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URL',        Cue = 'URL0107_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Bot',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 550,
     BuildIconSortPriority = 20,
     Categories = {
         "BOT",

--- a/units/DRLK001/DRLK001_unit.bp
+++ b/units/DRLK001/DRLK001_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         StopMove      = Sound { Bank = 'URL',        Cue = 'URL0107_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection   = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Bot',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1900,
     BuildIconSortPriority = 25,
     Categories = {
         "ANTIAIR",

--- a/units/DRLK005/DRLK005_unit.bp
+++ b/units/DRLK005/DRLK005_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         EggSink        = Sound { Bank = 'URLDestroy', Cue = 'URB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10,
     BuildIconSortPriority = 25,
     Categories = {
         "CONSTRUCTION",

--- a/units/DSLK004/DSLK004_unit.bp
+++ b/units/DSLK004/DSLK004_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XSL',            Cue = 'XSL0303_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Tank', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1800,
     BuildIconSortPriority = 35,
     Categories = {
         "ANTIAIR",

--- a/units/SRL0310/SRL0310_unit.bp
+++ b/units/SRL0310/SRL0310_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URL',        Cue = 'URL0107_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Bot',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     Buffs = {
         Regen = {
             Level1 = 3,

--- a/units/UAA0101/UAA0101_unit.bp
+++ b/units/UAA0101/UAA0101_unit.bp
@@ -35,6 +35,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UAA',        Cue = 'UAA0101_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 25,
     BuildIconSortPriority = 20,
     Categories = {
         "AEON",

--- a/units/UAA0102/UAA0102_unit.bp
+++ b/units/UAA0102/UAA0102_unit.bp
@@ -41,6 +41,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UAA',        Cue = 'UAA0102_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 285,
     BuildIconSortPriority = 30,
     Categories = {
         "AEON",

--- a/units/UAA0103/UAA0103_unit.bp
+++ b/units/UAA0103/UAA0103_unit.bp
@@ -41,6 +41,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UAA',        Cue = 'UAA0103_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 205,
     BuildIconSortPriority = 40,
     Categories = {
         "AEON",

--- a/units/UAA0104/UAA0104_unit.bp
+++ b/units/UAA0104/UAA0104_unit.bp
@@ -39,7 +39,7 @@ UnitBlueprint{
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
         Unload             = Sound { Bank = 'UAA',        Cue = 'UAA0104_Unit_Unload',    LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 1575,
     BuildIconSortPriority = 40,
     Categories = {
         "AEON",

--- a/units/UAA0107/UAA0107_unit.bp
+++ b/units/UAA0107/UAA0107_unit.bp
@@ -39,7 +39,7 @@ UnitBlueprint{
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
         Unload             = Sound { Bank = 'UAA',        Cue = 'UAA0104_Unit_Unload',    LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 500,
     BuildIconSortPriority = 50,
     Categories = {
         "AEON",

--- a/units/UAA0203/UAA0203_unit.bp
+++ b/units/UAA0203/UAA0203_unit.bp
@@ -35,7 +35,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UAA',        Cue = 'UAA0203_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 848,
     BuildIconSortPriority = 30,
     Categories = {
         "AEON",

--- a/units/UAA0204/UAA0204_unit.bp
+++ b/units/UAA0204/UAA0204_unit.bp
@@ -38,6 +38,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UAA',        Cue = 'UAA0204_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 820,
     BuildIconSortPriority = 20,
     Categories = {
         "AEON",

--- a/units/UAA0302/UAA0302_unit.bp
+++ b/units/UAA0302/UAA0302_unit.bp
@@ -35,6 +35,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UAA',        Cue = 'UAA0302_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1050,
     BuildIconSortPriority = 20,
     Categories = {
         "AEON",

--- a/units/UAA0303/UAA0303_unit.bp
+++ b/units/UAA0303/UAA0303_unit.bp
@@ -41,6 +41,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UAA',        Cue = 'UAA0303_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2250,
     BuildIconSortPriority = 25,
     Categories = {
         "AEON",

--- a/units/UAA0304/UAA0304_unit.bp
+++ b/units/UAA0304/UAA0304_unit.bp
@@ -40,6 +40,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UAA',        Cue = 'UAA0304_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3800,
     BuildIconSortPriority = 40,
     Categories = {
         "AEON",

--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -45,6 +45,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UAA',        Cue = 'UAA0310_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 40000,
     BuildIconSortPriority = 110,
     Categories = {
         "AEON",

--- a/units/UAB0101/UAB0101_unit.bp
+++ b/units/UAB0101/UAB0101_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB0101_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Factory',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3200,
     BuildIconSortPriority = 10,
     Categories = {
         "AEON",

--- a/units/UAB0102/UAB0102_unit.bp
+++ b/units/UAB0102/UAB0102_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB0102_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Factory',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3200,
     BuildIconSortPriority = 20,
     Categories = {
         "AEON",

--- a/units/UAB0103/UAB0103_unit.bp
+++ b/units/UAB0103/UAB0103_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB0103_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Factory',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3700,
     BuildIconSortPriority = 30,
     Categories = {
         "AEON",

--- a/units/UAB0201/UAB0201_unit.bp
+++ b/units/UAB0201/UAB0201_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB0201_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Factory',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6400,
     BuildIconSortPriority = 50,
     Categories = {
         "AEON",

--- a/units/UAB0202/UAB0202_unit.bp
+++ b/units/UAB0202/UAB0202_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB0202_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Factory',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6400,
     BuildIconSortPriority = 60,
     Categories = {
         "AEON",

--- a/units/UAB0203/UAB0203_unit.bp
+++ b/units/UAB0203/UAB0203_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB0203_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Factory',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 12800,
     BuildIconSortPriority = 70,
     Categories = {
         "AEON",

--- a/units/UAB0301/UAB0301_unit.bp
+++ b/units/UAB0301/UAB0301_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB0301_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Factory',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 12800,
     BuildIconSortPriority = 40,
     Categories = {
         "AEON",

--- a/units/UAB0302/UAB0302_unit.bp
+++ b/units/UAB0302/UAB0302_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB0302_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Factory',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 12800,
     BuildIconSortPriority = 50,
     Categories = {
         "AEON",

--- a/units/UAB0303/UAB0303_unit.bp
+++ b/units/UAB0303/UAB0303_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB0303_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Factory',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 21000,
     BuildIconSortPriority = 60,
     Categories = {
         "AEON",

--- a/units/UAB0304/UAB0304_unit.bp
+++ b/units/UAB0304/UAB0304_unit.bp
@@ -20,6 +20,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB0304_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Structure',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10000,
     BuildIconSortPriority = 220,
     Categories = {
         "AEON",

--- a/units/UAB1101/UAB1101_unit.bp
+++ b/units/UAB1101/UAB1101_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB1101_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 525,
     BuildIconSortPriority = 60,
     Categories = {
         "AEON",

--- a/units/UAB1102/UAB1102_unit.bp
+++ b/units/UAB1102/UAB1102_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB1102_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1600,
     BuildIconSortPriority = 70,
     Categories = {
         "AEON",

--- a/units/UAB1103/UAB1103_unit.bp
+++ b/units/UAB1103/UAB1103_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB1103_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 370,
     BuildIconSortPriority = 40,
     Categories = {
         "AEON",

--- a/units/UAB1104/UAB1104_unit.bp
+++ b/units/UAB1104/UAB1104_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB1104_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 360,
     BuildIconSortPriority = 50,
     Categories = {
         "AEON",

--- a/units/UAB1105/UAB1105_unit.bp
+++ b/units/UAB1105/UAB1105_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB1105_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 80,
     Categories = {
         "AEON",

--- a/units/UAB1106/UAB1106_unit.bp
+++ b/units/UAB1106/UAB1106_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB1106_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 650,
     BuildIconSortPriority = 50,
     Categories = {
         "AEON",

--- a/units/UAB1201/UAB1201_unit.bp
+++ b/units/UAB1201/UAB1201_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB1201_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Resource',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2300,
     BuildIconSortPriority = 70,
     Categories = {
         "AEON",

--- a/units/UAB1202/UAB1202_unit.bp
+++ b/units/UAB1202/UAB1202_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB1202_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1900,
     BuildIconSortPriority = 40,
     Categories = {
         "AEON",

--- a/units/UAB1301/UAB1301_unit.bp
+++ b/units/UAB1301/UAB1301_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB1301_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Resource',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6200,
     BuildIconSortPriority = 70,
     Categories = {
         "AEON",

--- a/units/UAB1302/UAB1302_unit.bp
+++ b/units/UAB1302/UAB1302_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB1302_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6500,
     BuildIconSortPriority = 40,
     Categories = {
         "AEON",

--- a/units/UAB1303/UAB1303_unit.bp
+++ b/units/UAB1303/UAB1303_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB1303_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6000,
     BuildIconSortPriority = 50,
     Categories = {
         "AEON",

--- a/units/UAB2101/UAB2101_unit.bp
+++ b/units/UAB2101/UAB2101_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB2101_Activate', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Gun',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1300,
     BuildIconSortPriority = 110,
     Categories = {
         "AEON",

--- a/units/UAB2104/UAB2104_unit.bp
+++ b/units/UAB2104/UAB2104_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB2104_Activate', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Gun',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     BuildIconSortPriority = 120,
     Categories = {
         "AEON",

--- a/units/UAB2108/UAB2108_unit.bp
+++ b/units/UAB2108/UAB2108_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         Open           = Sound { Bank = 'UAB',        Cue = 'UAB2108_Doors',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Gun',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 900,
     BuildIconSortPriority = 150,
     Categories = {
         "AEON",

--- a/units/UAB2109/UAB2109_unit.bp
+++ b/units/UAB2109/UAB2109_unit.bp
@@ -11,6 +11,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB2109_Activate', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Gun',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1625,
     BuildIconSortPriority = 130,
     Categories = {
         "AEON",

--- a/units/UAB2204/UAB2204_unit.bp
+++ b/units/UAB2204/UAB2204_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB2204_Activate', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Gun',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2450,
     BuildIconSortPriority = 120,
     Categories = {
         "AEON",

--- a/units/UAB2205/UAB2205_unit.bp
+++ b/units/UAB2205/UAB2205_unit.bp
@@ -12,6 +12,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB2205_Activate', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Gun',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6100,
     BuildIconSortPriority = 130,
     Categories = {
         "AEON",

--- a/units/UAB2301/UAB2301_unit.bp
+++ b/units/UAB2301/UAB2301_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB2301_Activate', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Gun',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2000,
     BuildIconSortPriority = 110,
     Categories = {
         "AEON",

--- a/units/UAB2302/UAB2302_unit.bp
+++ b/units/UAB2302/UAB2302_unit.bp
@@ -12,6 +12,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB2302_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Gun',            LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 12000,
     BuildIconSortPriority = 140,
     Categories = {
         "AEON",

--- a/units/UAB2303/UAB2303_unit.bp
+++ b/units/UAB2303/UAB2303_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB2303_Activate', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Gun',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2200,
     BuildIconSortPriority = 140,
     Categories = {
         "AEON",

--- a/units/UAB2304/UAB2304_unit.bp
+++ b/units/UAB2304/UAB2304_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB2304_Activate', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Gun',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 5000,
     BuildIconSortPriority = 120,
     Categories = {
         "AEON",

--- a/units/UAB2305/UAB2305_unit.bp
+++ b/units/UAB2305/UAB2305_unit.bp
@@ -11,6 +11,7 @@ UnitBlueprint{
         Open                  = Sound { Bank = 'UAB',        Cue = 'UAB2305_Center_Open',                   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Gun',                       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 4000,
     BuildIconSortPriority = 150,
     Categories = {
         "AEON",

--- a/units/UAB3101/UAB3101_unit.bp
+++ b/units/UAB3101/UAB3101_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB3101_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Radar', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10,
     BuildIconSortPriority = 180,
     Categories = {
         "AEON",

--- a/units/UAB3102/UAB3102_unit.bp
+++ b/units/UAB3102/UAB3102_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB3102_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Sonar', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 400,
     BuildIconSortPriority = 190,
     Categories = {
         "AEON",

--- a/units/UAB3104/UAB3104_unit.bp
+++ b/units/UAB3104/UAB3104_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB3104_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Radar', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 100,
     BuildIconSortPriority = 200,
     Categories = {
         "AEON",

--- a/units/UAB3201/UAB3201_unit.bp
+++ b/units/UAB3201/UAB3201_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB3201_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Radar', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 50,
     BuildIconSortPriority = 180,
     Categories = {
         "AEON",

--- a/units/UAB3202/UAB3202_unit.bp
+++ b/units/UAB3202/UAB3202_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB3102_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Sonar', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     BuildIconSortPriority = 190,
     Categories = {
         "AEON",

--- a/units/UAB4201/UAB4201_unit.bp
+++ b/units/UAB4201/UAB4201_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         Open           = Sound { Bank = 'UAB',        Cue = 'UAB4201_Doors',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Gun',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 155,
     Categories = {
         "AEON",

--- a/units/UAB4202/UAB4202_unit.bp
+++ b/units/UAB4202/UAB4202_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         ShieldOn    = Sound { Bank = 'UAB',        Cue = 'UAB4202_Activate',      LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Structure', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 150,
     BuildIconSortPriority = 160,
     Categories = {
         "AEON",

--- a/units/UAB4203/UAB4203_unit.bp
+++ b/units/UAB4203/UAB4203_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UAB',        Cue = 'UAB4203_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Radar',          LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 175,
     BuildIconSortPriority = 200,
     Categories = {
         "AEON",

--- a/units/UAB4301/UAB4301_unit.bp
+++ b/units/UAB4301/UAB4301_unit.bp
@@ -11,6 +11,7 @@ UnitBlueprint{
         ShieldOn       = Sound { Bank = 'UAB',        Cue = 'UAB4301_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Structure',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 300,
     BuildIconSortPriority = 160,
     Categories = {
         "AEON",

--- a/units/UAB4302/UAB4302_unit.bp
+++ b/units/UAB4302/UAB4302_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         Open           = Sound { Bank = 'UAB',        Cue = 'UAB4302_Doors',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Gun',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3800,
     BuildIconSortPriority = 155,
     Categories = {
         "AEON",

--- a/units/UAB5101/UAB5101_unit.bp
+++ b/units/UAB5101/UAB5101_unit.bp
@@ -4,6 +4,7 @@ UnitBlueprint{
         Destroyed   = Sound { Bank = 'UALDestroy', Cue = 'UAB_Destroy_Huge',      LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Structure', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 140,
     Categories = {
         "AEON",

--- a/units/UAB5102/UAB5102_unit.bp
+++ b/units/UAB5102/UAB5102_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint{
     Description = "<LOC uab5102_desc>Aeon Transport Beacon",
+    AverageDensity = 10,
     Categories = {
         "AEON",
         "FERRYBEACON",

--- a/units/UAB5103/UAB5103_unit.bp
+++ b/units/UAB5103/UAB5103_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint{
     Description = "<LOC uab5103_desc>Aeon Quantum Gate Beacon",
+    AverageDensity = 10,
     Categories = {
         "AEON",
         "PRODUCTSC1",

--- a/units/UAB5202/UAB5202_unit.bp
+++ b/units/UAB5202/UAB5202_unit.bp
@@ -13,6 +13,7 @@ UnitBlueprint{
         Destroyed      = Sound { Bank = 'UALDestroy', Cue = 'UAB_Destroy_Huge',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Structure',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 210,
     Categories = {
         "AEON",

--- a/units/UAB5204/UAB5204_unit.bp
+++ b/units/UAB5204/UAB5204_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint{
     Description = "<LOC uab5204_desc>Concrete",
+    AverageDensity = 1,
     Categories = {
         "AEON",
         "LAND",

--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -34,6 +34,7 @@ UnitBlueprint{
         TeleportIn                    = Sound { Bank = 'Impacts',     Cue = 'AEON_Expl_Lrg_Naval',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection                   = Sound { Bank = 'Interface',   Cue = 'Aeon_Select_Commander',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 11000,
     Categories = {
         "AEON",
         "AMPHIBIOUS",

--- a/units/UAL0101/UAL0101_unit.bp
+++ b/units/UAL0101/UAL0101_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'UAL',        Cue = 'UAL0101_Move_Stop',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10.0,
     BuildIconSortPriority = 20,
     Categories = {
         "AEON",

--- a/units/UAL0103/UAL0103_unit.bp
+++ b/units/UAL0103/UAL0103_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UAL',        Cue = 'UAL0103_Move_Stop',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 150,
     BuildIconSortPriority = 60,
     Categories = {
         "AEON",

--- a/units/UAL0104/UAL0104_unit.bp
+++ b/units/UAL0104/UAL0104_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UAL',        Cue = 'UAL0104_Move_Stop',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 265,
     BuildIconSortPriority = 50,
     Categories = {
         "AEON",

--- a/units/UAL0105/UAL0105_unit.bp
+++ b/units/UAL0105/UAL0105_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'UAL',        Cue = 'UAL0105_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Vehicle',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 60.0,
     BuildIconSortPriority = 10,
     Categories = {
         "AEON",

--- a/units/UAL0106/UAL0106_unit.bp
+++ b/units/UAL0106/UAL0106_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UAL',        Cue = 'UAL0106_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Bot',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 115,
     BuildIconSortPriority = 30,
     Categories = {
         "AEON",

--- a/units/UAL0111/UAL0111_unit.bp
+++ b/units/UAL0111/UAL0111_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
         Unpack      = Sound { Bank = 'UAL',        Cue = 'UAL0111_Open',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 750,
     BuildIconSortPriority = 30,
     Categories = {
         "AEON",

--- a/units/UAL0201/UAL0201_unit.bp
+++ b/units/UAL0201/UAL0201_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UAL',        Cue = 'UAL0201_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Tank',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 77.5,
     BuildIconSortPriority = 40,
     Categories = {
         "AEON",

--- a/units/UAL0202/UAL0202_unit.bp
+++ b/units/UAL0202/UAL0202_unit.bp
@@ -11,6 +11,7 @@ UnitBlueprint{
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Tank',   LodCutoff = 'UnitMove_LodCutoff' },
         Unpack      = Sound { Bank = 'UAL',        Cue = 'UAL0202_Open',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1250,
     BuildIconSortPriority = 20,
     Categories = {
         "AEON",

--- a/units/UAL0205/UAL0205_unit.bp
+++ b/units/UAL0205/UAL0205_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'UAL',        Cue = 'UAL0205_Move_Stop',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500.0,
     BuildIconSortPriority = 25,
     Categories = {
         "AEON",

--- a/units/UAL0208/UAL0208_unit.bp
+++ b/units/UAL0208/UAL0208_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'UAL',        Cue = 'UAL0208_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Vehicle',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 170.0,
     BuildIconSortPriority = 10,
     Categories = {
         "AEON",

--- a/units/UAL0301/UAL0301_unit.bp
+++ b/units/UAL0301/UAL0301_unit.bp
@@ -24,6 +24,7 @@ UnitBlueprint{
         TeleportIn                    = Sound { Bank = 'Impacts',     Cue = 'AEON_Expl_Lrg_Naval',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection                   = Sound { Bank = 'Interface',   Cue = 'Aeon_Select_Commander',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 15000,
     BuildIconSortPriority = 10,
     Categories = {
         "AEON",

--- a/units/UAL0303/UAL0303_unit.bp
+++ b/units/UAL0303/UAL0303_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         StopMove      = Sound { Bank = 'UAL',        Cue = 'UAL0303_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection   = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Bot',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3600,
     BuildIconSortPriority = 20,
     Categories = {
         "AEON",

--- a/units/UAL0304/UAL0304_unit.bp
+++ b/units/UAL0304/UAL0304_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UAL',        Cue = 'UAL0304_Move_Stop',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 900,
     BuildIconSortPriority = 30,
     Categories = {
         "AEON",

--- a/units/UAL0307/UAL0307_unit.bp
+++ b/units/UAL0307/UAL0307_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UAL',        Cue = 'UAL0307_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Vehicle',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 50.0,
     BuildIconSortPriority = 50,
     Categories = {
         "AEON",

--- a/units/UAL0309/UAL0309_unit.bp
+++ b/units/UAL0309/UAL0309_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'UAL',        Cue = 'UAL0309_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Vehicle',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 340.0,
     BuildIconSortPriority = 10,
     Categories = {
         "AEON",

--- a/units/UAL0401/UAL0401_unit.bp
+++ b/units/UAL0401/UAL0401_unit.bp
@@ -19,6 +19,7 @@ UnitBlueprint{
         StopMove              = Sound { Bank = 'UAL',        Cue = 'UAL0401_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Bot',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 99999,
     BuildIconSortPriority = 100,
     Categories = {
         "AEON",

--- a/units/UAS0102/UAS0102_unit.bp
+++ b/units/UAS0102/UAS0102_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UAS',        Cue = 'UAS0102_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Naval',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     BuildIconSortPriority = 40,
     Categories = {
         "AEON",

--- a/units/UAS0103/UAS0103_unit.bp
+++ b/units/UAS0103/UAS0103_unit.bp
@@ -19,6 +19,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UAS',        Cue = 'UAS0103_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Naval',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1850,
     BuildIconSortPriority = 40,
     Categories = {
         "AEON",

--- a/units/UAS0201/UAS0201_unit.bp
+++ b/units/UAS0201/UAS0201_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UAS',        Cue = 'UAS0201_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Naval',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 7200,
     BuildIconSortPriority = 30,
     Categories = {
         "AEON",

--- a/units/UAS0202/UAS0202_unit.bp
+++ b/units/UAS0202/UAS0202_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UAS',        Cue = 'UAS0202_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Naval',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3250,
     BuildIconSortPriority = 40,
     Categories = {
         "AEON",

--- a/units/UAS0203/UAS0203_unit.bp
+++ b/units/UAS0203/UAS0203_unit.bp
@@ -13,6 +13,7 @@ UnitBlueprint{
         SurfaceStart   = Sound { Bank = 'UAS',        Cue = 'UAS_Sub_Surface',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Sub',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 775,
     BuildIconSortPriority = 30,
     Categories = {
         "AEON",

--- a/units/UAS0302/UAS0302_unit.bp
+++ b/units/UAS0302/UAS0302_unit.bp
@@ -19,6 +19,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UAS',        Cue = 'UAS0302_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Naval',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 48000,
     BuildIconSortPriority = 18,
     Categories = {
         "AEON",

--- a/units/UAS0303/UAS0303_unit.bp
+++ b/units/UAS0303/UAS0303_unit.bp
@@ -25,6 +25,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UAS',        Cue = 'UAS0303_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Naval',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 22000,
     BuildIconSortPriority = 30,
     Categories = {
         "AEON",

--- a/units/UAS0304/UAS0304_unit.bp
+++ b/units/UAS0304/UAS0304_unit.bp
@@ -23,6 +23,7 @@ UnitBlueprint{
         SurfaceStart          = Sound { Bank = 'UAS',        Cue = 'UAS_Sub_Surface',                       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Sub',                       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3750,
     BuildIconSortPriority = 15,
     Categories = {
         "AEON",

--- a/units/UAS0305/UAS0305_unit.bp
+++ b/units/UAS0305/UAS0305_unit.bp
@@ -4,6 +4,7 @@ UnitBlueprint{
         Killed      = Sound { Bank = 'UASDestroy', Cue = 'UAS0305_Destroy',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Sonar', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1500,
     BuildIconSortPriority = 190,
     Categories = {
         "AEON",

--- a/units/UAS0401/UAS0401_unit.bp
+++ b/units/UAS0401/UAS0401_unit.bp
@@ -28,6 +28,7 @@ UnitBlueprint{
         SurfaceStart   = Sound { Bank = 'UAS',        Cue = 'UAS0401_Surface',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Naval',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 60000,
     BuildIconSortPriority = 120,
     Categories = {
         "AEON",

--- a/units/UEA0101/UEA0101_unit.bp
+++ b/units/UEA0101/UEA0101_unit.bp
@@ -34,6 +34,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'UEA',        Cue = 'UEA0101_Move_Stop',      LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 35,
     BuildIconSortPriority = 20,
     Categories = {
         "AIR",

--- a/units/UEA0102/UEA0102_unit.bp
+++ b/units/UEA0102/UEA0102_unit.bp
@@ -41,6 +41,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UEA',        Cue = 'UEA0102_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 295,
     BuildIconSortPriority = 30,
     Categories = {
         "AIR",

--- a/units/UEA0103/UEA0103_unit.bp
+++ b/units/UEA0103/UEA0103_unit.bp
@@ -41,6 +41,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UEA',        Cue = 'UEA0103_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 215,
     BuildIconSortPriority = 40,
     Categories = {
         "AIR",

--- a/units/UEA0104/UEA0104_unit.bp
+++ b/units/UEA0104/UEA0104_unit.bp
@@ -39,7 +39,7 @@ UnitBlueprint{
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',         LodCutoff = 'UnitMove_LodCutoff' },
         Unload             = Sound { Bank = 'UEA',        Cue = 'UEA0104_Unit_Unload',    LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 1675,
     BuildIconSortPriority = 40,
     Categories = {
         "AIR",

--- a/units/UEA0107/UEA0107_unit.bp
+++ b/units/UEA0107/UEA0107_unit.bp
@@ -38,7 +38,7 @@ UnitBlueprint{
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',         LodCutoff = 'UnitMove_LodCutoff' },
         Unload             = Sound { Bank = 'UEA',        Cue = 'UEA0107_Unit_Unload',    LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 500,
     BuildIconSortPriority = 50,
     Categories = {
         "AIR",

--- a/units/UEA0203/UEA0203_unit.bp
+++ b/units/UEA0203/UEA0203_unit.bp
@@ -39,7 +39,7 @@ UnitBlueprint{
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',         LodCutoff = 'UnitMove_LodCutoff' },
         Unload             = Sound { Bank = 'UEA',        Cue = 'UEA0104_Unit_Unload',    LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 700,
     BuildIconSortPriority = 30,
     Categories = {
         "AIR",

--- a/units/UEA0204/UEA0204_unit.bp
+++ b/units/UEA0204/UEA0204_unit.bp
@@ -39,6 +39,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UEA',        Cue = 'UEA0204_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 860,
     BuildIconSortPriority = 20,
     Categories = {
         "AIR",

--- a/units/UEA0302/UEA0302_unit.bp
+++ b/units/UEA0302/UEA0302_unit.bp
@@ -35,6 +35,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UEA',        Cue = 'UEA0302_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1150,
     BuildIconSortPriority = 20,
     Categories = {
         "AIR",

--- a/units/UEA0303/UEA0303_unit.bp
+++ b/units/UEA0303/UEA0303_unit.bp
@@ -41,6 +41,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UEA',        Cue = 'UEA0303_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2300,
     BuildIconSortPriority = 30,
     Categories = {
         "AIR",

--- a/units/UEA0304/UEA0304_unit.bp
+++ b/units/UEA0304/UEA0304_unit.bp
@@ -40,6 +40,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UEA',        Cue = 'UEA0304_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 4000,
     BuildIconSortPriority = 40,
     Categories = {
         "AIR",

--- a/units/UEA0305/UEA0305_unit.bp
+++ b/units/UEA0305/UEA0305_unit.bp
@@ -33,7 +33,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'UEA',        Cue = 'UEA0305_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',         LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 6000,
     BuildIconSortPriority = 50,
     Categories = {
         "AIR",

--- a/units/UEB0101/UEB0101_unit.bp
+++ b/units/UEB0101/UEB0101_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB0101_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Factory',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 4000,
     BuildIconSortPriority = 10,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/UEB0102/UEB0102_unit.bp
+++ b/units/UEB0102/UEB0102_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB0102_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Factory',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 4000,
     BuildIconSortPriority = 20,
     Categories = {
         "AIR",

--- a/units/UEB0103/UEB0103_unit.bp
+++ b/units/UEB0103/UEB0103_unit.bp
@@ -17,6 +17,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB0103_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Factory',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 4500,
     BuildIconSortPriority = 30,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/UEB0201/UEB0201_unit.bp
+++ b/units/UEB0201/UEB0201_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB0201_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Factory',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 8000,
     BuildIconSortPriority = 50,
     Categories = {
         "BUILTBYTIER1FACTORY",

--- a/units/UEB0202/UEB0202_unit.bp
+++ b/units/UEB0202/UEB0202_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB0202_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Factory',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 8000,
     BuildIconSortPriority = 60,
     Categories = {
         "AIR",

--- a/units/UEB0203/UEB0203_unit.bp
+++ b/units/UEB0203/UEB0203_unit.bp
@@ -17,6 +17,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB0203_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Factory',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 16000,
     BuildIconSortPriority = 70,
     Categories = {
         "BUILTBYTIER1FACTORY",

--- a/units/UEB0301/UEB0301_unit.bp
+++ b/units/UEB0301/UEB0301_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB0301_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Factory',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 16000,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/UEB0302/UEB0302_unit.bp
+++ b/units/UEB0302/UEB0302_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB0302_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Factory',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 16000,
     BuildIconSortPriority = 50,
     Categories = {
         "AIR",

--- a/units/UEB0303/UEB0303_unit.bp
+++ b/units/UEB0303/UEB0303_unit.bp
@@ -17,6 +17,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB0303_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Factory',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 26000,
     BuildIconSortPriority = 60,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/UEB0304/UEB0304_unit.bp
+++ b/units/UEB0304/UEB0304_unit.bp
@@ -18,6 +18,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB0304_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Structure',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10000,
     BuildIconSortPriority = 220,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/UEB1101/UEB1101_unit.bp
+++ b/units/UEB1101/UEB1101_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB1101_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Resource',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 600,
     BuildIconSortPriority = 70,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/UEB1102/UEB1102_unit.bp
+++ b/units/UEB1102/UEB1102_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB1102_Activate',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1800,
     BuildIconSortPriority = 80,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/UEB1103/UEB1103_unit.bp
+++ b/units/UEB1103/UEB1103_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB1103_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Resource',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 400,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/UEB1104/UEB1104_unit.bp
+++ b/units/UEB1104/UEB1104_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB1104_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Resource',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 360,
     BuildIconSortPriority = 50,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/UEB1105/UEB1105_unit.bp
+++ b/units/UEB1105/UEB1105_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB1105_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Resource',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 90,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/UEB1106/UEB1106_unit.bp
+++ b/units/UEB1106/UEB1106_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB1106_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Resource',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     BuildIconSortPriority = 60,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/UEB1201/UEB1201_unit.bp
+++ b/units/UEB1201/UEB1201_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB1201_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Resource',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2500,
     BuildIconSortPriority = 70,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/UEB1202/UEB1202_unit.bp
+++ b/units/UEB1202/UEB1202_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB1202_Activate',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2000,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/UEB1301/UEB1301_unit.bp
+++ b/units/UEB1301/UEB1301_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB1301_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Resource',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 9000,
     BuildIconSortPriority = 70,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/UEB1302/UEB1302_unit.bp
+++ b/units/UEB1302/UEB1302_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB1202_Activate',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 7000,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/UEB1303/UEB1303_unit.bp
+++ b/units/UEB1303/UEB1303_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB1303_Activate',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6000,
     BuildIconSortPriority = 50,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/UEB2101/UEB2101_unit.bp
+++ b/units/UEB2101/UEB2101_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB2101_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1300,
     BuildIconSortPriority = 110,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/UEB2104/UEB2104_unit.bp
+++ b/units/UEB2104/UEB2104_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB2104_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     BuildIconSortPriority = 120,
     Categories = {
         "ANTIAIR",

--- a/units/UEB2108/UEB2108_unit.bp
+++ b/units/UEB2108/UEB2108_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         Open           = Sound { Bank = 'UEB',        Cue = 'UEB2108_Doors',        LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 900,
     BuildIconSortPriority = 150,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/UEB2109/UEB2109_unit.bp
+++ b/units/UEB2109/UEB2109_unit.bp
@@ -11,6 +11,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB2109_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1700,
     BuildIconSortPriority = 130,
     Categories = {
         "ANTINAVY",

--- a/units/UEB2204/UEB2204_unit.bp
+++ b/units/UEB2204/UEB2204_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB2204_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2590,
     BuildIconSortPriority = 120,
     Categories = {
         "ANTIAIR",

--- a/units/UEB2205/UEB2205_unit.bp
+++ b/units/UEB2205/UEB2205_unit.bp
@@ -12,6 +12,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB2205_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6400,
     BuildIconSortPriority = 130,
     Categories = {
         "ANTINAVY",

--- a/units/UEB2301/UEB2301_unit.bp
+++ b/units/UEB2301/UEB2301_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB2301_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2250,
     BuildIconSortPriority = 110,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/UEB2302/UEB2302_unit.bp
+++ b/units/UEB2302/UEB2302_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB2302_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',             LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 15000,
     BuildIconSortPriority = 140,
     Categories = {
         "ARTILLERY",

--- a/units/UEB2303/UEB2303_unit.bp
+++ b/units/UEB2303/UEB2303_unit.bp
@@ -11,6 +11,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB2303_Activate', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3600,
     BuildIconSortPriority = 140,
     Categories = {
         "ARTILLERY",

--- a/units/UEB2304/UEB2304_unit.bp
+++ b/units/UEB2304/UEB2304_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB2304_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 5000,
     BuildIconSortPriority = 120,
     Categories = {
         "ANTIAIR",

--- a/units/UEB2305/UEB2305_unit.bp
+++ b/units/UEB2305/UEB2305_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         Open                  = Sound { Bank = 'UEB',        Cue = 'UEB2305_Open',                          LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',                        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 4000,
     BuildIconSortPriority = 150,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/UEB2401/UEB2401_unit.bp
+++ b/units/UEB2401/UEB2401_unit.bp
@@ -14,6 +14,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB2401_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',             LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 8000,
     BuildIconSortPriority = 150,
     Categories = {
         "ARTILLERY",

--- a/units/UEB3101/UEB3101_unit.bp
+++ b/units/UEB3101/UEB3101_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB3101_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Radar',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10,
     BuildIconSortPriority = 10,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/UEB3102/UEB3102_unit.bp
+++ b/units/UEB3102/UEB3102_unit.bp
@@ -11,6 +11,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB3102_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Sonar',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 400,
     BuildIconSortPriority = 20,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/UEB3104/UEB3104_unit.bp
+++ b/units/UEB3104/UEB3104_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB3104_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Radar',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 100,
     BuildIconSortPriority = 200,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/UEB3201/UEB3201_unit.bp
+++ b/units/UEB3201/UEB3201_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB3201_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Radar',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 50,
     BuildIconSortPriority = 180,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/UEB3202/UEB3202_unit.bp
+++ b/units/UEB3202/UEB3202_unit.bp
@@ -11,6 +11,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB3202_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Sonar',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     BuildIconSortPriority = 190,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/UEB4201/UEB4201_unit.bp
+++ b/units/UEB4201/UEB4201_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB4201_Activate', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1000,
     BuildIconSortPriority = 155,
     Categories = {
         "ANTIMISSILE",

--- a/units/UEB4202/UEB4202_unit.bp
+++ b/units/UEB4202/UEB4202_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         ShieldOn    = Sound { Bank = 'UEB',        Cue = 'UEB4202_Activate', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 250,
     BuildIconSortPriority = 160,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/UEB4203/UEB4203_unit.bp
+++ b/units/UEB4203/UEB4203_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB4203_Activate', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Radar', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 225,
     BuildIconSortPriority = 190,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/UEB4301/UEB4301_unit.bp
+++ b/units/UEB4301/UEB4301_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         ShieldOn    = Sound { Bank = 'UEB',        Cue = 'UEB4301_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Structure', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 160,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/UEB4302/UEB4302_unit.bp
+++ b/units/UEB4302/UEB4302_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         Open           = Sound { Bank = 'UEB',        Cue = 'UEB4302_Door',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3800,
     BuildIconSortPriority = 155,
     Categories = {
         "ANTIMISSILE",

--- a/units/UEB5101/UEB5101_unit.bp
+++ b/units/UEB5101/UEB5101_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB5101_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Structure', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 130,
     Categories = {
         "BENIGN",

--- a/units/UEB5102/UEB5102_unit.bp
+++ b/units/UEB5102/UEB5102_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint{
     Description = "<LOC ueb5102_desc>UEF Transport Beacon",
+    AverageDensity = 10,
     Categories = {
         "FERRYBEACON",
         "PRODUCTSC1",

--- a/units/UEB5103/UEB5103_unit.bp
+++ b/units/UEB5103/UEB5103_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint{
     Description = "<LOC ueb5103_desc>UEF Quantum Gate Beacon",
+    AverageDensity = 10,
     Categories = {
         "PRODUCTSC1",
         "SIZE4",

--- a/units/UEB5202/UEB5202_unit.bp
+++ b/units/UEB5202/UEB5202_unit.bp
@@ -14,6 +14,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'UEB',        Cue = 'UEB5202_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Structure',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 210,
     Categories = {
         "AIRSTAGINGPLATFORM",

--- a/units/UEB5204/UEB5204_unit.bp
+++ b/units/UEB5204/UEB5204_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint{
     Description = "<LOC ueb5204_desc>Concrete",
+    AverageDensity = 1,
     Categories = {
         "LAND",
         "PRODUCTSC1",

--- a/units/UEB5208/UEB5208_unit.bp
+++ b/units/UEB5208/UEB5208_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint{
     Description = "<LOC ueb5208_desc>Sonar Beacon",
+    AverageDensity = 5,
     Categories = {
         "PRODUCTSC1",
         "SONAR",

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -35,6 +35,7 @@ UnitBlueprint{
         TeleportIn                    = Sound { Bank = 'Impacts',     Cue = 'UEF_Expl_Lrg_Naval',      LodCutoff = 'UnitMove_LodCutoff' },
         UISelection                   = Sound { Bank = 'Interface',   Cue = 'UEF_Select_Commander',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 12000,
     Categories = {
         "AMPHIBIOUS",
         "BUBBLESHIELDSPILLOVERCHECK",

--- a/units/UEL0101/UEL0101_unit.bp
+++ b/units/UEL0101/UEL0101_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UEL',        Cue = 'UEL0101_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Vehicle',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 29,
     BuildIconSortPriority = 20,
     Categories = {
         "BUILTBYTIER1FACTORY",

--- a/units/UEL0103/UEL0103_unit.bp
+++ b/units/UEL0103/UEL0103_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UEL',        Cue = 'UEL0103_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Vehicle',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 205,
     BuildIconSortPriority = 60,
     Categories = {
         "ARTILLERY",

--- a/units/UEL0104/UEL0104_unit.bp
+++ b/units/UEL0104/UEL0104_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UEL',        Cue = 'UEL0104_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Vehicle',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 310,
     BuildIconSortPriority = 50,
     Categories = {
         "ANTIAIR",

--- a/units/UEL0105/UEL0105_unit.bp
+++ b/units/UEL0105/UEL0105_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'UEL',        Cue = 'UEL0105_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Vehicle',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 150,
     BuildIconSortPriority = 10,
     Categories = {
         "AMPHIBIOUS",

--- a/units/UEL0106/UEL0106_unit.bp
+++ b/units/UEL0106/UEL0106_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UEL',        Cue = 'UEL0106_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Bot',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 60,
     BuildIconSortPriority = 30,
     Categories = {
         "BOT",

--- a/units/UEL0111/UEL0111_unit.bp
+++ b/units/UEL0111/UEL0111_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Vehicle',   LodCutoff = 'UnitMove_LodCutoff' },
         Unpack      = Sound { Bank = 'UEL',        Cue = 'UEL0111_Open',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 825,
     BuildIconSortPriority = 100,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/UEL0201/UEL0201_unit.bp
+++ b/units/UEL0201/UEL0201_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UEL',        Cue = 'UEL0201_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Tank',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 300,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYTIER1FACTORY",

--- a/units/UEL0202/UEL0202_unit.bp
+++ b/units/UEL0202/UEL0202_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UEL',        Cue = 'UEL0202_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Tank',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1500,
     BuildIconSortPriority = 20,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/UEL0203/UEL0203_unit.bp
+++ b/units/UEL0203/UEL0203_unit.bp
@@ -11,6 +11,7 @@ UnitBlueprint{
         TransitionWater    = Sound { Bank = 'UEL',        Cue = 'UEL0203_Into_Water',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Tank',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 900.0,
     BuildIconSortPriority = 25,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/UEL0205/UEL0205_unit.bp
+++ b/units/UEL0205/UEL0205_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UEL',        Cue = 'UEL0205_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Vehicle',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1000,
     BuildIconSortPriority = 90,
     Categories = {
         "ANTIAIR",

--- a/units/UEL0208/UEL0208_unit.bp
+++ b/units/UEL0208/UEL0208_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'UEL',        Cue = 'UEL0208_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Vehicle',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 400,
     BuildIconSortPriority = 10,
     Categories = {
         "AMPHIBIOUS",

--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -27,6 +27,7 @@ UnitBlueprint{
         StopMove              = Sound { Bank = 'UEL',         Cue = 'UEL0301_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'Interface',   Cue = 'UEF_Select_Commander',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 16000,
     BuildIconSortPriority = 10,
     Categories = {
         "AMPHIBIOUS",

--- a/units/UEL0303/UEL0303_unit.bp
+++ b/units/UEL0303/UEL0303_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UEL',        Cue = 'UEL0303_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Bot',          LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2400,
     BuildIconSortPriority = 20,
     Categories = {
         "BOT",

--- a/units/UEL0304/UEL0304_unit.bp
+++ b/units/UEL0304/UEL0304_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UEL',        Cue = 'UEL0304_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 950,
     BuildIconSortPriority = 30,
     Categories = {
         "ARTILLERY",

--- a/units/UEL0307/UEL0307_unit.bp
+++ b/units/UEL0307/UEL0307_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UEL',        Cue = 'UEL0307_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Vehicle',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 150,
     BuildIconSortPriority = 110,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/UEL0309/UEL0309_unit.bp
+++ b/units/UEL0309/UEL0309_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'UEL',        Cue = 'UEL0309_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Vehicle',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     BuildIconSortPriority = 10,
     Categories = {
         "AMPHIBIOUS",

--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -32,6 +32,7 @@ UnitBlueprint{
         TransitionWater  = Sound { Bank = 'UEL',        Cue = 'UEL0401_Water_Trans',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection      = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Tank',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 12500,
     BuildIconSortPriority = 10,
     Categories = {
         "AIRSTAGINGPLATFORM",

--- a/units/UES0103/UES0103_unit.bp
+++ b/units/UES0103/UES0103_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UES',        Cue = 'UES0103_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Naval',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2120,
     BuildIconSortPriority = 30,
     Categories = {
         "BUILTBYTIER1FACTORY",

--- a/units/UES0201/UES0201_unit.bp
+++ b/units/UES0201/UES0201_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UES',        Cue = 'UES0201_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Naval',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 8000,
     BuildIconSortPriority = 30,
     Categories = {
         "ANTINAVY",

--- a/units/UES0202/UES0202_unit.bp
+++ b/units/UES0202/UES0202_unit.bp
@@ -17,6 +17,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UES',        Cue = 'UES0202_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Naval',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2500,
     BuildIconSortPriority = 35,
     Categories = {
         "ANTIAIR",

--- a/units/UES0203/UES0203_unit.bp
+++ b/units/UES0203/UES0203_unit.bp
@@ -13,6 +13,7 @@ UnitBlueprint{
         SurfaceStart   = Sound { Bank = 'UES',        Cue = 'UES_Sub_Surface',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Sub',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     BuildIconSortPriority = 20,
     Categories = {
         "ANTINAVY",

--- a/units/UES0302/UES0302_unit.bp
+++ b/units/UES0302/UES0302_unit.bp
@@ -23,6 +23,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'UES',        Cue = 'UES0302_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Naval',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 51000,
     BuildIconSortPriority = 20,
     Categories = {
         "ANTIMISSILE",

--- a/units/UES0304/UES0304_unit.bp
+++ b/units/UES0304/UES0304_unit.bp
@@ -18,6 +18,7 @@ UnitBlueprint{
         SurfaceStart          = Sound { Bank = 'UES',        Cue = 'UES_Sub_Surface',                       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Sub',                        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 4000,
     BuildIconSortPriority = 15,
     Categories = {
         "BUILTBYTIER3FACTORY",

--- a/units/UES0305/UES0305_unit.bp
+++ b/units/UES0305/UES0305_unit.bp
@@ -14,6 +14,7 @@ UnitBlueprint{
         StopMove       = Sound { Bank = 'UES',        Cue = 'UES0305_Move_Stop',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Sonar',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2000,
     BuildIconSortPriority = 190,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/UES0401/UES0401_unit.bp
+++ b/units/UES0401/UES0401_unit.bp
@@ -28,6 +28,7 @@ UnitBlueprint{
         SurfaceStart   = Sound { Bank = 'UES',        Cue = 'UES_Sub_Surface',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Naval',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 40000,
     BuildIconSortPriority = 20,
     Categories = {
         "AIRSTAGINGPLATFORM",

--- a/units/URA0001O/URA0001O_unit.bp
+++ b/units/URA0001O/URA0001O_unit.bp
@@ -22,6 +22,7 @@ UnitBlueprint{
         StartTurnDistance = 5,
         Winged = false,
     },
+    AverageDensity = 30,
     Categories = {
         "CONSTRUCTION",
         "DUMMYUNIT",

--- a/units/URA0002O/URA0002O_unit.bp
+++ b/units/URA0002O/URA0002O_unit.bp
@@ -22,6 +22,7 @@ UnitBlueprint{
         StartTurnDistance = 5,
         Winged = false,
     },
+    AverageDensity = 30,
     Categories = {
         "CONSTRUCTION",
         "DUMMYUNIT",

--- a/units/URA0003O/URA0003O_unit.bp
+++ b/units/URA0003O/URA0003O_unit.bp
@@ -22,6 +22,7 @@ UnitBlueprint{
         StartTurnDistance = 5,
         Winged = false,
     },
+    AverageDensity = 30,
     Categories = {
         "CONSTRUCTION",
         "DUMMYUNIT",

--- a/units/URA0004/URA0004_unit.bp
+++ b/units/URA0004/URA0004_unit.bp
@@ -21,6 +21,7 @@ UnitBlueprint{
         StartTurnDistance = 5,
         Winged = false,
     },
+    AverageDensity = 30,
     Categories = {
         "CONSTRUCTION",
         "ENGINEER",

--- a/units/URA0101/URA0101_unit.bp
+++ b/units/URA0101/URA0101_unit.bp
@@ -35,6 +35,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'URA',        Cue = 'URA0101_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Air',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 26,
     BuildIconSortPriority = 20,
     Categories = {
         "AIR",

--- a/units/URA0102/URA0102_unit.bp
+++ b/units/URA0102/URA0102_unit.bp
@@ -41,6 +41,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'URA',        Cue = 'URA0102_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Air',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 280,
     BuildIconSortPriority = 30,
     Categories = {
         "AIR",

--- a/units/URA0103/URA0103_unit.bp
+++ b/units/URA0103/URA0103_unit.bp
@@ -41,6 +41,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'URA',        Cue = 'URA0103_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Air',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 200,
     BuildIconSortPriority = 40,
     Categories = {
         "AIR",

--- a/units/URA0104/URA0104_unit.bp
+++ b/units/URA0104/URA0104_unit.bp
@@ -37,7 +37,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'URA',        Cue = 'URA0104_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Air',      LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 1525,
     BuildIconSortPriority = 40,
     Categories = {
         "AIR",

--- a/units/URA0107/URA0107_unit.bp
+++ b/units/URA0107/URA0107_unit.bp
@@ -37,7 +37,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'URA',        Cue = 'URA0104_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Air',      LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 500,
     BuildIconSortPriority = 50,
     Categories = {
         "AIR",

--- a/units/URA0203/URA0203_unit.bp
+++ b/units/URA0203/URA0203_unit.bp
@@ -35,7 +35,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'URA',        Cue = 'URA0103_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Air',      LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 832,
     BuildIconSortPriority = 30,
     Categories = {
         "AIR",

--- a/units/URA0204/URA0204_unit.bp
+++ b/units/URA0204/URA0204_unit.bp
@@ -38,6 +38,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'URA',        Cue = 'URA0204_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Air',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     BuildIconSortPriority = 20,
     Categories = {
         "AIR",

--- a/units/URA0302/URA0302_unit.bp
+++ b/units/URA0302/URA0302_unit.bp
@@ -35,6 +35,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'URA',        Cue = 'URA0302_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Air',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 700,
     BuildIconSortPriority = 20,
     Categories = {
         "AIR",

--- a/units/URA0303/URA0303_unit.bp
+++ b/units/URA0303/URA0303_unit.bp
@@ -41,6 +41,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'URA',        Cue = 'URA0303_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Air',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2225,
     BuildIconSortPriority = 30,
     Categories = {
         "AIR",

--- a/units/URA0304/URA0304_unit.bp
+++ b/units/URA0304/URA0304_unit.bp
@@ -41,6 +41,7 @@ UnitBlueprint{
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Air',      LodCutoff = 'UnitMove_LodCutoff' },
         Unload             = Sound { Bank = 'UEA',        Cue = 'UEA0104_Unit_Unload',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3700,
     BuildIconSortPriority = 40,
     Categories = {
         "AIR",

--- a/units/URA0401/URA0401_unit.bp
+++ b/units/URA0401/URA0401_unit.bp
@@ -45,7 +45,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'URA',        Cue = 'URA0401_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Air',      LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 75000,
     BuildIconSortPriority = 100,
     Categories = {
         "AIR",

--- a/units/URB0101/URB0101_unit.bp
+++ b/units/URB0101/URB0101_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB0101_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2750,
     BuildIconSortPriority = 10,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/URB0102/URB0102_unit.bp
+++ b/units/URB0102/URB0102_unit.bp
@@ -14,6 +14,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB0102_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2750,
     BuildIconSortPriority = 20,
     Categories = {
         "AIR",

--- a/units/URB0103/URB0103_unit.bp
+++ b/units/URB0103/URB0103_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB0103_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3200,
     BuildIconSortPriority = 30,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/URB0201/URB0201_unit.bp
+++ b/units/URB0201/URB0201_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB0201_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 5500,
     BuildIconSortPriority = 50,
     Categories = {
         "BUILTBYTIER1FACTORY",

--- a/units/URB0202/URB0202_unit.bp
+++ b/units/URB0202/URB0202_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB0202_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 5500,
     BuildIconSortPriority = 60,
     Categories = {
         "AIR",

--- a/units/URB0203/URB0203_unit.bp
+++ b/units/URB0203/URB0203_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB0203_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 11000,
     BuildIconSortPriority = 70,
     Categories = {
         "BUILTBYTIER1FACTORY",

--- a/units/URB0301/URB0301_unit.bp
+++ b/units/URB0301/URB0301_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB0301_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 11000,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/URB0302/URB0302_unit.bp
+++ b/units/URB0302/URB0302_unit.bp
@@ -17,6 +17,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB0302_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 11000,
     BuildIconSortPriority = 50,
     Categories = {
         "AIR",

--- a/units/URB0303/URB0303_unit.bp
+++ b/units/URB0303/URB0303_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB0303_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 17000,
     BuildIconSortPriority = 60,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/URB0304/URB0304_unit.bp
+++ b/units/URB0304/URB0304_unit.bp
@@ -19,6 +19,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB0304_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Structure',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10000,
     BuildIconSortPriority = 220,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/URB1101/URB1101_unit.bp
+++ b/units/URB1101/URB1101_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB1101_Activate',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 70,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/URB1102/URB1102_unit.bp
+++ b/units/URB1102/URB1102_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB1102_Activate',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1400,
     BuildIconSortPriority = 80,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/URB1103/URB1103_unit.bp
+++ b/units/URB1103/URB1103_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB1103_Activate',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 360,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/URB1104/URB1104_unit.bp
+++ b/units/URB1104/URB1104_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB1104_Activate',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 360,
     BuildIconSortPriority = 50,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/URB1105/URB1105_unit.bp
+++ b/units/URB1105/URB1105_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB1105_Activate',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 90,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/URB1106/URB1106_unit.bp
+++ b/units/URB1106/URB1106_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB1106_Activate',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 600,
     BuildIconSortPriority = 60,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/URB1201/URB1201_unit.bp
+++ b/units/URB1201/URB1201_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB1201_Activate',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2200,
     BuildIconSortPriority = 70,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/URB1202/URB1202_unit.bp
+++ b/units/URB1202/URB1202_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',       Cue = 'URB1202_Activate',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface', Cue = 'Cybran_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1800,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/URB1301/URB1301_unit.bp
+++ b/units/URB1301/URB1301_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB1301_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Resource',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6000,
     BuildIconSortPriority = 70,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/URB1302/URB1302_unit.bp
+++ b/units/URB1302/URB1302_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB1302_Activate',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6250,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/URB1303/URB1303_unit.bp
+++ b/units/URB1303/URB1303_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB1303_Activate',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6000,
     BuildIconSortPriority = 50,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/URB2101/URB2101_unit.bp
+++ b/units/URB2101/URB2101_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Gun', LodCutoff = 'UnitMove_LodCutoff' },
         Unpack         = Sound { Bank = 'URB',        Cue = 'URB2101_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1300,
     BuildIconSortPriority = 110,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/URB2104/URB2104_unit.bp
+++ b/units/URB2104/URB2104_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Gun', LodCutoff = 'UnitMove_LodCutoff' },
         Unpack         = Sound { Bank = 'URB',        Cue = 'URB2104_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     BuildIconSortPriority = 120,
     Categories = {
         "ANTIAIR",

--- a/units/URB2108/URB2108_unit.bp
+++ b/units/URB2108/URB2108_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',       Cue = 'URB2108_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface', Cue = 'Cybran_Select_Gun', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 900,
     BuildIconSortPriority = 150,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/URB2109/URB2109_unit.bp
+++ b/units/URB2109/URB2109_unit.bp
@@ -12,6 +12,7 @@ UnitBlueprint{
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Gun', LodCutoff = 'UnitMove_LodCutoff' },
         Unpack         = Sound { Bank = 'URB',        Cue = 'URB2109_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1600,
     BuildIconSortPriority = 130,
     Categories = {
         "ANTINAVY",

--- a/units/URB2204/URB2204_unit.bp
+++ b/units/URB2204/URB2204_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB2204_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Gun', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2380,
     BuildIconSortPriority = 120,
     Categories = {
         "ANTIAIR",

--- a/units/URB2205/URB2205_unit.bp
+++ b/units/URB2205/URB2205_unit.bp
@@ -12,6 +12,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB2205_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Gun', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 5800,
     BuildIconSortPriority = 130,
     Categories = {
         "ANTINAVY",

--- a/units/URB2301/URB2301_unit.bp
+++ b/units/URB2301/URB2301_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB2301_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Gun', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2000,
     BuildIconSortPriority = 110,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/URB2302/URB2302_unit.bp
+++ b/units/URB2302/URB2302_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB2302_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Gun',          LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10500,
     BuildIconSortPriority = 140,
     Categories = {
         "ARTILLERY",

--- a/units/URB2303/URB2303_unit.bp
+++ b/units/URB2303/URB2303_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB2303_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Gun', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3150,
     BuildIconSortPriority = 140,
     Categories = {
         "ARTILLERY",

--- a/units/URB2304/URB2304_unit.bp
+++ b/units/URB2304/URB2304_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB2304_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Gun', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 5000,
     BuildIconSortPriority = 120,
     Categories = {
         "ANTIAIR",

--- a/units/URB2305/URB2305_unit.bp
+++ b/units/URB2305/URB2305_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         Open                  = Sound { Bank = 'URB',        Cue = 'URB2305_Open',                          LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Gun',                     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 4000,
     BuildIconSortPriority = 150,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/URB3101/URB3101_unit.bp
+++ b/units/URB3101/URB3101_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB3101_Activate',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Radar', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10,
     BuildIconSortPriority = 180,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/URB3102/URB3102_unit.bp
+++ b/units/URB3102/URB3102_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB3102_Activate',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Sonar', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 400,
     BuildIconSortPriority = 190,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/URB3103/URB3103_unit.bp
+++ b/units/URB3103/URB3103_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint{
     Description = "<LOC urb3103_desc>Scout-Deployed Land Sensor",
+    AverageDensity = 1,
     Categories = {
         "CYBRAN",
         "INTELLIGENCE",

--- a/units/URB3104/URB3104_unit.bp
+++ b/units/URB3104/URB3104_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB3104_Activate',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Radar', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 100,
     BuildIconSortPriority = 200,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/URB3201/URB3201_unit.bp
+++ b/units/URB3201/URB3201_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB3201_Activate',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Radar', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 50,
     BuildIconSortPriority = 180,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/URB3202/URB3202_unit.bp
+++ b/units/URB3202/URB3202_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB3202_Activate',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Sonar', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     BuildIconSortPriority = 190,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/URB4201/URB4201_unit.bp
+++ b/units/URB4201/URB4201_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB4201_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Gun', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 950,
     BuildIconSortPriority = 155,
     Categories = {
         "ANTIMISSILE",

--- a/units/URB4202/URB4202_unit.bp
+++ b/units/URB4202/URB4202_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         ShieldOn       = Sound { Bank = 'URB',        Cue = 'URB4202_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Structure',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 160,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/URB4203/URB4203_unit.bp
+++ b/units/URB4203/URB4203_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB4203_Activate',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Radar', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 150,
     BuildIconSortPriority = 200,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/URB4204/URB4204_unit.bp
+++ b/units/URB4204/URB4204_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         ShieldOn       = Sound { Bank = 'URB',        Cue = 'URB4202_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Structure',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 162,
     Categories = {
         "CYBRAN",

--- a/units/URB4205/URB4205_unit.bp
+++ b/units/URB4205/URB4205_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         ShieldOn       = Sound { Bank = 'URB',        Cue = 'URB4202_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Structure',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 163,
     Categories = {
         "CYBRAN",

--- a/units/URB4206/URB4206_unit.bp
+++ b/units/URB4206/URB4206_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         ShieldOn       = Sound { Bank = 'URB',        Cue = 'URB4202_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Structure',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 164,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/URB4207/URB4207_unit.bp
+++ b/units/URB4207/URB4207_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         ShieldOn       = Sound { Bank = 'URB',        Cue = 'URB4202_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Structure',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 165,
     Categories = {
         "CYBRAN",

--- a/units/URB4302/URB4302_unit.bp
+++ b/units/URB4302/URB4302_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URL',        Cue = 'URB4302_Activate',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Gun', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3800,
     BuildIconSortPriority = 170,
     Categories = {
         "ANTIMISSILE",

--- a/units/URB5101/URB5101_unit.bp
+++ b/units/URB5101/URB5101_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'URB',        Cue = 'URB5101_Activate',        LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Structure', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 200,
     Categories = {
         "BENIGN",

--- a/units/URB5102/URB5102_unit.bp
+++ b/units/URB5102/URB5102_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint{
     Description = "<LOC urb5102_desc>Cybran Transport Beacon",
+    AverageDensity = 10,
     Categories = {
         "CYBRAN",
         "FERRYBEACON",

--- a/units/URB5103/URB5103_unit.bp
+++ b/units/URB5103/URB5103_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint{
     Description = "<LOC urb5103_desc>Quantum Gate Beacon",
+    AverageDensity = 10,
     Categories = {
         "CYBRAN",
         "PRODUCTSC1",

--- a/units/URB5202/URB5202_unit.bp
+++ b/units/URB5202/URB5202_unit.bp
@@ -13,6 +13,7 @@ UnitBlueprint{
         Destroyed      = Sound { Bank = 'URLDestroy', Cue = 'URB_Destroy_Huge',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Structure',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 210,
     Categories = {
         "AIRSTAGINGPLATFORM",

--- a/units/URB5204/URB5204_unit.bp
+++ b/units/URB5204/URB5204_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint{
     Description = "<LOC urb5204_desc>Concrete",
+    AverageDensity = 1,
     Categories = {
         "CYBRAN",
         "LAND",

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -35,6 +35,7 @@ UnitBlueprint{
         TeleportIn                    = Sound { Bank = 'Impacts',     Cue = 'XSA_Bomb_Explosion_01',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection                   = Sound { Bank = 'Interface',   Cue = 'Cybran_Select_Commander', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10000,
     BuildBotTotal = 2,
     Categories = {
         "AMPHIBIOUS",

--- a/units/URL0101/URL0101_unit.bp
+++ b/units/URL0101/URL0101_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URL',        Cue = 'URL0101_Move_Stop',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 15,
     BuildIconSortPriority = 20,
     Categories = {
         "BOT",

--- a/units/URL0103/URL0103_unit.bp
+++ b/units/URL0103/URL0103_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URL',        Cue = 'URL0103_Move_Stop',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 140,
     BuildIconSortPriority = 60,
     Categories = {
         "ARTILLERY",

--- a/units/URL0104/URL0104_unit.bp
+++ b/units/URL0104/URL0104_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URL',        Cue = 'URL0104_Move_Stop',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 260,
     BuildIconSortPriority = 50,
     Categories = {
         "ANTIAIR",

--- a/units/URL0105/URL0105_unit.bp
+++ b/units/URL0105/URL0105_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'URL',        Cue = 'URL0105_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Vehicle',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 145,
     BuildBotTotal = 1,
     BuildIconSortPriority = 10,
     Categories = {

--- a/units/URL0106/URL0106_unit.bp
+++ b/units/URL0106/URL0106_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URL',        Cue = 'URL0106_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Bot',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 90,
     BuildIconSortPriority = 30,
     Categories = {
         "BOT",

--- a/units/URL0107/URL0107_unit.bp
+++ b/units/URL0107/URL0107_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         StopMove      = Sound { Bank = 'URL',        Cue = 'URL0107_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection   = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Bot',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 270,
     BuildIconSortPriority = 40,
     Categories = {
         "BOT",

--- a/units/URL0111/URL0111_unit.bp
+++ b/units/URL0111/URL0111_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URL',        Cue = 'URL0111_Move_Stop',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 700,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/URL0202/URL0202_unit.bp
+++ b/units/URL0202/URL0202_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URL',        Cue = 'URL0202_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Tank', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1900,
     BuildIconSortPriority = 20,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/URL0203/URL0203_unit.bp
+++ b/units/URL0203/URL0203_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         StopMove         = Sound { Bank = 'URL',        Cue = 'URL0203_Move_Stop',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection      = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Tank',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1200,
     BuildIconSortPriority = 25,
     Categories = {
         "AMPHIBIOUS",

--- a/units/URL0205/URL0205_unit.bp
+++ b/units/URL0205/URL0205_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URL',        Cue = 'URL0205_Move_Stop',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1000,
     BuildIconSortPriority = 30,
     Categories = {
         "ANTIAIR",

--- a/units/URL0208/URL0208_unit.bp
+++ b/units/URL0208/URL0208_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'URL',        Cue = 'URL0208_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Vehicle',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 390,
     BuildBotTotal = 2,
     BuildIconSortPriority = 10,
     Categories = {

--- a/units/URL0301/URL0301_unit.bp
+++ b/units/URL0301/URL0301_unit.bp
@@ -27,6 +27,7 @@ UnitBlueprint{
         StopMove              = Sound { Bank = 'URL',         Cue = 'URL0301_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'Interface',   Cue = 'Cybran_Select_Commander', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 19000,
     BuildBotTotal = 3,
     BuildIconSortPriority = 10,
     Categories = {

--- a/units/URL0303/URL0303_unit.bp
+++ b/units/URL0303/URL0303_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URL',       Cue = 'URL0303_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface', Cue = 'Cybran_Select_Bot',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3000,
     BuildIconSortPriority = 20,
     Categories = {
         "ANTIMISSILE",

--- a/units/URL0304/URL0304_unit.bp
+++ b/units/URL0304/URL0304_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URL',        Cue = 'URL0304_Move_Stop',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 850,
     BuildIconSortPriority = 30,
     Categories = {
         "ARTILLERY",

--- a/units/URL0306/URL0306_unit.bp
+++ b/units/URL0306/URL0306_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URL',        Cue = 'URL0306_Move_Stop',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 350,
     BuildIconSortPriority = 60,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/URL0309/URL0309_unit.bp
+++ b/units/URL0309/URL0309_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'URL',        Cue = 'URL0309_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Vehicle',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 740,
     BuildBotTotal = 3,
     BuildIconSortPriority = 10,
     Categories = {

--- a/units/URL0401/URL0401_unit.bp
+++ b/units/URL0401/URL0401_unit.bp
@@ -13,6 +13,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URL',       Cue = 'URL0401_Move_Stop',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface', Cue = 'Cybran_Select_Gun',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 9000,
     BuildIconSortPriority = 10,
     Categories = {
         "AMPHIBIOUS",

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -25,6 +25,7 @@ UnitBlueprint{
         StopMove              = Sound { Bank = 'URL',        Cue = 'URL0402_Move_Stop',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Spider',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 45000,
     BuildIconSortPriority = 20,
     Categories = {
         "AMPHIBIOUS",

--- a/units/URS0103/URS0103_unit.bp
+++ b/units/URS0103/URS0103_unit.bp
@@ -18,6 +18,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URS',        Cue = 'URS0103_Move_Stop',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Naval', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1900,
     BuildIconSortPriority = 40,
     Categories = {
         "ANTIAIR",

--- a/units/URS0201/URS0201_unit.bp
+++ b/units/URS0201/URS0201_unit.bp
@@ -21,6 +21,7 @@ UnitBlueprint{
         TransitionWater                = Sound { Bank = 'URSStream',  Cue = 'URS0201_Land_Retract',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection                    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Naval',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6500,
     BuildIconSortPriority = 25,
     Categories = {
         "AMPHIBIOUS",

--- a/units/URS0202/URS0202_unit.bp
+++ b/units/URS0202/URS0202_unit.bp
@@ -22,6 +22,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URS',        Cue = 'URS0202_Move_Stop',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Naval', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3000,
     BuildIconSortPriority = 30,
     Categories = {
         "AIRSTAGINGPLATFORM",

--- a/units/URS0203/URS0203_unit.bp
+++ b/units/URS0203/URS0203_unit.bp
@@ -13,6 +13,7 @@ UnitBlueprint{
         SurfaceStart   = Sound { Bank = 'URS',        Cue = 'URS_Sub_Surface',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Sub',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 775,
     BuildIconSortPriority = 30,
     Categories = {
         "ANTINAVY",

--- a/units/URS0302/URS0302_unit.bp
+++ b/units/URS0302/URS0302_unit.bp
@@ -19,6 +19,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URS',        Cue = 'URS0302_Move_Stop',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Naval', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 44500,
     BuildIconSortPriority = 30,
     Categories = {
         "ANTIMISSILE",

--- a/units/URS0303/URS0303_unit.bp
+++ b/units/URS0303/URS0303_unit.bp
@@ -20,6 +20,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'URS',        Cue = 'URS0303_Move_Stop',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Naval', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 20000,
     BuildIconSortPriority = 40,
     Categories = {
         "AIRSTAGINGPLATFORM",

--- a/units/URS0304/URS0304_unit.bp
+++ b/units/URS0304/URS0304_unit.bp
@@ -17,6 +17,7 @@ UnitBlueprint{
         SurfaceStart          = Sound { Bank = 'URS',        Cue = 'URS_Sub_Surface',                       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Sub',                     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3500,
     BuildIconSortPriority = 20,
     Categories = {
         "ANTINAVY",

--- a/units/URS0305/URS0305_unit.bp
+++ b/units/URS0305/URS0305_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         StopMove       = Sound { Bank = 'URS',        Cue = 'URS0305_Move_Stop',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Sonar', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1200,
     BuildIconSortPriority = 190,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/UXL0021/UXL0021_unit.bp
+++ b/units/UXL0021/UXL0021_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint{
     Description = "<LOC gameui_0000>Test Unit Arc Projectile",
+    AverageDensity = 25,
     Categories = {
         "ARTILLERY",
         "DEBUG",

--- a/units/XAA0202/XAA0202_unit.bp
+++ b/units/XAA0202/XAA0202_unit.bp
@@ -38,6 +38,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XAA',        Cue = 'XAA0202_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     BuildIconSortPriority = 15,
     Categories = {
         "AEON",

--- a/units/XAA0305/XAA0305_unit.bp
+++ b/units/XAA0305/XAA0305_unit.bp
@@ -35,7 +35,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XAA',        Cue = 'XAA0305_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 6000,
     BuildIconSortPriority = 50,
     Categories = {
         "AEON",

--- a/units/XAA0306/XAA0306_unit.bp
+++ b/units/XAA0306/XAA0306_unit.bp
@@ -41,6 +41,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XAA',        Cue = 'XAA0306_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3750,
     BuildIconSortPriority = 30,
     Categories = {
         "AEON",

--- a/units/XAB1401/XAB1401_unit.bp
+++ b/units/XAB1401/XAB1401_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'Explosions', Cue = 'Aeon_Nuke_Impact',     LodCutoff = 'Weapon_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Resource', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 5000,
     BuildIconSortPriority = 140,
     Categories = {
         "AEON",

--- a/units/XAB2307/XAB2307_unit.bp
+++ b/units/XAB2307/XAB2307_unit.bp
@@ -12,6 +12,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XAB',        Cue = 'XAB2307_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Gun',            LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 9000,
     BuildIconSortPriority = 150,
     Categories = {
         "AEON",

--- a/units/XAB3301/XAB3301_unit.bp
+++ b/units/XAB3301/XAB3301_unit.bp
@@ -13,6 +13,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XAB',        Cue = 'XAB3301_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Radar',          LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 250,
     BuildIconSortPriority = 200,
     Categories = {
         "ABILITYBUTTON",

--- a/units/XAL0203/XAL0203_unit.bp
+++ b/units/XAL0203/XAL0203_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XAL',        Cue = 'XAL0203_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Tank',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500.0,
     BuildIconSortPriority = 20,
     Categories = {
         "AEON",

--- a/units/XAL0305/XAL0305_unit.bp
+++ b/units/XAL0305/XAL0305_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XAL',        Cue = 'XAL0305_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Bot',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 15,
     Categories = {
         "AEON",

--- a/units/XAS0204/XAS0204_unit.bp
+++ b/units/XAS0204/XAS0204_unit.bp
@@ -13,6 +13,7 @@ UnitBlueprint{
         SurfaceStart   = Sound { Bank = 'UAS',        Cue = 'UAS_Sub_Surface',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Sub',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1800,
     BuildIconSortPriority = 15,
     Categories = {
         "AEON",

--- a/units/XAS0306/XAS0306_unit.bp
+++ b/units/XAS0306/XAS0306_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XAS',        Cue = 'XAS0306_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Aeon_Select_Naval',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 7500,
     BuildIconSortPriority = 20,
     Categories = {
         "AEON",

--- a/units/XEA0002/XEA0002_unit.bp
+++ b/units/XEA0002/XEA0002_unit.bp
@@ -25,6 +25,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XEA',        Cue = 'XEA0306_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 100,
     BuildIconSortPriority = 10,
     Categories = {
         "AIR",

--- a/units/XEA0306/XEA0306_unit.bp
+++ b/units/XEA0306/XEA0306_unit.bp
@@ -41,7 +41,7 @@ UnitBlueprint{
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',         LodCutoff = 'UnitMove_LodCutoff' },
         Unload             = Sound { Bank = 'XEA',        Cue = 'XEA0306_Unit_Unload',    LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 4500,
     BuildIconSortPriority = 60,
     Categories = {
         "AIR",

--- a/units/XEA3204/XEA3204_unit.bp
+++ b/units/XEA3204/XEA3204_unit.bp
@@ -36,8 +36,10 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XEA',        Cue = 'XEA3204_Move_Thruster',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Air',          LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 50,
     Categories = {
         "AIR",
+        "CANLANDONWATER",
         "CAPTURE",
         "ENGINEER",
         "MOBILE",

--- a/units/XEB0104/XEB0104_unit.bp
+++ b/units/XEB0104/XEB0104_unit.bp
@@ -14,6 +14,7 @@ UnitBlueprint{
         Open           = Sound { Bank = 'XEB',        Cue = 'XEB0104_Open',            LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Structure',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1000,
     BuildIconSortPriority = 200,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/XEB0204/XEB0204_unit.bp
+++ b/units/XEB0204/XEB0204_unit.bp
@@ -14,6 +14,7 @@ UnitBlueprint{
         Open           = Sound { Bank = 'XEB',        Cue = 'XEB0204_Open',            LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Structure',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2500,
     BuildIconSortPriority = 200,
     Categories = {
         "CONSTRUCTION",

--- a/units/XEB2306/XEB2306_unit.bp
+++ b/units/XEB2306/XEB2306_unit.bp
@@ -5,6 +5,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XEB',        Cue = 'XEB2306_Activate',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Gun',       LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6500,
     BuildIconSortPriority = 110,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/XEB2402/XEB2402_unit.bp
+++ b/units/XEB2402/XEB2402_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         MoveArms       = Sound { Bank = 'XEB',         Cue = 'XEB2402_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',   Cue = 'UEF_Select_Factory',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 9000,
     Categories = {
         "AIR",
         "BUILTBYTIER3COMMANDER",

--- a/units/XEL0209/XEL0209_unit.bp
+++ b/units/XEL0209/XEL0209_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'XEL',        Cue = 'XEL0209_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Vehicle',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1040,
     BuildIconSortPriority = 15,
     Categories = {
         "AMPHIBIOUS",

--- a/units/XEL0305/XEL0305_unit.bp
+++ b/units/XEL0305/XEL0305_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XEL',        Cue = 'XEL0305_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Bot',          LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 7200,
     BuildIconSortPriority = 30,
     Categories = {
         "AMPHIBIOUS",

--- a/units/XEL0306/XEL0306_unit.bp
+++ b/units/XEL0306/XEL0306_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         UISelection = Sound { Bank = 'Interface',  Cue = 'UEF_Select_Vehicle',   LodCutoff = 'UnitMove_LodCutoff' },
         Unpack      = Sound { Bank = 'UEL',        Cue = 'UEL0111_Open',         LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1700,
     BuildIconSortPriority = 30,
     Categories = {
         "BUILTBYTIER3FACTORY",

--- a/units/XES0102/XES0102_unit.bp
+++ b/units/XES0102/XES0102_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XES',         Cue = 'XES0102_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',   Cue = 'UEF_Select_Naval',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2000,
     BuildIconSortPriority = 20,
     Categories = {
         "ANTINAVY",

--- a/units/XES0205/XES0205_unit.bp
+++ b/units/XES0205/XES0205_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XES',         Cue = 'XES0205_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',   Cue = 'UEF_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 550,
     BuildIconSortPriority = 60,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/XES0307/XES0307_unit.bp
+++ b/units/XES0307/XES0307_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XES',         Cue = 'XES0307_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',   Cue = 'UEF_Select_Naval',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 25000,
     BuildIconSortPriority = 20,
     Categories = {
         "ANTIMISSILE",

--- a/units/XRA0105/XRA0105_unit.bp
+++ b/units/XRA0105/XRA0105_unit.bp
@@ -35,7 +35,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XRA',        Cue = 'XRA0105_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Air',      LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 350,
     BuildIconSortPriority = 40,
     Categories = {
         "AIR",

--- a/units/XRA0305/XRA0305_unit.bp
+++ b/units/XRA0305/XRA0305_unit.bp
@@ -33,7 +33,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XRA',        Cue = 'XRA0305_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Air',      LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 5900,
     BuildIconSortPriority = 50,
     Categories = {
         "AIR",

--- a/units/XRB0104/XRB0104_unit.bp
+++ b/units/XRB0104/XRB0104_unit.bp
@@ -18,6 +18,7 @@ UnitBlueprint{
         StartReclaim   = Sound { Bank = 'URL',        Cue = 'URL0105_Reclaim_Start',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildBotTotal = 1,
     BuildIconSortPriority = 200,
     Categories = {

--- a/units/XRB0204/XRB0204_unit.bp
+++ b/units/XRB0204/XRB0204_unit.bp
@@ -19,6 +19,7 @@ UnitBlueprint{
         StartReclaim   = Sound { Bank = 'URL',        Cue = 'URL0105_Reclaim_Start',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1000,
     BuildBotTotal = 2,
     BuildIconSortPriority = 200,
     Categories = {

--- a/units/XRB0304/XRB0304_unit.bp
+++ b/units/XRB0304/XRB0304_unit.bp
@@ -19,6 +19,7 @@ UnitBlueprint{
         StartReclaim   = Sound { Bank = 'URL',        Cue = 'URL0105_Reclaim_Start',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2000,
     BuildBotTotal = 3,
     BuildIconSortPriority = 200,
     Categories = {

--- a/units/XRB2308/XRB2308_unit.bp
+++ b/units/XRB2308/XRB2308_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'Explosions', Cue = 'Expl_Water_Lrg_01',          LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Gun',          LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 9000,
     BuildIconSortPriority = 130,
     Categories = {
         "ANTINAVY",

--- a/units/XRB2309/XRB2309_unit.bp
+++ b/units/XRB2309/XRB2309_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'Explosions', Cue = 'Expl_Water_Lrg_01',          LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Gun',          LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 9000,
     BuildIconSortPriority = 130,
     Categories = {
         "ANTINAVY",

--- a/units/XRB3301/XRB3301_unit.bp
+++ b/units/XRB3301/XRB3301_unit.bp
@@ -13,6 +13,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XRB',        Cue = 'XRB3301_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Radar',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 200,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/XRL0002/XRL0002_unit.bp
+++ b/units/XRL0002/XRL0002_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         EggSink        = Sound { Bank = 'URLDestroy', Cue = 'URB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10,
     BuildIconSortPriority = 10,
     Categories = {
         "CONSTRUCTION",

--- a/units/XRL0003/XRL0003_unit.bp
+++ b/units/XRL0003/XRL0003_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         EggSink        = Sound { Bank = 'XRL_Stream', Cue = 'XRL_Crab_Sink',              LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10,
     BuildIconSortPriority = 20,
     Categories = {
         "CONSTRUCTION",

--- a/units/XRL0004/XRL0004_unit.bp
+++ b/units/XRL0004/XRL0004_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         EggSink        = Sound { Bank = 'XRL_Stream', Cue = 'XRL_Crab_Sink',              LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10,
     BuildIconSortPriority = 30,
     Categories = {
         "CONSTRUCTION",

--- a/units/XRL0005/XRL0005_unit.bp
+++ b/units/XRL0005/XRL0005_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         EggSink        = Sound { Bank = 'XRL_Stream', Cue = 'XRL_Crab_Sink',              LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Factory',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10,
     BuildIconSortPriority = 30,
     Categories = {
         "CONSTRUCTION",

--- a/units/XRL0302/XRL0302_unit.bp
+++ b/units/XRL0302/XRL0302_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'XRL',        Cue = 'XRL0302_Move_Stop',        LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Vehicle',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 400,
     Buffs = {
         Stun = {
             Add = {

--- a/units/XRL0305/XRL0305_unit.bp
+++ b/units/XRL0305/XRL0305_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XRL',       Cue = 'XRL0305_Move_Stop',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface', Cue = 'Cybran_Select_Bot',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 7500,
     BuildIconSortPriority = 20,
     Categories = {
         "AMPHIBIOUS",

--- a/units/XRL0403/XRL0403_unit.bp
+++ b/units/XRL0403/XRL0403_unit.bp
@@ -25,6 +25,7 @@ UnitBlueprint{
         StopMove              = Sound { Bank = 'XRL',         Cue = 'XRL0403_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'Interface',   Cue = 'Cybran_Select_Spider',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 110000,
     BuildBotTotal = 12,
     BuildIconSortPriority = 30,
     Categories = {

--- a/units/XRO4001/XRO4001_unit.bp
+++ b/units/XRO4001/XRO4001_unit.bp
@@ -3,6 +3,7 @@ UnitBlueprint{
     Audio = {
         UISelection = Sound { Bank = 'Interface', Cue = 'Cybran_Select_Structure', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1000,
     Categories = {
         "OPERATION",
         "RECLAIMABLE",

--- a/units/XRS0204/XRS0204_unit.bp
+++ b/units/XRS0204/XRS0204_unit.bp
@@ -13,6 +13,7 @@ UnitBlueprint{
         SurfaceStart   = Sound { Bank = 'URS',        Cue = 'URS_Sub_Surface',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Sub',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1430,
     BuildIconSortPriority = 20,
     Categories = {
         "ANTINAVY",

--- a/units/XRS0205/XRS0205_unit.bp
+++ b/units/XRS0205/XRS0205_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XRS',        Cue = 'XRS0205_Move_Stop',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'Interface',  Cue = 'Cybran_Select_Naval', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1500,
     BuildIconSortPriority = 40,
     Categories = {
         "ANTITORPEDO",

--- a/units/XSA0101/XSA0101_unit.bp
+++ b/units/XSA0101/XSA0101_unit.bp
@@ -35,6 +35,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XSA',            Cue = 'XSA0101_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Air',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 32,
     BuildIconSortPriority = 20,
     Categories = {
         "AIR",

--- a/units/XSA0102/XSA0102_unit.bp
+++ b/units/XSA0102/XSA0102_unit.bp
@@ -41,6 +41,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XSA',            Cue = 'XSA0102_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Air',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 290,
     BuildIconSortPriority = 30,
     Categories = {
         "AIR",

--- a/units/XSA0103/XSA0103_unit.bp
+++ b/units/XSA0103/XSA0103_unit.bp
@@ -41,6 +41,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XSA',            Cue = 'XSA0103_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Air',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 210,
     BuildIconSortPriority = 40,
     Categories = {
         "AIR",

--- a/units/XSA0104/XSA0104_unit.bp
+++ b/units/XSA0104/XSA0104_unit.bp
@@ -40,7 +40,7 @@ UnitBlueprint{
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
         Unload             = Sound { Bank = 'XSA',            Cue = 'XSA0104_Unit_Unload',        LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 1625,
     BuildIconSortPriority = 40,
     Categories = {
         "AIR",

--- a/units/XSA0107/XSA0107_unit.bp
+++ b/units/XSA0107/XSA0107_unit.bp
@@ -40,7 +40,7 @@ UnitBlueprint{
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Air',        LodCutoff = 'UnitMove_LodCutoff' },
         Unload             = Sound { Bank = 'XSA',            Cue = 'XSA0107_Unit_Unload',        LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 500,
     BuildIconSortPriority = 50,
     Categories = {
         "AIR",

--- a/units/XSA0202/XSA0202_unit.bp
+++ b/units/XSA0202/XSA0202_unit.bp
@@ -40,6 +40,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XSA',            Cue = 'XSA0202_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Air',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1000,
     BuildIconSortPriority = 15,
     Categories = {
         "AIR",

--- a/units/XSA0203/XSA0203_unit.bp
+++ b/units/XSA0203/XSA0203_unit.bp
@@ -35,7 +35,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XSA',            Cue = 'XSA0203_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Air',    LodCutoff = 'UnitMove_LodCutoff' },
     },
-    AverageDensity = 1,
+    AverageDensity = 1800,
     BuildIconSortPriority = 30,
     Categories = {
         "AIR",

--- a/units/XSA0204/XSA0204_unit.bp
+++ b/units/XSA0204/XSA0204_unit.bp
@@ -36,6 +36,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XSA',            Cue = 'XSA0204_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Air',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 840,
     BuildIconSortPriority = 20,
     Categories = {
         "AIR",

--- a/units/XSA0302/XSA0302_unit.bp
+++ b/units/XSA0302/XSA0302_unit.bp
@@ -35,6 +35,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XSA',            Cue = 'XSA0302_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Air',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1100,
     BuildIconSortPriority = 20,
     Categories = {
         "AIR",

--- a/units/XSA0303/XSA0303_unit.bp
+++ b/units/XSA0303/XSA0303_unit.bp
@@ -41,6 +41,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XSA',            Cue = 'XSA0303_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Air',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2275,
     BuildIconSortPriority = 30,
     Categories = {
         "AIR",

--- a/units/XSA0304/XSA0304_unit.bp
+++ b/units/XSA0304/XSA0304_unit.bp
@@ -40,6 +40,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XSA',            Cue = 'XSA0304_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Air',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3900,
     BuildIconSortPriority = 40,
     Categories = {
         "AIR",

--- a/units/XSA0402/XSA0402_unit.bp
+++ b/units/XSA0402/XSA0402_unit.bp
@@ -49,6 +49,7 @@ UnitBlueprint{
         Thruster           = Sound { Bank = 'XSA',            Cue = 'XSA0402_Move_Thruster',  LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Air',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 52000,
     BuildIconSortPriority = 10,
     Categories = {
         "AIR",

--- a/units/XSB0101/XSB0101_unit.bp
+++ b/units/XSB0101/XSB0101_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XSB',            Cue = 'XSB0101_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Factory',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3500,
     BuildIconSortPriority = 10,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/XSB0102/XSB0102_unit.bp
+++ b/units/XSB0102/XSB0102_unit.bp
@@ -14,6 +14,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XSB',            Cue = 'XSB0102_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Factory',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3500,
     BuildIconSortPriority = 20,
     Categories = {
         "AIR",

--- a/units/XSB0103/XSB0103_unit.bp
+++ b/units/XSB0103/XSB0103_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XSB',            Cue = 'XSB0103_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Factory',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 4000,
     BuildIconSortPriority = 30,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/XSB0201/XSB0201_unit.bp
+++ b/units/XSB0201/XSB0201_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XSB',            Cue = 'XSB0201_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Factory',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 7000,
     BuildIconSortPriority = 50,
     Categories = {
         "BUILTBYTIER1FACTORY",

--- a/units/XSB0202/XSB0202_unit.bp
+++ b/units/XSB0202/XSB0202_unit.bp
@@ -14,6 +14,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XSB',            Cue = 'XSB0202_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Factory',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 7000,
     BuildIconSortPriority = 60,
     Categories = {
         "AIR",

--- a/units/XSB0203/XSB0203_unit.bp
+++ b/units/XSB0203/XSB0203_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XSB',            Cue = 'XSB0203_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Factory',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 14000,
     BuildIconSortPriority = 70,
     Categories = {
         "BUILTBYTIER1FACTORY",

--- a/units/XSB0301/XSB0301_unit.bp
+++ b/units/XSB0301/XSB0301_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XSB',            Cue = 'XSB0301_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Factory',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 14000,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/XSB0302/XSB0302_unit.bp
+++ b/units/XSB0302/XSB0302_unit.bp
@@ -14,6 +14,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XSB',            Cue = 'XSB0302_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Factory',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 14000,
     BuildIconSortPriority = 50,
     Categories = {
         "AIR",

--- a/units/XSB0303/XSB0303_unit.bp
+++ b/units/XSB0303/XSB0303_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XSB',            Cue = 'XSB0303_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Factory',    LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 23000,
     BuildIconSortPriority = 60,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/XSB0304/XSB0304_unit.bp
+++ b/units/XSB0304/XSB0304_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XSB',            Cue = 'XSB0304_Activate',           LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Structure',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10000,
     BuildIconSortPriority = 220,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/XSB1101/XSB1101_unit.bp
+++ b/units/XSB1101/XSB1101_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Resource',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 550,
     BuildIconSortPriority = 70,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/XSB1102/XSB1102_unit.bp
+++ b/units/XSB1102/XSB1102_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Resource',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1700,
     BuildIconSortPriority = 80,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/XSB1103/XSB1103_unit.bp
+++ b/units/XSB1103/XSB1103_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Resource',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 380,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/XSB1104/XSB1104_unit.bp
+++ b/units/XSB1104/XSB1104_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Resource',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 360,
     BuildIconSortPriority = 50,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/XSB1105/XSB1105_unit.bp
+++ b/units/XSB1105/XSB1105_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Resource',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 90,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/XSB1106/XSB1106_unit.bp
+++ b/units/XSB1106/XSB1106_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Resource',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 700,
     BuildIconSortPriority = 60,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/XSB1201/XSB1201_unit.bp
+++ b/units/XSB1201/XSB1201_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Resource',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2400,
     BuildIconSortPriority = 70,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/XSB1202/XSB1202_unit.bp
+++ b/units/XSB1202/XSB1202_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Resource',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1950,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/XSB1301/XSB1301_unit.bp
+++ b/units/XSB1301/XSB1301_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Resource',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 7000,
     BuildIconSortPriority = 70,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/XSB1302/XSB1302_unit.bp
+++ b/units/XSB1302/XSB1302_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Resource',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6750,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/XSB1303/XSB1303_unit.bp
+++ b/units/XSB1303/XSB1303_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Resource',   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6000,
     BuildIconSortPriority = 50,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/XSB2101/XSB2101_unit.bp
+++ b/units/XSB2101/XSB2101_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_gun',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1300,
     BuildIconSortPriority = 110,
     Categories = {
         "BUILTBYCOMMANDER",

--- a/units/XSB2104/XSB2104_unit.bp
+++ b/units/XSB2104/XSB2104_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_gun',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     BuildIconSortPriority = 120,
     Categories = {
         "ANTIAIR",

--- a/units/XSB2108/XSB2108_unit.bp
+++ b/units/XSB2108/XSB2108_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         Open           = Sound { Bank = 'XSB',            Cue = 'XSB2108_Doors_Open',         LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_gun',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 900,
     BuildIconSortPriority = 150,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/XSB2109/XSB2109_unit.bp
+++ b/units/XSB2109/XSB2109_unit.bp
@@ -12,6 +12,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_gun',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1650,
     BuildIconSortPriority = 130,
     Categories = {
         "ANTINAVY",

--- a/units/XSB2204/XSB2204_unit.bp
+++ b/units/XSB2204/XSB2204_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_gun',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2520,
     BuildIconSortPriority = 120,
     Categories = {
         "ANTIAIR",

--- a/units/XSB2205/XSB2205_unit.bp
+++ b/units/XSB2205/XSB2205_unit.bp
@@ -12,6 +12,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_gun',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 4800,
     BuildIconSortPriority = 130,
     Categories = {
         "ANTINAVY",

--- a/units/XSB2301/XSB2301_unit.bp
+++ b/units/XSB2301/XSB2301_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_gun',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2100,
     BuildIconSortPriority = 110,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/XSB2302/XSB2302_unit.bp
+++ b/units/XSB2302/XSB2302_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_gun',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 13500,
     BuildIconSortPriority = 140,
     Categories = {
         "ARTILLERY",

--- a/units/XSB2303/XSB2303_unit.bp
+++ b/units/XSB2303/XSB2303_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_gun',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2850,
     BuildIconSortPriority = 140,
     Categories = {
         "ARTILLERY",

--- a/units/XSB2304/XSB2304_unit.bp
+++ b/units/XSB2304/XSB2304_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_gun',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 5000,
     BuildIconSortPriority = 120,
     Categories = {
         "ANTIAIR",

--- a/units/XSB2305/XSB2305_unit.bp
+++ b/units/XSB2305/XSB2305_unit.bp
@@ -11,6 +11,7 @@ UnitBlueprint{
         Open                  = Sound { Bank = 'XSB',            Cue = 'XSB2305_Open',                          LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_gun',                   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 4000,
     BuildIconSortPriority = 150,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/XSB2401/XSB2401_unit.bp
+++ b/units/XSB2401/XSB2401_unit.bp
@@ -12,6 +12,7 @@ UnitBlueprint{
         NukeCharge            = Sound { Bank = 'XSB',            Cue = 'XSB2401_Nuke_Charge',                   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_gun',                   LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 12000,
     BuildIconSortPriority = 150,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/XSB3101/XSB3101_unit.bp
+++ b/units/XSB3101/XSB3101_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Radar',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 10,
     BuildIconSortPriority = 180,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/XSB3102/XSB3102_unit.bp
+++ b/units/XSB3102/XSB3102_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Sonar',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 190,
     Categories = {
         "BUILTBYTIER1ENGINEER",

--- a/units/XSB3104/XSB3104_unit.bp
+++ b/units/XSB3104/XSB3104_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Radar',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 100,
     BuildIconSortPriority = 200,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/XSB3201/XSB3201_unit.bp
+++ b/units/XSB3201/XSB3201_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Radar',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 50,
     BuildIconSortPriority = 180,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/XSB3202/XSB3202_unit.bp
+++ b/units/XSB3202/XSB3202_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         SurfaceStart   = Sound { Bank = 'XSS',            Cue = 'XSS_Sub_Surface',            LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Sonar',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 1400,
     BuildIconSortPriority = 190,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/XSB4201/XSB4201_unit.bp
+++ b/units/XSB4201/XSB4201_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_gun',        LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 975,
     BuildIconSortPriority = 155,
     Categories = {
         "ANTIMISSILE",

--- a/units/XSB4202/XSB4202_unit.bp
+++ b/units/XSB4202/XSB4202_unit.bp
@@ -11,6 +11,7 @@ UnitBlueprint{
         ShieldOn       = Sound { Bank = 'XSB',            Cue = 'XSB4202_On_Off',             LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Structure',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 400,
     BuildIconSortPriority = 160,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/XSB4203/XSB4203_unit.bp
+++ b/units/XSB4203/XSB4203_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Radar',      LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 200,
     BuildIconSortPriority = 200,
     Categories = {
         "BUILTBYTIER2COMMANDER",

--- a/units/XSB4301/XSB4301_unit.bp
+++ b/units/XSB4301/XSB4301_unit.bp
@@ -12,6 +12,7 @@ UnitBlueprint{
         ShieldOn       = Sound { Bank = 'XSB',            Cue = 'XSB4301_On_Off',             LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Structure',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 600,
     BuildIconSortPriority = 160,
     Categories = {
         "BUILTBYTIER3COMMANDER",

--- a/units/XSB4302/XSB4302_unit.bp
+++ b/units/XSB4302/XSB4302_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         DoneBeingBuilt = Sound { Bank = 'XSB',            Cue = 'XSB4302_Activate',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_gun', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 3800,
     BuildIconSortPriority = 155,
     Categories = {
         "ANTIMISSILE",

--- a/units/XSB5101/XSB5101_unit.bp
+++ b/units/XSB5101/XSB5101_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Structure',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 160,
     Categories = {
         "BENIGN",

--- a/units/XSB5102/XSB5102_unit.bp
+++ b/units/XSB5102/XSB5102_unit.bp
@@ -1,5 +1,6 @@
 UnitBlueprint{
     Description = "<LOC xsb5102_desc>Seraphim Transport Beacon",
+    AverageDensity = 10,
     Categories = {
         "FERRYBEACON",
         "PRODUCTFA",

--- a/units/XSB5202/XSB5202_unit.bp
+++ b/units/XSB5202/XSB5202_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         Killed         = Sound { Bank = 'XSL_Destroy',    Cue = 'XSB_Destroy_Lrg_PreDestroy', LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Structure',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500,
     BuildIconSortPriority = 210,
     Categories = {
         "AIRSTAGINGPLATFORM",

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -43,6 +43,7 @@ UnitBlueprint{
         TeleportOut                   = Sound { Bank = 'XSB',            Cue = 'XSB0101_Activate',          LodCutoff = 'UnitMove_LodCutoff' },
         UISelection                   = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Commander', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 11500,
     Categories = {
         "ABILITYBUTTON",
         "AMPHIBIOUS",

--- a/units/XSL0101/XSL0101_unit.bp
+++ b/units/XSL0101/XSL0101_unit.bp
@@ -9,6 +9,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'XSL',            Cue = 'XSL0101_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Bot',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 35,
     BuildIconSortPriority = 20,
     Categories = {
         "BOT",

--- a/units/XSL0103/XSL0103_unit.bp
+++ b/units/XSL0103/XSL0103_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XSL',            Cue = 'XSL0103_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 85.0,
     BuildIconSortPriority = 60,
     Categories = {
         "ARTILLERY",

--- a/units/XSL0104/XSL0104_unit.bp
+++ b/units/XSL0104/XSL0104_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XSL',            Cue = 'XSL0104_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Bot',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 310,
     BuildIconSortPriority = 50,
     Categories = {
         "ANTIAIR",

--- a/units/XSL0105/XSL0105_unit.bp
+++ b/units/XSL0105/XSL0105_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'XSL',            Cue = 'XSL0105_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 62.5,
     BuildIconSortPriority = 10,
     Categories = {
         "BUILTBYTIER1FACTORY",

--- a/units/XSL0111/XSL0111_unit.bp
+++ b/units/XSL0111/XSL0111_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XSL',            Cue = 'XSL0111_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Tank', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 800,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/XSL0201/XSL0201_unit.bp
+++ b/units/XSL0201/XSL0201_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XSL',            Cue = 'XSL0201_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Tank', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 280,
     BuildIconSortPriority = 20,
     Categories = {
         "BUILTBYTIER1FACTORY",

--- a/units/XSL0202/XSL0202_unit.bp
+++ b/units/XSL0202/XSL0202_unit.bp
@@ -7,6 +7,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XSL',            Cue = 'XSL0202_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Bot',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2500,
     BuildIconSortPriority = 20,
     Categories = {
         "BOT",

--- a/units/XSL0203/XSL0203_unit.bp
+++ b/units/XSL0203/XSL0203_unit.bp
@@ -11,6 +11,7 @@ UnitBlueprint{
         TransitionWater    = Sound { Bank = 'UEL',            Cue = 'UEL0203_Into_Water',   LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Tank', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 675.0,
     BuildIconSortPriority = 30,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/XSL0205/XSL0205_unit.bp
+++ b/units/XSL0205/XSL0205_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'XSL',            Cue = 'XSL0205_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 500.0,
     BuildIconSortPriority = 35,
     Categories = {
         "ANTIAIR",

--- a/units/XSL0208/XSL0208_unit.bp
+++ b/units/XSL0208/XSL0208_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'XSL',            Cue = 'XSL0208_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 175.0,
     BuildIconSortPriority = 10,
     Categories = {
         "BUILTBYTIER2FACTORY",

--- a/units/XSL0301/XSL0301_unit.bp
+++ b/units/XSL0301/XSL0301_unit.bp
@@ -28,6 +28,7 @@ UnitBlueprint{
         TeleportOut                   = Sound { Bank = 'XSB',            Cue = 'XSB0101_Activate',          LodCutoff = 'UnitMove_LodCutoff' },
         UISelection                   = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Commander', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 15500,
     BuildIconSortPriority = 10,
     Categories = {
         "AMPHIBIOUS",

--- a/units/XSL0303/XSL0303_unit.bp
+++ b/units/XSL0303/XSL0303_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XSL',            Cue = 'XSL0303_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Tank', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 4700,
     BuildIconSortPriority = 20,
     Categories = {
         "AMPHIBIOUS",

--- a/units/XSL0304/XSL0304_unit.bp
+++ b/units/XSL0304/XSL0304_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XSL',            Cue = 'XSL0304_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Bot',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 925,
     BuildIconSortPriority = 50,
     Categories = {
         "ARTILLERY",

--- a/units/XSL0305/XSL0305_unit.bp
+++ b/units/XSL0305/XSL0305_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XSL',            Cue = 'XSL0305_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 700,
     BuildIconSortPriority = 20,
     Categories = {
         "BOT",

--- a/units/XSL0307/XSL0307_unit.bp
+++ b/units/XSL0307/XSL0307_unit.bp
@@ -10,6 +10,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XSL',            Cue = 'XSL0307_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 200.0,
     BuildIconSortPriority = 50,
     Categories = {
         "BUILTBYTIER3FACTORY",

--- a/units/XSL0309/XSL0309_unit.bp
+++ b/units/XSL0309/XSL0309_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove           = Sound { Bank = 'XSL',            Cue = 'XSL0309_Move_Stop',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection        = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Vehicle', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 350.0,
     BuildIconSortPriority = 10,
     Categories = {
         "BUILTBYTIER3FACTORY",

--- a/units/XSL0401/XSL0401_unit.bp
+++ b/units/XSL0401/XSL0401_unit.bp
@@ -17,6 +17,7 @@ UnitBlueprint{
         StopMove              = Sound { Bank = 'XSL',            Cue = 'XSL0401_Move_Stop',    LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Bot',  LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 67000,
     BuildIconSortPriority = 30,
     Categories = {
         "AMPHIBIOUS",

--- a/units/XSL0402/XSL0402_unit.bp
+++ b/units/XSL0402/XSL0402_unit.bp
@@ -6,6 +6,7 @@ UnitBlueprint{
         HoverKilledOnWater = Sound { Bank = 'Explosions',  Cue = 'Expl_Water_Lrg_01', LodCutoff = 'UnitMove_LodCutoff' },
         Spawn              = Sound { Bank = 'XSL',         Cue = 'XSL0402_Spawn',     LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 50.0,
     BuildIconSortPriority = 10,
     Categories = {
         "EXPERIMENTAL",

--- a/units/XSS0103/XSS0103_unit.bp
+++ b/units/XSS0103/XSS0103_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XSS',            Cue = 'XSS0103_Move_Stop',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Naval', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2000,
     BuildIconSortPriority = 40,
     Categories = {
         "BUILTBYTIER1FACTORY",

--- a/units/XSS0201/XSS0201_unit.bp
+++ b/units/XSS0201/XSS0201_unit.bp
@@ -16,6 +16,7 @@ UnitBlueprint{
         SurfaceStart   = Sound { Bank = 'XSS',            Cue = 'XSS_Sub_Surface',       LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Naval', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 6900,
     BuildIconSortPriority = 30,
     Categories = {
         "ANTINAVY",

--- a/units/XSS0202/XSS0202_unit.bp
+++ b/units/XSS0202/XSS0202_unit.bp
@@ -8,6 +8,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XSS',            Cue = 'XSS0202_Move_Stop',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Naval', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 2700,
     BuildIconSortPriority = 30,
     Categories = {
         "ANTIAIR",

--- a/units/XSS0203/XSS0203_unit.bp
+++ b/units/XSS0203/XSS0203_unit.bp
@@ -13,6 +13,7 @@ UnitBlueprint{
         SurfaceStart   = Sound { Bank = 'XSS',            Cue = 'XSS_Sub_Surface',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Sub', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 550,
     BuildIconSortPriority = 30,
     Categories = {
         "ANTINAVY",

--- a/units/XSS0302/XSS0302_unit.bp
+++ b/units/XSS0302/XSS0302_unit.bp
@@ -21,6 +21,7 @@ UnitBlueprint{
         StopMove              = Sound { Bank = 'XSS',            Cue = 'XSS0302_Move_Stop',                     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection           = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Naval',                 LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 49000,
     BuildIconSortPriority = 20,
     Categories = {
         "ANTIMISSILE",

--- a/units/XSS0303/XSS0303_unit.bp
+++ b/units/XSS0303/XSS0303_unit.bp
@@ -15,6 +15,7 @@ UnitBlueprint{
         StopMove    = Sound { Bank = 'XSS',            Cue = 'XSS0303_Move_Stop',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Naval', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 24000,
     BuildIconSortPriority = 30,
     Categories = {
         "AIRSTAGINGPLATFORM",

--- a/units/XSS0304/XSS0304_unit.bp
+++ b/units/XSS0304/XSS0304_unit.bp
@@ -13,6 +13,7 @@ UnitBlueprint{
         SurfaceStart   = Sound { Bank = 'XSS',            Cue = 'XSS_Sub_Surface',     LodCutoff = 'UnitMove_LodCutoff' },
         UISelection    = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Sub', LodCutoff = 'UnitMove_LodCutoff' },
     },
+    AverageDensity = 4000,
     BuildIconSortPriority = 15,
     Categories = {
         "ANTIAIR",


### PR DESCRIPTION
## Description of the proposed changes

Affects the behavior of units when they bump into each other. Units with more weight push units with less weight. As a result units with more health will receive less to no pushback from units with less health.

Units still try to stop for other units. When the engine decides for the unit to push on through the unit with the most health will have a much, much better time.

## Testing done on the proposed changes

Start the game and spawn in various units with different health values and observe how they behave.

## Additional context

The current values are the same as used in this mod that was created to allow people to test the behavior changes:

![image](https://github.com/FAForever/fa/assets/15778155/bf341619-ba86-4495-9218-a6f5bf910373)

## Checklist

- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
