### PR TITLE
[NOPUBLISH] Reduce memory consumption of formations

### DIFF
--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1584,8 +1584,6 @@ function CategorizeUnits(formationUnits)
             Shields = {},
             RemainingCategory = {},
 
-            UnitTotal = 0,
-            AreaTotal = 0,
             FootprintCounts = {},
             FootprintSizes = {},
         },
@@ -1601,8 +1599,6 @@ function CategorizeUnits(formationUnits)
             AEngineer = {},
             RemainingCategory = {},
 
-            UnitTotal = 0,
-            AreaTotal = 0,
             FootprintCounts = {},
             FootprintSizes = {},
         },
@@ -1618,8 +1614,6 @@ function CategorizeUnits(formationUnits)
             MobileSonarCount = {},
             RemainingCategory = {},
 
-            UnitTotal = 0,
-            AreaTotal = 0,
             FootprintCounts = {},
             FootprintSizes = {},
         },
@@ -1627,12 +1621,17 @@ function CategorizeUnits(formationUnits)
         Subs = {
             SubCount = {},
 
-            UnitTotal = 0,
-            AreaTotal = 0,
             FootprintCounts = {},
             FootprintSizes = {},
         },
     }
+
+    -- initialize common fields for each unit type
+    for _, unitType in {'Land', 'Air', 'Naval', 'Subs'} do
+        for _, commonIntField in {'UnitTotal', 'AreaTotal'} do
+            unitsList[unitType][commonIntField] = 0
+        end
+    end
 
     -- TODO: @ostrovaya @NOPUBLISH
     LOG('CategorizeUnits called!')
@@ -1699,6 +1698,13 @@ function CategorizeUnits(formationUnits)
             end
         end
     end
+
+    -- TODO: @ostrovaya @NOPUBLISH
+    LOG("air unit total")
+    LOG(reprsl(unitsList.Air.UnitTotal))
+    LOG("land unit total")
+    LOG(reprsl(unitsList.Land.UnitTotal))
+    -- LOG(reprsl(unitsList))
 
     CalculateSizes(unitsList)
 

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1592,7 +1592,7 @@ function CategorizeUnits(formationUnits)
     end
 
     -- initialize common fields for each unit type
-    for _, unitType in {'Land', 'Air', 'Naval', 'Subs'} do
+    for unitType, _ in categoryTables do
         for _, commonNumberField in {'UnitTotal', 'AreaTotal'} do
             unitsList[unitType][commonNumberField] = 0
         end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1645,27 +1645,29 @@ function CategorizeUnits(formationUnits)
             local categorizationForType = unitsList[type]
 
             for category, _ in table do
-                if EntityCategoryContains(table[category], unit) then
-                    local blueprint = unit:GetBlueprint()
-                    local footprintSize = math.max(blueprint.Footprint.SizeX, blueprint.Footprint.SizeZ)
-                    local id = blueprint.BlueprintId
-
-                    local categoryFootprintSizes = categorizationForType[category]
-
-                    if not categoryFootprintSizes[footprintSize] then
-                        categoryFootprintSizes[footprintSize] = {Count = 0, Categories = {}}
-                    end
-                    categoryFootprintSizes[footprintSize].Count = categoryFootprintSizes[footprintSize].Count + 1
-                    categoryFootprintSizes[footprintSize].Categories[id] = categories[id]
-                    categorizationForType.FootprintCounts[footprintSize] = (categorizationForType.FootprintCounts[footprintSize] or 0) + 1
-
-                    if category == "RemainingCategory" then
-                        LOG('*FORMATION DEBUG: Unit ' .. tostring(unit:GetBlueprint().BlueprintId) .. ' does not match any ' .. type .. ' categories.')
-                    end
-                    categorizationForType.UnitTotal = categorizationForType.UnitTotal + 1
-                    identified = true
-                    break
+                if not EntityCategoryContains(table[category], unit) then
+                    continue
                 end
+
+                local blueprint = unit:GetBlueprint()
+                local footprintSize = math.max(blueprint.Footprint.SizeX, blueprint.Footprint.SizeZ)
+                local id = blueprint.BlueprintId
+
+                local categoryFootprintSizes = categorizationForType[category]
+
+                if not categoryFootprintSizes[footprintSize] then
+                    categoryFootprintSizes[footprintSize] = {Count = 0, Categories = {}}
+                end
+                categoryFootprintSizes[footprintSize].Count = categoryFootprintSizes[footprintSize].Count + 1
+                categoryFootprintSizes[footprintSize].Categories[id] = categories[id]
+                categorizationForType.FootprintCounts[footprintSize] = (categorizationForType.FootprintCounts[footprintSize] or 0) + 1
+
+                if category == "RemainingCategory" then
+                    LOG('*FORMATION DEBUG: Unit ' .. tostring(unit:GetBlueprint().BlueprintId) .. ' does not match any ' .. type .. ' categories.')
+                end
+                categorizationForType.UnitTotal = categorizationForType.UnitTotal + 1
+                identified = true
+                break
             end
 
             if identified then

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1583,9 +1583,6 @@ function CategorizeUnits(formationUnits)
             Util1 = {}, Util2 = {}, Util3 = {}, Util4 = {},
             Shields = {},
             RemainingCategory = {},
