### PR TITLE
Fix Salvation fire rate not being reduced when missing T1 pgens

### DIFF
--- a/changelog/snippets/fix.6416.md
+++ b/changelog/snippets/fix.6416.md
@@ -1,0 +1,1 @@
+- (#6416) Fix Salvation's reload time not increasing from 2.5 to 2.6 when missing T1 power generator adjacency and only having T3 power generators.

--- a/lua/sim/AdjacencyBuffs.lua
+++ b/lua/sim/AdjacencyBuffs.lua
@@ -218,7 +218,7 @@ local adj = {           -- SIZE4     SIZE8   SIZE12    SIZE16   SIZE20
         EnergyActive=       {-0.1875, -0.1875,  -0.1875, -0.1562,  -0.05},
         EnergyMaintenance=  {-0.1875, -0.1875,  -0.1875, -0.1875,  -0.1875},
         EnergyWeapon=       {-0.075,  -0.075,   -0.075,  -0.075,   -0.075},
-        RateOfFire=         {-0.1,    -0.1,     -0.1,    -0.1,     -0.045},
+        RateOfFire=         {-0.1,    -0.1,     -0.1,    -0.1,     -0.040},
     },
     T1MassExtractor={
         MassActive=         {-0.1, -0.05, -0.0333, -0.075, -0.075},


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes a [Discord bug report](https://discord.com/channels/197033481883222026/1265682067874775071) where Salvation fire rate wasn't decreased when T1 pgens were not present. This was caused by the fire rate being increased from `0.31` to `10/31` (which equals `0.323`).

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spawn 2 salvations, one with full adjacency and one with only t3 pgen adjacency. Hold fire, target ground, then pause, enable firing, and then confirm that the salvation with t1 pgens fires after 25 ticks stepped, and the one without pgens after 26 ticks.

## Checklist
- [x] Changes are documented in the changelog for the next game version
