### PR TITLE
Fix the "assist to upgrade" and "assist to unpause" settings conflicting and not pausing upgraded units during lag

### DIFF
--- a/changelog/snippets/fix.6446.md
+++ b/changelog/snippets/fix.6446.md
@@ -1,0 +1,1 @@
+- (#6446) Fix the "assist to upgrade" and "assist to unpause" game options conflicting and causing upgrading units to unpause during lag spikes.

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -449,7 +449,7 @@ local function OnGuardUnpause(guardees, target)
                                         target.ThreadUnpauseCandidates = nil
                                         target.ThreadUnpause = nil
                                         SetPaused({ target }, false)
-                                        break
+                                        return
                                     end
                                     -- engineer is idle, died, we switch armies, ...
                                 else
@@ -459,7 +459,7 @@ local function OnGuardUnpause(guardees, target)
                         else
                             target.ThreadUnpauseCandidates = nil
                             target.ThreadUnpause = nil
-                            break
+                            return
                         end
 
                         WaitSeconds(1.0)

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -338,12 +338,14 @@ local function UpgradeUnit(unit)
 
     -- paused units do not start upgrades
     if GetIsPaused(units) then
+        WARN('Paused the unit: ', unit, GameTick(), debug.getinfo(1, 'l')['currentline'])
         SetPaused(units, false)
         WaitTicks(5)
     end
 
     -- check if unit still exists
     if IsDestroyed(unit) then
+        WARN('Unit DESTROYED: ', unit, GameTick(), debug.getinfo(1, 'l')['currentline'])
         return
     end
 
@@ -360,8 +362,11 @@ local function UpgradeUnit(unit)
     -- pause it
     WaitTicks(5)
     if IsDestroyed(unit) then
+        WARN('Unit DESTROYED: ', unit, GameTick(), debug.getinfo(1, 'l')['currentline'])
         return
     end
+
+    WARN('Paused the unit: ', unit, GameTick(), debug.getinfo(1, 'l')['currentline'])
 
     SetPaused(units, true)
 end
@@ -435,6 +440,7 @@ local function OnGuardUnpause(guardees, target)
                                     if focus == target:GetFocus() then
                                         target.ThreadUnpauseCandidates = nil
                                         target.ThreadUnpause = nil
+                                        WARN('UNPaused the unit: ', engineer, GameTick(), debug.getinfo(1, 'l')['currentline'])
                                         SetPaused({ target }, false)
                                         break
                                     end

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -410,10 +410,21 @@ end
 ---@param target UserUnit
 local function OnGuardUnpause(guardees, target)
     local prefs = Prefs.GetFieldFromCurrentProfile('options').assist_to_unpause
-    if prefs == 'On' or
-        (
-        prefs == 'ExtractorsAndRadars' and
-            EntityCategoryContains((categories.MASSEXTRACTION + categories.RADAR) * categories.STRUCTURE, target))
+    local bp = __blueprints[target:GetUnitId()]
+    -- only create the unpause thread for units that have the ability to unpause
+    if  (
+            prefs == 'On' and 
+            (
+                EntityCategoryContains(categories.REPAIR + categories.FACTORY + categories.SILO, target)  -- REPAIR includes mantis and harbs, compared to ENGINEER category
+                or (bp.General.UpgradesTo and bp.General.UpgradesTo ~= '') -- upgradeables can also be assisted
+            )
+        )
+        or
+        (   
+            prefs == 'ExtractorsAndRadars'
+            and EntityCategoryContains((categories.MASSEXTRACTION + categories.RADAR) * categories.STRUCTURE, target) 
+            and (bp.General.UpgradesTo and bp.General.UpgradesTo ~= '') -- use `and` to make sure the mex/radar is upgradeable
+        )
     then
 
         -- start a single thread to keep track of when to unpause, logic feels a bit convoluted

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -338,14 +338,12 @@ local function UpgradeUnit(unit)
 
     -- paused units do not start upgrades
     if GetIsPaused(units) then
-        WARN('Paused the unit: ', unit, GameTick(), debug.getinfo(1, 'l')['currentline'])
         SetPaused(units, false)
         WaitTicks(5)
     end
 
     -- check if unit still exists
     if IsDestroyed(unit) then
-        WARN('Unit DESTROYED: ', unit, GameTick(), debug.getinfo(1, 'l')['currentline'])
         return
     end
 
@@ -362,11 +360,8 @@ local function UpgradeUnit(unit)
     -- pause it
     WaitTicks(5)
     if IsDestroyed(unit) then
-        WARN('Unit DESTROYED: ', unit, GameTick(), debug.getinfo(1, 'l')['currentline'])
         return
     end
-
-    WARN('Paused the unit: ', unit, GameTick(), debug.getinfo(1, 'l')['currentline'])
 
     SetPaused(units, true)
 end
@@ -442,7 +437,6 @@ local function OnGuardUnpause(guardees, target)
                                     if targetFocus and targetFocus == engineer:GetFocus() then
                                         target.ThreadUnpauseCandidates = nil
                                         target.ThreadUnpause = nil
-                                        WARN('UNPaused the unit: ', engineer, GameTick(), debug.getinfo(1, 'l')['currentline'])
                                         SetPaused({ target }, false)
                                         break
                                     end

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -436,8 +436,10 @@ local function OnGuardUnpause(guardees, target)
                             for id, _ in candidates do
                                 local engineer = GetUnitById(id)
                                 if engineer and not engineer:IsIdle() then
-                                    local focus = engineer:GetFocus()
-                                    if focus == target:GetFocus() then
+                                    -- ensure the target focus exists, since this thread may be targeted at something that is not building anything,
+                                    -- but might start to build something after some network delay, which you won't want to unpause due to `nil == nil`
+                                    local targetFocus = target:GetFocus()
+                                    if targetFocus and targetFocus == engineer:GetFocus() then
                                         target.ThreadUnpauseCandidates = nil
                                         target.ThreadUnpause = nil
                                         WARN('UNPaused the unit: ', engineer, GameTick(), debug.getinfo(1, 'l')['currentline'])

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -406,6 +406,44 @@ local function OnGuardUpgrade(guardees, unit)
     end
 end
 
+--- Thread to keep track of when to unpause, 
+--- logic is a bit convoluted but guarantees that we still have access to the user units as the game progresses
+---@param targetId EntityId
+local function UnpauseThread(targetId)
+    WaitTicks(10)
+    local target = GetUnitById(targetId)
+    while target do
+        local candidates = target.ThreadUnpauseCandidates
+        if (candidates and not table.empty(candidates)) then
+            for id, _ in candidates do
+                local engineer = GetUnitById(id)
+                -- check if it is idle instead of its guarded entity to allow queuing orders before the assist command
+                if engineer and not engineer:IsIdle() then
+                    -- ensure the target focus exists, since this thread may be targeted at something that is not building anything,
+                    -- but might start to build something after some network delay, which you won't want to unpause due to `nil == nil`
+                    local targetFocus = target:GetFocus()
+                    if targetFocus and targetFocus == engineer:GetFocus() then
+                        target.ThreadUnpauseCandidates = nil
+                        target.ThreadUnpause = nil
+                        SetPaused({ target }, false)
+                        return
+                    end
+                else
+                    -- engineer is idle, died, we switch armies, ...
+                    candidates[id] = nil
+                end
+            end
+        else
+            target.ThreadUnpauseCandidates = nil
+            target.ThreadUnpause = nil
+            return
+        end
+
+        WaitTicks(10)
+        target = GetUnitById(targetId)
+    end
+end
+
 ---@param guardees UserUnit[]
 ---@param target UserUnit
 local function OnGuardUnpause(guardees, target)
@@ -426,53 +464,15 @@ local function OnGuardUnpause(guardees, target)
             and (bp.General.UpgradesTo and bp.General.UpgradesTo ~= '') -- use `and` to make sure the mex/radar is upgradeable
         )
     then
