### PR TITLE
Remove ASF armor against Ahwassa bomb

### DIFF
--- a/changelog/snippets/balance.6530.md
+++ b/changelog/snippets/balance.6530.md
@@ -1,0 +1,2 @@
+- (#6530) Remove ASF's armor against Ahwassa bomb, as it is no longer necessary with the new delayed explosion.
+  - Air superiority fighters: Damage taken from Ahwassa bomb 10% -> 100%

--- a/lua/armordefinition.lua
+++ b/lua/armordefinition.lua
@@ -20,7 +20,6 @@
 ---| "FireBeetleExplosion"
 ---| "Normal"
 ---| "Nuke"
----| "OtheTacticalBomb"
 ---| "Overcharge"
 ---| "Reclaimed"
 ---| "Spell"
@@ -105,7 +104,6 @@ armordefinition = {
         -- Armor Definition
         'Normal 1.0',
         'CzarBeam 0.25',
-        'OtheTacticalBomb 0.1',
     },
     {
         -- Armor Type name

--- a/units/XSA0402/XSA0402_unit.bp
+++ b/units/XSA0402/XSA0402_unit.bp
@@ -210,7 +210,7 @@ UnitBlueprint{
             Damage = 11000,
             DamageFriendly = true,
             DamageRadius = 19,
-            DamageType = "OtheTacticalBomb",
+            DamageType = "Normal",
             DisplayName = "Othe Tactical Bomb",
             FireTargetLayerCapsTable = {
                 Air = "Land|Water|Seabed",


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Reasoning for the changes
Since a delay was added to the Ahwassa bomb, it is possible to micro ASF out of the explosion, and the armor against it is no longer necessary.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
- Removes the armor type: I don't think anyone outside of FAF was using the damage type for this specific balance feature.
- Changes the Ahwassa bomb's damage type to normal.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
- Checked that the damage type is not mentioned anywhere.
- Verified that ASF take full damage
- Verified that it is possible to move out of range of a ground fired bomb's explosion even if it lands on top of the ASF
  - Note: since the damage radius is spherical, the high altitude of ASFs means that the bomb actually has as small effective blast radius against ASF, about half the ground radius.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version
