### PR TITLE
Fix exploit that spawns partially built units out of external factories on transfer

### DIFF
--- a/changelog/snippets/fix.6701.md
+++ b/changelog/snippets/fix.6701.md
@@ -1,0 +1,1 @@
+- (#6701) Fix an exploit where transferring external factories with unbuilt units would spawn built units instead.

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -156,6 +156,12 @@ function TransferUnitsOwnership(units, toArmy, captured)
 
         unit.IsBeingTransferred = true
 
+        -- For external factories, destroy the unit being built since otherwise it will be transferred as a built unit because it is attached indirectly
+        local externalUnitBeingBuilt = unit.ExternalFactory.UnitBeingBuilt
+        if externalUnitBeingBuilt then
+            externalUnitBeingBuilt:Destroy()
+        end
+
         -- changing owner
         local newUnit = ChangeUnitArmy(unit, toArmy)
         if not newUnit then


### PR DESCRIPTION
## Issue
First reported by @4z0t.
Units currently building in an external factory are attached indirectly, so the engine's usual army transfer behavior for standard factories doesn't destroy those units, and instead the unbuilt units are spawned as damaged units. In other words you can have an unit building in an external factory, transfer it to another player, and the unbuilt unit would respawn as a built but damaged unit for the other army.

https://github.com/user-attachments/assets/80bf1d32-a947-4927-bbb1-676e7b69f894


## Description of the proposed changes
In the SimUtils transfer function, before using the engine `ChangeUnitArmy` function, destroy the building unit in the external factory if it exists. All user transfers go through here, as well as all the share on death type of transfers. Some scenario or AI utils don't, but they don't seem to be an issue with this specific exploit.

## Testing done on the proposed changes
You can no longer spawn built units from transferring external factories with unbuilt units.
```
CreateUnitAtMouse('uas0303', 1,    0.00,    0.00, -0.00000)
```
```
import('/lua/SimUtils.lua').TransferUnitsOwnership(DebugGetSelection(), 1, false)
```

https://github.com/user-attachments/assets/f225db64-2828-4cb9-be41-c393e8af8677

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version