### PR TITLE
Change the URL for changelogs from `patches/` to `changelog/`

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -88,7 +88,7 @@ jobs:
       # Append the generated changelogs to the Jekyll-compatible templates
       - name: Append the generated changelogs
         run: |
-          cat generated/fafdevelop.md >> patches/fafdevelop.md
+          cat generated/fafdevelop.md >> changelog/fafdevelop.md
 
       
       # Update the posts directory contents

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,7 +81,7 @@ Assuming [Jekyll] and [Bundler] are installed on your computer:
 
 2.  Run `bundle install`.
 
-3.  Run `bundle exec jekyll serve --config _config.yml,_config_debug.ym` to build your site and preview it at `localhost:4000`.
+3.  Run `bundle exec jekyll serve --config _config.yml,_config_debug.yml` to build your site and preview it at `localhost:4000`.
 
     The built site is stored in the directory `_site`.
 

--- a/docs/_posts/2014-12-12-3636.md
+++ b/docs/_posts/2014-12-12-3636.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3636
-permalink: patches/3636
+permalink: changelog/3636
 ---
 
 # Patch 3636 (Dec 12, 2014)

--- a/docs/_posts/2014-12-12-3637.md
+++ b/docs/_posts/2014-12-12-3637.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3637
-permalink: patches/3637
+permalink: changelog/3637
 ---
 
 # Patch 3637 (Dec 12, 2014)

--- a/docs/_posts/2014-12-24-3638.md
+++ b/docs/_posts/2014-12-24-3638.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3638
-permalink: patches/3638
+permalink: changelog/3638
 ---
 
 # Patch 3638 (Dec 24, 2014)

--- a/docs/_posts/2015-02-05-3639.md
+++ b/docs/_posts/2015-02-05-3639.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3639
-permalink: patches/3639
+permalink: changelog/3639
 ---
 
 # Patch 3639 (Jan 5, 2015)

--- a/docs/_posts/2015-02-06-3640.md
+++ b/docs/_posts/2015-02-06-3640.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3640
-permalink: patches/3640
+permalink: changelog/3640
 ---
 
 # Patch 3640 (Jan 6, 2015)

--- a/docs/_posts/2015-06-12-3641.md
+++ b/docs/_posts/2015-06-12-3641.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3641
-permalink: patches/3641
+permalink: changelog/3641
 ---
 
 # Patch 3641 (July 12, 2015)

--- a/docs/_posts/2015-06-13-3642.md
+++ b/docs/_posts/2015-06-13-3642.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3642
-permalink: patches/3642
+permalink: changelog/3642
 ---
 
 # Patch 3642 (July 13, 2015)

--- a/docs/_posts/2015-06-24-3643.md
+++ b/docs/_posts/2015-06-24-3643.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3643
-permalink: patches/3643
+permalink: changelog/3643
 ---
 
 # Patch 3643 (July 24, 2015)

--- a/docs/_posts/2015-06-27-3644.md
+++ b/docs/_posts/2015-06-27-3644.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3644
-permalink: patches/3644
+permalink: changelog/3644
 ---
 
 # Patch 3644 (July 27, 2015)

--- a/docs/_posts/2015-08-05-3644.1.md
+++ b/docs/_posts/2015-08-05-3644.1.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3644.1
-permalink: patches/3644.1
+permalink: changelog/3644.1
 ---
 
 # Patch 3644.1 (August 5, 2015)

--- a/docs/_posts/2015-08-11-3646.md
+++ b/docs/_posts/2015-08-11-3646.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3646
-permalink: patches/3646
+permalink: changelog/3646
 ---
 
 # Patch 3646 (August 11, 2015)

--- a/docs/_posts/2015-08-13-3648.md
+++ b/docs/_posts/2015-08-13-3648.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3648
-permalink: patches/3648
+permalink: changelog/3648
 ---
 
 # Patch 3648 (August 13, 2015)

--- a/docs/_posts/2015-08-19-3650.md
+++ b/docs/_posts/2015-08-19-3650.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3650
-permalink: patches/3650
+permalink: changelog/3650
 ---
 
 # Patch 3650 (August 19, 2015)

--- a/docs/_posts/2016-01-19-3671.md
+++ b/docs/_posts/2016-01-19-3671.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3671
-permalink: patches/3671
+permalink: changelog/3671
 ---
 
 # Patch 3671 (January 19th, 2017)

--- a/docs/_posts/2016-05-02-3652.md
+++ b/docs/_posts/2016-05-02-3652.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3652
-permalink: patches/3652
+permalink: changelog/3652
 ---
 
 # Patch 3652 (May 2, 2016)

--- a/docs/_posts/2016-05-30-3654.md
+++ b/docs/_posts/2016-05-30-3654.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3654
-permalink: patches/3654
+permalink: changelog/3654
 ---
 
 # Patch 3654 (May 30, 2016)

