### PR TITLE
Improve the 'start here' documentation

### DIFF
--- a/docs/development-start-here.md
+++ b/docs/development-start-here.md
@@ -8,7 +8,7 @@ permalink: development/start-here
 
 # At the start of a journey
 
-Exciting times - welcome Commander to assist in improving the status quo of FAForever. Contributors are the bread and butter of our community. The association and all of its assets exist because of them. Here you'll learn the best practices surrounding Lua development for the game. 
+Welcome Commander to assist in improving the status quo of FAForever. Contributors are the bread and butter of our community. The association and all of its assets exist because of them. Here you'll learn the best practices surrounding Lua development for the game. 
 
 Do note that this is not a guide on how to write Lua code or on how development works in general. It is also not a guide on how Git and/or GitHub works.
 

--- a/docs/development-start-here.md
+++ b/docs/development-start-here.md
@@ -1,0 +1,15 @@
+---
+layout: page
+nav_order: 4
+title: Development - Start here
+has_children: true
+permalink: development/start-here
+---
+
+# At the start of a journey
+
+Exciting times - welcome Commander to assist in improving the status quo of FAForever. Contributors are the bread and butter of our community. The association and all of its assets exist because of them. Here you'll learn the best practices surrounding Lua development for the game. 
+
+Do note that this is not a guide on how to write Lua code or on how development works in general. It is also not a guide on how Git and/or GitHub works.
+
+{: .no_toc}

--- a/docs/development-start-here/lua-debugger.md
+++ b/docs/development-start-here/lua-debugger.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 nav_order: 2
-title: Lua debugger
+title: 02. Lua debugger
 parent: Development - Start here
 permalink: development/start-here/lua-debugger
 ---

--- a/docs/development-start-here/lua-debugger.md
+++ b/docs/development-start-here/lua-debugger.md
@@ -1,9 +1,9 @@
 ---
 layout: page
 nav_order: 2
-title: 02. Lua debugger
-parent: Development
-permalink: development/lua-debugger
+title: Lua debugger
+parent: Development - Start here
+permalink: development/start-here/lua-debugger
 ---
 
 # Lua debugger

--- a/docs/development-start-here/lua-setup.md
+++ b/docs/development-start-here/lua-setup.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 nav_order: 1
-title: Lua development environment
+title: 01. Lua development environment
 parent: Development - Start here
 permalink: development/start-here/lua-setup
 ---

