### PR TITLE
Bump the default depth for recursive printing to 3

### DIFF
--- a/changelog/snippets/other.6526.md
+++ b/changelog/snippets/other.6526.md
@@ -1,0 +1,3 @@
+- (#6526) Default the depth of recursive printing/logging to 3 tables deep
+
+The new default applies to all the `repr`-like functions. This only changes the developers experience.

--- a/lua/system/repr.lua
+++ b/lua/system/repr.lua
@@ -260,7 +260,7 @@ end
 local function inspect(root, options)
     options = options or {}
 
-    local depth = options.depth or 1
+    local depth = options.depth or 3
     local newline = options.newline or '\n'
     local indent = options.indent or '  '
     local meta = options.meta or false

--- a/lua/system/repr.lua
+++ b/lua/system/repr.lua
@@ -286,6 +286,10 @@ end
 repr = inspect
 repru = inspect
 reprs = inspect
+
+---@param root any
+---@param options? DebugInspectOptions
+---@return string
 reprsl = function(root, options)
     local str = inspect(root, options)
     LOG(str)


### PR DESCRIPTION
## Description of the proposed changes

A value of 1 is a little inaccessible. Often you are dealing with tables-in-tables. The second parameter that represents the configuration is a little difficult to find however. With this change, we make the default what you want on average.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
