### PR TITLE
Improve documentation of terrain types

### DIFF
--- a/changelog/snippets/other.6633.md
+++ b/changelog/snippets/other.6633.md
@@ -1,0 +1,1 @@
+- (#6633) Improve documentation of the terrain type features

--- a/lua/TerrainTypes.lua
+++ b/lua/TerrainTypes.lua
@@ -23,7 +23,7 @@
     200-219 reserved for snowy
     220-255 reserved for water
  
-- Map Style List (7)-
+- Style Key List (7)-
     Desert
     Evergreen
     Geothermal
@@ -31,7 +31,16 @@
     RedRock
     Tropical
     Tundra    
+
+    The style keys control an unused but working feature that allows swapping a unit's
+    textures and even the mesh depending on the terrain type it gets built on.
+    This could for example be used to give units built in areas marked as Tundra the
+    appearance of being covered with snow.
+    As this requires to provide additional textures for every unit and every terrain style
+    it is unlikely to ever be implemented. The memory requirements of all these textures
+    would be significant. 
  
+
 - Effect mapping key descriptions -
 
     These type mappings map to effect 'Type' names, mapped in unit display 


### PR DESCRIPTION
I had a closer look at the terrain types while I was working with the map editor and noticed that the documentation what they actually do is a bit lacking, so we should fix that.

I tried to understand how types that differ from the default are handled, but I have not fully figured it out. Apparently the game sometimes falls back onto the default terrain type if it can't find certain effects, but it also seems possible to remove default effects. @Hdt80bro you had a closer look at this all a while ago, can you provide some insights?

Somewhat related:
A discussion on discord: https://discord.com/channels/197033481883222026/1044974379232149535/1048015638502846535
A mod by balthazar to edit unit blueprints to use the feature: https://github.com/The-Balthazar/BrewLAN/tree/master/mods/BrewLAN_Plenae/ExpertCamo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed "Map Style List" heading to "Style Key List" in terrain docs.
  * Added a multi-line explanatory note clarifying an unused texture/mesh swap feature, its high memory cost, and low likelihood of being implemented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->