### PR TITLE
Fix strategic bomber's 2nd formation

### DIFF
--- a/changelog/snippets/fix.6729.md
+++ b/changelog/snippets/fix.6729.md
@@ -1,0 +1,1 @@
+- (#6729) Fix 2nd formation (hold RMB + left click) for strategic bombers. The formation itself is more wider than default one, so it's easier to attack a target protected by SAMs and other AoE AAs.

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -813,6 +813,8 @@ function GrowthFormation(formationUnits)
     BlockBuilderLand(subUnitsList, subBlock, SubCategories, 1)
 
     if not table.empty(unitsList.Air.Bomb3) then
+        -- unitsList.Air.Bomb3 contains no more than one table with selected strat bombers in it
+        -- Cycle puts it at index 1 (as it was in the past) otherwise some code below won't work.
         for k,v in unitsList.Air.Bomb3 do
             if k != 1 then 
                 unitsList.Air.Bomb3[1] = unitsList.Air.Bomb3[k]

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -812,7 +812,13 @@ function GrowthFormation(formationUnits)
     BlockBuilderLand(seaUnitsList, seaBlock, NavalCategories, 1)
     BlockBuilderLand(subUnitsList, subBlock, SubCategories, 1)
 
-    if unitsList.Air.Bomb3[1] then
+    if not table.empty(unitsList.Air.Bomb3) then
+        for k,v in unitsList.Air.Bomb3 do
+            if k != 1 then 
+                unitsList.Air.Bomb3[1] = unitsList.Air.Bomb3[k]
+            end
+            break
+        end
         local count = unitsList.Air.Bomb3[1].Count
         local oldAirArea = unitsList.Air.AreaTotal
         local oldUnitTotal = unitsList.Air.UnitTotal
@@ -820,7 +826,7 @@ function GrowthFormation(formationUnits)
         unitsList.Air.AreaTotal = count
         unitsList.Air.UnitTotal = count
 
-        BlockBuilderAirT3Bombers(unitsList.Air, 1.5) --strats formation
+        BlockBuilderAirT3Bombers(unitsList.Air, 1.2) --initial spacing was 1.5 that is a bit too wide
 
         --strats are already in formation so we remove them from table and adjust all parameters.
         unitsList.Air.Bomb3 = {}


### PR DESCRIPTION
## Description of the proposed changes
A more wider 2nd formation for strat bombers was added a long time ago (see: https://github.com/FAForever/fa/pull/2740)
Then it got broken (well, it's basically just my code being bad but w/e)

An old vid displaying changes: https://youtu.be/KDxRhz5J-h4

## Checklist
- [x] Changes are documented in the changelog for the next game version