### PR TITLE
Improve comments for unit-specific blueprint fields

### DIFF
--- a/changelog/snippets/other.6587.md
+++ b/changelog/snippets/other.6587.md
@@ -1,0 +1,1 @@
+- (#6587) Improve annotations for unit-specific blueprint fields.

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -52,13 +52,13 @@
 --- the localised language). If the localisation part is not set, the description in tags will be
 --- used for any language, which would be "Medium Tank" for this example
 ---@field Description UnlocalizedString
---- used by the Othuy ("lighting storm") script
+--- used by the XSL0402 (Othuy "lighting storm") script
 ---@field Lifetime? number
---- used by the Othuy ("lighting storm") script
+--- used by the XSL0402 (Othuy "lighting storm") script
 ---@field MaxMoveRange? number
---- used by the Loyalist script
+--- used by the URL0303 (Loyalist) script
 ---@field SecondsBeforeChargeKicksIn? number
---- used by the Loyalist script
+--- used by the URL0303 (Loyalist) script
 ---@field SecondsBeforeExplosionWhenCharging? number
 --- if defined, the collision shape will be a sphere of this radius using the
 --- `CollisionSphereOffset` species of collision offsets
@@ -343,7 +343,7 @@
 
 
 ---@class UnitBlueprintDefense
---- used by the Loyalist script
+--- used by URL0303 (Loyalist) script
 ---@field AntiMissile? {AttachBone: Bone, Radius: number, RedirectRateOfFire: number}
 --- the armor type name
 ---@field ArmorType ArmorType
@@ -476,7 +476,7 @@
 ---@field AnimationBuildRate? number
 --- The table of animations shown at death. One will be randomly pulled.
 ---@field AnimationDeath UnitBlueprintAnimationDeath[]
---- used by the HARMS script
+--- used by the XRB2309 (submerged HARMS) script
 ---@field AnimationDeploy? FileName
 --- factories will play this animation on land units they build
 ---@field AnimationFinishBuildLand? FileName
@@ -493,7 +493,7 @@
 ---@field AnimationSurface? FileName
 --- used by several transports' scripts
 ---@field AnimationTakeOff? FileName
---- used by the Salem class destroyer script
+--- used by the URS0201 (Salem class destroyer) script
 ---@field AnimationTransform? FileName
 --- the animation that is played when the unit is upgrading
 ---@field AnimationUpgrade FileName
@@ -512,7 +512,7 @@
 ---@field BuildAttachBone? Bone
 --- used while cloaked
 ---@field CloakMeshBlueprint? FileName
---- used by the Seraphim Yathsou script
+--- used by the XSS0304 and XSS0203 (Seraphim T3 and T1 sub) scripts
 ---@field CannonOpenAnimation? FileName
 ---@field DamageEffects? UnitBlueprintDamageEffect[]
 --- overrides the rolloff point's orientation
@@ -522,7 +522,7 @@
 --- Effects displayed when the unit is idle (e.g. glow beneath hovering units), multiple layers can
 --- be used. The key should be the name of the layer where effects should be displayed
 ---@field IdleEffects table<Layer, UnitBlueprintEffects>
---- used by the Salem Class destroyer script 
+--- used by the URS0201 (Salem class destroyer) script 
 ---@field LandAnimationDeath? {Animation: FileName, Weight: number}
 --- effects displayed when the unit changes layers (e.g. when an aircraft lands or takes off)
 --- Defines for what transition the effects are created. 'string' is composed of 2 names of layers,
@@ -530,14 +530,14 @@
 --- aircraft landing, so the old layer is Air and the new one is Land, then the 'string' will be
 --- airLand (LandAir would be the opposite - take off). Note: there is NO space between layer names
 ---@field LayerChangeEffects table<LayerChangeType, UnitBlueprintEffects>
