### PR TITLE
Hide the map preview for now

### DIFF
--- a/changelog/snippets/features.6479.md
+++ b/changelog/snippets/features.6479.md
@@ -1,6 +1,8 @@
 - (#6479) Rework the in-game matchmaker lobby from the ground up
 
-From a user perspective the matchmaker lobby now has a map preview and a connection matrix. The map preview can help the players to understand what they'll be gating into. The connection matrix can help players to understand what source (a player) is connected to what source (another player). The diagonal represents what sources (other players) the local client is connected to. When you receive a message from a peer then it blinks the corresponding box in the matrix.
+From a user perspective there should be essentially no changes. A new connection matrix is introduced that can help players to understand what source (a player) is connected to what source (another player). The diagonal represents what sources (other players) the local client is connected to. When you receive a message from a peer then it blinks the corresponding box in the matrix.
+
+There are further features ready such as a map preview that can help you prepare for the match ahead. That is not shown however until we have better tooling in place to gauge its impact.
 
 From a developers perspective the matchmaker lobby is now maintainable. You can now start the matchmaker lobby locally through your development environment. This allows you to run the matchmaker lobby as if you would find a match in the client. The matchmaker lobby is build from the ground up with maintainability in mind. It now supports a hot reload-like functionality for the interface. This allows you to change the interface on the go, without having to relaunch the game.
 

--- a/lua/ui/lobby/autolobby/AutolobbyInterface.lua
+++ b/lua/ui/lobby/autolobby/AutolobbyInterface.lua
@@ -134,8 +134,9 @@ local AutolobbyInterface = Class(Group) {
         self.State.PlayerOptions = playerOptions
 
         if pathToScenarioInfo and playerOptions then
-            self.Preview:Show()
-            self.Preview:UpdateScenario(pathToScenarioInfo, playerOptions)
+            -- hide it for now until we have a better way to decipher its possible (negative) impact
+            -- self.Preview:Show()
+            -- self.Preview:UpdateScenario(pathToScenarioInfo, playerOptions)
         end
     end,
 


### PR DESCRIPTION
## Description of the proposed changes

Hides the map preview for now.


## Additional context

Requires functionality such as:

- https://github.com/FAForever/server/pull/1028


## Checklist

- [ ] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
