### PR TITLE
Fix platoon bug introduced in 6083

### DIFF
--- a/changelog/snippets/fix.6335.md
+++ b/changelog/snippets/fix.6335.md
@@ -1,0 +1,1 @@
+AI - Fixed a bug with recording a platoon's plan and certain other platoon related logic

--- a/lua/platoon.lua
+++ b/lua/platoon.lua
@@ -192,7 +192,7 @@ Platoon = Class(moho.platoon_methods) {
     ---@param self Platoon
     ---@param plan? string
     SetAIPlan = function(self, plan)
-        if not plan or self[plan] then return end
+        if not (plan or self[plan]) then return end
         if self.AIThread then
             self.AIThread:Destroy()
         end


### PR DESCRIPTION
Previous change meant :GetPlan() no longer worked on platoons

## Description of the proposed changes
The pull request 6083 changed various parts of platoon.lua:
https://github.com/FAForever/fa/pull/6083/files

One of these was changing "if not self[plan] then return end" to:
"if not plan or self[plan] then return end"

I.e. it was aborting if self[plan] was not nil, when the intent was presumably to abort if it was nil

## Testing done on the proposed changes
Without this change - tested on M27, it has an error that breaks the mod (since it relies on :GetPlan() which returns nil for its platoons); Also confirmed such an error didn't occur on the FAF release in April 2024 (before PR 6083).
With this change - re-ran a replay where M27 was broken and it works again.