### PR TITLE
Fix Hives building their upgrades as a separate unit

### DIFF
--- a/changelog/snippets/fix.6709.md
+++ b/changelog/snippets/fix.6709.md
@@ -1,0 +1,1 @@
+- (#6709) Fix hives being able to build their upgrades as a separate unit.

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -694,8 +694,8 @@
 ---@field AdjacentEnergyProductionMod? number
 ---@field AdjacentMassProductionMod? number
 ---@field AdjacentStructureEnergyMod? number
---- this define what units could be produced
----@field BuildableCategory CategoryName[]
+--- Defines what units can be built. Used by the engine.
+---@field BuildableCategory UnparsedCategory[]
 --- Defines what buildable units can only be produced through upgrading. Used in Lua.
 ---@field UpgradeOnlyCategory UnparsedCategory[]
 --- energy cost to build this unit

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -696,6 +696,8 @@
 ---@field AdjacentStructureEnergyMod? number
 --- this define what units could be produced
 ---@field BuildableCategory CategoryName[]
+--- Defines what buildable units can only be produced through upgrading. Used in Lua.
+---@field UpgradeOnlyCategory UnparsedCategory[]
 --- energy cost to build this unit
 ---@field BuildCostEnergy number
 --- mass cost to build this unit

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2819,6 +2819,20 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
             return false -- Report failure of OnStartBuild
         end
 
+        -- If desired, prevent engineer stations from building their upgrades as a separate unit
+        -- We need a separate table for this just in case a unit is intended to be able to build its own upgrade as a separate unit too
+        -- Its type is `UnparsedCategory[]` to make it behave identically to `Blueprint.Economy.BuildableCategory`
+        local upgradeOnlyCategory = self.Blueprint.Economy.UpgradeOnlyCategory
+        if upgradeOnlyCategory and order == "MobileBuild" then
+            for _, unparsedCat in upgradeOnlyCategory do
+                if EntityCategoryContains(ParseEntityCategory(unparsedCat), built) then
+                    -- Destroying the built unit will clear the command too, so we don't need to clear the entire queue (in case this exploit was done on accident).
+                    built:Destroy()
+                    return false
+                end
+            end
+        end
+
         -- We just started a construction (and haven't just been tasked to work on a half-done
         -- project.)
         if built:GetHealth() == 1 then

--- a/lua/sim/units/cybran/CConstructionStructureUnit.lua
+++ b/lua/sim/units/cybran/CConstructionStructureUnit.lua
@@ -130,7 +130,8 @@ CConstructionStructureUnit = ClassUnit(CStructureUnit, CConstructionTemplate) {
     ---@param unitBeingBuilt Unit
     ---@param order string
     OnStartBuild = function(self, unitBeingBuilt, order)
-        CStructureUnitOnStartBuild(self, unitBeingBuilt, order)
+        -- Don't create effects if the build fails due to building an upgraded hive as a unit instead of an upgrade
+        if not CStructureUnitOnStartBuild(self, unitBeingBuilt, order) then return false end
 
         -- quickly open the hive
         AnimatorSetRate(self.AnimationManipulator, 1)

--- a/units/XRB0104/XRB0104_unit.bp
+++ b/units/XRB0104/XRB0104_unit.bp
@@ -95,6 +95,7 @@ UnitBlueprint{
         BuildRate = 20,
         BuildTime = 1171,
         BuildableCategory = { "xrb0204" },
+        UpgradeOnlyCategory = { "xrb0204" },
         MaxBuildDistance = 15,
         RebuildBonusIds = { "xrb0104" },
     },

--- a/units/XRB0204/XRB0204_unit.bp
+++ b/units/XRB0204/XRB0204_unit.bp
@@ -91,6 +91,7 @@ UnitBlueprint{
         BuildRate = 37,
         BuildTime = 1171,
         BuildableCategory = { "xrb0304" },
+        UpgradeOnlyCategory = { "xrb0304" },
         DifferentialUpgradeCostCalculation = true,
         MaxBuildDistance = 20,
         RebuildBonusIds = { "xrb0104" },


### PR DESCRIPTION
## Issue
Hives are a unique unit in that they have the `REPAIR` category/capability and an upgrade they can build. This allows them to build their upgrades through UI tricks (issue a repair on a wreck of the upgrade then move the order) or UI scripts:

![{A7D12500-676C-460F-975F-E56A48C89770}](https://github.com/user-attachments/assets/ddb14f51-c69a-46fa-8cb7-65376fafd484)


## Description of the proposed changes
The engine doesn't distinguish between buildable units and upgradeable units so this has to be fixed in Lua.

- Add `UpgradeOnlyCategory` to `UnitBlueprint.Economy`, which is a table of `UnparsedCategory` just like `BuildableCategory`, and if any categories are found inside the table they are not allowed to be built through `BuildMobile`.

## Testing done on the proposed changes
With the following script a level 1 hive cannot build level 2 hives.
```
import("/lua/ui/game/commandmode.lua").StartCommandMode('build', {name = 'xrb0204'})
```
With the following script a level 2 hive cannot build level 3 hives.
```
import("/lua/ui/game/commandmode.lua").StartCommandMode('build', {name = 'xrb0304'})
```

## Additional context
I left the option as a separate table, since technically you could have units that upgrade into but also build their upgrades, although this isn't supported by the construction UI and it seems to cause issues with orders on an engine level, where the hover order and order assignment is based on the parent unit.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version