### PR TITLE
Correct the annotation for MaxHeightDiff

### DIFF
--- a/engine/Core/Blueprints/WeaponBlueprint.lua
+++ b/engine/Core/Blueprints/WeaponBlueprint.lua
@@ -168,8 +168,8 @@
 --- registered properly by the engine and the unit will remain stuck on the first order, never firing again until the
 --- player clears the command queue and re-issues the order
 ---@field ManualFire? boolean
---- changes the weapon range from spherical to cylindrical, where the cylinder has a height of
---- this twice this value
+--- The maximum height difference upon which the weapon can fire at targets (cylindrical range).
+--- Defaults to nil, which gives infinite vertical range.
 ---@field MaxHeightDiff? number
 --- this weapon can only hold this many counted projectiles
 ---@field MaxProjectileStorage number


### PR DESCRIPTION
## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
I asked @Hdt80bro about it and he doesn't know why the annotation was written this way. It's well known that all weapons can fire in cylinders and that spherical range doesn't exist in the game.