### PR TITLE
Don't block death nukes with mobile shields.

### DIFF
--- a/changelog/snippets/balance.6060.md
+++ b/changelog/snippets/balance.6060.md
@@ -1,4 +1,6 @@
-- (#6060) Make shields absorb ACU explosions.
+- (#6060, #6296) Make static shields absorb ACU explosions.
 
-  Both mobile and static shields absorb full damage from ACU explosions. For example, this prevents ACU explosions from killing all engineers inside shielded bases/firebases or killing all units in mobile-shielded T2 armies.
+  Static shields absorb full damage from ACU explosions. For example, this prevents ACU explosions from killing all engineers inside shielded bases/firebases.
+  Mobile shields do not absorb damage from ACU explosions because the ACU explosion is an anti-snowball mechanic and it would be very unfair for Aeon and UEF T2 to ignore it.
+
   The structure part of static shields still takes reduced structure damage from ACU explosions.

--- a/lua/ShieldAbsorptionValues.lua
+++ b/lua/ShieldAbsorptionValues.lua
@@ -22,12 +22,17 @@
 
 ---@alias AbsorptionType
 ---| "Default"
+---| "StaticShield"
 
 --- Defines what proportion of damage a shield of `AbsorptionType` absorbs from a specific `DamageType`
 --- Overrides the behavior of shields absorbing damage depending on their owner's armor type
 ---@type table<AbsorptionType, table<DamageType, number>>
 shieldAbsorptionValues = {
 	["Default"] = {
+		["Deathnuke"] = 0.0,
+		["Overcharge"] = 1.0,
+	},
+	["StaticShield"] = { -- For mod support, auto-assigned if the owner has STRUCTURE category.
 		["Deathnuke"] = 1.0,
 		["Overcharge"] = 1.0,
 	},

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -224,7 +224,7 @@ Shield = ClassShield(moho.shield_methods, Entity) {
         end
 
         -- lookup our damage absorption type's table
-        self.AbsorptionTypeDamageTypeToMulti = shieldAbsorptionValues[ownerBp.Defense.Shield.AbsorptionType or "Default"]
+        self.AbsorptionTypeDamageTypeToMulti = shieldAbsorptionValues[spec.AbsorptionType or "Default"]
 
         -- use trashbag of the unit that owns us
         self.Trash = self.Owner.Trash

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -214,17 +214,23 @@ Shield = ClassShield(moho.shield_methods, Entity) {
         -- attach us to the owner
         EntityAttachBoneTo(self, -1, spec.Owner, -1)
 
-        -- lookup as to whether we're static or a commander shield
+
+        -- lookup whether we're a static shield for absorbing deathnukes with modded shields that don't have the value set
+        local absorptionType = spec.AbsorptionType
+        -- lookup whether we're a static or a commander shield for overcharge's fixed damage
         local ownerBp = self.Owner.Blueprint
         local ownerCategories = ownerBp.CategoriesHash
         if ownerCategories.STRUCTURE then
             self.StaticShield = true
+            if not absorptionType then
+                absorptionType = "StaticShield"
+            end
         elseif ownerCategories.COMMAND then
             self.CommandShield = true
         end
 
         -- lookup our damage absorption type's table
-        self.AbsorptionTypeDamageTypeToMulti = shieldAbsorptionValues[spec.AbsorptionType or "Default"]
+        self.AbsorptionTypeDamageTypeToMulti = shieldAbsorptionValues[absorptionType or "Default"]
 
         -- use trashbag of the unit that owns us
         self.Trash = self.Owner.Trash

--- a/units/UAB4202/UAB4202_unit.bp
+++ b/units/UAB4202/UAB4202_unit.bp
@@ -36,6 +36,7 @@ UnitBlueprint{
         Health = 150,
         MaxHealth = 150,
         Shield = {
+            AbsorptionType = "StaticShield",
             ImpactEffects = "AeonShieldHit01",
             ImpactMesh = "/effects/entities/ShieldSection01/ShieldSection01_mesh",
             Mesh = "/effects/entities/AeonShield01/AeonShield01_mesh",

--- a/units/UAB4301/UAB4301_unit.bp
+++ b/units/UAB4301/UAB4301_unit.bp
@@ -35,6 +35,7 @@ UnitBlueprint{
         Health = 300,
         MaxHealth = 300,
         Shield = {
+            AbsorptionType = "StaticShield",
             ImpactEffects = "AeonShieldHit01",
             ImpactMesh = "/effects/entities/ShieldSection01/ShieldSection01_mesh",
             Mesh = "/effects/entities/AeonShield01/AeonShield01_mesh",

--- a/units/UEB4202/UEB4202_unit.bp
+++ b/units/UEB4202/UEB4202_unit.bp
@@ -36,6 +36,7 @@ UnitBlueprint{
         Health = 250,
         MaxHealth = 250,
         Shield = {
+            AbsorptionType = "StaticShield",
             ImpactEffects = "UEFShieldHit01",
             ImpactMesh = "/effects/entities/ShieldSection01/ShieldSection01_mesh",
             Mesh = "/effects/entities/Shield01/Shield01_mesh",

--- a/units/UEB4301/UEB4301_unit.bp
+++ b/units/UEB4301/UEB4301_unit.bp
@@ -33,6 +33,7 @@ UnitBlueprint{
         Health = 500,
         MaxHealth = 500,
         Shield = {
+            AbsorptionType = "StaticShield",
             ImpactEffects = "UEFShieldHit01",
             ImpactMesh = "/effects/entities/ShieldSection01/ShieldSection01_mesh",
             Mesh = "/effects/entities/Shield01/Shield01_mesh",

--- a/units/URB4202/URB4202_unit.bp
+++ b/units/URB4202/URB4202_unit.bp
@@ -37,6 +37,7 @@ UnitBlueprint{
         Health = 500,
         MaxHealth = 500,
         Shield = {
+            AbsorptionType = "StaticShield",
             ImpactEffects = "CybranShieldHit01",
             ImpactMesh = "/effects/entities/ShieldSection01/ShieldSection01b_mesh",
             Mesh = "/effects/entities/CybranShield01/CybranShield01_mesh",

--- a/units/URB4204/URB4204_unit.bp
+++ b/units/URB4204/URB4204_unit.bp
@@ -32,6 +32,7 @@ UnitBlueprint{
         Health = 500,
         MaxHealth = 500,
         Shield = {
+            AbsorptionType = "StaticShield",
             ImpactEffects = "CybranShieldHit01",
             ImpactMesh = "/effects/entities/ShieldSection01/ShieldSection01b_mesh",
             Mesh = "/effects/entities/CybranShield01/CybranShield01_mesh",

--- a/units/URB4205/URB4205_unit.bp
+++ b/units/URB4205/URB4205_unit.bp
@@ -33,6 +33,7 @@ UnitBlueprint{
         Health = 500,
         MaxHealth = 500,
         Shield = {
+            AbsorptionType = "StaticShield",
             ImpactEffects = "CybranShieldHit01",
             ImpactMesh = "/effects/entities/ShieldSection01/ShieldSection01b_mesh",
             Mesh = "/effects/entities/CybranShield01/CybranShield01_mesh",

--- a/units/URB4206/URB4206_unit.bp
+++ b/units/URB4206/URB4206_unit.bp
@@ -36,6 +36,7 @@ UnitBlueprint{
         Health = 500,
         MaxHealth = 500,
         Shield = {
+            AbsorptionType = "StaticShield",
             ImpactEffects = "CybranShieldHit01",
             ImpactMesh = "/effects/entities/ShieldSection01/ShieldSection01b_mesh",
             Mesh = "/effects/entities/CybranShield01/CybranShield01_mesh",

--- a/units/URB4207/URB4207_unit.bp
+++ b/units/URB4207/URB4207_unit.bp
@@ -33,6 +33,7 @@ UnitBlueprint{
         Health = 500,
         MaxHealth = 500,
         Shield = {
+            AbsorptionType = "StaticShield",
             ImpactEffects = "CybranShieldHit01",
             ImpactMesh = "/effects/entities/ShieldSection01/ShieldSection01b_mesh",
             Mesh = "/effects/entities/CybranShield01/CybranShield01_mesh",

--- a/units/XAC2101/XAC2101_unit.bp
+++ b/units/XAC2101/XAC2101_unit.bp
@@ -51,6 +51,7 @@ UnitBlueprint {
         Health = 12000,
         MaxHealth = 12000,
         Shield = {
+            AbsorptionType = "StaticShield",
             ImpactEffects = 'AeonShieldHit01',
             ImpactMesh = '/effects/entities/ShieldSection01/ShieldSection01_mesh',
             Mesh = '/effects/entities/AeonShield01/AeonShield01_mesh',

--- a/units/XSB4202/XSB4202_unit.bp
+++ b/units/XSB4202/XSB4202_unit.bp
@@ -38,6 +38,7 @@ UnitBlueprint{
         Health = 400,
         MaxHealth = 400,
         Shield = {
+            AbsorptionType = "StaticShield",
             ImpactEffects = "SeraphimShieldHit01",
             ImpactMesh = "/effects/entities/ShieldSection01/ShieldSection01_mesh",
             Mesh = "/effects/entities/SeraphimShield01/SeraphimShield01_mesh",

--- a/units/XSB4301/XSB4301_unit.bp
+++ b/units/XSB4301/XSB4301_unit.bp
@@ -36,6 +36,7 @@ UnitBlueprint{
         Health = 600,
         MaxHealth = 600,
         Shield = {
+            AbsorptionType = "StaticShield",
             ImpactEffects = "SeraphimShieldHit01",
             ImpactMesh = "/effects/entities/ShieldSection01/ShieldSection01_mesh",
             Mesh = "/effects/entities/SeraphimShield01/SeraphimShield01_mesh",


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Issue
Mobile shields blocking ACU explosions gives an obvious snowballing advantage to Aeon and UEF T2, and to an extent Seraphim T3. This advantage should no go into live because it would easily unbalance the game and currently there are no changes made to counteract this newfound advantage.
While it creates inconsistency, it's worth it; the original issue was that ACUs in bases would kill all engis, or that teleporting ACUs would kill all engis, and that is still being solved after these changes. Nobody asked for OP mobile shields, it just came as a consequence of an easy, consistent implementation.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Implements a `StaticShield` absorption type with automatic mod support based on categories. 
The default absorption type no longer blocks `DeathNuke` damage, instead the `StaticShield` absorption type does. This means modded mobile shields also do not block death nukes. It also opens up a trivial opportunity to add `DeathNuke` absorption to the UEF ACU shield, UEF SACU shield, and Fatboy shield.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spawn all static/mobile shields and an engi target underneath them then blow up ACUs to confirm they don't kill the engis.
<details> <summary> Spawn units command: </summary>

```
   CreateUnitAtMouse('url0208', 0,  -54.66,   82.50,  0.00000)
   CreateUnitAtMouse('uab4301', 0,    7.91,  -38.79, -0.00110)
   CreateUnitAtMouse('url0208', 0,   30.34,    7.50,  0.00000)
   CreateUnitAtMouse('uel0307', 0,   51.34,  -31.50,  0.00024)
   CreateUnitAtMouse('uel0401ef', 0,   50.84,  -60.87, -0.00008)
   CreateUnitAtMouse('uel0401ef', 0,   50.41,  -61.29, -0.00008)
   CreateUnitAtMouse('url0208', 0,   41.34,   20.50,  0.00000)
   CreateUnitAtMouse('uel0208', 0,   53.34,  -48.50, -0.00002)
   CreateUnitAtMouse('uel0208', 0,  -59.66,   13.50,  0.09655)
   CreateUnitAtMouse('xac2101', 0, -107.09,    7.21,  0.00682)
   CreateUnitAtMouse('url0208', 0,   -2.66,  -39.50, -0.00000)
   CreateUnitAtMouse('ual0307', 0,   67.34,  -19.50,  0.00015)
   CreateUnitAtMouse('xsl0307', 0,   71.34,  -39.50,  0.00098)
   CreateUnitAtMouse('url0208', 0,   65.34,  -22.50,  0.00005)
   CreateUnitAtMouse('uel0401', 0,   50.84,  -56.00, -0.00008)
   CreateUnitAtMouse('url0208', 0,  -21.66,  -21.50,  0.00000)
   CreateUnitAtMouse('url0208', 0,   40.34,   20.50,  0.00000)
   CreateUnitAtMouse('urb4206', 0,  -51.09,  -39.79,  0.00000)
   CreateUnitAtMouse('xsb4301', 0,  -37.09,   41.21, -0.00030)
   CreateUnitAtMouse('url0208', 0,  -35.66,   75.50,  0.00000)
   CreateUnitAtMouse('uab4202', 0,  -62.09,   65.21, -0.15651)
   CreateUnitAtMouse('urb4204', 0,   28.91,    1.21, -0.01026)
   CreateUnitAtMouse('url0208', 0,   67.34,  -36.50,  0.00043)
   CreateUnitAtMouse('xab1401', 0, -106.85,   11.71, -0.00000)
   CreateUnitAtMouse('ueb4301', 0,  -24.09,   -5.79,  0.00000)
   CreateUnitAtMouse('ueb4202', 0,  -28.09,   78.21,  0.00000)
   CreateUnitAtMouse('url0208', 0,  -57.66,   66.50, -0.00086)
   CreateUnitAtMouse('url0208', 0,  -41.66,  -37.50,  0.00000)
   CreateUnitAtMouse('url0208', 0,   55.34,  -31.50,  0.00017)
   CreateUnitAtMouse('urb4207', 0,  -21.09,  -64.79, -0.01029)
   CreateUnitAtMouse('xsb4202', 0,   49.91,   22.21,  0.00000)
   CreateUnitAtMouse('urb4205', 0,  -56.09,   91.21,  0.00000)
   CreateUnitAtMouse('url0208', 0,  -20.66,  -51.50,  0.00021)
   CreateUnitAtMouse('url0208', 0,   26.34,   21.50,  0.00000)
   CreateUnitAtMouse('urb4202', 0,   21.91,   22.21,  0.00000)
   CreateUnitAtMouse('url0208', 0,  -42.66,   58.50, -0.00040)
```
</details>

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
