### PR TITLE
Remove the chat sound when watching a replay

### DIFF
--- a/changelog/snippets/fix.6646.md
+++ b/changelog/snippets/fix.6646.md
@@ -1,1 +1,1 @@
-- (#6646) Remove the chat bleeps when watching a replay
+- (#6646) Remove the chat beeps when watching a replay

--- a/changelog/snippets/fix.6646.md
+++ b/changelog/snippets/fix.6646.md
@@ -1,0 +1,1 @@
+- (#6646) Remove the chat bleeps when watching a replay

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -888,9 +888,6 @@ function ReceiveChatFromSim(sender, msg)
             GUI.chatContainer:ScrollToBottom()
         end
     end
-    if SessionIsReplay() then
-        PlaySound(Sound({Bank = 'Interface', Cue = 'UI_Diplomacy_Close'}))
-    end
 end
 
 function ToggleChat()


### PR DESCRIPTION
## Description of the proposed changes

This refers to the sound when you receive a message. The sound plays in replays. I personally find it to be an annoying sound, but this is of course subjective.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version