### PR TITLE
Make air staging detach units when killed

### DIFF
--- a/changelog/snippets/balance.6665.md
+++ b/changelog/snippets/balance.6665.md
@@ -1,0 +1,1 @@
+- (#6665) Air staging now detaches aircraft when killed or ctrl-k'd (to work around an engine bug where aircraft get stuck inside air staging).

--- a/engine/Sim/Entity.lua
+++ b/engine/Sim/Entity.lua
@@ -280,7 +280,7 @@ end
 function Entity:IsValidBone(bone, allowNil)
 end
 
----@overload fun(): 
+---@overload fun()
 ---@param instigator Unit
 ---@param damageType DamageType
 ---@param excessDamageRatio number

--- a/lua/sim/units/AirStagingPlatformUnit.lua
+++ b/lua/sim/units/AirStagingPlatformUnit.lua
@@ -23,4 +23,17 @@
 local StructureUnit = import("/lua/sim/units/structureunit.lua").StructureUnit
 
 ---@class AirStagingPlatformUnit : StructureUnit
-AirStagingPlatformUnit = ClassUnit(StructureUnit) {}
+AirStagingPlatformUnit = ClassUnit(StructureUnit) {
+    ---@param self AirStagingPlatformUnit
+    ---@param instigator Unit
+    ---@param damageType DamageType
+    ---@param excessDamageRatio number
+    Kill = function(self, instigator, damageType, excessDamageRatio)
+        self:TransportDetachAllUnits(false)
+        if instigator then
+            StructureUnit.Kill(self, instigator, damageType, excessDamageRatio)
+        else
+            StructureUnit.Kill(self)
+        end
+    end,
+}

--- a/lua/sim/units/AirStagingPlatformUnit.lua
+++ b/lua/sim/units/AirStagingPlatformUnit.lua
@@ -24,12 +24,15 @@ local StructureUnit = import("/lua/sim/units/structureunit.lua").StructureUnit
 
 ---@class AirStagingPlatformUnit : StructureUnit
 AirStagingPlatformUnit = ClassUnit(StructureUnit) {
+    --- Detach units from air staging on death to allow working around an engine bug 
+    --- where units get stuck in the air staging.
     ---@param self AirStagingPlatformUnit
     ---@param instigator Unit
     ---@param damageType DamageType
     ---@param excessDamageRatio number
     Kill = function(self, instigator, damageType, excessDamageRatio)
         self:TransportDetachAllUnits(false)
+        -- `Kill` can only be called with 4 args or 1 arg
         if instigator then
             StructureUnit.Kill(self, instigator, damageType, excessDamageRatio)
         else


### PR DESCRIPTION
## Issue
Workaround for a bug posted on discord: https://discord.com/channels/197033481883222026/1322240211429883935
Units can get stuck inside air staging late game when there are many units.

## Description of the proposed changes
Detach units from the air staging when it is killed.
`Kill` is hooked because the C function `Kill` kills all attached units, so we cannot detach them in `OnKilled`.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spawn an air staging and get some aircraft to low fuel with `wld_runwiththewind`. Dock the aircraft and kill the air staging with ctrl k or a unit. The aircraft should detach when it dies.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version