### PR TITLE
Make Ahwassa bomb ignore ASF collisions

### DIFF
--- a/changelog/snippets/balance.6415.md
+++ b/changelog/snippets/balance.6415.md
@@ -1,0 +1,1 @@
+- (#6415) Make Ahwassa's bomb ignore collisions with ASF, same as strategic bombers.

--- a/projectiles/SBOOhwalliStrategicBomb01/SBOOhwalliStrategicBomb01_proj.bp
+++ b/projectiles/SBOOhwalliStrategicBomb01/SBOOhwalliStrategicBomb01_proj.bp
@@ -5,6 +5,7 @@ ProjectileBlueprint{
         ImpactWater   = Sound { Bank = 'XSA_Destroy', Cue = 'XSA_Strag_Bomb_Explosion', LodCutoff = 'Weapon_LodCutoff' },
     },
     Categories = {
+        "IGNOREASFONCOLLISION",
         "INDIRECTFIRE",
         "PROJECTILE",
         "SERAPHIM",


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Adds the category used on strat bombs to Ahwassa's bomb so it ignores collisions with ASF.

## Reasoning for the changes
Strat bombers already set a precedent for ASF not being able to block bomber snipes, due to the bombers frequently having a one-opportunity type of situation where every bomb matters and can decide the game. Being able to block an even larger and more impactful Ahwassa bomb makes no sense with this precedent, both balance-wise and aesthetically. Ahwassa also doesn't get any meaningful reward for doing so due to the old 10% damage vs ASF armor and the newer explosion delay.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Flying a bunch of ASF under the ahwassa when it bombs doesn't explode the bomb prematurely.

## Checklist
- [x] Changes are documented in the changelog for the next game version
