### PR TITLE
Reduce Aeon and Seraphim T2 PD damage

### DIFF
--- a/changelog/snippets/balance.6590.md
+++ b/changelog/snippets/balance.6590.md
@@ -1,0 +1,8 @@
+- (#6590) Reduce the damage of Aeon and Seraphim T2 PD, as they have better DPS/mass than the UEF PD, and the Aeon one has higher muzzle velocity while the Seraphim one has a beam weapon.
+
+  - Aeon T2 PD:
+    - Damage: 600 -> 560 (DPS: 150 -> 140)
+  - Seraphim T2 PD:
+    - Damage: 605 -> 550 (DPS: 151 -> 138)
+
+  For comparison, the Triad has 124 DPS, and all three PDs cost the same amount.

--- a/units/UAB2301/UAB2301_unit.bp
+++ b/units/UAB2301/UAB2301_unit.bp
@@ -127,7 +127,7 @@ UnitBlueprint{
             },
             BallisticArc = "RULEUBA_LowArc",
             CollideFriendly = false,
-            Damage = 600,
+            Damage = 560,
             DamageFriendly = false,
             DamageRadius = 2,
             DamageType = "Normal",

--- a/units/XSB2301/XSB2301_unit.bp
+++ b/units/XSB2301/XSB2301_unit.bp
@@ -140,7 +140,7 @@ UnitBlueprint{
             BeamCollisionDelay = 0,
             BeamLifetime = 1,
             CollideFriendly = false,
-            Damage = 55,
+            Damage = 50,
             DamageRadius = 0,
             DamageType = "Normal",
             DisplayName = "Ultrachromatic Beam Generator",


### PR DESCRIPTION

<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Closes #6554
- Seraphim: 605 -> 550 damage total
  - Beam lifetime preserved for sound effect compatibility (not that it would be very noticeable to be fair).


## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
The point defenses do the correct amount of damage.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version