-
-            FootprintCounts = {},
-            FootprintSizes = {},
         },
 
         Air = {
@@ -1598,9 +1595,6 @@ function CategorizeUnits(formationUnits)
             AExper = {},
             AEngineer = {},
             RemainingCategory = {},
-
-            FootprintCounts = {},
-            FootprintSizes = {},
         },
 
         Naval = {
@@ -1613,16 +1607,10 @@ function CategorizeUnits(formationUnits)
             NukeSubCount = {},
             MobileSonarCount = {},
             RemainingCategory = {},
-
-            FootprintCounts = {},
-            FootprintSizes = {},
         },
 
         Subs = {
             SubCount = {},
-
-            FootprintCounts = {},
-            FootprintSizes = {},
         },
     }
 
@@ -1630,6 +1618,10 @@ function CategorizeUnits(formationUnits)
     for _, unitType in {'Land', 'Air', 'Naval', 'Subs'} do
         for _, commonNumberField in {'UnitTotal', 'AreaTotal'} do
             unitsList[unitType][commonNumberField] = 0
+        end
+
+        for _, commonTableField in {'FootprintCounts', 'FootprintSizes'} do
+            unitsList[unitType][commonTableField] = {}
         end
     end
 

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1572,6 +1572,7 @@ end
 ---@param formationUnits Unit[]
 ---@return table
 function CategorizeUnits(formationUnits)
+    -- TODO: @ostrovaya @NOPUBLISH
     LOG('wtf')
     LOG('test')
     LOG('gross')

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1628,8 +1628,8 @@ function CategorizeUnits(formationUnits)
 
     -- initialize common fields for each unit type
     for _, unitType in {'Land', 'Air', 'Naval', 'Subs'} do
-        for _, commonIntField in {'UnitTotal', 'AreaTotal'} do
-            unitsList[unitType][commonIntField] = 0
+        for _, commonNumberField in {'UnitTotal', 'AreaTotal'} do
+            unitsList[unitType][commonNumberField] = 0
         end
     end
 

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1572,47 +1572,23 @@ end
 ---@param formationUnits Unit[]
 ---@return table
 function CategorizeUnits(formationUnits)
-    local unitsList = {
-        Land = {
-            Bot1 = {}, Bot2 = {}, Bot3 = {}, Bot4 = {},
-            Tank1 = {}, Tank2 = {}, Tank3 = {}, Tank4 = {},
-            Sniper1 = {}, Sniper2 = {}, Sniper3 = {}, Sniper4 = {},
-            Art1 = {}, Art2 = {}, Art3 = {}, Art4 = {},
-            AA1 = {}, AA2 = {}, AA3 = {},
-            Com1 = {}, Com2 = {}, Com3 = {}, Com4 = {},
-            Util1 = {}, Util2 = {}, Util3 = {}, Util4 = {},
-            Shields = {},
-            RemainingCategory = {},
-        },
+    LOG('wtf')
+    LOG('test')
+    LOG('gross')
 
-        Air = {
-            Ground1 = {}, Ground2 = {}, Ground3 = {},
-            Trans1 = {}, Trans2 = {}, Trans3 = {},
-            Bomb1 = {}, Bomb2 = {}, Bomb3 = {},
-            AA1 = {}, AA2 = {}, AA3 = {},
-            AN1 = {}, AN2 = {}, AN3 = {},
-            AIntel1 = {}, AIntel2 = {}, AIntel3 = {},
-            AExper = {},
-            AEngineer = {},
-            RemainingCategory = {},
-        },
+    local unitsList = {}
 
-        Naval = {
-            CarrierCount = {},
-            BattleshipCount = {},
-            DestroyerCount = {},
-            CruiserCount = {},
-            FrigateCount = {},
-            LightCount = {},
-            NukeSubCount = {},
-            MobileSonarCount = {},
-            RemainingCategory = {},
-        },
+    -- initialize each unit type section by its categories
+    local categoryTables = { Land = LandCategories, Air = AirCategories, Naval = NavalCategories, Subs = SubCategories}
+    for unitType, typeCategories in categoryTables do
+        if not unitsList[unitType] then
+            unitsList[unitType] = {}
+        end
 
-        Subs = {
-            SubCount = {},
-        },
-    }
+        for categoryName, _ in typeCategories do
+            unitsList[unitType][categoryName] = {}
+        end
+    end
 
     -- initialize common fields for each unit type
     for _, unitType in {'Land', 'Air', 'Naval', 'Subs'} do
@@ -1627,8 +1603,6 @@ function CategorizeUnits(formationUnits)
 
     -- TODO: @ostrovaya @NOPUBLISH
     LOG('CategorizeUnits called!')
