### PR TITLE
Shader rework

### DIFF
--- a/changelog/snippets/other.6485.md
+++ b/changelog/snippets/other.6485.md
@@ -1,0 +1,2 @@
+- (#6485) The new, better way of calculating the water absorption is now available for all terrain shaders. The only requirement is that the light multiplier is set to more than 2.1. Decals now use PBR light calculations if the terrain shader uses it, making them more consistent with the ground they are on.
+- 

--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -378,7 +378,7 @@ struct SHIELDIMPACT_VERTEX
 ///
 ///////////////////////////////////////
 
-bool IsExperimentalShader() {
+bool MapUsesAdvancedWater() {
     // lightMultiplier is one of the few variables that is driven by the map,
     // but accessible by the mesh shader.
     return lightMultiplier > 2.1;
@@ -602,7 +602,7 @@ float3 ApplyWaterColor(float depth, float3 viewDirection, float3 color, float3 e
     // disable the whole thing on land-only maps
     if (surfaceElevation > 0) {
         // we need this switch to make it consistent with the terrain shader coloration
-        if (IsExperimentalShader()) {
+        if (MapUsesAdvancedWater()) {
             // We need to multiply by 2 to match the terrain shader.
             float scaledDepth = (-depth / (surfaceElevation - abyssElevation)) * 2;
             float3 up = float3(0,1,0);

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -504,12 +504,12 @@ float GeometrySmith(float3 n, float nDotV, float3 l, float roughness)
     return gs1 * gs2;
 }
 
-float3 PBR(VS_OUTPUT inV, float4 position, float3 albedo, float3 n, float roughness, float waterDepth) {
+float3 PBR(VS_OUTPUT inV, float3 albedo, float3 n, float roughness, float waterDepth) {
     // See https://blog.selfshadow.com/publications/s2013-shading-course/
 
     float shadow = 1;
     if (ShadowsEnabled == 1) {
-        float terrainShadow = tex2D(UpperAlbedoSampler, position.xy).w; // 1 where sun is, 0 where shadow is
+        float terrainShadow = tex2D(UpperAlbedoSampler, TerrainScale * inV.mTexWT).w; // 1 where sun is, 0 where shadow is
         shadow = tex2D(ShadowSampler, inV.mShadow.xy).g; // 1 where sun is, 0 where shadow is
         shadow *= terrainShadow;
     }
@@ -1352,7 +1352,7 @@ float4 DecalsPS( VS_OUTPUT inV, uniform bool inShadows) : COLOR
     float3 color;
     // We want the decals to behave consistently with the rest of the ground
     if (ShaderUsesPbrRendering()) {
-        color = PBR(inV, TerrainScale * inV.mTexWT, decalAlbedo.rgb, normal, 1-decalSpec.r, waterDepth);
+        color = PBR(inV, decalAlbedo.rgb, normal, 1-decalSpec.r, waterDepth);
     } else {
         color = CalculateLighting(normal, inV.mTexWT.xyz, decalAlbedo.xyz, decalSpec.r, waterDepth, inV.mShadow, inShadows).xyz;
     }
@@ -2037,7 +2037,7 @@ float4 TerrainPBRAlbedoPS ( VS_OUTPUT inV) : COLOR
     float roughness = saturate(albedo.a * mask1.w * 2 + 0.01);
 
     float waterDepth = tex2D(UpperAlbedoSampler, position.xy).b;
-    float3 color = PBR(inV, position, albedo, normal, roughness, waterDepth);
+    float3 color = PBR(inV, albedo, normal, roughness, waterDepth);
     color = ApplyWaterColor(-1 * inV.mViewDirection, inV.mTexWT.z, waterDepth, color);
 
     return float4(color, 0.01f);
@@ -2631,7 +2631,7 @@ float4 Terrain101AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
     float roughness = saturate(albedo.a * mask1.w * 2 + 0.01);
 
     float waterDepth = tex2D(UpperAlbedoSampler, position.xy).b;
-    float3 color = PBR(inV, position, albedo, normal, roughness, waterDepth);
+    float3 color = PBR(inV, albedo, normal, roughness, waterDepth);
     color = ApplyWaterColor(-1 * inV.mViewDirection, inV.mTexWT.z, waterDepth, color);
 
     return float4(color, 0.01f);
@@ -2816,7 +2816,7 @@ float4 Terrain301AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
     float roughness = saturate(albedo.a * mask1.w * 2 + 0.01);
     
     float waterDepth = tex2D(UpperAlbedoSampler, position.xy).b;
-    float3 color = PBR(inV, position, albedo, normal, roughness, waterDepth);
+    float3 color = PBR(inV, albedo, normal, roughness, waterDepth);
     color = ApplyWaterColor(-1 * inV.mViewDirection, inV.mTexWT.z, waterDepth, color);
 
     return float4(color, 0.01f);

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -352,7 +352,7 @@ bool ShaderUsesTerrainInfoTexture() {
     // the tile value for anything else.
 
     // In order to trigger this you need to set the albedo scale to be bigger than the 
-    // map size. Use the value 10000 to be safe for any map
+    // map size in the editor. Use the value 10000 to be safe for any map
     return UpperAlbedoTile.x < 1.0;
 }
 
@@ -364,7 +364,7 @@ bool ShaderUsesPbrRendering() {
     // the tile value for anything else.
 
     // In order to trigger this you need to set the normal scale to be bigger than the 
-    // map size. Use the value 10000 to be safe for any map
+    // map size in the editor. Use the value 10000 to be safe for any map
     return Stratum7NormalTile.x < 1.0;
 }
 

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -1352,7 +1352,7 @@ float4 DecalsPS( VS_OUTPUT inV, uniform bool inShadows) : COLOR
     float3 color;
     // We want the decals to behave consistently with the rest of the ground
     if (ShaderUsesPbrRendering()) {
-        color = PBR(inV, decalAlbedo.rgb, normal, 1-decalSpec.r, waterDepth);
+        color = PBR(inV, decalAlbedo.rgb, normal, 0.9 * (1-decalSpec.r), waterDepth);
     } else {
         color = CalculateLighting(normal, inV.mTexWT.xyz, decalAlbedo.xyz, decalSpec.r, waterDepth, inV.mShadow, inShadows).xyz;
     }


### PR DESCRIPTION
Depends on #6452, so the diff will be misleading until that one is merged.

Now every shader is capable of using the new, better way of calculating the water absorption. The only requirement is that the light multiplier is bigger than 2.1. This is good, because the mesh shader doesn't know what terrain shader is in use and has worked like this before. This could lead to unfitting results, if the light multiplier was big enough, but a terrain shader was used that only supported the legacy water calculation. This is now fixed.

I also made the decals able to use pbr light calculations. Now they behave consistently like the ground they are on. (Also the map editor does this automatically and we can't prevent it, so it helps the editor produce results that are consistent with the game.)
We could also do this for splats, I haven't decided on that yet.

One thing about the decals is that they theoretically have a texture to define the specularity (or roughness), but this texture was black for all decals that I tested. I don't know if there are any decals that have this defined.



## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version