### PR TITLE
Remove duplicated code that adjust the LODs of props

### DIFF
--- a/changelog/snippets/other.6750.md
+++ b/changelog/snippets/other.6750.md
@@ -1,0 +1,1 @@
+- (#6750) Remove duplicated code that post processes LOD values of props

--- a/lua/system/blueprints-lod.lua
+++ b/lua/system/blueprints-lod.lua
@@ -1,35 +1,6 @@
 ---@declare-global
 local MathSqrt = math.sqrt
 
----@param prop PropBlueprint to compute the LODs for
-local function CalculateLODOfProp(prop)
-    local sx = prop.SizeX or 1
-    local sy = prop.SizeY or 1
-    local sz = prop.SizeZ or 1
-
-    -- give more emphasis to the x / z value as that is easier to see in the average camera angle
-    local weighted = 0.40 * sx + 0.2 * sy + 0.4 * sz
-    if prop.ScriptClass == 'Tree' or prop.ScriptClass == 'TreeGroup' then
-        weighted = 2.6
-    end
-
-    -- https://www.desmos.com/calculator (1.1 * sqrt(100 * 500 * x))
-    local lod = 0.9 * MathSqrt(100 * 500 * weighted)
-
-    if prop.Display and prop.Display.Mesh and prop.Display.Mesh.LODs then
-        local n = table.getn(prop.Display.Mesh.LODs)
-        for k = 1, n do
-            local data = prop.Display.Mesh.LODs[k]
-
-            -- https://www.desmos.com/calculator (x * x)
-            local factor = (k / n) * (k / n)
-            local LODCutoff = factor * lod + 10
-            -- LOG(string.format("(%s) / %d: %d -> %d", unit.BlueprintId, k, data.LODCutoff, LODCutoff))
-            data.LODCutoff = LODCutoff
-        end
-    end
-end
-
 ---@param unit UnitBlueprint
 local function CalculateLODOfUnit(unit)
     local sx = unit.Physics.SkirtSizeX or unit.SizeX or 1
@@ -60,13 +31,6 @@ local function CalculateLODOfUnit(unit)
     end
 end
 
----@param props PropBlueprint[]
-local function CalculateLODsOfProps(props)
-    for _, prop in props do
-        CalculateLODOfProp(prop)
-    end
-end
-
 ---@param units UnitBlueprint[]
 local function CalculateLODsOfUnits(units)
     for _, unit in units do
@@ -76,6 +40,5 @@ end
 
 ---@param bps BlueprintsTable
 function CalculateLODs(bps)
-    CalculateLODsOfProps(bps.Prop)
     CalculateLODsOfUnits(bps.Unit)
 end


### PR DESCRIPTION
## Description of the proposed changes

Removes duplicated code related to computing the LOD values of props. This should've been part of https://github.com/FAForever/fa/pull/6274. The same computations are applied in:

- https://github.com/FAForever/fa/blob/develop/lua/system/blueprints-props.lua

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in the changelog for the next game version