-
-    local categoryTables = {Land = LandCategories, Air = AirCategories, Naval = NavalCategories, Subs = SubCategories}
 
     -- Loop through each unit to get its category and size
     for _, unit in formationUnits do
@@ -1692,11 +1666,11 @@ function CategorizeUnits(formationUnits)
     end
 
     -- TODO: @ostrovaya @NOPUBLISH
+    LOG(reprsl(unitsList))
     LOG("air unit total")
     LOG(reprsl(unitsList.Air.UnitTotal))
     LOG("land unit total")
     LOG(reprsl(unitsList.Land.UnitTotal))
-    -- LOG(reprsl(unitsList))
 
     CalculateSizes(unitsList)
 

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1642,26 +1642,27 @@ function CategorizeUnits(formationUnits)
     for _, unit in formationUnits do
         local identified = false
         for type, table in categoryTables do
+            local categorizationForType = unitsList[type]
+
             for category, _ in table do
                 if EntityCategoryContains(table[category], unit) then
                     local blueprint = unit:GetBlueprint()
                     local footprintSize = math.max(blueprint.Footprint.SizeX, blueprint.Footprint.SizeZ)
                     local id = blueprint.BlueprintId
 
-                    local typeCategories = unitsList[type]
-                    local categoryFootprintSizes = typeCategories[category]
+                    local categoryFootprintSizes = categorizationForType[category]
 
                     if not categoryFootprintSizes[footprintSize] then
                         categoryFootprintSizes[footprintSize] = {Count = 0, Categories = {}}
                     end
                     categoryFootprintSizes[footprintSize].Count = categoryFootprintSizes[footprintSize].Count + 1
                     categoryFootprintSizes[footprintSize].Categories[id] = categories[id]
-                    typeCategories.FootprintCounts[footprintSize] = (typeCategories.FootprintCounts[footprintSize] or 0) + 1
+                    categorizationForType.FootprintCounts[footprintSize] = (categorizationForType.FootprintCounts[footprintSize] or 0) + 1
 
                     if category == "RemainingCategory" then
                         LOG('*FORMATION DEBUG: Unit ' .. tostring(unit:GetBlueprint().BlueprintId) .. ' does not match any ' .. type .. ' categories.')
                     end
-                    typeCategories.UnitTotal = typeCategories.UnitTotal + 1
+                    categorizationForType.UnitTotal = categorizationForType.UnitTotal + 1
                     identified = true
                     break
                 end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1634,6 +1634,8 @@ function CategorizeUnits(formationUnits)
         },
     }
 
+    LOG('CategorizeUnits called!')
+
     local categoryTables = {Land = LandCategories, Air = AirCategories, Naval = NavalCategories, Subs = SubCategories}
 
     -- Loop through each unit to get its category and size
@@ -1646,19 +1648,20 @@ function CategorizeUnits(formationUnits)
                     local footprintSize = math.max(blueprint.Footprint.SizeX, blueprint.Footprint.SizeZ)
                     local id = blueprint.BlueprintId
 
-                    local categoryFootprintSizes = unitsList[type][category]
+                    local typeCategories = unitsList[type]
+                    local categoryFootprintSizes = typeCategories[category]
 
                     if not categoryFootprintSizes[footprintSize] then
                         categoryFootprintSizes[footprintSize] = {Count = 0, Categories = {}}
                     end
                     categoryFootprintSizes[footprintSize].Count = categoryFootprintSizes[footprintSize].Count + 1
                     categoryFootprintSizes[footprintSize].Categories[id] = categories[id]
-                    unitsList[type].FootprintCounts[footprintSize] = (unitsList[type].FootprintCounts[footprintSize] or 0) + 1
+                    typeCategories.FootprintCounts[footprintSize] = (typeCategories.FootprintCounts[footprintSize] or 0) + 1
 
                     if category == "RemainingCategory" then
                         LOG('*FORMATION DEBUG: Unit ' .. tostring(unit:GetBlueprint().BlueprintId) .. ' does not match any ' .. type .. ' categories.')
                     end
-                    unitsList[type].UnitTotal = unitsList[type].UnitTotal + 1
+                    typeCategories.UnitTotal = typeCategories.UnitTotal + 1
                     identified = true
                     break
                 end
@@ -1676,8 +1679,9 @@ function CategorizeUnits(formationUnits)
     -- Loop through each category and combine the types within into a single filter category for each size
     for type, table in categoryTables do
         for category, _ in table do
-            if unitsList[type][category] then
-                for footprintSize, data in unitsList[type][category] do
+            local categoryFootprintSizes = unitsList[type][category]
+            if categoryFootprintSizes then
+                for footprintSize, data in categoryFootprintSizes do
                     local filter = nil
                     for _, category in data.Categories do
                         if not filter then
@@ -1686,7 +1690,7 @@ function CategorizeUnits(formationUnits)
                             filter = filter + category
                         end
                     end
