### PR TITLE
Preserve the world camera when switching to/from split view

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,9 @@
   "Lua.runtime.exportEnvDefault": true,
   "Lua.completion.autoRequire": false,
   "Lua.diagnostics.globals": ["ScenarioInfo"],
+  "Lua.format.defaultConfig": {
+    "max_line_length": "unset",
+  },
 
   // used for grammar checks of changelog
   "grammarly.files.include": [

--- a/changelog/snippets/features.6576.md
+++ b/changelog/snippets/features.6576.md
@@ -1,3 +1,3 @@
 - (#6576) Preserve the world camera when switching to/from split view
 
-When you switch to/from split view the primary camera (the left camera) is now preserved. This makes it less disorientating for a player (or caster) to switch to/from split view.
+  When you switch to/from split view the primary camera (the left camera) is now preserved. This makes it less disorientating for a player (or caster) to switch to/from split view.

--- a/changelog/snippets/features.6576.md
+++ b/changelog/snippets/features.6576.md
@@ -1,0 +1,3 @@
+- (#6576) Preserve the world camera when switching to/from split view
+
+When you switch to/from split view the primary camera (the left camera) is now preserved. This makes it less disorientating for a player (or caster) to switch to/from split view.

--- a/lua/ui/game/worldview.lua
+++ b/lua/ui/game/worldview.lua
@@ -93,6 +93,7 @@ local function CreatePositionMarker(army, worldView)
         if not worldView:IsHidden() then
             local pos = worldView:Project(self.pos)
             LayoutHelpers.AtLeftTopIn(self, worldView, (pos.x - self.Width() / 2) / LayoutHelpers.GetPixelScaleFactor(), (pos.y - self.Height() / 2) / LayoutHelpers.GetPixelScaleFactor())
+
             if (self:Left() < worldView:Left() or self:Top() < worldView:Top() or self:Right() > worldView:Right() or self:Bottom() > worldView:Bottom()) then
                 if not self:IsHidden() then
                     self:Hide()

--- a/lua/ui/game/worldview.lua
+++ b/lua/ui/game/worldview.lua
@@ -78,8 +78,7 @@ local function CreatePositionMarker(army, worldView)
     -- That often happens even if the cursor is nowhere near the marker, so it's unusable. This way isn't pretty, but at least it works correctly.
     local oldWVHandleEvent = worldView.HandleEvent
     worldView.HandleEvent = function(self, event)
-        if marker and event.Type == 'ButtonPress' and not event.Modifiers.Middle and
-            marker.frame:HitTest(event.MouseX, event.MouseY) then
+        if marker and event.Type == 'ButtonPress' and not event.Modifiers.Middle and marker.frame:HitTest(event.MouseX, event.MouseY) then
             if positionMarkers[marker.army].views == 1 then
                 positionMarkers[marker.army] = nil
             end
@@ -93,12 +92,8 @@ local function CreatePositionMarker(army, worldView)
     marker.OnFrame = function(self, delta)
         if not worldView:IsHidden() then
             local pos = worldView:Project(self.pos)
-            LayoutHelpers.AtLeftTopIn(self, worldView, (pos.x - self.Width() / 2) / LayoutHelpers.GetPixelScaleFactor(),
-                (pos.y - self.Height() / 2) / LayoutHelpers.GetPixelScaleFactor())
-
-            if (
-                self:Left() < worldView:Left() or self:Top() < worldView:Top() or self:Right() > worldView:Right() or
-                    self:Bottom() > worldView:Bottom()) then
+            LayoutHelpers.AtLeftTopIn(self, worldView, (pos.x - self.Width() / 2) / LayoutHelpers.GetPixelScaleFactor(), (pos.y - self.Height() / 2) / LayoutHelpers.GetPixelScaleFactor())
+            if (self:Left() < worldView:Left() or self:Top() < worldView:Top() or self:Right() > worldView:Right() or self:Bottom() > worldView:Bottom()) then
                 if not self:IsHidden() then
                     self:Hide()
                 end
@@ -124,8 +119,7 @@ function MarkStartPositions(startPositions)
             local faction = armyData.faction + 1
             local color = armyData.color
 
-            positionMarkers[armyId] = { army = armyId, pos = pos, name = name, faction = faction, color = color,
-                views = 0 }
+            positionMarkers[armyId] = { army = armyId, pos = pos, name = name, faction = faction, color = color, views = 0 }
 
             for viewName, view in MapControls do
                 if viewName ~= 'MiniMap' then
@@ -224,13 +218,11 @@ function Expand()
 
         viewLeft.Top:Set(gameViewTemp.Top)
         viewLeft.Left:Set(gameViewTemp.Left)
-        viewLeft.Right:Set(function() return (gameViewTemp.Left() - 2) +
-            ((gameViewTemp.Right() - gameViewTemp.Left()) / 2) end)
+        viewLeft.Right:Set(function() return (gameViewTemp.Left() - 2) + ((gameViewTemp.Right() - gameViewTemp.Left()) / 2) end)
         viewLeft.Bottom:Set(gameViewTemp.Bottom)
 
         viewRight.Top:Set(gameViewTemp.Top)
-        viewRight.Left:Set(function() return (gameViewTemp.Left() + 2) +
-            ((gameViewTemp.Right() - gameViewTemp.Left()) / 2) end)
+        viewRight.Left:Set(function() return (gameViewTemp.Left() + 2) + ((gameViewTemp.Right() - gameViewTemp.Left()) / 2) end)
         viewRight.Right:Set(gameViewTemp.Right)
         viewRight.Bottom:Set(gameViewTemp.Bottom)
     else

--- a/lua/ui/game/worldview.lua
+++ b/lua/ui/game/worldview.lua
@@ -47,7 +47,7 @@ local function CreatePositionMarker(army, worldView)
     marker.frame.Depth:Set(marker:Depth() - 1)
 
     marker.name = UIUtil.CreateText(marker, data.name, 12, UIUtil.bodyFont)
-	marker.name:DisableHitTest()
+    marker.name:DisableHitTest()
     marker.name:SetColor('white')
 
     if Factions[data.faction] then
@@ -78,7 +78,8 @@ local function CreatePositionMarker(army, worldView)
     -- That often happens even if the cursor is nowhere near the marker, so it's unusable. This way isn't pretty, but at least it works correctly.
     local oldWVHandleEvent = worldView.HandleEvent
     worldView.HandleEvent = function(self, event)
-        if marker and event.Type == 'ButtonPress' and not event.Modifiers.Middle and marker.frame:HitTest(event.MouseX, event.MouseY) then
+        if marker and event.Type == 'ButtonPress' and not event.Modifiers.Middle and
+            marker.frame:HitTest(event.MouseX, event.MouseY) then
             if positionMarkers[marker.army].views == 1 then
                 positionMarkers[marker.army] = nil
             end
@@ -92,9 +93,12 @@ local function CreatePositionMarker(army, worldView)
     marker.OnFrame = function(self, delta)
         if not worldView:IsHidden() then
             local pos = worldView:Project(self.pos)
-            LayoutHelpers.AtLeftTopIn(self, worldView, (pos.x - self.Width() / 2) / LayoutHelpers.GetPixelScaleFactor(), (pos.y - self.Height() / 2) / LayoutHelpers.GetPixelScaleFactor())
+            LayoutHelpers.AtLeftTopIn(self, worldView, (pos.x - self.Width() / 2) / LayoutHelpers.GetPixelScaleFactor(),
+                (pos.y - self.Height() / 2) / LayoutHelpers.GetPixelScaleFactor())
 
-            if (self:Left() < worldView:Left() or self:Top() < worldView:Top() or self:Right() > worldView:Right() or self:Bottom() > worldView:Bottom()) then
+            if (
+                self:Left() < worldView:Left() or self:Top() < worldView:Top() or self:Right() > worldView:Right() or
+                    self:Bottom() > worldView:Bottom()) then
                 if not self:IsHidden() then
                     self:Hide()
                 end
@@ -120,7 +124,8 @@ function MarkStartPositions(startPositions)
             local faction = armyData.faction + 1
             local color = armyData.color
 
-            positionMarkers[armyId] = {army = armyId, pos = pos, name = name, faction = faction, color = color, views = 0}
+            positionMarkers[armyId] = { army = armyId, pos = pos, name = name, faction = faction, color = color,
+                views = 0 }
 
             for viewName, view in MapControls do
                 if viewName ~= 'MiniMap' then
@@ -132,6 +137,16 @@ function MarkStartPositions(startPositions)
 end
 
 function CreateMainWorldView(parent, mapGroup, mapGroupRight)
+    -- feature: preserve the world camera when changing views
+    ---@type UserCamera
+    local worldCamera = GetCamera('WorldCamera')
+
+    ---@type UserCameraSettings | nil
+    local worldCameraSettings = nil
+    if worldCamera then
+        worldCameraSettings = worldCamera:SaveSettings()
+    end
+
     if viewLeft then
         viewLeft:Destroy()
         viewLeft = false
@@ -176,6 +191,15 @@ function CreateMainWorldView(parent, mapGroup, mapGroupRight)
         view:DisableHitTest()
         LayoutHelpers.FillParent(view, viewLeft)
     end
+
+    -- feature: preserve the world camera when changing views
+    if worldCameraSettings then
+        local newWorldCamera = GetCamera('WorldCamera')
+        if newWorldCamera then
+            newWorldCamera:RestoreSettings(worldCameraSettings)
+        end
+    end
+
     import("/lua/ui/game/multifunction.lua").RefreshMapDialog()
 end
 
@@ -200,11 +224,13 @@ function Expand()
 
         viewLeft.Top:Set(gameViewTemp.Top)
         viewLeft.Left:Set(gameViewTemp.Left)
-        viewLeft.Right:Set(function() return (gameViewTemp.Left() - 2) + ((gameViewTemp.Right() - gameViewTemp.Left()) / 2) end)
+        viewLeft.Right:Set(function() return (gameViewTemp.Left() - 2) +
+            ((gameViewTemp.Right() - gameViewTemp.Left()) / 2) end)
         viewLeft.Bottom:Set(gameViewTemp.Bottom)
 
         viewRight.Top:Set(gameViewTemp.Top)
-        viewRight.Left:Set(function() return (gameViewTemp.Left() + 2) + ((gameViewTemp.Right() - gameViewTemp.Left()) / 2) end)
+        viewRight.Left:Set(function() return (gameViewTemp.Left() + 2) +
+            ((gameViewTemp.Right() - gameViewTemp.Left()) / 2) end)
         viewRight.Right:Set(gameViewTemp.Right)
         viewRight.Bottom:Set(gameViewTemp.Bottom)
     else


### PR DESCRIPTION
## Description of the proposed changes

Preserves the settings of the primary world camera when switching to/from split view.

## Testing done on the proposed changes

Start up the game and switch to/from split view.

## Additional context

https://github.com/user-attachments/assets/24cb0417-1aa6-4368-b85c-b48fbdacc453

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
