### PR TITLE
Increase novax HP so it survives 1 mavor shell

### DIFF
--- a/changelog/snippets/balance.6603.md
+++ b/changelog/snippets/balance.6603.md
@@ -1,0 +1,4 @@
+- (#6603) Increase Novax HP so that it can survive at least 1 of any artillery shell, reducing the impact of the random chance that artillery hits your novax while it is flying over to the artillery.
+
+  - Novax satellite:
+    - HP: 100 -> 16500

--- a/units/XEA0002/XEA0002_unit.bp
+++ b/units/XEA0002/XEA0002_unit.bp
@@ -46,8 +46,8 @@ UnitBlueprint{
     },
     Defense = {
         ArmorType = "Normal",
-        Health = 100,
-        MaxHealth = 100,
+        Health = 16500,
+        MaxHealth = 16500,
         SurfaceThreatLevel = 24,
     },
     Display = {


### PR DESCRIPTION
## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
While the projectile simulation is cool, it can be game deciding for Novax satellites to be destroyed by essentially random artillery fire. Increasing the HP so it survives at least one shell from any artillery reduces this unfair randomness while keeping a cool aspect of the simulation.
This is a tradeoff between immersion and gameplay balance.

- Novax satellite:
  - HP: 100 -> 16500

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
It has more HP than any one artillery shell.
Mod compatibility (specifically BlackOpsFAF Unleashed) seems to be fine as the satellite has the `UNTARGETABLE` category.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version
