### PR TITLE
Fix error when using distribute queue on dying unit

### DIFF
--- a/changelog/snippets/fix.6645.md
+++ b/changelog/snippets/fix.6645.md
@@ -1,0 +1,1 @@
+- (#6645) Fix an error when using distribute orders on a unit that dies shortly after.

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4988,21 +4988,27 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     ---@param self Unit
     ---@return UnitCommand[]
     GetCommandQueue = function(self)
-        local queue = cUnit.GetCommandQueue(self)
-        if queue then
-            for k, order in queue do
-                if order.targetId then
-                    local target = GetEntityById(order.targetId)
-                    if target and IsEntity(target) then
-                        order.target = target
-                        -- take position of the entity, used to sort the units
-                        order.x, order.y, order.z = moho.entity_methods.GetPositionXYZ(target)
+        local ok, msg = pcall(cUnit.GetCommandQueue, self)
+        if not ok then
+            WARN('unit getcqueue errored:', self.UnitId, self.EntityId, 'dead, destroyed:', self.Dead, IsDestroyed(self))
+            WARN(msg)
+        else
+            local queue = cUnit.GetCommandQueue(self)
+            if queue then
+                for k, order in queue do
+                    if order.targetId then
+                        local target = GetEntityById(order.targetId)
+                        if target and IsEntity(target) then
+                            order.target = target
+                            -- take position of the entity, used to sort the units
+                            order.x, order.y, order.z = moho.entity_methods.GetPositionXYZ(target)
+                        end
                     end
                 end
             end
-        end
 
-        return queue
+            return queue
+        end
     end,
 
     --- Stuns the unit, if it isn't set to be immune by the flag unit.ImmuneToStun

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4988,27 +4988,21 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     ---@param self Unit
     ---@return UnitCommand[]
     GetCommandQueue = function(self)
-        local ok, msg = pcall(cUnit.GetCommandQueue, self)
-        if not ok then
-            WARN('unit getcqueue errored:', self.UnitId, self.EntityId, 'dead, destroyed:', self.Dead, IsDestroyed(self))
-            WARN(msg)
-        else
-            local queue = cUnit.GetCommandQueue(self)
-            if queue then
-                for k, order in queue do
-                    if order.targetId then
-                        local target = GetEntityById(order.targetId)
-                        if target and IsEntity(target) then
-                            order.target = target
-                            -- take position of the entity, used to sort the units
-                            order.x, order.y, order.z = moho.entity_methods.GetPositionXYZ(target)
-                        end
+        local queue = cUnit.GetCommandQueue(self)
+        if queue then
+            for k, order in queue do
+                if order.targetId then
+                    local target = GetEntityById(order.targetId)
+                    if target and IsEntity(target) then
+                        order.target = target
+                        -- take position of the entity, used to sort the units
+                        order.x, order.y, order.z = moho.entity_methods.GetPositionXYZ(target)
                     end
                 end
             end
-
-            return queue
         end
+
+        return queue
     end,
 
     --- Stuns the unit, if it isn't set to be immune by the flag unit.ImmuneToStun

--- a/lua/sim/commands/distribute-queue.lua
+++ b/lua/sim/commands/distribute-queue.lua
@@ -52,7 +52,7 @@ DistributeOrders = function(units, target, clearCommands, doPrint)
         return
     end
 
-    if (not target) or (IsDestroyed(target)) then
+    if (not target) or (IsDestroyed(target)) or (target.Dead) then
         return
     end
 


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Issue
There is a random error when using distribute queue in normal games.
```
warning: Error running sim lua callback function 'DistributeOrders':
         UnitScript:GetCommandQueue invalid UnitCommandQueue
         stack traceback:
         	[C]: in function `GetCommandQueue'
         	...\lua.nx2\lua\sim\unit.lua(4987): in function `GetCommandQueue'
         	...\lua.nx2\lua\sim\commands\distribute-queue.lua(77): in function `DistributeOrders'
         	...\lua.nx2\lua\simcallbacks.lua(569): in function `fn'
         	...\lua.nx2\lua\simcallbacks.lua(58): in function <...\lua.nx2\lua\simcallbacks.lua:54>
```
The debug setup reveals the following information:
```
warning: unit getcqueue errored:	url0301_rambo	41	dead, destroyed:	true	false
warning: UnitScript:GetCommandQueue invalid UnitCommandQueue
warning: stack traceback:
warning:         [C]: ?
warning:         [C]: in function `pcall'
warning:         ...\fa\lua\sim\unit.lua(4991): in function `GetCommandQueue'
warning:         ...\fa\lua\sim\commands\distribute-queue.lua(77): in function `DistributeOrders'
warning:         ...\fa\lua\simcallbacks.lua(569): in function `fn'
warning:         ...\fa\lua\simcallbacks.lua(58): in function <...\fa\lua\simcallbacks.lua:54>
```
It seems like the engine does not have a command queue to get for dead units, so it throws an error.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Check if the target unit we are copying the queue from is dead.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spam orders and distribute queue on a bunch of units as they go to their death. The error should not show up.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version