### PR TITLE
fix mesh table srl0310 (Pulsar)

### DIFF
--- a/units/SRL0310/SRL0310_unit.bp
+++ b/units/SRL0310/SRL0310_unit.bp
@@ -103,16 +103,6 @@ UnitBlueprint{
                     Scrolling = true,
                     ShaderName = "Insect",
                 },
-                {
-                    LODCutoff = 512,
-                    Scrolling = true,
-                    ShaderName = "Insect",
-                },
-                {
-                    LODCutoff = 1024,
-                    Scrolling = true,
-                    ShaderName = "Insect",
-                },
             },
         },
         MovementEffects = {


### PR DESCRIPTION
Removed unnecessary mesh tables that were causing errors.

Caused error:
```
Initializing mesh blueprint for /units/srl0310/srl0310_mesh
    Initializing field LODs of RMeshBlueprint at 0x163e8a80
        WARNING: Invalid type for RMeshBlueprintLOD at 0x12b9b84c: nil
```

This may have been for testing purposes and should be commented out rather than deleted?!?