### PR TITLE
Fix localization for disconnect delay being used by disconnect share options

### DIFF
--- a/changelog/snippets/fix.6809.md
+++ b/changelog/snippets/fix.6809.md
@@ -1,0 +1,1 @@
+-(#6809) Fix the disconnection delay option using the title/description text of the disconnect ACU share option.

--- a/changelog/snippets/fix.6809.md
+++ b/changelog/snippets/fix.6809.md
@@ -1,1 +1,1 @@
--(#6809) Fix the disconnection delay option using the title/description text of the disconnect ACU share option.
+-(#6809) Fix the disconnection delay option using the title/description texts of the disconnect ACU share option.

--- a/loc/US/strings_db.lua
+++ b/loc/US/strings_db.lua
@@ -7762,6 +7762,15 @@ lobui_0805="This game will be rated if all the criteria for a rated game are met
 lobui_0806="Yes"
 lobui_0807="This game will not be rated."
 
+lobui_0808="Disconnection delay"
+lobui_0809="Sets the disconnect delay when a player has trouble connecting."
+lobui_0810="Tournament"
+lobui_0811="The eject delay is set to 10 seconds and after 90 seconds the player is ejected automatically."
+lobui_0812="Quick"
+lobui_0813="The eject delay is set to 30 seconds and after 90 seconds the player is ejected automatically."
+lobui_0814="Regular"
+lobui_0815="The eject delay is set to 90 seconds and after 180 seconds the player is ejected automatically."
+
 -- On-disconnect share options
 lobui_dc_share_01="DC Share Conditions"
 lobui_dc_share_02="Set what happens to a player's units when they disconnect. In Assassination, only applies if an ACU has not been damaged in the last 2 minutes."

--- a/loc/US/strings_db.lua
+++ b/loc/US/strings_db.lua
@@ -7754,11 +7754,6 @@ lobui_0795="No manual sharing of units"
 lobui_0796="Partial Share"
 lobui_0797="Your buildings and engineers will be transferred to your highest rated ally when you die.  Your other units will be destroyed when you die, except those captured by the enemy."
 
-lobui_0798="DC Share Conditions"
-lobui_0799="Set what happens to a player's units when they disconnect. In Assassination, only applies if an ACU has not been damaged in the last 2 minutes."
-lobui_0800="Same as Share Condition"
-lobui_0801="Treat disconnecting players the same as defeated players."
-
 -- unranked lobby option
 lobui_0802="Unrate"
 lobui_0803="Provides a toggle to unrate a game. Note that if this is set to no the game can still be unrated due to other lobby options, unrated sim mods and / or the map being unrated."
@@ -7767,17 +7762,22 @@ lobui_0805="This game will be rated if all the criteria for a rated game are met
 lobui_0806="Yes"
 lobui_0807="This game will not be rated."
 
--- More share options
-lobui_0808="DC ACU Share Conditions"
-lobui_0809="Set what happens to a player's ACU when they disconnect. In Assassination, the DC share condition is *not* applied if the ACU was damaged 2 minutes ago or dies within 2 minutes."
-lobui_0810="Explode"
-lobui_0811="ACUs explode when their player disconnects."
-lobui_0812="Recall"
-lobui_0813="ACUs not damaged in the last 2 minutes are recalled when their player disconnects."
-lobui_0814="Delayed Recall"
-lobui_0815="Disconnected ACUs are shared to allies for 2 minutes or until 5 minutes into the match before it recalls."
-lobui_0816="Permanent"
-lobui_0817="Disconnected ACUs are permanently shared to allies."
+-- On-disconnect share options
+lobui_dc_share_01="DC Share Conditions"
+lobui_dc_share_02="Set what happens to a player's units when they disconnect. In Assassination, only applies if an ACU has not been damaged in the last 2 minutes."
+lobui_dc_share_03="Same as Share Condition"
+lobui_dc_share_04="Treat disconnecting players the same as defeated players."
+
+lobui_dc_share_05="DC ACU Share Conditions"
+lobui_dc_share_06="Set what happens to a player's ACU when they disconnect. In Assassination, the DC share condition is *not* applied if the ACU was damaged 2 minutes ago or dies within 2 minutes."
+lobui_dc_share_07="Explode"
+lobui_dc_share_08="ACUs explode when their player disconnects."
+lobui_dc_share_09="Recall"
+lobui_dc_share_10="ACUs not damaged in the last 2 minutes are recalled when their player disconnects."
+lobui_dc_share_11="Delayed Recall"
+lobui_dc_share_12="Disconnected ACUs are shared to allies for 2 minutes or until 5 minutes into the match before it recalls."
+lobui_dc_share_13="Permanent"
+lobui_dc_share_14="Disconnected ACUs are permanently shared to allies."
 
 aisettings_0001="AIx Cheat Multiplier"
 aisettings_0002="Set the cheat multiplier for the cheating AIs."

--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -237,13 +237,13 @@ globalOpts = {
     },
     {
         default = 1,
-        label = "<LOC lobui_0798>DC Share Conditions",
-        help = "<LOC lobui_0799>Set what happens to a player's units when they disconnect.",
+        label = "<LOC lobui_dc_share_01>DC Share Conditions",
+        help = "<LOC lobui_dc_share_02>Set what happens to a player's units when they disconnect.",
         key = 'DisconnectShare',
         values = {
             {
-                text = "<LOC lobui_0800>Same as Share Condition",
-                help = "<LOC lobui_0801>Treat disconnecting players the same as defeated players.",
+                text = "<LOC lobui_dc_share_03>Same as Share Condition",
+                help = "<LOC lobui_dc_share_04>Treat disconnecting players the same as defeated players.",
                 key = 'SameAsShare',
             },
             -- Commented out until further discussion on how the feature should behave and what options should be available.
@@ -282,30 +282,30 @@ globalOpts = {
     },
     {
         default = 1,
-        label = "<LOC lobui_0808>DC ACU Share Conditions",
-        help = "<LOC lobui_0809>Set what happens to a player's ACU when they disconnect. In Assassination, the DC share condition is *not* applied if the ACU was damaged 2 minutes ago or dies within 2 minutes.",
+        label = "<LOC lobui_dc_share_05>DC ACU Share Conditions",
+        help = "<LOC lobui_dc_share_06>Set what happens to a player's ACU when they disconnect. In Assassination, the DC share condition is *not* applied if the ACU was damaged 2 minutes ago or dies within 2 minutes.",
         key = 'DisconnectShareCommanders',
         values = {
             {
-                text = "<LOC lobui_0810>Explode",
-                help = "<LOC lobui_0811>ACUs explode when their player disconnects.",
+                text = "<LOC lobui_dc_share_07>Explode",
+                help = "<LOC lobui_dc_share_08>ACUs explode when their player disconnects.",
                 key = 'Explode',
             },
             -- Commented out until further discussion on how the feature should behave and what options should be available.
             -- The single choice option above is sent to the sim but does not show in the lobby UI, so everything will work as before.
             -- {
-            --     text = "<LOC lobui_0812>Recall",
-            --     help = "<LOC lobui_0813>ACUs not damaged in the last 2 minutes are recalled when their player disconnects.",
+            --     text = "<LOC lobui_dc_share_09>Recall",
+            --     help = "<LOC lobui_dc_share_10>ACUs not damaged in the last 2 minutes are recalled when their player disconnects.",
             --     key = 'Recall',
             -- },
             -- {
-            --     text = "<LOC lobui_0814>Delayed Recall",
-            --     help = "<LOC lobui_0815>Disconnected ACUs are shared to allies for 2 minutes or until 5 minutes into the match before it recalls.",
+            --     text = "<LOC lobui_dc_share_11>Delayed Recall",
+            --     help = "<LOC lobui_dc_share_12>Disconnected ACUs are shared to allies for 2 minutes or until 5 minutes into the match before it recalls.",
             --     key = 'RecallDelayed',
             -- },
             -- {
-            --     text = "<LOC lobui_0816>Permanent",
-            --     help = "<LOC lobui_0817>Disconnected ACUs are permanently shared to allies.",
+            --     text = "<LOC lobui_dc_share_13>Permanent",
+            --     help = "<LOC lobui_dc_share_14>Disconnected ACUs are permanently shared to allies.",
             --     key = 'Permanent',
             -- },
         },


### PR DESCRIPTION
## Issue
In #6612 new localization tags were added for the disconnect delay, but those tags were also used at the same time in #5971. This is the fault of the loc tag numbered naming convention and not automatically placing the default US text from the code into the US db once a tag is created.

This caused the disconnect delay options to read like the disconnect share options in the US localization.

## Description of the proposed changes
- Change the disconnect share localization to use new tags with a subname and a number.
- Add the new tags for disconnect delay to the us db with the default text from the code.

## Testing done on the proposed changes
Start a **multiplayer LAN** lobby. The Disconnection delay option should be there with correct titles and descriptions.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
