### PR TITLE
Fix Sera T1 transport attempting to load more T3 units than it has slots with "load into transports"

### DIFF
--- a/changelog/snippets/fix.6723.md
+++ b/changelog/snippets/fix.6723.md
@@ -1,0 +1,1 @@
+- (#6723) Fix Seraphim T1 transport attempting to load more T3 units than it has slots with the "load into transports" command.

--- a/units/XSA0107/XSA0107_unit.bp
+++ b/units/XSA0107/XSA0107_unit.bp
@@ -173,7 +173,7 @@ UnitBlueprint{
         Class1Capacity = 8,
         Class2AttachSize = 2,
         Class3AttachSize = 4,
-        SlotsLarge = 2,
+        SlotsLarge = 1,
         SlotsMedium = 4,
         SlotsSmall = 8,
         TransportClass = 10,


### PR DESCRIPTION
## Description of the proposed changes
Fixes #6717.

## Testing done on the proposed changes
Spawn 5 transports and 5 Othuums. Right click the transport button to issue "load into transports". The Othuums load into individual transports correctly.
```
   CreateUnitAtMouse('xsa0107', 0,   10.23,  -13.00, -1.77485)
   CreateUnitAtMouse('xsl0303', 0,    0.29,  -13.59,  1.60127)
   CreateUnitAtMouse('xsl0303', 0,   -0.03,   -6.52,  1.60127)
   CreateUnitAtMouse('xsa0107', 0,  -13.65,   -6.07, -1.79022)
   CreateUnitAtMouse('xsa0107', 0,   10.23,    1.00, -1.77478)
   CreateUnitAtMouse('xsl0303', 0,   -0.73,    5.90,  1.60127)
   CreateUnitAtMouse('xsa0107', 0,    9.23,    7.00, -1.77466)
   CreateUnitAtMouse('xsl0303', 0,   -1.07,   12.08,  1.60127)
   CreateUnitAtMouse('xsa0107', 0,  -14.65,   12.93, -1.79047)
   CreateUnitAtMouse('xsl0303', 0,    0.16,    0.25,  1.60127)
```

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version