### PR TITLE
Update annotation for `IsObserver()`

### DIFF
--- a/changelog/snippets/other.6703.md
+++ b/changelog/snippets/other.6703.md
@@ -1,0 +1,1 @@
+- (#6703) Update annotation for `IsObserver()`.

--- a/engine/User.lua
+++ b/engine/User.lua
@@ -818,10 +818,9 @@ end
 function IsKeyDown(keyCode)
 end
 
----
----@param playerId string
+---Returns whether current focus army is an observer.
 ---@return boolean
-function IsObserver(playerId)
+function IsObserver()
 end
 
 --- Issue a factory build or upgrade command to your selection


### PR DESCRIPTION
Proper annotation for `IsObserver()`. According to engine it doesn't take any arguments.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version