### PR TITLE
Fix factories not immediately building queue after finished upgrades or cancelled land/navy units

### DIFF
--- a/changelog/snippets/fix.6692.md
+++ b/changelog/snippets/fix.6692.md
@@ -1,1 +1,1 @@
-- (#6692) Fix factories not immediately starting to build queued units after the factory finishes upgrading.
+- (#6692) Fix factories not immediately starting to build queued units after the factory finishes upgrading, or when a currently building land or navy unit is cancelled.

--- a/changelog/snippets/fix.6692.md
+++ b/changelog/snippets/fix.6692.md
@@ -1,0 +1,1 @@
+- (#6692) Fix factories not immediately starting to build queued units after the factory finishes upgrading.

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -1,4 +1,7 @@
 
+local Unit = import("/lua/sim/unit.lua").Unit
+local UnitOnStopBuild = Unit.OnStopBuild
+
 local StructureUnit = import("/lua/sim/units/structureunit.lua").StructureUnit
 local StructureUnitOnCreate = StructureUnit.OnCreate
 local StructureUnitOnDestroy = StructureUnit.OnDestroy
@@ -426,6 +429,30 @@ FactoryUnit = ClassUnit(StructureUnit) {
         ---@param self FactoryUnit
         Main = function(self)
             self:RolloffBody()
+        end,
+    },
+
+    UpgradingState = State(StructureUnit.UpgradingState) {
+        --- Adapted from StructureUnit to unblock the build area when the factory upgrade finishes.
+        ---@param self FactoryUnit
+        ---@param unitBuilding Unit
+        ---@param order string
+        OnStopBuild = function(self, unitBuilding, order)
+            UnitOnStopBuild(self, unitBuilding, order)
+            self:EnableDefaultToggleCaps()
+
+            if unitBuilding:GetFractionComplete() == 1 then
+                NotifyUpgrade(self, unitBuilding)
+                self:StopUpgradeEffects(unitBuilding)
+                self:PlayUnitSound('UpgradeEnd')
+
+                -- Since `Destroy` wouldn't do so, immediately unblock the build area
+                -- of the new factory by setting collision shape to none. This allows
+                -- the new factory to immediately start working on its queue.
+                self:SetCollisionShape("None")
+
+                self:Destroy()
+            end
         end,
     },
 

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -196,6 +196,8 @@ FactoryUnit = ClassUnit(StructureUnit) {
 
     ---@param self FactoryUnit
     OnFailedToBuild = function(self)
+        -- Instantly clear the build area so the next build can start, since unit `Destroy` doesn't do so.
+        self.UnitBeingBuilt:SetCollisionShape('None')
         StructureUnitOnFailedToBuild(self)
         self.FactoryBuildFailed = true
         self:StopBuildFx()


### PR DESCRIPTION
## Issue
The old factory blocks the build area of the new factory right when the upgrade finishes, causing the new factory to see that its build area is blocked and waiting to start building its queue.

https://github.com/user-attachments/assets/751ab022-d043-42f9-b735-92933477de40



## Description of the proposed changes
Remove the collision box of the old factory when the upgrade finishes so that the build area is unblocked immediately.


## Testing done on the proposed changes
Queue units after an upgrade in a factory and see that the units immediately start building when the upgrade is finished.

```
   CreateUnitAtMouse('xrb0304', 0,    0.41,   -0.60, -0.00000)
   CreateUnitAtMouse('xrb0304', 0,    0.41,   -0.60, -0.00000)
   CreateUnitAtMouse('xrb0304', 0,    0.41,   -0.60, -0.00000)
   CreateUnitAtMouse('xrb0304', 0,    0.41,   -0.60, -0.00000)
   CreateUnitAtMouse('xrb0304', 0,    0.41,   -0.60, -0.00000)
   CreateUnitAtMouse('xrb0304', 0,    0.41,   -0.60, -0.00000)
   CreateUnitAtMouse('xrb0304', 0,    0.41,   -0.60, -0.00000)
   CreateUnitAtMouse('xrb0304', 0,    0.41,   -0.60, -0.00000)
   CreateUnitAtMouse('xrb0304', 0,    0.41,   -0.60, -0.00000)
   CreateUnitAtMouse('xrb0304', 0,    0.41,   -0.60, -0.00000)
   CreateUnitAtMouse('xab1401', 0,    2.47,    7.65, -0.00000)
   CreateUnitAtMouse('uab0102', 0,   -6.59,   -1.60, -0.00000)
```

https://github.com/user-attachments/assets/c789c198-9fe9-48b5-9d59-3cfe1cb0764e

## Additional context
It could be considered that fixing this bug takes away from the micro detail where you manually queue units into an empty queue right after an upgrade to get them building in the factory quicker.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version