### PR TITLE
Fix Czar missing carrier auto deploy functionality

### DIFF
--- a/changelog/snippets/fix.6549.md
+++ b/changelog/snippets/fix.6549.md
@@ -1,0 +1,1 @@
+- (#6549) Fix CZAR's deploy button not being like that of other aircraft carriers where you can right click it to enable automatic deployment of built units.

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -979,7 +979,7 @@
 --- table of toggle capabilities available for this unit
 ---@field ToggleCaps table<ToggleCap, boolean>
 --- table of boolean toggles set/got with SetStatByCallback/GetStat
----@field StatToggles table<string, table>
+---@field StatToggles? table<string, true>
 --- name of the unit
 ---@field UnitName UnlocalizedString
 ---@field UnitWeight number unused

--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -169,9 +169,15 @@ UnitBlueprint{
         Icon = "air",
         OrderOverrides = {
             RULEUCC_Transport = {
-                bitmapId = "deploy",
-                helpText = "deploy",
+                bitmapId = 'deploy',
+                helpText = 'auto_deploy',
+                behavior = 'AutoDeployBehavior',
+                initialStateFunc = 'AutoDeployInit',
+                statToggle = 'AutoDeploy',
             },
+        },
+        StatToggles = {
+            AutoDeploy = true,
         },
         ToggleCaps = { RULEUTC_ShieldToggle = true },
         UnitName = "<LOC uaa0310_name>CZAR",


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Issue
CZAR does not have the `CARRIER` category, so `blueprints-units.lua` external factory processing for carriers does not pick it up:
https://github.com/FAForever/fa/blob/3f034d13505450b406994746590d6668ed322826/lua/system/blueprints-units.lua#L675-L698

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
- Manually add in the order override and stat toggle added by `blueprints-units.lua`.
- Fix type annotation of the `StatToggles` blueprint field. Not sure why it was incorrectly written in #5581 5dcaac5771cc26d84ec0326de72707e47d4a13d4

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
The button's description is corrected, and when you right click it gets highlighted and constructed units automatically deploy.
![{E107CE8C-0027-4862-99E4-93C3A9E0314A}](https://github.com/user-attachments/assets/eaf96367-b1e9-4e7a-aced-d5a74cc15d57)
![{E6F41DE5-5E96-4EB5-A765-5367404447B9}](https://github.com/user-attachments/assets/05d98f7e-8109-48eb-8964-dd1cd430c254)

## Additional context
<!-- Add any other context about the pull request here. -->
This is the second bug I've seen because of CZAR being a flying carrier, the first being that intel/counterintel remains enabled for units inside the CZAR because its base class is that of an air transport and not a (naval) aircraft carrier.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
