### PR TITLE
Reduce Cybran T1 mobile AA's damage

### DIFF
--- a/changelog/snippets/balance.6843.md
+++ b/changelog/snippets/balance.6843.md
@@ -1,0 +1,5 @@
+- (#6843) Reduce the damage of the Cybran T1 mobile anti-air since its projectiles can now retarget, and it no longer needs so much damage to match the AA of other factions.
+
+  **Sky Slammer: T1 Mobile Anti-Air Gun (URL0104)**
+    - Nanodart Launcher (Anti Air)
+      - Damage: 16 -> 14

--- a/changelog/snippets/balance.6843.md
+++ b/changelog/snippets/balance.6843.md
@@ -2,4 +2,4 @@
 
   **Sky Slammer: T1 Mobile Anti-Air Gun (URL0104)**
     - Nanodart Launcher (Anti Air)
-      - Damage: 16 -> 14
+      - Damage: 16 -> 14 (DPS 32 -> 28)

--- a/units/URL0104/URL0104_unit.bp
+++ b/units/URL0104/URL0104_unit.bp
@@ -205,7 +205,7 @@ UnitBlueprint{
             BallisticArc = "RULEUBA_None",
             CannotAttackGround = true,
             CollideFriendly = false,
-            Damage = 16,
+            Damage = 14,
             DamageType = "Normal",
             DisplayName = "Nanodart Launcher",
             FireTargetLayerCapsTable = { Land = "Air" },


### PR DESCRIPTION

## Description of the proposed changes
Since the projectiles can retarget the AA doesn't need so much DPS to stay equal with other factions.

- **Sky Slammer: T1 Mobile Anti-Air Gun (URL0104)**
  - Nanodart Launcher (Anti Air)
    - Damage: 16 -> 14

## Testing done on the proposed changes
A bomber flying over the AA now takes 182 damage instead of 208. Aeon and Sera deal 168 and 169 damage, while UEF deals 182 damage too.

A group of 3 AA seems to deal with 3 bombers just slightly faster than other factions, owing to its inability to miss and still slightly higher DPS.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