---- used by the Seraphim hydrocarbon powerplant script
+--- used by the XSB1102 (Seraphim hydrocarbon powerplant) script
 ---@field LoopingAnimation? FileName
 ---@field MaxRockSpeed? number
 ---@field Mesh MeshBlueprint
 ---@field MeshBlueprint FileName
 --- used for the wreackge if `Wreckage.UseCustomMesh` is set
 ---@field MeshBlueprintWrecked? FileName
---- used by the Yolona Oss script
+--- used by the XSB2401 (Yolona Oss) script
 ---@field MissileBone? Bone
 ---@field MotionChangeEffects table<MotionChangeType, UnitBlueprintEffects>
 --- Effects displayed during movement of the unit. Key should be Name of the layer for which the
@@ -556,7 +556,7 @@
 --- this the collision hitbox should be adapted under `SizeX`, `SizeY`, and `SizeZ` as well.
 ---@field UniformScale number
 ---@field WarpInEffect? UnitBlueprintWarpInEffect
---- used by the Salem Class            
+--- used by the URS0201 (Salem class destroyer) script 
 ---@field WaterAnimationDeath? {}                   
 ---
 --- auto-generated field that points to the mesh to use while building
@@ -700,7 +700,7 @@
 ---@field BuildTime number
 --- present in UEF engineering drones
 ---@field BuildRadius? number
