### PR TITLE
Reduce omni radius of Aeon ACU Sensors

### DIFF
--- a/changelog/snippets/balance.6745.md
+++ b/changelog/snippets/balance.6745.md
@@ -1,0 +1,4 @@
+- (#6745) Reduce the Aeon ACU sensor upgrade's omni radius to make fire beetles a viable option against Aeon, and to allow more counterplay for cloaked units in general.
+
+    Aeon ACU (UAL0001) Sensor System:
+    - Omni radius: 80 -> 36

--- a/changelog/snippets/balance.6745.md
+++ b/changelog/snippets/balance.6745.md
@@ -1,4 +1,4 @@
 - (#6745) Reduce the Aeon ACU sensor upgrade's omni radius to make fire beetles a viable option against Aeon, and to allow more counterplay for cloaked units in general.
 
-    Aeon ACU (UAL0001) Sensor System:
-    - Omni radius: 80 -> 36
+  Aeon ACU (UAL0001) Sensor System:
+  - Omni radius: 80 -> 36

--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -322,7 +322,7 @@ UnitBlueprint{
             BuildTime = 500,
             Icon = "ess",
             Name = "<LOC enhancements_0006>Enhanced Sensor System",
-            NewOmniRadius = 80,
+            NewOmniRadius = 36,
             NewVisionRadius = 80,
             ShowBones = { "Right_Upgrade" },
             Slot = "RCH",


### PR DESCRIPTION
## Balance Discussion
[Discord post](https://discord.com/channels/197033481883222026/1363756065702809640)
The Aeon ACU's sensor upgrade unfairly counters firebeetles with its huge 80 omni range and very cheap cost. A mention goes to cloaked (S)ACUs too, but they are built at a stage of the game where Aeon ACU typically leaves the battlefield entirely, although it does invalidate the occasional cloaked ACUs sneaking around the back of the map to snipe a base. It can also detect stealthed underwater units, but that is an even more niche use case than detecting cloaked (S)ACUs.

The vision range and cost are powerful but I didn't change them because they are not as blatant of an issue as the omni range because those stats are trying to make sensors broadly usable on small maps.
- low tech/ACU fights are more common so the fire rate upgrade is more valuable
- resources are more scarce so the cost is not as negligible
- Stealth is less common so the vision isn't as good compared to radar

## Description of the proposed changes
Make fire beetles more viable against Aeon by reducing the omni range of the sensors upgrade so that the ACU has to stay at the front to use the omni effectively, which allows counterplay since the ACU and army are possible to threaten. The range is enough to match gun advanced range.

Aeon ACU (UAL0001) Sensor System:
 - Omni radius: 80 -> 36

## Testing done on the proposed changes


## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in the changelog for the next game version