### PR TITLE
Yet another shader rework

### DIFF
--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -2374,9 +2374,9 @@ technique Terrain050 <
 // base layer and gets blended on top of everything again according to its alpha.
 // The specularity texture allows fine control over the specularity of the map.
 
-float4 UDNBlending(float4 n1, float4 n2, float factor) {
+float3 UDNBlending(float3 n1, float3 n2, float factor) {
     n2.xy *= factor;
-    return normalize(float4(n1.xy + n2.xy, n1.z, 0));
+    return normalize(float3(n1.xy + n2.xy, n1.z));
 }
 
 float4 Terrain001NormalsPS( VS_OUTPUT pixel, uniform bool halfRange ) : COLOR
@@ -2400,16 +2400,16 @@ float4 Terrain001NormalsPS( VS_OUTPUT pixel, uniform bool halfRange ) : COLOR
         mask1 = saturate(mask1 * 2 - 1);
     }
 
-    float4 base =           normalize(tex2D(LowerNormalSampler,    coordinates * LowerNormalTile.xx   ) * 2 - 1);
-    float4 stratum0Normal = normalize(tex2D(Stratum0NormalSampler, coordinates * Stratum0NormalTile.xx) * 2 - 1);
-    float4 stratum1Normal = normalize(tex2D(Stratum1NormalSampler, coordinates * Stratum1NormalTile.xx) * 2 - 1);
-    float4 stratum2Normal = normalize(tex2D(Stratum2NormalSampler, coordinates * Stratum2NormalTile.xx) * 2 - 1);
-    float4 stratum3Normal = normalize(tex2D(Stratum3NormalSampler, coordinates * Stratum3NormalTile.xx) * 2 - 1);
-    float4 stratum4Normal = normalize(tex2D(Stratum4NormalSampler, coordinates * Stratum4NormalTile.xx) * 2 - 1);
-    float4 stratum5Normal = normalize(tex2D(Stratum5NormalSampler, coordinates * Stratum5NormalTile.xx) * 2 - 1);
-    float4 stratum6Normal = normalize(tex2D(Stratum6NormalSampler, coordinates * Stratum6NormalTile.xx) * 2 - 1);
+    float3 base =           normalize(tex2D(LowerNormalSampler,    coordinates * LowerNormalTile.xx   ) * 2 - 1);
+    float3 stratum0Normal = normalize(tex2D(Stratum0NormalSampler, coordinates * Stratum0NormalTile.xx) * 2 - 1);
+    float3 stratum1Normal = normalize(tex2D(Stratum1NormalSampler, coordinates * Stratum1NormalTile.xx) * 2 - 1);
+    float3 stratum2Normal = normalize(tex2D(Stratum2NormalSampler, coordinates * Stratum2NormalTile.xx) * 2 - 1);
+    float3 stratum3Normal = normalize(tex2D(Stratum3NormalSampler, coordinates * Stratum3NormalTile.xx) * 2 - 1);
+    float3 stratum4Normal = normalize(tex2D(Stratum4NormalSampler, coordinates * Stratum4NormalTile.xx) * 2 - 1);
+    float3 stratum5Normal = normalize(tex2D(Stratum5NormalSampler, coordinates * Stratum5NormalTile.xx) * 2 - 1);
+    float3 stratum6Normal = normalize(tex2D(Stratum6NormalSampler, coordinates * Stratum6NormalTile.xx) * 2 - 1);
 
-    float4 normal = base;
+    float3 normal = base;
     normal = UDNBlending(normal,stratum0Normal,mask0.x);
     normal = UDNBlending(normal,stratum1Normal,mask0.y);
     normal = UDNBlending(normal,stratum2Normal,mask0.z);
@@ -2418,7 +2418,7 @@ float4 Terrain001NormalsPS( VS_OUTPUT pixel, uniform bool halfRange ) : COLOR
     normal = UDNBlending(normal,stratum5Normal,mask1.y);
     normal = UDNBlending(normal,stratum6Normal,mask1.z);
 
-    return float4( (normal.xyz * 0.5 + 0.5) , normal.w);
+    return float4( (normal.xyz * 0.5 + 0.5) , 1);
 }
 
 float4 Terrain001AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