-
-        -- start a single thread to keep track of when to unpause, logic feels a bit convoluted
-        -- but that is purely to guarantee that we still have access to the user units as the
-        -- game progresses
-        if not target.ThreadUnpause then
-            local id = target:GetEntityId()
-            target.ThreadUnpause = ForkThread(
-                function()
-                    WaitSeconds(1.0)
-                    local target = GetUnitById(id)
-                    while target do
-                        local candidates = target.ThreadUnpauseCandidates
-                        if (candidates and not table.empty(candidates)) then
-                            for id, _ in candidates do
-                                local engineer = GetUnitById(id)
-                                if engineer and not engineer:IsIdle() then
-                                    -- ensure the target focus exists, since this thread may be targeted at something that is not building anything,
-                                    -- but might start to build something after some network delay, which you won't want to unpause due to `nil == nil`
-                                    local targetFocus = target:GetFocus()
-                                    if targetFocus and targetFocus == engineer:GetFocus() then
-                                        target.ThreadUnpauseCandidates = nil
-                                        target.ThreadUnpause = nil
-                                        SetPaused({ target }, false)
-                                        return
-                                    end
-                                    -- engineer is idle, died, we switch armies, ...
-                                else
-                                    candidates[id] = nil
-                                end
-                            end
-                        else
-                            target.ThreadUnpauseCandidates = nil
-                            target.ThreadUnpause = nil
-                            return
-                        end
-
-                        WaitSeconds(1.0)
-                        target = GetUnitById(id)
-                    end
-                end
-            )
-        end
-
-        -- add these to keep track
+        -- save the guardees' entity ids to keep track of in the unpause thread
         target.ThreadUnpauseCandidates = target.ThreadUnpauseCandidates or {}
         for k, guardee in guardees do
             target.ThreadUnpauseCandidates[guardee:GetEntityId()] = true
