### PR TITLE
Fix text overflow in fixed width tooltips when using UI scaling

### DIFF
--- a/changelog/snippets/fix.6608.md
+++ b/changelog/snippets/fix.6608.md
@@ -1,0 +1,1 @@
+- (#6608) Fix text overflow in mods manager tooltips

--- a/changelog/snippets/fix.6608.md
+++ b/changelog/snippets/fix.6608.md
@@ -1,1 +1,1 @@
-- (#6608) Fix text overflow in mods manager tooltips
+- (#6608) Fix text in fixed width tooltips (such as some of the tooltips in the mod manager) overflowing when UI scaling is used.

--- a/lua/ui/game/tooltip.lua
+++ b/lua/ui/game/tooltip.lua
@@ -199,6 +199,11 @@ function CreateExtendedToolTip(parent, text, desc, width, padding, descFontSize,
     -- when adjusting position of tooltip elements
     -- default padding should be 2-4 to text is not to close to tooltip border but kept original value
     padding = LayoutHelpers.ScaleNumber(padding or 0)
+    -- scale width by UI scaling factor so we do not need to do this later in code adjusting tooltip width.
+    -- If width is absent, the text advance will be used instead, which is already scaled through font size.
+    if width then
+        width = LayoutHelpers.ScaleNumber(width)
+    end
     -- using passed font size or falling back to default values which should be the same but kept original values
     descFontSize = descFontSize or 12
     textFontSize = textFontSize or 14
@@ -261,7 +266,7 @@ function CreateExtendedToolTip(parent, text, desc, width, padding, descFontSize,
                     textBoxWidth = math.max(textBoxWidth, tooltip.title.TextAdvance())
                 end
             else
-                textBoxWidth = LayoutHelpers.ScaleNumber(width - padding - padding)
+                textBoxWidth = width - padding - padding
             end
             tempTable = import("/lua/maui/text.lua").WrapText(desc, textBoxWidth,
             function(text)

--- a/lua/ui/lobby/ModsManager.lua
+++ b/lua/ui/lobby/ModsManager.lua
@@ -1436,7 +1436,6 @@ end
 function AddTooltip(control, title, description, width, padding, fontSize, position)
     if not fontSize then fontSize = 14 end
     if not position then position = 'left' end
-    if width then width = LayoutHelpers.ScaleNumber(width) end
     import("/lua/ui/game/tooltip.lua").AddControlTooltipManual(control, title, description, 0, width, 6, fontSize or 14, fontSize, position or 'left')
 end
 

--- a/lua/ui/lobby/ModsManager.lua
+++ b/lua/ui/lobby/ModsManager.lua
@@ -1436,6 +1436,7 @@ end
 function AddTooltip(control, title, description, width, padding, fontSize, position)
     if not fontSize then fontSize = 14 end
     if not position then position = 'left' end
+    if width then width = LayoutHelpers.ScaleNumber(width) end
     import("/lua/ui/game/tooltip.lua").AddControlTooltipManual(control, title, description, 0, width, 6, fontSize or 14, fontSize, position or 'left')
 end
 


### PR DESCRIPTION
The mod manager is using some custom logic for the tooltips and its was not scaling the width of the tooltip causing text overflow on couple of the elements.