--- a/docs/_posts/2016-08-08-3656.md
+++ b/docs/_posts/2016-08-08-3656.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3656
-permalink: patches/3656
+permalink: changelog/3656
 ---
 
 # Hotfix Patch 3656 (August 8, 2016)

--- a/docs/_posts/2016-08-29-3658.md
+++ b/docs/_posts/2016-08-29-3658.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3658
-permalink: patches/3658
+permalink: changelog/3658
 ---
 
 # Patch 3658 (August 29th, 2016)

--- a/docs/_posts/2016-09-12-3659.md
+++ b/docs/_posts/2016-09-12-3659.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3659
-permalink: patches/3659
+permalink: changelog/3659
 ---
 
 # Hotfix Patch 3659 (September 12th, 2016)

--- a/docs/_posts/2016-10-24-3660.md
+++ b/docs/_posts/2016-10-24-3660.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3660
-permalink: patches/3660
+permalink: changelog/3660
 ---
 
 # Patch 3660 (October 24th, 2016)

--- a/docs/_posts/2016-10-24-3661.md
+++ b/docs/_posts/2016-10-24-3661.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3661
-permalink: patches/3661
+permalink: changelog/3661
 ---
 
 # Hotfix Patch 3661 (October 24th, 2016)

--- a/docs/_posts/2016-11-09-3662.md
+++ b/docs/_posts/2016-11-09-3662.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3662
-permalink: patches/3662
+permalink: changelog/3662
 ---
 
 # Patch 3662 (November 9th, 2016)

--- a/docs/_posts/2016-11-12-3663.md
+++ b/docs/_posts/2016-11-12-3663.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3663
-permalink: patches/3663
+permalink: changelog/3663
 ---
 
 # Patch 3663 (November 12th, 2016)

--- a/docs/_posts/2016-12-21-3664.md
+++ b/docs/_posts/2016-12-21-3664.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3664
-permalink: patches/3664
+permalink: changelog/3664
 ---
 
 # Patch 3664 (December 21st, 2016)

--- a/docs/_posts/2016-12-21-3665.md
+++ b/docs/_posts/2016-12-21-3665.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3665
-permalink: patches/3665
+permalink: changelog/3665
 ---
 
 # Hotfix Patch 3665 (December 21st, 2016)

--- a/docs/_posts/2016-12-21-3666.md
+++ b/docs/_posts/2016-12-21-3666.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3666
-permalink: patches/3666
+permalink: changelog/3666
 ---
 
 # Hotfix Patch 3666 (December 21st, 2016)

--- a/docs/_posts/2016-12-22-3667.md
+++ b/docs/_posts/2016-12-22-3667.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3667
-permalink: patches/3667
+permalink: changelog/3667
 ---
 
 # Hotfix Patch 3667 (December 22nd, 2016)

--- a/docs/_posts/2017-01-17-3668.md
+++ b/docs/_posts/2017-01-17-3668.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3668
-permalink: patches/3668
+permalink: changelog/3668
 ---
 
 # Patch 3668 (January 17th, 2017)

--- a/docs/_posts/2017-01-17-3669.md
+++ b/docs/_posts/2017-01-17-3669.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3669
-permalink: patches/3669
+permalink: changelog/3669
 ---
 
 # Patch 3669 (January 17th, 2017)

--- a/docs/_posts/2017-01-17-3670.md
+++ b/docs/_posts/2017-01-17-3670.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3670
-permalink: patches/3670
+permalink: changelog/3670
 ---
 
 # Patch 3670 (January 17th, 2017)

--- a/docs/_posts/2017-01-24-3672.md
+++ b/docs/_posts/2017-01-24-3672.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3672
-permalink: patches/3672
+permalink: changelog/3672
 ---
 
 # Patch 3672 (January 24th, 2017)

--- a/docs/_posts/2017-02-05-3674.md
+++ b/docs/_posts/2017-02-05-3674.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3674
-permalink: patches/3674
+permalink: changelog/3674
 ---
 
 # Patch 3674 (5th February, 2017)

--- a/docs/_posts/2017-02-05-3675.md
+++ b/docs/_posts/2017-02-05-3675.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3675
-permalink: patches/3675
+permalink: changelog/3675
 ---
 
 # Patch 3675 (5th February, 2017)

--- a/docs/_posts/2017-02-27-3676.md
+++ b/docs/_posts/2017-02-27-3676.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3676
-permalink: patches/3676
+permalink: changelog/3676
 ---
 
 # Patch 3676 (27th February, 2017)

--- a/docs/_posts/2017-05-03-3677.md
+++ b/docs/_posts/2017-05-03-3677.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3677
-permalink: patches/3677
+permalink: changelog/3677
 ---
 
 # Patch 3677 (3rd May, 2017)

