### PR TITLE
Improve guards for `table.copy` to fix blueprint reloading crash

### DIFF
--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -73,8 +73,10 @@ function table.getsize(t)
     return size
 end
 
---- table.copy(t) returns a shallow copy of t.
----@overload fun(t: Vector): Vector
+--- Returns a shallow copy of t
+---@generic T
+---@param t T
+---@return T
 function table.copy(t)
     if type(t) ~= 'table' then return t end
 

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -76,13 +76,13 @@ end
 --- table.copy(t) returns a shallow copy of t.
 ---@overload fun(t: Vector): Vector
 function table.copy(t)
-    if t then -- prevents looping over nil table
-        local r = {}
-        for k,v in t do
-            r[k] = v
-        end
-        return r
+    if type(t) ~= 'table' then return t end
+
+    local r = {}
+    for k, v in t do
+        r[k] = v
     end
+    return r
 end
 
 --- table.find(t,val) returns the key for val if it is in t table.
@@ -131,7 +131,7 @@ end
 function table.deepcopy(t,backrefs)
     backrefs = backrefs or { }
 
-    if type(t)=='table' then
+    if type(t) == 'table' then
 
         -- do not deep-copy anything with a metatable as that doesn't make sense. With this we
         -- naturally exclude deep-copying a brain, unit or other tables that are usually unique


### PR DESCRIPTION

<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes in-game blueprint reloading crash caused by #6273 ([specific diff](https://github.com/FAForever/fa/pull/6273/files?diff=unified&w=0#diff-36fc4661c2ca0ef4424b14ce65a6831bb9c6b5b78cf99ae96d9051263f71c676L311-R311)) from `blueprints-units.lua:311` due to spawn dummies having `CommandCaps = "0"`. Instead of checking for nil, checks for the value to be a table.

The function could use a better annotation if possible.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
The game no longer crashes when reloading blueprints during a session.

## Checklist
- [x] Changes are annotated, including comments where useful
~~- [ ] Changes are documented in the changelog for the next game version~~ Not necessary.
