### PR TITLE
Reduce table accesses of projectiles especially on impact

### DIFF
--- a/changelog/snippets/performance.6862.md
+++ b/changelog/snippets/performance.6862.md
@@ -1,0 +1,1 @@
+- (#6862) Reduce table accesses of projectiles especially on impact.

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -807,24 +807,25 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         if not tbl then return end
         if not tbl.Radius then return end
         local radius = tbl.Radius
+        local category = tbl.Category
 
         self.MyFlare = Flare {
             Owner = self,
             Radius = radius,
-            Category = tbl.Category, -- We pass the category bp value along so that it actually has a function.
+            Category = category, -- We pass the category bp value along so that it actually has a function.
         }
         if tbl.Stack == true then -- Secondary flare hitboxes, one above, one below (Aeon TMD)
             self.MyUpperFlare = Flare {
                 Owner = self,
                 Radius = radius,
                 OffsetMult = tbl.OffsetMult,
-                Category = tbl.Category,
+                Category = category,
             }
             self.MyLowerFlare = Flare {
                 Owner = self,
                 Radius = radius,
                 OffsetMult = -tbl.OffsetMult,
-                Category = tbl.Category,
+                Category = category,
             }
             self.Trash:Add(self.MyUpperFlare)
             self.Trash:Add(self.MyLowerFlare)

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -42,6 +42,7 @@ local EntitySetHealth = EntityMethods.SetHealth
 local EntityGetPositionXYZ = EntityMethods.GetPositionXYZ
 local EntityDestroy = EntityMethods.Destroy
 local EntityGetOrientation = EntityMethods.GetOrientation
+local EntityPlaySound = EntityMethods.PlaySound
 
 local TrashBag = TrashBag
 local TrashBagAdd = TrashBag.Add
@@ -461,9 +462,9 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         -- Sounds for all other impacts, ie: Impact<TargetTypeName>
         local snd = blueprintAudio['Impact' .. targetType]
         if snd then
-            self:PlaySound(snd)
+            EntityPlaySound(self, snd)
         elseif blueprintAudio.Impact then
-            self:PlaySound(blueprintAudio.Impact)
+            EntityPlaySound(self, blueprintAudio.Impact)
         end
 
         -- Possible 'target' values are:
@@ -546,7 +547,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
             end
 
             if blueprintAudio then
-                self:PlaySound(blueprintAudio)
+                EntityPlaySound(self, blueprintAudio)
             end
         end
     end,
@@ -564,7 +565,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
             end
 
             if blueprintAudio then
-                self:PlaySound(blueprintAudio)
+                EntityPlaySound(self, blueprintAudio)
             end
         end
     end,

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -805,7 +805,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
 
     --- Called by Lua to add a flare
     ---@param self Projectile
-    ---@param tbl? table
+    ---@param tbl? WeaponBlueprintFlare
     AddFlare = function(self, tbl)
         if not (tbl and tbl.Radius) then return end
         local radius = tbl.Radius

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -860,6 +860,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     ---@param effectScale? number
     CreateImpactEffects = function(self, army, effectTable, effectScale)
         local emit = nil
+        local scaleEmit = effectScale and effectScale ~= 1
         local fxImpactTrajectoryAligned = self.FxImpactTrajectoryAligned
         for _, v in effectTable do
             if fxImpactTrajectoryAligned then
@@ -868,7 +869,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
                 emit = CreateEmitterAtEntity(self, army, v)
             end
 
-            if effectScale and effectScale ~= 1 then
+            if scaleEmit then
                 emit:ScaleEmitter(effectScale or 1)
             end
         end
@@ -881,9 +882,11 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     ---@param effectScale? number
     CreateTerrainEffects = function(self, army, effectTable, effectScale)
         local emit = nil
+        local scaleEmit = effectScale and effectScale ~= 1
         for _, v in effectTable do
             emit = CreateEmitterAtBone(self, -2, army, v)
-            if emit and effectScale and effectScale ~= 1 then
+            if emit and scaleEmit then
+                ---@diagnostic disable-next-line: param-type-mismatch
                 emit:ScaleEmitter(effectScale)
             end
         end

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -815,6 +815,8 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
             Radius = radius,
             Category = category, -- We pass the category bp value along so that it actually has a function.
         }
