### PR TITLE
Fix errors when self destruct is called with 0 units

### DIFF
--- a/changelog/snippets/fix.6788.md
+++ b/changelog/snippets/fix.6788.md
@@ -1,0 +1,1 @@
+- (#6788) Fix errors when self destruct is used with no selection.

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -320,7 +320,7 @@ Callbacks.SelfDestruct = function(data, selection)
         return
     end
 
-    import("/lua/sim/commands/self-destruct.lua").RingExtractor(selection, true)
+    import("/lua/sim/commands/self-destruct.lua").SelfDestruct(selection, true)
 end
 
 --#endregion

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -306,8 +306,10 @@ end
 -------------------------------------------------------------------------------
 --#region General orders
 
+--- Instant self destruct that only works on the selection.
+--- Alternative, simplified implementation that is unused.
 ---@param data { }
----@param selection Unit[]
+---@param selection? Unit[]
 Callbacks.SelfDestruct = function(data, selection)
     -- verify selection
     selection = SecureUnits(selection)

--- a/lua/selfdestruct.lua
+++ b/lua/selfdestruct.lua
@@ -21,11 +21,14 @@ end
 
 --- Toggles the destruction of the units
 ---@param data { owner: number, noDelay: boolean }
----@param units Unit[]
+---@param units? Unit[]
 function ToggleSelfDestruct(data, units)
 
     -- suppress self destruct in tutorial missions as they screw up the mission end
-    if ScenarioInfo.tutorial and ScenarioInfo.tutorial == true then
+    if ScenarioInfo.tutorial and ScenarioInfo.tutorial == true
+        -- handle call with empty selection
+        or not units
+    then
         return
     end
 

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -274,9 +274,11 @@ do
         -- inform allies about self-destructed units
         if callback.Func == 'ToggleSelfDestruct' then
             local selectedUnits = GetSelectedUnits()
+            if selectedUnits then
+                -- try to inform moderators
+                ForkThread(SendModeratorEventThread, string.format('Self-destructed %d units', TableGetn(selectedUnits)))
+            end
 
-            -- try to inform moderators
-            ForkThread(SendModeratorEventThread, string.format('Self-destructed %d units', TableGetn(selectedUnits)))
         end
 
         -- inform moderators about pings


### PR DESCRIPTION
## Description of the proposed changes
- Fix errors when self destruct is called with 0 units.
  - in sim
  - in moderator message
- Fix + annotate unused `SelfDestruct` callback.

## Testing done on the proposed changes
The usual self destruct command no longer errors when you issue it with no selection.
The alternative one now destroys units.

## Additional context
The alternative was added by @Garanas  in https://github.com/FAForever/fa/commit/d00642c705cd795f09c83baf438dec516e4535a5 but seemingly never finished and there seems to be no documentation or discussion about how it should work.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