--- a/docs/_posts/2017-05-11-3680.md
+++ b/docs/_posts/2017-05-11-3680.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3680
-permalink: patches/3680
+permalink: changelog/3680
 ---
 
 # Patch 3680 (11th May 2017)

--- a/docs/_posts/2017-05-12-3681.md
+++ b/docs/_posts/2017-05-12-3681.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3681
-permalink: patches/3681
+permalink: changelog/3681
 ---
 
 # Patch 3681 (12th May 2017)

--- a/docs/_posts/2017-05-16-3682.md
+++ b/docs/_posts/2017-05-16-3682.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3682
-permalink: patches/3682
+permalink: changelog/3682
 ---
 
 # Patch 3682 (16th May 2017)

--- a/docs/_posts/2017-05-27-3684.md
+++ b/docs/_posts/2017-05-27-3684.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3684
-permalink: patches/3684
+permalink: changelog/3684
 ---
 
 # Patch 3684 (27th May 2017)

--- a/docs/_posts/2017-08-13-3686.md
+++ b/docs/_posts/2017-08-13-3686.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3686
-permalink: patches/3686
+permalink: changelog/3686
 ---
 
 # Patch 3686 (13th August 2017)

--- a/docs/_posts/2017-09-24-3688.md
+++ b/docs/_posts/2017-09-24-3688.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3688
-permalink: patches/3688
+permalink: changelog/3688
 ---
 
 # Patch 3688 (24th September 2017)

--- a/docs/_posts/2017-10-01-3689.md
+++ b/docs/_posts/2017-10-01-3689.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3689
-permalink: patches/3689
+permalink: changelog/3689
 ---
 
 # Patch 3689 (1st October 2017)

--- a/docs/_posts/2017-11-15-3690.md
+++ b/docs/_posts/2017-11-15-3690.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3690
-permalink: patches/3690
+permalink: changelog/3690
 ---
 
 # Patch 3690 (15th November 2017)

--- a/docs/_posts/2017-12-01-3692.md
+++ b/docs/_posts/2017-12-01-3692.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3692
-permalink: patches/3692
+permalink: changelog/3692
 ---
 
 # Patch 3692 (1st December, 2017)

--- a/docs/_posts/2017-12-03-3693.md
+++ b/docs/_posts/2017-12-03-3693.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3693
-permalink: patches/3693
+permalink: changelog/3693
 ---
 
 # Patch 3693 (3rd December, 2017)

--- a/docs/_posts/2017-12-21-3694.md
+++ b/docs/_posts/2017-12-21-3694.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3694
-permalink: patches/3694
+permalink: changelog/3694
 ---
 
 # Patch 3694 (21st December, 2017)

--- a/docs/_posts/2017-12-25-3695.md
+++ b/docs/_posts/2017-12-25-3695.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3695
-permalink: patches/3695
+permalink: changelog/3695
 ---
 
 # Patch 3695 (25th December, 2017)

--- a/docs/_posts/2018-05-26-3696.md
+++ b/docs/_posts/2018-05-26-3696.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3696
-permalink: patches/3696
+permalink: changelog/3696
 ---
 
 # Patch 3696 (26 May, 2018)

--- a/docs/_posts/2018-08-17-3697.md
+++ b/docs/_posts/2018-08-17-3697.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3697
-permalink: patches/3697
+permalink: changelog/3697
 ---
 
 # Patch 3697 (17 August, 2018)

--- a/docs/_posts/2018-08-24-3698.md
+++ b/docs/_posts/2018-08-24-3698.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3698
-permalink: patches/3698
+permalink: changelog/3698
 ---
 
 # Hotfix Patch 3698 (24 August, 2018)

--- a/docs/_posts/2018-10-20-3699.md
+++ b/docs/_posts/2018-10-20-3699.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3699
-permalink: patches/3699
+permalink: changelog/3699
 ---
 
 # Patch 3699 (20 October, 2018)

--- a/docs/_posts/2018-10-20-3700.md
+++ b/docs/_posts/2018-10-20-3700.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3700
-permalink: patches/3700
+permalink: changelog/3700
 ---
 
 # Hotfix Patch 3700 (20 October, 2018)

--- a/docs/_posts/2018-10-28-3701.md
+++ b/docs/_posts/2018-10-28-3701.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3701
-permalink: patches/3701
+permalink: changelog/3701
 ---
 
 # Hotfix Patch 3701 (28 October 2018)

--- a/docs/_posts/2018-12-28-3702.md
+++ b/docs/_posts/2018-12-28-3702.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3702
-permalink: patches/3702
+permalink: changelog/3702
 ---
 
 # Patch 3702 (28 December, 2018)

--- a/docs/_posts/2019-01-13-3703.md
+++ b/docs/_posts/2019-01-13-3703.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3703
-permalink: patches/3703
+permalink: changelog/3703
 ---
 
 # Hotfix Patch 3703 (13 January 2019)

