### PR TITLE
Fix air units colliding with projectiles after death

### DIFF
--- a/changelog/snippets/balance.6448.md
+++ b/changelog/snippets/balance.6448.md
@@ -1,0 +1,1 @@
+- (#6448) Fix projectiles colliding with dead air units. From a balance perspective, this increases the effectiveness of SAMs against groups of aircraft flying directly at them. 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1496,7 +1496,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
                 self:PlayUnitSound('Killed')
             end
 
-            -- apply death animation on half built units (do not apply for ML and mega)
+            -- apply death animation on half built units (do not apply for half-built units that may animate underground like Monkeylord and Megalith)
             local FractionThreshold = bp.General.FractionThreshold or 0.5
             if self.PlayDeathAnimation and self:GetFractionComplete() > FractionThreshold then
                 self:ForkThread(self.PlayAnimationThread, 'AnimationDeath')

--- a/lua/sim/units/AirUnit.lua
+++ b/lua/sim/units/AirUnit.lua
@@ -192,6 +192,9 @@ AirUnit = ClassUnit(MobileUnit) {
                 self:DoUnitCallbacks('OnKilled')
                 self:DisableShield()
 
+                -- The unit falling is a death animation, so it needs collision turned off
+                self.DisallowCollisions = true
+
                 -- Store our death weapon's damage on the unit so it can be edited remotely by the shield bouncer projectile
                 local bp = self.Blueprint
                 local i = 1

--- a/projectiles/ShieldCollider/ShieldCollider_script.lua
+++ b/projectiles/ShieldCollider/ShieldCollider_script.lua
@@ -51,7 +51,7 @@ ShieldCollider = ClassProjectile(Projectile) {
     ---@param other any
     OnCollisionCheck = function(self, other)
         -- We intercept this just incase the projectile collides with something it shouldn't
-        WARN('Shield collision projectile checking collision! Fix me!')
+        WARN('Shield collision projectile checking collision! Fix me!', debug.traceback())
         if IsUnit(other) then WARN('It was a unit!') return end
 
         Projectile.OnCollisionCheck(self, other)


### PR DESCRIPTION
## Issue
Air units do not instantly die (get `Unit:Destroy()` called); they wait until they impact the ground. Since the unit is not destroyed, it still has collision while falling through the air. Units undergoing a death animation should not have collision, this is already the case for land units like the Megalith and Monkeylord.

## Description of the proposed changes
Adds `self.DisallowCollisions = true` in the `OnKilled` override function used by air units.

## Testing done on the proposed changes
Spawn a UEF SAM and an enemy Cybran spy plane in front of the SAM. The SAM shouldn't waste all 6 shots (1200 damage) on the spy plane (700 hp), 2 shots should pass through. 
Make sure that the SAM doesn't kill the spy plane before all 6 shots are fired, or else it will cancel the volley early and you won't see 2 remaining shots.

## Balance implications
This increases the effectiveness of SAMs against groups of aircraft flying towards them, since previously an aircraft getting killed in the front could block a significant number of missiles from hitting the aircraft behind it.

A compromise to solve the bug while maintaining current balance could be to imitate damaging the wreckage of the overkilled aircraft if it gets hit while falling.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
