### PR TITLE
Make mass fabs use overflowed energy

### DIFF
--- a/changelog/snippets/fix.6660.md
+++ b/changelog/snippets/fix.6660.md
@@ -1,0 +1,1 @@
+- (#6660) Fix mass fabs not always using overflowed energy.

--- a/engine/Core.lua
+++ b/engine/Core.lua
@@ -41,7 +41,7 @@
 
 ---@alias Color string `EnumColor` or hexcode like `'RrGgBb'`, or `'AaRrGgBb'` with transparency
 ---@alias Bone string | number
----@alias Army string | number
+---@alias Army number
 ---@alias Language "cn" | "cz" | "de" | "es" | "fr" | "it" | "pl" | "ru" | "tw" | "tzm" | "us"
 
 -- note that these object span both the sim and user states

--- a/engine/Core.lua
+++ b/engine/Core.lua
@@ -41,7 +41,7 @@
 
 ---@alias Color string `EnumColor` or hexcode like `'RrGgBb'`, or `'AaRrGgBb'` with transparency
 ---@alias Bone string | number
----@alias Army number
+---@alias Army string | integer
 ---@alias Language "cn" | "cz" | "de" | "es" | "fr" | "it" | "pl" | "ru" | "tw" | "tzm" | "us"
 
 -- note that these object span both the sim and user states

--- a/engine/Sim/CAiBrain.lua
+++ b/engine/Sim/CAiBrain.lua
@@ -114,7 +114,7 @@ end
 ---@unknown
 function CAiBrain:FindClosestArmyWithBase()
 end
- 
+
 --- Takes a builder and returns the closest point that the structure can be
 --- built at in the list of building templates with matching builder types.
 ---
@@ -191,9 +191,9 @@ end
 ---@alias AIBrainBlueprintStatEconomy
 --- | 'Economy_TotalProduced_Energy'
 --- | 'Economy_TotalConsumed_Energy'
---- | 'Economy_Income_Energy' 
---- | 'Economy_Output_Energy' 
---- | 'Economy_Stored_Energy' 
+--- | 'Economy_Income_Energy'
+--- | 'Economy_Output_Energy'
+--- | 'Economy_Stored_Energy'
 --- | 'Economy_Reclaimed_Energy'
 --- | 'Economy_Ratio_Energy'
 --- | 'Economy_MaxStorage_Energy'
@@ -228,19 +228,19 @@ end
 function CAiBrain:GetAvailableFactories(location, radius)
 end
 
----@alias AIBrainBlueprintStatUnits 
+---@alias AIBrainBlueprintStatUnits
 --- | 'Units_History'
 --- | 'Units_Killed'
---- | 'Units_BeingBuilt' 
---- | 'Units_Active' 
---- | 'Units_TotalDamageDealt' 
+--- | 'Units_BeingBuilt'
+--- | 'Units_Active'
+--- | 'Units_TotalDamageDealt'
 --- | 'Units_TotalDamageReceive'
 
 ---@alias AIBrainBlueprintStatEnemies
 --- | 'Enemies_Killed'
 --- | 'Enemies_MassValue_Destroyed'
---- | 'Enemies_EnergyValue_Destroyed' 
---- | 'Enemies_Commanders_Destroyed' 
+--- | 'Enemies_EnergyValue_Destroyed'
+--- | 'Enemies_Commanders_Destroyed'
 
 ---@alias AIBrainBlueprintStatDamage
 --- | 'DamageStats_TotalDamageReceived'
@@ -313,7 +313,7 @@ end
 --- Always reports a threatvalue of zero for Allies or self.
 --- threatType and armyIndex are not required.
 ----@param ring number 1 or 2
---- 1 = Single, 2 = With surrounding IMPA blocks 
+--- 1 = Single, 2 = With surrounding IMPA blocks
 --- ..........   ..........
 --- ..........   ....xxx...
 --- .....X....   ....xXx...
@@ -502,7 +502,7 @@ end
 ---@param triggerName string # unique name of the trigger. See `RemoveArmyStatsTrigger` to remove occupied names.
 ---@param compareType ComparatorString # available types: `LessThan`, `LessThanOrEqual`, `GreaterThan`, `GreaterThanOrEqual`, `Equal`
 ---@param value number #
----@param category EntityCategory? # 
+---@param category EntityCategory? #
 function CAiBrain:SetArmyStatsTrigger(statName, triggerName, compareType, value, category)
 end
 

--- a/engine/Sim/CAiBrain.lua
+++ b/engine/Sim/CAiBrain.lua
@@ -532,6 +532,7 @@ end
 --- Removes resources from brain.
 ---@param type 'ENERGY' | 'MASS'
 ---@param amount number # how much to take.
+---@return number # actual amount taken
 function CAiBrain:TakeResource(type, amount)
 end
 

--- a/engine/Sim/CAiBrain.lua
+++ b/engine/Sim/CAiBrain.lua
@@ -60,7 +60,7 @@ end
 -- Usually passed table with only one factory as AI picks the highest tech factory as a primary and others are assisting.
 ---@param template table # Platoon's template.
 ---@param factories table # containing units-factories.
----@return table: tblUnits # containing units-factories.
+---@return table tblUnits # containing units-factories.
 function CAiBrain:CanBuildPlatoon(template, factories)
 end
 
@@ -137,14 +137,14 @@ end
 --- structure blueprint has the `"HYDROCARBON"` category) are queried and no
 --- points in the template are used.
 ---
