### PR TITLE
Increase UEF T3 shield regen delay 1 -> 3 seconds

### DIFF
--- a/changelog/snippets/balance.6589.md
+++ b/changelog/snippets/balance.6589.md
@@ -1,0 +1,4 @@
+- (#6589) Increase the UEF T3 shield's regen start time (the amount of time after taking damage before regeneration starts) to make it consistent with other shields, as it was missed by accident during regen start time changes a long time ago.
+    
+    - UEF T3 Shield Generator:
+      - Regen start time: 1 -> 3 seconds

--- a/units/UEB4301/UEB4301_unit.bp
+++ b/units/UEB4301/UEB4301_unit.bp
@@ -44,7 +44,7 @@ UnitBlueprint{
             ShieldMaxHealth = 17000,
             ShieldRechargeTime = 23,
             ShieldRegenRate = 131,
-            ShieldRegenStartTime = 1,
+            ShieldRegenStartTime = 3,
             ShieldSize = 44,
             ShieldVerticalOffset = -6,
         },


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Closes https://github.com/FAForever/fa/issues/6556

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
The shield starts regenerating at the same time as other shields.
```
   CreateUnitAtMouse('ueb4301', 0,  -17.33,    4.67, -0.00000)
   CreateUnitAtMouse('uab4202', 0,   12.67,    3.67, -0.00000)
   CreateUnitAtMouse('ual0301_shieldcombat', 0,    4.67,   -8.33, -0.00000)
```

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version
