### PR TITLE
Add guards to verify that the unit instance still exists

### DIFF
--- a/changelog/snippets/fix.6342.md
+++ b/changelog/snippets/fix.6342.md
@@ -1,0 +1,1 @@
+- (#6342) Fix an error related to the blinking lights of structures

--- a/lua/aibrains/components/StorageManagerBrainComponent.lua
+++ b/lua/aibrains/components/StorageManagerBrainComponent.lua
@@ -124,11 +124,13 @@ StorageManagerBrainComponent = ClassSimple {
             self.MassStorageState = state
 
             for _, unit in self.UnitMassStorage do
-                local onMassStorageStateChange = unit.OnMassStorageStateChange
-                if onMassStorageStateChange then
-                    local ok, msg = pcall(onMassStorageStateChange, unit, state)
-                    if not ok then
-                        -- WARN("")
+                if not IsDestroyed(unit) then
+                    local onMassStorageStateChange = unit.OnMassStorageStateChange
+                    if onMassStorageStateChange then
+                        local ok, msg = pcall(onMassStorageStateChange, unit, state)
+                        if not ok then
+                            -- WARN("")
+                        end
                     end
                 end
             end
@@ -164,11 +166,13 @@ StorageManagerBrainComponent = ClassSimple {
             self.EnergyStorageState = state
 
             for _, unit in self.UnitEnergyStorage do
-                local onEnergyStorageStateChange = unit.OnEnergyStorageStateChange
-                if onEnergyStorageStateChange then
-                    local ok, msg = pcall(onEnergyStorageStateChange, unit, state)
-                    if not ok then
-                        -- WARN("")
+                if not IsDestroyed(unit) then
+                    local onEnergyStorageStateChange = unit.OnEnergyStorageStateChange
+                    if onEnergyStorageStateChange then
+                        local ok, msg = pcall(onEnergyStorageStateChange, unit, state)
+                        if not ok then
+                            -- WARN("")
+                        end
                     end
                 end
             end


### PR DESCRIPTION
## Description of the proposed changes

Fixes a rather invisible bug from https://github.com/FAForever/fa/pull/6263 .

The logging when the `pcall` fails is disabled at the moment. Luckily, the errors are caught and registered by the c-debugger. The tables with unit references in them are cleaned up automagically by the garbage collector, but there can be a few ticks in between the unit dying and the unit being collected. In those few ticks it can generate various errors.

```
@c:\programdata\faforever\replaydata\gamedata\lua.nx2\lua\aibrains\components\storagemanagerbraincomponent.lua 179
CObject:.?AVCAiBrain@Moho@@, CFunc, "EconMidMassStore", "EconMidEnergyStore"
@c:\programdata\faforever\replaydata\gamedata\lua.nx2\lua\aibrains\components\storagemanagerbraincomponent.lua 187
CObject:.?AVCAiBrain@Moho@@, "EconMidEnergyStore", CFunc, Table, "8388651", Table, Func:@c:\programdata\faforever\replaydata\gamedata\lua.nx2\lua\sim\units\factoryunit.lua 510
@c:\programdata\faforever\replaydata\gamedata\lua.nx2\lua\aibrains\components\storagemanagerbraincomponent.lua 169
@CFunc: 0x0090F5B0
Table, "EconMidEnergyStore"
@c:\programdata\faforever\replaydata\gamedata\lua.nx2\lua\sim\units\factoryunit.lua 514
Table, "Green", "Red", CObject:.?AVCAiBrain@Moho@@
@c:\programdata\faforever\replaydata\gamedata\lua.nx2\lua\sim\units\components\blinkinglightsunitcomponent.lua 56
Table, UData:1B2F8F88, "...sim\units\components\blinkinglightsunitcomponent.lua(56): Game object has been destroyed
stack traceback:
	[C]: in function `GetNumBuildOrders'
	...sim\units\components\blinkinglightsunitcomponent.lua(56): in function `ChangeBlinkingLights'
	...ydata\gamedata\lua.nx2\lua\sim\units\factoryunit.lua(514): in function <...ydata\gamedata\lua.nx2\lua\sim\units\factoryunit.lua:510>
	[C]: in function `pcall'
	...aibrains\components\storagemanagerbraincomponent.lua(169): in function `ApplyEnergyStorageState'
	...aibrains\components\storagemanagerbraincomponent.lua(187): in function <...aibrains\components\storagemanagerbraincomponent.lua:179>"
```

## Checklist
- [ ] ~~Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version