--- a/docs/_posts/2019-06-14-3706.md
+++ b/docs/_posts/2019-06-14-3706.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3706
-permalink: patches/3706
+permalink: changelog/3706
 ---
 
 # Patch 3706 (14 July, 2019)

--- a/docs/_posts/2019-06-18-3704.md
+++ b/docs/_posts/2019-06-18-3704.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3704
-permalink: patches/3704
+permalink: changelog/3704
 ---
 
 # Patch 3704 (18 June, 2019)

--- a/docs/_posts/2019-07-05-3705.md
+++ b/docs/_posts/2019-07-05-3705.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3705
-permalink: patches/3705
+permalink: changelog/3705
 ---
 
 # Patch 3705 (5 July, 2019)

--- a/docs/_posts/2019-07-14-3707.md
+++ b/docs/_posts/2019-07-14-3707.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3707
-permalink: patches/3707
+permalink: changelog/3707
 ---
 
 # Patch 3707 (14 July, 2019)

--- a/docs/_posts/2019-10-19-3708.md
+++ b/docs/_posts/2019-10-19-3708.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3708
-permalink: patches/3708
+permalink: changelog/3708
 ---
 
 # Patch 3708 (19 October, 2019)

--- a/docs/_posts/2019-12-16-3709.md
+++ b/docs/_posts/2019-12-16-3709.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3709
-permalink: patches/3709
+permalink: changelog/3709
 ---
 
 # Patch 3709 (16 December, 2019)

--- a/docs/_posts/2020-01-26-3710.md
+++ b/docs/_posts/2020-01-26-3710.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3710
-permalink: patches/3710
+permalink: changelog/3710
 ---
 
 # Patch 3710 (26 January, 2020)

--- a/docs/_posts/2020-03-15-3711.md
+++ b/docs/_posts/2020-03-15-3711.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3711
-permalink: patches/3711
+permalink: changelog/3711
 ---
 
 # Patch 3711 (15 March, 2020)

--- a/docs/_posts/2020-04-04-3712.md
+++ b/docs/_posts/2020-04-04-3712.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3712
-permalink: patches/3712
+permalink: changelog/3712
 ---
 
 # Patch 3712 (4 April, 2020)

--- a/docs/_posts/2020-04-07-3713.md
+++ b/docs/_posts/2020-04-07-3713.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3713
-permalink: patches/3713
+permalink: changelog/3713
 ---
 
 # Patch 3713 (7 April, 2020)

--- a/docs/_posts/2020-05-03-3714.md
+++ b/docs/_posts/2020-05-03-3714.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3714
-permalink: patches/3714
+permalink: changelog/3714
 ---
 
 # Patch 3714 (3 May, 2020)

--- a/docs/_posts/2020-09-12-3715.md
+++ b/docs/_posts/2020-09-12-3715.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3715
-permalink: patches/3715
+permalink: changelog/3715
 ---
 
 # Patch 3715 (12 September, 2020)

--- a/docs/_posts/2020-09-12-3716.md
+++ b/docs/_posts/2020-09-12-3716.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3716
-permalink: patches/3716
+permalink: changelog/3716
 ---
 
 # Hotfix 3716 (12 September, 2020)

--- a/docs/_posts/2020-09-13-3717.md
+++ b/docs/_posts/2020-09-13-3717.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3717
-permalink: patches/3717
+permalink: changelog/3717
 ---
 
 # Hotfix 3717 (13 September, 2020)

--- a/docs/_posts/2020-11-29-3718.md
+++ b/docs/_posts/2020-11-29-3718.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3718
-permalink: patches/3718
+permalink: changelog/3718
 ---
 
 # Patch 3718 (29 November, 2020)

--- a/docs/_posts/2020-12-02-3719.md
+++ b/docs/_posts/2020-12-02-3719.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3719
-permalink: patches/3719
+permalink: changelog/3719
 ---
 
 # Hotfix 3719 (2 December, 2020)

--- a/docs/_posts/2021-04-22-3732.md
+++ b/docs/_posts/2021-04-22-3732.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3732
-permalink: patches/3732
+permalink: changelog/3732
 ---
 
 # Game version 3732 (22nd of April, 2022)

--- a/docs/_posts/2021-05-14-3720.md
+++ b/docs/_posts/2021-05-14-3720.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3720
-permalink: patches/3720
+permalink: changelog/3720
 ---
 
 # Patch 3720 (14 May, 2021)

--- a/docs/_posts/2021-09-19-3721.md
+++ b/docs/_posts/2021-09-19-3721.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3721
-permalink: patches/3721
+permalink: changelog/3721
 ---
 
 # Patch 3721 (19 September, 2021)

--- a/docs/_posts/2021-09-19-3722.md
+++ b/docs/_posts/2021-09-19-3722.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3722
-permalink: patches/3722
+permalink: changelog/3722
 ---
 
 # Patch 3722 (19 September, 2021)

