### PR TITLE
Console improvements

### DIFF
--- a/changelog/snippets/fix.6684.md
+++ b/changelog/snippets/fix.6684.md
@@ -1,0 +1,5 @@
+- (#6684) Improve the search result list in the console:
+
+  - Results are now listed alphabetically.
+  - Clicking on an item doesn't steal focus from the text input, so up/down arrows can be used to keep moving through the list.
+  - The list correctly follows the focus item and wraps around if needed.

--- a/lua/ui/dialogs/console.lua
+++ b/lua/ui/dialogs/console.lua
@@ -145,6 +145,7 @@ function CreateDialog()
                 conFuncsList.Height:Set(function()
                     return math.min(consoleOutput.Height(), conFuncsList:GetRowHeight() * numMatches)
                 end)
+                -- guarantee order so it is sorted alphabetically (case-insensitive)
                 for i,v in ipairs(matches) do
                     conFuncsList:AddItem(v)
                 end

--- a/lua/ui/dialogs/console.lua
+++ b/lua/ui/dialogs/console.lua
@@ -145,7 +145,7 @@ function CreateDialog()
                 conFuncsList.Height:Set(function()
                     return math.min(consoleOutput.Height(), conFuncsList:GetRowHeight() * numMatches)
                 end)
-                for i,v in matches do
+                for i,v in ipairs(matches) do
                     conFuncsList:AddItem(v)
                 end
 
@@ -155,6 +155,12 @@ function CreateDialog()
 
                 conFuncsList:SetSelection(conFuncsList:GetItemCount() - 1)
                 conFuncsList:ScrollToBottom()
+
+                local oldOnClick = conFuncsList.OnClick
+                conFuncsList.OnClick = function(self, row, event)
+                    oldOnClick(conFuncsList, row, event)
+                    edit:AcquireFocus()
+                end
 
                 conFuncsList.OnDoubleClick = function(self, row)
                     edit:SetText(conFuncsList:GetItem(row))
@@ -175,8 +181,14 @@ function CreateDialog()
 
     edit.OnNonTextKeyPressed = function(self, keycode)
         local function ChangeConFuncSelection(direction)
-            local selection = math.max(math.min(conFuncsList:GetSelection() + direction, conFuncsList:GetItemCount() - 1), 0)
+            local selection = conFuncsList:GetSelection() + direction
+            if selection < 0 then
+                selection = conFuncsList:GetItemCount() - 1
+            elseif selection == conFuncsList:GetItemCount() then
+                selection = 0
+            end
             conFuncsList:SetSelection(selection)
+            conFuncsList:ShowItem(selection)
             raiseConFuncList = false
             edit:SetText(conFuncsList:GetItem(selection))
             raiseConFuncList = true


### PR DESCRIPTION
- search results are now sorted alphabetically
- clicking on an item doesnt steal the focus from the Edit, so UP/DOWN keys can be used to keep moving through the list
- the item list correctly follows the focus item and wraps around if needed