### PR TITLE
feat : Update docs-build to include PR link rewrites

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -55,7 +55,8 @@ jobs:
 
   build:
     name: Build the documentation
-    needs: [changelog-develop, changelog-beta]
+    #needs: [changelog-develop, changelog-beta]
+    needs: [changelog-develop]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -74,11 +75,11 @@ jobs:
           echo "${{ github.workspace }}/.github/workflows/scripts" >> $GITHUB_PATH
 
       # Retrieve the generated changelogs
-      - name: Download artifact changelog of FAF Develop
-        uses: actions/download-artifact@v4
-        with:
-          name: changelog-fafdevelop
-          path: docs/generated
+      #- name: Download artifact changelog of FAF Develop
+      #  uses: actions/download-artifact@v4
+      #  with:
+      #    name: changelog-fafdevelop
+      #    path: docs/generated
 
       - name: Download artifact changelog of FAF Beta
         uses: actions/download-artifact@v4
@@ -90,7 +91,7 @@ jobs:
       - name: Append the generated changelogs
         run: |
           cat generated/fafdevelop.md >> patches/fafdevelop.md
-          cat generated/fafbeta.md >> patches/fafbeta.md
+
       
       # Update the posts directory contents
       - name: Update changelog posts directory

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -74,18 +74,18 @@ jobs:
         run: |
           echo "${{ github.workspace }}/.github/workflows/scripts" >> $GITHUB_PATH
 
-      # Retrieve the generated changelogs
-      #- name: Download artifact changelog of FAF Develop
-      #  uses: actions/download-artifact@v4
-      #  with:
-      #    name: changelog-fafdevelop
-      #    path: docs/generated
-
-      - name: Download artifact changelog of FAF Beta
+       Retrieve the generated changelogs
+      - name: Download artifact changelog of FAF Develop
         uses: actions/download-artifact@v4
         with:
-          name: changelog-fafbeta
+          name: changelog-fafdevelop
           path: docs/generated
+
+      #- name: Download artifact changelog of FAF Beta
+      #  uses: actions/download-artifact@v4
+      #  with:
+      #    name: changelog-fafbeta
+      #    path: docs/generated
 
       # Append the generated changelogs to the Jekyll-compatible templates
       - name: Append the generated changelogs

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -97,13 +97,13 @@ jobs:
       - name: Update changelog posts directory
         shell: bash
         run: |
-          ./changelog-links.sh docs/_posts FAForever fa github.com
+          changelog-links.sh docs/_posts FAForever fa github.com
 
       # Update the patches directory contents
       - name: Update changelog patches directory
         shell: bash
         run: |
-          ./changelog-links.sh docs/patches FAForever fa github.com
+          changelog-links.sh docs/patches FAForever fa github.com
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -47,11 +47,11 @@ jobs:
     with:
       reference: deploy/fafdevelop
 
-  changelog-beta:
-    name: Create changelog of FAF Beta
-    uses: ./.github/workflows/docs-changelog.yaml
-    with:
-      reference: deploy/fafbeta
+  #changelog-beta:
+  #  name: Create changelog of FAF Beta
+  #  uses: ./.github/workflows/docs-changelog.yaml
+  #  with:
+  #    reference: deploy/fafbeta
 
   build:
     name: Build the documentation

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -97,13 +97,13 @@ jobs:
       - name: Update changelog posts directory
         shell: bash
         run: |
-          changelog-links.sh docs/_posts FAForever fa github.com
+          changelog-links.sh _posts FAForever fa github.com
 
       # Update the patches directory contents
       - name: Update changelog patches directory
         shell: bash
         run: |
-          changelog-links.sh docs/patches FAForever fa github.com
+          changelog-links.sh patches FAForever fa github.com
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -22,8 +22,9 @@ name: Documentation - Build and deploy
 
 on:
   push:
-    branches: ["develop", "deploy/fafdevelop", "deploy/fafbeta", "deploy/faf"]
-    paths: ["docs/**", "changelog/snippets/*.md"]
+    branches: ["feat/pages-link-rewrite"]
+    #branches: ["develop", "deploy/fafdevelop", "deploy/fafbeta", "deploy/faf"]
+    #paths: ["docs/**", "changelog/snippets/*.md"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -65,6 +66,12 @@ jobs:
         with:
           sparse-checkout: |
             docs
+            .github/workflows/scripts
+
+      # Set environment path for scripts so we can access it later
+      - name: Update environment path
+        run: |
+          echo "${{ github.workspace }}/.github/workflows/scripts" >> $GITHUB_PATH
 
       # Retrieve the generated changelogs
       - name: Download artifact changelog of FAF Develop
@@ -84,6 +91,18 @@ jobs:
         run: |
           cat generated/fafdevelop.md >> patches/fafdevelop.md
           cat generated/fafbeta.md >> patches/fafbeta.md
