### PR TITLE
Add structure armor resistances to TMD armor

### DIFF
--- a/changelog/snippets/fix.6418.md
+++ b/changelog/snippets/fix.6418.md
@@ -1,0 +1,1 @@
+- (#6418) Fix ACU explosions being able to kill TMD structures.

--- a/lua/armordefinition.lua
+++ b/lua/armordefinition.lua
@@ -113,6 +113,8 @@ armordefinition = {
 
         -- Armor Definition
         'Normal 1.0',
+        'Overcharge 0.25',
+        'Deathnuke 0.032',
         'TacticalMissile 0.55',
     },
 }


### PR DESCRIPTION
Deathnuke and Overcharge
OC armor doesn't do anything with FAF's OC, but it's good to have for consistency

<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes #6362.
Adds the `Overcharge` and `Deathnuke` resistances to TMD armor, as they are also structures.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
ACU no longer blows up TMD, and deals 80 damage instead.
FAF's OC overrides any damage dealt with the structure damage blueprint property, so it cannot be tested.

## Checklist
- [x] Changes are documented in the changelog for the next game version
