### PR TITLE
Reduce the delay before pausing to 1 tick

### DIFF
--- a/changelog/snippets/features.6691.md
+++ b/changelog/snippets/features.6691.md
@@ -1,0 +1,3 @@
+- (#6691) Reduce delay of automatically pausing upgrades after assisting to 1 tick
+
+This was initially 5 ticks, but apparently it also works after waiting just 1 tick. No resources are 'leaked' to the upgrade by waiting only 1 tick.

--- a/changelog/snippets/features.6691.md
+++ b/changelog/snippets/features.6691.md
@@ -1,3 +1,3 @@
 - (#6691) Reduce delay of automatically pausing upgrades after assisting to 1 tick
 
-This was initially 5 ticks, but apparently it also works after waiting just 1 tick. No resources are 'leaked' to the upgrade by waiting only 1 tick.
+This was initially 5 ticks. By waiting 5 ticks _some_ resources would be spent on the upgrade. After careful testing the feature appears to work fine when waiting just a single tick. And if we only wait a single tick then no resources are spent on the upgrade.

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -361,12 +361,14 @@ local function UpgradeUnit(unit)
     -- inform the user
     print("Upgrade unit")
 
-    -- pause it
-    WaitTicks(5)
+    -- wait one tick for the upgrade to start
+    WaitTicks(1)
+
     if IsDestroyed(unit) then
         return
     end
 
+    -- pause the unit (again)
     SetPaused(units, true)
 end
 


### PR DESCRIPTION
## Description of the proposed changes

Reduces the delay before a unit is paused to just 1 tick. I'm not entirely sure why it was 5 ticks to begin with. Because of the additional ticks _some_ resources would be spent on the unit in question.

Based on a discussion on [Discord](https://discord.com/channels/197033481883222026/1349762080428789791).

## Testing done on the proposed changes

Run a game and observe that the feature still works as expected. No resources are 'leaked' to the upgrade.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version