### PR TITLE
Fix functions being called on destroyed unbuilt units in factory class

### DIFF
--- a/changelog/snippets/fix.6692.md
+++ b/changelog/snippets/fix.6692.md
@@ -1,1 +1,1 @@
-- (#6692) Fix factories not immediately starting to build queued units after the factory finishes upgrading, or when a currently building land or navy unit is cancelled.
+- (#6692, #6789) Fix factories not immediately starting to build queued units after the factory finishes upgrading, or when a currently building land or navy unit is cancelled.

--- a/changelog/snippets/fix.6700.md
+++ b/changelog/snippets/fix.6700.md
@@ -1,1 +1,1 @@
-- (#6700) Fix an edge case where mobile build orders issued to a factory and then cancelled would cause the unbuilt unit to not get destroyed and block the factory forever.
+- (#6700, #6789) Fix an edge case where mobile build orders issued to a factory and then cancelled would cause the unbuilt unit to not get destroyed and block the factory forever.

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2913,6 +2913,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         self.Brain:OnUnitStopBuild(self, built, order)
     end,
 
+    --- Called by the engine when the current *build* order (not repair order) is cancelled.
     ---@param self Unit
     OnFailedToBuild = function(self)
         self:DoOnFailedToBuildCallbacks()

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -141,7 +141,7 @@ FactoryUnit = ClassUnit(StructureUnit) {
         end
 
         -- Factory can stop building but still have an unbuilt unit if a mobile build order is issued and the order is cancelled
-        if not unitBeingBuilt.Dead and not unitBeingBuilt.isFinishedUnit then
+        if not IsDestroyed(unitBeingBuilt) and not unitBeingBuilt.isFinishedUnit then
             unitBeingBuilt:Destroy()
         end
 
@@ -206,7 +206,8 @@ FactoryUnit = ClassUnit(StructureUnit) {
         -- needs to have its collision removed so that the next unit can start building immediately,
         -- since destroying the unit doesn't immediately clear the build area.
         local unitBeingBuilt = self.UnitBeingBuilt
-        if unitBeingBuilt and not unitBeingBuilt.Dead then
+        if not IsDestroyed(unitBeingBuilt) then
+            ---@diagnostic disable-next-line: need-check-nil
             unitBeingBuilt:SetCollisionShape('None')
         end
         StructureUnitOnFailedToBuild(self)

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -201,8 +201,13 @@ FactoryUnit = ClassUnit(StructureUnit) {
 
     ---@param self FactoryUnit
     OnFailedToBuild = function(self)
-        -- Instantly clear the build area so the next build can start, since unit `Destroy` doesn't do so.
-        self.UnitBeingBuilt:SetCollisionShape('None')
+        -- When a factory has a queue and you cancel the currently building unit, this unit
+        -- needs to have its collision removed so that the next unit can start building immediately,
+        -- since destroying the unit doesn't immediately clear the build area.
+        local unitBeingBuilt = self.UnitBeingBuilt
+        if unitBeingBuilt and not unitBeingBuilt.Dead then
+            unitBeingBuilt:SetCollisionShape('None')
+        end
         StructureUnitOnFailedToBuild(self)
         self.FactoryBuildFailed = true
         self:StopBuildFx()

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -141,7 +141,7 @@ FactoryUnit = ClassUnit(StructureUnit) {
         end
 
         -- Factory can stop building but still have an unbuilt unit if a mobile build order is issued and the order is cancelled
-        if unitBeingBuilt:GetFractionComplete() < 1 then
+        if not unitBeingBuilt.Dead and not unitBeingBuilt.isFinishedUnit then
             unitBeingBuilt:Destroy()
         end
 

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -199,6 +199,7 @@ FactoryUnit = ClassUnit(StructureUnit) {
         self:CreateBlinkingLights()
     end,
 
+    --- Called by the engine when the current *build* order (not repair order) is cancelled.
     ---@param self FactoryUnit
     OnFailedToBuild = function(self)
         -- When a factory has a queue and you cancel the currently building unit, this unit


### PR DESCRIPTION
## Description of the proposed changes
Resolves the following two errors from replay [#24837676](https://replay.faforever.com/24837676) (FAF Develop).
```
WARNING: Error running OnFailedToBuild script in Entity zrb9601 at 2f11db08: ...ydata\gamedata\lua.nx5\lua\sim\units\factoryunit.lua(205): Game object has been destroyed
         stack traceback:
             [C]: in function `SetCollisionShape'
             ...ydata\gamedata\lua.nx5\lua\sim\units\factoryunit.lua(205): in function <...ydata\gamedata\lua.nx5\lua\sim\units\factoryunit.lua:203>
```
```
WARNING: Error running OnStopBuild script in Entity zrb9601 at 2f11db08: ...ydata\gamedata\lua.nx5\lua\sim\units\factoryunit.lua(144): attempt to call method `GetFractionComplete' (a nil value)
         stack traceback:
             ...ydata\gamedata\lua.nx5\lua\sim\units\factoryunit.lua(144): in function <...ydata\gamedata\lua.nx5\lua\sim\units\factoryunit.lua:132>
```

These errors are caused when a player dies and their unfinished units are transferred. The transfer function destroys the old unbuilt unit, then destroys the factory, which causes the logic that pertains to failed/stopped builds to run, and at that point it tries to operate with the now-destroyed unbuilt unit.

- Add checks if the unbuilt unit is destroyed before running the code.

## Testing done on the proposed changes
The following lua code tests unfinished unit transfer by rebuilding all your units back to yourself. With #6784 it will no longer work for unbuilt units inside factories, so that PR can be an alternative fix, but I don't really see the harm in doing this check anyway if any other code wants to mess with Destroying factories/unbuilt units simultaneously.
```lua
ConExecute([[SimLua 
local f = import("/lua/SimUtils.lua").TransferUnfinishedUnitsAfterDeath
local focus = GetFocusArmy()
ForkThread(f, ArmyBrains[focus]:GetListOfUnits(categories.ALLUNITS, false, false), {focus})
]])
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
