### PR TITLE
Fix excess projectiles in the same tick impacting entities that die that tick

### DIFF
--- a/changelog/snippets/fix.6532.md
+++ b/changelog/snippets/fix.6532.md
@@ -1,0 +1,1 @@
+- (#6532) Fix excess projectiles impacting entities that die in the same tick. For example, 6 tactical missiles impacting a shield at the same time, despite only 3 being needed to bring down the shield.

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -322,6 +322,12 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     ---@param targetType string
     ---@param targetEntity Unit | Prop
     OnImpact = function(self, targetType, targetEntity)
+        -- Since collision is checked before impacts are run, collision changes caused by impacts need to be checked by impacts
+        -- For example, a shield will first tell every projectile that it can collide with it, and then only afterwards will
+        -- HP be drained from the shield, and collisions turned off due to the shield being down. The same applies for units.
+        if targetEntity.DisallowCollisions then
+            return
+        end
 
         -- localize information for performance
         local position = self:GetPosition()

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -328,7 +328,6 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         if targetEntity.DisallowCollisions then
             return
         end
-        LOG('impacted', targetType, GetGameTick())
 
         -- localize information for performance
         local position = self:GetPosition()

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -328,6 +328,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         if targetEntity.DisallowCollisions then
             return
         end
+        LOG('impacted', targetType, GetGameTick())
 
         -- localize information for performance
         local position = self:GetPosition()

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -319,7 +319,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
 
     --- Called by the engine when the projectile impacts something
     ---@param self Projectile
-    ---@param targetType string
+    ---@param targetType ImpactType
     ---@param targetEntity Unit | Prop
     OnImpact = function(self, targetType, targetEntity)
         -- Since collision is checked before impacts are run, collision changes caused by impacts need to be checked by impacts


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Issue
If multiple projectiles hit a target in the same tick, they will all impact it regardless of the target's HP.
For example, 6 TML (36000 damage) placed in a line will all impact a 13000 HP shield if they hit on the same tick. In general, any line/concave formation of units could be susceptible to this bug.

This is because collisions are checked for all projectiles before any impact scripts are run, so the usual `OnCollisionCheck` `if self.DisallowCollisions then return false end` doesn't work if `DisallowCollisions` is adjusted due to damage taken from impacts.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
- Check `DisallowCollisions` in the `OnImpact` function of the projectile, so that projectiles have an up-to-date status on the entity's collision as HP gets adjusted due to previous impacts.
- Add the `DisallowCollisions` boolean to shields because:
  1. `_IsUp` would be an extra check for all projectiles
  2. `_IsUp` is adjusted by state changes, which are forked threads that happen after all impact scripts are run.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Use a logging statement to see how many projectiles impact a unit or shield and how many impact the terrain. The projectiles are from 15 TML stacked on top of each other, although realistic scenarios like 6 TML in a line can also impact a shield in the same tick.
The logging statement shows that just enough projectiles to kill the unit/shield hit it, and the rest passed on to hit the terrain behind/under it.

Tested with a shield, a Ythotha (unit with death animation), Percival (standard unit), and a Tempest (sinking animation unit). Before the changes, all 15 TML would impact the target, and after the changes only the necessary amount impact the target.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
