### PR TITLE
Add a game option for shadow LOD

### DIFF
--- a/changelog/snippets/graphics.6763.md
+++ b/changelog/snippets/graphics.6763.md
@@ -1,0 +1,3 @@
+- (#6763) Introduce a new slider to adjust the rendering distance of shadows
+
+Strogoo made the observation that the extensive (default) rendering distance of shadows can have a significant impact on the framerate. We increased the default rendering distance of shadows in FAForever two years ago. At the time we did not notice this impact. With these changes we turn it into a slider in the graphics options. The default matches the value of the game on Steam. 

--- a/changelog/snippets/graphics.6763.md
+++ b/changelog/snippets/graphics.6763.md
@@ -1,3 +1,3 @@
 - (#6763) Introduce a new slider to adjust the rendering distance of shadows
 
-Strogoo made the observation that the extensive (default) rendering distance of shadows can have a significant impact on the framerate. We increased the default rendering distance of shadows in FAForever two years ago. At the time we did not notice this impact. With these changes we turn it into a slider in the graphics options. The default matches the value of the game on Steam. 
+Strogo made the observation that the extensive (default) rendering distance of shadows can have a significant impact on the framerate. We increased the default rendering distance of shadows in FAForever two years ago. At the time we did not notice this impact. With these changes we turn it into a slider in the graphics options. The default value (260) matches the value used by Steam version of the game.

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -1630,6 +1630,23 @@ options = {
                 },
             },
             {
+                title = "<LOC OPTIONS_SHADOW_RENDER_DISTANCE_TITLE>Shadow render distance",
+                key = 'shadow_render_distance',
+                type = 'slider',
+                default = 260,
+                update = function(control, value)
+                    ConExecute(string.format("ren_ShadowLOD %d", value))
+                end,
+                set = function(key, value, startup)
+                    ConExecute(string.format("ren_ShadowLOD %d", value))
+                end,
+                custom = {
+                    min = 200,
+                    max = 440,
+                    inc = 20,
+                },
+            },
+            {
                 title = "<LOC OPTIONS_0015>Anti-Aliasing",
                 key = 'antialiasing',
                 type = 'toggle',

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -192,9 +192,6 @@ function CreateUI(isReplay)
     ConExecute("ren_ClipDecalLevel 4")          -- standard value of 2, causes a lot of clipping
     ConExecute("ren_DecalFadeFraction 0.25")    -- standard value of 0.5, causes decals to suddenly pop into screen
 
-    -- always try and render shadows
-    ConExecute("ren_ShadowLOD 20000")
-
     local focusArmy = GetFocusArmy()
 
     -- keep track of the original focus army

--- a/lua/ui/help/tooltips.lua
+++ b/lua/ui/help/tooltips.lua
@@ -729,7 +729,11 @@ Tooltips = {
     },
     options_shadow_resolution = {
         title = "<LOC OPTIONS_SHADOW_RESOLUTION_TITLE>Shadow Resolution",
-        description = "<LOC OPTIONS_SHADOW_RESOLUTION_DESCRIPTION>Sets resolution of shadows (lower = faster).",
+        description = "<LOC OPTIONS_SHADOW_RESOLUTION_DESCRIPTION>Sets resolution of shadows (lower = faster). High values require more VRAM.",
+    },
+    options_shadow_render_distance = {
+        title = "<LOC OPTIONS_SHADOW_RENDER_DISTANCE_TITLE>Shadow Resolution",
+        description = "<LOC OPTIONS_SHADOW_RENDER_DISTANCE_DESCRIPTION>Sets the rendering distance (level of detail) of shadows (lower = faster). High values can have a significant impact on your framerate.",
     },
     options_antialiasing = {
         title = "<LOC OPTIONS_0015>Anti-Aliasing",


### PR DESCRIPTION
## Description of the proposed changes

Introduces a game option to adjust the LOD for shadows. This is introduced because of an observation of @Strogoo at https://github.com/FAForever/FA-Binary-Patches/pull/115.

## Testing done on the proposed changes

Observed that the shadow rendering distance is adjusted (live) as you change the settings.

## Additional context

The default value is 250 in Steam. The options default to 260. The default value in FAForever was 20.000 the past two years, see also https://github.com/FAForever/fa/issues/5093. 

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
