### PR TITLE
Upvalue and localize frequently used functions and tables in formations

### DIFF
--- a/changelog/snippets/performance.6854.md
+++ b/changelog/snippets/performance.6854.md
@@ -1,0 +1,1 @@
+- (#6854) Upvalue and localize frequently used functions and tables in formations

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -14,6 +14,7 @@
 
 
 local TableGetn = table.getn
+local MathAbs = math.abs
 local MathCeil = math.ceil
 local MathFloor = math.floor
 local MathMod = math.mod
@@ -1430,7 +1431,7 @@ function GetLargeAirPositions(unitsList, airBlock)
                 formationLength = formationLength + 1
                 whichCol = 1
                 local x, y = GetChevronPosition(1, currRowLen, formationLength)
-                wideRow = math.abs(x) >= radius
+                wideRow = MathAbs(x) >= radius
             else
                 whichCol = whichCol + 2
             end
@@ -1440,7 +1441,7 @@ function GetLargeAirPositions(unitsList, airBlock)
             end
 
             local xPos, yPos = GetChevronPosition(1, whichCol, formationLength)
-            if whichCol ~= 1 and math.abs(xPos) < radius then
+            if whichCol ~= 1 and MathAbs(xPos) < radius then
                 continue
             end
 

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -746,7 +746,7 @@ function AttackFormation(formationUnits)
     else -- 20 wide
         landBlock = EightRowAttackFormationBlock
     end
-    BlockBuilderLand(landUnitsList, landBlock, LandCategories, 1)
+    BlockBuilderLand(landUnitsList, landBlock, LandCategories)
 
     local seaUnitsList = unitsList.Naval
     local subUnitsList = unitsList.Subs
@@ -768,8 +768,8 @@ function AttackFormation(formationUnits)
         seaBlock = ElevenWideNavalAttackFormation
         subBlock = TenWideSubAttackFormation
     end
-    BlockBuilderLand(seaUnitsList, seaBlock, NavalCategories, 1)
-    BlockBuilderLand(subUnitsList, subBlock, SubCategories, 1)
+    BlockBuilderLand(seaUnitsList, seaBlock, NavalCategories)
+    BlockBuilderLand(subUnitsList, subBlock, SubCategories)
     BlockBuilderAir(unitsList.Air, AttackChevronBlock, 1)
 
     CacheResults(FormationPos, formationUnits, 'AttackFormation')
@@ -803,7 +803,7 @@ function GrowthFormation(formationUnits)
     else
         landBlock = EightWideAttackFormationBlock
     end
-    BlockBuilderLand(landUnitsList, landBlock, LandCategories, 1)
+    BlockBuilderLand(landUnitsList, landBlock, LandCategories)
 
     local seaUnitsList = unitsList.Naval
     local subUnitsList = unitsList.Subs
@@ -825,8 +825,8 @@ function GrowthFormation(formationUnits)
         seaBlock = NineNavalGrowthFormation
         subBlock = EightWideSubGrowthFormation
     end
-    BlockBuilderLand(seaUnitsList, seaBlock, NavalCategories, 1)
-    BlockBuilderLand(subUnitsList, subBlock, SubCategories, 1)
+    BlockBuilderLand(seaUnitsList, seaBlock, NavalCategories)
+    BlockBuilderLand(subUnitsList, subBlock, SubCategories)
 
     local airUnitsList = unitsList.Air
     local stratBombers = airUnitsList.Bomb3
@@ -953,10 +953,9 @@ end
 ---@param unitsList table
 ---@param formationBlock any
 ---@param categoryTable EntityCategory[]
----@param spacing? number defaults to 1
 ---@return table
-function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
-    spacing = (spacing or 1) * unitsList.Scale
+function BlockBuilderLand(unitsList, formationBlock, categoryTable)
+    local spacing = unitsList.Scale
     local numRows = TableGetn(formationBlock)
     local rowNum = 1
     local whichRow = 1

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -15,6 +15,7 @@
 
 local TableGetn = table.getn
 local MathCeil = math.ceil
+local MathFloor = math.floor
 local MathMod = math.mod
 local MathMin = math.min
 local MathMax = math.max
@@ -1104,7 +1105,7 @@ function IsLandSpaceOccupied(occupiedSpaces, size, rowNum, whichCol, currRowLen,
     if whichCol == 1 and (not evenRowLen) and evenSize and remainingUnits > 1 then -- Don't put an even-sized unit in the middle of an odd-length row unless it's the last unit
         return true
     end
-    if whichCol > currRowLen - math.floor(size / 2) * 2 and size <= math.floor(currRowLen / 2) then -- Don't put a large unit at the end of a row unless the row is too narrow
+    if whichCol > currRowLen - MathFloor(size / 2) * 2 and size <= MathFloor(currRowLen / 2) then -- Don't put a large unit at the end of a row unless the row is too narrow
         return true
     end
     for y = 0, size - 1, 1 do
@@ -1167,7 +1168,7 @@ function GetColSpot(rowLen, col)
     if MathMod(col, 2) == 0 then
         colType = 'right'
     end
-    local colSpot = math.floor(col / 2)
+    local colSpot = MathFloor(col / 2)
     local halfSpot = len/2
     if colType == 'left' then
         return halfSpot - colSpot
@@ -1473,15 +1474,15 @@ end
 ---@return number xPos
 ---@return number yPos
 function GetChevronPosition(chevronPos, currCol, formationLen)
-    local offset = math.floor(chevronPos / 2)
+    local offset = MathFloor(chevronPos / 2)
     local xPos = offset * 0.5
     if MathMod(chevronPos, 2) == 0 then
         xPos = -xPos
     end
-    local column = math.floor(currCol / 2)
+    local column = MathFloor(currCol / 2)
     local yPos = (-offset + column * column) * 0.86603
     yPos = yPos - formationLen * 1.73205
-    local blockOff = math.floor(currCol / 2) * 2.5
+    local blockOff = MathFloor(currCol / 2) * 2.5
     if MathMod(currCol, 2) == 1 then
         blockOff = -blockOff
     end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -828,8 +828,8 @@ function GrowthFormation(formationUnits)
     if not table.empty(unitsList.Air.Bomb3) then
         -- unitsList.Air.Bomb3 contains no more than one table with selected strat bombers in it
         -- Cycle puts it at index 1 (as it was in the past) otherwise some code below won't work.
-        for k,v in unitsList.Air.Bomb3 do
-            if k != 1 then 
+        for k in unitsList.Air.Bomb3 do
+            if k != 1 then
                 unitsList.Air.Bomb3[1] = unitsList.Air.Bomb3[k]
             end
             break

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -14,6 +14,7 @@
 
 
 local TableGetn = table.getn
+local MathMod = math.mod
 
 SurfaceFormations = {
     'AttackFormation',
@@ -950,7 +951,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
     local currRowLen = TableGetn(formationBlock[whichRow])
     local rowModifier = GetLandRowModifer(unitsList, categoryTable, currRowLen)
     currRowLen = currRowLen - rowModifier
-    local evenRowLen = math.mod(currRowLen, 2) == 0
+    local evenRowLen = MathMod(currRowLen, 2) == 0
     local rowType = false
     local formationLength = 0
     local inserted = false
@@ -974,7 +975,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
                 rowModifier = GetLandRowModifer(unitsList, categoryTable, currRowLen)
             end
             currRowLen = currRowLen - rowModifier
-            evenRowLen = math.mod(currRowLen, 2) == 0
+            evenRowLen = MathMod(currRowLen, 2) == 0
         end
 
         if occupiedSpaces[rowNum] and occupiedSpaces[rowNum][whichCol] then
@@ -996,7 +997,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
                     local groupData = nil
                     for k, v in unitsList[group] do
                         size = unitsList.FootprintSizes[k]
-                        evenSize = math.mod(size, 2) == 0
+                        evenSize = MathMod(size, 2) == 0
                         if v.Count > 0 then
                             if size > 1 and IsLandSpaceOccupied(occupiedSpaces, size, rowNum, whichCol, currRowLen, unitsList.UnitTotal) then
                                 continue
@@ -1024,7 +1025,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
                         local xPos
                         if evenRowLen then
                             xPos = math.ceil(whichCol/2) - .5 + offsetX
-                            if not (math.mod(whichCol, 2) == 0) then
+                            if not (MathMod(whichCol, 2) == 0) then
                                 xPos = xPos * -1
                             end
                         else
@@ -1032,7 +1033,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
                                 xPos = 0
                             else
                                 xPos = math.ceil(((whichCol-1) /2)) + offsetX
-                                if not (math.mod(whichCol, 2) == 0) then
+                                if not (MathMod(whichCol, 2) == 0) then
                                     xPos = xPos * -1
                                 end
                             end
@@ -1069,7 +1070,7 @@ end
 ---@param currRowLen number
 ---@return number
 function GetLandRowModifer(unitsList, categoryTable, currRowLen)
-    if unitsList.UnitTotal >= currRowLen or math.mod(unitsList.UnitTotal, 2) == math.mod(currRowLen, 2) then
+    if unitsList.UnitTotal >= currRowLen or MathMod(unitsList.UnitTotal, 2) == MathMod(currRowLen, 2) then
         return 0
     end
 
@@ -1094,8 +1095,8 @@ end
 ---@param remainingUnits number
 ---@return boolean
 function IsLandSpaceOccupied(occupiedSpaces, size, rowNum, whichCol, currRowLen, remainingUnits)
-    local evenRowLen = math.mod(currRowLen, 2) == 0
-    local evenSize = math.mod(size, 2) == 0
+    local evenRowLen = MathMod(currRowLen, 2) == 0
+    local evenSize = MathMod(size, 2) == 0
 
     if whichCol == 1 and (not evenRowLen) and evenSize and remainingUnits > 1 then -- Don't put an even-sized unit in the middle of an odd-length row unless it's the last unit
         return true
@@ -1131,8 +1132,8 @@ end
 ---@param whichCol number
 ---@param currRowLen number
 function OccupyLandSpace(occupiedSpaces, size, rowNum, whichCol, currRowLen)
-    local evenRowLen = math.mod(currRowLen, 2) == 0
-    local evenSize = math.mod(size, 2) == 0
+    local evenRowLen = MathMod(currRowLen, 2) == 0
+    local evenSize = MathMod(size, 2) == 0
 
     for y = 0, size - 1, 1 do
         local yPos = rowNum + y
@@ -1156,11 +1157,11 @@ end
 ---@return number
 function GetColSpot(rowLen, col)
     local len = rowLen
-    if math.mod(rowLen, 2) == 1 then
+    if MathMod(rowLen, 2) == 1 then
         len = rowLen + 1
     end
     local colType = 'left'
-    if math.mod(col, 2) == 0 then
+    if MathMod(col, 2) == 0 then
         colType = 'right'
     end
     local colSpot = math.floor(col / 2)
@@ -1211,19 +1212,19 @@ function BlockBuilderAir(unitsList, airBlock, spacing)
         end
     end
 
-    if unitsList.UnitTotal < chevronSize and math.mod(unitsList.UnitTotal, 2) == 0 then
+    if unitsList.UnitTotal < chevronSize and MathMod(unitsList.UnitTotal, 2) == 0 then
         chevronPos = 2
     end
 
     while unitsList.UnitTotal > 0 do
         if chevronPos > chevronSize then
-            if unitsList.UnitTotal < chevronSize and math.mod(unitsList.UnitTotal, 2) == 0 then
+            if unitsList.UnitTotal < chevronSize and MathMod(unitsList.UnitTotal, 2) == 0 then
                 chevronPos = 2
             else
                 chevronPos = 1
             end
             chevronType = false
-            if whichCol >= currRowLen or unitsList.UnitTotal < chevronSize or unitsList.UnitTotal < chevronSize * 2 and math.mod(whichCol, 2) == 1 then
+            if whichCol >= currRowLen or unitsList.UnitTotal < chevronSize or unitsList.UnitTotal < chevronSize * 2 and MathMod(whichCol, 2) == 1 then
                 if whichRow >= numRows then
                     if airBlock.RepeatAllRows then
                         whichRow = 1
@@ -1318,19 +1319,19 @@ function BlockBuilderAirT3Bombers(unitsList, spacing)
     local formationLength = 0
 
 
-    if unitsList.UnitTotal < chevronSize and math.mod(unitsList.UnitTotal, 2) == 0 then
+    if unitsList.UnitTotal < chevronSize and MathMod(unitsList.UnitTotal, 2) == 0 then
         chevronPos = 2
     end
 
     while unitsList.UnitTotal > 0 do
         if chevronPos > chevronSize then
-            if unitsList.UnitTotal < chevronSize and math.mod(unitsList.UnitTotal, 2) == 0 then
+            if unitsList.UnitTotal < chevronSize and MathMod(unitsList.UnitTotal, 2) == 0 then
                 chevronPos = 2
             else
                 chevronPos = 1
             end
             chevronType = false
-            if whichCol >= currRowLen or unitsList.UnitTotal < chevronSize or unitsList.UnitTotal < chevronSize * 2 and math.mod(whichCol, 2) == 1 then
+            if whichCol >= currRowLen or unitsList.UnitTotal < chevronSize or unitsList.UnitTotal < chevronSize * 2 and MathMod(whichCol, 2) == 1 then
                 if whichRow >= numRows then
                     if airBlock.RepeatAllRows then
                         whichRow = 1
@@ -1471,14 +1472,14 @@ end
 function GetChevronPosition(chevronPos, currCol, formationLen)
     local offset = math.floor(chevronPos / 2)
     local xPos = offset * 0.5
-    if math.mod(chevronPos, 2) == 0 then
+    if MathMod(chevronPos, 2) == 0 then
         xPos = -xPos
     end
     local column = math.floor(currCol / 2)
     local yPos = (-offset + column * column) * 0.86603
     yPos = yPos - formationLen * 1.73205
     local blockOff = math.floor(currCol / 2) * 2.5
-    if math.mod(currCol, 2) == 1 then
+    if MathMod(currCol, 2) == 1 then
         blockOff = -blockOff
     end
     xPos = xPos + blockOff

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -13,8 +13,10 @@
 ---@alias UnitFormations 'AttackFormation' | 'GrowthFormation' | 'NoFormation' | 'None' | 'none'
 
 
+local TableEmpty = table.empty
 local TableGetn = table.getn
 local TableInsert = table.insert
+local TableRemove = table.remove
 local MathAbs = math.abs
 local MathCeil = math.ceil
 local MathCos = math.cos
@@ -82,7 +84,7 @@ function CacheResults(results, formationUnits, formationType)
 
     local cache = FormationCache[formationType]
     if TableGetn(cache) >= MaxCacheSize then
-        table.remove(cache)
+        TableRemove(cache)
     end
     TableInsert(cache, 1, {Results = results, Units = formationUnits, UnitCount = TableGetn(formationUnits)})
 end
@@ -828,7 +830,7 @@ function GrowthFormation(formationUnits)
 
     local airUnitsList = unitsList.Air
     local stratBombers = airUnitsList.Bomb3
-    if not table.empty(stratBombers) then
+    if not TableEmpty(stratBombers) then
         -- stratBombers contains no more than one table with selected strat bombers in it
         -- Cycle puts it at index 1 (as it was in the past) otherwise some code below won't work.
         for k in stratBombers do

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -849,11 +849,9 @@ function GrowthFormation(formationUnits)
         airUnitsList.Bomb3 = {}
         airUnitsList.AreaTotal = oldAirArea - count
         airUnitsList.UnitTotal = oldUnitTotal - count
-
-        BlockBuilderAir(airUnitsList, GrowthChevronBlock, 1)
-    else
-        BlockBuilderAir(airUnitsList, GrowthChevronBlock, 1)
     end
+
+    BlockBuilderAir(airUnitsList, GrowthChevronBlock, 1)
 
 
     CacheResults(FormationPos, formationUnits, 'GrowthFormation')

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -825,32 +825,34 @@ function GrowthFormation(formationUnits)
     BlockBuilderLand(seaUnitsList, seaBlock, NavalCategories, 1)
     BlockBuilderLand(subUnitsList, subBlock, SubCategories, 1)
 
-    if not table.empty(unitsList.Air.Bomb3) then
-        -- unitsList.Air.Bomb3 contains no more than one table with selected strat bombers in it
+    local airUnitsList = unitsList.Air
+    local stratBombers = airUnitsList.Bomb3
+    if not table.empty(stratBombers) then
+        -- stratBombers contains no more than one table with selected strat bombers in it
         -- Cycle puts it at index 1 (as it was in the past) otherwise some code below won't work.
-        for k in unitsList.Air.Bomb3 do
+        for k in stratBombers do
             if k != 1 then
-                unitsList.Air.Bomb3[1] = unitsList.Air.Bomb3[k]
+                stratBombers[1] = stratBombers[k]
             end
             break
         end
-        local count = unitsList.Air.Bomb3[1].Count
-        local oldAirArea = unitsList.Air.AreaTotal
-        local oldUnitTotal = unitsList.Air.UnitTotal
+        local count = stratBombers[1].Count
+        local oldAirArea = airUnitsList.AreaTotal
+        local oldUnitTotal = airUnitsList.UnitTotal
 
-        unitsList.Air.AreaTotal = count
-        unitsList.Air.UnitTotal = count
+        airUnitsList.AreaTotal = count
+        airUnitsList.UnitTotal = count
 
-        BlockBuilderAirT3Bombers(unitsList.Air, 1.2) --initial spacing was 1.5 that is a bit too wide
+        BlockBuilderAirT3Bombers(airUnitsList, 1.2) --initial spacing was 1.5 that is a bit too wide
 
         --strats are already in formation so we remove them from table and adjust all parameters.
-        unitsList.Air.Bomb3 = {}
-        unitsList.Air.AreaTotal = oldAirArea - count
-        unitsList.Air.UnitTotal = oldUnitTotal - count
+        airUnitsList.Bomb3 = {}
+        airUnitsList.AreaTotal = oldAirArea - count
+        airUnitsList.UnitTotal = oldUnitTotal - count
 
-        BlockBuilderAir(unitsList.Air, GrowthChevronBlock, 1)
+        BlockBuilderAir(airUnitsList, GrowthChevronBlock, 1)
     else
-        BlockBuilderAir(unitsList.Air, GrowthChevronBlock, 1)
+        BlockBuilderAir(airUnitsList, GrowthChevronBlock, 1)
     end
 
 

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -16,6 +16,7 @@
 local TableGetn = table.getn
 local MathMod = math.mod
 local MathMin = math.min
+local MathMax = math.max
 
 SurfaceFormations = {
     'AttackFormation',
@@ -878,7 +879,7 @@ function GuardFormation(formationUnits)
     local smallestFootprint = 9999
     local minCount = remainingUnits / numSizes -- This could theoretically divide by 0, but it wouldn't be a problem because the result would never be used.
     for fs, count in footprintCounts do
-        largestFootprint = math.max(largestFootprint, fs)
+        largestFootprint = MathMax(largestFootprint, fs)
         if count >= minCount then
             smallestFootprint = MathMin(smallestFootprint, fs)
         end
@@ -913,7 +914,7 @@ function GuardFormation(formationUnits)
             else
                 shieldsInRing = 0
             end
-            shieldsInRing = math.max(shieldsInRing, remainingShields - (remainingUnits - ringChange))
+            shieldsInRing = MathMax(shieldsInRing, remainingShields - (remainingUnits - ringChange))
 
             if shieldsInRing > 0 then
                 unitsPerShield = ringChange / shieldsInRing

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -15,6 +15,7 @@
 
 local TableGetn = table.getn
 local MathMod = math.mod
+local MathMin = math.min
 
 SurfaceFormations = {
     'AttackFormation',
@@ -879,7 +880,7 @@ function GuardFormation(formationUnits)
     for fs, count in footprintCounts do
         largestFootprint = math.max(largestFootprint, fs)
         if count >= minCount then
-            smallestFootprint = math.min(smallestFootprint, fs)
+            smallestFootprint = MathMin(smallestFootprint, fs)
         end
     end
 
@@ -906,9 +907,9 @@ function GuardFormation(formationUnits)
             end
 
             if ringCount == 2 or remainingShields >= (remainingUnits + ringChange + 6) * 0.19 then
-                shieldsInRing = math.min(ringChange / 2, remainingShields)
+                shieldsInRing = MathMin(ringChange / 2, remainingShields)
             elseif remainingShields >= (remainingUnits + ringChange + 6) * 0.13 then
-                shieldsInRing = math.min(ringChange / 3, remainingShields)
+                shieldsInRing = MathMin(ringChange / 3, remainingShields)
             else
                 shieldsInRing = 0
             end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -925,8 +925,8 @@ function GuardFormation(formationUnits)
             end
         end
         local ringPosition = unitCount / ringChange * math.pi * 2.0
-        offsetX = sizeMult * math.sin(ringPosition)
-        offsetY = -sizeMult * math.cos(ringPosition)
+        local offsetX = sizeMult * math.sin(ringPosition)
+        local offsetY = -sizeMult * math.cos(ringPosition)
         if shieldsInRing > 0 and unitCount >= nextShield then
             table.insert(FormationPos, { offsetX, offsetY, shieldCategory, 0, rotate })
             remainingShields = remainingShields - 1
@@ -1201,7 +1201,7 @@ function BlockBuilderAir(unitsList, airBlock, spacing)
             for _, type in currSlot do
                 for _, group in type do
                     for fs, groupData in unitsList[group] do
-                        size = unitsList.FootprintSizes[fs]
+                        local size = unitsList.FootprintSizes[fs]
                         if groupData.Count > 0 and size == data.size then
                             table.insert(FormationPos, {data.xPos * spacing, data.yPos * spacing, groupData.Filter, 0, true})
                             groupData.Count = groupData.Count - 1

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -14,6 +14,7 @@
 
 
 local TableGetn = table.getn
+local TableInsert = table.insert
 local MathAbs = math.abs
 local MathCeil = math.ceil
 local MathCos = math.cos
@@ -82,7 +83,7 @@ function CacheResults(results, formationUnits, formationType)
     if TableGetn(cache) >= MaxCacheSize then
         table.remove(cache)
     end
-    table.insert(cache, 1, {Results = results, Units = formationUnits, UnitCount = TableGetn(formationUnits)})
+    TableInsert(cache, 1, {Results = results, Units = formationUnits, UnitCount = TableGetn(formationUnits)})
 end
 
 -- =========================================
@@ -930,11 +931,11 @@ function GuardFormation(formationUnits)
         local offsetX = sizeMult * MathSin(ringPosition)
         local offsetY = -sizeMult * MathCos(ringPosition)
         if shieldsInRing > 0 and unitCount >= nextShield then
-            table.insert(FormationPos, { offsetX, offsetY, shieldCategory, 0, rotate })
+            TableInsert(FormationPos, { offsetX, offsetY, ShieldCategory, 0, rotate })
             remainingShields = remainingShields - 1
             nextShield = nextShield + unitsPerShield
         else
-            table.insert(FormationPos, { offsetX, offsetY, nonShieldCategory, 0, rotate })
+            TableInsert(FormationPos, { offsetX, offsetY, NonShieldCategory, 0, rotate })
         end
         unitCount = unitCount + 1
         remainingUnits = remainingUnits - 1
@@ -1050,7 +1051,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
                             rowType = type
                         end
 
-                        table.insert(FormationPos, {xPos * spacing, (-formationLength - offsetY) * spacing, groupData.Filter, formationLength, true})
+                        TableInsert(FormationPos, {xPos * spacing, (-formationLength - offsetY) * spacing, groupData.Filter, formationLength, true})
                         inserted = true
 
                         groupData.Count = groupData.Count - 1
@@ -1205,7 +1206,7 @@ function BlockBuilderAir(unitsList, airBlock, spacing)
                     for fs, groupData in unitsList[group] do
                         local size = unitsList.FootprintSizes[fs]
                         if groupData.Count > 0 and size == data.size then
-                            table.insert(FormationPos, {data.xPos * spacing, data.yPos * spacing, groupData.Filter, 0, true})
+                            TableInsert(FormationPos, {data.xPos * spacing, data.yPos * spacing, groupData.Filter, 0, true})
                             groupData.Count = groupData.Count - 1
                             if groupData.Count <= 0 then
                                 unitsList[group][fs] = nil
@@ -1270,7 +1271,7 @@ function BlockBuilderAir(unitsList, airBlock, spacing)
                         if airBlock.HomogenousBlocks and not chevronType then
                             chevronType = type
                         end
-                        table.insert(FormationPos, {xPos * spacing, yPos * spacing, groupData.Filter, 0, true})
+                        TableInsert(FormationPos, {xPos * spacing, yPos * spacing, groupData.Filter, 0, true})
                         inserted = true
 
                         groupData.Count = groupData.Count - 1
@@ -1377,7 +1378,7 @@ function BlockBuilderAirT3Bombers(unitsList, spacing)
                         if airBlock.HomogenousBlocks and not chevronType then
                             chevronType = type
                         end
-                        table.insert(FormationPos, {xPos * spacing, yPos * spacing, groupData.Filter, 0, true})
+                        TableInsert(FormationPos, {xPos * spacing, yPos * spacing, groupData.Filter, 0, true})
                         inserted = true
 
                         groupData.Count = groupData.Count - 1
@@ -1457,11 +1458,11 @@ function GetLargeAirPositions(unitsList, airBlock)
                 end
             end
             if not blocked then
-                table.insert(results, {row = whichRow, col = whichCol, xPos = xPos, yPos = yPos, size = size})
+                TableInsert(results, {row = whichRow, col = whichCol, xPos = xPos, yPos = yPos, size = size})
                 count = count - 1
                 numResults = numResults + 1
                 if whichCol ~= 1 then
-                    table.insert(results, {row = whichRow, col = whichCol - 1, xPos = -xPos, yPos = yPos, size = size})
+                    TableInsert(results, {row = whichRow, col = whichCol - 1, xPos = -xPos, yPos = yPos, size = size})
                     count = count - 1
                     numResults = numResults + 1
                 end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -726,18 +726,19 @@ function AttackFormation(formationUnits)
 
     local unitsList = CategorizeUnits(formationUnits)
     local landUnitsList = unitsList.Land
+    local landArea = landUnitsList.AreaTotal
     local landBlock
-    if landUnitsList.AreaTotal <= 16 then -- 8 wide
+    if landArea <= 16 then -- 8 wide
         landBlock = TwoRowAttackFormationBlock
-    elseif landUnitsList.AreaTotal <= 30 then -- 10 wide
+    elseif landArea <= 30 then -- 10 wide
         landBlock = ThreeRowAttackFormationBlock
-    elseif landUnitsList.AreaTotal <= 48 then -- 12 wide
+    elseif landArea <= 48 then -- 12 wide
         landBlock = FourRowAttackFormationBlock
-    elseif landUnitsList.AreaTotal <= 70 then -- 14 wide
+    elseif landArea <= 70 then -- 14 wide
         landBlock = FiveRowAttackFormationBlock
-    elseif landUnitsList.AreaTotal <= 96 then -- 16 wide
+    elseif landArea <= 96 then -- 16 wide
         landBlock = SixRowAttackFormationBlock
-    elseif landUnitsList.AreaTotal <= 126 then -- 18 wide
+    elseif landArea <= 126 then -- 18 wide
         landBlock = SevenRowAttackFormationBlock
     else -- 20 wide
         landBlock = EightRowAttackFormationBlock
@@ -784,16 +785,17 @@ function GrowthFormation(formationUnits)
 
     local unitsList = CategorizeUnits(formationUnits)
     local landUnitsList = unitsList.Land
+    local landArea = landUnitsList.AreaTotal
     local landBlock
-    if landUnitsList.AreaTotal <= 3 then
+    if landArea <= 3 then
         landBlock = ThreeWideAttackFormationBlock
-    elseif landUnitsList.AreaTotal <= 12 then
+    elseif landArea <= 12 then
         landBlock = FourWideAttackFormationBlock
-    elseif landUnitsList.AreaTotal <= 20 then
+    elseif landArea <= 20 then
         landBlock = FiveWideAttackFormationBlock
-    elseif landUnitsList.AreaTotal <= 30 then
+    elseif landArea <= 30 then
         landBlock = SixWideAttackFormationBlock
-    elseif landUnitsList.AreaTotal <= 42 then
+    elseif landArea <= 42 then
         landBlock = SevenWideAttackFormationBlock
     else
         landBlock = EightWideAttackFormationBlock

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1085,7 +1085,8 @@ end
 ---@param currRowLen number
 ---@return number
 function GetLandRowModifer(unitsList, categoryTable, currRowLen)
-    if unitsList.UnitTotal >= currRowLen or MathMod(unitsList.UnitTotal, 2) == MathMod(currRowLen, 2) then
+    local unitTotal = unitsList.UnitTotal
+    if unitTotal >= currRowLen or MathMod(unitTotal, 2) == MathMod(currRowLen, 2) then
         return 0
     end
 

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -22,6 +22,7 @@ local MathFloor = math.floor
 local MathMod = math.mod
 local MathMin = math.min
 local MathMax = math.max
+local MathPi = math.pi
 local MathSin = math.sin
 
 SurfaceFormations = {
@@ -929,7 +930,7 @@ function GuardFormation(formationUnits)
                 nextShield = unitsPerShield - 0.01 -- Rounding error could result in missing a shield if nextShield is supposed to equal ringChange.
             end
         end
-        local ringPosition = unitCount / ringChange * math.pi * 2.0
+        local ringPosition = unitCount / ringChange * MathPi * 2.0
         local offsetX = sizeMult * MathSin(ringPosition)
         local offsetY = -sizeMult * MathCos(ringPosition)
         if shieldsInRing > 0 and unitCount >= nextShield then

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -45,7 +45,7 @@ local MaxCacheSize = 30
 
 ---@param formationUnits Unit[]
 ---@param formationType UnitFormations
----@return boolean
+---@return false | table
 function GetCachedResults(formationUnits, formationType)
     local cache = FormationCache[formationType]
     if not cache then

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -16,10 +16,12 @@
 local TableGetn = table.getn
 local MathAbs = math.abs
 local MathCeil = math.ceil
+local MathCos = math.cos
 local MathFloor = math.floor
 local MathMod = math.mod
 local MathMin = math.min
 local MathMax = math.max
+local MathSin = math.sin
 
 SurfaceFormations = {
     'AttackFormation',
@@ -925,8 +927,8 @@ function GuardFormation(formationUnits)
             end
         end
         local ringPosition = unitCount / ringChange * math.pi * 2.0
-        local offsetX = sizeMult * math.sin(ringPosition)
-        local offsetY = -sizeMult * math.cos(ringPosition)
+        local offsetX = sizeMult * MathSin(ringPosition)
+        local offsetY = -sizeMult * MathCos(ringPosition)
         if shieldsInRing > 0 and unitCount >= nextShield then
             table.insert(FormationPos, { offsetX, offsetY, shieldCategory, 0, rotate })
             remainingShields = remainingShields - 1

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -936,11 +936,11 @@ function GuardFormation(formationUnits)
         local offsetX = sizeMult * MathSin(ringPosition)
         local offsetY = -sizeMult * MathCos(ringPosition)
         if shieldsInRing > 0 and unitCount >= nextShield then
-            TableInsert(FormationPos, { offsetX, offsetY, ShieldCategory, 0, rotate })
+            TableInsert(FormationPos, { offsetX, offsetY, shieldCategory, 0, rotate })
             remainingShields = remainingShields - 1
             nextShield = nextShield + unitsPerShield
         else
-            TableInsert(FormationPos, { offsetX, offsetY, NonShieldCategory, 0, rotate })
+            TableInsert(FormationPos, { offsetX, offsetY, nonShieldCategory, 0, rotate })
         end
         unitCount = unitCount + 1
         remainingUnits = remainingUnits - 1

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -970,6 +970,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable)
     local occupiedSpaces = {}
 
     local homogenousRows = formationBlock.HomogenousRows
+    local lineBreak = formationBlock.LineBreak or 0
 
     while unitsList.UnitTotal > 0 do
         if whichCol > currRowLen then
@@ -979,7 +980,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable)
             else
                 whichRow = whichRow + 1
             end
-            formationLength = formationLength + 1 + (formationBlock.LineBreak or 0)
+            formationLength = formationLength + 1 + lineBreak
             whichCol = 1
             rowType = false
             currRowLen = TableGetn(formationBlock[whichRow])
@@ -1031,7 +1032,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable)
                             else
                                 offsetX = (size - 1) / 2
                             end
-                            offsetY = (size - 1) / 2 * (1 + (formationBlock.LineBreak or 0))
+                            offsetY = (size - 1) / 2 * (1 + lineBreak)
 
                             OccupyLandSpace(occupiedSpaces, size, rowNum, whichCol, currRowLen)
                         end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -13,6 +13,8 @@
 ---@alias UnitFormations 'AttackFormation' | 'GrowthFormation' | 'NoFormation' | 'None' | 'none'
 
 
+local TableGetn = table.getn
+
 SurfaceFormations = {
     'AttackFormation',
     'GrowthFormation',
@@ -41,7 +43,7 @@ function GetCachedResults(formationUnits, formationType)
         return false
     end
 
-    local unitCount = table.getn(formationUnits)
+    local unitCount = TableGetn(formationUnits)
     for _, data in cache do
         if data.UnitCount == unitCount then
             local match = true
@@ -69,10 +71,10 @@ function CacheResults(results, formationUnits, formationType)
     end
 
     local cache = FormationCache[formationType]
-    if table.getn(cache) >= MaxCacheSize then
+    if TableGetn(cache) >= MaxCacheSize then
         table.remove(cache)
     end
-    table.insert(cache, 1, {Results = results, Units = formationUnits, UnitCount = table.getn(formationUnits)})
+    table.insert(cache, 1, {Results = results, Units = formationUnits, UnitCount = TableGetn(formationUnits)})
 end
 
 -- =========================================
@@ -854,7 +856,7 @@ function GuardFormation(formationUnits)
     local shieldCategory = ShieldCat
     local nonShieldCategory = categories.ALLUNITS - shieldCategory
     local footprintCounts = {}
-    local remainingUnits = table.getn(formationUnits)
+    local remainingUnits = TableGetn(formationUnits)
     local remainingShields = 0
     for _, u in formationUnits do
         if EntityCategoryContains(ShieldCat, u) then
@@ -941,11 +943,11 @@ end
 ---@return table
 function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
     spacing = (spacing or 1) * unitsList.Scale
-    local numRows = table.getn(formationBlock)
+    local numRows = TableGetn(formationBlock)
     local rowNum = 1
     local whichRow = 1
     local whichCol = 1
-    local currRowLen = table.getn(formationBlock[whichRow])
+    local currRowLen = TableGetn(formationBlock[whichRow])
     local rowModifier = GetLandRowModifer(unitsList, categoryTable, currRowLen)
     currRowLen = currRowLen - rowModifier
     local evenRowLen = math.mod(currRowLen, 2) == 0
@@ -965,7 +967,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
             formationLength = formationLength + 1 + (formationBlock.LineBreak or 0)
             whichCol = 1
             rowType = false
-            currRowLen = table.getn(formationBlock[whichRow])
+            currRowLen = TableGetn(formationBlock[whichRow])
             if occupiedSpaces[rowNum] then
                 rowModifier = 0
             else
@@ -1177,11 +1179,11 @@ end
 ---@return table
 function BlockBuilderAir(unitsList, airBlock, spacing)
     spacing = (spacing or 1) * unitsList.Scale
-    local numRows = table.getn(airBlock)
+    local numRows = TableGetn(airBlock)
     local whichRow = 1
     local whichCol = 1
     local chevronPos = 1
-    local currRowLen = table.getn(airBlock[whichRow])
+    local currRowLen = TableGetn(airBlock[whichRow])
     local chevronSize = airBlock.ChevronSize or 5
     local chevronType = false
     local formationLength = 0
@@ -1225,11 +1227,11 @@ function BlockBuilderAir(unitsList, airBlock, spacing)
                 if whichRow >= numRows then
                     if airBlock.RepeatAllRows then
                         whichRow = 1
-                        currRowLen = table.getn(airBlock[whichRow])
+                        currRowLen = TableGetn(airBlock[whichRow])
                     end
                 else
                     whichRow = whichRow + 1
-                    currRowLen = table.getn(airBlock[whichRow])
+                    currRowLen = TableGetn(airBlock[whichRow])
                 end
                 formationLength = formationLength + 1
                 whichCol = 1
@@ -1306,11 +1308,11 @@ function BlockBuilderAirT3Bombers(unitsList, spacing)
         }
     end
 
-    local numRows = table.getn(airBlock)
+    local numRows = TableGetn(airBlock)
     local whichRow = 1
     local whichCol = 1
     local chevronPos = 1
-    local currRowLen = table.getn(airBlock[whichRow])
+    local currRowLen = TableGetn(airBlock[whichRow])
     local chevronSize = 1
     local chevronType = false
     local formationLength = 0
@@ -1332,11 +1334,11 @@ function BlockBuilderAirT3Bombers(unitsList, spacing)
                 if whichRow >= numRows then
                     if airBlock.RepeatAllRows then
                         whichRow = 1
-                        currRowLen = table.getn(airBlock[whichRow])
+                        currRowLen = TableGetn(airBlock[whichRow])
                     end
                 else
                     whichRow = whichRow + 1
-                    currRowLen = table.getn(airBlock[whichRow])
+                    currRowLen = TableGetn(airBlock[whichRow])
                 end
                 formationLength = formationLength + 1
                 whichCol = 1
@@ -1399,7 +1401,7 @@ function GetLargeAirPositions(unitsList, airBlock)
         end
     end
 
-    local numRows = table.getn(airBlock)
+    local numRows = TableGetn(airBlock)
     local whichRow = 0
     local whichCol = 0
     local currRowLen = 0
@@ -1414,11 +1416,11 @@ function GetLargeAirPositions(unitsList, airBlock)
                 if whichRow >= numRows then
                     if airBlock.RepeatAllRows then
                         whichRow = 1
-                        currRowLen = table.getn(airBlock[whichRow])
+                        currRowLen = TableGetn(airBlock[whichRow])
                     end
                 else
                     whichRow = whichRow + 1
-                    currRowLen = table.getn(airBlock[whichRow])
+                    currRowLen = TableGetn(airBlock[whichRow])
                 end
                 formationLength = formationLength + 1
                 whichCol = 1

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1157,13 +1157,14 @@ function OccupyLandSpace(occupiedSpaces, size, rowNum, whichCol, currRowLen)
         if not occupiedSpaces[yPos] then
             occupiedSpaces[yPos] = {}
         end
+        local occupiedYPos = occupiedSpaces[yPos]
         if whichCol == 1 and evenRowLen == evenSize then
             for x = 0, size - 1, 1 do
-                occupiedSpaces[yPos][whichCol + x] = true
+                occupiedYPos[whichCol + x] = true
             end
         else
             for x = 0, (size - 1) * 2, 2 do
-                occupiedSpaces[yPos][whichCol + x] = true
+                occupiedYPos[whichCol + x] = true
             end
         end
     end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1413,8 +1413,9 @@ end
 ---@return table
 function GetLargeAirPositions(unitsList, airBlock)
     local sizeCounts = {}
-    for fs, count in unitsList.FootprintCounts do
-        local size = unitsList.FootprintSizes[fs]
+    local footprintCounts = unitsList.FootprintCounts
+    for fs, count in footprintCounts do
+        local size = footprintCounts[fs]
         if size > 1 then
             sizeCounts[size] = (sizeCounts[size] or 0) + count
         end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -14,6 +14,7 @@
 
 
 local TableGetn = table.getn
+local MathCeil = math.ceil
 local MathMod = math.mod
 local MathMin = math.min
 local MathMax = math.max
@@ -1026,7 +1027,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
 
                         local xPos
                         if evenRowLen then
-                            xPos = math.ceil(whichCol/2) - .5 + offsetX
+                            xPos = MathCeil(whichCol/2) - .5 + offsetX
                             if not (MathMod(whichCol, 2) == 0) then
                                 xPos = xPos * -1
                             end
@@ -1034,7 +1035,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable, spacing)
                             if whichCol == 1 then
                                 xPos = 0
                             else
-                                xPos = math.ceil(((whichCol-1) /2)) + offsetX
+                                xPos = MathCeil(((whichCol-1) /2)) + offsetX
                                 if not (MathMod(whichCol, 2) == 0) then
                                     xPos = xPos * -1
                                 end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -969,6 +969,8 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable)
     local inserted = false
     local occupiedSpaces = {}
 
+    local homogenousRows = formationBlock.HomogenousRows
+
     while unitsList.UnitTotal > 0 do
         if whichCol > currRowLen then
             rowNum = rowNum + 1
@@ -1002,7 +1004,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable)
                 break
             end
             for _, group in type do
-                if not formationBlock.HomogenousRows or (rowType == false or rowType == type) then
+                if not homogenousRows or (rowType == false or rowType == type) then
                     local fs = 0
                     local size = 0
                     local evenSize = true
@@ -1051,7 +1053,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable)
                             end
                         end
 
