### PR TITLE
Balance cost and DPS stats of T3 arty

### DIFF
--- a/changelog/snippets/balance.6481.md
+++ b/changelog/snippets/balance.6481.md
@@ -1,0 +1,31 @@
+- (#6481) Balance cost and DPS stats of T3 static artillery:
+  1. Aeon Emissary set to 79k mass in proportion to old UEF artillery DPS/M.
+  2. Artillery costs spread evenly across 70-79k mass. Artillery costs are not reduced below their current costs because that would make them come out earlier.
+  3. Damage adjusted for more per-artillery variety in shots to kill T3 shields, while also evening out STK vs different faction T3 shields.
+  4. Reload adjusted so that avg DPS vs T3 shields (this accounts for regen) per mass is equal to Aeon artillery.
+  - Aeon Emissary: 
+    - Mass cost: 79000 -> 73200 (+7.9%)
+    - Energy cost: 1372500 -> 1481000 (+7.9%)
+    - Build time: 120000 -> 129500 (+7.9%)
+    - DPS with 4 T3 pgens: 1000
+  - UEF Duke:
+    - Mass cost: 72000 -> 76000 (+5.6%)
+    - Energy cost: 1350000 -> 1424000 (+5.5%)
+    - Build time: 115000 -> 121400 (+5.6%)
+    - DPS with 4 T3 pgens: 917 -> 980 (+6.9%)
+      - Damage: 5500 -> 7840
+      - Base Reload: 10s -> 13.3s
+  - Seraphim Hovatham:
+    - Mass cost: 70800 -> 73000 (+3.1%)
+    - Energy cost: 1327500 -> 1369000 (+3.1%)
+    - Build time: 110000 -> 113400 (+3.1%)
+    - DPS with 4 T3 pgens: 833 -> 935 (+12.3%)
+      - Damage: 5000 -> 5800
+      - Base Reload: 10s -> 10.4s
+  - Cybran Disruptor:
+    - Mass cost: 69600 -> 70000 (+0.6%)
+    - Energy cost: 1305000 -> 1313000 (+0.6%)
+    - Build time: 105000 -> 105600 (+0.6%)
+    - DPS with 4 T3 pgens: 804 -> 884 (+9.87%)
+      - Damage: 3700 -> 3800
+      - Base Reload: 7.7s -> 7.2s

--- a/changelog/snippets/balance.6481.md
+++ b/changelog/snippets/balance.6481.md
@@ -4,7 +4,7 @@
   3. Damage adjusted for more per-artillery variety in shots to kill T3 shields, while also evening out STK vs different faction T3 shields.
   4. Reload adjusted so that avg DPS vs T3 shields (this accounts for regen) per mass is equal to Aeon artillery.
   - Aeon Emissary: 
-    - Mass cost: 79000 -> 73200 (+7.9%)
+    - Mass cost: 73200 -> 79000 (+7.9%)
     - Energy cost: 1372500 -> 1481000 (+7.9%)
     - Build time: 120000 -> 129500 (+7.9%)
     - DPS with 4 T3 pgens: 1000

--- a/units/UAB2302/UAB2302_unit.bp
+++ b/units/UAB2302/UAB2302_unit.bp
@@ -72,9 +72,9 @@ UnitBlueprint{
         UniformScale = 0.125,
     },
     Economy = {
-        BuildCostEnergy = 1372500,
-        BuildCostMass = 73200,
-        BuildTime = 120000,
+        BuildCostEnergy = 1481000,
+        BuildCostMass = 79000,
+        BuildTime = 129500,
         RebuildBonusIds = { "uab2302" },
     },
     Footprint = {

--- a/units/UEB2302/UEB2302_unit.bp
+++ b/units/UEB2302/UEB2302_unit.bp
@@ -66,9 +66,9 @@ UnitBlueprint{
         UniformScale = 0.04,
     },
     Economy = {
-        BuildCostEnergy = 1350000,
-        BuildCostMass = 72000,
-        BuildTime = 115000,
+        BuildCostEnergy = 1424000,
+        BuildCostMass = 76000,
+        BuildTime = 121400,
         RebuildBonusIds = { "ueb2302" },
     },
     Footprint = {
@@ -137,7 +137,7 @@ UnitBlueprint{
             CameraShakeMin = 0,
             CameraShakeRadius = 50,
             CollideFriendly = false,
-            Damage = 5500,
+            Damage = 7840,
             DamageFriendly = true,
             DamageRadius = 6,
             DamageType = "Normal",
@@ -176,7 +176,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_IndirectFire",
-            RateOfFire = 10/100, --10/integer interval in ticks
+            RateOfFire = 10/133, --10/integer interval in ticks
             RenderFireClock = true,
             TargetPriorities = {
                 "EXPERIMENTAL MASSFABRICATION",

--- a/units/URB2302/URB2302_unit.bp
+++ b/units/URB2302/URB2302_unit.bp
@@ -60,9 +60,9 @@ UnitBlueprint{
         UniformScale = 0.09,
     },
     Economy = {
-        BuildCostEnergy = 1305000,
-        BuildCostMass = 69600,
-        BuildTime = 105000,
+        BuildCostEnergy = 1313000,
+        BuildCostMass = 70000,
+        BuildTime = 105600,
         RebuildBonusIds = { "urb2302" },
     },
     Footprint = {
@@ -126,7 +126,7 @@ UnitBlueprint{
             CameraShakeMin = 0,
             CameraShakeRadius = 50,
             CollideFriendly = false,
-            Damage = 3700,
+            Damage = 3800,
             DamageFriendly = true,
             DamageRadius = 9,
             DamageType = "Normal",
@@ -164,7 +164,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_IndirectFire",
-            RateOfFire = 10/77, --10/integer interval in ticks
+            RateOfFire = 10/72, --10/integer interval in ticks
             RenderFireClock = true,
             TargetPriorities = {
                 "EXPERIMENTAL MASSFABRICATION",

--- a/units/XSB2302/XSB2302_unit.bp
+++ b/units/XSB2302/XSB2302_unit.bp
@@ -77,9 +77,9 @@ UnitBlueprint{
         UniformScale = 0.05,
     },
     Economy = {
-        BuildCostEnergy = 1327500,
-        BuildCostMass = 70800,
-        BuildTime = 110000,
+        BuildCostEnergy = 1369000,
+        BuildCostMass = 73000,
+        BuildTime = 113400,
         RebuildBonusIds = { "xsb2302" },
     },
     Footprint = {
@@ -149,7 +149,7 @@ UnitBlueprint{
             CameraShakeMin = 0,
             CameraShakeRadius = 50,
             CollideFriendly = false,
-            Damage = 5000,
+            Damage = 5800,
             DamageFriendly = true,
             DamageRadius = 7,
             DamageType = "Normal",
@@ -188,7 +188,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_IndirectFire",
-            RateOfFire = 10/100, --10/integer interval in ticks
+            RateOfFire = 10/104, --10/integer interval in ticks
             RenderFireClock = true,
             TargetPriorities = {
                 "EXPERIMENTAL MASSFABRICATION",


### PR DESCRIPTION
## Issue
[Related Discord thread.](https://discord.com/channels/197033481883222026/1272828981367803967) Currently it's well known that Aeon arty is by far the best T3 arty. It has double the alpha damage of other arties (can one shot shields with only two arties, one shots targets if it hits), has better dps per unit and dps per mass than other arties (compared to Cybran: 19%/mass 24%/unit), and has very good accuracy that boosts the damage output compared to others even further.
To a lesser known extent, UEF arty is 10% better DPS per mass than Cybran arty, and 8% compared to Sera, so in general T3 arties could use some balance altogether. Balancing the arties altogether is a good first step before seeing if Aeon arty needs to be addressed.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
### Balance of arty DPS by cost:
1. Aeon arty set to 79k mass in proportion to old UEF arty DPS/M.
2. Arty costs spread evenly across 70-79k mass. Arty costs are not reduced below their current costs because that would make them come out earlier.
3. Damage adjusted for more per-artillery variety in shots to kill T3 shields, while also evening out STK vs different faction T3 shields.
4. Reload adjusted so that avg DPS vs T3 shields (this accounts for regen) per mass is equal to Aeon arty.
5. Energy and buildtime adjusted for the new mass costs with some rounding, but practically the same per-mass ratios.

![image](https://github.com/user-attachments/assets/54e5f0e7-9e97-4a43-83aa-e19c56e73ac2)

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Shooting at a test target, no artillery seems excessively powerful, due to the inaccuracy massively reducing the DPS of artillery with high splash radius.
<details> <summary> Spawn target command: </summary>

UEF structure/Seraphim shield air grid test target spawned at the edge of the arty range so that the top shield edge is roughly at max range of the artillery:
```
CreateUnitAtMouse('xsb4301', 1,    3.63,   11.13, -0.00017)
CreateUnitAtMouse('ueb0302', 1,  -27.38,  -11.88, -0.00009)
CreateUnitAtMouse('ueb1301', 1,   12.63,  -11.88,  0.00010)
CreateUnitAtMouse('ueb1301', 1,  -11.38,   12.13,  0.00000)
CreateUnitAtMouse('ueb1301', 1,  -19.38,    4.13,  0.00000)
CreateUnitAtMouse('zeb9602', 1,  -11.38,   20.13,  0.00018)
CreateUnitAtMouse('zeb9602', 1,  -11.38,    4.13, -0.00024)
CreateUnitAtMouse('zeb9602', 1,  -19.38,   12.13,  0.00012)
CreateUnitAtMouse('zeb9602', 1,   -3.38,   12.13, -0.00011)
CreateUnitAtMouse('zeb9602', 1,   12.63,   -3.88, -0.00113)
CreateUnitAtMouse('zeb9602', 1,    4.63,  -11.88, -0.00152)
CreateUnitAtMouse('zeb9602', 1,   12.63,   12.13, -0.00060)
CreateUnitAtMouse('ueb1301', 1,   12.63,    4.13, -0.00086)
CreateUnitAtMouse('zeb9602', 1,   20.63,    4.13, -0.00052)
CreateUnitAtMouse('xsb4202', 1,   -0.38,  -18.88, -0.00008)
CreateUnitAtMouse('xsb4301', 1,  -12.38,   -2.88, -0.00043)
CreateUnitAtMouse('xsb4301', 1,    5.63,  -18.88, -0.00032)
CreateUnitAtMouse('xsb4202', 1,  -12.38,  -10.88, -0.00014)
CreateUnitAtMouse('zeb9602', 1,  -27.38,    4.13,  0.00009)
CreateUnitAtMouse('zeb9602', 1,  -19.38,   -3.88,  0.00000)
CreateUnitAtMouse('xsb4202', 1,   25.63,   -4.88,  0.00022)
CreateUnitAtMouse('xsb4202', 1,    3.63,   17.13,  0.00000)
CreateUnitAtMouse('xsb4301', 1,   19.63,   -4.88,  0.00129)
CreateUnitAtMouse('zeb9602', 1,   20.63,  -11.88,  0.01918)
CreateUnitAtMouse('zeb9602', 1,   12.63,  -19.88,  0.07159)
CreateUnitAtMouse('zeb9602', 1,   -3.38,   -3.88, -0.00042)
CreateUnitAtMouse('ueb1301', 1,   -3.38,    4.13, -0.00019)
CreateUnitAtMouse('zeb9602', 1,    4.63,    4.13, -0.00056)
CreateUnitAtMouse('ueb1301', 1,    4.63,   -3.88, -0.00121)
CreateUnitAtMouse('xsb4301', 1,  -20.38,  -10.88,  0.00018)
CreateUnitAtMouse('ueb1301', 1,  -27.38,   -3.88,  0.00006)
```
</details>

## Additional context
<!-- Add any other context about the pull request here. -->
A separate PR will address the accuracy balance, as it is a much more difficult question with the randomness and splash damage involved.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version
