### PR TITLE
Move hidden crash damage out of Ahwassa and CZAR scripts

### DIFF
--- a/changelog/snippets/fix.6311.md
+++ b/changelog/snippets/fix.6311.md
@@ -1,0 +1,1 @@
+- (#6311) Ahwassa and CZAR dealt an extra 1000 crash damage due to a line hidden in their script, which doesn't show up with the 7000 crash damage listed in the UI. The 1000 damage is added to the 7000 damage to make it work in the UI. As a consequence, the radius where that extra damage is dealt is increased from 5 to 10/15.

--- a/units/UAA0310/UAA0310_script.lua
+++ b/units/UAA0310/UAA0310_script.lua
@@ -98,8 +98,6 @@ UAA0310 = ClassUnit(AirTransport, ExternalFactoryComponent) {
     ---@param z number
     OnAnimTerrainCollision = function(self, bone, x, y, z)
         local blueprint = self.Blueprint
-        local position = { x, y, z }
-        DamageArea(self, position, 5, 1, 'TreeForce', false)
         explosion.CreateDefaultHitExplosionAtBone(self, bone, 5.0)
         explosion.CreateDebrisProjectiles(self, explosion.GetAverageBoundingXYZRadius(self),
             { blueprint.SizeX, blueprint.SizeY, blueprint.SizeZ })

--- a/units/UAA0310/UAA0310_script.lua
+++ b/units/UAA0310/UAA0310_script.lua
@@ -99,7 +99,6 @@ UAA0310 = ClassUnit(AirTransport, ExternalFactoryComponent) {
     OnAnimTerrainCollision = function(self, bone, x, y, z)
         local blueprint = self.Blueprint
         local position = { x, y, z }
-        DamageArea(self, position, 5, 1000, 'Default', true, false)
         DamageArea(self, position, 5, 1, 'TreeForce', false)
         explosion.CreateDefaultHitExplosionAtBone(self, bone, 5.0)
         explosion.CreateDebrisProjectiles(self, explosion.GetAverageBoundingXYZRadius(self),

--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -726,7 +726,7 @@ UnitBlueprint{
         },
         {
             AboveWaterTargetsOnly = true,
-            Damage = 7000,
+            Damage = 8000,
             DamageFriendly = true,
             DamageRadius = 15,
             DamageType = "Normal",

--- a/units/XSA0402/XSA0402_script.lua
+++ b/units/XSA0402/XSA0402_script.lua
@@ -44,7 +44,6 @@ XSA0402 = ClassUnit(SAirUnit) {
 
     OnAnimTerrainCollision = function(self, bone,x,y,z)
         local position = {x, y, z}
-        DamageArea(self, position, 5, 1000, 'Default', true, false)
         DamageArea(self, position, 5, 1, 'TreeForce', false)
         explosion.CreateDefaultHitExplosionAtBone( self, bone, 5.0 )
         explosion.CreateDebrisProjectiles(self, explosion.GetAverageBoundingXYZRadius(self), {self:GetUnitSizes()})

--- a/units/XSA0402/XSA0402_script.lua
+++ b/units/XSA0402/XSA0402_script.lua
@@ -43,8 +43,6 @@ XSA0402 = ClassUnit(SAirUnit) {
     end,
 
     OnAnimTerrainCollision = function(self, bone,x,y,z)
-        local position = {x, y, z}
-        DamageArea(self, position, 5, 1, 'TreeForce', false)
         explosion.CreateDefaultHitExplosionAtBone( self, bone, 5.0 )
         explosion.CreateDebrisProjectiles(self, explosion.GetAverageBoundingXYZRadius(self), {self:GetUnitSizes()})
     end,

--- a/units/XSA0402/XSA0402_unit.bp
+++ b/units/XSA0402/XSA0402_unit.bp
@@ -507,7 +507,7 @@ UnitBlueprint{
         },
         {
             AboveWaterTargetsOnly = true,
-            Damage = 7000,
+            Damage = 8000,
             DamageFriendly = true,
             DamageRadius = 10,
             DamageType = "Normal",


### PR DESCRIPTION
## Issue
Ahwassa/CZAR deals 1000 damage in 5 radius due to a line in its script, which makes that information unknown to the user because it is not in the blueprint.

## Description of the proposed changes
Removes the scripted damage and adds it to the blueprint. This results in:
- high damage area radius: 5 -> 10 (Ahwassa) / 15 (CZAR)
- high damage area damage through Seraphim T3 shields: 1000 (constant) + 2800 (reduced by shields) -> 3800 (reduced by shields)
  - The shield choice is relevant because shields can reduce crash damage by up to 20% of their max HP. That means the max crash damage reduction in normal games is `21k * 0.2 = 4200`. 3800 damage under shields keeps the ability to one shot SMDs with crash damage.
- high damage against unshielded targets: remains the same

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Crashing these air T4s through shields deals expected damage.

## Additional context
Previous balance PR reducing crash damage: https://github.com/FAForever/fa/pull/4543

## Checklist
- [ ] Changes are documented in the changelog for the next game version
