### PR TITLE
Update Yolona's missile position after changing army

### DIFF
--- a/changelog/snippets/fix.6321.md
+++ b/changelog/snippets/fix.6321.md
@@ -1,0 +1,1 @@
+- (#6321) Fix the Yolona's missile staying underground after being shared to another player.

--- a/units/XSB2401/XSB2401_script.lua
+++ b/units/XSB2401/XSB2401_script.lua
@@ -1,7 +1,7 @@
 -----------------------------------------------------------------
 -- File     :  /cdimage/units/XSB2401/XSB2401_script.lua
 -- Author(s):  John Comes, David Tomandl, Matt Vainio
--- Summary  :  Seraphim Tactical Missile Launcher Script
+-- Summary  :  Seraphim Experimental Strategic Missile Launcher Script
 -- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
 local SStructureUnit = import("/lua/seraphimunits.lua").SStructureUnit

--- a/units/XSB2401/XSB2401_script.lua
+++ b/units/XSB2401/XSB2401_script.lua
@@ -32,6 +32,16 @@ XSB2401 = ClassUnit(SStructureUnit) {
         DeathWeapon = ClassWeapon(DeathNukeWeapon) {},
     },
 
+    OnGiven = function(self, newUnit)
+        SStructureUnit.OnGiven(self, newUnit)
+        if self.MissileBuilt then
+            newUnit.MissileSlider:SetGoal(0, 0, 115)
+            newUnit.MissileBuilt = true
+        else
+            newUnit.MissileSlider:SetGoal(0, 0, 115 * self:GetWorkProgress())
+        end
+    end,
+
     ---@param self XSB2401
     ---@param builder Unit
     ---@param layer string

--- a/units/XSB2401/XSB2401_script.lua
+++ b/units/XSB2401/XSB2401_script.lua
@@ -67,6 +67,7 @@ XSB2401 = ClassUnit(SStructureUnit) {
         end
         -- Convey to the player how the launcher reloads by showing the effect right when it is built
         -- Also creates the initial pulsing glow for when the launcher is reloaded and missile is built
+        -- Though this doesn't mean that the launcher is unable to fire, since the weapon's state starts reloaded.
         self.PlayReloadEffects(self:GetWeapon(1))
     end,
 
@@ -145,15 +146,18 @@ XSB2401 = ClassUnit(SStructureUnit) {
         -- Create the reload stage effects: 3 effects in the middle column and a blue glow when the missile is built and launcher is reloaded
         local reloadTime = bp.RackSalvoReloadTime
         weapon.Trash:Add(ForkThread(function()
+            -- stage effects
             local stage = 0
             while stage < 3 do
                 WaitSeconds(reloadTime/3)
                 stage = stage + 1
                 unit:CreateReloadEmitter(stage)
             end
+            -- wait until the missile is built
             while not unit.MissileBuilt do
                 WaitTicks(1)
             end
+            -- play the "missile built and launcher reloaded" effects
             local template = EffectTemplate.SIFExperimentalStrategicLauncherLoaded01
             for i, effect in template do
                 if not unit.MissileEffect[stage + 1] then

--- a/units/XSB2401/XSB2401_script.lua
+++ b/units/XSB2401/XSB2401_script.lua
@@ -71,7 +71,7 @@ XSB2401 = ClassUnit(SStructureUnit) {
         -- Convey to the player how the launcher reloads by showing the effect right when it is built
         -- Also creates the initial pulsing glow for when the launcher is reloaded and missile is built
         -- Though this doesn't mean that the launcher is unable to fire, since the weapon's state starts reloaded.
-        self.PlayReloadEffects(self:GetWeapon(1))
+        self.PlayReloadEffects(self.WeaponInstances[1])
     end,
 
     ---@param self XSB2401

--- a/units/XSB2401/XSB2401_script.lua
+++ b/units/XSB2401/XSB2401_script.lua
@@ -32,6 +32,9 @@ XSB2401 = ClassUnit(SStructureUnit) {
         DeathWeapon = ClassWeapon(DeathNukeWeapon) {},
     },
 
+    --- Run any OnGiven callbacks then update the missile slider on the new unit to the correct position.
+    ---@param self XSB2401
+    ---@param newUnit Unit
     OnGiven = function(self, newUnit)
         SStructureUnit.OnGiven(self, newUnit)
         if self.MissileBuilt then

--- a/units/XSB2401/XSB2401_script.lua
+++ b/units/XSB2401/XSB2401_script.lua
@@ -84,20 +84,20 @@ XSB2401 = ClassUnit(SStructureUnit) {
         SStructureUnit.OnSiloBuildStart(self, weapon)
     end,
 
-    --- @param self XSB2401
-    --- @param weapon SIFExperimentalStrategicMissile
+    ---@param self XSB2401
+    ---@param weapon SIFExperimentalStrategicMissile
     OnSiloBuildEnd = function(self, weapon)
         self.MissileBuilt = true
         SStructureUnit.OnSiloBuildEnd(self,weapon)
     end,
 
-    --- @param self XSB2401
+    ---@param self XSB2401
     PlayBuildEffects = function(self)
         self:PlayUnitSound('Construct')
         self:PlayUnitAmbientSound('ConstructLoop')
     end,
 
-    --- @param self XSB2401
+    ---@param self XSB2401
     StopBuildEffects = function(self)
         self:StopUnitAmbientSound('ConstructLoop')
         self:PlayUnitSound('ConstructStop')
@@ -120,7 +120,7 @@ XSB2401 = ClassUnit(SStructureUnit) {
         end
     end,
 
-    --- @param self XSB2401
+    ---@param self XSB2401
     DestroyReloadEmitters = function(self)
         local effectBones = self.Blueprint.General.BuildBones.BuildEffectBones
         for bidx, bone in self.MissileEffect do
@@ -131,7 +131,7 @@ XSB2401 = ClassUnit(SStructureUnit) {
     end,
 
     -- Keep this function here instead of in the weapon so OnStopBeingBuilt can call it.
-    --- @param weapon SIFExperimentalStrategicMissile
+    ---@param weapon SIFExperimentalStrategicMissile
     PlayReloadEffects = function(weapon)
         local bp = weapon.Blueprint
         local muzzleBones = bp.RackBones[weapon.CurrentRackSalvoNumber].MuzzleBones
@@ -175,7 +175,7 @@ XSB2401 = ClassUnit(SStructureUnit) {
     end,
 
     --- Raises the missile depending on completion progress.
-    --- @param self XSB2401
+    ---@param self XSB2401
     RaiseMissileThread = function(self)
         self.NotCancelled = true
         WaitTicks(6)
@@ -197,13 +197,13 @@ XSB2401 = ClassUnit(SStructureUnit) {
         end
     end,
 
-    --- @param self XSB2401
+    ---@param self XSB2401
     HideMissile = function(self)
         WaitTicks(2)
         self:RetractMissile()
     end,
 
-    --- @param self XSB2401
+    ---@param self XSB2401
     RetractMissile = function(self)
         local missileBone = self.Blueprint.Display.MissileBone
         if missileBone then
@@ -215,7 +215,7 @@ XSB2401 = ClassUnit(SStructureUnit) {
     end,
 
     --- Hides the missile if building is cancelled.
-    --- @param self XSB2401
+    ---@param self XSB2401
     WatchBuild = function(self)
         while true do
             if not self:IsUnitState('SiloBuildingAmmo') and not self.MissileBuilt then
@@ -228,7 +228,7 @@ XSB2401 = ClassUnit(SStructureUnit) {
         end
     end,
 
-    --- @param self XSB2401
+    ---@param self XSB2401
     ChargeNukeSound = function(self)
         WaitTicks(16)
         self:PlayUnitAmbientSound('NukeCharge')


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes the visual issue where the missile stays underground after being transferred, even though the missile can be partially/fully built.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Play with an AI on my team then spawn a Paragon, Yolona, and a bunch of hives then transfer the Yolona around to see that the missile stays in the correct position after transfer.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
