### PR TITLE
Enable the SR's Iridium Rocket Pack to deal damage in an area of effect

### DIFF
--- a/changelog/snippets/balance.6383.md
+++ b/changelog/snippets/balance.6383.md
@@ -1,0 +1,7 @@
+- (#6383) The Soul Ripper's Iridium Rocket Packs gain the same area of effect radius as its primary weapons. Visually, these weapons appeared like they dealt damage in an area of effect, however, this was never the case. Due to being very inaccurate, this caused them to underperform against smaller units.
+
+    - Soul Ripper: Experimental Gunship (URA0401):
+    - Iridium Rocket Pack (x2):
+      - DamageRadius: 0 --> 3
+      - Damage: 190 --> 150
+      - DPS: 295 --> 225

--- a/changelog/snippets/balance.6383.md
+++ b/changelog/snippets/balance.6383.md
@@ -1,6 +1,6 @@
 - (#6383) The Soul Ripper's Iridium Rocket Packs gain the same area of effect radius as its primary weapons. Visually, these weapons appeared like they dealt damage in an area of effect, however, this was never the case. Due to being very inaccurate, this caused them to underperform against smaller units.
 
-    - Soul Ripper: Experimental Gunship (URA0401):
+  - Soul Ripper: Experimental Gunship (URA0401):
     - Iridium Rocket Pack (x2):
       - DamageRadius: 0 --> 3
       - Damage: 190 --> 150

--- a/changelog/snippets/balance.6383.md
+++ b/changelog/snippets/balance.6383.md
@@ -4,4 +4,4 @@
     - Iridium Rocket Pack (x2):
       - DamageRadius: 0 --> 3
       - Damage: 190 --> 150
-      - DPS: 295 --> 225
+      - DPS: 285 --> 225

--- a/units/URA0401/URA0401_unit.bp
+++ b/units/URA0401/URA0401_unit.bp
@@ -229,7 +229,8 @@ UnitBlueprint{
             AutoInitiateAttackCommand = true,
             BallisticArc = "RULEUBA_None",
             CollideFriendly = false,
-            Damage = 190,
+            Damage = 150,
+            DamageRadius = 3,
             DamageType = "Normal",
             DisplayName = "Iridium Rocket Pack",
             FireTargetLayerCapsTable = {

--- a/units/URA0401/URA0401_unit.bp
+++ b/units/URA0401/URA0401_unit.bp
@@ -294,7 +294,8 @@ UnitBlueprint{
             AutoInitiateAttackCommand = true,
             BallisticArc = "RULEUBA_None",
             CollideFriendly = false,
-            Damage = 190,
+            Damage = 150,
+            DamageRadius = 3,
             DamageType = "Normal",
             DisplayName = "Iridium Rocket Pack",
             FireTargetLayerCapsTable = {


### PR DESCRIPTION
## Description of the proposed changes
The SR has four air-to-ground weapons: two bolters, which are the more dominant weapons, and two rocket packs, which are often overlooked. In the current release, only the bolters have area of effect damage, the rocket packs have none at all. 

From a design perspective, this is suboptimal since the rockets have a decently large explosion effect. The Renegade uses the same projectile with similar effects and has an area of effect radius of 3. It is also not intuitive, because it could be reasonably assumed that the rocket packs perform similarly to either the Renegade or the other air-to-ground weapons of the SR. Balance wise, it results in the rocket packs underperforming against smaller targets, such as Titans.

**Soul Ripper: Experimental Gunship (URA0401)**:
   - Iridium Rocket Pack (x2):
      - DamageRadius: 0 --> 3
      - Damage: 190 --> 150
      - DPS: 285 --> 225

## Additional context
Since this does increase the effectiveness of the rocket packs, their DPS is reduced.

## Checklist
- [x] Changes are documented in the changelog for the next game version