### PR TITLE
Fix Ythotha being able to move backwards

### DIFF
--- a/changelog/snippets/balance.6466.md
+++ b/changelog/snippets/balance.6466.md
@@ -1,0 +1,2 @@
+- (#6466) Fix Ythotha being able to walk backwards.
+  - `MaxSpeedReverse`: 2.5 -> 0

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -1119,7 +1119,7 @@
 ---@field MaxGroundVariation number
 --- maximum speed for the unit
 ---@field MaxSpeed number
---- maximum speed for the unit in reverse
+--- maximum speed for the unit in reverse. Defaults to the same value as MaxSpeed
 ---@field MaxSpeedReverse number
 --- maximum steer force magnitude that can be applied to acceleration
 ---@field MaxSteerForce number

--- a/units/XSL0401/XSL0401_unit.bp
+++ b/units/XSL0401/XSL0401_unit.bp
@@ -195,6 +195,7 @@ UnitBlueprint{
         MaxAcceleration = 2.5,
         MaxBrake = 2.5,
         MaxSpeed = 2.5,
+        MaxSpeedReverse = 0,
         MaxSteerForce = 10,
         MeshExtentsX = 2.75,
         MeshExtentsY = 6.75,


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Issue

Ythotha can walk backwards (with 2.5 speed at that) which is obviously overpowered and also looks very weird.

https://github.com/user-attachments/assets/0f12a23d-e2c9-4ee6-8391-00605244a5e6

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->

Set its reverse speed to 0 so it cannot walk backwards.


## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->

Spawn it and confirm it cannot walk backwards when given move orders near close behind it.
```
   CreateUnitAtMouse('xsl0401', 0,    0.00,    0.00,  0)
```

## Additional context
<!-- Add any other context about the pull request here. -->
`BackUpDistance` gets a default value from the engine, but I'm not sure how it is calculated, so I didn't add a comment in the annotation about it.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
