### PR TITLE
Fix sub-optimal drag build of the air grid template

### DIFF
--- a/changelog/snippets/fix.6285.md
+++ b/changelog/snippets/fix.6285.md
@@ -1,0 +1,3 @@
+- (#6285) Fix sub-optimal drag build of the air grid template
+
+When you drag build the air grid template from the context-based template setup it now slightly overlaps. This way we can create the optimal pattern for air grids when drag building the template. 

--- a/lua/ui/game/hotkeys/context-based-templates-data/AppendAirGrid.lua
+++ b/lua/ui/game/hotkeys/context-based-templates-data/AppendAirGrid.lua
@@ -27,8 +27,8 @@ Template = {
     TemplateBlueprintId = 'zeb9602',
     TemplateSortingOrder = 100,
     TemplateData = {
-        24,
-        24,
+        16,
+        16,
         {
             'dummy',
             0,

--- a/lua/ui/game/hotkeys/context-based-templates-data/AppendAirGrid.lua
+++ b/lua/ui/game/hotkeys/context-based-templates-data/AppendAirGrid.lua
@@ -27,8 +27,8 @@ Template = {
     TemplateBlueprintId = 'zeb9602',
     TemplateSortingOrder = 100,
     TemplateData = {
-        16,
-        16,
+        16, -- intentional 16 instead of 24 to make drag-building optimal
+        16, -- intentional 16 instead of 24 to make drag-building optimal
         {
             'dummy',
             0,


### PR DESCRIPTION
## Description of the proposed changes

https://github.com/FAForever/fa/assets/15778155/3dc4217c-f710-4498-a1d8-a9a08e832389

## Testing done on the proposed changes

Drag-build an air grid template.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
