### PR TITLE
Reduce Seraphim Destroyer underwater speed 5 -> 4.5

### DIFF
--- a/changelog/snippets/balance.6588.md
+++ b/changelog/snippets/balance.6588.md
@@ -1,0 +1,4 @@
+- (#6558) The Seraphim destroyer is currently too powerful due to its micro potential, but nerfing its main stats like range or damage would make it weaker than it already is when not micro'd, which would be unfun at lower levels. Considering this, the underwater speed is reduced to allow counterplay potential without heavily affecting lower level gameplay: Aeon and Cybran destroyers can catch Seraphim destroyers that overcommitted, and all destroyers (particularly UEF) can flee from submerged Seraphim destroyers and get out of torpedo range.
+
+    - Seraphim Destroyer (Uashavoh):
+      - Underwater speed: 5 -> 4.5

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -1167,7 +1167,7 @@
 ---@field SkirtSizeZ number
 --- Stands upright regardless of terrain
 ---@field StandUpright boolean
---- used by XSB3202 when the vertical layer changes from top to sub
+--- used by XSB3202 (T2 sonar) and XSS0201 (Destroyer) when the vertical layer changes from top to sub
 ---@field SubSpeedMultiplier? number
 --- turn facing damping for the unit, usually used for hover units only
 ---@field TurnFacingRate number

--- a/units/XSS0201/XSS0201_script.lua
+++ b/units/XSS0201/XSS0201_script.lua
@@ -55,14 +55,17 @@ XSS0201 = ClassUnit(SSubUnit) {
         if new == 'Top' then
             self:SetWeaponEnabledByLabel('FrontTurret', true)
             self:SetWeaponEnabledByLabel('BackTurret', true)
+            self:SetSpeedMult(1)
         elseif new == 'Down' then
             self:SetWeaponEnabledByLabel('FrontTurret', false)
             self:SetWeaponEnabledByLabel('BackTurret', false)
+            self:SetSpeedMult(self.Blueprint.Physics.SubSpeedMultiplier or 1)
         end
     end,
 
     OnStopBeingBuilt = function(self, builer, layer)
         SSubUnit.OnStopBeingBuilt(self, builer, layer)
+        self:SetSpeedMult(self.Blueprint.Physics.SubSpeedMultiplier or 1)
         if self.originalBuilder then
             IssueDive({self})
         end

--- a/units/XSS0201/XSS0201_unit.bp
+++ b/units/XSS0201/XSS0201_unit.bp
@@ -164,6 +164,7 @@ UnitBlueprint{
         MeshExtentsY = 2,
         MeshExtentsZ = 6.25,
         MotionType = "RULEUMT_SurfacingSub",
+        SubSpeedMultiplier = 0.9,
         TurnRadius = 15,
         TurnRate = 50,
     },


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
The Seraphim destroyer is currently too powerful due to its micro potential, but nerfing its main stats like range or damage would make it weaker than it already is when not micro'd, which would be unfun at lower levels. Considering this, reducing the underwater speed allows counterplay potential without heavily affecting lower level gameplay: Aeon and Cybran destroyers can catch Seraphim destroyers that overcommitted, and all destroyers (particularly UEF) can flee from submerged Seraphim destroyers and get out of torpedo range.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
The submerged destroyer is slightly slower than unsubmerged destroyers.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
