### PR TITLE
Reduce T2 amphibious tank vision

### DIFF
--- a/changelog/snippets/balance.6417.md
+++ b/changelog/snippets/balance.6417.md
@@ -1,0 +1,4 @@
+- (#6417) Reduce T2 Amphibious Tank vision by 2 to give them a weapon range disadvantage of 2 when behind enemy lines and lacking intel, similar to T2 land tanks. Riptide is an exception, as it already has a short 18 vision/weapon range.
+    - Blaze: Vision radius 24 -> 22
+    - Yenzyne: Vision radius 20 -> 18
+    - Wagner: Vision radius 22 -> 20

--- a/units/UEL0203/UEL0203_unit.bp
+++ b/units/UEL0203/UEL0203_unit.bp
@@ -143,9 +143,7 @@ UnitBlueprint{
         Icon = "amph",
         UnitName = "<LOC uel0203_name>Riptide",
     },
-    Intel = { 
-        VisionRadius = 18,
-    },
+    Intel = { VisionRadius = 18 },
     LifeBarHeight = 0.075,
     LifeBarOffset = 0.4,
     LifeBarSize = 0.75,

--- a/units/UEL0203/UEL0203_unit.bp
+++ b/units/UEL0203/UEL0203_unit.bp
@@ -143,7 +143,9 @@ UnitBlueprint{
         Icon = "amph",
         UnitName = "<LOC uel0203_name>Riptide",
     },
-    Intel = { VisionRadius = 18 },
+    Intel = { 
+        VisionRadius = 18,
+    },
     LifeBarHeight = 0.075,
     LifeBarOffset = 0.4,
     LifeBarSize = 0.75,

--- a/units/URL0203/URL0203_unit.bp
+++ b/units/URL0203/URL0203_unit.bp
@@ -109,7 +109,7 @@ UnitBlueprint{
     },
     Intel = {
         VisionRadius = 20,
-        WaterVisionRadius = 18,
+        WaterVisionRadius = 20,
     },
     LifeBarHeight = 0.075,
     LifeBarOffset = 0.3,

--- a/units/URL0203/URL0203_unit.bp
+++ b/units/URL0203/URL0203_unit.bp
@@ -108,8 +108,8 @@ UnitBlueprint{
         UnitName = "<LOC url0203_name>Wagner",
     },
     Intel = {
-        VisionRadius = 22,
-        WaterVisionRadius = 20,
+        VisionRadius = 20,
+        WaterVisionRadius = 18,
     },
     LifeBarHeight = 0.075,
     LifeBarOffset = 0.3,

--- a/units/XAL0203/XAL0203_unit.bp
+++ b/units/XAL0203/XAL0203_unit.bp
@@ -131,7 +131,7 @@ UnitBlueprint{
         Icon = "amph",
         UnitName = "<LOC xal0203_name>Blaze",
     },
-    Intel = { VisionRadius = 24 },
+    Intel = { VisionRadius = 22 },
     LifeBarHeight = 0.075,
     LifeBarOffset = 0.6,
     LifeBarSize = 0.8,

--- a/units/XSL0203/XSL0203_unit.bp
+++ b/units/XSL0203/XSL0203_unit.bp
@@ -136,7 +136,7 @@ UnitBlueprint{
         Icon = "amph",
         UnitName = "<LOC xsl0203_name>Yenzyne",
     },
-    Intel = { VisionRadius = 20 },
+    Intel = { VisionRadius = 18 },
     LifeBarHeight = 0.075,
     LifeBarOffset = 0.4,
     LifeBarSize = 0.75,


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Continuation of #6358 (the repo is archived so it can no longer be merged/updated).
Implements the changes proposed on [Discord](https://discord.com/channels/197033481883222026/1262834398818996285) by balance team.
Reduces vision of amphibious T2 tanks to 2 less than their main weapon range in a similar fashion to T2 land tanks. Riptide doesn't get a 2 vision reduction as it already has a short 18 weapon and vision range.

This nerfs hover's ability to fight behind enemy lines with no intel, which is especially powerful with Blaze currently.

## Checklist
- [x] Changes are documented in the changelog for the next game version
