### PR TITLE
Fix error when full share transfers units to a dead player

### DIFF
--- a/changelog/snippets/fix.6432.md
+++ b/changelog/snippets/fix.6432.md
@@ -1,0 +1,1 @@
+- (#6432) Fix units failing to transfer after defeat if the player that is being transferred to is defeated during the transfer process.

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -808,10 +808,10 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
                 for _, brain in brains do
                     local units = self:GetListOfUnits(cat, false)
                     if units and units[1] then
-                        local givenUnitCount = table.getn(TransferUnitsOwnership(units, brain.index) or {})
+                        local givenUnits = TransferUnitsOwnership(units, brain.index)
 
                         -- only show message when we actually gift that player some units
-                        if givenUnitCount > 0 then
+                        if not table.empty(givenUnits) then
                             Sync.ArmyTransfer = { {
                                 from = army,
                                 to = brain.index,

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -495,10 +495,10 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
                             units = self:GetListOfUnits(categories.ALLUNITS - categories.WALL - categories.COMMAND, false)
                         end
                         if units and not table.empty(units) then
-                            local givenUnitCount = table.getn(TransferUnitsOwnership(units, brain.index) or {})
+                            local givenUnits = TransferUnitsOwnership(units, brain.index)
 
                             -- only show message when we actually gift that player some units
-                            if givenUnitCount > 0 then
+                            if givenUnits and next(givenUnits) then
                                 Sync.ArmyTransfer = { { from = selfIndex, to = brain.index, reason = "fullshare" } }
                             end
 

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -498,7 +498,7 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
                             local givenUnits = TransferUnitsOwnership(units, brain.index)
 
                             -- only show message when we actually gift that player some units
-                            if givenUnits and next(givenUnits) then
+                            if not table.empty(givenUnits) then
                                 Sync.ArmyTransfer = { { from = selfIndex, to = brain.index, reason = "fullshare" } }
                             end
 

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -495,7 +495,7 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
                             units = self:GetListOfUnits(categories.ALLUNITS - categories.WALL - categories.COMMAND, false)
                         end
                         if units and not table.empty(units) then
-                            local givenUnitCount = table.getn(TransferUnitsOwnership(units, brain.index))
+                            local givenUnitCount = table.getn(TransferUnitsOwnership(units, brain.index) or {})
 
                             -- only show message when we actually gift that player some units
                             if givenUnitCount > 0 then
@@ -808,7 +808,7 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
                 for _, brain in brains do
                     local units = self:GetListOfUnits(cat, false)
                     if units and units[1] then
-                        local givenUnitCount = table.getn(TransferUnitsOwnership(units, brain.index))
+                        local givenUnitCount = table.getn(TransferUnitsOwnership(units, brain.index) or {})
 
                         -- only show message when we actually gift that player some units
                         if givenUnitCount > 0 then


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Issue
Reported on [Discord](https://discord.com/channels/197033481883222026/1277749416878669925). Replay [23190625](https://replay.faforever.com/23190625).
```
WARNING: Error running lua script: ...aforever\replaydata\gamedata\lua.nx2\lua\aibrain.lua(498): bad argument #1 to `getn' (table expected, got no value)
         stack traceback:
         	[C]: in function `getn'
         	...aforever\replaydata\gamedata\lua.nx2\lua\aibrain.lua(498): in function <...aforever\replaydata\gamedata\lua.nx2\lua\aibrain.lua:479>
         	...aforever\replaydata\gamedata\lua.nx2\lua\aibrain.lua(526): in function `TransferUnitsToHighestBrain'
         	...aforever\replaydata\gamedata\lua.nx2\lua\aibrain.lua(608): in function <...aforever\replaydata\gamedata\lua.nx2\lua\aibrain.lua:440>
```
The game tried to transfer units to a defeated player which causes the `TransferUnitsOwnership` function to return nil, and `TransferUnitsToBrain` didn't handle this case before putting the results into `table.getn`.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Add a guard so that it puts an empty table into `getn` if the result is nil.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Running the replay again with the changes properly transfers the units after the player dies.
To run the replay with changes from your local repo, load the replay from the FAF client to unpack it, and then run the console command: 
```
UI_Lua LaunchReplaySession('C:/ProgramData/FAForever/data/cache/temp.SCFAReplay')
```

## Checklist
- [x] Changes are annotated, including comments where useful
  - The `TransferUnitsOwnership` function has a proper return value of `Unit[]?`
- [x] Changes are documented in the changelog for the next game version
