### PR TITLE
Add a delay to the pause feature

### DIFF
--- a/changelog/snippets/features.6643.md
+++ b/changelog/snippets/features.6643.md
@@ -1,0 +1,3 @@
+- (#6643) Introduce a small enforced delay before a paused session can resume
+
+The delay applies to all players but the player that initiated the pause. The delay is 10 seconds. The delay is not configurable. 

--- a/engine/User.lua
+++ b/engine/User.lua
@@ -1096,10 +1096,11 @@ end
 --- Resume the world simulation
 function SessionResume()
 end
- 
----
----@param client? number | number[] client or clients
----@param message table | number | string
+
+--- Sends a message to one, more or all other connected clients. This message is sent separately from the simulation. But it is sent in order.
+---@overload fun(message: table | number | string)
+---@param client? number | number[]         # client or clients
+---@param message table | number | string   # 
 function SessionSendChatMessage(client, message)
 end
 

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -725,9 +725,12 @@ function OnQueueChanged(newQueue)
     end
 end
 
--- Called after the Sim has confirmed the game is indeed paused. This will happen
--- on everyone's machine in a network game.
+--- Called by the engine after the sim confirmed that the game is indeed paused. This is run on all instances that are connected to the lobby.
+---@param pausedBy integer   # The index of the client in the clients list (that you get via `GetSessionClients`)
+---@param timeoutsRemaining number
 function OnPause(pausedBy, timeoutsRemaining)
+    import("/lua/ui/game/pause.lua").OnPause(pausedBy, timeoutsRemaining)
+
     PauseSound("World",true)
     PauseSound("Music",true)
     PauseVoice("VO",true)
@@ -737,11 +740,19 @@ end
 
 -- Called after the Sim has confirmed that the game has resumed.
 local ResumedBy = nil
+
+--- Transmitted via a Chat command by another user to inform Lua who send the resume command. 
+---@param sender string # The name of the player that resumed the game. 
 function SendResumedBy(sender)
+    import("/lua/ui/game/pause.lua").SendResumedBy(sender)
+
     if not ResumedBy then ResumedBy = sender end
 end
 
+--- Called by the engine when the simulation
 function OnResume()
+    import("/lua/ui/game/pause.lua").OnResume()
+
     PauseSound("World",false)
     PauseSound("Music",false)
     PauseVoice("VO",false)
@@ -753,6 +764,8 @@ end
 -- Called immediately when the user hits the pause button on the machine
 -- that initiated the pause and other network players won't call this function
 function OnUserPause(pause)
+    import("/lua/ui/game/pause.lua").OnUserPause(pause)
+
     local Tabs = import("/lua/ui/game/tabs.lua")
     local focus = GetArmiesTable().focusArmy
     if Tabs.CanUserPause() then
@@ -1051,6 +1064,8 @@ end
 ---@param sender string     # username
 ---@param data table        
 function ReceiveChat(sender, data)
+    LOG("ReceiveChat", sender)
+    reprsl(data)
     if data.Identifier then
 
         -- we highly encourage to use the 'Identifier' field to quickly identify the correct function

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -744,8 +744,6 @@ local ResumedBy = nil
 --- Transmitted via a Chat command by another user to inform Lua who sent the resume command. 
 ---@param sender string # The name of the player that resumed the game. 
 function SendResumedBy(sender)
-    import("/lua/ui/game/pause.lua").SendResumedBy(sender)
-
     if not ResumedBy then ResumedBy = sender end
 end
 

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -741,7 +741,7 @@ end
 -- Called after the Sim has confirmed that the game has resumed.
 local ResumedBy = nil
 
---- Transmitted via a Chat command by another user to inform Lua who send the resume command. 
+--- Transmitted via a Chat command by another user to inform Lua who sent the resume command. 
 ---@param sender string # The name of the player that resumed the game. 
 function SendResumedBy(sender)
     import("/lua/ui/game/pause.lua").SendResumedBy(sender)

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -783,7 +783,7 @@ function OnUserPause(pause)
             else
                 SessionSendChatMessage(import('/lua/ui/game/clientutils.lua').GetAll(), {
                     to = 'all',
-                    text = 'Unpaused the game',
+                    text = 'Resumed the game',
                     Chat = true,
                 })
             end

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -1062,8 +1062,6 @@ end
 ---@param sender string     # username
 ---@param data table        
 function ReceiveChat(sender, data)
-    LOG("ReceiveChat", sender)
-    reprsl(data)
     if data.Identifier then
 
         -- we highly encourage to use the 'Identifier' field to quickly identify the correct function

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -749,7 +749,7 @@ function SendResumedBy(sender)
     if not ResumedBy then ResumedBy = sender end
 end
 
---- Called by the engine when the simulation
+--- Called by the engine when the simulation is resumed
 function OnResume()
     import("/lua/ui/game/pause.lua").OnResume()
 

--- a/lua/ui/game/pause.lua
+++ b/lua/ui/game/pause.lua
@@ -94,18 +94,19 @@ _G.SessionResume = function()
     end
 
     -- we waited long enough, we're good
-    if GetSystemTimeSeconds() - OnPauseTimestamp > PauseThreshold then
+    local timeDifference = GetSystemTimeSeconds() - OnPauseTimestamp
+    if timeDifference > PauseThreshold then
         LOG("Threshold is met to resume")
         oldSessionResume()
         return 'Accepted'
+    else
+        -- inform other clients
+        SessionSendChatMessage(import('/lua/ui/game/clientutils.lua').GetAll(), {
+            to = 'all',
+            text = string.format('Wants to resume the game but has to wait %d seconds', PauseThreshold - timeDifference),
+            Chat = true,
+        })
+
+        return 'Declined'
     end
-
-    -- inform other clients
-    SessionSendChatMessage(import('/lua/ui/game/clientutils.lua').GetAll(), {
-        to = 'all',
-        text = 'Wants to continue the game',
-        Chat = true,
-    })
-
-    return 'Declined'
 end

--- a/lua/ui/game/pause.lua
+++ b/lua/ui/game/pause.lua
@@ -1,0 +1,111 @@
+--******************************************************************************************************
+--** Copyright (c) 2025 Willem 'Jip' Wijnia
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
+---@type integer
+local OnPauseClientIndex = -1
+
+---@type number
+local OnPauseTimestamp = 0
+
+---@type number
+local PauseThreshold = 10
+
+---@return integer  # The index of the client, like the parameter `pausedBy` of OnPause
+---@return Client?  # The data of the client
+local function FindLocalClient()
+    local allClients = GetSessionClients()
+    for k = 1, table.getn(allClients) do
+        local client = allClients[k]
+        if client["local"] then
+            return k, client
+        end
+    end
+
+    return -1, nil
+end
+
+--- Called by the engine when the simulation pauses for all clients.
+---@param pausedBy integer  # The index of the client in the clients list (that you get via `GetSessionClients`)
+---@param timeoutsRemaining number
+function OnPause(pausedBy, timeoutsRemaining)
+    -- keep track of who paused and when
+    OnPauseClientIndex = pausedBy
+    OnPauseTimestamp = GetSystemTimeSeconds()
+end
+
+--- Called by the engine when the simulation resumed for all clients.
+function OnResume()
+    OnPauseClientIndex = -1
+    OnPauseTimestamp = 0
+end
+
+-- Called immediately by the engine on the machine that initiated the pause. This function is called only by the client that is initiating the (un)pause.
+function OnUserPause(pause)
+end
+
+local oldSessionRequestPause = _G.SessionRequestPause
+_G.SessionRequestPause = function()
+    -- makes no sense to request a pause on top of a pause
+    if SessionIsPaused() then
+        return
+    end
+
+    oldSessionRequestPause()
+end
+
+local oldSessionResume = _G.SessionResume
+---@return 'Accepted' | 'Declined'
+_G.SessionResume = function()
+    LOG("SessionResume")
+
+    -- scenario's that are all good
+    if SessionIsReplay() or
+        not SessionIsMultiplayer()
+    then
+        oldSessionResume()
+        return 'Accepted'
+    end
+
+    -- local client initiated the pause, we're all good
+    local localClientIndex, clientData = FindLocalClient()
+    if OnPauseClientIndex == localClientIndex then
+        LOG("Same client unpauses")
+        oldSessionResume()
+        return 'Accepted'
+    end
+
+    -- we waited long enough, we're good
+    if GetSystemTimeSeconds() - OnPauseTimestamp > PauseThreshold then
+        LOG("Threshold is met to resume")
+        oldSessionResume()
+        return 'Accepted'
+    end
+
+    -- inform other clients
+    SessionSendChatMessage(import('/lua/ui/game/clientutils.lua').GetAll(), {
+        to = 'all',
+        text = 'Wants to continue the game',
+        Chat = true,
+    })
+
+    return 'Declined'
+end

--- a/lua/ui/game/pause.lua
+++ b/lua/ui/game/pause.lua
@@ -77,7 +77,7 @@ local oldSessionResume = _G.SessionResume
 _G.SessionResume = function()
     LOG("SessionResume")
 
-    -- scenario's that are all good
+    -- no unpause restrictions in replays or singleplayer
     if SessionIsReplay() or
         not SessionIsMultiplayer()
     then

--- a/lua/ui/game/pause.lua
+++ b/lua/ui/game/pause.lua
@@ -27,7 +27,7 @@ local OnPauseClientIndex = -1
 local OnPauseTimestamp = 0
 
 ---@type number
-local PauseThreshold = 10
+local PauseThreshold = 10 -- seconds
 
 ---@return integer  # The index of the client, like the parameter `pausedBy` of OnPause
 ---@return Client?  # The data of the client

--- a/lua/ui/game/pause.lua
+++ b/lua/ui/game/pause.lua
@@ -75,8 +75,6 @@ end
 local oldSessionResume = _G.SessionResume
 ---@return 'Accepted' | 'Declined'
 _G.SessionResume = function()
-    LOG("SessionResume")
-
     -- no unpause restrictions in replays or singleplayer
     if SessionIsReplay() or
         not SessionIsMultiplayer()
@@ -88,7 +86,6 @@ _G.SessionResume = function()
     -- no unpause restriction if our local client initiated the pause
     local localClientIndex, clientData = FindLocalClient()
     if OnPauseClientIndex == localClientIndex then
-        LOG("Same client unpauses")
         oldSessionResume()
         return 'Accepted'
     end
@@ -96,7 +93,6 @@ _G.SessionResume = function()
     -- unpause if we have waited longer than the unpause threshold
     local timeDifference = GetSystemTimeSeconds() - OnPauseTimestamp
     if timeDifference > PauseThreshold then
-        LOG("Threshold is met to resume")
         oldSessionResume()
         return 'Accepted'
     else

--- a/lua/ui/game/pause.lua
+++ b/lua/ui/game/pause.lua
@@ -27,7 +27,7 @@ local OnPauseClientIndex = -1
 local OnPauseTimestamp = 0
 
 ---@type number
-local PauseThreshold = 10 -- seconds
+local ResumeThreshold = 10 -- seconds
 
 ---@return integer  # The index of the client, like the parameter `pausedBy` of OnPause
 ---@return Client?  # The data of the client
@@ -92,14 +92,14 @@ _G.SessionResume = function()
 
     -- unpause if we have waited longer than the unpause threshold
     local timeDifference = GetSystemTimeSeconds() - OnPauseTimestamp
-    if timeDifference > PauseThreshold then
+    if timeDifference > ResumeThreshold then
         oldSessionResume()
         return 'Accepted'
     else
         -- inform other clients
         SessionSendChatMessage(import('/lua/ui/game/clientutils.lua').GetAll(), {
             to = 'all',
-            text = string.format('Wants to resume the game but has to wait %d seconds', PauseThreshold - timeDifference),
+            text = string.format('Wants to resume the game but has to wait %d seconds', ResumeThreshold - timeDifference),
             Chat = true,
         })
 

--- a/lua/ui/game/pause.lua
+++ b/lua/ui/game/pause.lua
@@ -35,7 +35,7 @@ local function FindLocalClient()
     local allClients = GetSessionClients()
     for k = 1, table.getn(allClients) do
         local client = allClients[k]
-        if client["local"] then
+        if client.local then
             return k, client
         end
     end

--- a/lua/ui/game/pause.lua
+++ b/lua/ui/game/pause.lua
@@ -93,7 +93,7 @@ _G.SessionResume = function()
         return 'Accepted'
     end
 
-    -- we waited long enough, we're good
+    -- unpause if we have waited longer than the unpause threshold
     local timeDifference = GetSystemTimeSeconds() - OnPauseTimestamp
     if timeDifference > PauseThreshold then
         LOG("Threshold is met to resume")

--- a/lua/ui/game/pause.lua
+++ b/lua/ui/game/pause.lua
@@ -35,7 +35,7 @@ local function FindLocalClient()
     local allClients = GetSessionClients()
     for k = 1, table.getn(allClients) do
         local client = allClients[k]
-        if client.local then
+        if client["local"] then
             return k, client
         end
     end

--- a/lua/ui/game/pause.lua
+++ b/lua/ui/game/pause.lua
@@ -43,7 +43,7 @@ local function FindLocalClient()
     return -1, nil
 end
 
---- Called by the engine when the simulation pauses for all clients.
+--- Called from `gamemain.lua` when the simulation pauses for all clients.
 ---@param pausedBy integer  # The index of the client in the clients list (that you get via `GetSessionClients`)
 ---@param timeoutsRemaining number
 function OnPause(pausedBy, timeoutsRemaining)

--- a/lua/ui/game/pause.lua
+++ b/lua/ui/game/pause.lua
@@ -85,7 +85,7 @@ _G.SessionResume = function()
         return 'Accepted'
     end
 
-    -- local client initiated the pause, we're all good
+    -- no unpause restriction if our local client initiated the pause
     local localClientIndex, clientData = FindLocalClient()
     if OnPauseClientIndex == localClientIndex then
         LOG("Same client unpauses")

--- a/lua/ui/game/tabs.lua
+++ b/lua/ui/game/tabs.lua
@@ -506,16 +506,22 @@ function CommonLogic()
                 end
             end
             tab.OnCheck = function(self, checked)
-                if checked then
+                if not SessionIsPaused() then
                     if not CanUserPause() then
                         return
                     end
+
                     SessionRequestPause()
                     self:SetGlowState(checked)
                 else
-                    SessionSendChatMessage({SendResumedBy=true})
-                    SessionResume()
-                    self:SetGlowState(checked)
+                    local status = SessionResume()
+                    if status == 'Accepted' then
+                        SessionSendChatMessage({SendResumedBy=true})
+                        self:SetGlowState(checked)
+                    else
+                        -- reset the check since the resume was declined
+                        self:SetCheck(not checked, true)
+                    end
                 end
             end
             tab.OnClick = function(self, modifiers)

--- a/lua/ui/game/tabs.lua
+++ b/lua/ui/game/tabs.lua
@@ -516,7 +516,6 @@ function CommonLogic()
                 else
                     local status = SessionResume()
                     if status == 'Accepted' then
-                        SessionSendChatMessage({SendResumedBy=true})
                         self:SetGlowState(checked)
                     else
                         -- reset the check since the resume was declined


### PR DESCRIPTION
## Description of the proposed changes

Related to:

- https://forum.faforever.com/topic/8648/suggesting-rule-change-make-immediately-unpausing-after-a-player-asked-for-a-pause-against-the-rules/1

Introduces a small delay before user A can resume the session after a pause initiated by user B. At all times, user B can resume immediately. A chat message is posted when a user pauses the session, attempts to resume the session and when the session is resumed.

![image](https://github.com/user-attachments/assets/705fa286-60f4-42e1-92c2-8a080e6f7051)

## Testing done on the proposed changes

Launched the game directly into the match maker lobby with the [LaunchScripts](https://github.com/FAForever/fa/blob/develop/scripts/LaunchFAInstances.ps1) made by @lL1l1 .

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version