### PR TITLE
Apply the relative URL filter for relative URLs in the documentation

### DIFF
--- a/docs/patches.md
+++ b/docs/patches.md
@@ -8,16 +8,14 @@ nav_order: 8
 
 # Overview of game patches
 
-
-
 ## Deployment branches
 
 <ul>
   <li>
-    <a class="preview-title" href="fafbeta">FAF Beta Balance</a>
+    <a class="preview-title" href="{{ 'patches/fafbeta' | relative_url }}">FAF Beta Balance</a>
   </li>
   <li>
-    <a class="preview-title" href="fafdevelop">FAF Develop</a>
+    <a class="preview-title" href="{{ 'patches/fafdevelop' | relative_url }}">FAF Develop</a>
   </li>
 </ul>
 
@@ -36,8 +34,8 @@ nav_order: 8
     {% endif %}
 
     <li>
-      <a class="preview-title" href="{{ post.url }}">{{ post.title }}</a>
+      <a class="preview-title" href="{{ post.url | relative_url }}">{{ post.title }}</a>
       <span>{{ post.date | date: "%b %Y" }}</span>
     </li>
-  {% endfor %}
+{% endfor %}
 </ul>


### PR DESCRIPTION
## Description of the proposed changes

Relative URLs are a little shaky because the base url is different between a development (no base url, therefore `/`) and a production environment (base url is `/fa`). This was a little tricky to understand since I did not know what to search for. It turns out that Jekyll has a [filter](https://jekyllrb.com/docs/liquid/filters/) for this called `relative_url`, which manages all of this for you.