### PR TITLE
Fix unbuilt units not being destroyed in factories when mobile build orders are cancelled

### DIFF
--- a/changelog/snippets/fix.6700.md
+++ b/changelog/snippets/fix.6700.md
@@ -1,0 +1,1 @@
+- (#6700) Fix an edge case where mobile build orders issued to a factory and then cancelled would cause the unbuilt unit to not get destroyed and block the factory forever.

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -137,6 +137,11 @@ FactoryUnit = ClassUnit(StructureUnit) {
             self.DisabledAssist = nil
         end
 
+        -- Factory can stop building but still have an unbuilt unit if a mobile build order is issued and the order is cancelled
+        if unitBeingBuilt:GetFractionComplete() < 1 then
+            unitBeingBuilt:Destroy()
+        end
+
         if not (self.FactoryBuildFailed or IsDestroyed(self)) then
             self:StopBuildFx()
 


### PR DESCRIPTION

<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->
## Issue
You can do "OnStopBuild" with an unfinished unit by cancelling a `BuildMobile` order on the ground. This gets the factory locked up since there is no way to remove the unfinished unit.

![{EEAB1C1F-DD16-4452-9024-B40D635282E2}](https://github.com/user-attachments/assets/e7beeef7-5999-4d38-ba78-bebc1532d145)


## Description of the proposed changes
Destroy unbuilt units in FactoryUnit.OnStopBuild

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
An unfinished unit no longer remains in the factory after the mobile build order is cancelled.
Copy-paste command for testing:
```
CreateUnitAtMouse('urb0301', 0,    0.00,    0.00, -0.00000)
ForkThread(function() 
WaitTicks(10) 
ConExecute('UI_SelectByCategory +nearest FACTORY CYBRAN TECH3')
import('/lua/ui/game/commandmode.lua').StartCommandMode('build', {name = 'url0303'}) 
end)
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version