### PR TITLE
Fix radial dragger appearing when mouse isn't moved

### DIFF
--- a/changelog/snippets/features.6095.md
+++ b/changelog/snippets/features.6095.md
@@ -1,0 +1,1 @@
+- (#6095, #6312) Implement a new area attack order when you left click and drag while issuing an attack command. It issues extra orders within the radius of the command which you can then distribute to spread out the attacks.

--- a/lua/ui/controls/draggers/radial.lua
+++ b/lua/ui/controls/draggers/radial.lua
@@ -66,6 +66,10 @@ RadialDragger = Class(Dragger) {
         self.ShapeStart = trash:Add(UIRenderableCircle(view, 'rectangle-dragger-start', mouseWorldPosition[1],
             mouseWorldPosition[2], mouseWorldPosition[3], size, 'ffffff', thickness))
 
+        if minimumDistance > 0 then
+            self.ShapeStart:Hide()
+        end
+
         self.Origin = mouseWorldPosition
 
         -- register the dragger


### PR DESCRIPTION
## Issue
The radial dragger appears under the mouse when the mouse stays still.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Hides the dragger on init if minimum distance > 0.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
The radial dragger does not appear for attack move when the mouse isn't moved.

## Checklist
- [x] Changes are documented in the changelog for the next game version
