### PR TITLE
Fix TTerrainXPExt

### DIFF
--- a/changelog/snippets/fix.6770.md
+++ b/changelog/snippets/fix.6770.md
@@ -1,0 +1,1 @@
+- (#6770) Fix the TTerrainXPExt shader (and Terrain000 and Terrain050) that were using the terrain info texture incorrectly.


### PR DESCRIPTION
When I was reworking the shaders in https://github.com/FAForever/fa/pull/6683 I apparently didn't update the explaining comment correctly. Consequently I botched the implementation of TTerrainXPExt because it queries the wrong channels of the terrain info texture. This is fixed now.
I also decided that it is nicer to always enable the terrain shadows, even if the shadow settings are off. I opted for this because the terrain shadows are not expensive like the unit shadows that use a shadow map and on low shadow settings you have the effect that units are lit while standing in the terrain shadow. This is what we wanted to avoid originally because it looks a bit odd, but as it turns out this will happen anyway if someone uses low shadow settings, so we might as well keep this effect when unit shadows are turned off entirely.


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
