### PR TITLE
fix keymapper check

### DIFF
--- a/lua/keymap/keymapper.lua
+++ b/lua/keymap/keymapper.lua
@@ -207,7 +207,7 @@ function GetKeyActions()
     local debugKeyActions = import("/lua/keymap/debugkeyactions.lua").debugKeyActions
 
     for k,v in keyActions do
-        if ret[k] and ret[k] != v.action then
+        if ret[k] and ret[k].action != v.action then
             WARN(string.format("Overwriting user key action: %s -> %s", k, ret[k].action))
         end
 

--- a/lua/shared/components/DebugComponent.lua
+++ b/lua/shared/components/DebugComponent.lua
@@ -35,7 +35,7 @@ DebugComponent = ClassSimple {
     EnabledLogging = true,
     EnabledWarnings = true,
     EnabledErrors = true,
-    EnabledDrawing = true,
+    EnabledDrawing = false,
 
     --#endregion
 }

--- a/lua/version.lua
+++ b/lua/version.lua
@@ -28,9 +28,9 @@
 -- - https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-fafbeta.yaml
 -- - https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-fafdevelop.yaml
 
-local GameType = 'unknown'  -- The use of `'` instead of `"` is **intentional**
+local GameType = "FAF Develop"  -- The use of `'` instead of `"` is **intentional**
 
-local Commit = 'unknown'    -- The use of `'` instead of `"` is **intentional**
+local Commit = "3f034d13505450b406994746590d6668ed322826"    -- The use of `'` instead of `"` is **intentional**
 
 --#endregion
 


### PR DESCRIPTION
Resolved nil error in key check; added missing comparison for action.

example table:
```
ret["select_inview_idle_mex"] = {
    action = "UI_SelectByCategory +inview +idle MASSEXTRACTION",
    category = "user",
    order = 30
}
```