### PR TITLE
Fix scope for enhancement-locked weapon transfer

### DIFF
--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -46,22 +46,6 @@ local function TransferUnitsOwnershipComparator(a, b)
     return a.Economy.BuildCostMass > b.Economy.BuildCostMass
 end
 
---- Temporarily disables the weapons of gifted units
----@param weapon Weapon
-local function TransferUnitsOwnershipDelayedWeapons(weapon)
-    if not weapon:BeenDestroyed() then
-        -- compute delay
-        local bp = weapon.Blueprint
-        local delay = 1 / bp.RateOfFire
-        WaitSeconds(delay)
-
-        -- enable the weapon again if it still exists
-        if not weapon:BeenDestroyed() then
-            weapon:SetEnabled(true)
-        end
-    end
-end
-
 --- Transfers units to an army, returning the new units (since changing the army
 --- replaces the units with new ones)
 ---@param units Unit[]
@@ -282,17 +266,6 @@ function TransferUnitsOwnership(units, toArmy, captured)
 
         if unit.OnGiven then
             unit:OnGiven(newUnit)
-        end
-
-        -- disable all weapons and enable after a delay
-        for i = 1, newUnit.WeaponCount do
-            local weapon = newUnit.WeaponInstances[i]
-            -- Weapons disabled by enhancement shouldn't be re-enabled unless the enhancement is built
-            local enablingEnhancement = weapon.Blueprint.EnabledByEnhancement
-            if weapon and not enablingEnhancement or (activeEnhancements and activeEnhancements[enablingEnhancement]) then
-                weapon:SetEnabled(false)
-                weapon:ForkThread(TransferUnitsOwnershipDelayedWeapons)
-            end
         end
     end
 

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -283,6 +283,17 @@ function TransferUnitsOwnership(units, toArmy, captured)
         if unit.OnGiven then
             unit:OnGiven(newUnit)
         end
+
+        -- disable all weapons and enable after a delay
+        for i = 1, newUnit.WeaponCount do
+            local weapon = newUnit.WeaponInstances[i]
+            -- Weapons disabled by enhancement shouldn't be re-enabled unless the enhancement is built
+            local enablingEnhancement = weapon.Blueprint.EnabledByEnhancement
+            if weapon and not enablingEnhancement or (activeEnhancements and activeEnhancements[enablingEnhancement]) then
+                weapon:SetEnabled(false)
+                weapon:ForkThread(TransferUnitsOwnershipDelayedWeapons)
+            end
+        end
     end
 
     if not captured then
@@ -294,20 +305,6 @@ function TransferUnitsOwnership(units, toArmy, captured)
         end
         if upgradeKennels[1] then
             ForkThread(UpgradeTransferredKennels, upgradeKennels)
-        end
-    end
-
-    -- add delay on turning on each weapon
-    for _, unit in newUnits do
-        -- disable all weapons, enable with a delay
-        for k = 1, unit.WeaponCount do
-            local weapon = unit:GetWeapon(k)
-            -- Weapons disabled by enhancement shouldn't be re-enabled unless the enhancement is built
-            local enablingEnhancement = weapon.Blueprint.EnabledByEnhancement
-            if not enablingEnhancement or (activeEnhancements and activeEnhancements[enablingEnhancement]) then
-                weapon:SetEnabled(false)
-                weapon:ForkThread(TransferUnitsOwnershipDelayedWeapons)
-            end
         end
     end
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -150,6 +150,9 @@ local cUnitGetBuildRate = cUnit.GetBuildRate
 ---@field Sync { id: string, army: Army } # Sync table replicated to the global sync table as to be copied to the user layer at sync time.
 ---@field ignoreDetectionFrom table<Army, true>? # Armies being given free vision to reveal beams hitting targets
 ---@field reallyDetectedBy table<Army, true>?    # Armies that detected the unit without free vision and don't need intel flushed when beam weapons stop hitting
+---@field Weapons table<string, Weapon> # string is weapon Label
+---@field WeaponInstances Weapon[]
+---@field WeaponCount number
 Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUnitComponent) {
 
     IsUnit = true,

--- a/units/XRL0403/XRL0403_script.lua
+++ b/units/XRL0403/XRL0403_script.lua
@@ -49,6 +49,23 @@ XRL0403 = ClassUnit(CWalkingLandUnit, CConstructionTemplate) {
         self:SetWeaponEnabledByLabel('HackPegLauncher', true)
     end,
 
+    --- Temporarily disable the unit's weapons when it is transferred to prevent bypassing the fire rate
+    --- Add an exception for the hack peg launcher.
+    ---@param newUnit XRL0403
+    OnGivenDisableWeapons = function(newUnit)
+        -- disable all weapons and enable after a delay
+        local disableWeaponsThread = newUnit.OnGivenDisableWeaponsThread
+        for i = 1, newUnit.WeaponCount do
+            local weapon = newUnit.WeaponInstances[i]
+            -- Weapons disabled by enhancement shouldn't be re-enabled unless the enhancement is built
+            local enablingEnhancement = weapon.Blueprint.EnabledByEnhancement
+            if weapon.Label ~= "HackPegLauncher" and (not enablingEnhancement or newUnit:HasEnhancement(enablingEnhancement)) then
+                weapon:SetEnabled(false)
+                weapon:ForkThread(disableWeaponsThread)
+            end
+        end
+    end,
+
     ---@param self XRL0403 |m
     OnCreate = function(self)
         CWalkingLandUnit.OnCreate(self)


### PR DESCRIPTION
## Issue
In #6544 I accidentally wrote the function in the wrong scope and didn't test it before merging somehow.
```
warning: Error running lua script: ...\lua\simutils.lua(308): access to nonexistent global variable "activeEnhancements"
         stack traceback:
         	[C]: in function `error'
         	...\lua\system\config.lua(58): in function <...\lua\system\config.lua:57>
         	...\lua\simutils.lua(308): in function <...\lua\simutils.lua:71>
         	...\lua\aibrain.lua(499): in function <...\lua\aibrain.lua:480>
         	...\lua\aibrain.lua(527): in function `TransferUnitsToHighestBrain'
         	...\lua\aibrain.lua(609): in function <...\lua\aibrain.lua:441>
```

The same PR also mentions that the Megalith hack peg launcher activates after unit transfer, although it shouldn't since it is reserved for a campaign script.

## Description of the proposed changes
- Refactor the function into the unit class so the Megalith can override it.
  - Use `newUnit:HasEnhancement()` instead of `activeEnhancements` to fix the nonexistent variable issue.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Start a fullshare game with teammates, spawn some Seraphim SACU (xsl0301) since they have enhancement-locked weapons, then ctrl k your acu and wait until the units automatically transfer. 
There should be no errors.
The hack peg launcher firing effect should not appear:
![{0239AFBE-F885-4251-9575-A6A1F0EC03D1}](https://github.com/user-attachments/assets/d9bfe125-eb03-4605-8ca1-ec10fa51d059)

```
   CreateUnitAtMouse('xsl0301', 2,    8.97,   -9.67,  0.00000)
   CreateUnitAtMouse('xrl0403', 2,   -2.53,   -5.17,  0.00000)
   CreateUnitAtMouse('xsl0301_rambo', 6,   -6.45,   14.85, -0.00000)
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version