### PR TITLE
Transfer all unbuilt units on death

### DIFF
--- a/changelog/snippets/features.6363.md
+++ b/changelog/snippets/features.6363.md
@@ -1,0 +1,2 @@
+- (#6363) When an army is defeated, transfer all unbuilt units instead of only Experimentals and T3 Arty.
+  - When a unit fails to rebuild because its build site was blocked (for example a unit in factory), the mass invested is returned as a wreck.

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -8,7 +8,7 @@
 
 local CreateWreckage = import("/lua/wreckage.lua").CreateWreckage
 
-local transferUnbuiltCategory = categories.EXPERIMENTAL + categories.TECH3 * categories.STRUCTURE * categories.ARTILLERY
+local transferUnbuiltCategory = categories.EXPERIMENTAL + categories.STRUCTURE
 local transferUnitsCategory = categories.ALLUNITS - categories.INSIGNIFICANTUNIT
 local buildersCategory = categories.ALLUNITS - categories.CONSTRUCTION - categories.ENGINEER
 
@@ -66,7 +66,7 @@ end
 --- replaces the units with new ones)
 ---@param units Unit[]
 ---@param toArmy number
----@param captured boolean
+---@param captured boolean?
 ---@return Unit[]?
 function TransferUnitsOwnership(units, toArmy, captured)
     local toBrain = GetArmyBrain(toArmy)

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -8,7 +8,7 @@
 
 local CreateWreckage = import("/lua/wreckage.lua").CreateWreckage
 
-local transferUnbuiltCategory = categories.EXPERIMENTAL + categories.STRUCTURE
+local transferUnbuiltCategory = categories.ALLUNITS
 local transferUnitsCategory = categories.ALLUNITS - categories.INSIGNIFICANTUNIT
 local buildersCategory = categories.ALLUNITS - categories.CONSTRUCTION - categories.ENGINEER
 
@@ -569,12 +569,16 @@ end
 ---@param blockingEntities RevertibleCollisionShapeEntity[]
 function FinalizeRebuiltUnits(trackers, blockingEntities)
     for _, tracker in trackers do
-        if not tracker.Success and tracker.CanCreateWreck then -- create 50% wreck. Copied from Unit:CreateWreckageProp()
+        if not tracker.Success and tracker.CanCreateWreck then
             local bp = tracker.UnitBlueprint
             local pos = tracker.UnitPos
             local orientation = tracker.UnitOrientation
-            local mass = bp.Economy.BuildCostMass * 0.57 --0.57 to compensate some multipliers in CreateWreckage()
+            -- Refund exactly how much mass was put into the unit
+            local completionFactor = tracker.TargetBuildTime / bp.Economy.BuildTime
+            local mass = bp.Economy.BuildCostMass * completionFactor 
+            -- Don't refund energy because it would be counterintuitive for wreckage
             local energy = 0
+            -- global 2x time multiplier for unit wrecks, see `Unit:CreateWreckageProp`
             local time = (bp.Wreckage.ReclaimTimeMultiplier or 1) * 2
             CreateWreckage(bp, pos, orientation, mass, energy, time)
         end


### PR DESCRIPTION
## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Resolves #6361.
- Changes the categories for structure transfer from T4s and T3 Arty to all units. 
- Adjusts the stats of the wreckage created when a unit rebuild fails so that the wreckage has the full mass of the failed unit.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spawn a paragon and some t3 engineers (they dont shoot) then build any unfinished structure or unit from a factory and run the console command to transfer the units to the opposite of the current focused army:
```lua
SimLua 
local units = ArmyBrains[GetFocusArmy()]:GetListOfUnits(categories.ALLUNITS)
local SimUtils = import('/lua/SimUtils.lua')
local target = GetFocusArmy() == 2 and {1} or {2}
ForkThread(SimUtils.TransferUnfinishedUnitsAfterDeath, units, target, false)
```
All structures get shared properly, and unbuilt units in factories turn into wrecks of the same partial cost as the unbuilt unit.

Didn't test performance, I'm not sure how to.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
