### PR TITLE
Fix painting canvas hidden selection issues

### DIFF
--- a/engine/User.lua
+++ b/engine/User.lua
@@ -529,8 +529,8 @@ end
 function GetScriptBit(unit, bit)
 end
 
---- Returns a table of the currently selected units
----@return UserUnit[]
+--- Returns a table of the currently selected units. Returns `nil` for an empty selection.
+---@return UserUnit[]?
 function GetSelectedUnits()
 end
 

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -195,7 +195,7 @@ function StartCommandMode(newCommandMode, data)
     import("/lua/ui/game/painting/PaintingCanvas.lua").InhibitAllPaintings("commandmode")
 end
 
---- Called when the command mode ends and deconstructs all the data.
+--- Called when the command mode ends and deconstructs all the data or by the engine when the selection changes.
 ---@param isCancel boolean # set when we're at the end of (a sequence of) order(s), is usually always true. False when the mode is ended with right click, except for "ping" mode.
 function EndCommandMode(isCancel)
     if ignoreSelection then

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -629,6 +629,14 @@ function OnSelectionChanged(oldSelection, newSelection, added, removed)
     cachedSelection.removed = removed
     ObserveSelection:Set(cachedSelection)
 
+    -- limitation: only enable painting when no unit is selected. This limitation enables us 
+    -- to use a wide range of (mouse) buttons that would otherwise be used by engine functions
+    if table.empty(newSelection) then
+        import("/lua/ui/game/painting/PaintingCanvas.lua").LiftInhibitionOfAllPaintings("selection")
+    else
+        import("/lua/ui/game/painting/PaintingCanvas.lua").InhibitAllPaintings("selection")
+    end
+
     if not hotkeyLabelsOnSelectionChanged then
         hotkeyLabelsOnSelectionChanged = import("/lua/keymap/hotkeylabels.lua").onSelectionChanged
     end

--- a/lua/ui/game/selection.lua
+++ b/lua/ui/game/selection.lua
@@ -47,7 +47,7 @@ end
 function Hidden(callback)
     local CM = import("/lua/ui/game/commandmode.lua")
 
-    local old_selection = GetSelectedUnits() or {}
+    local old_selection = GetSelectedUnits() or EmptyTable
     hidden_select = true
     CM.SetIgnoreSelection(true)
 

--- a/lua/ui/game/selection.lua
+++ b/lua/ui/game/selection.lua
@@ -46,13 +46,15 @@ end
 
 function Hidden(callback)
     local CM = import("/lua/ui/game/commandmode.lua")
-    local current_command = CM.GetCommandMode()
-    local old_selection = GetSelectedUnits() or {}
 
+    local old_selection = GetSelectedUnits() or {}
     hidden_select = true
+    CM.SetIgnoreSelection(true)
+
     callback()
+
     SelectUnits(old_selection)
-    CM.StartCommandMode(current_command[1], current_command[2])
+    CM.SetIgnoreSelection(false)
     hidden_select = false
 end
 


### PR DESCRIPTION
## Description of the proposed changes
- Fix painting canvas by inhibited by hidden selections due to command mode being restarted.
- Re-add the code in `gamemain` `onselectionchanged` as that should handle hidden selections correctly, it's just that when I was testing my mods the way the mods do hidden selections is just outdated.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
The following hidden selection commands should not inhibit painting, as they use FAF code. Use the paste buffer hotkey and bind it to something that doesn't use `shift` or `alt`, then copy the commands and execute the paste buffer while holding right click to draw. The log will tell you when you hidden-selected units after executing the commands.
```lua
  local f = import('/lua/ui/game/selection.lua').Hidden
f(function ()
    UISelectionByCategory('ALLUNITS', false, false, false, false)
    LOG('selected this many units: ', table.getsize(GetSelectedUnits()))
end)
```
```lua
local onSelIgnore = import('/lua/ui/game/gamemain.lua').SetIgnoreSelection
local CMIgnore = import('/lua/ui/game/commandmode.lua').SetIgnoreSelection
onSelIgnore(true)
CMIgnore(true)
local oldSelection = GetSelectedUnits() or EmptyTable

UISelectionByCategory('ALLUNITS', false, false, false, false)
LOG('selected this many units: ', table.getsize(GetSelectedUnits()))

SelectUnits(oldSelection)
CMIgnore(false)
onSelIgnore(false)
```

## Checklist
- [x] Changes are annotated, including comments where useful
~~- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).~~
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