--- a/docs/_posts/2021-09-19-3723.md
+++ b/docs/_posts/2021-09-19-3723.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3723
-permalink: patches/3723
+permalink: changelog/3723
 ---
 
 # Patch 3723 (19 September, 2021)

--- a/docs/_posts/2021-10-04-3724.md
+++ b/docs/_posts/2021-10-04-3724.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3724
-permalink: patches/3724
+permalink: changelog/3724
 ---
 
 # Patch 3724 (04th October, 2021)

--- a/docs/_posts/2021-11-26-3725.md
+++ b/docs/_posts/2021-11-26-3725.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3725
-permalink: patches/3725
+permalink: changelog/3725
 ---
 
 # Patch 3725 (26th November, 2021)

--- a/docs/_posts/2021-11-26-3726.md
+++ b/docs/_posts/2021-11-26-3726.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3726
-permalink: patches/3726
+permalink: changelog/3726
 ---
 
 # Hotfix 3726 (26th November, 2021)

--- a/docs/_posts/2021-11-26-3727.md
+++ b/docs/_posts/2021-11-26-3727.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3727
-permalink: patches/3727
+permalink: changelog/3727
 ---
 
 # Hotfix 3727 (26th November, 2021)

--- a/docs/_posts/2021-12-20-3728.md
+++ b/docs/_posts/2021-12-20-3728.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3728
-permalink: patches/3728
+permalink: changelog/3728
 ---
 
 # Patch 3728 (20th of December, 2021)

--- a/docs/_posts/2021-12-20-3729.md
+++ b/docs/_posts/2021-12-20-3729.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3729
-permalink: patches/3729
+permalink: changelog/3729
 ---
 
 # Patch 3729 (20th of December, 2021)

--- a/docs/_posts/2021-12-23-3730.md
+++ b/docs/_posts/2021-12-23-3730.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3730
-permalink: patches/3730
+permalink: changelog/3730
 ---
 
 # Patch 3730 (23th of December, 2021)

--- a/docs/_posts/2021-12-30-3731.md
+++ b/docs/_posts/2021-12-30-3731.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3731
-permalink: patches/3731
+permalink: changelog/3731
 ---
 
 # Game version 3731 (30th of December, 2021)

--- a/docs/_posts/2022-04-22-3733.md
+++ b/docs/_posts/2022-04-22-3733.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3733
-permalink: patches/3733
+permalink: changelog/3733
 ---
 
 # Game version 3733 (22nd of April, 2022)

--- a/docs/_posts/2022-04-22-3734.md
+++ b/docs/_posts/2022-04-22-3734.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3734
-permalink: patches/3734
+permalink: changelog/3734
 ---
 
 # Game version 3734 (22nd of April, 2022)

--- a/docs/_posts/2022-04-24-3735.md
+++ b/docs/_posts/2022-04-24-3735.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3735
-permalink: patches/3735
+permalink: changelog/3735
 ---
 
 # Game version 3735 (24th of April, 2022)

--- a/docs/_posts/2022-05-06-3736.md
+++ b/docs/_posts/2022-05-06-3736.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3736
-permalink: patches/3736
+permalink: changelog/3736
 ---
 
 # Game version 3736 (6th of May, 2022)

--- a/docs/_posts/2022-05-15-3737.md
+++ b/docs/_posts/2022-05-15-3737.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3737
-permalink: patches/3737
+permalink: changelog/3737
 ---
 
 # Game version 3737 (15th of May, 2022)

--- a/docs/_posts/2022-06-19-3738.md
+++ b/docs/_posts/2022-06-19-3738.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3738
-permalink: patches/3738
+permalink: changelog/3738
 ---
 
 # Game version 3738 (19th of June, 2022)

--- a/docs/_posts/2022-06-20-3739.md
+++ b/docs/_posts/2022-06-20-3739.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3739
-permalink: patches/3739
+permalink: changelog/3739
 ---
 
 # Game version 3739 (20th of June, 2022)

--- a/docs/_posts/2022-06-23-3740.md
+++ b/docs/_posts/2022-06-23-3740.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3740
-permalink: patches/3740
+permalink: changelog/3740
 ---
 
 # Game version 3740 (23th of June, 2022)

--- a/docs/_posts/2022-07-21-3741.md
+++ b/docs/_posts/2022-07-21-3741.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3741
-permalink: patches/3741
+permalink: changelog/3741
 ---
 
 # Game version 3741 (21st of August, 2022)

--- a/docs/_posts/2022-08-21-3742.md
+++ b/docs/_posts/2022-08-21-3742.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3742
-permalink: patches/3742
+permalink: changelog/3742
 ---
 
 # Game version 3742 (21st of August, 2022)

