### PR TITLE
Increase the `StrategicIconSize` of the Seraphim ACU's OC projectile to match that of the other ACUs

### DIFF
--- a/changelog/snippets/fix.6871.md
+++ b/changelog/snippets/fix.6871.md
@@ -1,0 +1,1 @@
+- (#6871) Increase the `StrategicIconSize` of the Seraphim ACU's OC projectile to match that of the other ACUs.

--- a/projectiles/SDFChronatronCannon02/SDFChronatronCannon02_proj.bp
+++ b/projectiles/SDFChronatronCannon02/SDFChronatronCannon02_proj.bp
@@ -11,7 +11,7 @@ ProjectileBlueprint{
     },
     Display = {
         ImpactEffects = { Type = "Medium01" },
-        StrategicIconSize = 1,
+        StrategicIconSize = 3,
     },
     General = {
         Category = "Direct Fire",


### PR DESCRIPTION
## Description of the proposed changes
As per the title.

## Checklist
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).