### PR TITLE
Add an intermediate staging phase for deployments

### DIFF
--- a/.github/workflows/deploy-fafbeta.yaml
+++ b/.github/workflows/deploy-fafbeta.yaml
@@ -30,7 +30,7 @@ concurrency:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 21 1 * *"
+    - cron: "0 23 1 * *"
 
 jobs:
   test:

--- a/.github/workflows/deploy-fafbeta.yaml
+++ b/.github/workflows/deploy-fafbeta.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           ssh-key: ${{ secrets.SSH_FAFOREVER_MACHINE_USER }}
           repository: FAForever/fa
-          ref: develop
+          ref: staging/fafbeta
 
       # Allows us to better understand the game version and the specific commit hash when we receive a log
       - name: Update version references

--- a/.github/workflows/stage-fafbeta.yaml
+++ b/.github/workflows/stage-fafbeta.yaml
@@ -18,19 +18,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-name: Deploy to FAF Develop
-
-# Prevent simultaneous deployments across all deployment branches as
-# the server is unable to process multiple deployments at the same time.
-
-concurrency:
-  cancel-in-progress: true
-  group: deployment
+name: Stage changes for FAF Beta Balance
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 21 * * 4"
+    - cron: "0 20 1 * *"
 
 jobs:
   test:
@@ -46,40 +39,14 @@ jobs:
         with:
           ssh-key: ${{ secrets.SSH_FAFOREVER_MACHINE_USER }}
           repository: FAForever/fa
-          ref: staging/fafdevelop
+          ref: develop
 
-      # Allows us to better understand the game version and the specific commit hash when we receive a log
-      - name: Update version references
-        run: |
-          COMMITHASH=$(git rev-parse HEAD)
-          sed -i "s/local Commit = 'unknown'/local Commit = \"${COMMITHASH}\"/" "lua/version.lua"
-          sed -i "s/local GameType = 'unknown'/local GameType = \"FAF Develop\"/" "lua/version.lua"
-
-          # debugging
-          cat lua/version.lua
-
-      # Disable debugging statements
-      #
-      # You can overwrite these adjustments by setting up a `Debug` folder
-      - name: Overwrite debug references
-        run: |
-          sed -i "s/EnabledDrawing = true,/EnabledDrawing = false,/" "lua/shared/components/DebugComponent.lua"
-
-          # debugging
-          cat lua/shared/components/DebugComponent.lua
-
-      # Create a commit with the changes of the workflow in it
-      - name: Create a commit
+      # Update the staging/fafbeta branch, we force push here because
+      # we're not interested in fixing conflicts
+      - name: Update staging/fafbeta
         run: |
           # Configure git
           git config user.email "github@faforever.com"
           git config user.name "FAForever Machine User"
-
-          git add .
-          git commit -m "Post-process deployment"
-
-      # Update the deploy/fafdevelop branch, we force push here because
-      # we're not interested in fixing conflicts
-      - name: Update deploy/fafdevelop
-        run: |
-          git push origin HEAD:deploy/fafdevelop --force
+          
+          git push origin HEAD:staging/fafbeta --force

--- a/.github/workflows/stage-fafbeta.yaml
+++ b/.github/workflows/stage-fafbeta.yaml
@@ -23,7 +23,7 @@ name: Stage changes for FAF Beta Balance
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 20 1 * *"
+    - cron: "0 22 1 * *"
 
 jobs:
   test:

--- a/.github/workflows/stage-fafdevelop.yaml
+++ b/.github/workflows/stage-fafdevelop.yaml
@@ -18,19 +18,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-name: Deploy to FAF Develop
-
-# Prevent simultaneous deployments across all deployment branches as
-# the server is unable to process multiple deployments at the same time.
-
-concurrency:
-  cancel-in-progress: true
-  group: deployment
+name: Stage changes for FAF Develop
 
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 21 * * 4"
+    - cron: "0 20 * * 4"
 
 jobs:
   test:
@@ -46,40 +39,14 @@ jobs:
         with:
           ssh-key: ${{ secrets.SSH_FAFOREVER_MACHINE_USER }}
           repository: FAForever/fa
-          ref: staging/fafdevelop
+          ref: develop
 
-      # Allows us to better understand the game version and the specific commit hash when we receive a log
-      - name: Update version references
-        run: |
-          COMMITHASH=$(git rev-parse HEAD)
-          sed -i "s/local Commit = 'unknown'/local Commit = \"${COMMITHASH}\"/" "lua/version.lua"
-          sed -i "s/local GameType = 'unknown'/local GameType = \"FAF Develop\"/" "lua/version.lua"
-
-          # debugging
-          cat lua/version.lua
-
-      # Disable debugging statements
-      #
-      # You can overwrite these adjustments by setting up a `Debug` folder
-      - name: Overwrite debug references
-        run: |
-          sed -i "s/EnabledDrawing = true,/EnabledDrawing = false,/" "lua/shared/components/DebugComponent.lua"
-
-          # debugging
-          cat lua/shared/components/DebugComponent.lua
-
-      # Create a commit with the changes of the workflow in it
-      - name: Create a commit
+      # Update the staging/fafdevelop branch, we force push here because
+      # we're not interested in fixing conflicts
+      - name: Update staging/fafdevelop
         run: |
           # Configure git
           git config user.email "github@faforever.com"
           git config user.name "FAForever Machine User"
-
-          git add .
-          git commit -m "Post-process deployment"
-
-      # Update the deploy/fafdevelop branch, we force push here because
-      # we're not interested in fixing conflicts
-      - name: Update deploy/fafdevelop
-        run: |
-          git push origin HEAD:deploy/fafdevelop --force
+          
+          git push origin HEAD:staging/fafdevelop --force

