### PR TITLE
Remove the hotkey to kill all your units

### DIFF
--- a/changelog/snippets/other.6463.md
+++ b/changelog/snippets/other.6463.md
@@ -1,0 +1,3 @@
+- (#6463) Remove the 'Kill all your units' hotkey and related functionality
+
+The existence of the hotkey makes it appear legitimate while it is typically against the rules.

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -1587,10 +1587,6 @@ local keyActionsOrders = {
         action = 'UI_Lua import("/lua/ui/game/confirmunitdestroy.lua").ConfirmUnitDestruction(true)',
         category = 'orders',
     },
-    ['Kill_All'] = {
-        action = 'UI_Lua import("/lua/ui/game/confirmunitdestroy.lua").ConfirmUnitDestruction(true, true)',
-        category = 'orders',
-    },
     ['dock'] = {
         action = 'UI_Lua import("/lua/ui/game/orders.lua").Dock(true)',
         category = 'orders',

--- a/lua/selfdestruct.lua
+++ b/lua/selfdestruct.lua
@@ -20,7 +20,7 @@ local function SelfDestructThread(unit)
 end
 
 --- Toggles the destruction of the units
----@param data { owner: number, noDelay: boolean, allUnits: boolean }
+---@param data { owner: number, noDelay: boolean }
 ---@param units Unit[]
 function ToggleSelfDestruct(data, units)
 
@@ -31,11 +31,6 @@ function ToggleSelfDestruct(data, units)
 
     -- do not allow observers to use this
     if data.owner ~= -1 and OkayToMessWithArmy(data.owner) then
-
-        -- if we want to destroy all units
-        if data.allUnits then
-            units = GetArmyBrain(data.owner):GetListOfUnits(categories.ALLUNITS, false, false)
-        end
 
         -- just take them all out
         if data.noDelay then

--- a/lua/ui/game/confirmunitdestroy.lua
+++ b/lua/ui/game/confirmunitdestroy.lua
@@ -3,18 +3,14 @@
 local CreateAnnouncement = import("/lua/ui/game/announcement.lua").CreateAnnouncement
 
 ---@param instant boolean
----@param allUnits boolean
-function ConfirmUnitDestruction(instant, allUnits)
-    local units = GetSelectedUnits()
+function ConfirmUnitDestruction(instant)
 
-
-    if -- do not allow self destructing of command units
+    if -- do not allow self destructing of command units in campaign
     import("/lua/ui/campaign/campaignmanager.lua").campaignMode and
-        not table.empty(EntityCategoryFilterDown(categories.COMMAND, units))
+        not table.empty(EntityCategoryFilterDown(categories.COMMAND, GetSelectedUnits()))
     then
         CreateAnnouncement('<LOC confirm_0001>You cannot self destruct during an operation!')
     else
-        SimCallback({ Func = 'ToggleSelfDestruct',
-            Args = { owner = GetFocusArmy(), noDelay = instant, allUnits = allUnits } }, true)
+        SimCallback({ Func = 'ToggleSelfDestruct', Args = { owner = GetFocusArmy(), noDelay = instant } }, true)
     end
 end


### PR DESCRIPTION
## Description of the proposed changes

Removes the hotkey, UI and sim capabilities to kill all of your units at a click of a button. As requested by the moderators on [Discord](https://discord.com/channels/197033481883222026/1288427189313994823).

## Testing done on the proposed changes

Ran the game and went on a rampage. All appears good.


## Additional context

In addition, I've checked whether campaign/coop maps use this functionality and they do not.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
