### PR TITLE
Fix unit view clipping in replays for the mini layout

### DIFF
--- a/changelog/snippets/fix.6291.md
+++ b/changelog/snippets/fix.6291.md
@@ -1,0 +1,1 @@
+- (#6291) Fix unit tooltip clipping with contruction tech level selection or enhancement slot selection UI in replays on the default layout (mini).

--- a/lua/ui/game/layouts/unitview_left.lua
+++ b/lua/ui/game/layouts/unitview_left.lua
@@ -4,6 +4,8 @@ local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
 local Prefs = import("/lua/user/prefs.lua")
 local options = Prefs.GetFromCurrentProfile('options')
 local NinePatch = import("/lua/ui/controls/ninepatch.lua").NinePatch
+local controls = import("/lua/ui/game/unitview.lua").controls
+local consControl = import("/lua/ui/game/construction.lua").controls.constructionGroup
 
 local iconPositions = {
     [1] = {Left = 70, Top = 55},
@@ -29,7 +31,6 @@ local iconTextures = {
 }
 
 function SetLayout()
-    local controls = import("/lua/ui/game/unitview.lua").controls
     controls.bg:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/build-over-back_bmp.dds'))
     LayoutHelpers.AtLeftIn(controls.bg, controls.parent)
     LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
@@ -171,8 +172,6 @@ function SetBG(controls)
 end
 
 function PositionWindow()
-    local controls = import("/lua/ui/game/unitview.lua").controls
-    local consControl = import("/lua/ui/game/construction.lua").controls.constructionGroup
     if consControl:IsHidden() then
         LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
         LayoutHelpers.AtLeftIn(controls.bg, consControl, 18)

--- a/lua/ui/game/layouts/unitview_mini.lua
+++ b/lua/ui/game/layouts/unitview_mini.lua
@@ -3,6 +3,9 @@ local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
 local Prefs = import("/lua/user/prefs.lua")
 local options = Prefs.GetFromCurrentProfile('options')
 local NinePatch = import("/lua/ui/controls/ninepatch.lua").NinePatch
+local controls = import("/lua/ui/game/unitview.lua").controls
+local consControl = import("/lua/ui/game/construction.lua").controls.constructionGroup
+local ordersControls = import("/lua/ui/game/orders.lua").controls
 
 local iconPositions = {
     [1] = {Left = 70, Top = 55},
@@ -28,8 +31,6 @@ local iconTextures = {
 }
 
 function SetLayout()
-    local controls = import("/lua/ui/game/unitview.lua").controls
-    
     controls.bg:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/build-over-back_bmp.dds'))
     LayoutHelpers.AtLeftIn(controls.bg, controls.parent)
     LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
@@ -165,14 +166,11 @@ function SetBG(controls)
 end
 
 function PositionWindow()
-    local controls = import("/lua/ui/game/unitview.lua").controls
-    local consControl = import("/lua/ui/game/construction.lua").controls.constructionGroup
     if consControl:IsHidden() then
         LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
         LayoutHelpers.AtBottomIn(controls.abilities, controls.bg, 24)
     else
-        local ordersControl = import("/lua/ui/game/orders.lua").controls
-        if ordersControl.bg then
+        if ordersControls.bg then
             LayoutHelpers.AtBottomIn(controls.bg, controls.parent, 120)
             LayoutHelpers.AtBottomIn(controls.abilities, controls.bg, 42)
         else

--- a/lua/ui/game/layouts/unitview_mini.lua
+++ b/lua/ui/game/layouts/unitview_mini.lua
@@ -171,8 +171,16 @@ function PositionWindow()
         LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
         LayoutHelpers.AtBottomIn(controls.abilities, controls.bg, 24)
     else
-        LayoutHelpers.AtBottomIn(controls.bg, controls.parent, 120)
-        LayoutHelpers.AtBottomIn(controls.abilities, controls.bg, 42)
+        local ordersControl = import("/lua/ui/game/orders.lua").controls
+        if ordersControl.bg then
+            LayoutHelpers.AtBottomIn(controls.bg, controls.parent, 120)
+            LayoutHelpers.AtBottomIn(controls.abilities, controls.bg, 42)
+        else
+            -- Replay? Anyway, the orders control does not exist so the construction control is all the way to the left.
+            -- The construction control is taller than the orders control, so we have to move unit view higher.
+            LayoutHelpers.AtBottomIn(controls.bg, controls.parent, 140)
+            LayoutHelpers.AtLeftIn(controls.bg, controls.parent, 18)
+        end
     end
     LayoutHelpers.AtLeftIn(controls.bg, controls.parent, 17)
 end

--- a/lua/ui/game/layouts/unitview_right.lua
+++ b/lua/ui/game/layouts/unitview_right.lua
@@ -3,6 +3,8 @@ local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
 local Prefs = import("/lua/user/prefs.lua")
 local options = Prefs.GetFromCurrentProfile('options')
 local NinePatch = import("/lua/ui/controls/ninepatch.lua").NinePatch
+local controls = import("/lua/ui/game/unitview.lua").controls
+local consControl = import("/lua/ui/game/construction.lua").controls.constructionGroup
 
 local iconPositions = {
     [1] = {Left = 70, Top = 55},
@@ -28,7 +30,6 @@ local iconTextures = {
 }
 
 function SetLayout()
-    local controls = import("/lua/ui/game/unitview.lua").controls
     controls.bg:SetTexture(UIUtil.UIFile('/game/unit-build-over-panel/build-over-back_bmp.dds'))
     LayoutHelpers.AtLeftIn(controls.bg, controls.parent)
     LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
@@ -164,8 +165,6 @@ function SetBG(controls)
 end
 
 function PositionWindow()
-    local controls = import("/lua/ui/game/unitview.lua").controls
-    local consControl = import("/lua/ui/game/construction.lua").controls.constructionGroup
     if consControl:IsHidden() then
         LayoutHelpers.AtBottomIn(controls.bg, controls.parent)
         LayoutHelpers.AtLeftIn(controls.bg, controls.parent, 18)


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
Before:
![image](https://github.com/FAForever/fa/assets/5189292/c2f560e5-81af-45ba-bec0-79198e27fe5c)
After:
![image](https://github.com/FAForever/fa/assets/5189292/1fb91af2-d7bf-4581-acad-a731f321c6f1)

I have changed the unit view positioning in replays for the mini layout to the same as the right layout, which is effectively an identical layout because they differ only in:
1) The orders control position but there is no orders control in replays.
2) The clipping issue itself, which I assume is not intended :)

In order to achieve that, I have added a condition that checks whether the orders control exists.

Additionally, I have moved imports in layouts to the top of the file since that is tradition, it avoids import duplication in some cases and it is theoretically faster (it saves up to 30% processing time of the PositionWindow() method, but that still amounts to nothing in the grand scheme of things).

No changes to non-replay positioning of the mini layout:
![image](https://github.com/FAForever/fa/assets/5189292/39798d91-47b9-419c-ae93-5d363b6c8b42)

## Testing done on the proposed changes
Replay testing:
 * Ran a replay
 * Switched to a specific player
 * For each layout
    * Verified unit view renders correctly without selection
    * Verified unit view renders correctly while a factory is selected
 * Switched to the observer full view
 * For each layout
     * Verified unit view renders correctly while a factory is selected

Skirmish testing:
 * Started a skirmish as a player
 * For each layout
    * Verified unit view renders correctly without selection
    * Verified unit view renders correctly while a factory is selected 

Skirmish observer testing:
 * Same as replay testing except the observer has the orders control so it looks the same as actually playing

## Additional context
I wondered if Gyle runs into this in his casts but he mostly selects combat units that do not have the extra bits at the top of the construction control.


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
