### PR TITLE
Add nil check for GuardScanRadius in build range overlay

### DIFF
--- a/changelog/snippets/fix.6419.md
+++ b/changelog/snippets/fix.6419.md
@@ -1,0 +1,1 @@
+- (#6419) Fix engineer stations without a `GuardScanRadius` defaulting to 300 radius for their build range overlay. They now display their full build range in the radius for better compatibility with the reclaim tower mods, even though `GuardScanRadius` defaults to 25.

--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -235,10 +235,10 @@ local function PostProcessUnit(unit)
         -- Engine allows building +2 range outside the max distance (or even more for large buildings)
         local overlayRadius = (unit.Economy.MaxBuildDistance or 5) + 2
 
-        -- Display auto-assist range for engineer stations instead of max build distance if it is smaller
+        -- Display auto-assist range for engineer stations instead of max build distance if it is smaller and exists
         if unit.CategoriesHash['ENGINEERSTATION'] then
             local guardScanRadius = unit.AI.GuardScanRadius
-            if guardScanRadius < overlayRadius then
+            if guardScanRadius and guardScanRadius < overlayRadius then
                 overlayRadius = guardScanRadius
             end
         end


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
The reclaim tower mod adds a unit with the engineer station category and behavior based on its build range but does not specify a guard scan radius. Although guard scan radius defaults to 25, it seems that engineer station mods write in their guard scan radius just like base game engineer stations, so displaying the true build range instead of the assist range when the stat is missing seems to be better for compatibility with the reclaim tower mods without affecting engi station mods.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Used the Reclaim Tower mod and checked that air staging radius equals max build distance in the blueprint viewer.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
