### PR TITLE
Reduce the `TransportSpeedReduction` stat of the Fire Beetle

### DIFF
--- a/changelog/snippets/balance.6469.md
+++ b/changelog/snippets/balance.6469.md
@@ -1,4 +1,4 @@
-- (#6469) Similar to Tech 1 units, the Fire Beetle only takes up one clamp on transports. To ensure that the unit does not slow transports down excessively, its TransportSpeedReduction stat is reduced to match that of Tech 1 units.
+- (#6469) Unlike other Tech 2 units, the Fire Beetle only takes up one clamp on transports. This makes it possible to load the same quantities of Fire Beetles and Tech 1 units into transports. To ensure that the Fire Beetle does not slow transports down excessively, its `TransportSpeedReduction` stat is reduced to match that of Tech 1 units.
 
   - Fire Beetle: T2 Mobile Bomb (XRL0302):
     - TransportSpeedReduction: 0.3 --> 0.15

--- a/changelog/snippets/balance.6469.md
+++ b/changelog/snippets/balance.6469.md
@@ -1,0 +1,4 @@
+- (#6469) Similar to Tech 1 units, the Fire Beetle only takes up one clamp on transports. To ensure that the unit does not slow transports down excessively, its TransportSpeedReduction stat is reduced to match that of Tech 1 units.
+
+  - Fire Beetle: T2 Mobile Bomb (XRL0302):
+    - TransportSpeedReduction: 0.3 --> 0.15

--- a/units/XRL0302/XRL0302_unit.bp
+++ b/units/XRL0302/XRL0302_unit.bp
@@ -139,6 +139,7 @@ UnitBlueprint{
         MeshExtentsY = 0.25,
         MeshExtentsZ = 0.65,
         MotionType = "RULEUMT_Land",
+        TransportSpeedReduction = 0.15,
         TurnRadius = 4,
         TurnRate = 200,
     },


### PR DESCRIPTION
## Description of the proposed changes
Unlike other Tech 2 units, the Fire Beetle only takes up one clamp on transports. This makes it possible to load the same quantities of Fire Beetles and Tech 1 units into transports. To ensure that the Fire Beetle does not slow transports down excessively, its `TransportSpeedReduction` stat is reduced to match that of Tech 1 units.

**Fire Beetle: T2 Mobile Bomb (XRL0302):**
   - TransportSpeedReduction: 0.3 --> 0.15

## Checklist
- [x] Changes are documented in the changelog for the next game version