### PR TITLE
Fix GuardScanRadius for SACUs not matching upgraded gun range

### DIFF
--- a/changelog/snippets/fix.6604.md
+++ b/changelog/snippets/fix.6604.md
@@ -1,0 +1,1 @@
+- (#6604) Fix SACUs with gun range upgrades not stopping at max range when on an attack move order due to insufficient `GuardScanRadius`.

--- a/units/UAL0301/UAL0301_unit.bp
+++ b/units/UAL0301/UAL0301_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint{
     Description = "<LOC ual0301_desc>Support Armored Command Unit",
-    AI = { GuardScanRadius = 26 },
+    AI = { GuardScanRadius = 44 },
     Audio = {
         CaptureLoop                   = Sound { Bank = 'UAL',         Cue = 'UAL0301_Capture_Loop',    LodCutoff = 'UnitMove_LodCutoff' },
         CommanderArrival              = Sound { Bank = 'UAL',         Cue = 'UAL0001_Gate_In',         LodCutoff = 'UnitMove_LodCutoff' },

--- a/units/UEL0301/UEL0301_unit.bp
+++ b/units/UEL0301/UEL0301_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint{
     Description = "<LOC uel0301_desc>Support Armored Command Unit",
     AI = {
-        GuardScanRadius = 26,
+        GuardScanRadius = 39,
         TargetBones = {
             "UEL0301",
             "Head",

--- a/units/URL0301/URL0301_unit.bp
+++ b/units/URL0301/URL0301_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint{
     Description = "<LOC url0301_desc>Support Armored Command Unit",
     AI = {
-        GuardScanRadius = 26,
+        GuardScanRadius = 39,
         TargetBones = {
             "Torso",
             "Head",

--- a/units/XSL0301/XSL0301_unit.bp
+++ b/units/XSL0301/XSL0301_unit.bp
@@ -1,7 +1,7 @@
 UnitBlueprint{
     Description = "<LOC xsl0301_desc>Support Armored Command Unit",
     AI = {
-        GuardScanRadius = 26,
+        GuardScanRadius = 39,
         InitialAutoMode = true,
     },
     Audio = {


### PR DESCRIPTION

<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Issue
SACU can get 35/40 max gun range with enhancements, so they need a proper radius for attack move to work. Currently their attack move walks into 26 range instead of stopping at gun range.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Increase the radius to 110% of their max gun range, same as `blueprints-units.lua`:
https://github.com/FAForever/fa/blob/3f034d13505450b406994746590d6668ed322826/lua/system/blueprints-units.lua#L205-L206

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Attack moving combatant SACU (since Seraphim Rambo does not have the gun range upgrade) for all factions stop at max range fire.
```
   CreateUnitAtMouse('uel0301_combat', 0,    3.00,    0.00, -0.00000)
   CreateUnitAtMouse('url0301_combat', 0,    1.00,    0.00, -0.00000)
   CreateUnitAtMouse('xsl0301_combat', 0,   -1.00,    0.00, -0.00000)
   CreateUnitAtMouse('ual0301_simplecombat', 0,   -3.00,    0.00, -0.00000)
   CreateUnitAtMouse('xsl0301_nanocombat', 1,    0.00,    45.00, -0.00000)
```

## Additional Context
ACUs already have 31.5/36.75 guard scan radius from older changes.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version
