### PR TITLE
Remove unused lastAccel field from default projectile weapon salvo data

### DIFF
--- a/changelog/snippets/performance.6864.md
+++ b/changelog/snippets/performance.6864.md
@@ -1,0 +1,1 @@
+- (#6864) Remove unused lastAccel field from default projectile weapon salvo data.

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -305,8 +305,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             if halfHeight < 0.01 then return 4.9 end
             time = MathSqrt(0.816326530612 * halfHeight) + spread
 
-            local acc = halfHeight / (time * time)
-            return acc
+            return halfHeight / (time * time)
         end
 
         -- calculate flat (exclude y-axis) distance and velocity between projectile and target

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -213,7 +213,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         projVelZ = projVelZ * multiplier
 
         local targetPos
-        local targetVelX, targetVelZ = 0, 0
+        local targetVelX, _, targetVelZ = 0, nil, 0
 
         local data = self.CurrentSalvoData
 

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -18,7 +18,6 @@ local MathSqrt = math.sqrt
 ---@class WeaponSalvoData
 ---@field target? Unit | Prop   if absent, will use `targetPos` instead
 ---@field targetPos Vector      stores the last location upon which we dropped bombs for a target, or the ground fire location
----@field lastAccel number      stores the last acceleration that was used
 
 -- Most weapons derive from this class, including beam weapons later in this file
 ---@class DefaultProjectileWeapon : Weapon
@@ -260,7 +259,6 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                 return 200 * projPosY / (time * time)
             else -- otherwise, calculate & cache a couple things the first time only
                 data = {
-                    lastAccel = 4.9,
                     targetPos = targetPos,
                 }
                 if target then
@@ -308,7 +306,6 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             time = MathSqrt(0.816326530612 * halfHeight) + spread
 
             local acc = halfHeight / (time * time)
-            data.lastAccel = acc
             return acc
         end
 
@@ -316,7 +313,6 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         -- velocity will eventually need to multiplied by 10 due to being per tick instead of per second
         local distVel = VDist2(projVelX, projVelZ, targetVelX, targetVelZ)
         if distVel == 0 then
-            data.lastAccel = 4.9
             return 4.9
         end
         local targetPosX, targetPosZ = targetPos[1], targetPos[3]
@@ -334,7 +330,6 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         local time = distPos / distVel
         local adjustedTime = time + self.AdjustedSalvoDelay * (self.SalvoSpreadStart + self.CurrentSalvoNumber)
         if adjustedTime == 0 then
-            data.lastAccel = 4.9
             return 4.9
         end
 
@@ -359,10 +354,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         -- a = 2 * h / t^2
 
         -- also convert time from ticks to seconds (multiply by 10, twice)
-        local acc = 200 * projPosY / (adjustedTime * adjustedTime)
-
-        data.lastAccel = acc
-        return acc
+        return 200 * projPosY / (adjustedTime * adjustedTime)
     end,
 
     -- Triggers when the weapon is moved horizontally, usually by owner's motion

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -213,7 +213,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         projVelZ = projVelZ * multiplier
 
         local targetPos
-        local targetVelX, _, targetVelZ = 0, nil, 0
+        local targetVelX, targetVelY, targetVelZ = 0, 0, 0
 
         local data = self.CurrentSalvoData
 
@@ -224,7 +224,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             if target then -- target is a unit / prop
                 targetPos = EntityGetPosition(target)
                 if not target.IsProp then
-                    targetVelX, _, targetVelZ = UnitGetVelocity(target)
+                    targetVelX, targetVelY, targetVelZ = UnitGetVelocity(target)
                 end
             else -- target is a position i.e. attack ground
                 targetPos = self:GetCurrentTargetPos()
@@ -237,7 +237,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                     return 4.9
                 end
                 if target and not target.IsProp then
-                    targetVelX, _, targetVelZ = UnitGetVelocity(target)
+                    targetVelX, targetVelY, targetVelZ = UnitGetVelocity(target)
                 end
                 local targetPosX, targetPosZ = targetPos[1], targetPos[3]
                 local distVel = VDist2(projVelX, projVelZ, targetVelX, targetVelZ)
@@ -278,7 +278,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
                     targetPos = data.targetPos
                 else
                     if not target.IsProp then
-                        targetVelX, _, targetVelZ = UnitGetVelocity(target)
+                        targetVelX, targetVelY, targetVelZ = UnitGetVelocity(target)
                     end
                     targetPos = EntityGetPosition(target)
                 end

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -212,7 +212,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
         projVelX = projVelX * multiplier
         projVelZ = projVelZ * multiplier
 
-        local targetPos, _
+        local targetPos
         local targetVelX, targetVelZ = 0, 0
 
         local data = self.CurrentSalvoData


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->

A `DefaultProjectileWeapon` holds `WeaponSalvoData` to store later-used data. However, `lastAccel` is never used and should be removed. 


## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->

### Replay simulation

Rebase onto #6825 (release 3824) and simulate replay 25053165.

Observe no desyncs and unrelated warnings.
```
WARNING: Duplicate definition of console command ""
WARNING:  NUM PROPS = 5182
WARNING: GetResource: Invalid name ""
WARNING: GetResource: Invalid name ""
WARNING: GetResource: Invalid name ""
WARNING: ACU kill detected. Rating for ranked games is now enforced.
WARNING: FactoryRebuildUnits failed to rebuild correctly for factory urb0303 (entity ID 7340047).
WARNING: Rebuild data:
WARNING: Progress: 0.916706
WARNING: BuildTime: 23100.998047
WARNING: Health: 40667.328125
WARNING: 150
WARNING: FactoryRebuildUnits failed to rebuild correctly for factory zab9501 (entity ID 7341109).
WARNING: Rebuild data:
WARNING: Progress: 0.073846
WARNING: BuildTime: 47.999996
WARNING: Health: 26.107695
WARNING: 40
WARNING: FactoryRebuildUnits failed to rebuild correctly for factory zab9503 (entity ID 7341108).
WARNING: Rebuild data:
WARNING: Progress: 0.401329
WARNING: BuildTime: 3210.627930
WARNING: Health: 1304.484009
WARNING: 90
WARNING: FactoryRebuildUnits failed to rebuild correctly for factory zrb9603 (entity ID 1048668).
WARNING: Rebuild data:
WARNING: Progress: 0.186747
WARNING: BuildTime: 4706.027344
WARNING: Health: 5810.049805
WARNING: 150
WARNING: FactoryRebuildUnits failed to rebuild correctly for factory zrb9503 (entity ID 1048699).
WARNING: Rebuild data:
WARNING: Progress: 0.417000
WARNING: BuildTime: 3336.003662
WARNING: Health: 1252.000000
WARNING: 90
```


## Additional context
<!-- Add any other context about the pull request here. -->


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
