### PR TITLE
Change Aeon ACU's personal shield from blue to green

### DIFF
--- a/changelog/snippets/graphics.6794.md
+++ b/changelog/snippets/graphics.6794.md
@@ -1,0 +1,1 @@
+- (#6794) Change Aeon ACU's personal shield from UEF's blue shield to Aeon's green shield effect.

--- a/units/UAL0001/UAL0001_PhaseShield_mesh.bp
+++ b/units/UAL0001/UAL0001_PhaseShield_mesh.bp
@@ -4,7 +4,7 @@ MeshBlueprint{
         {
             LODCutoff = 195,
             LookupName = "/effects/entities/PhaseShield/PhaseShieldLookup.dds",
-            ShaderName = "PhaseShield",
+            ShaderName = "AeonPhaseShield",
             MeshName = "ual0001_lod0.scm",
             AlbedoName = "ual0001_albedo.dds",
             NormalsName = "ual0001_normals.dds",


### PR DESCRIPTION
## Description of the proposed changes
- Changes the shader so that it matches other Aeon units.

## Testing done on the proposed changes

Old|New
-|-
![{82C05C8E-66C0-4C6E-ABE5-4BD55E0EA8FB}](https://github.com/user-attachments/assets/affe7436-d108-4919-8fc7-cd50dabd09fa) | ![{CA556765-33DA-40BB-89BD-CF87E6883CDC}](https://github.com/user-attachments/assets/a79bf7ef-5a98-4852-a850-80be6a936951)

## Additional Context

This change was originally made on gapforever https://github.com/gapforever2/fa/commit/5709d4aee66f261f856bbb95ea7e9d4cfc39eb1b.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~ (we don't have an aesthetics guideline afaik)
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
