### PR TITLE
Include the projectile in the OnMissileIntercepted callback

### DIFF
--- a/changelog/snippets/other.6601
+++ b/changelog/snippets/other.6601
@@ -1,0 +1,1 @@
+- (#6601) Expanded an AI related callback for when TML missiles are intercepted by TMD

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -309,7 +309,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         -- callbacks for launcher to have an idea what is going on for AIs
         local launcher = self.Launcher
         if not IsDestroyed(launcher) then
-            launcher:OnMissileIntercepted(self:GetCurrentTargetPosition(), instigator, self:GetPosition())
+            launcher:OnMissileIntercepted(self:GetCurrentTargetPosition(), instigator, self:GetPosition(), self)
 
             -- keep track of the number of intercepted missiles
             if not IsDestroyed(instigator) and instigator.GetStat then

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -5084,7 +5084,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     ---@param defense Unit Requires an `IsDestroyed` check as the defense may have been destroyed when the missile is intercepted
     ---@param position Vector Location where the missile got intercepted
     ---@param self Unit
-    OnMissileIntercepted = function(self, target, defense, position, self)
+    OnMissileIntercepted = function(self, target, defense, position, projectile)
         -- try and run callbacks
         if self.EventCallbacks['OnMissileIntercepted'] then
             for k, callback in self.EventCallbacks['OnMissileIntercepted'] do

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -5083,7 +5083,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     ---@param target Vector
     ---@param defense Unit Requires an `IsDestroyed` check as the defense may have been destroyed when the missile is intercepted
     ---@param position Vector Location where the missile got intercepted
-    OnMissileIntercepted = function(self, target, defense, position)
+    ---@param self Unit
+    OnMissileIntercepted = function(self, target, defense, position, self)
         -- try and run callbacks
         if self.EventCallbacks['OnMissileIntercepted'] then
             for k, callback in self.EventCallbacks['OnMissileIntercepted'] do


### PR DESCRIPTION
As certain information may be included on the projectile that is of interest to AI when the missile is intercepted

## Description of the proposed changes
Adds the projectile to the onmissileintercepted callback, for if the projectile contains information of use to the AI.


## Testing done on the proposed changes
Did a destructive hook of the code change to check it provided the desired functionality.


## Additional context
The target position provided from the callback is unreliable; this way when a projectile is created I can record against the projectile the intended unit target, and then access this when the intercepted callback is triggered.
