### PR TITLE
Move teleport reticle out of command mode data

### DIFF
--- a/changelog/snippets/other.6797.md
+++ b/changelog/snippets/other.6797.md
@@ -1,0 +1,1 @@
+- (#6797) Remove the teleport reticle object from the command mode data.

--- a/lua/ui/controls/worldview.lua
+++ b/lua/ui/controls/worldview.lua
@@ -643,7 +643,7 @@ WorldView = ClassUI(moho.UIWorldView, Control, WorldViewShapeComponent, WorldVie
                 local cursor = self.Cursor
                 cursor[1], cursor[2], cursor[3], cursor[4], cursor[5] = UIUtil.GetCursor(identifier)
                 self:ApplyCursor()
-                CommandMode.GetCommandMode()[2].reticle = TeleportReticle(self)
+                TeleportReticle(self)
             end
         end
     end,


### PR DESCRIPTION
## Issue
`IssueCommand` will crash if command data has non-serializable types, so data unrelated to commands should not go near command data things.
Implements the changes discussed here: https://github.com/FAForever/fa/pull/6585#discussion_r1895080716

## Description of the proposed changes
Teleport reticle gets initialized without being stored anywhere.

## Testing done on the proposed changes
Unnecessary.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
