### PR TITLE
Update annotations of engine projectile methods

### DIFF
--- a/changelog/snippets/other.6399.md
+++ b/changelog/snippets/other.6399.md
@@ -1,0 +1,1 @@
+- (#6399) Document method chaining of projectile engine functions

--- a/engine/Sim/Projectile.lua
+++ b/engine/Sim/Projectile.lua
@@ -8,11 +8,15 @@ function Projectile:GetBlueprint()
 end
 
 --- Change the detonate above height for the projectile, relative to the terrain
+---
+--- Note: does **not** support chained calls
 ---@param height number
 function Projectile:ChangeDetonateAboveHeight(height)
 end
 
 --- Change the detonate below height for the projectile, relative to the terrain
+---
+--- Note: does **not** support chained calls
 ---@param height number
 function Projectile:ChangeDetonateBelowHeight(height)
 end
@@ -20,6 +24,7 @@ end
 --- Change the amount of zig-zag in degrees per second
 ---
 --- You can use `Projectile:GetMaxZigZag()` to retrieve the current zig zag distance.
+--- Note: does **not** support chained calls
 ---@param max number
 function Projectile:ChangeMaxZigZag(max)
 end
@@ -27,6 +32,7 @@ end
 --- Change the frequency of the zig-zag
 ---
 --- You can use `Projectile:GetZigZagFrequency()` to retrieve the current zig zag frequency.
+--- Note: does **not** support chained calls
 ---@param freq number
 function Projectile:ChangeZigZagFrequency(freq)
 end
@@ -86,110 +92,141 @@ function Projectile:GetVelocity()
 end
 
 --- Override the acceleration value in the blueprint.
+---@generic T
+---@param self T
 ---@param accel number
+---@return T
 function Projectile:SetAcceleration(accel)
 end
 
 --- Set the vertical (gravitational) acceleration of the projectile. Default is -4.9, which is expected by the engine's weapon targeting and firing
+---@generic T
+---@param self T
 ---@param accel number
+---@return T
 function Projectile:SetBallisticAcceleration(accel)
 end
 
 --- Whether or not this projecile collides with units and shields, should not be used for dummy projectiles as this is expensive
+---@generic T
+---@param self T
 ---@param collide boolean
+---@return T
 function Projectile:SetCollideEntity(collide)
 end
 
 --- Whether or not this projectile collides with the terrain and water surface
+---@generic T
+---@param self T
 ---@param collide boolean
+---@return T
 function Projectile:SetCollideSurface(collide)
 end
 
----
+---@generic T
+---@param self T
 ---@param collide boolean
 ---@return Projectile
+---@return T
 function Projectile:SetCollision(collide)
 end
 
----
+--- Note: does **not** support chained calls
 ---@param flag boolean
 function Projectile:SetDestroyOnWater(flag)
 end
 
----
+---@generic T
+---@param self T
 ---@param seconds number
+---@return T
 function Projectile:SetLifetime(seconds)
 end
 
----
+---@generic T
+---@param self T
 ---@param x number
 ---@param y number
 ---@param z number
+---@return T
 function Projectile:SetLocalAngularVelocity(x, y, z)
 end
 
----
+---@generic T
+---@param self T
 ---@param speed number
+---@return T
 function Projectile:SetMaxSpeed(speed)
 end
 
----
+--- Note: does **not** support chained calls
 ---@param object Blip | Entity | Unit | Projectile
 function Projectile:SetNewTarget(object)
 end
 
----
+--- Note: does **not** support chained calls
 ---@param location Vector
 function Projectile:SetNewTargetGround(location)
 end
 
+--- Note: does **not** support chained calls
 ---@param x number
 ---@param y number
 ---@param z number
 function Projectile:SetNewTargetGroundXYZ(x, y, z)
 end
 
----
+---@generic T
+---@param self T
 ---@param svx number
 ---@param svy number
 ---@param svz number
+---@return T
 function Projectile:SetScaleVelocity(svx, svy, svz)
 end
 
----
+--- Note: does **not** support chained calls
 ---@param upright boolean
 function Projectile:SetStayUpright(upright)
 end
 
----
+---@generic T
+---@param self T
 ---@param degreesPerSecond number
+---@return T
 function Projectile:SetTurnRate(degreesPerSecond)
 end
 
----
+---@generic T
+---@param self T
 ---@param velX number
 ---@param velY? number
 ---@param velZ? number
----@return Projectile
+---@return T
 function Projectile:SetVelocity(velX, velY, velZ)
 end
 
----
+--- Note: does **not** support chained calls
 ---@param align boolean
 function Projectile:SetVelocityAlign(align)
 end
 
+--- Note: does **not** support chained calls
 ---@unknown
 function Projectile:SetVelocityRandomUpVector()
 end
 
----
+---@generic T
+---@param self T
 ---@param stay boolean
+---@return T
 function Projectile:StayUnderwater(stay)
 end
 
----
+---@generic T
+---@param self T
 ---@param track boolean
+---@return T
 function Projectile:TrackTarget(track)
 end
 

--- a/engine/Sim/Projectile.lua
+++ b/engine/Sim/Projectile.lua
@@ -9,14 +9,14 @@ end
 
 --- Change the detonate above height for the projectile, relative to the terrain
 ---
---- Note: does **not** support chained calls
+--- Note: does **not** support method chaining
 ---@param height number
 function Projectile:ChangeDetonateAboveHeight(height)
 end
 
 --- Change the detonate below height for the projectile, relative to the terrain
 ---
---- Note: does **not** support chained calls
+--- Note: does **not** support method chaining
 ---@param height number
 function Projectile:ChangeDetonateBelowHeight(height)
 end
@@ -24,7 +24,7 @@ end
 --- Change the amount of zig-zag in degrees per second
 ---
 --- You can use `Projectile:GetMaxZigZag()` to retrieve the current zig zag distance.
---- Note: does **not** support chained calls
+--- Note: does **not** support method chaining
 ---@param max number
 function Projectile:ChangeMaxZigZag(max)
 end
@@ -32,7 +32,7 @@ end
 --- Change the frequency of the zig-zag
 ---
 --- You can use `Projectile:GetZigZagFrequency()` to retrieve the current zig zag frequency.
---- Note: does **not** support chained calls
+--- Note: does **not** support method chaining
 ---@param freq number
 function Projectile:ChangeZigZagFrequency(freq)
 end
@@ -131,7 +131,7 @@ end
 function Projectile:SetCollision(collide)
 end
 
---- Note: does **not** support chained calls
+--- Note: does **not** support method chaining
 ---@param flag boolean
 function Projectile:SetDestroyOnWater(flag)
 end
@@ -159,17 +159,17 @@ end
 function Projectile:SetMaxSpeed(speed)
 end
 
---- Note: does **not** support chained calls
+--- Note: does **not** support method chaining
 ---@param object Blip | Entity | Unit | Projectile
 function Projectile:SetNewTarget(object)
 end
 
---- Note: does **not** support chained calls
+--- Note: does **not** support method chaining
 ---@param location Vector
 function Projectile:SetNewTargetGround(location)
 end
 
---- Note: does **not** support chained calls
+--- Note: does **not** support method chaining
 ---@param x number
 ---@param y number
 ---@param z number
@@ -185,7 +185,7 @@ end
 function Projectile:SetScaleVelocity(svx, svy, svz)
 end
 
---- Note: does **not** support chained calls
+--- Note: does **not** support method chaining
 ---@param upright boolean
 function Projectile:SetStayUpright(upright)
 end
@@ -206,12 +206,12 @@ end
 function Projectile:SetVelocity(velX, velY, velZ)
 end
 
---- Note: does **not** support chained calls
+--- Note: does **not** support method chaining
 ---@param align boolean
 function Projectile:SetVelocityAlign(align)
 end
 
---- Note: does **not** support chained calls
+--- Note: does **not** support method chaining
 ---@unknown
 function Projectile:SetVelocityRandomUpVector()
 end


### PR DESCRIPTION
## Description of the proposed changes

Document the support for method chaining of the projectile engine methods. I noticed this behavior as I was working on #6398.

## Testing done on the proposed changes

I called every function and checked the output of the log with logging the instance. If the references match then the function supports method chaining.

```
LOG(self) -- returns memory reference
LOG("ChangeDetonateAboveHeight", self:ChangeDetonateAboveHeight(0)) -- returns nil
LOG("SetLifetime", self:SetLifetime(10)) -- returns memory reference
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
