### PR TITLE
Fix error when Cybran air factories die while building

### DIFF
--- a/changelog/snippets/fix.6636.md
+++ b/changelog/snippets/fix.6636.md
@@ -1,0 +1,1 @@
+- (#6636) Fix an error that occurs when a Cybran air factory dies while building something.

--- a/changelog/snippets/graphics.6636.md
+++ b/changelog/snippets/graphics.6636.md
@@ -1,0 +1,1 @@
+- (#6636) Fix some build effects for Cybran land and air factories never appearing.

--- a/lua/EffectUtilities.lua
+++ b/lua/EffectUtilities.lua
@@ -382,7 +382,7 @@ local UnitBuildEffects = {
 ---@param buildBones BuildBones
 ---@param buildEffectsBag TrashBag
 function CreateCybranFactoryBuildEffects(builder, unitBeingBuilt, buildBones, buildEffectsBag)
-    CreateCybranBuildBeamsOpti(builder, nil, unitBeingBuilt, buildEffectsBag, false)
+    TrashBagAdd(buildEffectsBag, ForkThread(CreateCybranBuildBeamsOpti, builder, nil, unitBeingBuilt, buildEffectsBag, false))
 
     local builderArmy = builder.Army
     for _, bone in buildBones.BuildEffectBones do

--- a/lua/EffectUtilities.lua
+++ b/lua/EffectUtilities.lua
@@ -48,6 +48,49 @@ local IEffectSetEmitterCurveParam = moho.IEffect.SetEmitterCurveParam
 local IEffectSetEmitterParam = moho.IEffect.SetEmitterParam
 local TrashBagAdd = TrashBag.Add
 
+--#region Optimized functions
+
+local EffectUtilitiesOpti = import("/lua/effectutilitiesopti.lua")
+local EffectUtilitiesUEF = import("/lua/effectutilitiesuef.lua")
+local EffectUtilitiesGeneric = import("/lua/effectutilitiesgeneric.lua")
+local EffectUtilitiesAeon = import("/lua/effectutilitiesaeon.lua")
+
+CreateCybranEngineerBuildEffectsOpti = EffectUtilitiesOpti.CreateCybranEngineerBuildEffects
+CreateCybranBuildBeamsOpti = EffectUtilitiesOpti.CreateCybranBuildBeams
+SpawnBuildBotsOpti = EffectUtilitiesOpti.SpawnBuildBots
+
+CreateAeonBuildBaseThread = EffectUtilitiesAeon.CreateAeonBuildBaseThread
+CreateAeonConstructionUnitBuildingEffects = EffectUtilitiesAeon.CreateAeonConstructionUnitBuildingEffects
+CreateAeonCommanderBuildingEffects = EffectUtilitiesAeon.CreateAeonCommanderBuildingEffects
+CreateAeonFactoryBuildingEffects = EffectUtilitiesAeon.CreateAeonFactoryBuildingEffects
+CreateAeonColossusBuildingEffects = EffectUtilitiesAeon.CreateAeonColossusBuildingEffects
+CreateAeonCZARBuildingEffects = EffectUtilitiesAeon.CreateAeonCZARBuildingEffects
+CreateAeonTempestBuildingEffects = EffectUtilitiesAeon.CreateAeonTempestBuildingEffects
+CreateAeonParagonBuildingEffects = EffectUtilitiesAeon.CreateAeonParagonBuildingEffects
+
+CreateEffectsOpti = EffectUtilitiesGeneric.CreateEffectsOpti
+CreateEffectsInTrashbag = EffectUtilitiesGeneric.CreateEffectsInTrashbag
+CreateEffectsWithOffsetOpti = EffectUtilitiesGeneric.CreateEffectsWithOffsetOpti
+CreateEffectsWithOffsetInTrashbag = EffectUtilitiesGeneric.CreateEffectsWithOffsetInTrashbag
+CreateEffectsWithRandomOffsetOpti = EffectUtilitiesGeneric.CreateEffectsWithRandomOffsetOpti
+CreateEffectsWithRandomOffsetInTrashbag = EffectUtilitiesGeneric.CreateEffectsWithRandomOffsetInTrashbag
+CreateBoneEffectsOpti = EffectUtilitiesGeneric.CreateBoneEffectsOpti
+CreateBoneEffectsInTrashbag = EffectUtilitiesGeneric.CreateBoneEffectsInTrashbag
+CreateBoneEffectsOffsetOpti = EffectUtilitiesGeneric.CreateBoneEffectsOffsetOpti
+CreateBoneEffectsOffsetInTrashbag = EffectUtilitiesGeneric.CreateBoneEffectsOffsetInTrashbag
+CreateRandomEffectsOpti = EffectUtilitiesGeneric.CreateRandomEffectsOpti
+CreateRandomEffectsInTrashbag = EffectUtilitiesGeneric.CreateRandomEffectsInTrashbag
+PlayReclaimEffects = EffectUtilitiesGeneric.PlayReclaimEffects
+PlayReclaimEndEffects = EffectUtilitiesGeneric.PlayReclaimEndEffects
+ApplyWindDirection = EffectUtilitiesGeneric.ApplyWindDirection
+
+CreateDefaultBuildBeams = EffectUtilitiesUEF.CreateDefaultBuildBeams
+CreateUEFBuildSliceBeams = EffectUtilitiesUEF.CreateUEFBuildSliceBeams
+CreateUEFUnitBeingBuiltEffects = EffectUtilitiesUEF.CreateUEFUnitBeingBuiltEffects
+CreateUEFCommanderBuildSliceBeams = EffectUtilitiesUEF.CreateUEFCommanderBuildSliceBeams
+CreateBuildCubeThread = EffectUtilitiesUEF.CreateBuildCubeThread
+--#endregion
+
 -- local DeprecatedWarnings = { }
 
 ---@alias AdjacencyBeam {Unit: Unit, Trash: TrashBag}
@@ -1477,45 +1520,3 @@ function DestroyRemainingTeleportChargingEffects(unit, effectsBag)
         unit.TeleportCybranSphere:Destroy()
     end
 end
-
---- Optimized functions --
-
-local EffectUtilitiesOpti = import("/lua/effectutilitiesopti.lua")
-local EffectUtilitiesUEF = import("/lua/effectutilitiesuef.lua")
-local EffectUtilitiesGeneric = import("/lua/effectutilitiesgeneric.lua")
-local EffectUtilitiesAeon = import("/lua/effectutilitiesaeon.lua")
-
-CreateCybranEngineerBuildEffectsOpti = EffectUtilitiesOpti.CreateCybranEngineerBuildEffects
-CreateCybranBuildBeamsOpti = EffectUtilitiesOpti.CreateCybranBuildBeams
-SpawnBuildBotsOpti = EffectUtilitiesOpti.SpawnBuildBots
-
-CreateAeonBuildBaseThread = EffectUtilitiesAeon.CreateAeonBuildBaseThread
-CreateAeonConstructionUnitBuildingEffects = EffectUtilitiesAeon.CreateAeonConstructionUnitBuildingEffects
-CreateAeonCommanderBuildingEffects = EffectUtilitiesAeon.CreateAeonCommanderBuildingEffects
-CreateAeonFactoryBuildingEffects = EffectUtilitiesAeon.CreateAeonFactoryBuildingEffects
-CreateAeonColossusBuildingEffects = EffectUtilitiesAeon.CreateAeonColossusBuildingEffects
-CreateAeonCZARBuildingEffects = EffectUtilitiesAeon.CreateAeonCZARBuildingEffects
-CreateAeonTempestBuildingEffects = EffectUtilitiesAeon.CreateAeonTempestBuildingEffects
-CreateAeonParagonBuildingEffects = EffectUtilitiesAeon.CreateAeonParagonBuildingEffects
-
-CreateEffectsOpti = EffectUtilitiesGeneric.CreateEffectsOpti
-CreateEffectsInTrashbag = EffectUtilitiesGeneric.CreateEffectsInTrashbag
-CreateEffectsWithOffsetOpti = EffectUtilitiesGeneric.CreateEffectsWithOffsetOpti
-CreateEffectsWithOffsetInTrashbag = EffectUtilitiesGeneric.CreateEffectsWithOffsetInTrashbag
-CreateEffectsWithRandomOffsetOpti = EffectUtilitiesGeneric.CreateEffectsWithRandomOffsetOpti
-CreateEffectsWithRandomOffsetInTrashbag = EffectUtilitiesGeneric.CreateEffectsWithRandomOffsetInTrashbag
-CreateBoneEffectsOpti = EffectUtilitiesGeneric.CreateBoneEffectsOpti
-CreateBoneEffectsInTrashbag = EffectUtilitiesGeneric.CreateBoneEffectsInTrashbag
-CreateBoneEffectsOffsetOpti = EffectUtilitiesGeneric.CreateBoneEffectsOffsetOpti
-CreateBoneEffectsOffsetInTrashbag = EffectUtilitiesGeneric.CreateBoneEffectsOffsetInTrashbag
-CreateRandomEffectsOpti = EffectUtilitiesGeneric.CreateRandomEffectsOpti
-CreateRandomEffectsInTrashbag = EffectUtilitiesGeneric.CreateRandomEffectsInTrashbag
-PlayReclaimEffects = EffectUtilitiesGeneric.PlayReclaimEffects
-PlayReclaimEndEffects = EffectUtilitiesGeneric.PlayReclaimEndEffects
-ApplyWindDirection = EffectUtilitiesGeneric.ApplyWindDirection
-
-CreateDefaultBuildBeams = EffectUtilitiesUEF.CreateDefaultBuildBeams
-CreateUEFBuildSliceBeams = EffectUtilitiesUEF.CreateUEFBuildSliceBeams
-CreateUEFUnitBeingBuiltEffects = EffectUtilitiesUEF.CreateUEFUnitBeingBuiltEffects
-CreateUEFCommanderBuildSliceBeams = EffectUtilitiesUEF.CreateUEFCommanderBuildSliceBeams
-CreateBuildCubeThread = EffectUtilitiesUEF.CreateBuildCubeThread

--- a/lua/EffectUtilities.lua
+++ b/lua/EffectUtilities.lua
@@ -336,7 +336,7 @@ local UnitBuildEffects = {
 --- Creates the Cybran factor build effects
 ---@param builder Unit
 ---@param unitBeingBuilt Unit
----@param buildBones Bone[]
+---@param buildBones BuildBones
 ---@param buildEffectsBag TrashBag
 function CreateCybranFactoryBuildEffects(builder, unitBeingBuilt, buildBones, buildEffectsBag)
     CreateCybranBuildBeamsOpti(builder, nil, unitBeingBuilt, buildEffectsBag, false)

--- a/lua/EffectUtilitiesOpti.lua
+++ b/lua/EffectUtilitiesOpti.lua
@@ -131,7 +131,7 @@ end
 --- bots share the welding point which each other, as does the builder with
 --- itself.
 ---@param builder Unit A builder with builder.buildEffectBones set
----@param bots Unit[] The bots of the builder
+---@param bots? Unit[] The bots of the builder
 ---@param unitBeingBuilt Unit The unit that we're building
 ---@param buildEffectsBag TrashBag The bag that we use to store / trash all effects
 ---@param noBuilderBeams boolean Whether or not the builder is a building

--- a/lua/sim/units/cybran/CAirFactoryUnit.lua
+++ b/lua/sim/units/cybran/CAirFactoryUnit.lua
@@ -38,11 +38,14 @@ local AnimatorSetRate = moho.AnimationManipulator.SetRate
 ---@class CAirFactoryUnit : AirFactoryUnit
 ---@field BuildEffectsBag TrashBag
 ---@field BuildAnimManip moho.AnimationManipulator
+---@field BuildBones BuildBones
 CAirFactoryUnit = ClassUnit(AirFactoryUnit) {
 
     ---@param self AirFactoryUnit
     OnCreate = function(self)
         AirFactoryUnitOnCreate(self)
+
+        self.BuildBones = self.Blueprint.General.BuildBones
 
         local buildAnimManip = CreateAnimator(self)
         AnimatorPlayAnim(buildAnimManip, self.Blueprint.Display.AnimationBuild, true)
@@ -59,7 +62,7 @@ CAirFactoryUnit = ClassUnit(AirFactoryUnit) {
         end
 
         WaitTicks(2)
-        CreateCybranFactoryBuildEffects(self, unitBeingBuilt, self.BuildEffectBones, self.BuildEffectsBag)
+        CreateCybranFactoryBuildEffects(self, unitBeingBuilt, self.BuildBones, self.BuildEffectsBag)
     end,
 
     ---@param self CAirFactoryUnit

--- a/lua/sim/units/cybran/CLandFactoryUnit.lua
+++ b/lua/sim/units/cybran/CLandFactoryUnit.lua
@@ -38,6 +38,7 @@ local AnimatorSetRate = moho.AnimationManipulator.SetRate
 ---@class CLandFactoryUnit : LandFactoryUnit
 ---@field BuildEffectsBag TrashBag
 ---@field BuildAnimManip moho.AnimationManipulator
+---@field BuildBones BuildBones
 CLandFactoryUnit = ClassUnit(LandFactoryUnit) {
 
     ---@param self AirFactoryUnit
@@ -48,6 +49,8 @@ CLandFactoryUnit = ClassUnit(LandFactoryUnit) {
         AnimatorPlayAnim(buildAnimManip, self.Blueprint.Display.AnimationBuild, true)
         AnimatorSetRate(buildAnimManip, 0)
         self.BuildAnimManip = self.Trash:Add(buildAnimManip)
+
+        self.BuildBones = self.Blueprint.General.BuildBones
     end,
 
     ---@param self CLandFactoryUnit
@@ -58,7 +61,7 @@ CLandFactoryUnit = ClassUnit(LandFactoryUnit) {
         end
 
         WaitTicks(2)
-        CreateCybranFactoryBuildEffects(self, unitBeingBuilt, self.Blueprint.General.BuildBones, self.BuildEffectsBag)
+        CreateCybranFactoryBuildEffects(self, unitBeingBuilt, self.BuildBones, self.BuildEffectsBag)
     end,
 
     ---@param self CLandFactoryUnit

--- a/lua/sim/units/cybran/CSeaFactoryUnit.lua
+++ b/lua/sim/units/cybran/CSeaFactoryUnit.lua
@@ -46,6 +46,7 @@ local AnimatorSetRate = moho.AnimationManipulator.SetRate
 
 ---@class CSeaFactoryUnit : SeaFactoryUnit
 ---@field BuildEffectsBag TrashBag
+---@field BuildBones BuildBones
 CSeaFactoryUnit = ClassUnit(SeaFactoryUnit) {
 
     ---@param self CSeaFactoryUnit
@@ -56,8 +57,9 @@ CSeaFactoryUnit = ClassUnit(SeaFactoryUnit) {
         AnimatorPlayAnim(buildAnimManip, self.Blueprint.Display.AnimationBuild, true)
         AnimatorSetRate(buildAnimManip, 0)
         self.BuildAnimManip = self.Trash:Add(buildAnimManip)
-    end,
 
+        self.BuildBones = self.Blueprint.General.BuildBones
+    end,
 
     ---@param self CAirFactoryUnit
     ---@param unitBeingBuilt Unit
@@ -68,7 +70,7 @@ CSeaFactoryUnit = ClassUnit(SeaFactoryUnit) {
         end
 
         WaitTicks(2)
-        CreateCybranFactoryBuildEffects(self, unitBeingBuilt, self.BuildEffectBones, self.BuildEffectsBag)
+        CreateCybranFactoryBuildEffects(self, unitBeingBuilt, self.BuildBones, self.BuildEffectsBag)
     end,
 
     ---@param self CSeaFactoryUnit


### PR DESCRIPTION
## Issue 
When a Cybran air factory dies while building the following error occurs:
```
warning: Error running lua script: ...\fa\lua\effectutilities.lua(345): attempt to loop over field `BuildEffectBones' (a nil value)
         stack traceback:
         	...\fa\lua\effectutilities.lua(345): in function <...\fa\lua\effectutilities.lua:341>
         	...\fa\lua\sim\units\cybran\cairfactoryunit.lua(62): in function <...\fa\lua\sim\units\cybran\cairfactoryunit.lua:56>
```
The error occurs because the wrong blueprint value is passed to the function, and it occurs after the factory dies because the function is stuck in a loop before the erroring code runs. The loop can be traced to b7169abb53cc97fed8c2ebdaebf9c1c16a9854d4 (10 years ago) where the Cybran naval factory build beams which are forked in a thread were added to land/air factories without being forked.

## Description of the proposed changes
- Fix the wrong value being passed
- Fork the build beam thread so that the other effects work: a glow under the unit, sparks on the tips of the build arms, and sparks in the unit hitbox. The build animation is noticeably brighter because of these functional effects.
  - Since it's been 10 years I'd recommend taking a close look. I think it's a good addition so I didn't change anything.
- Fix related intellisense warnings (unknown global and wrong param type)

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spawn factories and build something in them. There should be no errors in the log and the aforementioned effects should be visible.
Paragon + all land/air factories affected:
```lua
   CreateUnitAtMouse('urb0202', 0,   14.55,    7.91,  0.00000)
   CreateUnitAtMouse('urb0302', 0,   14.55,   -2.09,  0.00000)
   CreateUnitAtMouse('xab1401', 0,    1.55,   -6.09,  0.00000)
   CreateUnitAtMouse('urb0102', 0,   18.55,   16.91,  0.00000)
   CreateUnitAtMouse('zrb9602', 0,   24.55,   -1.09,  0.00000)
   CreateUnitAtMouse('urb0301', 0,  -23.45,  -11.09,  0.00000)
   CreateUnitAtMouse('zrb9502', 0,   23.55,    7.91,  0.00000)
   CreateUnitAtMouse('urb0201', 0,  -23.45,   -3.09,  0.00000)
   CreateUnitAtMouse('zrb9601', 0,  -15.45,  -11.09,  0.00000)
   CreateUnitAtMouse('urb0101', 0,  -19.45,    4.91,  0.00000)
   CreateUnitAtMouse('zrb9501', 0,  -15.45,   -3.09,  0.00000)
```
Despite having using the function in `CSeaFactoryUnit`, Cybran naval factories are not affected as their unit scripts replace `CreateBuildEffects` with the fancier 1/2/3 build arm component's `CreateBuildEffects`.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version