### PR TITLE
Fix factories being able to build their upgrades as a unit

### DIFF
--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -1045,6 +1045,11 @@ end
 function MetaImpact(instigator, location, maxRadius, amount, affectsCategory, damageFriendly)
 end
 
+--- Handles command structure when a unit upgrades to another:
+--- - Adds the new unit to the old unit's queued commands.
+--- - Retargets assisters onto the new unit.
+--- - Sets repeat queue.
+--- - Sets missing health proportion of the new unit.
 ---@param from Unit
 ---@param to Unit
 function NotifyUpgrade(from, to)

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4087,6 +4087,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         return false
     end,
 
+    --- Called by the engine on `FactoryBuild` and `MobileBuild` orders to determine if a unit is allowed to be built.
     ---@param self Unit
     ---@param target_bp UnitBlueprint
     ---@return boolean

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2844,20 +2844,6 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
             return false -- Report failure of OnStartBuild
         end
 
-        -- If desired, prevent engineer stations and factories from building their upgrades as a separate unit
-        -- We need a separate table for this just in case a unit is intended to be able to build its own upgrade as a separate unit too
-        -- Its type is `UnparsedCategory[]` to make it behave identically to `Blueprint.Economy.BuildableCategory`
-        local upgradeOnlyCategory = self.Blueprint.Economy.UpgradeOnlyCategory
-        if upgradeOnlyCategory and (order == "MobileBuild" or order == "FactoryBuild") then
-            for _, unparsedCat in upgradeOnlyCategory do
-                if EntityCategoryContains(ParseEntityCategory(unparsedCat), built) then
-                    -- Destroying the built unit will clear the command too, so we don't need to clear the entire queue (in case this exploit was done on accident).
-                    built:Destroy()
-                    return false
-                end
-            end
-        end
-
         -- We just started a construction (and haven't just been tasked to work on a half-done
         -- project.)
         if built:GetHealth() == 1 then
@@ -4106,6 +4092,19 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     ---@return boolean
     CheckBuildRestriction = function(self, target_bp)
         if self:CanBuild(target_bp.BlueprintId) then
+
+            -- If desired, prevent engineer stations and factories from building their upgrades as a separate unit
+            -- We need a separate table for this just in case a unit is intended to be able to build its own upgrade as a separate unit too
+            -- Its type is `UnparsedCategory[]` to make it behave identically to `Blueprint.Economy.BuildableCategory`
+            local upgradeOnlyCategory = self.Blueprint.Economy.UpgradeOnlyCategory
+            if upgradeOnlyCategory then
+                for _, unparsedCat in upgradeOnlyCategory do
+                    if EntityCategoryContains(ParseEntityCategory(unparsedCat), target_bp.BlueprintId) then
+                        return false
+                    end
+                end
+            end
+
             return true
         else
             return false

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2844,11 +2844,11 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
             return false -- Report failure of OnStartBuild
         end
 
-        -- If desired, prevent engineer stations from building their upgrades as a separate unit
+        -- If desired, prevent engineer stations and factories from building their upgrades as a separate unit
         -- We need a separate table for this just in case a unit is intended to be able to build its own upgrade as a separate unit too
         -- Its type is `UnparsedCategory[]` to make it behave identically to `Blueprint.Economy.BuildableCategory`
         local upgradeOnlyCategory = self.Blueprint.Economy.UpgradeOnlyCategory
