### PR TITLE
Annotate the damage data passed from weapons to projectiles

### DIFF
--- a/changelog/snippets/sections/other.6458.md
+++ b/changelog/snippets/sections/other.6458.md
@@ -1,0 +1,1 @@
+- (#6458) Annotate the damage data table passed from weapons to projectiles.

--- a/lua/sim/CollisionBeam.lua
+++ b/lua/sim/CollisionBeam.lua
@@ -19,6 +19,7 @@ local GetTerrainType = GetTerrainType
 local DefaultTerrainType = GetTerrainType(-1, -1)
 
 ---@class CollisionBeam : moho.CollisionBeamEntity
+---@field DamageTable WeaponDamageTable
 ---@field Trash TrashBag
 CollisionBeam = Class(moho.CollisionBeamEntity) {
 
@@ -358,9 +359,11 @@ CollisionBeam = Class(moho.CollisionBeamEntity) {
         return self.CollideFriendly
     end,
 
+    --- Creates a new `WeaponDamageTable` in `self.DamageTable` using the weapon blueprint
     ---@param self CollisionBeam
     SetDamageTable = function(self)
         local weaponBlueprint = self.Weapon:GetBlueprint()
+        ---@type WeaponDamageTable
         self.DamageTable = {}
         self.DamageTable.DamageRadius = weaponBlueprint.DamageRadius
         self.DamageTable.DamageAmount = weaponBlueprint.Damage

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -1058,7 +1058,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         self.DamageData.Buffs = DamageData.Buffs
         self.DamageData.ArtilleryShieldBlocks = DamageData.ArtilleryShieldBlocks
         self.DamageData.InitialDamageAmount = DamageData.InitialDamageAmount
-        self.CollideFriendly = self.DamageData.CollideFriendly
+        self.CollideFriendly = DamageData.CollideFriendly
     end,
 
     ---root of all performance evil

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -91,7 +91,7 @@ local VectorCached = Vector(0, 0, 0)
 ---@field Trash TrashBag
 ---@field Launcher Unit
 ---@field OriginalTarget? Unit
----@field DamageData table
+---@field DamageData WeaponDamageTable
 ---@field CreatedByWeapon Weapon
 ---@field IsRedirected? boolean
 ---@field InnerRing? NukeAOE
@@ -617,7 +617,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
 
     --- Called by Lua to pass the damage data as a metatable
     ---@param self Projectile
-    ---@param data table
+    ---@param data WeaponDamageTable
     PassMetaDamage = function(self, data)
         self.DamageData = {}
         setmetatable(self.DamageData, data)
@@ -631,7 +631,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     -- @param cachedPosition A cached position that is passed to prevent table allocations, can not be used in fork threads and / or after a yield statement
     ---@param self Projectile
     ---@param instigator Unit
-    ---@param DamageData table
+    ---@param DamageData WeaponDamageTable # passed by the weapon
     ---@param targetEntity Unit | Prop | nil
     ---@param cachedPosition Vector
     DoDamage = function(self, instigator, DamageData, targetEntity, cachedPosition)
@@ -1045,7 +1045,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
 
     ---@deprecated
     ---@param self Projectile
-    ---@param DamageData table
+    ---@param DamageData WeaponDamageTable
     PassDamageData = function(self, DamageData)
         self.DamageData = {}
         self.DamageData.DamageRadius = DamageData.DamageRadius


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
This is the table passed from weapons to projectiles so that the projectiles know their damage-dealing behavior

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Started from `GetDamageTableInternal` and manually traced wherever the data was passed and used.
Also checked that my explanation of the metatable was correct by checking the projectile's vs weapon's `debug.allocatedsize()` of the damage table (40 vs 360 bytes) on the Aeon ACU's main gun.

## Additional context
<!-- Add any other context about the pull request here. -->
I noticed that `CollideFriendly`'s functionality is broken. There is also an unused `CollideFriendlyShield` field that could be cleaned up.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
