### PR TITLE
Make Terrain000 use the water channel in the map info texture

### DIFF
--- a/changelog/snippets/graphics.6621.md
+++ b/changelog/snippets/graphics.6621.md
@@ -1,0 +1,1 @@
+- (#6621, #6648) Add new terrain shaders that allow better texturing of mesa-like terrain. Slight tweaks to other recently added terrain shaders. These changes have no immediate effects on existing maps, because virtually no maps use these shaders yet.


### PR DESCRIPTION
The map editor will be able to automatically generate the map info texture with all the channels, so there is no reason not to use the higher resolution water texture.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version