### PR TITLE
Fix error when air staging gets killed when dead

### DIFF
--- a/changelog/snippets/balance.6665.md
+++ b/changelog/snippets/balance.6665.md
@@ -1,1 +1,1 @@
-- (#6665) Air staging now detaches aircraft when killed or ctrl-k'd (to work around an engine bug where aircraft get stuck inside air staging).
+- (#6665, #6743) Air staging now detaches aircraft when killed or ctrl-k'd (to work around an engine bug where aircraft get stuck inside air staging).

--- a/lua/sim/units/AirStagingPlatformUnit.lua
+++ b/lua/sim/units/AirStagingPlatformUnit.lua
@@ -24,14 +24,17 @@ local StructureUnit = import("/lua/sim/units/structureunit.lua").StructureUnit
 
 ---@class AirStagingPlatformUnit : StructureUnit
 AirStagingPlatformUnit = ClassUnit(StructureUnit) {
-    --- Detach units from air staging on death to allow working around an engine bug 
+    --- Detach units from air staging on death to allow working around an engine bug
     --- where units get stuck in the air staging.
     ---@param self AirStagingPlatformUnit
     ---@param instigator Unit
     ---@param damageType DamageType
     ---@param excessDamageRatio number
     Kill = function(self, instigator, damageType, excessDamageRatio)
-        self:TransportDetachAllUnits(false)
+        -- check if we're dead because we can still take damage/be killed during death animations
+        if not self.Dead then
+            self:TransportDetachAllUnits(false)
+        end
         -- `Kill` can only be called with 4 args or 1 arg
         if instigator then
             StructureUnit.Kill(self, instigator, damageType, excessDamageRatio)


### PR DESCRIPTION
## Issue
The air staging's transport status goes away when it's declared dead through the first C function call, which can cause an error because lua allows units to keep being killed after being killed once.
```
warning: Error running OnDamage script in Entity xsb5202 at 28315608: Unit:TransportDetachAllUnits can only be called for transports
         stack traceback:
         	[C]: in function `TransportDetachAllUnits'
         	...\lua\sim\units\airstagingplatformunit.lua(34): in function `Kill'
         	...\lua\sim\unit.lua(1402): in function <...\lua\sim\unit.lua:1378>
         	...\lua\sim\units\structureunit.lua(705): in function `DoTakeDamage'
         	...\lua\sim\unit.lua(1368): in function <...\lua\sim\unit.lua:1352>
         	[C]: in function `DamageArea'
         	...\lua\sim\collisionbeam.lua(133): in function `DoDamage'
         	...\lua\sim\collisionbeam.lua(313): in function `OnImpact'
         	...\lua\sim\collisionbeams\phasonlasercollisionbeam.lua(30): in function <...\lua\sim\collisionbeams\phasonlasercollisionbeam.lua:21>
```

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
- Check if the air staging is dead before detaching all units

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Spawn a Galactic Colossus and a few enemy air stagings, there should be no errors.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version