### PR TITLE
Initialize utils before repr in RuleInit

### DIFF
--- a/changelog/snippets/fix.6447.md
+++ b/changelog/snippets/fix.6447.md
@@ -1,0 +1,1 @@
+- (#6447) Fix `repr` causing an "attempt to call upval 'match' (a nil value)" error when used in the blueprint loading scripts.

--- a/lua/RuleInit.lua
+++ b/lua/RuleInit.lua
@@ -8,9 +8,9 @@
 __blueprints = {}
 
 doscript '/lua/system/config.lua'
+doscript '/lua/system/utils.lua'
 doscript '/lua/system/repr.lua'
 doscript '/lua/system/debug.lua'
-doscript '/lua/system/utils.lua'
 
 LOG('Active game mods for blueprint loading: ',repr(__active_mods))
 

--- a/lua/RuleInit.lua
+++ b/lua/RuleInit.lua
@@ -9,6 +9,7 @@ __blueprints = {}
 
 doscript '/lua/system/config.lua'
 doscript '/lua/system/utils.lua'
+-- repr depends on utils creating string.match
 doscript '/lua/system/repr.lua'
 doscript '/lua/system/debug.lua'
 

--- a/lua/globalInit.lua
+++ b/lua/globalInit.lua
@@ -17,6 +17,7 @@ doscript '/lua/system/config.lua'
 -- Load system modules
 doscript '/lua/system/import.lua'
 doscript '/lua/system/utils.lua'
+-- repr depends on utils creating string.match
 doscript '/lua/system/repr.lua'
 doscript '/lua/system/debug.lua'
 doscript '/lua/system/class.lua'


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Issue
`repr` cannot be used in `blueprints.lua` due to upvaluing `string.match` before it exists.
Reported on [Discord](https://discord.com/channels/197033481883222026/832710161847287819/1284328122103103578):
```
warning: Problem Blueprints Loading: modded files from "Endgame Prime" mod: /mods/endgameprime/effects/emitters/cybran_teleport_charge_01_emit.bp:
warning: ...mdata\faforever\gamedata\lua.nx5\lua\system\repr.lua(68): attempt to call upval match' (a nil value)
warning: stack traceback:
warning:         ...mdata\faforever\gamedata\lua.nx5\lua\system\repr.lua(68): in function <...mdata\faforever\gamedata\lua.nx5\lua\system\repr.lua:67>
warning:         ...mdata\faforever\gamedata\lua.nx5\lua\system\repr.lua(195): in function putValue'
warning:         ...mdata\faforever\gamedata\lua.nx5\lua\system\repr.lua(279): in function repr'
warning:         ...ata\faforever\gamedata\lua.nx5\lua\system\config.lua(54): in function <...ata\faforever\gamedata\lua.nx5\lua\system\config.lua:53>
warning:         ...e\effects\emitters\cybran_teleport_charge_01_emit.bp(7): in main chunk
warning:         [C]: in function doscript'
warning:         [C]: ?
warning:         ...data\faforever\gamedata\lua.nx5\lua\system\utils.lua(47): in function safecall'
warning:         ...faforever\gamedata\lua.nx5\lua\system\blueprints.lua(1069): in function LoadBlueprints'
warning:         ...gramdata\faforever\gamedata\lua.nx5\lua\ruleinit.lua(19): in main chunk
```

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Initialize `utils` (which creates the function `string.match`) before `repr` in `RuleInit`.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Checked `utils.lua` to make sure it had no dependencies on `repr`. Also, `globalInit.lua` runs `utils` before `repr` and this works just fine.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
