### PR TITLE
Implement basic gesture detection to delete commands

### DIFF
--- a/engine/User.lua
+++ b/engine/User.lua
@@ -7,6 +7,7 @@
 ---@field targetId? EntityId
 ---@field blueprintId? UnitId
 ---@field commandType number
+---@field commandId number
 
 ---@alias SubmergeStatus
 ---| -1  # submerged
@@ -480,7 +481,7 @@ end
 
 ---
 ---@param key string
----@return string[]
+---@return string
 function GetOptions(key)
 end
 

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -1416,7 +1416,6 @@ options = {
                 },
 
                 set = function(control, value, startup)
-                    LOG(value)
                     import("/lua/ui/game/cursor/deletebuildcommand.lua").SetGestureDetectionCommandType(value)
                 end,
             },

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -1416,7 +1416,9 @@ options = {
                 },
 
                 set = function(control, value, startup)
-                    import("/lua/ui/game/cursor/deletebuildcommand.lua").SetGestureDetectionCommandType(value)
+                    if SessionIsActive() then
+                        import("/lua/ui/game/cursor/deletebuildcommand.lua").SetGestureDetectionCommandType(value)
+                    end
                 end,
             },
         },

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -1391,6 +1391,35 @@ options = {
                     end
                 end,
             },
+
+            {
+                title = 'Gesture control',
+                type = 'header',
+
+                -- these are expected everywhere
+                default = '',
+                key = '',
+            },
+
+            {
+                title = "<LOC OPTIONS_0315>Gesture to delete commands",
+                key = 'gesture_delete_commands',
+                type = 'toggle',
+                default = 'off',
+                custom = {
+                    states = {
+                        { text = "<LOC _Off>", key = 'off' },
+                        { text = "<LOC gesture_build>Build commands only", key = 'build' },
+                        { text = "<LOC gesture_build>Engineer related commands only", key = 'engineering' },
+                        { text = "<LOC gesture_build>All commands", key = 'all' },
+                    },
+                },
+
+                set = function(control, value, startup)
+                    LOG(value)
+                    import("/lua/ui/game/cursor/deletebuildcommand.lua").SetGestureDetectionCommandType(value)
+                end,
+            },
         },
     },
     video = {

--- a/lua/ui/game/cursor/DeleteBuildCommand.lua
+++ b/lua/ui/game/cursor/DeleteBuildCommand.lua
@@ -118,6 +118,7 @@ StartGestureDetectionThread = function()
     ModuleTrash:Add(ForkThread(GestureDetectionThread))
 end
 
+--- Sets the gesture detection command type and attempts to restart the gesture detection thread.
 ---@param commandType UIGestureDetectionCommandType
 SetGestureDetectionCommandType = function(commandType)
     GestureDetectionCommandType = commandType

--- a/lua/ui/game/cursor/DeleteBuildCommand.lua
+++ b/lua/ui/game/cursor/DeleteBuildCommand.lua
@@ -1,0 +1,146 @@
+--******************************************************************************************************
+--** Copyright (c) 2024 FAForever
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
+---@alias UIGestureDetectionCommandType 'off' | 'build' | 'engineering' | 'all'
+
+--- See also:  https://github.com/FAForever/FA-Binary-Patches/pull/22
+local BuildCommandTypes = {
+    [8] = true, -- BuildMobile
+    [9] = true, -- BuildAssist
+}
+
+--- See also:  https://github.com/FAForever/FA-Binary-Patches/pull/22
+local EngineeringCommandTypes = {
+    [8] = true, -- BuildMobile
+    [9] = true, -- BuildAssist
+    [15] = true, -- Guard
+    [19] = true, -- Reclaim
+    [20] = true, -- Repair
+    [21] = true, -- Capture
+    [32] = true, -- Sacrifice
+}
+
+---@type UIGestureDetectionCommandType
+local GestureDetectionCommandType = import("/lua/user/prefs.lua").GetOption('gesture_delete_commands')
+
+---@type number
+local GestureDetectionSuccessionThreshold = 3
+
+---@type thread?
+local GestureDetectionThreadInstance = nil;
+
+--- Starts a basic gesture detection thread to delete a (build) command
+local GestureDetectionThread = function()
+
+    local gestureStart = 0
+    local gestureTargetId = nil
+    local gestureSuccessive = 0
+    local oldCommand = nil
+
+    while true do
+        WaitFrames(1)
+
+        -- check for early exit
+        if GestureDetectionCommandType == 'off' then
+            return
+        end
+
+        -- retrieve a command
+        local command = GetHighlightCommand()
+
+        -- only register the event when we just started hovering over a command
+        if command and not oldCommand then
+            -- check for early exit
+            if GestureDetectionCommandType == 'build' and not BuildCommandTypes[command.commandType] then
+                gestureTargetId = nil
+                continue
+            elseif GestureDetectionCommandType == 'engineering' and not EngineeringCommandTypes[command.commandType] then
+                gestureTargetId = nil
+                continue
+            end
+
+            -- keep track of the gesture
+            local gameTimeSeconds = GetGameTimeSeconds()
+            if command.commandId == gestureTargetId and gameTimeSeconds - gestureStart < 0.5 then
+                gestureSuccessive = gestureSuccessive + 1
+                gestureStart = gameTimeSeconds
+            else
+                gestureStart = gameTimeSeconds
+                gestureTargetId = command.commandId
+                gestureSuccessive = 0
+            end
+            
+            if gestureSuccessive == GestureDetectionSuccessionThreshold then
+                DeleteCommand(gestureTargetId)
+                gestureTargetId = 0
+            end
+        end
+
+        oldCommand = command
+    end
+end
+
+---@return thread
+StartGestureDetectionThread = function()
+    -- prevent duplicate threads
+    if GestureDetectionThreadInstance and type(GestureDetectionThreadInstance) == "thread" then
+        KillThread(GestureDetectionThreadInstance)
+    end
+
+    GestureDetectionThreadInstance = ForkThread(GestureDetectionThread)
+    return GestureDetectionThreadInstance
+end
+
+---@param commandType UIGestureDetectionCommandType
+SetGestureDetectionCommandType = function(commandType)
+    GestureDetectionCommandType = commandType
+    StartGestureDetectionThread()
+end
+
+-------------------------------------------------------------------------------
+--#region Debugging
+
+--- Called by the module manager when this module is reloaded
+---@param newModule any
+function __moduleinfo.OnReload(newModule)
+    newModule.StartGestureDetectionThread()
+end
+
+--- Called by the module manager when this module becomes dirty
+function __moduleinfo.OnDirty()
+    reprsl(__moduleinfo, { depth = 2 })
+
+    -- kill current thread
+    if GestureDetectionThreadInstance and type(GestureDetectionThreadInstance) == "thread" then
+        KillThread(GestureDetectionThreadInstance)
+    end
+
+    -- trigger a reload
+    ForkThread(
+        function()
+            WaitSeconds(1.0)
+            import(__moduleinfo.name)
+        end
+    )
+end
+
+--#endregion

--- a/lua/ui/game/cursor/DeleteBuildCommand.lua
+++ b/lua/ui/game/cursor/DeleteBuildCommand.lua
@@ -51,6 +51,13 @@ local GestureDetectionSuccessionThreshold = 3
 --- Starts a basic gesture detection thread to delete a (build) command
 local GestureDetectionThread = function()
 
+    -- local scope for performance
+    local WaitFrames = WaitFrames
+    local GetHighlightCommand = GetHighlightCommand
+    local GetGameTimeSeconds = GetGameTimeSeconds
+    local DeleteCommand = DeleteCommand
+
+    -- internal state
     local gestureStart = 0
     local gestureTargetId = nil
     local gestureSuccessive = 0

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -164,6 +164,7 @@ function CreateUI(isReplay)
     import("/lua/system/performance.lua")
     import("/lua/ui/game/cursor/depth.lua")
     import("/lua/ui/game/cursor/hover.lua")
+    import("/lua/ui/game/cursor/DeleteBuildCommand.lua").StartGestureDetectionThread()
 
     -- casting tools
 


### PR DESCRIPTION
## Description of the proposed changes

Adds a basic gesture detection to allow you to delete commands while in command mode. This is in particular useful when you do not use hotkeys. Often I find myself in the situation that I miss placed a build order. When you do not use hotkeys, this looks like:

- (0) Miss click a build order.
- (1) Right click to cancel command mode.
- (2) Right click to remove the build order.
- (3) Move mouse to the correct build icon and left-click it.

In particular, step 3 can be time consuming. With this feature it can be simplified to:

- (0) Miss click a build order.
- (1) Rage-move the mouse across the build order until it disappears.

And problem solved. See it also in action:

https://github.com/user-attachments/assets/687aceb0-7522-4172-bbbe-106da39a7c5d

## Testing done on the proposed changes

All is tested during development. All the code is annotated. Debugging is in particular trivial since it requires no reloading of the game - see also the nice trick with using `OnDirty` and `OnReload` of the module 😃 ! 

## Additional context

Requires https://github.com/FAForever/FA-Binary-Patches/pull/90, which is available on the FAF Develop game type. To test this pull request you'll need to start a lobby using the FAF Develop game type to retrieve the correct executable.

With thanks to @4z0t for his time and effort.

## Checklist

- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
