### PR TITLE
Add water vision to CZAR depth charge on impact

### DIFF
--- a/changelog/snippets/other.6431.md
+++ b/changelog/snippets/other.6431.md
@@ -1,0 +1,1 @@
+- (#6431) Make CZAR depth charges give underwater vision on impact alongside the normal vision they give.

--- a/projectiles/AANDepthCharge01/AANDepthCharge01_script.lua
+++ b/projectiles/AANDepthCharge01/AANDepthCharge01_script.lua
@@ -80,6 +80,7 @@ AANDepthCharge01 = ClassProjectile(ADepthChargeProjectile) {
         marker:UpdatePosition(px, pz)
         marker:UpdateDuration(5)
         marker:UpdateIntel(self.Army, 5, 'Vision', true)
+        marker:UpdateIntel(self.Army, 5, 'WaterVision', true)
         ADepthChargeProjectileOnImpact(self, TargetType, TargetEntity)
     end,
 }


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Adds water vision to CZAR's depth charge on impact so that it makes sense alongside the normal vision it gives on impact.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Underwater units get revealed when hit by the depth charge.

## Checklist
- [x] Changes are documented in the changelog for the next game version