----@param type          string
+---@param type string
 ---@param structureName FileName # blueprint file
 ---@param buildingTypes BuildingTemplate[]
----@param relative      boolean
----@param builder       Unit
----@param optIgnoreAlliance?   AllianceType | nil # defaults to `nil`
----@param optOverridePosX?     number  # defaults to 0.0; ignored if `optOverridePosZ` is absent
----@param optOverridePosZ?     number  # defaults to 0.0
+---@param relative boolean
+---@param builder Unit
+---@param optIgnoreAlliance? AllianceType # defaults to `nil`
+---@param optOverridePosX? number # defaults to 0.0; ignored if `optOverridePosZ` is absent
+---@param optOverridePosZ? number # defaults to 0.0
 ---@param optIgnoreThreatOver? integer # defaults to 0 (accept all)
 ---@return Vector2 location # a new table of `{x, z, 0}` for resource builder types, the actual point otherwise
 function CAiBrain:FindPlaceToBuild(type, structureName, buildingTypes, relative, builder, optIgnoreAlliance, optOverridePosX, optOverridePosZ, optIgnoreThreatOver)
@@ -183,8 +183,8 @@ end
 -- return x, z
 
 --- Returns the army start position
----@return number X coordinate
----@return number Z coordinate
+---@return number Xcoordinate
+---@return number Zcoordinate
 function CAiBrain:GetArmyStartPos()
 end
 
@@ -285,7 +285,7 @@ function CAiBrain:GetEconomyStored(resource)
 end
 
 --- Returns the ratio between resource in storage to maximum storage amout.
----@param resource  'ENERGY' | 'MASS'
+---@param resource 'ENERGY' | 'MASS'
 ---@return number
 function CAiBrain:GetEconomyStoredRatio(resource)
 end
@@ -338,7 +338,7 @@ function CAiBrain:GetListOfUnits(category, needToBeIdle, requireBuilt)
 end
 
 --- Returns a ratio between water and land.
----@return number 0.0 - 1.0
+---@return number # 0.0 - 1.0
 function CAiBrain:GetMapWaterRatio()
 end
 
@@ -431,7 +431,7 @@ function CAiBrain:GetUnitsAroundPoint(category, position, radius, alliance)
 end
 
 --- Gives resources to brain.
----@param type  'ENERGY' | 'MASS'
+---@param type 'ENERGY' | 'MASS'
 ---@param amount number
 function CAiBrain:GiveResource(type, amount)
 end
@@ -455,7 +455,7 @@ function CAiBrain:IsOpponentAIRunning()
 end
 
 --- Creates a new platoon.
----@param name string   # unique name for platoon
+---@param name string # unique name for platoon
 ---@param aiPlan string # to follow for this platoon or '', the function for the plan is in '/lua/platoon.lua'.
 ---@return Platoon
 function CAiBrain:MakePlatoon(name, aiPlan)

--- a/engine/Sim/CAiBrain.lua
+++ b/engine/Sim/CAiBrain.lua
@@ -276,16 +276,16 @@ end
 function CAiBrain:GetCurrentUnits(category)
 end
 
---- Returns current resource income.
----@param resource 'ENERGY'|'MASS'.
--- @return Number.
+--- Returns current income per tick of the resouce.
+---@param resource 'ENERGY'|'MASS'
+---@return number
 function CAiBrain:GetEconomyIncome(resource)
 end
 
