### PR TITLE
Fix WrapText not picking up trailing single characters after newlines

### DIFF
--- a/changelog/snippets/fix.6816.md
+++ b/changelog/snippets/fix.6816.md
@@ -1,0 +1,1 @@
+- (#6816) Fix `WrapText` not picking up single trailing characters after newlines.

--- a/lua/maui/text.lua
+++ b/lua/maui/text.lua
@@ -188,7 +188,7 @@ function WrapText(text, lineWidth, advanceFunction)
                 -- find the next line feed
                 lfStartIndex = string.find(packedWord, "\n", curIndex)
                 -- pick up any trailing word
-                if not lfStartIndex and curIndex < bytes then
+                if not lfStartIndex and curIndex <= bytes then
                     table.insert(words, string.sub(packedWord, curIndex, bytes))
                 end
             end


### PR DESCRIPTION
## Description of the proposed changes
- Fix an off by one error where WrapText wouldn't pick up a trailing single char after a newline. Probably caused by Lua's 1-indexing allowing iteratation with `index <= arraysize`.

## Testing done on the proposed changes
Run the following command from the front end UI (to avoid restarting the game on file change) with/without the changes.
```lua
reprsl(import('/lua/maui/text.lua').WrapText('a\nb', 1, function() return 1 end))
```
Correct output:
```
{ -- table: 11D84578 (72 bytes)
  [2] = "a ",
  [4] = "b "
}
```
Incorrect output:
```
{ -- table: 11C381B8 (56 bytes)
  [2] = "a "
}
```

I don't know why its a space after `a`, but the fact that the `b` character is missing entirely is wrong.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
