### PR TITLE
Refactor screen indicator

### DIFF
--- a/changelog/snippets/other.6741.md
+++ b/changelog/snippets/other.6741.md
@@ -1,0 +1,3 @@
+- (#6741) Extract the camera indicator functionality into a separate class
+
+This makes it more convenient to maintain. Other features can now also use this to indicate the location of other events.

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -1263,108 +1263,23 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
         end
     end,
 
+    ---@param self WorldView
+    ---@param parent Control
+    ---@param location Vector   # in world coordinates
+    ---@param color Color
+    ---@param stayOnScreen? boolean
+    ---@return UIOffScreenIndicator
     CreateCameraIndicator = function(self, parent, location, color, stayOnScreen)
-        local Arrow = Button(parent, UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_b_up.dds'),
-                UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_b_down.dds'),
-                UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_b_over.dds'),
-                UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_b_up.dds'))
-        Arrow.State = 'b'
-        LayoutHelpers.AtCenterIn(Arrow, self)
-        Arrow:SetNeedsFrameUpdate(true)
-        Arrow.Depth:Set(parent:GetRootFrame():GetTopmostDepth() + 1)
-        Arrow.Glow = Bitmap(Arrow, UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_glow.dds'))
-        LayoutHelpers.AtCenterIn(Arrow.Glow, Arrow)
-        Arrow.Glow:SetNeedsFrameUpdate(true)
-        Arrow.Glow:SetAlpha(0)
-        Arrow.Glow.time = 0
-        Arrow.Glow:DisableHitTest()
-        Arrow.Glow.OnFrame = function(glow, delta)
-            if delta then
-                glow.time = glow.time + math.pi * 0.05
-                glow:SetAlpha(MATH_Lerp(math.sin(glow.time), -1.0, 1.0, 0.0, 0.5))
-            end
+        local OffScreenIndicator = import("/lua/ui/game/OffScreenIndicator.lua")
+
+        if color == 'blue' then
+            return OffScreenIndicator.CreateYellowOffScreenIndicator(parent, self, location)
+        elseif color == 'red' then
+            return OffScreenIndicator.CreateRedOffScreenIndicator(parent, self, location)
         end
-        Arrow.OnClick = function(arrow, modifiers)
-            local currentCamSettings = GetCamera('WorldCamera'):SaveSettings()
-            currentCamSettings.Focus = location
-            GetCamera(self._cameraName):RestoreSettings(currentCamSettings)
-        end
-        Arrow.OnFrame = function(arrow, deltatime)
-            local coords = self:Project(Vector(location[1], location[2], location[3]))
-            local horzStr = ''
-            local vertStr = ''
-            if self.Left() + coords.x < self.Left() then
-                horzStr = 'l'
-                arrow.Left:Set(self.Left)
-                LayoutHelpers.AtLeftIn(arrow.Glow, arrow, -10)
-                LayoutHelpers.ResetRight(arrow.Glow)
-                LayoutHelpers.ResetRight(arrow)
-            elseif coords.x > self.Right() then
-                horzStr = 'r'
-                arrow.Right:Set(self.Right)
-                LayoutHelpers.AtRightIn(arrow.Glow, arrow, -10)
-                LayoutHelpers.ResetLeft(arrow.Glow)
-                LayoutHelpers.ResetLeft(arrow)
-            else
-                arrow.Left:Set(function() return coords.x - arrow.Width() / 2 end)
-                LayoutHelpers.AtHorizontalCenterIn(arrow.Glow, arrow)
-                LayoutHelpers.ResetRight(arrow.Glow)
-                LayoutHelpers.ResetRight(arrow)
-            end
-            if self.Top() + coords.y > self.Bottom() then
-                vertStr = 't'
-                arrow.Bottom:Set(self.Bottom)
-                LayoutHelpers.AtBottomIn(arrow.Glow, arrow, -10)
-                LayoutHelpers.ResetTop(arrow.Glow)
-                LayoutHelpers.ResetTop(arrow)
-            elseif coords.y < self.Top() then
-                vertStr = 'b'
-                arrow.Top:Set(self.Top)
-                LayoutHelpers.AtTopIn(arrow.Glow, arrow, -10)
-                LayoutHelpers.ResetBottom(arrow.Glow)
-                LayoutHelpers.ResetBottom(arrow)
-            else
-                arrow.Top:Set(function() return coords.y - arrow.Height() / 2 end)
-                LayoutHelpers.AtVerticalCenterIn(arrow.Glow, arrow)
-                LayoutHelpers.ResetBottom(arrow.Glow)
-                LayoutHelpers.ResetBottom(arrow)
-            end
-            if horzStr != '' or vertStr != '' then
-                if arrow:IsHidden() then
-                    arrow:Show()
-                end
-                if arrow.State != vertStr..horzStr then
-                    arrow:SetTexture(UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_'..vertStr..horzStr..'_up.dds'))
-                    arrow:SetNewTextures(UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_'..vertStr..horzStr..'_up.dds'),
-                    UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_'..vertStr..horzStr..'_down.dds'),
-                    UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_'..vertStr..horzStr..'_over.dds'),
-                    UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_'..vertStr..horzStr..'_up.dds'))
-                    arrow.State = vertStr..horzStr
-                end
-                if arrow:IsDisabled() then
-                    arrow:Enable()
-                end
-            else
-                if stayOnScreen then
-                    if arrow.State != 't' then
-                        arrow:SetTexture(UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_t_up.dds'))
-                        arrow:SetNewTextures(UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_t_up.dds'),
-                        UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_t_down.dds'),
-                        UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_t_over.dds'),
-                        UIUtil.UIFile('/game/ping_edge/ping_edge_'..color..'_t_up.dds'))
-                        arrow.State = 't'
-                    end
-                else
-                    if not arrow:IsHidden() then
-                        arrow:Hide()
-                    end
-                end
-                if not arrow:IsDisabled() then
-                    arrow:Disable()
-                end
-            end
-        end
-        return Arrow
+
+       -- default to yellow
+       return OffScreenIndicator.CreateYellowOffScreenIndicator(parent, self, location)
     end,
 
     Register = function(self, cameraName, disableMarkers, displayName, order)

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -1273,7 +1273,7 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
         local module = import("/lua/ui/game/OffscreenMarkerIndicator.lua")
 
         if color == 'blue' then
-            return module.CreateYellowOffScreenIndicator(parent, self, location)
+            return module.CreateBlueOffScreenIndicator(parent, self, location)
         elseif color == 'red' then
             return module.CreateRedOffScreenIndicator(parent, self, location)
         end

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -1273,13 +1273,13 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
         local module = import("/lua/ui/game/OffscreenMarkerIndicator.lua")
 
         if color == 'blue' then
-            return module.CreateBlueOffScreenMarkerIndicator(parent, self, location)
+            return module.CreateOffScreenMarkerIndicatorFromPreset(parent, self, location, 'Blue')
         elseif color == 'red' then
-            return module.CreateRedOffScreenMarkerIndicator(parent, self, location)
+            return module.CreateOffScreenMarkerIndicatorFromPreset(parent, self, location, 'Red')
         end
 
        -- default to yellow
-       return module.CreateYellowOffScreenMarkerIndicator(parent, self, location)
+       return module.CreateOffScreenMarkerIndicatorFromPreset(parent, self, location, 'Yellow')
     end,
 
     Register = function(self, cameraName, disableMarkers, displayName, order)

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -1270,16 +1270,16 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
     ---@param stayOnScreen? boolean
     ---@return UIOffScreenIndicator
     CreateCameraIndicator = function(self, parent, location, color, stayOnScreen)
-        local OffScreenIndicator = import("/lua/ui/game/OffScreenIndicator.lua")
+        local module = import("/lua/ui/game/OffScreenIndicatorForMarkers.lua")
 
         if color == 'blue' then
-            return OffScreenIndicator.CreateYellowOffScreenIndicator(parent, self, location)
+            return module.CreateYellowOffScreenIndicator(parent, self, location)
         elseif color == 'red' then
-            return OffScreenIndicator.CreateRedOffScreenIndicator(parent, self, location)
+            return module.CreateRedOffScreenIndicator(parent, self, location)
         end
 
        -- default to yellow
-       return OffScreenIndicator.CreateYellowOffScreenIndicator(parent, self, location)
+       return module.CreateYellowOffScreenIndicator(parent, self, location)
     end,
 
     Register = function(self, cameraName, disableMarkers, displayName, order)

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -1270,7 +1270,7 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
     ---@param stayOnScreen? boolean
     ---@return UIOffScreenIndicator
     CreateCameraIndicator = function(self, parent, location, color, stayOnScreen)
-        local module = import("/lua/ui/game/OffScreenIndicatorForMarkers.lua")
+        local module = import("/lua/ui/game/OffscreenMarkerIndicator.lua")
 
         if color == 'blue' then
             return module.CreateYellowOffScreenIndicator(parent, self, location)

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -1273,13 +1273,13 @@ WorldView = ClassUI(moho.UIWorldView, Control) {
         local module = import("/lua/ui/game/OffscreenMarkerIndicator.lua")
 
         if color == 'blue' then
-            return module.CreateBlueOffScreenIndicator(parent, self, location)
+            return module.CreateBlueOffScreenMarkerIndicator(parent, self, location)
         elseif color == 'red' then
-            return module.CreateRedOffScreenIndicator(parent, self, location)
+            return module.CreateRedOffScreenMarkerIndicator(parent, self, location)
         end
 
        -- default to yellow
-       return module.CreateYellowOffScreenIndicator(parent, self, location)
+       return module.CreateYellowOffScreenMarkerIndicator(parent, self, location)
     end,
 
     Register = function(self, cameraName, disableMarkers, displayName, order)

--- a/lua/ui/game/OffScreenIndicator.lua
+++ b/lua/ui/game/OffScreenIndicator.lua
@@ -44,6 +44,47 @@ local AnimatedGlow = import("/lua/ui/game/common/AnimatedGlow.lua")
 ---@field EastNorth UIOffScreenIndicatorTextureStates
 ---@field Glow FileName
 
+--- A utility function to help create a preset. It assumes that all files end with:
+---
+--- - <direction>_<state>.dds
+---
+--- Where:
+--- - <direction> is the direction of the image. It can be `b`, `bl`, `l`, `tl`, `t`, `tr`, `r` or `br`
+--- - <state> is the button state. It can be `up`, `over` or `down`
+--- 
+--- As an example of a preset:
+---
+--- ```lua
+--- GeneratePathForPreset('/textures/ui/common/game/ping_edge/ping_edge_blue_')
+--- ```
+--- 
+--- Will generate the following paths:
+---
+--- - '/textures/ui/common/game/ping_edge/ping_edge_blue_b_up.dds', 
+--- - '/textures/ui/common/game/ping_edge/ping_edge_blue_b_over.dds'
+--- - '/textures/ui/common/game/ping_edge/ping_edge_blue_b_down.dds'
+---
+--- Which it will pack up so that a screen indicator can use them.
+---@param filename FileName     # As an example, /textures/ui/common/game/ping_edge/ping_edge_blue_
+---@return UIOffScreenIndicatorTextureSet
+function GeneratePreset(filename)
+    ---@type UIOffScreenIndicatorTextureSet
+    local preset = {
+        North = { Up = filename .. 'b_up.dds', Over = filename .. 'b_over.dds', Down = filename .. 'b_down.dds' },
+        NorthWest = { Up = filename .. 'bl_up.dds', Over = filename .. 'bl_over.dds', Down = filename .. 'bl_down.dds' },
+        West = { Up = filename .. 'l_up.dds', Over = filename .. 'l_over.dds', Down = filename .. 'l_down.dds' },
+        WestSouth = { Up = filename .. 'tl_up.dds', Over = filename .. 'tl_over.dds', Down = filename .. 'tl_down.dds' },
+        South = { Up = filename .. 't_up.dds', Over = filename .. 't_over.dds', Down = filename .. 't_down.dds' },
+        SouthEast = { Up = filename .. 'tr_up.dds', Over = filename .. 'tr_over.dds', Down = filename .. 'tr_down.dds' },
+        East = { Up = filename .. 'r_up.dds', Over = filename .. 'r_over.dds', Down = filename .. 'r_down.dds' },
+        EastNorth = { Up = filename .. 'br_up.dds', Over = filename .. 'br_over.dds', Down = filename .. 'br_down.dds' },
+        Glow = filename .. 'glow.dds'
+    }
+
+    return preset
+end
+
+
 --- A utility class to help you point to events that happen off screen. This is an abstract class, it won't do anything on its own.
 ---@class UIOffScreenIndicator : Button
 ---@field TextureSet UIOffScreenIndicatorTextureSet

--- a/lua/ui/game/OffScreenIndicator.lua
+++ b/lua/ui/game/OffScreenIndicator.lua
@@ -108,16 +108,16 @@ OffScreenIndicator = Class(Button) {
     ---@return UIOffScreenIndicatorDirection    # vertical axis
     GetDirectionToTarget = function(self, worldView, controlSpaceCoordinates)
         local horizontal = "OnScreen"
-        if controlSpaceCoordinates.x < 0 then
+        if controlSpaceCoordinates.x < 0.5 * self.Width() then
             horizontal = "West"
-        elseif controlSpaceCoordinates.x > worldView.Width() then
+        elseif controlSpaceCoordinates.x > worldView.Width() - 0.5 * self.Width() then
             horizontal = "East"
         end
 
         local vertical = "OnScreen"
-        if controlSpaceCoordinates.y < 0 then
+        if controlSpaceCoordinates.y < 0.5 * self.Height() then
             vertical = "North"
-        elseif controlSpaceCoordinates.y > worldView.Height() then
+        elseif controlSpaceCoordinates.y > worldView.Height() - 0.5 * self.Height() then
             vertical = "South"
         end
 

--- a/lua/ui/game/OffScreenIndicator.lua
+++ b/lua/ui/game/OffScreenIndicator.lua
@@ -1,0 +1,254 @@
+--******************************************************************************************************
+--** Copyright (c) 2022  Willem 'Jip' Wijnia
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
+local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
+local UIUtil = import("/lua/ui/uiutil.lua")
+
+local Button = import("/lua/maui/button.lua").Button
+local AnimatedGlow = import("/lua/ui/game/common/AnimatedGlow.lua")
+
+---@class UIOffScreenIndicatorTextureStates
+---@field Up FileName
+---@field Over FileName
+---@field Down FileName
+
+---@class UIOffScreenIndicatorTextureSet
+---@field North UIOffScreenIndicatorTextureStates
+---@field NorthWest UIOffScreenIndicatorTextureStates
+---@field West UIOffScreenIndicatorTextureStates
+---@field WestSouth UIOffScreenIndicatorTextureStates
+---@field South UIOffScreenIndicatorTextureStates
+---@field SouthEast UIOffScreenIndicatorTextureStates
+---@field East UIOffScreenIndicatorTextureStates
+---@field EastNorth UIOffScreenIndicatorTextureStates
+---@field Glow FileName
+
+---@type UIOffScreenIndicatorTextureSet
+local TexturesBlue = {
+    North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_down.dds' },
+    NorthWest = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_bl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_bl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_bl_down.dds' },
+    West = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_l_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_l_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_l_down.dds' },
+    WestSouth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_tl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_tl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_tl_down.dds' },
+    South = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_t_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_t_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_t_down.dds' },
+    SouthEast = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_tr_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_tr_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_tr_down.dds' },
+    East = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_r_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_r_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_r_down.dds' },
+    EastNorth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_br_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_br_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_br_down.dds' },
+    Glow = '/textures/ui/common/game/ping_edge/ping_edge_blue_glow.dds'
+}
+
+---@type UIOffScreenIndicatorTextureSet
+local TexturesYellow = {
+    North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_down.dds' },
+    NorthWest = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_bl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_bl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_bl_down.dds' },
+    West = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_l_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_l_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_l_down.dds' },
+    WestSouth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tl_down.dds' },
+    South = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_t_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_t_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_t_down.dds' },
+    SouthEast = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tr_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tr_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tr_down.dds' },
+    East = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_r_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_r_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_r_down.dds' },
+    EastNorth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_br_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_br_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_br_down.dds' },
+    Glow = '/textures/ui/common/game/ping_edge/ping_edge_yellow_glow.dds'
+}
+
+---@type UIOffScreenIndicatorTextureSet
+local TexturesRed = {
+    North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_b_down.dds' },
+    NorthWest = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_bl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_bl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_bl_down.dds' },
+    West = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_l_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_l_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_l_down.dds' },
+    WestSouth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_tl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_tl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_tl_down.dds' },
+    South = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_t_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_t_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_t_down.dds' },
+    SouthEast = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_tr_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_tr_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_tr_down.dds' },
+    East = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_r_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_r_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_r_down.dds' },
+    EastNorth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_br_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_br_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_br_down.dds' },
+    Glow = '/textures/ui/common/game/ping_edge/ping_edge_red_glow.dds'
+}
+
+--- A utility class to help you point to events that happen off screen.
+---@class UIOffScreenIndicator : Button
+---@field TextureSet UIOffScreenIndicatorTextureSet
+---@field Target Vector     # in world coordinates
+---@field WorldView WorldView
+---@field AnimatedGlow UIAnimatedGlow
+OffScreenIndicator = Class(Button) {
+
+    ---@param self UIOffScreenIndicator
+    ---@param parent Control
+    ---@param worldView WorldView
+    ---@param textures UIOffScreenIndicatorTextureSet
+    __init = function(self, parent, worldView, textures, target)
+        Button.__init(
+            self, parent,
+            UIUtil.UIFile(textures.North.Up),
+            UIUtil.UIFile(textures.North.Down),
+            UIUtil.UIFile(textures.North.Over),
+            UIUtil.UIFile(textures.North.Up)
+        )
+
+        self.WorldView = worldView
+        self.TextureSet = textures
+        self.Target = target
+        self.AnimatedGlow = AnimatedGlow.CreateAnimatedGlow(self, textures.Glow)
+    end,
+
+    ---@param self UIOffScreenIndicator
+    ---@param parent Control
+    __post_init = function(self, parent)
+        LayoutHelpers.LayoutFor(self)
+            :NeedsFrameUpdate(true)
+            :Fill(parent)
+            :End()
+    end,
+
+    ---@param self UIOffScreenIndicator
+    ---@param textureStates UIOffScreenIndicatorTextureStates
+    UpdateTextures = function(self, textureStates)
+        self:SetNewTextures(
+            UIUtil.UIFile(textureStates.Up),
+            UIUtil.UIFile(textureStates.Down),
+            UIUtil.UIFile(textureStates.Over),
+            UIUtil.UIFile(textureStates.Up)
+        )
+    end,
+
+    ---@param self UIOffScreenIndicator
+    OnFrame = function(self, delta)
+        local worldView = self.WorldView
+        local coords = worldView:Project(self.Target)
+
+        -- figure out horizontal positioning
+        local horizontal = "None"
+        if worldView.Left() + coords.x < worldView.Left() then
+            horizontal = "West"
+            self.Left:Set(worldView.Left)
+            LayoutHelpers.AtLeftIn(self.AnimatedGlow, self, -10)
+            LayoutHelpers.ResetRight(self.AnimatedGlow)
+            LayoutHelpers.ResetRight(self)
+        elseif coords.x > worldView.Right() then
+            horizontal = "East"
+            self.Right:Set(worldView.Right)
+            LayoutHelpers.AtRightIn(self.AnimatedGlow, self, -10)
+            LayoutHelpers.ResetLeft(self.AnimatedGlow)
+            LayoutHelpers.ResetLeft(self)
+        else
+            horizontal = "None"
+            self.Left:Set(function() return coords.x - self.Width() / 2 end)
+            LayoutHelpers.AtHorizontalCenterIn(self.AnimatedGlow, self)
+            LayoutHelpers.ResetRight(self.AnimatedGlow)
+            LayoutHelpers.ResetRight(self)
+        end
+
+        -- figure out vertical positioning
+        local vertical = 'None'
+        if worldView.Top() + coords.y > worldView.Bottom() then
+            vertical = 'South'
+            self.Bottom:Set(worldView.Bottom)
+            LayoutHelpers.AtBottomIn(self.AnimatedGlow, self, -10)
+            LayoutHelpers.ResetTop(self.AnimatedGlow)
+            LayoutHelpers.ResetTop(self)
+        elseif coords.y < worldView.Top() then
+            vertical = 'North'
+            self.Top:Set(worldView.Top)
+            LayoutHelpers.AtTopIn(self.AnimatedGlow, self, -10)
+            LayoutHelpers.ResetBottom(self.AnimatedGlow)
+            LayoutHelpers.ResetBottom(self)
+        else
+            vertical = 'None'
+            self.Top:Set(function() return coords.y - self.Height() / 2 end)
+            LayoutHelpers.AtVerticalCenterIn(self.AnimatedGlow, self)
+            LayoutHelpers.ResetBottom(self.AnimatedGlow)
+            LayoutHelpers.ResetBottom(self)
+        end
+
+        if horizontal == 'None' and vertical == 'None' then
+            -- on screen, hide it
+            self:Hide()
+            self:Disable()
+
+        else
+            -- off screen, show it
+            self:Show()
+            self:Enable()
+
+            -- determine what textures to show
+            if horizontal == 'None' and vertical == 'North' then
+                self:UpdateTextures(self.TextureSet.North)
+            elseif horizontal == 'None' and vertical == 'South' then
+                self:UpdateTextures(self.TextureSet.South)
+            elseif horizontal == 'West' and vertical == 'None' then
+                self:UpdateTextures(self.TextureSet.West)
+            elseif horizontal == 'East' and vertical == 'None' then
+                self:UpdateTextures(self.TextureSet.East)
+            elseif horizontal == 'West' and vertical == 'North' then
+                self:UpdateTextures(self.TextureSet.NorthWest)
+            elseif horizontal == 'East' and vertical == 'North' then
+                self:UpdateTextures(self.TextureSet.EastNorth)
+            elseif horizontal == 'West' and vertical == 'South' then
+                self:UpdateTextures(self.TextureSet.WestSouth)
+            elseif horizontal == 'East' and vertical == 'South' then
+                self:UpdateTextures(self.TextureSet.SouthEast)
+            end
+        end
+    end,
+
+    ---@param self UIOffScreenIndicator
+    OnClick = function(self)
+        local currentCamSettings = GetCamera('WorldCamera'):SaveSettings()
+        currentCamSettings.Focus = self.Target
+        GetCamera(self.WorldView._cameraName):RestoreSettings(currentCamSettings)
+    end,
+}
+
+---@param parent Control
+---@param worldView WorldView
+---@param target Vector # in world coordinates
+---@return UIOffScreenIndicator
+CreateYellowOffScreenIndicator = function(parent, worldView, target)
+    local indicator = OffScreenIndicator(parent, worldView, TexturesYellow, target) --[[@as UIOffScreenIndicator]]
+    return indicator
+end
+
+---@param parent Control
+---@param worldView WorldView
+---@param target Vector # in world coordinates
+---@return UIOffScreenIndicator
+CreateBlueOffScreenIndicator = function(parent, worldView, target)
+    local indicator = OffScreenIndicator(parent, worldView, TexturesBlue, target) --[[@as UIOffScreenIndicator]]
+    return indicator
+end
+
+---@param parent Control
+---@param worldView WorldView
+---@param target Vector # in world coordinates
+---@return UIOffScreenIndicator
+CreateRedOffScreenIndicator = function(parent, worldView, target)
+    local indicator = OffScreenIndicator(parent, worldView, TexturesRed, target) --[[@as UIOffScreenIndicator]]
+    return indicator
+end
+
+---@param parent Control
+---@param worldView WorldView
+---@param textures UIOffScreenIndicatorTextureSet
+---@param target Vector # in world coordinates
+---@return UIOffScreenIndicator
+CreateOffScreenIndicator = function(parent, worldView, textures, target)
+    local indicator = OffScreenIndicator(parent, worldView, textures, target) --[[@as UIOffScreenIndicator]]
+    return indicator
+end

--- a/lua/ui/game/OffScreenIndicator.lua
+++ b/lua/ui/game/OffScreenIndicator.lua
@@ -168,6 +168,7 @@ OffScreenIndicator = Class(Button) {
         self:Enable()
     end,
 
+    --- Clamps the indicator to the top of the world view, following the target horizontally.
     ---@param self UIOffScreenIndicator
     ---@param screenCoordinatesOfTarget Vector2
     PointNorth = function(self, screenCoordinatesOfTarget)
@@ -186,6 +187,7 @@ OffScreenIndicator = Class(Button) {
         LayoutHelpers.ResetBottom(self)
     end,
 
+    --- Clamps the indicator to the bottom of the world view, following the target horizontally.
     ---@param self UIOffScreenIndicator
     ---@param screenCoordinatesOfTarget Vector2
     PointSouth = function(self, screenCoordinatesOfTarget)
@@ -204,6 +206,7 @@ OffScreenIndicator = Class(Button) {
         LayoutHelpers.ResetTop(self)
     end,
 
+    --- Clamps the indicator to the right of the world view, following the target vertically.
     ---@param self UIOffScreenIndicator
     ---@param screenCoordinatesOfTarget Vector2
     PointEast = function(self, screenCoordinatesOfTarget)
@@ -222,6 +225,7 @@ OffScreenIndicator = Class(Button) {
         LayoutHelpers.ResetBottom(self)
     end,
 
+    --- Clamps the indicator to the left of the world view, following the target vertically.
     ---@param self UIOffScreenIndicator
     ---@param screenCoordinatesOfTarget Vector2
     PointWest = function(self, screenCoordinatesOfTarget)
@@ -240,6 +244,7 @@ OffScreenIndicator = Class(Button) {
         LayoutHelpers.ResetBottom(self)
     end,
 
+    --- Clamps the indicator to the top left corner of the world view.
     ---@param self UIOffScreenIndicator
     ---@param screenCoordinatesOfTarget Vector2
     PointNorthWest = function(self, screenCoordinatesOfTarget)
@@ -257,6 +262,7 @@ OffScreenIndicator = Class(Button) {
         LayoutHelpers.ResetRight(self)
     end,
 
+    --- Clamps the indicator to the top right corner of the world view.
     ---@param self UIOffScreenIndicator
     ---@param screenCoordinatesOfTarget Vector2
     PointNorthEast = function(self, screenCoordinatesOfTarget)
@@ -274,6 +280,7 @@ OffScreenIndicator = Class(Button) {
         LayoutHelpers.ResetLeft(self)
     end,
 
+    --- Clamps the indicator to the bottom left corner of the world view.
     ---@param self UIOffScreenIndicator
     ---@param screenCoordinatesOfTarget Vector2
     PointSouthWest = function(self, screenCoordinatesOfTarget)
@@ -291,6 +298,7 @@ OffScreenIndicator = Class(Button) {
         LayoutHelpers.ResetRight(self)
     end,
 
+    --- Clamps the indicator to the bottom right corner of the world view.
     ---@param self UIOffScreenIndicator
     ---@param screenCoordinatesOfTarget Vector2
     PointSouthEast = function(self, screenCoordinatesOfTarget)
@@ -308,8 +316,9 @@ OffScreenIndicator = Class(Button) {
         LayoutHelpers.ResetLeft(self)
     end,
 
+    --- Updates the direction of the off screen indicator. If the target is on screen, the indicator is hidden. 
     ---@param self UIOffScreenIndicator
-    OnFrame = function(self, delta)
+    UpdateDirection = function(self)
         local screenCoordinatesOfTarget = self.WorldView:Project(self.Target)
         local dirHorizontal, dirVertical = self:GetDirectionToTarget(self.WorldView, screenCoordinatesOfTarget)
         if dirHorizontal == 'OnScreen' and dirVertical == 'OnScreen' then
@@ -335,6 +344,11 @@ OffScreenIndicator = Class(Button) {
                 self:PointSouthEast(screenCoordinatesOfTarget)
             end
         end
+    end,
+
+    ---@param self UIOffScreenIndicator
+    OnFrame = function(self, delta)
+        self:UpdateDirection()
     end,
 
     ---@param self UIOffScreenIndicator

--- a/lua/ui/game/OffScreenIndicator.lua
+++ b/lua/ui/game/OffScreenIndicator.lua
@@ -67,7 +67,7 @@ OffScreenIndicator = Class(Button) {
 
         self.WorldView = worldView
         self.TextureSet = textures
-        self.AnimatedGlow = AnimatedGlow.CreateAnimatedGlow(self, textures.Glow)
+        self.AnimatedGlow = AnimatedGlow.CreateAnimatedGlow(self, textures.Glow, 10)
     end,
 
     ---@param self UIOffScreenIndicator

--- a/lua/ui/game/OffScreenIndicator.lua
+++ b/lua/ui/game/OffScreenIndicator.lua
@@ -20,7 +20,7 @@
 --** SOFTWARE.
 --******************************************************************************************************
 
-local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
+local Layouter = import("/lua/maui/layouthelpers.lua").Layouter
 local UIUtil = import("/lua/ui/uiutil.lua")
 
 local Button = import("/lua/maui/button.lua").Button
@@ -113,7 +113,7 @@ OffScreenIndicator = Class(Button) {
     ---@param self UIOffScreenIndicator
     ---@param parent Control
     __post_init = function(self, parent)
-        LayoutHelpers.LayoutFor(self)
+        Layouter(self)
             :NeedsFrameUpdate(true)
             :Fill(parent)
             :End()
@@ -174,17 +174,19 @@ OffScreenIndicator = Class(Button) {
     PointNorth = function(self, screenCoordinatesOfTarget)
         self:UpdateTextures(self.TextureSet.North)
 
-        -- point at the target vertically
-        self.Left:Set(function() return screenCoordinatesOfTarget.x - self.Width() / 2 end)
-        LayoutHelpers.AtHorizontalCenterIn(self.AnimatedGlow, self)
-        LayoutHelpers.ResetRight(self.AnimatedGlow)
-        LayoutHelpers.ResetRight(self)
+        Layouter(self)
+            :Top(self.WorldView.Top)
+            :Left(function() return screenCoordinatesOfTarget.x - self.Width() / 2 end)
+            :ResetBottom()
+            :ResetRight()
+            :End()
 
-        -- position at the top of the screen
-        self.Top:Set(self.WorldView.Top)
-        LayoutHelpers.AtTopIn(self.AnimatedGlow, self, -10)
-        LayoutHelpers.ResetBottom(self.AnimatedGlow)
-        LayoutHelpers.ResetBottom(self)
+        Layouter(self.AnimatedGlow)
+            :AtHorizontalCenterIn(self)
+            :AtTopIn(self, -10)
+            :ResetRight()
+            :ResetBottom()
+            :End()
     end,
 
     --- Clamps the indicator to the bottom of the world view, following the target horizontally.
@@ -193,17 +195,19 @@ OffScreenIndicator = Class(Button) {
     PointSouth = function(self, screenCoordinatesOfTarget)
         self:UpdateTextures(self.TextureSet.South)
 
-        -- point at the target vertically
-        self.Left:Set(function() return screenCoordinatesOfTarget.x - self.Width() / 2 end)
-        LayoutHelpers.AtHorizontalCenterIn(self.AnimatedGlow, self)
-        LayoutHelpers.ResetRight(self.AnimatedGlow)
-        LayoutHelpers.ResetRight(self)
+        Layouter(self)
+            :Left(function() return screenCoordinatesOfTarget.x - self.Width() / 2 end)
+            :Bottom(self.WorldView.Bottom)
+            :ResetTop()
+            :ResetRight()
+            :End()
 
-        -- position at the bottom of the screen
-        self.Bottom:Set(self.WorldView.Bottom)
-        LayoutHelpers.AtBottomIn(self.AnimatedGlow, self, -10)
-        LayoutHelpers.ResetTop(self.AnimatedGlow)
-        LayoutHelpers.ResetTop(self)
+        Layouter(self.AnimatedGlow)
+            :AtHorizontalCenterIn(self)
+            :AtBottomIn(self, -10)
+            :ResetTop()
+            :ResetRight()
+            :End()
     end,
 
     --- Clamps the indicator to the right of the world view, following the target vertically.
@@ -212,17 +216,19 @@ OffScreenIndicator = Class(Button) {
     PointEast = function(self, screenCoordinatesOfTarget)
         self:UpdateTextures(self.TextureSet.East)
 
-        -- position to the right of the screen
-        self.Right:Set(self.WorldView.Right)
-        LayoutHelpers.AtRightIn(self.AnimatedGlow, self, -10)
-        LayoutHelpers.ResetLeft(self.AnimatedGlow)
-        LayoutHelpers.ResetLeft(self)
+        Layouter(self)
+            :Right(self.WorldView.Right)
+            :Top(function() return screenCoordinatesOfTarget.y - self.Height() / 2 end)
+            :ResetBottom()
+            :ResetLeft()
+            :End()
 
-        -- point at the target horizontally
-        self.Top:Set(function() return screenCoordinatesOfTarget.y - self.Height() / 2 end)
-        LayoutHelpers.AtVerticalCenterIn(self.AnimatedGlow, self)
-        LayoutHelpers.ResetBottom(self.AnimatedGlow)
-        LayoutHelpers.ResetBottom(self)
+        Layouter(self.AnimatedGlow)
+            :AtVerticalCenterIn(self)
+            :AtRightIn(self, -10)
+            :ResetLeft()
+            :ResetBottom()
+            :End()
     end,
 
     --- Clamps the indicator to the left of the world view, following the target vertically.
@@ -231,17 +237,19 @@ OffScreenIndicator = Class(Button) {
     PointWest = function(self, screenCoordinatesOfTarget)
         self:UpdateTextures(self.TextureSet.West)
 
-        -- position to the left of the screen
-        self.Left:Set(self.WorldView.Left)
-        LayoutHelpers.AtLeftIn(self.AnimatedGlow, self, -10)
-        LayoutHelpers.ResetRight(self.AnimatedGlow)
-        LayoutHelpers.ResetRight(self)
+        Layouter(self)
+            :Left(self.WorldView.Left)
+            :Top(function() return screenCoordinatesOfTarget.y - self.Height() / 2 end)
+            :ResetBottom()
+            :ResetRight()
+            :End()
 
-        -- point at the target horizontally
-        self.Top:Set(function() return screenCoordinatesOfTarget.y - self.Height() / 2 end)
-        LayoutHelpers.AtVerticalCenterIn(self.AnimatedGlow, self)
-        LayoutHelpers.ResetBottom(self.AnimatedGlow)
-        LayoutHelpers.ResetBottom(self)
+        Layouter(self.AnimatedGlow)
+            :AtVerticalCenterIn(self)
+            :AtLeftIn(self, -10)
+            :ResetRight()
+            :ResetBottom()
+            :End()
     end,
 
     --- Clamps the indicator to the top left corner of the world view.
@@ -250,16 +258,19 @@ OffScreenIndicator = Class(Button) {
     PointNorthWest = function(self, screenCoordinatesOfTarget)
         self:UpdateTextures(self.TextureSet.NorthWest)
 
-        -- position to the top left corner
-        self.Top:Set(self.WorldView.Top)
-        LayoutHelpers.AtTopIn(self.AnimatedGlow, self, -10)
-        LayoutHelpers.ResetBottom(self.AnimatedGlow)
-        LayoutHelpers.ResetBottom(self)
+        Layouter(self)
+            :Top(self.WorldView.Top)
+            :Left(self.WorldView.Left)
+            :ResetBottom()
+            :ResetRight()
+            :End()
 
-        self.Left:Set(self.WorldView.Left)
-        LayoutHelpers.AtLeftIn(self.AnimatedGlow, self, -10)
-        LayoutHelpers.ResetRight(self.AnimatedGlow)
-        LayoutHelpers.ResetRight(self)
+        Layouter(self.AnimatedGlow)
+            :AtTopIn(self, -10)
+            :AtLeftIn(self, -10)
+            :ResetRight()
+            :ResetBottom()
+            :End()
     end,
 
     --- Clamps the indicator to the top right corner of the world view.
@@ -268,16 +279,19 @@ OffScreenIndicator = Class(Button) {
     PointNorthEast = function(self, screenCoordinatesOfTarget)
         self:UpdateTextures(self.TextureSet.EastNorth)
 
-        -- position to the top right corner
-        self.Top:Set(self.WorldView.Top)
-        LayoutHelpers.AtTopIn(self.AnimatedGlow, self, -10)
-        LayoutHelpers.ResetBottom(self.AnimatedGlow)
-        LayoutHelpers.ResetBottom(self)
+        Layouter(self)
+            :Top(self.WorldView.Top)
+            :Right(self.WorldView.Right)
+            :ResetBottom()
+            :ResetLeft()
+            :End()
 
-        self.Right:Set(self.WorldView.Right)
-        LayoutHelpers.AtRightIn(self.AnimatedGlow, self, -10)
-        LayoutHelpers.ResetLeft(self.AnimatedGlow)
-        LayoutHelpers.ResetLeft(self)
+        Layouter(self.AnimatedGlow)
+            :AtTopIn(self, -10)
+            :AtRightIn(self, -10)
+            :ResetLeft()
+            :ResetBottom()
+            :End()
     end,
 
     --- Clamps the indicator to the bottom left corner of the world view.
@@ -286,16 +300,19 @@ OffScreenIndicator = Class(Button) {
     PointSouthWest = function(self, screenCoordinatesOfTarget)
         self:UpdateTextures(self.TextureSet.WestSouth)
 
-        -- position to the bottom left corner
-        self.Bottom:Set(self.WorldView.Bottom)
-        LayoutHelpers.AtBottomIn(self.AnimatedGlow, self, -10)
-        LayoutHelpers.ResetTop(self.AnimatedGlow)
-        LayoutHelpers.ResetTop(self)
+        Layouter(self)
+            :Bottom(self.WorldView.Bottom)
+            :Left(self.WorldView.Left)
+            :ResetTop()
+            :ResetRight()
+            :End()
 
-        self.Left:Set(self.WorldView.Left)
-        LayoutHelpers.AtLeftIn(self.AnimatedGlow, self, -10)
-        LayoutHelpers.ResetRight(self.AnimatedGlow)
-        LayoutHelpers.ResetRight(self)
+        Layouter(self.AnimatedGlow)
+            :AtBottomIn(self, -10)
+            :AtLeftIn(self, -10)
+            :ResetRight()
+            :ResetTop()
+            :End()
     end,
 
     --- Clamps the indicator to the bottom right corner of the world view.
@@ -304,19 +321,22 @@ OffScreenIndicator = Class(Button) {
     PointSouthEast = function(self, screenCoordinatesOfTarget)
         self:UpdateTextures(self.TextureSet.SouthEast)
 
-        -- position to the bottom right corner
-        self.Bottom:Set(self.WorldView.Bottom)
-        LayoutHelpers.AtBottomIn(self.AnimatedGlow, self, -10)
-        LayoutHelpers.ResetTop(self.AnimatedGlow)
-        LayoutHelpers.ResetTop(self)
+        Layouter(self)
+            :Bottom(self.WorldView.Bottom)
+            :Right(self.WorldView.Right)
+            :ResetTop()
+            :ResetLeft()
+            :End()
 
-        self.Right:Set(self.WorldView.Right)
-        LayoutHelpers.AtRightIn(self.AnimatedGlow, self, -10)
-        LayoutHelpers.ResetLeft(self.AnimatedGlow)
-        LayoutHelpers.ResetLeft(self)
+        Layouter(self.AnimatedGlow)
+            :AtBottomIn(self, -10)
+            :AtRightIn(self, -10)
+            :ResetLeft()
+            :ResetTop()
+            :End()
     end,
 
-    --- Updates the direction of the off screen indicator. If the target is on screen, the indicator is hidden. 
+    --- Updates the direction of the off screen indicator. If the target is on screen, the indicator is hidden.
     ---@param self UIOffScreenIndicator
     UpdateDirection = function(self)
         local screenCoordinatesOfTarget = self.WorldView:Project(self.Target)

--- a/lua/ui/game/OffScreenIndicator.lua
+++ b/lua/ui/game/OffScreenIndicator.lua
@@ -44,49 +44,7 @@ local AnimatedGlow = import("/lua/ui/game/common/AnimatedGlow.lua")
 ---@field EastNorth UIOffScreenIndicatorTextureStates
 ---@field Glow FileName
 
---- A preset set of textures for UIOffScreenIndicator that match the blue ping.
----@type UIOffScreenIndicatorTextureSet
-local TexturesBlue = {
-    North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_down.dds' },
-    NorthWest = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_bl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_bl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_bl_down.dds' },
-    West = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_l_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_l_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_l_down.dds' },
-    WestSouth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_tl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_tl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_tl_down.dds' },
-    South = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_t_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_t_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_t_down.dds' },
-    SouthEast = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_tr_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_tr_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_tr_down.dds' },
-    East = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_r_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_r_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_r_down.dds' },
-    EastNorth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_br_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_br_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_br_down.dds' },
-    Glow = '/textures/ui/common/game/ping_edge/ping_edge_blue_glow.dds'
-}
-
---- A preset set of textures for UIOffScreenIndicator that match the yellow ping.
----@type UIOffScreenIndicatorTextureSet
-local TexturesYellow = {
-    North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_down.dds' },
-    NorthWest = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_bl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_bl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_bl_down.dds' },
-    West = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_l_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_l_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_l_down.dds' },
-    WestSouth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tl_down.dds' },
-    South = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_t_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_t_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_t_down.dds' },
-    SouthEast = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tr_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tr_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tr_down.dds' },
-    East = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_r_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_r_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_r_down.dds' },
-    EastNorth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_br_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_br_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_br_down.dds' },
-    Glow = '/textures/ui/common/game/ping_edge/ping_edge_yellow_glow.dds'
-}
-
---- A preset set of textures for UIOffScreenIndicator that match the red ping.
----@type UIOffScreenIndicatorTextureSet
-local TexturesRed = {
-    North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_b_down.dds' },
-    NorthWest = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_bl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_bl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_bl_down.dds' },
-    West = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_l_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_l_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_l_down.dds' },
-    WestSouth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_tl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_tl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_tl_down.dds' },
-    South = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_t_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_t_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_t_down.dds' },
-    SouthEast = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_tr_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_tr_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_tr_down.dds' },
-    East = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_r_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_r_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_r_down.dds' },
-    EastNorth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_br_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_br_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_br_down.dds' },
-    Glow = '/textures/ui/common/game/ping_edge/ping_edge_red_glow.dds'
-}
-
---- A utility class to help you point to events that happen off screen.
+--- A utility class to help you point to events that happen off screen. This is an abstract class, it won't do anything on its own.
 ---@class UIOffScreenIndicator : Button
 ---@field TextureSet UIOffScreenIndicatorTextureSet
 ---@field Target Vector     # in world coordinates
@@ -98,7 +56,7 @@ OffScreenIndicator = Class(Button) {
     ---@param parent Control
     ---@param worldView WorldView
     ---@param textures UIOffScreenIndicatorTextureSet
-    __init = function(self, parent, worldView, textures, target)
+    __init = function(self, parent, worldView, textures)
         Button.__init(
             self, parent,
             UIUtil.UIFile(textures.North.Up),
@@ -109,17 +67,26 @@ OffScreenIndicator = Class(Button) {
 
         self.WorldView = worldView
         self.TextureSet = textures
-        self.Target = target
         self.AnimatedGlow = AnimatedGlow.CreateAnimatedGlow(self, textures.Glow)
     end,
 
     ---@param self UIOffScreenIndicator
     ---@param parent Control
     __post_init = function(self, parent)
+
+        -- to be overwritten by subclass
         Layouter(self)
-            :NeedsFrameUpdate(true)
             :Fill(parent)
             :End()
+    end,
+
+    --- Retrieves the target location of the indicator.
+    ---@param self UIOffScreenIndicator
+    ---@return Vector
+    GetTarget = function(self)
+
+        -- to be overwritten by subclass
+        return { 0, 0, 0 }
     end,
 
     --- Updates the set of textures to use for the button.
@@ -342,7 +309,8 @@ OffScreenIndicator = Class(Button) {
     --- Updates the direction of the off screen indicator. If the target is on screen, the indicator is hidden.
     ---@param self UIOffScreenIndicator
     UpdateDirection = function(self)
-        local screenCoordinatesOfTarget = self.WorldView:Project(self.Target)
+        local target = self:GetTarget()
+        local screenCoordinatesOfTarget = self.WorldView:Project(target)
         local dirHorizontal, dirVertical = self:GetDirectionToTarget(self.WorldView, screenCoordinatesOfTarget)
         if dirHorizontal == 'OnScreen' and dirVertical == 'OnScreen' then
             self:OnPointingOnScreen()
@@ -368,53 +336,4 @@ OffScreenIndicator = Class(Button) {
             end
         end
     end,
-
-    ---@param self UIOffScreenIndicator
-    OnFrame = function(self, delta)
-        self:UpdateDirection()
-    end,
-
-    ---@param self UIOffScreenIndicator
-    OnClick = function(self)
-        local currentCamSettings = GetCamera('WorldCamera'):SaveSettings()
-        currentCamSettings.Focus = self.Target
-        GetCamera(self.WorldView._cameraName):RestoreSettings(currentCamSettings)
-    end,
 }
-
----@param parent Control
----@param worldView WorldView
----@param target Vector # in world coordinates
----@return UIOffScreenIndicator
-CreateYellowOffScreenIndicator = function(parent, worldView, target)
-    local indicator = OffScreenIndicator(parent, worldView, TexturesYellow, target) --[[@as UIOffScreenIndicator]]
-    return indicator
-end
-
----@param parent Control
----@param worldView WorldView
----@param target Vector # in world coordinates
----@return UIOffScreenIndicator
-CreateBlueOffScreenIndicator = function(parent, worldView, target)
-    local indicator = OffScreenIndicator(parent, worldView, TexturesBlue, target) --[[@as UIOffScreenIndicator]]
-    return indicator
-end
-
----@param parent Control
----@param worldView WorldView
----@param target Vector # in world coordinates
----@return UIOffScreenIndicator
-CreateRedOffScreenIndicator = function(parent, worldView, target)
-    local indicator = OffScreenIndicator(parent, worldView, TexturesRed, target) --[[@as UIOffScreenIndicator]]
-    return indicator
-end
-
----@param parent Control
----@param worldView WorldView
----@param textures UIOffScreenIndicatorTextureSet
----@param target Vector # in world coordinates
----@return UIOffScreenIndicator
-CreateOffScreenIndicator = function(parent, worldView, textures, target)
-    local indicator = OffScreenIndicator(parent, worldView, textures, target) --[[@as UIOffScreenIndicator]]
-    return indicator
-end

--- a/lua/ui/game/OffScreenIndicator.lua
+++ b/lua/ui/game/OffScreenIndicator.lua
@@ -1,5 +1,5 @@
 --******************************************************************************************************
---** Copyright (c) 2022  Willem 'Jip' Wijnia
+--** Copyright (c) 2025  Willem 'Jip' Wijnia
 --**
 --** Permission is hereby granted, free of charge, to any person obtaining a copy
 --** of this software and associated documentation files (the "Software"), to deal
@@ -20,8 +20,8 @@
 --** SOFTWARE.
 --******************************************************************************************************
 
-local Layouter = import("/lua/maui/layouthelpers.lua").Layouter
 local UIUtil = import("/lua/ui/uiutil.lua")
+local Layouter = import("/lua/maui/layouthelpers.lua").Layouter
 
 local Button = import("/lua/maui/button.lua").Button
 local AnimatedGlow = import("/lua/ui/game/common/AnimatedGlow.lua")
@@ -44,6 +44,7 @@ local AnimatedGlow = import("/lua/ui/game/common/AnimatedGlow.lua")
 ---@field EastNorth UIOffScreenIndicatorTextureStates
 ---@field Glow FileName
 
+--- A preset set of textures for UIOffScreenIndicator that match the blue ping.
 ---@type UIOffScreenIndicatorTextureSet
 local TexturesBlue = {
     North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_down.dds' },
@@ -57,6 +58,7 @@ local TexturesBlue = {
     Glow = '/textures/ui/common/game/ping_edge/ping_edge_blue_glow.dds'
 }
 
+--- A preset set of textures for UIOffScreenIndicator that match the yellow ping.
 ---@type UIOffScreenIndicatorTextureSet
 local TexturesYellow = {
     North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_down.dds' },
@@ -70,6 +72,7 @@ local TexturesYellow = {
     Glow = '/textures/ui/common/game/ping_edge/ping_edge_yellow_glow.dds'
 }
 
+--- A preset set of textures for UIOffScreenIndicator that match the red ping.
 ---@type UIOffScreenIndicatorTextureSet
 local TexturesRed = {
     North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_b_down.dds' },

--- a/lua/ui/game/OffScreenIndicator.lua
+++ b/lua/ui/game/OffScreenIndicator.lua
@@ -21,7 +21,7 @@
 --******************************************************************************************************
 
 local UIUtil = import("/lua/ui/uiutil.lua")
-local Layouter = import("/lua/maui/layouthelpers.lua").Layouter
+local ReusedLayoutFor = import("/lua/maui/layouthelpers.lua").ReusedLayoutFor
 
 local Button = import("/lua/maui/button.lua").Button
 local AnimatedGlow = import("/lua/ui/game/common/AnimatedGlow.lua")
@@ -75,7 +75,7 @@ OffScreenIndicator = Class(Button) {
     __post_init = function(self, parent)
 
         -- to be overwritten by subclass
-        Layouter(self)
+        ReusedLayoutFor(self)
             :Fill(parent)
             :End()
     end,
@@ -103,21 +103,21 @@ OffScreenIndicator = Class(Button) {
 
     ---@param self UIOffScreenIndicator
     ---@param worldView WorldView
-    ---@param screenCoordinates Vector2
+    ---@param controlSpaceCoordinates Vector2   # control space coordinates
     ---@return UIOffScreenIndicatorDirection    # horizontal axis
     ---@return UIOffScreenIndicatorDirection    # vertical axis
-    GetDirectionToTarget = function(self, worldView, screenCoordinates)
+    GetDirectionToTarget = function(self, worldView, controlSpaceCoordinates)
         local horizontal = "OnScreen"
-        if worldView.Left() + screenCoordinates.x < worldView.Left() then
+        if controlSpaceCoordinates.x < 0 then
             horizontal = "West"
-        elseif screenCoordinates.x > worldView.Right() then
+        elseif controlSpaceCoordinates.x > worldView.Width() then
             horizontal = "East"
         end
 
         local vertical = "OnScreen"
-        if worldView.Top() + screenCoordinates.y < worldView.Top() then
+        if controlSpaceCoordinates.y < 0 then
             vertical = "North"
-        elseif screenCoordinates.y > worldView.Bottom() then
+        elseif controlSpaceCoordinates.y > worldView.Height() then
             vertical = "South"
         end
 
@@ -140,18 +140,18 @@ OffScreenIndicator = Class(Button) {
 
     --- Clamps the indicator to the top of the world view, following the target horizontally.
     ---@param self UIOffScreenIndicator
-    ---@param screenCoordinatesOfTarget Vector2
-    PointNorth = function(self, screenCoordinatesOfTarget)
+    ---@param controlSpaceCoordinates Vector2   # control space coordinates
+    PointNorth = function(self, controlSpaceCoordinates)
         self:UpdateTextures(self.TextureSet.North)
 
-        Layouter(self)
+        ReusedLayoutFor(self)
             :Top(self.WorldView.Top)
-            :Left(function() return screenCoordinatesOfTarget.x - self.Width() / 2 end)
+            :Left(function() return self.WorldView.Left() + controlSpaceCoordinates.x - self.Width() * 0.5 end)
             :ResetBottom()
             :ResetRight()
             :End()
 
-        Layouter(self.AnimatedGlow)
+        ReusedLayoutFor(self.AnimatedGlow)
             :AtHorizontalCenterIn(self)
             :AtTopIn(self, -10)
             :ResetRight()
@@ -161,18 +161,18 @@ OffScreenIndicator = Class(Button) {
 
     --- Clamps the indicator to the bottom of the world view, following the target horizontally.
     ---@param self UIOffScreenIndicator
-    ---@param screenCoordinatesOfTarget Vector2
-    PointSouth = function(self, screenCoordinatesOfTarget)
+    ---@param controlSpaceCoordinates Vector2   # control space coordinates
+    PointSouth = function(self, controlSpaceCoordinates)
         self:UpdateTextures(self.TextureSet.South)
 
-        Layouter(self)
-            :Left(function() return screenCoordinatesOfTarget.x - self.Width() / 2 end)
+        ReusedLayoutFor(self)
+            :Left(function() return self.WorldView.Left() + controlSpaceCoordinates.x - self.Width() / 2 end)
             :Bottom(self.WorldView.Bottom)
             :ResetTop()
             :ResetRight()
             :End()
 
-        Layouter(self.AnimatedGlow)
+        ReusedLayoutFor(self.AnimatedGlow)
             :AtHorizontalCenterIn(self)
             :AtBottomIn(self, -10)
             :ResetTop()
@@ -182,18 +182,18 @@ OffScreenIndicator = Class(Button) {
 
     --- Clamps the indicator to the right of the world view, following the target vertically.
     ---@param self UIOffScreenIndicator
-    ---@param screenCoordinatesOfTarget Vector2
-    PointEast = function(self, screenCoordinatesOfTarget)
+    ---@param controlSpaceCoordinates Vector2   # control space coordinates
+    PointEast = function(self, controlSpaceCoordinates)
         self:UpdateTextures(self.TextureSet.East)
 
-        Layouter(self)
-            :Right(self.WorldView.Right)
-            :Top(function() return screenCoordinatesOfTarget.y - self.Height() / 2 end)
+        ReusedLayoutFor(self)
+            :AnchorToRight(self)
+            :Top(function() return self.WorldView.Top() + controlSpaceCoordinates.y - self.Height() / 2 end)
             :ResetBottom()
             :ResetLeft()
             :End()
 
-        Layouter(self.AnimatedGlow)
+        ReusedLayoutFor(self.AnimatedGlow)
             :AtVerticalCenterIn(self)
             :AtRightIn(self, -10)
             :ResetLeft()
@@ -203,18 +203,18 @@ OffScreenIndicator = Class(Button) {
 
     --- Clamps the indicator to the left of the world view, following the target vertically.
     ---@param self UIOffScreenIndicator
-    ---@param screenCoordinatesOfTarget Vector2
-    PointWest = function(self, screenCoordinatesOfTarget)
+    ---@param controlSpaceCoordinates Vector2   # control space coordinates
+    PointWest = function(self, controlSpaceCoordinates)
         self:UpdateTextures(self.TextureSet.West)
 
-        Layouter(self)
+        ReusedLayoutFor(self)
             :Left(self.WorldView.Left)
-            :Top(function() return screenCoordinatesOfTarget.y - self.Height() / 2 end)
+            :Top(function() return self.WorldView.Top() + controlSpaceCoordinates.y - self.Height() / 2 end)
             :ResetBottom()
             :ResetRight()
             :End()
 
-        Layouter(self.AnimatedGlow)
+        ReusedLayoutFor(self.AnimatedGlow)
             :AtVerticalCenterIn(self)
             :AtLeftIn(self, -10)
             :ResetRight()
@@ -224,18 +224,18 @@ OffScreenIndicator = Class(Button) {
 
     --- Clamps the indicator to the top left corner of the world view.
     ---@param self UIOffScreenIndicator
-    ---@param screenCoordinatesOfTarget Vector2
-    PointNorthWest = function(self, screenCoordinatesOfTarget)
+    ---@param controlSpaceCoordinates Vector2   # control space coordinates
+    PointNorthWest = function(self, controlSpaceCoordinates)
         self:UpdateTextures(self.TextureSet.NorthWest)
 
-        Layouter(self)
+        ReusedLayoutFor(self)
             :Top(self.WorldView.Top)
             :Left(self.WorldView.Left)
             :ResetBottom()
             :ResetRight()
             :End()
 
-        Layouter(self.AnimatedGlow)
+        ReusedLayoutFor(self.AnimatedGlow)
             :AtTopIn(self, -10)
             :AtLeftIn(self, -10)
             :ResetRight()
@@ -245,18 +245,18 @@ OffScreenIndicator = Class(Button) {
 
     --- Clamps the indicator to the top right corner of the world view.
     ---@param self UIOffScreenIndicator
-    ---@param screenCoordinatesOfTarget Vector2
-    PointNorthEast = function(self, screenCoordinatesOfTarget)
+    ---@param controlSpaceCoordinates Vector2   # control space coordinates
+    PointNorthEast = function(self, controlSpaceCoordinates)
         self:UpdateTextures(self.TextureSet.EastNorth)
 
-        Layouter(self)
+        ReusedLayoutFor(self)
             :Top(self.WorldView.Top)
             :Right(self.WorldView.Right)
             :ResetBottom()
             :ResetLeft()
             :End()
 
-        Layouter(self.AnimatedGlow)
+        ReusedLayoutFor(self.AnimatedGlow)
             :AtTopIn(self, -10)
             :AtRightIn(self, -10)
             :ResetLeft()
@@ -266,18 +266,18 @@ OffScreenIndicator = Class(Button) {
 
     --- Clamps the indicator to the bottom left corner of the world view.
     ---@param self UIOffScreenIndicator
-    ---@param screenCoordinatesOfTarget Vector2
-    PointSouthWest = function(self, screenCoordinatesOfTarget)
+    ---@param controlSpaceCoordinates Vector2   # control space coordinates
+    PointSouthWest = function(self, controlSpaceCoordinates)
         self:UpdateTextures(self.TextureSet.WestSouth)
 
-        Layouter(self)
+        ReusedLayoutFor(self)
             :Bottom(self.WorldView.Bottom)
             :Left(self.WorldView.Left)
             :ResetTop()
             :ResetRight()
             :End()
 
-        Layouter(self.AnimatedGlow)
+        ReusedLayoutFor(self.AnimatedGlow)
             :AtBottomIn(self, -10)
             :AtLeftIn(self, -10)
             :ResetRight()
@@ -287,18 +287,18 @@ OffScreenIndicator = Class(Button) {
 
     --- Clamps the indicator to the bottom right corner of the world view.
     ---@param self UIOffScreenIndicator
-    ---@param screenCoordinatesOfTarget Vector2
-    PointSouthEast = function(self, screenCoordinatesOfTarget)
+    ---@param controlSpaceCoordinates Vector2   # control space coordinates
+    PointSouthEast = function(self, controlSpaceCoordinates)
         self:UpdateTextures(self.TextureSet.SouthEast)
 
-        Layouter(self)
+        ReusedLayoutFor(self)
             :Bottom(self.WorldView.Bottom)
             :Right(self.WorldView.Right)
             :ResetTop()
             :ResetLeft()
             :End()
 
-        Layouter(self.AnimatedGlow)
+        ReusedLayoutFor(self.AnimatedGlow)
             :AtBottomIn(self, -10)
             :AtRightIn(self, -10)
             :ResetLeft()
@@ -310,29 +310,29 @@ OffScreenIndicator = Class(Button) {
     ---@param self UIOffScreenIndicator
     UpdateDirection = function(self)
         local target = self:GetTarget()
-        local screenCoordinatesOfTarget = self.WorldView:Project(target)
-        local dirHorizontal, dirVertical = self:GetDirectionToTarget(self.WorldView, screenCoordinatesOfTarget)
+        local controlSpaceCoordinates = self.WorldView:Project(target)
+        local dirHorizontal, dirVertical = self:GetDirectionToTarget(self.WorldView, controlSpaceCoordinates)
         if dirHorizontal == 'OnScreen' and dirVertical == 'OnScreen' then
             self:OnPointingOnScreen()
         else
             self:OnPointingOffScreen()
             -- determine what textures to show
             if dirHorizontal == 'OnScreen' and dirVertical == 'North' then
-                self:PointNorth(screenCoordinatesOfTarget)
+                self:PointNorth(controlSpaceCoordinates)
             elseif dirHorizontal == 'OnScreen' and dirVertical == 'South' then
-                self:PointSouth(screenCoordinatesOfTarget)
+                self:PointSouth(controlSpaceCoordinates)
             elseif dirHorizontal == 'West' and dirVertical == 'OnScreen' then
-                self:PointWest(screenCoordinatesOfTarget)
+                self:PointWest(controlSpaceCoordinates)
             elseif dirHorizontal == 'East' and dirVertical == 'OnScreen' then
-                self:PointEast(screenCoordinatesOfTarget)
+                self:PointEast(controlSpaceCoordinates)
             elseif dirHorizontal == 'West' and dirVertical == 'North' then
-                self:PointNorthWest(screenCoordinatesOfTarget)
+                self:PointNorthWest(controlSpaceCoordinates)
             elseif dirHorizontal == 'East' and dirVertical == 'North' then
-                self:PointNorthEast(screenCoordinatesOfTarget)
+                self:PointNorthEast(controlSpaceCoordinates)
             elseif dirHorizontal == 'West' and dirVertical == 'South' then
-                self:PointSouthWest(screenCoordinatesOfTarget)
+                self:PointSouthWest(controlSpaceCoordinates)
             elseif dirHorizontal == 'East' and dirVertical == 'South' then
-                self:PointSouthEast(screenCoordinatesOfTarget)
+                self:PointSouthEast(controlSpaceCoordinates)
             end
         end
     end,

--- a/lua/ui/game/OffScreenIndicatorForMarkers.lua
+++ b/lua/ui/game/OffScreenIndicatorForMarkers.lua
@@ -1,0 +1,140 @@
+--******************************************************************************************************
+--** Copyright (c) 2025  Willem 'Jip' Wijnia
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
+local Layouter = import("/lua/maui/layouthelpers.lua").Layouter
+
+local OffScreenIndicator = import("/lua/ui/game/OffScreenIndicator.lua").OffScreenIndicator
+
+--- A preset set of textures for UIOffScreenIndicator that match the blue ping.
+---@type UIOffScreenIndicatorTextureSet
+local TexturesBlue = {
+    North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_down.dds' },
+    NorthWest = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_bl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_bl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_bl_down.dds' },
+    West = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_l_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_l_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_l_down.dds' },
+    WestSouth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_tl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_tl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_tl_down.dds' },
+    South = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_t_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_t_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_t_down.dds' },
+    SouthEast = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_tr_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_tr_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_tr_down.dds' },
+    East = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_r_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_r_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_r_down.dds' },
+    EastNorth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_br_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_br_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_br_down.dds' },
+    Glow = '/textures/ui/common/game/ping_edge/ping_edge_blue_glow.dds'
+}
+
+--- A preset set of textures for UIOffScreenIndicator that match the yellow ping.
+---@type UIOffScreenIndicatorTextureSet
+local TexturesYellow = {
+    North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_down.dds' },
+    NorthWest = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_bl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_bl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_bl_down.dds' },
+    West = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_l_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_l_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_l_down.dds' },
+    WestSouth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tl_down.dds' },
+    South = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_t_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_t_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_t_down.dds' },
+    SouthEast = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tr_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tr_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tr_down.dds' },
+    East = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_r_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_r_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_r_down.dds' },
+    EastNorth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_br_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_br_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_br_down.dds' },
+    Glow = '/textures/ui/common/game/ping_edge/ping_edge_yellow_glow.dds'
+}
+
+--- A preset set of textures for UIOffScreenIndicator that match the red ping.
+---@type UIOffScreenIndicatorTextureSet
+local TexturesRed = {
+    North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_b_down.dds' },
+    NorthWest = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_bl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_bl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_bl_down.dds' },
+    West = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_l_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_l_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_l_down.dds' },
+    WestSouth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_tl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_tl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_tl_down.dds' },
+    South = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_t_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_t_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_t_down.dds' },
+    SouthEast = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_tr_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_tr_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_tr_down.dds' },
+    East = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_r_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_r_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_r_down.dds' },
+    EastNorth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_br_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_br_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_br_down.dds' },
+    Glow = '/textures/ui/common/game/ping_edge/ping_edge_red_glow.dds'
+}
+
+--- An off screen indicator for markers to help users be aware of them.
+---@class UIOffScreenIndicatorForMarkers : UIOffScreenIndicator
+---@field Target Vector     # in world coordinates
+OffScreenIndicatorForMarkers = Class(OffScreenIndicator) {
+
+    ---@param self UIOffScreenIndicator
+    ---@param parent Control
+    ---@param worldView WorldView
+    ---@param textures UIOffScreenIndicatorTextureSet
+    __init = function(self, parent, worldView, textures, target)
+        OffScreenIndicator.__init(
+            self, parent, worldView, textures
+        )
+
+        self.Target = target
+    end,
+
+    ---@param self UIOffScreenIndicator
+    ---@param parent Control
+    __post_init = function(self, parent)
+        Layouter(self)
+            :NeedsFrameUpdate(true)
+            :Fill(parent)
+            :End()
+    end,
+
+    --- Returns the world position of the marker.
+    ---@param self UIOffScreenIndicatorForMarkers
+    ---@return Vector
+    GetTarget = function(self)
+        return self.Target
+    end,
+
+    ---@param self UIOffScreenIndicator
+    OnFrame = function(self, delta)
+        self:UpdateDirection()
+    end,
+
+    ---@param self UIOffScreenIndicator
+    OnClick = function(self)
+        local currentCamSettings = GetCamera('WorldCamera'):SaveSettings()
+        currentCamSettings.Focus = self:GetTarget()
+        GetCamera(self.WorldView._cameraName):RestoreSettings(currentCamSettings)
+    end,
+}
+
+---@param parent Control
+---@param worldView WorldView
+---@param target Vector # in world coordinates
+---@return UIOffScreenIndicator
+CreateYellowOffScreenIndicator = function(parent, worldView, target)
+    local indicator = OffScreenIndicatorForMarkers(parent, worldView, TexturesYellow, target) --[[@as UIOffScreenIndicatorForMarkers]]
+    return indicator
+end
+
+---@param parent Control
+---@param worldView WorldView
+---@param target Vector # in world coordinates
+---@return UIOffScreenIndicatorForMarkers
+CreateBlueOffScreenIndicator = function(parent, worldView, target)
+    local indicator = OffScreenIndicatorForMarkers(parent, worldView, TexturesBlue, target) --[[@as UIOffScreenIndicatorForMarkers]]
+    return indicator
+end
+
+---@param parent Control
+---@param worldView WorldView
+---@param target Vector # in world coordinates
+---@return UIOffScreenIndicatorForMarkers
+CreateRedOffScreenIndicator = function(parent, worldView, target)
+    local indicator = OffScreenIndicatorForMarkers(parent, worldView, TexturesRed, target) --[[@as UIOffScreenIndicatorForMarkers]]
+    return indicator
+end

--- a/lua/ui/game/OffScreenMarkerIndicator.lua
+++ b/lua/ui/game/OffScreenMarkerIndicator.lua
@@ -106,6 +106,7 @@ OffscreenMarkerIndicator = Class(OffScreenIndicator) {
 
     ---@param self UIOffScreenIndicator
     OnClick = function(self)
+        -- feature: click to navigate to the ping
         local currentCamSettings = GetCamera('WorldCamera'):SaveSettings()
         currentCamSettings.Focus = self:GetTarget()
         GetCamera(self.WorldView._cameraName):RestoreSettings(currentCamSettings)

--- a/lua/ui/game/OffScreenMarkerIndicator.lua
+++ b/lua/ui/game/OffScreenMarkerIndicator.lua
@@ -112,29 +112,43 @@ OffscreenMarkerIndicator = Class(OffScreenIndicator) {
     end,
 }
 
+--- Creates an off screen marker for the target position. Uses a texture preset that matches with the yellow ping.
 ---@param parent Control
 ---@param worldView WorldView
 ---@param target Vector # in world coordinates
 ---@return UIOffScreenIndicator
-CreateYellowOffScreenIndicator = function(parent, worldView, target)
+CreateYellowOffScreenMarkerIndicator = function(parent, worldView, target)
     local indicator = OffscreenMarkerIndicator(parent, worldView, TexturesYellow, target) --[[@as UIOffscreenMarkerIndicator]]
     return indicator
 end
 
+--- Creates an off screen marker for the target position. Uses a texture preset that matches with the blue ping.
 ---@param parent Control
 ---@param worldView WorldView
 ---@param target Vector # in world coordinates
 ---@return UIOffscreenMarkerIndicator
-CreateBlueOffScreenIndicator = function(parent, worldView, target)
+CreateBlueOffScreenMarkerIndicator = function(parent, worldView, target)
     local indicator = OffscreenMarkerIndicator(parent, worldView, TexturesBlue, target) --[[@as UIOffscreenMarkerIndicator]]
     return indicator
 end
 
+--- Creates an off screen marker for the target position. Uses a texture preset that matches with the red ping.
 ---@param parent Control
 ---@param worldView WorldView
 ---@param target Vector # in world coordinates
 ---@return UIOffscreenMarkerIndicator
-CreateRedOffScreenIndicator = function(parent, worldView, target)
+CreateRedOffScreenMarkerIndicator = function(parent, worldView, target)
+    local indicator = OffscreenMarkerIndicator(parent, worldView, TexturesRed, target) --[[@as UIOffscreenMarkerIndicator]]
+    return indicator
+end
+
+--- Creates an off screen marker for the target position.
+---@param parent Control
+---@param worldView WorldView
+---@param textures UIOffScreenIndicatorTextureSet
+---@param target Vector # in world coordinates
+---@return UIOffscreenMarkerIndicator
+CreateOffScreenMarkerIndicator = function(parent, worldView, textures, target)
     local indicator = OffscreenMarkerIndicator(parent, worldView, TexturesRed, target) --[[@as UIOffscreenMarkerIndicator]]
     return indicator
 end

--- a/lua/ui/game/OffScreenMarkerIndicator.lua
+++ b/lua/ui/game/OffScreenMarkerIndicator.lua
@@ -66,6 +66,13 @@ local TexturesRed = {
     Glow = '/textures/ui/common/game/ping_edge/ping_edge_red_glow.dds'
 }
 
+--- All available texture presets. To register a new preset you can add an entry to this table.
+local TexturePresets = {
+    Blue = TexturesBlue,
+    Red = TexturesRed,
+    Yellow = TexturesYellow
+}
+
 --- An off screen indicator for markers to help users be aware of them.
 ---@class UIOffscreenMarkerIndicator : UIOffScreenIndicator
 ---@field Target Vector     # in world coordinates
@@ -113,33 +120,20 @@ OffscreenMarkerIndicator = Class(OffScreenIndicator) {
     end,
 }
 
---- Creates an off screen marker for the target position. Uses a texture preset that matches with the yellow ping.
+--- Creates an off screen marker for the target position. Textures originate from a preset.
 ---@param parent Control
 ---@param worldView WorldView
----@param target Vector # in world coordinates
----@return UIOffScreenIndicator
-CreateYellowOffScreenMarkerIndicator = function(parent, worldView, target)
-    local indicator = OffscreenMarkerIndicator(parent, worldView, TexturesYellow, target) --[[@as UIOffscreenMarkerIndicator]]
-    return indicator
-end
-
---- Creates an off screen marker for the target position. Uses a texture preset that matches with the blue ping.
----@param parent Control
----@param worldView WorldView
----@param target Vector # in world coordinates
+---@param preset 'Yellow' | 'Blue' | 'Red'
+---@param target Vector     # in world coordinates
 ---@return UIOffscreenMarkerIndicator
-CreateBlueOffScreenMarkerIndicator = function(parent, worldView, target)
-    local indicator = OffscreenMarkerIndicator(parent, worldView, TexturesBlue, target) --[[@as UIOffscreenMarkerIndicator]]
-    return indicator
-end
+CreateOffScreenMarkerIndicatorFromPreset = function(parent, worldView, target, preset)
+    local texturePreset = TexturePresets[preset]
+    if not texturePreset then
+        WARN(string.format("Invalid texture preset for off screen marker indicator: %s. Defaulting to the yellow preset", preset))
+        texturePreset = TexturePresets.Yellow
+    end
 
---- Creates an off screen marker for the target position. Uses a texture preset that matches with the red ping.
----@param parent Control
----@param worldView WorldView
----@param target Vector # in world coordinates
----@return UIOffscreenMarkerIndicator
-CreateRedOffScreenMarkerIndicator = function(parent, worldView, target)
-    local indicator = OffscreenMarkerIndicator(parent, worldView, TexturesRed, target) --[[@as UIOffscreenMarkerIndicator]]
+    local indicator = OffscreenMarkerIndicator(parent, worldView, texturePreset, target) --[[@as UIOffscreenMarkerIndicator]]
     return indicator
 end
 
@@ -147,7 +141,7 @@ end
 ---@param parent Control
 ---@param worldView WorldView
 ---@param textures UIOffScreenIndicatorTextureSet
----@param target Vector # in world coordinates
+---@param target Vector     # in world coordinates
 ---@return UIOffscreenMarkerIndicator
 CreateOffScreenMarkerIndicator = function(parent, worldView, textures, target)
     local indicator = OffscreenMarkerIndicator(parent, worldView, TexturesRed, target) --[[@as UIOffscreenMarkerIndicator]]

--- a/lua/ui/game/OffScreenMarkerIndicator.lua
+++ b/lua/ui/game/OffScreenMarkerIndicator.lua
@@ -22,55 +22,26 @@
 
 local Layouter = import("/lua/maui/layouthelpers.lua").Layouter
 
+local OffScreenIndicatorModule = import("/lua/ui/game/OffScreenIndicator.lua")
 local OffScreenIndicator = import("/lua/ui/game/OffScreenIndicator.lua").OffScreenIndicator
 
 --- A preset set of textures for UIOffScreenIndicator that match the blue ping.
 ---@type UIOffScreenIndicatorTextureSet
-local TexturesBlue = {
-    North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_b_down.dds' },
-    NorthWest = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_bl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_bl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_bl_down.dds' },
-    West = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_l_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_l_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_l_down.dds' },
-    WestSouth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_tl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_tl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_tl_down.dds' },
-    South = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_t_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_t_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_t_down.dds' },
-    SouthEast = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_tr_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_tr_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_tr_down.dds' },
-    East = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_r_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_r_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_r_down.dds' },
-    EastNorth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_blue_br_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_blue_br_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_blue_br_down.dds' },
-    Glow = '/textures/ui/common/game/ping_edge/ping_edge_blue_glow.dds'
-}
+local PresetForBluePing = OffScreenIndicatorModule.GeneratePreset('/textures/ui/common/game/ping_edge/ping_edge_blue_')
 
 --- A preset set of textures for UIOffScreenIndicator that match the yellow ping.
 ---@type UIOffScreenIndicatorTextureSet
-local TexturesYellow = {
-    North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_b_down.dds' },
-    NorthWest = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_bl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_bl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_bl_down.dds' },
-    West = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_l_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_l_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_l_down.dds' },
-    WestSouth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tl_down.dds' },
-    South = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_t_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_t_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_t_down.dds' },
-    SouthEast = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tr_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tr_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_tr_down.dds' },
-    East = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_r_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_r_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_r_down.dds' },
-    EastNorth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_yellow_br_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_yellow_br_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_yellow_br_down.dds' },
-    Glow = '/textures/ui/common/game/ping_edge/ping_edge_yellow_glow.dds'
-}
+local PresetForYellowPing = OffScreenIndicatorModule.GeneratePreset('/textures/ui/common/game/ping_edge/ping_edge_yellow_')
 
 --- A preset set of textures for UIOffScreenIndicator that match the red ping.
 ---@type UIOffScreenIndicatorTextureSet
-local TexturesRed = {
-    North = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_b_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_b_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_b_down.dds' },
-    NorthWest = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_bl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_bl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_bl_down.dds' },
-    West = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_l_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_l_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_l_down.dds' },
-    WestSouth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_tl_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_tl_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_tl_down.dds' },
-    South = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_t_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_t_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_t_down.dds' },
-    SouthEast = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_tr_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_tr_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_tr_down.dds' },
-    East = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_r_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_r_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_r_down.dds' },
-    EastNorth = { Up = '/textures/ui/common/game/ping_edge/ping_edge_red_br_up.dds', Over = '/textures/ui/common/game/ping_edge/ping_edge_red_br_over.dds', Down = '/textures/ui/common/game/ping_edge/ping_edge_red_br_down.dds' },
-    Glow = '/textures/ui/common/game/ping_edge/ping_edge_red_glow.dds'
-}
+local PresetForRedPing = OffScreenIndicatorModule.GeneratePreset('/textures/ui/common/game/ping_edge/ping_edge_red_')
 
 --- All available texture presets. To register a new preset you can add an entry to this table.
 local TexturePresets = {
-    Blue = TexturesBlue,
-    Red = TexturesRed,
-    Yellow = TexturesYellow
+    Blue = PresetForBluePing,
+    Red = PresetForRedPing,
+    Yellow = PresetForYellowPing
 }
 
 --- An off screen indicator for markers to help users be aware of them.

--- a/lua/ui/game/OffScreenMarkerIndicator.lua
+++ b/lua/ui/game/OffScreenMarkerIndicator.lua
@@ -67,9 +67,9 @@ local TexturesRed = {
 }
 
 --- An off screen indicator for markers to help users be aware of them.
----@class UIOffScreenIndicatorForMarkers : UIOffScreenIndicator
+---@class UIOffscreenMarkerIndicator : UIOffScreenIndicator
 ---@field Target Vector     # in world coordinates
-OffScreenIndicatorForMarkers = Class(OffScreenIndicator) {
+OffscreenMarkerIndicator = Class(OffScreenIndicator) {
 
     ---@param self UIOffScreenIndicator
     ---@param parent Control
@@ -93,7 +93,7 @@ OffScreenIndicatorForMarkers = Class(OffScreenIndicator) {
     end,
 
     --- Returns the world position of the marker.
-    ---@param self UIOffScreenIndicatorForMarkers
+    ---@param self UIOffscreenMarkerIndicator
     ---@return Vector
     GetTarget = function(self)
         return self.Target
@@ -117,24 +117,24 @@ OffScreenIndicatorForMarkers = Class(OffScreenIndicator) {
 ---@param target Vector # in world coordinates
 ---@return UIOffScreenIndicator
 CreateYellowOffScreenIndicator = function(parent, worldView, target)
-    local indicator = OffScreenIndicatorForMarkers(parent, worldView, TexturesYellow, target) --[[@as UIOffScreenIndicatorForMarkers]]
+    local indicator = OffscreenMarkerIndicator(parent, worldView, TexturesYellow, target) --[[@as UIOffscreenMarkerIndicator]]
     return indicator
 end
 
 ---@param parent Control
 ---@param worldView WorldView
 ---@param target Vector # in world coordinates
----@return UIOffScreenIndicatorForMarkers
+---@return UIOffscreenMarkerIndicator
 CreateBlueOffScreenIndicator = function(parent, worldView, target)
-    local indicator = OffScreenIndicatorForMarkers(parent, worldView, TexturesBlue, target) --[[@as UIOffScreenIndicatorForMarkers]]
+    local indicator = OffscreenMarkerIndicator(parent, worldView, TexturesBlue, target) --[[@as UIOffscreenMarkerIndicator]]
     return indicator
 end
 
 ---@param parent Control
 ---@param worldView WorldView
 ---@param target Vector # in world coordinates
----@return UIOffScreenIndicatorForMarkers
+---@return UIOffscreenMarkerIndicator
 CreateRedOffScreenIndicator = function(parent, worldView, target)
-    local indicator = OffScreenIndicatorForMarkers(parent, worldView, TexturesRed, target) --[[@as UIOffScreenIndicatorForMarkers]]
+    local indicator = OffscreenMarkerIndicator(parent, worldView, TexturesRed, target) --[[@as UIOffscreenMarkerIndicator]]
     return indicator
 end

--- a/lua/ui/game/common/AnimatedGlow.lua
+++ b/lua/ui/game/common/AnimatedGlow.lua
@@ -23,10 +23,9 @@
 local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
 local Bitmap = import("/lua/maui/bitmap.lua").Bitmap
 
+--- A small utility class that will 'animate' a bitmap by pulsing it on and off by manipulating its alpha channel.
 ---@class UIAnimatedGlow : Bitmap
 AnimatedGlow = Class(Bitmap) {
-
-    DebugName = "AnimatedGlow",
 
     ---@param self UIAnimatedGlow
     ---@param parent Control
@@ -39,6 +38,7 @@ AnimatedGlow = Class(Bitmap) {
             :End()
     end,
 
+    --- An 'animation' that will pulse over the current time to influence the opacity of the texture.
     ---@param self UIAnimatedGlow
     ---@param delta number
     OnFrame = function(self, delta)

--- a/lua/ui/game/common/AnimatedGlow.lua
+++ b/lua/ui/game/common/AnimatedGlow.lua
@@ -1,0 +1,57 @@
+--******************************************************************************************************
+--** Copyright (c) 2022  Willem 'Jip' Wijnia
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
+local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
+local Bitmap = import("/lua/maui/bitmap.lua").Bitmap
+
+---@class UIAnimatedGlow : Bitmap
+AnimatedGlow = Class(Bitmap) {
+
+    DebugName = "AnimatedGlow",
+
+    ---@param self UIAnimatedGlow
+    ---@param parent Control
+    __post_init = function(self, parent, texture)
+        LayoutHelpers.LayoutFor(self)
+            :Texture(texture)
+            :DisableHitTest(true)
+            :NeedsFrameUpdate(true)
+            :Fill(parent)
+            :End()
+    end,
+
+    ---@param self UIAnimatedGlow
+    ---@param delta number
+    OnFrame = function(self, delta)
+        if delta then
+            local alpha = MATH_Lerp(math.sin(10 * CurrentTime()), -1.0, 1.0, 0.0, 0.5)
+            self:SetAlpha(alpha)
+        end
+    end,
+}
+
+---@param parent Control
+---@param texture Lazy<FileName> | FileName | string
+CreateAnimatedGlow = function(parent, texture)
+    local animatedGlow = AnimatedGlow(parent, texture) --[[@as UIAnimatedGlow]]
+    return animatedGlow
+end

--- a/lua/ui/game/common/AnimatedGlow.lua
+++ b/lua/ui/game/common/AnimatedGlow.lua
@@ -25,11 +25,18 @@ local Bitmap = import("/lua/maui/bitmap.lua").Bitmap
 
 --- A small utility class that will 'animate' a bitmap by pulsing it on and off by manipulating its alpha channel.
 ---@class UIAnimatedGlow : Bitmap
+---@field Rate number   # factor to make the animation go faster or slower
 AnimatedGlow = Class(Bitmap) {
+
+    __init = function(self, parent, texture, rate)
+        Bitmap.__init(self, parent, texture)
+
+        self.Rate = rate
+    end,
 
     ---@param self UIAnimatedGlow
     ---@param parent Control
-    __post_init = function(self, parent, texture)
+    __post_init = function(self, parent, texture, rate)
         LayoutHelpers.LayoutFor(self)
             :Texture(texture)
             :DisableHitTest(true)
@@ -43,15 +50,17 @@ AnimatedGlow = Class(Bitmap) {
     ---@param delta number
     OnFrame = function(self, delta)
         if delta then
-            local alpha = MATH_Lerp(math.sin(10 * CurrentTime()), -1.0, 1.0, 0.0, 0.5)
+            local alpha = MATH_Lerp(math.sin(CurrentTime() * self.Rate), -1.0, 1.0, 0.0, 0.5)
             self:SetAlpha(alpha)
         end
     end,
 }
 
+--- Create an instance of the animated glow utility class.
 ---@param parent Control
 ---@param texture Lazy<FileName> | FileName | string
-CreateAnimatedGlow = function(parent, texture)
-    local animatedGlow = AnimatedGlow(parent, texture) --[[@as UIAnimatedGlow]]
+---@param rate number # factor to make the animation go faster or slower
+CreateAnimatedGlow = function(parent, texture, rate)
+    local animatedGlow = AnimatedGlow(parent, texture, rate) --[[@as UIAnimatedGlow]]
     return animatedGlow
 end


### PR DESCRIPTION
## Description of the proposed changes

Factors out the camera indicator into a separate and extendable class. The camera indicator was previously baked into the world view. By factoring out we reduce the clutter in the world view class.

## Testing done on the proposed changes

Tested using split and non-split world views. 

## Additional context

And we make it possible to re-use the camera indicator, for paintings for example 😃 !

## Checklist

- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in the changelog for the next game version