### PR TITLE
Fix cancelling tempest firing cycle

### DIFF
--- a/changelog/snippets/balance.6790.md
+++ b/changelog/snippets/balance.6790.md
@@ -1,0 +1,1 @@
+- (#6790) The tempest can now be retargeted while it is charging without triggering a full 12.5 second reload.

--- a/lua/sim/weapons/aeon/ADFCannonOblivionWeapon02.lua
+++ b/lua/sim/weapons/aeon/ADFCannonOblivionWeapon02.lua
@@ -26,5 +26,5 @@ local EffectTemplate = import('/lua/effecttemplates.lua')
 ---@class ADFCannonOblivionWeapon02 : DefaultProjectileWeapon
 ADFCannonOblivionWeapon02 = ClassWeapon(DefaultProjectileWeapon) {
     FxMuzzleFlash = EffectTemplate.AOblivionCannonMuzzleFlash02,
-    FxChargeMuzzleFlash = EffectTemplate.AOblivionCannonChargeMuzzleFlash02,
+    FxRackChargeMuzzleFlash = EffectTemplate.AOblivionCannonChargeMuzzleFlash02,
 }

--- a/units/UAS0401/UAS0401_unit.bp
+++ b/units/UAS0401/UAS0401_unit.bp
@@ -283,7 +283,7 @@ UnitBlueprint{
             FiringTolerance = 2,
             Label = "MainGun",
             MaxRadius = 150,
-            MuzzleChargeDelay = 1.5,
+            MuzzleChargeDelay = 0,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 35,
@@ -300,12 +300,13 @@ UnitBlueprint{
             RackFireTogether = false,
             RackRecoilDistance = -3,
             RackReloadTimeout = 10,
-            RackSalvoChargeTime = 0,
-            RackSalvoReloadTime = 0,
+            RackSalvoChargeTime = 1.5,
+            RackSalvoFiresAfterCharge = true,
+            RackSalvoReloadTime = 10.9,
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
-            RateOfFire = 10/125, --10/integer interval in ticks
+            RateOfFire = 10/1, --10/integer interval in ticks
             SlavedToBody = false,
             TargetPriorities = {
                 "NAVAL MOBILE",


### PR DESCRIPTION
## Description of the proposed changes
Resolves #6443
MuzzleChargeDelay is bad because it desyncs the projectile creation and the projectile firing from the engine when the weapon is aimed. We ignore the engine's behavior by instead basing the reload on rack salvo reload time, and setting the fire rate low. This allows us to cancel firing during the charging sequence without firing and without triggering the reload delay.


## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
- The tempest can be retargeted without triggering a long reload now.
- The tempest doesn't charge its weapon against units outside of range and it cannot hold its charge (this mimics the target acquisition->firing behavior of MuzzleChargeDelay, it is what "fires after charge" is for.)

The tempest will charge and fire when it *gets* a target instead of when it is *on* target, which can easily cause it to miss due to the turn speed. This is fixed with https://github.com/FAForever/fa/pull/6791.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
