### PR TITLE
Finalize the automagic changelogs for the deployment branches

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -109,13 +109,13 @@ jobs:
       - name: Update reference
         run: |
           echo "NAME=${{ inputs.reference }}#deploy/" >> $GITHUB_ENV
-          echo $NAME
-          echo ${{ env.NAME }}
 
       - name: Create the changelog
         working-directory: fa/changelog/snippets # script assumes it is in this directory
         run: |
-          changelog-combine.sh $NAME
+          echo $NAME
+          echo ${{ env.NAME }}
+          changelog-combine.sh ${{ env.NAME }}
 
       - name: Add the changelog as an artifact
         uses: actions/upload-artifact@v4
@@ -123,4 +123,4 @@ jobs:
           # we need to remove `deploy/` from the reference
           name: changelog-${{ (inputs.reference == 'deploy/fafdevelop' && 'fafdevelop') || (inputs.reference == 'deploy/fafbeta' && 'fafbeta') || inputs.reference }}
           path: |
-            fa/changelog/snippets/$NAME.md
+            fa/changelog/snippets/${{ env.NAME }}.md

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -23,7 +23,7 @@ name: Documentation - Generate changelog
 on:
   workflow_dispatch:
     inputs:
-      reference: 
+      reference:
         required: true
         type: choice
         default: develop
@@ -35,19 +35,19 @@ on:
 
   workflow_call:
     inputs:
-      reference: 
+      reference:
         required: true
         type: string
         default: develop
         description: The reference (branch or tag) to use to compile the changelog snippets from
-        
+
   pull_request:
     paths:
       - "changelog/snippets/*.md"
   push:
     branches:
       - deploy/fafdevelop
-      
+
 jobs:
   verify:
     name: Verify snippets
@@ -71,7 +71,7 @@ jobs:
             changelog/snippets
 
       - name: Update environment path
-        run: | 
+        run: |
           ls
           echo "${{ github.workspace }}/scripts/.github/workflows/scripts" >> $GITHUB_PATH
 
@@ -102,13 +102,20 @@ jobs:
             changelog/snippets
 
       - name: Update environment path
-        run: | 
+        run: |
           echo "${{ github.workspace }}/scripts/.github/workflows/scripts" >> $GITHUB_PATH
+
+      # We need to do this to remove `deploy/` from the reference. Specifically the `/` is problematic
+      - name: Update reference
+        run: |
+          echo "NAME=${{ inputs.reference }}#deploy/" >> $GITHUB_ENV
+          echo $NAME
+          echo ${{ env.NAME }}
 
       - name: Create the changelog
         working-directory: fa/changelog/snippets # script assumes it is in this directory
         run: |
-          changelog-combine.sh
+          changelog-combine.sh $NAME
 
       - name: Add the changelog as an artifact
         uses: actions/upload-artifact@v4
@@ -116,4 +123,4 @@ jobs:
           # we need to remove `deploy/` from the reference
           name: changelog-${{ (inputs.reference == 'deploy/fafdevelop' && 'fafdevelop') || (inputs.reference == 'deploy/fafbeta' && 'fafbeta') || inputs.reference }}
           path: |
-            fa/changelog/snippets/faf-develop.md
+            fa/changelog/snippets/$NAME.md

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -108,7 +108,8 @@ jobs:
       # We need to do this to remove `deploy/` from the reference. Specifically the `/` is problematic
       - name: Update reference
         run: |
-          echo "NAME=${{ inputs.reference }}#deploy/" >> $GITHUB_ENV
+          NAME="${${{ inputs.reference }}#deploy/}"
+          echo "NAME=$NAME" >> $GITHUB_ENV
 
       - name: Create the changelog
         working-directory: fa/changelog/snippets # script assumes it is in this directory

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -109,6 +109,7 @@ jobs:
       - name: Update reference
         run: |
           NAME="${${{ inputs.reference }}#deploy/}"
+          echo $NAME
           echo "NAME=$NAME" >> $GITHUB_ENV
 
       - name: Create the changelog

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -108,8 +108,8 @@ jobs:
       # We need to do this to remove `deploy/` from the reference. Specifically the `/` is problematic
       - name: Update reference
         run: |
-          NAME="${${{ inputs.reference }}#deploy/}"
-          echo $NAME
+          REFERENCE="${{ inputs.reference }}"
+          NAME="${REFERENCE#deploy/}"
           echo "NAME=$NAME" >> $GITHUB_ENV
 
       - name: Create the changelog
@@ -122,7 +122,6 @@ jobs:
       - name: Add the changelog as an artifact
         uses: actions/upload-artifact@v4
         with:
-          # we need to remove `deploy/` from the reference
-          name: changelog-${{ (inputs.reference == 'deploy/fafdevelop' && 'fafdevelop') || (inputs.reference == 'deploy/fafbeta' && 'fafbeta') || inputs.reference }}
+          name: changelog-${{ env.NAME }}
           path: |
             fa/changelog/snippets/${{ env.NAME }}.md

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -65,6 +65,8 @@ jobs:
 
       - name: Append the generated changelogs
         run: |
+          ls ..
+          ls ../raw-changelog-fafdevelop
           cat ../raw-changelog-fafdevelop >> changelogs/fafdevelop.md
           cat ../raw-changelog-fafbeta >> changelogs/fafbeta.md
 

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -55,13 +55,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: changelog-fafdevelop
-          path: raw-changelog-fafdevelop
 
       - name: Download artifact changelog of FAF Beta
         uses: actions/download-artifact@v4
         with:
           name: changelog-fafbeta
-          path: raw-changelog-fafbeta
 
       - name: Append the generated changelogs
         run: |

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -65,10 +65,9 @@ jobs:
 
       - name: Append the generated changelogs
         run: |
