### PR TITLE
Fix `QuatFromXZDirection` for negative dx inputs causing ACUs to spawn the wrong direction

### DIFF
--- a/changelog/snippets/fix.6630.md
+++ b/changelog/snippets/fix.6630.md
@@ -1,0 +1,1 @@
+- (#6630) Fix ACUs spawned on the right side of the map not facing towards the middle of the map.

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2262,8 +2262,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     ---@param self Unit
     ---@param tpos Vector
     RotateTowards = function(self, tpos)
-        local pos = self:GetPosition()
-        local dx, dz = tpos[1] - pos[1], tpos[3] - pos[3]
+        local pX, _, pZ = self:GetPositionXYZ()
+        local dx, dz = tpos[1] - pX, tpos[3] - pZ
         self:SetOrientation(utilities.QuatFromXZDirection(dx, dz), true)
     end,
 

--- a/lua/utilities.lua
+++ b/lua/utilities.lua
@@ -487,13 +487,32 @@ end
 ---@param dz number
 ---@return Quaternion
 function QuatFromXZDirection(dx, dz)
-    -- ang = atan2(dx, dz) -- `dz` is adjacent
-    -- {0, sin(ang/2), 0, cos(ang/2)}
+    -- division by zero case
+    if dx == 0 and dz == 0 then
+        return UnsafeQuaternion(0, 0, 0, 1)
+    end
+
+    -- q = (0, sin(ang/2), 0, cos(ang/2))       -- definition of our y-axis rotation quaternion we want to get for angle `ang`
+
+    -- sin(ang/2) = +/-sqrt((1-cos(ang))/2)     -- half angle formula for sin. +/- is sign of sin(ang/2)
+    --            = +/-sqrt( 0.5 - cos(ang)/2 )
+    --            = +/-sqrt( 0.5 - a/2h )       -- cos(ang) = adjacent/hypotenuse
+    -- similar is repeated for cos(ang/2)
+
     local hypot = MathSqrt(dx*dx + dz*dz)
-    -- use the half-angle formulas
     local halfCosA = dz / (2 * hypot)
     local sinHalfA = MathSqrt(0.5 - halfCosA)
     local cosHalfA = MathSqrt(0.5 + halfCosA)
+
+    -- Resolve the +/- part of our result:
+    -- sign of sin(ang/2) is + for ang in (0, 2pi)
+    -- sign of cos(ang/2) is + for ang in (0, pi) and - for ang in (pi, 2pi)
+    -- ang in (pi, 2pi) is when dx is negative, so negate cosHalfA in that case
+
+    if dx < 0 then
+        return UnsafeQuaternion(0, sinHalfA, 0, -cosHalfA)
+    end
+
     return UnsafeQuaternion(0, sinHalfA, 0, cosHalfA)
 end
 


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Issue
Initially reported on [Discord](https://discord.com/channels/197033481883222026/1323915745104625714) that ACUs would sometimes not spawn facing the correct direction after the release with https://github.com/FAForever/fa/pull/6438.

This is because the math used in the `QuatFromXZDirection(dx, dz)` function did not properly account for signs, and was giving the wrong output when `dx` was negative. ACUs on the right side of the map have a negative `dx` when rotating towards the middle of the map.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
- Accounts for the sign of -dx
- Explain the mathematics more thoroughly
- Account for the division by zero case as it would print `Unit ual0001 is attempting to move to an invalid coord` to the log about the unit moving to an invalid coord when `SetOrientation({0, 1.#INF, 0, 1.#INF}, true)` happened.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
- Fill all slots on Crossfire Canal and verify that all ACUs spawn with the correct orientation. Using Crossfire Canal accounts for all quadrants of the unit circle. Make sure to pause the game right after the spawn sequence if using AI, as the AI will move the ACUs.

<details> <summary> The follow script tests the differences between the old and new results of RotateTowards, but I didn't bother making the function results exactly the same (there are some switches in sign) because the end result for ACU orientation at the start was fine. </summary>

```lua
local utilities = import("/lua/utilities.lua")
local oldRotateTowards = function(self, tpos)
    local pos = self.pos
    local rad = math.atan2(tpos[1] - pos[1], tpos[3] - pos[3])
    local function SetRotation(angle)
        local function QuatFromRotation(rotation, x, y, z)
            local angleRot, qw, qx, qy, qz, angle
            angle = 0.00872664625 * rotation
            angleRot = math.sin(angle)
            qw = math.cos(angle)
            qx = x * angleRot
            qy = y * angleRot
            qz = z * angleRot
            return qx, qy, qz, qw
        end
        return QuatFromRotation(angle, 0, 1, 0)
    end
    return SetRotation(rad * (180 / math.pi))
end
LOG(oldRotateTowards({pos = {0, 1, 0}}, {0, 0, 0}))
LOG(repr(utilities.QuatFromXZDirection(0, 0)))

LOG(oldRotateTowards({pos = {0, 1, 0}}, {1, 0, 0}))
LOG(repr(utilities.QuatFromXZDirection(1, 0)))
LOG(oldRotateTowards({pos = {0, 1, 0}}, {0, 0, 1}))
LOG(repr(utilities.QuatFromXZDirection(0, 1)))
LOG(oldRotateTowards({pos = {0, 1, 0}}, {-1, 0, 0}))
LOG(repr(utilities.QuatFromXZDirection(-1, 0)))
LOG(oldRotateTowards({pos = {0, 1, 0}}, {0, 0, -1}))
LOG(repr(utilities.QuatFromXZDirection(0, -1)))

LOG(oldRotateTowards({pos = {0, 1, 0}}, {1, 0, 1}))
LOG(repr(utilities.QuatFromXZDirection(1, 1)))
LOG(oldRotateTowards({pos = {0, 1, 0}}, {1, 0, -1}))
LOG(repr(utilities.QuatFromXZDirection(1, -1)))
LOG(oldRotateTowards({pos = {0, 1, 0}}, {-1, 0, -1}))
LOG(repr(utilities.QuatFromXZDirection(-1, -1)))
LOG(oldRotateTowards({pos = {0, 1, 0}}, {-1, 0, 1}))
LOG(repr(utilities.QuatFromXZDirection(-1, 1)))
```

</details>

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version
