### PR TITLE
Use `Vector` types instead of tables for Scathis script 

### DIFF
--- a/lua/EffectTemplates.lua
+++ b/lua/EffectTemplates.lua
@@ -1456,7 +1456,7 @@ CArtilleryFlash01 = {
     EmtBpPath .. 'proton_artillery_muzzle_08_emit.bp',
 }
 CArtilleryFlash02 = {
-    EmtBpPath .. 'proton_artillery_muzzle_07_emit.bp',
+    EmtBpPath .. 'proton_artillery_muzzle_07_emit.bp', -- Large, faint rings of air expanding outwards
 }
 
 CArtilleryHit01 = DefaultHitExplosion01

--- a/units/URL0401/URL0401_Script.lua
+++ b/units/URL0401/URL0401_Script.lua
@@ -24,7 +24,9 @@ URL0401 = ClassUnit(CLandUnit) {
         ---@field PitchRotators moho.RotateManipulator[] # Pitch rotators for the fake turret barrels
         ---@field currentbarrel number # Which barrel is currently aligned with the aim's yaw
         ---@field Goal number # Yaw goal of fake barrels
-        ---@field restdirvector { x: number, y: number, z: number }
+        ---@field restdirvector Vector
+        ---@field dirvector Vector
+        ---@field basedirvector Vector
         ---@field basediftorest number # "BaseDifToRest" angle in between Yaw aim bone and the resting fake barrel
         ---@field pitchdif number # "PitchDif" angle in between fake barrel pitch and aim barrel pitch
         ---@field rotatedbarrel true? # unused
@@ -37,7 +39,9 @@ URL0401 = ClassUnit(CLandUnit) {
                 self.losttarget = false
                 self.initialaim = true
                 self.PitchRotators = {}
-                self.restdirvector = {}
+                self.restdirvector = Vector(0, 0, 0)
+                self.dirvector = Vector(0, 0, 0)
+                self.basedirvector = Vector(0, 0, 0)
                 self.currentbarrel = 1
             end,
 
@@ -89,21 +93,21 @@ URL0401 = ClassUnit(CLandUnit) {
 
                     -- fake barrel with the same yaw as the aim yaw
                     local barrel = self.currentbarrel
-                    local basedirvector = {}
+                    local basedirvector = self.basedirvector
 
                     self.Goal = 0
-                    self.restdirvector.x, self.restdirvector.y, self.restdirvector.z = self.unit:GetBoneDirection(barrelBones
+                    self.restdirvector[1], self.restdirvector[2], self.restdirvector[3] = self.unit:GetBoneDirection(barrelBones
                         [barrel])
-                    basedirvector.x, basedirvector.y, basedirvector.z = self.unit:GetBoneDirection('Turret_Aim')
+                    basedirvector[1], basedirvector[2], basedirvector[3] = self.unit:GetBoneDirection('Turret_Aim')
                     self.basediftorest = Util.GetAngleInBetween(self.restdirvector, basedirvector)
                 end
 
                 -- since we got a new target, adjust the pitch of the fake barrels to match the aim barrel
                 if self.losttarget or self.initialaim then
-                    local dirvector = {}
-                    dirvector.x, dirvector.y, dirvector.z = self.unit:GetBoneDirection('Turret_Aim_Barrel')
-                    local basedirvector = {}
-                    basedirvector.x, basedirvector.y, basedirvector.z = self.unit:GetBoneDirection('Turret_Aim')
+                    local dirvector = self.dirvector
+                    dirvector[1], dirvector[2], dirvector[3] = self.unit:GetBoneDirection('Turret_Aim_Barrel')
+                    local basedirvector = self.basedirvector
+                    basedirvector[1], basedirvector[2], basedirvector[3] = self.unit:GetBoneDirection('Turret_Aim')
 
                     local basediftoaim = Util.GetAngleInBetween(dirvector, basedirvector)
 

--- a/units/URL0401/URL0401_Script.lua
+++ b/units/URL0401/URL0401_Script.lua
@@ -131,15 +131,7 @@ URL0401 = ClassUnit(CLandUnit) {
                     end
                 end
 
-                local muzzleIdx = 0
-                for i = 1, self.unit:GetBoneCount() do
-                    if self.unit:GetBoneName(i) == 'Turret_Aim_Barrel_Muzzle' then
-                        muzzleIdx = i
-                        break
-                    end
-                end
-
-                CIFArtilleryWeapon.CreateProjectileAtMuzzle(self, muzzleIdx)
+                CIFArtilleryWeapon.CreateProjectileAtMuzzle(self, muzzle)
                 self.Trash:Add(ForkThread(self.LaunchEffects, self))
                 self.Trash:Add(ForkThread(self.RotateBarrels, self))
             end,

--- a/units/URL0401/URL0401_Script.lua
+++ b/units/URL0401/URL0401_Script.lua
@@ -29,7 +29,6 @@ URL0401 = ClassUnit(CLandUnit) {
         ---@field basedirvector Vector
         ---@field basediftorest number # "BaseDifToRest" angle in between Yaw aim bone and the resting fake barrel
         ---@field pitchdif number # "PitchDif" angle in between fake barrel pitch and aim barrel pitch
-        ---@field rotatedbarrel true? # unused
         ---@field Rotator moho.RotateManipulator # Yaw rotator for the `"Turret_Fake"` bone created every time the weapon fires after being packed
         ---@field unit URL0401
         Gun01 = ClassWeapon(CIFArtilleryWeapon) {
@@ -157,7 +156,6 @@ URL0401 = ClassUnit(CLandUnit) {
                     if self.currentbarrel > 6 then
                         self.currentbarrel = 1
                     end
-                    self.rotatedbarrel = true
                 end
             end,
         },

--- a/units/URL0401/URL0401_Script.lua
+++ b/units/URL0401/URL0401_Script.lua
@@ -74,6 +74,12 @@ URL0401 = ClassUnit(CLandUnit) {
                 end
             end,
 
+            --- Empty function because `CreateProjectileAtMuzzle` will wait when aiming the fake barrels, so the FX needs to be created in there for correct timing
+            ---@param self URL0401_Gun01
+            ---@param muzzle Bone
+            PlayFxMuzzleSequence = function(self, muzzle)
+            end,
+
             ---@param self URL0401_Gun01
             ---@param muzzle Bone
             CreateProjectileAtMuzzle = function(self, muzzle)
@@ -131,6 +137,7 @@ URL0401 = ClassUnit(CLandUnit) {
                     end
                 end
 
+                CIFArtilleryWeapon.PlayFxMuzzleSequence(self, muzzle)
                 CIFArtilleryWeapon.CreateProjectileAtMuzzle(self, muzzle)
                 self.Trash:Add(ForkThread(self.LaunchEffects, self))
                 self.Trash:Add(ForkThread(self.RotateBarrels, self))


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes #6524.
- Changes the Scathis's script to use cached `Vector`s instead of local tables `{ x: number, y: number, z: number}`
This is more performant and easier to maintain.
  - For performance, the vectors are also accessed with indices instead of hash keys, avoiding a Vector's `__newindex` call.
- Annotate and explain the Scathis script

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
There are 3 scenarios for the `CreateProjectileAtMuzzle` function changed in this PR: 
- Firing after unpacking (`self.initialaim`)
- Firing while unpacked, but changing targets (`self.losttarget`)
- Firing without changing targets (no special bool)

In all three scenarios the Scathis fires without errors in the log. The fake barrels are misaligned with the real barrel due to a refactoring error fixed in #6525.

## Additional context
<!-- Add any other context about the pull request here. -->
- How should unit weapon annotations be handled? Classes seem to be global, so the name of the unit weapon class has to be unique. I opted for "[UnitID]_[WeaponName]" here.
- I dislike how the script is designed because it interrupts the standard weapon cycle for its own animations, and would personally redesign it to use the `OnStartTracking` and `OnStopTracking` weapon functions.

## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
