### PR TITLE
Enhance the periodic logging to help understand memory usage

### DIFF
--- a/changelog/snippets/other.6310.md
+++ b/changelog/snippets/other.6310.md
@@ -1,0 +1,5 @@
+- (#6310) Enhance the periodic logging of the session time. It now makes a distinction between game time and session time. It also prints the heap information.
+
+As an example:
+
+- DEBUG: Session time: 00:35:01	Game time: 00:09:33	Heap: 288.0M / 253.2M

--- a/changelog/snippets/other.6310.md
+++ b/changelog/snippets/other.6310.md
@@ -1,5 +1,5 @@
-- (#6310) Enhance the periodic logging of the session time. It now makes a distinction between game time and session time. It also prints the heap information.
+- (#6310) Enhance the periodic logging of the session time.
 
-As an example:
+The logging now differentiates between the session time and the game time. It also prints information about the allocated memory on the heap. This is useful for debugging memory issues.
 
-- DEBUG: Session time: 00:35:01	Game time: 00:09:33	Heap: 288.0M / 253.2M
+As an example: `DEBUG: Session time: 00:35:01 Game time: 00:09:33 Heap: 288.0M / 253.2M`

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -335,9 +335,6 @@ function BeginSession()
     -- add on game over callbacks
     ForkThread(GameOverListenerThread)
 
-    -- log game time
-    ForkThread(GameTimeLogger)
-
     -- keep track of units off map
     OnStartOffMapPreventionThread()
 
@@ -542,17 +539,6 @@ function BeginSessionEffects()
                 end
             end
         end
-    end
-end
-
-function GameTimeLogger()
-    while true do
-        GTS = GetGameTimeSeconds()
-        hours   = math.floor(GTS / 3600);
-        minutes = math.floor((GTS - (hours * 3600)) / 60);
-        seconds = GTS - (hours * 3600) - (minutes * 60);
-        SPEW(string.format('Current gametime: %02d:%02d:%02d', hours, minutes, seconds))
-        WaitSeconds(30)
     end
 end
 

--- a/lua/system/logger.lua
+++ b/lua/system/logger.lua
@@ -1,0 +1,71 @@
+--******************************************************************************************************
+--** Copyright (c) 2024 Willem 'Jip' Wijnia
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
+--- This module is responsible for periodically logging various information
+--- about the current session that can be useful for debugging purposes.
+
+--- Retrieves various engine statistics.
+---@return integer  # Heap committed
+---@return integer  # Heap total
+local function GetEngineStatistics()
+
+    local heapCommitted = 0
+    local heapTotal = 0
+
+    if __EngineStats and __EngineStats.Children then
+        for _, a in pairs(__EngineStats.Children) do
+            if a.Name == 'Heap' then
+                for _, b in pairs(a.Children) do
+                    if b.Name == 'Committed' then
+                        heapCommitted = b.Value
+                    end
+
+                    if b.Name == 'Total' then
+                        heapTotal = b.Value
+                    end
+                end
+            end
+        end
+    end
+
+    return heapCommitted, heapTotal
+end
+
+function LoggingThread()
+    while true do
+        local sessionTime = CurrentTime()
+        local gameTime = GameTime()
+        local heapCommitted, heapTotal = GetEngineStatistics()
+
+        SPEW(
+            string.format("Session time: %s", FormatTime(sessionTime)),
+            string.format("Game time: %s", FormatTime(gameTime)),
+            string.format("Heap: %s / %s", heapTotal, heapCommitted)
+        )
+
+        for k = 1, 10 do
+            WaitSeconds(1)
+        end
+    end
+end
+
+ForkThread(LoggingThread)

--- a/lua/system/logger.lua
+++ b/lua/system/logger.lua
@@ -62,9 +62,7 @@ function LoggingThread()
             string.format("Heap: %s / %s", heapTotal, heapCommitted)
         )
 
-        for k = 1, 10 do
-            WaitSeconds(1)
-        end
+        WaitSeconds(10)
     end
 end
 

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -160,6 +160,7 @@ function CreateUI(isReplay)
 
     -- start long-running threads
 
+    import("/lua/system/logger.lua")
     import("/lua/system/performance.lua")
     import("/lua/ui/game/cursor/depth.lua")
     import("/lua/ui/game/cursor/hover.lua")

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -113,7 +113,6 @@ if replayID then
     LOG("REPLAY ID: " .. replayID)
 end
 
-
 do
 
     -- Moderation functionality


### PR DESCRIPTION
## Description of the proposed changes

Removes the sim-based game time logger. Introduces a ui-based game time logger. This allows us to make the logging more relevant by including the session time and the heap usage.

## Testing done on the proposed changes

Start a game and observe the log. It should contain entries such as:

- `DEBUG: Session time: 00:35:01	Game time: 00:09:33	Heap: 288.0M / 253.2M`

## Additional context

It's also a great reminder to take a break as a developer when the session time reaches more than two hours. This is a common feature in games such as the [Anno series](https://www.reddit.com/r/anno/comments/10bjtbl/anyone_has_the_list_of_2_hours_reminders/) which we now make available for developers. Time to stretch those legs!

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
