### PR TITLE
Revert "Fix factories not immediately building queue after finished upgrades or cancelled land/navy units"

### DIFF
--- a/changelog/snippets/fix.6835.md
+++ b/changelog/snippets/fix.6835.md
@@ -1,0 +1,1 @@
+- (#6835) Revert the change that made factories immediately start building after an upgrade or after cancelling a unit, since it seems to be causing occassional desyncs.

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -1,7 +1,4 @@
 
-local Unit = import("/lua/sim/unit.lua").Unit
-local UnitOnStopBuild = Unit.OnStopBuild
-
 local StructureUnit = import("/lua/sim/units/structureunit.lua").StructureUnit
 local StructureUnitOnCreate = StructureUnit.OnCreate
 local StructureUnitOnDestroy = StructureUnit.OnDestroy
@@ -201,8 +198,6 @@ FactoryUnit = ClassUnit(StructureUnit) {
 
     ---@param self FactoryUnit
     OnFailedToBuild = function(self)
-        -- Instantly clear the build area so the next build can start, since unit `Destroy` doesn't do so.
-        self.UnitBeingBuilt:SetCollisionShape('None')
         StructureUnitOnFailedToBuild(self)
         self.FactoryBuildFailed = true
         self:StopBuildFx()
@@ -466,30 +461,6 @@ FactoryUnit = ClassUnit(StructureUnit) {
         ---@param self FactoryUnit
         Main = function(self)
             self:RolloffBody()
-        end,
-    },
-
-    UpgradingState = State(StructureUnit.UpgradingState) {
-        --- Adapted from StructureUnit to unblock the build area when the factory upgrade finishes.
-        ---@param self FactoryUnit
-        ---@param unitBuilding Unit
-        ---@param order string
-        OnStopBuild = function(self, unitBuilding, order)
-            UnitOnStopBuild(self, unitBuilding, order)
-            self:EnableDefaultToggleCaps()
-
-            if unitBuilding:GetFractionComplete() == 1 then
-                NotifyUpgrade(self, unitBuilding)
-                self:StopUpgradeEffects(unitBuilding)
-                self:PlayUnitSound('UpgradeEnd')
-
-                -- Since `Destroy` wouldn't do so, immediately unblock the build area
-                -- of the new factory by setting collision shape to none. This allows
-                -- the new factory to immediately start working on its queue.
-                self:SetCollisionShape("None")
-
-                self:Destroy()
-            end
         end,
     },
 


### PR DESCRIPTION
Reverts FAForever/fa#6692

Resolves #6836

I think it may be causing desyncs, I would like to merge it in and see if reports of desyncs decrease.