-                        if formationBlock.HomogenousRows and not rowType then
+                        if homogenousRows and not rowType then
                             rowType = type
                         end
 

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1091,9 +1091,10 @@ function GetLandRowModifer(unitsList, categoryTable, currRowLen)
     end
 
     local sizeTotal = 0
+    local footprintSizes = unitsList.FootprintSizes
     for group, _ in categoryTable do
         for fs, data in unitsList[group] do
-            sizeTotal = sizeTotal + unitsList.FootprintSizes[fs] * data.Count
+            sizeTotal = sizeTotal + footprintSizes[fs] * data.Count
         end
     end
     if sizeTotal < currRowLen then -- This doesn't allow for large units hanging over the sides, but it's too hard to handle that correctly.


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->

This PR changes `formations.lua` to use locals and upvalues when possible. Using an upvalue or `local` for frequently used functions and tables performs better than frequent table lookups.

Removes the unnecessary (optional, always `1`) `spacing` parameter on `BlockBuilderLand`.

Fix annotation of `GetCachedResults`.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->

### Replay simulation

Rebase on `af859b5d21a8bf165ac20863557f572d216c7633`. Simulate replay #25004163 with `wld_RunWithTheWind`.

Observe no desycns and unrelated warnings:
```
WARNING: Duplicate definition of console command ""
WARNING:  NUM PROPS = 5182
WARNING: GetResource: Invalid name ""
WARNING: GetResource: Invalid name ""
WARNING: GetResource: Invalid name ""
WARNING: ACU kill detected. Rating for ranked games is now enforced.
WARNING: FactoryRebuildUnits failed to rebuild correctly for factory urb0101 (entity ID 3145834).
WARNING: Rebuild data:
WARNING: Progress: 0.050000
WARNING: BuildTime: 10.000001
WARNING: Health: 8.000000
WARNING: 20
WARNING: ACU kill detected. Rating for ranked games is now enforced.
WARNING: FactoryRebuildUnits failed to rebuild correctly for factory ueb0301 (entity ID 2097577).
WARNING: Rebuild data:
WARNING: Progress: 0.924063
WARNING: BuildTime: 1441.538696
WARNING: Health: 740.233337
WARNING: 90
WARNING: ACU kill detected. Rating for ranked games is now enforced.
WARNING: ACU kill detected. Rating for ranked games is now enforced.
```

## Additional context
<!-- Add any other context about the pull request here. -->


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