+        self.Trash:Add(self.MyFlare)
+
         if tbl.Stack == true then -- Secondary flare hitboxes, one above, one below (Aeon TMD)
             self.MyUpperFlare = Flare {
                 Owner = self,
@@ -822,17 +824,16 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
                 OffsetMult = offsetMult,
                 Category = category,
             }
+            self.Trash:Add(self.MyUpperFlare)
+
             self.MyLowerFlare = Flare {
                 Owner = self,
                 Radius = radius,
                 OffsetMult = -offsetMult,
                 Category = category,
             }
-            self.Trash:Add(self.MyUpperFlare)
             self.Trash:Add(self.MyLowerFlare)
         end
-
-        self.Trash:Add(self.MyFlare)
     end,
 
     ---@param self TDepthChargeProjectile

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -850,7 +850,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
             ProjectilesToDeflect = blueprint.ProjectilesToDeflect
         }
 
-        self.MyDepthCharge = self.Trash:Add(DepthCharge(depthChargeSpec))
+        self.MyDepthCharge = TrashBagAdd(self.Trash, DepthCharge(depthChargeSpec))
     end,
 
     --- Called by Lua to create the impact effects

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -375,15 +375,15 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         -- air units are affected by this, see also the pull request for a visual aid on this issue on Github
         if radius > 0 and targetEntity then
             if targetType == 'Unit' or targetType == 'UnitAir' then
-                local vx, vy, vz = targetEntity:GetVelocity()
-                vc[1] = vc[1] + vx
-                vc[2] = vc[2] + vy
-                vc[3] = vc[3] + vz
+                local velx, vely, velz = targetEntity:GetVelocity()
+                vc[1] = vc[1] + velx
+                vc[2] = vc[2] + vely
+                vc[3] = vc[3] + velz
             elseif targetType == 'Shield' then
-                local vx, vy, vz = targetEntity.Owner:GetVelocity()
-                vc[1] = vc[1] + vx
-                vc[2] = vc[2] + vy
-                vc[3] = vc[3] + vz
+                local velx, vely, velz = targetEntity.Owner:GetVelocity()
+                vc[1] = vc[1] + velx
+                vc[2] = vc[2] + vely
+                vc[3] = vc[3] + velz
             end
         end
 

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -804,7 +804,8 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     ---@param self Projectile
     ---@param tbl? table
     AddFlare = function(self, tbl)
-        if not tbl or not tbl.Radius then return end
+        if not tbl then return end
+        if not tbl.Radius then return end
         local radius = tbl.Radius
         local category = tbl.Category
 

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -808,6 +808,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         if not tbl.Radius then return end
         local radius = tbl.Radius
         local category = tbl.Category
+        local offsetMult = tbl.OffsetMult
 
         self.MyFlare = Flare {
             Owner = self,
@@ -818,13 +819,13 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
             self.MyUpperFlare = Flare {
                 Owner = self,
                 Radius = radius,
-                OffsetMult = tbl.OffsetMult,
+                OffsetMult = offsetMult,
                 Category = category,
             }
             self.MyLowerFlare = Flare {
                 Owner = self,
                 Radius = radius,
-                OffsetMult = -tbl.OffsetMult,
+                OffsetMult = -offsetMult,
                 Category = category,
             }
             self.Trash:Add(self.MyUpperFlare)

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -814,7 +814,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
             Radius = radius,
             Category = category, -- We pass the category bp value along so that it actually has a function.
         }
-        self.Trash:Add(self.MyFlare)
+        TrashBagAdd(self.Trash, self.MyFlare)
 
         if tbl.Stack == true then -- Secondary flare hitboxes, one above, one below (Aeon TMD)
             self.MyUpperFlare = Flare {
@@ -823,7 +823,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
                 OffsetMult = offsetMult,
                 Category = category,
             }
