### PR TITLE
Separate the scripts and the data of the changelog generation workflow

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -112,6 +112,7 @@ jobs:
       - name: Add the changelog as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: changelog-${{ inputs.reference }}
+          # we need to remove `deploy/` from the reference
+          name: changelog-${{ (inputs.reference == 'deploy/fafdevelop' && 'fafdevelop') || (inputs.reference == 'deploy/fafbeta' && 'fafbeta') || inputs.reference }}
           path: |
             fa/changelog/snippets/faf-develop.md

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Update environment path
         run: | 
+          ls
           echo "${{ github.workspace }}/scripts/.github/workflows/scripts" >> $GITHUB_PATH
 
       - name: Verify the changelog snippets

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -56,6 +56,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          path: scripts
+          ref: develop
+          sparse-checkout: |
+            .github/workflows/scripts
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          path: fa
           ref: ${{ inputs.reference }}
           sparse-checkout: |
             .github/workflows/scripts
@@ -63,10 +72,10 @@ jobs:
 
       - name: Update environment path
         run: | 
-          echo "${{ github.workspace }}/.github/workflows/scripts" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/scripts/.github/workflows/scripts" >> $GITHUB_PATH
 
       - name: Verify the changelog snippets
-        working-directory: changelog/snippets # script assumes it is in this directory
+        working-directory: fa/changelog/snippets # script assumes it is in this directory
         run: |
           changelog-verify.sh
 
@@ -78,16 +87,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          path: scripts
+          ref: develop
+          sparse-checkout: |
+            .github/workflows/scripts
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          path: fa
           sparse-checkout: |
             .github/workflows/scripts
             changelog/snippets
 
       - name: Update environment path
         run: | 
-          echo "${{ github.workspace }}/.github/workflows/scripts" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/scripts/.github/workflows/scripts" >> $GITHUB_PATH
 
       - name: Create the changelog
-        working-directory: changelog/snippets # script assumes it is in this directory
+        working-directory: fa/changelog/snippets # script assumes it is in this directory
         run: |
           changelog-combine.sh
 
@@ -96,4 +114,4 @@ jobs:
         with:
           name: changelog-${{ inputs.reference }}
           path: |
-            changelog/snippets/faf-develop.md
+            fa/changelog/snippets/faf-develop.md

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -53,13 +53,13 @@ jobs:
       - name: Download artifact changelog of FAF Develop
         uses: actions/download-artifact@v3
         with:
-          name: changelog-deploy/fafdevelop
+          name: changelog-fafdevelop
           path: changelog-fafdevelop
 
       - name: Download artifact changelog of FAF Beta
         uses: actions/download-artifact@v3
         with:
-          name: changelog-deploy/fafbeta
+          name: changelog-fafbeta
           path: changelog-fafbeta
 
       - name: Append the generated changelogs


### PR DESCRIPTION
## Description

The scripts may not live in the same Git reference as the snippets. We now always retrieve the scripts from `develop`, while we retrieve the snippets from the designated branch.

We need to do a little string manipulation because artifacts do not support `/` in the file paths. In practice [expressions](https://docs.github.com/en/actions/learn-github-actions/expressions) in GitHub only allows you to add to strings, but it does not allow you to remove things from it. Ideally we'd use [startsWith](https://docs.github.com/en/actions/learn-github-actions/expressions#startswith) in combination with removing the first seven characters. But we can't, so now we have this odd and extensive if expression 😃 !