### PR TITLE
Add information about the game type and commit hash to the game

### DIFF
--- a/.github/workflows/deploy-faf.yaml
+++ b/.github/workflows/deploy-faf.yaml
@@ -43,8 +43,15 @@ jobs:
             repository: FAForever/fa
             ref: master
 
+      # Allows us to better understand the game version and the specific commit hash when we receive a log
+      - name: Update version references
+        run: |
+          COMMITHASH=$(git rev-parse HEAD)
+          sed -i 's/local Commit = \"unknown\"/local Commit = \"${COMMITHASH}\"/' "lua/version.lua"
+          sed -i 's/local GameType = \"unknown\"/local GameType = \"FAF\"/' "lua/version.lua"
+
       # Disable debugging statements
-      - name: Update references
+      - name: Overwrite debug references
         run: |
           sed -i 's/EnabledSpewing = true,/EnabledSpewing = false,/' "lua/shared/components/DebugComponent.lua"
           sed -i 's/EnabledLogging = true,/EnabledLogging = false,/' "lua/shared/components/DebugComponent.lua"

--- a/.github/workflows/deploy-fafbeta.yaml
+++ b/.github/workflows/deploy-fafbeta.yaml
@@ -44,12 +44,19 @@ jobs:
             repository: FAForever/fa
             ref: develop
 
+      # Allows us to better understand the game version and the specific commit hash when we receive a log
+      - name: Update version references
+        run: |
+          COMMITHASH=$(git rev-parse HEAD)
+          sed -i 's/local Commit = \"unknown\"/local Commit = \"${COMMITHASH}\"/' "lua/version.lua"
+          sed -i 's/local GameType = \"unknown\"/local GameType = \"FAF Beta Balance\"/' "lua/version.lua"
+
       # Disable debugging statements
       # 
       # You can overwrite these adjustments by setting up a `Debug` folder
-      - name: Update references
+      - name: Overwrite debug references
         run: |
-          sed -i 's/EnabledDrawing = true,/EnabledDrawing = false,/' "/lua/shared/components/DebugComponent.lua"
+          sed -i 's/EnabledDrawing = true,/EnabledDrawing = false,/' "lua/shared/components/DebugComponent.lua"
 
       # Update the deploy/fafbeta branch, we force push here because 
       # we're not interested in fixing conflicts

--- a/.github/workflows/deploy-fafdevelop.yaml
+++ b/.github/workflows/deploy-fafdevelop.yaml
@@ -44,12 +44,19 @@ jobs:
             repository: FAForever/fa
             ref: develop
 
+      # Allows us to better understand the game version and the specific commit hash when we receive a log
+      - name: Update version references
+        run: |
+          COMMITHASH=$(git rev-parse HEAD)
+          sed -i 's/local Commit = \"unknown\"/local Commit = \"${COMMITHASH}\"/' "lua/version.lua"
+          sed -i 's/local GameType = \"unknown\"/local GameType = \"FAF Develop\"/' "lua/version.lua"
+
       # Disable debugging statements
       # 
       # You can overwrite these adjustments by setting up a `Debug` folder
-      - name: Update references
+      - name: Overwrite debug references
         run: |
-          sed -i 's/EnabledDrawing = true,/EnabledDrawing = false,/' "/lua/shared/components/DebugComponent.lua"
+          sed -i 's/EnabledDrawing = true,/EnabledDrawing = false,/' "lua/shared/components/DebugComponent.lua"
 
       # Update the deploy/fafdevelop branch, we force push here because 
       # we're not interested in fixing conflicts

--- a/lua/globalInit.lua
+++ b/lua/globalInit.lua
@@ -33,15 +33,29 @@ doscript '/lua/system/BuffBlueprints.lua'
 import("/lua/sim/buffdefinitions.lua")
 
 EmptyTable = {}
-setmetatable(EmptyTable, {__newindex = function()
+setmetatable(EmptyTable, { __newindex = function()
     WARN("Attempt to set field of the empty table")
-end})
+end })
 
 InitialRegistration = false
 
 -- Classes exported from the engine are in the 'moho' table. But they aren't full
 -- classes yet, just lists of exported methods and base classes. Turn them into
 -- real classes.
-for name,cclass in moho do
+for name, cclass in moho do
     ConvertCClassToLuaSimplifiedClass(cclass, name)
 end
+
+-- Inform the developer that a Lua environment is created
+local version, gametype, commit = import("/lua/version.lua").GetVersionData()
+SPEW(
+    string.format(
+        "Lua environment initialized with game version %s, game type %s and at commit hash %s",
+        version,
+        gametype,
+        commit
+    )
+)
+
+-- Helps the developer understand the type of environment created
+SPEW(debug.traceback())

--- a/lua/shared/components/DebugComponent.lua
+++ b/lua/shared/components/DebugComponent.lua
@@ -22,9 +22,20 @@
 
 ---@class DebugComponent
 DebugComponent = ClassSimple {
+
+    ---------------------------------------------------------------------------
+    --#region Workflow automation
+
+    -- The following fields are overwritten when a deployment happens. See also:
+    -- - https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-faf.yaml
+    -- - https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-fafbeta.yaml
+    -- - https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-fafdevelop.yaml
+    
     EnabledSpewing = true,
     EnabledLogging = true,
     EnabledWarnings = true,
     EnabledErrors = true,
     EnabledDrawing = true,
+
+    --#endregion
 }

--- a/lua/version.lua
+++ b/lua/version.lua
@@ -1,9 +1,51 @@
+--******************************************************************************************************
+--** Copyright (c) 2024 FAForever
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
+---------------------------------------------------------------------------
+--#region Workflow automation
+
+-- The following fields are overwritten when a deployment happens. See also:
+-- - https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-faf.yaml
+-- - https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-fafbeta.yaml
+-- - https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-fafdevelop.yaml
+
+local GameType = "unknown"
+
+local Commit = "unknown"
+
+--#endregion
 
 local Version = "3811"
 ---@alias PATCH "3811"
 ---@alias VERSION "1.5.3811"
----@return PATCH
+---@return PATCH    # Game release
 function GetVersion()
-    LOG('Supreme Commander: Forged Alliance version ' .. Version)
+    LOG(string.format('Supreme Commander: Forged Alliance Lua version %s at %s (%s)', Version, GameType, Commit))
     return Version
+end
+
+---@return PATCH
+---@return string # game type
+---@return string # commit hash
+function GetVersionData()
+    return Version, GameType, Commit
 end


### PR DESCRIPTION
## Description of the proposed changes

Embed the hash and game type into the game by processing the files just before we deploy them. For now we can log this information to make it easier to understand for the developerat what commit a replay was. In the future we can use the same data to inform the host that a new game version is available and that he should restart.

## Testing done on the proposed changes

I ran the bash scripts manually by copying them into a bash interpreter.

## Additional context

Users always experience a (short) duration of desyncs when a release happens. And in general, users are unaware of the exact version that resides on the FAF Develop and FAF Beta Balance game types