### PR TITLE
Fix bombers missing during vertical movement

### DIFF
--- a/changelog/snippets/fix.6572.md
+++ b/changelog/snippets/fix.6572.md
@@ -1,0 +1,1 @@
+- (#6572) Fix bombers missing when bombing while changing altitude.

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -211,7 +211,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         projVelX = projVelX * multiplier
         projVelZ = projVelZ * multiplier
 
-        local targetPos
+        local targetPos, _
         local targetVelX, targetVelZ = 0, 0
 
         local data = self.CurrentSalvoData

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -13,6 +13,7 @@ local UnitGetVelocity = UnitMethods.GetVelocity
 local UnitGetTargetEntity = UnitMethods.GetTargetEntity
 
 local MathClamp = math.clamp
+local MathSqrt = math.sqrt
 
 ---@class WeaponSalvoData
 ---@field target? Unit | Prop   if absent, will use `targetPos` instead
@@ -207,7 +208,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         -- The projectile will have velocity in the horizontal plane equal to the unit's 3 dimensional speed
         -- Multiply the XZ components by the ratio of the XYZ to XZ speeds to get the correct XZ components
         local projVelXZSquareSum = projVelX * projVelX + projVelZ * projVelZ
-        local multiplier = math.sqrt((projVelXZSquareSum + projVelY * projVelY) / (projVelXZSquareSum))
+        local multiplier = MathSqrt((projVelXZSquareSum + projVelY * projVelY) / (projVelXZSquareSum))
         projVelX = projVelX * multiplier
         projVelZ = projVelZ * multiplier
 
@@ -289,7 +290,6 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         if not targetPos then
             -- put the bomb cluster in free-fall
             local GetSurfaceHeight = GetSurfaceHeight
-            local MathSqrt = math.sqrt
             local spread = self.AdjustedSalvoDelay * (self.SalvoSpreadStart + self.CurrentSalvoNumber)
             -- default gravitational acceleration is 4.9; however, bomb clusters adjust the time it takes to land
             -- so we convert the acceleration to time to add the spread and convert back:

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -204,6 +204,13 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         local projPosX, projPosY, projPosZ = EntityGetPositionXYZ(projectile)
         local projVelX, _, projVelZ = UnitGetVelocity(launcher)
 
+        -- The projectile will have velocity in the horizontal plane equal to the unit's 3 dimensional speed
+        -- Multiply the XZ components by the ratio of the XYZ to XZ speeds to get the correct XZ components
+        local projVelXZSquareSum = projVelX * projVelX + projVelZ * projVelZ
+        local multiplier = math.sqrt((projVelXZSquareSum + _ * _) / (projVelXZSquareSum))
+        projVelX = projVelX * multiplier
+        projVelZ = projVelZ * multiplier
+
         local targetPos
         local targetVelX, targetVelZ = 0, 0
 

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -202,12 +202,12 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         -- Get projectile position and velocity
         -- velocity will need to be multiplied by 10 due to being returned /tick instead of /s
         local projPosX, projPosY, projPosZ = EntityGetPositionXYZ(projectile)
-        local projVelX, _, projVelZ = UnitGetVelocity(launcher)
+        local projVelX, projVelY, projVelZ = UnitGetVelocity(launcher)
 
         -- The projectile will have velocity in the horizontal plane equal to the unit's 3 dimensional speed
         -- Multiply the XZ components by the ratio of the XYZ to XZ speeds to get the correct XZ components
         local projVelXZSquareSum = projVelX * projVelX + projVelZ * projVelZ
-        local multiplier = math.sqrt((projVelXZSquareSum + _ * _) / (projVelXZSquareSum))
+        local multiplier = math.sqrt((projVelXZSquareSum + projVelY * projVelY) / (projVelXZSquareSum))
         projVelX = projVelX * multiplier
         projVelZ = projVelZ * multiplier
 


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Issue
Bombers miss when moving vertically because bombs inherit launcher XYZ momentum rotated onto the XZ plane, but the Lua calculation assumes only launcher XZ momentum is inherited.



## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Add a few lines fixing the XZ momentum used by the Lua calcuation.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Order a bomber to attack somewhere where it will be changing altitude, it should be perfectly accurate now. The easiest way is to groundfire in front of a landed bomber. You can also groundfire the peak of a mountain.
Left: no fix. Right: fixed

https://github.com/user-attachments/assets/1cc9f317-dfdd-4961-8bb2-5bdb1e8951d1

## Additional context
<!-- Add any other context about the pull request here. -->
The engine still calculates the bomb drop zone independently for firing the bomb, and may not let the bomb fire at all. You can use `ai_RenderBombDropZone` to see the drop zone.

Bombs still have a speed limit in the projectile bp in an effort to reduce the minimum bomb drop time in the case of bombing right under the bomber, but this can make them miss when they fire downwards from a high altitude, where the bomb will accelerate a lot.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