-          ls -Rla
           ls -Rla generated
-          cat generated/changelog-fafdevelop.md >> changelogs/fafdevelop.md
-          cat generated/changelog-fafbeta.md >> changelogs/fafbeta.md
+          cat generated/fafdevelop.md >> changelogs/fafdevelop.md
+          cat generated/fafbeta.md >> changelogs/fafbeta.md
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -55,13 +55,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: changelog-fafdevelop
-          path: generated
+          path: docs/generated
 
       - name: Download artifact changelog of FAF Beta
         uses: actions/download-artifact@v4
         with:
           name: changelog-fafbeta
-          path: generated
+          path: docs/generated
 
       - name: Append the generated changelogs
         run: |

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -63,8 +63,12 @@ jobs:
 
       - name: Append the generated changelogs
         run: |
+          ls 
+          echo "check"
           ls ..
+          echo "check"
           ls ../raw-changelog-fafdevelop
+          echo "check"
           cat ../raw-changelog-fafdevelop >> changelogs/fafdevelop.md
           cat ../raw-changelog-fafbeta >> changelogs/fafbeta.md
 

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Append the generated changelogs
         run: |
+          ls
           cat raw-changelog-fafdevelop >> changelogs/fafdevelop.md
           cat raw-changelog-fafbeta >> changelogs/fafbeta.md
 

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -55,22 +55,19 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: changelog-fafdevelop
+          path: docs/raw-changelog-fafdevelop.md
 
       - name: Download artifact changelog of FAF Beta
         uses: actions/download-artifact@v4
         with:
           name: changelog-fafbeta
+          path: docs/raw-changelog-fafbeta.md
 
       - name: Append the generated changelogs
         run: |
           ls 
-          echo "check"
-          ls ..
-          echo "check"
-          ls ../raw-changelog-fafdevelop
-          echo "check"
-          cat ../raw-changelog-fafdevelop >> changelogs/fafdevelop.md
-          cat ../raw-changelog-fafbeta >> changelogs/fafbeta.md
+          cat raw-changelog-fafdevelop >> changelogs/fafdevelop.md
+          cat raw-changelog-fafbeta >> changelogs/fafbeta.md
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -65,7 +65,8 @@ jobs:
 
       - name: Append the generated changelogs
         run: |
-          ls -r
+          ls -Rla
+          ls -Rla generated
           cat generated/changelog-fafdevelop.md >> changelogs/fafdevelop.md
           cat generated/changelog-fafbeta.md >> changelogs/fafbeta.md
 

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -65,9 +65,8 @@ jobs:
 
       - name: Append the generated changelogs
         run: |
-          ls
-          cat raw-changelog-fafdevelop >> changelogs/fafdevelop.md
-          cat raw-changelog-fafbeta >> changelogs/fafbeta.md
+          cat ../raw-changelog-fafdevelop >> changelogs/fafdevelop.md
+          cat ../raw-changelog-fafbeta >> changelogs/fafbeta.md
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -55,21 +55,19 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: changelog-fafdevelop
-          path: docs/raw-changelog-fafdevelop.md
+          path: generated
 
       - name: Download artifact changelog of FAF Beta
         uses: actions/download-artifact@v4
         with:
           name: changelog-fafbeta
-          path: docs/raw-changelog-fafbeta.md
+          path: generated
 
       - name: Append the generated changelogs
         run: |
-          ls 
-          cat raw-changelog-fafdevelop.md
-          cat raw-changelog-fafbeta.md
-          cat raw-changelog-fafdevelop.md >> changelogs/fafdevelop.md
-          cat raw-changelog-fafbeta.md >> changelogs/fafbeta.md
+          ls -r
+          cat generated/changelog-fafdevelop.md >> changelogs/fafdevelop.md
+          cat generated/changelog-fafbeta.md >> changelogs/fafbeta.md
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -66,8 +66,10 @@ jobs:
       - name: Append the generated changelogs
         run: |
           ls 
-          cat raw-changelog-fafdevelop >> changelogs/fafdevelop.md
-          cat raw-changelog-fafbeta >> changelogs/fafbeta.md
+          cat raw-changelog-fafdevelop.md
+          cat raw-changelog-fafbeta.md
+          cat raw-changelog-fafdevelop.md >> changelogs/fafdevelop.md
+          cat raw-changelog-fafbeta.md >> changelogs/fafbeta.md
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/scripts/changelog-combine.sh
+++ b/.github/workflows/scripts/changelog-combine.sh
@@ -123,6 +123,8 @@ if [ "$1" ]; then
     output="$1.md"
 fi
 
+echo "Writing output to: $output"
+
 rm -f "$output"
 
 # Add the initial header

--- a/.github/workflows/scripts/changelog-combine.sh
+++ b/.github/workflows/scripts/changelog-combine.sh
@@ -119,7 +119,7 @@ process_snippets() {
 
 # Output file name
 output="changelog.md"
-if ["$1" ]; then
+if [ "$1" ]; then
     output="$1.md"
 fi
 

--- a/.github/workflows/scripts/changelog-combine.sh
+++ b/.github/workflows/scripts/changelog-combine.sh
@@ -118,7 +118,11 @@ process_snippets() {
 }
 
 # Output file name
-output="faf-develop.md"
+output="changelog.md"
+if ["$1" ]; then
+    output="$1.md"
+fi
+
 rm -f "$output"
 
 # Add the initial header

--- a/test-draft.sh
+++ b/test-draft.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+REFERENCE="deploy/fafdevelop"
+NAME="${REFERENCE#deploy/}"
+echo "$NAME"
+echo "TEST"
+
+
+
+


### PR DESCRIPTION
## Description

Removes the `deploy/` from the reference if it exists. In general, the reference (indirectly) used as part of a file name and that can't contain the character `/`.