### PR TITLE
Fix intel state not being assigned

### DIFF
--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -373,7 +373,7 @@ local function PostProcessUnit(unit)
         for name, value in pairs(intelBlueprint) do
 
             -- may contain tables, such as `JamRadius`
-            if not type(value) == 'table' then
+            if type(value) ~= 'table' then
                 if value == true or value > 0 then
                     local intel = BlueprintNameToIntel[name]
                     if intel and not activeIntel[intel] then


### PR DESCRIPTION
## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Caused by #6273. Intel was not being put into the intel tables used for the intel state table because of a bad order of operations on some booleans.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
`UI_Lua LOG('number' ~= 'table')` prints true, while `UI_Lua LOG(not 'number' == 'table') prints false. Enemy radar blips show up ingame.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
~~- [ ] Changes are documented in the changelog for the next game version~~ Not necessary.
