### PR TITLE
Experiment setup to determine sane LOD values for tree (groups)

### DIFF
--- a/lua/keymap/debugKeyActions.lua
+++ b/lua/keymap/debugKeyActions.lua
@@ -315,15 +315,19 @@ local keyActionsDebugAI = {
         category = 'debug'
     },
     ['test_camera_angle_02'] = {
-        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").TestCameraAngle1(430)',
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").TestCameraAngle1(470)',
         category = 'debug'
     },
     ['test_camera_angle_03'] = {
-        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").TestCameraAngle1(490)',
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").TestCameraAngle1(570)',
         category = 'debug'
     },
     ['test_camera_angle_04'] = {
-        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").TestCameraAngle1(550)',
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").TestCameraAngle1(670)',
+        category = 'debug'
+    },
+    ['test_camera_angle_05'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").TestCameraAngle1(770)',
         category = 'debug'
     },
 }

--- a/lua/keymap/debugKeyActions.lua
+++ b/lua/keymap/debugKeyActions.lua
@@ -315,7 +315,15 @@ local keyActionsDebugAI = {
         category = 'debug'
     },
     ['test_camera_angle_02'] = {
-        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").TestCameraAngle1(420)',
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").TestCameraAngle1(430)',
+        category = 'debug'
+    },
+    ['test_camera_angle_03'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").TestCameraAngle1(490)',
+        category = 'debug'
+    },
+    ['test_camera_angle_04'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").TestCameraAngle1(550)',
         category = 'debug'
     },
 }

--- a/lua/keymap/debugKeyActions.lua
+++ b/lua/keymap/debugKeyActions.lua
@@ -309,6 +309,15 @@ local keyActionsDebugAI = {
         action = 'UI_Lua import("/lua/ui/game/aichunktemplates.lua").AddUnitSelectionToEmptyChunkTemplate(32)',
         category = 'ai'
     },
+
+    ['test_camera_angle_01'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").TestCameraAngle1(370)',
+        category = 'debug'
+    },
+    ['test_camera_angle_02'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").TestCameraAngle1(420)',
+        category = 'debug'
+    },
 }
 
 ---@type table<string, UIKeyAction>

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -693,3 +693,18 @@ SelectCommander = function(zoomTo)
         UIZoomTo(selectedUnits, 0)
     end
 end
+
+function TestCameraAngle1(zoom)
+
+    -- camera in bottom right corner of Seton's Clutch
+
+    ConExecute("sc_VerticalSync 0")
+    ConExecute("cam_free 0")
+    ConExecute("sc_FrameTimeClamp 1")
+
+    local camera = GetCamera("WorldCamera")
+    local settings = camera:SaveSettings()
+    settings.Focus = Vector(230, 26, 860)
+    settings.Zoom = zoom
+    camera:RestoreSettings(settings)
+end

--- a/lua/proptree.lua
+++ b/lua/proptree.lua
@@ -268,12 +268,29 @@ Tree = Class(Prop) {
     end,
 }
 
+local id = 0
+
 ---@class TreeGroup : Prop
 TreeGroup = Class(Prop) {
 
     IsTree = true,
     IsTreeGroup = true,
-    
+
+    OnCreate = function(self)
+        Prop.OnCreate(self)
+
+        -- break half of all trees for testing
+        ForkThread(
+            function()
+                WaitTicks(1)
+                id = id + 1
+                if math.mod(id, 2) == 0 then
+                    self:Breakup()
+                end
+            end
+        )
+    end,
+
     --- Break when colliding with a projectile of some sort
     ---@param self TreeGroup
     ---@param other string

--- a/lua/system/blueprints-props.lua
+++ b/lua/system/blueprints-props.lua
@@ -113,9 +113,10 @@ local function ProcessLOD(prop)
     local sz = prop.SizeZ or 1
 
     -- give more emphasis to the x / z value as that is easier to see in the average camera angle
+    local isTreeLike = prop.ScriptClass == 'Tree' or prop.ScriptClass == 'TreeGroup'
     local weighted = 0.40 * sx + 0.2 * sy + 0.4 * sz
-    if prop.ScriptClass == 'Tree' or prop.ScriptClass == 'TreeGroup' then
-        weighted = 3.4
+    if isTreeLike then
+        weighted = 2.6
     end
 
     -- https://www.desmos.com/calculator (0.9 * sqrt(100 * 500 * x))
@@ -132,6 +133,11 @@ local function ProcessLOD(prop)
 
             -- sanitize the value
             data.LODCutoff = MathFloor(LODCutoff / 10 + 1) * 10
+
+            if isTreeLike then
+                -- log the values to screen
+                LOG(prop.Interface.HelpText, k, data.LODCutoff)
+            end
         end
     end
 end

--- a/lua/system/blueprints-props.lua
+++ b/lua/system/blueprints-props.lua
@@ -115,7 +115,7 @@ local function ProcessLOD(prop)
     -- give more emphasis to the x / z value as that is easier to see in the average camera angle
     local weighted = 0.40 * sx + 0.2 * sy + 0.4 * sz
     if prop.ScriptClass == 'Tree' or prop.ScriptClass == 'TreeGroup' then
-        weighted = 2.6
+        weighted = 3.4
     end
 
     -- https://www.desmos.com/calculator (0.9 * sqrt(100 * 500 * x))


### PR DESCRIPTION
## Description of the proposed changes

Now that we have https://github.com/FAForever/fa/pull/6752 to bake properties we have the ability to bake in the LOD values that we want. And since https://github.com/FAForever/fa/pull/6751 is merged in we can safely assume that all players will start with the 'High' settings for LODs. Users that take the 'Extreme' setting are on their own.

With that we have everything we need to restart the discussion in https://github.com/FAForever/fa/pull/6715.

This pull request provides a standardized test that we can use to inspect the behavior and compare it between hardware configurations. We have to make some assumptions.

- We assume that individual trees and tree groups should have the same LOD to minimize the intel that is leaked through the fog of war when units move through tree groups.
- We assume that the map that is being played is Seton's Clutch. We also assume that this map is representative.
- We assume that players do not play optimal, and therefore do not reclaim tree groups. As a result there will be a lot of broken tree groups because of units traversing them. 
- We assume that breaking half the tree groups is representative of this.

With these assumptions we can get some data. The tree groups are broken automatically. There's two hotkeys with a standardized camera configuration:

![image](https://github.com/user-attachments/assets/87c83e4e-3541-43e0-be28-3fe12ad4f158)

Then you can open the console using `~`. You can open the statistics by typing `ShowStats`. If you open the entity count tab then you can see there's quite a few props. If you open the frame tab then you can see the current time (in milliseconds) it takes to render a frame. This is a combination of he Lua code being run (in the UI thread, each frame) and the rendering of what is on screen. You can also see the current frames per second (fps).

Then the experiment can start:

- Set game option to for level of detail in the graphics tab to 'High'.
- Change the `weight` factor of tree groups in [blueprint-props.lua](). Ideally we check all values ranging from 2.6 up to 14.0 in steps of 2.0.
- (Re)start the map (default hotkey is CTRL + F10)
- Open the statistics.
- For each hotkey with fixed camera positions
- - Write down the frame time. 

## Additional context

Note that https://github.com/FAForever/FA-Binary-Patches/pull/115 also exists. It does not solve the problem of this pull request - if you increase the LOD by too much it will still just lag. but it may (instead) give players the ability to scale the LOD values of the entities (units, projectiles or props) that the player is most interested in. 

I'm not sure if being able to scale LOD values of props, units and/or projectiles is a healthy game option to have. It's super specific and technical. Not a lot of players will understand that.
