### PR TITLE
Fix matchmaker games not launching

### DIFF
--- a/docs/_posts/2024-11-29-3814.md
+++ b/docs/_posts/2024-11-29-3814.md
@@ -1,0 +1,16 @@
+---
+layout: post
+title: Game version 3814
+permalink: changelog/3814
+---
+
+
+# Game version 3814 (29th of November, 2024)
+
+A log statement accessed an uninitialized variable, which causes matchmaker games to crash.
+We fixed the log statement and matchmaker should now work again.
+Special thanks to clyf and Nomander for being the emergency response team!
+
+With kind regards,
+
+BlackYps

--- a/lua/ui/lobby/autolobby.lua
+++ b/lua/ui/lobby/autolobby.lua
@@ -42,7 +42,7 @@ local AutolobbyCommunicationsInstance = false
 ---@param natTraversalProvider any
 ---@return UIAutolobbyCommunications
 function CreateLobby(protocol, localPort, desiredPlayerName, localPlayerUID, natTraversalProvider)
-    LOG("CreateLobby", protocol, localPort, desiredPlayerName, localPlayerUID, natTraversalProvider)
+    LOG("CreateLobby", protocol, localPort, desiredPlayerName, localPlayerUID)
 
     -- create the interface, needs to be done before the lobby is
     local playerCount = tonumber(GetCommandLineArg("/players", 1)[1]) or 8

--- a/lua/ui/lobby/changelogData.lua
+++ b/lua/ui/lobby/changelogData.lua
@@ -1,8 +1,25 @@
 ---@type number
-last_version = 3813
+last_version = 3814
 
 ---@type PatchNotes[]
 gamePatches = {
+    {
+        version = 3814,
+        name = "Hotfix",
+        hasPrettyGithubRelease = true,
+        hasPrettyPatchnotes = false,
+        description = {
+            "# Game version 3814 (29th of November, 2024)",
+            "",
+            "A log statement accessed an uninitialized variable, which causes matchmaker games to crash.",
+            "We fixed the log statement and matchmaker should now work again.",
+            "Special thanks to clyf and Nomander for being the emergency response team!",
+            "",
+            "With kind regards,",
+            "",
+            "BlackYps",
+        },
+    },
     {
         version = 3813,
         name = "Developers patch",

--- a/lua/version.lua
+++ b/lua/version.lua
@@ -34,9 +34,9 @@ local Commit = 'unknown'    -- The use of `'` instead of `"` is **intentional**
 
 --#endregion
 
-local Version = "3813"
----@alias PATCH "3813"
----@alias VERSION "1.5.3813"
+local Version = "3814"
+---@alias PATCH "3814"
+---@alias VERSION "1.5.3814"
 ---@return PATCH    # Game release
 function GetVersion()
     LOG(string.format('Supreme Commander: Forged Alliance Lua version %s at %s (%s)', Version, GameType, Commit))

--- a/mod_info.lua
+++ b/mod_info.lua
@@ -27,7 +27,7 @@
 -- - https://github.com/FAForever/fa/blob/deploy/fafdevelop/lua/MODS.LUA
 
 name = "Forged Alliance Forever"
-version = 3813          -- needs to be an integer as it is parsed as a short (16 bit integer)
+version = 3814          -- needs to be an integer as it is parsed as a short (16 bit integer)
 _faf_modname='faf'
 copyright = "Forged Alliance Forever Community"
 description = "Forged Alliance Forever extends Forged Alliance, bringing new patches, game modes, units, ladder, and much more!"


### PR DESCRIPTION
Hosts of matchmaker games got the following error: `warning: GPGNET: Error processing gpg.net command CreateLobby: Attempting to lookup the RType for class Moho::CGpgNetInterface before it is registered.`

According to the debugger, the log statement was at fault.