### PR TITLE
Remove `natTraversalProvider` from CreateLobby LOG

### DIFF
--- a/lua/ui/lobby/autolobby.lua
+++ b/lua/ui/lobby/autolobby.lua
@@ -42,7 +42,7 @@ local AutolobbyCommunicationsInstance = false
 ---@param natTraversalProvider any
 ---@return UIAutolobbyCommunications
 function CreateLobby(protocol, localPort, desiredPlayerName, localPlayerUID, natTraversalProvider)
-    LOG("CreateLobby", protocol, localPort, desiredPlayerName, localPlayerUID, natTraversalProvider)
+    LOG("CreateLobby", protocol, localPort, desiredPlayerName, localPlayerUID)
 
     -- create the interface, needs to be done before the lobby is
     local playerCount = tonumber(GetCommandLineArg("/players", 1)[1]) or 8


### PR DESCRIPTION
Fixes `warning: GPGNET: Error processing gpg.net command CreateLobby: Attempting to lookup the RType for class Moho::CGpgNetInterface before it is registered.`

<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->


## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->


## Additional context
<!-- Add any other context about the pull request here. -->


## Checklist
- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version