-        if upgradeOnlyCategory and order == "MobileBuild" then
+        if upgradeOnlyCategory and (order == "MobileBuild" or order == "FactoryBuild") then
             for _, unparsedCat in upgradeOnlyCategory do
                 if EntityCategoryContains(ParseEntityCategory(unparsedCat), built) then
                     -- Destroying the built unit will clear the command too, so we don't need to clear the entire queue (in case this exploit was done on accident).

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -107,8 +107,9 @@ FactoryUnit = ClassUnit(StructureUnit) {
     ---@param self FactoryUnit
     ---@param unitBeingBuilt Unit
     ---@param order string
+    ---@return boolean
     OnStartBuild = function(self, unitBeingBuilt, order)
-        StructureUnitOnStartBuild(self, unitBeingBuilt, order)
+        if not StructureUnitOnStartBuild(self, unitBeingBuilt, order) then return false end
 
         self.FactoryBuildFailed = nil
         self.BuildingUnit = true
@@ -120,6 +121,8 @@ FactoryUnit = ClassUnit(StructureUnit) {
             self:RemoveCommandCap('RULEUCC_Guard')
             self.DisabledAssist = true
         end
+
+        return true
     end,
 
     --- Introduce a rolloff delay, where defined.

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -289,20 +289,6 @@ FactoryUnit = ClassUnit(StructureUnit) {
     end,
 
     ---@param self FactoryUnit
-    ---@param target_bp UnitBlueprint
-    ---@return boolean
-    CheckBuildRestriction = function(self, target_bp)
-        -- Check basic build restrictions first (Unit.CheckBuildRestriction but we only go up one inheritance level)
-        if not StructureUnitCheckBuildRestriction(self, target_bp) then
-            return false
-        end
-        -- Factories never build factories (this does not break Upgrades since CheckBuildRestriction is never called for Upgrades)
-        -- Note: We check for the primary category, since e.g. AircraftCarriers have the FACTORY category.
-        -- TODO: This is a hotfix for --1043, remove when engymod design is properly fixed
-        return target_bp.General.Category ~= 'Factory'
-    end,
-
-    ---@param self FactoryUnit
     CalculateRollOffPoint = function(self)
         local px, py, pz = self:GetPositionXYZ()
 

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -289,7 +289,7 @@ FactoryUnit = ClassUnit(StructureUnit) {
     end,
 
     ---@param self FactoryUnit
-    ---@param target_bp any
+    ---@param target_bp UnitBlueprint
     ---@return boolean
     CheckBuildRestriction = function(self, target_bp)
         -- Check basic build restrictions first (Unit.CheckBuildRestriction but we only go up one inheritance level)

--- a/lua/sim/units/StructureUnit.lua
+++ b/lua/sim/units/StructureUnit.lua
@@ -590,10 +590,11 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
     ---@param self StructureUnit
     ---@param unitBeingBuilt Unit
     ---@param order string
+    ---@return boolean
     OnStartBuild = function(self, unitBeingBuilt, order)
         -- Check for death loop
         if not UnitOnStartBuild(self, unitBeingBuilt, order) then
-            return
+            return false
         end
         self.UnitBeingBuilt = unitBeingBuilt
 
@@ -635,6 +636,8 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
                 end
             end
         end
+
+        return true
     end,
 
     ---@param self StructureUnit

--- a/units/UAB0101/UAB0101_unit.bp
+++ b/units/UAB0101/UAB0101_unit.bp
@@ -105,6 +105,9 @@ UnitBlueprint{
             "BUILTBYTIER1FACTORY AEON STRUCTURE LAND",
             "BUILTBYTIER1FACTORY AEON MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER1FACTORY AEON STRUCTURE LAND",
+        },
         RebuildBonusIds = { "uab0101" },
         StorageEnergy = 0,
         StorageMass = 80,

--- a/units/UAB0102/UAB0102_unit.bp
+++ b/units/UAB0102/UAB0102_unit.bp
@@ -101,6 +101,9 @@ UnitBlueprint{
             "BUILTBYTIER1FACTORY AEON MOBILE AIR",
             "TRANSPORTBUILTBYTIER1FACTORY AEON MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER1FACTORY AEON STRUCTURE AIR",
+        },
         RebuildBonusIds = { "uab0102" },
         StorageEnergy = 0,
         StorageMass = 80,

--- a/units/UAB0103/UAB0103_unit.bp
+++ b/units/UAB0103/UAB0103_unit.bp
@@ -91,6 +91,9 @@ UnitBlueprint{
             "BUILTBYTIER1FACTORY AEON STRUCTURE NAVAL",
             "BUILTBYTIER1FACTORY AEON MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER1FACTORY AEON STRUCTURE NAVAL",
+        },
         InitialRallyX = 0,
         InitialRallyZ = 10,
         RebuildBonusIds = { "uab0103" },

--- a/units/UAB0201/UAB0201_unit.bp
+++ b/units/UAB0201/UAB0201_unit.bp
@@ -101,6 +101,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY AEON STRUCTURE LAND",
             "BUILTBYTIER2FACTORY AEON MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2FACTORY AEON STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "uab0201" },
         StorageEnergy = 0,

--- a/units/UAB0202/UAB0202_unit.bp
+++ b/units/UAB0202/UAB0202_unit.bp
@@ -94,6 +94,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY AEON MOBILE AIR",
             "TRANSPORTBUILTBYTIER2FACTORY AEON MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2FACTORY AEON STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "uab0202" },
         StorageEnergy = 0,

--- a/units/UAB0203/UAB0203_unit.bp
+++ b/units/UAB0203/UAB0203_unit.bp
@@ -91,6 +91,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY AEON STRUCTURE NAVAL",
             "BUILTBYTIER2FACTORY AEON MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2FACTORY AEON STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/UAB0301/UAB0301_unit.bp
+++ b/units/UAB0301/UAB0301_unit.bp
@@ -100,6 +100,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY AEON STRUCTURE LAND",
             "BUILTBYTIER3FACTORY AEON MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY AEON STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "uab0301" },
         StorageEnergy = 0,

--- a/units/UAB0302/UAB0302_unit.bp
+++ b/units/UAB0302/UAB0302_unit.bp
@@ -93,6 +93,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY AEON MOBILE AIR",
             "TRANSPORTBUILTBYTIER3FACTORY AEON MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY AEON STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "uab0302" },
         StorageEnergy = 0,

--- a/units/UAB0303/UAB0303_unit.bp
+++ b/units/UAB0303/UAB0303_unit.bp
@@ -90,6 +90,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY AEON STRUCTURE NAVAL",
             "BUILTBYTIER3FACTORY AEON MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY AEON STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/UEB0101/UEB0101_unit.bp
+++ b/units/UEB0101/UEB0101_unit.bp
@@ -96,6 +96,9 @@ UnitBlueprint{
             "BUILTBYTIER1FACTORY UEF STRUCTURE LAND",
             "BUILTBYTIER1FACTORY UEF MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER1FACTORY UEF STRUCTURE LAND",
+        },
         RebuildBonusIds = { "ueb0101" },
         StorageEnergy = 0,
         StorageMass = 80,

--- a/units/UEB0102/UEB0102_unit.bp
+++ b/units/UEB0102/UEB0102_unit.bp
@@ -97,6 +97,9 @@ UnitBlueprint{
             "BUILTBYTIER1FACTORY UEF MOBILE AIR",
             "TRANSPORTBUILTBYTIER1FACTORY UEF MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER1FACTORY UEF STRUCTURE AIR",
+        },
         RebuildBonusIds = { "ueb0102" },
         StorageEnergy = 0,
         StorageMass = 80,

--- a/units/UEB0103/UEB0103_unit.bp
+++ b/units/UEB0103/UEB0103_unit.bp
@@ -96,6 +96,9 @@ UnitBlueprint{
             "BUILTBYTIER1FACTORY UEF STRUCTURE NAVAL",
             "BUILTBYTIER1FACTORY UEF MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER1FACTORY UEF STRUCTURE NAVAL",
+        },
         InitialRallyX = 0,
         InitialRallyZ = 10,
         RebuildBonusIds = { "ueb0103" },

--- a/units/UEB0201/UEB0201_unit.bp
+++ b/units/UEB0201/UEB0201_unit.bp
@@ -97,6 +97,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY UEF MOBILE LAND",
             "BUILTBYLANDTIER2FACTORY UEF MOBILE CONSTRUCTION",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2FACTORY UEF STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "ueb0201" },
         StorageEnergy = 0,

--- a/units/UEB0202/UEB0202_unit.bp
+++ b/units/UEB0202/UEB0202_unit.bp
@@ -97,6 +97,9 @@ UnitBlueprint{
             "TRANSPORTBUILTBYTIER2FACTORY UEF MOBILE AIR",
             "BUILTBYAIRTIER2FACTORY UEF MOBILE CONSTRUCTION",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2FACTORY UEF STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "ueb0202" },
         StorageEnergy = 0,

--- a/units/UEB0203/UEB0203_unit.bp
+++ b/units/UEB0203/UEB0203_unit.bp
@@ -96,6 +96,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY UEF MOBILE NAVAL",
             "BUILTBYNAVALTIER2FACTORY UEF MOBILE CONSTRUCTION",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2FACTORY UEF STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/UEB0301/UEB0301_unit.bp
+++ b/units/UEB0301/UEB0301_unit.bp
@@ -95,6 +95,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY UEF MOBILE LAND",
             "BUILTBYLANDTIER3FACTORY UEF MOBILE CONSTRUCTION",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY UEF STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "ueb0301" },
         StorageEnergy = 0,

--- a/units/UEB0302/UEB0302_unit.bp
+++ b/units/UEB0302/UEB0302_unit.bp
@@ -95,6 +95,9 @@ UnitBlueprint{
             "TRANSPORTBUILTBYTIER3FACTORY UEF MOBILE AIR",
             "BUILTBYAIRTIER3FACTORY UEF MOBILE CONSTRUCTION",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY UEF STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "ueb0302" },
         StorageEnergy = 0,

--- a/units/UEB0303/UEB0303_unit.bp
+++ b/units/UEB0303/UEB0303_unit.bp
@@ -96,6 +96,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY UEF MOBILE NAVAL",
             "BUILTBYNAVALTIER3FACTORY UEF MOBILE CONSTRUCTION",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY UEF STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/URB0101/URB0101_unit.bp
+++ b/units/URB0101/URB0101_unit.bp
@@ -96,6 +96,9 @@ UnitBlueprint{
             "BUILTBYTIER1FACTORY CYBRAN STRUCTURE LAND",
             "BUILTBYTIER1FACTORY CYBRAN MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER1FACTORY CYBRAN STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "urb0101" },
         StorageEnergy = 0,

--- a/units/URB0102/URB0102_unit.bp
+++ b/units/URB0102/URB0102_unit.bp
@@ -103,6 +103,9 @@ UnitBlueprint{
             "BUILTBYTIER1FACTORY CYBRAN MOBILE AIR",
             "TRANSPORTBUILTBYTIER1FACTORY CYBRAN MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER1FACTORY CYBRAN STRUCTURE AIR",
+        },
         RebuildBonusIds = { "urb0102" },
         StorageEnergy = 0,
         StorageMass = 80,

--- a/units/URB0103/URB0103_unit.bp
+++ b/units/URB0103/URB0103_unit.bp
@@ -101,6 +101,9 @@ UnitBlueprint{
             "BUILTBYTIER1FACTORY CYBRAN STRUCTURE NAVAL",
             "BUILTBYTIER1FACTORY CYBRAN MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER1FACTORY CYBRAN STRUCTURE NAVAL",
+        },
         InitialRallyX = 0,
         InitialRallyZ = 10,
         RebuildBonusIds = { "urb0103" },

--- a/units/URB0201/URB0201_unit.bp
+++ b/units/URB0201/URB0201_unit.bp
@@ -95,6 +95,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY CYBRAN STRUCTURE LAND",
             "BUILTBYTIER2FACTORY CYBRAN MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2FACTORY CYBRAN STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "urb0201" },
         StorageEnergy = 0,

--- a/units/URB0202/URB0202_unit.bp
+++ b/units/URB0202/URB0202_unit.bp
@@ -104,6 +104,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY CYBRAN MOBILE AIR",
             "TRANSPORTBUILTBYTIER2FACTORY CYBRAN MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2FACTORY CYBRAN STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "urb0202" },
         StorageEnergy = 0,

--- a/units/URB0203/URB0203_unit.bp
+++ b/units/URB0203/URB0203_unit.bp
@@ -101,6 +101,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY CYBRAN STRUCTURE NAVAL",
             "BUILTBYTIER2FACTORY CYBRAN MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2FACTORY CYBRAN STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/URB0301/URB0301_unit.bp
+++ b/units/URB0301/URB0301_unit.bp
@@ -93,6 +93,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY CYBRAN STRUCTURE LAND",
             "BUILTBYTIER3FACTORY CYBRAN MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY CYBRAN STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "urb0301" },
         StorageEnergy = 0,

--- a/units/URB0302/URB0302_unit.bp
+++ b/units/URB0302/URB0302_unit.bp
@@ -103,6 +103,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY CYBRAN MOBILE AIR",
             "TRANSPORTBUILTBYTIER3FACTORY CYBRAN MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY CYBRAN STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "urb0302" },
         StorageEnergy = 0,

--- a/units/URB0303/URB0303_unit.bp
+++ b/units/URB0303/URB0303_unit.bp
@@ -100,6 +100,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY CYBRAN STRUCTURE NAVAL",
             "BUILTBYTIER3FACTORY CYBRAN MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY CYBRAN STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/XSB0101/XSB0101_unit.bp
+++ b/units/XSB0101/XSB0101_unit.bp
@@ -112,6 +112,9 @@ UnitBlueprint{
             "BUILTBYTIER1FACTORY SERAPHIM STRUCTURE LAND",
             "BUILTBYTIER1FACTORY SERAPHIM MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER1FACTORY SERAPHIM STRUCTURE LAND",
+        },
         RebuildBonusIds = { "xsb0101" },
         StorageEnergy = 0,
         StorageMass = 80,

--- a/units/XSB0102/XSB0102_unit.bp
+++ b/units/XSB0102/XSB0102_unit.bp
@@ -112,6 +112,9 @@ UnitBlueprint{
             "BUILTBYTIER1FACTORY SERAPHIM MOBILE AIR",
             "TRANSPORTBUILTBYTIER1FACTORY SERAPHIM MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER1FACTORY SERAPHIM STRUCTURE AIR",
+        },
         RebuildBonusIds = { "xsb0102" },
         StorageEnergy = 0,
         StorageMass = 80,

--- a/units/XSB0103/XSB0103_unit.bp
+++ b/units/XSB0103/XSB0103_unit.bp
@@ -103,6 +103,9 @@ UnitBlueprint{
             "BUILTBYTIER1FACTORY SERAPHIM STRUCTURE NAVAL",
             "BUILTBYTIER1FACTORY SERAPHIM MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER1FACTORY SERAPHIM STRUCTURE NAVAL",
+        },
         InitialRallyX = 0,
         InitialRallyZ = 10,
         RebuildBonusIds = { "xsb0103" },

--- a/units/XSB0201/XSB0201_unit.bp
+++ b/units/XSB0201/XSB0201_unit.bp
@@ -101,6 +101,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY SERAPHIM STRUCTURE LAND",
             "BUILTBYTIER2FACTORY SERAPHIM MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2FACTORY SERAPHIM STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "xsb0201" },
         StorageEnergy = 0,

--- a/units/XSB0202/XSB0202_unit.bp
+++ b/units/XSB0202/XSB0202_unit.bp
@@ -105,6 +105,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY SERAPHIM MOBILE AIR",
             "TRANSPORTBUILTBYTIER2FACTORY SERAPHIM MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2FACTORY SERAPHIM STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "xsb0202" },
         StorageEnergy = 0,

--- a/units/XSB0203/XSB0203_unit.bp
+++ b/units/XSB0203/XSB0203_unit.bp
@@ -105,6 +105,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY SERAPHIM STRUCTURE NAVAL",
             "BUILTBYTIER2FACTORY SERAPHIM MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2FACTORY SERAPHIM STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/XSB0301/XSB0301_unit.bp
+++ b/units/XSB0301/XSB0301_unit.bp
@@ -99,6 +99,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY SERAPHIM STRUCTURE LAND",
             "BUILTBYTIER3FACTORY SERAPHIM MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY SERAPHIM STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "xsb0301" },
         StorageEnergy = 0,

--- a/units/XSB0302/XSB0302_unit.bp
+++ b/units/XSB0302/XSB0302_unit.bp
@@ -110,6 +110,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY SERAPHIM MOBILE AIR",
             "TRANSPORTBUILTBYTIER3FACTORY SERAPHIM MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY SERAPHIM STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "xsb0302" },
         StorageEnergy = 0,

--- a/units/XSB0303/XSB0303_unit.bp
+++ b/units/XSB0303/XSB0303_unit.bp
@@ -104,6 +104,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY SERAPHIM STRUCTURE NAVAL",
             "BUILTBYTIER3FACTORY SERAPHIM MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY SERAPHIM STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/ZAB9501/ZAB9501_unit.bp
+++ b/units/ZAB9501/ZAB9501_unit.bp
@@ -103,6 +103,9 @@ UnitBlueprint{
             "BUILTBYTIER2SUPPORTFACTORY AEON STRUCTURE LAND",
             "BUILTBYTIER2FACTORY AEON MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2SUPPORTFACTORY AEON STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zab9501" },
         StorageEnergy = 0,

--- a/units/ZAB9502/ZAB9502_unit.bp
+++ b/units/ZAB9502/ZAB9502_unit.bp
@@ -97,6 +97,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY AEON MOBILE AIR",
             "TRANSPORTBUILTBYTIER2FACTORY AEON MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2SUPPORTFACTORY AEON STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zab9502" },
         StorageEnergy = 0,

--- a/units/ZAB9503/ZAB9503_unit.bp
+++ b/units/ZAB9503/ZAB9503_unit.bp
@@ -94,6 +94,9 @@ UnitBlueprint{
             "BUILTBYTIER2SUPPORTFACTORY AEON STRUCTURE NAVAL",
             "BUILTBYTIER2FACTORY AEON MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2SUPPORTFACTORY AEON STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/ZAB9601/ZAB9601_unit.bp
+++ b/units/ZAB9601/ZAB9601_unit.bp
@@ -99,6 +99,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY AEON STRUCTURE LAND",
             "BUILTBYTIER3FACTORY AEON MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY AEON STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zab9601" },
         StorageEnergy = 0,

--- a/units/ZAB9602/ZAB9602_unit.bp
+++ b/units/ZAB9602/ZAB9602_unit.bp
@@ -94,6 +94,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY AEON MOBILE AIR",
             "TRANSPORTBUILTBYTIER3FACTORY AEON MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY AEON STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zab9602" },
         StorageEnergy = 0,

--- a/units/ZAB9603/ZAB9603_unit.bp
+++ b/units/ZAB9603/ZAB9603_unit.bp
@@ -91,6 +91,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY AEON STRUCTURE NAVAL",
             "BUILTBYTIER3FACTORY AEON MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY AEON STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/ZEB9501/ZEB9501_unit.bp
+++ b/units/ZEB9501/ZEB9501_unit.bp
@@ -100,6 +100,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY UEF MOBILE LAND",
             "BUILTBYLANDTIER2FACTORY UEF MOBILE CONSTRUCTION",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2SUPPORTFACTORY UEF STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zeb9501" },
         StorageEnergy = 0,

--- a/units/ZEB9502/ZEB9502_unit.bp
+++ b/units/ZEB9502/ZEB9502_unit.bp
@@ -101,6 +101,9 @@ UnitBlueprint{
             "TRANSPORTBUILTBYTIER2FACTORY UEF MOBILE AIR",
             "BUILTBYAIRTIER2FACTORY UEF MOBILE CONSTRUCTION",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2SUPPORTFACTORY UEF STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zeb9502" },
         StorageEnergy = 0,

--- a/units/ZEB9503/ZEB9503_unit.bp
+++ b/units/ZEB9503/ZEB9503_unit.bp
@@ -99,6 +99,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY UEF MOBILE NAVAL",
             "BUILTBYNAVALTIER2FACTORY UEF MOBILE CONSTRUCTION",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2SUPPORTFACTORY UEF STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/ZEB9601/ZEB9601_unit.bp
+++ b/units/ZEB9601/ZEB9601_unit.bp
@@ -97,6 +97,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY UEF MOBILE LAND",
             "BUILTBYLANDTIER3FACTORY UEF MOBILE CONSTRUCTION",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY UEF STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zeb9601" },
         StorageEnergy = 0,

--- a/units/ZEB9602/ZEB9602_unit.bp
+++ b/units/ZEB9602/ZEB9602_unit.bp
@@ -97,6 +97,9 @@ UnitBlueprint{
             "TRANSPORTBUILTBYTIER3FACTORY UEF MOBILE AIR",
             "BUILTBYAIRTIER3FACTORY UEF MOBILE CONSTRUCTION",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY UEF STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zeb9602" },
         StorageEnergy = 0,

--- a/units/ZEB9603/ZEB9603_unit.bp
+++ b/units/ZEB9603/ZEB9603_unit.bp
@@ -97,6 +97,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY UEF MOBILE NAVAL",
             "BUILTBYNAVALTIER3FACTORY UEF MOBILE CONSTRUCTION",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY UEF STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/ZRB9501/ZRB9501_unit.bp
+++ b/units/ZRB9501/ZRB9501_unit.bp
@@ -98,6 +98,9 @@ UnitBlueprint{
             "BUILTBYTIER2SUPPORTFACTORY CYBRAN STRUCTURE LAND",
             "BUILTBYTIER2FACTORY CYBRAN MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2SUPPORTFACTORY CYBRAN STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zrb9501" },
         StorageEnergy = 0,

--- a/units/ZRB9502/ZRB9502_unit.bp
+++ b/units/ZRB9502/ZRB9502_unit.bp
@@ -105,6 +105,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY CYBRAN MOBILE AIR",
             "TRANSPORTBUILTBYTIER2FACTORY CYBRAN MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2SUPPORTFACTORY CYBRAN STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zrb9502" },
         StorageEnergy = 0,

--- a/units/ZRB9503/ZRB9503_unit.bp
+++ b/units/ZRB9503/ZRB9503_unit.bp
@@ -104,6 +104,9 @@ UnitBlueprint{
             "BUILTBYTIER2SUPPORTFACTORY CYBRAN STRUCTURE NAVAL",
             "BUILTBYTIER2FACTORY CYBRAN MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2SUPPORTFACTORY CYBRAN STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/ZRB9601/ZRB9601_unit.bp
+++ b/units/ZRB9601/ZRB9601_unit.bp
@@ -94,6 +94,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY CYBRAN STRUCTURE LAND",
             "BUILTBYTIER3FACTORY CYBRAN MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY CYBRAN STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zrb9601" },
         StorageEnergy = 0,

--- a/units/ZRB9602/ZRB9602_unit.bp
+++ b/units/ZRB9602/ZRB9602_unit.bp
@@ -101,6 +101,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY CYBRAN MOBILE AIR",
             "TRANSPORTBUILTBYTIER3FACTORY CYBRAN MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY CYBRAN STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zrb9602" },
         StorageEnergy = 0,

--- a/units/ZRB9603/ZRB9603_unit.bp
+++ b/units/ZRB9603/ZRB9603_unit.bp
@@ -101,6 +101,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY CYBRAN STRUCTURE NAVAL",
             "BUILTBYTIER3FACTORY CYBRAN MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY CYBRAN STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/ZSB9501/ZSB9501_unit.bp
+++ b/units/ZSB9501/ZSB9501_unit.bp
@@ -111,6 +111,9 @@ UnitBlueprint{
             "BUILTBYTIER2SUPPORTFACTORY SERAPHIM STRUCTURE LAND",
             "BUILTBYTIER2FACTORY SERAPHIM MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2SUPPORTFACTORY SERAPHIM STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zsb9501" },
         StorageEnergy = 0,

--- a/units/ZSB9502/ZSB9502_unit.bp
+++ b/units/ZSB9502/ZSB9502_unit.bp
@@ -108,6 +108,9 @@ UnitBlueprint{
             "BUILTBYTIER2FACTORY SERAPHIM MOBILE AIR",
             "TRANSPORTBUILTBYTIER2FACTORY SERAPHIM MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2SUPPORTFACTORY SERAPHIM STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zsb9502" },
         StorageEnergy = 0,

--- a/units/ZSB9503/ZSB9503_unit.bp
+++ b/units/ZSB9503/ZSB9503_unit.bp
@@ -108,6 +108,9 @@ UnitBlueprint{
             "BUILTBYTIER2SUPPORTFACTORY SERAPHIM STRUCTURE NAVAL",
             "BUILTBYTIER2FACTORY SERAPHIM MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER2SUPPORTFACTORY SERAPHIM STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,

--- a/units/ZSB9601/ZSB9601_unit.bp
+++ b/units/ZSB9601/ZSB9601_unit.bp
@@ -107,6 +107,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY SERAPHIM STRUCTURE LAND",
             "BUILTBYTIER3FACTORY SERAPHIM MOBILE LAND",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY SERAPHIM STRUCTURE LAND",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zsb9601" },
         StorageEnergy = 0,

--- a/units/ZSB9602/ZSB9602_unit.bp
+++ b/units/ZSB9602/ZSB9602_unit.bp
@@ -105,6 +105,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY SERAPHIM MOBILE AIR",
             "TRANSPORTBUILTBYTIER3FACTORY SERAPHIM MOBILE AIR",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY SERAPHIM STRUCTURE AIR",
+        },
         DifferentialUpgradeCostCalculation = true,
         RebuildBonusIds = { "zsb9602" },
         StorageEnergy = 0,

