### PR TITLE
URL0001 Set upgrade effects for muzzle to correct bone name

### DIFF
--- a/changelog/snippets/fix.6734.md
+++ b/changelog/snippets/fix.6734.md
@@ -1,0 +1,1 @@
+- (#6723) Fix Cybran ACU to use correct muzzle bone for enhancement effects.

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -241,7 +241,7 @@ UnitBlueprint{
             UpgradeEffectBones = {
                 "Right_Upgrade",
                 "Right_Turret",
-                "Right_Muzzle_02",
+                "Turret_Muzzle_02",
             },
             UpgradeUnitAmbientBones = { "URL0001" },
         },
@@ -299,7 +299,7 @@ UnitBlueprint{
             UpgradeEffectBones = {
                 "Right_Upgrade",
                 "Right_Turret",
-                "Right_Muzzle_02",
+                "Turret_Muzzle_02",
             },
             UpgradeUnitAmbientBones = { "URL0001" },
         },
@@ -508,7 +508,7 @@ UnitBlueprint{
             UpgradeEffectBones = {
                 "Right_Upgrade",
                 "Right_Turret",
-                "Right_Muzzle_02",
+                "Turret_Muzzle_02",
             },
             UpgradeUnitAmbientBones = { "URL0001" },
         },


### PR DESCRIPTION

## Description of the proposed changes
This PR fixes an error on the Cybran ACU upgrade effects. The blueprint uses Right_Muzzle_02  bone for upgrade effects which should be Turret_Muzzle_02


## Testing done on the proposed changes

Incorrect
![image](https://github.com/user-attachments/assets/dce486ce-c3f8-4388-9600-01bd9ee376c4)


Correct
![image](https://github.com/user-attachments/assets/732d04ac-16ac-4770-8a7a-3809598d9017)



## Additional context
<!-- Add any other context about the pull request here. -->


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version