### PR TITLE
Fix error when unit with no fire rate is shared

### DIFF
--- a/changelog/snippets/fix.6807.md
+++ b/changelog/snippets/fix.6807.md
@@ -1,0 +1,1 @@
+- (#6807) Fix an error when units with 0 fire rate are shared, for example the Seraphim Sniper Bot (XSL0305).

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1016,13 +1016,11 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         end
     end,
 
-    --- Enables weapon after waiting its fire rate interval
+    --- Enables weapon after waiting a given delay (typically the fire rate interval)
     ---@param weapon Weapon
-    OnGivenDisableWeaponsThread = function(weapon)
+    ---@param delay number # Must be >= 0
+    OnGivenDisableWeaponsThread = function(weapon, delay)
         if not weapon:BeenDestroyed() then
-            -- compute delay
-            local bp = weapon.Blueprint
-            local delay = 1 / bp.RateOfFire
             WaitSeconds(delay)
 
             -- enable the weapon again if it still exists
@@ -1036,14 +1034,18 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     ---@param newUnit Unit
     OnGivenDisableWeapons = function(newUnit)
         -- disable all weapons and enable after a delay
-        local disableWeaponsThread = newUnit.OnGivenDisableWeaponsThread
         for i = 1, newUnit.WeaponCount do
             local weapon = newUnit.WeaponInstances[i]
-            -- Weapons disabled by enhancement shouldn't be re-enabled unless the enhancement is built
-            local enablingEnhancement = weapon.Blueprint.EnabledByEnhancement
-            if not enablingEnhancement or newUnit:HasEnhancement(enablingEnhancement) then
+            local bp = weapon.Blueprint
+            local enablingEnhancement = bp.EnabledByEnhancement
+            local rateOfFire = bp.RateOfFire
+            -- Dummy weapons can have 0 fire rate so that the engine never fires them
+            if rateOfFire > 0
+                -- Weapons disabled by enhancement shouldn't be re-enabled unless the enhancement is built
+                and (not enablingEnhancement or newUnit:HasEnhancement(enablingEnhancement))
+            then
                 weapon:SetEnabled(false)
-                weapon:ForkThread(disableWeaponsThread)
+                weapon:ForkThread(newUnit.OnGivenDisableWeaponsThread, 1 / rateOfFire)
             end
         end
     end,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1039,9 +1039,9 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
             local bp = weapon.Blueprint
             local enablingEnhancement = bp.EnabledByEnhancement
             local rateOfFire = bp.RateOfFire
-            -- Dummy weapons can have 0 fire rate so that the engine never fires them
+            -- Dummy weapons with 0 fire rate shouldn't be disabled
             if rateOfFire > 0
-                -- Weapons disabled by enhancement shouldn't be re-enabled unless the enhancement is built
+                -- Weapons disabled by enhancement shouldn't be disabled unless the enhancement is built
                 and (not enablingEnhancement or newUnit:HasEnhancement(enablingEnhancement))
             then
                 weapon:SetEnabled(false)


### PR DESCRIPTION
## Issue
Caused by #6651
```
warning: Invalid args to yield(); tick count must be >=0
         stack traceback:
         	[C]: in function `WaitTicks'
         	...ogramdata\faforever\gamedata\lua.nx2\lua\siminit.lua(39): in function `WaitSeconds'
         	...gramdata\faforever\gamedata\lua.nx2\lua\sim\unit.lua(1026): in function <...gramdata\faforever\gamedata\lua.nx2\lua\sim\unit.lua:1021>
```

This happens with XSL0305 due to its 0 fire rate dummy weapon:
https://github.com/FAForever/fa/blob/e725005f374984ca49120ea8fe930ffac47bd70a/units/XSL0305/XSL0305_unit.bp#L206


## Description of the proposed changes
Check that the fire rate is greater than 0 before disabling and re-enabling the weapon

## Testing done on the proposed changes
Spawn XSL0305, select it, and transfer it using this command (simply copy and run it from clipboard):
```
ConExecute([[SimLua 
ForkThread(function ()
    local focus = GetFocusArmy()
    local f = import('/lua/SimUtils.lua').TransferUnitsOwnership
    local units = DebugGetSelection()
    units = f(units, focus + 1, false)
    WaitTicks(10)
    f(units, focus, false)
end)
]])
```
there was an error before, now there isn't.

I found the unit by spawning all units and then transferring them with a UnitId log statement to see which units errored:
```
local count = 0
for i,v in __blueprints do
	if type(i) == 'number' or string.find(i, '[/_]') then continue end
	local ch = v.CategoriesHash
	if (
		true
	) and not (ch["INSIGNIFICANTUNIT"] or ch["CIVILIAN"] or ch["OPERATION"])
	then
		CreateUnitAtMouse(i, GetFocusArmy()-1, math.mod(count, 17)*9, math.floor(count/17)*9, 0)
		count = count + 1
	end
end
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
