### PR TITLE
Fix `GetArmyBrain` being called on observers in sim side of recall

### DIFF
--- a/changelog/snippets/fix.6396.md
+++ b/changelog/snippets/fix.6396.md
@@ -1,0 +1,1 @@
+- (#6396, #6538) Fix recall failing on 1 "no" vote less than needed, dead players having their previous recall votes still in effect, and multiple bugs with the voting UI (mainly previous votes showing up again for new recalls).

--- a/lua/sim/Recall.lua
+++ b/lua/sim/Recall.lua
@@ -111,8 +111,13 @@ end
 ---@return CannotRecallReason
 ---@return number? cooldown no timeout/cooldown if absent
 function ArmyRecallRequestCooldown(army)
+    if army == -1 then
+        return "observer"
+    end
+
     local brain = GetArmyBrain(army)
-    if army == -1 or brain:IsDefeated() then
+
+    if brain:IsDefeated() then
         return "observer"
     end
     if ScenarioInfo.RecallDisabled then


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Caused by #6396 with https://github.com/FAForever/fa/pull/6396/commits/81a2588cc63a50c8e08f5ce6fa52c035fc0025dd.
Fixes the following error:
```
warning: Error running lua script: Invalid army -1. (Use a 1-based index)
         stack traceback:
         	[C]: in function `GetArmyBrain'
         	...\fa\lua\sim\recall.lua(114): in function `ArmyRecallRequestCooldown'
         	...\fa\lua\sim\recall.lua(474): in function <...\fa\lua\sim\recall.lua:465>
```
The error is caused when switching to observer.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Switching to observer no longer generates the error.

## Additional context
<!-- Add any other context about the pull request here. -->

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version
