### PR TITLE
Fix unit transfer enabling enhancement-locked weapons

### DIFF
--- a/changelog/snippets/fix.6544.md
+++ b/changelog/snippets/fix.6544.md
@@ -1,0 +1,1 @@
+- (#6544) Fix unit transfer enabling weapons locked by enhancements, such as the TML of the Seraphim SACU.

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -302,8 +302,12 @@ function TransferUnitsOwnership(units, toArmy, captured)
         -- disable all weapons, enable with a delay
         for k = 1, unit.WeaponCount do
             local weapon = unit:GetWeapon(k)
-            weapon:SetEnabled(false)
-            weapon:ForkThread(TransferUnitsOwnershipDelayedWeapons)
+            -- Weapons disabled by enhancement shouldn't be re-enabled unless the enhancement is built
+            local enablingEnhancement = weapon.Blueprint.EnabledByEnhancement
+            if not enablingEnhancement or (activeEnhancements and activeEnhancements[enablingEnhancement]) then
+                weapon:SetEnabled(false)
+                weapon:ForkThread(TransferUnitsOwnershipDelayedWeapons)
+            end
         end
     end
 


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes a bug where transferring units (Seraphim SACU) enables their enhancement-disabled weapons (Seraphim SACU TML) despite the enhancement not being built.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
1. Spawn a Seraphim SACU without any upgrades.
2. Transfer it to another team.
3. It should not start building a missile. You also should not be able to order it to fire a missile by selecting a TML along with the SACU to be able to give the launch and build orders.
  - In contrast, a missile preset is able to load and fire missiles without any workaround.

## Additional context
<!-- Add any other context about the pull request here. -->
The overcharge weapon seems to not re-enable itself without these changes anyway, I'm not sure why.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