--- a/changelog/snippets/other.6736.md
+++ b/changelog/snippets/other.6736.md
@@ -1,0 +1,3 @@
+- (#6736) Add a separate staging area for deployments
+
+Through the staging area it becomes more convenient to test experimental changes without the necessity to first merge them into the `develop` branch. As an example, you can now force push a pull request onto the staging area and then proceed with deploying the staging area. 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -21,7 +21,7 @@ The deployment procedure can be a lengthy process because it involves various st
 
 ### Deployment of engine patches
 
-The deployment of engine patches to the release branch is a manual process. This is intentional from a security perspective - it provides a second pair of eyes from a server administrator who is usually not directly related to the game team. 
+The deployment of engine patches to the release branch is a manual process. This is intentional from a security perspective - it provides a second pair of eyes from a server administrator who is usually not directly related to the game team.
 
 - (1) Make sure that any open changes that you want to include are merged to the `master` branch of the [Binary patches](https://github.com/FAForever/FA-Binary-Patches) repository.
 - (2) Update the executable of the `FAF Develop` and `FAF Beta Balance` game types using the [Upload workflow](https://github.com/FAForever/FA-Binary-Patches/actions).
@@ -65,7 +65,7 @@ At this point you need to wait until the `changelog branch` is merged.
 ### Deployment - final steps
 
 - (1) Create a [release on GitHub](https://github.com/FAForever/fa/releases) that targets the [master](https://github.com/FAForever/fa/tree/master) branch.
-- - (1.1) Set the tag with the game version. 
+- - (1.1) Set the tag with the game version.
 - - (1.2) Match the format of the title with that of previous releases.
 - - (1.3) Copy and paste the changelog into the description. Make sure to remove the title as a release has its own title.
 - - (1.4) Create the release.
@@ -78,15 +78,47 @@ The workflow requires an approval of another maintainer. Once approved, wait for
 
 Once all this is run you can review the status of the deployment by the server in the [production environment](https://github.com/FAForever/fa/deployments/production). Once that returns green the deployment succeeded and you can inform the community of the deployment. Congratulations!
 
-## Automated deployments
+## Automation
 
-There are three workflows to help with deployment:
+Some facets of deployment are automated to make development easier.
 
-- [FAF game type](https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-faf.yaml)
-- [FAF Beta Balance game type](https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-fafbeta.yaml)
-- [FAF Develop game type](https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-fafdevelop.yaml)
+### Staging
 
-The workflows for Beta Balance and Develop trigger periodically. You can review when by evaluating the [cron expression](https://crontab.cronhub.io/). The [API of FAForever](https://github.com/FAForever/faf-java-api/blob/develop/src/main/java/com/faforever/api/deployment/GitHubDeploymentService.java) registers the push to a deployment branch via a webhook. The server creates (and updates) a [deployment status](https://github.com/FAForever/fa/deployments). During that process the server retrieves the game related files, processes it and when everything is fine the new game version will be available in roughly 5 to 10 minutes.
+There are two workflows for staging changes:
+
+- [Stage FAF Beta Balance game type](https://github.com/FAForever/fa/blob/develop/.github/workflows/stage-fafbeta.yaml)
+- [Stage FAF Develop game type](https://github.com/FAForever/fa/blob/develop/.github/workflows/stage-fafdevelop.yaml)
+
+Relevant branches for the respective game types:
+
+- FAF: `master`
+- FAF Beta Balance: `staging/fafbeta`
+- FAF Develop: `staging/fafdevelop`
+
+Staging branches make it easier to:
+
+- **Test individual changes or commits**: Force push the `master` branch to a staging branch, proceed to cherry-pick the desired changes and then trigger the deployment workflow.
+- **Test experimental changes from a pull request**: Force push the branch to a staging branch, then trigger the deployment workflow.
+
+Staging branches are periodically updated automatically to keep them aligned with ongoing development. You can review the schedule by evaluating the [cron expression](https://crontab.cronhub.io/) in the workflow files.
+
+### Deployment
+
+There are three workflows for deployment:
+
+- [Deploy FAF game type](https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-faf.yaml)
+- [Deploy FAF Beta Balance game type](https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-fafbeta.yaml)
+- [Deploy FAF Develop game type](https://github.com/FAForever/fa/blob/develop/.github/workflows/deploy-fafdevelop.yaml)
+
+Each deployment workflow picks up commits from a staging branch, post-processes them, and force pushes them to a branch that triggers deployment. Relevant branches:
+
+- FAF: `master` -> `deploy/faf`
+- FAF Beta Balance: `staging/fafbeta` -> `staging/fafbeta`
+- FAF Develop: `staging/fafdevelop` -> `staging/fafdevelop`
+
+The deployment workflows for FAF Beta Balance and FAF Develop are triggered periodically. You can review the schedule by evaluating the [cron expression](https://crontab.cronhub.io/) in the workflow files.
+
+The [FAForever API](https://github.com/FAForever/faf-java-api/blob/develop/src/main/java/com/faforever/api/deployment/GitHubDeploymentService.java) registers the push to a deployment branch via webhook. The server creates and updates a [deployment status](https://github.com/FAForever/fa/deployments). During this process, the server retrieves and processes the relevant game files. If successful, the new game version becomes available within approximately 5 to 10 minutes.
 
 ## Related deployments
 


### PR DESCRIPTION
## Description of the proposed changes

Introduces separate staging area's for deployment to the FAF Beta Balance and FAF Develop game types.

## Additional context

These changes allow you to force push a branch to a staging area for FAF Beta Balance or FAF Develop. You can then deploy these changes using the existing deployment workflows. This makes it more convenient to test experimental changes with a wider audience, without the need to merge those changes into `develop` first.

Note that all replays on FAF Beta Balance and FAF Develop desync the moment you make a deployment. This is a limitation of the system.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version