### PR TITLE
AI - add filter for non engineering units in Engineer Manager callback

### DIFF
--- a/changelog/snippets/fix.6735.md
+++ b/changelog/snippets/fix.6735.md
@@ -1,0 +1,1 @@
+- (#6735) Add filter to AI Engineer Manager to stop non engineers being assigned engineer task loop functions. Added filter to stop engineering stations being included in engineer tables of the AI Engineer Manager.

--- a/lua/sim/EngineerManager.lua
+++ b/lua/sim/EngineerManager.lua
@@ -666,15 +666,12 @@ EngineerManager = Class(BuilderManager) {
     ---@param unit Unit
     ---@param finishedUnit Unit
     UnitConstructionFinished = function(self, unit, finishedUnit)
-        local dontAssignEngineerTask = true
         if EntityCategoryContains(categories.FACTORY * categories.STRUCTURE, finishedUnit) and finishedUnit:GetAIBrain():GetArmyIndex() == self.Brain:GetArmyIndex() then
             self.Brain.BuilderManagers[self.LocationType].FactoryManager:AddFactory(finishedUnit)
         end
         if finishedUnit:GetAIBrain():GetArmyIndex() == self.Brain:GetArmyIndex() then
-            if EntityCategoryContains(categories.ENGINEER - categories.ENGINEERSTATION, finishedUnit) then
-                dontAssignEngineerTask = false
-            end
-            self:AddUnit(finishedUnit, dontAssignEngineerTask)
+            local dontAssign = not EntityContainsCategory(finishedUnit, categories.ENGINEER - categories.ENGINEERSTATION)
+            self:AddUnit(finishedUnit, dontAssign)
         end
     end,
 

--- a/lua/sim/EngineerManager.lua
+++ b/lua/sim/EngineerManager.lua
@@ -670,11 +670,15 @@ EngineerManager = Class(BuilderManager) {
     ---@param unit Unit
     ---@param finishedUnit Unit
     UnitConstructionFinished = function(self, unit, finishedUnit)
+        local dontAssignEngineerTask = true
         if EntityCategoryContains(categories.FACTORY * categories.STRUCTURE, finishedUnit) and finishedUnit:GetAIBrain():GetArmyIndex() == self.Brain:GetArmyIndex() then
             self.Brain.BuilderManagers[self.LocationType].FactoryManager:AddFactory(finishedUnit)
         end
         if finishedUnit:GetAIBrain():GetArmyIndex() == self.Brain:GetArmyIndex() then
-            self:AddUnit(finishedUnit)
+            if EntityCategoryContains(categories.ENGINEER - categories.ENGINEERSTATION, finishedUnit) then
+                dontAssignEngineerTask = false
+            end
+            self:AddUnit(finishedUnit, dontAssignEngineerTask)
         end
     end,
 

--- a/lua/sim/EngineerManager.lua
+++ b/lua/sim/EngineerManager.lua
@@ -36,7 +36,7 @@ EngineerManager = Class(BuilderManager) {
 
         self.ConsumptionUnits = {
             Engineers = { Category = categories.ENGINEER - categories.ENGINEERSTATION, Units = {}, UnitsList = {}, Count = 0, },
-            EngineerStation = { Category = categories.ENGINEERSTATION, Units = {}, UnitsList = {}, Count = 0, },
+            EngineerStations = { Category = categories.ENGINEERSTATION, Units = {}, UnitsList = {}, Count = 0, },
             Fabricators = { Category = categories.MASSFABRICATION * categories.STRUCTURE, Units = {}, UnitsList = {}, Count = 0, },
             Shields = { Category = categories.SHIELD * categories.STRUCTURE, Units = {}, UnitsList = {}, Count = 0, },
             MobileShields = { Category = categories.SHIELD * categories.MOBILE, Units = {}, UnitsList = {}, Count = 0, },

--- a/lua/sim/EngineerManager.lua
+++ b/lua/sim/EngineerManager.lua
@@ -35,12 +35,8 @@ EngineerManager = Class(BuilderManager) {
         self.LocationType = self.LocationType or lType
 
         self.ConsumptionUnits = {
-            Engineers = { Category = categories.ENGINEER, Units = {}, UnitsList = {}, Count = 0, },
-
-
-
-
-            
+            Engineers = { Category = categories.ENGINEER - categories.ENGINEERSTATION, Units = {}, UnitsList = {}, Count = 0, },
+            EngineerStation = { Category = categories.ENGINEERSTATION, Units = {}, UnitsList = {}, Count = 0, },
             Fabricators = { Category = categories.MASSFABRICATION * categories.STRUCTURE, Units = {}, UnitsList = {}, Count = 0, },
             Shields = { Category = categories.SHIELD * categories.STRUCTURE, Units = {}, UnitsList = {}, Count = 0, },
             MobileShields = { Category = categories.SHIELD * categories.MOBILE, Units = {}, UnitsList = {}, Count = 0, },


### PR DESCRIPTION
## Description of the proposed changes
This PR adds a filter to the UnitConstructionFinished function of the AI engineer manager. It was found that any units in the ConsumptionUnits table were being put into the engineer assignment function loop. This results in many units checking for engineer builders that will not get any due to not being engineers, but will consume compute resources due to this.

It also separates engineers from engineering stations in the consumption table of the engineer manager, this is done so that functions that return engineer counts against engineer managers are not incorrectly counting engineering stations as engineers.


## Testing done on the proposed changes
Added logs and validated that invalid units were being assigned engineering tasks.
Added logs and validated that changes to code stopped this from happening.
Detected HIVES were being counted as normal engineers for builder conditions and reran replays to confirm this was no longer happening post changes.


## Additional context
This has been a silent failure in the default AI and was present in the original SCFA code base. Since the units did not pick up engineering jobs and silently failed no one would know it was happening.


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version