--- a/docs/development-start-here/lua-setup.md
+++ b/docs/development-start-here/lua-setup.md
@@ -1,0 +1,79 @@
+---
+layout: page
+nav_order: 1
+title: Lua development environment
+parent: Development - Start here
+permalink: development/start-here/lua-setup
+---
+
+# Setup of a development environment
+
+Development can be difficult when your development environment is not flexible enough. In this section we explain what we think works best. We do not provide details on how to use the tooling outside of specifics that are related to Supreme Commander.
+
+In general we assume that you made a [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) of the [fa repository](https://github.com/FAForever/fa) and that you have [cloned](https://docs.github.com/en/desktop/adding-and-cloning-repositories/cloning-a-repository-from-github-to-github-desktop) your fork to the device that you intend to use to develop on.
+
+## Tooling
+
+Everything works and breaks with your tooling. We recommend the following tooling:
+
+- [Visual Studio Code](https://code.visualstudio.com/) as your interactive development environment (IDE).
+- [Github Desktop](https://github.com/apps/desktop) or [Github CLI](https://git-scm.com/) as your tool to interact with Git.
+
+For Visual Studio Code we recommend the following extensions:
+
+- [FA Lua extension](https://github.com/FAForever/fa-lua-vscode-extension/releases): introduces intellisense - absolutely vital to development.
+- [Gitlens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens): useful for seeing who made what change.
+- [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode): useful for formatting.
+- [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker): useful to prevent common spelling mistakes.
+
+## Running the game with your changes
+
+Open up two explorers. Navigate to where you cloned the repository in one. Navigate to the bin folder of the FAForever client in another. Usually the bin folder of the client is located in:
+
+- `C:\ProgramData\FAForever\bin`
+
+Copy the `init_local_development.lua` file your fork to the the bin folder. The game uses an initialisation file to understand where it should (not) search for game files. The initialisation file you just copied is an adjusted initialisation file that tells the game to also look at your local repository. We still need to tell it where that is. Open up the file that you copied. At the top you'll find:
+
+```lua
+-- change this to the location of the repository on your disk. Note that `\` is used
+-- for escaping characters and you can just use `/` in your path instead.
+local locationOfRepository = 'your-fa-repository-location'
+```
+
+Update the path to where your local repository is. Make sure that it is still valid Lua. And make sure that you use `/` instead of `\`.
+
+Now we need to tell the game to launch with the adjusted initialisation file. We can do this through program arguments. We recommend you to create a small batch script file in the bin folder called `dev_windows`. The content should be roughly similar to:
+
+```batch
+ForgedAlliance.exe /init "init_local_development.lua" /EnableDiskWatch /showlog /log "local-development.log" /nomovie
+
+REM /init               Defines what initialisation file to use
+REM /EnableDiskWatch    Allows the game to reload files when it sees they're changed on disk
+REM /showlog            Opens the moho log by default
+REM /log                Defines where to store the log file
+REM /nomovie            Removes potentially lagging starting/launching movies (will require you to hit escape on startup)
+REM
+REM Other interesting program arguments:
+REM /debug              Start the game with the Lua debugger enabled
+```
+
+For Linux users you can use the following bash script file instead:
+
+```bash
+#! /bin/sh
+
+# Change this to the location of your run proton run script (you will have copied this into your client folder https://wiki.faforever.com/en/FAQ/Client-Setup)
+RunProton="$HOME/Applications/FAF/downlords-faf-client-1.6.0/run"
+$RunProton $HOME/.faforever/bin/ForgedAlliance.exe /init init_dev.lua /showlog /log "dev.log" /EnableDiskWatch /nomovie
+
+# /init               Define what initialisation file to use
+# /EnableDiskWatch    Allows the game to reload files when it sees they're changed on disk
+# /showlog            Opens the moho log by default
+# /log                Informs the game where to store the log
+# /nomovie            Removes potentially lagging starting/launching movies (will require you to hit escape on startup)
+#
+# Other interesting program arguments:
+# /debug              Start the game with the Lua debugger enabled
+```
+
+Now you can start the game by executing the batch/bash script file. If all is good then the game starts as usual and you'll be in the main menu. If something is off then the game usually does not start. In that case you likely made a typo.

--- a/docs/development-start-here/lua-syntax.md
+++ b/docs/development-start-here/lua-syntax.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 nav_order: 3
-title: Lua version and syntax
+title: 03. Lua version and syntax
 parent: Development - Start here
 permalink: development/start-here/lua-syntax
 ---

--- a/docs/development-start-here/lua-syntax.md
+++ b/docs/development-start-here/lua-syntax.md
@@ -1,0 +1,40 @@
+---
+layout: page
+nav_order: 3
+title: Lua version and syntax
+parent: Development - Start here
+permalink: development/start-here/lua-syntax
+---
+
+# Lua
+
+[Lua](https://www.lua.org/) is a programming language that can be embedded in software. There are many different versions of Lua both in terms of syntax and in whether the Lua code is interpret or (just in time) compiled. In Supreme Commander: Forged Alliance we have LuaPlus version 5.01 with build number 1081 from February 2024. This is not to be confused with [Lua++](https://docs.luaplusplus.org/). This version of Lua is an interpreter. Often the byte code is almost a one-to-one representation of interpret Lua code.
+
+## Lua syntax
+
+In general the following list is valid syntax in LuaPlus. You're not encouraged to use them however. Using them may be confusing to other developers. And all files that use this syntax is incompatible with external tools that may perform some form of postprocessing.
+
+- The operator `^` is the bit-wise XOR operator and **not** the typical power operator, which is `math.pow`.
+- The operator `|` is the bit-wise OR operator.
+- The operator `&` is the bit-wise AND operator.
+- The operators `>>` and `<<` are the bit-wise shift operators.
+- The operator `!=` is an alternative to `~=` to check for inequality.
+- The syntax `#` is an alternative to `--` for creating comments.
+
+One useful exception is the following statement.
+
+- The statement `continue` exists, which works like you'd expect in other languages with the `continue` keyword.
+
+And another useful exception is the following syntax:
+
+- The `{h&a&}` is new syntax to create a table with a pre-allocated hash and array sections. The value `h` pre-allocates `math.pow(2, h)` entries in the hash section of a table. The value `a` pre-allocates `a` entries in the array section of a table. 
+
+It is for example applied in [#4539](https://github.com/FAForever/fa/issues/4539) to significantly improve the performance of the game.
+
+## Lua modules
+
+Due to safety concerns various modules and/or functions that are part of the default Lua library are not available. This primarily applies to the entire `io` and `os` modules, which is only available during the initialisation phase of the game. [Interfacing with a C package](https://www.lua.org/pil/8.2.html) is also not available. In general anything that would provide access outside of the sandbox of the game is not available. There are some alternatives such as `DiskFindFiles` and `DiskGetFileInfo` that provide basic access to files that are made accessible during the initialisation phase of the game.
+
+## Tips and tricks
+
+In general the white paper '[The Implementation of Lua 5.0](https://www.lua.org/doc/jucs05.pdf)' is a great introduction on understanding the Lua interpreter of Supreme Commander: Forged Alliance. 

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 layout: page
 title: Development
 permalink: /development
-nav_order: 4
+nav_order: 5
 has_children: true
 ---
 


### PR DESCRIPTION
## Description of the proposed changes

Improves the documentation by separating out the topics into separate pages that are all clearly marked as introductionary.

## Screenshots

![image](https://github.com/user-attachments/assets/4a36c3c3-492e-4db5-b6df-26d81c0524a9)

![image](https://github.com/user-attachments/assets/f2c4c952-0a4e-4ae1-88d7-c29ce6ccd6d3)

![image](https://github.com/user-attachments/assets/15bb639b-8be9-496c-9848-a427c3ff746d)