---- Return how much of the resource the brains wants to use.
--- This is used for calculating Paragon's production.
----@param resource 'ENERGY'|'MASS'.
--- @return Number.
+--- Returns how much of the resource the brain wants to use per tick.
+--- This is used for calculating Paragon's production.
+---@param resource 'ENERGY'|'MASS'
+---@return number
 function CAiBrain:GetEconomyRequested(resource)
 end
 

--- a/engine/Sim/CAiBrain.lua
+++ b/engine/Sim/CAiBrain.lua
@@ -35,9 +35,9 @@ function CAiBrain:AssignUnitsToPlatoon(platoon, unit, squad, formation)
 end
 
 --- Orders factories to build a platoon.
--- @param template Format: {name, plan, {bpID, min, max, squad, formation}, {...}, ...} .
--- @param factories Table of units-factories to build the platoon.
--- @param count How many times to built it.
+---@param template table # Format: {name, plan, {bpID, min, max, squad, formation}, {...}, ...} .
+---@param factories Unit[] # Table of units-factories to build the platoon.
+---@param count number # How many times to built it.
 function CAiBrain:BuildPlatoon(template, factories, count)
 end
 
@@ -58,9 +58,9 @@ end
 
 --- Filteres factories that can build the platoon and returns them.
 -- Usually passed table with only one factory as AI picks the highest tech factory as a primary and others are assisting.
--- @param tempate Platoon's template.
--- @param factories Table containing units-factories.
--- @return tblUnits Table containing units-factories.
+---@param template table # Platoon's template.
+---@param factories table # containing units-factories.
+---@return table: tblUnits # containing units-factories.
 function CAiBrain:CanBuildPlatoon(template, factories)
 end
 
@@ -95,9 +95,9 @@ function CAiBrain:CreateUnitNearSpot(blueprintID, posX, posY)
 end
 
 --- Returns UnitID for buildingType
--- @param builder Unit-engineer to build with.
--- @param buildingType Type of building (T1LandFactory, T4AirExperimental1, T1HydroCarbon etc)
--- @param buildingTemplate Table for each faction to get the UnitID for a buildingType
+---@param builder Unit # engineer to build with.
+---@param buildingType string # Type of building (T1LandFactory, T4AirExperimental1, T1HydroCarbon etc)
+---@param buildingTemplate table # table for each faction to get the UnitID for a buildingType
 function CAiBrain:DecideWhatToBuild(builder, buildingType, buildingTemplate)
 end
 
@@ -158,23 +158,21 @@ function CAiBrain:FindUnit(category, needToBeIdle)
 end
 
 --- Return a unit and it's upgrade blueprint.
--- TODO untested.
--- @param upgradeList Table, see '/lua/upgradetemplates.lua'.
--- @return TODO.
-
----@unknown
+--- TODO untested.
+---@param upgradeList UnitUpgradeTemplates # Table, see '/lua/upgradetemplates.lua'.
+---@return any # TODO.
 function CAiBrain:FindUnitToUpgrade(upgradeList)
 end
 
 --- Return an upgrade blueprint for the unit passed in.
--- @param unitName Blueprint ID of the unit to upgrade, example 'ueb0101'.
--- @param upgradeList Table, see '/lua/upgradetemplates.lua'.
--- @return BlueprintID, example 'ueb0201'
+---@param unitName UnitId # ID of the unit to upgrade, example 'ueb0101'.
+---@param upgradeList table # Table, see '/lua/upgradetemplates.lua'.
+---@return UnitId # example 'ueb0201'
 function CAiBrain:FindUpgradeBP(unitName, upgradeList)
 end
 
 --- Returns the ArmyIndex of the army represented by this brain.
--- @return Number.
+---@return number
 
 --- Returns the army index
 ---@return number
@@ -189,11 +187,6 @@ end
 ---@return number Z coordinate
 function CAiBrain:GetArmyStartPos()
 end
-
---- Returns the relevant stat or default value.
--- @param statName String, name of the stats to get.
--- @param defaultValue Ff the stat doesn't exists, it creates it and returns this value.
--- @return Number.
 
 ---@alias AIBrainBlueprintStatEconomy
 --- | 'Economy_TotalProduced_Energy'
@@ -266,10 +259,6 @@ end
 function CAiBrain:GetCurrentEnemy()
 end
 
---- Return how many units of the given categories exist.
--- @param category Unit's category, example: categories.TECH2 .
--- @return Number.
-
 --- Returns the number of units of the given categories
 ---@param category EntityCategory
 ---@return number
