### PR TITLE
Fix factories destroying finished built units

### DIFF
--- a/changelog/snippets/fix.6824.md
+++ b/changelog/snippets/fix.6824.md
@@ -1,0 +1,1 @@
+- (#6824) Fix factory upgrades disappearing upon completion.

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -252,7 +252,9 @@ FactoryUnit = ClassUnit(StructureUnit) {
     DestroyUnitBeingBuilt = function(self)
         local unitBeingBuilt = self.UnitBeingBuilt --[[@as Unit]]
         -- unit is dead, so it should destroy itself
-        if not unitBeingBuilt.Dead and not IsDestroyed(unitBeingBuilt) then
+        if not unitBeingBuilt.Dead and not IsDestroyed(unitBeingBuilt)
+            and not unitBeingBuilt.isFinishedUnit
+        then
             unitBeingBuilt:Destroy()
         end
     end,


### PR DESCRIPTION
## Issue
Caused by #6784
There was no check if the unit being built was finished, so finished units, particularly factory upgrades, were being destroyed because no new unit started building before the factory was destroyed and the variable is cached even after the unit finishes.

## Description of the proposed changes
Check if the unit is finished.

## Testing done on the proposed changes
Factory upgrades no longer Destroy themselves on upgrade completion.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
