### PR TITLE
Fix torrent attackmove range

### DIFF
--- a/changelog/snippets/fix.6712.md
+++ b/changelog/snippets/fix.6712.md
@@ -1,0 +1,1 @@
+- (#6712) Fix the attack-move engagement range for Torrent (increased from 120 to 180)

--- a/units/XAS0306/XAS0306_unit.bp
+++ b/units/XAS0306/XAS0306_unit.bp
@@ -3,6 +3,7 @@ UnitBlueprint{
     AI = {
         AttackAngle = 60,
         GuardReturnRadius = 15,
+        GuardScanRadius = 180,
         TargetBones = {
             "Turret_Front",
             "Turret_Back",


### PR DESCRIPTION
## Description of the proposed changes
Torrent (Aeon T3 missile ship) guardscanradius isn't specified, and so is restricted to 120 on a range of 200.  This leads to the unit getting very close to enemy units, especially given its minimum range of 80.

I've changed to set the guardscanradius as 180 (partly as it doesn't 'feel' as bugged the closer to 200 it gets, but the higher the number the worse the theoretical performance impact).
That said, given how these units dont generally get built in large numbers, I think the performance impact should be negligible.

I'm happy for it to be 200 rather than 180 if felt like it's not necessary to be reduced at all.

I've done by changing the unit blueprint instead of the more general change that limits ranges to 120 in case there would be unforseen consequences from limiting the general range to 120.  However, I think it still worth considering adjusting the general range (e.g. instead of making it 120, making it math.max(120, math.min(200, (primaryWeapon.MaxRadius or 120), (primaryWeapon.MinRadius or 0) * 2) 
in other words, ensuring the guardscanradius is double the min range (subject to a limit of 200, or the weapon's actual range).

See also:
https://discord.com/channels/197033481883222026/1357604099545366588

## Testing done on the proposed changes
Replay used before and after change; before the change the missile ship got too close to enemy buildings:
![image](https://github.com/user-attachments/assets/8bd74542-baea-4546-92a7-8cacadf02e06)

After the change it stopped (when given the attack move) when the enemy building was only slightly inside its range (which is the normal behaviour I'd expect).

## Checklist
- [x] Changes are annotated, including comments where useful - Not applicable here (1 line blueprint change that doesnt require comment)
- [x] Changes are documented in the changelog for the next game version