### PR TITLE
Fix : AI - Correct SurfaceThreatLevel values for all ACU units

### DIFF
--- a/changelog/snippets/fix.6867.md
+++ b/changelog/snippets/fix.6867.md
@@ -1,1 +1,0 @@
-- (#6867) Correct ACU threat values after they were accidentally miscalcuated in a previous PR. SurfaceThreatLevel from an average of 765 to 45.

--- a/changelog/snippets/fix.6867.md
+++ b/changelog/snippets/fix.6867.md
@@ -1,0 +1,1 @@
+- (#6867) Correct ACU threat values after they were accidentally miscalcuated in a previous PR. SurfaceThreatLevel from an average of 765 to 45.

--- a/changelog/snippets/fix.6868.md
+++ b/changelog/snippets/fix.6868.md
@@ -1,0 +1,1 @@
+- (#6868) Correct ACU threat values after they were accidentally miscalcuated in a previous PR. SurfaceThreatLevel from an average of 765 to 45.

--- a/units/UAL0001/UAL0001_unit.bp
+++ b/units/UAL0001/UAL0001_unit.bp
@@ -62,12 +62,11 @@ UnitBlueprint{
     },
     Defense = {
         ArmorType = "Commander",
-        EconomyThreatLevel = 686,
         Health = 11000,
         MaxHealth = 11000,
         RegenRate = 10,
         SkipDynamicThreatCalculations = true,
-        SurfaceThreatLevel = 765,
+        SurfaceThreatLevel = 45,
     },
     Display = {
         Abilities = {

--- a/units/UEL0001/UEL0001_unit.bp
+++ b/units/UEL0001/UEL0001_unit.bp
@@ -69,12 +69,11 @@ UnitBlueprint{
     },
     Defense = {
         ArmorType = "Commander",
-        EconomyThreatLevel = 746,
         Health = 12000,
         MaxHealth = 12000,
         RegenRate = 10,
         SkipDynamicThreatCalculations = true,
-        SurfaceThreatLevel = 765,
+        SurfaceThreatLevel = 45,
     },
     Display = {
         Abilities = {

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -64,12 +64,11 @@ UnitBlueprint{
     },
     Defense = {
         ArmorType = "Commander",
-        EconomyThreatLevel = 626,
         Health = 10000,
         MaxHealth = 10000,
         RegenRate = 18,
         SkipDynamicThreatCalculations = true,
-        SurfaceThreatLevel = 765,
+        SurfaceThreatLevel = 45,
     },
     Display = {
         Abilities = {

--- a/units/XSL0001/XSL0001_unit.bp
+++ b/units/XSL0001/XSL0001_unit.bp
@@ -75,12 +75,11 @@ UnitBlueprint{
     },
     Defense = {
         ArmorType = "Commander",
-        EconomyThreatLevel = 716,
         Health = 11500,
         MaxHealth = 11500,
         RegenRate = 10,
         SkipDynamicThreatCalculations = true,
-        SurfaceThreatLevel = 765,
+        SurfaceThreatLevel = 45,
     },
     Display = {
         Abilities = {


### PR DESCRIPTION
## Description of the proposed changes
Revert the accidental change of acu SurfaceThreatLevel values from an average of 765 to 45. Remove economic threat values.


## Testing done on the proposed changes
Tested in game and validated IMAP values being returned from ACU are correct again.


## Additional context
Fixes #6861


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
