### PR TITLE
Increase mass fab throttle maximum energy storage to allow for full damage overcharge

### DIFF
--- a/changelog/snippets/fix.6280.md
+++ b/changelog/snippets/fix.6280.md
@@ -1,0 +1,1 @@
+- (#6280) Increase the maximum amount of energy that can be stored before mass fabricators turn on from 61000 to 108000 to allow full damage overcharges.

--- a/lua/shared/FabricatorBehaviorParams.lua
+++ b/lua/shared/FabricatorBehaviorParams.lua
@@ -1,6 +1,6 @@
 
 DisableRatio = 0.8
-DisableStorage = 105000
+DisableStorage = 105000 -- 100000 energy needed for max overcharge damage, also add 5k as a buffer
 
 EnableRatio = 0.9
 EnableTrend = 100

--- a/lua/shared/FabricatorBehaviorParams.lua
+++ b/lua/shared/FabricatorBehaviorParams.lua
@@ -1,7 +1,7 @@
 
 DisableRatio = 0.8
-DisableStorage = 59000
+DisableStorage = 105000
 
 EnableRatio = 0.9
 EnableTrend = 100
-EnableStorage = 61000
+EnableStorage = 108000


### PR DESCRIPTION
## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Increases how much energy can be stored before turning on mass fabricators so that overcharge can always deal full damage. First reported on [discord](https://discord.com/channels/197033481883222026/1224799508249055395/1224864468052217857).

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spawn at least 13 energy storages, then a bunch of T3 fabs(12), T3 pgens (11), and T3 air facs producing strategic bombers (16). The energy doesn't go below 100k unless all air factories are turned off and then turned on right when all mass fabs turn on, which means it can handle rather extreme fluctuations.
<details> <summary> Spawn units command </summary>

```
   CreateUnitAtMouse('xsb1303', 0,   -7.98,    0.33, -0.00002)
   CreateUnitAtMouse('xsb1303', 0,   -1.98,   -7.67, -0.00000)
   CreateUnitAtMouse('xsb1303', 0,   -9.98,  -13.67,  0.00000)
   CreateUnitAtMouse('xsb1303', 0,  -15.98,   -5.67, -0.00006)
   CreateUnitAtMouse('xsb0302', 0,  -10.98,  -20.67, -0.00000)
   CreateUnitAtMouse('xsb0302', 0,  -22.98,   -4.67, -0.00000)
   CreateUnitAtMouse('xsb0302', 0,   -2.98,  -14.67, -0.00000)
   CreateUnitAtMouse('xsb1301', 0,  -38.98,    3.33,  0.00127)
   CreateUnitAtMouse('xsb1301', 0,  -20.98,   29.33,  0.00018)
   CreateUnitAtMouse('xsb1301', 0,  -28.98,   23.33,  0.00109)
   CreateUnitAtMouse('xsb1301', 0,  -30.98,    9.33,  0.00046)
   CreateUnitAtMouse('xsb0302', 0,  -20.98,    9.33, -0.00000)
   CreateUnitAtMouse('xsb1301', 0,  -24.98,  -18.67, -0.00001)
   CreateUnitAtMouse('xsb1303', 0,  -21.98,    2.33,  0.00002)
   CreateUnitAtMouse('xsb1301', 0,  -14.98,    1.33,  0.00001)
   CreateUnitAtMouse('xsb1303', 0,  -13.98,    8.33,  0.00001)
   CreateUnitAtMouse('xsb0302', 0,   25.02,   25.33, -0.00000)
   CreateUnitAtMouse('ueb1105', 0,   17.02,  -19.67, -0.00002)
   CreateUnitAtMouse('xsb0302', 0,   28.02,    1.33, -0.00000)
   CreateUnitAtMouse('xsb0302', 0,   27.02,    9.33, -0.00000)
   CreateUnitAtMouse('xsb0302', 0,   26.02,   17.33, -0.00000)
   CreateUnitAtMouse('xsb0302', 0,   24.02,   33.33, -0.00000)
   CreateUnitAtMouse('ueb1105', 0,   14.02,  -15.67, -0.00002)
   CreateUnitAtMouse('ueb1105', 0,   15.02,  -17.67, -0.00002)
   CreateUnitAtMouse('xsb0302', 0,   -0.98,   -0.67, -0.00000)
   CreateUnitAtMouse('xsb0302', 0,   29.02,   -6.67, -0.00000)
   CreateUnitAtMouse('xsb0302', 0,  -12.98,   15.33, -0.00000)
   CreateUnitAtMouse('xsb1303', 0,   -5.98,   14.33,  0.00000)
   CreateUnitAtMouse('xsb1303', 0,    0.02,    6.33,  0.00000)
   CreateUnitAtMouse('xsb1303', 0,    2.02,   20.33,  0.00000)
   CreateUnitAtMouse('xsb1303', 0,  -23.98,  -11.67, -0.00001)
   CreateUnitAtMouse('xsb1303', 0,  -17.98,  -19.67, -0.00004)
   CreateUnitAtMouse('xsb1303', 0,    8.02,   12.33,  0.00000)
   CreateUnitAtMouse('xsb1301', 0,    1.02,   13.33,  0.00000)
   CreateUnitAtMouse('xsb1301', 0,   -6.98,    7.33,  0.00000)
   CreateUnitAtMouse('xsb1301', 0,  -16.98,  -12.67,  0.00000)
   CreateUnitAtMouse('xsb1301', 0,   -8.98,   -6.67,  0.00000)
   CreateUnitAtMouse('ueb1105', 0,    8.02,   -6.67,  0.00000)
   CreateUnitAtMouse('ueb1105', 0,   11.02,   -9.67,  0.00000)
   CreateUnitAtMouse('ueb1105', 0,   12.02,  -11.67, -0.00002)
   CreateUnitAtMouse('ueb1105', 0,    0.02,    4.33,  0.00000)
   CreateUnitAtMouse('ueb1105', 0,   18.02,  -21.67, -0.00002)
   CreateUnitAtMouse('ueb1105', 0,   19.02,  -23.67, -0.00006)
   CreateUnitAtMouse('xsb0302', 0,   17.02,   10.33, -0.00000)
   CreateUnitAtMouse('xsb0302', 0,   15.02,   18.33, -0.00000)
   CreateUnitAtMouse('xsb0302', 0,   14.02,   26.33, -0.00000)
   CreateUnitAtMouse('ueb1105', 0,   13.02,  -13.67,  0.00000)
   CreateUnitAtMouse('ueb1105', 0,   20.02,  -25.67,  0.00000)
   CreateUnitAtMouse('ueb1105', 0,   21.02,  -27.67, -0.00001)
   CreateUnitAtMouse('ueb1105', 0,    5.02,   -2.67,  0.00000)
   CreateUnitAtMouse('xsb0302', 0,   18.02,    2.33, -0.00000)
   CreateUnitAtMouse('xsb1301', 0,  -22.98,   15.33,  0.00017)
```
</details>

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
