### PR TITLE
Fix an OnImpact error for CZAR depth charges

### DIFF
--- a/changelog/snippets/fix.6430.md
+++ b/changelog/snippets/fix.6430.md
@@ -1,0 +1,1 @@
+- (#6430) Fix an `OnImpact` error caused by CZAR's depth charges.

--- a/projectiles/AANDepthCharge01/AANDepthCharge01_script.lua
+++ b/projectiles/AANDepthCharge01/AANDepthCharge01_script.lua
@@ -75,6 +75,7 @@ AANDepthCharge01 = ClassProjectile(ADepthChargeProjectile) {
 
     ---@param self AANDepthCharge01
     OnImpact = function(self, TargetType, TargetEntity)
+        self.HasImpacted = true
         local px, _, pz = self:GetPositionXYZ()
         local marker = VisionMarkerOpti({ Owner = self })
         marker:UpdatePosition(px, pz)


### PR DESCRIPTION
## Issue
The `HasImpacted = true` line was not added back in during the refactor in #4517.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Add back the line.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
The CZAR no longer gives errors after hitting an underwater unit with the depth charges.

## Checklist
- [x] Changes are documented in the changelog for the next game version
