### PR TITLE
Automatically rotate the Monkeylord towards targets, limited outside a range

### DIFF
--- a/changelog/snippets/balance.6437.md
+++ b/changelog/snippets/balance.6437.md
@@ -1,0 +1,3 @@
+- (#6437) Automatically rotate Cybran Carrier, Othuum, and Monkeylord towards their targets when idle or attacking so that all their weapons can fire.
+    - Monkeylord will not automatically rotate when the laser is firing, to make it get in the way of micro less.
+    - The units rotate in place when aiming like this.

--- a/changelog/snippets/balance.6437.md
+++ b/changelog/snippets/balance.6437.md
@@ -1,3 +1,3 @@
-- (#6437) Automatically rotate Cybran Carrier, Othuum, and Monkeylord towards their targets when idle or attacking so that all their weapons can fire.
-    - Monkeylord will not automatically rotate when the laser is firing, to make it get in the way of micro less.
+- (#6437, #6574) Automatically rotate Cybran Carrier, Othuum, and Monkeylord towards their targets when idle or attacking so that all their weapons can fire.
+    - Monkeylord will not automatically rotate within 50 range, to make it not get in the way of micro.
     - The units rotate in place when aiming like this.

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -310,8 +310,6 @@ UnitBlueprint{
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
             RateOfFire = 10/1, --10/integer interval in ticks
-            SlavedToBody = true,
-            SlavedToBodyArcRange = 180,
             TargetPriorities = {
                 "EXPERIMENTAL",
                 "SUBCOMMANDER",
@@ -336,6 +334,23 @@ UnitBlueprint{
             WeaponCategory = "Direct Fire Experimental",
             WeaponRepackTimeout = 0,
             WeaponUnpacks = false,
+        },
+        {
+            -- Dummy weapon limiting the auto rotate behavior of the secondaries to outside a range
+            AboveWaterTargetsOnly = true,
+            FireTargetLayerCapsTable = {
+                Land = "Land|Water|Seabed",
+                Seabed = "Land|Water|Seabed",
+                Water = "Land|Water|Seabed",
+            },
+            TrackingRadius = 1,
+            TargetCheckInterval = 0.1,
+            RateOfFire = 0,
+            MaxRadius = 50,
+            SlavedToBody = true,
+            SlavedToBodyArcRange = 180,
+            TargetPriorities = { "ALLUNITS" },
+            TargetRestrictDisallow = "UNTARGETABLE",
         },
         {
             AboveWaterFireOnly = true,

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -378,7 +378,8 @@ UnitBlueprint{
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_IndirectFire",
             RateOfFire = 10/7, --10/integer interval in ticks
-            SlavedToBody = false,
+            SlavedToBody = true,
+            SlavedToBodyArcRange = 39,
             TargetPriorities = {
                 "TECH1 MOBILE",
                 "TECH2 MOBILE",
@@ -444,7 +445,8 @@ UnitBlueprint{
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_IndirectFire",
             RateOfFire = 10/7, --10/integer interval in ticks
-            SlavedToBody = false,
+            SlavedToBody = true,
+            SlavedToBodyArcRange = 39,
             TargetPriorities = {
                 "TECH1 MOBILE",
                 "TECH2 MOBILE",

--- a/units/URL0402/URL0402_unit.bp
+++ b/units/URL0402/URL0402_unit.bp
@@ -310,6 +310,8 @@ UnitBlueprint{
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
             RateOfFire = 10/1, --10/integer interval in ticks
+            SlavedToBody = true,
+            SlavedToBodyArcRange = 180,
             TargetPriorities = {
                 "EXPERIMENTAL",
                 "SUBCOMMANDER",


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Cherry picked the now-reverted Monkeylord auto-rotation changes from https://github.com/FAForever/fa/pull/6437. In summary, the ML has angle-restricted weapons that it cannot use when idle, and they make up a significant 450 DPS, so it would be nice if they fired automatically when they can, but on the other hand the ML is slow turning and reliant on micro so turning it automatically is not exactly desired.

Add a dummy weapon that limits the bolters' auto rotation behavior to outside 50 range:
- The target check interval is 0.1 so that the ML doesn't rotate in the time it takes for the dummy weapon to acquire the target.
- The rate of fire is 0 so that `OnFire` only ever gets called once.
- The tracking radius is 1 so that the range in the BP is what is actually used for the unit behavior.
- The necessary targeting fields mimic the bolters/laser valid targets.
- The `SlavedToBody` fields stop the autorotation behavior of the bolters.
- It is placed after the laser so that the unit walks into laser range on an attack task, but after the bolters so that its `SlavedToBody` angle limits have priority.

I think this is the absolute minimum for an AI dummy weapon, it should be replicated to the other dummy weapons (various forms of AA-only units, and transports).

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Testing from the previous PR (since this is cherry picked):
> The units can hit a spirit moving around the unit at max range.

- ML does not rotate for targets outside 50 range, and it goes into laser range when on attack task (attack order, attack move/patrol order).
- Logging the `OnFire` and `OnGot/LostTarget` functions of the base weapon class.

## Checklist
- [x] Changes are annotated, including comments where useful
  - will split blueprint annotations to a different PR since this is a dubious change for balance
- [x] Changes are documented in the changelog for the next game version
