### PR TITLE
Annotate exit callbacks

### DIFF
--- a/changelog/snippets/other.6799.md
+++ b/changelog/snippets/other.6799.md
@@ -1,0 +1,1 @@
+- (#6799) Annotate exit callbacks.

--- a/lua/system/performance.lua
+++ b/lua/system/performance.lua
@@ -594,6 +594,7 @@ end
 ---@field Samples number
 ---@field UnitCount? { Min: number, Max: number}
 
+---@param exitType ExitType
 local function StoreSamples(exitType)
 
     -- this is usually testing, no need to keep track of that

--- a/lua/ui/override/Exit.lua
+++ b/lua/ui/override/Exit.lua
@@ -6,9 +6,14 @@ local GlobalRestartSession = _G.RestartSession
 
 local OnExitCallbacks = { }
 
+---@alias ExitType
+---| 'ExitGame'
+---| 'ExitApplication'
+---| 'RestartSession'
+
 --- Add a callback to be run when the game exits gracefully
 ---@param identifier string
----@param callback function
+---@param callback fun(exitType: ExitType)
 function AddOnExitCallback(identifier, callback)
     OnExitCallbacks[identifier] = callback
 end
@@ -20,6 +25,7 @@ function RemoveOnExitCallback(identifier)
 end
 
 --- Run all on exit callbacks
+---@param type ExitType
 local function RunOnExitCallbacks(type)
     for k, callback in OnExitCallbacks do
         local ok, msg = pcall(callback, type)


### PR DESCRIPTION
## Additional Context

There are exit callbacks with anonymous functions I didn't add params for as it is automatically added by intellisense:
https://github.com/FAForever/fa/blob/fd3205075499e36833f185ebb114b2419cf15957/lua/ui/game/cursor/depth.lua#L99-L104
![{8FBCCB58-C960-49EB-80EE-30CB9E50E1EC}](https://github.com/user-attachments/assets/b84b9b5c-4cee-4e45-a186-8e10ecf94361)

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