-                    unitsList[type][category][footprintSize] = {Count = data.Count, Filter = filter}
+                    categoryFootprintSizes[footprintSize] = {Count = data.Count, Filter = filter}
                 end
             end
         end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1634,6 +1634,7 @@ function CategorizeUnits(formationUnits)
         },
     }
 
+    -- TODO: @ostrovaya @NOPUBLISH
     LOG('CategorizeUnits called!')
 
     local categoryTables = {Land = LandCategories, Air = AirCategories, Naval = NavalCategories, Subs = SubCategories}

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1640,20 +1640,20 @@ function CategorizeUnits(formationUnits)
     for _, u in formationUnits do
         local identified = false
         for type, table in categoryTables do
-            for cat, _ in table do
-                if EntityCategoryContains(table[cat], u) then
+            for category, _ in table do
+                if EntityCategoryContains(table[category], u) then
                     local bp = u:GetBlueprint()
                     local fs = math.max(bp.Footprint.SizeX, bp.Footprint.SizeZ)
                     local id = bp.BlueprintId
 
-                    if not unitsList[type][cat][fs] then
-                        unitsList[type][cat][fs] = {Count = 0, Categories = {}}
+                    if not unitsList[type][category][fs] then
+                        unitsList[type][category][fs] = {Count = 0, Categories = {}}
                     end
-                    unitsList[type][cat][fs].Count = unitsList[type][cat][fs].Count + 1
-                    unitsList[type][cat][fs].Categories[id] = categories[id]
+                    unitsList[type][category][fs].Count = unitsList[type][category][fs].Count + 1
+                    unitsList[type][category][fs].Categories[id] = categories[id]
                     unitsList[type].FootprintCounts[fs] = (unitsList[type].FootprintCounts[fs] or 0) + 1
 
-                    if cat == "RemainingCategory" then
+                    if category == "RemainingCategory" then
                         LOG('*FORMATION DEBUG: Unit ' .. tostring(u:GetBlueprint().BlueprintId) .. ' does not match any ' .. type .. ' categories.')
                     end
                     unitsList[type].UnitTotal = unitsList[type].UnitTotal + 1
@@ -1673,9 +1673,9 @@ function CategorizeUnits(formationUnits)
 
     -- Loop through each category and combine the types within into a single filter category for each size
     for type, table in categoryTables do
-        for cat, _ in table do
-            if unitsList[type][cat] then
-                for fs, data in unitsList[type][cat] do
+        for category, _ in table do
+            if unitsList[type][category] then
+                for fs, data in unitsList[type][category] do
                     local filter = nil
                     for _, category in data.Categories do
                         if not filter then
@@ -1684,7 +1684,7 @@ function CategorizeUnits(formationUnits)
                             filter = filter + category
                         end
                     end
-                    unitsList[type][cat][fs] = {Count = data.Count, Filter = filter}
+                    unitsList[type][category][fs] = {Count = data.Count, Filter = filter}
                 end
             end
         end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -13,6 +13,7 @@
 ---@alias UnitFormations 'AttackFormation' | 'GrowthFormation' | 'NoFormation' | 'None' | 'none'
 
 local TableGetn = table.getn
