### PR TITLE
Reduce conditional table accesses of projectiles when colliding or losing targets

### DIFF
--- a/changelog/snippets/performance.6853.md
+++ b/changelog/snippets/performance.6853.md
@@ -1,0 +1,1 @@
+- (#6853) Reduce conditional table accesses of projectiles when colliding or losing targets

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -218,9 +218,6 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
             return false
         end
 
-        -- flag if we can hit allied projectiles
-        local alliedCheck = not (self.CollideFriendly and IsAlly(self.Army, other.Army))
-
         local selfHashedCategories = self.Blueprint.CategoriesHash
         local otherHashedCategories = other.Blueprint.CategoriesHash
 
@@ -243,7 +240,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         end
 
         -- enemies always hit
-        return alliedCheck
+        return not (self.CollideFriendly and IsAlly(self.Army, other.Army)) -- flag if we can hit allied projectiles
     end,
 
     --- Called by the engine when a projectile collides with a collision beam to check if the collision is valid

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -253,9 +253,6 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
             return false
         end
 
-        -- flag that indicates whether we should impact allied projectiles
-        local alliedCheck = not (self.CollideFriendly and IsAlly(self.Army, firingWeapon.Army))
-
         local selfHashedCategories = self.Blueprint.CategoriesHash
 
         -- check for projectile types that require a defensive weapon to intercept
@@ -268,7 +265,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         end
 
         -- depend on allied flag whether we hit or not
-        return alliedCheck
+        return not (self.CollideFriendly and IsAlly(self.Army, firingWeapon.Army)) -- flag that indicates whether we should impact allied projectiles
     end,
 
     --- Called by the engine when the projectile receives damage

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -572,8 +572,8 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     OnLostTarget = function(self)
         local bp = self.Blueprint.Physics
         local trackTarget = bp.TrackTarget
-        local trackTargetGround = bp.TrackTargetGround
-        if trackTarget and (not trackTargetGround) then
+        if not trackTarget then return end
+        if not bp.TrackTargetGround then
             TrashBagAdd(self.Trash, ForkThread(self.RetargetThread, self))
         end
     end,

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -571,8 +571,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     ---@param self Projectile
     OnLostTarget = function(self)
         local bp = self.Blueprint.Physics
-        local trackTarget = bp.TrackTarget
-        if not trackTarget then return end
+        if not bp.TrackTarget then return end
         if not bp.TrackTargetGround then
             TrashBagAdd(self.Trash, ForkThread(self.RetargetThread, self))
         end

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -165,8 +165,10 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     ---@param self Projectile
     OnTrackTargetGround = function(self)
         local target = self.OriginalTarget or self:GetTrackingTarget() or self.Launcher:GetTargetEntity()
-        if target and target.IsUnit then
+        local physics = self.Blueprint.Physics
+        local offset = physics.TrackTargetGroundOffset or 0
 
+        if target and target.IsUnit then
             local unitBlueprint = target.Blueprint
 
             -- X-offset units often have displaced center bones, so they're not accounted for.
@@ -180,9 +182,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
                 cy = 0
             end
 
-            local physics = self.Blueprint.Physics
             local fuzziness = physics.TrackTargetGroundFuzziness or 0.8
-            local offset = physics.TrackTargetGroundOffset or 0
             sx = sx + offset
             sz = sz + offset
 
@@ -193,14 +193,12 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
             local orientation = EntityGetOrientation(target)
 
             dx, dy, dz = RotateVectorXYZByQuat(dx, dy, dz, orientation)
-            
+
             self:SetNewTargetGroundXYZ(px + dx, py + dy, pz + dz)
         else
             local px, _, pz = self:GetCurrentTargetPositionXYZ()
 
-            local physics = self.Blueprint.Physics
             local fuzziness = physics.TrackTargetGroundFuzziness or 0
-            local offset = physics.TrackTargetGroundOffset or 0
             local tx = px + (Random() - 0.5) * fuzziness * (1 + offset)
             local tz = pz + (Random() - 0.5) * fuzziness * (1 + offset)
 

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -563,8 +563,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     ---@param self Projectile
     OnLostTarget = function(self)
         local bp = self.Blueprint.Physics
-        if not bp.TrackTarget then return end
-        if not bp.TrackTargetGround then
+        if bp.TrackTarget and not bp.TrackTargetGround then
             TrashBagAdd(self.Trash, ForkThread(self.RetargetThread, self))
         end
     end,

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -192,7 +192,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
 
             local orientation = EntityGetOrientation(target)
 
-            local dx, dy, dz = RotateVectorXYZByQuat(dx, dy, dz, orientation)
+            dx, dy, dz = RotateVectorXYZByQuat(dx, dy, dz, orientation)
             
             self:SetNewTargetGroundXYZ(px + dx, py + dy, pz + dz)
         else


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->

These table accesses don't always get used even though their locals are always instantiated. So, the code now better uses data as late as possible to reduce unnecessary table operations.

Fixes some linting issues and duplicated code.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->

### Replay simulation

Rebase on `af859b5d21a8bf165ac20863557f572d216c7633`. Simulate replay #24965988 with `wld_RunWithTheWind`.

Observe no desycns and unrelated warnings:
```
WARNING: Duplicate definition of console command ""
WARNING:  NUM PROPS = 5182
WARNING: GetResource: Invalid name ""
WARNING: GetResource: Invalid name ""
WARNING: GetResource: Invalid name ""
```


## Additional context
<!-- Add any other context about the pull request here. -->


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