--- a/units/ZSB9603/ZSB9603_unit.bp
+++ b/units/ZSB9603/ZSB9603_unit.bp
@@ -105,6 +105,9 @@ UnitBlueprint{
             "BUILTBYTIER3FACTORY SERAPHIM STRUCTURE NAVAL",
             "BUILTBYTIER3FACTORY SERAPHIM MOBILE NAVAL",
         },
+        UpgradeOnlyCategory = {
+        	"BUILTBYTIER3FACTORY SERAPHIM STRUCTURE NAVAL",
+        },
         DifferentialUpgradeCostCalculation = true,
         InitialRallyX = 0,
         InitialRallyZ = 10,


### PR DESCRIPTION
## Issue
- Fixes *the sim side* of an issue reported on [Discord](https://discord.com/channels/197033481883222026/1372439916700631131) where using the "Build T2 support factory" hotkey you can build the support factory as a unit instead of an upgrade.
Spawn `uab0102` and give the following order to reproduce the bug:
```
IssueBlueprintCommandToUnits(GetSelectedUnits(), "UNITCOMMAND_BuildFactory", 'uab0202', 1, false)
```
  - This is a return of the issue in https://github.com/FAForever/fa/issues/1043. In that discussion there were talks about fixing the construction panel to display upgrades without needing them in the buildable categories. At the moment I don't find that feasible because @clyfordv is working on a construction panel rework.

## Description of the proposed changes

- Add the appropriate `UpgradeOnlyCategory` for all 60 factories.
- Move the `UpgradeOnlyCategory` logic into `CheckBuildRestrictions`, as that is the only place where it is needed since it only matters for `FactoryBuild` and `BuildMobile` orders. This simplifies the logic overall.
- Fix the factory and structure units not returning when the base class's `OnStartBuild` reports a failure. In particular this fixed errors when the factory was ordered to build (not upgrade) a factory upgrade and `UpgradeOnlyCategory` logic was not in `CheckBuildRestrictions`.

## Testing done on the proposed changes
Test hives again since the logic added by https://github.com/FAForever/fa/pull/6709 was changed. Use xrb0104.
```
import("/lua/ui/game/commandmode.lua").StartCommandMode('build', {name = 'xrb0204'})
```
Test that factories cannot factory build their own upgrades. Use uab0102.
```
IssueBlueprintCommandToUnits(GetSelectedUnits(), "UNITCOMMAND_BuildFactory", 'uab0202', 1, false)
```

## Checklist
- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
