### PR TITLE
Optimize backup distance based on reverse speed and turn speed

### DIFF
--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -613,6 +613,21 @@ local function PostProcessUnit(unit)
             unit.Display.AnimationDeath = nil
         end
     end
+
+    -- Optimize reverse movement
+    local bpPhysics = unit.Physics
+    local maxSpeedReverse = bpPhysics.MaxSpeedReverse
+    if maxSpeedReverse then
+        local maxSpeed = bpPhysics.MaxSpeed
+        local reverseSpeedDiff = maxSpeed - maxSpeedReverse
+        if reverseSpeedDiff > 0 then
+            local effectiveTurnRate = math.max(57.2957795131 / (bpPhysics.TurnRadius / maxSpeed), bpPhysics.TurnRate)
+            local optimalBackUpDistance = 180 / effectiveTurnRate * maxSpeedReverse / reverseSpeedDiff
+            bpPhysics.BackUpDistance = bpPhysics.BackUpDistance and math.max(bpPhysics.BackUpDistance, optimalBackUpDistance) or optimalBackUpDistance
+        else
+            bpPhysics.BackUpDistance = 32
+        end
+    end
 end
 
 --- Feature: re-apply the ability to land on water


### PR DESCRIPTION
## Description of the proposed changes
In the discussion about giving all units backup distances (https://github.com/FAForever/fa/issues/5754) I wrote down a formula that optimizes backup distance based on reverse speed and turn speed. In the end, a lot of units got a small backup distance in but have equal reverse and forward speed, which made no sense to me.

This is an implementation of that formula, with the new backup distance being used if it is greater than the value in the bp (this exception exists for the Megalith). 
The max is 32 as that is the max distance between pathfinding nodes, so 32 basically makes units always try to reverse, unless the engine decides otherwise, which I can't control with greater backup distances.

This is quite subjective so I wrote this as a discussion item, and it wouldn't be unexpected if its rejected.

## Testing done on the proposed changes
`dbg` has different navigation debug overlays to use to see the pathfinding nodes. `ren_steering` shows the steering behavior of units. I just played around with units like Megalith or fatboy (both of these heavily utilize reverse movement) or Othuum (reverse movement has been talked about as beneficial for pathfinding).

## Checklist
- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
