### PR TITLE
Fix error when eye of rhianne finishes building during e stall

### DIFF
--- a/changelog/snippets/fix.6844.md
+++ b/changelog/snippets/fix.6844.md
@@ -1,0 +1,1 @@
+- (#6844) Fix error when eye of rhianne finishes building during an energy stall.

--- a/units/XAB3301/XAB3301_script.lua
+++ b/units/XAB3301/XAB3301_script.lua
@@ -28,21 +28,23 @@ XAB3301 = ClassUnit(AStructureUnit) {
     ---@param builder Unit
     ---@param layer Layer
     OnStopBeingBuilt = function(self, builder, layer)
-        AStructureUnit.OnStopBeingBuilt(self, builder, layer)
-
-        self.Trash:Add(CreateRotator(self, 'spin02', 'x', nil, 0, 15, 60 + Random(0, 20)))
-        self.Trash:Add(CreateRotator(self, 'spin02', 'y', nil, 0, 15, 60 + Random(0, 20)))
-        self.Trash:Add(CreateRotator(self, 'spin02', 'z', nil, 0, 15, 60 + Random(0, 20)))
-
+        -- Create manipulators before the main function since we can be instantly disabled
+        -- due to having no energy, and disabling requires the manipulators to exist.
         self.Animator = CreateAnimator(self)
         self.Animator:PlayAnim("/units/xab3301/XAB3301_activate.sca")
         self.Animator:SetRate(0)
         self.Trash:Add(self.Animator)
 
+        self.Trash:Add(CreateRotator(self, 'spin02', 'x', nil, 0, 15, 60 + Random(0, 20)))
+        self.Trash:Add(CreateRotator(self, 'spin02', 'y', nil, 0, 15, 60 + Random(0, 20)))
+        self.Trash:Add(CreateRotator(self, 'spin02', 'z', nil, 0, 15, 60 + Random(0, 20)))
+
         self.RotatorBot = CreateRotator(self, 'spin01', 'y', nil, 0, 3, 6)
         self.RotatorTop = CreateRotator(self, 'spin03', 'y', nil, 0, -2, -4)
 
         self.TrashAmbientEffects = TrashBag()
+
+        AStructureUnit.OnStopBeingBuilt(self, builder, layer)
     end,
 
     ---@param self XAB3301

--- a/units/XAB3301/XAB3301_script.lua
+++ b/units/XAB3301/XAB3301_script.lua
@@ -21,30 +21,52 @@ AStructureUnit = RemoteViewing(AStructureUnit)
 ---@field Animator moho.AnimationManipulator
 ---@field RotatorBot moho.RotateManipulator
 ---@field RotatorTop moho.RotateManipulator
+---@field RotatorOrbX moho.RotateManipulator
+---@field RotatorOrbY moho.RotateManipulator
+---@field RotatorOrbZ moho.RotateManipulator
 ---@field TrashAmbientEffects TrashBag
 ---@field ScryEnabled boolean
 XAB3301 = ClassUnit(AStructureUnit) {
     ---@param self XAB3301
+    OnCreate = function(self)
+        AStructureUnit.OnCreate(self)
+
+        local animator = self.Trash:Add(CreateAnimator(self))
+        animator:PlayAnim("/units/xab3301/XAB3301_activate.sca"):SetRate(0):Disable()
+        self.Animator = animator
+
+        local rotatorOrbX = self.Trash:Add(CreateRotator(self, 'spin02', 'x', nil, 0, 15, 60 + Random(0, 20)))
+        local rotatorOrbY = self.Trash:Add(CreateRotator(self, 'spin02', 'y', nil, 0, 15, 60 + Random(0, 20)))
+        local rotatorOrbZ = self.Trash:Add(CreateRotator(self, 'spin02', 'z', nil, 0, 15, 60 + Random(0, 20)))
+        rotatorOrbX:Disable()
+        rotatorOrbY:Disable()
+        rotatorOrbZ:Disable()
+        self.RotatorOrbX = rotatorOrbX
+        self.RotatorOrbY = rotatorOrbY
+        self.RotatorOrbZ = rotatorOrbZ
+
+        local rotatorBot = CreateRotator(self, 'spin01', 'y', nil, 0, 3, 6)
+        local rotatorTop = CreateRotator(self, 'spin03', 'y', nil, 0, -2, -4)
+        rotatorBot:Disable()
+        rotatorTop:Disable()
+        self.RotatorBot = rotatorBot
+        self.RotatorTop = rotatorTop
+
+        self.TrashAmbientEffects = TrashBag()
+    end,
+
+    ---@param self XAB3301
     ---@param builder Unit
     ---@param layer Layer
     OnStopBeingBuilt = function(self, builder, layer)
-        -- Create manipulators before the main function since we can be instantly disabled
-        -- due to having no energy, and disabling requires the manipulators to exist.
-        self.Animator = CreateAnimator(self)
-        self.Animator:PlayAnim("/units/xab3301/XAB3301_activate.sca")
-        self.Animator:SetRate(0)
-        self.Trash:Add(self.Animator)
-
-        self.Trash:Add(CreateRotator(self, 'spin02', 'x', nil, 0, 15, 60 + Random(0, 20)))
-        self.Trash:Add(CreateRotator(self, 'spin02', 'y', nil, 0, 15, 60 + Random(0, 20)))
-        self.Trash:Add(CreateRotator(self, 'spin02', 'z', nil, 0, 15, 60 + Random(0, 20)))
-
-        self.RotatorBot = CreateRotator(self, 'spin01', 'y', nil, 0, 3, 6)
-        self.RotatorTop = CreateRotator(self, 'spin03', 'y', nil, 0, -2, -4)
-
-        self.TrashAmbientEffects = TrashBag()
-
         AStructureUnit.OnStopBeingBuilt(self, builder, layer)
+
+        self.Animator:Enable()
+        self.RotatorOrbX:Enable()
+        self.RotatorOrbY:Enable()
+        self.RotatorOrbZ:Enable()
+        self.RotatorBot:Enable()
+        self.RotatorTop:Enable()
     end,
 
     ---@param self XAB3301

--- a/units/XAB3301/XAB3301_script.lua
+++ b/units/XAB3301/XAB3301_script.lua
@@ -46,7 +46,7 @@ XAB3301 = ClassUnit(AStructureUnit) {
         self.RotatorOrbZ = rotatorOrbZ
 
         local rotatorBot = CreateRotator(self, 'spin01', 'y', nil, 0, 3, 6)
-        local rotatorTop = CreateRotator(self, 'spin03', 'y', nil, 0, -2, -4)
+        local rotatorTop = CreateRotator(self, 'spin03', '-y', nil, 0, 2, 4)
         rotatorBot:Disable()
         rotatorTop:Disable()
         self.RotatorBot = rotatorBot
@@ -86,7 +86,7 @@ XAB3301 = ClassUnit(AStructureUnit) {
 
                 self.Animator:SetRate(1)
                 self.RotatorBot:SetTargetSpeed(12)
-                self.RotatorTop:SetTargetSpeed(-8)
+                self.RotatorTop:SetTargetSpeed(8)
 
                 for k, v in AQuantumGateAmbient do
                     self.TrashAmbientEffects:Add(CreateAttachedEmitter(self, 'spin02', self.Army, v):ScaleEmitter(0.6))
@@ -102,7 +102,7 @@ XAB3301 = ClassUnit(AStructureUnit) {
 
         self.Animator:SetRate(-1)
         self.RotatorBot:SetTargetSpeed(6)
-        self.RotatorTop:SetTargetSpeed(-4)
+        self.RotatorTop:SetTargetSpeed(4)
 
         self.TrashAmbientEffects:Destroy()
         self.ScryEnabled = false


### PR DESCRIPTION
## Issue
During an energy stall, the AIBrain disables intel when the Eye is finished building but the manipulators are not set up yet, so the script errors:

```
warning: Error running OnStopBeingBuilt script in Entity xab3301 at 24269b08: ...\units\xab3301\xab3301_script.lua(79): attempt to call method `SetRate' (a nil value)
         stack traceback:
         	...\units\xab3301\xab3301_script.lua(79): in function `DisableVisibleEntity'
         	...\lua\remoteviewing.lua(175): in function `OnIntelDisabled'
         	...\lua\defaultcomponents.lua(102): in function `DisableUnitIntel'
         	...\lua\defaultcomponents.lua(64): in function `OnEnergyDepleted'
         	...\aibrains\components\energymanagerbraincomponent.lua(61): in function `AddEnergyDependingEntity'
         	...\lua\defaultcomponents.lua(56): in function `OnStopBeingBuilt'
         	...\lua\sim\unit.lua(2387): in function <...\lua\sim\unit.lua:2376>
         	...\lua\sim\units\structureunit.lua(313): in function `OnStopBeingBuilt'
         	...\lua\remoteviewing.lua(47): in function `OnStopBeingBuilt'
         	...\units\xab3301\xab3301_script.lua(31): in function <...\units\xab3301\xab3301_script.lua:30>
         	[C]: in function `CreateUnitHPR'
         	...\lua\simcallbacks.lua(1010): in function `fn'
         	...\lua\simcallbacks.lua(60): in function <...\lua\simcallbacks.lua:56>
```

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Init manipulators before the base function is called.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
The eye no longer errors when spawned during an energy stall.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
