### PR TITLE
Rework shader names and add biplanar shader

### DIFF
--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -2080,7 +2080,7 @@ float4 TerrainPBRAlbedoPS ( VS_OUTPUT inV) : COLOR
 // Append a "B" to the name, if the shader uses Biplanar mapping.
 
 // ----------------------------------------------------------------------------
-//#region TerrainXP+, Terrain000 and Terrain050
+//#region TTerrainXPExt, Terrain000 and Terrain050
 
 // Layer| Albedo stratum                                               | Normal stratum
 //      | R           | G             | B            | A               | R             | G             | B             | A            |
@@ -2103,7 +2103,7 @@ float4 TerrainPBRAlbedoPS ( VS_OUTPUT inV) : COLOR
 // are designed as a drop-in replacement that solely introduce the map-wide
 // normals and map-wide shadows.
 
-// TTerrainXP+ keeps the different interpretation of mask ranges between
+// TTerrainXPExt keeps the different interpretation of mask ranges between
 // albedo and normal textures, so it is a direct drop-in replacement.
 // Terrain000 enables the full mask range for both textures.
 // Terrain050 only uses half the mask range. We choose to provide this option
@@ -2239,7 +2239,7 @@ float4 Terrain000AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 /* # Similar to TTerrainXP, but upperAlbedo is used for map-wide #
    # textures.                                                   #
    # It is designed to be a drop-in replacement for TTerrainXP.  # */
-technique TTerrainXP+ <
+technique TTerrainXPExt <
     string usage = "composite";
     string normals = "TTerrainNormalsXP";
 >

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -2437,7 +2437,7 @@ float4 Terrain003AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
     float4 stratum4Albedo = tex2D(Stratum4AlbedoSampler, coordinates * Stratum4AlbedoTile.xx);
     float4 stratum5Albedo = tex2D(Stratum5AlbedoSampler, coordinates * Stratum5AlbedoTile.xx);
     float4 stratum6Albedo = tex2D(Stratum6AlbedoSampler, coordinates * Stratum6AlbedoTile.xx);
-    float4 stratum7Albedo = tex2D(Stratum7AlbedoSampler, coordinates);
+    float4 stratum7Albedo = tex2D(Stratum7AlbedoSampler, coordinates * Stratum7AlbedoTile.xx);
 
     // blend the albedo
     float4 albedo = lowerAlbedo;
@@ -2448,7 +2448,7 @@ float4 Terrain003AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
     albedo = lerp(albedo, stratum4Albedo, mask1.x);
     albedo = lerp(albedo, stratum5Albedo, mask1.y);
 
-    // blend map-wide albedo
+    // blend macrotexture
     albedo = lerp(albedo, stratum7Albedo, stratum7Albedo.w);
 
     // compute the shadows, combining the baked and dynamic shadows
@@ -2624,8 +2624,8 @@ float4 Terrain101AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
     albedo = lerp(albedo,stratum4Albedo,mask1.x);
     albedo = lerp(albedo,stratum5Albedo,mask1.y);
     albedo = lerp(albedo,stratum6Albedo,mask1.z);
-    float4 mapwide = tex2D(Stratum7AlbedoSampler, position.xy);
-    albedo.rgb = lerp(albedo.rgb, mapwide.rgb, mapwide.a);
+    float4 macrotexture = tex2D(Stratum7AlbedoSampler, position.xy * Stratum7AlbedoTile.xy);
+    albedo.rgb = lerp(albedo.rgb, macrotexture.rgb, macrotexture.a);
 
     // We need to add 0.01 as the reflection disappears at 0
     float roughness = saturate(albedo.a * mask1.w * 2 + 0.01);
@@ -2809,8 +2809,8 @@ float4 Terrain301AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
     albedo = splatLerp(albedo, stratum4Albedo, stratum4Height, mask1.x, SpecularColor.r);
     albedo = splatLerp(albedo, stratum5Albedo, stratum5Height, mask1.y, SpecularColor.r);
     albedo = splatLerp(albedo, stratum6Albedo, stratum6Height, mask1.z, SpecularColor.r);
