### PR TITLE
Add list of reviewers and snippet guidelines to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,5 @@
 
 ## Checklist
 - [ ] Changes are annotated, including comments where useful
-- [ ] Changes are documented in the changelog for the next game version
+- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
+- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


### PR DESCRIPTION
Resolves #6713. The 2-3 reviewers part is from @BlackYps recommendation he gave on [Discord](https://discord.com/channels/197033481883222026/947508605958098955/1358866320887906324).

The concept is that contributors can click "Preview" to click on the links and view the topics before creating the PR, or just go to the links as they work through the checklist.

Here is how the new template looks:

<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->


## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->


## Additional context
<!-- Add any other context about the pull request here. -->


## Checklist
- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
