### PR TITLE
Re-implement announcements

### DIFF
--- a/changelog/snippets/fix.6813.md
+++ b/changelog/snippets/fix.6813.md
@@ -1,0 +1,2 @@
+- (#6813) Fix an issue in co-op where the cinematic mode would not exit
+  

--- a/changelog/snippets/other.6813.md
+++ b/changelog/snippets/other.6813.md
@@ -1,0 +1,3 @@
+- (#6813) Rework announcements from the ground up
+
+With this rework they become much more easier to maintain. It's now also much easier to make more specific announcements with more rich content such as images.

--- a/lua/keymap/debugKeyActions.lua
+++ b/lua/keymap/debugKeyActions.lua
@@ -309,6 +309,10 @@ local keyActionsDebugAI = {
         action = 'UI_Lua import("/lua/ui/game/aichunktemplates.lua").AddUnitSelectionToEmptyChunkTemplate(32)',
         category = 'ai'
     },
+    ['create_dummy_announcement'] = {
+        action = 'UI_Lua import("/lua/ui/game/announcement.lua").CreateAnnouncement("Test announcement", nil, nil, function() end)',
+        category = 'debug'
+    },
 }
 
 ---@type table<string, UIKeyAction>

--- a/lua/keymap/debugKeyActions.lua
+++ b/lua/keymap/debugKeyActions.lua
@@ -309,8 +309,12 @@ local keyActionsDebugAI = {
         action = 'UI_Lua import("/lua/ui/game/aichunktemplates.lua").AddUnitSelectionToEmptyChunkTemplate(32)',
         category = 'ai'
     },
-    ['create_dummy_announcement'] = {
-        action = 'UI_Lua import("/lua/ui/game/announcement.lua").CreateAnnouncement("Test announcement", nil, nil, function() end)',
+    ['create_title_announcement'] = {
+        action = 'UI_Lua import("/lua/ui/game/announcement.lua").DebugTitleAnnouncement()',
+        category = 'debug'
+    },
+    ['create_title_text_announcement'] = {
+        action = 'UI_Lua import("/lua/ui/game/announcement.lua").DebugTitleTextAnnouncement()',
         category = 'debug'
     },
 }

--- a/lua/ui/controls/textarea.lua
+++ b/lua/ui/controls/textarea.lua
@@ -48,14 +48,6 @@ TextArea = ClassUI(ItemList) {
         self.Width.OnDirty = function(var)
             self:ReflowText()
         end
-
-        -- Reflow text when the text properties of this ItemList are changed (see itemlist.lua)
-        local fontOnDirty = function(var)
-            self:_internalSetFont()
-        end
-
-        self._font._family.OnDirty = fontOnDirty
-        self._font._pointsize.OnDirty = fontOnDirty
     end,
 
     ---@param self TextArea

--- a/lua/ui/controls/textarea.lua
+++ b/lua/ui/controls/textarea.lua
@@ -36,7 +36,7 @@ TextArea = ClassUI(ItemList) {
         self._textWidth = 0
 
         -- The advance function for Text.WrapText. Delegates to the ItemList.GetStringAdvance.
-        -- Initialize before the default font below reflows the text
+        -- Initialize before setting default font.
         self.advanceFunction = function(text) return self:GetStringAdvance(text) end
 
         -- By default, inherit colour and font from UIUtil (this will update with the skin, too,
@@ -50,6 +50,7 @@ TextArea = ClassUI(ItemList) {
         end
     end,
 
+    --- Changes the font and then reflows the text.
     ---@param self TextArea
     _internalSetFont = function(self)
         if not self._lockFontChanges then

--- a/lua/ui/controls/textarea.lua
+++ b/lua/ui/controls/textarea.lua
@@ -60,9 +60,9 @@ TextArea = ClassUI(ItemList) {
     end,
 
     ---@param self TextArea
-    ---@param text string
+    ---@param text? string | number
     SetText = function(self, text)
-        self.text = text
+        self.text = tostring(text)
         self:ReflowText()
     end,
 

--- a/lua/ui/controls/textarea.lua
+++ b/lua/ui/controls/textarea.lua
@@ -35,13 +35,14 @@ TextArea = ClassUI(ItemList) {
         self.text = ""
         self._textWidth = 0
 
+        -- The advance function for Text.WrapText. Delegates to the ItemList.GetStringAdvance.
+        -- Initialize before the default font below reflows the text
+        self.advanceFunction = function(text) return self:GetStringAdvance(text) end
+
         -- By default, inherit colour and font from UIUtil (this will update with the skin, too,
         -- because LazyVars are magical.
         self:SetColors(UIUtil.fontColor, "00000000", UIUtil.fontColor, "00000000")
         self:SetFont(UIUtil.bodyFont, 14)
-
-        -- The advance function for Text.WrapText. Delegates to the ItemList.GetStringAdvance.
-        self.advanceFunction = function(text) return self:GetStringAdvance(text) end
 
         -- Reflow text when the width is changed.
         self.Width.OnDirty = function(var)
@@ -49,12 +50,18 @@ TextArea = ClassUI(ItemList) {
         end
 
         -- Reflow text when the text properties of this ItemList are changed (see itemlist.lua)
-        self._font._family.OnDirty = function(var)
+        local fontOnDirty = function(var)
             self:_internalSetFont()
-            self:ReflowText()
         end
-        self._font._pointsize.OnDirty = function(var)
-            self:_internalSetFont()
+
+        self._font._family.OnDirty = fontOnDirty
+        self._font._pointsize.OnDirty = fontOnDirty
+    end,
+
+    ---@param self TextArea
+    _internalSetFont = function(self)
+        if not self._lockFontChanges then
+            self:SetNewFont(self._font._family(), self._font._pointsize())
             self:ReflowText()
         end
     end,

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -132,7 +132,8 @@ end
 ---@param bodyText? UnlocalizedString
 ---@param goalControl? Control          # if defined, the announcement visually expands and contracts to this control.
 function CreateAnnouncement(titleText, bodyText, goalControl)
-    if type(bodyText) == "string" then
+    local typeOfBodyText = type(bodyText)
+    if typeOfBodyText == "string" or typeOfBodyText == "number" then
         return import("/lua/ui/game/announcement.lua").CreateTitleTextAnnouncement (titleText, bodyText, goalControl)
     else
         return import("/lua/ui/game/announcement.lua").CreateTitleAnnouncement(titleText, goalControl)

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -83,11 +83,11 @@ CreateTitleAnnouncement = function(titleText, goalControl)
     goalControl = goalControl or CreateDefaultGoalControl(frame)
 
     -- developers note: lazy load the module so that it remains unloaded unless used
-    local SmallAnnouncement = import("/lua/ui/game/announcement/SmallAnnouncement.lua").SmallAnnouncement
+    local TitleAnnouncement = import("/lua/ui/game/announcement/TitleAnnouncement.lua").TitleAnnouncement
 
     -- create the announcement
     ---@type UIAbstractAnnouncement
-    local announcement = SmallAnnouncement(frame, titleText)
+    local announcement = TitleAnnouncement(frame, titleText)
     announcement:Animate(goalControl, 1.4)
     Announcements:Add(announcement)
 

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -5,19 +5,24 @@
 --*
 --* Copyright � 2007 Gas Powered Games, Inc.  All rights reserved.
 --*****************************************************************************
-local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
-local Layouter = LayoutHelpers.ReusedLayoutFor
-
-local UIUtil = import("/lua/ui/uiutil.lua")
 local Group = import("/lua/maui/group.lua").Group
-local Bitmap = import("/lua/maui/bitmap.lua").Bitmap
-local TextArea = import("/lua/ui/controls/textarea.lua").TextArea
 
 local SmallAnnouncement = import("/lua/ui/game/announcement/SmallAnnouncement.lua").SmallAnnouncement
 
-local MATH_Lerp = MATH_Lerp
+---@type TrashBag | UIAbstractAnnouncement[]
+local Announcements = TrashBag()
 
-local bg = false
+--- Creates the default goal control that originates from the top of the screen, in the center.
+---@param frame Frame
+local function CreateDefaultGoalControl(frame)
+    goalControl = Group(frame)
+    goalControl.Left:Set(function() return frame.Left() + 0.49 * frame.Right() end)
+    goalControl.Right:Set(function() return frame.Left() + 0.51 * frame.Right() end)
+    goalControl.Top:Set(function() return frame.Top() end);
+    goalControl.Height:Set(0)
+
+    return goalControl
+end
 
 --- Create an announcement UI for sending general messages to the user
 ---@param text UnlocalizedString # title text
@@ -25,220 +30,50 @@ local bg = false
 ---@param secondaryText? UnlocalizedString # body text
 ---@param onFinished? function
 function CreateAnnouncement(text, goalControl, secondaryText, onFinished)
-    local frame = GetFrame(0)
+    -- early exit: don't show announcements when the score dialog is open
+    local scoreModule = import("/lua/ui/dialogs/score.lua")
+    if scoreModule.dialog then
+        return
+    end
 
+    local frame = GetFrame(0) --[[@as Frame]]
+
+    -- create a dummy goal control if we don't have one
     if not goalControl then
-        -- make it originate from the top of the screen
-        goalControl = Group(frame)
-        goalControl.Left:Set(function() return frame.Left() + 0.49 * frame.Right() end)
-        goalControl.Right:Set(function() return frame.Left() + 0.51 * frame.Right() end)
-        goalControl.Top:Set(function() return frame.Top() end);
-        goalControl.Height:Set(0)
+        goalControl = CreateDefaultGoalControl(frame)
     end
 
-    do
-        -- just do nothing
-        LOG(text, goalControl, secondaryText, onFinished)
-
-        ForkThread(
-            function()
-                ---@type UIAbstractAnnouncement
-                local announcement = SmallAnnouncement(frame, text)
-                announcement:ExpandBackground(goalControl, 0.4)
-                WaitSeconds(0.4)
-
-                announcement:AnimateContent(0.6, 1.0)
-                WaitSeconds(2.0)
-
-                announcement:AnimateContent(0.4, 0.0)
-                WaitSeconds(0.4)
-
-                announcement:ContractBackground(goalControl, 0.4)
-                WaitSeconds(0.4)
-
-                announcement:Destroy()
-            end
-        )
-
-        return
+    -- abort all existing announcements
+    for k, announcement in Announcements do
+        announcement:AbortAnnouncement()
     end
 
+    -- create the announcement
+    ---@type UIAbstractAnnouncement
+    local announcement = SmallAnnouncement(frame, text)
+    announcement:Animate(goalControl)
+    Announcements:Add(announcement)
 
-
-    local scoreDlg = import("/lua/ui/dialogs/score.lua")
-    if scoreDlg.dialog then
-        if onFinished then
-            onFinished()
-        end
-        return
-    end
-
-    if bg then
-        if bg.OnFinished then
-            bg.OnFinished()
-        end
-        bg.OnFrame = function(self, delta)
-            local newAlpha = self:GetAlpha() - (delta*2)
-            if newAlpha < 0 then
-                newAlpha = 0
-                self:Destroy()
-                bg.OnFinished = nil
-                bg = false
-                CreateAnnouncement(text, goalControl, secondaryText, onFinished)
-            end
-            self:SetAlpha(newAlpha, true)
-            if bg.secText then
-                bg.secText:SetAlphaOfColors(newAlpha)
-            end
-        end
-        return
-    end
-
-    PlaySound(Sound({Bank = 'Interface', Cue = 'UI_Announcement_Open'}))
-
-    bg = Layouter(Bitmap(frame, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_m.dds')))
-        :Height(0):Width(0):Over(frame, 1):AtCenterIn(goalControl):End()
-    bg.border = CreateBorder(bg)
-
-    local textGroup = Group(bg)
-
-    local title = Layouter(UIUtil.CreateText(textGroup, text, 22, UIUtil.titleFont))
-        :AtCenterIn(frame, -250)
-        :DropShadow(true):Color(UIUtil.fontColor)
-        :NeedsFrameUpdate(true):End()
-
-    local secText
-    if secondaryText then
-        secText = TextArea(textGroup, 600, 60)
-        secText:SetFont(UIUtil.bodyFont, 18)
-        secText:SetText(secondaryText)
-        secText:FitToText()
-        secText:SetTextAlignment(0.5)
-        secText:SetColors(UIUtil.fontColor)
-        secText:SetAlphaOfColors(0)
-        Layouter(secText):CenteredBelow(title, 10):End()
-        bg.secText = secText
-
-        Layouter(textGroup):Top(title.Top)
-            :Left(function() return math.min(secText.Left(), title.Left()) end)
-            :Right(function() return math.max(secText.Right(), title.Right()) end)
-            :Bottom(secText.Bottom):End()
-    else
-        LayoutHelpers.FillParent(textGroup, title)
-    end
-    bg:DisableHitTest(true)
-
-    textGroup:SetAlpha(0, true)
-
-    bg:SetNeedsFrameUpdate(true)
-
-    bg.OnFinished = onFinished
-    bg.time = 0
-    local tGTop, tGLeft, tGRight, tGBottom, tGHeight, tGWidth = textGroup.Top(), textGroup.Left(), textGroup.Right(), textGroup.Bottom(), textGroup.Height(), textGroup.Width()
-    local gCTop, gCLeft, gCRight, gCBottom, gCHeight, gCWidth = goalControl.Top(), goalControl.Left(), goalControl.Right(), goalControl.Bottom(), goalControl.Height(), goalControl.Width()
-
-    bg.OnFrame = function(self, delta)
-        local time = self.time + delta
-        self.time = time
-
-        -- expansion animation
-        if time < .2 then
-            local lerpMult = MATH_Lerp(time, 0, 0.2, 0, 1)
-            self.Top:Set(MATH_Lerp(lerpMult, gCTop, tGTop))
-            self.Left:Set(MATH_Lerp(lerpMult, gCLeft, tGLeft))
-            self.Right:Set(MATH_Lerp(lerpMult, gCRight, tGRight))
-            self.Bottom:Set(MATH_Lerp(lerpMult, gCBottom, tGBottom))
-            self.Height:Set(MATH_Lerp(lerpMult, gCHeight, tGHeight))
-            self.Width:Set(MATH_Lerp(lerpMult, gCWidth, tGWidth))
-        -- stationary
-        elseif time > .2 and time < 3.5 and not self.TextGroupReached then
-            Layouter(self):Fill(textGroup):End()
-            self.TextGroupReached = true
-        -- contraction animation
-        elseif time >= 3.5 and time < 3.7 then
-            if not self.CloseSoundPlayed then
-                PlaySound(Sound({Bank = 'Interface', Cue = 'UI_Announcement_Close'}))
-                self.CloseSoundPlayed = true
-            end
-            local lerpMult = MATH_Lerp(time, 3.5, 3.7, 0, 1)
-            self.Top:Set(MATH_Lerp(lerpMult, tGTop, gCTop))
-            self.Left:Set(MATH_Lerp(lerpMult, tGLeft, gCLeft))
-            self.Right:Set(MATH_Lerp(lerpMult, tGRight, gCRight))
-            self.Bottom:Set(MATH_Lerp(lerpMult, tGBottom, gCBottom))
-            self.Height:Set(MATH_Lerp(lerpMult, tGHeight, gCHeight))
-            self.Width:Set(MATH_Lerp(lerpMult, tGWidth, gCWidth))
-        end
-
-        local textGroupAlpha = textGroup:GetAlpha()
-        local titleAlpha = title:GetAlpha()
-        -- fade out the text at the end of the announcement
-        if time > 3 and textGroupAlpha ~= 0 then
-            local newAlpha = math.max(textGroupAlpha - (delta * 2), 0)
-            textGroup:SetAlpha(newAlpha, true)
-            if secText then
-                secText:SetAlphaOfColors(newAlpha)
-            end
-        -- fade in the text when the announcement appears
-        elseif time > .2 and time < 3 and titleAlpha ~= 1 then
-            local newAlpha = math.min(titleAlpha + (delta * 2), 1)
-            textGroup:SetAlpha(newAlpha, true)
-            if secText then
-                secText:SetAlphaOfColors(newAlpha)
-            end
-        end
-
-        if time > 3.7 then
-            if bg.OnFinished then
-                bg.OnFinished()
-            end
-            bg:Destroy()
-            bg.OnFinished = nil
-            bg = false
-        end
-    end
-
+    -- feature: immediately hide announcements when game UI is hidden
     if import("/lua/ui/game/gamemain.lua").gameUIHidden then
-        bg:Hide()
+        announcement:Hide()
     end
 end
 
 --- Instantly hides the current announcement
 function Contract()
-    if bg then
-        bg:Hide()
+    for k, announcement in Announcements do
+        if not IsDestroyed(announcement) then
+            announcement:Hide()
+        end
     end
 end
 
 --- Instantly shows the current announcement
 function Expand()
-    if bg then
-        bg:Show()
+    for k, announcement in Announcements do
+        if not IsDestroyed(announcement) then
+            announcement:Show()
+        end
     end
-end
-
---- Create a border around the `parent` with the `filter-ping-list-panel` files
----@param parent Control
----@return { tl: Bitmap, tm: Bitmap, tr: Bitmap, ml: Bitmap, mr: Bitmap, bl: Bitmap, bm: Bitmap, br: Bitmap } border
-function CreateBorder(parent)
-    -- t, m, b = top, middle, bottm
-    -- l, m, r = left, middle, right
-    local tl = Bitmap(parent, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_ul.dds'))
-    local tm = Bitmap(parent, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_horz_um.dds'))
-    local tr = Bitmap(parent, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_ur.dds'))
-    local ml = Bitmap(parent, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_vert_l.dds'))
-    local mr = Bitmap(parent, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_vert_r.dds'))
-    local bl = Bitmap(parent, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_ll.dds'))
-    local bm = Bitmap(parent, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_lm.dds'))
-    local br = Bitmap(parent, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_lr.dds'))
-
-    Layouter(tl):TopLeftOf(parent):End()
-    Layouter(tm):CenteredAbove(parent):FillHorizontally(parent):End()
-    Layouter(tr):TopRightOf(parent):End()
-    Layouter(ml):CenteredLeftOf(parent):FillVertically(parent):End()
-    Layouter(mr):CenteredRightOf(parent):FillVertically(parent):End()
-    Layouter(bl):BottomLeftOf(parent):End()
-    Layouter(bm):CenteredBelow(parent):FillHorizontally(parent):End()
-    Layouter(br):BottomRightOf(parent):End()
-
-    return { ["tl"] = tl, ["tm"] = tm, ["tr"] = tr, ["ml"] = ml, ["mr"] = mr, ["bl"] = bl, ["bm"] = bm, ["br"] = br }
 end

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -75,8 +75,8 @@ function CreateAnnouncement(text, goalControl)
 end
 
 --- Create an announcement UI for sending general messages to the user
----@param titleText string
----@param bodyText string
+---@param titleText UnlocalizedString
+---@param bodyText UnlocalizedString
 ---@param goalControl? Control
 CreateTitleTextAnnouncement = function(titleText, bodyText, goalControl)
     -- early exit: don't show announcements when the score dialog is open

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -35,7 +35,7 @@ function CreateAnnouncement(text, goalControl, secondaryText, onFinished)
             function()
                 local announcement = SmallAnnouncement(frame, goalControl, onFinished, text)
                 WaitSeconds(3)
-                announcement:Destroy()
+                announcement:FadeOut(3)
             end
         )
 

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -66,7 +66,7 @@ function CreateAnnouncement(text, goalControl, secondaryText)
     -- create the announcement
     ---@type UIAbstractAnnouncement
     local announcement = SmallAnnouncement(frame, text)
-    announcement:Animate(goalControl)
+    announcement:Animate(goalControl, 1.4)
     Announcements:Add(announcement)
 
     -- feature: immediately hide announcements when game UI is hidden

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -37,7 +37,7 @@ local function CreateDefaultGoalControl(frame)
     return goalControl
 end
 
---- A utility function that determines when announcements should be skipped
+--- Determines when an announcement should be skipped.
 ---@return boolean
 local function ShouldSkipAnnouncement()
     -- early exit: don't show announcements when the score dialog is open
@@ -49,7 +49,7 @@ local function ShouldSkipAnnouncement()
     return false
 end
 
---- A utility function that determines when announcements should be immediately hidden
+--- Determines when an announcement should be hidden immediately.
 local function ShouldImmediatelyHideAnnouncement()
     -- feature: immediately hide announcements when game UI is hidden
     if import("/lua/ui/game/gamemain.lua").gameUIHidden then
@@ -57,6 +57,15 @@ local function ShouldImmediatelyHideAnnouncement()
     end
 
     return false
+end
+
+--- Aborts all existing announcements.
+local function AbortExistingAnnouncements()
+    for k, announcement in Announcements do
+        if not IsDestroyed(announcement) then
+            announcement:AbortAnnouncement()
+        end
+    end
 end
 
 --- Create an announcement with a title.
@@ -67,21 +76,13 @@ CreateTitleAnnouncement = function(titleText, goalControl)
         return
     end
 
-    local frame = GetFrame(0) --[[@as Frame]]
+    AbortExistingAnnouncements()
 
     -- create a dummy goal control if we don't have one
-    if not goalControl then
-        goalControl = CreateDefaultGoalControl(frame)
-    end
+    local frame = GetFrame(0) --[[@as Frame]]
+    goalControl = goalControl or CreateDefaultGoalControl(frame)
 
-    -- abort all existing announcements
-    for k, announcement in Announcements do
-        if not IsDestroyed(announcement) then
-            announcement:AbortAnnouncement()
-        end
-    end
-
-    -- lazy load the module
+    -- developers note: lazy load the module so that it remains unloaded unless used
     local SmallAnnouncement = import("/lua/ui/game/announcement/SmallAnnouncement.lua").SmallAnnouncement
 
     -- create the announcement
@@ -90,7 +91,6 @@ CreateTitleAnnouncement = function(titleText, goalControl)
     announcement:Animate(goalControl, 1.4)
     Announcements:Add(announcement)
 
-    -- feature: immediately hide announcements when game UI is hidden
     if ShouldImmediatelyHideAnnouncement() then
         announcement:Hide()
     end
@@ -105,21 +105,13 @@ CreateTitleTextAnnouncement = function(titleText, bodyText, goalControl)
         return
     end
 
-    local frame = GetFrame(0) --[[@as Frame]]
+    AbortExistingAnnouncements()
 
     -- create a dummy goal control if we don't have one
-    if not goalControl then
-        goalControl = CreateDefaultGoalControl(frame)
-    end
+    local frame = GetFrame(0) --[[@as Frame]]
+    goalControl = goalControl or CreateDefaultGoalControl(frame)
 
-    -- abort all existing announcements
-    for k, announcement in Announcements do
-        if not IsDestroyed(announcement) then
-            announcement:AbortAnnouncement()
-        end
-    end
-
-    -- lazy load the module
+    -- developers note: lazy load the module so that it remains unloaded unless used
     local TitleTextAnnouncement = import("/lua/ui/game/announcement/TitleTextAnnouncement.lua").TitleTextAnnouncement
 
     -- create the announcement
@@ -128,7 +120,6 @@ CreateTitleTextAnnouncement = function(titleText, bodyText, goalControl)
     announcement:Animate(goalControl, 2.2)
     Announcements:Add(announcement)
 
-    -- feature: immediately hide announcements when game UI is hidden
     if ShouldImmediatelyHideAnnouncement() then
         announcement:Hide()
     end
@@ -174,7 +165,7 @@ DebugTitleAnnouncement = function()
     CreateAnnouncement("Title because X is defeated")
 end
 
---- Creates a title text announcement for debugging.
+--- Creates a title-with-text announcement for debugging.
 DebugTitleTextAnnouncement = function()
     CreateAnnouncement("Title", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.")
 end

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -37,13 +37,23 @@ local function CreateDefaultGoalControl(frame)
     return goalControl
 end
 
+--- A utility function that determines when announcements should be skipped
+---@return boolean
+local function ShouldSkipAnnouncement()
+    -- early exit: don't show announcements when the score dialog is open
+    local scoreModule = import("/lua/ui/dialogs/score.lua")
+    if scoreModule.dialog then
+        return true
+    end
+
+    return false
+end
+
 --- Create an announcement with a title.
 ---@param titleText UnlocalizedString
 ---@param goalControl? Control          # if defined, the announcement visually expands and contracts to this control.
 CreateTitleAnnouncement = function(titleText, goalControl)
-    -- early exit: don't show announcements when the score dialog is open
-    local scoreModule = import("/lua/ui/dialogs/score.lua")
-    if scoreModule.dialog then
+    if ShouldSkipAnnouncement() then
         return
     end
 
@@ -81,9 +91,7 @@ end
 ---@param bodyText UnlocalizedString
 ---@param goalControl? Control          # if defined, the announcement visually expands and contracts to this control.
 CreateTitleTextAnnouncement = function(titleText, bodyText, goalControl)
-    -- early exit: don't show announcements when the score dialog is open
-    local scoreModule = import("/lua/ui/dialogs/score.lua")
-    if scoreModule.dialog then
+    if ShouldSkipAnnouncement() then
         return
     end
 

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -13,6 +13,8 @@ local Group = import("/lua/maui/group.lua").Group
 local Bitmap = import("/lua/maui/bitmap.lua").Bitmap
 local TextArea = import("/lua/ui/controls/textarea.lua").TextArea
 
+local SmallAnnouncement = import("/lua/ui/game/announcement/SmallAnnouncement.lua").SmallAnnouncement
+
 local MATH_Lerp = MATH_Lerp
 
 local bg = false
@@ -25,13 +27,28 @@ local bg = false
 function CreateAnnouncement(text, goalControl, secondaryText, onFinished)
     local frame = GetFrame(0)
 
+    do
+        -- just do nothing
+        LOG(text, goalControl, secondaryText, onFinished)
+
+        ForkThread(
+            function()
+                local announcement = SmallAnnouncement(frame, goalControl, onFinished, text)
+                WaitSeconds(3)
+                announcement:Destroy()
+            end
+        )
+
+        return
+    end
+
     if not goalControl then
         -- make it originate from the top
         goalControl = Group(frame)
         goalControl.Left:Set(function() return frame.Left() + 0.49 * frame.Right() end)
         goalControl.Right:Set(function() return frame.Left() + 0.51 * frame.Right() end)
-        goalControl.Top = frame.Top
-        goalControl.Bottom = frame.Top
+        goalControl.Top:Set(function() return frame.Top() end);
+        goalControl.Height:Set(0)
     end
 
     local scoreDlg = import("/lua/ui/dialogs/score.lua")

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -22,8 +22,6 @@
 
 local Group = import("/lua/maui/group.lua").Group
 
-local SmallAnnouncement = import("/lua/ui/game/announcement/SmallAnnouncement.lua").SmallAnnouncement
-
 ---@type TrashBag | UIAbstractAnnouncement[]
 local Announcements = TrashBag()
 
@@ -61,6 +59,9 @@ function CreateAnnouncement(text, goalControl, secondaryText)
     for k, announcement in Announcements do
         announcement:AbortAnnouncement()
     end
+
+    -- lazy load the module
+    local SmallAnnouncement = import("/lua/ui/game/announcement/SmallAnnouncement.lua").SmallAnnouncement
 
     -- create the announcement
     ---@type UIAbstractAnnouncement

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -49,6 +49,16 @@ local function ShouldSkipAnnouncement()
     return false
 end
 
+--- A utility function that determines when announcements should be immediately hidden
+local function ShouldImmediatelyHideAnnouncement()
+    -- feature: immediately hide announcements when game UI is hidden
+    if import("/lua/ui/game/gamemain.lua").gameUIHidden then
+        return true
+    end
+
+    return false
+end
+
 --- Create an announcement with a title.
 ---@param titleText UnlocalizedString
 ---@param goalControl? Control          # if defined, the announcement visually expands and contracts to this control.
@@ -81,7 +91,7 @@ CreateTitleAnnouncement = function(titleText, goalControl)
     Announcements:Add(announcement)
 
     -- feature: immediately hide announcements when game UI is hidden
-    if import("/lua/ui/game/gamemain.lua").gameUIHidden then
+    if ShouldImmediatelyHideAnnouncement() then
         announcement:Hide()
     end
 end
@@ -119,7 +129,7 @@ CreateTitleTextAnnouncement = function(titleText, bodyText, goalControl)
     Announcements:Add(announcement)
 
     -- feature: immediately hide announcements when game UI is hidden
-    if import("/lua/ui/game/gamemain.lua").gameUIHidden then
+    if ShouldImmediatelyHideAnnouncement() then
         announcement:Hide()
     end
 end

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -40,8 +40,7 @@ end
 --- Create an announcement UI for sending general messages to the user
 ---@param text UnlocalizedString # title text
 ---@param goalControl? Control The control where the announcement appears out of.
----@param secondaryText? UnlocalizedString # body text
-function CreateAnnouncement(text, goalControl, secondaryText)
+function CreateAnnouncement(text, goalControl)
     -- early exit: don't show announcements when the score dialog is open
     local scoreModule = import("/lua/ui/dialogs/score.lua")
     if scoreModule.dialog then
@@ -75,6 +74,44 @@ function CreateAnnouncement(text, goalControl, secondaryText)
     end
 end
 
+--- Create an announcement UI for sending general messages to the user
+---@param titleText string
+---@param bodyText string
+---@param goalControl? Control
+CreateTitleTextAnnouncement = function(titleText, bodyText, goalControl)
+    -- early exit: don't show announcements when the score dialog is open
+    local scoreModule = import("/lua/ui/dialogs/score.lua")
+    if scoreModule.dialog then
+        return
+    end
+
+    local frame = GetFrame(0) --[[@as Frame]]
+
+    -- create a dummy goal control if we don't have one
+    if not goalControl then
+        goalControl = CreateDefaultGoalControl(frame)
+    end
+
+    -- abort all existing announcements
+    for k, announcement in Announcements do
+        announcement:AbortAnnouncement()
+    end
+
+    -- lazy load the module
+    local TitleTextAnnouncement = import("/lua/ui/game/announcement/TitleTextAnnouncement.lua").TitleTextAnnouncement
+
+    -- create the announcement
+    ---@type UIAbstractAnnouncement
+    local announcement = TitleTextAnnouncement(frame, titleText, bodyText)
+    announcement:Animate(goalControl, 2.2)
+    Announcements:Add(announcement)
+
+    -- feature: immediately hide announcements when game UI is hidden
+    if import("/lua/ui/game/gamemain.lua").gameUIHidden then
+        announcement:Hide()
+    end
+end
+
 --- Instantly hides the current announcement
 function Contract()
     for k, announcement in Announcements do
@@ -92,3 +129,18 @@ function Expand()
         end
     end
 end
+
+-------------------------------------------------------------------------------
+--#region Debug functionality
+
+--- Creates a title announcement for debugging.
+DebugTitleAnnouncement = function()
+    CreateAnnouncement("Title because X is defeated")
+end
+
+--- Creates a title text announcement for debugging.
+DebugTitleTextAnnouncement = function()
+    CreateTitleTextAnnouncement("Title", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.")
+end
+
+--#endregion

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -27,29 +27,43 @@ local bg = false
 function CreateAnnouncement(text, goalControl, secondaryText, onFinished)
     local frame = GetFrame(0)
 
-    do
-        -- just do nothing
-        LOG(text, goalControl, secondaryText, onFinished)
-
-        ForkThread(
-            function()
-                local announcement = SmallAnnouncement(frame, goalControl, onFinished, text)
-                WaitSeconds(3)
-                announcement:FadeOut(3)
-            end
-        )
-
-        return
-    end
-
     if not goalControl then
-        -- make it originate from the top
+        -- make it originate from the top of the screen
         goalControl = Group(frame)
         goalControl.Left:Set(function() return frame.Left() + 0.49 * frame.Right() end)
         goalControl.Right:Set(function() return frame.Left() + 0.51 * frame.Right() end)
         goalControl.Top:Set(function() return frame.Top() end);
         goalControl.Height:Set(0)
     end
+
+    do
+        -- just do nothing
+        LOG(text, goalControl, secondaryText, onFinished)
+
+        ForkThread(
+            function()
+                ---@type UIAbstractAnnouncement
+                local announcement = SmallAnnouncement(frame, text)
+                announcement:ExpandBackground(goalControl, 0.4)
+                WaitSeconds(0.4)
+
+                announcement:AnimateContent(0.6, 1.0)
+                WaitSeconds(2.0)
+
+                announcement:AnimateContent(0.4, 0.0)
+                WaitSeconds(0.4)
+
+                announcement:ContractBackground(goalControl, 0.4)
+                WaitSeconds(0.4)
+
+                announcement:Destroy()
+            end
+        )
+
+        return
+    end
+
+
 
     local scoreDlg = import("/lua/ui/dialogs/score.lua")
     if scoreDlg.dialog then

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -1,10 +1,25 @@
---*****************************************************************************
---* File: lua/modules/ui/game/announcement.lua
---* Author: Ted Snook
---* Summary: Announcement UI for sending general messages to the user
---*
---* Copyright � 2007 Gas Powered Games, Inc.  All rights reserved.
---*****************************************************************************
+--******************************************************************************************************
+--** Copyright (c) 2025  Willem 'Jip' Wijnia
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
 local Group = import("/lua/maui/group.lua").Group
 
 local SmallAnnouncement = import("/lua/ui/game/announcement/SmallAnnouncement.lua").SmallAnnouncement
@@ -28,8 +43,7 @@ end
 ---@param text UnlocalizedString # title text
 ---@param goalControl? Control The control where the announcement appears out of.
 ---@param secondaryText? UnlocalizedString # body text
----@param onFinished? function
-function CreateAnnouncement(text, goalControl, secondaryText, onFinished)
+function CreateAnnouncement(text, goalControl, secondaryText)
     -- early exit: don't show announcements when the score dialog is open
     local scoreModule = import("/lua/ui/dialogs/score.lua")
     if scoreModule.dialog then

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -56,7 +56,9 @@ CreateTitleAnnouncement = function(titleText, goalControl)
 
     -- abort all existing announcements
     for k, announcement in Announcements do
-        announcement:AbortAnnouncement()
+        if not IsDestroyed(announcement) then
+            announcement:AbortAnnouncement()
+        end
     end
 
     -- lazy load the module
@@ -94,7 +96,9 @@ CreateTitleTextAnnouncement = function(titleText, bodyText, goalControl)
 
     -- abort all existing announcements
     for k, announcement in Announcements do
-        announcement:AbortAnnouncement()
+        if not IsDestroyed(announcement) then
+            announcement:AbortAnnouncement()
+        end
     end
 
     -- lazy load the module

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -37,10 +37,10 @@ local function CreateDefaultGoalControl(frame)
     return goalControl
 end
 
---- Create an announcement UI for sending general messages to the user
----@param text UnlocalizedString # title text
----@param goalControl? Control The control where the announcement appears out of.
-function CreateAnnouncement(text, goalControl)
+--- Create an announcement with a title.
+---@param titleText UnlocalizedString
+---@param goalControl? Control          # if defined, the announcement visually expands and contracts to this control.
+CreateTitleAnnouncement = function(titleText, goalControl)
     -- early exit: don't show announcements when the score dialog is open
     local scoreModule = import("/lua/ui/dialogs/score.lua")
     if scoreModule.dialog then
@@ -64,7 +64,7 @@ function CreateAnnouncement(text, goalControl)
 
     -- create the announcement
     ---@type UIAbstractAnnouncement
-    local announcement = SmallAnnouncement(frame, text)
+    local announcement = SmallAnnouncement(frame, titleText)
     announcement:Animate(goalControl, 1.4)
     Announcements:Add(announcement)
 
@@ -74,10 +74,10 @@ function CreateAnnouncement(text, goalControl)
     end
 end
 
---- Create an announcement UI for sending general messages to the user
+--- Create an announcement with a title and some text.
 ---@param titleText UnlocalizedString
 ---@param bodyText UnlocalizedString
----@param goalControl? Control
+---@param goalControl? Control          # if defined, the announcement visually expands and contracts to this control.
 CreateTitleTextAnnouncement = function(titleText, bodyText, goalControl)
     -- early exit: don't show announcements when the score dialog is open
     local scoreModule = import("/lua/ui/dialogs/score.lua")
@@ -112,6 +112,20 @@ CreateTitleTextAnnouncement = function(titleText, bodyText, goalControl)
     end
 end
 
+--- A general function to create an announcement UI for sending general messages to the user.
+---
+--- Exists for backwards compatibility.
+---@param titleText UnlocalizedString
+---@param bodyText? UnlocalizedString
+---@param goalControl? Control          # if defined, the announcement visually expands and contracts to this control.
+function CreateAnnouncement(titleText, bodyText, goalControl)
+    if type(bodyText) == "string" then
+        return import("/lua/ui/game/announcement.lua").CreateTitleTextAnnouncement (titleText, bodyText, goalControl)
+    else
+        return import("/lua/ui/game/announcement.lua").CreateTitleAnnouncement(titleText, goalControl)
+    end
+end
+
 --- Instantly hides the current announcement
 function Contract()
     for k, announcement in Announcements do
@@ -140,7 +154,7 @@ end
 
 --- Creates a title text announcement for debugging.
 DebugTitleTextAnnouncement = function()
-    CreateTitleTextAnnouncement("Title", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.")
+    CreateAnnouncement("Title", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.")
 end
 
 --#endregion

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -48,7 +48,7 @@ local CreateLazyVar = import("/lua/lazyvar.lua").Create
 ---@field ContentArea Group                     # Content area that we animate to/from
 AbstractAnnouncement = ClassUI(Group) {
 
-    -- Announcements works by morphing the background from a control, to the content are and back. By doing so,
+    -- Announcements works by morphing the background from a control, to the content area, and then back. By doing so,
     -- we give the player an idea what the announcement is connected to. The content of the announcement is never 
     -- moved, only the background is. The alpha of the content is adjusted when the announcement arrives and 
     -- leaves again.

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -222,7 +222,6 @@ AbstractAnnouncement = ClassUI(Group) {
     ---@param duration number
     ---@param target number
     AnimateContentThread = function(self, duration, from, target)
-        -- animate it
         local startTime = GetSystemTimeSeconds()
         local endTime = startTime + duration
         while not IsDestroyed(self) do

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -1,0 +1,104 @@
+local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
+local Layouter = LayoutHelpers.ReusedLayoutFor
+
+local UIUtil = import("/lua/ui/uiutil.lua")
+local Group = import("/lua/maui/group.lua").Group
+local Bitmap = import("/lua/maui/bitmap.lua").Bitmap
+local TextArea = import("/lua/ui/controls/textarea.lua").TextArea
+
+---@class UIAbstractAnnouncement : Bitmap, Destroyable
+---@field Trash TrashBag
+---@field GoalControl Control
+---@field OnFinishedCallback? fun()
+AbstractAnnouncement = ClassUI(Bitmap) {
+
+    ---@param self UIAbstractAnnouncement
+    ---@param parent Control
+    ---@param goalControl Control
+    ---@param onFinishedCallback? fun()
+    __init = function(self, parent, goalControl, onFinishedCallback)
+        Bitmap.__init(self, parent, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_m.dds'))
+
+        self.Trash = TrashBag();
+        self.GoalControl = goalControl
+        self.OnFinishedCallback = onFinishedCallback
+    end,
+
+    ---@param self UIAbstractAnnouncement
+    ---@param parent Control
+    ---@param goalControl Control
+    ---@param onFinishedCallback fun()
+    __post_init = function(self, parent, goalControl, onFinishedCallback)
+        -- initial layout
+        LayoutHelpers.LayoutFor(self)
+            :Height(0)
+            :Width(0)
+            :Over(parent, 1)
+            :AtCenterIn(self.GoalControl)
+            :NeedsFrameUpdate(true)
+            :End()
+
+        self:CreateBorder()
+    end,
+
+    ---@param self UIAbstractAnnouncement
+    OnDestroy = function(self)
+        Bitmap.OnDestroy(self)
+
+        if self.OnFinishedCallback then
+            self.OnFinishedCallback()
+        end
+    end,
+
+    --- Fades out the announcement, destroying it when it's done.
+    ---@param self UIAbstractAnnouncement
+    ---@param duration number       # in seconds
+    FadeOut = function(self, duration)
+        self.Trash:Add(ForkThread(self.FadeOutThread, self, duration))
+    end,
+
+    --- The thread for fading out the announcement, destroying it when it's done.
+    ---@param self UIAbstractAnnouncement
+    ---@param duration number       # in seconds
+    FadeOutThread = function(self, duration)
+
+        local startTime = GetSystemTimeSeconds()
+        local endTime = startTime + 1000 * duration
+        while not IsDestroyed(self) do
+            WaitFrames(1)
+
+            -- fade out over time
+            local currentTime = GetSystemTimeSeconds()
+            local alpha = 1 - (currentTime - startTime) / (endTime - startTime)
+            self:SetAlpha(alpha)
+
+            if CurrentTime > endTime then
+                break
+            end
+        end
+
+        self:Destroy()
+    end,
+
+    ---@param self UIAbstractAnnouncement
+    CreateBorder = function(self)
+        local tl = Bitmap(self, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_ul.dds'))
+        local tm = Bitmap(self, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_horz_um.dds'))
+        local tr = Bitmap(self, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_ur.dds'))
+        local ml = Bitmap(self, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_vert_l.dds'))
+        local mr = Bitmap(self, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_vert_r.dds'))
+        local bl = Bitmap(self, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_ll.dds'))
+        local bm = Bitmap(self, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_lm.dds'))
+        local br = Bitmap(self, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_lr.dds'))
+    
+        Layouter(tl):TopLeftOf(self):End()
+        Layouter(tm):CenteredAbove(self):FillHorizontally(self):End()
+        Layouter(tr):TopRightOf(self):End()
+        Layouter(ml):CenteredLeftOf(self):FillVertically(self):End()
+        Layouter(mr):CenteredRightOf(self):FillVertically(self):End()
+        Layouter(bl):BottomLeftOf(self):End()
+        Layouter(bm):CenteredBelow(self):FillHorizontally(self):End()
+        Layouter(br):BottomRightOf(self):End()
+    end,
+}
+

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -343,7 +343,7 @@ AbstractAnnouncement = ClassUI(Group) {
             WaitFrames(1)
         end
 
-        -- make sure animation ends properly even when there are frame drops
+        -- make sure animation completes properly even when there are frame drops
         if state == 'Expand' then
             progress:Set(1)
         else
@@ -356,6 +356,7 @@ AbstractAnnouncement = ClassUI(Group) {
     ---------------------------------------------------------------------------
     --#region Interface to abort 
 
+    --- Aborts the announcement. All animations are stopped. The announcement is turned transparent and then destroyed.
     ---@param self UIAbstractAnnouncement
     AbortAnnouncement = function(self)
         -- make the function idempotent
@@ -369,6 +370,7 @@ AbstractAnnouncement = ClassUI(Group) {
         self.AbortAnimationThreadInstance = self.Trash:Add(ForkThread(self.AbortAnimationThread, self))
     end,
 
+    --- Aborts the announcement by turning it completely transparent. The announcement is destroyed at the end of it.
     ---@param self UIAbstractAnnouncement
     AbortAnimationThread = function(self)
         local alphaContent = self.ContentArea:GetAlpha()
@@ -391,6 +393,7 @@ AbstractAnnouncement = ClassUI(Group) {
         self:Destroy()
     end,
 
+    --- Cancels the animation thread.
     ---@param self UIAbstractAnnouncement
     CancelAnimation = function(self)
         if self.AnimateThreadInstance then
@@ -398,6 +401,7 @@ AbstractAnnouncement = ClassUI(Group) {
         end
     end,
 
+    --- Cancels the animation of the background, stopping it in its tracks.
     ---@param self UIAbstractAnnouncement
     CancelBackgroundAnimation = function(self)
         if self.AnimateBackgroundThreadInstance then
@@ -405,6 +409,7 @@ AbstractAnnouncement = ClassUI(Group) {
         end
     end,
 
+    --- Cancels the animation of the content, stopping it in its tracks. 
     ---@param self UIAbstractAnnouncement
     CancelContentAnimation = function(self)
         if self.AnimateContentThreadInstance then

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -153,19 +153,21 @@ AbstractAnnouncement = ClassUI(Group) {
     --- The default animation sequence for an announcement. The announcement is destroyed at the end of the animation.
     ---@param self UIAbstractAnnouncement
     ---@param control Control
-    Animate = function(self, control)
+    ---@param durationForContent number
+    Animate = function(self, control, durationForContent)
         -- do not allow other animations
         if self.AnimateThreadInstance then
             self.AnimateThreadInstance:Destroy()
         end
 
-        self.AnimateThreadInstance = self.Trash:Add(ForkThread(self.AnimateThread, self, control))
+        self.AnimateThreadInstance = self.Trash:Add(ForkThread(self.AnimateThread, self, control, durationForContent))
     end,
 
     --- The default animation sequence for an announcement. The announcement is destroyed at the end of the animation.
     ---@param self UIAbstractAnnouncement
     ---@param control Control
-    AnimateThread = function(self, control)
+    ---@param durationForContent number
+    AnimateThread = function(self, control, durationForContent)
         -- early exist for edge case
         if IsDestroyed(self) then
             return
@@ -174,8 +176,7 @@ AbstractAnnouncement = ClassUI(Group) {
         -- internal configuration of the animation
         local expandDuration = 0.4
         local contractDuration = 0.4
-        local contentDuration = 2.0
-        local contentShowDuration = 0.6
+        local contentShowDuration = 0.5
         local contentHideDuration = 0.4
 
         -- expand animation
@@ -187,7 +188,7 @@ AbstractAnnouncement = ClassUI(Group) {
 
         -- show content and hide it
         self:AnimateContent(contentShowDuration, 1.0)
-        WaitSeconds(contentShowDuration + contentDuration)
+        WaitSeconds(contentShowDuration + durationForContent)
         if IsDestroyed(self) then
             return
         end
@@ -246,6 +247,9 @@ AbstractAnnouncement = ClassUI(Group) {
 
             WaitFrames(1)
         end
+
+        -- always make sure the target is reached
+        self.ContentArea:SetAlpha(target, true)
     end,
 
     --- Expands the background of the announcement, starting at the provided control towards the content area.

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -375,9 +375,15 @@ AbstractAnnouncement = ClassUI(Group) {
         local alphaContent = self.ContentArea:GetAlpha()
         local alphaBackground = self.Background:GetAlpha()
 
+        local lastTime = GetSystemTimeSeconds()
         while not IsDestroyed(self) do
-            alphaContent = math.clamp(alphaContent - 0.05, 0, 1)
-            alphaBackground = math.clamp(alphaBackground - 0.05, 0, 1)
+            -- frame rate independent
+            local currentTime = GetSystemTimeSeconds()
+            local diff = 2 * (currentTime - lastTime)
+            lastTime = currentTime
+
+            alphaContent = math.clamp(alphaContent - diff, 0, 1)
+            alphaBackground = math.clamp(alphaBackground - diff, 0, 1)
 
             self.ContentArea:SetAlpha(alphaContent, true)
             self.Background:SetAlpha(alphaBackground, true)

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -185,7 +185,7 @@ AbstractAnnouncement = ClassUI(Group) {
         -- internal configuration of the animation
         local expandDuration = 0.4
         local contractDuration = 0.4
-        local contentShowDuration = 0.5
+        local contentShowDuration = 0.2
         local contentHideDuration = 0.4
 
         -- expand animation

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -408,7 +408,7 @@ AbstractAnnouncement = ClassUI(Group) {
         end
     end,
 
-    --- Cancels the animation of the content, stopping it in its tracks. 
+    --- Cancels the animation of the content.
     ---@param self UIAbstractAnnouncement
     CancelContentAnimation = function(self)
         if self.AnimateContentThreadInstance then

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -54,7 +54,7 @@ AbstractAnnouncement = ClassUI(Group) {
     -- leaves again.
 
     -- To make it more concrete:
-    -- - The 'ContentArea' is the area that we animate to/from
+    -- - The 'ContentArea' is the area that we animate towards when displaying the announcement, and away from when hiding it
     -- - The 'Background' is the background that we animate
 
     ---@param self UIAbstractAnnouncement

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -392,7 +392,7 @@ AbstractAnnouncement = ClassUI(Group) {
         self:Destroy()
     end,
 
-    --- Cancels the animation thread.
+    --- Cancels the main animation thread.
     ---@param self UIAbstractAnnouncement
     CancelAnimation = function(self)
         if self.AnimateThreadInstance then

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -147,6 +147,15 @@ AbstractAnnouncement = ClassUI(Group) {
         self.Trash:Destroy()
     end,
 
+    --- A utility function to set the alpha of the content. Concrete implementations 
+    --- can hook this function to set the alpha value of UI elements that do propagate 
+    --- properly when the alpha of a parent is set (looking at you, TextArea).
+    ---@param self UIAbstractAnnouncement
+    ---@param value number
+    SetAlphaOfContent = function(self, value)
+        self.ContentArea:SetAlpha(value, true)
+    end,
+
     ---------------------------------------------------------------------------
     --#region Interface to animate
 
@@ -243,13 +252,13 @@ AbstractAnnouncement = ClassUI(Group) {
 
             local progress = (currentTime - startTime) / duration
             local alpha = math.clamp(MATH_Lerp(progress, from, target), 0, 1)
-            self.ContentArea:SetAlpha(alpha, true)
+            self:SetAlphaOfContent(alpha)
 
             WaitFrames(1)
         end
 
         -- always make sure the target is reached
-        self.ContentArea:SetAlpha(target, true)
+        self:SetAlphaOfContent(target)
     end,
 
     --- Expands the background of the announcement, starting at the provided control towards the content area.
@@ -409,7 +418,7 @@ AbstractAnnouncement = ClassUI(Group) {
             alphaContent = math.clamp(alphaContent - diff, 0, 1)
             alphaBackground = math.clamp(alphaBackground - diff, 0, 1)
 
-            self.ContentArea:SetAlpha(alphaContent, true)
+            self:SetAlphaOfContent(alphaContent)
             self.Background:SetAlpha(alphaBackground, true)
 
             if alphaContent == 0 and alphaBackground == 0 then

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -410,7 +410,6 @@ AbstractAnnouncement = ClassUI(Group) {
 
         local lastTime = GetSystemTimeSeconds()
         while not IsDestroyed(self) do
-            -- frame rate independent
             local currentTime = GetSystemTimeSeconds()
             local diff = 2 * (currentTime - lastTime) -- 100% alpha change in 0.5 seconds
             lastTime = currentTime

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -412,7 +412,7 @@ AbstractAnnouncement = ClassUI(Group) {
         while not IsDestroyed(self) do
             -- frame rate independent
             local currentTime = GetSystemTimeSeconds()
-            local diff = 2 * (currentTime - lastTime)
+            local diff = 2 * (currentTime - lastTime) -- 100% alpha change in 0.5 seconds
             lastTime = currentTime
 
             alphaContent = math.clamp(alphaContent - diff, 0, 1)

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -238,7 +238,7 @@ AbstractAnnouncement = ClassUI(Group) {
         end
     end,
 
-    --- Expands the background of the announcement, starting at the provided control towards the center of the screen.
+    --- Expands the background of the announcement, starting at the provided control towards the content area.
     ---@param self UIAbstractAnnouncement
     ---@param control Control
     ---@param duration number

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -6,22 +6,24 @@ local Group = import("/lua/maui/group.lua").Group
 local Bitmap = import("/lua/maui/bitmap.lua").Bitmap
 local TextArea = import("/lua/ui/controls/textarea.lua").TextArea
 
+local CreateLazyVar = import("/lua/lazyvar.lua").Create
+
 ---@class UIAbstractAnnouncement : Bitmap, Destroyable
 ---@field Trash TrashBag
 ---@field GoalControl Control
 ---@field OnFinishedCallback? fun()
+---@field FadeThreadInstance? thread
 AbstractAnnouncement = ClassUI(Bitmap) {
 
     ---@param self UIAbstractAnnouncement
     ---@param parent Control
-    ---@param goalControl Control
     ---@param onFinishedCallback? fun()
-    __init = function(self, parent, goalControl, onFinishedCallback)
+    __init = function(self, parent, onFinishedCallback)
         Bitmap.__init(self, parent, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_m.dds'))
 
         self.Trash = TrashBag();
-        self.GoalControl = goalControl
         self.OnFinishedCallback = onFinishedCallback
+
     end,
 
     ---@param self UIAbstractAnnouncement
@@ -34,7 +36,6 @@ AbstractAnnouncement = ClassUI(Bitmap) {
             :Height(0)
             :Width(0)
             :Over(parent, 1)
-            :AtCenterIn(self.GoalControl)
             :NeedsFrameUpdate(true)
             :End()
 
@@ -50,36 +51,120 @@ AbstractAnnouncement = ClassUI(Bitmap) {
         end
     end,
 
-    --- Fades out the announcement, destroying it when it's done.
+    --- Fades out the announcement. Starts the fade out at the current alpha value, scaling the duration accordingly.
     ---@param self UIAbstractAnnouncement
     ---@param duration number       # in seconds
     FadeOut = function(self, duration)
-        self.Trash:Add(ForkThread(self.FadeOutThread, self, duration))
-    end,
-
-    --- The thread for fading out the announcement, destroying it when it's done.
-    ---@param self UIAbstractAnnouncement
-    ---@param duration number       # in seconds
-    FadeOutThread = function(self, duration)
-
-        local startTime = GetSystemTimeSeconds()
-        local endTime = startTime + 1000 * duration
-        while not IsDestroyed(self) do
-            WaitFrames(1)
-
-            -- fade out over time
-            local currentTime = GetSystemTimeSeconds()
-            local alpha = 1 - (currentTime - startTime) / (endTime - startTime)
-            self:SetAlpha(alpha)
-
-            if CurrentTime > endTime then
-                break
-            end
+        if self.FadeThreadInstance then
+            self.FadeThreadInstance:Destroy()
         end
 
-        self:Destroy()
+        local from = self:GetAlpha()
+        local scaledDuration = duration * from
+        self.FadeThreadInstance = self.Trash:Add(ForkThread(self.FadeThread, self, scaledDuration, from, 0))
     end,
 
+    --- Fades in the announcement. Starts the fade out at the current alpha value, scaling the duration accordingly.
+    ---@param self UIAbstractAnnouncement
+    ---@param duration number       # in seconds
+    FadeIn = function(self, duration)
+        if self.FadeThreadInstance then
+            self.FadeThreadInstance:Destroy()
+        end
+
+        local from = self:GetAlpha()
+        local scaledDuration = duration * (1 - from)
+        self.FadeThreadInstance = self.Trash:Add(ForkThread(self.FadeThread, self, scaledDuration, from, 1))
+    end,
+
+    --- The thread for fading the announcement.
+    ---@param self UIAbstractAnnouncement
+    ---@param duration number       # in seconds
+    FadeThread = function(self, duration, from, to)
+        local startTime = GetSystemTimeSeconds()
+        local endTime = startTime + duration
+        while not IsDestroyed(self) do
+            -- fade over time
+            local currentTime = GetSystemTimeSeconds()
+            local progress = (currentTime - startTime) / (endTime - startTime)
+            local alpha = MATH_Lerp(progress, from, to)
+            self:SetAlpha(alpha, true)
+
+            if currentTime > endTime then
+                break
+            end
+
+            WaitFrames(1)
+        end
+    end,
+
+
+    ---@param self UIAbstractAnnouncement
+    ---@param duration number
+    ---@param originControl Control
+    ---@param targetControl Control
+    ExpandAnimation = function(self, duration, originControl, targetControl)
+        -- animate alpha
+        self:SetAlpha(0)
+        self:FadeIn(duration)
+
+        -- animate position and scale
+        self.Trash:Add(self.ExpandAnimationThread, self, originControl, duration)
+    end,
+
+
+
+    ---@param self UIAbstractAnnouncement
+    ---@param originControl Control
+    ExpandAnimationThread = function(self, originControl, duration)
+
+    end,
+
+    -- ContractAnimation = function(self, duration, destinationControl)
+    --     PlaySound(Sound({Bank = 'Interface', Cue = 'UI_Announcement_Close'}))
+    --     self.Trash:Add(self.ContractAnimationThread, self, destinationControl, duration)
+    -- end,
+
+    -- ---@param self UIAbstractAnnouncement
+    -- ---@param destinationControl Control
+    -- ContractAnimationThread = function(self, destinationControl, duration)
+
+    -- end,
+
+    ---@param self UIAbstractAnnouncement
+    ---@param control Control       # the control where the announcement 'expands' from and 'contracts' to
+    ---@param onFinishedCallback? fun()
+    Animate = function(self, control, onFinishedCallback)
+        local thread = ForkThread(self.AnimateThread, self, control, onFinishedCallback)
+        self.Trash:Add(thread)
+    end,
+
+    ---@param self UIAbstractAnnouncement
+    ---@param goalControl Control
+    ---@param onFinishedCallback? fun()
+    AnimateThread = function(self, goalControl, onFinishedCallback)
+
+        local expandDuration = 2
+        local contractDuration = 1.5
+        local stationaryDuration = 3
+
+        -- expand animation
+        self:SetAlpha(0, true)
+        self:FadeIn(expandDuration)
+        self:ExpandAnimation(expandDuration, goalControl)
+
+        -- wait for the expand animation to finish
+        WaitSeconds(expandDuration)
+
+
+        -- keep the message stationary for a while before contracting
+        WaitSeconds(stationaryDuration)
+
+        self:FadeOut(contractDuration)
+        self:ContractAnimation(contractDuration, goalControl)
+    end,
+
+    --- Creates the border for the announcement control.
     ---@param self UIAbstractAnnouncement
     CreateBorder = function(self)
         local tl = Bitmap(self, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_ul.dds'))
@@ -90,7 +175,7 @@ AbstractAnnouncement = ClassUI(Bitmap) {
         local bl = Bitmap(self, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_ll.dds'))
         local bm = Bitmap(self, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_lm.dds'))
         local br = Bitmap(self, UIUtil.SkinnableFile('/game/filter-ping-list-panel/panel_brd_lr.dds'))
-    
+
         Layouter(tl):TopLeftOf(self):End()
         Layouter(tm):CenteredAbove(self):FillHorizontally(self):End()
         Layouter(tr):TopRightOf(self):End()

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -166,6 +166,11 @@ AbstractAnnouncement = ClassUI(Group) {
     ---@param self UIAbstractAnnouncement
     ---@param control Control
     AnimateThread = function(self, control)
+        -- early exist for edge case
+        if IsDestroyed(self) then
+            return
+        end
+
         -- internal configuration of the animation
         local expandDuration = 0.4
         local contractDuration = 0.4
@@ -222,6 +227,11 @@ AbstractAnnouncement = ClassUI(Group) {
     ---@param duration number
     ---@param target number
     AnimateContentThread = function(self, duration, from, target)
+        -- early exit for edge case
+        if IsDestroyed(self) then
+            return
+        end
+
         local startTime = GetSystemTimeSeconds()
         local endTime = startTime + duration
         while not IsDestroyed(self) do
@@ -277,6 +287,11 @@ AbstractAnnouncement = ClassUI(Group) {
     ---@param duration number
     ---@param state 'Expand' | 'Contract'
     AnimateBackgroundThread = function(self, control, duration, state)
+        -- early exit for edge case
+        if IsDestroyed(self) then
+            return
+        end
+
         -- local scope for performance
         local background = self.Background
         local content = self.ContentArea
@@ -372,6 +387,11 @@ AbstractAnnouncement = ClassUI(Group) {
     --- Aborts the announcement by turning it completely transparent. The announcement is destroyed at the end of it.
     ---@param self UIAbstractAnnouncement
     AbortAnimationThread = function(self)
+        -- early exit for edge case
+        if IsDestroyed(self) then
+            return
+        end
+
         local alphaContent = self.ContentArea:GetAlpha()
         local alphaBackground = self.Background:GetAlpha()
 

--- a/lua/ui/game/announcement/SmallAnnouncement.lua
+++ b/lua/ui/game/announcement/SmallAnnouncement.lua
@@ -33,17 +33,17 @@ SmallAnnouncement = ClassUI(AbstractAnnouncement) {
 
     ---@param self UISmallAnnouncement
     ---@param parent Control
-    ---@param text string
-    __init = function(self, parent, text)
+    ---@param titleText UnlocalizedString
+    __init = function(self, parent, titleText)
         AbstractAnnouncement.__init(self, parent)
 
-        self.Title = UIUtil.CreateText(self.ContentArea, text, 22, UIUtil.titleFont)
+        self.Title = UIUtil.CreateText(self.ContentArea, LOC(titleText), 22, UIUtil.titleFont)
     end,
 
     ---@param self UISmallAnnouncement
     ---@param parent Control
-    ---@param text string
-    __post_init = function(self, parent, text)
+    ---@param titleText UnlocalizedString
+    __post_init = function(self, parent, titleText)
         AbstractAnnouncement.__post_init(self, parent)
 
         Layouter(self.Title)

--- a/lua/ui/game/announcement/SmallAnnouncement.lua
+++ b/lua/ui/game/announcement/SmallAnnouncement.lua
@@ -1,0 +1,44 @@
+local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
+local Layouter = LayoutHelpers.ReusedLayoutFor
+
+local UIUtil = import("/lua/ui/uiutil.lua")
+local Group = import("/lua/maui/group.lua").Group
+local Bitmap = import("/lua/maui/bitmap.lua").Bitmap
+local TextArea = import("/lua/ui/controls/textarea.lua").TextArea
+
+local AbstractAnnouncement = import("/lua/ui/game/announcement/AbstractAnnouncement.lua").AbstractAnnouncement
+
+--- An announcement with just a title.
+---@class UISmallAnnouncement : UIAbstractAnnouncement
+---@field Title Text
+SmallAnnouncement = ClassUI(AbstractAnnouncement) {
+
+    ---@param self UISmallAnnouncement
+    ---@param parent Control
+    ---@param goalControl Control
+    ---@param onFinishedCallback fun()
+    ---@param text string
+    __init = function(self, parent, goalControl, onFinishedCallback, text)
+        AbstractAnnouncement.__init(self, parent, goalControl, onFinishedCallback)
+
+        self.Title = UIUtil.CreateText(self, text, 22, UIUtil.titleFont)
+    end,
+
+    ---@param self UISmallAnnouncement
+    ---@param parent Control
+    ---@param goalControl Control
+    ---@param onFinishedCallback fun()
+    ---@param text string
+    __post_init = function(self, parent, goalControl, onFinishedCallback, text)
+        AbstractAnnouncement.__post_init(self, parent, goalControl, onFinishedCallback)
+
+        LayoutHelpers.LayoutFor(self.Title)
+            :AtCenterIn(GetFrame(0), -250)
+            :DropShadow(true)
+            :Color(UIUtil.fontColor)
+            :End()
+
+        LayoutHelpers.LayoutFor(self)
+            :Fill(self.Title)
+    end,
+}

--- a/lua/ui/game/announcement/SmallAnnouncement.lua
+++ b/lua/ui/game/announcement/SmallAnnouncement.lua
@@ -15,29 +15,33 @@ SmallAnnouncement = ClassUI(AbstractAnnouncement) {
 
     ---@param self UISmallAnnouncement
     ---@param parent Control
-    ---@param onFinishedCallback fun()
     ---@param text string
-    __init = function(self, parent, onFinishedCallback, text)
-        AbstractAnnouncement.__init(self, parent, onFinishedCallback)
+    __init = function(self, parent, text)
+        AbstractAnnouncement.__init(self, parent)
 
-        self.Title = UIUtil.CreateText(self, text, 22, UIUtil.titleFont)
+        self.Title = UIUtil.CreateText(self.ContentArea, text, 22, UIUtil.titleFont)
     end,
 
     ---@param self UISmallAnnouncement
     ---@param parent Control
-    ---@param goalControl Control
-    ---@param onFinishedCallback fun()
     ---@param text string
-    __post_init = function(self, parent, goalControl, onFinishedCallback, text)
-        AbstractAnnouncement.__post_init(self, parent, goalControl, onFinishedCallback)
+    __post_init = function(self, parent, text)
+        AbstractAnnouncement.__post_init(self, parent)
 
-        LayoutHelpers.LayoutFor(self.Title)
-            :AtCenterIn(GetFrame(0), -250)
-            :DropShadow(true)
-            :Color(UIUtil.fontColor)
+        Layouter(self.Title)
+            :AtCenterIn(parent, -250)
             :End()
 
-        LayoutHelpers.LayoutFor(self)
-            :Fill(self.Title)
+        -- match the content area with the title
+        Layouter(self.ContentArea)
+            :Left(self.Title.Left)
+            :Right(self.Title.Right)
+            :AtTopIn(self.Title, 10)
+            :Bottom(self.Title.Bottom)
+            :ResetWidth()
+            :ResetHeight()
+            :Alpha(0, true)
+            :End()
+
     end,
 }

--- a/lua/ui/game/announcement/SmallAnnouncement.lua
+++ b/lua/ui/game/announcement/SmallAnnouncement.lua
@@ -1,11 +1,29 @@
+--******************************************************************************************************
+--** Copyright (c) 2025  Willem 'Jip' Wijnia
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
 local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
 local Layouter = LayoutHelpers.ReusedLayoutFor
 
 local UIUtil = import("/lua/ui/uiutil.lua")
-local Group = import("/lua/maui/group.lua").Group
-local Bitmap = import("/lua/maui/bitmap.lua").Bitmap
-local TextArea = import("/lua/ui/controls/textarea.lua").TextArea
-
 local AbstractAnnouncement = import("/lua/ui/game/announcement/AbstractAnnouncement.lua").AbstractAnnouncement
 
 --- An announcement with just a title.
@@ -36,12 +54,11 @@ SmallAnnouncement = ClassUI(AbstractAnnouncement) {
         Layouter(self.ContentArea)
             :Left(self.Title.Left)
             :Right(self.Title.Right)
-            :AtTopIn(self.Title, 10)
+            :AtTopIn(self.Title)
             :Bottom(self.Title.Bottom)
             :ResetWidth()
             :ResetHeight()
             :Alpha(0, true)
             :End()
-
     end,
 }

--- a/lua/ui/game/announcement/SmallAnnouncement.lua
+++ b/lua/ui/game/announcement/SmallAnnouncement.lua
@@ -15,11 +15,10 @@ SmallAnnouncement = ClassUI(AbstractAnnouncement) {
 
     ---@param self UISmallAnnouncement
     ---@param parent Control
-    ---@param goalControl Control
     ---@param onFinishedCallback fun()
     ---@param text string
-    __init = function(self, parent, goalControl, onFinishedCallback, text)
-        AbstractAnnouncement.__init(self, parent, goalControl, onFinishedCallback)
+    __init = function(self, parent, onFinishedCallback, text)
+        AbstractAnnouncement.__init(self, parent, onFinishedCallback)
 
         self.Title = UIUtil.CreateText(self, text, 22, UIUtil.titleFont)
     end,

--- a/lua/ui/game/announcement/TitleAnnouncement.lua
+++ b/lua/ui/game/announcement/TitleAnnouncement.lua
@@ -27,11 +27,11 @@ local UIUtil = import("/lua/ui/uiutil.lua")
 local AbstractAnnouncement = import("/lua/ui/game/announcement/AbstractAnnouncement.lua").AbstractAnnouncement
 
 --- An announcement with just a title.
----@class UISmallAnnouncement : UIAbstractAnnouncement
+---@class UITitleAnnouncement : UIAbstractAnnouncement
 ---@field Title Text
-SmallAnnouncement = ClassUI(AbstractAnnouncement) {
+TitleAnnouncement = ClassUI(AbstractAnnouncement) {
 
-    ---@param self UISmallAnnouncement
+    ---@param self UITitleAnnouncement
     ---@param parent Control
     ---@param titleText UnlocalizedString
     __init = function(self, parent, titleText)
@@ -40,7 +40,7 @@ SmallAnnouncement = ClassUI(AbstractAnnouncement) {
         self.Title = UIUtil.CreateText(self.ContentArea, LOC(titleText), 22, UIUtil.titleFont)
     end,
 
-    ---@param self UISmallAnnouncement
+    ---@param self UITitleAnnouncement
     ---@param parent Control
     ---@param titleText UnlocalizedString
     __post_init = function(self, parent, titleText)

--- a/lua/ui/game/announcement/TitleTextAnnouncement.lua
+++ b/lua/ui/game/announcement/TitleTextAnnouncement.lua
@@ -36,7 +36,8 @@ TitleTextAnnouncement = ClassUI(AbstractAnnouncement) {
 
     ---@param self UITitleTextAnnouncement
     ---@param parent Control
-    ---@param text string
+    ---@param text UnlocalizedString
+    ---@param bodyText UnlocalizedString
     __init = function(self, parent, text, bodyText)
         AbstractAnnouncement.__init(self, parent)
 

--- a/lua/ui/game/announcement/TitleTextAnnouncement.lua
+++ b/lua/ui/game/announcement/TitleTextAnnouncement.lua
@@ -36,20 +36,20 @@ TitleTextAnnouncement = ClassUI(AbstractAnnouncement) {
 
     ---@param self UITitleTextAnnouncement
     ---@param parent Control
-    ---@param text UnlocalizedString
+    ---@param titleText UnlocalizedString
     ---@param bodyText UnlocalizedString
-    __init = function(self, parent, text, bodyText)
+    __init = function(self, parent, titleText, bodyText)
         AbstractAnnouncement.__init(self, parent)
 
-        self.Title = UIUtil.CreateText(self.ContentArea, text, 22, UIUtil.titleFont)
+        self.Title = UIUtil.CreateText(self.ContentArea, LOC(titleText), 22, UIUtil.titleFont)
         self.Text = TextArea(self.ContentArea, 600, 60)
         self.Text:SetText(LOC(bodyText))
     end,
 
     ---@param self UITitleTextAnnouncement
     ---@param parent Control
-    ---@param text string
-    __post_init = function(self, parent, text, bodyText)
+    ---@param titleText UnlocalizedString
+    __post_init = function(self, parent, titleText, bodyText)
         AbstractAnnouncement.__post_init(self, parent)
 
         Layouter(self.Title)

--- a/lua/ui/game/announcement/TitleTextAnnouncement.lua
+++ b/lua/ui/game/announcement/TitleTextAnnouncement.lua
@@ -1,0 +1,87 @@
+--******************************************************************************************************
+--** Copyright (c) 2025  Willem 'Jip' Wijnia
+--**
+--** Permission is hereby granted, free of charge, to any person obtaining a copy
+--** of this software and associated documentation files (the "Software"), to deal
+--** in the Software without restriction, including without limitation the rights
+--** to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+--** copies of the Software, and to permit persons to whom the Software is
+--** furnished to do so, subject to the following conditions:
+--**
+--** The above copyright notice and this permission notice shall be included in all
+--** copies or substantial portions of the Software.
+--**
+--** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+--** IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+--** FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+--** AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+--** LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+--** OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+--** SOFTWARE.
+--******************************************************************************************************
+
+local LayoutHelpers = import("/lua/maui/layouthelpers.lua")
+local Layouter = LayoutHelpers.ReusedLayoutFor
+
+local UIUtil = import("/lua/ui/uiutil.lua")
+local TextArea = import("/lua/ui/controls/textarea.lua").TextArea
+
+local AbstractAnnouncement = import("/lua/ui/game/announcement/AbstractAnnouncement.lua").AbstractAnnouncement
+
+--- An announcement with a title and some text below it.
+---@class UITitleTextAnnouncement : UIAbstractAnnouncement
+---@field Title Text
+---@field Text TextArea
+TitleTextAnnouncement = ClassUI(AbstractAnnouncement) {
+
+    ---@param self UITitleTextAnnouncement
+    ---@param parent Control
+    ---@param text string
+    __init = function(self, parent, text, bodyText)
+        AbstractAnnouncement.__init(self, parent)
+
+        self.Title = UIUtil.CreateText(self.ContentArea, text, 22, UIUtil.titleFont)
+        self.Text = TextArea(self.ContentArea, 600, 60)
+        self.Text:SetText(bodyText)
+    end,
+
+    ---@param self UITitleTextAnnouncement
+    ---@param parent Control
+    ---@param text string
+    __post_init = function(self, parent, text, bodyText)
+        AbstractAnnouncement.__post_init(self, parent)
+
+        Layouter(self.Title)
+            :AtCenterIn(parent, -250)
+            :End()
+
+        local text = self.Text
+        text:SetFont(UIUtil.bodyFont, 18)
+        text:FitToText()
+        text:SetTextAlignment(0.5)
+        text:SetColors(UIUtil.fontColor)
+        text:SetAlphaOfColors(0)
+
+        Layouter(self.Text)
+            :CenteredBelow(self.Title, 10)
+            :End()
+
+        -- match the content area with the title
+        Layouter(self.ContentArea)
+            :Left(function() return math.min(self.Title.Left(), self.Text.Left()) end)
+            :Right(function() return math.max(self.Title.Right(), self.Text.Right()) end)
+            :AtTopIn(self.Title)
+            :Bottom(self.Text.Bottom())
+            :ResetWidth()
+            :ResetHeight()
+            :Alpha(0, true)
+            :End()
+    end,
+
+    ---@param self UITitleTextAnnouncement
+    ---@param value number
+    SetAlphaOfContent = function(self, value)
+        AbstractAnnouncement.SetAlphaOfContent(self, value)
+        self.Text:SetAlphaOfColors(value)
+    end,
+}

--- a/lua/ui/game/announcement/TitleTextAnnouncement.lua
+++ b/lua/ui/game/announcement/TitleTextAnnouncement.lua
@@ -43,7 +43,7 @@ TitleTextAnnouncement = ClassUI(AbstractAnnouncement) {
 
         self.Title = UIUtil.CreateText(self.ContentArea, text, 22, UIUtil.titleFont)
         self.Text = TextArea(self.ContentArea, 600, 60)
-        self.Text:SetText(bodyText)
+        self.Text:SetText(LOC(bodyText))
     end,
 
     ---@param self UITitleTextAnnouncement

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -1424,22 +1424,11 @@ end
 ---@param secondary UnlocalizedString
 ---@param control? Control defaults to dummy control at center of screen 
 function CreateAnnouncementStd(primary, secondary, control)
-    -- make it originate from the top
-    if not control then
-        local frame = GetFrame(0)
-        control = Group(frame)
-        control.Left:Set(function() return frame.Left() + 0.49 * frame.Right() end)
-        control.Right:Set(function() return frame.Left() + 0.51 * frame.Right() end)
-        control.Top = frame.Top
-        control.Bottom = frame.Top
+    if not secondary then
+        return import("/lua/ui/game/announcement.lua").CreateAnnouncement(primary, control)
+    else
+        return import("/lua/ui/game/announcement.lua").CreateTitleTextAnnouncement(primary, secondary, control)
     end
-
-    -- create the announcement accordingly
-    import("/lua/ui/game/announcement.lua").CreateAnnouncement(
-        primary,
-        control,
-        secondary
-    )
 end
 
 


### PR DESCRIPTION
## Description of the proposed changes

Implements how announcements work from the ground up! There was an error introduced with https://github.com/FAForever/fa/pull/5971 but I could not figure out where the circular dependency was. The existing code was quite like spaghetti and after half an hour I figured - let's just rework it.

The new setup produces an animation that works exactly like the old one. It's now also easier to introduce different type of announcements. 

## Testing done on the proposed changes

Introduced a debug hotkey that you can use to trigger the announcement. Played campaign maps to make sure objectives work properly again.

## Additional context

The way announcements work is very interesting! To help the player understand to what the announcement is related it 'morphs' from a control to the center of the screen when expanding, just to morph back again when it's contracting. The content does not morph - it just becomes opaque to become transparent again by adjusting the alpha.

As an example of how the old animation looks like:


https://github.com/user-attachments/assets/088bea20-3d5a-4cd6-b8b1-f8b90a552586

And it starts like this:

![image](https://github.com/user-attachments/assets/756390d0-5235-49bb-a468-b5d0b14b7975)

![image](https://github.com/user-attachments/assets/bdb8e8e1-c923-41f1-88c4-8e87a36d1428)

![image](https://github.com/user-attachments/assets/70c769a4-955d-402f-ba94-c06e4d175519)

Up to the point where it encapsulates the content of the announcement. Once it arrived at its destination the content shows up by reducing the transparency.

To make this easier to work with I introduced a `ContentArea` field which is where the announcement will morph to. Where ever that is, and of whatever size it is - when morphing the announcement will wrap itself around it. This makes it much more convenient to create separate types of announcement that involve more then just text! 

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
