### PR TITLE
Fix error with new stop command pausing silos

### DIFF
--- a/changelog/snippets/fix.6617.md
+++ b/changelog/snippets/fix.6617.md
@@ -1,0 +1,1 @@
+- (#6617) Fix an error when silos are given a hard-stop order, causing them to not pause missile construction.

--- a/engine/User.lua
+++ b/engine/User.lua
@@ -837,6 +837,14 @@ end
 function IssueBlueprintCommandToUnit(unit, command, blueprintid, count, clear)
 end
 
+--- Issue a command to a given unit
+---@param unit UserUnit
+---@param command UserUnitCommand # Will crash the game if not a valid command.
+---@param luaParams? table | string | number | boolean # Will crash the game if the table contains non-serializable types.
+---@param clear? boolean
+IssueUnitCommandToUnit = function(unit, command, luaParams, clear)
+end
+
 --- Issue a command to the current selection. 
 ---@param command UserUnitCommand # Will crash the game if not a valid command.
 ---@param luaParams? table | string | number | boolean # Will crash the game if the table contains non-serializable types.

--- a/engine/User.lua
+++ b/engine/User.lua
@@ -587,7 +587,7 @@ function GetUIControlsAlpha()
 end
 
 --- Given a set of units, gets the union of orders and unit categories (for determining builds). You can use `GetUnitCommandFromCommandCap` to convert the toggles to unit commands
----@param unitSet any
+---@param unitSet UserUnit[]
 ---@return string[] orders
 ---@return CommandCap[] availableToggles
 ---@return EntityCategory buildableCategories
@@ -595,7 +595,7 @@ function GetUnitCommandData(unitSet)
 end
 
 --- Retrieves the orders, toggles and buildable categories of the given unit. You can use `GetUnitCommandFromCommandCap` to convert the toggles to unit commands
----@param unit any
+---@param unit UserUnit
 ---@return string[] orders
 ---@return CommandCap[] availableToggles
 ---@return EntityCategory buildableCategories
@@ -675,8 +675,8 @@ end
 function IN_RemoveKeyMapTable(keyMapTable)
 end
 
----
----@param queueIndex any
+--- Increase the count at a given location of the current build queue
+---@param queueIndex number
 ---@param count number
 function IncreaseBuildCountInQueue(queueIndex, count)
 end

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -1464,7 +1464,7 @@ local keyActionsOrders = {
         category = 'orders',
     },
     ['shift_stop'] = {
-        action = 'IssueCommand Stop',
+        action = 'UI_Lua import("/lua/ui/game/orders.lua").Stop()',
         category = 'orders',
     },
     ['shift_dive'] = {

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -329,7 +329,7 @@ function Stop(units)
             if not GetIsPausedOfUnit(silo) then
                 local missileInfo = silo:GetMissileInfo()
                 if missileInfo.nukeSiloBuildCount > 0 or missileInfo.tacticalSiloBuildCount > 0 then
-                    IssueUnitCommand(silo, 'Pause')
+                    IssueUnitCommandToUnit(silo, 'Pause')
                 end
             end
         end

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -396,6 +396,16 @@ do
         UnitsCache[1] = unit
         IssueBlueprintCommandToUnits(UnitsCache, command, blueprintid, count, clear)
     end
+
+    --- Issue a command to a given unit
+    ---@param unit UserUnit
+    ---@param command UserUnitCommand # Will crash the game if not a valid command.
+    ---@param luaParams? table | string | number | boolean # Will crash the game if the table contains non-serializable types.
+    ---@param clear? boolean
+    _G.IssueUnitCommandToUnit = function(unit, command, luaParams, clear)
+        UnitsCache[1] = unit
+        IssueUnitCommand(UnitsCache, command, luaParams, clear)
+    end
 end
 
 do

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -387,7 +387,7 @@ do
         commandMode.RestoreCommandMode(true)
     end
 
-    ---@param unit UserUnit[]
+    ---@param unit UserUnit
     ---@param command UserUnitBlueprintCommand
     ---@param blueprintid UnitId
     ---@param count number


### PR DESCRIPTION
## Issue
`IssueUnitCommand` was being given a `UserUnit` instead of a `UserUnit[]` in the new behavior from #6557, causing the following error:
```
WARNING: Error running HandleEvent script in CScriptObject at 19c8a700: ...rs\colon3\documents\github\fa\lua\ui\game\orders.lua(332): Expected a game object. (Did you call with '.' instead of ':'?)
         stack traceback:
         	[C]: in function `IssueUnitCommand'
         	...rs\colon3\documents\github\fa\lua\ui\game\orders.lua(332): in function `Stop'
         	...rs\colon3\documents\github\fa\lua\ui\game\orders.lua(355): in function `OnClick'
         	...ers\colon3\documents\github\fa\lua\maui\checkbox.lua(143): in function `HandleEvent'
         	...rs\colon3\documents\github\fa\lua\ui\game\orders.lua(1303): in function <...rs\colon3\documents\github\fa\lua\ui\game\orders.lua:1281>
```

## Description of the proposed changes
- Like was done for a few other User functions, add a single unit version of `IssueUnitCommand`.
  - Use this new function in the stop order behavior to correctly issue the pause order to the silos.
- Fix the shift version of stop not using the new stop behavior.
- related annotations

## Testing done on the proposed changes
Spawn some silos and make sure the stop command and its shift version work
```
   CreateUnitAtMouse('xsb2108', 0,    0.00,   -2.00, -0.00000)
   CreateUnitAtMouse('xsb2108', 0,    0.00,    0.00, -0.00000)
   CreateUnitAtMouse('xsb2108', 0,    0.00,    2.00, -0.00000)
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
