### PR TITLE
Use LOD instead of always emitting for Chrono visuals

### DIFF
--- a/effects/emitters/aeon_chrono_dampener_large_02_emit.bp
+++ b/effects/emitters/aeon_chrono_dampener_large_02_emit.bp
@@ -1,5 +1,5 @@
 EmitterBlueprint {
-	BlueprintId = 'aeon_chrono_dampener_02',
+	BlueprintId = 'aeon_chrono_dampener_large_02',
 	Lifetime = 1.00,
 	Repeattime = 1.00,
 	TextureFramecount = 1.00,
@@ -10,8 +10,8 @@ EmitterBlueprint {
 	AlignRotation = false,
 	AlignToBone = false,
 	Flat = true,
-	LODCutoff = 250.00,
-	EmitIfVisible = false,
+	LODCutoff = 1100.00,
+	EmitIfVisible = true,
 	CatchupEmit = true,
 	CreateIfVisible = false,
 	SnapToWaterline = false,
@@ -23,8 +23,8 @@ EmitterBlueprint {
 	LowFidelity = true,
 	MedFidelity = true,
 	HighFidelity = true,
-	Texture = '/textures/particles/ring_white_06.dds',
-	RampTexture = '/textures/particles/ramp_chrono_dampener.dds',
+	Texture = [[/textures/particles/ring_white_06.dds]],
+	RampTexture = [[/textures/particles/ramp_chrono_dampener.dds]],
 	XDirectionCurve = {
 		XRange = 1.00,
 		Keys = {
@@ -130,7 +130,7 @@ EmitterBlueprint {
 	RotationRateCurve = {
 		XRange = 1.00,
 		Keys = {
-			{ x=0.0,y=3.0,z=0.000 },
+			{ x=0.000,y=3.000,z=0.000 },
 		},
 	},
 	FrameRateCurve = {

--- a/effects/emitters/aeon_chrono_dampener_large_04_emit.bp
+++ b/effects/emitters/aeon_chrono_dampener_large_04_emit.bp
@@ -1,5 +1,5 @@
 EmitterBlueprint {
-	BlueprintId = 'aeon_chrono_dampener_04',
+	BlueprintId = 'aeon_chrono_dampener_large_04',
 	Lifetime = 1.00,
 	Repeattime = 1.00,
 	TextureFramecount = 1.00,
@@ -10,8 +10,8 @@ EmitterBlueprint {
 	AlignRotation = false,
 	AlignToBone = false,
 	Flat = true,
-	LODCutoff = 250.00,
-	EmitIfVisible = false,
+	LODCutoff = 1100.00,
+	EmitIfVisible = true,
 	CatchupEmit = true,
 	CreateIfVisible = false,
 	SnapToWaterline = false,
@@ -23,8 +23,8 @@ EmitterBlueprint {
 	LowFidelity = true,
 	MedFidelity = true,
 	HighFidelity = true,
-	Texture = '/textures/particles/ring_07.dds',
-	RampTexture = '/textures/particles/ramp_quantum_warhead_flash_01.dds',
+	Texture = [[/textures/particles/ring_07.dds]],
+	RampTexture = [[/textures/particles/ramp_quantum_warhead_flash_01.dds]],
 	XDirectionCurve = {
 		XRange = 1.00,
 		Keys = {
@@ -130,7 +130,7 @@ EmitterBlueprint {
 	RotationRateCurve = {
 		XRange = 1.00,
 		Keys = {
-			{ x=0.0,y=-3.000,z=0.000 },
+			{ x=0.000,y=-3.000,z=0.000 },
 		},
 	},
 	FrameRateCurve = {


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Issue
Due to #5883, Chrono's effects are visible through fog of war.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Use LOD instead of making the effects always visible. The 1100 LOD makes it always visible from a max zoomed out view on a 10 km map, and for 20 km maps, visible if about 1/4th of the map is visible. This is appropriate for the huge AoE Chrono has: it's larger than a nuke's inner radius. It's still weaker than a nuke, so it doesn't have unlimited LOD.

I used the emitter editor to make the changes so the file format is changed.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Build a chrono ACU and have it groundfire. Zoom out to see the effects are visible at a reasonable zoom level. Switch to civilian army and turn on fog of war to check that the effects don't emit if the ACU is not visible.

## Checklist
- [x] Changes are documented in the changelog for the next game version
