### PR TITLE
Revert delay to pause to 5 ticks when assisting to upgrade

### DIFF
--- a/changelog/snippets/fix.6819.md
+++ b/changelog/snippets/fix.6819.md
@@ -1,0 +1,3 @@
+- (#6819) Fix units not pausing after using the assist-to-upgrade feature
+
+With these changes we revert it to the old duration of waiting 5 ticks before pausing. We can look into it properly with the next major release.

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -378,7 +378,7 @@ local function UpgradeUnit(unit)
     print("Upgrade unit")
 
     -- wait one tick for the upgrade to start
-    WaitTicks(1)
+    WaitTicks(5)
 
     if IsDestroyed(unit) then
         return


### PR DESCRIPTION
## Description of the proposed changes

Reverts https://github.com/FAForever/fa/pull/6691
