### PR TITLE
Fix matchmaker games from the autolobby not sharing units on death

### DIFF
--- a/changelog/snippets/fix.6810.md
+++ b/changelog/snippets/fix.6810.md
@@ -1,0 +1,1 @@
+- (#6810) Fix fullshare not working when a player disconnects in matchmaker games.

--- a/lua/ui/lobby/autolobby/AutolobbyController.lua
+++ b/lua/ui/lobby/autolobby/AutolobbyController.lua
@@ -210,6 +210,8 @@ AutolobbyCommunications = Class(MohoLobbyMethods, AutolobbyServerCommunicationsC
             Share = 'FullShare',
             ShareUnitCap = 'allies',
             DisconnectionDelay02 = '90',
+            DisconnectShare = 'SameAsShare',
+            DisconnectShareCommanders = 'Explode',
 
             -- yep, great
             Ranked = true,


### PR DESCRIPTION
## Issue
The disconnect share options were missing and the autolobby has no default options logic like the lobby so these options were `nil`, which results in default behavior of exploding the ACU and destroying all units.

## Description of the proposed changes
Add the correct disconnect share options that match the current game.

## Testing done on the proposed changes
Start a 4 player LAN game using the script. Spawn some units for a player and have them leave. Look from their teammate's perspective to see that their units are transferred correctly instead of just dying.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