--- a/docs/_posts/2022-08-23-3743.md
+++ b/docs/_posts/2022-08-23-3743.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3743
-permalink: patches/3743
+permalink: changelog/3743
 ---
 
 # Game version 3743 (23rd of August, 2022)

--- a/docs/_posts/2022-08-25-3744.md
+++ b/docs/_posts/2022-08-25-3744.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3744
-permalink: patches/3744
+permalink: changelog/3744
 ---
 
 # Game version 3744 (25th of August, 2022)

--- a/docs/_posts/2022-11-06-3745.md
+++ b/docs/_posts/2022-11-06-3745.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3745
-permalink: patches/3745
+permalink: changelog/3745
 ---
 
 # Game version 3745 (6th of November, 2022)

--- a/docs/_posts/2022-11-06-3746.md
+++ b/docs/_posts/2022-11-06-3746.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3746
-permalink: patches/3746
+permalink: changelog/3746
 ---
 
 # Game version 3746 (6th of November, 2022)

--- a/docs/_posts/2022-11-15-3747.md
+++ b/docs/_posts/2022-11-15-3747.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3747
-permalink: patches/3747
+permalink: changelog/3747
 ---
 
 # Game version 3747 (15th of November, 2022)

--- a/docs/_posts/2022-11-16-3748.md
+++ b/docs/_posts/2022-11-16-3748.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3748
-permalink: patches/3748
+permalink: changelog/3748
 ---
 
 # Game version 3748 (16th of November, 2022)

--- a/docs/_posts/2023-01-28-3750.md
+++ b/docs/_posts/2023-01-28-3750.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3750
-permalink: patches/3750
+permalink: changelog/3750
 ---
 
 # Game version 3750 (28th of January, 2023)

--- a/docs/_posts/2023-02-25-3751.md
+++ b/docs/_posts/2023-02-25-3751.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3751
-permalink: patches/3751
+permalink: changelog/3751
 ---
 
 # Game version 3751 (25th of February, 2023)

--- a/docs/_posts/2023-02-25-3752.md
+++ b/docs/_posts/2023-02-25-3752.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3752
-permalink: patches/3752
+permalink: changelog/3752
 ---
 
 # Game version 3752 (25th of February, 2023)

--- a/docs/_posts/2023-02-25-3753.md
+++ b/docs/_posts/2023-02-25-3753.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3753
-permalink: patches/3753
+permalink: changelog/3753
 ---
 
 # Game version 3753 (25th of February, 2023)

--- a/docs/_posts/2023-03-05-3754.md
+++ b/docs/_posts/2023-03-05-3754.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3754
-permalink: patches/3754
+permalink: changelog/3754
 ---
 
 # Game version 3754 (5th of March, 2023)

--- a/docs/_posts/2023-03-05-3755.md
+++ b/docs/_posts/2023-03-05-3755.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3755
-permalink: patches/3755
+permalink: changelog/3755
 ---
 
 # Game version 3755 (5th of March, 2023)

--- a/docs/_posts/2023-03-18-3756.md
+++ b/docs/_posts/2023-03-18-3756.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3756
-permalink: patches/3756
+permalink: changelog/3756
 ---
 
 # Game version 3756 (18th of March, 2023)

--- a/docs/_posts/2023-05-20-3757.md
+++ b/docs/_posts/2023-05-20-3757.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3757
-permalink: patches/3757
+permalink: changelog/3757
 ---
 
 # Game version 3757 (20th of May, 2023)

--- a/docs/_posts/2023-06-24-3758.md
+++ b/docs/_posts/2023-06-24-3758.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3758
-permalink: patches/3758
+permalink: changelog/3758
 ---
 
 # Game version 3758 (24th of June, 2023)

--- a/docs/_posts/2023-06-27-3760.md
+++ b/docs/_posts/2023-06-27-3760.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3760
-permalink: patches/3760
+permalink: changelog/3760
 ---
 
 # Game version 3760 (27th of June, 2023)

--- a/docs/_posts/2023-06-27-3761.md
+++ b/docs/_posts/2023-06-27-3761.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3761
-permalink: patches/3761
+permalink: changelog/3761
 ---
 
 # Game version 3761 (27th of June, 2023)

--- a/docs/_posts/2023-07-22-3762.md
+++ b/docs/_posts/2023-07-22-3762.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3762
-permalink: patches/3762
+permalink: changelog/3762
 ---
 
 # Game version 3762 (22th of July, 2023)

--- a/docs/_posts/2023-07-23-3763.md
+++ b/docs/_posts/2023-07-23-3763.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3763
-permalink: patches/3763
+permalink: changelog/3763
 ---
 
 # Game version 3763 (23th of July, 2023)

--- a/docs/_posts/2023-07-29-3764.md
+++ b/docs/_posts/2023-07-29-3764.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3764
-permalink: patches/3764
+permalink: changelog/3764
 ---
 
 # Game version 3764 (29th of July, 2023)

