### PR TITLE
Improve merge bp compatibility with removing fields

### DIFF
--- a/changelog/snippets/fix.6637.md
+++ b/changelog/snippets/fix.6637.md
@@ -1,0 +1,1 @@
+- (#6637) Improve merge blueprint compatibility with removal of enhancements.

--- a/changelog/snippets/fix.6637.md
+++ b/changelog/snippets/fix.6637.md
@@ -1,1 +1,1 @@
-- (#6637) Improve merge blueprint compatibility with removal of enhancements.
+- (#6637) Improve merge blueprint compatibility with removal of enhancements, enhancement presets, and weapon Buffs.

--- a/engine/Core.lua
+++ b/engine/Core.lua
@@ -4,6 +4,9 @@
 ---@class FileName: string, stringlib
 ---@operator concat(FileName | string): FileName
 
+---@class string: stringlib
+---@operator concat(FileName): FileName
+
 ---@class VectorBase
 ---@field [1] number    # x
 ---@field [2] number    # y

--- a/engine/Core/Blueprints/EntityBlueprint.lua
+++ b/engine/Core/Blueprints/EntityBlueprint.lua
@@ -5,6 +5,8 @@
 ---@field AltFootprint? FootprintBlueprint
 --- unit average density in tons / m^3 (default is 0.49). Affects the behavior of units when they bump into each other. Units with more weight push units with less weight.
 ---@field AverageDensity? number
+--- Used by engine behavior to find the correct blueprint. Should not be assigned to existing ordinals in lua code.
+---@field BlueprintOrdinal? number
 --- list of category names that this entity belongs to
 ---@field Categories CategoryName[]
 --- hash of category names that this entity belongs to

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -1182,7 +1182,7 @@
 --- turn facing damping for the unit, usually used for hover units only
 ---@field TurnFacingRate number
 --- turn radius for the unit, in world units. Used when the nav waypoint is further than `TurnRadius` distance,
---- and if it results in a faster turn rate than `TurnRate`. Disabled at 0
+--- and if it results in a faster turn rate than `TurnRate`. Disabled at 0. Turnrate = 180 deg / (pi*radius/speed)
 ---@field TurnRadius number
 --- turn rate for the unit, in degrees per second. Turning acts improperly when at 0
 ---@field TurnRate number

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -3244,9 +3244,13 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     end;
 
     ---@param self Unit
-    ---@param enh Enhancement
+    ---@param enh Enhancement | false
     ---@return boolean
     CreateEnhancement = function(self, enh)
+        -- enh == false due to a merge blueprint
+        if not enh then
+            return false
+        end
         local bp = self.Blueprint.Enhancements[enh]
         if not bp then
             WARN(string.format('Got `CreateEnhancement` call with enhancement "%s" that does not exist in the blueprint.\n%s', tostring(enh), debug.traceback()))

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -3249,7 +3249,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     CreateEnhancement = function(self, enh)
         local bp = self.Blueprint.Enhancements[enh]
         if not bp then
-            error('*ERROR: Got CreateEnhancement call with an enhancement that doesnt exist in the blueprint.', 2)
+            WARN(string.format('Got `CreateEnhancement` call with enhancement "%s" that does not exist in the blueprint.\n%s', tostring(enh), debug.traceback()))
             return false
         end
 

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -491,7 +491,7 @@ Weapon = ClassWeapon(WeaponMethods, DebugWeaponComponent) {
 
         -- Add buff
         damageTable.Buffs = {}
-        if weaponBlueprint.Buffs ~= nil then
+        if weaponBlueprint.Buffs then
             for k, v in weaponBlueprint.Buffs do
                 if not self.DisabledBuffs[v.BuffType] then
                     damageTable.Buffs[k] = v

--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -127,7 +127,7 @@ local function AssignIcons(units, assignments, identifier)
         local unit = units[id]
         if unit then
             local path = identifier .. "/" .. icon
-            unit.StrategicIconName =  path
+            unit.StrategicIconName = path
         end
     end
 
@@ -145,7 +145,6 @@ local function AssignIcons(units, assignments, identifier)
         end
     end
 end
-
 
 --- Creates a new basic environment that's safe for the UI to interact with
 ---@return table
@@ -246,8 +245,6 @@ local function NewSafeEnv()
     return env
 end
 
-
-
 --- Finds and applies custom strategic icons defined by UI mods
 --- @param all_bps BlueprintsTable the table with all blueprint values
 local function FindCustomStrategicIcons(all_bps)
@@ -258,8 +255,8 @@ local function FindCustomStrategicIcons(all_bps)
     if preGameData and preGameData.IconReplacements then
         for _, info in preGameData.IconReplacements do
             -- data that is set in the lobby
-            -- info.Name = mod.name 
-            -- info.Author = mod.author 
+            -- info.Name = mod.name
+            -- info.Author = mod.author
             -- info.Location = mod.location
             -- info.Identifier = string.lower(utils.StringSplit(mod.location, '/')[2])
             -- info.UID = uid
@@ -285,10 +282,10 @@ local function FindCustomStrategicIcons(all_bps)
                 WARN(msg)
             end
 
-            ok, msg = pcall (
+            ok, msg = pcall(
                 function()
                     -- scripted approach
-                    if state.ScriptedIconAssignments then 
+                    if state.ScriptedIconAssignments then
                         -- retrieve data, make sure it is a deepcopy to prevent ui mods messing with the original
                         local units = table.deepcopy(all_bps.Unit)
                         local projectiles = table.deepcopy(all_bps.Projectile)
@@ -306,12 +303,12 @@ local function FindCustomStrategicIcons(all_bps)
                     end
 
                     -- manual approach
-                    if state.UnitIconAssignments then 
+                    if state.UnitIconAssignments then
                         AssignIcons(all_bps.Unit, state.UnitIconAssignments, info.Identifier)
 
                         -- inform the dev
                         local n = table.getsize(state.UnitIconAssignments)
-                        if n > 0 then 
+                        if n > 0 then
                             SPEW("Blueprints.lua - Found (" .. n .. ") manual icon assignments in " .. info.Name .. " by " .. info.Author .. ".")
                         end
                     end
@@ -393,7 +390,7 @@ local function SetLongId(bp)
     bp.Source = bp.Source or GetSource()
     if not bp.BlueprintId then
         local id = lower(bp.Source)
-        id = gsub(id, "%.bp$", "")                          -- strip trailing .bp
+        id = gsub(id, "%.bp$", "") -- strip trailing .bp
         --id = gsub(id, "/([^/]+)/%1_([a-z]+)$", "/%1_%2")    -- strip redundant directory name
         bp.BlueprintId = id
     end
@@ -441,7 +438,7 @@ function ExtractMeshBlueprint(bp)
     if disp.MeshBlueprint == nil then
         -- For a blueprint file "/units/uel0001/uel0001_unit.bp", the default
         -- mesh blueprint is "/units/uel0001/uel0001_mesh"
-        local meshname,subcount = gsub(bp.Source, "_[a-z]+%.bp$", "_mesh")
+        local meshname, subcount = gsub(bp.Source, "_[a-z]+%.bp$", "_mesh")
         if subcount == 1 then
             disp.MeshBlueprint = meshname
         end
@@ -469,7 +466,7 @@ function ExtractWreckageBlueprint(bp)
     local wreckbp = table.deepcopy(meshbp)
     if wreckbp.LODs then
         for _, lod in wreckbp.LODs do
-            if  lod.ShaderName == 'TMeshAlpha' or
+            if lod.ShaderName == 'TMeshAlpha' or
                 lod.ShaderName == 'NormalMappedAlpha' or
                 lod.ShaderName == 'UndulatingNormalMappedAlpha'
             then
@@ -709,7 +706,7 @@ function HandleUnitWithBuildPresets(bps, all_bps)
             tempBp.BuildIconSortPriority = preset.BuildIconSortPriority or tempBp.BuildIconSortPriority or 0
             tempBp.General.SelectionPriority = preset.SelectionPriority or tempBp.General.SelectionPriority or 1
             tempBp.General.UnitName = preset.UnitName or tempBp.General.UnitName
-            tempBp.Interface = tempBp.Interface or { }
+            tempBp.Interface = tempBp.Interface or {}
             tempBp.Interface.HelpText = preset.HelpText or tempBp.Interface.HelpText
             tempBp.Description = preset.Description or tempBp.Description
             tempBp.CategoriesHash['ISPREENHANCEDUNIT'] = true
@@ -719,7 +716,6 @@ function HandleUnitWithBuildPresets(bps, all_bps)
             tempBp.EnhancementPresets = nil
             -- synchronizing Categories with CategoriesHash for compatibility
             tempBp.Categories = table.unhash(tempBp.CategoriesHash)
-
             all_bps.Unit[tempBp.BlueprintId] = tempBp
 
             BlueprintLoaderUpdateProgress()
@@ -764,7 +760,6 @@ function ExtractCloakMeshBlueprint(bp)
     MeshBlueprint(cloakmeshbp)
 end
 
-
 --- Adapts all unit blueprints before they're passed onto mods.
 ---@param all_bps BlueprintsTable All the blueprints of the game.
 function PreModBlueprints(all_bps)
@@ -794,7 +789,7 @@ function PreModBlueprints(all_bps)
             -- Add common category values for easier lookup
 
             -- Add tech category
-            for _, category in {'EXPERIMENTAL', 'SUBCOMMANDER', 'COMMAND', 'TECH1', 'TECH2', 'TECH3'} do
+            for _, category in { 'EXPERIMENTAL', 'SUBCOMMANDER', 'COMMAND', 'TECH1', 'TECH2', 'TECH3' } do
                 if bp.CategoriesHash[category] then
                     bp.TechCategory = category
                     break
@@ -802,7 +797,7 @@ function PreModBlueprints(all_bps)
             end
 
             -- Add layer category
-            for _, category in {'LAND', 'AIR', 'NAVAL'} do
+            for _, category in { 'LAND', 'AIR', 'NAVAL' } do
                 if bp.CategoriesHash[category] then
                     bp.LayerCategory = category
                     break
@@ -853,8 +848,10 @@ end
 local NewDummies = {}
 
 local function GetFoot(bp, axe) return math.ceil(bp.Footprint and bp.Footprint[axe] or bp[axe] or 1) end
-local function GetSkirt(bp, axe) return math.max((bp.Physics and bp.Physics['Skirt'..axe] or 1), GetFoot(bp, axe)) end
-local function GetOffset(bp, axe) return (bp.Physics and bp.Physics['SkirtOffset'..axe] or 0) end
+
+local function GetSkirt(bp, axe) return math.max((bp.Physics and bp.Physics['Skirt' .. axe] or 1), GetFoot(bp, axe)) end
+
+local function GetOffset(bp, axe) return (bp.Physics and bp.Physics['SkirtOffset' .. axe] or 0) end
 
 local function ReduceFoot(val)
     local modded = math.mod(val, 2)
@@ -862,7 +859,7 @@ local function ReduceFoot(val)
 end
 
 local function NewOffset(offset, foot, reduced)
-    return offset-(foot-reduced)/2
+    return offset - (foot - reduced) / 2
 end
 
 local function SpawnMenuDummyChanges(all_bps)
@@ -880,7 +877,7 @@ local function SpawnMenuDummyChanges(all_bps)
 
             local SOffsetX, SOffsetZ = NewOffset(GetOffset(bp, 'X'), FootX, ReducedFootX), NewOffset(GetOffset(bp, 'Z'), FootZ, ReducedFootZ)
 
-            local DummyID = 'spawn_dummy_'..SkirtX..SkirtZ..'_'..SOffsetX..SOffsetZ..'_'..ReducedFootX..ReducedFootZ
+            local DummyID = 'spawn_dummy_' .. SkirtX .. SkirtZ .. '_' .. SOffsetX .. SOffsetZ .. '_' .. ReducedFootX .. ReducedFootZ
 
 
             if not NewDummies[DummyID] then
@@ -925,7 +922,6 @@ local function SpawnMenuDummyChanges(all_bps)
     end
 end
 
-
 ---@param all_bps BlueprintsTable
 function PostModBlueprints(all_bps)
     -- Brute51: Modified code for ship wrecks and added code for SCU presets.
@@ -933,13 +929,13 @@ function PostModBlueprints(all_bps)
     local preset_bps = {}
 
     SpawnMenuDummyChanges(all_bps.Unit)
-    
+
     for _, bp in all_bps.Unit do
         -- skip units without categories
         if bp.Categories then
             -- check if blueprint was changed in ModBlueprints(all_bps)
             if bp.Mod or table.getsize(bp.CategoriesHash) ~= table.getsize(bp.Categories) then
-            bp.CategoriesHash = table.hash(bp.Categories)
+                bp.CategoriesHash = table.hash(bp.Categories)
             end
 
             if bp.CategoriesHash.USEBUILDPRESETS then
@@ -964,7 +960,7 @@ function PostModBlueprints(all_bps)
 
     HandleUnitWithBuildPresets(preset_bps, all_bps)
 
-    -- find custom strategic icons defined by ui mods, this should be the very last thing 
+    -- find custom strategic icons defined by ui mods, this should be the very last thing
     -- we do before releasing the blueprint values to the game as we want to catch all
     -- units, even those included by mods
     FindCustomStrategicIcons(all_bps)
@@ -988,10 +984,10 @@ function PostModBlueprints(all_bps)
     PostProcessProps(all_bps.Prop)
 end
 
---- Loads all blueprints with optional parameters  
---- NOTE now it supports loading blueprints on UI-side in addition to loading on Sim-side  
---- `Sim -> LoadBlueprints() - no arguments, no changes!`  
---- `UI  -> LoadBlueprints('*_unit.bp', {'/units'}, mods, true, true, true, taskNotifier)`  used in ModsManager.lua  
+--- Loads all blueprints with optional parameters
+--- NOTE now it supports loading blueprints on UI-side in addition to loading on Sim-side
+--- `Sim -> LoadBlueprints() - no arguments, no changes!`
+--- `UI  -> LoadBlueprints('*_unit.bp', {'/units'}, mods, true, true, true, taskNotifier)`  used in ModsManager.lua
 --- `UI  -> LoadBlueprints('*_unit.bp', {'/units'}, mods, false, true, true, taskNotifier)` used in UnitsAnalyzer.lua
 ---@param pattern? string            pattern of files to load, defaults to `'*.bp'`
 ---@param directories? string[]      paths to load blueprints from, defaults to all directories
@@ -1009,7 +1005,7 @@ function LoadBlueprints(pattern, directories, mods, skipGameFiles, skipExtractio
     -- set default parameters if they are not provided
     if not pattern then pattern = '*.bp' end
     if not directories then
-        directories = {'/effects', '/env', '/meshes', '/projectiles', '/props', '/units'}
+        directories = { '/effects', '/env', '/meshes', '/projectiles', '/props', '/units' }
     end
 
     LOG('Blueprints Loading... \'' .. tostring(pattern) .. '\' files')
@@ -1030,7 +1026,7 @@ function LoadBlueprints(pattern, directories, mods, skipGameFiles, skipExtractio
                 BlueprintLoaderUpdateProgress()
                 -- update UnitManager UI via taskNotifier only if it exists
                 if taskNotifier then
-                   taskNotifier:Update(task, total, k)
+                    taskNotifier:Update(task, total, k)
                 end
                 safecall(task .. ': ' .. file, doscript, file)
             end
@@ -1050,7 +1046,7 @@ function LoadBlueprints(pattern, directories, mods, skipGameFiles, skipExtractio
             BlueprintLoaderUpdateProgress()
             -- update UnitManager UI via taskNotifier only if it exists
             if taskNotifier then
-               taskNotifier:Update(task, total, k)
+                taskNotifier:Update(task, total, k)
             end
 
             safecall(task .. ': ' .. file, doscript, file)
@@ -1064,11 +1060,11 @@ function LoadBlueprints(pattern, directories, mods, skipGameFiles, skipExtractio
         total = table.getsize(files)
         LOG(task)
 
-        for k,file in files do
+        for k, file in files do
             BlueprintLoaderUpdateProgress()
             -- update UnitManager UI via taskNotifier only if it exists
             if taskNotifier then
-               taskNotifier:Update(task, total, k)
+                taskNotifier:Update(task, total, k)
             end
             safecall(task .. ': ' .. file, doscript, file)
         end
@@ -1092,13 +1088,13 @@ function LoadBlueprints(pattern, directories, mods, skipGameFiles, skipExtractio
     stats.UnitsPreset = stats.UnitsTotal - stats.UnitsOrg - stats.UnitsMod
     if stats.UnitsTotal > 0 then
         LOG('Blueprints Loading... completed: ' .. stats.UnitsOrg .. ' original, '
-                                                .. stats.UnitsMod .. ' modded, and '
-                                                .. stats.UnitsPreset .. ' preset units')
+            .. stats.UnitsMod .. ' modded, and '
+            .. stats.UnitsPreset .. ' preset units')
     end
     stats.ProjsTotal = table.getsize(original_blueprints.Projectile)
     if stats.ProjsTotal > 0 then
         LOG('Blueprints Loading... completed: ' .. stats.ProjsOrg .. ' original and '
-                                                .. stats.ProjsMod .. ' modded projectiles')
+            .. stats.ProjsMod .. ' modded projectiles')
     end
 
     if not skipRegistration then

--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -808,13 +808,6 @@ function PreModBlueprints(all_bps)
             -- Add faction category
             bp.FactionCategory = string.upper(bp.General.FactionName or 'Unknown')
 
-            -- Adjust weapon blueprints
-            for i, w in bp.Weapon or {} do
-                -- add in weapon blueprint id
-                local label = w.Label or "Unlabelled"
-                w.BlueprintId = bp.BlueprintId .. "-" .. i .. "-" .. label
-            end
-
             -- Hotfix for naval wrecks
             if bp.CategoriesHash.NAVAL and not bp.Wreckage then
                 bp.Wreckage = {

--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -48,20 +48,21 @@
 --   default to its old value, not to 0 or its normal default.
 --
 
+---@type BlueprintsTable
+local original_blueprints
+---@type ModInfo
+local current_mod
+
+-- upvalue for performance
 local sub = string.sub
 local gsub = string.gsub
 local lower = string.lower
 local getinfo = debug.getinfo
+local pcall = pcall
+local doscript = doscript
+local DiskFindFiles = DiskFindFiles
+
 local here = getinfo(1).source
-
----@type BlueprintsTable
-local original_blueprints
-local current_mod
-
--- upvalue for performance
-pcall = pcall
-doscript = doscript
-DiskFindFiles = DiskFindFiles
 
 doscript("/lua/system/blueprints-ai.lua")
 doscript("/lua/system/blueprints-lod.lua")

--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -641,6 +641,9 @@ function HandleUnitWithBuildPresets(bps, all_bps)
 
     for _, bp in bps do
         for name, preset in bp.EnhancementPresets do
+            -- allow removing presets using merge bp
+            if not preset then continue end
+
             -- start with clean copy of the original unit BP
             tempBp = table.deepcopy(bp)
 

--- a/lua/system/Blueprints.lua
+++ b/lua/system/Blueprints.lua
@@ -450,7 +450,9 @@ function ExtractMeshBlueprint(bp)
             local meshbp = disp.Mesh
             meshbp.Source = meshbp.Source or bp.Source
             meshbp.BlueprintId = disp.MeshBlueprint
-            -- roates:  Commented out so the info would stay in the unit BP and I could use it to precache by unit.
+            -- Robert Oates:  Commented out so the info would stay in the unit BP and I could use it to precache by unit.
+            -- The above comment likely refers to PrefetchUtilities.lua `CreatePrefetchSetFromBlueprints`
+            -- The Mesh table is also needed for dynamic LOD of structure tarmacs and build effects in lua
             -- disp.Mesh = nil
             MeshBlueprint(meshbp)
         end

--- a/lua/system/blueprints-weapons.lua
+++ b/lua/system/blueprints-weapons.lua
@@ -138,6 +138,11 @@ local function ProcessWeapon(unit, weapon, projectile)
 
     -- Floor target check interval to ticks
     weapon.TargetCheckInterval = 0.1 * math.floor(10 * weapon.TargetCheckInterval)
+
+    -- Game will constantly give warnings without any info when a weapon has 0 radius, so give some info in case it happens
+    if weapon.MaxRadius == 0 then
+        WARN(string.format('%s has 0 max radius for weapon %s', unit.BlueprintId, weapon.BlueprintId))
+    end
 end
 
 ---@param allBlueprints BlueprintsTable

--- a/lua/system/blueprints-weapons.lua
+++ b/lua/system/blueprints-weapons.lua
@@ -3,7 +3,8 @@ local weaponTargetCheckUpperLimit = 6000
 ---@param unit UnitBlueprint
 ---@param weapon WeaponBlueprint
 ---@param projectile? ProjectileBlueprint
-local function ProcessWeapon(unit, weapon, projectile)
+---@param weaponIndex number
+local function ProcessWeapon(unit, weapon, projectile, weaponIndex)
     -- pre-compute flags
     local isAir = false
     local isStructure = false
@@ -22,7 +23,11 @@ local function ProcessWeapon(unit, weapon, projectile)
         end
     end
 
-    -- process weapon
+    -- Add an identifier to the weapon
+    local label = weapon.Label or "Unlabelled"
+    weapon.BlueprintId = unit.BlueprintId .. "-" .. weaponIndex .. "-" .. label
+
+    -- process tracking radius
 
     -- Death weapons of any kind
     if weapon.DamageType == "DeathExplosion" or weapon.Label == "DeathWeapon" or weapon.Label == "DeathImpact" then
@@ -157,7 +162,7 @@ function ProcessWeapons(allBlueprints, units)
     for _, unit in units do
         if not unitsToSkip[StringLower(unit.Blueprint.BlueprintId or "")] then
             if unit.Weapon then
-                for _, weapon in unit.Weapon do
+                for weaponIndex, weapon in unit.Weapon do
                     if not weapon.DummyWeapon then
 
                         local projectile
@@ -169,7 +174,7 @@ function ProcessWeapons(allBlueprints, units)
                             end
                         end
 
-                        ProcessWeapon(unit, weapon, projectile)
+                        ProcessWeapon(unit, weapon, projectile, weaponIndex)
                     end
                 end
             end

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -317,6 +317,9 @@ end
 -- table.keys(t) -- returns keys in increasing order (low performance with large tables)
 -- table.keys(t, function(a, b) return a > b end) -- returns keys in decreasing order (low performance with large tables)
 -- table.keys(t, false) -- returns keys without comparing/sorting (better performance with large tables)
+---@param t table
+---@param comp? fun(a, b): boolean | false
+---@return table
 function table.keys(t, comp)
     local r = {}
     if not t then return r end -- prevents looping over nil table
@@ -352,7 +355,8 @@ end
 ---   for k,v in sortedpairs(t) do
 ---       print(k,v)
 ---   end
---- @param comp is an optional comparison function, defaulting to less-than.
+---@param t table
+---@param comp? fun(a, b): boolean # optional comparison function, defaulting to less-than.
 function sortedpairs(t, comp)
     local keys = table.keys(t, comp)
     local i=1

--- a/lua/ui/game/unitviewDetail.lua
+++ b/lua/ui/game/unitviewDetail.lua
@@ -453,7 +453,10 @@ function WrapAndPlaceText(bp, builder, descID, control)
     if builder and bp.EnhancementPresetAssigned then
         table.insert(lines, LOC('<LOC uvd_upgrades>')..':')
         for _, v in bp.EnhancementPresetAssigned.Enhancements do
-            table.insert(lines, '    '..LOC(bp.Enhancements[v].Name))
+            local bpEnh = bp.Enhancements[v]
+            if bpEnh then
+                table.insert(lines, '    ' .. LOC(bpEnh.Name))
+            end
         end
         table.insert(blocks, {color = 'FFB0FFB0', lines = lines})
     elseif bp then

--- a/lua/ui/lobby/UnitsAnalyzer.lua
+++ b/lua/ui/lobby/UnitsAnalyzer.lua
@@ -1152,8 +1152,8 @@ local function CacheUnit(bp)
 
     -- Extract and cache enhancements so they can be restricted individually
     for name, enh in bp.Enhancements or {} do
-        -- Skip slots or 'removable' enhancements
-        if name ~= 'Slots' and not string.find(name, 'Remove') then
+        -- Skip slots, 'Remove' enhancements, and enhancements removed by merging `false`
+        if enh and name ~= 'Slots' and not string.find(name, 'Remove') then
             -- Some enhancements are shared between factions, e.g. Teleporter
             -- and other enhancements have different stats and icons
             -- depending on faction or whether they are for ACU or SCU

--- a/units/UAL0301/UAL0301_script.lua
+++ b/units/UAL0301/UAL0301_script.lua
@@ -4,6 +4,7 @@
 -- Summary  :  Aeon Sub Commander Script
 -- Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
+
 ---@alias AeonSCUEnhancementBuffType
 ---| "SCUBUILDRATE"
 ---| "SCUREGENRATE"

--- a/units/XSL0101/XSL0101_script.lua
+++ b/units/XSL0101/XSL0101_script.lua
@@ -3,6 +3,7 @@
 -- Summary  :  Seraphim Land Scout Script
 -- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
+
 ---@alias SelenBuffType "SELENCLOAKBONUS"
 ---@alias SelenBuffName "SelenCloakVisionDebuff"
 


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Issue
Merge blueprints cannot set fields in the base bp to `nil` since lua does not allow storing table keys with a value of nil. The alternative to doing that is to set those keys to `false`, but not all code works well with that.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fix errors/bugs I encountered when modding SACUs, so code using blueprints and related to enhancements, enhancement presets, and weapons.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
- Units with enhancement presets that have a `false` value do not error and the enhancements work properly.
- Setting a preset to `false` does not error.
- Setting weapon buffs to `false` doesn't break it.

## Additional context
<!-- Add any other context about the pull request here. -->
An alternative could be to create a special value like `"__nil"` that `table.merged` treats as setting a field to `nil`.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version