### PR TITLE
Add the DifferentialUpgradeCostCalculation to UEF & Sera T3 Shields

### DIFF
--- a/changelog/snippets/balance.6347.md
+++ b/changelog/snippets/balance.6347.md
@@ -1,3 +1,3 @@
-- (#6347) Add DifferentialUpgradeCostCalculation to UEF and Seraphime Tech 3 Shield
+- (#6347) Enable `DifferentialUpgradeCostCalculation` for UEF and Seraphim Tech 3 Shields.
 
-By adding this is it will make it so when upgrading from T2 -> T3 it wont cost the full t3 shield price only the extra that is need. All the Cybran Shield already have this in place.
+This makes upgrading from T2 to T3 shields get discounted by the cost of the T2 shield. All Cybran Shields already have this in place.

--- a/changelog/snippets/balance.6347.md
+++ b/changelog/snippets/balance.6347.md
@@ -1,0 +1,3 @@
+- (#6347) Add DifferentialUpgradeCostCalculation to UEF and Seraphime Tech 3 Shield
+
+By adding this is it will make it so when upgrading from T2 -> T3 it wont cost the full t3 shield price only the extra that is need. All the Cybran Shield already have this in place.

--- a/units/UEB4301/UEB4301_unit.bp
+++ b/units/UEB4301/UEB4301_unit.bp
@@ -85,6 +85,7 @@ UnitBlueprint{
         BuildCostMass = 3300,
         BuildTime = 5000,
         MaintenanceConsumptionPerSecondEnergy = 400,
+        DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "ueb4301" },
     },
     Footprint = {

--- a/units/XSB4301/XSB4301_unit.bp
+++ b/units/XSB4301/XSB4301_unit.bp
@@ -98,6 +98,7 @@ UnitBlueprint{
         BuildCostMass = 3600,
         BuildTime = 5800,
         MaintenanceConsumptionPerSecondEnergy = 500,
+        DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "xsb4301" },
     },
     Footprint = {


### PR DESCRIPTION
The Make is so when Upgrading the Shield your Not paying the Full price of the next shield on the cost difference. UEF and Sera should have this as it is enabled on all the cybran shields.


## Checklist
- [x] Changes are documented in the changelog for the next game version
