### PR TITLE
Improve T2 Static Artillery's ability to shoot up cliffs

### DIFF
--- a/changelog/snippets/fix.6389.md
+++ b/changelog/snippets/fix.6389.md
@@ -1,0 +1,1 @@
+- (#6389) Improve tech 2 static artillery's ability to shoot up cliffs.

--- a/units/UAB2303/UAB2303_unit.bp
+++ b/units/UAB2303/UAB2303_unit.bp
@@ -146,8 +146,8 @@ UnitBlueprint{
             MinRadius = 50,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 26.13,
-            MuzzleVelocityReduceDistance = 120,
+            MuzzleVelocity = 27.8,
+            MuzzleVelocityReduceDistance = 115,
             ProjectileId = "/projectiles/AIFMiasmaShell01/AIFMiasmaShell01_proj.bp",
             ProjectilesPerOnFire = 1,
             RackBones = {

--- a/units/UEB2303/UEB2303_unit.bp
+++ b/units/UEB2303/UEB2303_unit.bp
@@ -153,8 +153,8 @@ UnitBlueprint{
             MinRadius = 50,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 26.13,
-            MuzzleVelocityReduceDistance = 120,
+            MuzzleVelocity = 27.8,
+            MuzzleVelocityReduceDistance = 115,
             ProjectileId = "/projectiles/TIFArtillery01/TIFArtillery01_proj.bp",
             ProjectilesPerOnFire = 1,
             RackBones = {

--- a/units/URB2303/URB2303_unit.bp
+++ b/units/URB2303/URB2303_unit.bp
@@ -140,8 +140,8 @@ UnitBlueprint{
             MinRadius = 50,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 26.13,
-            MuzzleVelocityReduceDistance = 120,
+            MuzzleVelocity = 27.8,
+            MuzzleVelocityReduceDistance = 115,
             ProjectileId = "/projectiles/CIFMolecularResonanceShell01/CIFMolecularResonanceShell01_proj.bp",
             ProjectilesPerOnFire = 1,
             RackBones = {

--- a/units/XSB2303/XSB2303_unit.bp
+++ b/units/XSB2303/XSB2303_unit.bp
@@ -158,8 +158,8 @@ UnitBlueprint{
             MuzzleChargeDelay = 1,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
-            MuzzleVelocity = 26.13,
-            MuzzleVelocityReduceDistance = 120,
+            MuzzleVelocity = 27.8,
+            MuzzleVelocityReduceDistance = 115,
             ProjectileId = "/projectiles/SIFZthuthaamArtilleryShell02/SIFZthuthaamArtilleryShell02_proj.bp",
             ProjectilesPerOnFire = 1,
             RackBones = {


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Issue
T2 static artillery cannot shoot up not very extreme cliffs, making it very confusing for players. Dualgap is a well known example with the plateaus near the bases having a very limited amount of firing positions for artillery on the bottom to hit anything up top.
![image](https://github.com/user-attachments/assets/dd1887f8-290d-489a-87c7-c7919721369a)


## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Slightly increase the muzzle velocity of the arty so that it can reach a taller arc to hit targets up cliffs.
Reduce the `MuzzleVelocityReduceDistance` to go along with the reduced max range from #5572.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Valid firing positions after changes:
![image](https://github.com/user-attachments/assets/382736d7-520d-48c2-b974-4408b8b431ea)

The accuracy of the artillery against targets at an equal altitude seems a little reduced due to the lower firing arc causing randomly spread out projectiles to hit a more oblong area than before.

## Checklist
- [x] Changes are documented in the changelog for the next game version
