### PR TITLE
Remove rounding in weapon tracking radius sanitization

### DIFF
--- a/changelog/snippets/fix.6536.md
+++ b/changelog/snippets/fix.6536.md
@@ -1,0 +1,5 @@
+- (#6536) Fix the tracking radius for unit weapons being floored to the nearest tenth, which made units not track targets that are near the outside of their range.
+  - Mobile unit weapons: 1.0x of weapon range -> 1.05x
+  - Anti-air weapons: 1.10x -> 1.15x
+  - Bomber weapons: 1.2x -> 1.25x
+  - Structure weapons: 1x -> 1x

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -145,6 +145,7 @@
 ---@see SetAutoMode
 ---@field InitialAutoMode boolean
 --- unit should unpack before firing weapon
+--- Engine sets tracking radius to 1x, calls OnLostTarget when given a move order, and OnGotTarget only when not moving
 ---@field NeedUnpack boolean
 --- this muliplier is applied when a staging platform is refueling an air unit
 ---@field RefuelingMultiplier number

--- a/lua/system/blueprints-weapons.lua
+++ b/lua/system/blueprints-weapons.lua
@@ -1,11 +1,10 @@
-
 local weaponTargetCheckUpperLimit = 6000
 
 ---@param unit UnitBlueprint
 ---@param weapon WeaponBlueprint
 ---@param projectile? ProjectileBlueprint
 local function ProcessWeapon(unit, weapon, projectile)
-    -- pre-compute flags   
+    -- pre-compute flags
     local isAir = false
     local isStructure = false
     local isBomber = false
@@ -81,7 +80,7 @@ local function ProcessWeapon(unit, weapon, projectile)
         end
     end
 
-    -- process target tracking radius 
+    -- process target tracking radius
 
     -- if it is set then we use that - allows us to make adjustments as we see fit
     if weapon.TrackingRadius == nil then
@@ -99,7 +98,7 @@ local function ProcessWeapon(unit, weapon, projectile)
         end
 
         -- add significant target checking radius for bombers
-        if isBomber then 
+        if isBomber then
             weapon.TrackingRadius = 1.25
         end
     end
@@ -112,8 +111,8 @@ local function ProcessWeapon(unit, weapon, projectile)
         -- by default, do not recheck targets as that is expensive when a lot of units are stacked on top of another
         weapon.AlwaysRecheckTarget = false
 
-        -- allow 
-        if  weapon.RangeCategory == 'UWRC_DirectFire' or
+        -- allow
+        if weapon.RangeCategory == 'UWRC_DirectFire' or
             weapon.RangeCategory == "UWRC_IndirectFire" or
             weapon.MaxRadius > 50 and (weapon.RangeCategory ~= "UWRC_AntiNavy") then
             weapon.AlwaysRecheckTarget = true

--- a/lua/system/blueprints-weapons.lua
+++ b/lua/system/blueprints-weapons.lua
@@ -136,6 +136,7 @@ local function ProcessWeapon(unit, weapon, projectile)
         weapon.AlwaysRecheckTarget = false
     end
 
+    -- Floor target check interval to ticks
     weapon.TargetCheckInterval = 0.1 * math.floor(10 * weapon.TargetCheckInterval)
 end
 

--- a/lua/system/blueprints-weapons.lua
+++ b/lua/system/blueprints-weapons.lua
@@ -138,7 +138,6 @@ local function ProcessWeapon(unit, weapon, projectile)
     end
 
     weapon.TargetCheckInterval = 0.1 * math.floor(10 * weapon.TargetCheckInterval)
-    weapon.TrackingRadius = 0.1 * math.floor(10 * weapon.TrackingRadius)
 end
 
 ---@param allBlueprints BlueprintsTable


### PR DESCRIPTION
## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes a bug where most weapons got 1.0 tracking radius because they were set to 1.05 but floored to 1.0.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spawn a unit and see that it does aim at targets at 1.05x its range.

## Additional context
<!-- Add any other context about the pull request here. -->
- I was investigating why T3 mobile artillery wasn't unpacking when targets were outside on the edge of its range in reponse to this [Discord suggestion](https://discord.com/channels/197033481883222026/1306178958357823510) for a manual pack/unpack for T3 mobile artillery when I found out that the tracking radius wasn't applying for any units. It still doesn't apply for T3 mobile arty because of `NeedsUnpack = true`. Working around that engine AI logic adds lots of conditionals to the lua which is buggy, and deploying when targets are nearby is possibly undesired anyway.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
