### PR TITLE
Check if instigator is destroyed in Fatboy `DeathThread`

### DIFF
--- a/changelog/snippets/fix.6629.md
+++ b/changelog/snippets/fix.6629.md
@@ -1,0 +1,1 @@
+- (#6629) Fix a rare error that would cause the Fatboy to not finish dying.

--- a/units/UEL0401/UEL0401_script.lua
+++ b/units/UEL0401/UEL0401_script.lua
@@ -260,6 +260,7 @@ UEL0401 = ClassUnit(TMobileFactoryUnit, ExternalFactoryComponent) {
         local explosionBones = {}
         local explosionBoneCount = table.getn(self.ExplosionBones)
 
+        -- Since this is a thread, it is delayed by 1 tick so the instigator may be destroyed
         if not IsDestroyed(instigator) then
             -- if there is an instigator, favor exploding bits that are near the instigator
             local ix, iy, iz = instigator:GetPositionXYZ()

--- a/units/UEL0401/UEL0401_script.lua
+++ b/units/UEL0401/UEL0401_script.lua
@@ -17,6 +17,8 @@ local EffectUtil = import("/lua/effectutilities.lua")
 local ExternalFactoryComponent = import("/lua/defaultcomponents.lua").ExternalFactoryComponent
 local DefaultExplosions = import("/lua/defaultexplosions.lua")
 
+local IsDestroyed = IsDestroyed
+
 ---@class UEL0401 : TMobileFactoryUnit, ExternalFactoryComponent
 ---@field UnitBeingBuilt Unit | nil
 ---@field AttachmentSliderManip moho.SlideManipulator
@@ -258,7 +260,7 @@ UEL0401 = ClassUnit(TMobileFactoryUnit, ExternalFactoryComponent) {
         local explosionBones = {}
         local explosionBoneCount = table.getn(self.ExplosionBones)
 
-        if instigator then
+        if not IsDestroyed(instigator) then
             -- if there is an instigator, favor exploding bits that are near the instigator
             local ix, iy, iz = instigator:GetPositionXYZ()
             for k, bone in self.ExplosionBones do


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Issue 
Since the instigator is used in a thread, and threads start 1 tick later, it can be passed from OnKilled and then get destroyed.
Replay: https://replay.faforever.com/24087043 Right side fatboy for south team at 29:00 errors out when dying
Error:
```
warning: Error running lua script: ...\gamedata\units.nx2\units\uel0401\uel0401_script.lua(263): Game object has been destroyed
         stack traceback:
         	[C]: in function `GetPositionXYZ'
         	...\gamedata\units.nx2\units\uel0401\uel0401_script.lua(263): in function <...\gamedata\units.nx2\units\uel0401\uel0401_script.lua:253>
```

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
- Check if the instigator was destroyed before calling `GetPositionXYZ` on it. I didn't opt for using `Unit.Dead` because this code won't run often and `.Dead` is true after dying, which is before C-object destruction.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
- Running the replay from deploy/faf (805bdd34446cf8e8664ae74743c597cdb2ad56a4) with the fix commit cherry picked on top causes the fatboy to successfully die
- Checked that no other `DeathThread`s use the instigator value.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