@@ -290,19 +279,19 @@ function CAiBrain:GetEconomyRequested(resource)
 end
 
 --- Return current resource amout in storage.
----@param resource 'ENERGY'|'MASS'.
--- @return Number.
+---@param resource 'ENERGY'|'MASS'
+---@return number
 function CAiBrain:GetEconomyStored(resource)
 end
 
 --- Returns the ratio between resource in storage to maximum storage amout.
----@param resource  'ENERGY' | 'MASS'.
+---@param resource  'ENERGY' | 'MASS'
 ---@return number
 function CAiBrain:GetEconomyStoredRatio(resource)
 end
 
 --- Returns the relative resource income. (production - usage)
----@param resource 'ENERGY'|'MASS'.
+---@param resource 'ENERGY'|'MASS'
 ---@return number  (0.1 = 1)
 function CAiBrain:GetEconomyTrend(resource)
 end
@@ -323,7 +312,7 @@ end
 --- Returns a position with highest threat and the threat value.
 --- Always reports a threatvalue of zero for Allies or self.
 --- threatType and armyIndex are not required.
---- @param ring number 1 or 2
+----@param ring number 1 or 2
 --- 1 = Single, 2 = With surrounding IMPA blocks 
 --- ..........   ..........
 --- ..........   ....xxx...
@@ -390,7 +379,7 @@ function CAiBrain:GetPlatoonUniquelyNamed(name)
 end
 
 --- Returns brain's platoons
--- @return tblPlatoons Table containing platoons.
+---@return Platoon[]
 function CAiBrain:GetPlatoonsList()
 end
 
@@ -442,14 +431,14 @@ function CAiBrain:GetUnitsAroundPoint(category, position, radius, alliance)
 end
 
 --- Gives resources to brain.
--- @param type 'Energy', 'Mass'.
--- @param amout Number, how much to give.
+---@param type  'ENERGY' | 'MASS'
+---@param amount number
 function CAiBrain:GiveResource(type, amount)
 end
 
 --- Gives storage to brain.
--- @param type 'Energy', 'Mass'.
--- @param amout Number, how much to give.
+---@param type 'ENERGY' | 'MASS'
+---@param amount number
 function CAiBrain:GiveStorage(type, amount)
 end
 
@@ -459,8 +448,9 @@ end
 function CAiBrain:IsAnyEngineerBuilding(category)
 end
 
+---@deprecated not used in faf
 --- Returns true if opponent AI should be running.
--- @return true/false (not used in FAF)
+---@return boolean
 function CAiBrain:IsOpponentAIRunning()
 end
 
@@ -483,7 +473,8 @@ function CAiBrain:PickBestAttackVector()
 end
 
 --- Returns true if platoon exists.
--- @return true/false.
+---@param platoon Platoon
+---@return boolean
 function CAiBrain:PlatoonExists(platoon)
 end
 
@@ -516,7 +507,7 @@ function CAiBrain:SetArmyStatsTrigger(statName, triggerName, compareType, value,
 end
 
 --- Set the current enemy for this brain to attack.
--- @param armyIndex Target's army number.
+---@param armyIndex Army
 function CAiBrain:SetCurrentEnemy(armyIndex)
 end
 
@@ -539,8 +530,8 @@ function CAiBrain:SetUpAttackVectorsToArmy(category)
 end
 
 --- Removes resources from brain.
--- @param type 'Energy', 'Mass'.
--- @param amout Number, how much to take.
+---@param type 'ENERGY' | 'MASS'
+---@param amount number # how much to take.
 function CAiBrain:TakeResource(type, amount)
 end
 

--- a/engine/User.lua
+++ b/engine/User.lua
@@ -271,9 +271,9 @@ function EntityCategoryFilterOut(category, units)
 end
 
 --- Executes some Lua code in the sim. Requires cheats to be enabled
----@param func function
----@param value any
-function ExecLuaInSim(func, value)
+---@param func string # global sim func
+---@param arg any # arg to the func
+function ExecLuaInSim(func, arg)
 end
 
 --- Requests that the application shut down

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -82,6 +82,7 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
     ---@param self AIBrain
     ---@param planName string
     CreateBrainShared = function(self, planName)
+        self.PlanName = planName
         self.Army = self:GetArmyIndex()
         self.Trash = TrashBag()
         self.TriggerList = {}
@@ -1523,3 +1524,49 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
     --#endregion
     -------------------------------------------------------------------------------
 }
