### PR TITLE
Prevent TML from overflying TMD when the target is at a higher altitude

### DIFF
--- a/changelog/snippets/fix.6333.md
+++ b/changelog/snippets/fix.6333.md
@@ -1,0 +1,1 @@
+(#6333) Prevent TML from overflying TMD when firing at targets at higher elevation

--- a/lua/sim/projectiles/components/SemiBallisticComponent.lua
+++ b/lua/sim/projectiles/components/SemiBallisticComponent.lua
@@ -214,8 +214,7 @@ SemiBallisticComponent = ClassSimple {
     ---@return number
     OptimalMaxHeight = function(self)
         local horizDist = self:HorizontalDistanceToTarget()
-        local targetHeight = self:GetCurrentTargetPosition()[2]
-        local maxHeight = targetHeight + horizDist/(self.HeightDistanceFactor + self.HeightDistanceFactorRange * (2 * Random() - 1))
+        local maxHeight = self:GetPosition()[2] + horizDist/(self.HeightDistanceFactor + self.HeightDistanceFactorRange * (2 * Random() - 1))
         return maxHeight
     end,
 


### PR DESCRIPTION
See discussion here: https://forum.faforever.com/topic/7834/tml-height-needs-to-be-lowered/9

**Overview**
Fix to prevent TML from (more easily) overflying TMD when shooting at targets at higher elevation. Previously the height of the target was used to calculate the highest point of the arc; this uses the height of the launcher instead. Note that with this fix (and, implicitly, prior to the original projectile rework) it's still possible for missiles to overfly nearby TMD, but this narrows the window.

**Possible Issues**
The original intention behind using the height of the target was to eliminate an edge case where the target is so high that the missile doesn't arc properly. This reintroduces that (exceedingly rare--missiles fly very high relative to the terrain) possibility.