### PR TITLE
Add `OVERLAYINDIRECTFIRE` to Aeon destroyer so depth charge's range ring appears

### DIFF
--- a/changelog/snippets/fix.6433.md
+++ b/changelog/snippets/fix.6433.md
@@ -1,0 +1,1 @@
+- (#6433) Fix Aeon destroyer's depth charge's indirect fire range ring not appearing.

--- a/units/UAS0201/UAS0201_unit.bp
+++ b/units/UAS0201/UAS0201_unit.bp
@@ -24,6 +24,7 @@ UnitBlueprint{
         "OVERLAYANTINAVY",
         "OVERLAYDEFENSE",
         "OVERLAYDIRECTFIRE",
+        "OVERLAYINDIRECTFIRE",
         "OVERLAYRADAR",
         "OVERLAYSONAR",
         "PRODUCTSC1",


### PR DESCRIPTION
## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Add the necessary category for the range ring to show up normally (without UI mods).

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spawn a destro and make sure the ring exists.
![image](https://github.com/user-attachments/assets/09474f99-182b-4809-abb3-b8b3502e7f23)

## Additional Context
#3438 changed depth charge's range category to indirect fire.

## Checklist
- [x] Changes are documented in the changelog for the next game version
