### PR TITLE
Fix the hitbox of the Volcano

### DIFF
--- a/changelog/snippets/fix.6714.md
+++ b/changelog/snippets/fix.6714.md
@@ -1,1 +1,1 @@
-- (#6714) Prevent beam weapons from missing the Volcano (Aeon TMD).
+- (#6714) Prevent beam weapons from missing the Volcano (Aeon TMD) while it is firing. Also increase its hitbox size to match the firing animation.

--- a/changelog/snippets/fix.6714.md
+++ b/changelog/snippets/fix.6714.md
@@ -1,0 +1,1 @@
+- (#6714) Prevent beam weapons from missing the Volcano (Aeon TMD).

--- a/units/UAB4201/UAB4201_unit.bp
+++ b/units/UAB4201/UAB4201_unit.bp
@@ -2,7 +2,7 @@ UnitBlueprint{
     Description = "<LOC uab4201_desc>Tactical Missile Defense",
     AI = {
         TargetBones = {
-            "Door_Rt",
+            "Dome",
             "UAB4201",
         },
     },
@@ -118,7 +118,7 @@ UnitBlueprint{
     SelectionThickness = 0.45,
     CollisionOffsetY = -0.4,
     SizeX = 0.65,
-    SizeY = 0.9,
+    SizeY = 1.0,
     SizeZ = 1.25,
     StrategicIconName = "icon_structure2_antimissile",
     StrategicIconSortPriority = 200,


### PR DESCRIPTION
## Description of the proposed changes
Lasers could still miss the Volcano sometimes. The Volcano's `SizeY` now corresponds to the unit's height when it's deploying its flare.


## Checklist
- [x] Changes are documented in the changelog for the next game version