+local TableInsert = table.insert
 
 SurfaceFormations = {
     'AttackFormation',
@@ -73,7 +74,7 @@ function CacheResults(results, formationUnits, formationType)
     if TableGetn(cache) >= MaxCacheSize then
         table.remove(cache)
     end
-    table.insert(cache, 1, {Results = results, Units = formationUnits, UnitCount = TableGetn(formationUnits)})
+    TableInsert(cache, 1, {Results = results, Units = formationUnits, UnitCount = TableGetn(formationUnits)})
 end
 
 -- =========================================
@@ -921,11 +922,11 @@ function GuardFormation(formationUnits)
         offsetX = sizeMult * math.sin(ringPosition)
         offsetY = -sizeMult * math.cos(ringPosition)
         if shieldsInRing > 0 and unitCount >= nextShield then
-            table.insert(FormationPos, { offsetX, offsetY, shieldCategory, 0, rotate })
+            TableInsert(FormationPos, { offsetX, offsetY, shieldCategory, 0, rotate })
             remainingShields = remainingShields - 1
             nextShield = nextShield + unitsPerShield
         else
-            table.insert(FormationPos, { offsetX, offsetY, nonShieldCategory, 0, rotate })
+            TableInsert(FormationPos, { offsetX, offsetY, nonShieldCategory, 0, rotate })
         end
         unitCount = unitCount + 1
         remainingUnits = remainingUnits - 1
@@ -1041,7 +1042,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
                             rowType = type
                         end
 
-                        table.insert(FormationPos, {xPos * spacing, (-formationLength - offsetY) * spacing, groupData.Filter, formationLength, true})
+                        TableInsert(FormationPos, {xPos * spacing, (-formationLength - offsetY) * spacing, groupData.Filter, formationLength, true})
                         inserted = true
 
                         groupData.Count = groupData.Count - 1
@@ -1196,7 +1197,7 @@ function BlockBuilderAir(unitsList, airBlock, spacing)
                     for fs, groupData in unitsList[group] do
                         size = unitsList.FootprintSizes[fs]
                         if groupData.Count > 0 and size == data.size then
-                            table.insert(FormationPos, {data.xPos * spacing, data.yPos * spacing, groupData.Filter, 0, true})
+                            TableInsert(FormationPos, {data.xPos * spacing, data.yPos * spacing, groupData.Filter, 0, true})
                             groupData.Count = groupData.Count - 1
                             if groupData.Count <= 0 then
                                 unitsList[group][fs] = nil
@@ -1261,7 +1262,7 @@ function BlockBuilderAir(unitsList, airBlock, spacing)
                         if airBlock.HomogenousBlocks and not chevronType then
                             chevronType = type
                         end
-                        table.insert(FormationPos, {xPos * spacing, yPos * spacing, groupData.Filter, 0, true})
+                        TableInsert(FormationPos, {xPos * spacing, yPos * spacing, groupData.Filter, 0, true})
                         inserted = true
 
                         groupData.Count = groupData.Count - 1
@@ -1368,7 +1369,7 @@ function BlockBuilderAirT3Bombers(unitsList, spacing)
                         if airBlock.HomogenousBlocks and not chevronType then
                             chevronType = type
                         end
-                        table.insert(FormationPos, {xPos * spacing, yPos * spacing, groupData.Filter, 0, true})
+                        TableInsert(FormationPos, {xPos * spacing, yPos * spacing, groupData.Filter, 0, true})
                         inserted = true
 
                         groupData.Count = groupData.Count - 1
@@ -1448,11 +1449,11 @@ function GetLargeAirPositions(unitsList, airBlock)
                 end
             end
             if not blocked then
-                table.insert(results, {row = whichRow, col = whichCol, xPos = xPos, yPos = yPos, size = size})
+                TableInsert(results, {row = whichRow, col = whichCol, xPos = xPos, yPos = yPos, size = size})
                 count = count - 1
                 numResults = numResults + 1
                 if whichCol ~= 1 then
-                    table.insert(results, {row = whichRow, col = whichCol - 1, xPos = -xPos, yPos = yPos, size = size})
+                    TableInsert(results, {row = whichRow, col = whichCol - 1, xPos = -xPos, yPos = yPos, size = size})
                     count = count - 1
                     numResults = numResults + 1
                 end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1646,11 +1646,13 @@ function CategorizeUnits(formationUnits)
                     local footprintSize = math.max(blueprint.Footprint.SizeX, blueprint.Footprint.SizeZ)
                     local id = blueprint.BlueprintId
 
-                    if not unitsList[type][category][footprintSize] then
-                        unitsList[type][category][footprintSize] = {Count = 0, Categories = {}}
+                    local categoryFootprintSizes = unitsList[type][category]
+
+                    if not categoryFootprintSizes[footprintSize] then
+                        categoryFootprintSizes[footprintSize] = {Count = 0, Categories = {}}
                     end
-                    unitsList[type][category][footprintSize].Count = unitsList[type][category][footprintSize].Count + 1
-                    unitsList[type][category][footprintSize].Categories[id] = categories[id]
+                    categoryFootprintSizes[footprintSize].Count = categoryFootprintSizes[footprintSize].Count + 1
+                    categoryFootprintSizes[footprintSize].Categories[id] = categories[id]
                     unitsList[type].FootprintCounts[footprintSize] = (unitsList[type].FootprintCounts[footprintSize] or 0) + 1
 
                     if category == "RemainingCategory" then

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -13,6 +13,7 @@
 ---@alias UnitFormations 'AttackFormation' | 'GrowthFormation' | 'NoFormation' | 'None' | 'none'
 
 local MathAbs = math.abs
+local MathFloor = math.floor
 
 local TableGetn = table.getn
 local TableInsert = table.insert
@@ -1102,7 +1103,7 @@ function IsLandSpaceOccupied(occupiedSpaces, size, rowNum, whichCol, currRowLen,
     if whichCol == 1 and (not evenRowLen) and evenSize and remainingUnits > 1 then -- Don't put an even-sized unit in the middle of an odd-length row unless it's the last unit
         return true
     end
-    if whichCol > currRowLen - math.floor(size / 2) * 2 and size <= math.floor(currRowLen / 2) then -- Don't put a large unit at the end of a row unless the row is too narrow
+    if whichCol > currRowLen - MathFloor(size / 2) * 2 and size <= MathFloor(currRowLen / 2) then -- Don't put a large unit at the end of a row unless the row is too narrow
         return true
     end
     for y = 0, size - 1, 1 do
@@ -1165,7 +1166,7 @@ function GetColSpot(rowLen, col)
     if math.mod(col, 2) == 0 then
         colType = 'right'
     end
-    local colSpot = math.floor(col / 2)
+    local colSpot = MathFloor(col / 2)
     local halfSpot = len/2
     if colType == 'left' then
         return halfSpot - colSpot
@@ -1471,15 +1472,15 @@ end
 ---@return number xPos
 ---@return number yPos
 function GetChevronPosition(chevronPos, currCol, formationLen)
-    local offset = math.floor(chevronPos / 2)
+    local offset = MathFloor(chevronPos / 2)
     local xPos = offset * 0.5
     if math.mod(chevronPos, 2) == 0 then
         xPos = -xPos
     end
-    local column = math.floor(currCol / 2)
+    local column = MathFloor(currCol / 2)
     local yPos = (-offset + column * column) * 0.86603
     yPos = yPos - formationLen * 1.73205
-    local blockOff = math.floor(currCol / 2) * 2.5
+    local blockOff = MathFloor(currCol / 2) * 2.5
     if math.mod(currCol, 2) == 1 then
         blockOff = -blockOff
     end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -13,6 +13,7 @@
 ---@alias UnitFormations 'AttackFormation' | 'GrowthFormation' | 'NoFormation' | 'None' | 'none'
 
 local MathAbs = math.abs
+local MathCeil = math.ceil
 local MathFloor = math.floor
 
 local TableGetn = table.getn
@@ -1026,7 +1027,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
 
                         local xPos
                         if evenRowLen then
-                            xPos = math.ceil(whichCol/2) - .5 + offsetX
+                            xPos = MathCeil(whichCol/2) - .5 + offsetX
                             if not (math.mod(whichCol, 2) == 0) then
                                 xPos = xPos * -1
                             end
@@ -1034,7 +1035,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
                             if whichCol == 1 then
                                 xPos = 0
                             else
-                                xPos = math.ceil(((whichCol-1) /2)) + offsetX
+                                xPos = MathCeil(((whichCol-1) /2)) + offsetX
                                 if not (math.mod(whichCol, 2) == 0) then
                                     xPos = xPos * -1
                                 end
@@ -1558,7 +1559,7 @@ function CalculateSizes(unitsList)
             unitData.Scale = gridSize / (largestFootprint + 2)
 
             for fs, count in unitData.FootprintCounts do
-                local size = math.ceil(fs * data.MinSeparationFraction / gridSize)
+                local size = MathCeil(fs * data.MinSeparationFraction / gridSize)
                 unitData.FootprintSizes[fs] = size
                 unitData.AreaTotal = unitData.AreaTotal + count * size * size
             end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1642,9 +1642,9 @@ function CategorizeUnits(formationUnits)
         for type, table in categoryTables do
             for category, _ in table do
                 if EntityCategoryContains(table[category], u) then
-                    local bp = u:GetBlueprint()
-                    local fs = math.max(bp.Footprint.SizeX, bp.Footprint.SizeZ)
-                    local id = bp.BlueprintId
+                    local blueprint = u:GetBlueprint()
+                    local fs = math.max(blueprint.Footprint.SizeX, blueprint.Footprint.SizeZ)
+                    local id = blueprint.BlueprintId
 
                     if not unitsList[type][category][fs] then
                         unitsList[type][category][fs] = {Count = 0, Categories = {}}

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -12,6 +12,8 @@
 
 ---@alias UnitFormations 'AttackFormation' | 'GrowthFormation' | 'NoFormation' | 'None' | 'none'
 
+local MathAbs = math.abs
+
 local TableGetn = table.getn
 local TableInsert = table.insert
 
@@ -1425,7 +1427,7 @@ function GetLargeAirPositions(unitsList, airBlock)
                 formationLength = formationLength + 1
                 whichCol = 1
                 local x, y = GetChevronPosition(1, currRowLen, formationLength)
-                wideRow = math.abs(x) >= radius
+                wideRow = MathAbs(x) >= radius
             else
                 whichCol = whichCol + 2
             end
@@ -1435,7 +1437,7 @@ function GetLargeAirPositions(unitsList, airBlock)
             end
 
             local xPos, yPos = GetChevronPosition(1, whichCol, formationLength)
-            if whichCol ~= 1 and math.abs(xPos) < radius then
+            if whichCol ~= 1 and MathAbs(xPos) < radius then
                 continue
             end
 

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -12,6 +12,7 @@
 
 ---@alias UnitFormations 'AttackFormation' | 'GrowthFormation' | 'NoFormation' | 'None' | 'none'
 
+local TableGetn = table.getn
 
 SurfaceFormations = {
     'AttackFormation',
@@ -41,7 +42,7 @@ function GetCachedResults(formationUnits, formationType)
         return false
     end
 
-    local unitCount = table.getn(formationUnits)
+    local unitCount = TableGetn(formationUnits)
     for _, data in cache do
         if data.UnitCount == unitCount then
             local match = true
@@ -69,10 +70,10 @@ function CacheResults(results, formationUnits, formationType)
     end
 
     local cache = FormationCache[formationType]
-    if table.getn(cache) >= MaxCacheSize then
+    if TableGetn(cache) >= MaxCacheSize then
         table.remove(cache)
     end
-    table.insert(cache, 1, {Results = results, Units = formationUnits, UnitCount = table.getn(formationUnits)})
+    table.insert(cache, 1, {Results = results, Units = formationUnits, UnitCount = TableGetn(formationUnits)})
 end
 
 -- =========================================
@@ -854,7 +855,7 @@ function GuardFormation(formationUnits)
     local shieldCategory = ShieldCat
     local nonShieldCategory = categories.ALLUNITS - shieldCategory
     local footprintCounts = {}
-    local remainingUnits = table.getn(formationUnits)
+    local remainingUnits = TableGetn(formationUnits)
     local remainingShields = 0
     for _, u in formationUnits do
         if EntityCategoryContains(ShieldCat, u) then
@@ -941,11 +942,11 @@ end
 ---@return table
 function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
     spacing = (spacing or 1) * unitsList.Scale
-    local numRows = table.getn(formationBlock)
+    local numRows = TableGetn(formationBlock)
     local rowNum = 1
     local whichRow = 1
     local whichCol = 1
-    local currRowLen = table.getn(formationBlock[whichRow])
+    local currRowLen = TableGetn(formationBlock[whichRow])
     local rowModifier = GetLandRowModifer(unitsList, categoryTable, currRowLen)
     currRowLen = currRowLen - rowModifier
     local evenRowLen = math.mod(currRowLen, 2) == 0
@@ -965,7 +966,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
             formationLength = formationLength + 1 + (formationBlock.LineBreak or 0)
             whichCol = 1
             rowType = false
-            currRowLen = table.getn(formationBlock[whichRow])
+            currRowLen = TableGetn(formationBlock[whichRow])
             if occupiedSpaces[rowNum] then
                 rowModifier = 0
             else
@@ -1177,11 +1178,11 @@ end
 ---@return table
 function BlockBuilderAir(unitsList, airBlock, spacing)
     spacing = (spacing or 1) * unitsList.Scale
-    local numRows = table.getn(airBlock)
+    local numRows = TableGetn(airBlock)
     local whichRow = 1
     local whichCol = 1
     local chevronPos = 1
-    local currRowLen = table.getn(airBlock[whichRow])
+    local currRowLen = TableGetn(airBlock[whichRow])
     local chevronSize = airBlock.ChevronSize or 5
     local chevronType = false
     local formationLength = 0
@@ -1225,11 +1226,11 @@ function BlockBuilderAir(unitsList, airBlock, spacing)
                 if whichRow >= numRows then
                     if airBlock.RepeatAllRows then
                         whichRow = 1
-                        currRowLen = table.getn(airBlock[whichRow])
+                        currRowLen = TableGetn(airBlock[whichRow])
                     end
                 else
                     whichRow = whichRow + 1
-                    currRowLen = table.getn(airBlock[whichRow])
+                    currRowLen = TableGetn(airBlock[whichRow])
                 end
                 formationLength = formationLength + 1
                 whichCol = 1
@@ -1306,11 +1307,11 @@ function BlockBuilderAirT3Bombers(unitsList, spacing)
         }
     end
 
-    local numRows = table.getn(airBlock)
+    local numRows = TableGetn(airBlock)
     local whichRow = 1
     local whichCol = 1
     local chevronPos = 1
-    local currRowLen = table.getn(airBlock[whichRow])
+    local currRowLen = TableGetn(airBlock[whichRow])
     local chevronSize = 1
     local chevronType = false
     local formationLength = 0
@@ -1332,11 +1333,11 @@ function BlockBuilderAirT3Bombers(unitsList, spacing)
                 if whichRow >= numRows then
                     if airBlock.RepeatAllRows then
                         whichRow = 1
-                        currRowLen = table.getn(airBlock[whichRow])
+                        currRowLen = TableGetn(airBlock[whichRow])
                     end
                 else
                     whichRow = whichRow + 1
-                    currRowLen = table.getn(airBlock[whichRow])
+                    currRowLen = TableGetn(airBlock[whichRow])
                 end
                 formationLength = formationLength + 1
                 whichCol = 1
@@ -1399,7 +1400,7 @@ function GetLargeAirPositions(unitsList, airBlock)
         end
     end
 
-    local numRows = table.getn(airBlock)
+    local numRows = TableGetn(airBlock)
     local whichRow = 0
     local whichCol = 0
     local currRowLen = 0
@@ -1414,11 +1415,11 @@ function GetLargeAirPositions(unitsList, airBlock)
                 if whichRow >= numRows then
                     if airBlock.RepeatAllRows then
                         whichRow = 1
-                        currRowLen = table.getn(airBlock[whichRow])
+                        currRowLen = TableGetn(airBlock[whichRow])
                     end
                 else
                     whichRow = whichRow + 1
-                    currRowLen = table.getn(airBlock[whichRow])
+                    currRowLen = TableGetn(airBlock[whichRow])
                 end
                 formationLength = formationLength + 1
                 whichCol = 1

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1643,15 +1643,15 @@ function CategorizeUnits(formationUnits)
             for category, _ in table do
                 if EntityCategoryContains(table[category], u) then
                     local blueprint = u:GetBlueprint()
-                    local fs = math.max(blueprint.Footprint.SizeX, blueprint.Footprint.SizeZ)
+                    local footprintSize = math.max(blueprint.Footprint.SizeX, blueprint.Footprint.SizeZ)
                     local id = blueprint.BlueprintId
 
-                    if not unitsList[type][category][fs] then
-                        unitsList[type][category][fs] = {Count = 0, Categories = {}}
+                    if not unitsList[type][category][footprintSize] then
+                        unitsList[type][category][footprintSize] = {Count = 0, Categories = {}}
                     end
-                    unitsList[type][category][fs].Count = unitsList[type][category][fs].Count + 1
-                    unitsList[type][category][fs].Categories[id] = categories[id]
-                    unitsList[type].FootprintCounts[fs] = (unitsList[type].FootprintCounts[fs] or 0) + 1
+                    unitsList[type][category][footprintSize].Count = unitsList[type][category][footprintSize].Count + 1
+                    unitsList[type][category][footprintSize].Categories[id] = categories[id]
+                    unitsList[type].FootprintCounts[footprintSize] = (unitsList[type].FootprintCounts[footprintSize] or 0) + 1
 
                     if category == "RemainingCategory" then
                         LOG('*FORMATION DEBUG: Unit ' .. tostring(u:GetBlueprint().BlueprintId) .. ' does not match any ' .. type .. ' categories.')
@@ -1675,7 +1675,7 @@ function CategorizeUnits(formationUnits)
     for type, table in categoryTables do
         for category, _ in table do
             if unitsList[type][category] then
-                for fs, data in unitsList[type][category] do
+                for footprintSize, data in unitsList[type][category] do
                     local filter = nil
                     for _, category in data.Categories do
                         if not filter then
@@ -1684,7 +1684,7 @@ function CategorizeUnits(formationUnits)
                             filter = filter + category
                         end
                     end
-                    unitsList[type][category][fs] = {Count = data.Count, Filter = filter}
+                    unitsList[type][category][footprintSize] = {Count = data.Count, Filter = filter}
                 end
             end
         end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1637,12 +1637,12 @@ function CategorizeUnits(formationUnits)
     local categoryTables = {Land = LandCategories, Air = AirCategories, Naval = NavalCategories, Subs = SubCategories}
 
     -- Loop through each unit to get its category and size
-    for _, u in formationUnits do
+    for _, unit in formationUnits do
         local identified = false
         for type, table in categoryTables do
             for category, _ in table do
-                if EntityCategoryContains(table[category], u) then
-                    local blueprint = u:GetBlueprint()
+                if EntityCategoryContains(table[category], unit) then
+                    local blueprint = unit:GetBlueprint()
                     local footprintSize = math.max(blueprint.Footprint.SizeX, blueprint.Footprint.SizeZ)
                     local id = blueprint.BlueprintId
 
@@ -1656,7 +1656,7 @@ function CategorizeUnits(formationUnits)
                     unitsList[type].FootprintCounts[footprintSize] = (unitsList[type].FootprintCounts[footprintSize] or 0) + 1
 
                     if category == "RemainingCategory" then
-                        LOG('*FORMATION DEBUG: Unit ' .. tostring(u:GetBlueprint().BlueprintId) .. ' does not match any ' .. type .. ' categories.')
+                        LOG('*FORMATION DEBUG: Unit ' .. tostring(unit:GetBlueprint().BlueprintId) .. ' does not match any ' .. type .. ' categories.')
                     end
                     unitsList[type].UnitTotal = unitsList[type].UnitTotal + 1
                     identified = true
@@ -1669,7 +1669,7 @@ function CategorizeUnits(formationUnits)
             end
         end
         if not identified then
-            WARN('*FORMATION DEBUG: Unit ' .. u.UnitId .. ' was excluded from the formation because its layer could not be determined.')
+            WARN('*FORMATION DEBUG: Unit ' .. unit.UnitId .. ' was excluded from the formation because its layer could not be determined.')
         end
     end
 


### PR DESCRIPTION
**THIS IS NOT READY FOR REVIEW - LEAVE COMMENTS AT YOUR OWN PERIL**

_aka please don't :(_

basically: stop allocating 5-6KB each time formations are categorizing units and only allocate tables as necessary. initial testing shows minimum table size of 0.65KB so there's potential for improvement here 

<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->


## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->


## Additional context
<!-- Add any other context about the pull request here. -->


## Checklist
- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
