### PR TITLE
Proper type annotation for `GetCommandMode`

### DIFF
--- a/changelog/snippets/other.6823.md
+++ b/changelog/snippets/other.6823.md
@@ -1,0 +1,1 @@
+- (#6823) Proper type annotation for `GetCommandMode`.

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -249,11 +249,16 @@ function RestoreCommandMode(ignorePreviousCommands)
     end
 end
 
+---@class CommandModeTable
+---@field [1] CommandMode
+---@field [2] CommandModeData
+
 -- allocate the table once for performance
+---@type CommandModeTable
 local commandModeTable = {}
 
 --- Retrieves the current command mode information.
----@return { [1]: CommandModeDataOrder, [2]: CommandModeData }
+---@return CommandModeTable
 function GetCommandMode()
     commandModeTable[1] = commandMode
     commandModeTable[2] = modeData


### PR DESCRIPTION

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