@@ -2569,8 +2569,7 @@ technique Terrain051 <
 // ----------------------------------------------------------------------------
 //#region Terrain100
 
-// These shaders use PBR rendering.
-// The normal map scales are controlled by the albedo scales to ensure that they use the same values.
+// These shaders use PBR rendering. UDN blending is used for the normals.
 // The layer mask of S7 acts as a roughness multiplier with 0.5 as the neutral value.
 
 float4 Terrain100NormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
@@ -2585,23 +2584,23 @@ float4 Terrain100NormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
         mask1 = saturate(mask1 * 2 - 1);
     }
 
-    float3 lowerNormal    = normalize(tex2D(LowerNormalSampler,    position.xy * LowerAlbedoTile.xy   ).rgb * 2 - 1);
-    float3 stratum0Normal = normalize(tex2D(Stratum0NormalSampler, position.xy * Stratum0AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum1Normal = normalize(tex2D(Stratum1NormalSampler, position.xy * Stratum1AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum2Normal = normalize(tex2D(Stratum2NormalSampler, position.xy * Stratum2AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum3Normal = normalize(tex2D(Stratum3NormalSampler, position.xy * Stratum3AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum4Normal = normalize(tex2D(Stratum4NormalSampler, position.xy * Stratum4AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum5Normal = normalize(tex2D(Stratum5NormalSampler, position.xy * Stratum5AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum6Normal = normalize(tex2D(Stratum6NormalSampler, position.xy * Stratum6AlbedoTile.xy).rgb * 2 - 1);
+    float3 lowerNormal    = normalize(tex2D(LowerNormalSampler,    position.xy * LowerNormalTile.xy   ).rgb * 2 - 1);
+    float3 stratum0Normal = normalize(tex2D(Stratum0NormalSampler, position.xy * Stratum0NormalTile.xy).rgb * 2 - 1);
+    float3 stratum1Normal = normalize(tex2D(Stratum1NormalSampler, position.xy * Stratum1NormalTile.xy).rgb * 2 - 1);
+    float3 stratum2Normal = normalize(tex2D(Stratum2NormalSampler, position.xy * Stratum2NormalTile.xy).rgb * 2 - 1);
+    float3 stratum3Normal = normalize(tex2D(Stratum3NormalSampler, position.xy * Stratum3NormalTile.xy).rgb * 2 - 1);
+    float3 stratum4Normal = normalize(tex2D(Stratum4NormalSampler, position.xy * Stratum4NormalTile.xy).rgb * 2 - 1);
+    float3 stratum5Normal = normalize(tex2D(Stratum5NormalSampler, position.xy * Stratum5NormalTile.xy).rgb * 2 - 1);
+    float3 stratum6Normal = normalize(tex2D(Stratum6NormalSampler, position.xy * Stratum6NormalTile.xy).rgb * 2 - 1);
 
     float3 normal = lowerNormal;
-    normal = normalize(lerp(normal,stratum0Normal,mask0.x));
-    normal = normalize(lerp(normal,stratum1Normal,mask0.y));
-    normal = normalize(lerp(normal,stratum2Normal,mask0.z));
-    normal = normalize(lerp(normal,stratum3Normal,mask0.w));
-    normal = normalize(lerp(normal,stratum4Normal,mask1.x));
-    normal = normalize(lerp(normal,stratum5Normal,mask1.y));
-    normal = normalize(lerp(normal,stratum6Normal,mask1.z));
+    normal = UDNBlending(normal,stratum0Normal,mask0.x);
+    normal = UDNBlending(normal,stratum1Normal,mask0.y);
+    normal = UDNBlending(normal,stratum2Normal,mask0.z);
+    normal = UDNBlending(normal,stratum3Normal,mask0.w);
+    normal = UDNBlending(normal,stratum4Normal,mask1.x);
+    normal = UDNBlending(normal,stratum5Normal,mask1.y);
+    normal = UDNBlending(normal,stratum6Normal,mask1.z);
 
     return float4( 0.5 + 0.5 * normal.rgb, 1);
 }
@@ -2610,7 +2609,6 @@ float4 Terrain100AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange, uniform float
 {
     float2 position = TerrainScale * inV.mTexWT;
 
-    // do arithmetics to get range from (0, 1) to (-1, 1) as normal maps store their values as (0, 1)
     float3 normal = normalize(2 * SampleScreen(NormalSampler,inV.mTexSS).xyz - 1);
 
     float4 mask0 = tex2D(UtilitySamplerA, position.xy);
@@ -2774,29 +2772,29 @@ float4 Terrain100BNormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
         mask1 = saturate(mask1 * 2 - 1);
     }
 
-    float3 lowerNormal    = normalize(tex2D(LowerNormalSampler,    position.xy * LowerAlbedoTile.xy   ).rgb * 2 - 1);
-    float3 stratum0Normal = normalize(tex2D(Stratum0NormalSampler, position.xy * Stratum0AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum1Normal = normalize(tex2D(Stratum1NormalSampler, position.xy * Stratum1AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum4Normal = normalize(tex2D(Stratum4NormalSampler, position.xy * Stratum4AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum5Normal = normalize(tex2D(Stratum5NormalSampler, position.xy * Stratum5AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum6Normal = normalize(tex2D(Stratum6NormalSampler, position.xy * Stratum6AlbedoTile.xy).rgb * 2 - 1);
+    float3 lowerNormal    = normalize(tex2D(LowerNormalSampler,    position.xy * LowerNormalTile.xy   ).rgb * 2 - 1);
+    float3 stratum0Normal = normalize(tex2D(Stratum0NormalSampler, position.xy * Stratum0NormalTile.xy).rgb * 2 - 1);
+    float3 stratum1Normal = normalize(tex2D(Stratum1NormalSampler, position.xy * Stratum1NormalTile.xy).rgb * 2 - 1);
+    float3 stratum4Normal = normalize(tex2D(Stratum4NormalSampler, position.xy * Stratum4NormalTile.xy).rgb * 2 - 1);
+    float3 stratum5Normal = normalize(tex2D(Stratum5NormalSampler, position.xy * Stratum5NormalTile.xy).rgb * 2 - 1);
+    float3 stratum6Normal = normalize(tex2D(Stratum6NormalSampler, position.xy * Stratum6NormalTile.xy).rgb * 2 - 1);
 
     float2 blendWeights = calculateBlendWeights(position.xy);
-    float3 stratum2NormalXZ = normalize(tex2D(Stratum2NormalSampler, position.xz * Stratum2AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum2NormalYZ = normalize(tex2D(Stratum2NormalSampler, position.yz * Stratum2AlbedoTile.xy).rgb * 2 - 1);
+    float3 stratum2NormalXZ = normalize(tex2D(Stratum2NormalSampler, position.xz * Stratum2NormalTile.xy).rgb * 2 - 1);
+    float3 stratum2NormalYZ = normalize(tex2D(Stratum2NormalSampler, position.yz * Stratum2NormalTile.xy).rgb * 2 - 1);
     float3 stratum2Normal = stratum2NormalYZ * blendWeights.x + stratum2NormalXZ * blendWeights.y;
-    float3 stratum3NormalXZ = normalize(tex2D(Stratum3NormalSampler, position.xz * Stratum3AlbedoTile.xy).rgb * 2 - 1);
-    float3 stratum3NormalYZ = normalize(tex2D(Stratum3NormalSampler, position.yz * Stratum3AlbedoTile.xy).rgb * 2 - 1);
+    float3 stratum3NormalXZ = normalize(tex2D(Stratum3NormalSampler, position.xz * Stratum3NormalTile.xy).rgb * 2 - 1);
+    float3 stratum3NormalYZ = normalize(tex2D(Stratum3NormalSampler, position.yz * Stratum3NormalTile.xy).rgb * 2 - 1);
     float3 stratum3Normal = stratum3NormalYZ * blendWeights.x + stratum3NormalXZ * blendWeights.y;
 
     float3 normal = lowerNormal;
-    normal = normalize(lerp(normal,stratum0Normal,mask0.x));
-    normal = normalize(lerp(normal,stratum1Normal,mask0.y));
-    normal = normalize(lerp(normal,stratum2Normal,mask0.z));
-    normal = normalize(lerp(normal,stratum3Normal,mask0.w));
-    normal = normalize(lerp(normal,stratum4Normal,mask1.x));
-    normal = normalize(lerp(normal,stratum5Normal,mask1.y));
-    normal = normalize(lerp(normal,stratum6Normal,mask1.z));
+    normal = UDNBlending(normal,stratum0Normal,mask0.x);
+    normal = UDNBlending(normal,stratum1Normal,mask0.y);
+    normal = UDNBlending(normal,stratum2Normal,mask0.z);
+    normal = UDNBlending(normal,stratum3Normal,mask0.w);
+    normal = UDNBlending(normal,stratum4Normal,mask1.x);
+    normal = UDNBlending(normal,stratum5Normal,mask1.y);
+    normal = UDNBlending(normal,stratum6Normal,mask1.z);
 
     return float4( 0.5 + 0.5 * normal.rgb, 1);
 }
@@ -2970,9 +2968,9 @@ technique Terrain152B <
 //#region Terrain200
 
 // These shaders use PBR rendering and height maps for texture splatting. UDN blending is used for the normals.
-// The normal map scales are controlled by the albedo scales to ensure that they use the same values.
-// The layer mask of S7 acts as a roughness multiplier with 0.5 as the neutral value.
 // Height processing happens at two scales, the albedo scales control the near scale and the normal scales control the far scale.
+// Consequently the normal map scales are controlled by the albedo scales except on the lower layer.
+// The layer mask of S7 acts as a roughness multiplier with 0.5 as the neutral value.
 // SpecularColor.r is used to control the blurriness of the texture splatting
 // Every second stratum is rotated by 30 degrees to help break up texture repetion by loading the same texture into two adjacent slots.
 // The better texture splatting allows this, traditional lerping would just produce mushed results if attempting this. That's why the
@@ -2993,7 +2991,7 @@ float4 Terrain200NormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
         mask1 = saturate(mask1 * 2 - 1);
     }
 
-    float3 lowerNormal    = normalize(tex2D(LowerNormalSampler,    position.xy * LowerAlbedoTile.xy   ).rgb * 2 - 1);
+    float3 lowerNormal    = normalize(tex2D(LowerNormalSampler,    position.xy * LowerNormalTile.xy   ).rgb * 2 - 1);
     float3 stratum0Normal = normalize(tex2D(Stratum0NormalSampler, rotated_pos * Stratum0AlbedoTile.xy).rgb * 2 - 1);
     float3 stratum1Normal = normalize(tex2D(Stratum1NormalSampler, position.xy * Stratum1AlbedoTile.xy).rgb * 2 - 1);
     float3 stratum2Normal = normalize(tex2D(Stratum2NormalSampler, rotated_pos * Stratum2AlbedoTile.xy).rgb * 2 - 1);
@@ -3214,7 +3212,7 @@ float4 Terrain200BNormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
         mask1 = saturate(mask1 * 2 - 1);
     }
 
-    float3 lowerNormal    = normalize(tex2D(LowerNormalSampler,    position.xy * LowerAlbedoTile.xy   ).rgb * 2 - 1);
+    float3 lowerNormal    = normalize(tex2D(LowerNormalSampler,    position.xy * LowerNormalTile.xy   ).rgb * 2 - 1);
     float3 stratum0Normal = normalize(tex2D(Stratum0NormalSampler, rotated_pos * Stratum0AlbedoTile.xy).rgb * 2 - 1);
     float3 stratum1Normal = normalize(tex2D(Stratum1NormalSampler, position.xy * Stratum1AlbedoTile.xy).rgb * 2 - 1);
     float3 stratum4Normal = normalize(tex2D(Stratum4NormalSampler, rotated_pos * Stratum4AlbedoTile.xy).rgb * 2 - 1);

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -2442,12 +2442,7 @@ float4 Terrain001AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
         mask1 = saturate(mask1 * 2 - 1);
     }
 
-    // x = ambient occlusion
-    // y = shadows
-    // z = shadows
-    // w = water depth
-    float4 terrainInfo = tex2D(Stratum7AlbedoSampler, coordinates.xy);
-    float terrainShadow = terrainInfo.g;
+    float terrainShadow = tex2D(Stratum7AlbedoSampler, coordinates.xy).a;
 
     // disable shadows when game settings tell us to
     if (0 == ShadowsEnabled) {

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -1360,6 +1360,7 @@ float4 DecalsPS( VS_OUTPUT inV, uniform bool inShadows) : COLOR
     // We want the decals to behave consistently with the rest of the ground
     if (ShaderUsesPbrRendering()) {
         color = PBR(inV, decalAlbedo.rgb, normal, 0.9 * (1-decalSpec.r), waterDepth);
+        color = ApplyWaterColor(-1 * inV.mViewDirection, inV.mTexWT.z, waterDepth, color);
     } else {
         color = CalculateLighting(normal, inV.mTexWT.xyz, decalAlbedo.xyz, decalSpec.r, waterDepth, inV.mShadow, inShadows).xyz;
     }

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -2594,7 +2594,8 @@ float4 Terrain100AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 
     if (halfRange) {
         mask0 = saturate(mask0 * 2 - 1);
-        mask1 = saturate(mask1 * 2 - 1);
+        // Don't touch the roughness mask
+        mask1.xyz = saturate(mask1.xyz * 2 - 1);
     }
 
     float4 lowerAlbedo =    sampleAlbedo(LowerAlbedoSampler,    position.xy, LowerAlbedoTile.xy,    float2(0.0, 0.0), true);
@@ -2780,7 +2781,8 @@ float4 Terrain200AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 
     if (halfRange) {
         mask0 = saturate(mask0 * 2 - 1);
-        mask1 = saturate(mask1 * 2 - 1);
+        // Don't touch the roughness mask
+        mask1.xyz = saturate(mask1.xyz * 2 - 1);
     }
 
     // This shader wouldn't compile because it would have to store too many variables if we didn't use this trick in the vertex shader
@@ -2969,7 +2971,8 @@ float4 Terrain200BAlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 
     if (halfRange) {
         mask0 = saturate(mask0 * 2 - 1);
-        mask1 = saturate(mask1 * 2 - 1);
+        // Don't touch the roughness mask
+        mask1.xyz = saturate(mask1.xyz * 2 - 1);
     }
 
     // This shader wouldn't compile because it would have to store too many variables if we didn't use this trick in the vertex shader

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -2866,7 +2866,7 @@ technique Terrain250 <
 }
 
 // Stratum2 and Stratum3 use biplanar mapping to improve cliff texturing
-float4 Terrain200BNormalsPS ( VS_OUTPUT inV, uniform bool halfRange, uniform float macrotextureblend ) : COLOR
+float4 Terrain200BNormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 {
     // height is now in the z coordinate
     float3 position = TerrainScale.xxx * inV.mTexWT;
@@ -2926,7 +2926,7 @@ float4 Terrain200BNormalsPS ( VS_OUTPUT inV, uniform bool halfRange, uniform flo
     return float4( 0.5 + 0.5 * normal.rgb, 1);
 }
 
-float4 Terrain200BAlbedoPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
+float4 Terrain200BAlbedoPS ( VS_OUTPUT inV, uniform bool halfRange, uniform float macrotextureblend ) : COLOR
 {
     float3 position = TerrainScale.xxx * inV.mTexWT;
     // 30° rotation

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -2737,6 +2737,14 @@ float4 Terrain200NormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
     float3 stratum5Normal = normalize(tex2D(Stratum5NormalSampler, position.xy * Stratum5AlbedoTile.xy).rgb * 2 - 1);
     float3 stratum6Normal = normalize(tex2D(Stratum6NormalSampler, rotated_pos * Stratum6AlbedoTile.xy).rgb * 2 - 1);
 
+    // We need to rotate the normal vectors back.
+    // I thought we would have to flip the multiplication order,
+    // compared to the uv rotation, but empirically this is correct.
+    stratum0Normal.xy = mul(stratum0Normal.xy, rotationMatrix);
+    stratum2Normal.xy = mul(stratum2Normal.xy, rotationMatrix);
+    stratum4Normal.xy = mul(stratum4Normal.xy, rotationMatrix);
+    stratum6Normal.xy = mul(stratum6Normal.xy, rotationMatrix);
+
     float stratum0Height = sampleHeight(rotated_pos, Stratum0AlbedoTile.xy, Stratum0NormalTile.xy, float2(0.5, 0.0), true);
     float stratum1Height = sampleHeight(position.xy, Stratum1AlbedoTile.xy, Stratum1NormalTile.xy, float2(0.0, 0.5), true);
     float stratum2Height = sampleHeight(rotated_pos, Stratum2AlbedoTile.xy, Stratum2NormalTile.xy, float2(0.5, 0.5), true);
@@ -2908,6 +2916,11 @@ float4 Terrain200BNormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
     float3 stratum4Normal = normalize(tex2D(Stratum4NormalSampler, rotated_pos * Stratum4AlbedoTile.xy).rgb * 2 - 1);
     float3 stratum5Normal = normalize(tex2D(Stratum5NormalSampler, position.xy * Stratum5AlbedoTile.xy).rgb * 2 - 1);
     float3 stratum6Normal = normalize(tex2D(Stratum6NormalSampler, rotated_pos * Stratum6AlbedoTile.xy).rgb * 2 - 1);
+
+    // we need to rotate the normal vectors back
+    stratum0Normal.xy = mul(stratum0Normal.xy, rotationMatrix);
+    stratum4Normal.xy = mul(stratum4Normal.xy, rotationMatrix);
+    stratum6Normal.xy = mul(stratum6Normal.xy, rotationMatrix);
 
     float stratum0Height = sampleHeight(rotated_pos, Stratum0AlbedoTile.xy, Stratum0NormalTile.xy, float2(0.5, 0.0), true);
     float stratum1Height = sampleHeight(position.xy, Stratum1AlbedoTile.xy, Stratum1NormalTile.xy, float2(0.0, 0.5), true);


### PR DESCRIPTION
It is time for another stab at the terrain shader file. I gathered some new insights on what is important to produce the best results possible, partly from looking at BAR maps, partly from looking at maps from @sting-2 and these insights are the basis for the following changes.

The way to achieve the best quality seems have a huge (4-8k) map-wide albedo texture and to interpolate it with the other stratums that provide details. This way the map albedo texture can break up the texture repetition and provide much more color variation than you could by just tiling 8 regular textures.
The mapwide normal should ideally also be huge. To justify thse file sizes we need compression. Until now we stored the shadows, water depth and map normals all in one texture. Compressing these leads to severe artifacts and basically all our inputs are sensitive to artifacts. The dds compression was meant for colors, but if we store non-color data we notice this much more.
But we can utilize a trick. The alpha channel does not suffer from artifacts and the color channels also have basically no compression if we store the same value in all color channels. So we can store two channels per texture, with compression, and it still looks good. We put the normals in the texture like this:
R: normal y
G: normal y
B: normal y
A: normal X
A nice upside of this is that normal decals are compatible to this encoding. So if someone has made a normal decal for their map normals in the past, they can use this texture directly.
By separating the normals from the shadows and water, we can crank up the resolution on the normal texture and choose a lower resolution on our shadows and water, saving disk space.

In fact, we only need the water channel when we have a map with biplanar mapping (BPM), because then we need to sample one more texture and we are already at the limit of texture samplers. We store the channels like this:
R: AO or water depth
G: AO
B: AO
A: shadow
When we have a non-BPM map, then we can fill the water channel with AO and save the texture with compression without artifacts. On BPM maps we have to save uncompressed because we need the water channel.

The downside of all this is that we have one more texture now. I changed the slots of our map textures to accomodate this as well as possible.

The macro texture now does not have a dedicated slot anymore. Instead the lower albedo can get used as a macrotexture. Different shader variants allow control over how the lower albedo gets treated.

I changed the order of the height an roughness channels in the PBR atlas. This way you can omit the alpha channel with BC1 compression for shaders that don't need the height information. This helps saving a little bit of disk space.

**Summary of the changes:**

_Previous layout:_
upper albedo: map info texture: map normal + water depth + shadow
stratum7 albedo: macrotexture with alpha
stratum7 normal: heightroughness texture

_New Layout:_
upper albedo: RoughnessAndHeight texture
stratum7 albedo: terrain info texture: water depth + ambient occlusion + shadow
stratum7 normal: terrain normal: normal y + normal x

- Usage of these textures is controlled by their respective scale.
- Added a biplanar mapping version for the Terrain100 shaders.
- Added shaders for different ways to blend the lower albedo on top.
- Increased the contrast of the height blending
- Switched height and roughness channels


