### PR TITLE
Disable collisions with dead units consistently

### DIFF
--- a/changelog/snippets/fix.6543.md
+++ b/changelog/snippets/fix.6543.md
@@ -1,0 +1,1 @@
+- (#6543) Fix dead units having collision with projectiles and beams for 0.1-0.6 seconds after death.

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1474,6 +1474,9 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         -- this flag is used to skip the need of `IsDestroyed`
         self.Dead = true
 
+        -- don't allow projectiles/beams to collide since we are dead
+        self.DisallowCollisions = true
+
         local layer = self.Layer
         local bp = self.Blueprint
         local army = self.Army
@@ -1500,7 +1503,6 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
             local FractionThreshold = bp.General.FractionThreshold or 0.5
             if self.PlayDeathAnimation and self:GetFractionComplete() > FractionThreshold then
                 self:ForkThread(self.PlayAnimationThread, 'AnimationDeath')
-                self.DisallowCollisions = true
             end
 
             self:DoUnitCallbacks('OnKilled')
@@ -1942,8 +1944,6 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         end
 
         if shallSink then
-            self.DisallowCollisions = true
-
             -- Bubbles and stuff coming off the sinking wreck.
             self:ForkThread(self.SinkDestructionEffects)
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -156,7 +156,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     FxDamage2 = {EffectTemplate.DamageFireSmoke01, EffectTemplate.DamageSparks01},
     FxDamage3 = {EffectTemplate.DamageFire01, EffectTemplate.DamageSparks01},
 
-    -- Disables all collisions. This will be true for all units being constructed as upgrades
+    -- Disables all collisions. This will be true for all units being constructed as upgrades and dead units
     DisallowCollisions = false,
 
     -- Destruction parameters
@@ -1574,7 +1574,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     ---@param firingWeapon Weapon The weapon that the projectile originates from
     ---@return boolean
     OnCollisionCheck = function(self, other, firingWeapon)
-        -- bail out immediately
+       -- dead unit or unit that is an upgrade
         if self.DisallowCollisions then
             return false
         end
@@ -1595,8 +1595,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     ---@param firingWeapon Weapon The weapon the beam originates from that we're checking the collision with
     ---@return boolean
     OnCollisionCheckWeapon = function(self, firingWeapon)
-
-       -- bail out immediately
+       -- dead unit or unit that is an upgrade
         if self.DisallowCollisions then
             return false
         end


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Issue
This bit of code runs for all units and causes them to wait while dead before being destroyed, making them block damage when they shouldn't:
https://github.com/FAForever/fa/blob/9948335f0fe0699dead4f1e0070f08ebcfdd9fcc/lua/sim/Unit.lua#L1982-L1994

This code does the same, but makes up a much more significant portion of the wait time (0-0.5 seconds vs 0.1)
https://github.com/FAForever/fa/blob/9948335f0fe0699dead4f1e0070f08ebcfdd9fcc/lua/sim/Unit.lua#L1921-L1924

For a practical example, spawn a line of hives and an enemy monkeylord. The monkeylord's laser will be blocked while the dead hive is going through its explosion FX.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
- add `DisallowCollisions = true` to `OnKilled` as that is the entry point for all the issues that arise with collisions after death (`DeathThreadDestructionWaitTime`, sinking, and death animations)
  - remove the statement in the sinking and death animation cases as it is no longer necessary

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
- Monkeylord can laser through a line of hives without getting blocked
- Monkeylord can kill a cruiser, then kill another cruiser spawned 1 ogrid behind the dead one (the sinking cruiser's hitbox remains on the surface)
- Monkeylord can kill a monkeylord and the laser immediately goes through to a target behind the monkeylord in the death animation

## Additional context
<!-- Add any other context about the pull request here. -->
This does not apply to air units because they overwrite `OnKilled`.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
