### PR TITLE
Resolve circular dependency of WorldView and CommandMode

### DIFF
--- a/changelog/snippets/other.6679.md
+++ b/changelog/snippets/other.6679.md
@@ -1,0 +1,1 @@
+- (#6679) Resolve circular dependency of WorldView and CommandMode.

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -14,7 +14,6 @@ local watchForQueueChange = import("/lua/ui/game/construction.lua").watchForQueu
 local checkBadClean = import("/lua/ui/game/construction.lua").checkBadClean
 local EnhancementQueueFile = import("/lua/ui/notify/enhancementqueue.lua")
 
-local WorldView = import("/lua/ui/controls/worldview.lua")
 local GameMain = import("/lua/ui/game/gamemain.lua")
 local RadialDragger = import("/lua/ui/controls/draggers/radial.lua").RadialDragger
 


### PR DESCRIPTION
## Description of the proposed changes
Remove import of `WorldView.lua` in `CommandMode.lua` which is imported inside `WorldView.lua` causing circular dependency of these 2 modules.


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version