### PR TITLE
Fix blueprint loading crash for `nil` death animation

### DIFF
--- a/changelog/snippets/fix.6731.md
+++ b/changelog/snippets/fix.6731.md
@@ -1,0 +1,1 @@
+- (#6731) Fix blueprint loading crash when a unit has `nil` for its death animation. This fixes DDDX's "Survival Mayhem&BO balance" mod crashing the game on start.

--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -603,7 +603,7 @@ local function PostProcessUnit(unit)
     if deathAnimationTables then
         for i, animationTable in deathAnimationTables do
             local animationPath = animationTable.Animation
-            if not DiskGetFileInfo(animationPath) then
+            if animationPath and not DiskGetFileInfo(animationPath) then
                 WARN(string.format('Unit "%s": Could not find death animation at path: "%s" \nRemoving the animation so that the unit does not get stuck dying!', tostring(unit.BlueprintId), tostring(animationPath)))
 
                 unit.Display.AnimationDeath[i] = nil


### PR DESCRIPTION
## Issue 
Initially reported on https://forum.faforever.com/topic/8833/dddx-survival-rpg-balance-mod-does-not-let-me-start-the-match/

Caused by https://github.com/FAForever/fa/pull/6449

The mod "Survival Mayhem&BO Balance" by DDDX has a unit `XSL9901` with the following death animation table in its blueprint:
```lua
        AnimationDeath = {
            {
              --  Animation = '/mods/BlackOpsFAF-Unleashed/units/BEL0402/BEL0402_ADeath01.sca',
                AnimationRateMax = 2.35,
                AnimationRateMin = 0.35,
                Weight = 100,
            },
        },
```

This causes a crash during blueprint loading when the death animation check does `DiskGetFileInfo(nil)`.

## Description of the proposed changes
Add a nil check for the death animation check. I didn't remove the entire death animation table just in case it is used.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
The game loads with the mod enabled. A note for testing: spawning the unit XSL9901 will only work on the DDDX RPG Survival map, and in general the Balance mod needs BlackOps Unleashed, BlackOps ACUs, and Total Mayhem active.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version