### PR TITLE
Improve annotations related to Buffs

### DIFF
--- a/changelog/snippets/other.6837.md
+++ b/changelog/snippets/other.6837.md
@@ -1,0 +1,1 @@
+- (#6837) Improve annotations related to Buffs.

--- a/lua/sim/AdjacencyBuffFunctions.lua
+++ b/lua/sim/AdjacencyBuffFunctions.lua
@@ -14,7 +14,7 @@ local TableGetn = table.getn
 
 ---@param buff BlueprintBuff unused
 ---@param unit StructureUnit
----@param instigator StructureUnit
+---@param instigator? StructureUnit
 DefaultBuffRemove = function(buff, unit, instigator)
     unit:DestroyAdjacentEffects(instigator)
 end
@@ -142,7 +142,7 @@ end
 
 ---@param buff BlueprintBuff
 ---@param unit StructureUnit
----@param instigator StructureUnit
+---@param instigator? StructureUnit
 EnergyWeaponBuffRemove = function(buff, unit, instigator)
     DefaultBuffRemove(buff, unit, instigator)
 end
@@ -193,7 +193,7 @@ end
 
 ---@param buff BlueprintBuff
 ---@param unit StructureUnit
----@param instigator StructureUnit
+---@param instigator? StructureUnit
 EnergyProductionBuffRemove = function(buff, unit, instigator)
     DefaultBuffRemove(buff, unit, instigator)
 end
@@ -219,7 +219,7 @@ end
 
 ---@param buff BlueprintBuff
 ---@param unit StructureUnit
----@param instigator StructureUnit
+---@param instigator? StructureUnit
 MassProductionBuffRemove = function(buff, unit, instigator)
     DefaultBuffRemove(buff, unit, instigator)
 end

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -53,7 +53,7 @@
 ---@param buffName string
 ---@param affectType string
 ---@param initialVal integer
----@param initialBool boolean
+---@param initialBool? boolean
 ---@return number, boolean
 local BuffRegenFieldCalculate = function (unit, buffName, affectType, initialVal, initialBool)
 

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -115,7 +115,7 @@ local BuffRegenFieldCalculate = function (unit, buffName, affectType, initialVal
 
                 -- If >1 it's probably deliberate, but silly, so let's bail. If it's THAT deliberate
                 -- they will remove this
-                if v.Mult > 1 then WARN('Regen mult too high, should be <1, for unit ' .. unit.UnitId .. ' and buff ' .. buffName) return end
+                if v.Mult > 1 then WARN('Regen mult too high, should be <1, for unit ' .. unit.UnitId .. ' and buff ' .. buffName) return initialVal, bool end
 
                 -- GPG default for mult is 1. To avoid changing loads of scripts for now, let's do this
                 if v.Mult ~= 1 then
@@ -210,7 +210,7 @@ function BuffCalculate(unit, buffName, affectType, initialVal, initialBool)
 
                 -- If >1 it's probably deliberate, but silly, so let's bail. If it's THAT deliberate
                 -- they will remove this
-                if v.Mult > 1 then WARN('Regen mult too high, should be <1, for unit ' .. unit.UnitId .. ' and buff ' .. buffName) return end
+                if v.Mult > 1 then WARN('Regen mult too high, should be <1, for unit ' .. unit.UnitId .. ' and buff ' .. buffName) return initialVal, bool end
 
                 -- GPG default for mult is 1. To avoid changing loads of scripts for now, let's do this
                 if v.Mult ~= 1 then

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -249,10 +249,15 @@ end
 -- that was on the unit. However, this doesn't work for stunned units because it's a fire-and-forget
 -- type buff, not a fire-and-keep-track-of type buff.
 BuffEffects = {
-
-    Stun = function(buffDef, buffValues, unit, buffName, instigator, afterRemove) -- most dont use the last two args, so most don't have them. This is fine.
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
+    ---@param instigator Unit # can be the unit itself
+    ---@param afterRemove boolean
+    Stun = function(buffDefinition, buffValues, unit, buffName, instigator, afterRemove) -- most dont use the last two args, so most don't have them. This is fine.
         if unit.ImmuneToStun or afterRemove then return end
-        unit:SetStunned(buffDef.Duration or 1, instigator)
+        unit:SetStunned(buffDefinition.Duration or 1, instigator)
         if unit.Anims then
             for k, manip in unit.Anims do
                 manip:SetRate(0)
@@ -261,6 +266,11 @@ BuffEffects = {
     end,
 
     --- Quite confident that this one is broken
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
+    ---@param instigator Unit # can be the unit itself
     Health = function(buffDefinition, buffValues, unit, buffName, instigator)
         -- Note: With health we don't actually look at the unit's table because it's an instant
         -- happening. We don't want to overcalculate something as pliable as health.
@@ -282,6 +292,10 @@ BuffEffects = {
         end
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     MaxHealth = function(buffDefinition, buffValues, unit, buffName)
         -- With this type of buff, the idea is to adjust the Max Health of a unit.
         -- The DoNotFill flag is set when we want to adjust the max ONLY and not have the
@@ -300,6 +314,10 @@ BuffEffects = {
         end
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     Regen = function(buffDefinition, buffValues, unit, buffName)
         -- Adjusted to use a special case of adding mults and calculating the final value
         -- in BuffCalculate to fix bugs where adds and mults would clash or cancel
@@ -309,6 +327,10 @@ BuffEffects = {
         unit:SetRegen(val)
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     Damage = function(buffDefinition, buffValues, unit, buffName)
         for i = 1, unit:GetWeaponCount() do
             local wep = unit:GetWeapon(i)
@@ -328,6 +350,10 @@ BuffEffects = {
         end
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     DamageRadius = function(buffDefinition, buffValues, unit, buffName)
         for i = 1, unit:GetWeaponCount() do
             local wep = unit:GetWeapon(i)
@@ -339,6 +365,10 @@ BuffEffects = {
         end
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     MaxRadius = function(buffDefinition, buffValues, unit, buffName)
         for i = 1, unit:GetWeaponCount() do
             local wep = unit:GetWeapon(i)
@@ -350,6 +380,10 @@ BuffEffects = {
         end
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     MoveMult = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'MoveMult', 1)
         unit:SetSpeedMult(val)
@@ -357,6 +391,10 @@ BuffEffects = {
         unit:SetTurnMult(val)
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     WeaponsEnable = function(buffDefinition, buffValues, unit, buffName)
         for i = 1, unit:GetWeaponCount() do
             local wep = unit:GetWeapon(i)
@@ -365,11 +403,19 @@ BuffEffects = {
         end
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     VisionRadius = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'VisionRadius', unit:GetBlueprint().Intel.VisionRadius or 0)
         unit:SetIntelRadius('Vision', val)
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     RadarRadius = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'RadarRadius', unit:GetBlueprint().Intel.RadarRadius or 0)
         if not unit:IsIntelEnabled('Radar') then
@@ -385,6 +431,10 @@ BuffEffects = {
         end
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     OmniRadius = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'OmniRadius', unit:GetBlueprint().Intel.OmniRadius or 0)
         if not unit:IsIntelEnabled('Omni') then
@@ -400,48 +450,81 @@ BuffEffects = {
         end
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     BuildRate = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'BuildRate', unit:GetBlueprint().Economy.BuildRate or 1)
         unit:SetBuildRate(val)
     end,
 
-    -------- ADJACENCY BELOW --------
+    --#region Adjacency Buffs
+
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     EnergyActive = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'EnergyActive', 1)
         unit.EnergyBuildAdjMod = val
         unit:UpdateConsumptionValues()
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     MassActive = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'MassActive', 1)
         unit.MassBuildAdjMod = val
         unit:UpdateConsumptionValues()
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     EnergyMaintenance = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'EnergyMaintenance', 1)
         unit.EnergyMaintAdjMod = val
         unit:UpdateConsumptionValues()
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     MassMaintenance = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'MassMaintenance', 1)
         unit.MassMaintAdjMod = val
         unit:UpdateConsumptionValues()
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     EnergyProduction = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'EnergyProduction', 1)
         unit.EnergyProdAdjMod = val
         unit:UpdateProductionValues()
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     MassProduction = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'MassProduction', 1)
         unit.MassProdAdjMod = val
         unit:UpdateProductionValues()
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     EnergyWeapon = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'EnergyWeapon', 1)
         for i = 1, unit:GetWeaponCount() do
@@ -452,6 +535,10 @@ BuffEffects = {
         end
     end,
 
+    ---@param buffDefinition BlueprintBuff
+    ---@param buffValues BlueprintBuffAffect
+    ---@param unit Unit
+    ---@param buffName BuffName
     RateOfFire = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'RateOfFire', 1)
 
@@ -464,6 +551,7 @@ BuffEffects = {
         end
     end,
 
+    --#endregion
 }
 
 local buffMissingWarnings = {}

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -55,7 +55,7 @@
 ---@param initialVal integer
 ---@param initialBool? boolean
 ---@return number, boolean
-local BuffRegenFieldCalculate = function (unit, buffName, affectType, initialVal, initialBool)
+local BuffRegenFieldCalculate = function(unit, buffName, affectType, initialVal, initialBool)
 
     local adds = 0
     local mults = 1.0
@@ -120,12 +120,12 @@ local BuffRegenFieldCalculate = function (unit, buffName, affectType, initialVal
                 -- GPG default for mult is 1. To avoid changing loads of scripts for now, let's do this
                 if v.Mult ~= 1 then
                     local maxHealth = unit:GetBlueprint().Defense.MaxHealth
-                    for i=1,v.Count do
+                    for i = 1, v.Count do
                         multsTotal = multsTotal + math.min((v.Mult * maxHealth), ceil)
                     end
                 end
             else
-                for i=1,v.Count do
+                for i = 1, v.Count do
                     mults = mults * v.Mult
                 end
             end
@@ -145,7 +145,7 @@ local BuffRegenFieldCalculate = function (unit, buffName, affectType, initialVal
 end
 
 -- A key -> function table for buffs, uses the buffName parameter
-local UniqueBuffs = { }
+local UniqueBuffs = {}
 UniqueBuffs['SeraphimACURegenAura'] = BuffRegenFieldCalculate
 UniqueBuffs['SeraphimACUAdvancedRegenAura'] = BuffRegenFieldCalculate
 
@@ -215,12 +215,12 @@ function BuffCalculate(unit, buffName, affectType, initialVal, initialBool)
                 -- GPG default for mult is 1. To avoid changing loads of scripts for now, let's do this
                 if v.Mult ~= 1 then
                     local maxHealth = unit:GetBlueprint().Defense.MaxHealth
-                    for i=1,v.Count do
+                    for i = 1, v.Count do
                         multsTotal = multsTotal + math.min((v.Mult * maxHealth), ceil or 99999)
                     end
                 end
             else
-                for i=1,v.Count do
+                for i = 1, v.Count do
                     mults = mults * v.Mult
                 end
             end
@@ -419,7 +419,7 @@ BuffEffects = {
     RadarRadius = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'RadarRadius', unit:GetBlueprint().Intel.RadarRadius or 0)
         if not unit:IsIntelEnabled('Radar') then
-            unit:InitIntel(unit.Army,'Radar', val)
+            unit:InitIntel(unit.Army, 'Radar', val)
             unit:EnableIntel('Radar')
         else
             unit:SetIntelRadius('Radar', val)
@@ -438,7 +438,7 @@ BuffEffects = {
     OmniRadius = function(buffDefinition, buffValues, unit, buffName)
         local val = BuffCalculate(unit, buffName, 'OmniRadius', unit:GetBlueprint().Intel.OmniRadius or 0)
         if not unit:IsIntelEnabled('Omni') then
-            unit:InitIntel(unit.Army,'Omni', val)
+            unit:InitIntel(unit.Army, 'Omni', val)
             unit:EnableIntel('Omni')
         else
             unit:SetIntelRadius('Omni', val)
@@ -578,7 +578,7 @@ function BuffAffectUnit(unit, buffName, instigator, afterRemove)
             BuffEffects[atype](buffDef, vals, unit, buffName, instigator, afterRemove)
         elseif not buffMissingWarnings[atype] then
             buffMissingWarnings[atype] = true
-            WARN('Missing buff effect function '..tostring(atype))
+            WARN('Missing buff effect function ' .. tostring(atype))
         end
     end
 end
@@ -596,7 +596,7 @@ function RemoveBuff(unit, buffName, removeAllCounts, instigator)
         return
     end
 
-    for atype,_ in def.Affects do
+    for atype, _ in def.Affects do
         local list = unit.Buffs.Affects[atype]
         if list and list[buffName] then
             -- If we're removing all buffs of this name, only remove as
@@ -631,7 +631,7 @@ function RemoveBuff(unit, buffName, removeAllCounts, instigator)
     if def.Icon then
         -- If the user layer was displaying an icon, remove it from the sync table
         local newTable = unit.Sync.Buffs
-        table.removeByValue(newTable,buffName)
+        table.removeByValue(newTable, buffName)
         unit.Sync.Buffs = table.copy(newTable)
     end
 
@@ -683,7 +683,7 @@ function PlayBuffEffect(unit, buffName, trsh)
     end
 end
 
---- Function to apply a buff to a unit. This function is a fire-and-forget. 
+--- Function to apply a buff to a unit. This function is a fire-and-forget.
 --- Apply this and it'll be applied over time if there is a duration.
 ---@param unit Unit
 ---@param buffName BuffName
@@ -705,7 +705,7 @@ function ApplyBuff(unit, buffName, instigator)
     --buff = table of buff data
     local def = Buffs[buffName]
     if not def then
-        error("*ERROR: Tried to add a buff that doesn\'t exist! Name: ".. buffName, 2)
+        error("*ERROR: Tried to add a buff that doesn\'t exist! Name: " .. buffName, 2)
         return
     end
 
@@ -767,7 +767,7 @@ function ApplyBuff(unit, buffName, instigator)
 
     local uaffects = unit.Buffs.Affects
     if def.Affects then
-        for k,v in def.Affects do
+        for k, v in def.Affects do
             -- Don't save off 'instant' type affects like health and energy
             if k ~= 'Health' and k ~= 'Energy' then
                 if not uaffects[k] then
@@ -828,7 +828,7 @@ end
 --- Prints the `Buffs` table of the currently selected units
 _G.PrintBuffs = function()
     local selection = DebugGetSelection()
-    for k,unit in selection do
+    for k, unit in selection do
         if unit.Buffs then
             LOG('Buffs = ', repr(unit.Buffs))
         end

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -751,6 +751,12 @@ function ApplyBuff(unit, buffName, instigator)
 
     local data = ubt[def.BuffType][buffName]
     if not data then
+        --- Container for buff state on a unit.
+        ---@class BuffData
+        ---@field Count integer
+        ---@field Trash TrashBag
+        ---@field BuffName BuffName
+
         -- This is a new buff (as opposed to an additional one being stacked)
         data = {
             Count = 1,

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -257,7 +257,7 @@ BuffEffects = {
     ---@param afterRemove boolean
     Stun = function(buffDefinition, buffValues, unit, buffName, instigator, afterRemove) -- most dont use the last two args, so most don't have them. This is fine.
         if unit.ImmuneToStun or afterRemove then return end
-        unit:SetStunned(buffDefinition.Duration or 1, instigator)
+        unit:SetStunned(buffDefinition.Duration or 1)
         if unit.Anims then
             for k, manip in unit.Anims do
                 manip:SetRate(0)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -167,6 +167,9 @@ local cUnitGetBuildRate = cUnit.GetBuildRate
 ---@field TargetUpgradeBuildTime? number # Keeps track of upgrades *during* unit transfer
 ---@field TargetFractionComplete? number # When an unbuilt unit is rebuilt during unit transfer, this overrides what fraction it is rebuilt to.
 ---@field isFinishedUnit? boolean # set to true in `OnStopBeingBuilt`
+---@field ImmuneToStun? boolean
+---@field Anims? Animator[] # Animators that get stopped when a unit is stunned. Not used in FAF.
+---@field IsBeingTransferred? boolean
 Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUnitComponent) {
 
     IsUnit = true,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -135,7 +135,7 @@ local cUnitGetBuildRate = cUnit.GetBuildRate
 ---@field UnitId UnitId
 ---@field EntityId EntityId
 ---@field EventCallbacks table<string, function[]>
----@field Buffs { Affects: table<BuffAffectName, table<BuffName, BlueprintBuffAffect> >, BuffTable: table<string, table> }
+---@field Buffs { Affects: table<BuffAffectName, table<BuffName, BlueprintBuffAffectState> >, BuffTable: table<string, table> }
 ---@field EngineFlags? table<string, any>
 ---@field TerrainType TerrainType
 ---@field EngineCommandCap? table<string, boolean>

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -119,6 +119,10 @@ SyncMeta = {
 local cUnit = moho.unit_methods
 local cUnitGetBuildRate = cUnit.GetBuildRate
 
+---@class UnitBuffsTable
+---@field Affects table<BuffAffectName, table<BuffName, BlueprintBuffAffectState>>
+---@field BuffTable table<BuffType, table<BuffName, BuffData>>
+
 ---@class Unit : moho.unit_methods, InternalObject, IntelComponent, VeterancyComponent, AIUnitProperties, CampaignAIUnitProperties, UnitBuffFields, DebugUnitComponent
 ---@field CDRHome? LocationType
 ---@field AIManagerIdentifier? string
@@ -135,7 +139,7 @@ local cUnitGetBuildRate = cUnit.GetBuildRate
 ---@field UnitId UnitId
 ---@field EntityId EntityId
 ---@field EventCallbacks table<string, function[]>
----@field Buffs { Affects: table<BuffAffectName, table<BuffName, BlueprintBuffAffectState> >, BuffTable: table<string, table> }
+---@field Buffs UnitBuffsTable
 ---@field EngineFlags? table<string, any>
 ---@field TerrainType TerrainType
 ---@field EngineCommandCap? table<string, boolean>

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -135,7 +135,7 @@ local cUnitGetBuildRate = cUnit.GetBuildRate
 ---@field UnitId UnitId
 ---@field EntityId EntityId
 ---@field EventCallbacks table<string, function[]>
----@field Buffs {Affects: table<BuffEffectName, BlueprintBuff.Effect>, buffTable: table<string, table>}
+---@field Buffs { Affects: table<BuffAffectName, table<BuffName, BlueprintBuffAffect> >, BuffTable: table<string, table> }
 ---@field EngineFlags? table<string, any>
 ---@field TerrainType TerrainType
 ---@field EngineCommandCap? table<string, boolean>

--- a/lua/sim/units/StructureUnit.lua
+++ b/lua/sim/units/StructureUnit.lua
@@ -939,7 +939,7 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
     end,
 
     ---@param self StructureUnit
-    ---@param adjacentUnit StructureUnit
+    ---@param adjacentUnit? StructureUnit
     DestroyAdjacentEffects = function(self, adjacentUnit)
         if not self.AdjacencyBeamsBag then return end
 

--- a/lua/system/BuffBlueprints.lua
+++ b/lua/system/BuffBlueprints.lua
@@ -73,6 +73,7 @@ Buffs = {}
 --- if we don't want unit properties connected the affect type to also change (e.g. changing
 --- `MaxHealth` also increases `Health` unless this flag is set)
 ---@field DoNotFill? boolean
+---@field Bool? boolean
 
 --- Buff affect data stored for a unit. Includes the affect blueprint and the buff stack count,
 --- except for instant affects "Health" and "Energy".

--- a/lua/system/BuffBlueprints.lua
+++ b/lua/system/BuffBlueprints.lua
@@ -100,6 +100,7 @@ Buffs = {}
 ---@field BuffCheckFunction? fun(self: BlueprintBuff, unit: Unit): boolean
 ---@field OnBuffAffect? fun(self: BlueprintBuff, unit: Unit, instigator: Unit)
 ---@field OnBuffRemove? fun(self: BlueprintBuff, unit: Unit, instigator: Unit)
+---@field OnApplyBuff? fun(self: BlueprintBuff, unit: Unit, instigator: Unit)
 --- table of how the buff will affect the units (not VFX)
 ---@field Affects? table<BuffAffectName, BlueprintBuffAffect>
 --- table of VFX (not the how the buff affects units)

--- a/lua/system/BuffBlueprints.lua
+++ b/lua/system/BuffBlueprints.lua
@@ -74,6 +74,12 @@ Buffs = {}
 --- `MaxHealth` also increases `Health` unless this flag is set)
 ---@field DoNotFill? boolean
 
+--- Buff affect data stored for a unit. Includes the affect blueprint and the buff stack count,
+--- except for instant affects "Health" and "Energy".
+---@class BlueprintBuffAffectState : BlueprintBuffAffect
+--- Used in the buff calculation
+---@field Count? number
+
 --- The blueprint definition of a buff, as stored in `Buffs` (with the buff name as the key).
 ---
 --- Generally, adding a buff to a unit will apply a certain number of buff effects (that we call

--- a/lua/system/BuffBlueprints.lua
+++ b/lua/system/BuffBlueprints.lua
@@ -105,7 +105,7 @@ Buffs = {}
 --- If present, this function will be called to determine if the buff should be applied for a unit.
 ---@field BuffCheckFunction? fun(self: BlueprintBuff, unit: Unit): boolean
 ---@field OnBuffAffect? fun(self: BlueprintBuff, unit: Unit, instigator: Unit)
----@field OnBuffRemove? fun(self: BlueprintBuff, unit: Unit, instigator: Unit)
+---@field OnBuffRemove? fun(self: BlueprintBuff, unit: Unit, instigator: Unit?)
 ---@field OnApplyBuff? fun(self: BlueprintBuff, unit: Unit, instigator: Unit)
 --- table of how the buff will affect the units (not VFX)
 ---@field Affects? table<BuffAffectName, BlueprintBuffAffect>


### PR DESCRIPTION
## Description of the proposed changes
- Solves annotation warnings without changing functionality.
  - except for fixing an incorrect return value in buff calculate, but it's just for a warning message and returns defaults just like when the function fails due to lacking a buff affect.
- adds missing annotations for buff effect functions
  - I wish I could do `table<BuffAffectName, fun(buffdef: BuffBlueprint ... afterRemove: boolean )>` but function annotations only work for function params (calling the param inside the function and inputting params when calling the function)

## Testing done on the proposed changes
Verified that all the changes are refactoring how code is placed or what comments are written. Also spawned a preset SACU to test that buffs work on a basic level.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
