### PR TITLE
Fix a bug that could freeze up a weapon and even the simulation

### DIFF
--- a/changelog/snippets/fix.6345.md
+++ b/changelog/snippets/fix.6345.md
@@ -1,0 +1,3 @@
+- (#6345) Fix a bug where the air-to-ground weapons of Bombers would break
+
+- (#6345) Fix a bug where the Scorcher can freeze the simulation indefinitely

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -296,6 +296,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             -- now that we know roughly when we'll land, we can find a better guess for where
             -- we'll land, and thus guess the true falling height better as well
             halfHeight = 0.5 * (projPosY - GetSurfaceHeight(projPosX + time * projVelX, projPosX + time * projVelX))
+            if halfHeight < 0.01 then return 4.9 end
             time = MathSqrt(0.816326530612 * halfHeight) + spread
 
             local acc = halfHeight / (time * time)

--- a/lua/sim/weapons/uef/TIFCarpetBombWeapon.lua
+++ b/lua/sim/weapons/uef/TIFCarpetBombWeapon.lua
@@ -43,7 +43,11 @@ TIFCarpetBombWeapon = ClassWeapon(DefaultProjectileWeapon) {
                 -- we don't want to keep updating this location, so remove the target.
                 data.target = nil
             end
-            self:SetTargetGround(data.targetPos)
+
+            -- may be missing when the engine switches between attack ground commands, see also the blueprint field `AttackGroundTries`
+            if data.targetPos then
+                self:SetTargetGround(data.targetPos)
+            end
         end
         return DefaultProjectileWeaponCreateProjectileAtMuzzle(self, muzzle)
     end,


### PR DESCRIPTION
## Description of the proposed changes

Related to this [forum post](https://forum.faforever.com/topic/7889/improve-area-attack-and-reclaim-orders-6095-bug) and [this Discord post](https://discord.com/channels/197033481883222026/1261072611904061471).

Weapons now properly use the `AttackGroundTries` field because of https://github.com/FAForever/fa/pull/6277. For the average unit this is fine, but for bombers and specifically bombers with multiple projectiles per salvo it introduced an unusual problem: the first projectile would aim at the current target. All remaining projectiles may aim at the next target. This doesn't apply to all bombers, but in particular the UEF Tech 1 bomber (Scorcher) fell victim to this bug. 

When the bug happens we end up in an unstable state. To the user this would show as:

- (1) A bomber with a weapon that is no longer functional.
- (2) The simulation freezes up.

These issues are related to how we re-compute the (vertical) bomb trajectory in Lua. We do this in Lua to fix an engine bug where bombers would constantly miss their target. For a salvo the code assumes that the ground target does not suddenly shift _as the salvo is being processed_. This is a safe assumption as any normal interrupt would also cancel the salvo. But now that the engine can use the `AttackGroundTries` field again it is suddenly very possible that this happens throughout the salvo. And as a result the computations are all messed up. And because of that we try to get the square root of a negative number. This imaginary number does not exist in the real world and since we simulate the real world here (ha) the game returns an invalid number: `-1.#ND`. 

This introduces all sorts of problems. One of them is (1). The other is (2) as we pass the invalid number to `SetBallisticAcceleration`. The moment that happens the simulation freezes.

## Testing done on the proposed changes

Spawn in various bombers and make them bomb random patches of ground.

## Additional context

The behavior of the Scorcher is consistent between FAForever and Steam - for some odd reason the Janus works as expected and the Scorcher appears to switch targets too soon. Could it be because it is the primary weapon of the Scorcher?

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
