### PR TITLE
Fix order button tooltips not disappearing on mouse exit

### DIFF
--- a/changelog/snippets/fix.6654.md
+++ b/changelog/snippets/fix.6654.md
@@ -1,0 +1,1 @@
+- (#6654) Fix order button tooltips not disappearing when the mouse is moved off the order button.

--- a/lua/ui/controls.lua
+++ b/lua/ui/controls.lua
@@ -1,5 +1,15 @@
+-----------------------------------------------------------------
+-- File: lua/ui/controls.lua
+-- Author: Crotalus
+-- Summary: Let this file have all references to UI controls to make UI behave better
+-- when hot-reloading lua files
+-----------------------------------------------------------------
+
 local controls = {}
 
+--- Returns a table that persists between file reloads.
+---@param key? string # key for the table. Defaults to the source of the calling file.
+---@return table
 function Get(key)
     if not key then
         key = debug.getinfo(2, "S").source

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -101,11 +101,6 @@ local function CreateAutoBuildEffect(parent)
 end
 
 function CreateMouseoverDisplay(parent, ID)
-    if controls.mouseoverDisplay then
-        controls.mouseoverDisplay:Destroy()
-        controls.mouseoverDisplay = false
-    end
-
     if not Prefs.GetOption('tooltips') then return end
 
     local createDelay = Prefs.GetOption('tooltip_delay') or 0
@@ -116,7 +111,7 @@ function CreateMouseoverDisplay(parent, ID)
         return
     end
 
-    controls.mouseoverDisplay = Tooltip.CreateMouseoverDisplay(parent, {["text"] = text, ["body"] = desc}, nil, true)
+    Tooltip.CreateMouseoverDisplay(parent, {["text"] = text, ["body"] = desc}, nil, true)
 end
 
 local function CreateOrderButtonGrid()
@@ -382,9 +377,7 @@ local function BuildOrderBehavior(self, modifiers)
             self._curHelpText = self._data.helpText
             self.autoBuildEffect:Destroy()
         end
-        if controls.mouseoverDisplay.text then
-            controls.mouseoverDisplay.text:SetText(self._curHelpText)
-        end
+        Tooltip.SetTooltipText(self._curHelpText)
         SetAutoMode(currentSelection, self:IsChecked())
     end
 end
@@ -451,9 +444,7 @@ local function DiveOrderBehavior(self, modifiers)
             self.autoModeIcon:SetAlpha(1)
             self._isAutoMode = true
         end
-        if controls.mouseoverDisplay.text then
-            controls.mouseoverDisplay.text:SetText(self._curHelpText)
-        end
+        Tooltip.SetTooltipText(self._curHelpText)
         SetAutoSurfaceMode(currentSelection, self._isAutoMode)
     end
 end
@@ -587,9 +578,7 @@ local function ScriptButtonOrderBehavior(self, modifiers, subState)
         ToggleScriptBit(currentSelection, self._data.extraInfo, state)
     end
 
-    if controls.mouseoverDisplay.text then
-        controls.mouseoverDisplay.text:SetText(self._curHelpText)
-    end
+    Tooltip.SetTooltipText(self._curHelpText)
     if subState == nil then
         Checkbox.OnClick(self)
     end
@@ -642,9 +631,7 @@ local function StatToggleOrderBehavior(self, modifiers, subState)
         SimCallback( { Func="SetStatByCallback", Args= {[self._data.statToggle] = not state}}, true)
     end
 
-    if controls.mouseoverDisplay.text then
-        controls.mouseoverDisplay.text:SetText(self._curHelpText)
-    end
+    Tooltip.SetTooltipText(self._curHelpText)
     if subState == nil then
         Checkbox.OnClick(self)
     else
@@ -798,10 +785,7 @@ local function CreateFirestatePopup(parent, selected)
             if event.Type == 'MouseEnter' then
                 CreateMouseoverDisplay(control, control.info.helpText, 1)
             elseif event.Type == 'MouseExit' then
-                if controls.mouseoverDisplay then
-                    controls.mouseoverDisplay:Destroy()
-                    controls.mouseoverDisplay = false
-                end
+                Tooltip.DestroyMouseoverDisplay()
             end
             return Checkbox.HandleEvent(control, event)
         end
@@ -1021,9 +1005,7 @@ function OverchargeBehavior(self, modifiers)
             self._isAutoMode = true
         end
 
-        if controls.mouseoverDisplay.text then
-            controls.mouseoverDisplay.text:SetText(self._curHelpText)
-        end
+        Tooltip.SetTooltipText(self._curHelpText)
 
         SimCallback({Func = 'AutoOvercharge', Args = {auto = self._isAutoMode == true} }, true)
     end
@@ -1303,10 +1285,7 @@ local function AddOrder(orderInfo, slot, batchMode)
                 glowThread = CreateOrderGlow(self)
             end
         elseif event.Type == 'MouseExit' then
-            if controls.mouseoverDisplay then
-                controls.mouseoverDisplay:Destroy()
-                controls.mouseoverDisplay = false
-            end
+            Tooltip.DestroyMouseoverDisplay()
             if controls.orderGlow then
                 controls.orderGlow:Destroy()
                 controls.orderGlow = false
@@ -1699,10 +1678,7 @@ function SetAvailableOrders(availableOrders, availableToggles, newSelection)
 end
 
 function CreateControls()
-    if controls.mouseoverDisplay then
-        controls.mouseoverDisplay:Destroy()
-        controls.mouseoverDisplay = false
-    end
+    Tooltip.DestroyMouseoverDisplay()
     if not controls.bg then
         controls.bg = Bitmap(controls.controlClusterGroup)
     end

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -1752,3 +1752,27 @@ function Expand()
         controls.bg:Hide()
     end
 end
+
+--#region Backwards compatibility
+function CreateMouseoverDisplay(parent, ID)
+    Tooltip.CreateMouseoverDisplay(parent, ID, nil, true)
+end
+local _mouseoverDisplay = setmetatable({}, { __index = { Destroy = Tooltip.DestroyMouseoverDisplay, text = { SetText = Tooltip.SetTooltipText } }, __newindex = function() end })
+setmetatable(controls, {
+    __index = function(t, k)
+        if k == 'mouseoverDisplay' then
+            LOG('__index')
+            return _mouseoverDisplay
+        else
+            return rawget(t, k)
+        end
+    end,
+    __newindex = function(t, k, v)
+        if k == 'mouseoverDisplay' then
+            LOG('__newindex')
+            return
+        else
+            rawset(t, k, v)
+        end
+    end,
+})

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -100,22 +100,6 @@ local function CreateAutoBuildEffect(parent)
     return glow
 end
 
----@param parent Control
----@param ID string
-function CreateMouseoverDisplay(parent, ID)
-    if not Prefs.GetOption('tooltips') then return end
-
-    local createDelay = Prefs.GetOption('tooltip_delay') or 0
-    local text = TooltipInfo['Tooltips'][ID]['title'] or ID
-    local desc = TooltipInfo['Tooltips'][ID]['description'] or ID
-
-    if not text or not desc then
-        return
-    end
-
-    Tooltip.CreateMouseoverDisplay(parent, {["text"] = text, ["body"] = desc}, nil, true)
-end
-
 local function CreateOrderButtonGrid()
     controls.orderButtonGrid = Grid(controls.bg, GameCommon.iconWidth, GameCommon.iconHeight)
     controls.orderButtonGrid:SetName("Orders Grid")
@@ -785,7 +769,7 @@ local function CreateFirestatePopup(parent, selected)
         btn.index = index
         btn.HandleEvent = function(control, event)
             if event.Type == 'MouseEnter' then
-                CreateMouseoverDisplay(control, control.info.helpText)
+                Tooltip.CreateMouseoverDisplay(control, control.info.helpText, nil, true)
             elseif event.Type == 'MouseExit' then
                 Tooltip.DestroyMouseoverDisplay()
             end
@@ -1277,7 +1261,7 @@ local function AddOrder(orderInfo, slot, batchMode)
     -- Set up tooltips
     checkbox.HandleEvent = function(self, event)
         if event.Type == 'MouseEnter' then
-            CreateMouseoverDisplay(self, self._curHelpText)
+            Tooltip.CreateMouseoverDisplay(self, self._curHelpText, nil, true)
 
             if not self:IsDisabled() then
                 if controls.orderGlow then

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -100,6 +100,8 @@ local function CreateAutoBuildEffect(parent)
     return glow
 end
 
+---@param parent Control
+---@param ID string
 function CreateMouseoverDisplay(parent, ID)
     if not Prefs.GetOption('tooltips') then return end
 
@@ -783,7 +785,7 @@ local function CreateFirestatePopup(parent, selected)
         btn.index = index
         btn.HandleEvent = function(control, event)
             if event.Type == 'MouseEnter' then
-                CreateMouseoverDisplay(control, control.info.helpText, 1)
+                CreateMouseoverDisplay(control, control.info.helpText)
             elseif event.Type == 'MouseExit' then
                 Tooltip.DestroyMouseoverDisplay()
             end
@@ -1275,7 +1277,7 @@ local function AddOrder(orderInfo, slot, batchMode)
     -- Set up tooltips
     checkbox.HandleEvent = function(self, event)
         if event.Type == 'MouseEnter' then
-            CreateMouseoverDisplay(self, self._curHelpText, 1)
+            CreateMouseoverDisplay(self, self._curHelpText)
 
             if not self:IsDisabled() then
                 if controls.orderGlow then

--- a/lua/ui/game/tooltip.lua
+++ b/lua/ui/game/tooltip.lua
@@ -22,6 +22,7 @@ local createThread = false
 
 -- creates a tooltip box from ID table and with optional parameters
 ---@param ID table e.g. { text = 'tooltip header', body = 'tooltip description' } 
+---@param delay? number minimum delay compared against the prefs `tooltip_delay` option
 ---@param extended? boolean indicates whether to just create tooltip header or also tooltip description
 ---@param width? number is optional width of tooltip or it is auto calculated based on length of header/description
 ---@param forced? boolean determine if the tooltip should override hiding tooltips set in game options
@@ -37,7 +38,7 @@ function CreateMouseoverDisplay(parent, ID, delay, extended, width, forced, padd
     local text = ""
     local body = ""
     if not position then position = 'center' end
-    
+
     -- remove previous instance
     if mouseoverDisplay then
         mouseoverDisplay:Destroy()


### PR DESCRIPTION
## Issue
https://github.com/FAForever/fa/pull/6173 broke the mouse exit behavior because it didn't update all usages of the tooltip, under the incorrect assumption that the create function would return a Control that can be destroyed by the rest of the code like usual.

## Description of the proposed changes
Update the remaining code for the order button tooltips to use the Tooltip class correctly.

## Testing done on the proposed changes
Mouse over order buttons then move the mouse away and the tooltips should disappear. Previously the order button tooltips would only disappear when a new tooltip was created.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version