### PR TITLE
Update SimHooks.lua to fix BREW LAN crashing

### DIFF
--- a/lua/SimHooks.lua
+++ b/lua/SimHooks.lua
@@ -8,7 +8,14 @@ end
 do
     -- upvalue for performance
     local EntityCategoryFilterDown = EntityCategoryFilterDown
-    local CategoriesNoDummyUnits = categories.ALLUNITS - categories.DUMMYUNIT
+    local CategoriesNoDummyUnits
+
+    -- Check if categories.ALLUNITS and categories.DUMMYUNIT exist
+    if categories and categories.ALLUNITS and categories.DUMMYUNIT then
+        CategoriesNoDummyUnits = categories.ALLUNITS - categories.DUMMYUNIT
+    else
+        CategoriesNoDummyUnits = categories.ALLUNITS or categories.DUMMYUNIT or categories.UNITCATEGORY
+    end
 
     --- Retrieves all units in a rectangle, Excludes dummy units, such as the Cybran Build Drone, by default.
     -- @param rectangle The rectangle to look for units in {x0, z0, x1, z1}.
@@ -21,7 +28,6 @@ do
     -- @return nil if none found or a table.
     local oldGetUnitsInRect = _G.GetUnitsInRect
     _G.GetUnitsInRect = function(rtlx, tlz, brx, brz)
-
         -- try and retrieve units
         local units
         if brx then


### PR DESCRIPTION
Hey FAF Team. The last patch to simhooks lua I believe broke it. when loading the game the loading screen just loops endlessly. The log is attached below: 
[game_23284188.log](https://github.com/user-attachments/files/16938915/game_23284188.log)

Fix: Handle nil categories in SimHooks.lua
This commit adds a check for the existence of categories.ALLUNITS and categories.DUMMYUNIT before performing arithmetic operations. If either is nil, it falls back to using ALLUNITS, DUMMYUNIT, or UNITCATEGORY, preventing the 'attempt to perform arithmetic on field ALLUNITS (a nil value)' error. This fixes a bug with Brew LAN

I was not able to test this change. I hope this will fix it, though my lua is not that great. Just know it was generated with the help claude 3.5 sonnet LLM model. 