+      
+      # Update the posts directory contents
+      - name: Update changelog posts directory
+        shell: bash
+        run: |
+          ./changelog-links.sh docs/_posts FAForever fa github.com
+
+      # Update the patches directory contents
+      - name: Update changelog patches directory
+        shell: bash
+        run: |
+          ./changelog-links.sh docs/patches FAForever fa github.com
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -109,13 +128,13 @@ jobs:
         with:
           path: "docs/_site/"
 
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+#  deploy:
+#    environment:
+#      name: github-pages
+#      url: ${{ steps.deployment.outputs.page_url }}
+#    runs-on: ubuntu-latest
+#    needs: build
+#    steps:
+#      - name: Deploy to GitHub Pages
+#        id: deployment
+#        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           echo "${{ github.workspace }}/.github/workflows/scripts" >> $GITHUB_PATH
 
-       Retrieve the generated changelogs
+      # Retrieve the generated changelogs
       - name: Download artifact changelog of FAF Develop
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -22,9 +22,8 @@ name: Documentation - Build and deploy
 
 on:
   push:
-    branches: ["feat/pages-link-rewrite"]
-    #branches: ["develop", "deploy/fafdevelop", "deploy/fafbeta", "deploy/faf"]
-    #paths: ["docs/**", "changelog/snippets/*.md"]
+    branches: ["develop", "deploy/fafdevelop", "deploy/fafbeta", "deploy/faf"]
+    paths: ["docs/**", "changelog/snippets/*.md"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -47,16 +46,15 @@ jobs:
     with:
       reference: deploy/fafdevelop
 
-  #changelog-beta:
-  #  name: Create changelog of FAF Beta
-  #  uses: ./.github/workflows/docs-changelog.yaml
-  #  with:
-  #    reference: deploy/fafbeta
+  changelog-beta:
+    name: Create changelog of FAF Beta
+    uses: ./.github/workflows/docs-changelog.yaml
+    with:
+      reference: deploy/fafbeta
 
   build:
     name: Build the documentation
-    #needs: [changelog-develop, changelog-beta]
-    needs: [changelog-develop]
+    needs: [changelog-develop, changelog-beta]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -81,11 +79,11 @@ jobs:
           name: changelog-fafdevelop
           path: docs/generated
 
-      #- name: Download artifact changelog of FAF Beta
-      #  uses: actions/download-artifact@v4
-      #  with:
-      #    name: changelog-fafbeta
-      #    path: docs/generated
+      - name: Download artifact changelog of FAF Beta
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog-fafbeta
+          path: docs/generated
 
       # Append the generated changelogs to the Jekyll-compatible templates
       - name: Append the generated changelogs

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -127,13 +127,13 @@ jobs:
         with:
           path: "docs/_site/"
 
-#  deploy:
-#    environment:
-#      name: github-pages
-#      url: ${{ steps.deployment.outputs.page_url }}
-#    runs-on: ubuntu-latest
-#    needs: build
-#    steps:
-#      - name: Deploy to GitHub Pages
-#        id: deployment
-#        uses: actions/deploy-pages@v4
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/scripts/changelog-links.sh
+++ b/.github/workflows/scripts/changelog-links.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+# -----------------------------------------------------------------------------
+# Copyright (c) 2024 FAForever
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# -----------------------------------------------------------------------------
+
 # Function to display usage information
 usage() {
     echo "Usage: $0 <folder_name> <org_name> <repository_name> <base_url>"

--- a/.github/workflows/scripts/changelog-links.sh
+++ b/.github/workflows/scripts/changelog-links.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Function to display usage information
+usage() {
+    echo "Usage: $0 <folder_name> <org_name> <repository_name> <base_url>"
+    exit 1
+}
+
+# Check if the correct number of arguments is provided
+if [ $# -ne 4 ]; then
+    usage
+fi
+
+# Assign input arguments to variables
+FOLDER_NAME=$1
+ORG_NAME=$2
+REPO_NAME=$3
+BASE_HOSTNAME=$4
+
+# Verify the folder exists
+if [ ! -d "$FOLDER_NAME" ]; then
+    echo "Error: Folder '$FOLDER_NAME' does not exist."
+    exit 1
+fi
+
+# Loop through all files in the folder and execute a command
+for FILE in "$FOLDER_NAME"/*; 
+do
+    if [[ -f "$FILE" && "$FILE" == *.md ]]; then
+        # Replace this with your actual command
+        echo "Executing command on file: $FILE"
+        # Example command
+        TMP_FILE=$(mktemp)
+        sed -E 's/#([0-9]{4,5})/[#\1](https:\/\/'"$BASE_HOSTNAME"'\/'"$ORG_NAME"'\/'"$REPO_NAME"'\/pull\/\1)/g' "$FILE" > "$TMP_FILE"
+        mv "$TMP_FILE" "$FILE"
+        echo "File $FILE has been updated."
+    fi
+done
+
+echo "Script execution completed."


### PR DESCRIPTION
Closes #6376

This PR updates the docs-build.yml workflow to update md files that include PR references.

It will loop through all files in the
docs/patches
docs/_posts

directories and rewrite any PR references using the #xxxxx expression and add the PR link.

The script takes 4 parameters. This is so it can be used with other repositories / environments in the future.
FOLDER_NAME - Where the md files are located
ORG_NAME - The github org name
REPO_NAME - The repository name
BASE_HOSTNAME - github.com

