### PR TITLE
Increase SaveGame character limit to 260

### DIFF
--- a/changelog/snippets/fix.6697.md
+++ b/changelog/snippets/fix.6697.md
@@ -1,0 +1,1 @@
+- (#6697) Fix saving games failing due to file path length limitations.

--- a/lua/ui/globals/InternalSaveGame.lua
+++ b/lua/ui/globals/InternalSaveGame.lua
@@ -29,7 +29,7 @@ do
     --- Hook to fix a buffer overflow security issue in the engine
     ---@param filename string
     _G.InternalSaveGame = function(filename, friendlyFilename, onCompletionCallback)
-        local characterLimit = 100
+        local characterLimit = 260 -- Windows's max filepath length
         if DebugAllocatedSize(filename) > characterLimit then
             filename = filename:sub(1, characterLimit)
         end


### PR DESCRIPTION
## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes #6673.

## Testing done on the proposed changes
My save path is 126 characters.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version