-            self.Trash:Add(self.MyUpperFlare)
+            TrashBagAdd(self.Trash, self.MyUpperFlare)
 
             self.MyLowerFlare = Flare {
                 Owner = self,
@@ -831,7 +831,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
                 OffsetMult = -offsetMult,
                 Category = category,
             }
-            self.Trash:Add(self.MyLowerFlare)
+            TrashBagAdd(self.Trash, self.MyLowerFlare)
         end
     end,
 

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -806,21 +806,23 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     AddFlare = function(self, tbl)
         if not tbl then return end
         if not tbl.Radius then return end
+        local radius = tbl.Radius
+
         self.MyFlare = Flare {
             Owner = self,
-            Radius = tbl.Radius,
+            Radius = radius,
             Category = tbl.Category, -- We pass the category bp value along so that it actually has a function.
         }
         if tbl.Stack == true then -- Secondary flare hitboxes, one above, one below (Aeon TMD)
             self.MyUpperFlare = Flare {
                 Owner = self,
-                Radius = tbl.Radius,
+                Radius = radius,
                 OffsetMult = tbl.OffsetMult,
                 Category = tbl.Category,
             }
             self.MyLowerFlare = Flare {
                 Owner = self,
-                Radius = tbl.Radius,
+                Radius = radius,
                 OffsetMult = -tbl.OffsetMult,
                 Category = tbl.Category,
             }

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -807,8 +807,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     ---@param self Projectile
     ---@param tbl? table
     AddFlare = function(self, tbl)
-        if not tbl then return end
-        if not tbl.Radius then return end
+        if not (tbl and tbl.Radius) then return end
         local radius = tbl.Radius
         local category = tbl.Category
 
@@ -843,8 +842,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     ---@param self TDepthChargeProjectile
     ---@param blueprint WeaponBlueprintDepthCharge
     AddDepthCharge = function(self, blueprint)
