### PR TITLE
Setup for automatically generating changelogs of deployment branches

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -22,6 +22,25 @@ name: Create changelog
 
 on:
   workflow_dispatch:
+    inputs:
+      reference: 
+        required: true
+        type: choice
+        default: develop
+        description: The reference (branch or tag) to use to compile the changelog snippets from
+        options:
+          - develop
+          - deploy/fafbeta
+          - deploy/fafdevelop
+
+  workflow_call:
+    inputs:
+      reference: 
+        required: true
+        type: string
+        default: develop
+        description: The reference (branch or tag) to use to compile the changelog snippets from
+        
   pull_request:
     paths:
       - "changelog/snippets/*.md"
@@ -37,6 +56,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.reference }}
           sparse-checkout: |
             .github/workflows/scripts
             changelog/snippets
@@ -74,6 +94,6 @@ jobs:
       - name: Add the changelog as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: changelog
+          name: changelog-${{ inputs.reference }}
           path: |
             changelog/snippets/faf-develop.md

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -27,6 +27,16 @@ concurrency:
 
 jobs:
   # Build job
+  changelog-develop:
+    uses: ./.github/workflows/changelog.yaml
+    with:
+      reference: deploy/fafdevelop
+
+  changelog-beta:
+    uses: ./.github/workflows/changelog.yaml
+    with:
+      reference: deploy/fafbeta
+    
   build:
     runs-on: ubuntu-latest
     defaults:
@@ -35,6 +45,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: develop
+          sparse-checkout: | 
+            - 'docs/'
+
+      - name: Download artifact changelog of FAF Develop
+        uses: actions/download-artifact@v3
+        with:
+          name: changelog-deploy/fafdevelop
+          path: changelog-fafdevelop
+
+      - name: Download artifact changelog of FAF Beta
+        uses: actions/download-artifact@v3
+        with:
+          name: changelog-deploy/fafbeta
+          path: changelog-fafbeta
+
+      - name: Append the generated changelogs
+        run: |
+          cat changelog-fafdevelop >> docs/changelogs/fafdevelop.md
+          cat changelog-fafbeta >> docs/changelogs/fafbeta.md
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 layout: page
 title: Changelog
 permalink: changelog
+has_children: true
 nav_order: 5
 ---
 

--- a/docs/changelogs/fafbeta.md
+++ b/docs/changelogs/fafbeta.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: Open changes on FAF Beta Balance
+permalink: changelog/fafbeta
+nav_order: 2
+parent: Changelog
+---
+
+Open changes on FAF Beta Balance

--- a/docs/changelogs/fafdevelop.md
+++ b/docs/changelogs/fafdevelop.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: Open changes on FAF Develop
+permalink: changelog/fafdevelop
+nav_order: 1
+parent: Changelog
+---
+
+Open changes on FAF Develop


### PR DESCRIPTION
## Description of the proposed changes

Extends the changelog workflow to generate a workflow from a specific reference (branch/tag). This allows us to generate a changelog from `deploy/fafdevelop` or `deploy/fafbeta`. As we build the pages, we can then update the pages dynamically.
