### PR TITLE
Air Staging adjustments

### DIFF
--- a/changelog/snippets/balance.6672.md
+++ b/changelog/snippets/balance.6672.md
@@ -1,6 +1,6 @@
 - (#6672) Repairing air units via Air Staging is now free in terms energy cost. Additionally, the BuildTime of Air Staging Platforms is reduced, as even after several buffs, they were still very slow to build compared to other structures of the same tier. As a point of reference, a Tech 1 engineer takes 60 seconds to build factories, while Air Staging Platforms took 70 seconds to construct and are also cheaper.
 
-  - **All Air Staging Platforms:**
+  **All Air Staging Platforms:**
     - AI
       - RepairConsumeEnergy: 30 --> 0
       - RepairConsumeMass: 0 (unchanged)

--- a/changelog/snippets/balance.6672.md
+++ b/changelog/snippets/balance.6672.md
@@ -1,0 +1,8 @@
+- (#6672) Repairing air units via Air Staging is now free in terms energy cost. Additionally, the BuildTime of Air Staging Platforms is reduced, as even after several buffs, they were still very slow to build compared to other structures of the same tier. As a point of reference, a Tech 1 engineer takes 60 seconds to build factories, while Air Staging Platforms took 70 seconds to construct and are also cheaper.
+
+  - **All Air Staging Platforms:**
+    - AI
+      - RepairConsumeEnergy: 30 --> 0
+      - RepairConsumeMass: 0 (unchanged)
+    - Economy (structures only)
+      - BuildTime: 350 --> 250 (70s --> 50s)

--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -4,7 +4,7 @@ UnitBlueprint{
         GuardReturnRadius = 175,
         RefuelingMultiplier = 50,
         RefuelingRepairAmount = 500,
-        RepairConsumeEnergy = 30,
+        RepairConsumeEnergy = 0,
         RepairConsumeMass = 0,
         TargetBones = {
             "Attachpoint01",

--- a/units/UAB5202/UAB5202_unit.bp
+++ b/units/UAB5202/UAB5202_unit.bp
@@ -3,7 +3,7 @@ UnitBlueprint{
     AI = {
         RefuelingMultiplier = 50,
         RefuelingRepairAmount = 500,
-        RepairConsumeEnergy = 30,
+        RepairConsumeEnergy = 0,
         RepairConsumeMass = 0,
         ShowAssistRangeOnSelect = true,
         StagingPlatformScanRadius = 300,

--- a/units/UAB5202/UAB5202_unit.bp
+++ b/units/UAB5202/UAB5202_unit.bp
@@ -75,7 +75,7 @@ UnitBlueprint{
     Economy = {
         BuildCostEnergy = 2100,
         BuildCostMass = 175,
-        BuildTime = 350,
+        BuildTime = 250,
         RebuildBonusIds = { "uab5202" },
     },
     General = {

--- a/units/UAS0303/UAS0303_unit.bp
+++ b/units/UAS0303/UAS0303_unit.bp
@@ -4,7 +4,7 @@ UnitBlueprint{
         GuardReturnRadius = 15,
         RefuelingMultiplier = 100,
         RefuelingRepairAmount = 500,
-        RepairConsumeEnergy = 30,
+        RepairConsumeEnergy = 0,
         RepairConsumeMass = 0,
         StagingPlatformScanRadius = 300,
         TargetBones = {

--- a/units/UEB5202/UEB5202_unit.bp
+++ b/units/UEB5202/UEB5202_unit.bp
@@ -3,7 +3,7 @@ UnitBlueprint{
     AI = {
         RefuelingMultiplier = 50,
         RefuelingRepairAmount = 500,
-        RepairConsumeEnergy = 30,
+        RepairConsumeEnergy = 0,
         RepairConsumeMass = 0,
         ShowAssistRangeOnSelect = true,
         StagingPlatformScanRadius = 300,

--- a/units/UEB5202/UEB5202_unit.bp
+++ b/units/UEB5202/UEB5202_unit.bp
@@ -75,7 +75,7 @@ UnitBlueprint{
     Economy = {
         BuildCostEnergy = 2100,
         BuildCostMass = 175,
-        BuildTime = 350,
+        BuildTime = 250,
         RebuildBonusIds = { "ueb5202" },
     },
     General = {

--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -4,7 +4,7 @@ UnitBlueprint{
         AttackAngle = 20,
         RefuelingMultiplier = 75,
         RefuelingRepairAmount = 500,
-        RepairConsumeEnergy = 30,
+        RepairConsumeEnergy = 0,
         RepairConsumeMass = 0,
         StagingPlatformScanRadius = 300,
         TargetBones = {

--- a/units/UES0401/UES0401_unit.bp
+++ b/units/UES0401/UES0401_unit.bp
@@ -4,7 +4,7 @@ UnitBlueprint{
         GuardReturnRadius = 0,
         RefuelingMultiplier = 100,
         RefuelingRepairAmount = 500,
-        RepairConsumeEnergy = 30,
+        RepairConsumeEnergy = 0,
         RepairConsumeMass = 0,
         StagingPlatformScanRadius = 300,
         TargetBones = {

--- a/units/URB5202/URB5202_unit.bp
+++ b/units/URB5202/URB5202_unit.bp
@@ -74,7 +74,7 @@ UnitBlueprint{
     Economy = {
         BuildCostEnergy = 2100,
         BuildCostMass = 175,
-        BuildTime = 350,
+        BuildTime = 250,
         RebuildBonusIds = { "urb5202" },
     },
     General = {

--- a/units/URB5202/URB5202_unit.bp
+++ b/units/URB5202/URB5202_unit.bp
@@ -3,7 +3,7 @@ UnitBlueprint{
     AI = {
         RefuelingMultiplier = 50,
         RefuelingRepairAmount = 500,
-        RepairConsumeEnergy = 30,
+        RepairConsumeEnergy = 0,
         RepairConsumeMass = 0,
         ShowAssistRangeOnSelect = true,
         StagingPlatformScanRadius = 300,

--- a/units/URS0202/URS0202_unit.bp
+++ b/units/URS0202/URS0202_unit.bp
@@ -5,7 +5,7 @@ UnitBlueprint{
         GuardReturnRadius = 30,
         RefuelingMultiplier = 50,
         RefuelingRepairAmount = 500,
-        RepairConsumeEnergy = 30,
+        RepairConsumeEnergy = 0,
         RepairConsumeMass = 0,
         StagingPlatformScanRadius = 300,
         TargetBones = {

--- a/units/URS0303/URS0303_unit.bp
+++ b/units/URS0303/URS0303_unit.bp
@@ -4,7 +4,7 @@ UnitBlueprint{
         GuardReturnRadius = 15,
         RefuelingMultiplier = 50,
         RefuelingRepairAmount = 500,
-        RepairConsumeEnergy = 30,
+        RepairConsumeEnergy = 0,
         RepairConsumeMass = 0,
         StagingPlatformScanRadius = 300,
         TargetBones = {

--- a/units/XSB5202/XSB5202_unit.bp
+++ b/units/XSB5202/XSB5202_unit.bp
@@ -3,7 +3,7 @@ UnitBlueprint{
     AI = {
         RefuelingMultiplier = 50,
         RefuelingRepairAmount = 500,
-        RepairConsumeEnergy = 30,
+        RepairConsumeEnergy = 0,
         RepairConsumeMass = 0,
         ShowAssistRangeOnSelect = true,
         StagingPlatformScanRadius = 300,

--- a/units/XSB5202/XSB5202_unit.bp
+++ b/units/XSB5202/XSB5202_unit.bp
@@ -87,7 +87,7 @@ UnitBlueprint{
     Economy = {
         BuildCostEnergy = 2100,
         BuildCostMass = 175,
-        BuildTime = 350,
+        BuildTime = 250,
         RebuildBonusIds = { "xsb5202" },
     },
     General = {

--- a/units/XSS0303/XSS0303_unit.bp
+++ b/units/XSS0303/XSS0303_unit.bp
@@ -4,7 +4,7 @@ UnitBlueprint{
         GuardReturnRadius = 15,
         RefuelingMultiplier = 50,
         RefuelingRepairAmount = 500,
-        RepairConsumeEnergy = 30,
+        RepairConsumeEnergy = 0,
         RepairConsumeMass = 0,
         StagingPlatformScanRadius = 300,
     },


### PR DESCRIPTION
## Description of the proposed changes
In #2774 repairing air units was made free in terms of mass cost. I believe part of the reason was because the mass drain caused units to get stuck on the platform when stalling. I tried to investigate whether changing the consumption figures fixes the issue, however to no avail. If someone has also done some testing on this, please let me know, it would be nice to get this fixed.

Additionally, the BuildTime of Air Staging Platforms is reduced further, as it was still very high for a Tech 1 structure. A Tech 1 engineer takes 70 seconds to build one, while factories (that also cost more) only take 60 seconds.

**Air Staging Platforms:**
  - AI
    - RepairConsumeEnergy: 30 --> 0
    - RepairConsumeMass: 0 (unchanged)
  - Economy (structures only)
    - BuildTime: 350 --> 250

## Checklist
- [x] Changes are documented in the changelog for the next game version