### PR TITLE
Fix movement effects warning spam due to contrails

### DIFF
--- a/changelog/snippets/fix.6436.md
+++ b/changelog/snippets/fix.6436.md
@@ -1,1 +1,1 @@
-- (#6436) Prevent the logging of an unecessary warning when certain units make landfall.
+- (#6436, #6480) Prevent the logging of an unecessary warning when certain units make landfall.

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -3635,7 +3635,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     ---@overload fun(self: Unit, effectTypeGroups: UnitBlueprintEffect[], fxBlockType: "FXImpact", impactType: ImpactType, suffix?: string, bag?: TrashBag, terrainType?: TerrainType)
     ---@overload fun(self: Unit, effectTypeGroups: UnitBlueprintEffect[], fxBlockType: "FXMotionChange", motionChange: MotionChangeType, suffix?: string, bag?: TrashBag, terrainType?: TerrainType)
     ---@overload fun(self: Unit, effectTypeGroups: UnitBlueprintEffect[], fxBlockType: "FXLayerChange", layerChange: LayerChangeType, suffix?: string, bag?: TrashBag, terrainType?: TerrainType)
-    ---
+    --- Creates effects defined in `TerrainTypes.lua` based on the terrain that a movement is moving on.
     ---@param self Unit
     ---@param effectTypeGroups UnitBlueprintEffect[]
     ---@param fxBlockType LayerTerrainEffectType
@@ -3708,11 +3708,12 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         end
     end,
 
+    --- Creates camera shake effects and also movement effects for the terrain a unit is moving on.
     ---@param self Unit
     ---@param EffectsBag TrashBag
     ---@param TypeSuffix string
-    ---@param TerrainType string
-    ---@return boolean
+    ---@param TerrainType TerrainType?
+    ---@return boolean?
     CreateMovementEffects = function(self, EffectsBag, TypeSuffix, TerrainType)
         local layer = self.Layer
         local bpTable = self.Blueprint.Display.MovementEffects
@@ -3727,8 +3728,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
             local effectTypeGroups = bpTable.Effects
 
             if not effectTypeGroups or (effectTypeGroups and (table.empty(effectTypeGroups))) then
-                -- warning isn't needed if this layer's table is used for Footfall without terrain effects
-                if not bpTable.Footfall then
+                -- warning isn't needed if this layer's table is used for Footfall or Contrails without terrain effects
+                if not bpTable.Footfall and not bpTable.Contrails then
                     WARN('*No movement effect groups defined for unit ', repr(self.UnitId), ', Effect groups with bone lists must be defined to play movement effects. Add these to the Display.MovementEffects.', layer, '.Effects table in unit blueprint.')
                 end
                 return false


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Issue
After #6436 contrails began to be able to trigger the movement fx warnings. I'm not sure for what reason.
```
warning: *No movement effect groups defined for unit 	"ura0102"	, Effect groups with bone lists must be defined to play movement effects. Add these to the Display.MovementEffects.	Air	.Effects table in unit blueprint.
```

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Prevents the warning if the movement effects table is only used for contrail effects or footfall effects.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Fly a Cybran interceptor (ura0102) at max speed and confirm that the warning no longer appears.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
