### PR TITLE
Github.io changelog: increase the font-weight of the level 1 heading

### DIFF
--- a/docs/_sass/color_schemes/faf.scss
+++ b/docs/_sass/color_schemes/faf.scss
@@ -1,2 +1,6 @@
 $link-color: $blue-100;
 $body-text-color: $grey-dk-300;
+
+h1 {
+  font-weight: 600;
+}


### PR DESCRIPTION
## Description of the proposed changes
As per the title. Currently, h2 has a higher weight than h1, which looks a bit odd.
