### PR TITLE
Fix notify messages for observers

### DIFF
--- a/lua/SimSync.lua
+++ b/lua/SimSync.lua
@@ -4,6 +4,7 @@
 -- synchronized on the sim beat (which is like a tick but happens even when the game is paused)
 ---@class SyncTable: table
 ---@field EnhanceRestrict table<Enhancement, true>
+---@field UnitData? { [EntityId]: { OwnerArmy: Army, Data: UnitSyncData }, Chat: { sender: string,  msg: table }[] }
 Sync = { }
 
 local SyncDefaults = {

--- a/lua/SimSync.lua
+++ b/lua/SimSync.lua
@@ -5,6 +5,7 @@
 ---@class SyncTable: table
 ---@field EnhanceRestrict table<Enhancement, true>
 ---@field UnitData? { [EntityId]: { OwnerArmy: Army, Data: UnitSyncData }, Chat: { sender: string,  msg: table }[] }
+---@field EnhanceMessage? NotifyMessageSyncData[]
 Sync = { }
 
 local SyncDefaults = {

--- a/lua/SimSync.lua
+++ b/lua/SimSync.lua
@@ -33,6 +33,7 @@ UnitData = {}
 ---@type EnhancementSyncTable
 SimUnitEnhancements = {}
 
+--- Called by the engine every sim beat
 function ResetSyncTable()
     local sync = Sync
     for k, v in sync do
@@ -140,6 +141,9 @@ function OnPostLoad()
     Sync.IsSavedGame = true
 end
 
+--- Called by the engine when the focus army is changed
+---@param new Army
+---@param old Army
 function NoteFocusArmyChanged(new, old)
     import("/lua/simping.lua").OnArmyChange()
     import("/lua/sim/recall.lua").OnArmyChange()

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4954,14 +4954,24 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
 
     -- Utility Functions
     ---@param self Unit
-    ---@param trigger any
-    ---@param source any
+    ---@param trigger NotifyTrigger
+    ---@param source? NotifySource
     SendNotifyMessage = function(self, trigger, source)
         local focusArmy = GetFocusArmy()
         if focusArmy == -1 or focusArmy == self.Army then
             local id
             local unitType
             local category
+            ---@alias NotifyTrigger 'started' | 'cancelled' | 'completed' | 'transferred'
+
+            ---@alias NotifySource Enhancement | string
+            ---| 'nuke'
+            ---| 'arty'
+
+            ---@alias NotifyCategory FactionCategory
+            ---| 'tech'
+            ---| 'other'
+            ---| 'experimentals'
 
             if not source then
                 local bp = self.Blueprint
@@ -4995,6 +5005,12 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
                 end
             else
                 if not Sync.EnhanceMessage then Sync.EnhanceMessage = {} end
+                ---@class NotifyMessageSyncData
+                ---@field source NotifySource
+                ---@field trigger NotifyTrigger
+                ---@field category NotifyCategory
+                ---@field id? EntityId
+                ---@field army Army
                 local message = {source = source or unitType, trigger = trigger, category = category, id = id, army = self.Army}
                 table.insert(Sync.EnhanceMessage, message)
             end

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -511,17 +511,17 @@ function FindClients(id)
     local focus = t.focusArmy
     local result = {}
     if focus == -1 then
-        for index,client in GetSessionClients() do
+        for index, client in GetSessionClients() do
             if not client.connected then
                 continue
             end
             local playerIsObserver = true
-            for id, player in GetArmiesTable().armiesTable do
-                if player.outOfGame and player.human and player.nickname == client.name then
+            for _, info in t.armiesTable do
+                if info.outOfGame and info.human and info.nickname == client.name then
                     table.insert(result, index)
                     playerIsObserver = false
                     break
-                elseif player.nickname == client.name then
+                elseif info.nickname == client.name then
                     playerIsObserver = false
                     break
                 end
@@ -532,24 +532,24 @@ function FindClients(id)
         end
     else
         local srcs = {}
-        for army,info in t.armiesTable do
+        for army, info in t.armiesTable do
             if id then
                 if army == id then
-                    for k,cmdsrc in info.authorizedCommandSources do
+                    for k, cmdsrc in info.authorizedCommandSources do
                         srcs[cmdsrc] = true
                     end
                     break
                 end
             else
                 if IsAlly(focus, army) then
-                    for k,cmdsrc in info.authorizedCommandSources do
+                    for _, cmdsrc in info.authorizedCommandSources do
                         srcs[cmdsrc] = true
                     end
                 end
             end
         end
-        for index,client in GetSessionClients() do
-            for k,cmdsrc in client.authorizedCommandSources do
+        for index, client in GetSessionClients() do
+            for _, cmdsrc in client.authorizedCommandSources do
                 if srcs[cmdsrc] then
                     table.insert(result, index)
                     break

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -826,8 +826,12 @@ function ReceiveChatFromSim(sender, msg)
         return
     end
 
-    if msg.to == 'notify' and not import("/lua/ui/notify/notify.lua").processIncomingMessage(sender, msg) then
-        return
+    if msg.to == 'notify' then
+        if not import("/lua/ui/notify/notify.lua").processIncomingMessage(sender, msg) then
+            return -- ignore unwanted messages
+        elseif SessionIsReplay() or GetFocusArmy() == -1 then
+            sender = GetArmyData(msg.from).nickname
+        end
     end
 
     if type(msg) == 'string' then

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -806,13 +806,13 @@ function ChatPageDown(mod)
 end
 
 function ReceiveChat(sender, msg)
-    if not msg.ConsoleOutput then
+    local isObsNotifyMessage = msg.to == 'notify' and GetFocusArmy() == -1
+    if not msg.ConsoleOutput and not isObsNotifyMessage then
         SimCallback({Func="GiveResourcesToPlayer", Args={ From=GetFocusArmy(), To=GetFocusArmy(), Mass=0, Energy=0, Sender=sender, Msg=msg},} , true)
     end
     if not SessionIsReplay() then
         ReceiveChatFromSim(sender, msg)
     end
-
 end
 
 function ReceiveChatFromSim(sender, msg)
@@ -827,9 +827,12 @@ function ReceiveChatFromSim(sender, msg)
     end
 
     if msg.to == 'notify' then
+        -- ignore unwanted messages
         if not import("/lua/ui/notify/notify.lua").processIncomingMessage(sender, msg) then
-            return -- ignore unwanted messages
-        elseif SessionIsReplay() or GetFocusArmy() == -1 then
+            return
+
+        -- if we are an observer, display the message as sent from the player making the upgrade
+        elseif GetFocusArmy() == -1 then
             sender = GetArmyData(msg.from).nickname
         end
     end

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -1567,3 +1567,14 @@ function CloseChatConfig()
         GUI.config = nil
     end
 end
+
+__module_info = {
+    OnReload = function(newModule)
+        for i, v in GUI do
+            if v.Destroy then v:Destroy() end
+            GUI[i] = nil
+        end
+
+        newModule.SetupChatLayout(import('/lua/ui/game/gamemain.lua').windowGroup)
+    end,
+}

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -1169,7 +1169,7 @@ SendChat = function()
                     if newChat then
                         chat.oldTime = GetGameTimeSeconds()
                         table.insert(oldData, chat)
-                        sendChat(chat.sender, chat.msg)
+                        import("/lua/ui/game/chat.lua").ReceiveChatFromSim(chat.sender, chat.msg)
                     end
                 end
                 UnitData.Chat = {}

--- a/lua/ui/notify/notify.lua
+++ b/lua/ui/notify/notify.lua
@@ -243,6 +243,7 @@ function sendMessage(msg)
 end
 
 -- This function processes messages sent from the sim from unit.lua and defaultunits.lua
+---@param messageTable NotifyMessageSyncData
 function sendEnhancementMessage(messageTable)
     local source = messageTable.source
     local category = messageTable.category
@@ -261,6 +262,10 @@ function sendEnhancementMessage(messageTable)
     end
 end
 
+---@param id EntityId?
+---@param army Army
+---@param category NotifyCategory
+---@param source NotifySource
 function onStartEnhancement(id, army, category, source)
     local msg = {from = army, to = 'notify', Chat = true, text = 'Starting ' .. messages()[category][source], data = {category = category, source = source, trigger = 'started'}}
 
@@ -282,6 +287,10 @@ function onStartEnhancement(id, army, category, source)
     sendMessage(msg)
 end
 
+---@param id EntityId?
+---@param army Army
+---@param category NotifyCategory
+---@param source NotifySource
 function onCancelledEnhancement(id, category, source, army)
     local msg = {from = army, to = 'notify', Chat = true, text = messages()[category][source] .. ' cancelled', data = {category = category, source = source, trigger = 'cancelled'}}
 
@@ -296,6 +305,10 @@ function onCancelledEnhancement(id, category, source, army)
 end
 
 -- Called from the enhancement watcher
+---@param id EntityId?
+---@param army Army
+---@param category NotifyCategory
+---@param source NotifySource
 function onCompletedEnhancement(id, category, source, army)
     local msg = {from = army, to = 'notify', Chat = true, text = messages()[category][source] .. ' done!', data = {category = category, source = source, trigger = 'completed'}}
 
@@ -320,6 +333,10 @@ function killWatcher(data)
     end
 end
 
+---@param id EntityId?
+---@param text string
+---@param category NotifyCategory
+---@param source NotifySource
 function watchEnhancement(id, text, category, source)
     local overlayData = {}
     overlayData.unit = GetUnitById(id)

--- a/lua/ui/notify/notify.lua
+++ b/lua/ui/notify/notify.lua
@@ -83,6 +83,12 @@ function setupStartDisables()
 end
 
 -- This function is called from chat.lua when a player receives a message from another player flagged as Notify = true. Generated below.
+
+--- Processes an incoming message according to player preferences and message limits.
+--- Returns false if the message should not be posted in chat.
+---@param sender string # sender player name
+---@param msg { data: { category: NotifyCategory, source: NotifySource, trigger: NotifyTrigger } }
+---@return boolean PostMessage
 function processIncomingMessage(sender, msg)
     local category = msg.data.category
     local source = msg.data.source

--- a/lua/ui/notify/notify.lua
+++ b/lua/ui/notify/notify.lua
@@ -249,14 +249,14 @@ function sendEnhancementMessage(messageTable)
     if trigger == 'started' then
         onStartEnhancement(id, army, category, source)
     elseif trigger == 'cancelled' then
-        onCancelledEnhancement(id, category, source)
+        onCancelledEnhancement(id, category, source, army)
     elseif trigger == 'completed' then
-        onCompletedEnhancement(id, category, source)
+        onCompletedEnhancement(id, category, source, army)
     end
 end
 
 function onStartEnhancement(id, army, category, source)
-    local msg = {to = 'notify', Chat = true, text = 'Starting ' .. messages()[category][source], data = {category = category, source = source, trigger = 'started'}}
+    local msg = {from = army, to = 'notify', Chat = true, text = 'Starting ' .. messages()[category][source], data = {category = category, source = source, trigger = 'started'}}
 
     -- Start by storing ACU IDs for future use
     if id and (focusArmy == -1 or army == focusArmy) then
@@ -276,8 +276,8 @@ function onStartEnhancement(id, army, category, source)
     sendMessage(msg)
 end
 
-function onCancelledEnhancement(id, category, source)
-    local msg = {to = 'notify', Chat = true, text = messages()[category][source] .. ' cancelled', data = {category = category, source = source, trigger = 'cancelled'}}
+function onCancelledEnhancement(id, category, source, army)
+    local msg = {from = army, to = 'notify', Chat = true, text = messages()[category][source] .. ' cancelled', data = {category = category, source = source, trigger = 'cancelled'}}
 
     if id then
         local data = ACUs[id]
@@ -290,8 +290,8 @@ function onCancelledEnhancement(id, category, source)
 end
 
 -- Called from the enhancement watcher
-function onCompletedEnhancement(id, category, source)
-    local msg = {to = 'notify', Chat = true, text = messages()[category][source] .. ' done!', data = {category = category, source = source, trigger = 'completed'}}
+function onCompletedEnhancement(id, category, source, army)
+    local msg = {from = army, to = 'notify', Chat = true, text = messages()[category][source] .. ' done!', data = {category = category, source = source, trigger = 'completed'}}
 
     if id then
         local data = ACUs[id]

--- a/scripts/LaunchFAInstances.ps1
+++ b/scripts/LaunchFAInstances.ps1
@@ -105,7 +105,7 @@ if ($players -eq 1) {
     $hostTeamArgument = Get-TeamArgument -instanceNumber 0
 
     $divisionArgText = Get-DivisionArgText
-    $hostArguments = "/log $hostLogFile /showlog /hostgame $hostProtocol $port $hostPlayerName $gameName $map /startspot 1 /players $players /$hostFaction $hostTeamArgument $baseArguments $divisionArgText /clan $($clans | Get-Random)"
+    $hostArguments = "/log $hostLogFile /showlog /hostgame $hostProtocol $port $hostPlayerName $gameName $map /startspot 1 /$hostFaction $hostTeamArgument $baseArguments $divisionArgText /clan $($clans | Get-Random)"
 
     # Launch host game instance
     Launch-GameInstance -instanceNumber 1 -xPos 0 -yPos 0 -arguments $hostArguments
@@ -122,7 +122,7 @@ if ($players -eq 1) {
         $clientFaction = $factions | Get-Random
         $clientTeamArgument = Get-TeamArgument -instanceNumber $i
         $divisionArgText = Get-DivisionArgText
-        $clientArguments = "/log $clientLogFile /joingame $hostProtocol localhost:$port $clientPlayerName /startspot $($i + 1) /players $players /$clientFaction $clientTeamArgument $baseArguments $divisionArgText /clan $($clans | Get-Random)"
+        $clientArguments = "/log $clientLogFile /joingame $hostProtocol localhost:$port $clientPlayerName /startspot $($i + 1) /$clientFaction $clientTeamArgument $baseArguments $divisionArgText /clan $($clans | Get-Random)"
         
         Launch-GameInstance -instanceNumber ($i + 1) -xPos $xPos -yPos $yPos -arguments $clientArguments
     }


### PR DESCRIPTION
## Issue
Observers duplicate notify messages in the replay.
Observers do not see who sent the notify message, this is relevant for live observers, who do not see ally chat.

## Description of the proposed changes
- Add the army of the notify message into its data.
  - Modify the sender (a nickname) using the given army.
- Do not save notify messages to replay when observing.

## Testing done on the proposed changes

## Checklist
- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