+
+__moduleinfo.OnDirty = function()
+    -- force a reload since the engine wont do it
+    ForkThread(function ()
+        -- wait a tick because OnDirty is called before the module is removed from the table of loaded modules
+        WaitTicks(1)
+        import('/lua/aibrain.lua')
+    end)
+end
+__moduleinfo.OnReload = function(newModule)
+    ---@module '/lua/aibrain.lua'
+    LOG('reloading brains...')
+    ---@param oldBrain AIBrain
+    for i, oldBrain in ArmyBrains do
+        ---@type AIBrain
+        local newBrain = table.assimilate(newModule.AIBrain(), oldBrain)
+        if newBrain.BrainType == 'Human' then
+            newBrain:OnCreateHuman(newBrain.PlanName)
+        else
+            newBrain:OnCreateAI(newBrain.PlanName)
+        end
+
+        local function clearLuaObjects(t)
+            for i, v in t do
+                -- engine rawgets the c object so it must exist in the original table
+                if i == '_c_object' then continue end
+                -- skip script modules and c objects (such as units)
+                if getmetatable(v).__index == _G or v._c_object then continue end
+                -- Destroy with a destroy method if given (threads, trashbags)
+                if v.Destroy then
+                    v:Destroy()
+                elseif type(v) == "table" then
+                    clearLuaObjects(v)
+                end
+                t[i] = nil
+            end
+        end
+        clearLuaObjects(oldBrain)
+        -- old table could be in variables or accessed with `GetArmyBrain`
+        setmetatable(oldBrain, {__index = newBrain, __newindex = newBrain})
+        ArmyBrains[i] = newBrain
+
+        LOG('brain reloaded:', oldBrain, '->', newBrain)
+    end
+    LOG('brains reloaded')
+end

