### PR TITLE
Fix various anti-air weapons being unable to engage units that fly right above them

### DIFF
--- a/changelog/snippets/balance.6753.md
+++ b/changelog/snippets/balance.6753.md
@@ -4,7 +4,6 @@
   
   <details><summary>Previously affected units:</summary>
 
-      ```
       Archer: T1 Mobile Anti-Air Gun (UEL0104)
       Sky Slammer: T1 Mobile Anti-Air Gun (URL0104)
       Cougar: T3 Mobile Rapid-fire AA Cannon (DELK002)
@@ -14,5 +13,5 @@
       Burst Master: T2 Anti-Air Flak Artillery (URB2204)
       Marr: T2 Anti-Air Flak Artillery (UAB2204)
       Sinnatha: T2 Anti-Air Flak Artillery (XSB2204)
-      ```
-    </details>
+
+  </details>

--- a/changelog/snippets/balance.6753.md
+++ b/changelog/snippets/balance.6753.md
@@ -1,0 +1,18 @@
+- (#6753) Fix various anti-air weapons being unable to engage units that fly right above them.
+
+  This bug was particularly significant for the Burst Master (Cybran Tech 2 Flak).
+  
+  <details><summary>Previously affected units:</summary>
+
+      ```
+      Archer: T1 Mobile Anti-Air Gun (UEL0104)
+      Sky Slammer: T1 Mobile Anti-Air Gun (URL0104)
+      Cougar: T3 Mobile Rapid-fire AA Cannon (DELK002)
+      Thunderhead Class: T1 Frigate (UES0103)
+      Trident Class: T1 Frigate (URS0103)
+      Air Cleaner: T2 Anti-Air Flak Artillery (UEB2204)
+      Burst Master: T2 Anti-Air Flak Artillery (URB2204)
+      Marr: T2 Anti-Air Flak Artillery (UAB2204)
+      Sinnatha: T2 Anti-Air Flak Artillery (XSB2204)
+      ```
+    </details>

--- a/changelog/snippets/other.6739.md
+++ b/changelog/snippets/other.6739.md
@@ -1,3 +1,0 @@
-- (#6739) Refactor how we want to approach the recently introduced rendering capabilities in the UI
-
-The rendering capabilities were only recently introduced in 2024 through assembly patches by 4z0t. With the introduction of the painting feature we now start using these capabilities. With these changes we hope to solidify the framework a bit before it's too late to make any significant changes.

--- a/changelog/snippets/other.6739.md
+++ b/changelog/snippets/other.6739.md
@@ -1,0 +1,3 @@
+- (#6739) Refactor how we want to approach the recently introduced rendering capabilities in the UI
+
+The rendering capabilities were only recently introduced in 2024 through assembly patches by 4z0t. With the introduction of the painting feature we now start using these capabilities. With these changes we hope to solidify the framework a bit before it's too late to make any significant changes.

--- a/units/DELK002/DELK002_unit.bp
+++ b/units/DELK002/DELK002_unit.bp
@@ -230,7 +230,7 @@ UnitBlueprint{
             TurretBoneYaw = "Turret",
             TurretDualManipulators = true,
             TurretPitch = 0,
-            TurretPitchRange = 30,
+            TurretPitchRange = 60,
             TurretPitchSpeed = 180,
             TurretYaw = 0,
             TurretYawRange = 180,

--- a/units/UAB2204/UAB2204_unit.bp
+++ b/units/UAB2204/UAB2204_unit.bp
@@ -196,7 +196,7 @@ UnitBlueprint{
             TurretBoneYaw = "Turret",
             TurretDualManipulators = false,
             TurretPitch = 35,
-            TurretPitchRange = 40,
+            TurretPitchRange = 55,
             TurretPitchSpeed = 180,
             TurretYaw = 0,
             TurretYawRange = 180,

--- a/units/UEB2204/UEB2204_unit.bp
+++ b/units/UEB2204/UEB2204_unit.bp
@@ -200,7 +200,7 @@ UnitBlueprint{
             TurretBoneYaw = "Turret",
             TurretDualManipulators = false,
             TurretPitch = 35,
-            TurretPitchRange = 45,
+            TurretPitchRange = 55,
             TurretPitchSpeed = 180,
             TurretYaw = 0,
             TurretYawRange = 180,

--- a/units/UEL0104/UEL0104_unit.bp
+++ b/units/UEL0104/UEL0104_unit.bp
@@ -213,7 +213,7 @@ UnitBlueprint{
             TurretBoneYaw = "Turret",
             TurretDualManipulators = false,
             TurretPitch = 45,
-            TurretPitchRange = 40,
+            TurretPitchRange = 45,
             TurretPitchSpeed = 180,
             TurretYaw = 0,
             TurretYawRange = 180,

--- a/units/UES0103/UES0103_unit.bp
+++ b/units/UES0103/UES0103_unit.bp
@@ -314,7 +314,7 @@ UnitBlueprint{
             TurretBoneYaw = "Back_Turret",
             TurretDualManipulators = false,
             TurretPitch = 45,
-            TurretPitchRange = 40,
+            TurretPitchRange = 45,
             TurretPitchSpeed = 180,
             TurretYaw = 0,
             TurretYawRange = 180,

--- a/units/URB2204/URB2204_unit.bp
+++ b/units/URB2204/URB2204_unit.bp
@@ -204,7 +204,7 @@ UnitBlueprint{
             TurretBoneYaw = "Turret",
             TurretDualManipulators = false,
             TurretPitch = 35,
-            TurretPitchRange = 40,
+            TurretPitchRange = 55,
             TurretPitchSpeed = 180,
             TurretYaw = 0,
             TurretYawRange = 180,

--- a/units/URL0104/URL0104_unit.bp
+++ b/units/URL0104/URL0104_unit.bp
@@ -249,7 +249,7 @@ UnitBlueprint{
             TurretBoneYaw = "Turret",
             TurretDualManipulators = false,
             TurretPitch = 35,
-            TurretPitchRange = 40,
+            TurretPitchRange = 55,
             TurretPitchSpeed = 180,
             TurretYaw = 0,
             TurretYawRange = 180,

--- a/units/URS0103/URS0103_unit.bp
+++ b/units/URS0103/URS0103_unit.bp
@@ -303,7 +303,7 @@ UnitBlueprint{
             TurretBoneYaw = "Back_Turret_AA",
             TurretDualManipulators = false,
             TurretPitch = 45,
-            TurretPitchRange = 40,
+            TurretPitchRange = 45,
             TurretPitchSpeed = 180,
             TurretYaw = 0,
             TurretYawRange = 180,

--- a/units/XSB2204/XSB2204_unit.bp
+++ b/units/XSB2204/XSB2204_unit.bp
@@ -208,7 +208,7 @@ UnitBlueprint{
             TurretBoneYaw = "Turret",
             TurretDualManipulators = false,
             TurretPitch = 35,
-            TurretPitchRange = 45,
+            TurretPitchRange = 55,
             TurretPitchSpeed = 180,
             TurretYaw = 0,
             TurretYawRange = 180,


### PR DESCRIPTION
## Description of the proposed changes
As per the title. As far as I know, this is another issue that has been present since the game's release.

The bug is easiest to reproduce with the Burst Master (Cybran Tech 2 stationary flak) by enabling `NoDamage` in the console and hovering air scouts directly over it. There are some exceptions, but generally, the weapon's `TurretPitch` and `TurretPitchRange` should sum up to 90 (degrees).

Previously affected units:

```
Archer: T1 Mobile Anti-Air Gun (UEL0104)
Sky Slammer: T1 Mobile Anti-Air Gun (URL0104)
Cougar: T3 Mobile Rapid-fire AA Cannon (DELK002)
Thunderhead Class: T1 Frigate (UES0103)
Trident Class: T1 Frigate (URS0103)
Air Cleaner: T2 Anti-Air Flak Artillery (UEB2204)
Burst Master: T2 Anti-Air Flak Artillery (URB2204)
Marr: T2 Anti-Air Flak Artillery (UAB2204)
Sinnatha: T2 Anti-Air Flak Artillery (XSB2204)
```

I decided to add the balance labels, as while it is mostly a bug fix, the changes do have balance implications.

## Checklist
- [x] Changes are documented in the changelog for the next game version