### PR TITLE
Annotate `ping` and `buildanchored` commandmode

### DIFF
--- a/changelog/snippets/other.6652.md
+++ b/changelog/snippets/other.6652.md
@@ -1,0 +1,1 @@
+- (#6652) Annotate "ping" and "buildanchored" command modes.

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -93,7 +93,7 @@ local MathAtan = math.atan
 -- during command mode (e.g., when you do a move order it turns your cursor into
 -- the blue move marker). This is fixed by reloading the game.
 
----@alias CommandMode 'order' | 'build' | 'buildanchored' | false
+---@alias CommandMode 'order' | 'build' | 'buildanchored' | 'ping' | false
 
 ---@class CommandModeDataBase
 ---@field cursor? CommandCap        # Similar to the field 'name'

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -93,7 +93,12 @@ local MathAtan = math.atan
 -- during command mode (e.g., when you do a move order it turns your cursor into
 -- the blue move marker). This is fixed by reloading the game.
 
----@alias CommandMode 'order' | 'build' | 'buildanchored' | 'ping' | false
+---@alias CommandMode
+---| 'order' 
+---| 'build' 
+---| 'buildanchored' 
+---| 'ping' # Does not issue commands or get canceled by right click. Basically passes data from `StartCommandMode` to `EndCommandMode`.
+---| false
 
 ---@class CommandModeDataBase
 ---@field cursor? CommandCap        # Similar to the field 'name'

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -184,7 +184,7 @@ function StartCommandMode(newCommandMode, data)
 end
 
 --- Called when the command mode ends and deconstructs all the data.
----@param isCancel boolean set when we're at the end of (a sequence of) order(s), is usually always true
+---@param isCancel boolean # set when we're at the end of (a sequence of) order(s), is usually always true. False when the mode is ended with right click, except for "ping" mode.
 function EndCommandMode(isCancel)
     if ignoreSelection then
         return

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -106,7 +106,12 @@ local MathAtan = math.atan
 ---@class CommandModeDataBuild : CommandModeDataBase
 ---@field name string # blueprint id of the unit being built
 
+--- Like 'build' mode but can only place structures within `MaxBuildDistance` of all selected units.
+--- Shows the distance as a range ring which jitters while the unit moves due to not using interpolated position.
+--- This distance does not represent the actual maximum build range (which adds builder footprint and target skirt).
+--- Not recommended for use.
 ---@class CommandModeDataBuildAnchored : CommandModeDataBase
+---@field name string # blueprint id of the unit being built
 
 ---@class CommandModeDataOrderScript : CommandModeDataOrder
 ---@field TaskName string


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Annotate these less often used and weird command modes.
- `ping` mode:
  - does not get cancelled by right click like other modes
  - passes data from `StartCommandMode` to `EndCommandMode` on left/right click without any modifications

- `buildanchored` mode: restrictive, inaccurate, and unpolished version of `build` mode.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
- check the engine for 'ping' string to be a command mode. If any other string is used in `StartCommandMode` the engine will give a warning (`CUIActionHandler::GetLeftMouseButtonAction got invalid commandMode: %s`), which can be used to find where all the strings are checked (func at `0x0081F7B0`).
- log the `IsCancel` param and click around with various command modes.
- Test `buildanchored` mode with multiple/single ACUs building a factory and a T1 pd.

```lua
import('/lua/ui/game/commandmode.lua').StartCommandMode("buildanchored", { name='uab0101' })
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version