### PR TITLE
Shader improvement

### DIFF
--- a/changelog/snippets/graphics.6683.md
+++ b/changelog/snippets/graphics.6683.md
@@ -1,0 +1,3 @@
+- (#6683 and #6704) Rework and improve the newly added terrain shaders.
+
+The actual changes are pretty technical, but if you are a mapper you can find an in-depth explanation on how to use the new shaders here: https://wiki.faforever.com/en/Development/Shaders/terrain-shaders

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -1795,33 +1795,26 @@ technique LowFidelityLighting
 /* # Blending techniques # */
 
 float splatLerp(float t1, float t2, float t2height, float opacity, uniform float blurriness) {
-    // We need to increase the contrast of the height
-    float height2 = (1.6 * (t2height * (1 - 2 * blurriness) + blurriness) - 0.3) + opacity;
-    float threshold = max(1, height2) - blurriness;
-    float factor = 0;
-    if (opacity > 0) {
-        factor = (opacity >= 1) ? 1 : max(height2 - threshold, 0) / blurriness;
-    }
-    return lerp(t1, t2, factor);
+    return splatLerp(t1.xxxx, t2.xxxx, t2height, opacity, blurriness).x;
 }
 
 float4 splatLerp(float4 t1, float4 t2, float t2height, float opacity, uniform float blurriness = 0.06) {
-    // We need to increase the contrast of the height
-    float height2 = (1.6 * (t2height * (1 - 2 * blurriness) + blurriness) - 0.3) + opacity;
-    float threshold = max(1, height2) - blurriness;
+    t2height = lerp(t2height, 0.5, blurriness);
+    // Increase the contrast of the height. 0.6 is a good default value for SpecularColor.g
+    t2height = (1 + SpecularColor.g) * t2height - 0.5 * SpecularColor.g;
     float factor = 0;
     if (opacity > 0) {
-        factor = (opacity >= 1) ? 1 : max(height2 - threshold, 0) / blurriness;
+        factor = (opacity >= 1) ? 1 : saturate((t2height + opacity - 1 + 0.5 * blurriness) / blurriness);
     }
     return lerp(t1, t2, factor);
 }
 
 float3 splatBlendNormal(float3 n1, float3 n2, float t2height, float opacity, uniform float blurriness = 0.06) {
-    float height2 = (1.6 * (t2height * (1 - 2 * blurriness) + blurriness) - 0.3) + opacity;
-    float threshold = max(1, height2) - blurriness;
+    t2height = lerp(t2height, 0.5, blurriness);
+    t2height = (1 + SpecularColor.g) * t2height - 0.5 * SpecularColor.g;
     float factor = 0;
     if (opacity > 0) {
-        factor = (opacity >= 1) ? 1 : max(height2 - threshold, 0) / blurriness;
+        factor = (opacity >= 1) ? 1 : saturate((t2height + opacity - 1 + 0.5 * blurriness) / blurriness);
     }
     // This modification is to make low opacity normal maps more visible,
     // as we notice small changes to the albedo maps more easily.

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -2969,7 +2969,7 @@ float4 Terrain200NormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
 {
     float2 position = TerrainScale * inV.mTexWT;
     // 30° rotation
-    float2x2 rotationMatrix = float2x2(float2(0.866, -0.5), float2(0.5, 0.866));
+    float2x2 rotationMatrix = float2x2(float2(SpecularColor.b, -SpecularColor.a), float2(SpecularColor.a, SpecularColor.b));
     float2 rotated_pos = mul(position.xy, rotationMatrix);
 
     float4 mask0 = tex2D(UtilitySamplerA, position.xy);
@@ -3021,7 +3021,7 @@ float4 Terrain200AlbedoPS ( VS_OUTPUT inV, uniform bool halfRange, uniform float
 {
     float2 position = TerrainScale * inV.mTexWT;
     // 30° rotation
-    float2x2 rotationMatrix = float2x2(float2(0.866, -0.5), float2(0.5, 0.866));
+    float2x2 rotationMatrix = float2x2(float2(SpecularColor.b, -SpecularColor.a), float2(SpecularColor.a, SpecularColor.b));
     float2 rotated_pos = mul(position.xy, rotationMatrix);
 
     // do arithmetics to get range from (0, 1) to (-1, 1) as normal maps store their values as (0, 1)
@@ -3190,7 +3190,7 @@ float4 Terrain200BNormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
     // height is now in the z coordinate
     float3 position = TerrainScale.xxx * inV.mTexWT;
     // 30° rotation
-    float2x2 rotationMatrix = float2x2(float2(0.866, -0.5), float2(0.5, 0.866));
+    float2x2 rotationMatrix = float2x2(float2(SpecularColor.b, -SpecularColor.a), float2(SpecularColor.a, SpecularColor.b));
     float2 rotated_pos = mul(position.xy, rotationMatrix);
 
     float4 mask0 = tex2D(UtilitySamplerA, position.xy);
@@ -3246,7 +3246,7 @@ float4 Terrain200BAlbedoPS ( VS_OUTPUT inV, uniform bool halfRange, uniform floa
 {
     float3 position = TerrainScale.xxx * inV.mTexWT;
     // 30° rotation
-    float2x2 rotationMatrix = float2x2(float2(0.866, -0.5), float2(0.5, 0.866));
+    float2x2 rotationMatrix = float2x2(float2(SpecularColor.b, -SpecularColor.a), float2(SpecularColor.a, SpecularColor.b));
     float2 rotated_pos = mul(position.xy, rotationMatrix);
 
     // do arithmetics to get range from (0, 1) to (-1, 1) as normal maps store their values as (0, 1)


### PR DESCRIPTION
Two small additions to the recent PR #6683.

_1)_ The specular color channels now control more behavior in the Terrain200 shaders. The green channel controls the contrast increase of the heightmaps that are used for texture blending. The blue and alpha channels store the values of the rotation matrix. This makes the rotation angle adjustable which could be beneficial in some cases.

The editor will not expose these values for now. Instead it will provide reasonable defaults. I plan to do it this way to give people time to first learn the important features of the new shaders. Then when they need more control I can expose these values. By doing this change now in the fa shaders and having the editor provide good default values, we ensure that all maps using Terrain200 shaders have reasonable values in the specular color and we won't break existing maps when we finally introduce the feature officially.

_2)_ The blurriness slider was not behaving properly after my recent refacter. Part of the reason is that the code was very hard to understand. The code should be more readable now and the behaviour is fixed. Now a high blurriness creates a smooth gradient over the whole mask range.

Low blurriness:
![grafik](https://github.com/user-attachments/assets/b98f38cd-c678-484d-93af-9d38b2988d03)

High blurriness:
![grafik](https://github.com/user-attachments/assets/4968f000-e1ba-47e7-9d50-d3e28d9026f7)

old behaviour with high blurriness: The gradient is only in the lower half.
![grafik](https://github.com/user-attachments/assets/21902a8d-f254-4b8c-9750-0ec391ce4fe4)




## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version