### PR TITLE
Fix icons of map preview of auto lobby being miss placed

### DIFF
--- a/changelog/snippets/fix.6768.md
+++ b/changelog/snippets/fix.6768.md
@@ -1,0 +1,3 @@
+- (#6768) Fix icons of the map preview of auto being miss placed
+
+This was the case for all users that use the in-game UI scaling.

--- a/changelog/snippets/fix.6768.md
+++ b/changelog/snippets/fix.6768.md
@@ -1,3 +1,2 @@
-- (#6768) Fix icons of the map preview of auto being miss placed
+- (#6768) Fix icons in the map preview of the autolobby being misplaced when using UI scaling.
 
-This was the case for all users that use the in-game UI scaling.

--- a/lua/ui/lobby/autolobby/AutolobbyMapPreview.lua
+++ b/lua/ui/lobby/autolobby/AutolobbyMapPreview.lua
@@ -114,10 +114,8 @@ local AutolobbyMapPreview = ClassUI(Group) {
         local x = xOffset + (px / scenarioWidth) * (size - 2) * xFactor
         local z = yOffset + (pz / scenarioHeight) * (size - 2) * yFactor
 
-        -- position it
-        LayoutHelpers.ReusedLayoutFor(icon)
-            :AtLeftTopIn(self.Preview, x - 0.5 * icon.Width(), z - 0.5 * icon.Height())
-            :End()
+        icon.Left:Set(function() return self.Preview.Left() + x - 0.5 * icon.Width() end)
+        icon.Top:Set(function() return self.Preview.Top() + z - 0.5 * icon.Height() end)
 
         return icon
     end,


### PR DESCRIPTION
## Description of the proposed changes

Closes https://github.com/FAForever/fa/issues/6767

## Testing done on the proposed changes

Started the auto lobby and confirmed that it works.

![image](https://github.com/user-attachments/assets/da80a752-eb67-4766-9fb8-2f676df0061c)

## Checklist

- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
