### PR TITLE
Fix shield assist issuing orders to an empty table

### DIFF
--- a/changelog/snippets/fix.6742.md
+++ b/changelog/snippets/fix.6742.md
@@ -1,0 +1,1 @@
+- (#6742) Fix an error when shields get damaged and they are assisted only by engineers with other commands queued after the assist order.

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -595,16 +595,22 @@ Shield = ClassShield(moho.shield_methods, Entity) {
                 local guards = UnitGetGuards(owner)
                 if not TableEmpty(guards) then
                     -- filter out guards with something queued after the shield assist order, as to not delete clear their queue
+                    -- keep track if we have guards left over to issue orders to
+                    local hasValidGuards = false
                     for i, guard in guards do
                         if TableGetn(UnitGetCommandQueue(guard)) >= 2 then
                             guards[i] = nil
+                        elseif not hasValidGuards then
+                            hasValidGuards = true
                         end
                     end
 
-                    -- For the filtered guards, clear their assist order, order repair, then re-add the assist order after
-                    IssueClearCommands(guards)
-                    IssueRepair(guards, owner)
-                    IssueGuard(guards, owner)
+                    if hasValidGuards then
+                        -- For the filtered guards, clear their assist order, order repair, then re-add the assist order after
+                        IssueClearCommands(guards)
+                        IssueRepair(guards, owner)
+                        IssueGuard(guards, owner)
+                    end
                 end
             end
 

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -595,17 +595,13 @@ Shield = ClassShield(moho.shield_methods, Entity) {
                 local guards = UnitGetGuards(owner)
                 if not TableEmpty(guards) then
                     -- filter out guards with something queued after the shield assist order, as to not delete clear their queue
-                    -- keep track if we have guards left over to issue orders to
-                    local hasValidGuards = false
                     for i, guard in guards do
                         if TableGetn(UnitGetCommandQueue(guard)) >= 2 then
                             guards[i] = nil
-                        elseif not hasValidGuards then
-                            hasValidGuards = true
                         end
                     end
 
-                    if hasValidGuards then
+                    if not TableEmpty(guards) then
                         -- For the filtered guards, clear their assist order, order repair, then re-add the assist order after
                         IssueClearCommands(guards)
                         IssueRepair(guards, owner)


### PR DESCRIPTION
## Issue
Reported on [Discord](https://discord.com/channels/197033481883222026/1363827638895902912/1363827638895902912) for replay [24723646](https://replay.faforever.com/24723646) (faf develop so it will desync in the future), and with the following error message:
```
WARNING: Error running OnDamage script in Entity  at 2531f880: ...faforever\replaydata\gamedata\lua.nx5\lua\shield.lua(605): Expected a game object. (Did you call with '.' instead of ':'?)
         stack traceback:
             [C]: ?
             ...faforever\replaydata\gamedata\lua.nx5\lua\shield.lua(605): in function `ApplyDamage'
             ...faforever\replaydata\gamedata\lua.nx5\lua\shield.lua(653): in function `ApplyDamage'
             ...faforever\replaydata\gamedata\lua.nx5\lua\shield.lua(520): in function <...faforever\replaydata\gamedata\lua.nx5\lua\shield.lua:511>
             [C]: in function `DamageArea'
             ...eplaydata\gamedata\lua.nx5\lua\sim\collisionbeam.lua(133): in function `DoDamage'
             ...eplaydata\gamedata\lua.nx5\lua\sim\collisionbeam.lua(313): in function `OnImpact'
             ...im\collisionbeams\orbitaldeathlasercollisionbeam.lua(32): in function <...im\collisionbeams\orbitaldeathlasercollisionbeam.lua:23>
```

## Description of the proposed changes
The error is caused by fully clearing the guards table and still using it to issue orders afterwards.

- Keep track if we left any guards in the table and only issue the orders if we did.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
To reproduce the error:
1. Damage a shield
2. Assist the shield with low enough buildpower that it doesn't repair fully before the next damage instance
3. Queue another order before the next damage instance arrives, do this for all guards.
4. The next damage instance no longer causes an error when it arrives.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version