### PR TITLE
Fix personal shields reflecting above the water surface

### DIFF
--- a/changelog/snippets/fix.6583.md
+++ b/changelog/snippets/fix.6583.md
@@ -1,0 +1,1 @@
+- (#6583) Fix personal shields reflecting above the water surface.

--- a/effects/mesh.fx
+++ b/effects/mesh.fx
@@ -4085,6 +4085,8 @@ float4 CybranShieldImpactPS( SHIELDIMPACT_VERTEX vertex, uniform float fadeTime,
 
 float4 PhaseShieldPS( VERTEXNORMAL_VERTEX vertex ) : COLOR
 {
+    if (1 == mirrored) clip(vertex.depth.x);
+
     float2 tc1 = vertex.texcoord0.xy * 0.5;
     tc1.x += 0.005 * vertex.material.x;
     tc1.y += 0.02 * vertex.material.x;
@@ -4108,6 +4110,8 @@ float4 PhaseShieldPS( VERTEXNORMAL_VERTEX vertex ) : COLOR
 
 float4 AeonPhaseShieldPS( VERTEXNORMAL_VERTEX vertex ) : COLOR
 {
+    if (1 == mirrored) clip(vertex.depth.x);
+
     float2 tc1 = vertex.texcoord0.xy * 2;
     tc1.x += 0.005 * vertex.material.x;
     tc1.y += 0.02 * vertex.material.x;
@@ -4131,6 +4135,8 @@ float4 AeonPhaseShieldPS( VERTEXNORMAL_VERTEX vertex ) : COLOR
 
 float4 CybranPhaseShieldPS( VERTEXNORMAL_VERTEX vertex ) : COLOR
 {
+    if (1 == mirrored) clip(vertex.depth.x);
+
     float2 tc1 = vertex.texcoord0.xy * 2;
     tc1.x += 0.1 * vertex.material.x;
     tc1.y += 0.5 * vertex.material.x;
@@ -4156,6 +4162,8 @@ float4 CybranPhaseShieldPS( VERTEXNORMAL_VERTEX vertex ) : COLOR
 
 float4 SeraphimPhaseShieldPS( VERTEXNORMAL_VERTEX vertex ) : COLOR
 {
+    if (1 == mirrored) clip(vertex.depth.x);
+
     float2 tc1 = vertex.texcoord0.xy * 0.5;
     tc1.x += 0.005 * vertex.material.x;
     tc1.y += 0.02 * vertex.material.x;


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes #5381.

Not sure if the changes need comments, as I have no experience with the shaders.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spawn rambo preset SACUs underwater, the shield mesh shouldn't show up above the water. Spawning multiple in one spot makes it easier to see.

Before:
![{F455D36F-388D-4480-95E7-95BD3DE59315}](https://github.com/user-attachments/assets/dee676bb-dc00-455e-a459-a8cfdfc704b1)

After:
![{8167D248-C658-4663-8406-AF651B24EA7F}](https://github.com/user-attachments/assets/075e36f7-f7c8-42da-bd46-1bb0ff67d138)

## Checklist
- [ ] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
