### PR TITLE
Display game version information to the user

### DIFF
--- a/lua/globalInit.lua
+++ b/lua/globalInit.lua
@@ -48,14 +48,32 @@ end
 
 -- Inform the developer that a Lua environment is created
 local version, gametype, commit = import("/lua/version.lua").GetVersionData()
-SPEW(
-    string.format(
-        "Lua environment initialized with game version %s, game type %s and at commit hash %s",
-        version,
-        gametype,
-        commit
+local trace = debug.traceback():lower()
+if trace:find("siminit.lua") then
+    SPEW(
+        string.format(
+            "Lua sim environment initialized with game version %s, game type %s and at commit hash %s",
+            version,
+            gametype,
+            commit
+        )
     )
-)
-
--- Helps the developer understand the type of environment created
-SPEW(debug.traceback())
+elseif trace:find("sessioninit.lua") then
+    SPEW(
+        string.format(
+            "Lua session environment initialized with game version %s, game type %s and at commit hash %s",
+            version,
+            gametype,
+            commit
+        )
+    )
+elseif trace:find("userinit.lua") then
+    SPEW(
+        string.format(
+            "Lua user environment initialized with game version %s, game type %s and at commit hash %s",
+            version,
+            gametype,
+            commit
+        )
+    )
+end

--- a/lua/ui/game/score.lua
+++ b/lua/ui/game/score.lua
@@ -543,9 +543,13 @@ function SetupPlayerLines()
     end
 
     -- add replay ID
+    local version, gametype, commit = import("/lua/version.lua").GetVersionData()
+
     mapData.MapDescription = LOC(description) ..
         "\r\n\r\n" .. LOC("<LOC map_version>Map version") .. ": " .. tostring(sessionInfo.map_version) ..
-        "\r\n" .. LOC("<LOC replay_id>Replay ID") .. ": " .. tostring(UIUtil.GetReplayId())
+        "\r\n" .. LOC("<LOC replay_id>Replay ID") .. ": " .. tostring(UIUtil.GetReplayId()) .. 
+        "\r\n" ..
+        "\r\n" .. "Game version: " .. version .. "\r\n" .. "Game type: " .. gametype .. "\r\n" .. "Commit: " .. commit
 
     -- add ladder icon
     mapData.Ranked = sessionInfo.Options.Ranked or false

--- a/lua/ui/game/tooltip.lua
+++ b/lua/ui/game/tooltip.lua
@@ -21,14 +21,14 @@ local mouseoverDisplay = false
 local createThread = false
 
 -- creates a tooltip box from ID table and with optional parameters
--- @param ID table e.g. { text = 'tooltip header', body = 'tooltip description' } 
--- @param extended boolean indicates whether to just create tooltip header or also tooltip description
--- @param width number is optional width of tooltip or it is auto calculated based on length of header/description
--- @param forced boolean determine if the tooltip should override hiding tooltips set in game options
--- @param padding number is optional space between tooltip description text and border of tooltip 
--- @param descFontSize number is optional font size for description text of tooltip 
--- @param textFontSize number is optional font size for header text of tooltip  
--- @param position string is optional string indicating position of tooltip relative to its parent: left, right, center (default)
+---@param ID table e.g. { text = 'tooltip header', body = 'tooltip description' } 
+---@param extended? boolean indicates whether to just create tooltip header or also tooltip description
+---@param width? number is optional width of tooltip or it is auto calculated based on length of header/description
+---@param forced? boolean determine if the tooltip should override hiding tooltips set in game options
+---@param padding? number is optional space between tooltip description text and border of tooltip 
+---@param descFontSize? number is optional font size for description text of tooltip 
+---@param textFontSize? number is optional font size for header text of tooltip  
+---@param position? string is optional string indicating position of tooltip relative to its parent: left, right, center (default)
 function CreateMouseoverDisplay(parent, ID, delay, extended, width, forced, padding, descFontSize, textFontSize, position)
 
     -- values used throughout the function
@@ -186,12 +186,12 @@ function CreateToolTip(parent, text)
 end
 
 -- creates a tooltip box with title text and/or description and with optional parameters
--- @param text string displayed in header of tooltip
--- @param desc string displayed in description of tooltip, this text is wrapped into multiple if longer than width
--- @param width number is optional width of tooltip or it is auto calculated based on length of header/description
--- @param padding is optional space between tooltip description text and border of tooltip 
--- @param descFontSize number is optional font size for description text of tooltip 
--- @param textFontSize number is optional font size for header text of tooltip
+---@param text string displayed in header of tooltip
+---@param desc string displayed in description of tooltip, this text is wrapped into multiple if longer than width
+---@param width? number is optional width of tooltip or it is auto calculated based on length of header/description
+---@param padding? number is optional space between tooltip description text and border of tooltip 
+---@param descFontSize? number is optional font size for description text of tooltip 
+---@param textFontSize? number is optional font size for header text of tooltip
 function CreateExtendedToolTip(parent, text, desc, width, padding, descFontSize, textFontSize)
     text = LOC(text)
     desc = LOC(desc)
@@ -363,12 +363,12 @@ end
 -- creates a tooltip box with specified title and description
 ---@param title string displayed in tooltip header
 ---@param description string displayed in tooltip body
----@param delay number is optional milliseconds used to delay tooltip popup
----@param width number is optional width of tooltip or it is auto calculated based on length of header/description
----@param padding number is optional space between tooltip description text and border of tooltip 
----@param descFontSize number is optional font size for description text of tooltip 
----@param textFontSize number is optional font size for header text of tooltip  
----@param position string is optional string indicating position of tooltip relative to its parent: left, right, center (default)
+---@param delay? number is optional milliseconds used to delay tooltip popup
+---@param width? number is optional width of tooltip or it is auto calculated based on length of header/description
+---@param padding? number is optional space between tooltip description text and border of tooltip 
+---@param descFontSize? number is optional font size for description text of tooltip 
+---@param textFontSize? number is optional font size for header text of tooltip  
+---@param position? string is optional string indicating position of tooltip relative to its parent: left, right, center (default)
 function AddControlTooltipManual(control, title, description, delay, width, padding, descFontSize, textFontSize, position)
 
     if not control.oldHandleEvent then

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -3146,11 +3146,15 @@ function CreateUI(maxPlayers)
     GUI.logo = Bitmap(GUI, '/textures/ui/common/scx_menu/lan-game-lobby/logo.dds')
     LayoutHelpers.AtLeftTopIn(GUI.logo, GUI, 1, 1)
 
-    -- Version texts
-    local bool ShowPatch = false
-    GUI.gameVersionText = UIUtil.CreateText(GUI.panel, "Game Patch " .. GameVersion(), 9, UIUtil.bodyFont)
+    local version, gametype, commit = import("/lua/version.lua").GetVersionData()
+    GUI.gameVersionText = UIUtil.CreateText(GUI.panel, "Game version " .. version, 9, UIUtil.bodyFont)
     GUI.gameVersionText:SetColor('677983')
     GUI.gameVersionText:SetDropShadow(true)
+
+    Tooltip.AddControlTooltipManual(GUI.gameVersionText, 'Version control', string.format(
+        'Game version: %s\nGame type: %s\nCommit hash: %s', version, gametype, commit
+    ))
+
     LayoutHelpers.AtLeftTopIn(GUI.gameVersionText, GUI.panel, 70, 3)
 
     -- Player Slots


### PR DESCRIPTION
## Description of the proposed changes

Displays the game version information in the lobby and in the (default) scoreboard.

![image](https://github.com/user-attachments/assets/5e936175-95a9-419c-a4e6-21ed40088877)

![image](https://github.com/user-attachments/assets/b6fcdf6d-816f-40c4-abba-b3694cae69ac)

## Testing done on the proposed changes

Launch the game and review the information that is displayed.

## Additional context

This should make it much more trivial for developers to understand at what commit a replay is running. It intentionally does **not** include the generated commit by the deployment branches, see also #6401 .

Note that these values default to 'unknown' as you develop. They are populated in the deployment workflows, see also:

-- - https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-faf.yaml
-- - https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-fafbeta.yaml
-- - https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-fafdevelop.yaml