### PR TITLE
Refactor weapon turret setup validation

### DIFF
--- a/changelog/snippets/other.6662.md
+++ b/changelog/snippets/other.6662.md
@@ -1,0 +1,1 @@
+- (#6662) Improve the detail of the error message when weapon turret setup fails.

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4051,13 +4051,13 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     end,
 
     ---@param self Unit
-    ---@param bone Bone
+    ---@param bone? Bone
     ---@return boolean
     ValidateBone = function(self, bone)
-        if self:IsValidBone(bone) then
+        if bone and self:IsValidBone(bone) then
             return true
         end
-        error('*ERROR: Trying to use the bone, ' .. bone .. ' on unit ' .. (self.UnitId or self:GetUnitId()) .. ' and it does not exist in the model.', 2)
+        WARN('Trying to use the bone, `' .. tostring(bone) .. '` on unit ' .. (self.UnitId or self:GetUnitId()) .. ' and it does not exist in the model.', 2)
 
         return false
     end,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -248,20 +248,19 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
             -- OnStartTransportLoading = {}
             -- OnStopTransportLoading = {}
         }
-    end,
-
-    ---@param self Unit
-    OnCreate = function(self)
-        local bp = self:GetBlueprint()
-
-        -- cache often accessed values into inner table
-        self.Blueprint = bp
 
         -- cache engine calls
+        -- weapons call OnCreate before the unit and they may use these values, so it should in PreCreate
+        self.Blueprint = self:GetBlueprint()
         self.EntityId = self:GetEntityId()
         self.Army = self:GetArmy()
         self.UnitId = self:GetUnitId()
         self.Brain = self:GetAIBrain()
+    end,
+
+    ---@param self Unit
+    OnCreate = function(self)
+        local bp = self.Blueprint
 
         -- used for rebuilding mechanic
         self.Repairers = {}
@@ -308,7 +307,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         self:UpdateStat("HitpointsRegeneration", bp.Defense.RegenRate)
 
         -- add support for keeping track of reclaim statistics
-        if self.Blueprint.General.CommandCapsHash['RULEUCC_Reclaim'] then
+        if bp.General.CommandCapsHash['RULEUCC_Reclaim'] then
             self.ReclaimedMass = 0
             self.ReclaimedEnergy = 0
             self:UpdateStat("ReclaimedMass", 0)
@@ -316,7 +315,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         end
 
         -- add support for automated jamming reset