+        end
+
+        -- start a single thread to keep track of when to unpause
+        if not target.ThreadUnpause then
+            target.ThreadUnpause = ForkThread(UnpauseThread, target:GetEntityId())
         end
     end
 end

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -119,16 +119,16 @@ do
     -- The following hooks and/or overloads exist to assist moderators in evaluation faul play
 
     local invalidConsoleCommands = {
-    --     "net_MinResendDelay",
-    --     "net_SendDelay",
-    --     "net_ResendPingMultiplier",
-    --     "net_ResendDelayBias",
-    --     "net_CompressionMethod",
-    --     "net_MaxSendRate",
-    --     "net_MaxResendDelay",
-    --     "net_MaxBacklog",
-    --     "net_AckDelay",
-    --     "net_Lag",
+        "net_MinResendDelay",
+        "net_SendDelay",
+        "net_ResendPingMultiplier",
+        "net_ResendDelayBias",
+        "net_CompressionMethod",
+        "net_MaxSendRate",
+        "net_MaxResendDelay",
+        "net_MaxBacklog",
+        "net_AckDelay",
+        "net_Lag",
     }
 
     -- upvalue scope for security reasons

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -119,16 +119,16 @@ do
     -- The following hooks and/or overloads exist to assist moderators in evaluation faul play
 
     local invalidConsoleCommands = {
-        "net_MinResendDelay",
-        "net_SendDelay",
-        "net_ResendPingMultiplier",
-        "net_ResendDelayBias",
-        "net_CompressionMethod",
-        "net_MaxSendRate",
-        "net_MaxResendDelay",
-        "net_MaxBacklog",
-        "net_AckDelay",
-        "net_Lag",
+    --     "net_MinResendDelay",
+    --     "net_SendDelay",
+    --     "net_ResendPingMultiplier",
+    --     "net_ResendDelayBias",
+    --     "net_CompressionMethod",
+    --     "net_MaxSendRate",
+    --     "net_MaxResendDelay",
+    --     "net_MaxBacklog",
+    --     "net_AckDelay",
+    --     "net_Lag",
     }
 
     -- upvalue scope for security reasons


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Issue
Reported on [Discord](https://discord.com/channels/197033481883222026/408556023180296193/1283069284548870310). 

With sufficient lag, the unpause thread checks the upgrading unit's focus before "assist to upgrade"'s upgrade order gets through. This means the upgrading unit's focus is `nil`, same as the engineer's, so an unpause order is sent at the moment. This unpause order is processed after the upgrade and pause orders of "assist to upgrade", causing the unit to upgrade -> pause -> unpause.

Replicable easily by using `net_Lag 3000` in the console. Make sure to remove the guards in `userInit.lua` not allowing that command to work. Just assist a mass extractor with any engineer and that much lag. It will upgrade, pause, and unpause.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
- Check if the target focus is `nil` before comparing it to the engineer's. This fixes the unpausing.
Other style/performance changes:
- Don't create threads for units that don't have anything to unpause.
- immediately kill the unpausing thread when it finishes its work.
- Move the thread out of the function.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Assisting mexes with both options enabled and `net_Lag 3000` no longer unpauses them.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
