### PR TITLE
Fix various issues with announcements

### DIFF
--- a/changelog/snippets/fix.6845.md
+++ b/changelog/snippets/fix.6845.md
@@ -1,0 +1,3 @@
+- (#6845) Fix various issues with the new setup for announcements.
+
+In campaign-like scenario's the interactions with the objectives should now be good again.

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -81,9 +81,11 @@ CreateTitleAnnouncement = function(titleText, goalControl, onCompleteCallback)
 
     -- create a dummy goal control if we don't have one
     local frame = GetFrame(0) --[[@as Frame]]
-    if not goalControl or IsDestroyed(goalControl) then
+    if IsDestroyed(goalControl) then
         goalControl = CreateDefaultGoalControl(frame)
     end
+
+    ---@cast goalControl -nil, -unknown
 
     -- developers note: lazy load the module so that it remains unloaded unless used
     local TitleAnnouncement = import("/lua/ui/game/announcement/TitleAnnouncement.lua").TitleAnnouncement
@@ -113,7 +115,11 @@ CreateTitleTextAnnouncement = function(titleText, bodyText, goalControl, onCompl
 
     -- create a dummy goal control if we don't have one
     local frame = GetFrame(0) --[[@as Frame]]
-    goalControl = goalControl or CreateDefaultGoalControl(frame)
+    if IsDestroyed(goalControl) then
+        goalControl = CreateDefaultGoalControl(frame)
+    end
+
+    ---@cast goalControl -nil, -unknown
 
     -- developers note: lazy load the module so that it remains unloaded unless used
     local TitleTextAnnouncement = import("/lua/ui/game/announcement/TitleTextAnnouncement.lua").TitleTextAnnouncement

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -71,7 +71,8 @@ end
 --- Create an announcement with a title.
 ---@param titleText UnlocalizedString
 ---@param goalControl? Control          # if defined, the announcement visually expands and contracts to this control.
-CreateTitleAnnouncement = function(titleText, goalControl)
+---@param onCompleteCallback? fun()
+CreateTitleAnnouncement = function(titleText, goalControl, onCompleteCallback)
     if ShouldSkipAnnouncement() then
         return
     end
@@ -80,7 +81,12 @@ CreateTitleAnnouncement = function(titleText, goalControl)
 
     -- create a dummy goal control if we don't have one
     local frame = GetFrame(0) --[[@as Frame]]
-    goalControl = goalControl or CreateDefaultGoalControl(frame)
+    if not goalControl or IsDestroyed(goalControl) then
+        LOG("No goal control found, creating default goal control")
+        reprsl(goalControl)
+        LOG(IsDestroyed(goalControl))
+        goalControl = CreateDefaultGoalControl(frame)
+    end
 
     -- developers note: lazy load the module so that it remains unloaded unless used
     local TitleAnnouncement = import("/lua/ui/game/announcement/TitleAnnouncement.lua").TitleAnnouncement
@@ -88,7 +94,7 @@ CreateTitleAnnouncement = function(titleText, goalControl)
     -- create the announcement
     ---@type UIAbstractAnnouncement
     local announcement = TitleAnnouncement(frame, titleText)
-    announcement:Animate(goalControl, 1.4)
+    announcement:Animate(goalControl, 1.4, onCompleteCallback)
     Announcements:Add(announcement)
 
     if ShouldImmediatelyHideAnnouncement() then
@@ -100,7 +106,8 @@ end
 ---@param titleText UnlocalizedString
 ---@param bodyText UnlocalizedString
 ---@param goalControl? Control          # if defined, the announcement visually expands and contracts to this control.
-CreateTitleTextAnnouncement = function(titleText, bodyText, goalControl)
+---@param onCompleteCallback? fun()
+CreateTitleTextAnnouncement = function(titleText, bodyText, goalControl, onCompleteCallback)
     if ShouldSkipAnnouncement() then
         return
     end
@@ -117,7 +124,7 @@ CreateTitleTextAnnouncement = function(titleText, bodyText, goalControl)
     -- create the announcement
     ---@type UIAbstractAnnouncement
     local announcement = TitleTextAnnouncement(frame, titleText, bodyText)
-    announcement:Animate(goalControl, 2.2)
+    announcement:Animate(goalControl, 2.2, onCompleteCallback)
     Announcements:Add(announcement)
 
     if ShouldImmediatelyHideAnnouncement() then
@@ -129,14 +136,15 @@ end
 ---
 --- Exists for backwards compatibility.
 ---@param titleText UnlocalizedString
----@param bodyText? UnlocalizedString
 ---@param goalControl? Control          # if defined, the announcement visually expands and contracts to this control.
-function CreateAnnouncement(titleText, bodyText, goalControl)
+---@param bodyText? UnlocalizedString
+---@param onCompleteCallback? fun()
+function CreateAnnouncement(titleText, goalControl, bodyText, onCompleteCallback)
     local typeOfBodyText = type(bodyText)
     if typeOfBodyText == "string" or typeOfBodyText == "number" then
-        return import("/lua/ui/game/announcement.lua").CreateTitleTextAnnouncement (titleText, bodyText, goalControl)
+        return CreateTitleTextAnnouncement(titleText, bodyText, goalControl, onCompleteCallback)
     else
-        return import("/lua/ui/game/announcement.lua").CreateTitleAnnouncement(titleText, goalControl)
+        return CreateTitleAnnouncement(titleText, goalControl, onCompleteCallback)
     end
 end
 
@@ -163,12 +171,14 @@ end
 
 --- Creates a title announcement for debugging.
 DebugTitleAnnouncement = function()
-    CreateAnnouncement("Title because X is defeated")
+    local control = CreateDefaultGoalControl(GetFrame(0))
+    CreateAnnouncement("Title because X is defeated", control)
+    control:Destroy()
 end
 
 --- Creates a title-with-text announcement for debugging.
 DebugTitleTextAnnouncement = function()
-    CreateAnnouncement("Title", "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.")
+    CreateAnnouncement("Title", nil, "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.")
 end
 
 --#endregion

--- a/lua/ui/game/announcement.lua
+++ b/lua/ui/game/announcement.lua
@@ -82,9 +82,6 @@ CreateTitleAnnouncement = function(titleText, goalControl, onCompleteCallback)
     -- create a dummy goal control if we don't have one
     local frame = GetFrame(0) --[[@as Frame]]
     if not goalControl or IsDestroyed(goalControl) then
-        LOG("No goal control found, creating default goal control")
-        reprsl(goalControl)
-        LOG(IsDestroyed(goalControl))
         goalControl = CreateDefaultGoalControl(frame)
     end
 

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -49,8 +49,8 @@ local CreateLazyVar = import("/lua/lazyvar.lua").Create
 AbstractAnnouncement = ClassUI(Group) {
 
     -- Announcements works by morphing the background from a control, to the content area, and then back. By doing so,
-    -- we give the player an idea what the announcement is connected to. The content of the announcement is never 
-    -- moved, only the background is. The alpha of the content is adjusted when the announcement arrives and 
+    -- we give the player an idea what the announcement is connected to. The content of the announcement is never
+    -- moved, only the background is. The alpha of the content is adjusted when the announcement arrives and
     -- leaves again.
 
     -- To make it more concrete:
@@ -147,8 +147,8 @@ AbstractAnnouncement = ClassUI(Group) {
         self.Trash:Destroy()
     end,
 
-    --- A utility function to set the alpha of the content. Concrete implementations 
-    --- can hook this function to set the alpha value of UI elements that do propagate 
+    --- A utility function to set the alpha of the content. Concrete implementations
+    --- can hook this function to set the alpha value of UI elements that do propagate
     --- properly when the alpha of a parent is set (looking at you, TextArea).
     ---@param self UIAbstractAnnouncement
     ---@param value number
@@ -163,20 +163,27 @@ AbstractAnnouncement = ClassUI(Group) {
     ---@param self UIAbstractAnnouncement
     ---@param control Control
     ---@param durationForContent number
-    Animate = function(self, control, durationForContent)
+    ---@param onCompleteCallback? fun()
+    Animate = function(self, control, durationForContent, onCompleteCallback)
         -- do not allow other animations
         if self.AnimateThreadInstance then
             self.AnimateThreadInstance:Destroy()
         end
 
-        self.AnimateThreadInstance = self.Trash:Add(ForkThread(self.AnimateThread, self, control, durationForContent))
+        LOG(control)
+        LOG(IsDestroyed(control))
+        LOG(debug.traceback())
+        local animationProgress = self:SetupBackgroundAnimation(control)
+
+        self.AnimateThreadInstance = self.Trash:Add(ForkThread(self.AnimateThread, self, animationProgress, durationForContent, onCompleteCallback))
     end,
 
     --- The default animation sequence for an announcement. The announcement is destroyed at the end of the animation.
     ---@param self UIAbstractAnnouncement
-    ---@param control Control
+    ---@param animationProgress LazyVar
     ---@param durationForContent number
-    AnimateThread = function(self, control, durationForContent)
+    ---@param onCompleteCallback? fun()
+    AnimateThread = function(self, animationProgress, durationForContent, onCompleteCallback)
         -- early exist for edge case
         if IsDestroyed(self) then
             return
@@ -189,7 +196,7 @@ AbstractAnnouncement = ClassUI(Group) {
         local contentHideDuration = 0.4
 
         -- expand animation
-        self:ExpandBackground(control, expandDuration)
+        self:ExpandBackground(animationProgress, expandDuration)
         WaitSeconds(expandDuration)
         if IsDestroyed(self) then
             return
@@ -209,10 +216,15 @@ AbstractAnnouncement = ClassUI(Group) {
         end
 
         -- contract animation
-        self:ContractBackground(control, contractDuration)
+        self:ContractBackground(animationProgress, contractDuration)
         WaitSeconds(contractDuration)
         if IsDestroyed(self) then
             return
+        end
+
+        -- trigger the callback
+        if onCompleteCallback then
+            onCompleteCallback()
         end
 
         self:Destroy()
@@ -263,80 +275,77 @@ AbstractAnnouncement = ClassUI(Group) {
 
     --- Expands the background of the announcement, starting at the provided control towards the content area.
     ---@param self UIAbstractAnnouncement
-    ---@param control Control
+    ---@param animationProgress LazyVar
     ---@param duration number
-    ExpandBackground = function(self, control, duration)
-        self:AnimateBackground(control, duration, 'Expand')
-        PlaySound(Sound({Bank = 'Interface', Cue = 'UI_Announcement_Open'}))
+    ExpandBackground = function(self, animationProgress, duration)
+        self:AnimateBackground(animationProgress, duration, 'Expand')
+        PlaySound(Sound({ Bank = 'Interface', Cue = 'UI_Announcement_Open' }))
     end,
 
     --- Contracts the background of the announcement, the provided control is the destination to contract to.
     ---@param self UIAbstractAnnouncement
-    ---@param control Control
+    ---@param animationProgress LazyVar
     ---@param duration number
-    ContractBackground = function(self, control, duration)
-        self:AnimateBackground(control, duration, 'Contract')
-        PlaySound(Sound({Bank = 'Interface', Cue = 'UI_Announcement_Close'}))
+    ContractBackground = function(self, animationProgress, duration)
+        self:AnimateBackground(animationProgress, duration, 'Contract')
+        PlaySound(Sound({ Bank = 'Interface', Cue = 'UI_Announcement_Close' }))
     end,
 
-    --- Animates the background. Use the utility functions `ExpandBackground` and `ContractBackground` to
+    --- Defines the animation of the announcement, and specifically of the background. Returns the a lazy variable that we can use to progress the animation.
     ---@param self UIAbstractAnnouncement
     ---@param control Control
-    ---@param duration number
-    ---@param state 'Expand' | 'Contract'
-    AnimateBackground = function(self, control, duration, state)
-        -- do not allow other animations
-        if self.AnimateBackgroundThreadInstance then
-            self.AnimateBackgroundThreadInstance:Destroy()
-        end
-
-        -- animate position and scale
-        self.AnimateBackgroundThreadInstance = self.Trash:Add(ForkThread(self.AnimateBackgroundThread, self, control, duration, state))
-    end,
-
-    --- Expands the background of the announcement, starting at the provided control towards the center of the screen.
-    ---@param self UIAbstractAnnouncement
-    ---@param control Control
-    ---@param duration number
-    ---@param state 'Expand' | 'Contract'
-    AnimateBackgroundThread = function(self, control, duration, state)
-        -- early exit for edge case
-        if IsDestroyed(self) then
-            return
-        end
-
+    ---@return LazyVar
+    SetupBackgroundAnimation = function(self, control)
         -- local scope for performance
         local background = self.Background
         local content = self.ContentArea
 
         ---@type LazyVar
-        local progress = CreateLazyVar(0)
+        local animationProgress = CreateLazyVar(0)
+
+        -- use last known position of control if it is destroyed, this happens when you fail an objective.
+        local controlTopValue = control.Top()
+        local controlBottomValue = control.Bottom()
+        local controlLeftValue = control.Left()
+        local controlRightValue = control.Right()
 
         background.Top:Set(
-            function() 
-                local percentage = progress()
-                return percentage * content.Top() + (1 - percentage) * control.Top()
+            function()
+                -- determine or use last known position of control
+                controlTopValue = control.Top and control.Top() or controlTopValue
+
+                local percentage = animationProgress()
+                return percentage * content.Top() + (1 - percentage) * controlTopValue
             end
         )
 
         background.Bottom:Set(
-            function() 
-                local percentage = progress()
-                return percentage * content.Bottom() + (1 - percentage) * control.Bottom()
+            function()
+                -- determine or use last known position of control
+                controlBottomValue = control.Bottom and control.Bottom() or controlBottomValue
+
+                local percentage = animationProgress()
+                return percentage * content.Bottom() + (1 - percentage) * controlBottomValue
             end
         )
 
         background.Left:Set(
-            function() 
-                local percentage = progress()
-                return percentage * content.Left() + (1 - percentage) * control.Left()
+            function()
+                -- determine or use last known position of control
+                controlLeftValue = control.Left and control.Left() or controlLeftValue
+
+                local percentage = animationProgress()
+                return percentage * content.Left() + (1 - percentage) * controlLeftValue
             end
         )
 
         background.Right:Set(
-            function() 
-                local percentage = progress()
-                return percentage * content.Right() + (1 - percentage) * control.Right()
+            function()
+                -- determine or use last known position of control
+                controlRightValue = control.Right and control.Right() or controlRightValue
+
+                local percentage = animationProgress()
+                return percentage * content.Right() + (1 - percentage) * controlRightValue
             end
         )
 
@@ -345,6 +354,38 @@ AbstractAnnouncement = ClassUI(Group) {
             :ResetWidth()
             :ResetHeight()
             :End()
+
+        return animationProgress
+    end,
+
+    --- Animates the background. Use the utility functions `ExpandBackground` and `ContractBackground` to
+    ---@param self UIAbstractAnnouncement
+    ---@param animationProgress LazyVar
+    ---@param duration number
+    ---@param state 'Expand' | 'Contract'
+    AnimateBackground = function(self, animationProgress, duration, state)
+        -- do not allow other animations
+        if self.AnimateBackgroundThreadInstance then
+            self.AnimateBackgroundThreadInstance:Destroy()
+        end
+
+        -- animate position and scale
+        self.AnimateBackgroundThreadInstance = self.Trash:Add(ForkThread(self.AnimateBackgroundThread, self, animationProgress, duration, state))
+    end,
+
+    --- Expands the background of the announcement, starting at the provided control towards the center of the screen.
+    ---@param self UIAbstractAnnouncement
+    ---@param animationController LazyVar
+    ---@param duration number
+    ---@param state 'Expand' | 'Contract'
+    AnimateBackgroundThread = function(self, animationController, duration, state)
+        -- early exit for edge case
+        if IsDestroyed(self) then
+            return
+        end
+
+        -- local scope for performance
+        local background = self.Background
 
         -- animate it
         local startTime = GetSystemTimeSeconds()
@@ -362,7 +403,7 @@ AbstractAnnouncement = ClassUI(Group) {
             end
 
             -- triggers the translation and scaling changes
-            progress:Set(percentage)
+            animationController:Set(percentage)
 
             -- update alpha separately
             background:SetAlpha(percentage, true)
@@ -372,16 +413,16 @@ AbstractAnnouncement = ClassUI(Group) {
 
         -- make sure animation completes properly even when there are frame drops
         if state == 'Expand' then
-            progress:Set(1)
+            animationController:Set(1)
         else
-            progress:Set(0)
+            animationController:Set(0)
         end
     end,
 
     --#endregion
 
     ---------------------------------------------------------------------------
-    --#region Interface to abort 
+    --#region Interface to abort
 
     --- Aborts the announcement. All animations are stopped. The announcement is turned transparent and then destroyed.
     ---@param self UIAbstractAnnouncement

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -170,9 +170,6 @@ AbstractAnnouncement = ClassUI(Group) {
             self.AnimateThreadInstance:Destroy()
         end
 
-        LOG(control)
-        LOG(IsDestroyed(control))
-        LOG(debug.traceback())
         local animationProgress = self:SetupBackgroundAnimation(control)
 
         self.AnimateThreadInstance = self.Trash:Add(ForkThread(self.AnimateThread, self, animationProgress, durationForContent, onCompleteCallback))


### PR DESCRIPTION
## Description of the proposed changes

Fixes various issues with the new setup for announcements. Closes #6841 .

It fixes the following behavior:

- Re-introduces the callback, which is now called when the announcement is finished. There was 1 place where this was used: objectives to cleanup after themselves when the announcement ends!
- Refactors the animation to be a separate function called `SetupBackgroundAnimation`. The applied animation can then be controlled by setting the progress variable that is returned.
- Fixes an edge case where the animation breaks if the origin/target control is destroyed during the animation.

Also fixes a subtle issue where the position of the origin/target control must be known before we fork a thread. By forking, we push the remaining logic to the end of the internal call stack. In the meantime the control can be destroyed, before the animation even had the time to process it.

## Testing done on the proposed changes

Launched various campaign maps and campaign-like maps to see and verify the interactions with the objectives. Specifically:

- Rainmakers Survival (ignore the initial warnings about deep copying).
- The first campaign map of the FA campaign.

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
