### PR TITLE
Fix profiler's `RemoveOutliers` when there is 0 IQR

### DIFF
--- a/changelog/snippets/fix.6833.md
+++ b/changelog/snippets/fix.6833.md
@@ -1,0 +1,1 @@
+- (#6833) Fix profiler discarding all benchmark data as outliers when all data points are the same exact value.

--- a/lua/shared/statistics.lua
+++ b/lua/shared/statistics.lua
@@ -156,7 +156,7 @@ function RemoveOutliers(t, n)
     local size = 0
     for i = 1, n do
         local result = sorted[i]
-        if math.abs(result - q2) < iqr15 then
+        if math.abs(result - q2) <= iqr15 then
             size = size + 1
             trimmed[size] = result
         end


### PR DESCRIPTION
## Issue
When all benchmark runs give the same exact results, all the results are removed from the final displayed statistics because they are within 1.5x of the IQR (which is 0), and are considered outliers. This shouldn't happen, as the comment for the function says that outliers are points "more than" 1.5x IQR, so keeping values equal to 1.5x IQR is correct.

## Description of the proposed changes
Don't consider points as outliers when they are equal to 1.5x the IQR.

## Testing done on the proposed changes
Fast benchmarks that return the exact same results now have data outputs instead of just all being zeroes.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
