### PR TITLE
Fix depth charges not applying the `ProjectilesToDeflect` blueprint field

### DIFF
--- a/changelog/snippets/fix.6507.md
+++ b/changelog/snippets/fix.6507.md
@@ -1,0 +1,3 @@
+- (#6507) Fix depth charges not applying the ProjectilesToDeflect blueprint field
+
+As a result, all depth charges would also deflect up to 3 projectiles. Mostly applies to torpedo defenses.

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -95,6 +95,9 @@ local VectorCached = Vector(0, 0, 0)
 ---@field OriginalTarget? Unit
 ---@field DamageData WeaponDamageTable
 ---@field MyDepthCharge? DepthCharge
+---@field MyFlare? Flare
+---@field MyUpperFlare? Flare
+---@field MyLowerFlare? Flare
 ---@field CreatedByWeapon Weapon
 ---@field IsRedirected? boolean
 ---@field InnerRing? NukeAOE

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -94,6 +94,7 @@ local VectorCached = Vector(0, 0, 0)
 ---@field Launcher Unit
 ---@field OriginalTarget? Unit
 ---@field DamageData WeaponDamageTable
+---@field MyDepthCharge? DepthCharge
 ---@field CreatedByWeapon Weapon
 ---@field IsRedirected? boolean
 ---@field InnerRing? NukeAOE

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -94,10 +94,10 @@ local VectorCached = Vector(0, 0, 0)
 ---@field Launcher Unit
 ---@field OriginalTarget? Unit
 ---@field DamageData WeaponDamageTable
----@field MyDepthCharge? DepthCharge    # If weapon blueprint has as (valid) `DepthCharge` field
----@field MyFlare? Flare            # If weapon blueprint has as (valid) `Flare` field
----@field MyUpperFlare? Flare       # If weapon blueprint has as (valid) `Flare` field that wants to be stacked
----@field MyLowerFlare? Flare       # If weapon blueprint has as (valid) `Flare` field that wants to be stacked
+---@field MyDepthCharge? DepthCharge    # If weapon blueprint has a (valid) `DepthCharge` field
+---@field MyFlare? Flare            # If weapon blueprint has a (valid) `Flare` field
+---@field MyUpperFlare? Flare       # If weapon blueprint has a (valid) `Flare` field that wants to be stacked
+---@field MyLowerFlare? Flare       # If weapon blueprint has a (valid) `Flare` field that wants to be stacked
 ---@field CreatedByWeapon Weapon
 ---@field IsRedirected? boolean
 ---@field InnerRing? NukeAOE

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -850,12 +850,15 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     AddDepthCharge = function(self, blueprint)
         if not blueprint then return end
         if not blueprint.Radius then return end
-        self.MyDepthCharge = DepthCharge {
+
+        ---@type DepthChargeSpec
+        local depthChargeSpec = {
             Owner = self,
             Radius = blueprint.Radius or 10,
-            DepthCharge = blueprint.ProjectilesToDeflect
+            ProjectilesToDeflect = blueprint.ProjectilesToDeflect
         }
-        self.Trash:Add(self.MyDepthCharge)
+
+        self.MyDepthCharge = self.Trash:Add(DepthCharge(depthChargeSpec))
     end,
 
     --- Called by Lua to create the impact effects

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -94,10 +94,10 @@ local VectorCached = Vector(0, 0, 0)
 ---@field Launcher Unit
 ---@field OriginalTarget? Unit
 ---@field DamageData WeaponDamageTable
----@field MyDepthCharge? DepthCharge
----@field MyFlare? Flare
----@field MyUpperFlare? Flare
----@field MyLowerFlare? Flare
+---@field MyDepthCharge? DepthCharge    # If weapon blueprint has as (valid) `DepthCharge` field
+---@field MyFlare? Flare            # If weapon blueprint has as (valid) `Flare` field
+---@field MyUpperFlare? Flare       # If weapon blueprint has as (valid) `Flare` field that wants to be stacked
+---@field MyLowerFlare? Flare       # If weapon blueprint has as (valid) `Flare` field that wants to be stacked
 ---@field CreatedByWeapon Weapon
 ---@field IsRedirected? boolean
 ---@field InnerRing? NukeAOE


### PR DESCRIPTION
## Description of the proposed changes

Fix an issue where the blueprint field `ProjectilesToDeflect` of a depth charge was ignored. It would always default to the value `3`.

## Testing done on the proposed changes

In the following test case I increased the redirect count of the depth charge of the UEF Destroyer to 10.

https://github.com/user-attachments/assets/68fa6e63-9c84-4a6e-a36b-d62aae46c0dd

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