---- used by crab eggs
+--- What unit spawns out of the egg. Used by `CConstructionEggUnit` (Megalith's crab eggs)
 ---@field BuildUnit? UnitId
 --- present in Cybran build drones
 ---@field ConsumptionPerSecondEnergy? number
@@ -713,7 +713,7 @@
 ---@field InitialRallyX number
 --- default rally point Z for the factory
 ---@field InitialRallyZ number
---- used by the Eye of Rhianne
+--- Total energy drain when changing scrying locations. Used by XAB3301 (Eye of Rhianne)
 ---@field InitialRemoteViewingEnergyDrain? number
 --- amount that define which amount of energy the unit is consuming per second; Used for Shields
 ---@field MaintenanceConsumptionPerSecondEnergy? number
@@ -721,9 +721,9 @@
 --- Maximum build range of the unit. The target must be within this range before the
 --- builder can perform operation.
 ---@field MaxBuildDistance number
---- used by the Paragon
+--- used by XAB1401 (Paragon) script
 ---@field MaxEnergy? number
---- used by the Paragon
+--- used by XAB1401 (Paragon) script
 ---@field MaxMass? number
 ---@field MinBuildTime number
 ---@field MinConsumptionPerSecondEnergy? number
@@ -1022,15 +1022,15 @@
 --- The intel is free. Without this, the unit will try drain energy for its
 --- intelligence (radar, sonar, etc) and turn off if you run out.
 ---@field FreeIntel boolean
---- used by the Seraphim T1 air scout for how long the after-death vison remains
+--- Used by XSA0101 (Seraphim T1 air scout) for how long the after-crash vison remains
 ---@field IntelDurationOnDeath? number
 --- how far we create fake blips
 ---@field JamRadius { Max: number, Min: number }
 --- How many blips a jammer produces. Maximum 255
 ---@field JammerBlips number
---- used by the Soothsayer
+--- Vision radius when powered on. Used by XRB3301 (Soothsayer).
 ---@field MaxVisionRadius? number
---- used by the Soothsayer
+--- Vision radius when powered off. Used by XRB3301 (Soothsayer).
 ---@field MinVisionRadius? number
 --- how far our omni coverage goes
 ---@field OmniRadius? number
@@ -1043,7 +1043,7 @@
 ---@field RadarStealthFieldRadius? number
 --- how long until this unit turns back on when you run out of power
 ---@field ReactivateTime? number
---- used by the Eye of Rianne for its scrying vision radius
+--- used by XAB3301 (Eye of Rianne) for its scrying vision radius
 ---@field RemoteViewingRadius? number
 --- Show intel radius of unit if selected
 ---@field ShowIntelOnSelect boolean
@@ -1056,11 +1056,11 @@
 ---@field SonarStealthFieldRadius number
 --- how far off displace blips
 ---@field SpoofRadius { Max: number, Min: number }
---- used by the Selen to define how it needs to sit still while its cloak is enabled for it to work
+--- used by XSL0101 (Selen) to define how it needs to sit still while its cloak is enabled for it to work
 ---@field StealthWaitTime? number
 --- how far the unit can see above water and land
 ---@field VisionRadius number
---- used by the Seraphim T1 air scout to set its vision radius when it crashes
+--- used by XSA0101 (Seraphim T1 air scout) to set its vision radius when it crashes
 ---@field VisionRadiusOnDeath? number
 --- how far the unit can see underwater
 ---@field WaterVisionRadius number
@@ -1107,8 +1107,8 @@
 ---@field GroundCollisionOffset? number
 --- Used in combination with `FlattenSkirt` to guarantee the result is completely horizontal
 ---@field HorizontalSkirt boolean
---- used by the Seraphim sniper bot script as the speed multiplier when the alternate sniper mode
---- is activated
+--- used by XSL0305 (Seraphim sniper bot) script as the speed multiplier during the reload of the alternate sniper mode
+--- also used by URS0201 (Salem class destroyer) script as the speed multiplier when walking on land
 ---@field LandSpeedMultiplier? number
 --- an offset to the layer change height used during the transition between seabed/water and land
 ---@field LayerChangeOffsetHeight number

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -1153,7 +1153,7 @@
 ---@field RotateOnSpot? boolean
 --- threshold speed in ogrids/s for rotate on spot to take effect. defaults to 0.5
 ---@field RotateOnSpotThreshold? number
---- unknown behavior, used by Spiderbot and Megabot
+--- Allows the unit to sink a bit into the ground so that its legs can touch the ground on uneven terrain.
 ---@field SinkLower? boolean
 --- used by the sinker projectile script as the acceleration to reach the bottom of the seabed
 ---@field SinkSpeed? number

--- a/engine/Core/Blueprints/WeaponBlueprint.lua
+++ b/engine/Core/Blueprints/WeaponBlueprint.lua
@@ -31,8 +31,6 @@
 ---@field AimsStraightOnDisable boolean
 --- always recheck for better target regardless of whether you already have one or not
 ---@field AlwaysRecheckTarget boolean
---- used by the Omen's script
----@field AnimationOpen? FileName
 --- animation played by the weapon's Rack Salvo Reload Sequence
 ---@field AnimationReload? FileName
 --- if an anti-artillery shield will block this projectile

--- a/engine/Core/Blueprints/WeaponBlueprint.lua
+++ b/engine/Core/Blueprints/WeaponBlueprint.lua
@@ -55,7 +55,7 @@
 ---@field BombDropThreshold? number
 --- information about the bonuses added to the weapon when it reaches a specific veterancy level
 ---@field Buffs BlueprintBuff[]
---- used by the Lobo script to pass the lifetime of the vision marker created upon landing
+--- used by UEL0103 (Lobo) script to pass the lifetime of the vision marker created upon landing
 ---@field CameraLifetime? number
 --- time to maintain the camera shake
 ---@field CameraShakeDuration? number
@@ -63,7 +63,7 @@
 ---@field CameraShakeMax? number
 --- minimum size of the camera shake
 ---@field CameraShakeMin? number
---- used by the Lobo script to pass the radius of the vision marker created upon landing
+--- used by UEL0103 (Lobo) script to pass the radius of the vision marker created upon landing
 ---@field CameraVisionRadius? number
 --- how far from the unit should the camera shake
 ---@field CameraShakeRadius number
@@ -191,7 +191,7 @@
 --- Speed at which the projectile comes out of the muzzle. This speed is used in the ballistics
 --- calculations. If you weapon doesn't fire at its max radius, this may be too low.
 ---@field MuzzleChargeStart? number
---- used by the Galactic Colossus
+--- Determines which bone units are tractored to. Used by `ADFTractorClaw` (UAL0401 Galactic Colossus's tractor beam)
 ---@field MuzzleSpecial? number
 --- the exit velocity of the projectile once created at the muzzle of the barrel 
 ---@field MuzzleVelocity number
@@ -277,7 +277,7 @@
 ---@field ReTargetOnMiss? boolean
 --- if `true`, will set the orange work progress bar to display the reload progress of this weapon
 ---@field RenderFireClock? boolean
---- used by the Othuy ("lighting storm") to define the time to re-aquire a new target before going
+--- used by the XSL0402 (Othuy "lighting storm") to define the time to re-aquire a new target before going
 --- through the next lighting strike process
 ---@field RequireTime? number
 --- the number of projectiles in the firing salvo

--- a/units/UAS0302/UAS0302_Script.lua
+++ b/units/UAS0302/UAS0302_Script.lua
@@ -15,12 +15,5 @@ UAS0302 = ClassUnit(ASeaUnit) {
         AntiMissile1 = ClassWeapon(AAMWillOWisp) {},
         AntiMissile2 = ClassWeapon(AAMWillOWisp) {},
     },
-
-    OnCreate = function(self)
-        ASeaUnit.OnCreate(self)
-        for i = 1, 3 do
-            self.Trash:Add(CreateAnimator(self):PlayAnim(self:GetBlueprint().Weapon[i].AnimationOpen))
-        end
-    end,
 }
 TypeClass = UAS0302

--- a/units/UAS0302/UAS0302_unit.bp
+++ b/units/UAS0302/UAS0302_unit.bp
@@ -173,7 +173,6 @@ UnitBlueprint{
     Weapon = {
         {
             AboveWaterTargetsOnly = true,
-            AnimationOpen = "/units/uas0302/uas0302_awepF01.sca",
             Audio = {
                 BarrelLoop  = Sound { Bank = 'UAS',       Cue = 'UAS_Turret_Lrg_Loop',     LodCutoff = 'WeaponBig_LodCutoff' },
                 BarrelStart = Sound { Bank = 'UAS',       Cue = 'UAS_Turret_Lrg_Start',    LodCutoff = 'WeaponBig_LodCutoff' },
@@ -236,7 +235,6 @@ UnitBlueprint{
         },
         {
             AboveWaterTargetsOnly = true,
-            AnimationOpen = "/units/uas0302/uas0302_awepM01.sca",
             Audio = {
                 BarrelLoop  = Sound { Bank = 'UAS',       Cue = 'UAS_Turret_Lrg_Loop',     LodCutoff = 'WeaponBig_LodCutoff' },
                 BarrelStart = Sound { Bank = 'UAS',       Cue = 'UAS_Turret_Lrg_Start',    LodCutoff = 'WeaponBig_LodCutoff' },
@@ -300,7 +298,6 @@ UnitBlueprint{
         },
         {
             AboveWaterTargetsOnly = true,
-            AnimationOpen = "/units/uas0302/uas0302_awepB01.sca",
             Audio = {
                 BarrelLoop  = Sound { Bank = 'UAS',       Cue = 'UAS_Turret_Lrg_Loop',     LodCutoff = 'WeaponBig_LodCutoff' },
                 BarrelStart = Sound { Bank = 'UAS',       Cue = 'UAS_Turret_Lrg_Start',    LodCutoff = 'WeaponBig_LodCutoff' },


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
- Improve descriptions for blueprint fields that say "used by" by adding the unit ID or class name
- Annotate SinkLower ("used by" megalith and monkeylord)
- Remove Omen's non-functional weapon opening animations

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
- Placed a monkeylord on a mountain peak to see what SinkLower does.
- Imported Omen's weapon animations into blender and noticed that they don't work because there are bones missing from the mesh.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
