### PR TITLE
Implement command line launch of the auto lobby for LAN games

### DIFF
--- a/changelog/snippets/other.6474.md
+++ b/changelog/snippets/other.6474.md
@@ -1,0 +1,2 @@
+- (#6474) Implement command line launch of the auto lobby for LAN games. This allows rapidly testing multiplayer in a local environment.
+  Further details on the command line switches used and an example script for launching multiple instances are in the linked pull request.

--- a/engine/User.lua
+++ b/engine/User.lua
@@ -355,9 +355,9 @@ end
 function GetCamera(name)
 end
 
---- Gets the following arguments to a commandline option. For example, if `/arg -flag key:value drop`
---- was passed to the commandline, then `GetCommandLineArg("/arg", 2)` would return
---- `{"-flag", "key:value"}`
+--- Gets the "arguments" (tokens split by spaces) that follow a commandline option,
+--- disregarding if they start with `/` like other commandline options.  
+--- Returns nil if there are not `maxArgs` tokens after the `option`.
 ---@see GetCommandLineArgTable(option) for parsing key-values
 ---@param option string
 ---@param maxArgs number

--- a/engine/User.lua
+++ b/engine/User.lua
@@ -357,11 +357,11 @@ end
 
 --- Gets the "arguments" (tokens split by spaces) that follow a commandline option,
 --- disregarding if they start with `/` like other commandline options.  
---- Returns nil if there are not `maxArgs` tokens after the `option`.
+--- Returns `false` if there are not `maxArgs` tokens after the `option`.
 ---@see GetCommandLineArgTable(option) for parsing key-values
 ---@param option string
 ---@param maxArgs number
----@return string[]?
+---@return string[] | false
 function GetCommandLineArg(option, maxArgs)
 end
 

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -731,12 +731,13 @@ end
 --  GetCommandLineArgTable("/arg") -> {key1="value1", key2="value2"}
 function GetCommandLineArgTable(option)
     -- Find total number of args
-    local next = 1
+    local nextMax = 1
     local args, nextArgs = nil, nil
     repeat
-        nextArgs, args = GetCommandLineArg(option, next), nextArgs
-        next = next + 1
-    until not nextArgs
+        nextArgs, args = GetCommandLineArg(option, nextMax), nextArgs
+        nextMax = nextMax + 1
+        -- GetCommandLineArg tokenizes without being limited by `/`, so we need to stop manually
+    until not nextArgs or nextArgs[nextMax - 1]:sub(0,1) ~= "/"
 
     -- Construct result table
     local result = {}

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -737,7 +737,7 @@ function GetCommandLineArgTable(option)
         nextArgs, args = GetCommandLineArg(option, nextMax), nextArgs
         nextMax = nextMax + 1
         -- GetCommandLineArg tokenizes without being limited by `/`, so we need to stop manually
-    until not nextArgs or nextArgs[nextMax - 1]:sub(0,1) ~= "/"
+    until not nextArgs or nextArgs[nextMax - 1]:sub(0,1) == "/"
 
     -- Construct result table
     local result = {}

--- a/lua/ui/lobby/autolobby.lua
+++ b/lua/ui/lobby/autolobby.lua
@@ -104,9 +104,9 @@ local function MakeLocalPlayerInfo(name)
     result.Team = tonumber(GetCommandLineArg("/team", 1)[1])
     result.StartSpot = tonumber(GetCommandLineArg("/startspot", 1)[1]) or false
 
-    result.DEV = tonumber(GetCommandLineArg("/deviation", 1)[1]) or ""
-    result.MEAN = tonumber(GetCommandLineArg("/mean", 1)[1]) or ""
-    result.NG = tonumber(GetCommandLineArg("/numgames", 1)[1]) or ""
+    result.DEV = tonumber(GetCommandLineArg("/deviation", 1)[1] or 500)
+    result.MEAN = tonumber(GetCommandLineArg("/mean", 1)[1] or 1500)
+    result.NG = tonumber(GetCommandLineArg("/numgames", 1)[1] or 0)
     result.DIV = (GetCommandLineArg("/division", 1)[1]) or ""
     result.SUBDIV = (GetCommandLineArg("/subdivision", 1)[1]) or ""
     result.PL = math.floor(result.MEAN - 3 * result.DEV)
@@ -447,7 +447,7 @@ end
 
 -- join an already existing lobby
 function JoinGame(address, asObserver, playerName, uid)
-    LOG("Joingame (name=" .. playerName .. ", uid=" .. uid .. ", address=" .. address ..")")
+    LOG("Joingame (name=" .. tostring(playerName) .. ", uid=" .. tostring(uid) .. ", address=" .. tostring(address) ..")")
     CreateUI()
 
     -- TODO: I'm not sure if this argument is passed along when you are joining a lobby

--- a/lua/ui/lobby/autolobby.lua
+++ b/lua/ui/lobby/autolobby.lua
@@ -92,8 +92,9 @@ local function MakeLocalPlayerInfo(name)
     local result = LobbyComm.GetDefaultPlayerOptions(name)
     result.Human = true
 
+    -- Game must have factions for players or else it won't start, so default to UEF.
+    result.Faction = 1
     local factionData = import("/lua/factions.lua")
-
     for index, tbl in factionData.Factions do
         if HasCommandLineArg("/" .. tbl.Key) then
             result.Faction = index

--- a/lua/ui/uimain.lua
+++ b/lua/ui/uimain.lua
@@ -63,11 +63,17 @@ function StartFrontEndUI()
     end
 end
 
-
---Used by command line to host a game
+--- Hosts a multiplayer LAN lobby.
+--- Called by the engine with the command line argument `/hostgame <protocol> <port> <playerName> <gameName> <mapName>`
+--- Add the argument `/players <number>` to use the auto lobby. `/<factionName>` to choose a faction.
+---@param protocol UILobbyProtocols
+---@param port number
+---@param playerName string
+---@param gameName string
+---@param mapName FileName
+---@param natTraversalProvider userdata?
 function StartHostLobbyUI(protocol, port, playerName, gameName, mapName, natTraversalProvider)
-    LOG("Command line hostlobby")
-    LOG(protocol, port, playerName, gameName, mapName, natTraversalProvider)
+    LOG("Hosting lobby from the command line")
     local lobby
     -- auto lobby only works with 2+ players
     local autoStart = GetCommandLineArg("/players", 1)[1] >= 2
@@ -80,8 +86,15 @@ function StartHostLobbyUI(protocol, port, playerName, gameName, mapName, natTrav
     lobby.HostGame(gameName, mapName, false)
 end
 
---Used by command line to join a game
+--- Joins a multiplayer LAN lobby.
+--- Called by the engine with the command line argument `/joingame <protocol> <address> <playerName>`
+--- Add the argument `/players <number>` to use the auto lobby. `/<factionName>` to choose a faction.
+---@param protocol UILobbyProtocols
+---@param address string
+---@param playerName string
+---@param natTraversalProvider userdata?
 function StartJoinLobbyUI(protocol, address, playerName, natTraversalProvider)
+    LOG("Joining lobby from the command line") -- can also be from lobby.lua ReturnToMenu(true), but that never gets called
     local lobby
     -- auto lobby only works with 2+ players
     local autoStart = GetCommandLineArg("/players", 1)[1] >= 2

--- a/lua/ui/uimain.lua
+++ b/lua/ui/uimain.lua
@@ -69,8 +69,9 @@ function StartHostLobbyUI(protocol, port, playerName, gameName, mapName, natTrav
     LOG("Command line hostlobby")
     LOG(protocol, port, playerName, gameName, mapName, natTraversalProvider)
     local lobby
-    local autoStart = GetCommandLineArg("/players", 1)
-    if autoStart then
+    -- auto lobby only works with 2+ players
+    local autoStart = GetCommandLineArg("/players", 1)[1] >= 2
+    if autoStart then   
         lobby = import("/lua/ui/lobby/autolobby.lua")
     else
         lobby = import("/lua/ui/lobby/lobby.lua")
@@ -81,7 +82,9 @@ end
 
 --Used by command line to join a game
 function StartJoinLobbyUI(protocol, address, playerName, natTraversalProvider)
-    local autoStart = GetCommandLineArg("/players", 1)
+    local lobby
+    -- auto lobby only works with 2+ players
+    local autoStart = GetCommandLineArg("/players", 1)[1] >= 2
     if autoStart then
         lobby = import("/lua/ui/lobby/autolobby.lua")
     else

--- a/lua/ui/uimain.lua
+++ b/lua/ui/uimain.lua
@@ -86,7 +86,7 @@ function StartHostLobbyUI(protocol, port, playerName, gameName, mapFile, natTrav
     lobby.HostGame(gameName, mapFile, false)
 end
 
---- Joins a multiplayer LAN lobby.
+--- Joins a multiplayer lobby.
 --- Called by the engine with the command line argument `/joingame <protocol> <address> <playerName>`
 --- Add the argument `/players <number>` to use the auto lobby. `/<factionName>` to choose a faction.
 ---@param protocol UILobbyProtocols

--- a/lua/ui/uimain.lua
+++ b/lua/ui/uimain.lua
@@ -67,14 +67,26 @@ end
 --Used by command line to host a game
 function StartHostLobbyUI(protocol, port, playerName, gameName, mapName, natTraversalProvider)
     LOG("Command line hostlobby")
-    local lobby = import("/lua/ui/lobby/lobby.lua")
+    LOG(protocol, port, playerName, gameName, mapName, natTraversalProvider)
+    local lobby
+    local autoStart = GetCommandLineArg("/players", 1)
+    if autoStart then
+        lobby = import("/lua/ui/lobby/autolobby.lua")
+    else
+        lobby = import("/lua/ui/lobby/lobby.lua")
+    end
     lobby.CreateLobby(protocol, port, playerName, nil, natTraversalProvider, GetFrame(0), StartFrontEndUI)
     lobby.HostGame(gameName, mapName, false)
 end
 
 --Used by command line to join a game
 function StartJoinLobbyUI(protocol, address, playerName, natTraversalProvider)
-    local lobby = import("/lua/ui/lobby/lobby.lua")
+    local autoStart = GetCommandLineArg("/players", 1)
+    if autoStart then
+        lobby = import("/lua/ui/lobby/autolobby.lua")
+    else
+        lobby = import("/lua/ui/lobby/lobby.lua")
+    end
     local port = 0
     lobby.CreateLobby(protocol, port, playerName, nil, natTraversalProvider, GetFrame(0), StartFrontEndUI)
     lobby.JoinGame(address, false)

--- a/lua/ui/uimain.lua
+++ b/lua/ui/uimain.lua
@@ -64,15 +64,15 @@ function StartFrontEndUI()
 end
 
 --- Hosts a multiplayer LAN lobby.
---- Called by the engine with the command line argument `/hostgame <protocol> <port> <playerName> <gameName> <mapName>`
+--- Called by the engine with the command line argument `/hostgame <protocol> <port> <playerName> <gameName> <mapFile>`
 --- Add the argument `/players <number>` to use the auto lobby. `/<factionName>` to choose a faction.
 ---@param protocol UILobbyProtocols
 ---@param port number
 ---@param playerName string
 ---@param gameName string
----@param mapName FileName
+---@param mapFile FileName
 ---@param natTraversalProvider userdata?
-function StartHostLobbyUI(protocol, port, playerName, gameName, mapName, natTraversalProvider)
+function StartHostLobbyUI(protocol, port, playerName, gameName, mapFile, natTraversalProvider)
     LOG("Hosting lobby from the command line")
     local lobby
     -- auto lobby only works with 2+ players
@@ -83,7 +83,7 @@ function StartHostLobbyUI(protocol, port, playerName, gameName, mapName, natTrav
         lobby = import("/lua/ui/lobby/lobby.lua")
     end
     lobby.CreateLobby(protocol, port, playerName, nil, natTraversalProvider, GetFrame(0), StartFrontEndUI)
-    lobby.HostGame(gameName, mapName, false)
+    lobby.HostGame(gameName, mapFile, false)
 end
 
 --- Joins a multiplayer LAN lobby.

--- a/scripts/LaunchFAInstances.ps1
+++ b/scripts/LaunchFAInstances.ps1
@@ -75,7 +75,7 @@ if ($players -eq 1) {
     $hostLogFile = "host_dev.log"
     $hostFaction = $factions | Get-Random
     $hostTeamArgument = Get-TeamArgument -instanceNumber 0
-    $hostArguments = "/log $hostLogFile /showlog /hostgame $hostProtocol $port $hostPlayerName $gameName $map /players $players /$hostFaction $hostTeamArgument $baseArguments"
+    $hostArguments = "/log $hostLogFile /showlog /hostgame $hostProtocol $port $hostPlayerName $gameName $map /startspot 1 /players $players /$hostFaction $hostTeamArgument $baseArguments"
 
     # Launch host game instance
     Launch-GameInstance -instanceNumber 1 -xPos 0 -yPos 0 -arguments $hostArguments
@@ -91,7 +91,7 @@ if ($players -eq 1) {
         $clientPlayerName = "ClientPlayer_$($i + 1)"
         $clientFaction = $factions | Get-Random
         $clientTeamArgument = Get-TeamArgument -instanceNumber $i
-        $clientArguments = "/log $clientLogFile /joingame $hostProtocol localhost:$port $clientPlayerName /players $players /$clientFaction $clientTeamArgument $baseArguments"
+        $clientArguments = "/log $clientLogFile /joingame $hostProtocol localhost:$port $clientPlayerName /startspot $($i + 1) /players $players /$clientFaction $clientTeamArgument $baseArguments"
         
         Launch-GameInstance -instanceNumber ($i + 1) -xPos $xPos -yPos $yPos -arguments $clientArguments
     }

--- a/scripts/LaunchFAInstances.ps1
+++ b/scripts/LaunchFAInstances.ps1
@@ -1,0 +1,89 @@
+﻿param (
+    [int]$InstanceCount = 2,  # Default to 2 instances (1 host, 1 client)
+    [string]$mapName = "/maps/scmp_009/SCMP_009_scenario.lua",  # Default map
+    [int]$port = 15000  # Default port for hosting the game
+)
+
+# Path to the game executable
+$gameExecutable = "C:\ProgramData\FAForever\bin\FAFDebugger.exe"
+
+# Command-line arguments common for all instances
+$baseArguments = '/init "init_dev.lua" /EnableDiskWatch /nomovie /RunWithTheWind'
+
+# Game-specific settings
+$hostProtocol = "udp"  # Protocol for hostgame and joingame
+$hostPlayerName = "HostPlayer"
+$gameName = "MyGame"
+$numPlayers = $InstanceCount  # Total number of players equals the number of instances
+
+# Array of factions to choose from
+$factions = @("UEF", "Seraphim", "Cybran", "Aeon")
+
+# Get the screen resolution (for placing and resizing the windows)
+$screenWidth = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width
+$screenHeight = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Height
+
+# Calculate the number of rows and columns for the grid layout
+$columns = [math]::Ceiling([math]::Sqrt($InstanceCount))
+$rows = [math]::Ceiling($InstanceCount / $columns)
+
+# Calculate the size of each window based on the grid
+# Limit the window size to 1024x768 as the game session will not launch if it is smaller
+$windowWidth = [math]::Max([math]::Floor($screenWidth / $columns), 1024); 
+$windowHeight = [math]::Max([math]::Floor($screenHeight / $rows), 768)
+
+# Function to launch a single game instance
+function Launch-GameInstance {
+    param (
+        [int]$instanceNumber,  # Instance number for identification
+        [int]$xPos,            # X position for the window
+        [int]$yPos,            # Y position for the window
+        [string]$arguments     # Command-line arguments specific to this instance
+    )
+
+    # Add window position and size arguments
+    $arguments += " /position $xPos $yPos /size $windowWidth $windowHeight"
+
+    # Start the process
+    Start-Process -FilePath $gameExecutable -ArgumentList $arguments -NoNewWindow
+    Write-Host "Launched instance $instanceNumber at position ($xPos, $yPos) with size ($windowWidth, $windowHeight) and arguments: $arguments"
+}
+
+# Handle the case where only 1 instance is specified
+if ($InstanceCount -eq 1) {
+    $logFile = "dev.log"
+    $arguments = "$baseArguments /log $logFile /showlog"
+    Launch-GameInstance -instanceNumber 1 -xPos 0 -yPos 0 -arguments $arguments
+} 
+else {
+    # Host game command-line arguments
+    $hostLogFile = "host_dev.log"
+    $hostFaction = $factions | Get-Random
+    $hostArguments = "$baseArguments /log $hostLogFile /showlog /hostgame $hostProtocol $port $hostPlayerName $gameName $mapName /players $numPlayers /$hostFaction"
+
+    # Client game instances
+    for ($i = 0; $i -lt $InstanceCount; $i++) {
+        $row = [math]::Floor($i / $columns)
+        $col = $i % $columns
+
+        # Calculate the position for this instance
+        $xPos = $col * $windowWidth
+        $yPos = $row * $windowHeight
+
+        if ($i -eq 0) {
+            # Launch the host game instance
+            Launch-GameInstance -instanceNumber ($i + 1) -xPos $xPos -yPos $yPos -arguments $hostArguments
+        }
+        else {
+            # Launch the client game instances
+            $clientNumber = $i + 1
+            $clientLogFile = "client_dev_$clientNumber.log"
+            $clientPlayerName = "ClientPlayer_$clientNumber"
+            $clientFaction = $factions | Get-Random
+            $clientArguments = "$baseArguments /log $clientLogFile /joingame $hostProtocol localhost:$port $clientPlayerName /players $numPlayers /$clientFaction"
+            Launch-GameInstance -instanceNumber $clientNumber -xPos $xPos -yPos $yPos -arguments $clientArguments
+        }
+    }
+}
+
+Write-Host "$InstanceCount instance(s) of the game launched. Host is running at port $port."

--- a/scripts/LaunchFAInstances.ps1
+++ b/scripts/LaunchFAInstances.ps1
@@ -1,6 +1,6 @@
 ﻿param (
-    [int]$InstanceCount = 2,  # Default to 2 instances (1 host, 1 client)
-    [string]$mapName = "/maps/scmp_009/SCMP_009_scenario.lua",  # Default map
+    [int]$players = 2,  # Default to 2 instances (1 host, 1 client)
+    [string]$map = "/maps/scmp_009/SCMP_009_scenario.lua",  # Default map: Seton's Clutch
     [int]$port = 15000,  # Default port for hosting the game
     [int]$teams = 2  # Default to two teams, 0 for FFA
 )
@@ -12,10 +12,9 @@ $gameExecutable = "C:\ProgramData\FAForever\bin\FAFDebugger.exe"
 $baseArguments = '/init "init_dev.lua" /EnableDiskWatch /nomovie /RunWithTheWind /gameoptions CheatsEnabled:true'
 
 # Game-specific settings
-$hostProtocol = "udp"  # Protocol for hostgame and joingame
+$hostProtocol = "udp"
 $hostPlayerName = "HostPlayer"
 $gameName = "MyGame"
-$numPlayers = $InstanceCount  # Total number of players equals the number of instances
 
 # Array of factions to choose from
 $factions = @("UEF", "Seraphim", "Cybran", "Aeon")
@@ -26,8 +25,8 @@ $screenWidth = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width
 $screenHeight = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Height
 
 # Calculate the number of rows and columns for the grid layout
-$columns = [math]::Ceiling([math]::Sqrt($InstanceCount))
-$rows = [math]::Ceiling($InstanceCount / $columns)
+$columns = [math]::Ceiling([math]::Sqrt($players))
+$rows = [math]::Ceiling($players / $columns)
 
 # Calculate the size of each window based on the grid
 # Limit the window size to 1024x768 as the game session will not launch if it is smaller
@@ -37,72 +36,65 @@ $windowHeight = [math]::Max([math]::Floor($screenHeight / $rows), 768)
 # Function to launch a single game instance
 function Launch-GameInstance {
     param (
-        [int]$instanceNumber,  # Instance number for identification
-        [int]$xPos,            # X position for the window
-        [int]$yPos,            # Y position for the window
-        [string]$arguments     # Command-line arguments specific to this instance
+        [int]$instanceNumber,
+        [int]$xPos,
+        [int]$yPos,
+        [string]$arguments
     )
 
     # Add window position and size arguments
     $arguments += " /position $xPos $yPos /size $windowWidth $windowHeight"
-
-    # Start the process
-    Start-Process -FilePath $gameExecutable -ArgumentList $arguments -NoNewWindow
-    Write-Host "Launched instance $instanceNumber at position ($xPos, $yPos) with size ($windowWidth, $windowHeight) and arguments: $arguments"
+    
+    try {
+        Start-Process -FilePath $gameExecutable -ArgumentList $arguments -NoNewWindow
+        Write-Host "Launched instance $instanceNumber at position ($xPos, $yPos) with size ($windowWidth, $windowHeight) and arguments: $arguments"
+    } catch {
+        Write-Host "Failed to launch instance ${instanceNumber}: $_"
+    }
 }
 
 # Function to calculate team argument based on instance number and team configuration
 function Get-TeamArgument {
     param (
-        [int]$instanceNumber,  # Instance number for identification
-        [int]$teams            # Number of teams, 0 for FFA
+        [int]$instanceNumber
     )
-
+    
     if ($teams -eq 0) {
         return ""  # No team argument for FFA
-    } else {
-        $teamNumber = ($instanceNumber % $teams) + 1 + 1 # additional +1 because player team indices are +1 on the Sim side
-        return "/team $teamNumber"
     }
+    
+    # Calculate team number; additional +1 because player team indices start at 2
+    return "/team $((($instanceNumber % $teams) + 1 + 1))"
 }
 
-# Handle the case where only 1 instance is specified
-if ($InstanceCount -eq 1) {
+# Prepare arguments and launch instances
+if ($players -eq 1) {
     $logFile = "dev.log"
-    $arguments = "$baseArguments /log $logFile /showlog"
-    Launch-GameInstance -instanceNumber 1 -xPos 0 -yPos 0 -arguments $arguments
-} 
-else {
-    # Host game command-line arguments
+    Launch-GameInstance -instanceNumber 1 -xPos 0 -yPos 0 -arguments "/log $logFile /showlog /map $map $baseArguments"
+} else {
     $hostLogFile = "host_dev.log"
     $hostFaction = $factions | Get-Random
-    $hostTeamArgument = Get-TeamArgument -instanceNumber 0 -teams $teams
-    $hostArguments = "$baseArguments /log $hostLogFile /showlog /hostgame $hostProtocol $port $hostPlayerName $gameName $mapName /players $numPlayers /$hostFaction $hostTeamArgument"
+    $hostTeamArgument = Get-TeamArgument -instanceNumber 0
+    $hostArguments = "/log $hostLogFile /showlog /hostgame $hostProtocol $port $hostPlayerName $gameName $map /players $players /$hostFaction $hostTeamArgument $baseArguments"
+
+    # Launch host game instance
+    Launch-GameInstance -instanceNumber 1 -xPos 0 -yPos 0 -arguments $hostArguments
 
     # Client game instances
-    for ($i = 0; $i -lt $InstanceCount; $i++) {
+    for ($i = 1; $i -lt $players; $i++) {
         $row = [math]::Floor($i / $columns)
         $col = $i % $columns
-
-        # Calculate the position for this instance
         $xPos = $col * $windowWidth
         $yPos = $row * $windowHeight
-
-        if ($i -eq 0) {
-            # Launch the host game instance
-            Launch-GameInstance -instanceNumber ($i + 1) -xPos $xPos -yPos $yPos -arguments $hostArguments
-        }
-        else {
-            # Launch the client game instances
-            $clientNumber = $i + 1
-            $clientLogFile = "client_dev_$clientNumber.log"
-            $clientPlayerName = "ClientPlayer_$clientNumber"
-            $clientFaction = $factions | Get-Random
-            $clientTeamArgument = Get-TeamArgument -instanceNumber $i -teams $teams
-            $clientArguments = "$baseArguments /log $clientLogFile /joingame $hostProtocol localhost:$port $clientPlayerName /players $numPlayers /$clientFaction $clientTeamArgument"
-            Launch-GameInstance -instanceNumber $clientNumber -xPos $xPos -yPos $yPos -arguments $clientArguments
-        }
+        
+        $clientLogFile = "client_dev_$($i + 1).log"
+        $clientPlayerName = "ClientPlayer_$($i + 1)"
+        $clientFaction = $factions | Get-Random
+        $clientTeamArgument = Get-TeamArgument -instanceNumber $i
+        $clientArguments = "/log $clientLogFile /joingame $hostProtocol localhost:$port $clientPlayerName /players $players /$clientFaction $clientTeamArgument $baseArguments"
+        
+        Launch-GameInstance -instanceNumber ($i + 1) -xPos $xPos -yPos $yPos -arguments $clientArguments
     }
 }
 
-Write-Host "$InstanceCount instance(s) of the game launched. Host is running at port $port."
+Write-Host "$players instance(s) of the game launched. Host is running at port $port."

--- a/scripts/LaunchFAInstances.ps1
+++ b/scripts/LaunchFAInstances.ps1
@@ -9,7 +9,7 @@
 $gameExecutable = "C:\ProgramData\FAForever\bin\FAFDebugger.exe"
 
 # Command-line arguments common for all instances
-$baseArguments = '/init "init_dev.lua" /EnableDiskWatch /nomovie /RunWithTheWind'
+$baseArguments = '/init "init_dev.lua" /EnableDiskWatch /nomovie /RunWithTheWind /gameoptions CheatsEnabled:true'
 
 # Game-specific settings
 $hostProtocol = "udp"  # Protocol for hostgame and joingame

--- a/scripts/LaunchFAInstances.ps1
+++ b/scripts/LaunchFAInstances.ps1
@@ -4,8 +4,6 @@
     [int]$port = 15000  # Default port for hosting the game
 )
 
-Add-Type -AssemblyName System.Windows.Forms
-
 # Path to the game executable
 $gameExecutable = "C:\ProgramData\FAForever\bin\FAFDebugger.exe"
 
@@ -22,6 +20,7 @@ $numPlayers = $InstanceCount  # Total number of players equals the number of ins
 $factions = @("UEF", "Seraphim", "Cybran", "Aeon")
 
 # Get the screen resolution (for placing and resizing the windows)
+Add-Type -AssemblyName System.Windows.Forms
 $screenWidth = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width
 $screenHeight = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Height
 
@@ -31,7 +30,7 @@ $rows = [math]::Ceiling($InstanceCount / $columns)
 
 # Calculate the size of each window based on the grid
 # Limit the window size to 1024x768 as the game session will not launch if it is smaller
-$windowWidth = [math]::Max([math]::Floor($screenWidth / $columns), 1024); 
+$windowWidth = [math]::Max([math]::Floor($screenWidth / $columns), 1024)
 $windowHeight = [math]::Max([math]::Floor($screenHeight / $rows), 768)
 
 # Function to launch a single game instance

--- a/scripts/LaunchFAInstances.ps1
+++ b/scripts/LaunchFAInstances.ps1
@@ -5,8 +5,24 @@
     [int]$teams = 2  # Default to two teams, 0 for FFA
 )
 
-# Path to the game executable
-$gameExecutable = "C:\ProgramData\FAForever\bin\FAFDebugger.exe"
+# Base path to the bin directory
+$binPath = "C:\ProgramData\FAForever\bin"
+
+# Paths to the potential executables within the base path
+$debuggerExecutable = Join-Path $binPath "FAFDebugger.exe"
+$regularExecutable = Join-Path $binPath "ForgedAlliance.exe"
+
+# Check for the existence of the executables and choose accordingly
+if (Test-Path $debuggerExecutable) {
+    $gameExecutable = $debuggerExecutable
+    Write-Output "Using debugger executable: $gameExecutable"
+} elseif (Test-Path $regularExecutable) {
+    $gameExecutable = $regularExecutable
+    Write-Output "Debugger not found, using regular executable: $gameExecutable"
+} else {
+    Write-Output "Neither debugger nor regular executable found in $binPath. Exiting script."
+    exit 1
+}
 
 # Command-line arguments common for all instances
 $baseArguments = '/init "init_dev.lua" /EnableDiskWatch /nomovie /RunWithTheWind /gameoptions CheatsEnabled:true'

--- a/scripts/LaunchFAInstances.ps1
+++ b/scripts/LaunchFAInstances.ps1
@@ -4,6 +4,8 @@
     [int]$port = 15000  # Default port for hosting the game
 )
 
+Add-Type -AssemblyName System.Windows.Forms
+
 # Path to the game executable
 $gameExecutable = "C:\ProgramData\FAForever\bin\FAFDebugger.exe"
 

--- a/scripts/LaunchFAInstances.ps1
+++ b/scripts/LaunchFAInstances.ps1
@@ -29,7 +29,7 @@ $baseArguments = '/init "init_dev.lua" /EnableDiskWatch /nomovie /RunWithTheWind
 
 # Game-specific settings
 $hostProtocol = "udp"
-$hostPlayerName = "HostPlayer"
+$hostPlayerName = "HostPlayer_1"
 $gameName = "MyGame"
 
 # Array of factions to choose from
@@ -88,7 +88,7 @@ if ($players -eq 1) {
     $logFile = "dev.log"
     Launch-GameInstance -instanceNumber 1 -xPos 0 -yPos 0 -arguments "/log $logFile /showlog /map $map $baseArguments"
 } else {
-    $hostLogFile = "host_dev.log"
+    $hostLogFile = "host_dev_1.log"
     $hostFaction = $factions | Get-Random
     $hostTeamArgument = Get-TeamArgument -instanceNumber 0
     $hostArguments = "/log $hostLogFile /showlog /hostgame $hostProtocol $port $hostPlayerName $gameName $map /startspot 1 /players $players /$hostFaction $hostTeamArgument $baseArguments"

--- a/scripts/LaunchFAInstances.ps1
+++ b/scripts/LaunchFAInstances.ps1
@@ -25,7 +25,7 @@ if (Test-Path $debuggerExecutable) {
 }
 
 # Command-line arguments common for all instances
-$baseArguments = '/init "init_dev.lua" /EnableDiskWatch /nomovie /RunWithTheWind /gameoptions CheatsEnabled:true'
+$baseArguments = '/init "init_dev.lua" /EnableDiskWatch /nomovie /RunWithTheWind /gameoptions CheatsEnabled:true GameSpeed:adjustable '
 
 # Game-specific settings
 $hostProtocol = "udp"

--- a/scripts/LaunchFAInstances.ps1
+++ b/scripts/LaunchFAInstances.ps1
@@ -1,7 +1,8 @@
 ﻿param (
     [int]$InstanceCount = 2,  # Default to 2 instances (1 host, 1 client)
     [string]$mapName = "/maps/scmp_009/SCMP_009_scenario.lua",  # Default map
-    [int]$port = 15000  # Default port for hosting the game
+    [int]$port = 15000,  # Default port for hosting the game
+    [int]$teams = 2  # Default to two teams, 0 for FFA
 )
 
 # Path to the game executable
@@ -50,6 +51,21 @@ function Launch-GameInstance {
     Write-Host "Launched instance $instanceNumber at position ($xPos, $yPos) with size ($windowWidth, $windowHeight) and arguments: $arguments"
 }
 
+# Function to calculate team argument based on instance number and team configuration
+function Get-TeamArgument {
+    param (
+        [int]$instanceNumber,  # Instance number for identification
+        [int]$teams            # Number of teams, 0 for FFA
+    )
+
+    if ($teams -eq 0) {
+        return ""  # No team argument for FFA
+    } else {
+        $teamNumber = ($instanceNumber % $teams) + 1 + 1 # additional +1 because player team indices are +1 on the Sim side
+        return "/team $teamNumber"
+    }
+}
+
 # Handle the case where only 1 instance is specified
 if ($InstanceCount -eq 1) {
     $logFile = "dev.log"
@@ -60,7 +76,8 @@ else {
     # Host game command-line arguments
     $hostLogFile = "host_dev.log"
     $hostFaction = $factions | Get-Random
-    $hostArguments = "$baseArguments /log $hostLogFile /showlog /hostgame $hostProtocol $port $hostPlayerName $gameName $mapName /players $numPlayers /$hostFaction"
+    $hostTeamArgument = Get-TeamArgument -instanceNumber 0 -teams $teams
+    $hostArguments = "$baseArguments /log $hostLogFile /showlog /hostgame $hostProtocol $port $hostPlayerName $gameName $mapName /players $numPlayers /$hostFaction $hostTeamArgument"
 
     # Client game instances
     for ($i = 0; $i -lt $InstanceCount; $i++) {
@@ -81,7 +98,8 @@ else {
             $clientLogFile = "client_dev_$clientNumber.log"
             $clientPlayerName = "ClientPlayer_$clientNumber"
             $clientFaction = $factions | Get-Random
-            $clientArguments = "$baseArguments /log $clientLogFile /joingame $hostProtocol localhost:$port $clientPlayerName /players $numPlayers /$clientFaction"
+            $clientTeamArgument = Get-TeamArgument -instanceNumber $i -teams $teams
+            $clientArguments = "$baseArguments /log $clientLogFile /joingame $hostProtocol localhost:$port $clientPlayerName /players $numPlayers /$clientFaction $clientTeamArgument"
             Launch-GameInstance -instanceNumber $clientNumber -xPos $xPos -yPos $yPos -arguments $clientArguments
         }
     }


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
By using `/players` in combination with `/hostgame`, the game can be launched on LAN into the auto lobby, which automatically launches the lobby once all players are connected. This allows rapidly testing multiplayer in a local environment by launching multiple instances with a script and hosting/joining as needed.

Guards are added for the arguments used in the auto lobby as it is now more accessible since `/hostgame` is simpler than `/gpgnet`.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
The powershell script added to the scripts folder in this PR launches multiple FA instances into the auto lobby and successfully starts everything. The faction launch argument can be omitted and the game launches too.
[scripts/LaunchFAInstances.ps1](https://github.com/FAForever/fa/blob/cd7c660d57b014b72c1e941a615680b95d4e968b/scripts/LaunchFAInstances.ps1)


## Additional context
<!-- Add any other context about the pull request here. -->
The [command line switches wiki page](https://wiki.faforever.com/en/Development/Game-Development/Command-Line-Switches) can be updated with the newfound knowledge.


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
