### PR TITLE
UVD: Remove unnecessary UI elements when the selected unit does not have a special `armorType`

### DIFF
--- a/changelog/snippets/features.6424.md
+++ b/changelog/snippets/features.6424.md
@@ -3,3 +3,5 @@
     - For example, the Ythotha (Seraphim Experimental Assault Bot), which has multiple weapons, is now displayed as possessing a combined total of `3794` direct fire DPS. This is displayed in an additional field in the UI, the stats of the individual weapons of the unit remain accessible in the same locations as before.
 
 - (#6424) Do not display the Mole's Target Tracker in the additional unit details displayed when `Show Armament Detail in Build Menu` is enabled.
+
+- (#6523) Remove unnecessary UI elements from the additional unit details displayed when `Show Armament Detail in Build Menu` is enabled and the selected unit does not have a special `armorType`.

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -516,8 +516,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                 local spaceWidth = control.Value[1]:GetStringAdvance(' ')
                 local str = LOC('<LOC uvd_ArmorType>')..LOC('<LOC at_'..armorType..'>')
                 local spaceCount = (195 - control.Value[1]:GetStringAdvance(str)) / spaceWidth
-                str = str..string.rep(' ', spaceCount)..LOC('<LOC uvd_DamageTaken>')
-                table.insert(lines, str)
+                local takesAdjustedDamage = false
                 for _, armor in armorDefinition do
                     if armor[1] == armorType then
                         local row = 0
@@ -525,6 +524,7 @@ function WrapAndPlaceText(bp, builder, descID, control)
                         local elemCount = table.getsize(armor)
                         for i = 2, elemCount do
                             if string.find(armor[i], '1.0') > 0 then continue end
+                            takesAdjustedDamage = true
                             local armorName = armor[i]
                             armorName = string.sub(armorName, 1, string.find(armorName, ' ') - 1)
                             armorName = LOC('<LOC an_'..armorName..'>')..' - '..string.format('%0.1f', tonumber(armor[i]:sub(armorName:len() + 2, armor[i]:len())) * 100)
@@ -545,6 +545,12 @@ function WrapAndPlaceText(bp, builder, descID, control)
                     end
                 end
                 table.insert(lines, '')
+
+                if takesAdjustedDamage then
+                    str = str..string.rep(' ', spaceCount)..LOC('<LOC uvd_DamageTaken>')
+                end
+                table.insert(lines, 1, str)
+
                 table.insert(blocks, {color = 'FF7FCFCF', lines = lines})
             end
             --Weapons

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -514,8 +514,8 @@ function WrapAndPlaceText(bp, builder, descID, control)
             local armorType = bp.Defense.ArmorType
             if armorType and armorType ~= '' then
                 local spaceWidth = control.Value[1]:GetStringAdvance(' ')
-                local str = LOC('<LOC uvd_ArmorType>')..LOC('<LOC at_'..armorType..'>')
-                local spaceCount = (195 - control.Value[1]:GetStringAdvance(str)) / spaceWidth
+                local headerString = LOC('<LOC uvd_ArmorType>')..LOC('<LOC at_'..armorType..'>')
+                local spaceCount = (195 - control.Value[1]:GetStringAdvance(headerString)) / spaceWidth
                 local takesAdjustedDamage = false
                 for _, armor in armorDefinition do
                     if armor[1] == armorType then
@@ -547,9 +547,9 @@ function WrapAndPlaceText(bp, builder, descID, control)
                 table.insert(lines, '')
 
                 if takesAdjustedDamage then
-                    str = str..string.rep(' ', spaceCount)..LOC('<LOC uvd_DamageTaken>')
+                    headerString = headerString..string.rep(' ', spaceCount)..LOC('<LOC uvd_DamageTaken>')
                 end
-                table.insert(lines, 1, str)
+                table.insert(lines, 1, headerString)
 
                 table.insert(blocks, {color = 'FF7FCFCF', lines = lines})
             end

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -433,6 +433,10 @@ GetAbilityDesc = {
     end
 }
 
+---@param bp UnitBlueprint
+---@param builder UserUnit
+---@param descID string
+---@param control Control
 function WrapAndPlaceText(bp, builder, descID, control)
     local lines = {}
     local blocks = {}

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -512,17 +512,15 @@ function WrapAndPlaceText(bp, builder, descID, control)
                 local spaceWidth = control.Value[1]:GetStringAdvance(' ')
                 local str = LOC('<LOC uvd_ArmorType>')..LOC('<LOC at_'..armorType..'>')
                 local spaceCount = (195 - control.Value[1]:GetStringAdvance(str)) / spaceWidth
-                if armorType ~= "Normal" then
-                    str = str..string.rep(' ', spaceCount)..LOC('<LOC uvd_DamageTaken>')
-                end
+                str = str..string.rep(' ', spaceCount)..LOC('<LOC uvd_DamageTaken>')
                 table.insert(lines, str)
                 for _, armor in armorDefinition do
-                    if armor[1] == armorType and armorType ~= "Normal" then
+                    if armor[1] == armorType then
                         local row = 0
                         local armorDetails = ''
                         local elemCount = table.getsize(armor)
                         for i = 2, elemCount do
-                            --if string.find(armor[i], '1.0') > 0 then continue end
+                            if string.find(armor[i], '1.0') > 0 then continue end
                             local armorName = armor[i]
                             armorName = string.sub(armorName, 1, string.find(armorName, ' ') - 1)
                             armorName = LOC('<LOC an_'..armorName..'>')..' - '..string.format('%0.1f', tonumber(armor[i]:sub(armorName:len() + 2, armor[i]:len())) * 100)

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -512,10 +512,12 @@ function WrapAndPlaceText(bp, builder, descID, control)
                 local spaceWidth = control.Value[1]:GetStringAdvance(' ')
                 local str = LOC('<LOC uvd_ArmorType>')..LOC('<LOC at_'..armorType..'>')
                 local spaceCount = (195 - control.Value[1]:GetStringAdvance(str)) / spaceWidth
-                str = str..string.rep(' ', spaceCount)..LOC('<LOC uvd_DamageTaken>')
+                if armorType ~= "Normal" then
+                    str = str..string.rep(' ', spaceCount)..LOC('<LOC uvd_DamageTaken>')
+                end
                 table.insert(lines, str)
                 for _, armor in armorDefinition do
-                    if armor[1] == armorType then
+                    if armor[1] == armorType and armorType ~= "Normal" then
                         local row = 0
                         local armorDetails = ''
                         local elemCount = table.getsize(armor)


### PR DESCRIPTION
## Description of the proposed changes
This is only a small UI tweak for units without a special `armorType` like, for example, the Striker. The current `armorType` portion of uvd.lua looks like this for these units:
```
Armor Type: Normal          (% of damage taken)
Normal - 100.0

```
This is the new output:
```
Armor Type: Normal
```

Both `(% of damage taken)` and `Normal - 100.0` do not provide the player with any relevant information, so they can be hidden.

## Testing done on the proposed changes
Only affects units without a special `armorType`.

## Checklist
- [x] Changes are documented in the changelog for the next game version