### PR TITLE
Fix issues with transport speed reduction

### DIFF
--- a/changelog/snippets/fix.6814.md
+++ b/changelog/snippets/fix.6814.md
@@ -1,0 +1,3 @@
+- (#6814) Fix air units and structures attached to transports through scripts causing an error.
+
+- (#6814) Add a 30% minimum speed limit to transport speed reduction to prevent modded/scripted transports from becoming completely immobile or moving backwards due to a negative speed multiplier.

--- a/lua/sim/units/AirTransportUnit.lua
+++ b/lua/sim/units/AirTransportUnit.lua
@@ -80,7 +80,9 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
         local transportspeed = self.Blueprint.Air.MaxAirspeed
         local totalweight = 0
         for _, unit in self:GetCargo() do
-            totalweight = totalweight + unit.Blueprint.Physics.TransportSpeedReduction
+            local reduction = unit.Blueprint.Physics.TransportSpeedReduction
+            if not reduction then continue end
+            totalweight = totalweight + reduction
 	    end
         self:SetSpeedMult(1 - (totalweight / transportspeed))
     end,

--- a/lua/sim/units/AirTransportUnit.lua
+++ b/lua/sim/units/AirTransportUnit.lua
@@ -90,7 +90,7 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
                 totalweight = maxWeight
                 break
             end
-	    end
+        end
         self:SetSpeedMult(1 - (totalweight / transportspeed))
     end,
 
@@ -148,7 +148,7 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
         end
         -- these need to be defined for certain behaviors (like ctrl-k) to function
         damageType = damageType or "Normal"
-        excessDamageRatio =  excessDamageRatio or 0
+        excessDamageRatio = excessDamageRatio or 0
         AirUnitKill(self, instigator, damageType, excessDamageRatio)
     end,
 

--- a/lua/sim/units/AirTransportUnit.lua
+++ b/lua/sim/units/AirTransportUnit.lua
@@ -78,11 +78,18 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
     ---@param self AirTransport
     ReduceTransportSpeed = function(self)
         local transportspeed = self.Blueprint.Air.MaxAirspeed
+        -- add a minimum speed of 30% base to prevent breaking the transport with a zero or negative speed multiplier
+        local maxWeight = transportspeed - transportspeed * 0.3
         local totalweight = 0
         for _, unit in self:GetCargo() do
             local reduction = unit.Blueprint.Physics.TransportSpeedReduction
             if not reduction then continue end
             totalweight = totalweight + reduction
+
+            if totalweight > maxWeight then
+                totalweight = maxWeight
+                break
+            end
 	    end
         self:SetSpeedMult(1 - (totalweight / transportspeed))
     end,

--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -552,10 +552,11 @@ local function PostProcessUnit(unit)
         unit.Interface.HelpText = unit.Description or "" --[[@as string]]
     end
 
-    -- Define a specific TransportSpeedReduction for all land and naval units.
-    -- Experimentals have a TransportSpeedReduction of 1 due to transports gaining 1 speed and some survival maps loading experimentals into transports.
+    -- Define a specific TransportSpeedReduction for all units.
+    -- Experimentals and structures have a TransportSpeedReduction of 1 due to transports gaining 1 speed
+    -- and some survival maps loading experimentals or structures into transports.
     -- Naval units also gain a TransportSpeedReduction of 1 to ensure mod compatibility.
-    if unit.Physics and not unit.Physics.TransportSpeedReduction and not isStructure then
+    if unit.Physics and not unit.Physics.TransportSpeedReduction then
         if isLand and isTech1 then
             unit.Physics.TransportSpeedReduction = 0.15
         elseif isLand and isTech2 then
@@ -568,7 +569,7 @@ local function PostProcessUnit(unit)
             unit.Physics.TransportSpeedReduction = 1
         elseif isACU then
             unit.Physics.TransportSpeedReduction = 1
-        elseif isNaval then
+        elseif isNaval or isStructure then
             unit.Physics.TransportSpeedReduction = 1
         end
     end


### PR DESCRIPTION
## Issue
- I heard Nomads transport starts moving backwards when loaded with huge amounts of units.
- The map "Survival Versus" places structures on transports (flying Paragon bombs), and I was told the map was broken due to this.
- Another map is Direct Strike, which places air units inside transports. Maybe that was the actual map I'm remembering.
- I also have this error from game 24916350, it seems to be due to a czar (uaa0310) so it's probably related to attaching aircraft.
```
warning: Error running OnTransportDetach script in Entity uaa0310 at 2e23b308: ...\gamedata\lua.nx2\lua\sim\units\airtransportunit.lua(83): attempt to perform arithmetic on field `TransportSpeedReduction' (a nil value)
         stack traceback:
         	...\gamedata\lua.nx2\lua\sim\units\airtransportunit.lua(83): in function `ReduceTransportSpeed'
         	...\gamedata\lua.nx2\lua\sim\units\airtransportunit.lua(103): in function <...\gamedata\lua.nx2\lua\sim\units\airtransportunit.lua:100>
```

## Description of the proposed changes
- Give transports 1 speed reduction for mod compatibility, just like we did with naval and experimental units. In theory all units should have the stat now.
- Add a nil check just in case some unit doesn't have the stat (air unit or no bp.Physics table)
- Add a minimum transport speed of 30% the base speed.

## Testing done on the proposed changes
The following UI code mimics the code Direct Strike uses, which is the scenario framework function. It needs multiple cargo because GetCargo doesn't see the very first unit attached. It uses Janus for the cargo since it is an air unit.
You can switch `dea0202` for `xab1401` to test with 2 Paragon structures attached.
You can adjust the max value in the loop to overload the transport with weight.
```lua
CreateUnitAtMouse('uea0107', GetFocusArmy() - 1, 0, 0, 0)
ForkThread(function ()
    WaitTicks(6)
    UISelectionByCategory('uea0107', false ,false, true, false)
    ConExecute([[SimLua 
    local t = {}
    for i = 1, 2 do
        t[i] = CreateUnitHPR('dea0202', GetFocusArmy(), 0, 0, 0, 0, 0, 0)
    end
    import('/lua/ScenarioFramework.lua').AttachUnitsToTransports(t, {SelectedUnit()})
    ]])
end)
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
