### PR TITLE
Fix being able to ctrl-k external factories

### DIFF
--- a/changelog/snippets/fix.6699.md
+++ b/changelog/snippets/fix.6699.md
@@ -1,0 +1,1 @@
+- (#6699) Fix being able to ctrl-k external factories.

--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -924,7 +924,7 @@ ExternalFactoryComponent = ClassSimple {
         if not IsDestroyed(self.ExternalFactory) then
             self.ExternalFactory:SetBusy(true)
             self.ExternalFactory:SetBlockCommandQueue(true)
-            self.ExternalFactory:Kill()
+            self.ExternalFactory:Destroy()
         end
     end,
 

--- a/lua/sim/units/ExternalFactoryUnit.lua
+++ b/lua/sim/units/ExternalFactoryUnit.lua
@@ -184,7 +184,7 @@ ExternalFactoryUnit = ClassUnit(Unit) {
 
     ---@param self ExternalFactoryUnit
     PlayFxRollOff = function(self)
-        self.Parent:StopBuPlayFxRollOffildFx()
+        self.Parent:PlayFxRollOff()
     end,
 
     ---@param self ExternalFactoryUnit

--- a/lua/sim/units/ExternalFactoryUnit.lua
+++ b/lua/sim/units/ExternalFactoryUnit.lua
@@ -95,7 +95,7 @@ ExternalFactoryUnit = ClassUnit(Unit) {
 
     ---@param self ExternalFactoryUnit
     ---@param unitbuilding Unit
-    ---@param order Layer
+    ---@param order "FactoryBuild" | "Repair" | "MobileBuild"
     OnStartBuild = function(self, unitbuilding, order)
         UnitOnStartBuild(self, unitbuilding, order)
         self.Parent:OnStartBuild(unitbuilding, order)
@@ -112,9 +112,10 @@ ExternalFactoryUnit = ClassUnit(Unit) {
 
     ---@param self ExternalFactoryUnit
     ---@param unitBeingBuilt Unit
-    OnStopBuild = function(self, unitBeingBuilt)
-        UnitOnStopBuild(self, unitBeingBuilt)
-        self.Parent:OnStopBuild(unitBeingBuilt)
+    ---@param order "FactoryBuild" | "Repair" | "MobileBuild"
+    OnStopBuild = function(self, unitBeingBuilt, order)
+        UnitOnStopBuild(self, unitBeingBuilt, order)
+        self.Parent:OnStopBuild(unitBeingBuilt, order)
         self.UnitBeingBuilt = nil
 
         if self.UpdateParentProgressThread then

--- a/lua/sim/units/ExternalFactoryUnit.lua
+++ b/lua/sim/units/ExternalFactoryUnit.lua
@@ -47,6 +47,7 @@ ExternalFactoryUnit = ClassUnit(Unit) {
 
         -- do not allow the unit to be killed or to take damage
         self.CanTakeDamage = false
+        self.CanBeKilled = false
 
         -- is inherited by units, mimic what factories have as their default
         self:SetFireState(2)


### PR DESCRIPTION
## Issue
You could ctrl-k external factories and they would be gone forever.

## Description of the proposed changes
- Sets `CanBeKilled` to false so that the factories cannot die.
- Since they cannot be killed anymore, Destroy must be called. External factories have no visuals or gameplay so none of that code should apply. @relent0r said that AI uses `.ExternalFactory` on the parent unit to interact with external factories, so the OnKilled callback no longer firing should also not be relevant.

## Testing done on the proposed changes
- Ordering an external factory to kill itself does not do anything.
- External factories are destroyed when the parent dies. Without the relevant change, they were draining resources while the parent unit was dead but not destroyed (for example when sinking).

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version