### PR TITLE
Fix xsb5101 not orientating to the terrain as intended

### DIFF
--- a/changelog/snippets/fix.6471.md
+++ b/changelog/snippets/fix.6471.md
@@ -1,0 +1,1 @@
+- (#6471) Fix Seraphim wall not orientating towards the terrain

--- a/changelog/snippets/fix.6471.md
+++ b/changelog/snippets/fix.6471.md
@@ -1,1 +1,1 @@
-- (#6471) Fix Seraphim wall not orientating towards the terrain
+- (#6471) Fix Seraphim walls not orientating towards the terrain

--- a/units/XSB5101/XSB5101_unit.bp
+++ b/units/XSB5101/XSB5101_unit.bp
@@ -70,7 +70,6 @@ UnitBlueprint{
         RebuildBonusIds = { "xsb5101" },
     },
     General = {
-        AlwaysAlignToTerrain = true,
         CapCost = 0.1,
         FactionName = "Seraphim",
         Icon = "land",
@@ -82,6 +81,7 @@ UnitBlueprint{
     LifeBarOffset = 0.55,
     LifeBarSize = 0.8,
     Physics = {
+        AlwaysAlignToTerrain = true,
         DragCoefficient = 0.2,
         MaxGroundVariation = 50,
         MeshExtentsX = 1.5,


### PR DESCRIPTION
## Description of the proposed changes

The Seraphim wall now orientates towards the terrain as intended.

## Testing done on the proposed changes

Create a line of walls across a cliff and inspect their orientation.

![image](https://github.com/user-attachments/assets/e57e8409-8ddd-400b-8f7f-a7339948d91e)

## Additional context

While reviewing https://github.com/FAForever/fa/pull/6438 I noticed that the Seraphim wall refuses to orientate to the terrain. 

## Checklist

- [x] Changes are documented in the changelog for the next game version
