### PR TITLE
Fix dragging in build queue getting stuck when two similar items are next to each other

### DIFF
--- a/changelog/snippets/fix.6689.md
+++ b/changelog/snippets/fix.6689.md
@@ -1,0 +1,1 @@
+- (#6689) Fix units being dragged in the build queue getting visually stuck when a unit moves directly behind another unit of the same type as a result of the dragging.

--- a/lua/ui/game/construction.lua
+++ b/lua/ui/game/construction.lua
@@ -2428,7 +2428,8 @@ function SetSecondaryDisplay(type)
                         table.insert(data, {type = 'enhancementqueue', unitID = item.id, icon = item.icon, name = item.name, enhancement = item.enhancement})
                     else
                         newStack = {type = 'queuestack', id = item.id, count = item.displayCount or item.count, position = index}
-                        if lastStack and lastStack.id == newStack.id then
+                        -- stacking the queue while dragging an item will make dragging show the wrong index
+                        if not dragging and lastStack and lastStack.id == newStack.id then
                             newStack.position = index - 1
                         else
                             index = index + 1


### PR DESCRIPTION
## Issue
If a unit in the queue was dragged in front of the same type of unit it would invisibly get stacked, thus getting the unit stuck in that position until it was moved away to an index which doesn't have the same unit type behind it.

Another way to think about it is that the stacking happening while the unit is being dragged desyncs the visual position of the item being dragged (the unit icon) and the actual position being dragged to (the drag indicator shown on the corners of the item).


https://github.com/user-attachments/assets/c5aa7070-be99-4301-b275-61becf6ba314


## Description of the proposed changes
Disable stacking of same-id queue items while dragging is enabled.

## Testing done on the proposed changes
The item being dragged does not get stuck when dragged around. Make sure you enable the draggable build queue game option when testing this.

https://github.com/user-attachments/assets/c0e6b267-7dad-460b-ace0-70c6dde20867



## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version