### PR TITLE
Fix unbuilt units staying around when issued with BuildMobile to external factories and cancelled

### DIFF
--- a/changelog/snippets/fix.6702.md
+++ b/changelog/snippets/fix.6702.md
@@ -1,0 +1,1 @@
+- (#6702) Fix being able to store unbuilt units inside carriers and place unbuilt units on the ground with the fatboy.

--- a/units/UEL0401/UEL0401_script.lua
+++ b/units/UEL0401/UEL0401_script.lua
@@ -102,6 +102,10 @@ UEL0401 = ClassUnit(TMobileFactoryUnit, ExternalFactoryComponent) {
     ---@param unitBeingBuilt Unit
     OnStopBuild = function(self, unitBeingBuilt)
         TMobileFactoryUnit.OnStopBuild(self, unitBeingBuilt)
+        -- Unbuilt units can be in `OnStopBuild` when a `BuildMobile` order gets cancelled.
+        if unitBeingBuilt:GetFractionComplete() < 1 then
+            unitBeingBuilt:Destroy()
+        end
         self.BuildingUnit = false
     end,
 
@@ -186,6 +190,13 @@ UEL0401 = ClassUnit(TMobileFactoryUnit, ExternalFactoryComponent) {
         ---@param unitBeingBuilt Unit
         OnStopBuild = function(self, unitBeingBuilt)
             TMobileFactoryUnit.OnStopBuild(self, unitBeingBuilt)
+            -- Unbuilt units can be in `OnStopBuild` when a `BuildMobile` order gets cancelled.
+            if unitBeingBuilt:GetFractionComplete() < 1 then
+                unitBeingBuilt:Destroy()
+                ChangeState(self, self.IdleState)
+                return
+            end
+
             ChangeState(self, self.RollingOffState)
         end,
     },


### PR DESCRIPTION
## Issue
First reported by @4z0t.
When a `BuildMobile` order is cancelled, `OnStopBuild` is called with an unbuilt unit. Carriers will put the unbuilt unit into their storage at that point because there are no checks for this scenario. Fatboy places the unbuilt unit on the ground. A `BuildMobile` order can be issued to factories trivially using UI mods. Thankfully it isn't a huge exploit because the unbuilt units are still unbuilt when they come out of storage.

https://github.com/user-attachments/assets/ccb41d39-8dd9-4bdd-b69d-0805989da310

After deployment:
![{90E9B0B3-9C13-43B7-A537-642E07BCDC61}](https://github.com/user-attachments/assets/214ee56e-bd4d-4acc-9789-81478de94cb8)

## Description of the proposed changes
- Carriers (Czar and all navy): Destroy unbuilt units in `OnStopBuildWithStorage` in the external factory component.
- Fatboy: Destroy unbuilt units in the `OnStopBuild` functions.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spawn a carrier, select the external factory, and then issue a buildmobile order within 5 range (default buildrange) near the rear of the carrier where the external factory is actually located. Then move the build order around to cancel it repeatedly. No units should be added to the carrier's storage.
```
CreateUnitAtMouse('uas0303', 0,    0.00,    0.00,  0.00000)
```
```
import('/lua/ui/game/commandmode.lua').StartCommandMode('build', {name = 'uaa0304'})
```
Fatboy test:
Execution is similar to the carrier but Fatboy has animations and delays so those have to be accounted for. It also does not use the same `OnStopBuildWithStorage` function.
```
CreateUnitAtMouse('uel0401', 0,    0.00,    0.00, -0.00000)
```
```
import('/lua/ui/game/commandmode.lua').StartCommandMode('build', {name = 'uel0304'})
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version