-    float4 mapwide = tex2D(Stratum7AlbedoSampler, position.xy);
-    albedo.rgb = lerp(albedo.rgb, mapwide.rgb, mapwide.a);
+    float4 macrotexture = tex2D(Stratum7AlbedoSampler, position.xy * Stratum7AlbedoTile.xy);
+    albedo.rgb = lerp(albedo.rgb, macrotexture.rgb, macrotexture.a);
 
     // We need to add 0.01 as the reflection disappears at 0
     float roughness = saturate(albedo.a * mask1.w * 2 + 0.01);

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -2330,7 +2330,7 @@ technique Terrain052 <
 // | S4 | R             G               B              unused          | X               Y               Z               unused       |
 // | S5 | R             G               B              unused          | X               Y               Z               unused       |
 // | S6 | R             G               B              unused          | X               Y               Z               unused       |
-// | S7 | albedo.r      albedo.g        albedo.b       transparency    | specular        unused          unused          unused       |
+// | S7 | albedo.r      albedo.g        albedo.b       transparency    | specular.r      specular.g      specular.b      specular sharpness  |
 //  ----            ---             ---             ---              ---             ---             ---             ---            ---
 // | U  | normal.x      normal.z        unused         shadow  | 
 
@@ -2396,7 +2396,7 @@ float4 Terrain003AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
     // x = stratum layer 4
     // y = stratum layer 5
     // z = stratum layer 6
-    // w = ??
+    // w = unused
     float4 mask1 = tex2D(UtilitySamplerB, coordinates);
 
     if (halfRange) {
@@ -2406,7 +2406,7 @@ float4 Terrain003AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 
     // x = normals-x
     // y = normals-z
-    // z = water depth
+    // z = unused
     // w = shadows
     float4 terrainInfo = tex2D(UpperAlbedoSampler, coordinates.xy);
     float terrainShadow = terrainInfo.w;
@@ -2416,14 +2416,13 @@ float4 Terrain003AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
         terrainShadow = 1.0f;
     }
 
-    // x = specular
-    // y = unused
-    // z = unused
-    // w = unused
-    float4 utility03 = tex2D(Stratum7NormalSampler, coordinates.xy);
-    float mapSpecular = utility03.r;
+    // x = specular red
+    // y = specular green
+    // z = specular blue
+    // w = specular sharpness
+    float4 mapSpecular = tex2D(Stratum7NormalSampler, coordinates.xy);
 
-    // sample the albedo's
+    // sample the albedos
     float4 lowerAlbedo =    tex2D(LowerAlbedoSampler,    coordinates * LowerAlbedoTile.xx);
     float4 stratum0Albedo = tex2D(Stratum0AlbedoSampler, coordinates * Stratum0AlbedoTile.xx);
     float4 stratum1Albedo = tex2D(Stratum1AlbedoSampler, coordinates * Stratum1AlbedoTile.xx);
@@ -2455,7 +2454,7 @@ float4 Terrain003AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 
     // compute specular
     float3 r = reflect(normalize(inV.mViewDirection), normal);
-    float3 specular = pow(saturate(dot(r, SunDirection)), 20) * mapSpecular * stratum7Albedo.w * shadow * SunColor;
+    float3 specular = pow(saturate(dot(r, SunDirection)), 80 * mapSpecular.a * SpecularColor.r) * mapSpecular.rgb * shadow * SunColor;
 
     // compute lighting
     float dotSunNormal = max(0, dot(SunDirection, normal));

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -116,7 +116,7 @@ texture DecalMaskTexture;
 float DecalAlpha;
 
 // defined by the engine, used to generate texture coordinates
-// this is basically 1/mapresolution
+// this is basically 1/mapresolution. Only holds x and y value.
 float4 TerrainScale; 
 
 // scale of Y coordinate as it's 16-bit
@@ -1894,7 +1894,7 @@ float sampleHeight(float2 position, uniform float2 nearScale, uniform float2 far
     return (heightNear + heightFar) / 2;
 }
 
