### PR TITLE
Fix being able to pass through invalid ballistic values

### DIFF
--- a/changelog/snippets/fix.6398.md
+++ b/changelog/snippets/fix.6398.md
@@ -1,0 +1,3 @@
+- (#6398) Fix a possible cause for a simulation freeze
+
+It was possible to pass invalid numbers (NaN or infinite) as a ballistic acceleration for a projectile. This would cause the engine to freeze up. With these changes we introduce Lua guards to catch the invalid numbers and throw an error instead of passing the invalid number to the engine.

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -1016,8 +1016,9 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         -- - https://stackoverflow.com/questions/19107302/in-lua-what-is-inf-and-ind
 
         -- guard to prevent invalid numbers (#IND) and infinite numbers (#INF) from reaching the engine function
-        if tostring(acceleration):find('#') then
-            acceleration = 4.9
+        local stringified = tostring(acceleration)
+        if stringified:find('#') then
+            error("Invalid acceleration value: " .. stringified)
         end
 
         return ProjectileMethodsSetBallisticAcceleration(self, acceleration)

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -152,11 +152,6 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         if blueprint.Physics.TrackTargetGround then
             TrashBagAdd(trash, ForkThread(self.OnTrackTargetGround, self))
         end
-
-        self:SetBallisticAcceleration(0/0)
-        self:SetBallisticAcceleration(1/0)
-        self:SetBallisticAcceleration(-1/0)
-        self:SetBallisticAcceleration(-0/0)
     end,
 
     --- Called by Lua during the `OnCreate` event when the blueprint field `TrackTargetGround` is set,

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -30,6 +30,7 @@ local ProjectileMethods = moho.projectile_methods
 local ProjectileMethodsCreateChildProjectile = ProjectileMethods.CreateChildProjectile
 local ProjectileMethodsGetMaxZigZag = ProjectileMethods.GetMaxZigZag
 local ProjectileMethodsGetZigZagFrequency = ProjectileMethods.GetZigZagFrequency
+local ProjectileMethodsSetBallisticAcceleration = ProjectileMethods.SetBallisticAcceleration
 
 local EntityMethods = _G.moho.entity_methods
 local EntityGetBlueprint = EntityMethods.GetBlueprint
@@ -151,6 +152,11 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         if blueprint.Physics.TrackTargetGround then
             TrashBagAdd(trash, ForkThread(self.OnTrackTargetGround, self))
         end
+
+        self:SetBallisticAcceleration(0/0)
+        self:SetBallisticAcceleration(1/0)
+        self:SetBallisticAcceleration(-1/0)
+        self:SetBallisticAcceleration(-0/0)
     end,
 
     --- Called by Lua during the `OnCreate` event when the blueprint field `TrackTargetGround` is set,
@@ -994,6 +1000,27 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         end
 
         return frequency
+    end,
+
+    --- Set the vertical (gravitational) acceleration of the projectile. Default is -4.9, which is expected by the engine's weapon targeting and firing
+    ---@param acceleration number
+    SetBallisticAcceleration = function(self, acceleration)
+
+        -- Fix an engine bug where the values `1.#INF` or `-1.#IND` passed 
+        -- into this particular engine function can cause the simulation to freeze up.
+        --
+        -- Since `math.huge` does not exist (and does not cover the #IND case) I see
+        -- no other approach than this to try and 'fix' it.
+        --
+        -- Related sources:
+        -- - https://stackoverflow.com/questions/19107302/in-lua-what-is-inf-and-ind
+
+        -- guard to prevent invalid numbers (#IND) and infinite numbers (#INF) from reaching the engine function
+        if tostring(acceleration):find('#') then
+            acceleration = 4.9
+        end
+
+        return ProjectileMethodsSetBallisticAcceleration(self, acceleration)
     end,
 
     ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description of the proposed changes

If you pass in an invalid value to `SetBallisticAcceleration` then the simulation will freeze up. This is a bug in the engine, but we can 'fix' it in Lua by simply error'ing out if we see such a value.

## Testing done on the proposed changes

Ran a game and tested/confirmed that regular values are untouched and all variants of invalid values are caught.

## Additional context

Possibly related to:

- https://forum.faforever.com/topic/8022/replays-of-games-stuck-in-infinite-loop/1

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