-        if self.Blueprint.Intel.JammerBlips > 0 then
+        if bp.Intel.JammerBlips > 0 then
             self.Brain:TrackJammer(self)
             self.ResetJammer = -1
         end

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -158,140 +158,145 @@ Weapon = ClassWeapon(WeaponMethods, DebugWeaponComponent) {
     SetupTurret = function(self, bp)
         bp = bp or self.Blueprint -- defensive programming
 
+        local unit = self.unit
+        local precedence = bp.AimControlPrecedence or 10
+
         local yawBone = bp.TurretBoneYaw
         local pitchBone = bp.TurretBonePitch
         local muzzleBone = bp.TurretBoneMuzzle
-        local precedence = bp.AimControlPrecedence or 10
-        local pitchBone2, muzzleBone2, yawBone2
+        local useDualManipulators = bp.TurretDualManipulators
+        local pitchBone2, muzzleBone2
+        if useDualManipulators then
+            pitchBone2, muzzleBone2 = bp.TurretBoneDualPitch, bp.TurretBoneDualMuzzle
+        end
+        local yawBone2 = bp.TurretBoneDualYaw
 
-        local boneDualPitch = bp.TurretBoneDualPitch
-        if boneDualPitch and boneDualPitch ~= '' then
-            pitchBone2 = boneDualPitch
-        end
-        local boneDualMuzzle = bp.TurretBoneDualMuzzle
-        if boneDualMuzzle and boneDualMuzzle ~= '' then
-            muzzleBone2 = boneDualMuzzle
-        end
-        local boneDualYaw = bp.TurretBoneDualYaw
-        if boneDualYaw and boneDualYaw ~= '' then
-            yawBone2 = boneDualYaw
+        -- verify bones so that issues are easier to debug, since `CreateAimController` fails silently.
+        local issues = ''
+        if not yawBone then issues = issues .. 'TurretBoneYaw missing from blueprint, '
+        elseif not unit:ValidateBone(yawBone) then issues = issues .. 'TurretBoneYaw "' .. tostring(yawBone) .. '" does not exist in unit mesh, ' end
+        if not pitchBone then issues = issues .. 'TurretBonePitch missing from blueprint, '
+        elseif not unit:ValidateBone(pitchBone) then issues = issues .. 'TurretBonePitch "' .. tostring(pitchBone) .. '" does not exist in unit mesh, ' end
+        if not muzzleBone then issues = issues .. 'TurretBoneMuzzle missing from blueprint, '
+        elseif not unit:ValidateBone(muzzleBone) then issues = issues .. 'TurretBoneMuzzle "' .. tostring(muzzleBone) .. '" does not exist in unit mesh, ' end
+
+        if useDualManipulators then
+            if not pitchBone then issues = issues .. 'TurretBonePitch missing from blueprint, '
+            elseif not unit:ValidateBone(pitchBone2) then issues = issues .. 'TurretBoneDualPitch "' .. tostring(pitchBone2) .. '" does not exist in unit mesh, ' end
+            if not muzzleBone then issues = issues .. 'TurretBoneMuzzle missing from blueprint, '
+            elseif not unit:ValidateBone(muzzleBone2) then issues = issues .. 'TurretBoneDualMuzzle "' .. tostring(muzzleBone2) .. '" does not exist in unit mesh, ' end
         end
 
-        local unit = self.unit
-        ---@diagnostic disable-next-line: param-type-mismatch
-        if not (unit:ValidateBone(yawBone) and unit:ValidateBone(pitchBone) and unit:ValidateBone(muzzleBone)) then
-            error('*ERROR: Bone aborting turret setup due to bone issues.', 2)
+        if yawBone2 and not unit:ValidateBone(yawBone2) then issues = issues .. 'TurretBoneDualYaw "' .. tostring(yawBone2) .. '" does not exist in unit mesh, ' end
+
+        if issues ~= '' then
+            WARN(string.format('Weapon "%s" aborting turret setup due to the following bone issues: %s.\n'
+                    , tostring(bp.BlueprintId or bp.Label)
+                    , string.sub(issues, 1, -3)
+                )
+                , debug.traceback()
+            )
             return
-        elseif pitchBone2 and muzzleBone2 then
-            if not (unit:ValidateBone(pitchBone2) and unit:ValidateBone(muzzleBone2)) then
-                error('*ERROR: Bone aborting turret setup due to pitch/muzzle bone2 issues.', 2)
-                return
-            end
-        elseif yawBone2 then
-            if not unit:ValidateBone(yawBone2) then
-                error('*ERROR: Bone aborting turret setup due to yaw bone2 issues.', 2)
-                return
-            end
         end
+
+        -- Set up turret aim controllers if bones are valid.
+
         local aimControl, aimRight, aimLeft, aimYaw2
-        if yawBone and pitchBone and muzzleBone then
-            local selfTrash = self.Trash
-            if bp.TurretDualManipulators then
-                aimControl = CreateAimController(self, 'Torso', yawBone)
-                aimRight = CreateAimController(self, 'Right', pitchBone, pitchBone, muzzleBone)
-                aimLeft = CreateAimController(self, 'Left', pitchBone2, pitchBone2, muzzleBone2)
-                self.AimRight = aimRight
-                self.AimLeft = aimLeft
-                aimControl:SetPrecedence(precedence)
-                aimRight:SetPrecedence(precedence)
-                aimLeft:SetPrecedence(precedence)
-                if EntityCategoryContains(categories.STRUCTURE, unit) then
-                    aimControl:SetResetPoseTime(9999999)
-                end
-                self:SetFireControl('Right')
-                selfTrash:Add(aimControl)
-                selfTrash:Add(aimRight)
-                selfTrash:Add(aimLeft)
-            else
-                aimControl = CreateAimController(self, 'Default', yawBone, pitchBone, muzzleBone)
-                if EntityCategoryContains(categories.STRUCTURE, unit) then
-                    aimControl:SetResetPoseTime(9999999)
-                end
-                selfTrash:Add(aimControl)
-                aimControl:SetPrecedence(precedence)
-                if bp.RackSlavedToTurret and not table.empty(bp.RackBones) then
-                    for _, v in bp.RackBones do
-                        local rackBone = v.RackBone
-                        if rackBone ~= pitchBone then
-                            local slaver = CreateSlaver(unit, rackBone, pitchBone)
-                            slaver:SetPrecedence(precedence - 1)
-                            selfTrash:Add(slaver)
-                        end
+        local selfTrash = self.Trash
+        if useDualManipulators then
+            ---@diagnostic disable-next-line: param-type-mismatch
+            aimControl = CreateAimController(self, 'Torso', yawBone)
+            ---@diagnostic disable-next-line: param-type-mismatch
+            aimRight = CreateAimController(self, 'Right', pitchBone, pitchBone, muzzleBone)
+            ---@diagnostic disable-next-line: param-type-mismatch
+            aimLeft = CreateAimController(self, 'Left', pitchBone2, pitchBone2, muzzleBone2)
+            self.AimRight = aimRight
+            self.AimLeft = aimLeft
+            aimControl:SetPrecedence(precedence)
+            aimRight:SetPrecedence(precedence)
+            aimLeft:SetPrecedence(precedence)
+            if EntityCategoryContains(categories.STRUCTURE, unit) then
+                aimControl:SetResetPoseTime(9999999)
+            end
+            self:SetFireControl('Right')
+            selfTrash:Add(aimControl)
+            selfTrash:Add(aimRight)
+            selfTrash:Add(aimLeft)
+        else
+            ---@diagnostic disable-next-line: param-type-mismatch
+            aimControl = CreateAimController(self, 'Default', yawBone, pitchBone, muzzleBone)
+            if EntityCategoryContains(categories.STRUCTURE, unit) then
+                aimControl:SetResetPoseTime(9999999)
+            end
+            selfTrash:Add(aimControl)
+            aimControl:SetPrecedence(precedence)
+            if bp.RackSlavedToTurret and not table.empty(bp.RackBones) then
+                for _, v in bp.RackBones do
+                    local rackBone = v.RackBone
+                    if rackBone ~= pitchBone then
+                        ---@diagnostic disable-next-line: param-type-mismatch
+                        local slaver = CreateSlaver(unit, rackBone, pitchBone)
+                        slaver:SetPrecedence(precedence - 1)
+                        selfTrash:Add(slaver)
                     end
                 end
             end
+        end
 
-            if yawBone2 then
-                aimYaw2 = CreateAimController(self, 'Yaw2', yawBone2, yawBone2)
-                aimYaw2:SetPrecedence(precedence - 1)
-                if EntityCategoryContains(categories.STRUCTURE, unit) then
-                    aimYaw2:SetResetPoseTime(9999999)
-                end
-                selfTrash:Add(aimYaw2)
+        if yawBone2 then
+            aimYaw2 = CreateAimController(self, 'Yaw2', yawBone2, yawBone2)
+            aimYaw2:SetPrecedence(precedence - 1)
+            if EntityCategoryContains(categories.STRUCTURE, unit) then
+                aimYaw2:SetResetPoseTime(9999999)
             end
-        else
-            error('*ERROR: Trying to setup a turreted weapon but there are yaw bones, pitch bones or muzzle bones missing from the blueprint.', 2)
+            selfTrash:Add(aimYaw2)
         end
         self.AimControl = aimControl
 
-        local numbersExist = true
-        local turretyawmin, turretyawmax, turretyawspeed
-        local turretpitchmin, turretpitchmax, turretpitchspeed
+        -- Validate turret yaw, pitch, and speeds
 
-        -- SETUP MANIPULATORS AND SET TURRET YAW, PITCH AND SPEED
-        if bp.TurretYaw and bp.TurretYawRange then
-            turretyawmin, turretyawmax = self:GetTurretYawMinMax(bp)
-        else
-            numbersExist = false
+        if not bp.TurretYaw then issues = issues .. 'TurretYaw missing from blueprint, ' end
+        if not bp.TurretYawRange then issues = issues .. 'TurretYawRange missing from blueprint, ' end
+        if not bp.TurretYawSpeed then issues = issues .. 'TurretYawSpeed missing from blueprint, ' end
+        if not bp.TurretPitch then issues = issues .. 'TurretPitch missing from blueprint, ' end
+        if not bp.TurretPitchRange then issues = issues .. 'TurretPitchRange missing from blueprint, ' end
+        if not bp.TurretPitchSpeed then issues = issues .. 'TurretPitchSpeed missing from blueprint, ' end
+
+        if issues ~= '' then
+            WARN(string.format('Weapon "%s" aborting turret setup due to the following turret number issues: %s.\n'
+                    , tostring(bp.BlueprintId or bp.Label)
+                    , string.sub(issues, 1, -3)
+                )
+                , debug.traceback()
+            )
+            return
         end
-        if bp.TurretYawSpeed then
-            turretyawspeed = self:GetTurretYawSpeed(bp)
-        else
-            numbersExist = false
+
+        -- Set up turret yaw, pitch, and speeds if they're valid.
+
+        local turretyawmin, turretyawmax = self:GetTurretYawMinMax(bp)
+        local turretyawspeed = self:GetTurretYawSpeed(bp)
+        local turretpitchmin, turretpitchmax = self:GetTurretPitchMinMax(bp)
+        local turretpitchspeed = self:GetTurretPitchSpeed(bp)
+
+        aimControl:SetFiringArc(turretyawmin, turretyawmax, turretyawspeed, turretpitchmin, turretpitchmax, turretpitchspeed)
+        if aimRight and aimLeft then -- although, they should both exist if either one does
+            turretyawmin = turretyawmin / 12
+            turretyawmax = turretyawmax / 12
+            aimRight:SetFiringArc(turretyawmin, turretyawmax, turretyawspeed, turretpitchmin, turretpitchmax, turretpitchspeed)
+            aimLeft:SetFiringArc(turretyawmin, turretyawmax, turretyawspeed, turretpitchmin, turretpitchmax, turretpitchspeed)
         end
-        if bp.TurretPitch and bp.TurretPitchRange then
-            turretpitchmin, turretpitchmax = self:GetTurretPitchMinMax(bp)
-        else
-            numbersExist = false
-        end
-        if bp.TurretPitchSpeed then
-            turretpitchspeed = self:GetTurretPitchSpeed(bp)
-        else
-            numbersExist = false
-        end
-        if numbersExist then
-            aimControl:SetFiringArc(turretyawmin, turretyawmax, turretyawspeed, turretpitchmin, turretpitchmax, turretpitchspeed)
-            if aimRight and aimLeft then -- although, they should both exist if either one does
-                turretyawmin = turretyawmin / 12
-                turretyawmax = turretyawmax / 12
-                aimRight:SetFiringArc(turretyawmin, turretyawmax, turretyawspeed, turretpitchmin, turretpitchmax, turretpitchspeed)
-                aimLeft:SetFiringArc(turretyawmin, turretyawmax, turretyawspeed, turretpitchmin, turretpitchmax, turretpitchspeed)
+
+        if aimYaw2 then
+            local turretYawMin2 = turretyawmin
+            local turretYawMax2 = turretyawmax
+            if bp.TurretDualYaw and bp.TurretDualYawRange then
+                turretYawMin2 = bp.TurretDualYaw - bp.TurretDualYawRange
+                turretYawMax2 = bp.TurretDualYaw + bp.TurretDualYawRange
             end
 
-            if aimYaw2 then
-                local turretYawMin2 = turretyawmin
-                local turretYawMax2 = turretyawmax
-                if bp.TurretDualYaw and bp.TurretDualYawRange then
-                    turretYawMin2 = bp.TurretDualYaw - bp.TurretDualYawRange
-                    turretYawMax2 = bp.TurretDualYaw + bp.TurretDualYawRange
-                end
-
-                local turretYawSpeed2 = bp.TurretDualYawSpeed or turretyawspeed
-                aimYaw2:SetFiringArc(turretYawMin2, turretYawMax2, turretYawSpeed2, turretpitchmin, turretpitchmax, turretpitchspeed)
-            end
-        else
-            local strg = '*ERROR: TRYING TO SETUP A TURRET WITHOUT ALL TURRET NUMBERS IN BLUEPRINT, ABORTING TURRET SETUP. WEAPON: ' .. bp.Label .. ' UNIT: ' .. unit.UnitId
-            error(strg, 2)
+            local turretYawSpeed2 = bp.TurretDualYawSpeed or turretyawspeed
+            aimYaw2:SetFiringArc(turretYawMin2, turretYawMax2, turretYawSpeed2, turretpitchmin, turretpitchmax, turretpitchspeed)
         end
     end,
 

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -693,11 +693,10 @@ Weapon = ClassWeapon(WeaponMethods, DebugWeaponComponent) {
     DisableBuff = function(self, buffname)
         if buffname then
             self.DisabledBuffs[buffname] = true
+            self.damageTableCache = false
         else
-            -- Error
-            error('ERROR: DisableBuff in weapon.lua does not have a buffname')
+            error('DisableBuff in weapon.lua does not have a buffname')
         end
-        self.damageTableCache = false
     end,
 
     ---@param self Weapon
@@ -705,11 +704,10 @@ Weapon = ClassWeapon(WeaponMethods, DebugWeaponComponent) {
     ReEnableBuff = function(self, buffname)
         if buffname then
             self.DisabledBuffs[buffname] = nil
+            self.damageTableCache = false
         else
-            -- Error
-            error('ERROR: ReEnableBuff in weapon.lua does not have a buffname')
+            error('ReEnableBuff in weapon.lua does not have a buffname')
         end
-        self.damageTableCache = false
     end,
 
     --- Method to mark weapon when parent unit gets loaded on to a transport unit

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -20,7 +20,7 @@ local DebugWeaponComponent = import("/lua/sim/weapons/components/DebugWeaponComp
 --- Table of damage information passed from the weapon to the projectile
 --- Can be assigned as a meta table to the projectile's damage table to reduce memory usage for unchanged values
 ---@class WeaponDamageTable
----@field DamageToShields number        # weaponBlueprint.DamageToShields 
+---@field DamageToShields number        # weaponBlueprint.DamageToShields
 ---@field InitialDamageAmount number    # weaponBlueprint.InitialDamage or 0
 ---@field DamageRadius number           # weaponBlueprint.DamageRadius + Weapon.DamageRadiusMod
 ---@field DamageAmount number           # weaponBlueprint.Damage + Weapon.DamageMod
@@ -233,7 +233,7 @@ Weapon = ClassWeapon(WeaponMethods, DebugWeaponComponent) {
 
             if yawBone2 then
                 aimYaw2 = CreateAimController(self, 'Yaw2', yawBone2, yawBone2)
-                aimYaw2:SetPrecedence(precedence-1)
+                aimYaw2:SetPrecedence(precedence - 1)
                 if EntityCategoryContains(categories.STRUCTURE, unit) then
                     aimYaw2:SetResetPoseTime(9999999)
                 end
@@ -277,7 +277,7 @@ Weapon = ClassWeapon(WeaponMethods, DebugWeaponComponent) {
                 aimRight:SetFiringArc(turretyawmin, turretyawmax, turretyawspeed, turretpitchmin, turretpitchmax, turretpitchspeed)
                 aimLeft:SetFiringArc(turretyawmin, turretyawmax, turretyawspeed, turretpitchmin, turretpitchmax, turretpitchspeed)
             end
-            
+
             if aimYaw2 then
                 local turretYawMin2 = turretyawmin
                 local turretYawMax2 = turretyawmax
@@ -290,7 +290,7 @@ Weapon = ClassWeapon(WeaponMethods, DebugWeaponComponent) {
                 aimYaw2:SetFiringArc(turretYawMin2, turretYawMax2, turretYawSpeed2, turretpitchmin, turretpitchmax, turretpitchspeed)
             end
         else
-            local strg = '*ERROR: TRYING TO SETUP A TURRET WITHOUT ALL TURRET NUMBERS IN BLUEPRINT, ABORTING TURRET SETUP. WEAPON: ' .. bp.Label .. ' UNIT: '.. unit.UnitId
+            local strg = '*ERROR: TRYING TO SETUP A TURRET WITHOUT ALL TURRET NUMBERS IN BLUEPRINT, ABORTING TURRET SETUP. WEAPON: ' .. bp.Label .. ' UNIT: ' .. unit.UnitId
             error(strg, 2)
         end
     end,
@@ -384,7 +384,7 @@ Weapon = ClassWeapon(WeaponMethods, DebugWeaponComponent) {
     ---@param self Weapon
     OnGotTarget = function(self)
         -- a few non-walker units may use `Animator` as well
-        local animator = self.unit--[[@as WalkingLandUnit]].Animator
+        local animator = self.unit--[[@as WalkingLandUnit]] .Animator
         if self.DisabledFiringBones and animator then
             for _, value in self.DisabledFiringBones do
                 animator:SetBoneEnabled(value, false)
@@ -395,7 +395,7 @@ Weapon = ClassWeapon(WeaponMethods, DebugWeaponComponent) {
     ---@param self Weapon
     OnLostTarget = function(self)
         -- a few non-walker units may use `Animator` as well
-        local animator = self.unit--[[@as WalkingLandUnit]].Animator
+        local animator = self.unit--[[@as WalkingLandUnit]] .Animator
         if self.DisabledFiringBones and animator then
             for _, value in self.DisabledFiringBones do
                 animator:SetBoneEnabled(value, true)
@@ -661,7 +661,7 @@ Weapon = ClassWeapon(WeaponMethods, DebugWeaponComponent) {
     end,
 
     ---@param self Weapon
-    ---@param dmgMod number 
+    ---@param dmgMod number
     AddDamageMod = function(self, dmgMod)
         self.DamageMod = self.DamageMod + dmgMod
         self.damageTableCache = false


### PR DESCRIPTION
## Issue
When turret setup fails it does not give very clear information because the error messages are vague or the stack trace is incorrect due to bone validation itself erroring. Most commonly this occurs when developing mods.

## Description of the proposed changes
- Refactors turret validation so the issues are clear.
- Change turret setup failure from `error` to `return`.
- Change Unit:ValidateBone so it doesn't error there, and instead just returns `false`.
- Fix ValidateBone not dealing with nil bones, a common case when turrets are setup incorrectly (forgetting a bone).
- Format weapon.lua

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Remove bones for a unit's turret setup and check the new warning message.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version