### PR TITLE
Fix : Remove unused personality calls in default skirmish AI code

### DIFF
--- a/changelog/snippets/fix.6602.md
+++ b/changelog/snippets/fix.6602.md
@@ -1,0 +1,1 @@
+- (#6602) Removed unused personalty function calls in default AI factory manager and platoon former manager.

--- a/engine/Sim/CPlatoon.lua
+++ b/engine/Sim/CPlatoon.lua
@@ -54,10 +54,10 @@ end
 --- TODO.
 -- Example: local formIt = poolPlatoon:CanFormPlatoon(template, personality:GetPlatoonSize(), self.Location, radius)
 ---@param template table The template table for the faction, see platoontemplates for more details.
----@param count number The number of platoons that should be formed.
+---@param multiplier number Multiplies the squad max size in the template by this number.
 ---@param location Vector The position vector to search for units from.
 ---@param radius number The radius to search for units.
-function CPlatoon:CanFormPlatoon(template, count, location, radius)
+function CPlatoon:CanFormPlatoon(template, multiplier, location, radius)
 end
 
 --- Destroys the platoon including all its units.
@@ -122,11 +122,11 @@ end
 --- TODO.
 -- Example: local hndl = poolPlatoon:FormPlatoon(template, personality:GetPlatoonSize(), self.Location, radius)
 ---@param template table The template table for the faction, see platoontemplates for more details.
----@param count number The number of platoons that should be formed.
+---@param multiplier number Multiplies the squad max size in the template by this number.
 ---@param position Vector The position vector to search for units from.
 ---@param radius number The radius to search for units.
 -- @return Formed platoon
-function CPlatoon:FormPlatoon(template, count, position, radius)
+function CPlatoon:FormPlatoon(template, multiplier, position, radius)
 end
 
 --- TODO.

--- a/engine/Sim/CPlatoon.lua
+++ b/engine/Sim/CPlatoon.lua
@@ -53,11 +53,11 @@ end
 
 --- TODO.
 -- Example: local formIt = poolPlatoon:CanFormPlatoon(template, personality:GetPlatoonSize(), self.Location, radius)
----@param template table
----@param size number
----@param location Vector
----@param radius number
-function CPlatoon:CanFormPlatoon(template, size, location, radius)
+---@param template table The template table for the faction, see platoontemplates for more details.
+---@param count number The number of platoons that should be formed.
+---@param location Vector The position vector to search for units from.
+---@param radius number The radius to search for units.
+function CPlatoon:CanFormPlatoon(template, count, location, radius)
 end
 
 --- Destroys the platoon including all its units.
@@ -121,8 +121,12 @@ end
 
 --- TODO.
 -- Example: local hndl = poolPlatoon:FormPlatoon(template, personality:GetPlatoonSize(), self.Location, radius)
+---@param template table The template table for the faction, see platoontemplates for more details.
+---@param count number The number of platoons that should be formed.
+---@param position Vector The position vector to search for units from.
+---@param radius number The radius to search for units.
 -- @return Formed platoon
-function CPlatoon:FormPlatoon()
+function CPlatoon:FormPlatoon(template, count, position, radius)
 end
 
 --- TODO.

--- a/lua/sim/FactoryBuilderManager.lua
+++ b/lua/sim/FactoryBuilderManager.lua
@@ -497,9 +497,6 @@ FactoryBuilderManager = Class(BuilderManager) {
             return false
         end
 
-        local personality = self.Brain:GetPersonality()
-        local ptnSize = personality:GetPlatoonSize()
-
         -- This function takes a table of factories to determine if it can build
         return self.Brain:CanBuildPlatoon(template, params)
     end,

--- a/lua/sim/PlatoonFormManager.lua
+++ b/lua/sim/PlatoonFormManager.lua
@@ -139,9 +139,9 @@ PlatoonFormManager = Class(BuilderManager) {
                 WARN('*Platoon Form: Could not find template named: ' .. builder:GetPlatoonTemplate())
                 return
             end
-            local formIt = poolPlatoon:CanFormPlatoon(template, personality:GetPlatoonSize(), self.Location, radius)
+            local formIt = poolPlatoon:CanFormPlatoon(template, 1, self.Location, radius)
             if formIt and builder:GetBuilderStatus() then
-                local hndl = poolPlatoon:FormPlatoon(template, personality:GetPlatoonSize(), self.Location, radius)
+                local hndl = poolPlatoon:FormPlatoon(template, 1, self.Location, radius)
 
                 --LOG('*AI DEBUG: ARMY ', repr(self.Brain:GetArmyIndex()),': Platoon Form Manager Forming - ',repr(builder.BuilderName),': Location = ',self.LocationType)
                 --LOG('*AI DEBUG: ARMY ', repr(self.Brain:GetArmyIndex()),': Platoon Form Manager - Platoon Size = ', table.getn(hndl:GetPlatoonUnits()))

--- a/lua/sim/PlatoonFormManager.lua
+++ b/lua/sim/PlatoonFormManager.lua
@@ -125,7 +125,6 @@ PlatoonFormManager = Class(BuilderManager) {
         BuilderManager.ManagerLoopBody(self,builder,bType)
         -- Try to form all builders that pass
         if self.Brain.BuilderManagers[self.LocationType] and builder.Priority >= 1 and builder:CheckInstanceCount() then
-            local personality = self.Brain:GetPersonality()
             local poolPlatoon = self.Brain:GetPlatoonUniquelyNamed('ArmyPool')
             local template = self:GetPlatoonTemplate(builder:GetPlatoonTemplate())
             builder:FormDebug()


### PR DESCRIPTION
## Description of the proposed changes
This PR removed unused code from the Skirmish AI factory and platoon former manager.
The personality function calls were present in both the factory manager and platoonformer manager.

In the factory manager they created a ptnsize variable that is unused.

In the platoonformer manager that are used twice in CanFormPlatoon and FormPlatoon as the platoon count parameter. I validated that in the default AI this is always returning 1. So I've removed the function calls and replaced with a static integer of 1.


## Testing done on the proposed changes
Tested that this change has no bearing on the AI functionality, nor does it cause a desync when comparing an replay with and without the changes indicating it is doing nothing out of what has already been analyzed.


## Additional context
The functions that are being modified are used by the AI multiple times per second so while removing the function calls may not seem like much it is saving some compute and memory.


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