--- a/docs/_posts/2023-09-02-3765.md
+++ b/docs/_posts/2023-09-02-3765.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3765
-permalink: patches/3765
+permalink: changelog/3765
 ---
 
 # Game version 3765 (2nd of September, 2023)

--- a/docs/_posts/2023-09-09-3766.md
+++ b/docs/_posts/2023-09-09-3766.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3766
-permalink: patches/3766
+permalink: changelog/3766
 ---
 
 # Game version 3766 (9th of September, 2023)

--- a/docs/_posts/2023-09-17-3767.md
+++ b/docs/_posts/2023-09-17-3767.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3767
-permalink: patches/3767
+permalink: changelog/3767
 ---
 
 # Game version 3767 (17th of September, 2023)

--- a/docs/_posts/2023-09-17-3768.md
+++ b/docs/_posts/2023-09-17-3768.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3768
-permalink: patches/3768
+permalink: changelog/3768
 ---
 
 # Game version 3768 (17th of September, 2023)

--- a/docs/_posts/2023-09-24-3769.md
+++ b/docs/_posts/2023-09-24-3769.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3769
-permalink: patches/3769
+permalink: changelog/3769
 ---
 
 

--- a/docs/_posts/2023-10-29-3771.md
+++ b/docs/_posts/2023-10-29-3771.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3771
-permalink: patches/3771
+permalink: changelog/3771
 ---
 
 # Game version 3771 (29th of October, 2023)

--- a/docs/_posts/2023-11-02-3772.md
+++ b/docs/_posts/2023-11-02-3772.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3772
-permalink: patches/3772
+permalink: changelog/3772
 ---
 
 # Game version 3772 (2th of November, 2023)

--- a/docs/_posts/2023-11-02-3773.md
+++ b/docs/_posts/2023-11-02-3773.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3773
-permalink: patches/3773
+permalink: changelog/3773
 ---
 
 # Game version 3773 (2th of November, 2023)

--- a/docs/_posts/2023-11-15-3774.md
+++ b/docs/_posts/2023-11-15-3774.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3774
-permalink: patches/3774
+permalink: changelog/3774
 ---
 
 # Game version 3774 (15th of November, 2023)

--- a/docs/_posts/2023-11-19-3775.md
+++ b/docs/_posts/2023-11-19-3775.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3775
-permalink: patches/3775
+permalink: changelog/3775
 ---
 
 # Game version 3775 (19th of November, 2023)

--- a/docs/_posts/2023-11-30-3776.md
+++ b/docs/_posts/2023-11-30-3776.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3776
-permalink: patches/3776
+permalink: changelog/3776
 ---
 
 # Game version 3776 (30th of November, 2023)

--- a/docs/_posts/2023-12-24-3777.md
+++ b/docs/_posts/2023-12-24-3777.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3777
-permalink: patches/3777
+permalink: changelog/3777
 ---
 
 # Game version 3777 (24th of December, 2023)

--- a/docs/_posts/2023-12-31-3778.md
+++ b/docs/_posts/2023-12-31-3778.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3778
-permalink: patches/3778
+permalink: changelog/3778
 ---
 
 # Game Version 3778 (31th of December, 2023)

--- a/docs/_posts/2024-01-22-3779.md
+++ b/docs/_posts/2024-01-22-3779.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3779
-permalink: patches/3779
+permalink: changelog/3779
 ---
 
 # Game Version 3779 (21th of January, 2024)

--- a/docs/_posts/2024-01-26-3780.md
+++ b/docs/_posts/2024-01-26-3780.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3780
-permalink: patches/3780
+permalink: changelog/3780
 ---
 
 # Game Version 3780 (26th of January, 2024)

--- a/docs/_posts/2024-01-26-3781.md
+++ b/docs/_posts/2024-01-26-3781.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3781
-permalink: patches/3781
+permalink: changelog/3781
 ---
 
 ## Bug Fixes

--- a/docs/_posts/2024-03-16-3801.md
+++ b/docs/_posts/2024-03-16-3801.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3801
-permalink: patches/3801
+permalink: changelog/3801
 ---
 
 # Game Version 3801 (16th of March, 2024)

--- a/docs/_posts/2024-03-17-3802.md
+++ b/docs/_posts/2024-03-17-3802.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3802
-permalink: patches/3802
+permalink: changelog/3802
 ---
 
 # Game Version 3802

--- a/docs/_posts/2024-03-17-3803.md
+++ b/docs/_posts/2024-03-17-3803.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3803
-permalink: patches/3803
+permalink: changelog/3803
 ---
 
 # Game Version 3803

--- a/docs/_posts/2024-03-24-3804.md
+++ b/docs/_posts/2024-03-24-3804.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3804
-permalink: patches/3804
+permalink: changelog/3804
 ---
 
 # Game Version 3804

