### PR TITLE
Give land scouts radar structure priority

### DIFF
--- a/changelog/snippets/balance.6842.md
+++ b/changelog/snippets/balance.6842.md
@@ -1,0 +1,1 @@
+- (#6842) Make land scouts prioritize radar structures over mobile units and remove their PD/static AA target priority.

--- a/units/UAL0101/UAL0101_unit.bp
+++ b/units/UAL0101/UAL0101_unit.bp
@@ -203,7 +203,7 @@ UnitBlueprint{
             RangeCategory = "UWRC_DirectFire",
             RateOfFire = 10/20, --10/integer interval in ticks
             TargetPriorities = {
-                "(MOBILE * SCOUT + INTELLIGENCE * STRUCTURE * RADAR)",
+                "RADAR INTELLIGENCE STRUCTURE",
                 "MOBILE",
                 "ALLUNITS",
             },

--- a/units/UAL0101/UAL0101_unit.bp
+++ b/units/UAL0101/UAL0101_unit.bp
@@ -203,8 +203,8 @@ UnitBlueprint{
             RangeCategory = "UWRC_DirectFire",
             RateOfFire = 10/20, --10/integer interval in ticks
             TargetPriorities = {
+                "(MOBILE * SCOUT + INTELLIGENCE * STRUCTURE * RADAR)",
                 "MOBILE",
-                "(STRUCTURE * DEFENSE - ANTIMISSILE)",
                 "ALLUNITS",
             },
             TargetRestrictDisallow = "UNTARGETABLE",

--- a/units/UEL0101/UEL0101_unit.bp
+++ b/units/UEL0101/UEL0101_unit.bp
@@ -176,8 +176,8 @@ UnitBlueprint{
             RangeCategory = "UWRC_DirectFire",
             RateOfFire = 10/20, --10/integer interval in ticks
             TargetPriorities = {
+                "(MOBILE * SCOUT + INTELLIGENCE * STRUCTURE * RADAR)",
                 "MOBILE",
-                "(STRUCTURE * DEFENSE - ANTIMISSILE)",
                 "ALLUNITS",
             },
             TargetRestrictDisallow = "UNTARGETABLE",

--- a/units/UEL0101/UEL0101_unit.bp
+++ b/units/UEL0101/UEL0101_unit.bp
@@ -176,7 +176,7 @@ UnitBlueprint{
             RangeCategory = "UWRC_DirectFire",
             RateOfFire = 10/20, --10/integer interval in ticks
             TargetPriorities = {
-                "(MOBILE * SCOUT + INTELLIGENCE * STRUCTURE * RADAR)",
+                "RADAR INTELLIGENCE STRUCTURE",
                 "MOBILE",
                 "ALLUNITS",
             },


### PR DESCRIPTION
## Description of the proposed changes
Land scouts have very low dps that is often not useful but can still kill radars, damaged units, and other land scouts. The target priorities are changed to better suit that.

## Testing done on the proposed changes
Spawning the units gives no errors and they target radars over other units.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
