### PR TITLE
Redundancies to avoid lua errors

### DIFF
--- a/changelog/snippets/fix.6413.md
+++ b/changelog/snippets/fix.6413.md
@@ -1,0 +1,1 @@
+(#6613) Fixed a couple of error messages that would appear when a projectile and a unit were destroyed

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -411,7 +411,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
     ---@param self DefaultProjectileWeapon
     EconomyDrainThread = function(self)
         WaitFor(self.EconDrain)
-        if self.unit.BeenDestroyed and not(self.unit:BeenDestroyed()) then
+        if self.unit and not(IsDestroyed(self.unit)) then
             RemoveEconomyEvent(self.unit, self.EconDrain)
         end
         self.EconDrain = nil

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -411,7 +411,9 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
     ---@param self DefaultProjectileWeapon
     EconomyDrainThread = function(self)
         WaitFor(self.EconDrain)
-        RemoveEconomyEvent(self.unit, self.EconDrain)
+        if not(self:BeenDestroyed()) then
+            RemoveEconomyEvent(self.unit, self.EconDrain)
+        end
         self.EconDrain = nil
     end,
 

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -411,7 +411,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
     ---@param self DefaultProjectileWeapon
     EconomyDrainThread = function(self)
         WaitFor(self.EconDrain)
-        if not(self:BeenDestroyed()) then
+        if self.unit.BeenDestroyed and not(self.unit:BeenDestroyed()) then
             RemoveEconomyEvent(self.unit, self.EconDrain)
         end
         self.EconDrain = nil

--- a/units/XAB3301/XAB3301_script.lua
+++ b/units/XAB3301/XAB3301_script.lua
@@ -47,11 +47,12 @@ XAB3301 = ClassUnit( AStructureUnit ) {
             end
 
             if not self.ScryEnabled then
-                self.ScryEnabled = true 
-                
-                self.Animator:SetRate(1)
-                self.RotatorBot:SetTargetSpeed(12)
-                self.RotatorTop:SetTargetSpeed(-8)
+                self.ScryEnabled = true
+                if self.Animator.SetRate then self.Animator:SetRate(1) end
+                if self.RotatorBot.SetTargetSpeed then
+                    self.RotatorBot:SetTargetSpeed(12)
+                    self.RotatorTop:SetTargetSpeed(-8)
+                end
 
                 for k, v in AQuantumGateAmbient do
                     self.TrashAmbientEffects:Add(CreateAttachedEmitter(self, 'spin02', self.Army, v):ScaleEmitter(0.6))

--- a/units/XAB3301/XAB3301_script.lua
+++ b/units/XAB3301/XAB3301_script.lua
@@ -36,6 +36,7 @@ XAB3301 = ClassUnit( AStructureUnit ) {
     end,
 
     CreateVisibleEntity = function(self)
+        if not(self.GetFractionComplete) or self:GetFractionComplete() < 1 then return nil end
         AStructureUnit.CreateVisibleEntity(self)
 
         if self.RemoteViewingData.VisibleLocation and self.RemoteViewingData.DisableCounter == 0 and self.RemoteViewingData.IntelButton then


### PR DESCRIPTION
This fixes two lua errors I received in a desynced replay (was an AI vs AI game I was testing offline hence no replay ID to refer to).

The first was:
WARNING: Error running lua script: ...\gamedata\units.nx2\units\xab3301\xab3301_script.lua(52): attempt to call method `SetRate' (a nil value)
         stack traceback:
         	...\gamedata\units.nx2\units\xab3301\xab3301_script.lua(52): in function `CreateVisibleEntity'
         	...ata\faforever\gamedata\lua.nx2\lua\remoteviewing.lua(57): in function <...ata\faforever\gamedata\lua.nx2\lua\remoteviewing.lua:49>

I've therefore added a check to make sure that the method SetRate isn't called if it doesn't exist (and for completeness have done the same with the following lines calling a separate method SetTargetSpeed)

The second error was:
WARNING: Error running lua script: ...ithub\fa\lua\sim\weapons\defaultprojectileweapon.lua(414): Game object has been destroyed
         stack traceback:
         	[C]: in function `RemoveEconomyEvent'
         	...ithub\fa\lua\sim\weapons\defaultprojectileweapon.lua(414): in function <...ithub\fa\lua\sim\weapons\defaultprojectileweapon.lua:412>

For this, I added a check if the object in question returned true for IsDestroyed() before going on to call RemoveEconomyEvent.

Re-running the replay with these changes, neither error appeared (and no other 'error running lua script' messages appeared either).