### PR TITLE
Buff Cybran navy's missile deflectors

### DIFF
--- a/changelog/snippets/balance.6744.md
+++ b/changelog/snippets/balance.6744.md
@@ -1,6 +1,6 @@
-- (#6744) Buff Cybran navy's missile deflector TMD so that they can defend against missile cruisers of other factions. Since deflectors ignore missile HP, they are given less fire rate than the gun TMD of UEF and Seraphim.
+- (#6744) Buff Cybran navy's missile deflector TMD so that they can defend against missile cruisers of other factions. Since deflectors ignore missile HP, they are given less fire rate and range than the gun TMD of UEF and Seraphim.
 
   Cybran cruiser (URS0202) and carrier (URS0303) Missile Deflectors:
   - Reload time: 4/2.5 seconds -> 1.9 seconds
-  - Range: 20/26 -> 60
+  - Range: 20/26 -> 44
   - Max target height: 8/10 -> infinite

--- a/changelog/snippets/balance.6744.md
+++ b/changelog/snippets/balance.6744.md
@@ -1,6 +1,6 @@
-- (#6744) Buff Cybran navy's missile deflector TMD to match gun TMD of other factions so that they can defend against missile cruisers.
+- (#6744) Buff Cybran navy's missile deflector TMD so that they can defend against missile cruisers of other factions. Since deflectors ignore missile HP, they are given less fire rate than the gun TMD of UEF and Seraphim.
 
   Cybran cruiser (URS0202) and carrier (URS0303) Missile Deflectors:
-  - Reload time: 4/2.5 seconds -> 1 second
+  - Reload time: 4/2.5 seconds -> 1.9 seconds
   - Range: 20/26 -> 60
   - Max target height: 8/10 -> infinite

--- a/changelog/snippets/balance.6744.md
+++ b/changelog/snippets/balance.6744.md
@@ -1,0 +1,6 @@
+- (#6744) Buff Cybran navy's missile deflector TMD to match gun TMD of other factions so that they can defend against missile cruisers.
+
+  Cybran cruiser (URS0202) and carrier (URS0303) Missile Deflectors:
+  - Reload time: 4/2.5 seconds -> 1 second
+  - Range: 20/26 -> 60
+  - Max target height: 8/10 -> infinite

--- a/units/URS0202/URS0202_unit.bp
+++ b/units/URS0202/URS0202_unit.bp
@@ -365,8 +365,8 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_Countermeasure",
-            RateOfFire = 10/10, --10/integer interval in ticks
-            TargetCheckInterval = 0.3,
+            RateOfFire = 10/19, --10/integer interval in ticks
+            TargetCheckInterval = 0.1,
             TargetRestrictDisallow = "UNTARGETABLE,STRATEGIC",
             TargetRestrictOnlyAllow = "TACTICAL,MISSILE",
             TargetType = "RULEWTT_Projectile",

--- a/units/URS0202/URS0202_unit.bp
+++ b/units/URS0202/URS0202_unit.bp
@@ -346,7 +346,7 @@ UnitBlueprint{
             FireTargetLayerCapsTable = { Water = "Air" },
             FiringTolerance = 5,
             Label = "RedirectMissile",
-            MaxRadius = 60,
+            MaxRadius = 44,
             MinRadius = 6,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,

--- a/units/URS0202/URS0202_unit.bp
+++ b/units/URS0202/URS0202_unit.bp
@@ -375,7 +375,7 @@ UnitBlueprint{
             TurretBoneYaw = "zapper",
             TurretDualManipulators = false,
             TurretPitch = 0,
-            TurretPitchRange = 70,
+            TurretPitchRange = 80,
             TurretPitchSpeed = 180,
             TurretYaw = 0,
             TurretYawRange = 180,

--- a/units/URS0202/URS0202_unit.bp
+++ b/units/URS0202/URS0202_unit.bp
@@ -346,8 +346,7 @@ UnitBlueprint{
             FireTargetLayerCapsTable = { Water = "Air" },
             FiringTolerance = 5,
             Label = "RedirectMissile",
-            MaxHeightDiff = 8,
-            MaxRadius = 20,
+            MaxRadius = 60,
             MinRadius = 6,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
@@ -366,7 +365,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_Countermeasure",
-            RateOfFire = 10/40, --10/integer interval in ticks
+            RateOfFire = 10/10, --10/integer interval in ticks
             TargetCheckInterval = 0.3,
             TargetRestrictDisallow = "UNTARGETABLE,STRATEGIC",
             TargetRestrictOnlyAllow = "TACTICAL,MISSILE",

--- a/units/URS0303/URS0303_unit.bp
+++ b/units/URS0303/URS0303_unit.bp
@@ -503,7 +503,8 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_Countermeasure",
-            RateOfFire = 10/10, --10/integer interval in ticks
+            RateOfFire = 10/19, --10/integer interval in ticks
+            TargetCheckInterval = 0.1,
             TargetRestrictDisallow = "UNTARGETABLE,STRATEGIC",
             TargetRestrictOnlyAllow = "TACTICAL,MISSILE",
             TargetType = "RULEWTT_Projectile",

--- a/units/URS0303/URS0303_unit.bp
+++ b/units/URS0303/URS0303_unit.bp
@@ -485,7 +485,7 @@ UnitBlueprint{
             FireTargetLayerCapsTable = { Water = "Air" },
             FiringTolerance = 5,
             Label = "RedirectMissile",
-            MaxRadius = 60,
+            MaxRadius = 44,
             MinRadius = 8,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,

--- a/units/URS0303/URS0303_unit.bp
+++ b/units/URS0303/URS0303_unit.bp
@@ -512,7 +512,7 @@ UnitBlueprint{
             TurretBoneYaw = "Zapper_Turret",
             TurretDualManipulators = false,
             TurretPitch = 0,
-            TurretPitchRange = 70,
+            TurretPitchRange = 80,
             TurretPitchSpeed = 180,
             TurretYaw = 0,
             TurretYawRange = 180,

--- a/units/URS0303/URS0303_unit.bp
+++ b/units/URS0303/URS0303_unit.bp
@@ -485,8 +485,7 @@ UnitBlueprint{
             FireTargetLayerCapsTable = { Water = "Air" },
             FiringTolerance = 5,
             Label = "RedirectMissile",
-            MaxHeightDiff = 10,
-            MaxRadius = 26,
+            MaxRadius = 60,
             MinRadius = 8,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
@@ -504,7 +503,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_Countermeasure",
-            RateOfFire = 10/25, --10/integer interval in ticks
+            RateOfFire = 10/10, --10/integer interval in ticks
             TargetRestrictDisallow = "UNTARGETABLE,STRATEGIC",
             TargetRestrictOnlyAllow = "TACTICAL,MISSILE",
             TargetType = "RULEWTT_Projectile",


### PR DESCRIPTION
## Issue
[Discord balance team thread](https://discord.com/channels/197033481883222026/1314781654841299014). Cybran navy is unable to properly defend itself against missile ships after they were changed to deflector type TMD with heavily nerfed fire rate and range.

## Description of the proposed changes
Increase the fire rate and range to match standard naval TMD.

Cybran cruiser/carrier TMD:
- Range: 20/26 -> 60
- Max target height: 8/10 -> infinite
- Reload time: 4/2.5 seconds -> 1 second

## Testing done on the proposed changes
Cybran cruisers/carriers can now defend fully against enemy missile cruisers. They can even kill UEF cruisers over some time, so it's not like the missiles being sent back are completely useless.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version