### PR TITLE
Fix Aeon sniper aim while walking

### DIFF
--- a/changelog/snippets/balance.6771.md
+++ b/changelog/snippets/balance.6771.md
@@ -1,0 +1,4 @@
+- (#6771) Fix the Aeon sniper missing when walking towards/away from the target due to insufficient turret pitch speed to compensate the walk animation.
+
+  **Sprite Striker: T3 Sniper Bot (XAL0305)**
+  - Turret pitch speed: 30 -> 50

--- a/units/XAL0305/XAL0305_unit.bp
+++ b/units/XAL0305/XAL0305_unit.bp
@@ -194,7 +194,7 @@ UnitBlueprint{
             FiringTolerance = 0,
             Label = "MainGun",
             MaxRadius = 60,
-            MuzzleChargeDelay = 0,
+            MuzzleChargeDelay = 1,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 90,
@@ -215,7 +215,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
-            RateOfFire = 10/1, --10/integer interval in ticks
+            RateOfFire = 10/67, --10/integer interval in ticks
             RenderFireClock = true,
             TargetPriorities = {
                 "SNIPER",

--- a/units/XAL0305/XAL0305_unit.bp
+++ b/units/XAL0305/XAL0305_unit.bp
@@ -194,7 +194,7 @@ UnitBlueprint{
             FiringTolerance = 0,
             Label = "MainGun",
             MaxRadius = 60,
-            MuzzleChargeDelay = 1,
+            MuzzleChargeDelay = 0,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 90,
@@ -215,7 +215,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
-            RateOfFire = 10/67, --10/integer interval in ticks
+            RateOfFire = 10/1, --10/integer interval in ticks
             RenderFireClock = true,
             TargetPriorities = {
                 "SNIPER",

--- a/units/XAL0305/XAL0305_unit.bp
+++ b/units/XAL0305/XAL0305_unit.bp
@@ -236,7 +236,7 @@ UnitBlueprint{
             TurretDualManipulators = false,
             TurretPitch = 10,
             TurretPitchRange = 60,
-            TurretPitchSpeed = 30,
+            TurretPitchSpeed = 50,
             TurretYaw = 0,
             TurretYawRange = 180,
             TurretYawSpeed = 110,


### PR DESCRIPTION
## Issue
Aeon sniper's walk animation pitches it up and down a lot, and the turret's pitch cannot keep up with this, so when walking about half the time the weapon is not pitched on target, and should not fire.
Keep in mind this is a pitch issue, so the issue appears when walking towards/away from the target.

The engine understands it should not fire, so in the test setup where it fires every tick the sniper does not always fire. Unfortunately the Lua places a muzzle charge delay on the weapon, which means the engine can fire when aimed but the delay creates the projectile when the weapon is no longer aimed, causing it to miss.

## Description of the proposed changes
Increase the pitch speed 30 -> 50 so that the sniper is always aimed; now the delay can never create the projectile when the muzzle isn't aimed.

## Testing done on the proposed changes
Use the test setup where the sniper fires every tick. Before the changes, the sniper would fire intermittently when moving towards/away from the target. After the changes, it fires every tick.

## Additional context
An alternative solution is to use the `RackSalvoChargeTime` value so that the weapon starts charging when it acquires the target, and only fires when it is exactly on target. This would also mean a sniper can charge up out of range and hold that shot forever though, which is a big difference visually so I didn't go with this solution.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
