### PR TITLE
AI - Fix incorrect unit set in T2LandAmphibious factory build template

### DIFF
--- a/changelog/snippets/ai.6286.md
+++ b/changelog/snippets/ai.6286.md
@@ -1,0 +1,1 @@
+- (#6286) Fix T2LandAmphibious factory template as the Aeon Aurora was being built instead of the Aeon Blaze

--- a/lua/AI/PlatoonTemplates/LandPlatoonTemplates.lua
+++ b/lua/AI/PlatoonTemplates/LandPlatoonTemplates.lua
@@ -320,7 +320,7 @@ PlatoonTemplate {
             { 'uel0203', 1, 1, 'attack', 'none' }
         },
         Aeon = {
-            { 'ual0201', 1, 1, 'attack', 'none' }
+            { 'xal0203', 1, 1, 'attack', 'none' }
         },
         Cybran = {
             { 'url0203', 1, 1, 'attack', 'none' }

--- a/lua/platoontemplates.lua
+++ b/lua/platoontemplates.lua
@@ -1061,12 +1061,12 @@ PlatoonTemplates = {
         T2LandAmphibious1={
             "T2LandAmphibious1",
             "PatrolBaseVectorsAI",
-            { "ual0201", 1, 6, "attack", "GrowthFormation" }
+            { "xal0203", 1, 6, "attack", "GrowthFormation" }
         },
         T2LandAmphibious2={
             "T2LandAmphibious2",
             "PatrolBaseVectorsAI",
-            { "ual0201", -1, 4, "attack", "GrowthFormation" }
+            { "xal0203", -1, 4, "attack", "GrowthFormation" }
         },
         T2LandArtillery1={
             "T2LandArtillery1",


### PR DESCRIPTION
## Description of the proposed changes
This PR fixes a small error in the AI platoon build templates. The T2LandAmphibious was set to build the Aeon Aurora instead of the Blaze.


## Testing done on the proposed changes
Validated that the correct unit was being built post change


## Additional context
According to the file history this error has been there for YEARS :D I even went back and checked the original SCFA lua files, the error was present then too.


## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
