### PR TITLE
Prevent simultaneous deployments across all branches

### DIFF
--- a/.github/workflows/deploy-faf.yaml
+++ b/.github/workflows/deploy-faf.yaml
@@ -20,9 +20,12 @@
 
 name: Deploy to FAF
 
+# Prevent simultaneous deployments across all deployment branches as 
+# the server is unable to process multiple deployments at the same time.
+
 concurrency:
   cancel-in-progress: true
-  group: deploy/faf
+  group: deployment
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-fafbeta.yaml
+++ b/.github/workflows/deploy-fafbeta.yaml
@@ -20,9 +20,12 @@
 
 name: Deploy to FAF Beta Balance
 
+# Prevent simultaneous deployments across all deployment branches as 
+# the server is unable to process multiple deployments at the same time.
+
 concurrency:
   cancel-in-progress: true
-  group: deploy/fafbeta
+  group: deployment
 
 on:
   workflow_dispatch:
@@ -49,7 +52,7 @@ jobs:
       # You can overwrite these adjustments by setting up a `Debug` folder
       - name: Update references
         run: |
-          sed -i 's/EnabledDrawing = true,/EnabledDrawing = false,/' "/lua/shared/components/DebugComponent.lua"
+          sed -i 's/EnabledDrawing = true,/EnabledDrawing = false,/' "lua/shared/components/DebugComponent.lua"
 
       # Update the deploy/fafbeta branch, we force push here because 
       # we're not interested in fixing conflicts

--- a/.github/workflows/deploy-fafdevelop.yaml
+++ b/.github/workflows/deploy-fafdevelop.yaml
@@ -20,9 +20,12 @@
 
 name: Deploy to FAF Develop
 
+# Prevent simultaneous deployments across all deployment branches as 
+# the server is unable to process multiple deployments at the same time.
+
 concurrency:
   cancel-in-progress: true
-  group: deploy/fafdevelop
+  group: deployment
 
 on:
   workflow_dispatch:
@@ -49,7 +52,7 @@ jobs:
       # You can overwrite these adjustments by setting up a `Debug` folder
       - name: Update references
         run: |
-          sed -i 's/EnabledDrawing = true,/EnabledDrawing = false,/' "/lua/shared/components/DebugComponent.lua"
+          sed -i 's/EnabledDrawing = true,/EnabledDrawing = false,/' "lua/shared/components/DebugComponent.lua"
 
       # Update the deploy/fafdevelop branch, we force push here because 
       # we're not interested in fixing conflicts


### PR DESCRIPTION
## Description of the proposed changes

By experience I know that multiple deployments in quick succession tend to not end up deploying. A commit to any of the `deploy/` branches is sufficient to trigger the deployment. The mistake is trivial to make as I just did it by accident:

![image](https://github.com/user-attachments/assets/1fc076e2-fc1f-41ff-b517-4d51c895bb8e)

Which resulted in:

![image](https://github.com/user-attachments/assets/137279e5-4ee1-41c9-a6cc-1cc2889e4c94)

With these changes the workflows should cancel when they detect there are concurrent workflows.
