### PR TITLE
Move `RollOfUnit()` to after the "finished building" animation

### DIFF
--- a/changelog/snippets/fix.6456.md
+++ b/changelog/snippets/fix.6456.md
@@ -1,0 +1,1 @@
+- (#6456) Fix engineers not rotating towards the optimal rolloff point in factories with "build finished" animations such as the UEF and Cybran air factories.

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -138,9 +138,6 @@ FactoryUnit = ClassUnit(StructureUnit) {
         end
 
         if not (self.FactoryBuildFailed or IsDestroyed(self)) then
-            if not EntityCategoryContains(categoriesAIR, unitBeingBuilt) then
-                self:RollOffUnit()
-            end
             self:StopBuildFx()
             self:ForkThread(self.FinishBuildThread, unitBeingBuilt, order)
         end
@@ -222,6 +219,12 @@ FactoryUnit = ClassUnit(StructureUnit) {
             WaitTicks(1)
             WaitFor(self.RollOffAnim)
         end
+
+        -- engineers can only be rotated during rolloff after the "build finished" animation ends
+        if not EntityCategoryContains(categoriesAIR, unitBeingBuilt) then
+            self:RollOffUnit()
+        end
+
         if unitBeingBuilt and not unitBeingBuilt.Dead then
             unitBeingBuilt:DetachFrom(true)
         end
@@ -249,6 +252,7 @@ FactoryUnit = ClassUnit(StructureUnit) {
         return target_bp.General.Category ~= 'Factory'
     end,
 
+    --- Rotates engineers towards the nearest roll off point and then orders the unit to move off the factory build site
     ---@param self FactoryUnit
     RollOffUnit = function(self)
         local rollOffPoint = self.RollOffPoint


### PR DESCRIPTION
## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes #5625. UEF and Cybran air factories have an animation that locks the unit's orientation, interfering with the rolloff rotation. The changes move the rolloff rotation to happen after the animation finishes.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spawn factories, give a rally point on one side, order an engineer, and then change the rally point to the other side before the engineer finishes building and see that it now gets rotated correctly in the UEF and Cybran factories.
```
   CreateUnitAtMouse('xab1401', 0,    0.14,   -8.65, -0.00000)
   CreateUnitAtMouse('xsb0302', 0,   -4.04,    2.16,  0.00000)
   CreateUnitAtMouse('ueb0302', 0,   11.96,    2.16,  0.00000)
   CreateUnitAtMouse('urb0302', 0,    3.96,    2.16,  0.00000)
   CreateUnitAtMouse('uab0302', 0,  -12.04,    2.16,  0.00000)
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