--- a/lua/aibrains/components/EnergyManagerBrainComponent.lua
+++ b/lua/aibrains/components/EnergyManagerBrainComponent.lua
@@ -114,12 +114,13 @@ EnergyManagerBrainComponent = ClassSimple {
             unitToProcess:OnNoExcessEnergy()
         end
 
+        __moduleinfo.track_imports = true
         local fabricatorParameters = import("/lua/shared/fabricatorbehaviorparams.lua")
+        __moduleinfo.track_imports = false
         local disableRatio = fabricatorParameters.DisableRatio
         local disableStorage = fabricatorParameters.DisableStorage
 
         local enableRatio = fabricatorParameters.EnableRatio
-        local enableTrend = fabricatorParameters.EnableTrend
         local enableStorage = fabricatorParameters.EnableStorage
 
         -- localize scope for better performance
@@ -152,20 +153,43 @@ EnergyManagerBrainComponent = ClassSimple {
         local EnergyExcessUnitsDisabled = self.EnergyExcessUnitsDisabled
         local EnergyExcessUnitsEnabled = self.EnergyExcessUnitsEnabled
 
+        local lastSwitchTick = 0
+
         while true do
 
             local energyStoredRatio = self:GetEconomyStoredRatio('ENERGY')
             local energyStored = self:GetEconomyStored('ENERGY')
-            local energyTrend = 10 * self:GetEconomyTrend('ENERGY')
+
+            local energyUsed = self:GetEconomyUsage('ENERGY')
+            local energyStorage = self:GetArmyStat('Economy_MaxStorage_Energy', 0).Value
+            -- Ally overflow leaves storage at `maxStorage - 1 tick excess resource needed`
+            -- So the minimum storage that overflow will leave us on is if all our energy comes from allies
+            -- In that case we will have `maxStorage - 1 tick energy income`, as overflow counts as income for our brain.
+            -- There is no way to see how much energy our brain gets as overflow.
+            local overflowStorageMin = energyStorage - energyUsed
+            local energyTrend = self:GetEconomyTrend('ENERGY')
 
             -- low on storage, start disabling them to fill our storages asap
-            if energyStoredRatio < disableRatio and energyStored < disableStorage then
+            if energyStoredRatio < disableRatio and energyStored < disableStorage and energyStored < overflowStorageMin * disableRatio
+                -- consuming more energy than our storage allows (if we're working off overflow), disable consumers
+                or overflowStorageMin < 0
+            then
+                local newSwitchTick = GetGameTick()
+                local dt = newSwitchTick - lastSwitchTick
+                LOG('disable reason:',
+                    energyStoredRatio < disableRatio and energyStored < disableStorage and energyStored < overflowStorageMin * disableRatio and dt .. ' low on storage: ' .. tostring(energyStored) or
+                    overflowStorageMin < 0 and dt .. ' overflowStorageMin below 0: ' .. tostring(overflowStorageMin)
+                )
+                lastSwitchTick = newSwitchTick
 
                 -- while we have units to disable
                 for id, unit in EnergyExcessUnitsEnabled do
                     if not unit:BeenDestroyed() then
 
                         local ecobp = unit.Blueprint.Economy
+                        local energyConsumption = ecobp.MaintenanceConsumptionPerSecondEnergy
+                        -- if we disable this unit then the min storage will go above our current storage, which will cause flickering in the eco bar when we rely on overflow
+                        if overflowStorageMin > 0 and energyConsumption * 0.1 > overflowStorageMin then continue end
                         self.EnergyExcessConsumed = self.EnergyExcessConsumed -
                             ecobp.MaintenanceConsumptionPerSecondEnergy
                         self.EnergyExcessRequired = self.EnergyExcessRequired +
@@ -188,13 +212,28 @@ EnergyManagerBrainComponent = ClassSimple {
                     end
                 end
 
-                -- high on storage and sufficient energy income, enable units
-            elseif (energyStoredRatio >= enableRatio and energyTrend > enableTrend) or energyStored > enableStorage then
+                -- high on storage, enable units
+            elseif energyStoredRatio >= enableRatio or energyStored > enableStorage
+                -- When we're accumulating energy above the minimum storage from overflow, we may not be receiving overflow due to insufficient consumption
+                -- compare to -1 because of floating point errors
+                or energyStored >= overflowStorageMin and energyTrend >= -1
+            then
+                local newSwitchTick = GetGameTick()
+                local dt = newSwitchTick - lastSwitchTick
+                LOG('enable reason:',
+                    energyStoredRatio >= enableRatio and dt .. ' stored above ratio: ' .. tostring(enableRatio) or
+                    energyStored > enableStorage and dt .. ' stored above limit: ' .. tostring(enableStorage) or
+                    energyStored >= overflowStorageMin and energyTrend >= -1 and dt .. ' storing above overflow min: ' .. tostring(overflowStorageMin)
+                )
+                lastSwitchTick = newSwitchTick
 
                 -- while we have units to retrieve
                 for id, unit in EnergyExcessUnitsDisabled do
                     if not unit:BeenDestroyed() then
                         local ecobp = unit.Blueprint.Economy
+                        local energyConsumption = ecobp.MaintenanceConsumptionPerSecondEnergy
+                        -- if we enable this unit then the min storage will go negative, which will cause flickering in the eco bar when we rely on overflow
+                        if energyConsumption * 0.1 > overflowStorageMin then continue end
                         self.EnergyExcessConsumed = self.EnergyExcessConsumed +
                             ecobp.MaintenanceConsumptionPerSecondEnergy
                         self.EnergyExcessRequired = self.EnergyExcessRequired -
@@ -216,6 +255,14 @@ EnergyManagerBrainComponent = ClassSimple {
                         break
                     end
                 end
+            else
+                -- LOG('idled'
+                -- , '\n energyStoredRatio', energyStoredRatio
+                -- , '\n energyStored', energyStored
+                -- , '\n overflowStorageMin', overflowStorageMin
+                -- , '\n energyTrend', energyTrend
+                -- , '\n overflowStorageMin disable at: ', overflowStorageMin * disableRatio
+                -- )
             end
 
             if self.Army == GetFocusArmy() then

--- a/lua/aibrains/components/EnergyManagerBrainComponent.lua
+++ b/lua/aibrains/components/EnergyManagerBrainComponent.lua
@@ -180,10 +180,8 @@ EnergyManagerBrainComponent = ClassSimple {
                         -- if we disable this unit then the min storage will go above our current storage, which will cause flickering in the eco bar when we rely on overflow
                         if overflowStorageMin > 0 and energyConsumption * 0.1 > overflowStorageMin then continue end
 
-                        self.EnergyExcessConsumed = self.EnergyExcessConsumed -
-                            ecobp.MaintenanceConsumptionPerSecondEnergy
-                        self.EnergyExcessRequired = self.EnergyExcessRequired +
-                            ecobp.MaintenanceConsumptionPerSecondEnergy
+                        self.EnergyExcessConsumed = self.EnergyExcessConsumed - energyConsumption
+                        self.EnergyExcessRequired = self.EnergyExcessRequired + energyConsumption
                         self.EnergyExcessConverted = self.EnergyExcessConverted - ecobp.ProductionPerSecondMass
 
                         -- update internal state
@@ -217,10 +215,8 @@ EnergyManagerBrainComponent = ClassSimple {
                         -- if we enable this unit then the min storage will go negative, which will cause flickering in the eco bar when we rely on overflow
                         if energyConsumption * 0.1 > overflowStorageMin then continue end
 
-                        self.EnergyExcessConsumed = self.EnergyExcessConsumed +
-                            ecobp.MaintenanceConsumptionPerSecondEnergy
-                        self.EnergyExcessRequired = self.EnergyExcessRequired -
-                            ecobp.MaintenanceConsumptionPerSecondEnergy
+                        self.EnergyExcessConsumed = self.EnergyExcessConsumed + energyConsumption
+                        self.EnergyExcessRequired = self.EnergyExcessRequired - energyConsumption
                         self.EnergyExcessConverted = self.EnergyExcessConverted + ecobp.ProductionPerSecondMass
 
                         -- update internal state

--- a/lua/shared/FabricatorBehaviorParams.lua
+++ b/lua/shared/FabricatorBehaviorParams.lua
@@ -3,5 +3,4 @@ DisableRatio = 0.8
 DisableStorage = 105000 -- 100000 energy needed for max overcharge damage, also add 5k as a buffer
 
 EnableRatio = 0.9
-EnableTrend = 100
 EnableStorage = 108000


### PR DESCRIPTION
## Issue
Mass fabs cannot use overflow because there is no way to detect available overflow, and resources overflow only to fulfill excess resource demand. So:
- The energy trend requirement stops mass fabs from turning on to use overflow as overflow sets the trend to 0 (or very low, depends on fab owner's power setup).
  - This is the main blocker for utilizing overflow energy. It can be overcomed by having over 100k energy storage, since the trend requirement doesn't apply past the storage limit.
- The storage ratio requirement stops mass fabs from turning on because when resources are limited by overflow, the max storage goes down to make space for the overflow income tick.
  - For example: with 44k storage the enabling limit is 39.6k. That is a difference of 4.4k, so you can only spend 44k energy per second on fabs. 88k by adding storage and then removing it, since 8.8k is the difference between the storage and the disabling limit.

## Description of the proposed changes
- Remove the energy trend requirement.
- Calculate the minimum storage we can have in the worst case scenario for overflow (all our consumption is powered by overflow), and if we're accumulating energy while above that storage requirement, try turning on consumers to see if there is more overflow to access.
  - comes with appropriate guards to prevent unwanted behavior when our consumption per tick is/would be greater than our storage

## Testing done on the proposed changes
Spawn power for an ally and fabs/storage for self, and check that all fabs are used from the massive overflow.
Before this fix, there were various small actions that prevent you from getting overflow, like destroying storages or starting/stopping the spending of energy.

<details> <summary> Spawn test command </summary>
This command allies army 1 and 2, deletes all units, and then spawns in the test units.

```lua
ConExecute('SimLua SetAlliance(1,2,"ally")')
ConExecute('Purge units')
CreateUnitAtMouse('ueb1303', 0,   23.76,  -62.39,  0.00000)
CreateUnitAtMouse('xsb1301', 1,  -13.24,   76.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,   30.76,   19.61,  0.00000)
CreateUnitAtMouse('ual0309', 0,    7.06,  -20.94,  0.00183)
CreateUnitAtMouse('ueb1303', 0,   42.76,   -8.39,  0.00000)
CreateUnitAtMouse('ual0309', 0,    6.06,  -20.94,  0.00327)
CreateUnitAtMouse('ueb1303', 0,  -37.24,  -51.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,  -30.24,  -63.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,  -12.24,  -63.39,  0.00000)
CreateUnitAtMouse('ual0309', 0,    4.06,  -20.94,  0.00374)
CreateUnitAtMouse('ueb1303', 0,  -37.24,  -27.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,  -37.24,  -39.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,   43.76,  -14.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,   43.76,  -20.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,   44.76,  -32.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,  -37.24,  -33.39,  0.00000)
CreateUnitAtMouse('xsb1301', 1,   -1.24,   20.61,  0.00000)
CreateUnitAtMouse('xsb1301', 1,  -25.24,   20.61,  0.00000)
CreateUnitAtMouse('xsb1301', 1,    5.76,   32.61,  0.00000)
CreateUnitAtMouse('xsb1301', 1,   22.76,   19.61,  0.00000)
CreateUnitAtMouse('ueb1303', 0,   35.76,  -61.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,   41.76,  -61.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,   29.76,  -61.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,   45.76,  -44.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,   45.76,  -50.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,  -37.24,   -9.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,  -37.24,    2.61,  0.00000)
CreateUnitAtMouse('ueb1303', 0,  -37.24,   -3.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,  -37.24,  -21.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,  -37.24,  -15.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,   17.76,  -62.39,  0.00000)
CreateUnitAtMouse('ual0309', 0,   -1.94,  -20.94,  0.00935)
CreateUnitAtMouse('ueb1303', 0,    5.76,  -62.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,   43.76,  -26.39,  0.00000)
CreateUnitAtMouse('ual0309', 0,    5.06,  -20.94, -0.00133)
CreateUnitAtMouse('ual0309', 0,    3.06,  -20.94,  0.00696)
CreateUnitAtMouse('ual0309', 0,    2.06,  -20.94,  0.00408)
CreateUnitAtMouse('ueb1303', 0,  -37.24,  -57.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,  -18.24,  -63.39,  0.00000)
CreateUnitAtMouse('xsb1301', 1,   20.76,   56.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,  -29.24,   78.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,  -21.24,   77.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,   13.76,   32.61,  0.00000)
CreateUnitAtMouse('xsb1301', 1,   38.76,   19.61,  0.00000)
CreateUnitAtMouse('xsb1301', 1,   -9.24,   20.61,  0.00000)
CreateUnitAtMouse('xsb1301', 1,   14.76,   19.61,  0.00000)
CreateUnitAtMouse('xsb1301', 1,    6.76,   20.61,  0.00000)
CreateUnitAtMouse('xsb1301', 1,  -26.24,   32.61,  0.00000)
CreateUnitAtMouse('xsb1301', 1,  -17.24,   20.61,  0.00000)
CreateUnitAtMouse('xsb1301', 1,   -2.24,   32.61,  0.00000)
CreateUnitAtMouse('xsb1301', 1,  -10.24,   32.61,  0.00000)
CreateUnitAtMouse('ueb1303', 0,  -37.24,  -45.39,  0.00000)
CreateUnitAtMouse('ual0309', 0,   -0.94,  -20.94,  0.00456)
CreateUnitAtMouse('ual0309', 0,    1.06,  -20.94,  0.00062)
CreateUnitAtMouse('ual0309', 0,   -2.94,  -20.94, -0.00056)
CreateUnitAtMouse('xsb1301', 1,   26.76,   71.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,   18.76,   72.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,   10.76,   73.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,    2.76,   74.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,   -5.24,   75.61, -0.00000)
CreateUnitAtMouse('xsl0001', 0,   -5.24,  -28.39, -0.00000)
CreateUnitAtMouse('xsb1301', 1,  -27.24,   62.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,  -11.24,   60.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,  -19.24,   61.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,   17.76,   46.61, -0.00000)
CreateUnitAtMouse('uab1105', 0,    0.76,  -24.39,  0.00000)
CreateUnitAtMouse('xsb1301', 1,  -30.24,   48.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,  -22.24,   48.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,  -14.24,   47.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,   -6.24,   47.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,    1.76,   47.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,    9.76,   47.61, -0.00000)
CreateUnitAtMouse('xsb1301', 1,    4.76,   58.61, -0.00000)
CreateUnitAtMouse('uab1105', 0,    2.76,  -26.39,  0.00000)
CreateUnitAtMouse('xsb1301', 1,   12.76,   57.61, -0.00000)
CreateUnitAtMouse('uab1105', 0,    0.76,  -26.39,  0.00000)
CreateUnitAtMouse('uab1105', 0,    2.76,  -24.39,  0.00000)
CreateUnitAtMouse('xsb1301', 1,   -3.24,   59.61, -0.00000)
CreateUnitAtMouse('ueb1303', 0,   11.76,  -62.39,  0.00000)
CreateUnitAtMouse('xsb1301', 1,  -18.24,   32.61,  0.00000)
CreateUnitAtMouse('ueb1303', 0,   -0.24,  -62.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,   -6.24,  -62.39,  0.00000)
CreateUnitAtMouse('ual0309', 0,    0.06,  -20.94, -0.00958)
CreateUnitAtMouse('ueb1303', 0,   44.76,  -38.39,  0.00000)
CreateUnitAtMouse('ueb1303', 0,  -24.24,  -63.39,  0.00000)
CreateUnitAtMouse('ual0309', 0,    8.06,  -20.94,  0.00607)
```

</details>

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version