-        if not blueprint then return end
-        if not blueprint.Radius then return end
+        if not (blueprint and blueprint.Radius) then return end
 
         ---@type DepthChargeSpec
         local depthChargeSpec = {

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -804,8 +804,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     ---@param self Projectile
     ---@param tbl? table
     AddFlare = function(self, tbl)
-        if not tbl then return end
-        if not tbl.Radius then return end
+        if not tbl or not tbl.Radius then return end
         local radius = tbl.Radius
         local category = tbl.Category
         local offsetMult = tbl.OffsetMult

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -899,8 +899,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     ---@param position Vector
     ---@return string[] | boolean
     GetTerrainEffects = function(self, targetType, impactEffectType, position)
-
-        local position = position or self:GetPosition()
+        position = position or self:GetPosition()
 
         local terrainType = nil
         if impactEffectType then

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -441,14 +441,16 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
                 -- radius, lod and lifetime share the same rng adjustment
                 local rngRadius = altRadius * Random()
 
+                local splatRadius = 0.75 * altRadius + 0.2 * rngRadius
+
                 CreateSplat(
                     vc, -- position
                     6.28 * Random(), -- heading
                     splat, -- splat
 
                     -- scale the splat, lod and duration randomly
-                    0.75 * altRadius + 0.2 * rngRadius, -- size x
-                    0.75 * altRadius + 0.2 * rngRadius, -- size z
+                    splatRadius, -- size x
+                    splatRadius, -- size z
                     10 + 30 * altRadius + 30 * rngRadius, -- lod
                     8 + 8 * altRadius + 8 * rngRadius, -- duration
                     self.Army-- owner of splat

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -808,33 +808,24 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
     ---@param tbl? WeaponBlueprintFlare
     AddFlare = function(self, tbl)
         if not (tbl and tbl.Radius) then return end
-        local radius = tbl.Radius
-        local category = tbl.Category
-
-        self.MyFlare = Flare {
+        local flareSpec = {
             Owner = self,
-            Radius = radius,
-            Category = category, -- We pass the category bp value along so that it actually has a function.
+            Radius = tbl.Radius,
+            Category = tbl.Category, -- We pass the category bp value along so that it actually has a function.
         }
+
+        self.MyFlare = Flare(flareSpec)
         TrashBagAdd(self.Trash, self.MyFlare)
 
         if tbl.Stack == true then -- Secondary flare hitboxes, one above, one below (Aeon TMD)
-            local offsetMult = tbl.OffsetMult
+            local offsetMutl = tbl.OffsetMult
 
-            self.MyUpperFlare = Flare {
-                Owner = self,
-                Radius = radius,
-                OffsetMult = offsetMult,
-                Category = category,
-            }
+            flareSpec.OffSetMult = offsetMutl
+            self.MyUpperFlare = Flare(flareSpec)
             TrashBagAdd(self.Trash, self.MyUpperFlare)
 
-            self.MyLowerFlare = Flare {
-                Owner = self,
-                Radius = radius,
-                OffsetMult = -offsetMult,
-                Category = category,
-            }
+            flareSpec.OffSetMult = -offsetMutl
+            self.MyLowerFlare = Flare(flareSpec)
             TrashBagAdd(self.Trash, self.MyLowerFlare)
         end
     end,

--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -807,7 +807,6 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         if not tbl or not tbl.Radius then return end
         local radius = tbl.Radius
         local category = tbl.Category
-        local offsetMult = tbl.OffsetMult
 
         self.MyFlare = Flare {
             Owner = self,
@@ -817,6 +816,8 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
         TrashBagAdd(self.Trash, self.MyFlare)
 
         if tbl.Stack == true then -- Secondary flare hitboxes, one above, one below (Aeon TMD)
+            local offsetMult = tbl.OffsetMult
+
             self.MyUpperFlare = Flare {
                 Owner = self,
                 Radius = radius,


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->

In `Projectile` there are a few places that benefit from using a `local` of constant values. 

In `OnImpact`, there are many table lookups that use values available outside of that table. The table itself is kept for functions that require it and is properly updated for that purpose.

A `local` is used for booleans that are recomputed for each emitter on impact when their evaluation doesn't change.

Uses some upvalues for functions that appear in a few places throughout the file.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->

### Replay simulation

Rebase changes on game version 3824 and simulate replay 25053165.

Observe no desyncs and unrelated warnings.

```
WARNING: Duplicate definition of console command ""
WARNING:  NUM PROPS = 5182
WARNING: GetResource: Invalid name ""
WARNING: GetResource: Invalid name ""
WARNING: GetResource: Invalid name ""
WARNING: ACU kill detected. Rating for ranked games is now enforced.
WARNING: FactoryRebuildUnits failed to rebuild correctly for factory urb0303 (entity ID 7340047).
WARNING: Rebuild data:
WARNING: Progress: 0.916706
WARNING: BuildTime: 23100.998047
WARNING: Health: 40667.328125
WARNING: 150
WARNING: FactoryRebuildUnits failed to rebuild correctly for factory zab9501 (entity ID 7341109).
WARNING: Rebuild data:
WARNING: Progress: 0.073846
WARNING: BuildTime: 47.999996
WARNING: Health: 26.107695
WARNING: 40
WARNING: FactoryRebuildUnits failed to rebuild correctly for factory zab9503 (entity ID 7341108).
WARNING: Rebuild data:
WARNING: Progress: 0.401329
WARNING: BuildTime: 3210.627930
WARNING: Health: 1304.484009
WARNING: 90
WARNING: FactoryRebuildUnits failed to rebuild correctly for factory zrb9603 (entity ID 1048668).
WARNING: Rebuild data:
WARNING: Progress: 0.186747
WARNING: BuildTime: 4706.027344
WARNING: Health: 5810.049805
WARNING: 150
WARNING: FactoryRebuildUnits failed to rebuild correctly for factory zrb9503 (entity ID 1048699).
WARNING: Rebuild data:
WARNING: Progress: 0.417000
WARNING: BuildTime: 3336.003662
WARNING: Health: 1252.000000
WARNING: 90
```


## Additional context
<!-- Add any other context about the pull request here. -->


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
