### PR TITLE
Refactor regen buff

### DIFF
--- a/changelog/snippets/features.6850.md
+++ b/changelog/snippets/features.6850.md
@@ -1,0 +1,5 @@
+- (#6850) Create a new `UniqueAffectCalculation` table in Buffs.lua, which allows a buff to have a unique calculation for how much it adds/multiplies an effect, while letting all other buffs that use the effect to calculate independently (unlike the old `UniqeBuffs` table).
+
+  An example is the Seraphim regen aura which adds regeneration to a unit by a percent of its max HP with maximum amounts based on tech level. Previously it was hijacking the entire multiplier calculation for the regen effect and also had to calculate additive regeneration effects from other buffs. Now it is refactoed to use the new system so it works without affecting the multipliers from other buffs and doesn't have to calculate the additive effects of other buffs.
+
+  Note for mod developers: If your mod relies on the regen multiplier effect to be based on unit HP, and isn't using the `SeraphimACURegenAura` or `SeraphimACUAdvancedRegenAura` buff names, it will break since the multiplier will be multiplying the additive effect of regen buffs.

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -102,7 +102,7 @@ UniqueAffectCalculation = {
     SeraphimACUAdvancedRegenAura = { Regen = regenAuraCalculate },
 }
 
---- Calculates the buff from all the buffs of the same time the unit has.
+--- Calculates the affect values from all the buffs a unit has for a given affect type.
 ---@param unit Unit
 ---@param buffName string
 ---@param affectType string

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -150,7 +150,7 @@ function BuffCalculate(unit, buffName, affectType, initialVal, initialBool)
             end
 
             local mult = affectState.Mult
-            if mult then
+            if mult and mult ~= 1 then
                 for i = 1, affectState.Count do
                     mults = mults * mult
                 end

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -64,9 +64,10 @@ local regenAuraDefaultCeilings = {
 ---@param unit Unit
 ---@param buffName BuffName
 ---@param affectState BlueprintBuffAffectState
+---@param buffsForAffect table<BuffName, BlueprintBuffAffectState>
 ---@return number add
 ---@return number mult
-local function regenAuraCalculate(unit, buffName, affectState)
+local function regenAuraCalculate(unit, buffName, affectState, buffsForAffect)
     local adds = 0
 
     if affectState.Add and affectState.Add ~= 0 then
@@ -93,7 +94,7 @@ local function regenAuraCalculate(unit, buffName, affectState)
 end
 
 --- A function that calculates buff add and mult values for a buff contributing to an "affect".
----@alias AffectCalculation fun(unit: Unit, affectBuffName: BuffName, affectState: BlueprintBuffAffectState): add: number, mult: number
+---@alias AffectCalculation fun(unit: Unit, affectBuffName: BuffName, affectState: BlueprintBuffAffectState, buffsForAffect: table<BuffName, BlueprintBuffAffectState>): add: number, mult: number
 
 ---@type table<BuffName, table<BuffName, AffectCalculation>>
 UniqueAffectCalculation = {
@@ -123,9 +124,10 @@ function BuffCalculate(unit, buffName, affectType, initialVal, initialBool)
     local bool = initialBool or false
     local floor = 0
 
-    if not unit.Buffs.Affects[affectType] then return initialVal, bool end
+    local buffsForAffect = unit.Buffs.Affects[affectType]
+    if not buffsForAffect then return initialVal, bool end
 
-    for originBuffName, affectState in unit.Buffs.Affects[affectType] do
+    for originBuffName, affectState in buffsForAffect do
         if affectState.Floor then
             floor = affectState.Floor
         end
@@ -138,7 +140,7 @@ function BuffCalculate(unit, buffName, affectType, initialVal, initialBool)
 
         local uniqueCalculation = UniqueAffectCalculation[originBuffName][affectType]
         if uniqueCalculation then
-            local add, mult = uniqueCalculation(unit, originBuffName, affectState)
+            local add, mult = uniqueCalculation(unit, originBuffName, affectState, buffsForAffect)
             adds = adds + add
             mults = mults * mult
         else

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -64,8 +64,8 @@ local regenAuraDefaultCeilings = {
 ---@param unit Unit
 ---@param affectBuffName BuffAffectName
 ---@param affectBp BlueprintBuffAffectState
----@return number
----@return number
+---@return number Add
+---@return number Mult
 local function regenAuraCalculate(unit, affectBuffName, affectBp)
     local adds = 0
 
@@ -74,10 +74,9 @@ local function regenAuraCalculate(unit, affectBuffName, affectBp)
     end
 
     -- Take regen values from bp, keys have to match techCategory options
-    local bpCeilings = affectBp.BPCeilings
+    local bpCeilings = affectBp.BPCeilings --[[@as table<TechCategory, number>]]
 
     local techCat = unit.Blueprint.TechCategory
-    ---@diagnostic disable-next-line: need-check-nil
     local ceil = bpCeilings[techCat] or regenAuraDefaultCeilings[techCat]
 
     local mult = affectBp.Mult

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -119,13 +119,13 @@ function BuffCalculate(unit, buffName, affectType, initialVal, initialBool)
 
     -- if not, do the typical buff computation
 
-    local adds = 0
-    local mults = 1.0
     local bool = initialBool or false
-    local floor = 0
-
     local buffsForAffect = unit.Buffs.Affects[affectType]
     if not buffsForAffect then return initialVal, bool end
+
+    local adds = 0
+    local mults = 1.0
+    local floor = 0
 
     for originBuffName, affectState in buffsForAffect do
         if affectState.Floor then

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -125,7 +125,7 @@ function BuffCalculate(unit, buffName, affectType, initialVal, initialBool)
 
     if not unit.Buffs.Affects[affectType] then return initialVal, bool end
 
-    for originBuffName, affectBp in pairs(unit.Buffs.Affects[affectType]) do
+    for originBuffName, affectBp in unit.Buffs.Affects[affectType] do
         if affectBp.Floor then
             floor = affectBp.Floor
         end

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -93,7 +93,7 @@ local function regenAuraCalculate(unit, affectBuffName, affectBp)
     return adds, 1
 end
 
---- A function that calculates buff add and mult values for 1 "affect" instance.
+--- A function that calculates buff add and mult values for a buff contributing to an "affect".
 ---@alias AffectCalculation fun(unit: Unit, affectBuffName: BuffAffectName, affectBp: BlueprintBuffAffectState): add: number, mult: number
 
 ---@type table<BuffName, table<BuffAffectName, AffectCalculation>>

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -62,11 +62,11 @@ local regenAuraDefaultCeilings = {
 
 --- Calculates regen for a unit using mults as a multiplier of the unit's HP that is then added to the final regen value.
 ---@param unit Unit
----@param affectBuffName BuffAffectName
+---@param buffName BuffName
 ---@param affectBp BlueprintBuffAffectState
----@return number Add
----@return number Mult
-local function regenAuraCalculate(unit, affectBuffName, affectBp)
+---@return number add
+---@return number mult
+local function regenAuraCalculate(unit, buffName, affectBp)
     local adds = 0
 
     if affectBp.Add and affectBp.Add ~= 0 then
@@ -93,9 +93,9 @@ local function regenAuraCalculate(unit, affectBuffName, affectBp)
 end
 
 --- A function that calculates buff add and mult values for a buff contributing to an "affect".
----@alias AffectCalculation fun(unit: Unit, affectBuffName: BuffAffectName, affectBp: BlueprintBuffAffectState): add: number, mult: number
+---@alias AffectCalculation fun(unit: Unit, affectBuffName: BuffName, affectBp: BlueprintBuffAffectState): add: number, mult: number
 
----@type table<BuffName, table<BuffAffectName, AffectCalculation>>
+---@type table<BuffName, table<BuffName, AffectCalculation>>
 UniqueAffectCalculation = {
     SeraphimACURegenAura = { Regen = regenAuraCalculate },
     SeraphimACUAdvancedRegenAura = { Regen = regenAuraCalculate },
@@ -125,7 +125,7 @@ function BuffCalculate(unit, buffName, affectType, initialVal, initialBool)
 
     if not unit.Buffs.Affects[affectType] then return initialVal, bool end
 
-    for affectBuffName, affectBp in pairs(unit.Buffs.Affects[affectType]) do
+    for originBuffName, affectBp in pairs(unit.Buffs.Affects[affectType]) do
         if affectBp.Floor then
             floor = affectBp.Floor
         end
@@ -136,9 +136,9 @@ function BuffCalculate(unit, buffName, affectType, initialVal, initialBool)
             bool = true
         end
 
-        local uniqueCalculation = UniqueAffectCalculation[affectBuffName][affectType]
+        local uniqueCalculation = UniqueAffectCalculation[originBuffName][affectType]
         if uniqueCalculation then
-            local add, mult = uniqueCalculation(unit, affectBuffName, affectBp)
+            local add, mult = uniqueCalculation(unit, originBuffName, affectBp)
             adds = adds + add
             mults = mults * mult
         else

--- a/lua/system/BuffBlueprints.lua
+++ b/lua/system/BuffBlueprints.lua
@@ -63,7 +63,7 @@ Buffs = {}
 ---@field Add? number
 --- List of ceilings to use depending on the `techCategory` of the unit. Takes precedence over
 --- `Ceil` but falls back on it if no ceiling for the teach category is found.
----@field BPCeilings? table<string, number>
+---@field BPCeilings? table<TechCategory, number>
 --- List of floors to use depending on the `techCategory` of the unit. Takes precedence over `Floor`
 --- but falls back on it if no floor for the teach category is found.
 ---@field BPFloors? table<string, number>


### PR DESCRIPTION
## Issue
- The default BuffCalculate function hijacks the Regen mult calculation as said in https://github.com/FAForever/fa/pull/5170#issuecomment-1619073588 by @Hdt80bro.

- The `UniqueBuffs` table does not give a way to stack different unique buffs; the unique buff has to do correct calculations for all buffs, while adding its own unique calculation in the middle.
  - It's worth noting the `UniqueBuffs` table was never used because BuffCalculate never passed in a buffname for Regen (the second param is `nil`).
  https://github.com/FAForever/fa/blob/5adcca7113beda198176d9511ffc827cd30bc855/lua/sim/Buff.lua#L325


## Description of the proposed changes
Branch is based on #6837.

Refactor the regen aura buff calculations into a new `UniqueAffectCalculation` function table. `UniqueAffectCalculation` can be used to give specific buffs a unique way of calculating adds or mults for a buff. `Floor` and `Bool` are not made available as they don't seem to make sense to adjust uniquely because they override values of the entire affect stack. This allows a single buff to have a unique calculation for its contribution to the overall affect, instead of having it calculate the entire stack with all buffs + its unique effect.
  - Since the UniqueBuffs table was not used, I refactored the base regen calculation and not the unique one into the new function.

This would break other mods that rely on the existing regen mult behavior and aren't using the correct buff names.

## Testing done on the proposed changes
Regen Aura ACU gives the correct regen amount to SACUs with regen upgrades.
```
   CreateUnitAtMouse('xab1401', 0,   -5.67,   -2.00, -0.00000)
   CreateUnitAtMouse('xsl0001', 0,    1.33,    2.00, -0.00000)
   CreateUnitAtMouse('ual0301_nanocombat', 0,    4.33,    0.00, -0.00000)
```

## Additional context
BlackOps FAF Unleashed shouldn't break due to these changes because it uses the same buff names as FAF:
[`SeraphimACURegenAura`](https://github.com/Uveso/BlackOpsFAF-ACUs/blob/e6cccf541a120546508f9ac4ddf793f2437e284d/units/ESL0001/ESL0001_script.lua#L479)
[`SeraphimACUAdvancedRegenAura`](https://github.com/Uveso/BlackOpsFAF-ACUs/blob/e6cccf541a120546508f9ac4ddf793f2437e284d/units/ESL0001/ESL0001_script.lua#L561C29-L561C57)

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
