### PR TITLE
Add a guard to prevent a buffer overflow when saving a game

### DIFF
--- a/changelog/snippets/fix.6647.md
+++ b/changelog/snippets/fix.6647.md
@@ -1,0 +1,1 @@
+- (#6647) Fix a buffer overflow exploit in the `InternalSaveGame` user global

--- a/lua/ui/globals/InternalSaveGame.lua
+++ b/lua/ui/globals/InternalSaveGame.lua
@@ -31,11 +31,11 @@ do
     ---@param filename string
     _G.InternalSaveGame = function(filename, friendlyFilename, onCompletionCallback)
         if DebugAllocatedSize(filename) > 50 then
-            filename = filename:sub(0, 50)
+            filename = filename:sub(1, 50)
         end
 
         if DebugAllocatedSize(friendlyFilename) > 50 then
-            friendlyFilename = friendlyFilename:sub(0, 50)
+            friendlyFilename = friendlyFilename:sub(1, 50)
         end
 
         return oldInternalSaveGame(filename, friendlyFilename, onCompletionCallback)

--- a/lua/ui/globals/InternalSaveGame.lua
+++ b/lua/ui/globals/InternalSaveGame.lua
@@ -24,18 +24,18 @@
 
 do
     local DebugAllocatedSize = debug.allocatedsize
-
     local oldInternalSaveGame = _G.InternalSaveGame
 
     --- Hook to fix a buffer overflow security issue in the engine
     ---@param filename string
     _G.InternalSaveGame = function(filename, friendlyFilename, onCompletionCallback)
-        if DebugAllocatedSize(filename) > 50 then
-            filename = filename:sub(1, 50)
+        local characterLimit = 100
+        if DebugAllocatedSize(filename) > characterLimit then
+            filename = filename:sub(1, characterLimit)
         end
 
-        if DebugAllocatedSize(friendlyFilename) > 50 then
-            friendlyFilename = friendlyFilename:sub(1, 50)
+        if DebugAllocatedSize(friendlyFilename) > characterLimit then
+            friendlyFilename = friendlyFilename:sub(1, characterLimit)
         end
 
         return oldInternalSaveGame(filename, friendlyFilename, onCompletionCallback)

--- a/lua/ui/globals/InternalSaveGame.lua
+++ b/lua/ui/globals/InternalSaveGame.lua
@@ -1,0 +1,39 @@
+---@declare-global
+
+--******************************************************************************************************
+--** Copyright (c) 2024 Willem 'Jip' Wijnia
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
+do
+    local DebugAllocatedSize = debug.allocatedsize
+
+    local oldInternalSaveGame = _G.InternalSaveGame
+
+    --- Hook to fix a buffer overflow security issue in the engine
+    ---@param filename string
+    _G.InternalSaveGame = function(filename)
+        if DebugAllocatedSize(filename) > 50 then
+            filename = filename:sub(0, 50)
+        end
+
+        return oldInternalSaveGame(filename)
+    end
+end

--- a/lua/ui/globals/InternalSaveGame.lua
+++ b/lua/ui/globals/InternalSaveGame.lua
@@ -29,11 +29,15 @@ do
 
     --- Hook to fix a buffer overflow security issue in the engine
     ---@param filename string
-    _G.InternalSaveGame = function(filename)
+    _G.InternalSaveGame = function(filename, friendlyFilename, onCompletionCallback)
         if DebugAllocatedSize(filename) > 50 then
             filename = filename:sub(0, 50)
         end
 
-        return oldInternalSaveGame(filename)
+        if DebugAllocatedSize(friendlyFilename) > 50 then
+            friendlyFilename = friendlyFilename:sub(0, 50)
+        end
+
+        return oldInternalSaveGame(filename, friendlyFilename, onCompletionCallback)
     end
 end

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -18,6 +18,7 @@ end
 -- # Global (and shared) init
 doscript '/lua/globalInit.lua'
 doscript '/lua/ui/globals/GpgNetSend.lua'
+doscript '/lua/ui/globals/InternalSaveGame.lua'
 
 -- Do we have an custom language set inside user-options ?
 local selectedlanguage = import("/lua/user/prefs.lua").GetFromCurrentProfile('options').selectedlanguage


### PR DESCRIPTION
## Description of the proposed changes

According to @4z0t there's a possible buffer overflow in this function. This function is exposed to UI mods. It would technically allow a UI mod to run arbitrary code when the UI mod is enabled.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version