### PR TITLE
Fix issues with `GiveNukeSiloBlocks`

### DIFF
--- a/changelog/snippets/fix.6855.md
+++ b/changelog/snippets/fix.6855.md
@@ -1,0 +1,6 @@
+- (#6855) Fix issues with `Unit.GiveNukeSiloBlocks` (function that sets missile build progress for a unit, used in unit transfer):
+  
+  - Crash if used on a unit whose first weapon does not have a `ProjectileId` in its blueprint.
+  - Setting incorrect progress for units whose first weapon is not the desired silo weapon (ex: missile SACU).
+  - Setting incorrect progress for units with buildrate different from their blueprint spec (ex: missile SACU).
+  - Yellow work progress bar not being updated after progress is set.

--- a/engine/Sim/Unit.lua
+++ b/engine/Sim/Unit.lua
@@ -320,8 +320,12 @@ end
 function Unit:GetWorkProgress()
 end
 
---- Adds nuclear missiles to the unit.
---- This is the method to call for both SML's and SMD's.
+--- With [FA-Binary-Patches#15](https://github.com/FAForever/FA-Binary-Patches/pull/15),
+--- `InBlocks` makes `amount` set the number of "blocks" for the in-progress tactical or nuclear missile.
+--- A projectile is built out of `10 * (buildTime / buildRate)` blocks.
+--- Use `Unit:GiveNukeSiloBlocks()` to use this feature.
+
+--- Adds nuclear missiles to the unit
 ---@see GiveTacticalSiloAmmo() # for tactical missiles
 ---@param amount number
 ---@param inBlocks? boolean

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -5021,7 +5021,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
             return
         end
 
-        local buildRate = self.Blueprint.Economy.BuildRate
+        local buildRate = self:GetEconomyBuildRate()
         if not buildRate then
             return
         end

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1124,18 +1124,21 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         self.BuildTimeMultiplier = time_mult
     end,
 
+    --- Used by the engine in silo build calculations.
     ---@param self Unit
     ---@return integer
     GetMassBuildAdjMod = function(self)
         return self.MassBuildAdjMod or 1
     end,
 
+    --- Used by the engine in silo build calculations.
     ---@param self Unit
     ---@return integer
     GetEnergyBuildAdjMod = function(self)
         return self.EnergyBuildAdjMod or 1
     end,
 
+    --- Used by the engine in silo build calculations.
     ---@param self Unit
     GetEconomyBuildRate = function(self)
         return self:GetBuildRate()
@@ -5008,12 +5011,14 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         end
     end,
 
+    --- Adds nuclear missiles to the unit.
     ---@param self Unit
     ---@param count number
     GiveNukeSiloAmmo = function(self, count)
         cUnit.GiveNukeSiloAmmo(self, count)
     end,
 
+    --- Sets build progress for nuclear/tactical missile construction.
     ---@param self Unit
     ---@param fraction number
     GiveNukeSiloBlocks = function(self, fraction)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -5037,7 +5037,6 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
             if weaponBp.MaxProjectileStorage >= 1 then
                 buildTime = __blueprints[weaponBp.ProjectileId].Economy.BuildTime
                 if buildTime then
-                    LOG('build time found', buildTime, weaponBp.ProjectileId)
                     break
                 end
             end
@@ -5046,7 +5045,6 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
 
         local total = 10 * (buildTime / buildRate)
         local blocks = math.ceil(fraction * total)
-        LOG('giving ', blocks, 'out of', total)
         cUnit.GiveNukeSiloAmmo(self, blocks, true)
         -- Engine won't update work progress so we do it manually
         self:SetWorkProgress(fraction)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -5026,10 +5026,17 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
             return
         end
 
-        local buildTime = self:GetWeapon(1):GetProjectileBlueprint().Economy.BuildTime
-        if not buildTime then
-            return
+        local buildTime
+        for i = 1, self.WeaponCount do
+            local weaponBp = self.WeaponInstances[i].Blueprint
+            if weaponBp.MaxProjectileStorage >= 1 then
+                buildTime = __blueprints[weaponBp.ProjectileId].Economy.BuildTime
+                if buildTime then
+                    break
+                end
+            end
         end
+        if not buildTime then return end
 
         local total = 10 * (buildTime / buildRate)
         local blocks = math.ceil(fraction * total)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -5048,6 +5048,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         local blocks = math.ceil(fraction * total)
         LOG('giving ', blocks, 'out of', total)
         cUnit.GiveNukeSiloAmmo(self, blocks, true)
+        -- Engine won't update work progress so we do it manually
+        self:SetWorkProgress(fraction)
     end,
 
     --- Updates a statistic that you can retrieve on the UI side using `userunit:GetStat`. See `unit:UpdateStat` for an alternative

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -5032,6 +5032,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
             if weaponBp.MaxProjectileStorage >= 1 then
                 buildTime = __blueprints[weaponBp.ProjectileId].Economy.BuildTime
                 if buildTime then
+                    LOG('build time found', buildTime, weaponBp.ProjectileId)
                     break
                 end
             end
@@ -5040,6 +5041,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
 
         local total = 10 * (buildTime / buildRate)
         local blocks = math.ceil(fraction * total)
+        LOG('giving ', blocks, 'out of', total)
         cUnit.GiveNukeSiloAmmo(self, blocks, true)
     end,
 


### PR DESCRIPTION
## Issue
Caused by #4867

1. The game will crash when it tries to get a projectile blueprint for a weapon without a ProjectileId in its blueprint. I encountered this when running a modded game and my teammate disconnected (replay 25046432).
<details> <summary> Debugger log </summary>

ECX is the non-existent projectile blueprint. `5C` is the offset for the ordinal field of the projectile bp.
```
ACCESS_VIOLATION: Read from 0x0000005C
EAX: 0x0525F89C, EBX: 0x00000000, ECX: 0x00000000, EDX: 0x0525F89C
ESI: 0x0525F8F4, EDI: 0x93BA4700, EBP: 0x0525F918, ESP: 0x0525F894

Stacktrace: 0x0050DFD8 0x006D8D23 0x00914415 0x0092B2DF ntdll.dll+0x00052D04 0x00AC520F 0x00461EB3 0x009145F1
LUA Fork thread
@c:\programdata\faforever\gamedata\lua.nx2\lua\simutils.lua 1015
CObject:.?AVCAiBrain@Moho@@, "FullShare", 1, Table
@c:\programdata\faforever\gamedata\lua.nx2\lua\simutils.lua 1033
CObject:.?AVCAiBrain@Moho@@, Table, true, nil, "FullShare", Table, Table, CFunc, Table, 1, CObject:.?AVCAiBrain@Moho@@
@c:\programdata\faforever\gamedata\lua.nx2\lua\simutils.lua 829
Table, 3, false, true, CObject:.?AVCAiBrain@Moho@@, UData:28D03F18, true, 2, Table, 0, Table, 0, Table, 0, Table, Table, CFunc, Table, 2, Table, 1, Table, Table, Table, Table, 0.628571, 0, 0, 10350.258789, 46470, nil, false, 0, false, 0, nil, 1, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, 0, Table, nil, Table, nil, Table, 70000
@c:\programdata\faforever\gamedata\lua.nx2\lua\simutils.lua 330
Table, 0.628571, 55
@c:\programdata\faforever\gamedata\lua.nx2\lua\sim\unit.lua 5022
CObject:.?AVUnitWeapon@Moho@@
```

</details>

2. The function only checks the first weapon for which to give ammo, which is incorrect for units with standard weapons + a silo weapon (missile SACU/ACU, modded units).

3. The ammo progress given is incorrect for missile preset SACUs.

4. The work progress after giving ammo progress is not updated by the engine after ammo progress is given, which is especially noticeable when the unit is paused.

## Description of the proposed changes
1. Use Lua to check for the buildtime, which won't error when `__blueprints` is indexed with `nil`.
2. Check over all weapons to find the one which stores projectiles.
3. Use the dynamic build rate used by the engine to give ammo progress instead of the base bp buildrate value.
4. Set work progress after ammo progress is given.

## Testing done on the proposed changes
Using the units
```
   CreateUnitAtMouse('url0001', 0,    2.28,    0.34, -2.85231)
   CreateUnitAtMouse('xsl0301_missile', 0,   -1.62,   -0.17, -0.00000)
   CreateUnitAtMouse('xsl0301_missile', 0,   -0.66,   -0.17, -0.00000)
```
and the command
```
ConExecute("SimLua SelectedUnit():GiveNukeSiloBlocks(0.5)")
```
- Missile preset SACU when paused updates the progress correctly
- Missile preset SACU unpaused updates the progress correctly
- Cybran ACU (has an AI-controlling weapon at index 1) does not crash the game.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
