### PR TITLE
Further refinements for factory transfer

### DIFF
--- a/changelog/snippets/fix.6821.md
+++ b/changelog/snippets/fix.6821.md
@@ -1,0 +1,3 @@
+- (#6821) Fix factory transfer when units that are meant to be rebuilt are restricted by HQ requirements.
+
+- (#6821) Fix transfer in the middle of factory transfer causing rebuilding to fail.

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -22,6 +22,7 @@ local buildersCategory = categories.ALLUNITS - categories.CONSTRUCTION - categor
 ---@param factoryRebuildDataTable FactoryRebuildDataTable
 function FactoryRebuildUnits(factoryRebuildDataTable)
     for buildUnitId, factories in factoryRebuildDataTable do
+        -- Remove support factories that can't build their unit due to lacking an HQ
         local noFactories = false
         for i, factory in factories do
             if not factory:CanBuild(buildUnitId) then

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -22,6 +22,19 @@ local buildersCategory = categories.ALLUNITS - categories.CONSTRUCTION - categor
 ---@param factoryRebuildDataTable FactoryRebuildDataTable
 function FactoryRebuildUnits(factoryRebuildDataTable)
     for buildUnitId, factories in factoryRebuildDataTable do
+        local noFactories = false
+        for i, factory in factories do
+            if not factory:CanBuild(buildUnitId) then
+                factories[i] = nil
+                if table.empty(factories) then
+                    factoryRebuildDataTable[buildUnitId] = nil
+                    noFactories = true
+                end
+                continue
+            end
+        end
+        if noFactories then continue end
+
         IssueClearCommands(factories)
         IssueBuildFactory(factories, buildUnitId, 1)
     end

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -40,8 +40,8 @@ function FactoryRebuildUnits(factoryRebuildDataTable)
     end
     -- wait for build order to start and then rebuild the units for free
     WaitTicks(1)
-    for k, factories in pairs(factoryRebuildDataTable) do
-        for i, factory in pairs(factories) do
+    for k, factories in factoryRebuildDataTable do
+        for i, factory in factories do
             if factory.Dead then
                 factories[i] = nil
                 if table.empty(factories) then
@@ -58,8 +58,8 @@ function FactoryRebuildUnits(factoryRebuildDataTable)
     end
     -- wait for buildpower to apply then return the factories to normal and pause them
     WaitTicks(1)
-    for k, factories in pairs(factoryRebuildDataTable) do
-        for i, factory in pairs(factories) do
+    for k, factories in factoryRebuildDataTable do
+        for i, factory in factories do
             if factory.Dead then
                 factories[i] = nil
                 if table.empty(factories) then

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -199,10 +199,10 @@ function TransferUnitsOwnership(units, toArmy, captured, noRestrictions)
         local defaultBuildRate
         local upgradeBuildTimeComplete
         local exclude
-        local FacRebuild_UnitId
-        local FacRebuild_Progress
-        local FacRebuild_BuildTime
-        local FacRebuild_Health
+        local FacRebuild_UnitId = unit.FacRebuild_UnitId
+        local FacRebuild_Progress = unit.FacRebuild_Progress
+        local FacRebuild_BuildTime = unit.FacRebuild_BuildTime
+        local FacRebuild_Health = unit.FacRebuild_Health
 
         local shield = unit.MyShield
         if shield then
@@ -394,6 +394,9 @@ function TransferUnitsOwnership(units, toArmy, captured, noRestrictions)
             else
                 table.insert(data, newFactoryUnit)
             end
+            -- store data for rebuilding
+            -- unit id is not needed during rebuild but is needed if transferred again in the middle of rebuild
+            newFactoryUnit.FacRebuild_UnitId = FacRebuild_UnitId
             newFactoryUnit.FacRebuild_Progress = FacRebuild_Progress
             newFactoryUnit.FacRebuild_BuildTime = FacRebuild_BuildTime
             newFactoryUnit.FacRebuild_Health = FacRebuild_Health

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -19,6 +19,16 @@ local buildersCategory = categories.ALLUNITS - categories.CONSTRUCTION - categor
 
 ---@alias FactoryRebuildDataTable table<UnitId, (FactoryUnit | FactoryRebuildData)[]>
 
+--- Clear data for a factory so transferring it doesn't try to rebuild units again
+---@param factory FactoryUnit | FactoryRebuildData
+local function clearFactoryRebuildData(factory)
+    factory.FacRebuild_UnitId = nil
+    factory.FacRebuild_Progress = nil
+    factory.FacRebuild_BuildTime = nil
+    factory.FacRebuild_Health = nil
+    factory.FacRebuild_OldBuildRate = nil
+end
+
 ---@param factoryRebuildDataTable FactoryRebuildDataTable
 function FactoryRebuildUnits(factoryRebuildDataTable)
     for buildUnitId, factories in factoryRebuildDataTable do
@@ -26,6 +36,7 @@ function FactoryRebuildUnits(factoryRebuildDataTable)
         local noFactories = false
         for i, factory in factories do
             if not factory:CanBuild(buildUnitId) then
+                clearFactoryRebuildData(factory)
                 factories[i] = nil
                 if table.empty(factories) then
                     factoryRebuildDataTable[buildUnitId] = nil
@@ -111,11 +122,7 @@ Health: %f
                 rebuiltUnit:SetHealth(nil, factory.FacRebuild_Health)
             end
 
-            -- clean up after the rebuilding
-            factory.FacRebuild_Progress = nil
-            factory.FacRebuild_BuildTime = nil
-            factory.FacRebuild_Health = nil
-            factory.FacRebuild_OldBuildRate = nil
+            clearFactoryRebuildData(factory)
         end
     end
 end


### PR DESCRIPTION
## Issue
Caused by https://github.com/FAForever/fa/pull/6784.
1. If you transfer a support factory building something it will give a warning message that the factory transfer failed. This is because the target army may not have an HQ to allow the support factory to build a given unit.
2. If you transfer a factory around too quickly (for example multiple players die at the same time), the rebuild data is lost.

## Description of the proposed changes
1. Removes factories that cannot build the given unit from the rebuild process.
2. Inherit transfer data from old factory unit in case the unit was transferred in the middle of rebuilding.

## Testing done on the proposed changes
Spawn an HQ and a support factory with Paragons to provide adequate resources for both armies:
```
   CreateUnitAtMouse('zrb9601', 0,    6.50,    9.50, -0.00000)
   CreateUnitAtMouse('xab1401', 1,   -2.50,  -19.50, -0.00000)
   CreateUnitAtMouse('xab1401', 0,   -2.50,    0.50, -0.00000)
   CreateUnitAtMouse('urb0301', 0,   -1.50,    9.50, -0.00000)
```

1. Build something restricted from the support factory and then transfer the factory by selecting it and using this command:
    - It no longer gives a warning in the log.

```
ConExecute([[SimLua 
ForkThread(function ()
    local focus = GetFocusArmy()
    local f = import('/lua/SimUtils.lua').TransferUnitsOwnership
    local units = DebugGetSelection()
    units = f(units, focus + 1, false)
    WaitTicks(10)
    f(units, focus, false)
end)
]])
```

2. Use the HQ to build something and then transfer it by selecting it and this command (it's the same as above but a shorter wait time):
   - It successfully rebuilds the unit despite the civilian never finishing the rebuild.
```
ConExecute([[SimLua 
ForkThread(function ()
    local focus = GetFocusArmy()
    local f = import('/lua/SimUtils.lua').TransferUnitsOwnership
    local units = DebugGetSelection()
    units = f(units, focus + 1, false)
    WaitTicks(3)
    f(units, focus, false)
end)
]])
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
