### PR TITLE
Don't initialize/alter objects during module loading in `Construction.lua`

### DIFF
--- a/changelog/snippets/fix.6681.md
+++ b/changelog/snippets/fix.6681.md
@@ -1,0 +1,3 @@
+- (#6681) Don't initialize/alter objects during module loading in Construction.lua
+
+Initializing/altering objects during loading of a module is a bad habbit, especially if it is from another module. In this case it can cause error and game freeze if UI mod tries to access `construction.lua` before UI is created.

--- a/changelog/snippets/fix.6681.md
+++ b/changelog/snippets/fix.6681.md
@@ -1,3 +1,3 @@
-- (#6681) Don't initialize/alter objects during module loading in Construction.lua
+- (#6681) Don't initialize/alter objects during module loading in `construction.lua` for the draggable queue option.
 
-Initializing/altering objects during loading of a module is a bad habbit, especially if it is from another module. In this case it can cause error and game freeze if UI mod tries to access `construction.lua` before UI is created.
+  Initializing/altering objects during loading of a module is a bad habit, especially if done from another module. In this case it caused an error and a game freeze if a UI mod tried to access `construction.lua` before the UI was created.

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -79,18 +79,6 @@ function setUpgradeAndAllowing(upgradesTo_, allowOthers_)
     allowOthers = allowOthers_
 end
 
-if options.gui_draggable_queue ~= 0 then
-    -- Add gameparent handleevent for if the drag ends outside the queue window
-    local gameParent = import("/lua/ui/game/gamemain.lua").GetGameParent()
-    local oldGameParentHandleEvent = gameParent.HandleEvent
-    gameParent.HandleEvent = function(self, event)
-        if event.Type == 'ButtonRelease' then
-            import("/lua/ui/game/construction.lua").ButtonReleaseCallback()
-        end
-        oldGameParentHandleEvent(self, event)
-    end
-end
-
 local cutA = 0
 local cutB = 0
 if options.gui_visible_template_names ~= 0 then

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -257,6 +257,16 @@ function CreateUI(isReplay)
 
     controls.gameParent = UIUtil.CreateScreenGroup(GetFrame(0), "GameMain ScreenGroup")
     gameParent = controls.gameParent
+    if options.gui_draggable_queue ~= 0 then
+        -- Add gameparent handleevent for if the drag ends outside the queue window
+        local oldGameParentHandleEvent = gameParent.HandleEvent
+        gameParent.HandleEvent = function(self, event)
+            if event.Type == 'ButtonRelease' then
+                import("/lua/ui/game/construction.lua").ButtonReleaseCallback()
+            end
+            return oldGameParentHandleEvent(self, event)
+        end
+    end
 
     controlClusterGroup, statusClusterGroup, mapGroup, windowGroup = import("/lua/ui/game/borders.lua").SetupBorderControl(gameParent)
 


### PR DESCRIPTION
## Description of the proposed changes
Initializing/altering objects during loading of a module is a bad habbit, especially if it is from another module. In this case it can cause error and game freeze if UI mod tries to access `construction.lua` before UI is created.

## Testing done on the proposed changes
Queue dragging works as normal.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version