### PR TITLE
Proper generic intellisense for LazyVar

### DIFF
--- a/engine/User/CMauiBitmap.lua
+++ b/engine/User/CMauiBitmap.lua
@@ -1,6 +1,8 @@
 ---@meta
 
 ---@class moho.bitmap_methods : moho.control_methods
+---@field BitmapWidth Lazy<number>
+---@field BitmapHeight Lazy<number>
 local CMauiBitmap = {}
 
 ---

--- a/engine/User/CMauiControl.lua
+++ b/engine/User/CMauiControl.lua
@@ -1,13 +1,13 @@
 ---@meta
 
 ---@class moho.control_methods : Destroyable
----@field Left LazyVar<number>
----@field Width LazyVar<number>
----@field Right LazyVar<number>
----@field Top LazyVar<number>
----@field Height LazyVar<number>
----@field Bottom LazyVar<number>
----@field Depth LazyVar<number>
+---@field Left Lazy<number>
+---@field Width Lazy<number>
+---@field Right Lazy<number>
+---@field Top Lazy<number>
+---@field Height Lazy<number>
+---@field Bottom Lazy<number>
+---@field Depth Lazy<number>
 local CMauiControl = {}
 
 ---

--- a/engine/User/CMauiScrollbar.lua
+++ b/engine/User/CMauiScrollbar.lua
@@ -14,10 +14,10 @@ function CMauiScrollbar:DoScrollLines(lines)
 end
 
 ---
----@param background string
----@param thumbMiddle string
----@param thumbTop string
----@param thumbBottom string
+---@param background string?
+---@param thumbMiddle string?
+---@param thumbTop string?
+---@param thumbBottom string?
 function CMauiScrollbar:SetNewTextures(background, thumbMiddle, thumbTop, thumbBottom)
 end
 

--- a/engine/User/CMauiText.lua
+++ b/engine/User/CMauiText.lua
@@ -1,10 +1,10 @@
 ---@meta
 
 ---@class moho.text_methods : moho.control_methods
----@field FontAscent LazyVar<number>
----@field FontDescent LazyVar<number>
----@field FontExternalLeading LazyVar<number>
----@field TextAdvance LazyVar<number>
+---@field FontAscent Lazy<number>
+---@field FontDescent Lazy<number>
+---@field FontExternalLeading Lazy<number>
+---@field TextAdvance Lazy<number>
 local CMauiText = {}
 
 ---

--- a/lua/lazyvar.lua
+++ b/lua/lazyvar.lua
@@ -15,7 +15,8 @@ local WeakKeyMeta = { __mode = 'k' }
 
 ---@alias Lazy<T> T | LazyVar<T> | fun(): T
 
----@class LazyVar<T> : Destroyable, OnDirtyListener, function
+---@class LazyVar<T> : { Set:(fun(self:LazyVar<T>, value:Lazy<T>)), Destroy: fun(self:LazyVar<T>), OnDirty: fun(var:LazyVar<T>) }
+---@class LazyVar: Destroyable, OnDirtyListener
 ---@field OnDirty? function
 ---@field [1] any                           # Cached result of what we represent
 ---@field [2] boolean                       # Flag whether the lazy var is busy
@@ -281,7 +282,7 @@ LazyVarMetaTable.__index = LazyVarMetaTable
 
 ---@generic T
 ---@param initial? T defaults to `0`
----@return LazyVar<T>
+---@return Lazy<T>
 function Create(initial)
     local setmetatable = setmetatable
     local WeakKeyMeta = WeakKeyMeta

--- a/lua/lazyvar.lua
+++ b/lua/lazyvar.lua
@@ -13,7 +13,10 @@ local ExtendedErrorMessages = false
 local EvalContext = nil
 local WeakKeyMeta = { __mode = 'k' }
 
+---Repesents callable instance of LazyVar
 ---@alias Lazy<T> LazyVar<T> | fun(): T
+
+---Repesents Lazy instance of Lazy T or the value itself
 ---@alias LazyValue<T> Lazy<T> | T
 
 ---@class LazyVar<T> : { Set: (fun(self:LazyVar<T>, value:LazyValue<T>)), Destroy: fun(self:LazyVar<T>), OnDirty: fun(var:LazyVar<T>), SetValue: fun(self:LazyVar<T>, value:T), SetFunction: fun(self:LazyVar<T>, f: Lazy<T>) }

--- a/lua/lazyvar.lua
+++ b/lua/lazyvar.lua
@@ -13,9 +13,10 @@ local ExtendedErrorMessages = false
 local EvalContext = nil
 local WeakKeyMeta = { __mode = 'k' }
 
----@alias Lazy<T> T | LazyVar<T> | fun(): T
+---@alias Lazy<T> LazyVar<T> | fun(): T
+---@alias LazyValue<T> Lazy<T> | T
 
----@class LazyVar<T> : { Set:(fun(self:LazyVar<T>, value:Lazy<T>)), Destroy: fun(self:LazyVar<T>), OnDirty: fun(var:LazyVar<T>) }
+---@class LazyVar<T> : { Set: (fun(self:LazyVar<T>, value:LazyValue<T>)), Destroy: fun(self:LazyVar<T>), OnDirty: fun(var:LazyVar<T>), SetValue: fun(self:LazyVar<T>, value:T), SetFunction: fun(self:LazyVar<T>, f: Lazy<T>) }
 ---@class LazyVar: Destroyable, OnDirtyListener
 ---@field OnDirty? function
 ---@field [1] any                           # Cached result of what we represent

--- a/lua/lazyvar.lua
+++ b/lua/lazyvar.lua
@@ -17,9 +17,9 @@ local WeakKeyMeta = { __mode = 'k' }
 ---@alias Lazy<T> LazyVar<T> | fun(): T
 
 ---Repesents Lazy instance of Lazy T or the value itself
----@alias LazyValue<T> Lazy<T> | T
+---@alias LazyOrValue<T> Lazy<T> | T
 
----@class LazyVar<T> : { Set: (fun(self:LazyVar<T>, value:LazyValue<T>)), Destroy: fun(self:LazyVar<T>), OnDirty: fun(var:LazyVar<T>), SetValue: fun(self:LazyVar<T>, value:T), SetFunction: fun(self:LazyVar<T>, f: Lazy<T>) }
+---@class LazyVar<T> : { Set: (fun(self:LazyVar<T>, value:LazyOrValue<T>)), Destroy: fun(self:LazyVar<T>), OnDirty: fun(var:LazyVar<T>), SetValue: fun(self:LazyVar<T>, value:T), SetFunction: fun(self:LazyVar<T>, f: Lazy<T>) }
 ---@class LazyVar: Destroyable, OnDirtyListener
 ---@field OnDirty? function
 ---@field [1] any                           # Cached result of what we represent

