### PR TITLE
Fix mass fabs not syncing their death to the mass fab panel

### DIFF
--- a/changelog/snippets/fix.6661.md
+++ b/changelog/snippets/fix.6661.md
@@ -1,0 +1,1 @@
+- (#6661) Fix mass fabricators not updating the mass fab panel's numbers when they are destroyed.

--- a/lua/sim/units/MassFabricationUnit.lua
+++ b/lua/sim/units/MassFabricationUnit.lua
@@ -1,4 +1,3 @@
-
 local StructureUnit = import("/lua/sim/units/structureunit.lua").StructureUnit
 local StructureUnitOnScriptBitSet = StructureUnit.OnScriptBitSet
 local StructureUnitOnScriptBitClear = StructureUnit.OnScriptBitClear
@@ -27,7 +26,7 @@ MassFabricationUnit = ClassUnit(StructureUnit) {
 
     ---@param self MassFabricationUnit
     ---@param bit number
-    OnScriptBitClear = function (self, bit)
+    OnScriptBitClear = function(self, bit)
         if bit == 4 then
             -- make brain track us to enable / disable accordingly
             self.Brain:AddDisabledEnergyExcessUnit(self)
@@ -46,6 +45,12 @@ MassFabricationUnit = ClassUnit(StructureUnit) {
 
         -- make brain track us to enable / disable accordingly
         self.Brain:AddEnabledEnergyExcessUnit(self)
+    end,
+
+    ---@param self MassFabricationUnit
+    OnDestroy = function(self)
+        self.Brain:RemoveEnergyExcessUnit(self)
+        StructureUnit.OnDestroy(self)
     end,
 
     ---@param self MassFabricationUnit
@@ -87,5 +92,4 @@ MassFabricationUnit = ClassUnit(StructureUnit) {
     OnNoExcessEnergy = function(self)
         self:OnProductionPaused()
     end,
-
 }


### PR DESCRIPTION
## Issue
The energy required, consumed, and mass converted displayed in the panel are updated in three places:
- On unit creation
- On unit disabling
- On unit enabling

The complement to "on unit creation" does not exist so the values are increased but never decreased.

Mass fab on/off count updates only because of garbage collection, so it updates slowly.

## Description of the proposed changes
Call the removal function in OnDestroy of the mass fab class.

## Testing done on the proposed changes
Spawn some fabricators with power. Kill/destroy them, the numbers in the mass fab panel should correctly update to match the reality.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version