### PR TITLE
Fix mod backwards compatibility in Aeon weapon files

### DIFF
--- a/changelog/snippets/fix.6293.md
+++ b/changelog/snippets/fix.6293.md
@@ -1,0 +1,1 @@
+- (#6293) Fix `CollisionBeamFile` being missing in the Aeon weapons file, which was causing large mod compatibility issues (for example with Xtreme Wars).

--- a/lua/aeonweapons.lua
+++ b/lua/aeonweapons.lua
@@ -57,6 +57,7 @@ ADFCannonOblivionNaval = import('/lua/sim/weapons/aeon/ADFCannonOblivionNaval.lu
 --- kept for mod backwards compatibility
 local PhasonLaserCollisionBeam = import("/lua/defaultcollisionbeams.lua").PhasonLaserCollisionBeam
 local DisruptorBeamCollisionBeam = import("/lua/defaultcollisionbeams.lua").DisruptorBeamCollisionBeam
+local CollisionBeamFile = import("/lua/defaultcollisionbeams.lua")
 local BareBonesWeapon = import("/lua/sim/defaultweapons.lua").BareBonesWeapon
 local EffectUtil = import("/lua/effectutilities.lua")
 local QuantumBeamGeneratorCollisionBeam = import("/lua/defaultcollisionbeams.lua").QuantumBeamGeneratorCollisionBeam

--- a/lua/aeonweapons.lua
+++ b/lua/aeonweapons.lua
@@ -54,19 +54,22 @@ AAMSaintWeapon = import('/lua/sim/weapons/aeon/AAMSaintWeapon.lua').AAMSaintWeap
 AAMWillOWisp = import('/lua/sim/weapons/aeon/AAMWillOWisp.lua').AAMWillOWisp
 ADFCannonOblivionNaval = import('/lua/sim/weapons/aeon/ADFCannonOblivionNaval.lua').ADFCannonOblivionNaval
 
---- kept for mod backwards compatibility
-local PhasonLaserCollisionBeam = import("/lua/defaultcollisionbeams.lua").PhasonLaserCollisionBeam
-local DisruptorBeamCollisionBeam = import("/lua/defaultcollisionbeams.lua").DisruptorBeamCollisionBeam
-local CollisionBeamFile = import("/lua/defaultcollisionbeams.lua")
+--#region kept for mod backwards compatibility
 local BareBonesWeapon = import("/lua/sim/defaultweapons.lua").BareBonesWeapon
-local EffectUtil = import("/lua/effectutilities.lua")
-local QuantumBeamGeneratorCollisionBeam = import("/lua/defaultcollisionbeams.lua").QuantumBeamGeneratorCollisionBeam
-local TractorClawCollisionBeam = import("/lua/defaultcollisionbeams.lua").TractorClawCollisionBeam
-local utilities = import('/lua/utilities.lua')
-local Explosion = import("/lua/defaultexplosions.lua")
 local KamikazeWeapon = import("/lua/sim/defaultweapons.lua").KamikazeWeapon
 local DefaultProjectileWeapon = import("/lua/sim/defaultweapons.lua").DefaultProjectileWeapon
 local DefaultBeamWeapon = import("/lua/sim/defaultweapons.lua").DefaultBeamWeapon
+
+local CollisionBeamFile = import("/lua/defaultcollisionbeams.lua")
+local DisruptorBeamCollisionBeam = CollisionBeamFile.DisruptorBeamCollisionBeam
+local PhasonLaserCollisionBeam = CollisionBeamFile.PhasonLaserCollisionBeam
+local QuantumBeamGeneratorCollisionBeam = CollisionBeamFile.QuantumBeamGeneratorCollisionBeam
+local TractorClawCollisionBeam = CollisionBeamFile.TractorClawCollisionBeam
+
+local EffectUtil = import("/lua/effectutilities.lua")
+local utilities = import('/lua/utilities.lua')
+local Explosion = import("/lua/defaultexplosions.lua")
 local EffectTemplate = import("/lua/effecttemplates.lua")
 local Entity = import("/lua/sim/entity.lua").Entity
 local Weapon = import("/lua/sim/weapon.lua").Weapon
+--#endregion

--- a/lua/cybranweapons.lua
+++ b/lua/cybranweapons.lua
@@ -5,7 +5,6 @@
 -- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 ------------------------------------------------------------------------------
 
---- Weapon Files ---
 CAAAutocannon = import('/lua/sim/weapons/cybran/CAAAutocannon.lua').CAAAutocannon
 CAANanoDartWeapon = import('/lua/sim/weapons/cybran/CAANanoDartWeapon.lua').CAANanoDartWeapon
 CAABurstCloudFlakArtilleryWeapon = import('/lua/sim/weapons/cybran/CAABurstCloudFlakArtilleryWeapon.lua').CAABurstCloudFlakArtilleryWeapon
@@ -49,14 +48,17 @@ CIFMissileLoaWeapon = import('/lua/sim/weapons/cybran/CIFMissileLoaWeapon.lua').
 CKrilTorpedoLauncherWeapon = import('/lua/sim/weapons/cybran/CKrilTorpedoLauncherWeapon.lua').CKrilTorpedoLauncherWeapon
 CMobileKamikazeBombWeapon = import('/lua/sim/weapons/cybran/CMobileKamikazeBombWeapon.lua').CMobileKamikazeBombWeapon
 
--- kept for mod backwards compatibility
+--#region kept for mod backwards compatibility
 local WeaponFile = import("/lua/sim/defaultweapons.lua")
 local BareBonesWeapon = WeaponFile.BareBonesWeapon
+local DefaultBeamWeapon = WeaponFile.DefaultBeamWeapon
+local DefaultProjectileWeapon = WeaponFile.DefaultProjectileWeapon
+local KamikazeWeapon = WeaponFile.KamikazeWeapon
+local OverchargeWeapon = WeaponFile.OverchargeWeapon
+
+local CollisionBeamFile = import("/lua/defaultcollisionbeams.lua")
+
+local EffectTemplate = import("/lua/effecttemplates.lua")
 local Explosion = import("/lua/defaultexplosions.lua")
 local Util = import("/lua/utilities.lua")
-local KamikazeWeapon = WeaponFile.KamikazeWeapon
-local DefaultProjectileWeapon = WeaponFile.DefaultProjectileWeapon
-local DefaultBeamWeapon = WeaponFile.DefaultBeamWeapon
-local OverchargeWeapon = WeaponFile.OverchargeWeapon
-local CollisionBeamFile = import("/lua/defaultcollisionbeams.lua")
-local EffectTemplate = import("/lua/effecttemplates.lua")
+--#endregion

--- a/lua/seraphimweapons.lua
+++ b/lua/seraphimweapons.lua
@@ -55,17 +55,20 @@ SDFSniperShotSniperMode = import('/lua/sim/weapons/seraphim/SDFSniperShotSniperM
 SB0OhwalliExperimentalStrategicBombWeapon = import('/lua/sim/weapons/seraphim/SB0OhwalliExperimentalStrategicBombWeapon.lua').SB0OhwalliExperimentalStrategicBombWeapon
 SAALightningWeapon = import("/lua/sim/weapons/seraphim/SAALightningWeapon.lua").SAALightningWeapon
 
---- Kept Mod Support
+--#region kept for mod backwards compatibility
 local WeaponFile = import("/lua/sim/defaultweapons.lua")
-local CollisionBeamFile = import("/lua/defaultcollisionbeams.lua")
-local KamikazeWeapon = WeaponFile.KamikazeWeapon
 local BareBonesWeapon = WeaponFile.BareBonesWeapon
-local Explosion = import("/lua/defaultexplosions.lua")
-local DisruptorBeamCollisionBeam = CollisionBeamFile.DisruptorBeamCollisionBeam
-local QuantumBeamGeneratorCollisionBeam = CollisionBeamFile.QuantumBeamGeneratorCollisionBeam
-local PhasonLaserCollisionBeam = CollisionBeamFile.PhasonLaserCollisionBeam
-local TractorClawCollisionBeam = CollisionBeamFile.TractorClawCollisionBeam
-local DefaultProjectileWeapon = WeaponFile.DefaultProjectileWeapon
 local DefaultBeamWeapon = WeaponFile.DefaultBeamWeapon
+local DefaultProjectileWeapon = WeaponFile.DefaultProjectileWeapon
+local KamikazeWeapon = WeaponFile.KamikazeWeapon
 local OverchargeWeapon = WeaponFile.OverchargeWeapon
+
+local CollisionBeamFile = import("/lua/defaultcollisionbeams.lua")
+local DisruptorBeamCollisionBeam = CollisionBeamFile.DisruptorBeamCollisionBeam
+local PhasonLaserCollisionBeam = CollisionBeamFile.PhasonLaserCollisionBeam
+local QuantumBeamGeneratorCollisionBeam = CollisionBeamFile.QuantumBeamGeneratorCollisionBeam
+local TractorClawCollisionBeam = CollisionBeamFile.TractorClawCollisionBeam
+
+local Explosion = import("/lua/defaultexplosions.lua")
 local EffectTemplate = import("/lua/effecttemplates.lua")
+--#endregion

--- a/lua/terranweapons.lua
+++ b/lua/terranweapons.lua
@@ -8,11 +8,6 @@
 --**  Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --****************************************************************************
 
-local WeaponFile = import("/lua/sim/defaultweapons.lua")
-local CollisionBeams = import("/lua/defaultcollisionbeams.lua")
-
--- Weapon Files --
-
 TDFFragmentationGrenadeLauncherWeapon = import('/lua/sim/weapons/uef/TDFFragmentationGrenadeLauncherWeapon.lua').TDFFragmentationGrenadeLauncherWeapon
 TDFPlasmaCannonWeapon = import('/lua/sim/weapons/uef/TDFPlasmaCannonWeapon.lua').TDFPlasmaCannonWeapon
 TIFFragLauncherWeapon = import('/lua/sim/weapons/uef/TIFFragLauncherWeapon.lua').TIFFragLauncherWeapon
@@ -50,10 +45,15 @@ TAMPhalanxWeapon = import('/lua/sim/weapons/uef/TAMPhalanxWeapon.lua').TAMPhalan
 TOrbitalDeathLaserBeamWeapon = import('/lua/sim/weapons/uef/TOrbitalDeathLaserBeamWeapon.lua').TOrbitalDeathLaserBeamWeapon
 
 
--- Kept for Mod backwards compatibility
-local BareBonesWeapon = WeaponFile.BareBonesWeapon
+--#region kept for mod backwards compatibility
+local CollisionBeams = import("/lua/defaultcollisionbeams.lua")
 local GinsuCollisionBeam = CollisionBeams.GinsuCollisionBeam
-local DefaultProjectileWeapon = WeaponFile.DefaultProjectileWeapon
-local DefaultBeamWeapon = WeaponFile.DefaultBeamWeapon
 local OrbitalDeathLaserCollisionBeam = CollisionBeams.OrbitalDeathLaserCollisionBeam
+
+local WeaponFile = import("/lua/sim/defaultweapons.lua")
+local BareBonesWeapon = WeaponFile.BareBonesWeapon
+local DefaultBeamWeapon = WeaponFile.DefaultBeamWeapon
+local DefaultProjectileWeapon = WeaponFile.DefaultProjectileWeapon
+
 local EffectTemplate = import("/lua/effecttemplates.lua")
+--#endregion


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Xtreme Wars was unable to hook the aeon weapons file because of a missing field that was not carried over in https://github.com/FAForever/fa/pull/5659.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
The game doesn't instantly give errors when you play Aeon with Xtreme Wars enabled.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
