### PR TITLE
Do not use the script-defined playable area when it is tiny

### DIFF
--- a/changelog/fix.6547.md
+++ b/changelog/fix.6547.md
@@ -1,0 +1,5 @@
+- (#6547) Fix an issue with the navigational mesh on unexplored maps
+
+The navigational mesh is used by AIs to understand the map. On unexplored maps the playable area is temporarily reduced to a very small fraction at the start of the map. This confuses the navigational mesh. We now introduce a check that if the current playable area is too small to be playable then we simply ignore it.
+
+This should only trigger on unexplored maps.

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -1228,7 +1228,16 @@ function PopulateCaches(tCache, dCache, daCache, pxCache, pzCache, pCache, bCach
     local isSkirmish = ScenarioInfo.type == 'skirmish'
 
     local tlx, tlz, brx, brz
-    if playableArea and isSkirmish then
+    if playableArea and isSkirmish and
+
+        -- check if the playable area is large enough. There are edge cases where maps temporarily decrease the playable 
+        -- area size. Since we can not re-generate the navigational mesh as AIs expect the structure to remain the 
+        -- same we just take the size of the map instead.
+
+        -- This for example applies to generated maps with the unexplored setting.
+        playableArea[3] - playableArea[1] > 32 and
+        playableArea[4] - playableArea[2] > 32
+    then
         tlx = playableArea[1]
         tlz = playableArea[2]
         brx = playableArea[3]


### PR DESCRIPTION
## Description of the proposed changes

Reported by @maudlin27 on the AI Discord, see also:

- https://discord.com/channels/619646141306503181/941273132818391100/1289285154145046623

Generated and unexplored maps temporarily set the playable area to 4. This confuses the navigational mesh. When the playable area is too small we instead opt to ignore it. This solution is not ideal.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