--- a/docs/_posts/2024-03-24-3805.md
+++ b/docs/_posts/2024-03-24-3805.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3805
-permalink: patches/3805
+permalink: changelog/3805
 ---
 
 # Game Version 3805

--- a/docs/_posts/2024-03-31-3806.md
+++ b/docs/_posts/2024-03-31-3806.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3806
-permalink: patches/3806
+permalink: changelog/3806
 ---
 
 # Game Version 3806

--- a/docs/_posts/2024-04-03-3807.md
+++ b/docs/_posts/2024-04-03-3807.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3807
-permalink: patches/3807
+permalink: changelog/3807
 ---
 
 # Game Version 3807

--- a/docs/_posts/2024-04-07-3808.md
+++ b/docs/_posts/2024-04-07-3808.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3808
-permalink: patches/3808
+permalink: changelog/3808
 ---
 
 # Game Version 3808

--- a/docs/_posts/2024-04-20-3809.md
+++ b/docs/_posts/2024-04-20-3809.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3809
-permalink: patches/3809
+permalink: changelog/3809
 ---
 
 # Game Version 3809

--- a/docs/_posts/2024-07-07-3810.md
+++ b/docs/_posts/2024-07-07-3810.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3810
-permalink: patches/3810
+permalink: changelog/3810
 ---
 
 # Game Version 3810

--- a/docs/_posts/2024-08-03-3811.md
+++ b/docs/_posts/2024-08-03-3811.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3811
-permalink: patches/3811
+permalink: changelog/3811
 ---
 
 # Game version 3811 (3th of August, 2024)

--- a/docs/_posts/2024-08-11-3812.md
+++ b/docs/_posts/2024-08-11-3812.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Game version 3812
-permalink: patches/3812
+permalink: changelog/3812
 ---
 
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,8 @@
 ---
 layout: page
-title: Patches
+title: Changelogs
 has_children: true
-permalink: /patches
+permalink: /changelog
 nav_order: 8
 ---
 
@@ -12,10 +12,10 @@ nav_order: 8
 
 <ul>
   <li>
-    <a class="preview-title" href="{{ 'patches/fafbeta' | relative_url }}">FAF Beta Balance</a>
+    <a class="preview-title" href="{{ 'changelog/fafbeta' | relative_url }}">FAF Beta Balance</a>
   </li>
   <li>
-    <a class="preview-title" href="{{ 'patches/fafdevelop' | relative_url }}">FAF Develop</a>
+    <a class="preview-title" href="{{ 'changelog/fafdevelop' | relative_url }}">FAF Develop</a>
   </li>
 </ul>
 

--- a/docs/changelog/fafbeta.md
+++ b/docs/changelog/fafbeta.md
@@ -1,11 +1,12 @@
 ---
 layout: page
-title: FAF Develop
-permalink: patches/fafdevelop
-nav_order: 2
+title: FAF Beta Balance
+permalink: changelog/fafbeta
+nav_order: 1
 parent: Patches
 ---
 
 <!--
     This is a template, content is appended automatically based on changelog snippets.
 -->
+

--- a/docs/changelog/fafdevelop.md
+++ b/docs/changelog/fafdevelop.md
@@ -1,12 +1,11 @@
 ---
 layout: page
-title: FAF Beta Balance
-permalink: patches/fafbeta
-nav_order: 1
+title: FAF Develop
+permalink: changelog/fafdevelop
+nav_order: 2
 parent: Patches
 ---
 
 <!--
     This is a template, content is appended automatically based on changelog snippets.
 -->
-

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,7 +44,7 @@ You can continue the deployment steps but you can not finalize it until the serv
 ---
 layout: post
 title: Game version 3811
-permalink: patches/3811
+permalink: changelog/3811
 ---
 ```
 

--- a/docs/development-changelog.md
+++ b/docs/development-changelog.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Development - Changelog
-permalink: changelog
+permalink: development/changelog
 has_children: true
 nav_order: 5
 ---

--- a/docs/development-changelog/balance-snippet.md
+++ b/docs/development-changelog/balance-snippet.md
@@ -2,7 +2,7 @@
 layout: page
 title: Balance snippet
 parent: Development - Changelog
-permalink: changelog/balance-snippet
+permalink: development/changelog/balance-snippet
 published: true
 ---
 

--- a/docs/development-changelog/other-snippet.md
+++ b/docs/development-changelog/other-snippet.md
@@ -2,7 +2,7 @@
 layout: page
 title: Other snippets
 parent: Development - Changelog
-permalink: changelog/other-snippet
+permalink: development/changelog/other-snippet
 published: true
 ---
 


### PR DESCRIPTION
## Description of the proposed changes

As discussed on [Discord](https://discord.com/channels/197033481883222026/984529346498813992/1267870676732219455), updates the url from `patches` to `changelog` for all changelogs.

