### PR TITLE
Fix outdated `Health` and `DamageRadius` buffs

### DIFF
--- a/changelog/snippets/fix.6839.md
+++ b/changelog/snippets/fix.6839.md
@@ -1,0 +1,1 @@
+- (#6839) Fix `Health` and `DamageRadius` buff effect types. Previously they would just error if you used them.

--- a/changelog/snippets/fix.6839.md
+++ b/changelog/snippets/fix.6839.md
@@ -1,1 +1,1 @@
-- (#6839) Fix `Health` and `DamageRadius` buff effect types. Previously they would just error if you used them.
+- (#6839) Fix `Health` (adjusts unit health) and `DamageRadius` (adjusts damage radius for unit weapons) buff effect types. Previously they would just error if you used them.

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -360,8 +360,8 @@ BuffEffects = {
             local wepbp = wep:GetBlueprint()
             local weprad = wepbp.DamageRadius
             local val = BuffCalculate(unit, buffName, 'DamageRadius', weprad)
-
-            wep:SetDamageRadius(val)
+            wep.DamageRadiusMod = val
+            wep.damageTableCache = false
         end
     end,
 

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -265,7 +265,6 @@ BuffEffects = {
         end
     end,
 
-    --- Quite confident that this one is broken
     ---@param buffDefinition BlueprintBuff
     ---@param buffValues BlueprintBuffAffect
     ---@param unit Unit
@@ -279,14 +278,12 @@ BuffEffects = {
         local healthadj = val - health
 
         if healthadj < 0 then
-            -- fixme: DoTakeDamage shouldn't be called directly
-            local data = {
-                Instigator = instigator,
-                Amount = -1 * healthadj,
-                Type = buffDefinition.DamageType or 'Spell',
-                Vector = VDiff(instigator:GetPosition(), unit:GetPosition()),
-            }
-            unit:DoTakeDamage(data)
+            unit:OnDamage(
+                instigator,
+                -1 * healthadj,
+                VDiff(instigator:GetPosition(), unit:GetPosition()),
+                buffDefinition.DamageType or 'Spell'
+            )
         else
             unit:AdjustHealth(instigator, healthadj)
         end

--- a/units/URL0301/URL0301_script.lua
+++ b/units/URL0301/URL0301_script.lua
@@ -101,12 +101,6 @@ URL0301 = ClassUnit(CCommandUnit) {
                         Add = bp.NewHealth,
                         Mult = 1.0,
                     },
-                    DamageRadius = {
-                        Add = 10,
-                    },
-                    Health = {
-                        Add = -10000,
-                    },
                 },
             }
         end

--- a/units/URL0301/URL0301_script.lua
+++ b/units/URL0301/URL0301_script.lua
@@ -101,6 +101,12 @@ URL0301 = ClassUnit(CCommandUnit) {
                         Add = bp.NewHealth,
                         Mult = 1.0,
                     },
+                    DamageRadius = {
+                        Add = 10,
+                    },
+                    Health = {
+                        Add = -10000,
+                    },
                 },
             }
         end


### PR DESCRIPTION
## Description of the proposed changes
Based on https://github.com/FAForever/fa/pull/6837

Fix outdated buffs that would just error if you used them.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Use debug setup and spawn units. The SACU will spawn with 10k HP damaged and it can groundfire to damage the paragon due to the damage radius buff.
```
   CreateUnitAtMouse('url0301_cloak', 0,    3.00,    0.61,  0.00000)
   CreateUnitAtMouse('xab1401', 0,   -3.00,   -0.61,  0.00000)
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
