### PR TITLE
Close automated attack move loophole

### DIFF
--- a/changelog/snippets/fix.6653.md
+++ b/changelog/snippets/fix.6653.md
@@ -1,0 +1,1 @@
+- (#6653) Close a loophole that allowed UI lua to issue attack move orders.

--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -727,11 +727,11 @@ end
 function IsUnit(object)
 end
 
---- Orders a group of units to attack-move to a position
+--- Orders a group of units to attack-move to a target
 ---@param units Unit[]
----@param position Vector
+---@param target Unit | Vector | Prop | Blip
 ---@return SimCommand
-function IssueAggressiveMove(units, position)
+function IssueAggressiveMove(units, target)
 end
 
 --- Orders a group of units to attack a target

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -17,6 +17,7 @@ local SimPing = import("/lua/simping.lua")
 local SimTriggers = import("/lua/scenariotriggers.lua")
 local SUtils = import("/lua/ai/sorianutilities.lua")
 local ScenarioFramework = import("/lua/scenarioframework.lua")
+local UnitQueueDataToCommand = import("/lua/sim/commands/shared.lua").UnitQueueDataToCommand
 
 -- upvalue table operations for performance
 local TableInsert = table.insert
@@ -26,6 +27,7 @@ local TableMerged = table.merged
 
 -- upvalue scope for performance
 local type = type
+local TableGetn = table.getn
 local Vector = Vector
 local IsEntity = IsEntity
 local GetEntityById = GetEntityById
@@ -264,14 +266,28 @@ Callbacks.ValidateAssist = function(data, units)
     end
 end
 
+--- Attack move doesn't exist as a command mode, so this callback substitutes that.
+---@param data { Clear: boolean }
+---@param units Unit[]
 Callbacks.AttackMove = function(data, units)
-    -- exclude structures as it makes no sense to apply a move command to them
+    -- exclude structures as they can't move and there is no sim command to issue attack move rally points for factories
     local allNonStructures = EntityCategoryFilterDown(categories.ALLUNITS - categories.STRUCTURE, units)
+
+    -- Verify that the user manually clicked to issue the command, and use that position.
+    -- assume all units in the selection were given the same order, so we only need to check one unit
+    local commandQueue = allNonStructures[1]:GetCommandQueue()
+    local lastcommand = commandQueue[TableGetn(commandQueue)]
+    LOG(repr(lastcommand), debug.traceback())
+    -- dummy script task should be used, although we can't check the script task's type
+    if UnitQueueDataToCommand[lastcommand.commandType].Type ~= "Script" then return end
+    -- script tasks issued without a target have x,y,z = 0
+    local x, y, z = lastcommand.x, lastcommand.y, lastcommand.z
+    if x == 0 and y == 0 and z == 0 then return end
 
     if data.Clear then
         IssueClearCommands(allNonStructures)
     end
-    IssueAggressiveMove(allNonStructures, data.Target)
+    IssueAggressiveMove(allNonStructures, { x, y, z })
 end
 
 --tells a unit to toggle its pointer

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -277,7 +277,6 @@ Callbacks.AttackMove = function(data, units)
     -- assume all units in the selection were given the same order, so we only need to check one unit
     local commandQueue = allNonStructures[1]:GetCommandQueue()
     local lastcommand = commandQueue[TableGetn(commandQueue)]
-    LOG(repr(lastcommand), debug.traceback())
     -- dummy script task should be used, although we can't check the script task's type
     if UnitQueueDataToCommand[lastcommand.commandType].Type ~= "Script" then return end
     -- script tasks issued without a target have x,y,z = 0

--- a/lua/sim/commands/shared.lua
+++ b/lua/sim/commands/shared.lua
@@ -20,12 +20,53 @@
 --** SOFTWARE.
 --******************************************************************************************************
 
+---@alias DistributeOrderInfoCommandName
+---| "Stop"                         # 1
+---| "Move"                         # 2
+---| "Dive"                         # 3
+---| "FormMove"                     # 4
+---| "BuildSiloTactical"            # 5
+---| "BuildSiloNuke"                # 6
+---| "BuildFactory"                 # 7
+---| "BuildMobile"                  # 8
+---| "BuildAssist"                  # 9
+---| "Attack"                       # 10
+---| "FormAttack"                   # 11
+---| "Nuke"                         # 12
+---| "Tactical"                     # 13
+---| "Teleport"                     # 14
+---| "Guard"                        # 15
+---| "Patrol"                       # 16
+---| "Ferry"                        # 17
+---| "FormPatrol"                   # 18
+---| "Reclaim"                      # 19
+---| "Repair"                       # 20
+---| "Capture"                      # 21
+---| "TransportLoadUnits"           # 22
+---| "TransportReverseLoadUnits"    # 23
+---| "TransportUnloadUnits"         # 24
+---| "TransportUnloadSpecificUnits" # 25
+---| "DetachFromTransport"          # 26
+---| "Upgrade"                      # 27
+---| "Script"                       # 28
+---| "AssistCommander"              # 29
+---| "KillSelf"                     # 30
+---| "DestroySelf"                  # 31
+---| "Sacrifice"                    # 32
+---| "Pause"                        # 33
+---| "OverCharge"                   # 34
+---| "AggressiveMove"               # 35
+---| "FormAggressiveMove"           # 36
+---| "AssistMove"                   # 37
+---| "SpecialAction"                # 38
+---| "Dock"                         # 39
+
 ---@class DistributeOrderInfo
 ---@field Callback? fun(units: Unit[], target: Vector | Entity, arg3?: any, arg4?: any): boolean
----@field Type string                   # Describes the intended order, useful for debugging
----@field BatchOrders boolean           # When set, assigns orders to groups of units
----@field FullRedundancy boolean        # When set, attempts to add full redundancy when reasonable by assigning multiple orders to each group
----@field Redundancy number             # When set, assigns orders to individual units. Number of orders assigned is equal to the redundancy factor
+---@field Type DistributeOrderInfoCommandName   # Describes the intended order, useful for debugging
+---@field BatchOrders boolean                   # When set, assigns orders to groups of units
+---@field FullRedundancy boolean                # When set, attempts to add full redundancy when reasonable by assigning multiple orders to each group
+---@field Redundancy number                     # When set, assigns orders to individual units. Number of orders assigned is equal to the redundancy factor
 
 -- upvalue scope for performance
 local IssueNuke = IssueNuke

--- a/lua/ui/game/commandgraph.lua
+++ b/lua/ui/game/commandgraph.lua
@@ -5,6 +5,10 @@
 --* Copyright © 2006 Gas Powered Games, Inc.  All rights reserved.
 --*****************************************************************************
 
+-- About dragging command graph nodes:
+-- If the target of an order is a unit/blip, its node will snap to units/blips in the same army.
+-- If the target of an order is a prop, its node cannot be dragged.
+
 local UIUtil = import("/lua/ui/uiutil.lua")
 local Group = import("/lua/maui/group.lua").Group
 local Bitmap = import("/lua/maui/bitmap.lua").Bitmap

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -603,24 +603,8 @@ end
 local function OnScriptIssued(command)
     if command.LuaParams then
         if command.LuaParams.TaskName == 'AttackMove' then
-            local avgPoint = { 0, 0 }
-            for _, unit in command.Units do
-                avgPoint[1] = avgPoint[1] + unit:GetPosition()[1]
-                avgPoint[2] = avgPoint[2] + unit:GetPosition()[3]
-            end
-            avgPoint[1] = avgPoint[1] / TableGetN(command.Units)
-            avgPoint[2] = avgPoint[2] / TableGetN(command.Units)
-
-            avgPoint[1] = command.Target.Position[1] - avgPoint[1]
-            avgPoint[2] = command.Target.Position[3] - avgPoint[2]
-
-            local rotation = MathAtan(avgPoint[1] / avgPoint[2])
-            rotation = rotation * 180 / MathPi
-            if avgPoint[2] < 0 then
-                rotation = rotation + 180
-            end
-            local cb = { Func = "AttackMove", Args = { Target = command.Target.Position, Rotation = rotation,
-                Clear = command.Clear } }
+            ---@type SimCallback
+            local cb = { Func = "AttackMove", Args = { Clear = command.Clear } }
             SimCallback(cb, true)
         elseif command.LuaParams.Enhancement then
             EnhancementQueueFile.enqueueEnhancement(command.Units, command.LuaParams.Enhancement)


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Issue
The attack move sim callback relies on position data written in lua on the user side, which allows for automation of attack move orders.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Thanks to an engine patch the sim can inspect a unit's command queue.
- Change the callback to get the target position from the command queue.
  - There is no way to add a position to that command queue data automatically, so the automation is fixed.
- related annotations

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
- Use the attack move button to issue shift/not shift attack moves
- Use this script (use in clipboard) to see that it doesn't work for lua script tasks:
```lua
    IssueUnitCommandToUnit(GetSelectedUnits()[1], "UNITCOMMAND_Script", {TaskName = 'AttackMove'})
```
- And this one to see the callback doesn't work automatically.
```lua
    local cb = { Func = "AttackMove", Args = { Clear = true, Target = {50, 50, 50} } }
    SimCallback(cb, true)
```

An unavoidable part of the implementation since the very beginning is that the unit queue is filled with useless script commands, so the unit is slightly unresponsive as it goes through the script command before moving on to the attack move task.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version