### PR TITLE
Filter out upgrade units from being rebuilt on transfer

### DIFF
--- a/changelog/snippets/fix.6404.md
+++ b/changelog/snippets/fix.6404.md
@@ -1,0 +1,1 @@
+- (#6404) Fix upgrading units being duplicated when transferred after death.

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -371,7 +371,6 @@ function UpgradeTransferredKennels(kennels)
 end
 
 --- Takes the units and tries to rebuild them for each army (in order).
---- The transfer procedure is fairly expensive, so it is filtered to important units (EXPs and T3 arty).
 ---@param units Unit[]
 ---@param armies Army[]
 function TransferUnfinishedUnitsAfterDeath(units, armies)

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -377,7 +377,8 @@ function TransferUnfinishedUnitsAfterDeath(units, armies)
     local unbuiltUnits = {}
     local unbuiltUnitCount = 0
     for _, unit in EntityCategoryFilterDown(transferUnbuiltCategory, units) do
-        if unit:IsBeingBuilt() then
+        -- Check if a unit is an upgrade to prevent duplicating it along with `UpgradeUnits`
+        if unit:IsBeingBuilt() and not unit.IsUpgrade then
             unbuiltUnitCount = unbuiltUnitCount + 1
             unbuiltUnits[unbuiltUnitCount] = unit
         end


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fix the duplication of upgrading units on transfer. `IsUpgrade` seems to be the most correct way to check for a unit being an upgrade from what I've found in the repo. It is set here in `Unit.OnStartBuild` (`built.IsUpgrade`):
https://github.com/FAForever/fa/blob/2158d74b7d63e0e65ae17d1b71b6b81a1a5e458f/lua/sim/Unit.lua#L2814-L2824

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Use this console command to inspect the unit data:
```lua
SimLua 
local units = ArmyBrains[GetFocusArmy()]:GetListOfUnits(categories.ALLUNITS)
for _, unit in units do
	LOG('Unit: ', unit, unit.Blueprint.BlueprintId, 'DefWorkOrd: ', unit:GetCurrentDefaultWorkOrder(), 'Unitbeingbuilt: ', unit.UnitBeingBuilt, 'originalBuilder: ', unit.originalBuilder)
	LOG('Am I being upgraded?', unit.originalBuilder and not unit.originalBuilder.Dead and unit.originalBuilder:IsUnitState('Upgrading') and unit.originalBuilder:GetFocusUnit() == unit, unit.IsUpgrade)
end
```
It has some other solutions I was looking at before I found the flag, what to look for is the second bool being true for  upgrading units, ex:
```
INFO: Unit: 	table: 1AD50848	uab1302	DefWorkOrd: 	BeingBuilt	Unitbeingbuilt: 	nil	originalBuilder: 	table: 2E488780
INFO: Am I being upgraded?	true	true
```

## Additional context
<!-- Add any other context about the pull request here. -->
Here's the weird `unit.originalBuilder` method of checking for upgrades.
https://github.com/FAForever/fa/blob/2158d74b7d63e0e65ae17d1b71b6b81a1a5e458f/lua/sim/Unit.lua#L1139

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