-float blendHeight(float4 position, float2 blendWeights, uniform float2 nearscale, uniform float2 farscale, uniform float2 offset, uniform bool firstBatch) {
+float blendHeight(float3 position, float2 blendWeights, uniform float2 nearscale, uniform float2 farscale, uniform float2 offset, uniform bool firstBatch) {
     float heightNearXZ;
     float heightFarXZ;
     float heightNearYZ;
@@ -1943,9 +1943,7 @@ float blendHeight(float4 position, float2 blendWeights, uniform float2 nearscale
 float4 TerrainPBRNormalsPS ( VS_OUTPUT inV ) : COLOR
 {
     // z coordinate of Terrainscale is 0
-    float4 position;
-    position.xyw = TerrainScale.xyw * inV.mTexWT.xyw;
-    position.z = TerrainScale.x * inV.mTexWT.z;
+    float3 position = TerrainScale.xxx * inV.mTexWT;
 
     float4 mask0 = tex2D(UtilitySamplerA, position.xy);
     float4 mask1 = tex2D(UtilitySamplerB, position.xy);
@@ -1987,10 +1985,7 @@ float4 TerrainPBRNormalsPS ( VS_OUTPUT inV ) : COLOR
 
 float4 TerrainPBRAlbedoPS ( VS_OUTPUT inV) : COLOR
 {
-    // z coordinate of Terrainscale is 0
-    float4 position;
-    position.xyw = TerrainScale.xyw * inV.mTexWT.xyw;
-    position.z = TerrainScale.x * inV.mTexWT.z;
+    float3 position = TerrainScale.xxx * inV.mTexWT;
 
     // do arithmetics to get range from (0, 1) to (-1, 1) as normal maps store their values as (0, 1)
     float3 normal = normalize(2 * SampleScreen(NormalSampler,inV.mTexSS).xyz - 1);
@@ -2560,7 +2555,7 @@ technique Terrain053 <
 
 float4 Terrain101NormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 {
-    float4 position = TerrainScale * inV.mTexWT;
+    float2 position = TerrainScale * inV.mTexWT;
 
     float4 mask0 = tex2D(UtilitySamplerA, position.xy);
     float4 mask1 = tex2D(UtilitySamplerB, position.xy);
@@ -2593,8 +2588,7 @@ float4 Terrain101NormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 
 float4 Terrain101AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 {
-    // height is now in the z coordinate
-    float4 position = TerrainScale * inV.mTexWT;
+    float2 position = TerrainScale * inV.mTexWT;
 
     // do arithmetics to get range from (0, 1) to (-1, 1) as normal maps store their values as (0, 1)
     float3 normal = normalize(2 * SampleScreen(NormalSampler,inV.mTexSS).xyz - 1);
@@ -2722,10 +2716,10 @@ technique Terrain151 <
 
 float4 Terrain301NormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 {
-    float4 position = TerrainScale * inV.mTexWT;
+    float2 position = TerrainScale * inV.mTexWT;
     // 30° rotation
     float2x2 rotationMatrix = float2x2(float2(0.866, -0.5), float2(0.5, 0.866));
-    position.zw = mul(position.xy, rotationMatrix);
+    float2 rotated_pos = mul(position.xy, rotationMatrix);
 
     float4 mask0 = tex2D(UtilitySamplerA, position.xy);
     float4 mask1 = tex2D(UtilitySamplerB, position.xy);
@@ -2736,21 +2730,21 @@ float4 Terrain301NormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
     }
 
     float3 lowerNormal    = normalize(tex2D(LowerNormalSampler,    position.xy * LowerAlbedoTile.xy   ).rgb * 2 - 1);
-    float3 stratum0Normal = normalize(tex2D(Stratum0NormalSampler, position.zw * Stratum0AlbedoTile.xy).rgb * 2 - 1);
+    float3 stratum0Normal = normalize(tex2D(Stratum0NormalSampler, rotated_pos * Stratum0AlbedoTile.xy).rgb * 2 - 1);
     float3 stratum1Normal = normalize(tex2D(Stratum1NormalSampler, position.xy * Stratum1AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum2Normal = normalize(tex2D(Stratum2NormalSampler, position.zw * Stratum2AlbedoTile.xy).rgb * 2 - 1);
+    float3 stratum2Normal = normalize(tex2D(Stratum2NormalSampler, rotated_pos * Stratum2AlbedoTile.xy).rgb * 2 - 1);
     float3 stratum3Normal = normalize(tex2D(Stratum3NormalSampler, position.xy * Stratum3AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum4Normal = normalize(tex2D(Stratum4NormalSampler, position.zw * Stratum4AlbedoTile.xy).rgb * 2 - 1);
+    float3 stratum4Normal = normalize(tex2D(Stratum4NormalSampler, rotated_pos * Stratum4AlbedoTile.xy).rgb * 2 - 1);
     float3 stratum5Normal = normalize(tex2D(Stratum5NormalSampler, position.xy * Stratum5AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum6Normal = normalize(tex2D(Stratum6NormalSampler, position.zw * Stratum6AlbedoTile.xy).rgb * 2 - 1);
+    float3 stratum6Normal = normalize(tex2D(Stratum6NormalSampler, rotated_pos * Stratum6AlbedoTile.xy).rgb * 2 - 1);
 
-    float stratum0Height = sampleHeight(position.zw, Stratum0AlbedoTile.xy, Stratum0NormalTile.xy, float2(0.5, 0.0), true);
+    float stratum0Height = sampleHeight(rotated_pos, Stratum0AlbedoTile.xy, Stratum0NormalTile.xy, float2(0.5, 0.0), true);
     float stratum1Height = sampleHeight(position.xy, Stratum1AlbedoTile.xy, Stratum1NormalTile.xy, float2(0.0, 0.5), true);
-    float stratum2Height = sampleHeight(position.zw, Stratum2AlbedoTile.xy, Stratum2NormalTile.xy, float2(0.5, 0.5), true);
+    float stratum2Height = sampleHeight(rotated_pos, Stratum2AlbedoTile.xy, Stratum2NormalTile.xy, float2(0.5, 0.5), true);
     float stratum3Height = sampleHeight(position.xy, Stratum3AlbedoTile.xy, Stratum3NormalTile.xy, float2(0.0, 0.0), false);
-    float stratum4Height = sampleHeight(position.zw, Stratum4AlbedoTile.xy, Stratum4NormalTile.xy, float2(0.5, 0.0), false);
+    float stratum4Height = sampleHeight(rotated_pos, Stratum4AlbedoTile.xy, Stratum4NormalTile.xy, float2(0.5, 0.0), false);
     float stratum5Height = sampleHeight(position.xy, Stratum5AlbedoTile.xy, Stratum5NormalTile.xy, float2(0.0, 0.5), false);
-    float stratum6Height = sampleHeight(position.zw, Stratum6AlbedoTile.xy, Stratum6NormalTile.xy, float2(0.5, 0.5), false);
+    float stratum6Height = sampleHeight(rotated_pos, Stratum6AlbedoTile.xy, Stratum6NormalTile.xy, float2(0.5, 0.5), false);
 
     float3 normal = lowerNormal;
     normal = splatBlendNormal(normal, stratum0Normal, stratum0Height, mask0.x, SpecularColor.r);
@@ -2766,11 +2760,10 @@ float4 Terrain301NormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 
 float4 Terrain301AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 {
-    // height is now in the z coordinate
-    float4 position = TerrainScale * inV.mTexWT;
+    float2 position = TerrainScale * inV.mTexWT;
     // 30° rotation
     float2x2 rotationMatrix = float2x2(float2(0.866, -0.5), float2(0.5, 0.866));
-    position.zw = mul(position.xy, rotationMatrix);
+    float2 rotated_pos = mul(position.xy, rotationMatrix);
 
     // do arithmetics to get range from (0, 1) to (-1, 1) as normal maps store their values as (0, 1)
     float3 normal = normalize(2 * SampleScreen(NormalSampler,inV.mTexSS).xyz - 1);
@@ -2785,21 +2778,21 @@ float4 Terrain301AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 
     // This shader wouldn't compile because it would have to store too many variables if we didn't use this trick in the vertex shader
     float4 lowerAlbedo =    sampleAlbedo(LowerAlbedoSampler,    position.xy, LowerAlbedoTile.xy,    float2(0.0, 0.0), true);
-    float4 stratum0Albedo = sampleAlbedo(Stratum0AlbedoSampler, position.zw, inV.nearScales.xx,     float2(0.5, 0.0), true);
+    float4 stratum0Albedo = sampleAlbedo(Stratum0AlbedoSampler, rotated_pos, inV.nearScales.xx,     float2(0.5, 0.0), true);
     float4 stratum1Albedo = sampleAlbedo(Stratum1AlbedoSampler, position.xy, inV.nearScales.yy,     float2(0.0, 0.5), true);
-    float4 stratum2Albedo = sampleAlbedo(Stratum2AlbedoSampler, position.zw, inV.nearScales.zz,     float2(0.5, 0.5), true);
+    float4 stratum2Albedo = sampleAlbedo(Stratum2AlbedoSampler, rotated_pos, inV.nearScales.zz,     float2(0.5, 0.5), true);
     float4 stratum3Albedo = sampleAlbedo(Stratum3AlbedoSampler, position.xy, inV.nearScales.ww,     float2(0.0, 0.0), false);
-    float4 stratum4Albedo = sampleAlbedo(Stratum4AlbedoSampler, position.zw, Stratum4AlbedoTile.xy, float2(0.5, 0.0), false);
+    float4 stratum4Albedo = sampleAlbedo(Stratum4AlbedoSampler, rotated_pos, Stratum4AlbedoTile.xy, float2(0.5, 0.0), false);
     float4 stratum5Albedo = sampleAlbedo(Stratum5AlbedoSampler, position.xy, Stratum5AlbedoTile.xy, float2(0.0, 0.5), false);
-    float4 stratum6Albedo = sampleAlbedo(Stratum6AlbedoSampler, position.zw, Stratum6AlbedoTile.xy, float2(0.5, 0.5), false);
+    float4 stratum6Albedo = sampleAlbedo(Stratum6AlbedoSampler, rotated_pos, Stratum6AlbedoTile.xy, float2(0.5, 0.5), false);
 
-    float stratum0Height = sampleHeight(position.zw, inV.nearScales.xx,     inV.farScales.xx,      float2(0.5, 0.0), true);
+    float stratum0Height = sampleHeight(rotated_pos, inV.nearScales.xx,     inV.farScales.xx,      float2(0.5, 0.0), true);
     float stratum1Height = sampleHeight(position.xy, inV.nearScales.yy,     inV.farScales.yy,      float2(0.0, 0.5), true);
-    float stratum2Height = sampleHeight(position.zw, inV.nearScales.zz,     inV.farScales.zz,      float2(0.5, 0.5), true);
+    float stratum2Height = sampleHeight(rotated_pos, inV.nearScales.zz,     inV.farScales.zz,      float2(0.5, 0.5), true);
     float stratum3Height = sampleHeight(position.xy, inV.nearScales.ww,     inV.farScales.ww,      float2(0.0, 0.0), false);
-    float stratum4Height = sampleHeight(position.zw, Stratum4AlbedoTile.xy, Stratum4NormalTile.xy, float2(0.5, 0.0), false);
+    float stratum4Height = sampleHeight(rotated_pos, Stratum4AlbedoTile.xy, Stratum4NormalTile.xy, float2(0.5, 0.0), false);
     float stratum5Height = sampleHeight(position.xy, Stratum5AlbedoTile.xy, Stratum5NormalTile.xy, float2(0.0, 0.5), false);
-    float stratum6Height = sampleHeight(position.zw, Stratum6AlbedoTile.xy, Stratum6NormalTile.xy, float2(0.5, 0.5), false);
+    float stratum6Height = sampleHeight(rotated_pos, Stratum6AlbedoTile.xy, Stratum6NormalTile.xy, float2(0.5, 0.5), false);
 
     float4 albedo = lowerAlbedo;
     albedo = splatLerp(albedo, stratum0Albedo, stratum0Height, mask0.x, SpecularColor.r);


### PR DESCRIPTION
There are several changes here:

- I noticed that we actually disabled being able to scale the slot that is supposed to store the macrotexture. This makes sense when only thinking about the scenario where you provide a custom map-wide texture. Then the user does not have to worry about providing the right scaling to make the texture fit neatly over the whole map. However, there are some gpg macrotextures that are supposed to tile. If we don't provide the ability to control the scale of this texture we are artificially limiting mapmakers, so I added this ability again.

- I reworked the naming scheme because I noticed that the previous naming scheme was too complicated and made it hard to remember what is what.

- I found a usage for previously unused texture channels in the Terrain003 (old name, new one is Terrain001) shader. This gives more artistic control and could produce interesting results if someone wants to make a stylized map.

- I added a new shader that uses biplanar mapping in two texture slots. Triplanar mapping is a well-known technique to minimize the problem of stretched textures. You can see an example in the beginning of this article here: https://bgolus.medium.com/normal-mapping-for-a-triplanar-shader-10bf39dca05a 
Actually I have to read this article properly at some point in the future to see if there are some easy improvements we could make. Thanks to @Garanas for linking it [here](https://github.com/FAForever/fa/pull/3585). This collection of links has been a great resource!
The shader only uses biplanar mapping because we omit the projection from the top. This is faster and as we want to use it for cliffs we don't need the top projection. The result looks like this:
![grafik](https://github.com/user-attachments/assets/36aa22fe-d301-47f3-87bf-db274db6ff5d)

- during the development of this shader I realized some peculiarities about texture coordinates so I did some small refactors to improve the code.
