### PR TITLE
Use faster Lua Vector operations in remaining non-AI sim code

### DIFF
--- a/changelog/snippets/performance.6852.md
+++ b/changelog/snippets/performance.6852.md
@@ -1,0 +1,1 @@
+- (#6852) Use faster Lua Vector operations in remaining non-AI sim code

--- a/engine/Sim/CAiNavigatorImpl.lua
+++ b/engine/Sim/CAiNavigatorImpl.lua
@@ -29,6 +29,7 @@ end
 
 ---
 --  This returns the current navigator target position for the unit
+---@return Vector
 function CNavigator:GetCurrentTargetPos()
 end
 

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -280,11 +280,13 @@ BuffEffects = {
 
         if healthadj < 0 then
             -- fixme: DoTakeDamage shouldn't be called directly
+            local instigatorPos = instigator:GetPosition()
+            local unitPos = unit:GetPosition()
             local data = {
                 Instigator = instigator,
                 Amount = -1 * healthadj,
                 Type = buffDefinition.DamageType or 'Spell',
-                Vector = VDiff(instigator:GetPosition(), unit:GetPosition()),
+                Vector = Vector(instigatorPos[1] - unitPos[1], instigatorPos[2] - unitPos[2], instigatorPos[3] - unitPos[3]),
             }
             unit:DoTakeDamage(data)
         else

--- a/lua/sim/DefaultProjectiles.lua
+++ b/lua/sim/DefaultProjectiles.lua
@@ -52,6 +52,7 @@ local Random = Random
 local CreateTrail = CreateTrail
 local CreateEmitterOnEntity = CreateEmitterOnEntity
 local CreateBeamEmitterOnEntity = CreateBeamEmitterOnEntity
+---@diagnostic disable-next-line: deprecated
 local VDist2 = VDist2
 local TableGetn = table.getn
 

--- a/lua/sim/defaultweapons.lua
+++ b/lua/sim/defaultweapons.lua
@@ -43,4 +43,5 @@ local UnitGetTargetEntity = UnitMethods.GetTargetEntity
 
 local MathClamp = math.clamp
 local GetSurfaceHeight = GetSurfaceHeight
+---@diagnostic disable-next-line: deprecated
 local VDist2 = VDist2

--- a/lua/sim/projectiles/NukeProjectile.lua
+++ b/lua/sim/projectiles/NukeProjectile.lua
@@ -22,6 +22,8 @@
 
 local NullShell = import("/lua/sim/projectiles/nullprojectile.lua").NullShell
 
+local MathSqrt = math.sqrt
+
 ---@class NukeProjectile : NullShell
 NukeProjectile = ClassProjectile(NullShell) {
 
@@ -80,7 +82,9 @@ NukeProjectile = ClassProjectile(NullShell) {
     GetDistanceToTarget = function(self)
         local tpos = self:GetCurrentTargetPosition()
         local mpos = self:GetPosition()
-        local dist = VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
+        local distX = tpos[1] - mpos[1]
+        local distZ = tpos[3] - mpos[3]
+        local dist = MathSqrt(distX * distX + distZ * distZ)
         return dist
     end,
 

--- a/lua/sim/projectiles/NukeProjectile.lua
+++ b/lua/sim/projectiles/NukeProjectile.lua
@@ -80,10 +80,10 @@ NukeProjectile = ClassProjectile(NullShell) {
     ---@param self NukeProjectile
     ---@return number
     GetDistanceToTarget = function(self)
-        local tpos = self:GetCurrentTargetPosition()
-        local mpos = self:GetPosition()
-        local distX = tpos[1] - mpos[1]
-        local distZ = tpos[3] - mpos[3]
+        local tx, _, tz = self:GetCurrentTargetPositionXYZ()
+        local mx, _, mz = self:GetPositionXYZ()
+        local distX = tx - mx
+        local distZ = tz - mz
         local dist = MathSqrt(distX * distX + distZ * distZ)
         return dist
     end,

--- a/lua/sim/projectiles/components/SemiBallisticComponent.lua
+++ b/lua/sim/projectiles/components/SemiBallisticComponent.lua
@@ -114,17 +114,17 @@ SemiBallisticComponent = ClassSimple {
     TurnRateFromDistance = function(self)
         local blueprintPhysics = self.Blueprint.Physics
 
-        local dist = self:DistanceToTarget()
-
         local targetX, targetY, targetZ = self:GetCurrentTargetPositionXYZ()
         local selfX, selfY, selfZ = self:GetPositionXYZ()
         local targetVector = Vector(targetX - selfX, targetY - selfY, targetZ - selfZ)
 
         local ux, uy, uz = self:GetVelocity()
         local velocityVector = Vector(ux, uy, uz)
-        local speed = self:GetCurrentSpeed()
 
         local dot = targetVector[1] * velocityVector[1] + targetVector[2] * velocityVector[2] + targetVector[3] * velocityVector[3]
+
+        local dist = self:DistanceToTarget()
+        local speed = self:GetCurrentSpeed()
         local theta = MathAcos(dot / (speed * dist))
         --local radius = dist/(2 * MathSin(theta))
         local arcLength = 2 * theta * dist/(2 * MathSin(theta))

--- a/lua/sim/projectiles/components/SemiBallisticComponent.lua
+++ b/lua/sim/projectiles/components/SemiBallisticComponent.lua
@@ -116,10 +116,9 @@ SemiBallisticComponent = ClassSimple {
 
         local targetX, targetY, targetZ = self:GetCurrentTargetPositionXYZ()
         local selfX, selfY, selfZ = self:GetPositionXYZ()
+        local velX, velY, velZ = self:GetVelocity()
 
-        local ux, uy, uz = self:GetVelocity()
-
-        local dot = (targetX - selfX) * ux + (targetY - selfY) * uy + (targetZ - selfZ) * uz
+        local dot = (targetX - selfX) * velX + (targetY - selfY) * velY + (targetZ - selfZ) * velZ
 
         local dist = self:DistanceToTarget()
         local speed = self:GetCurrentSpeed()

--- a/lua/sim/projectiles/components/SemiBallisticComponent.lua
+++ b/lua/sim/projectiles/components/SemiBallisticComponent.lua
@@ -21,7 +21,6 @@
 --******************************************************************************************************
 
 -- upvalue globals for performance
-local VDist2 = VDist2
 local VDist3 = VDist3
 local MathPow = math.pow
 local MathSqrt = math.sqrt
@@ -75,7 +74,9 @@ SemiBallisticComponent = ClassSimple {
         local ux, uy, uz = self:GetVelocity()
         local s0 = self:GetPosition()
         local target = self:GetCurrentTargetPosition()
-        local dist = VDist2(target[1], target[3], s0[1], s0[3])
+        local d1 = s0[1] - target[1]
+        local d2 =  s0[3] - target[3]
+        local dist = MathSqrt(d1 * d1 + d2 * d2)
 
         -- we need velocity in m/s, not in m/tick
         local ux, uy, uz = ux*10, uy*10, uz*10
@@ -184,7 +185,9 @@ SemiBallisticComponent = ClassSimple {
     HorizontalDistanceToTarget = function(self)
         local tpos = self:GetCurrentTargetPosition()
         local mpos = self:GetPosition()
-        return VDist2(mpos[1], mpos[3], tpos[1], tpos[3])
+        local d1 = tpos[1] - mpos[1]
+        local d2 = tpos[3] - mpos[3]
+        return MathSqrt(d1 * d1 + d2 * d2)
     end,
 
     -- Angle between the given vector and the horizontal plane
@@ -198,7 +201,7 @@ SemiBallisticComponent = ClassSimple {
         else
             vx, vy, vz = self:GetVelocity()
         end
-        local vh = VDist2(vx, vz, 0, 0)
+        local vh = MathSqrt(vx * vx + vz * vz)
         if vh == 0 then
             if vy >= 0 then
                 return MathPi/2

--- a/lua/sim/projectiles/components/SemiBallisticComponent.lua
+++ b/lua/sim/projectiles/components/SemiBallisticComponent.lua
@@ -116,12 +116,10 @@ SemiBallisticComponent = ClassSimple {
 
         local targetX, targetY, targetZ = self:GetCurrentTargetPositionXYZ()
         local selfX, selfY, selfZ = self:GetPositionXYZ()
-        local targetVector = Vector(targetX - selfX, targetY - selfY, targetZ - selfZ)
 
         local ux, uy, uz = self:GetVelocity()
-        local velocityVector = Vector(ux, uy, uz)
 
-        local dot = targetVector[1] * velocityVector[1] + targetVector[2] * velocityVector[2] + targetVector[3] * velocityVector[3]
+        local dot = (targetX - selfX) * ux + (targetY - selfY) * uy + (targetZ - selfZ) * uz
 
         local dist = self:DistanceToTarget()
         local speed = self:GetCurrentSpeed()

--- a/lua/sim/projectiles/components/SemiBallisticComponent.lua
+++ b/lua/sim/projectiles/components/SemiBallisticComponent.lua
@@ -115,7 +115,11 @@ SemiBallisticComponent = ClassSimple {
         local blueprintPhysics = self.Blueprint.Physics
 
         local dist = self:DistanceToTarget()
-        local targetVector = VDiff(self:GetCurrentTargetPosition(), self:GetPosition())
+
+        local targetX, targetY, targetZ = self:GetCurrentTargetPositionXYZ()
+        local selfX, selfY, selfZ = self:GetPositionXYZ()
+        local targetVector = Vector(targetX - selfX, targetY - selfY, targetZ - selfZ)
+
         local ux, uy, uz = self:GetVelocity()
         local velocityVector = Vector(ux, uy, uz)
         local speed = self:GetCurrentSpeed()

--- a/lua/sim/projectiles/components/SemiBallisticComponent.lua
+++ b/lua/sim/projectiles/components/SemiBallisticComponent.lua
@@ -124,7 +124,8 @@ SemiBallisticComponent = ClassSimple {
         local velocityVector = Vector(ux, uy, uz)
         local speed = self:GetCurrentSpeed()
 
-        local theta = MathAcos(VDot(targetVector, velocityVector) / (speed * dist))
+        local dot = targetVector[1] * velocityVector[1] + targetVector[2] * velocityVector[2] + targetVector[3] * velocityVector[3]
+        local theta = MathAcos(dot / (speed * dist))
         --local radius = dist/(2 * MathSin(theta))
         local arcLength = 2 * theta * dist/(2 * MathSin(theta))
 

--- a/lua/sim/projectiles/components/SemiBallisticComponent.lua
+++ b/lua/sim/projectiles/components/SemiBallisticComponent.lua
@@ -79,7 +79,7 @@ SemiBallisticComponent = ClassSimple {
         local dist = MathSqrt(d1 * d1 + d2 * d2)
 
         -- we need velocity in m/s, not in m/tick
-        local ux, uy, uz = ux*10, uy*10, uz*10
+        ux, uy, uz = ux*10, uy*10, uz*10
     
         local timeToImpact = dist / MathSqrt(MathPow(ux, 2) + MathPow(uz, 2))
         local ballisticAcceleration = (2 * ((target[2] - s0[2]) - uy * timeToImpact)) / MathPow(timeToImpact, 2)

--- a/lua/sim/units/AirTransportUnit.lua
+++ b/lua/sim/units/AirTransportUnit.lua
@@ -69,13 +69,16 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
                 local commandDistZ = command.z - pos[3]
                 local commandDist = MathSqrt(commandDistX * commandDistX + commandDistZ * commandDistZ)
 
+                if commandDist > 20 then
+                    return
+                end
+
                 local targetDistX = targetPos[1] - pos[1]
                 local targetDistZ = targetPos[3] - pos[3]
                 local targetDist = MathSqrt(targetDistX * targetDistX + targetDistZ * targetDistZ)
 
                 -- Don't drop if we're too far away from the target
-                if commandDist > 20
-                    or targetDist > HorzUnloadMargin
+                if targetDist > HorzUnloadMargin
                     or pos[2] - targetPos[2] > (self.Blueprint.Air.TransportHoverHeight or 6) * VertUnloadFactor
                 then
                     return

--- a/lua/sim/units/AirTransportUnit.lua
+++ b/lua/sim/units/AirTransportUnit.lua
@@ -69,17 +69,15 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
 
                 local commandDistX = command.x - posX
                 local commandDistZ = command.z - posZ
-                local commandDist = MathSqrt(commandDistX * commandDistX + commandDistZ * commandDistZ)
 
-                if commandDist > 20 then
+                if MathSqrt(commandDistX * commandDistX + commandDistZ * commandDistZ) > 20 then
                     return
                 end
 
                 local targetDistX = targetPos[1] - posX
                 local targetDistZ = targetPos[3] - posZ
-                local targetDist = MathSqrt(targetDistX * targetDistX + targetDistZ * targetDistZ)
 
-                if targetDist > HorzUnloadMargin
+                if MathSqrt(targetDistX * targetDistX + targetDistZ * targetDistZ) > HorzUnloadMargin
                     or posY - targetPos[2] > (self.Blueprint.Air.TransportHoverHeight or 6) * VertUnloadFactor
                 then
                     return

--- a/lua/sim/units/AirTransportUnit.lua
+++ b/lua/sim/units/AirTransportUnit.lua
@@ -61,13 +61,16 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
                 local targetPos = navigator:GetCurrentTargetPos()
                 local pos = self:GetPosition()
 
+                if not targetPos then
+                    return
+                end
+
                 local commandDistX = command.x - pos[1]
                 local commandDistZ = command.z - pos[3]
                 local commandDist = MathSqrt(commandDistX * commandDistX + commandDistZ * commandDistZ)
 
                 -- Don't drop if we're too far away from the target
-                if not targetPos
-                    or commandDist > 20
+                if commandDist > 20
                     or VDist2(pos[1], pos[3], targetPos[1], targetPos[3]) > HorzUnloadMargin
                     or pos[2] - targetPos[2] > (self.Blueprint.Air.TransportHoverHeight or 6) * VertUnloadFactor
                 then

--- a/lua/sim/units/AirTransportUnit.lua
+++ b/lua/sim/units/AirTransportUnit.lua
@@ -59,7 +59,7 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
             if UnloadCommands[command.commandType] then
                 local navigator = self:GetNavigator()
                 local targetPos = navigator:GetCurrentTargetPos()
-                local pos = self:GetPosition()
+                local posX, posY, posZ = self:GetPositionXYZ()
 
                 if not targetPos then
                     return
@@ -67,20 +67,20 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
 
                 -- Don't drop if we're too far away from the target
 
-                local commandDistX = command.x - pos[1]
-                local commandDistZ = command.z - pos[3]
+                local commandDistX = command.x - posX
+                local commandDistZ = command.z - posZ
                 local commandDist = MathSqrt(commandDistX * commandDistX + commandDistZ * commandDistZ)
 
                 if commandDist > 20 then
                     return
                 end
 
-                local targetDistX = targetPos[1] - pos[1]
-                local targetDistZ = targetPos[3] - pos[3]
+                local targetDistX = targetPos[1] - posX
+                local targetDistZ = targetPos[3] - posZ
                 local targetDist = MathSqrt(targetDistX * targetDistX + targetDistZ * targetDistZ)
 
                 if targetDist > HorzUnloadMargin
-                    or pos[2] - targetPos[2] > (self.Blueprint.Air.TransportHoverHeight or 6) * VertUnloadFactor
+                    or posY - targetPos[2] > (self.Blueprint.Air.TransportHoverHeight or 6) * VertUnloadFactor
                 then
                     return
                 end

--- a/lua/sim/units/AirTransportUnit.lua
+++ b/lua/sim/units/AirTransportUnit.lua
@@ -69,9 +69,13 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
                 local commandDistZ = command.z - pos[3]
                 local commandDist = MathSqrt(commandDistX * commandDistX + commandDistZ * commandDistZ)
 
+                local targetDistX = targetPos[1] - pos[1]
+                local targetDistZ = targetPos[3] - pos[3]
+                local targetDist = MathSqrt(targetDistX * targetDistX + targetDistZ * targetDistZ)
+
                 -- Don't drop if we're too far away from the target
                 if commandDist > 20
-                    or VDist2(pos[1], pos[3], targetPos[1], targetPos[3]) > HorzUnloadMargin
+                    or targetDist > HorzUnloadMargin
                     or pos[2] - targetPos[2] > (self.Blueprint.Air.TransportHoverHeight or 6) * VertUnloadFactor
                 then
                     return

--- a/lua/sim/units/AirTransportUnit.lua
+++ b/lua/sim/units/AirTransportUnit.lua
@@ -65,6 +65,8 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
                     return
                 end
 
+                -- Don't drop if we're too far away from the target
+
                 local commandDistX = command.x - pos[1]
                 local commandDistZ = command.z - pos[3]
                 local commandDist = MathSqrt(commandDistX * commandDistX + commandDistZ * commandDistZ)
@@ -77,7 +79,6 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
                 local targetDistZ = targetPos[3] - pos[3]
                 local targetDist = MathSqrt(targetDistX * targetDistX + targetDistZ * targetDistZ)
 
-                -- Don't drop if we're too far away from the target
                 if targetDist > HorzUnloadMargin
                     or pos[2] - targetPos[2] > (self.Blueprint.Air.TransportHoverHeight or 6) * VertUnloadFactor
                 then

--- a/lua/sim/units/AirTransportUnit.lua
+++ b/lua/sim/units/AirTransportUnit.lua
@@ -18,6 +18,8 @@ local BaseTransportOnStartTransportLoading = BaseTransport.OnStartTransportLoadi
 local BaseTransportOnStopTransportLoading = BaseTransport.OnStopTransportLoading
 local BaseTransportDestroyedOnTransport = BaseTransport.DestroyedOnTransport
 
+local MathSqrt = math.sqrt
+
 local UnloadCommands = {
     [24] = true, -- TransportUnloadUnits
     [25] = true, -- TransportUnloadSpecificUnits
@@ -59,9 +61,13 @@ AirTransport = ClassUnit(AirUnit, BaseTransport) {
                 local targetPos = navigator:GetCurrentTargetPos()
                 local pos = self:GetPosition()
 
+                local commandDistX = command.x - pos[1]
+                local commandDistZ = command.z - pos[3]
+                local commandDist = MathSqrt(commandDistX * commandDistX + commandDistZ * commandDistZ)
+
                 -- Don't drop if we're too far away from the target
                 if not targetPos
-                    or VDist2(pos[1], pos[3], command.x, command.z) > 20
+                    or commandDist > 20
                     or VDist2(pos[1], pos[3], targetPos[1], targetPos[3]) > HorzUnloadMargin
                     or pos[2] - targetPos[2] > (self.Blueprint.Air.TransportHoverHeight or 6) * VertUnloadFactor
                 then

--- a/lua/sim/units/SeaFactoryUnit.lua
+++ b/lua/sim/units/SeaFactoryUnit.lua
@@ -45,11 +45,13 @@ SeaFactoryUnit = ClassUnit(FactoryUnit) {
         -- find the nearest roll off point
         local bpKey = 1
         local distance, lowest = nil, nil
+
         local distX = bx - rallyPoint[1]
+        local distZPartial = pz - rallyPoint[3]
 
         for k, rolloffPoint in bp do
             local ropz = modz * rolloffPoint.Z
-            local distZ = (ropz + pz) - rallyPoint[3]
+            local distZ = ropz + distZPartial
             distance = MathSqrt(distX * distX + distZ * distZ)
             if not lowest or distance < lowest then
                 bpKey = k

--- a/lua/sim/units/SeaFactoryUnit.lua
+++ b/lua/sim/units/SeaFactoryUnit.lua
@@ -39,7 +39,7 @@ SeaFactoryUnit = ClassUnit(FactoryUnit) {
 
         -- find the attachpoint for the build location
         local bone = (self:IsValidBone('Attachpoint') and 'Attachpoint') or (self:IsValidBone('Attachpoint01') and 'Attachpoint01')
-        local bx, by, bz = self:GetPositionXYZ(bone)
+        local bx, _, _ = self:GetPositionXYZ(bone)
         local modz = 1.0 + 0.1 * self.UnitBeingBuilt.Blueprint.SizeZ
 
         -- find the nearest roll off point

--- a/lua/sim/units/SeaFactoryUnit.lua
+++ b/lua/sim/units/SeaFactoryUnit.lua
@@ -2,6 +2,8 @@
 local FactoryUnit = import("/lua/sim/units/factoryunit.lua").FactoryUnit
 local FactoryUnitCalculateRollOffPoint = FactoryUnit.CalculateRollOffPoint
 
+local MathSqrt = math.sqrt
+
 ---@class SeaFactoryUnit : FactoryUnit
 SeaFactoryUnit = ClassUnit(FactoryUnit) {
 
@@ -47,7 +49,9 @@ SeaFactoryUnit = ClassUnit(FactoryUnit) {
         for k, rolloffPoint in bp do
 
             local ropz = modz * rolloffPoint.Z
-            distance = VDist2(rallyPoint[1], rallyPoint[3], ropx + px, ropz + pz)
+            local distX = (ropx + px) - rallyPoint[1]
+            local distZ = (ropz + pz) - rallyPoint[3]
+            distance = MathSqrt(distX * distX + distZ * distZ)
             if not lowest or distance < lowest then
                 bpKey = k
                 lowest = distance

--- a/lua/sim/units/SeaFactoryUnit.lua
+++ b/lua/sim/units/SeaFactoryUnit.lua
@@ -50,8 +50,7 @@ SeaFactoryUnit = ClassUnit(FactoryUnit) {
         local distZPartial = pz - rallyPoint[3]
 
         for k, rolloffPoint in bp do
-            local ropz = modz * rolloffPoint.Z
-            local distZ = ropz + distZPartial
+            local distZ = distZPartial + (modz * rolloffPoint.Z)
             distance = MathSqrt(distX * distX + distZ * distZ)
             if not lowest or distance < lowest then
                 bpKey = k

--- a/lua/sim/units/SeaFactoryUnit.lua
+++ b/lua/sim/units/SeaFactoryUnit.lua
@@ -59,7 +59,7 @@ SeaFactoryUnit = ClassUnit(FactoryUnit) {
         end
 
         -- finalize the computation
-        local fx, fy, fz, spin
+        local fy, fz, spin
         local bpP = bp[bpKey]
         local unitBP = self.UnitBeingBuilt.Blueprint.Display.ForcedBuildSpin
         if unitBP then
@@ -68,11 +68,10 @@ SeaFactoryUnit = ClassUnit(FactoryUnit) {
             spin = bpP.UnitSpin
         end
 
-        fx = ropx + px
         fy = bpP.Y + py
         fz = modz * bpP.Z + pz
 
-        return spin, fx, fy, fz
+        return spin, bx, fy, fz
     end,
 
 }

--- a/lua/sim/units/SeaFactoryUnit.lua
+++ b/lua/sim/units/SeaFactoryUnit.lua
@@ -40,13 +40,12 @@ SeaFactoryUnit = ClassUnit(FactoryUnit) {
         -- find the attachpoint for the build location
         local bone = (self:IsValidBone('Attachpoint') and 'Attachpoint') or (self:IsValidBone('Attachpoint01') and 'Attachpoint01')
         local bx, by, bz = self:GetPositionXYZ(bone)
-        local ropx = bx - px
         local modz = 1.0 + 0.1 * self.UnitBeingBuilt.Blueprint.SizeZ
 
         -- find the nearest roll off point
         local bpKey = 1
         local distance, lowest = nil, nil
-        local distX = (ropx + px) - rallyPoint[1]
+        local distX = bx - rallyPoint[1]
 
         for k, rolloffPoint in bp do
             local ropz = modz * rolloffPoint.Z

--- a/lua/sim/units/SeaFactoryUnit.lua
+++ b/lua/sim/units/SeaFactoryUnit.lua
@@ -46,10 +46,10 @@ SeaFactoryUnit = ClassUnit(FactoryUnit) {
         -- find the nearest roll off point
         local bpKey = 1
         local distance, lowest = nil, nil
-        for k, rolloffPoint in bp do
+        local distX = (ropx + px) - rallyPoint[1]
 
+        for k, rolloffPoint in bp do
             local ropz = modz * rolloffPoint.Z
-            local distX = (ropx + px) - rallyPoint[1]
             local distZ = (ropz + pz) - rallyPoint[3]
             distance = MathSqrt(distX * distX + distZ * distZ)
             if not lowest or distance < lowest then

--- a/lua/sim/units/cybran/CConstructionTemplate.lua
+++ b/lua/sim/units/cybran/CConstructionTemplate.lua
@@ -221,7 +221,9 @@ CConstructionTemplate = ClassSimple {
                     local bot = bots[k]
                     if bot and not bot.Dead then
                         local bx, by, bz = EntityGetPositionXYZ(bot)
-                        local distance = VDist2Sq(tx, tz, bx, bz)
+                        local distX = bx - tx
+                        local distZ = bz - tz
+                        local distance = distX * distX + distZ * distZ
 
                         -- if close enough, just remove it
                         threshold = threshold + 0.1

--- a/lua/sim/units/cybran/CConstructionTemplate.lua
+++ b/lua/sim/units/cybran/CConstructionTemplate.lua
@@ -216,11 +216,11 @@ CConstructionTemplate = ClassSimple {
             for l = 1, 4 do
                 WaitTicks(3)
 
-                local tx, ty, tz = EntityGetPositionXYZ(self)
+                local tx, _, tz = EntityGetPositionXYZ(self)
                 for k = 1, buildBotTotal do
                     local bot = bots[k]
                     if bot and not bot.Dead then
-                        local bx, by, bz = EntityGetPositionXYZ(bot)
+                        local bx, _, bz = EntityGetPositionXYZ(bot)
                         local distX = bx - tx
                         local distZ = bz - tz
                         local distance = distX * distX + distZ * distZ

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -328,7 +328,9 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         local targetPosX, targetPosZ = targetPos[1], targetPos[3]
 
         -- calculate the distance for this particular bomb
-        local distPos = VDist2(projPosX, projPosZ, targetPosX, targetPosZ)
+        local posDiffX = targetPosX - projPosX
+        local posDiffY = targetPosZ - projPosZ
+        local distPos = MathSqrt(posDiffX * posDiffX + posDiffY * posDiffY)
         do
             local dropShort = self.DropBombShortRatio
             if dropShort then

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -1026,10 +1026,10 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                 end
 
                 if bp.FixedSpreadRadius then
-                    local weaponPos = unit:GetPosition()
+                    local weaponPosX, _, weaponPosZ = unit:GetPositionXYZ()
                     local targetPos = self:GetCurrentTargetPos()
-                    local posDiffX = targetPos[1] - weaponPos[1]
-                    local posDiffZ = targetPos[3] - weaponPos[3]
+                    local posDiffX = targetPos[1] - weaponPosX
+                    local posDiffZ = targetPos[3] - weaponPosZ
                     local distance = MathSqrt(posDiffX * posDiffX + posDiffZ * posDiffZ)
 
                     -- This formula was obtained empirically and somehow it works :)

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -1028,7 +1028,9 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                 if bp.FixedSpreadRadius then
                     local weaponPos = unit:GetPosition()
                     local targetPos = self:GetCurrentTargetPos()
-                    local distance = VDist2(weaponPos[1], weaponPos[3], targetPos[1], targetPos[3])
+                    local posDiffX = targetPos[1] - weaponPos[1]
+                    local posDiffZ = targetPos[3] - weaponPos[3]
+                    local distance = MathSqrt(posDiffX * posDiffX + posDiffZ * posDiffZ)
 
                     -- This formula was obtained empirically and somehow it works :)
                     local randomness = 12 * bp.FixedSpreadRadius / distance

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -1,10 +1,5 @@
 local Weapon = import("/lua/sim/weapon.lua").Weapon
 
---#region Backwards compatibility
----@diagnostic disable-next-line: deprecated
-local VDist2 = VDist2
---#endregion
-
 -- upvalue globals for performance
 local GetSurfaceHeight = GetSurfaceHeight
 
@@ -1366,3 +1361,8 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         end,
     },
 }
+
+--#region Backwards compatibility
+---@diagnostic disable-next-line: deprecated
+local VDist2 = VDist2
+--#endregion

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -349,8 +349,8 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         -- save the new predicted target position in case we lose the target
         -- so that we can drop the bomb salvo centered onto there.
         if data.target then
-            targetPos[1] = targetPos[1] + time * targetVelX
-            targetPos[3] = targetPos[3] + time * targetVelZ
+            targetPos[1] = targetPosX + time * targetVelX
+            targetPos[3] = targetPosZ + time * targetVelZ
             data.targetPos = targetPos
         end
 

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -318,7 +318,9 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
 
         -- calculate flat (exclude y-axis) distance and velocity between projectile and target
         -- velocity will eventually need to multiplied by 10 due to being per tick instead of per second
-        local distVel = VDist2(projVelX, projVelZ, targetVelX, targetVelZ)
+        local velDiffX = targetVelX - projVelX
+        local velDiffZ = targetVelZ - projVelZ
+        local distVel = MathSqrt(velDiffX * velDiffX + velDiffZ * velDiffZ)
         if distVel == 0 then
             data.lastAccel = 4.9
             return 4.9

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -241,7 +241,9 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                     targetVelX, _, targetVelZ = UnitGetVelocity(target)
                 end
                 local targetPosX, targetPosZ = targetPos[1], targetPos[3]
-                local distVel = VDist2(projVelX, projVelZ, targetVelX, targetVelZ)
+                local velDiffX = targetVelX - projVelX
+                local velDiffZ = targetVelZ - projVelZ
+                local distVel = MathSqrt(velDiffX * velDiffX + velDiffZ * velDiffZ)
                 if distVel == 0 then
                     return 4.9
                 end

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -200,7 +200,6 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         end
 
         local UnitGetVelocity = UnitGetVelocity
-        local VDist2 = VDist2
         -- Get projectile position and velocity
         -- velocity will need to be multiplied by 10 due to being returned /tick instead of /s
         local projPosX, projPosY, projPosZ = EntityGetPositionXYZ(projectile)

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -1,8 +1,12 @@
 local Weapon = import("/lua/sim/weapon.lua").Weapon
 
+--#region Backwards compatibility
+---@diagnostic disable-next-line: deprecated
+local VDist2 = VDist2
+--#endregion
+
 -- upvalue globals for performance
 local GetSurfaceHeight = GetSurfaceHeight
-local VDist2 = VDist2
 
 local EntityMethods = moho.entity_methods
 local EntityGetPosition = EntityMethods.GetPosition

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -247,7 +247,9 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                 if distVel == 0 then
                     return 4.9
                 end
-                local distPos = VDist2(projPosX, projPosZ, targetPosX, targetPosZ)
+                local posDiffX = targetPosX - projPosX
+                local posDiffZ = targetPosZ - projPosZ
+                local distPos = MathSqrt(posDiffX * posDiffX + posDiffZ * posDiffZ)
                 do
                     local dropShort = self.DropBombShortRatio
                     if dropShort then


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->

Most Vector engine functions are deprecated because they are slower than their Lua counterparts. However, they are used throughout. This PR removes all remaining non-AI references to the engine functions in `lua/sim`.

Commits are made granular for easier review.


## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->

### Replay simulation

Rebase on `af859b5d21a8bf165ac20863557f572d216c7633`. Simulate replay #24965988 with `wld_RunWithTheWind`.

#### Observe warnings and desyncs

```
WARNING: Duplicate definition of console command ""
WARNING:  NUM PROPS = 5182
WARNING: GetResource: Invalid name ""
WARNING: GetResource: Invalid name ""
WARNING: GetResource: Invalid name ""
WARNING: Checksum for beat 8900 mismatched: 8f33c8d8c622841c677bda1b54575ebd (sim) != 4c152bc128f3b29968aaca019f304f42 (Tersto).
WARNING: Checksum for beat 8900 mismatched: 8f33c8d8c622841c677bda1b54575ebd (sim) != 4c152bc128f3b29968aaca019f304f42 (ShadySocks).
WARNING: Checksum for beat 8900 mismatched: 8f33c8d8c622841c677bda1b54575ebd (sim) != 4c152bc128f3b29968aaca019f304f42 (VIP).
WARNING: Checksum for beat 8900 mismatched: 8f33c8d8c622841c677bda1b54575ebd (sim) != 4c152bc128f3b29968aaca019f304f42 (z00m3d-1n).
WARNING: Checksum for beat 8900 mismatched: 8f33c8d8c622841c677bda1b54575ebd (sim) != 4c152bc128f3b29968aaca019f304f42 (Nuggets).
WARNING: Checksum for beat 8900 mismatched: 8f33c8d8c622841c677bda1b54575ebd (sim) != 4c152bc128f3b29968aaca019f304f42 (JT_).
WARNING: Checksum for beat 8900 mismatched: 8f33c8d8c622841c677bda1b54575ebd (sim) != 4c152bc128f3b29968aaca019f304f42 (Seraphim-Noob).
WARNING: Checksum for beat 8900 mismatched: 8f33c8d8c622841c677bda1b54575ebd (sim) != 4c152bc128f3b29968aaca019f304f42 (Deli).
WARNING: Desync at beat 8903 tick 890.40002441406
WARNING: Desync at beat 8905 tick 890.60003662109
WARNING: Desync at beat 8906 tick 890.70001220703
WARNING: Checksum for beat 8950 mismatched: c9cbde8ec4f5403831eea5846c6b934f (sim) != c560aa0d0f1d8628298ecbe306e9224f (Tersto).
WARNING: Desync at beat 8953 tick 895.40002441406
WARNING: Checksum for beat 8950 mismatched: c9cbde8ec4f5403831eea5846c6b934f (sim) != c560aa0d0f1d8628298ecbe306e9224f (ShadySocks).
WARNING: Checksum for beat 8950 mismatched: c9cbde8ec4f5403831eea5846c6b934f (sim) != c560aa0d0f1d8628298ecbe306e9224f (VIP).
WARNING: Checksum for beat 8950 mismatched: c9cbde8ec4f5403831eea5846c6b934f (sim) != c560aa0d0f1d8628298ecbe306e9224f (Nuggets).
WARNING: Checksum for beat 8950 mismatched: c9cbde8ec4f5403831eea5846c6b934f (sim) != c560aa0d0f1d8628298ecbe306e9224f (JT_).
WARNING: Checksum for beat 8950 mismatched: c9cbde8ec4f5403831eea5846c6b934f (sim) != c560aa0d0f1d8628298ecbe306e9224f (Seraphim-Noob).
WARNING: Checksum for beat 8950 mismatched: c9cbde8ec4f5403831eea5846c6b934f (sim) != c560aa0d0f1d8628298ecbe306e9224f (Deli).
WARNING: Checksum for beat 8950 mismatched: c9cbde8ec4f5403831eea5846c6b934f (sim) != c560aa0d0f1d8628298ecbe306e9224f (z00m3d-1n).
WARNING: Desync at beat 8955 tick 895.60003662109
WARNING: Checksum for beat 9700 mismatched: 2a9b0d3b3261e3fc3330c633b2a49ea9 (sim) != 66c2aecb43c440a4506cb9f9e557fd64 (VIP).
WARNING: Checksum for beat 9700 mismatched: 2a9b0d3b3261e3fc3330c633b2a49ea9 (sim) != 66c2aecb43c440a4506cb9f9e557fd64 (ShadySocks).
WARNING: Checksum for beat 9700 mismatched: 2a9b0d3b3261e3fc3330c633b2a49ea9 (sim) != 66c2aecb43c440a4506cb9f9e557fd64 (Seraphim-Noob).
WARNING: Checksum for beat 9700 mismatched: 2a9b0d3b3261e3fc3330c633b2a49ea9 (sim) != 66c2aecb43c440a4506cb9f9e557fd64 (z00m3d-1n).
WARNING: Desync at beat 9686 tick 968.70001220703
WARNING: Desync at beat 9687 tick 968.79998779297
WARNING: Checksum for beat 9700 mismatched: 2a9b0d3b3261e3fc3330c633b2a49ea9 (sim) != 66c2aecb43c440a4506cb9f9e557fd64 (Tersto).
WARNING: Checksum for beat 9700 mismatched: 2a9b0d3b3261e3fc3330c633b2a49ea9 (sim) != 66c2aecb43c440a4506cb9f9e557fd64 (Nuggets).
WARNING: Checksum for beat 9700 mismatched: 2a9b0d3b3261e3fc3330c633b2a49ea9 (sim) != 66c2aecb43c440a4506cb9f9e557fd64 (JT_).
WARNING: Checksum for beat 9700 mismatched: 2a9b0d3b3261e3fc3330c633b2a49ea9 (sim) != 66c2aecb43c440a4506cb9f9e557fd64 (Deli).
WARNING: Desync at beat 9688 tick 968.90002441406
WARNING: Desync at beat 9689 tick 969
WARNING: Checksum for beat 10800 mismatched: 3e5d89885eeb00bb5a8bfe92a16e8638 (sim) != f2fba49701e8d673eae8ae977852dd31 (Seraphim-Noob).
WARNING: Checksum for beat 10800 mismatched: 3e5d89885eeb00bb5a8bfe92a16e8638 (sim) != f2fba49701e8d673eae8ae977852dd31 (ShadySocks).
WARNING: Desync at beat 10786 tick 1078.7000732422
WARNING: Checksum for beat 10800 mismatched: 3e5d89885eeb00bb5a8bfe92a16e8638 (sim) != f2fba49701e8d673eae8ae977852dd31 (Tersto).
WARNING: Checksum for beat 10800 mismatched: 3e5d89885eeb00bb5a8bfe92a16e8638 (sim) != f2fba49701e8d673eae8ae977852dd31 (VIP).
WARNING: Checksum for beat 10800 mismatched: 3e5d89885eeb00bb5a8bfe92a16e8638 (sim) != f2fba49701e8d673eae8ae977852dd31 (Nuggets).
WARNING: Checksum for beat 10800 mismatched: 3e5d89885eeb00bb5a8bfe92a16e8638 (sim) != f2fba49701e8d673eae8ae977852dd31 (JT_).
WARNING: Checksum for beat 10800 mismatched: 3e5d89885eeb00bb5a8bfe92a16e8638 (sim) != f2fba49701e8d673eae8ae977852dd31 (Deli).
WARNING: Checksum for beat 10800 mismatched: 3e5d89885eeb00bb5a8bfe92a16e8638 (sim) != f2fba49701e8d673eae8ae977852dd31 (z00m3d-1n).
WARNING: Desync at beat 10787 tick 1078.8000488281
WARNING: Desync at beat 10788 tick 1078.9000244141
WARNING: Checksum for beat 10850 mismatched: dd48f0078df96d981399d67cc88aa50c (sim) != 29789254e26e64288eecdb06ad114495 (Seraphim-Noob).
WARNING: Checksum for beat 10850 mismatched: dd48f0078df96d981399d67cc88aa50c (sim) != 29789254e26e64288eecdb06ad114495 (ShadySocks).
WARNING: Desync at beat 10836 tick 1083.7000732422
WARNING: Checksum for beat 10850 mismatched: dd48f0078df96d981399d67cc88aa50c (sim) != 29789254e26e64288eecdb06ad114495 (Tersto).
WARNING: Checksum for beat 10850 mismatched: dd48f0078df96d981399d67cc88aa50c (sim) != 29789254e26e64288eecdb06ad114495 (VIP).
WARNING: Checksum for beat 10850 mismatched: dd48f0078df96d981399d67cc88aa50c (sim) != 29789254e26e64288eecdb06ad114495 (Nuggets).
WARNING: Checksum for beat 10850 mismatched: dd48f0078df96d981399d67cc88aa50c (sim) != 29789254e26e64288eecdb06ad114495 (JT_).
WARNING: Checksum for beat 10850 mismatched: dd48f0078df96d981399d67cc88aa50c (sim) != 29789254e26e64288eecdb06ad114495 (Deli).
WARNING: Checksum for beat 10850 mismatched: dd48f0078df96d981399d67cc88aa50c (sim) != 29789254e26e64288eecdb06ad114495 (z00m3d-1n).
WARNING: Desync at beat 10837 tick 1083.8000488281
WARNING: Desync at beat 10838 tick 1083.9000244141
WARNING: Checksum for beat 11150 mismatched: b8750c98aec33b4a98d34e737945fca5 (sim) != 14828816c354ec5b4f5dafd4afeddf6c (Seraphim-Noob).
WARNING: Checksum for beat 11150 mismatched: b8750c98aec33b4a98d34e737945fca5 (sim) != 14828816c354ec5b4f5dafd4afeddf6c (ShadySocks).
WARNING: Checksum for beat 11150 mismatched: b8750c98aec33b4a98d34e737945fca5 (sim) != 14828816c354ec5b4f5dafd4afeddf6c (Tersto).
WARNING: Checksum for beat 11150 mismatched: b8750c98aec33b4a98d34e737945fca5 (sim) != 14828816c354ec5b4f5dafd4afeddf6c (VIP).
WARNING: Checksum for beat 11150 mismatched: b8750c98aec33b4a98d34e737945fca5 (sim) != 14828816c354ec5b4f5dafd4afeddf6c (Deli).
WARNING: Checksum for beat 11150 mismatched: b8750c98aec33b4a98d34e737945fca5 (sim) != 14828816c354ec5b4f5dafd4afeddf6c (Nuggets).
WARNING: Checksum for beat 11150 mismatched: b8750c98aec33b4a98d34e737945fca5 (sim) != 14828816c354ec5b4f5dafd4afeddf6c (JT_).
WARNING: Checksum for beat 11150 mismatched: b8750c98aec33b4a98d34e737945fca5 (sim) != 14828816c354ec5b4f5dafd4afeddf6c (z00m3d-1n).
WARNING: Desync at beat 11137 tick 1113.8000488281
WARNING: Desync at beat 11138 tick 1113.9000244141
WARNING: Desync at beat 11139 tick 1114
WARNING: Checksum for beat 11300 mismatched: 58862c0510b8017d1fd9fedcc4e0bfbd (sim) != 93a4c0436bcb5ed492f11681fc371f2c (Seraphim-Noob).
WARNING: Checksum for beat 11300 mismatched: 58862c0510b8017d1fd9fedcc4e0bfbd (sim) != 93a4c0436bcb5ed492f11681fc371f2c (ShadySocks).
WARNING: Checksum for beat 11300 mismatched: 58862c0510b8017d1fd9fedcc4e0bfbd (sim) != 93a4c0436bcb5ed492f11681fc371f2c (Tersto).
WARNING: Checksum for beat 11300 mismatched: 58862c0510b8017d1fd9fedcc4e0bfbd (sim) != 93a4c0436bcb5ed492f11681fc371f2c (Nuggets).
WARNING: Checksum for beat 11300 mismatched: 58862c0510b8017d1fd9fedcc4e0bfbd (sim) != 93a4c0436bcb5ed492f11681fc371f2c (z00m3d-1n).
WARNING: Desync at beat 11287 tick 1128.8000488281
WARNING: Checksum for beat 11300 mismatched: 58862c0510b8017d1fd9fedcc4e0bfbd (sim) != 93a4c0436bcb5ed492f11681fc371f2c (VIP).
WARNING: Checksum for beat 11300 mismatched: 58862c0510b8017d1fd9fedcc4e0bfbd (sim) != 93a4c0436bcb5ed492f11681fc371f2c (JT_).
WARNING: Checksum for beat 11300 mismatched: 58862c0510b8017d1fd9fedcc4e0bfbd (sim) != 93a4c0436bcb5ed492f11681fc371f2c (Deli).
WARNING: Desync at beat 11288 tick 1128.9000244141
WARNING: Desync at beat 11289 tick 1129
WARNING: Checksum for beat 11350 mismatched: 4a265dad959533e70cc7f2977936072d (sim) != 6261944de3302b6ef5e7b28c4e03ebe7 (Seraphim-Noob).
WARNING: Checksum for beat 11350 mismatched: 4a265dad959533e70cc7f2977936072d (sim) != 6261944de3302b6ef5e7b28c4e03ebe7 (ShadySocks).
WARNING: Checksum for beat 11350 mismatched: 4a265dad959533e70cc7f2977936072d (sim) != 6261944de3302b6ef5e7b28c4e03ebe7 (Tersto).
WARNING: Checksum for beat 11350 mismatched: 4a265dad959533e70cc7f2977936072d (sim) != 6261944de3302b6ef5e7b28c4e03ebe7 (VIP).
WARNING: Checksum for beat 11350 mismatched: 4a265dad959533e70cc7f2977936072d (sim) != 6261944de3302b6ef5e7b28c4e03ebe7 (Nuggets).
WARNING: Desync at beat 11336 tick 1133.7000732422
WARNING: Checksum for beat 11350 mismatched: 4a265dad959533e70cc7f2977936072d (sim) != 6261944de3302b6ef5e7b28c4e03ebe7 (JT_).
WARNING: Checksum for beat 11350 mismatched: 4a265dad959533e70cc7f2977936072d (sim) != 6261944de3302b6ef5e7b28c4e03ebe7 (Deli).
WARNING: Checksum for beat 11350 mismatched: 4a265dad959533e70cc7f2977936072d (sim) != 6261944de3302b6ef5e7b28c4e03ebe7 (z00m3d-1n).
WARNING: Desync at beat 11338 tick 1133.9000244141
WARNING: Desync at beat 11339 tick 1134
WARNING: Checksum for beat 11400 mismatched: a7fabd31b9171007bbf7650728768935 (sim) != 4910f5303dc6d896ab4c81903a02c184 (Seraphim-Noob).
WARNING: Desync at beat 11386 tick 1138.7000732422
WARNING: Checksum for beat 11400 mismatched: a7fabd31b9171007bbf7650728768935 (sim) != 4910f5303dc6d896ab4c81903a02c184 (ShadySocks).
WARNING: Checksum for beat 11400 mismatched: a7fabd31b9171007bbf7650728768935 (sim) != 4910f5303dc6d896ab4c81903a02c184 (Tersto).
WARNING: Checksum for beat 11400 mismatched: a7fabd31b9171007bbf7650728768935 (sim) != 4910f5303dc6d896ab4c81903a02c184 (VIP).
WARNING: Checksum for beat 11400 mismatched: a7fabd31b9171007bbf7650728768935 (sim) != 4910f5303dc6d896ab4c81903a02c184 (Nuggets).
WARNING: Checksum for beat 11400 mismatched: a7fabd31b9171007bbf7650728768935 (sim) != 4910f5303dc6d896ab4c81903a02c184 (Deli).
WARNING: Checksum for beat 11400 mismatched: a7fabd31b9171007bbf7650728768935 (sim) != 4910f5303dc6d896ab4c81903a02c184 (JT_).
WARNING: Checksum for beat 11400 mismatched: a7fabd31b9171007bbf7650728768935 (sim) != 4910f5303dc6d896ab4c81903a02c184 (z00m3d-1n).
WARNING: Desync at beat 11388 tick 1138.9000244141
WARNING: Desync at beat 11389 tick 1139
```

#### Observe no perceptible changes to end game state between base and  PR

![Screenshot from 2025-06-07 00-06-35](https://github.com/user-attachments/assets/89c20915-1a5a-4b73-9908-758edc647d18)

![Screenshot from 2025-06-07 00-06-31](https://github.com/user-attachments/assets/673c0634-a120-4de5-9c5d-3a2083cf0b86)

#### Root Cause
Commit `0bb5cf1ff19b9e4ffa78aaa9f0e2f1a7cf63d494` replaces `VDot` with the Lua equivalent. There is a suspected floating point calculation difference between them.

I logged differences between the two calculations being limited to:
- `+0.00000762939453125` or `+ (2 ^ -17)`
- `-0.00000762939453125` or `- (2 ^ -17)`
- `+0.00000381469726562` or `+ (2 ^ -18)`
- `-0.00000381469726562` or `- (2 ^ -18)`

There are no desyncs when excluding that commit.

## Additional context
<!-- Add any other context about the pull request here. -->


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
