### PR TITLE
Fix crash when enabling auto OC on non-sera SACU

### DIFF
--- a/changelog/snippets/fix.6364.md
+++ b/changelog/snippets/fix.6364.md
@@ -1,0 +1,1 @@
+- (#6364) Fix the game crashing when enabling auto-overcharge with a non-Seraphim SACU selected.

--- a/lua/sim/units/CommandUnit.lua
+++ b/lua/sim/units/CommandUnit.lua
@@ -142,7 +142,8 @@ CommandUnit = ClassUnit(WalkingLandUnit) {
     ---@param auto boolean
     SetAutoOvercharge = function(self, auto)
         local wep = self:GetWeaponByLabel('AutoOverCharge')
-        if wep.NeedsUpgrade then return end
+        -- non-OC SACU can get here if auto OC is ordered along with an OC capable ACU/SACU, so wep will be nil
+        if not wep or wep.NeedsUpgrade then return end
 
         wep:SetAutoOvercharge(auto)
         self:UpdateStat("AutoOC", auto and 1 or 0)


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Bug report:
Select an ACU and an SACU then enable auto OC, it will crash:
```
ACCESS_VIOLATION: Read from 0x00000090
EAX: 0x00000000, EBX: 0x00000000, ECX: 0x00000090, EDX: 0x77B1F5F0
ESI: 0x00000000, EDI: 0x00000000, EBP: 0x55F4EBD8, ESP: 0x55F4EBB8

Stacktrace: 0x00000090 ntdll.dll+0x000AF5D0 ntdll.dll+0x000AF59F ntdll.dll+0x0006D3FE 0x00909148 0x00A824C0 ntdll.dll+0x0007A9CA KERNELBASE.dll+0x001589FE
LUA Main thread
@c:\programdata\faforever\gamedata\lua.nx2\lua\simcallbacks.lua 54
"AutoOvercharge", Table, Table, 1218.323608, Func:@c:\programdata\faforever\gamedata\lua.nx2\lua\simcallbacks.lua 117
@c:\programdata\faforever\gamedata\lua.nx2\lua\simcallbacks.lua 58
Table, Table, CFunc, Table, 12, CObject:.?AVUnit@Moho@@ ID:418 BpName:url0301_cloak
@c:\programdata\faforever\gamedata\lua.nx2\lua\simcallbacks.lua 120
CObject:.?AVUnit@Moho@@ ID:418 BpName:url0301_cloak, true, nil, nil, nil, true, "attempt to call method `SetAutoOvercharge' (a nil value)", "...rever\gamedata\lua.nx2\lua\sim\units\commandunit.lua(147): attempt to call method `SetAutoOvercharge' (a nil value)
stack traceback:
	...rever\gamedata\lua.nx2\lua\sim\units\commandunit.lua(147): in function `SetAutoOvercharge'
	...data\faforever\gamedata\lua.nx2\lua\simcallbacks.lua(120): in function `fn'
	...data\faforever\gamedata\lua.nx2\lua\simcallbacks.lua(58): in function <...data\faforever\gamedata\lua.nx2\lua\simcallbacks.lua:54>"

.?AUUnitTypeInfo@Moho@@
.?AUEntityTypeInfo@Moho@@
```

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
- Add a nil check for the auto OC weapon in `SetAutoOvercharge`

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spawn a non-Sera SACU, select it along with the commander, and enable auto overcharge. It doesn't crash the game.

## Additional context
<!-- Add any other context about the pull request here. -->
Auto OC has a broken UI when selected with other SACU, it doesn't update the OC capability status or auto OC indicator correctly.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
