### PR TITLE
[performance][formations] Reuse unit categorization table instead of allocating a new one when issuing uncached formation orders

### DIFF
--- a/changelog/snippets/performance.6826.md
+++ b/changelog/snippets/performance.6826.md
@@ -1,0 +1,1 @@
+- (#6826) Reuse unit categorization table instead of allocating a new one when issuing uncached formation orders.

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1591,20 +1591,17 @@ function CategorizeUnits(formationUnits)
             for k in pairs(typeDataCategory) do
                 typeDataCategory[k] = nil
             end
-            table.setn(typeDataCategory, 0)
         end
 
         local footprintCounts = typeData.FootprintCounts
         for k in pairs(footprintCounts) do
             footprintCounts[k] = nil
         end
-        table.setn(footprintCounts, 0)
 
         local footprintSizes = typeData.FootprintSizes
         for k in pairs(footprintSizes) do
             footprintSizes[k] = nil
         end
-        table.setn(footprintSizes, 0)
 
         typeData.UnitTotal = 0
         typeData.AreaTotal = 0

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1565,23 +1565,50 @@ end
 
 -- reusable table for categorizing units in a formation 
 local UnitsList = {Land = {}, Air = {}, Naval = {}, Subs = {}}
+-- map layers to categories
+local CategoryTables = {Land = LandCategories, Air = AirCategories, Naval = NavalCategories, Subs = SubCategories}
+-- initialize the layer tables
+for unitType, categoriesForType in CategoryTables do
+    local typeData = UnitsList[unitType]
+    for unitTypeCategory, _ in categoriesForType do
+        typeData[unitTypeCategory] = {}
+    end
+    typeData.FootprintCounts = {}
+    typeData.FootprintSizes = {}
+end
 
 -- place units into formation categories, accumulate (unit type) & (unit type footprint counts by size), and map unit type category footprint size categories from blueprint id to global category of blueprint id
 ---@param formationUnits Unit[]
 ---@return table
 function CategorizeUnits(formationUnits)
-    local categoryTables = {Land = LandCategories, Air = AirCategories, Naval = NavalCategories, Subs = SubCategories}
+    local categoryTables = CategoryTables
 
-    -- flush and initialize the list
+    -- flush the table
     for unitType, categoriesForType in categoryTables do
         local typeData = UnitsList[unitType]
         for unitTypeCategory, _ in categoriesForType do
-            typeData[unitTypeCategory] = {}
+            local typeDataCategory = typeData[unitTypeCategory]
+            for k in pairs(typeDataCategory) do
+                typeDataCategory[k] = nil
+            end
+            table.setn(typeDataCategory, 0)
         end
+
+        local footprintCounts = typeData.FootprintCounts
+        for k in pairs(footprintCounts) do
+            footprintCounts[k] = nil
+        end
+        table.setn(footprintCounts, 0)
+
+        local footprintSizes = typeData.FootprintSizes
+        for k in pairs(footprintSizes) do
+            footprintSizes[k] = nil
+        end
+        table.setn(footprintSizes, 0)
+
         typeData.UnitTotal = 0
         typeData.AreaTotal = 0
-        typeData.FootprintCounts = {}
-        typeData.FootprintSizes = {}
+        typeData.Scale = nil -- set elsewhere in formations logic
     end
 
     -- Loop through each unit to get its category and size


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->

Issuing an uncached formation order always allocates a ~5KB table at the beginning of `CategorizeUnits`. By flushing a preallocated table the function byte code is ~2KB less.

**Known limitations:** *The overall table size increase is porportional to the number of different footprint sizes (combined area) for each unit type category (AKA Tech1AA, SubCount, etc.)*. Testing shows the table would get to 6.3KB and stay there. Worst case scenario: a player selects every possible unit in the game into a formation and never does it again. Mitigating this would require conditionally setting each of these unit type category footprint tables _which would require a dozen or two changes throughout the file_ so will not be done in the scope of this work _or_ `nil`ing the list entry and reallocating it again (which somewhat goes against the idea of reusing these tables).

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
### Simulate replay #24965988
Replay simulated without desyncs

Use `wld_RunWithTheWind`. Unrelated warnings (limited to `abstractannouncement`):
```
...
WARNING: Evaluating LazyVar failed: error evaluating lazy variable: ...fa\lua\ui\game\announcement\abstractannouncement.lua(332): attempt to call field `Left' (a nil value)
         stack traceback:
...
```

### Benchmarking

CPU: i7-6700k

Create [a benchmark for CategorizeUnits](https://github.com/ostrovaya/fa/blob/develop/lua/benchmarks/formations.lua). Set Profiler parameters to run 100 iterations instead of 10000. Collect samples.

develop @ 1c652a79bfde09257c78d8fe612333cfb606a6f6

![Screenshot from 2025-05-30 17-03-31](https://github.com/user-attachments/assets/8f71a997-70e1-454d-9062-9ccd0c486ce7)

performance-formation-categorize @ 4a87379eef6e23335dfdae325cdd8f1b481225d1

![Screenshot from 2025-05-31 10-55-44](https://github.com/user-attachments/assets/db9c94c7-1dbb-430e-b57f-faae3d8d4f19)


### Log bytecode

Modify code for logging
```lua
function AttackFormation(formationUnits)
    LOG('----- CategorizeUnits BYTE CODE -----') -- add this
    reprsl(debug.listcode(CategorizeUnits))      -- add this
    LOG('----- CategorizeUnits BYTE CODE -----') -- add this
    local cachedResults = GetCachedResults(formationUnits, 'AttackFormation')
    if cachedResults then
        return cachedResults
    end
```

Start a new game on Seton's Clutch with debugger attached and issue a move order on the ACU.
```
develop @ 1c652a79bfde09257c78d8fe612333cfb606a6f6

INFO: ----- CategorizeUnits BYTE CODE -----
INFO: { -- table: 1F997C80 (4216 bytes)
INFO:   "(1572)    0 - NEWTABLE       1    0    3",
INFO:   "(1573)    1 - NEWTABLE       2    0    6",
INFO:   "(1574)    2 - NEWTABLE       3    0    0",
INFO:   "(1574)    3 - SETTABLE       2  251    3",
INFO:   "(1574)    4 - NEWTABLE       3    0    0",
INFO:   "(1574)    5 - SETTABLE       2  252    3",
INFO:   "(1574)    6 - NEWTABLE       3    0    0",
INFO:   "(1574)    7 - SETTABLE       2  253    3",
INFO:   "(1574)    8 - NEWTABLE       3    0    0",
INFO:   "(1574)    9 - SETTABLE       2  254    3",
INFO:   "(1575)   10 - NEWTABLE       3    0    0",
INFO:   "(1575)   11 - SETTABLE       2  255    3",
INFO:   "(1575)   12 - NEWTABLE       3    0    0",
INFO:   "(1575)   13 - SETTABLE       2  256    3",
INFO:   "(1575)   14 - NEWTABLE       3    0    0",
INFO:   "(1575)   15 - SETTABLE       2  257    3",
INFO:   "(1575)   16 - NEWTABLE       3    0    0",
INFO:   "(1575)   17 - SETTABLE       2  258    3",
INFO:   "(1576)   18 - NEWTABLE       3    0    0",
INFO:   "(1576)   19 - SETTABLE       2  259    3",
INFO:   "(1576)   20 - NEWTABLE       3    0    0",
INFO:   "(1576)   21 - SETTABLE       2  260    3",
INFO:   "(1576)   22 - NEWTABLE       3    0    0",
INFO:   "(1576)   23 - SETTABLE       2  261    3",
INFO:   "(1576)   24 - NEWTABLE       3    0    0",
INFO:   "(1576)   25 - SETTABLE       2  262    3",
INFO:   "(1577)   26 - NEWTABLE       3    0    0",
INFO:   "(1577)   27 - SETTABLE       2  263    3",
INFO:   "(1577)   28 - NEWTABLE       3    0    0",
INFO:   "(1577)   29 - SETTABLE       2  264    3",
INFO:   "(1577)   30 - NEWTABLE       3    0    0",
INFO:   "(1577)   31 - SETTABLE       2  265    3",
INFO:   "(1577)   32 - NEWTABLE       3    0    0",
INFO:   "(1577)   33 - SETTABLE       2  266    3",
INFO:   "(1578)   34 - NEWTABLE       3    0    0",
INFO:   "(1578)   35 - SETTABLE       2  267    3",
INFO:   "(1578)   36 - NEWTABLE       3    0    0",
INFO:   "(1578)   37 - SETTABLE       2  268    3",
INFO:   "(1578)   38 - NEWTABLE       3    0    0",
INFO:   "(1578)   39 - SETTABLE       2  269    3",
INFO:   "(1579)   40 - NEWTABLE       3    0    0",
INFO:   "(1579)   41 - SETTABLE       2  270    3",
INFO:   "(1579)   42 - NEWTABLE       3    0    0",
INFO:   "(1579)   43 - SETTABLE       2  271    3",
INFO:   "(1579)   44 - NEWTABLE       3    0    0",
INFO:   "(1579)   45 - SETTABLE       2  272    3",
INFO:   "(1579)   46 - NEWTABLE       3    0    0",
INFO:   "(1579)   47 - SETTABLE       2  273    3",
INFO:   "(1580)   48 - NEWTABLE       3    0    0",
INFO:   "(1580)   49 - SETTABLE       2  274    3",
INFO:   "(1580)   50 - NEWTABLE       3    0    0",
INFO:   "(1580)   51 - SETTABLE       2  275    3",
INFO:   "(1580)   52 - NEWTABLE       3    0    0",
INFO:   "(1580)   53 - SETTABLE       2  276    3",
INFO:   "(1580)   54 - NEWTABLE       3    0    0",
INFO:   "(1580)   55 - SETTABLE       2  277    3",
INFO:   "(1581)   56 - NEWTABLE       3    0    0",
INFO:   "(1581)   57 - SETTABLE       2  278    3",
INFO:   "(1582)   58 - NEWTABLE       3    0    0",
INFO:   "(1582)   59 - SETTABLE       2  279    3",
INFO:   "(1584)   60 - SETTABLE       2  280  281",
INFO:   "(1585)   61 - SETTABLE       2  282  281",
INFO:   "(1586)   62 - NEWTABLE       3    0    0",
INFO:   "(1586)   63 - SETTABLE       2  283    3",
INFO:   "(1587)   64 - NEWTABLE       3    0    0",
INFO:   "(1587)   65 - SETTABLE       2  284    3",
INFO:   "(1588)   66 - SETTABLE       1  250    2",
INFO:   "(1590)   67 - NEWTABLE       2    0    5",
INFO:   "(1591)   68 - NEWTABLE       3    0    0",
INFO:   "(1591)   69 - SETTABLE       2  286    3",
INFO:   "(1591)   70 - NEWTABLE       3    0    0",
INFO:   "(1591)   71 - SETTABLE       2  287    3",
INFO:   "(1591)   72 - NEWTABLE       3    0    0",
INFO:   "(1591)   73 - SETTABLE       2  288    3",
INFO:   "(1592)   74 - NEWTABLE       3    0    0",
INFO:   "(1592)   75 - SETTABLE       2  289    3",
INFO:   "(1592)   76 - NEWTABLE       3    0    0",
INFO:   "(1592)   77 - SETTABLE       2  290    3",
INFO:   "(1592)   78 - NEWTABLE       3    0    0",
INFO:   "(1592)   79 - SETTABLE       2  291    3",
INFO:   "(1593)   80 - NEWTABLE       3    0    0",
INFO:   "(1593)   81 - SETTABLE       2  292    3",
INFO:   "(1593)   82 - NEWTABLE       3    0    0",
INFO:   "(1593)   83 - SETTABLE       2  293    3",
INFO:   "(1593)   84 - NEWTABLE       3    0    0",
INFO:   "(1593)   85 - SETTABLE       2  294    3",
INFO:   "(1594)   86 - NEWTABLE       3    0    0",
INFO:   "(1594)   87 - SETTABLE       2  267    3",
INFO:   "(1594)   88 - NEWTABLE       3    0    0",
INFO:   "(1594)   89 - SETTABLE       2  268    3",
INFO:   "(1594)   90 - NEWTABLE       3    0    0",
INFO:   "(1594)   91 - SETTABLE       2  269    3",
INFO:   "(1595)   92 - NEWTABLE       3    0    0",
INFO:   "(1595)   93 - SETTABLE       2  295    3",
INFO:   "(1595)   94 - NEWTABLE       3    0    0",
INFO:   "(1595)   95 - SETTABLE       2  296    3",
INFO:   "(1595)   96 - NEWTABLE       3    0    0",
INFO:   "(1595)   97 - SETTABLE       2  297    3",
INFO:   "(1596)   98 - NEWTABLE       3    0    0",
INFO:   "(1596)   99 - SETTABLE       2  298    3",
INFO:   "(1596)  100 - NEWTABLE       3    0    0",
INFO:   "(1596)  101 - SETTABLE       2  299    3",
INFO:   "(1596)  102 - NEWTABLE       3    0    0",
INFO:   "(1596)  103 - SETTABLE       2  300    3",
INFO:   "(1597)  104 - NEWTABLE       3    0    0",
INFO:   "(1597)  105 - SETTABLE       2  301    3",
INFO:   "(1598)  106 - NEWTABLE       3    0    0",
INFO:   "(1598)  107 - SETTABLE       2  302    3",
INFO:   "(1599)  108 - NEWTABLE       3    0    0",
INFO:   "(1599)  109 - SETTABLE       2  279    3",
INFO:   "(1601)  110 - SETTABLE       2  280  281",
INFO:   "(1602)  111 - SETTABLE       2  282  281",
INFO:   "(1603)  112 - NEWTABLE       3    0    0",
INFO:   "(1603)  113 - SETTABLE       2  283    3",
INFO:   "(1604)  114 - NEWTABLE       3    0    0",
INFO:   "(1604)  115 - SETTABLE       2  284    3",
INFO:   "(1605)  116 - SETTABLE       1  285    2",
INFO:   "(1607)  117 - NEWTABLE       2    0    4",
INFO:   "(1608)  118 - NEWTABLE       3    0    0",
INFO:   "(1608)  119 - SETTABLE       2  304    3",
INFO:   "(1609)  120 - NEWTABLE       3    0    0",
INFO:   "(1609)  121 - SETTABLE       2  305    3",
INFO:   "(1610)  122 - NEWTABLE       3    0    0",
INFO:   "(1610)  123 - SETTABLE       2  306    3",
INFO:   "(1611)  124 - NEWTABLE       3    0    0",
INFO:   "(1611)  125 - SETTABLE       2  307    3",
INFO:   "(1612)  126 - NEWTABLE       3    0    0",
INFO:   "(1612)  127 - SETTABLE       2  308    3",
INFO:   "(1613)  128 - NEWTABLE       3    0    0",
INFO:   "(1613)  129 - SETTABLE       2  309    3",
INFO:   "(1614)  130 - NEWTABLE       3    0    0",
INFO:   "(1614)  131 - SETTABLE       2  310    3",
INFO:   "(1615)  132 - NEWTABLE       3    0    0",
INFO:   "(1615)  133 - SETTABLE       2  311    3",
INFO:   "(1616)  134 - NEWTABLE       3    0    0",
INFO:   "(1616)  135 - SETTABLE       2  279    3",
INFO:   "(1618)  136 - SETTABLE       2  280  281",
INFO:   "(1619)  137 - SETTABLE       2  282  281",
INFO:   "(1620)  138 - NEWTABLE       3    0    0",
INFO:   "(1620)  139 - SETTABLE       2  283    3",
INFO:   "(1621)  140 - NEWTABLE       3    0    0",
INFO:   "(1621)  141 - SETTABLE       2  284    3",
INFO:   "(1622)  142 - SETTABLE       1  303    2",
INFO:   "(1624)  143 - NEWTABLE       2    0    3",
INFO:   "(1625)  144 - NEWTABLE       3    0    0",
INFO:   "(1625)  145 - SETTABLE       2  313    3",
INFO:   "(1627)  146 - SETTABLE       2  280  281",
INFO:   "(1628)  147 - SETTABLE       2  282  281",
INFO:   "(1629)  148 - NEWTABLE       3    0    0",
INFO:   "(1629)  149 - SETTABLE       2  283    3",
INFO:   "(1630)  150 - NEWTABLE       3    0    0",
INFO:   "(1630)  151 - SETTABLE       2  284    3",
INFO:   "(1631)  152 - SETTABLE       1  312    2",
INFO:   "(1634)  153 - NEWTABLE       2    0    3",
INFO:   "(1634)  154 - GETUPVAL       3    0    0",
INFO:   "(1634)  155 - SETTABLE       2  250    3",
INFO:   "(1634)  156 - GETUPVAL       3    1    0",
INFO:   "(1634)  157 - SETTABLE       2  285    3",
INFO:   "(1634)  158 - GETUPVAL       3    2    0",
INFO:   "(1634)  159 - SETTABLE       2  303    3",
INFO:   "(1634)  160 - GETUPVAL       3    3    0",
INFO:   "(1634)  161 - SETTABLE       2  312    3",
INFO:   "(1637)  162 - MOVE           3    0    0",
INFO:   "(1637)  163 - LOADNIL        4    6    0",
INFO:   "(1637)  164 - TFORPREP       3   97",
INFO:   "(1638)  165 - LOADBOOL       7    0    0",
INFO:   "(1639)  166 - MOVE           8    2    0",
INFO:   "(1639)  167 - LOADNIL        9   11    0",
INFO:   "(1639)  168 - TFORPREP       8   83",
INFO:   "(1640)  169 - MOVE          12   11    0",
INFO:   "(1640)  170 - LOADNIL       13   15    0",
INFO:   "(1640)  171 - TFORPREP      12   75",
INFO:   "(1641)  172 - GETGLOBAL     16   64",
INFO:   "(1641)  173 - GETTABLE      17   11   14",
INFO:   "(1641)  174 - MOVE          18    6    0",
INFO:   "(1641)  175 - CALL          16    3    2",
INFO:   "(1641)  176 - TEST          16   16    0",
INFO:   "(1641)  177 - JMP            0   69",
INFO:   "(1642)  178 - SELF          16    6  315",
INFO:   "(1642)  179 - CALL          16    2    2",
INFO:   "(1643)  180 - GETGLOBAL     17   66",
INFO:   "(1643)  181 - GETTABLE      17   17  317",
INFO:   "(1643)  182 - GETTABLE      18   16  318",
INFO:   "(1643)  183 - GETTABLE      18   18  319",
INFO:   "(1643)  184 - GETTABLE      19   16  318",
INFO:   "(1643)  185 - GETTABLE      19   19  320",
INFO:   "(1643)  186 - CALL          17    3    2",
INFO:   "(1644)  187 - GETTABLE      18   16  321",
INFO:   "(1646)  188 - GETTABLE      19    1   10",
INFO:   "(1646)  189 - GETTABLE      19   19   14",
INFO:   "(1646)  190 - GETTABLE      19   19   17",
INFO:   "(1646)  191 - TEST          19   19    1",
INFO:   "(1646)  192 - JMP            0    7",
INFO:   "(1647)  193 - GETTABLE      19    1   10",
INFO:   "(1647)  194 - GETTABLE      19   19   14",
INFO:   "(1647)  195 - NEWTABLE      20    0    2",
INFO:   "(1647)  196 - SETTABLE      20  322  281",
INFO:   "(1647)  197 - NEWTABLE      21    0    0",
INFO:   "(1647)  198 - SETTABLE      20  323   21",
INFO:   "(1647)  199 - SETTABLE      19   17   20",
INFO:   "(1649)  200 - GETTABLE      19    1   10",
INFO:   "(1649)  201 - GETTABLE      19   19   14",
INFO:   "(1649)  202 - GETTABLE      19   19   17",
INFO:   "(1649)  203 - GETTABLE      20    1   10",
INFO:   "(1649)  204 - GETTABLE      20   20   14",
INFO:   "(1649)  205 - GETTABLE      20   20   17",
INFO:   "(1649)  206 - GETTABLE      20   20  322",
INFO:   "(1649)  207 - ADD           20   20  324",
INFO:   "(1649)  208 - SETTABLE      19  322   20",
INFO:   "(1650)  209 - GETTABLE      19    1   10",
INFO:   "(1650)  210 - GETTABLE      19   19   14",
INFO:   "(1650)  211 - GETTABLE      19   19   17",
INFO:   "(1650)  212 - GETTABLE      19   19  323",
INFO:   "(1650)  213 - GETGLOBAL     20   75",
INFO:   "(1650)  214 - GETTABLE      20   20   18",
INFO:   "(1650)  215 - SETTABLE      19   18   20",
INFO:   "(1651)  216 - GETTABLE      19    1   10",
INFO:   "(1651)  217 - GETTABLE      19   19  283",
INFO:   "(1651)  218 - GETTABLE      20    1   10",
INFO:   "(1651)  219 - GETTABLE      20   20  283",
INFO:   "(1651)  220 - GETTABLE      20   20   17",
INFO:   "(1651)  221 - TEST          20   20    1",
INFO:   "(1651)  222 - JMP            0    1",
INFO:   "(1651)  223 - LOADK         20   31",
INFO:   "(1651)  224 - ADD           20   20  324",
INFO:   "(1651)  225 - SETTABLE      19   17   20",
INFO:   "(1653)  226 - EQ             0   14  279",
INFO:   "(1653)  227 - JMP            0   12",
INFO:   "(1654)  228 - GETGLOBAL     19   76",
INFO:   "(1654)  229 - LOADK         20   77",
INFO:   "(1654)  230 - GETGLOBAL     21   78",
INFO:   "(1654)  231 - SELF          22    6  315",
INFO:   "(1654)  232 - CALL          22    2    2",
INFO:   "(1654)  233 - GETTABLE      22   22  321",
INFO:   "(1654)  234 - CALL          21    2    2",
INFO:   "(1654)  235 - LOADK         22   79",
INFO:   "(1654)  236 - MOVE          23   10    0",
INFO:   "(1654)  237 - LOADK         24   80",
INFO:   "(1654)  238 - CONCAT        20   20   24",
INFO:   "(1654)  239 - CALL          19    2    1",
INFO:   "(1656)  240 - GETTABLE      19    1   10",
INFO:   "(1656)  241 - GETTABLE      20    1   10",
INFO:   "(1656)  242 - GETTABLE      20   20  280",
INFO:   "(1656)  243 - ADD           20   20  324",
INFO:   "(1656)  244 - SETTABLE      19  280   20",
INFO:   "(1657)  245 - LOADBOOL       7    1    0",
INFO:   "(1658)  246 - JMP            0    2",
INFO:   "(1640)  247 - TFORLOOP      12    0    1",
INFO:   "(1659)  248 - JMP            0  -77",
INFO:   "(1662)  249 - TEST           7    7    0",
INFO:   "(1662)  250 - JMP            0    1",
INFO:   "(1663)  251 - JMP            0    2",
INFO:   "(1639)  252 - TFORLOOP       8    0    1",
INFO:   "(1664)  253 - JMP            0  -85",
INFO:   "(1666)  254 - TEST           7    7    1",
INFO:   "(1666)  255 - JMP            0    6",
INFO:   "(1667)  256 - GETGLOBAL      8   81",
INFO:   "(1667)  257 - LOADK          9   77",
INFO:   "(1667)  258 - GETTABLE      10    6  332",
INFO:   "(1667)  259 - LOADK         11   83",
INFO:   "(1667)  260 - CONCAT         9    9   11",
INFO:   "(1667)  261 - CALL           8    2    1",
INFO:   "(1637)  262 - TFORLOOP       3    0    1",
INFO:   "(1668)  263 - JMP            0  -99",
INFO:   "(1672)  264 - MOVE           3    2    0",
INFO:   "(1672)  265 - LOADNIL        4    6    0",
INFO:   "(1672)  266 - TFORPREP       3   33",
INFO:   "(1673)  267 - MOVE           7    6    0",
INFO:   "(1673)  268 - LOADNIL        8   10    0",
INFO:   "(1673)  269 - TFORPREP       7   28",
INFO:   "(1674)  270 - GETTABLE      11    1    5",
INFO:   "(1674)  271 - GETTABLE      11   11    9",
INFO:   "(1674)  272 - TEST          11   11    0",
INFO:   "(1674)  273 - JMP            0   24",
INFO:   "(1675)  274 - GETTABLE      11    1    5",
INFO:   "(1675)  275 - GETTABLE      11   11    9",
INFO:   "(1675)  276 - LOADNIL       12   14    0",
INFO:   "(1675)  277 - TFORPREP      11   18",
INFO:   "(1676)  278 - LOADNIL       15   15    0",
INFO:   "(1677)  279 - GETTABLE      16   14  323",
INFO:   "(1677)  280 - LOADNIL       17   19    0",
INFO:   "(1677)  281 - TFORPREP      16    5",
INFO:   "(1678)  282 - TEST          15   15    1",
INFO:   "(1678)  283 - JMP            0    2",
INFO:   "(1679)  284 - MOVE          15   19    0",
INFO:   "(1679)  285 - JMP            0    1",
INFO:   "(1681)  286 - ADD           15   15   19",
INFO:   "(1677)  287 - TFORLOOP      16    0    1",
INFO:   "(1682)  288 - JMP            0   -7",
INFO:   "(1684)  289 - GETTABLE      16    1    5",
INFO:   "(1684)  290 - GETTABLE      16   16    9",
INFO:   "(1684)  291 - NEWTABLE      17    0    2",
INFO:   "(1684)  292 - GETTABLE      18   14  322",
INFO:   "(1684)  293 - SETTABLE      17  322   18",
INFO:   "(1684)  294 - SETTABLE      17  334   15",
INFO:   "(1684)  295 - SETTABLE      16   13   17",
INFO:   "(1675)  296 - TFORLOOP      11    0    1",
INFO:   "(1684)  297 - JMP            0  -20",
INFO:   "(1673)  298 - TFORLOOP       7    0    1",
INFO:   "(1686)  299 - JMP            0  -30",
INFO:   "(1672)  300 - TFORLOOP       3    0    1",
INFO:   "(1687)  301 - JMP            0  -35",
INFO:   "(1690)  302 - GETGLOBAL      3   85",
INFO:   "(1690)  303 - MOVE           4    1    0",
INFO:   "(1690)  304 - CALL           3    2    1",
INFO:   "(1692)  305 - RETURN         1    2    0",
INFO:   "(1693)  306 - RETURN         0    1    0",
INFO:   maxstack = 25,
INFO:   numparams = 1
INFO: }
INFO: ----- CategorizeUnits BYTE CODE -----
```

```
performance-formation-categorize @ d62afb9da2883984c285e336162e11de1f6bb25e

INFO: ----- CategorizeUnits BYTE CODE -----
INFO: { -- table: 1C0EF730 (2168 bytes)
INFO:   "(1587)    0 - GETUPVAL       1    0    0",
INFO:   "(1590)    1 - MOVE           2    1    0",
INFO:   "(1590)    2 - LOADNIL        3    5    0",
INFO:   "(1590)    3 - TFORPREP       2   34",
INFO:   "(1591)    4 - GETUPVAL       6    1    0",
INFO:   "(1591)    5 - GETTABLE       6    6    4",
INFO:   "(1592)    6 - MOVE           7    5    0",
INFO:   "(1592)    7 - LOADNIL        8   10    0",
INFO:   "(1592)    8 - TFORPREP       7    8",
INFO:   "(1593)    9 - GETTABLE      11    6    9",
INFO:   "(1594)   10 - GETGLOBAL     12    0",
INFO:   "(1594)   11 - MOVE          13   11    0",
INFO:   "(1594)   12 - CALL          12    2    4",
INFO:   "(1594)   13 - TFORPREP      12    1",
INFO:   "(1595)   14 - SETTABLE      11   14  251",
INFO:   "(1594)   15 - TFORLOOP      12    0    0",
INFO:   "(1595)   16 - JMP            0   -3",
INFO:   "(1592)   17 - TFORLOOP       7    0    1",
INFO:   "(1596)   18 - JMP            0  -10",
INFO:   "(1599)   19 - GETTABLE       7    6  252",
INFO:   "(1600)   20 - GETGLOBAL      8    0",
INFO:   "(1600)   21 - MOVE           9    7    0",
INFO:   "(1600)   22 - CALL           8    2    4",
INFO:   "(1600)   23 - TFORPREP       8    1",
INFO:   "(1601)   24 - SETTABLE       7   10  251",
INFO:   "(1600)   25 - TFORLOOP       8    0    0",
INFO:   "(1601)   26 - JMP            0   -3",
INFO:   "(1604)   27 - GETTABLE       8    6  253",
INFO:   "(1605)   28 - GETGLOBAL      9    0",
INFO:   "(1605)   29 - MOVE          10    8    0",
INFO:   "(1605)   30 - CALL           9    2    4",
INFO:   "(1605)   31 - TFORPREP       9    1",
INFO:   "(1606)   32 - SETTABLE       8   11  251",
INFO:   "(1605)   33 - TFORLOOP       9    0    0",
INFO:   "(1606)   34 - JMP            0   -3",
INFO:   "(1609)   35 - SETTABLE       6  254  255",
INFO:   "(1610)   36 - SETTABLE       6  256  255",
INFO:   "(1611)   37 - SETTABLE       6  257  251",
INFO:   "(1590)   38 - TFORLOOP       2    0    1",
INFO:   "(1611)   39 - JMP            0  -36",
INFO:   "(1615)   40 - MOVE           2    0    0",
INFO:   "(1615)   41 - LOADNIL        3    5    0",
INFO:   "(1615)   42 - TFORPREP       2  106",
INFO:   "(1616)   43 - LOADBOOL       6    0    0",
INFO:   "(1617)   44 - MOVE           7    1    0",
INFO:   "(1617)   45 - LOADNIL        8   10    0",
INFO:   "(1617)   46 - TFORPREP       7   92",
INFO:   "(1618)   47 - MOVE          11   10    0",
INFO:   "(1618)   48 - LOADNIL       12   14    0",
INFO:   "(1618)   49 - TFORPREP      11   84",
INFO:   "(1619)   50 - GETGLOBAL     15    8",
INFO:   "(1619)   51 - GETTABLE      16   10   13",
INFO:   "(1619)   52 - MOVE          17    5    0",
INFO:   "(1619)   53 - CALL          15    3    2",
INFO:   "(1619)   54 - TEST          15   15    0",
INFO:   "(1619)   55 - JMP            0   78",
INFO:   "(1620)   56 - SELF          15    5  259",
INFO:   "(1620)   57 - CALL          15    2    2",
INFO:   "(1621)   58 - GETGLOBAL     16   10",
INFO:   "(1621)   59 - GETTABLE      16   16  261",
INFO:   "(1621)   60 - GETTABLE      17   15  262",
INFO:   "(1621)   61 - GETTABLE      17   17  263",
INFO:   "(1621)   62 - GETTABLE      18   15  262",
INFO:   "(1621)   63 - GETTABLE      18   18  264",
INFO:   "(1621)   64 - CALL          16    3    2",
INFO:   "(1622)   65 - GETTABLE      17   15  265",
INFO:   "(1624)   66 - GETUPVAL      18    1    0",
INFO:   "(1624)   67 - GETTABLE      18   18    9",
INFO:   "(1624)   68 - GETTABLE      18   18   13",
INFO:   "(1624)   69 - GETTABLE      18   18   16",
INFO:   "(1624)   70 - TEST          18   18    1",
INFO:   "(1624)   71 - JMP            0    8",
INFO:   "(1625)   72 - GETUPVAL      18    1    0",
INFO:   "(1625)   73 - GETTABLE      18   18    9",
INFO:   "(1625)   74 - GETTABLE      18   18   13",
INFO:   "(1625)   75 - NEWTABLE      19    0    2",
INFO:   "(1625)   76 - SETTABLE      19  266  255",
INFO:   "(1625)   77 - NEWTABLE      20    0    0",
INFO:   "(1625)   78 - SETTABLE      19  267   20",
INFO:   "(1625)   79 - SETTABLE      18   16   19",
INFO:   "(1627)   80 - GETUPVAL      18    1    0",
INFO:   "(1627)   81 - GETTABLE      18   18    9",
INFO:   "(1627)   82 - GETTABLE      18   18   13",
INFO:   "(1627)   83 - GETTABLE      18   18   16",
INFO:   "(1627)   84 - GETUPVAL      19    1    0",
INFO:   "(1627)   85 - GETTABLE      19   19    9",
INFO:   "(1627)   86 - GETTABLE      19   19   13",
INFO:   "(1627)   87 - GETTABLE      19   19   16",
INFO:   "(1627)   88 - GETTABLE      19   19  266",
INFO:   "(1627)   89 - ADD           19   19  268",
INFO:   "(1627)   90 - SETTABLE      18  266   19",
INFO:   "(1628)   91 - GETUPVAL      18    1    0",
INFO:   "(1628)   92 - GETTABLE      18   18    9",
INFO:   "(1628)   93 - GETTABLE      18   18   13",
INFO:   "(1628)   94 - GETTABLE      18   18   16",
INFO:   "(1628)   95 - GETTABLE      18   18  267",
INFO:   "(1628)   96 - GETGLOBAL     19   19",
INFO:   "(1628)   97 - GETTABLE      19   19   17",
INFO:   "(1628)   98 - SETTABLE      18   17   19",
INFO:   "(1629)   99 - GETUPVAL      18    1    0",
INFO:   "(1629)  100 - GETTABLE      18   18    9",
INFO:   "(1629)  101 - GETTABLE      18   18  252",
INFO:   "(1629)  102 - GETUPVAL      19    1    0",
INFO:   "(1629)  103 - GETTABLE      19   19    9",
INFO:   "(1629)  104 - GETTABLE      19   19  252",
INFO:   "(1629)  105 - GETTABLE      19   19   16",
INFO:   "(1629)  106 - TEST          19   19    1",
INFO:   "(1629)  107 - JMP            0    1",
INFO:   "(1629)  108 - LOADK         19    5",
INFO:   "(1629)  109 - ADD           19   19  268",
INFO:   "(1629)  110 - SETTABLE      18   16   19",
INFO:   "(1631)  111 - EQ             0   13  270",
INFO:   "(1631)  112 - JMP            0   12",
INFO:   "(1632)  113 - GETGLOBAL     18   21",
INFO:   "(1632)  114 - LOADK         19   22",
INFO:   "(1632)  115 - GETGLOBAL     20   23",
INFO:   "(1632)  116 - SELF          21    5  259",
INFO:   "(1632)  117 - CALL          21    2    2",
INFO:   "(1632)  118 - GETTABLE      21   21  265",
INFO:   "(1632)  119 - CALL          20    2    2",
INFO:   "(1632)  120 - LOADK         21   24",
INFO:   "(1632)  121 - MOVE          22    9    0",
INFO:   "(1632)  122 - LOADK         23   25",
INFO:   "(1632)  123 - CONCAT        19   19   23",
INFO:   "(1632)  124 - CALL          18    2    1",
INFO:   "(1634)  125 - GETUPVAL      18    1    0",
INFO:   "(1634)  126 - GETTABLE      18   18    9",
INFO:   "(1634)  127 - GETUPVAL      19    1    0",
INFO:   "(1634)  128 - GETTABLE      19   19    9",
INFO:   "(1634)  129 - GETTABLE      19   19  254",
INFO:   "(1634)  130 - ADD           19   19  268",
INFO:   "(1634)  131 - SETTABLE      18  254   19",
INFO:   "(1635)  132 - LOADBOOL       6    1    0",
INFO:   "(1636)  133 - JMP            0    2",
INFO:   "(1618)  134 - TFORLOOP      11    0    1",
INFO:   "(1637)  135 - JMP            0  -86",
INFO:   "(1640)  136 - TEST           6    6    0",
INFO:   "(1640)  137 - JMP            0    1",
INFO:   "(1641)  138 - JMP            0    2",
INFO:   "(1617)  139 - TFORLOOP       7    0    1",
INFO:   "(1642)  140 - JMP            0  -94",
INFO:   "(1644)  141 - TEST           6    6    1",
INFO:   "(1644)  142 - JMP            0    6",
INFO:   "(1645)  143 - GETGLOBAL      7   26",
INFO:   "(1645)  144 - LOADK          8   22",
INFO:   "(1645)  145 - GETTABLE       9    5  277",
INFO:   "(1645)  146 - LOADK         10   28",
INFO:   "(1645)  147 - CONCAT         8    8   10",
INFO:   "(1645)  148 - CALL           7    2    1",
INFO:   "(1615)  149 - TFORLOOP       2    0    1",
INFO:   "(1646)  150 - JMP            0 -108",
INFO:   "(1650)  151 - MOVE           2    1    0",
INFO:   "(1650)  152 - LOADNIL        3    5    0",
INFO:   "(1650)  153 - TFORPREP       2   36",
INFO:   "(1651)  154 - MOVE           6    5    0",
INFO:   "(1651)  155 - LOADNIL        7    9    0",
INFO:   "(1651)  156 - TFORPREP       6   31",
INFO:   "(1652)  157 - GETUPVAL      10    1    0",
INFO:   "(1652)  158 - GETTABLE      10   10    4",
INFO:   "(1652)  159 - GETTABLE      10   10    8",
INFO:   "(1652)  160 - TEST          10   10    0",
INFO:   "(1652)  161 - JMP            0   26",
INFO:   "(1653)  162 - GETUPVAL      10    1    0",
INFO:   "(1653)  163 - GETTABLE      10   10    4",
INFO:   "(1653)  164 - GETTABLE      10   10    8",
INFO:   "(1653)  165 - LOADNIL       11   13    0",
INFO:   "(1653)  166 - TFORPREP      10   19",
INFO:   "(1654)  167 - LOADNIL       14   14    0",
INFO:   "(1655)  168 - GETTABLE      15   13  267",
INFO:   "(1655)  169 - LOADNIL       16   18    0",
INFO:   "(1655)  170 - TFORPREP      15    5",
INFO:   "(1656)  171 - TEST          14   14    1",
INFO:   "(1656)  172 - JMP            0    2",
INFO:   "(1657)  173 - MOVE          14   18    0",
INFO:   "(1657)  174 - JMP            0    1",
INFO:   "(1659)  175 - ADD           14   14   18",
INFO:   "(1655)  176 - TFORLOOP      15    0    1",
INFO:   "(1660)  177 - JMP            0   -7",
INFO:   "(1662)  178 - GETUPVAL      15    1    0",
INFO:   "(1662)  179 - GETTABLE      15   15    4",
INFO:   "(1662)  180 - GETTABLE      15   15    8",
INFO:   "(1662)  181 - NEWTABLE      16    0    2",
INFO:   "(1662)  182 - GETTABLE      17   13  266",
INFO:   "(1662)  183 - SETTABLE      16  266   17",
INFO:   "(1662)  184 - SETTABLE      16  279   14",
INFO:   "(1662)  185 - SETTABLE      15   12   16",
INFO:   "(1653)  186 - TFORLOOP      10    0    1",
INFO:   "(1662)  187 - JMP            0  -21",
INFO:   "(1651)  188 - TFORLOOP       6    0    1",
INFO:   "(1664)  189 - JMP            0  -33",
INFO:   "(1650)  190 - TFORLOOP       2    0    1",
INFO:   "(1665)  191 - JMP            0  -38",
INFO:   "(1668)  192 - GETGLOBAL      2   30",
INFO:   "(1668)  193 - GETUPVAL       3    1    0",
INFO:   "(1668)  194 - CALL           2    2    1",
INFO:   "(1670)  195 - GETUPVAL       2    1    0",
INFO:   "(1670)  196 - RETURN         2    2    0",
INFO:   "(1671)  197 - RETURN         0    1    0",
INFO:   maxstack = 24,
INFO:   numparams = 1
INFO: }
INFO: ----- CategorizeUnits BYTE CODE -----
```


## Additional context
<!-- Add any other context about the pull request here. -->

## Checklist
- [X] Changes are annotated, including comments where useful
- [X] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
