### PR TITLE
Prevent siloes from cancelling missiles when issued a hard-stop command

### DIFF
--- a/changelog/snippets/feature.6557.md
+++ b/changelog/snippets/feature.6557.md
@@ -1,0 +1,1 @@
+- (#6557) Siloes without engineering suites will not cancel missile construction when issued a hard-stop order (siloes will pause construction instead).

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -327,7 +327,10 @@ function Stop(units)
         ClearCommands(silos)
         for _, silo in silos do
             if not GetIsPausedOfUnit(silo) then
-                IssueUnitCommand(silo, 'Pause')
+                local missileInfo = silo:GetMissileInfo()
+                if missileInfo.nukeSiloBuildCount > 0 or missileInfo.tacticalSiloBuildCount > 0 then
+                    IssueUnitCommand(silo, 'Pause')
+                end
             end
         end
     end

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -318,18 +318,20 @@ function ClearCommands(units)
     SimCallback(cb, true)
 end
 
+-- This command (hard stop) will filter out non-construction silo units to avoid wasting partially completed missiles
+-- Those units will have their commands cleared, but will be paused instead of stopped
 function Stop(units)
     units = units or GetSelectedUnits()
-    local silos = EntityCategoryFilterDown(categories.SILO, units)
+    local silos = EntityCategoryFilterDown(categories.SILO - categories.CONSTRUCTION, units)
     if silos[1] then
         ClearCommands(silos)
-        for _, silo in EntityCategoryFilterOut(categories.CONSTRUCTION, units) do
+        for _, silo in silos do
             if not GetIsPausedOfUnit(silo) then
                 IssueUnitCommand(silo, 'Pause')
             end
         end
     end
-    local units = EntityCategoryFilterOut(categories.SILO, units)
+    units = EntityCategoryFilterOut(categories.SILO - categories.CONSTRUCTION, units)
     if units[1] then
         IssueUnitCommand(units, 'Stop')
     end

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -319,7 +319,7 @@ function ClearCommands(units)
 end
 
 function Stop(units)
-    local units = units or GetSelectedUnits()
+    units = units or GetSelectedUnits()
     local silos = EntityCategoryFilterDown(categories.SILO, units)
     if silos[1] then
         ClearCommands(silos)
@@ -336,7 +336,7 @@ function Stop(units)
 end
 
 function SoftStop(units)
-    local units = units or GetSelectedUnits()
+    units = units or GetSelectedUnits()
     Construction.ResetOrderQueues(units)
     ClearCommands(EntityCategoryFilterDown(categories.SILO, units))
     Stop(EntityCategoryFilterOut((categories.SHOWQUEUE * categories.STRUCTURE) + categories.FACTORY + categories.SILO, units))

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -298,14 +298,6 @@ local function MomentaryOrderBehavior(self, modifiers)
     self:SetCheck(false)
 end
 
-function Stop(units)
-    local units = units or GetSelectedUnits()
-
-    if units[1] then
-        IssueUnitCommand(units, 'Stop')
-    end
-end
-
 function ClearCommands(units)
     local cb = {Func = 'ClearCommands'}
 
@@ -324,6 +316,23 @@ function ClearCommands(units)
     end
 
     SimCallback(cb, true)
+end
+
+function Stop(units)
+    local units = units or GetSelectedUnits()
+    local silos = EntityCategoryFilterDown(categories.SILO, units)
+    if silos[1] then
+        ClearCommands(silos)
+        for _, silo in EntityCategoryFilterOut(categories.CONSTRUCTION, units) do
+            if not GetIsPausedOfUnit(silo) then
+                IssueUnitCommand(silo, 'Pause')
+            end
+        end
+    end
+    local units = EntityCategoryFilterOut(categories.SILO, units)
+    if units[1] then
+        IssueUnitCommand(units, 'Stop')
+    end
 end
 
 function SoftStop(units)


### PR DESCRIPTION
## Description of the proposed changes
- Silos without engineering suites (SML, TML, SML subs, Sera battleship) will pause missile construction instead of cancelling (and wasting progress) when issued a hard stop command mid-build.
- Silos with engineering suites (ACUs and SACUs) are unchanged, and will cancel missiles under construction when issued a hard-stop. This is to prevent a situation where you want to construct something with the unit but don't want to spend additional resources on constructing a missile at the same time.
- Code changes: `Stop` is moved below `ClearCommands` to prevent LLS errors/be next to soft stop. Unnecessary local redefinition of `units` at the beginning of `Stop` and `SoftStop` is removed.

## Testing done on the proposed changes
Spawn the following units and issue soft- and hard-stop commands. SACUs and ACUs will cancel missile orders when issued a hard-stop command. All other units will pause construction except Yolona (which can't be paused).

Naval unit spawn:
   CreateUnitAtMouse('urs0304', 0,   -4.50,   -0.79, -1.05475)
   CreateUnitAtMouse('xss0302', 0,   13.22,    2.00, -0.92170)
   CreateUnitAtMouse('uas0304', 0,  -11.28,   -0.49, -1.09571)
   CreateUnitAtMouse('ues0304', 0,    2.56,   -0.72, -1.05031)

Land unit and structure spawn:
   CreateUnitAtMouse('urb2305', 0,   -4.89,  -20.43,  0.00000)
   CreateUnitAtMouse('xrb0304', 0,   -5.89,   18.57, -0.00000)
   CreateUnitAtMouse('xrb0304', 0,   -7.89,   18.57, -0.00000)
   CreateUnitAtMouse('xrb0304', 0,   -1.89,   18.57, -0.00000)
   CreateUnitAtMouse('xrb0304', 0,   -3.89,   18.57, -0.00000)
   CreateUnitAtMouse('xsl0001', 0,    3.24,   -3.47,  0.00000)
   CreateUnitAtMouse('xsl0301', 0,    0.24,   -3.47,  0.00000)
   CreateUnitAtMouse('uel0001', 0,   -2.76,   -3.47,  0.00000)
   CreateUnitAtMouse('xrb0304', 0,    8.11,   18.57, -0.00000)
   CreateUnitAtMouse('xrb0304', 0,    6.11,   18.57, -0.00000)
   CreateUnitAtMouse('urb2108', 0,    2.11,   -8.43,  0.00000)
   CreateUnitAtMouse('xrb0304', 0,   10.11,   18.57, -0.00000)
   CreateUnitAtMouse('xsb2305', 0,    4.11,  -20.43,  0.00000)
   CreateUnitAtMouse('xsb2108', 0,    6.11,   -8.43,  0.00000)
   CreateUnitAtMouse('uab2305', 0,   13.11,  -20.43,  0.00000)
   CreateUnitAtMouse('ueb2305', 0,  -12.89,  -20.43,  0.00000)
   CreateUnitAtMouse('xsb2401', 0,    0.11,  -29.43,  0.00000)
   CreateUnitAtMouse('xrb0304', 0,    4.11,   18.57, -0.00000)
   CreateUnitAtMouse('ueb2108', 0,   -5.89,   -8.43,  0.00000)
   CreateUnitAtMouse('uab2108', 0,   -1.89,   -8.43,  0.00000)
   CreateUnitAtMouse('xrb0304', 0,    2.11,   18.57, -0.00000)
   CreateUnitAtMouse('xrb0304', 0,    0.11,   18.57, -0.00000)
   CreateUnitAtMouse('xab1401', 0,  -11.89,  -30.43, -0.00000)