### PR TITLE
Prevent weapons that fire after charging from charging while not aimed

### DIFF
--- a/changelog/snippets/features.6791.md
+++ b/changelog/snippets/features.6791.md
@@ -1,0 +1,1 @@
+- (#6791) Prevent weapons that fire after charging (using `RackSalvoChargeTime` and `RackSalvoFiresAfterCharge`) from charging while not aimed, as they would miss if the charging finished before the weapon finished aiming due to a slow turret turn speed.

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -780,7 +780,10 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                     ChangeState(self, self.WeaponUnpackingState)
                 else
                     if bp.RackSalvoChargeTime and bp.RackSalvoChargeTime > 0 then
-                        ChangeState(self, self.RackSalvoChargeState)
+                        -- don't charge and then possibly fire while unaimed
+                        if not bp.RackSalvoFiresAfterCharge then
+                            ChangeState(self, self.RackSalvoChargeState)
+                        end
                     else
                         ChangeState(self, self.RackSalvoFireReadyState)
                     end


### PR DESCRIPTION
## Issue
If a weapon that fires after charging charges while unaimed it can miss due to insufficient turret turn speed.

## Description of the proposed changes
Make it so that such weapons do not charge in `OnGotTarget`. Instead they start charging through `OnFire` (called by engine when the weapon is aimed and fire rate cooldown is ready).

## Testing done on the proposed changes
The following weapons should still work reasonably. They will have a small delay now as they aim -> charge -> fire (vs charge -> fire, ignoring aim), but that is a logical delay from a dev who is making such weapons.
-`ual0401-2-RightArmTractor`
-`ual0401-3-LeftArmTractor`
-`ura0104-1-EMPCannon`
-`xsb2204-1-AAFizz`
-`xsl0205-2-AAGun`

The above weapons turn quickly, but with #6790 we get the tempest which has a slow-turning weapon, this is for what unit I am fixing the behavior.
-`uas0401-1-MainGun`

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
