### PR TITLE
Fix billy nuke launches being synced to UI

### DIFF
--- a/changelog/snippets/fix.6546.md
+++ b/changelog/snippets/fix.6546.md
@@ -1,0 +1,1 @@
+- (#6546) Fix an exploit that allows being notified of enemy Billy nuke launches.

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -229,6 +229,7 @@ function OnSync()
     end
 
     if Sync.NukeLaunchData then
+        LOG(repr(Sync.NukeLaunchData))
         import("/lua/ui/game/nukelaunchping.lua").DoNukePing(Sync.NukeLaunchData)
     end
 

--- a/lua/UserSync.lua
+++ b/lua/UserSync.lua
@@ -229,7 +229,6 @@ function OnSync()
     end
 
     if Sync.NukeLaunchData then
-        LOG(repr(Sync.NukeLaunchData))
         import("/lua/ui/game/nukelaunchping.lua").DoNukePing(Sync.NukeLaunchData)
     end
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2154,14 +2154,10 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
             return
         end
 
-        local bp = self.Blueprint.Audio
+        local bp = self.Blueprint.Audio.NuclearLaunchDetected
         if bp then
             for num, aiBrain in ArmyBrains do
-                local factionIndex = aiBrain:GetFactionIndex()
-
-                if bp['NuclearLaunchDetected'] then
-                    aiBrain:NuclearLaunchDetected(bp['NuclearLaunchDetected'])
-                end
+                aiBrain:NuclearLaunchDetected(bp)
             end
         end
     end,

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -1058,18 +1058,26 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                     -- Decrement the ammo if they are a counted projectile
                     if proj and not proj:BeenDestroyed() and countedProjectile then
                         if bp.NukeWeapon then
+                            -- Play the "Strategic launch detected" VO to all armies
                             unit:NukeCreatedAtUnit()
                             unit:RemoveNukeSiloAmmo(1)
+
                             -- Generate UI notification for automatic nuke ping
-                            local launchData = {
-                                army = self.Army - 1,
-                                location = (GetFocusArmy() == -1 or IsAlly(self.Army, GetFocusArmy())) and
-                                    self:GetCurrentTargetPos() or nil
-                            }
-                            if not Sync.NukeLaunchData then
-                                Sync.NukeLaunchData = {}
+                            -- Enemies receive the notification without location data to avoid cheats, while still being notified visually instead of only by audio
+
+                            local isObsOrAlly = GetFocusArmy() == -1 or IsAlly(self.Army, GetFocusArmy())
+
+                            -- the global VO plays only when the audio exists, so notify enemies if it exists
+                            if isObsOrAlly or unit.Blueprint.Audio.NuclearLaunchDetected ~= nil then
+                                local launchData = {
+                                    army = self.Army - 1,
+                                    location = isObsOrAlly and self:GetCurrentTargetPos() or nil
+                                }
+                                if not Sync.NukeLaunchData then
+                                    Sync.NukeLaunchData = {}
+                                end
+                                table.insert(Sync.NukeLaunchData, launchData)
                             end
-                            table.insert(Sync.NukeLaunchData, launchData)
                         else
                             unit:RemoveTacticalSiloAmmo(1)
                         end


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Issue
An exploit that @clyfordv's mod discovered, where you can be notified of enemy billy nuke launches because the launch data is synced despite not having a VO line play.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes the exploit by adding the VO's condition from `Unit.NukeCreatedAtUnit` to the launch data sync condition. Allies still get pings for billy nukes.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Log the data that is synced when a nuke launches:
- Allies/yourself/observers receive data + location data of billy nukes and nukes
- When switching to an enemy army before launching the nuke, you receive data only for nukes and no data at all for billy nukes.

## Additional Context
There is currently no visual indicator for strategic launches by default, but it can be modded in.
Effectively a continuation of the anti-cheat logic in https://github.com/FAForever/fa/pull/5582.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
