### PR TITLE
Fix adjacency error caused by dummy unit from drones/external factories

### DIFF
--- a/changelog/snippets/fix.6863md
+++ b/changelog/snippets/fix.6863md
@@ -1,0 +1,1 @@
+- (#6863) Fix `OnAdjacentTo` error caused by dummy units attached to external factories and UEF engineering drones.

--- a/engine/Core/Categories.lua
+++ b/engine/Core/Categories.lua
@@ -59,6 +59,7 @@ categories = {
     CANNOTUSEAIRSTAGING = categoryValue,
     CANTRANSPORTCOMMANDER = categoryValue,
     CAPTURE = categoryValue,
+    --- Changes engine behavior of units attached to this unit: Hides units and makes them unselectable.
     CARRIER = categoryValue,
     --- Allows the unit to land on water. Is introduced by https://github.com/FAForever/FA-Binary-Patches/pull/20
     CANLANDONWATER = categoryValue,

--- a/lua/sim/units/StructureUnit.lua
+++ b/lua/sim/units/StructureUnit.lua
@@ -772,7 +772,9 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
     OnAdjacentTo = function(self, adjacentUnit, triggerUnit)
 
         -- make sure we're both finished building
-        if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt() then
+        if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt()
+            or adjacentUnit.Blueprint.CategoriesHash["DUMMYUNIT"]
+        then
             return
         end
 
@@ -832,7 +834,9 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
     OnNotAdjacentTo = function(self, adjacentUnit)
 
         -- make sure we're both finished building
-        if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt() then
+        if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt()
+            or adjacentUnit.Blueprint.CategoriesHash["DUMMYUNIT"]
+        then
             return
         end
 

--- a/lua/sim/units/StructureUnit.lua
+++ b/lua/sim/units/StructureUnit.lua
@@ -775,7 +775,6 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
         if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt()
             or adjacentUnit.Blueprint.CategoriesHash["DUMMYUNIT"]
         then
-            LOG('OnAdjacentTo return')
             return
         end
 
@@ -838,7 +837,6 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
         if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt()
             or adjacentUnit.Blueprint.CategoriesHash["DUMMYUNIT"]
         then
-            LOG('OnNotAdjacentTo return')
             return
         end
 

--- a/lua/sim/units/StructureUnit.lua
+++ b/lua/sim/units/StructureUnit.lua
@@ -775,6 +775,7 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
         if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt()
             or adjacentUnit.Blueprint.CategoriesHash["DUMMYUNIT"]
         then
+            LOG('OnAdjacentTo return')
             return
         end
 
@@ -837,6 +838,7 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
         if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt()
             or adjacentUnit.Blueprint.CategoriesHash["DUMMYUNIT"]
         then
+            LOG('OnNotAdjacentTo return')
             return
         end
 

--- a/lua/sim/units/StructureUnit.lua
+++ b/lua/sim/units/StructureUnit.lua
@@ -774,9 +774,7 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
     OnAdjacentTo = function(self, adjacentUnit, triggerUnit)
 
         -- make sure we're both finished building
-        if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt()
-            or adjacentUnit.Blueprint.CategoriesHash["DUMMYUNIT"]
-        then
+        if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt() then
             LOG('OnAdjacentTo return')
             return
         end
@@ -819,9 +817,7 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
     OnNotAdjacentTo = function(self, adjacentUnit)
 
         -- make sure we're both finished building
-        if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt()
-            or adjacentUnit.Blueprint.CategoriesHash["DUMMYUNIT"]
-        then
+        if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt() then
             LOG('OnNotAdjacentTo return')
             return
         end

--- a/lua/sim/units/StructureUnit.lua
+++ b/lua/sim/units/StructureUnit.lua
@@ -777,7 +777,6 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
         if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt()
             or adjacentUnit.Blueprint.CategoriesHash["DUMMYUNIT"]
         then
-            LOG('OnAdjacentTo return')
             return
         end
 
@@ -822,7 +821,6 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
         if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt()
             or adjacentUnit.Blueprint.CategoriesHash["DUMMYUNIT"]
         then
-            LOG('OnNotAdjacentTo return')
             return
         end
 

--- a/lua/sim/units/StructureUnit.lua
+++ b/lua/sim/units/StructureUnit.lua
@@ -774,7 +774,9 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
     OnAdjacentTo = function(self, adjacentUnit, triggerUnit)
 
         -- make sure we're both finished building
-        if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt() then
+        if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt()
+            or adjacentUnit.Blueprint.CategoriesHash["DUMMYUNIT"]
+        then
             return
         end
 
@@ -816,7 +818,9 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
     OnNotAdjacentTo = function(self, adjacentUnit)
 
         -- make sure we're both finished building
-        if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt() then
+        if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt()
+            or adjacentUnit.Blueprint.CategoriesHash["DUMMYUNIT"]
+        then
             return
         end
 

--- a/lua/sim/units/StructureUnit.lua
+++ b/lua/sim/units/StructureUnit.lua
@@ -775,7 +775,6 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
 
         -- make sure we're both finished building
         if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt() then
-            LOG('OnAdjacentTo return')
             return
         end
 
@@ -818,7 +817,6 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
 
         -- make sure we're both finished building
         if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt() then
-            LOG('OnNotAdjacentTo return')
             return
         end
 

--- a/lua/sim/units/StructureUnit.lua
+++ b/lua/sim/units/StructureUnit.lua
@@ -777,6 +777,7 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
         if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt()
             or adjacentUnit.Blueprint.CategoriesHash["DUMMYUNIT"]
         then
+            LOG('OnAdjacentTo return')
             return
         end
 
@@ -821,6 +822,7 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
         if self:IsBeingBuilt() or adjacentUnit:IsBeingBuilt()
             or adjacentUnit.Blueprint.CategoriesHash["DUMMYUNIT"]
         then
+            LOG('OnNotAdjacentTo return')
             return
         end
 

--- a/lua/sim/units/components/DebugUnitComponent.lua
+++ b/lua/sim/units/components/DebugUnitComponent.lua
@@ -22,6 +22,17 @@
 
 local DebugComponent = import("/lua/shared/components/debugcomponent.lua").DebugComponent
 
+---@type UnitState[]
+UnitStates = { 'Immobile', 'Moving', 'Attacking', 'Guarding', 'Building', 'Upgrading',
+    'WaitingForTransport', 'TransportLoading', 'TransportUnloading', 'MovingDown', 'MovingUp',
+    'Patrolling', 'Busy', 'Attached', 'BeingReclaimed', 'Repairing', 'Diving', 'Surfacing',
+    'Teleporting', 'Ferrying', 'WaitForFerry', 'AssistMoving', 'PathFinding', 'ProblemGettingToGoal',
+    'NeedToTerminateTask', 'Capturing', 'BeingCaptured', 'Reclaiming', 'AssistingCommander',
+    'Refueling', 'GuardBusy', 'ForceSpeedThrough', 'UnSelectable', 'DoNotTarget', 'LandingOnPlatform',
+    'CannotFindPlaceToLand', 'BeingUpgraded', 'Enhancing', 'BeingBuilt', 'NoReclaim', 'NoCost',
+    'BlockCommandQueue', 'MakingAttackRun', 'HoldingPattern', 'SiloBuildingAmmo',
+}
+
 ---@class DebugUnitComponent : DebugComponent
 DebugUnitComponent = Class(DebugComponent) {
 
@@ -117,5 +128,20 @@ DebugUnitComponent = Class(DebugComponent) {
 
         local blueprint = self.Blueprint
         DrawCircle(self:GetPosition(), math.max(blueprint.SizeX, blueprint.SizeY, blueprint.SizeZ), color)
+    end,
+
+    DebugActiveStates = function(self)
+        if not self.EnabledLogging then
+            return
+        end
+
+        local activeStates = {}
+        for _, state in UnitStates do
+            if self:IsUnitState(state) then
+                table.insert(activeStates, state)
+            end
+        end
+
+        self:DebugLog('Active states: ' .. table.concat(activeStates, ', '))
     end,
 }

--- a/lua/sim/units/uef/TConstructionPodUnit.lua
+++ b/lua/sim/units/uef/TConstructionPodUnit.lua
@@ -5,7 +5,7 @@ local oldGetGuards = TConstructionUnit.GetGuards
 ---@field Pod string
 ---@field Parent? UEL0301 | UEL0001 # Only these two units set the parent properly
 ---@field guardCache table
----@field guardDummy Unit
+---@field guardDummy Unit # Dummy unit to allow assist orders targeting the drone to persist after the drone docks and undocks
 ---@field rebuildDrone boolean # If true, the parent should rebuild the pod. Caches script bit 1.
 TConstructionPodUnit = ClassUnit(TConstructionUnit) {
     Parent = nil,

--- a/lua/sim/units/uef/TConstructionPodUnit.lua
+++ b/lua/sim/units/uef/TConstructionPodUnit.lua
@@ -40,9 +40,8 @@ TConstructionPodUnit = ClassUnit(TConstructionUnit) {
     ---@param transport Unit
     ---@param bone number
     OnAttachedToTransport = function(self, transport, bone)
-        local guards = self:GetGuards()
-        IssueClearCommands(guards)
-        IssueGuard(guards, self.guardDummy)
+        -- Removing the state allows guards to keep assisting the drone
+        self:SetUnitState("Attached", false)
         TConstructionUnit.OnAttachedToTransport(self, transport, bone)
     end,
 

--- a/lua/sim/units/uef/TConstructionPodUnit.lua
+++ b/lua/sim/units/uef/TConstructionPodUnit.lua
@@ -5,7 +5,6 @@ local oldGetGuards = TConstructionUnit.GetGuards
 ---@field Pod string
 ---@field Parent? UEL0301 | UEL0001 # Only these two units set the parent properly
 ---@field guardCache table
----@field guardDummy Unit # Dummy unit to allow assist orders targeting the drone to persist after the drone docks and undocks
 ---@field rebuildDrone boolean # If true, the parent should rebuild the pod. Caches script bit 1.
 TConstructionPodUnit = ClassUnit(TConstructionUnit) {
     Parent = nil,
@@ -13,9 +12,6 @@ TConstructionPodUnit = ClassUnit(TConstructionUnit) {
     ---@param self TConstructionPodUnit
     OnCreate = function(self)
         TConstructionUnit.OnCreate(self)
-        self.guardDummy = CreateUnitHPR('ZXA0003', self:GetArmy(), 0,0,0,0,0,0)
-        self.guardDummy:AttachTo(self, -1)
-        self.Trash:Add(self.guardDummy)
     end,
 
     ---@param self TConstructionPodUnit
@@ -43,16 +39,6 @@ TConstructionPodUnit = ClassUnit(TConstructionUnit) {
         -- Removing the state allows guards to keep assisting the drone
         self:SetUnitState("Attached", false)
         TConstructionUnit.OnAttachedToTransport(self, transport, bone)
-    end,
-
-    ---@param self TConstructionPodUnit
-    ---@param transport Unit
-    ---@param bone number
-    OnDetachedFromTransport = function(self, transport, bone)
-        TConstructionUnit.OnDetachedFromTransport(self, transport, bone)
-        local guards = self.guardDummy:GetGuards()
-        IssueClearCommands(guards)
-        IssueGuard(guards, self)
     end,
 
     ---@param self TConstructionPodUnit

--- a/lua/sim/units/uef/TConstructionPodUnit.lua
+++ b/lua/sim/units/uef/TConstructionPodUnit.lua
@@ -80,7 +80,7 @@ TConstructionPodUnit = ClassUnit(TConstructionUnit) {
     ---@param target Unit|Prop
     OnStopReclaim = function(self, target)
         TConstructionUnit.OnStopReclaim(self, target)
-        -- Check if we finished our reclaim task and clear our cached commaand if so
+        -- Check if we finished our reclaim task and clear our cached command if so
         if self.guardCache and table.empty(target) then
             self.guardCache = nil
         end

--- a/units/ZXA0002/ZXA0002_unit.bp
+++ b/units/ZXA0002/ZXA0002_unit.bp
@@ -10,7 +10,8 @@ UnitBlueprint {
         'SORTCONSTRUCTION',
         'DRAGBUILD',
         'SHOWQUEUE',
-        'EXTERNALFACTORYUNIT'
+        'EXTERNALFACTORYUNIT',
+        'UNSPAWNABLE',
     },
     Defense = {
         Health = 100000,

--- a/units/ZXA0002/ZXA0002_unit.bp
+++ b/units/ZXA0002/ZXA0002_unit.bp
@@ -5,7 +5,7 @@ UnitBlueprint {
         'FACTORY',
         'CONSTRUCTION',
         'SELECTABLE',
-        'UNTARGETTABLE',
+        'UNTARGETABLE',
         'RALLYPOINT',
         'SORTCONSTRUCTION',
         'DRAGBUILD',

--- a/units/ZXA0003/ZXA0003_script.lua
+++ b/units/ZXA0003/ZXA0003_script.lua
@@ -26,6 +26,8 @@ local DummyUnit = import('/lua/sim/unit.lua').DummyUnit
 ZXA0003 = ClassUnit(DummyUnit) {
 
     OnCreate = function (self)
+        DummyUnit.OnCreate(self)
+
         self:HideBone(0, true)
         -- do not allow the unit to be killed or to take damage
         self.CanTakeDamage = false

--- a/units/ZXA0003/ZXA0003_script.lua
+++ b/units/ZXA0003/ZXA0003_script.lua
@@ -26,8 +26,6 @@ local DummyUnit = import('/lua/sim/unit.lua').DummyUnit
 ZXA0003 = ClassUnit(DummyUnit) {
 
     OnCreate = function (self)
-        DummyUnit.OnCreate(self)
-
         self:HideBone(0, true)
         -- do not allow the unit to be killed or to take damage
         self.CanTakeDamage = false

--- a/units/ZXA0003/ZXA0003_script.lua
+++ b/units/ZXA0003/ZXA0003_script.lua
@@ -24,17 +24,6 @@ local DummyUnit = import('/lua/sim/unit.lua').DummyUnit
 
 ---@class ZXA0003 : DummyUnit
 ZXA0003 = ClassUnit(DummyUnit) {
-
-    OnCreate = function (self)
-        self:HideBone(0, true)
-        -- do not allow the unit to be killed or to take damage
-        self.CanTakeDamage = false
-
-        -- do not allow the unit to be reclaimed or targeted by weapons
-        self:SetReclaimable(false)
-        self:SetDoNotTarget(true)
-    end,
-
     DetachFrom = function(self)
     end,
 }

--- a/units/ZXA0003/ZXA0003_unit.bp
+++ b/units/ZXA0003/ZXA0003_unit.bp
@@ -8,40 +8,12 @@ UnitBlueprint{
         "UNTARGETABLE",
         "CARRIER",
     },
-    Defense = {
-        Health = 30,
-        MaxHealth = 30,
-    },
-    Display = {
-        Mesh = {
-            IconFadeInZoom = 2000,
-            LODs = {
-                {
-                    ShaderName = 'Unit',
-                    MeshName = '/Units/UEA0001/UEA0001_lod0.scm',
-                    AlbedoName = '/Units/UEA0001/UEA0001_Albedo.dds',
-                    NormalsName = '/Units/UEA0001/UEA0001_normalsTS.dds',
-                    SpecularName = '/Units/UEA0001/UEA0001_SpecTeam.dds',
-                },
-            },
-        },
-        UniformScale = 0.12,
-    },
-    Economy = {
-        BuildCostEnergy = 0,
-        BuildCostMass = 0,
-        BuildTime = 0,
-    },
     General = {
         CapCost = 0,
-        Category = '',
-        SelectionPriority = 3,
     },
     Intel = { VisionRadius = 0 },
     Physics = {
         MotionType = "RULEUMT_None",
     },
-    SizeX = 0,
-    SizeY = 0,
-    SizeZ = 0,
+    CollisionShape = "None"
 }


### PR DESCRIPTION
## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Fixes #6425. 

- Adds the dummy unit OnCreate to zxa0003's script. This fixes EntityId being missing from the unit.
- Disable doing adjacency for dummy units since it can allocate many tables considering that it occurs for all UEF construction drones which may be flying around building many structures.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
The t2 mass fab is placed here so that it triggers the adjacency for the dummy unit of the fatboy. Using debug logging it shows that the dummy unit is ignored correctly.
You can also trigger the adjacency by having the UEF engineer SACU build any structures.
```lua
   CreateUnitAtMouse('uel0301_engineer', 0,    1.93,   -0.48, -0.00000)
   CreateUnitAtMouse('uel0301_engineer', 0,   -2.00,   -0.48, -0.00000)
   CreateUnitAtMouse('uel0301_engineer', 0,   -3.32,   -0.48, -0.00000)
   CreateUnitAtMouse('uel0301_engineer', 0,   -4.84,   -0.48, -0.00000)
   CreateUnitAtMouse('uel0301_engineer', 0,   -0.72,   -0.48, -0.00000)
   CreateUnitAtMouse('uel0301_engineer', 0,    5.19,   -0.48, -0.00000)
   CreateUnitAtMouse('uel0301_engineer', 0,    3.34,   -0.48, -0.00000)
   CreateUnitAtMouse('uel0301_engineer', 0,    0.40,   -0.48, -0.00000)
   CreateUnitAtMouse('ueb1104', 0,   -2.32,    3.52,  0.00000)
   CreateUnitAtMouse('uel0401ef', 0,   -1.49,    2.89,  1.35140)
   CreateUnitAtMouse('uel0401', 0,    3.15,    3.92,  1.35140)
   CreateUnitAtMouse('xab1401', 0,    0.68,   -6.48, -0.00000)
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed errors involving units attached to external factories and engineering drones.
  - Improved construction pod attachment handling to prevent incorrect guard behavior.
  - Corrected unit targeting and spawning classifications for improved in-game behavior.
  - Updated attached-unit behavior so hidden units remain properly unselectable.

- **Diagnostics**
  - Added optional logging to help identify active unit states during gameplay troubleshooting.

- **Documentation**
  - Added a changelog entry detailing the attachment-related error fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->