### PR TITLE
Fix GC claw aim being disrupted by walking

### DIFF
--- a/changelog/snippets/fix.6429.md
+++ b/changelog/snippets/fix.6429.md
@@ -1,0 +1,1 @@
+- (#6429) Fix the aim of the GC's claws being disrupted by the walking animation.

--- a/units/UAL0401/UAL0401_Script.lua
+++ b/units/UAL0401/UAL0401_Script.lua
@@ -41,8 +41,16 @@ UAL0401 = ClassUnit(AWalkingLandUnit) {
                 return projectile
             end,
         },
-        RightArmTractor = ClassWeapon(ADFTractorClaw) {},
-        LeftArmTractor = ClassWeapon(ADFTractorClaw) {},
+        RightArmTractor = ClassWeapon(ADFPhasonLaser) {
+            DisabledFiringBones = {
+                'Right_Arm_B02',
+            },
+        },
+        LeftArmTractor = ClassWeapon(ADFPhasonLaser) {
+            DisabledFiringBones = {
+                'Left_Arm_B02',
+            },
+        },
     },
 
     OnCreate = function(self, spec)

--- a/units/UAL0401/UAL0401_Script.lua
+++ b/units/UAL0401/UAL0401_Script.lua
@@ -41,12 +41,12 @@ UAL0401 = ClassUnit(AWalkingLandUnit) {
                 return projectile
             end,
         },
-        RightArmTractor = ClassWeapon(ADFPhasonLaser) {
+        RightArmTractor = ClassWeapon(ADFTractorClaw) {
             DisabledFiringBones = {
                 'Right_Arm_B02',
             },
         },
-        LeftArmTractor = ClassWeapon(ADFPhasonLaser) {
+        LeftArmTractor = ClassWeapon(ADFTractorClaw) {
             DisabledFiringBones = {
                 'Left_Arm_B02',
             },


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Issue
The claws' aim is being disrupted by the walk animation. That makes up a small amount of erratic movement for units that are being tractored, although that mainly comes from the claws just rotating while they have no target due to tractoring one at the moment. Here is the aim problem demonstrated with lasers:

https://github.com/user-attachments/assets/95662165-f350-4eca-96b3-faa12619816f



## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Disable the left/right `B02` bones from being animated while the tractor claws fire since they are the pitch bone of the tractor claws.
The bones are the elbows of the GC's arms:
![image](https://github.com/user-attachments/assets/c9f6a053-29bb-40c0-8a16-00aabf179535)

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
I tested with replacing the tractor claws with lasers and walking into an Othuum (claws wont fire at T4s), and making sure it doesn't start missing.

https://github.com/user-attachments/assets/08907f54-44dc-4a1f-b040-0dfb364864ce


## Additional context
<!-- Add any other context about the pull request here. -->
Unfortunately with how DisabledFiringBones works, it only works when walking into a target, and not when starting to walk while having a target.


## Checklist
- [x] Changes are documented in the changelog for the next game version