--- a/lua/maui/bitmap.lua
+++ b/lua/maui/bitmap.lua
@@ -40,7 +40,7 @@ local ScaleNumber = import("/lua/maui/layouthelpers.lua").ScaleNumber
 Bitmap = ClassUI(moho.bitmap_methods, Control) {
     ---@param self Bitmap
     ---@param parent Control
-    ---@param filename? LazyValue<FileName>
+    ---@param filename? LazyOrValue<FileName>
     ---@param debugname? string
     __init = function(self, parent, filename, debugname)
         InternalCreateBitmap(self, parent)
@@ -64,7 +64,7 @@ Bitmap = ClassUI(moho.bitmap_methods, Control) {
     end,
 
     ---@param self Bitmap
-    ---@param texture LazyValue<FileName>
+    ---@param texture LazyOrValue<FileName>
     ---@param border? number defaults to 1
     SetTexture = function(self, texture, border)
         if self._filename then
@@ -75,7 +75,7 @@ Bitmap = ClassUI(moho.bitmap_methods, Control) {
     end,
 
     ---@param self Bitmap
-    ---@param color LazyValue<Color>
+    ---@param color LazyOrValue<Color>
     SetSolidColor = function(self, color)
         self._color:Set(color)
     end,

--- a/lua/maui/bitmap.lua
+++ b/lua/maui/bitmap.lua
@@ -40,7 +40,7 @@ local ScaleNumber = import("/lua/maui/layouthelpers.lua").ScaleNumber
 Bitmap = ClassUI(moho.bitmap_methods, Control) {
     ---@param self Bitmap
     ---@param parent Control
-    ---@param filename? Lazy<FileName>
+    ---@param filename? LazyValue<FileName>
     ---@param debugname? string
     __init = function(self, parent, filename, debugname)
         InternalCreateBitmap(self, parent)
@@ -64,7 +64,7 @@ Bitmap = ClassUI(moho.bitmap_methods, Control) {
     end,
 
     ---@param self Bitmap
-    ---@param texture Lazy<FileName>
+    ---@param texture LazyValue<FileName>
     ---@param border? number defaults to 1
     SetTexture = function(self, texture, border)
         if self._filename then
@@ -75,7 +75,7 @@ Bitmap = ClassUI(moho.bitmap_methods, Control) {
     end,
 
     ---@param self Bitmap
-    ---@param color Lazy<Color>
+    ---@param color LazyValue<Color>
     SetSolidColor = function(self, color)
         self._color:Set(color)
     end,

--- a/lua/maui/bitmap.lua
+++ b/lua/maui/bitmap.lua
@@ -31,12 +31,12 @@ local Control = import("/lua/maui/control.lua").Control
 local ScaleNumber = import("/lua/maui/layouthelpers.lua").ScaleNumber
 
 ---@class BitmapTexture
----@field _texture LazyVar<FileName>
+---@field _texture Lazy<FileName>
 ---@field _border number
 
 ---@class Bitmap : moho.bitmap_methods, Control, InternalObject
 ---@field _filename BitmapTexture
----@field _color LazyVar<Color>
+---@field _color Lazy<Color>
 Bitmap = ClassUI(moho.bitmap_methods, Control) {
     ---@param self Bitmap
     ---@param parent Control

--- a/lua/maui/border.lua
+++ b/lua/maui/border.lua
@@ -15,8 +15,8 @@
 local Control = import("/lua/maui/control.lua").Control
 
 ---@class MauiBorder : moho.border_methods, Control, InternalObject
----@field BorderWidth LazyVar
----@field BorderHeight LazyVar
+---@field BorderWidth Lazy<number>
+---@field BorderHeight Lazy<number>
 Border = ClassUI(moho.border_methods, Control) {
 
     __init = function(self, parent, debugname)

--- a/lua/maui/cursor.lua
+++ b/lua/maui/cursor.lua
@@ -6,7 +6,7 @@
 ---@class UICursor : moho.cursor_methods, InternalObject
 ---@field _hotspotX number
 ---@field _hotspotY number
----@field _filename LazyVar<FileName>
+---@field _filename Lazy<FileName>
 ---@field _animThread? thread
 ---@field ReticleInformation UIReticle
 Cursor = ClassUI(moho.cursor_methods) {
@@ -43,6 +43,7 @@ Cursor = ClassUI(moho.cursor_methods) {
         KillThread(self._animThread)
         if filename and numFrames and numFrames != 1 then
             local extPos = filename:find(".dds")
+            ---@diagnostic disable-next-line:cast-local-type
             filename = filename:sub(1, extPos - 1)
             self._animThread = ForkThread(function()
                 fps = 1 / fps

--- a/lua/maui/itemlist.lua
+++ b/lua/maui/itemlist.lua
@@ -22,6 +22,9 @@ local ScaleNumber = import("/lua/maui/layouthelpers.lua").ScaleNumber
 ---@class ItemList : moho.item_list_methods, Control, InternalObject
 ItemList = ClassUI(moho.item_list_methods, Control) {
 
+    ---@param self ItemList
+    ---@param parent Control
+    ---@param debugname? string
     __init = function(self, parent, debugname)
         InternalCreateItemList(self, parent)
         if debugname then

--- a/lua/maui/layouthelpers.lua
+++ b/lua/maui/layouthelpers.lua
@@ -118,7 +118,7 @@ end
 
 --- Sets a control's height to the height of a texture (with optional padding)
 ---@param control Control
----@param filename LazyValue<FileName>
+---@param filename LazyOrValue<FileName>
 ---@param padding? number
 function SetHeightFromTexture(control, filename, padding)
     if iscallable(filename) then -- skinnable file
@@ -1284,7 +1284,7 @@ local LayouterAttributeControl = ClassSimple {
     --- Sets the left edge of the control
     ---@generic T : LayouterAttributeControl
     ---@param self T
-    ---@param left LazyValue<number>
+    ---@param left LazyOrValue<number>
     ---@return T
     Left = function(self, left)
         self.layoutControl.Left:Set(left)
@@ -1294,7 +1294,7 @@ local LayouterAttributeControl = ClassSimple {
     --- Sets the top edge of the control
     ---@generic T : LayouterAttributeControl
     ---@param self T
-    ---@param top LazyValue<number>
+    ---@param top LazyOrValue<number>
     ---@return T
     Top = function(self, top)
         self.layoutControl.Top:Set(top)
@@ -1304,7 +1304,7 @@ local LayouterAttributeControl = ClassSimple {
     --- Sets the right edge of the control
     ---@generic T : LayouterAttributeControl
     ---@param self T
-    ---@param right LazyValue<number>
+    ---@param right LazyOrValue<number>
     ---@return T
     Right = function(self, right)
         self.layoutControl.Right:Set(right)
@@ -1314,7 +1314,7 @@ local LayouterAttributeControl = ClassSimple {
     --- Sets the bottom edge of the control
     ---@generic T : LayouterAttributeControl
     ---@param self T
-    ---@param bottom LazyValue<number>
+    ---@param bottom LazyOrValue<number>
     ---@return T
     Bottom = function(self, bottom)
         self.layoutControl.Bottom:Set(bottom)
@@ -2109,7 +2109,7 @@ local LayouterAttributeColor = ClassSimple {
     --- Sets the color of the control
     ---@generic T : LayouterAttributeColor
     ---@param self T
-    ---@param color LazyValue<Color> color as a hexcode
+    ---@param color LazyOrValue<Color> color as a hexcode
     ---@return T
     Color = function(self, color)
         local control = self.layoutControl

--- a/lua/maui/layouthelpers.lua
+++ b/lua/maui/layouthelpers.lua
@@ -2109,7 +2109,7 @@ local LayouterAttributeColor = ClassSimple {
     --- Sets the color of the control
     ---@generic T : LayouterAttributeColor
     ---@param self T
-    ---@param color Lazy<Color> color as a hexcode
+    ---@param color LazyValue<Color> color as a hexcode
     ---@return T
     Color = function(self, color)
         local control = self.layoutControl

--- a/lua/maui/layouthelpers.lua
+++ b/lua/maui/layouthelpers.lua
@@ -118,7 +118,7 @@ end
 
 --- Sets a control's height to the height of a texture (with optional padding)
 ---@param control Control
----@param filename Lazy<FileName>
+---@param filename LazyValue<FileName>
 ---@param padding? number
 function SetHeightFromTexture(control, filename, padding)
     if iscallable(filename) then -- skinnable file
@@ -1284,7 +1284,7 @@ local LayouterAttributeControl = ClassSimple {
     --- Sets the left edge of the control
     ---@generic T : LayouterAttributeControl
     ---@param self T
-    ---@param left Lazy<number>
+    ---@param left LazyValue<number>
     ---@return T
     Left = function(self, left)
         self.layoutControl.Left:Set(left)
@@ -1294,7 +1294,7 @@ local LayouterAttributeControl = ClassSimple {
     --- Sets the top edge of the control
     ---@generic T : LayouterAttributeControl
     ---@param self T
-    ---@param top Lazy<number>
+    ---@param top LazyValue<number>
     ---@return T
     Top = function(self, top)
         self.layoutControl.Top:Set(top)
@@ -1304,7 +1304,7 @@ local LayouterAttributeControl = ClassSimple {
     --- Sets the right edge of the control
     ---@generic T : LayouterAttributeControl
     ---@param self T
-    ---@param right Lazy<number>
+    ---@param right LazyValue<number>
     ---@return T
     Right = function(self, right)
         self.layoutControl.Right:Set(right)
@@ -1314,7 +1314,7 @@ local LayouterAttributeControl = ClassSimple {
     --- Sets the bottom edge of the control
     ---@generic T : LayouterAttributeControl
     ---@param self T
-    ---@param bottom Lazy<number>
+    ---@param bottom LazyValue<number>
     ---@return T
     Bottom = function(self, bottom)
         self.layoutControl.Bottom:Set(bottom)

--- a/lua/maui/scrollbar.lua
+++ b/lua/maui/scrollbar.lua
@@ -79,10 +79,10 @@ Scrollbar = ClassUI(moho.scrollbar_methods, Control) {
     end,
 
     ---@param self Scrollbar
-    ---@param background  LazyValue<FileName>?
-    ---@param thumbMiddle LazyValue<FileName>?
-    ---@param thumbTop    LazyValue<FileName>?
-    ---@param thumbBottom LazyValue<FileName>?
+    ---@param background  LazyOrValue<FileName>?
+    ---@param thumbMiddle LazyOrValue<FileName>?
+    ---@param thumbTop    LazyOrValue<FileName>?
+    ---@param thumbBottom LazyOrValue<FileName>?
     SetTextures = function(self, background, thumbMiddle, thumbTop, thumbBottom)
         if background and self._bg then self._bg:Set(background) end
         if thumbMiddle and self._tm then self._tm:Set(thumbMiddle) end

--- a/lua/maui/scrollbar.lua
+++ b/lua/maui/scrollbar.lua
@@ -14,10 +14,10 @@ ScrollAxis = {
 }
 
 ---@class Scrollbar : moho.scrollbar_methods, Control, InternalObject
----@field _bg LazyVar<FileName>
----@field _tm LazyVar<FileName>
----@field _tt LazyVar<FileName>
----@field _tb LazyVar<FileName>
+---@field _bg Lazy<FileName>
+---@field _tm Lazy<FileName>
+---@field _tt Lazy<FileName>
+---@field _tb Lazy<FileName>
 ---@field UpButton? Button
 ---@field DownButton? Button
 Scrollbar = ClassUI(moho.scrollbar_methods, Control) {

--- a/lua/maui/scrollbar.lua
+++ b/lua/maui/scrollbar.lua
@@ -79,10 +79,10 @@ Scrollbar = ClassUI(moho.scrollbar_methods, Control) {
     end,
 
     ---@param self Scrollbar
-    ---@param background  Lazy<FileName> | nil
-    ---@param thumbMiddle Lazy<FileName> | nil
-    ---@param thumbTop    Lazy<FileName> | nil
-    ---@param thumbBottom Lazy<FileName> | nil
+    ---@param background  LazyValue<FileName>?
+    ---@param thumbMiddle LazyValue<FileName>?
+    ---@param thumbTop    LazyValue<FileName>?
+    ---@param thumbBottom LazyValue<FileName>?
     SetTextures = function(self, background, thumbMiddle, thumbTop, thumbBottom)
         if background and self._bg then self._bg:Set(background) end
         if thumbMiddle and self._tm then self._tm:Set(thumbMiddle) end

--- a/lua/maui/statusbar.lua
+++ b/lua/maui/statusbar.lua
@@ -19,7 +19,7 @@ StatusBar = ClassUI(Bitmap) {
     ---@param rangeMax number
     ---@param vertical boolean # When true, the bar grows vertically instead of horizontally
     ---@param negative boolean # When true, the bar grows in the other direction
-    ---@param background LazyValue<FileName>
+    ---@param background LazyOrValue<FileName>
     ---@param bar FileName
     ---@param stretchTextures boolean
     ---@param debugname string

--- a/lua/maui/statusbar.lua
+++ b/lua/maui/statusbar.lua
@@ -19,7 +19,7 @@ StatusBar = ClassUI(Bitmap) {
     ---@param rangeMax number
     ---@param vertical boolean # When true, the bar grows vertically instead of horizontally
     ---@param negative boolean # When true, the bar grows in the other direction
-    ---@param background Lazy<FileName>
+    ---@param background LazyValue<FileName>
     ---@param bar FileName
     ---@param stretchTextures boolean
     ---@param debugname string

--- a/lua/maui/statusbar.lua
+++ b/lua/maui/statusbar.lua
@@ -6,7 +6,7 @@ local MathFloor = math.floor
 ---@field _rangeMin number
 ---@field _rangeMax number
 ---@field _minSlidePercent number
----@field _value LazyVar<number>
+---@field _value Lazy<number>
 ---@field _vertical boolean
 ---@field _negative boolean
 ---@field _stretch boolean
@@ -38,8 +38,8 @@ StatusBar = ClassUI(Bitmap) {
 
         if vertical then
             if negative then
-                self._bar.Top:SetFunction(self.Top)
-                self._bar.Bottom:SetFunction(
+                self._bar.Top:Set(self.Top)
+                self._bar.Bottom:Set(
                     function()
                         local rangePercent = self:_CalcRangePercent()
                         if not self._stretch then
@@ -49,8 +49,8 @@ StatusBar = ClassUI(Bitmap) {
                     end
                 )
             else
-                self._bar.Bottom:SetFunction(self.Bottom)
-                self._bar.Top:SetFunction(
+                self._bar.Bottom:Set(self.Bottom)
+                self._bar.Top:Set(
                     function()
                         local rangePercent = self:_CalcRangePercent()
                         if not self._stretch then
@@ -60,12 +60,12 @@ StatusBar = ClassUI(Bitmap) {
                     end
                 )
             end
-            self._bar.Left:SetFunction(self.Left)
-            self._bar.Width:SetFunction(self.Width)
+            self._bar.Left:Set(self.Left)
+            self._bar.Width:Set(self.Width)
         else
             if negative then
-                self._bar.Right:SetFunction(self.Right)
-                self._bar.Left:SetFunction(
+                self._bar.Right:Set(self.Right)
+                self._bar.Left:Set(
                     function()
                         local rangePercent = self:_CalcRangePercent()
                         if not self._stretch then
@@ -75,8 +75,8 @@ StatusBar = ClassUI(Bitmap) {
                     end
                 )
             else
-                self._bar.Left:SetFunction(self.Left)
-                self._bar.Right:SetFunction(
+                self._bar.Left:Set(self.Left)
+                self._bar.Right:Set(
                     function()
                         local rangePercent = self:_CalcRangePercent()
                         if not self._stretch then
@@ -86,8 +86,8 @@ StatusBar = ClassUI(Bitmap) {
                     end
                 )
             end
-            self._bar.Top:SetFunction(self.Top)
-            self._bar.Height:SetFunction(self.Height)
+            self._bar.Top:Set(self.Top)
+            self._bar.Height:Set(self.Height)
         end
     end,
 
@@ -103,7 +103,7 @@ StatusBar = ClassUI(Bitmap) {
             value = max
         end
 
-        self._value:SetValue(value)
+        self._value:Set(value)
     end,
 
     ---@param self StatusBar

--- a/lua/ui/controls/border.lua
+++ b/lua/ui/controls/border.lua
@@ -5,14 +5,14 @@ local NinePatch = import("/lua/ui/controls/ninepatch.lua").NinePatch
 Border = ClassUI(NinePatch) {
     ---@param self Border
     ---@param parent Control
-    ---@param topLeft LazyValue<FileName>
-    ---@param topRight LazyValue<FileName>
-    ---@param bottomLeft LazyValue<FileName>
-    ---@param bottomRight LazyValue<FileName>
-    ---@param left LazyValue<FileName>
-    ---@param right LazyValue<FileName>
-    ---@param top LazyValue<FileName>
-    ---@param bottom LazyValue<FileName>
+    ---@param topLeft LazyOrValue<FileName>
+    ---@param topRight LazyOrValue<FileName>
+    ---@param bottomLeft LazyOrValue<FileName>
+    ---@param bottomRight LazyOrValue<FileName>
+    ---@param left LazyOrValue<FileName>
+    ---@param right LazyOrValue<FileName>
+    ---@param top LazyOrValue<FileName>
+    ---@param bottom LazyOrValue<FileName>
     __init = function(self, parent, topLeft, topRight, bottomLeft, bottomRight, left, right, top, bottom)
         NinePatch.__init(self, parent, nil, topLeft, topRight, bottomLeft, bottomRight, left, right, top, bottom)
     end

--- a/lua/ui/controls/border.lua
+++ b/lua/ui/controls/border.lua
@@ -5,14 +5,14 @@ local NinePatch = import("/lua/ui/controls/ninepatch.lua").NinePatch
 Border = ClassUI(NinePatch) {
     ---@param self Border
     ---@param parent Control
-    ---@param topLeft Lazy<FileName>
-    ---@param topRight Lazy<FileName>
-    ---@param bottomLeft Lazy<FileName>
-    ---@param bottomRight Lazy<FileName>
-    ---@param left Lazy<FileName>
-    ---@param right Lazy<FileName>
-    ---@param top Lazy<FileName>
-    ---@param bottom Lazy<FileName>
+    ---@param topLeft LazyValue<FileName>
+    ---@param topRight LazyValue<FileName>
+    ---@param bottomLeft LazyValue<FileName>
+    ---@param bottomRight LazyValue<FileName>
+    ---@param left LazyValue<FileName>
+    ---@param right LazyValue<FileName>
+    ---@param top LazyValue<FileName>
+    ---@param bottom LazyValue<FileName>
     __init = function(self, parent, topLeft, topRight, bottomLeft, bottomRight, left, right, top, bottom)
         NinePatch.__init(self, parent, nil, topLeft, topRight, bottomLeft, bottomRight, left, right, top, bottom)
     end

--- a/lua/ui/controls/checkbox.lua
+++ b/lua/ui/controls/checkbox.lua
@@ -18,12 +18,12 @@ local Group = import("/lua/maui/group.lua").Group
 Checkbox = ClassUI(Group) {
     ---@param self Checkbox
     ---@param parent Control
-    ---@param normalUnchecked Lazy<FileName>
-    ---@param normalChecked Lazy<FileName>
-    ---@param overUnchecked? Lazy<FileName> defaults to `normalUnchecked`
-    ---@param overChecked? Lazy<FileName> defaults to `normalChecked`
-    ---@param disabledUnchecked? Lazy<FileName> defaults to `normalUnchecked`
-    ---@param disabledChecked? Lazy<FileName> defaults to `normalChecked`
+    ---@param normalUnchecked LazyValue<FileName>
+    ---@param normalChecked LazyValue<FileName>
+    ---@param overUnchecked? LazyValue<FileName> defaults to `normalUnchecked`
+    ---@param overChecked? LazyValue<FileName> defaults to `normalChecked`
+    ---@param disabledUnchecked? LazyValue<FileName> defaults to `normalUnchecked`
+    ---@param disabledChecked? LazyValue<FileName> defaults to `normalChecked`
     ---@param label? UnlocalizedString
     ---@param labelRight? boolean if the label on the checkbox is to its right or left
     ---@param labelSize? number defaults to `13`
@@ -80,12 +80,12 @@ Checkbox = ClassUI(Group) {
     end,
 
     ---@param self Checkbox
-    ---@param normalUnchecked Lazy<FileName>
-    ---@param normalChecked Lazy<FileName>
-    ---@param overUnchecked? Lazy<FileName> defaults to `normalUnchecked`
-    ---@param overChecked? Lazy<FileName> defaults to `normalChecked`
-    ---@param disabledUnchecked? Lazy<FileName> defaults to `normalUnchecked`
-    ---@param disabledChecked? Lazy<FileName> defaults to `normalChecked`
+    ---@param normalUnchecked LazyValue<FileName>
+    ---@param normalChecked LazyValue<FileName>
+    ---@param overUnchecked? LazyValue<FileName> defaults to `normalUnchecked`
+    ---@param overChecked? LazyValue<FileName> defaults to `normalChecked`
+    ---@param disabledUnchecked? LazyValue<FileName> defaults to `normalUnchecked`
+    ---@param disabledChecked? LazyValue<FileName> defaults to `normalChecked`
     SetNewTextures = function(self, normalUnchecked, normalChecked, overUnchecked, overChecked, disabledUnchecked, disabledChecked)
         self.checkedStates = {
             up = normalChecked,

--- a/lua/ui/controls/checkbox.lua
+++ b/lua/ui/controls/checkbox.lua
@@ -18,12 +18,12 @@ local Group = import("/lua/maui/group.lua").Group
 Checkbox = ClassUI(Group) {
     ---@param self Checkbox
     ---@param parent Control
-    ---@param normalUnchecked LazyValue<FileName>
-    ---@param normalChecked LazyValue<FileName>
-    ---@param overUnchecked? LazyValue<FileName> defaults to `normalUnchecked`
-    ---@param overChecked? LazyValue<FileName> defaults to `normalChecked`
-    ---@param disabledUnchecked? LazyValue<FileName> defaults to `normalUnchecked`
-    ---@param disabledChecked? LazyValue<FileName> defaults to `normalChecked`
+    ---@param normalUnchecked LazyOrValue<FileName>
+    ---@param normalChecked LazyOrValue<FileName>
+    ---@param overUnchecked? LazyOrValue<FileName> defaults to `normalUnchecked`
+    ---@param overChecked? LazyOrValue<FileName> defaults to `normalChecked`
+    ---@param disabledUnchecked? LazyOrValue<FileName> defaults to `normalUnchecked`
+    ---@param disabledChecked? LazyOrValue<FileName> defaults to `normalChecked`
     ---@param label? UnlocalizedString
     ---@param labelRight? boolean if the label on the checkbox is to its right or left
     ---@param labelSize? number defaults to `13`
@@ -80,12 +80,12 @@ Checkbox = ClassUI(Group) {
     end,
 
     ---@param self Checkbox
-    ---@param normalUnchecked LazyValue<FileName>
-    ---@param normalChecked LazyValue<FileName>
-    ---@param overUnchecked? LazyValue<FileName> defaults to `normalUnchecked`
-    ---@param overChecked? LazyValue<FileName> defaults to `normalChecked`
-    ---@param disabledUnchecked? LazyValue<FileName> defaults to `normalUnchecked`
-    ---@param disabledChecked? LazyValue<FileName> defaults to `normalChecked`
+    ---@param normalUnchecked LazyOrValue<FileName>
+    ---@param normalChecked LazyOrValue<FileName>
+    ---@param overUnchecked? LazyOrValue<FileName> defaults to `normalUnchecked`
+    ---@param overChecked? LazyOrValue<FileName> defaults to `normalChecked`
+    ---@param disabledUnchecked? LazyOrValue<FileName> defaults to `normalUnchecked`
+    ---@param disabledChecked? LazyOrValue<FileName> defaults to `normalChecked`
     SetNewTextures = function(self, normalUnchecked, normalChecked, overUnchecked, overChecked, disabledUnchecked, disabledChecked)
         self.checkedStates = {
             up = normalChecked,

--- a/lua/ui/controls/ninepatch.lua
+++ b/lua/ui/controls/ninepatch.lua
@@ -15,15 +15,15 @@ local ScaleNumber = import("/lua/maui/layouthelpers.lua").ScaleNumber
 NinePatch = ClassUI(Group) {
     ---@param self NinePatch
     ---@param parent Control
-    ---@param center Lazy<FileName> | nil
-    ---@param topLeft Lazy<FileName>
-    ---@param topRight Lazy<FileName>
-    ---@param bottomLeft Lazy<FileName>
-    ---@param bottomRight Lazy<FileName>
-    ---@param left Lazy<FileName>
-    ---@param right Lazy<FileName>
-    ---@param top Lazy<FileName>
-    ---@param bottom Lazy<FileName>
+    ---@param center LazyValue<FileName>?
+    ---@param topLeft LazyValue<FileName>
+    ---@param topRight LazyValue<FileName>
+    ---@param bottomLeft LazyValue<FileName>
+    ---@param bottomRight LazyValue<FileName>
+    ---@param left LazyValue<FileName>
+    ---@param right LazyValue<FileName>
+    ---@param top LazyValue<FileName>
+    ---@param bottom LazyValue<FileName>
     __init = function(self, parent, center, topLeft, topRight, bottomLeft, bottomRight, left, right, top, bottom)
         Group.__init(self, parent)
 

--- a/lua/ui/controls/ninepatch.lua
+++ b/lua/ui/controls/ninepatch.lua
@@ -15,15 +15,15 @@ local ScaleNumber = import("/lua/maui/layouthelpers.lua").ScaleNumber
 NinePatch = ClassUI(Group) {
     ---@param self NinePatch
     ---@param parent Control
-    ---@param center LazyValue<FileName>?
-    ---@param topLeft LazyValue<FileName>
-    ---@param topRight LazyValue<FileName>
-    ---@param bottomLeft LazyValue<FileName>
-    ---@param bottomRight LazyValue<FileName>
-    ---@param left LazyValue<FileName>
-    ---@param right LazyValue<FileName>
-    ---@param top LazyValue<FileName>
-    ---@param bottom LazyValue<FileName>
+    ---@param center LazyOrValue<FileName>?
+    ---@param topLeft LazyOrValue<FileName>
+    ---@param topRight LazyOrValue<FileName>
+    ---@param bottomLeft LazyOrValue<FileName>
+    ---@param bottomRight LazyOrValue<FileName>
+    ---@param left LazyOrValue<FileName>
+    ---@param right LazyOrValue<FileName>
+    ---@param top LazyOrValue<FileName>
+    ---@param bottom LazyOrValue<FileName>
     __init = function(self, parent, center, topLeft, topRight, bottomLeft, bottomRight, left, right, top, bottom)
         Group.__init(self, parent)
 

--- a/lua/ui/lobby/sim-performance-popup.lua
+++ b/lua/ui/lobby/sim-performance-popup.lua
@@ -41,7 +41,8 @@ local Instance = nil
 ---@field Background Bitmap
 ---@field Foreground Group
 ---@field MaximumUnits number
----@field Percentage LazyVar
+---@field PercentageTop Lazy<number>
+---@field PercentageBottom Lazy<number>
 ---@field Bar Bitmap
 ---@field Label Text
 UISimPerformanceElement = ClassUI(Group) {

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -142,9 +142,10 @@ VK_NEXT = 34
 VK_UP = 38
 VK_DOWN = 40
 VK_PAUSE = 310
-
+---@type Lazy<Skin>
 local currentSkin = LazyVar.Create()
-
+---@type string
+---@diagnostic disable-next-line:assign-type-mismatch
 currentLayout = false
 changeLayoutFunction = false    -- set this function to get called with the new layout name when layout changes
 
@@ -316,7 +317,7 @@ end
 
 --- Sets the current skin table
 ---@param skin Skin
----@param overrideTable table
+---@param overrideTable? table
 function SetCurrentSkin(skin, overrideTable)
     local skinTable = skins[skin]
     if not skinTable then
@@ -469,11 +470,12 @@ end
 --- Given a path and name relative to the skin path, returns the full path based on the current skin
 ---@param filespec FileName
 ---@param checkMods? boolean
----@return FileName
+---@return FileName?
 function UIFile(filespec, checkMods)
     if UIFileBlacklist[filespec] then return filespec end
     local skins = import("/lua/skins/skins.lua").skins
     local useSkin = currentSkin()
+    ---@type FileName
     local currentPath = skins[useSkin].texturesPath
     local origPath = currentPath
 
@@ -550,7 +552,7 @@ end
 --- placement and destruction can occur. This creates a group which fills the screen.
 ---@param root Control
 ---@param debugName? string defaults to `"screenGroup"`
----@return Group
+---@return Group?
 function CreateScreenGroup(root, debugName)
     if not root then return end
     local screenGroup = Group(root, debugName or "screenGroup")
@@ -691,10 +693,10 @@ end
 
 --- Returns a button set up with a text overlay and a click sound
 ---@param parent Control
----@param up FileName
----@param down FileName
----@param over FileName
----@param disabled FileName
+---@param up LazyValue<FileName>
+---@param down LazyValue<FileName>
+---@param over LazyValue<FileName>
+---@param disabled LazyValue<FileName>
 ---@param label? UnlocalizedString
 ---@param pointSize? number
 ---@param textOffsetVert? number
@@ -717,15 +719,19 @@ function CreateButton(parent, up, down, over, disabled, label, pointSize, textOf
         rolloverCue = rolloverCue or "UI_Menu_Rollover_Sml"
     end
     if type(up) == 'string' then
+        ---@diagnostic disable-next-line:param-type-mismatch
         up = SkinnableFile(up)
     end
     if type(down) == 'string' then
+        ---@diagnostic disable-next-line:param-type-mismatch
         down = SkinnableFile(down)
     end
     if type(over) == 'string' then
+        ---@diagnostic disable-next-line:param-type-mismatch
         over = SkinnableFile(over)
     end
     if type(disabled) == 'string' then
+        ---@diagnostic disable-next-line:param-type-mismatch
         disabled = SkinnableFile(disabled)
     end
 
@@ -878,6 +884,9 @@ end
 --- benefit of code that uses "radiobtn" for its checkboxs' texture names. These are:
 --- `-d_btn_up.dds`, `-s_btn_up.dds`, `-d_btn_over.dds`, `-s_btn_over.dds`,
 --- `-d_btn_dis.dds`, and `-s_btn_dis.dds`
+---@param parent Control
+---@param texturePath FileName
+---@return Checkbox
 function CreateCheckboxStd(parent, texturePath)
     return Checkbox(parent,
         SkinnableFile(texturePath .. '-d_btn_up.dds'),
@@ -898,7 +907,7 @@ end
 ---@param labelSize any
 ---@param clickCue any
 ---@param rollCue any
----@return unknown
+---@return Checkbox
 function CreateCheckbox(parent, texturePath, label, labelRight, labelSize, clickCue, rollCue)
     return Checkbox(parent,
         SkinnableFile(texturePath .. 'd_up.dds'),
@@ -923,6 +932,9 @@ function CreateCollapseArrow(parent, position)
     if position ~= 't' and position ~= 'r' and position ~= 'l' then
         error("Collapse arrow position must be one of: 'l', 't', 'r'", 2)
     end
+
+    ---@type FileName
+    ---@diagnostic disable-next-line:assign-type-mismatch
     local prefix = "/game/tab-" .. position .. "-btn/tab-"
     return Checkbox(parent,
         SkinnableFile(prefix .. "close_btn_up.dds"),
@@ -941,7 +953,7 @@ end
 ---@param title LocalizedString
 ---@param buttons any
 ---@param default any
----@return unknown
+---@return RadioButtons
 function CreateRadioButtonsStd(parent, texturePath, title, buttons, default)
     local radioButton = RadioButtons(parent, title, buttons, default, "Arial", 14, fontColor,
         SkinnableFile(texturePath .. 'd_up.dds'),
@@ -972,6 +984,13 @@ function CreateDialogButtonStd(parent, filename, label, pointSize, textOffsetVer
 end
 
 --* return the standard scrollbar
+---comment
+---@param attachto Control
+---@param offset_right? number
+---@param filename? FileName
+---@param offset_bottom? number
+---@param offset_top? number
+---@return Scrollbar
 function CreateVertScrollbarFor(attachto, offset_right, filename, offset_bottom, offset_top)
     offset_right = offset_right or 0
     offset_bottom = offset_bottom or 0
@@ -1105,6 +1124,9 @@ function QuickDialog(parent, dialogText, button1Text, button1Callback, button2Te
     )
 
     local textHeight = 0
+
+    ---@type Control
+    ---@diagnostic disable-next-line:assign-type-mismatch
     local prevControl = false
     for i, v in tempTable do
         if i == 1 then
@@ -1147,8 +1169,15 @@ function QuickDialog(parent, dialogText, button1Text, button1Callback, button2Te
         return button
     end
 
-    ---@type Button, Button, Button
-    local button1, button2, button3 = false, false, false
+    ---@type Button
+    ---@diagnostic disable-next-line:assign-type-mismatch
+    local button1 = false
+    ---@type Button
+    ---@diagnostic disable-next-line:assign-type-mismatch
+    local button2 = false
+    ---@type Button
+    ---@diagnostic disable-next-line:assign-type-mismatch
+    local button3 = false
     if button1Text then
         button1 = MakeButton(button1Text, button1Callback)
     end
@@ -1228,7 +1257,7 @@ function QuickDialog(parent, dialogText, button1Text, button1Callback, button2Te
 end
 
 ---@param parent Control
----@param colorOverride? Color defaults to black
+---@param colorOverride? LazyValue<Color> defaults to black
 function CreateWorldCover(parent, colorOverride)
     colorOverride = colorOverride or "ff000000"
     local NumFrame = GetNumRootFrames() - 1
@@ -1308,10 +1337,13 @@ end
 function CreateDialogBrackets(parent, leftOffset, topOffset, rightOffset, bottomOffset, altTextures)
     local ret = Group(parent)
 
+    ---@type FileName
     local texturePath
     if altTextures then
+        ---@type FileName
         texturePath = "/scx_menu/panel-brackets-small"
     else
+        ---@type FileName
         texturePath = "/scx_menu/panel-brackets"
     end
 
@@ -1476,6 +1508,8 @@ end
 function CreateAnnouncementStd(primary, secondary, control)
     -- make it originate from the top
     if not control then
+        ---@type Frame
+        ---@diagnostic disable-next-line:assign-type-mismatch
         local frame = GetFrame(0)
         control = Group(frame)
         control.Left:Set(function() return frame.Left() + 0.49 * frame.Right() end)

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -31,39 +31,90 @@ local Layouter = LayoutHelpers.LayoutFor
 
 
 --* Handy global variables to assist skinning
-buttonFont = LazyVar.Create()            -- default font used for button faces
-factionFont = LazyVar.Create()      -- default font used for dialog button faces
-dialogButtonFont = LazyVar.Create()      -- default font used for dialog button faces
-bodyFont = LazyVar.Create()              -- font used for all other text
-fixedFont = LazyVar.Create()             -- font used for fixed width characters
-titleFont = LazyVar.Create()             -- font used for titles and labels
-fontColor = LazyVar.Create()             -- common font color
-fontOverColor = LazyVar.Create()             -- common font color
-fontDownColor = LazyVar.Create()             -- common font color
-tooltipTitleColor = LazyVar.Create()             -- common font color
-tooltipBorderColor = LazyVar.Create()             -- common font color
-bodyColor = LazyVar.Create()             -- common color for dialog body text
-dialogCaptionColor = LazyVar.Create()    -- common color for dialog titles
-dialogColumnColor = LazyVar.Create()     -- common color for column headers in a dialog
-dialogButtonColor = LazyVar.Create()     -- common color for buttons in a dialog
-highlightColor = LazyVar.Create()        -- text highlight color
-disabledColor = LazyVar.Create()         -- text disabled color
-panelColor = LazyVar.Create()            -- default color when drawing a panel
-transparentPanelColor = LazyVar.Create() -- default color when drawing a transparent panel
-consoleBGColor = LazyVar.Create()        -- console background color
-consoleFGColor = LazyVar.Create()        -- console foreground color (text)
-consoleTextBGColor = LazyVar.Create()    -- console text background color
-menuFontSize = LazyVar.Create()          -- font size used on main in game escape menu
-factionTextColor = LazyVar.Create()      -- faction color for text foreground
-factionBackColor = LazyVar.Create()      -- faction color for text background
+-- default font used for button faces
+---@type Lazy<string>
+buttonFont = LazyVar.Create()
+-- default font used for dialog button faces
+---@type Lazy<string>
+factionFont = LazyVar.Create()
+-- default font used for dialog button faces
+---@type Lazy<string>
+dialogButtonFont = LazyVar.Create()
+-- font used for all other text
+---@type Lazy<string>
+bodyFont = LazyVar.Create()
+-- font used for fixed width characters
+---@type Lazy<string>
+fixedFont = LazyVar.Create()
+-- font used for titles and labels
+---@type Lazy<string>
+titleFont = LazyVar.Create()
+-- common font color
+---@type Lazy<Color>
+fontColor = LazyVar.Create()
+-- common font color
+---@type Lazy<Color>
+fontOverColor = LazyVar.Create()
+-- common font color
+---@type Lazy<Color>
+fontDownColor = LazyVar.Create()
+-- common font color
+---@type Lazy<Color>
+tooltipTitleColor = LazyVar.Create()
+-- common font color
+---@type Lazy<Color>
+tooltipBorderColor = LazyVar.Create()
+-- common color for dialog body text
+---@type Lazy<Color>
+bodyColor = LazyVar.Create()
+-- common color for dialog titles
+---@type Lazy<Color>
+dialogCaptionColor = LazyVar.Create()
+-- common color for column headers in a dialog
+---@type Lazy<Color>
+dialogColumnColor = LazyVar.Create()
+-- common color for buttons in a dialog
+---@type Lazy<Color>
+dialogButtonColor = LazyVar.Create()
+---Text highlight color
+---@type Lazy<Color>
+highlightColor = LazyVar.Create()
+-- text disabled color
+---@type Lazy<Color>
+disabledColor = LazyVar.Create()
+-- default color when drawing a panel
+---@type Lazy<Color>
+panelColor = LazyVar.Create()
+-- default color when drawing a transparent panel
+---@type Lazy<Color>
+transparentPanelColor = LazyVar.Create()
+-- console background color
+---@type Lazy<Color>
+consoleBGColor = LazyVar.Create()
+-- console foreground color (text)
+---@type Lazy<Color>
+consoleFGColor = LazyVar.Create()
+-- console text background color
+---@type Lazy<Color>
+consoleTextBGColor = LazyVar.Create()
+-- font size used on main in game escape menu
+---@type Lazy<number>
+menuFontSize = LazyVar.Create()
+-- faction color for text foreground
+---@type Lazy<Color>
+factionTextColor = LazyVar.Create()
+-- faction color for text background
+---@type Lazy<Color>
+factionBackColor = LazyVar.Create()
 
 -- table of layouts supported by this skin, not a lazy var as we don't need updates
 layouts = nil
 
 --* other handy variables!
 consoleDepth = false  -- in order to get the console to always be on top, assign this number and never go over
-
-networkBool = LazyVar.Create()    -- boolean whether the game is local or networked
+-- boolean whether the game is local or networked
+---@type Lazy<boolean>
+networkBool = LazyVar.Create()
 
 -- Default scenario for skirmishes / MP Lobby
 defaultScenario = '/maps/scmp_039/scmp_039_scenario.lua'
@@ -535,7 +586,7 @@ end
 ---@param parent Control
 ---@param label? UnlocalizedString
 ---@param pointSize? number
----@param font? LazyVarString
+---@param font? LazyValue<string>
 ---@param dropshadow? boolean
 ---@return Text
 function CreateText(parent, label, pointSize, font, dropshadow)
@@ -571,7 +622,7 @@ function CreateBitmapStd(parent, filename, border)
 end
 
 ---@param parent Control
----@param color LazyVarColor
+---@param color LazyValue<Color>
 ---@return Bitmap
 function CreateBitmapColor(parent, color)
     local bitmap = Bitmap(parent)
@@ -599,11 +650,11 @@ end
 
 
 ---@param control Edit
----@param foreColor? LazyVarColor
----@param backColor? LazyVarColor
----@param highlightFore? LazyVarColor
----@param highlightBack? LazyVarColor
----@param fontFace? LazyVarString
+---@param foreColor? LazyValue<Color>
+---@param backColor? LazyValue<Color>
+---@param highlightFore? LazyValue<Color>
+---@param highlightBack? LazyValue<Color>
+---@param fontFace? LazyValue<string>
 ---@param fontSize? number
 ---@param charLimit? number
 function SetupEditStd(control, foreColor, backColor, highlightFore, highlightBack, fontFace, fontSize, charLimit)
@@ -1395,10 +1446,10 @@ local windowTextures = {
 ---@param lockSize? boolean Toggle to allow the user to adjust the size of the window.
 ---@param lockPosition? boolean Toggle to allow the user to adjust the position of the window.
 ---@param preferenceID? string Identifier used in the preference file to remember where this window was located last
----@param defaultLeft? Lazy<number> The default left boundary of the window, defaults to 10
----@param defaultTop? Lazy<number> The default top boundary of the window, defaults to 300
----@param defaultBottom? Lazy<number> The default bottom boundary of the window, defaults to 600
----@param defaultRight? Lazy<number> The default right boundary of the window, defaults to 210
+---@param defaultLeft? LazyValue<number> The default left boundary of the window, defaults to 10
+---@param defaultTop? LazyValue<number> The default top boundary of the window, defaults to 300
+---@param defaultBottom? LazyValue<number> The default bottom boundary of the window, defaults to 600
+---@param defaultRight? LazyValue<number> The default right boundary of the window, defaults to 210
 ---@return Window
 function CreateWindowStd(parent, title, icon, pin, config, lockSize, lockPosition, preferenceID, defaultLeft, defaultTop, defaultBottom, defaultRight)
     parent = parent or GetFrame(0)

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -588,7 +588,7 @@ end
 ---@param parent Control
 ---@param label? UnlocalizedString
 ---@param pointSize? number
----@param font? LazyValue<string>
+---@param font? LazyOrValue<string>
 ---@param dropshadow? boolean
 ---@return Text
 function CreateText(parent, label, pointSize, font, dropshadow)
@@ -624,7 +624,7 @@ function CreateBitmapStd(parent, filename, border)
 end
 
 ---@param parent Control
----@param color LazyValue<Color>
+---@param color LazyOrValue<Color>
 ---@return Bitmap
 function CreateBitmapColor(parent, color)
     local bitmap = Bitmap(parent)
@@ -652,11 +652,11 @@ end
 
 
 ---@param control Edit
----@param foreColor? LazyValue<Color>
----@param backColor? LazyValue<Color>
----@param highlightFore? LazyValue<Color>
----@param highlightBack? LazyValue<Color>
----@param fontFace? LazyValue<string>
+---@param foreColor? LazyOrValue<Color>
+---@param backColor? LazyOrValue<Color>
+---@param highlightFore? LazyOrValue<Color>
+---@param highlightBack? LazyOrValue<Color>
+---@param fontFace? LazyOrValue<string>
 ---@param fontSize? number
 ---@param charLimit? number
 function SetupEditStd(control, foreColor, backColor, highlightFore, highlightBack, fontFace, fontSize, charLimit)
@@ -693,10 +693,10 @@ end
 
 --- Returns a button set up with a text overlay and a click sound
 ---@param parent Control
----@param up LazyValue<FileName>
----@param down LazyValue<FileName>
----@param over LazyValue<FileName>
----@param disabled LazyValue<FileName>
+---@param up LazyOrValue<FileName>
+---@param down LazyOrValue<FileName>
+---@param over LazyOrValue<FileName>
+---@param disabled LazyOrValue<FileName>
 ---@param label? UnlocalizedString
 ---@param pointSize? number
 ---@param textOffsetVert? number
@@ -1257,7 +1257,7 @@ function QuickDialog(parent, dialogText, button1Text, button1Callback, button2Te
 end
 
 ---@param parent Control
----@param colorOverride? LazyValue<Color> defaults to black
+---@param colorOverride? LazyOrValue<Color> defaults to black
 function CreateWorldCover(parent, colorOverride)
     colorOverride = colorOverride or "ff000000"
     local NumFrame = GetNumRootFrames() - 1
@@ -1478,10 +1478,10 @@ local windowTextures = {
 ---@param lockSize? boolean Toggle to allow the user to adjust the size of the window.
 ---@param lockPosition? boolean Toggle to allow the user to adjust the position of the window.
 ---@param preferenceID? string Identifier used in the preference file to remember where this window was located last
----@param defaultLeft? LazyValue<number> The default left boundary of the window, defaults to 10
----@param defaultTop? LazyValue<number> The default top boundary of the window, defaults to 300
----@param defaultBottom? LazyValue<number> The default bottom boundary of the window, defaults to 600
----@param defaultRight? LazyValue<number> The default right boundary of the window, defaults to 210
+---@param defaultLeft? LazyOrValue<number> The default left boundary of the window, defaults to 10
+---@param defaultTop? LazyOrValue<number> The default top boundary of the window, defaults to 300
+---@param defaultBottom? LazyOrValue<number> The default bottom boundary of the window, defaults to 600
+---@param defaultRight? LazyOrValue<number> The default right boundary of the window, defaults to 210
 ---@return Window
 function CreateWindowStd(parent, title, icon, pin, config, lockSize, lockPosition, preferenceID, defaultLeft, defaultTop, defaultBottom, defaultRight)
     parent = parent or GetFrame(0)


### PR DESCRIPTION
## Description of the proposed changes
Annotations for generic LazyVar. It addresses issues that were appearing when working with generic types of this class.
* `Lazy<T>` - common generic for it. Represents object or function.
* `LazyVar<T>` - represents only object that has methods `Set`, `SetValue`, `SetFunction`, `Destroy` and `OnDirty`.
* `LazyOrValue<T>` - `Lazy<T>` or `T`. 

## *Why like this?*
*This is done like this because our intellisense doesn't support generic classes properly and also generic operators*.

## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version