### PR TITLE
Fix issues in create unit dialog

### DIFF
--- a/changelog/snippets/fix.6664.md
+++ b/changelog/snippets/fix.6664.md
@@ -1,3 +1,3 @@
 - (#6664) Fix modded unit icons not being used in the cheat spawn menu.
 
-- (#6664) Fix errors in log when mousing over templates with unloaded modded units in the cheat spawn menu.
+- (#6664) Fix errors in log when mousing over templates in the cheat spawn menu.

--- a/changelog/snippets/fix.6664.md
+++ b/changelog/snippets/fix.6664.md
@@ -1,0 +1,3 @@
+- (#6664) Fix modded unit icons not being used in the cheat spawn menu.
+
+- (#6664) Fix errors in log when mousing over templates in the cheat spawn menu.

--- a/changelog/snippets/fix.6664.md
+++ b/changelog/snippets/fix.6664.md
@@ -1,3 +1,3 @@
 - (#6664) Fix modded unit icons not being used in the cheat spawn menu.
 
-- (#6664) Fix errors in log when mousing over templates in the cheat spawn menu.
+- (#6664) Fix errors in log when mousing over templates with unloaded modded units in the cheat spawn menu.

--- a/lua/ui/dialogs/createunit.lua
+++ b/lua/ui/dialogs/createunit.lua
@@ -1440,6 +1440,7 @@ function CreateDialog()
 
         for i = 3, table.getn(td) do
             local id = td[i][1]
+            if not __blueprints[id] then return end
             local w, h = GetUnitSkirtSizes(id)
             local posX, posZ = td[i][3], td[i][4]
             local cOffX, cOffZ = GetSkirtCentreOffset(id)
@@ -1474,7 +1475,7 @@ function CreateDialog()
 
         mouseover.Left:Set(x+20  * UIScale)
         mouseover.Top:Set(y+20 * UIScale)
-        LayoutHelpers.SetDimensions(mouseover.img, 300, 300)
+        LayoutHelpers.SetDimensions(mouseover, 300, 300)
         mouseover.Depth:Set(GetFrame(0):GetTopmostDepth() + 1)
     end
     local function CreateElementMouseover(unitData,x,y)

--- a/lua/ui/dialogs/createunit.lua
+++ b/lua/ui/dialogs/createunit.lua
@@ -1393,7 +1393,7 @@ function CreateDialog()
 
     local mouseover = false
     local function SetUnitImage(bitmap, id, smol)
-        local icon = UIUtil.UIFile('/textures/ui/common/icons/units/' .. id .. '_icon.dds', true)
+        local icon = UIUtil.UIFile('/icons/units/' .. id .. '_icon.dds', true)
         local lods = __blueprints[id].Display.Mesh.LODs
         local albedo = lods[smol and lods and table.getn(lods) or 1].AlbedoName
 
@@ -2013,7 +2013,7 @@ function CreateTemplateOptionsMenu(button)
                 end
             end
             for iconType, _ in contents do
-                local bmp = Bitmap(group, '/textures/ui/common/icons/units/'..iconType..'_icon.dds')
+                local bmp = Bitmap(group, UIUtil.UIFile('/icons/units/' .. iconType .. '_icon.dds', true))
                 bmp.Height:Set(30 * UIScale)
                 bmp.Width:Set(30 * UIScale)
                 bmp.ID = iconType

--- a/lua/ui/dialogs/createunit.lua
+++ b/lua/ui/dialogs/createunit.lua
@@ -1393,7 +1393,7 @@ function CreateDialog()
 
     local mouseover = false
     local function SetUnitImage(bitmap, id, smol)
-        local icon = __blueprints[id].Source and (__blueprints[id].Source):gsub('/units/.*', '')..'/textures/ui/common/icons/units/'..id..'_icon.dds'
+        local icon = UIUtil.UIFile('/textures/ui/common/icons/units/' .. id .. '_icon.dds', true)
         local lods = __blueprints[id].Display.Mesh.LODs
         local albedo = lods[smol and lods and table.getn(lods) or 1].AlbedoName
 


### PR DESCRIPTION
## Issue
1: The create unit dialog does not use the standard way of loading icons, so all modded units do not have a proper icon when hovered over.

2: There are errors when mousing over templates with unloaded modded units.
```
warning: Error running HandleEvent script in CScriptObject at 279a5800: ...\lua\ui\dialogs\createunit.lua(1425): attempt to perform arithmetic on local `XSkirtO' (a nil value)
         stack traceback:
         	...\lua\ui\dialogs\createunit.lua(1425): in function <...\lua\ui\dialogs\createunit.lua:1420>
         	...\lua\ui\dialogs\createunit.lua(1446): in function `?'
         	...\lua\ui\dialogs\createunit.lua(1577): in function <...\lua\ui\dialogs\createunit.lua:1574>
```

3. There are errors when mousing over templates.
```
warning: Error running HandleEvent script in CScriptObject at 2c0a6100: ...\lua\maui\layouthelpers.lua(79): attempt to call method `SetValue' (a nil value)
         stack traceback:
         	...\lua\maui\layouthelpers.lua(79): in function `SetWidth'
         	...\lua\maui\layouthelpers.lua(104): in function `SetDimensions'
         	...\lua\ui\dialogs\createunit.lua(1479): in function `?'
         	...\lua\ui\dialogs\createunit.lua(1578): in function <...\lua\ui\dialogs\createunit.lua:1575>
```

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Get the icon the standard way through UI Utils which is what is used for `construction.lua`.
Fix the errors.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Mousing over a modded unit in the create unit dialog gets the correct icon instead of falling back to the unit's albedo texture.
![{DAE74966-43B5-450C-88F2-AE15083C91D1}](https://github.com/user-attachments/assets/129a782f-3aa3-44fd-8579-f1e976d73650)
This green background is what fixing the mouseover creates by the way:
![{4CE86E05-9968-40CF-94FB-745AB788DB1B}](https://github.com/user-attachments/assets/2e1e7159-f364-48d8-9300-85459d42fcd4)

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version