### PR TITLE
Nerf Emissary against shield assistance

### DIFF
--- a/changelog/snippets/balance.6520.md
+++ b/changelog/snippets/balance.6520.md
@@ -1,0 +1,2 @@
+- (#6520) Increase the DoT time of the Aeon T3 Static Artillery (Emissary) to make it possible to block 2 Emissaries with a reasonable amount of buildpower repairing the shield.
+  - Emissary DoTTime: 1 second -> 3.8 seconds

--- a/units/UAB2302/UAB2302_unit.bp
+++ b/units/UAB2302/UAB2302_unit.bp
@@ -149,7 +149,7 @@ UnitBlueprint{
             DamageType = "Normal",
             DisplayName = "Sonance Artillery",
             DoTPulses = 2,
-            DoTTime = 1,
+            DoTTime = 3.8,
             EnergyDrainPerSecond = 4250,
             EnergyRequired = 17000,
             FireTargetLayerCapsTable = {


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Issue
Emissary is better against shield assistance than even T4 artillery because just two of them can kill any shield in one volley in the span of 1 second between the damage instances.
Currently it is impossible to shield assist against two Emissaries because engineers have a roughly 1 second reaction time when assisting a shield before they start repairing it. With #6464 the reaction time would be 0.1 seconds, resulting in the following absurd numbers of T3 engineers/engineering stations ("Assist" is to out-repair the DPS of 1 Emissary, "NextSurvival" is to survive the overkill from two shots):
![image](https://github.com/user-attachments/assets/7f93ffd7-25c8-4783-a325-af122cda3aa7)

Other artillery don't require more buildpower to survive the next shot than buildpower to survive the DPS, so Emissary having up to 5x in that place makes little sense.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Building off of #6464's reaction time changes, the DoT time is increased 1s -> 3.8s to produce much more reasonable amounts of buildpower needed to sustain a shield against two Emissaries.
![image](https://github.com/user-attachments/assets/0d9404ee-f370-47f7-99a6-197cfc2acd80)

Keep in mind the assist cost is for only 1 Emissary's DPS. When looking at 2 Emissaries, the number of engis needed to out-assist DPS would be more than or equal to what is needed to survive the overkill during the DoT for the highest tier shields.

## Reasoning for the changes
While the Emissary does need a good shield-breaking ability to compensate for its low fire rate and AoE being unable to kill shield structures themselves instead of just taking down shields, that ability shouldn't be so powerful that it makes shield assistance completely impossible. It also shouldn't go against the trend of requiring less engis to survive overkill than to survive artillery DPS, as that creates frustrating inconsistencies.

This isn't too strong of a nerf, as compared to other artilleries, you need enough engis to assist against the full DPS of the 2 Emissaries just to survive the overkill, while other artilleries only need half the DPS assistance's engis to survive the next shot and buy time for another shield to recharge. It also still leaves wide open the strong combo of 3 Emissaries killing any assisted shield, since 3 artilleries firing together is generally as powerful as a game ender with any faction's artillery.

## Additional context
<!-- Add any other context about the pull request here. -->
A graphics improvement for the Emissary's hit effect would be even more necessary with a longer DoT.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version
