### PR TITLE
Increase Solace damage per volley from 4k to 5k

### DIFF
--- a/changelog/snippets/balance.6522.md
+++ b/changelog/snippets/balance.6522.md
@@ -1,5 +1,7 @@
-- (#6522) In #5725 the number of child projectiles for the Solace was accidentally increased from 2 to 3 resulting in increased total damage (6k rather than 4k). This change is reversed, and the damage is now properly split between child projectiles instead of being a multiplier of the main projectile's damage.
+- (#6522, #6785) In #5725 the number of child projectiles for the Solace was accidentally increased from 2 to 3 resulting in massively increased total damage. This change is reversed only partially as the Solace was underused with the lower damage. In addition, the damage is now properly split from the main projectile to the child projectile, which comes into play when the main projectile falls on top of an enemy.
 
   **Solace: T3 Torpedo Bomber (XAA0306):**
-  - Number of child projectiles per torpedo: 3 -> 2 (Total damage 6000 -> 4000)
-  - Main projectiles now deal full damage if they fall directly onto an enemy (Damage 400 -> 800).
+  - Damage per volley: 6000 -> 5000
+    - Number of child projectiles per torpedo: 3 -> 2
+    - Main projectile damage: 400 -> 1000
+    - Child projectile damage: 400 -> 500

--- a/units/XAA0306/XAA0306_unit.bp
+++ b/units/XAA0306/XAA0306_unit.bp
@@ -199,7 +199,7 @@ UnitBlueprint{
             AutoInitiateAttackCommand = true,
             BallisticArc = "RULEUBA_None",
             CollideFriendly = false,
-            Damage = 800,
+            Damage = 1000,
             DamageType = "Normal",
             DisplayName = "Torpedo Cluster",
             FireTargetLayerCapsTable = {


### PR DESCRIPTION
## Description of the proposed changes
When balance team discussed the Solace we generally agreed that at 4k damage it was too weak, but too strong with the bug that made it deal 6k damage, so we want to try out 5k damage.

**Solace: T3 Torpedo Bomber (XAA0306)**
- Torpedo Cluster
  - Damage per volley: 4000 -> 5000

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
