### PR TITLE
Fix modded faction icons and tooltip colors in create unit dialog

### DIFF
--- a/changelog/snippets/fix.6872.md
+++ b/changelog/snippets/fix.6872.md
@@ -1,0 +1,1 @@
+- (#6872) Fix Nomads faction icon and inconsistent tooltip colors in the cheat spawn menu.

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -955,8 +955,8 @@
 --- command capability flags for this unit
 ---@field CommandCaps table<CommandCap, boolean>
 ---@field ExcludeFromVeterancy? boolean
---- faction the unit belongs to. Factions are 'Aeon', 'Cybran' and 'UEF'
----@field FactionName Faction
+--- Faction the unit belongs to.
+---@field FactionName FactionName
 ---@field FractionThreshold? number
 --- indicates the background for the build icon
 ---@field Icon IconBackgroundType

--- a/lua/factions.lua
+++ b/lua/factions.lua
@@ -15,7 +15,7 @@ end
 function GetNewFactionAINames()
     -- Gets a name for AI players
     local ainames = {}
-    for f,_ in NewFactionAiData do
+    for f, _ in NewFactionAiData do
         ainames[f] = NewFactionAiData[f].ainames or { 'nameless', }
     end
     return ainames
@@ -28,16 +28,16 @@ function GetNewFactionAIPlans(offset)
     -- Gets an AI plan for computer players. Offset is the key with which the table should begin, counting up from
     -- that value + 1.
     if table.empty(NewFactionAiData) then
-        local x = import("/lua/factions.lua").Factions  -- to make sure NewFactionAiData contains something
+        local x = import("/lua/factions.lua").Factions -- to make sure NewFactionAiData contains something
     end
     if not offset then
-        offset = 5  -- 5 for the 5 races
+        offset = 5 -- 5 for the 5 races
     end
     local aiplans = {}
     offset = math.max(0, offset)
-    for f,_ in NewFactionAiData do
+    for f, _ in NewFactionAiData do
         offset = offset + 1
-        aiplans[ offset ] = NewFactionAiData[f].AIPlansList or { '/lua/AI/aiarchetype-managerloader.lua', }
+        aiplans[offset] = NewFactionAiData[f].AIPlansList or { '/lua/AI/aiarchetype-managerloader.lua', }
     end
     return aiplans
 end
@@ -59,7 +59,7 @@ function GetCustomFactions(FactionsTable, AllowedMods)
 
         local FactionFile = import(file)
         if rawget(FactionFile, 'Factions') then
-            WARN('File '..repr(file)..' contains a "Factions" variable. Please change it to "FactionList", the old variable is not used.')
+            WARN('File ' .. repr(file) .. ' contains a "Factions" variable. Please change it to "FactionList", the old variable is not used.')
         end
         if not rawget(FactionFile, 'FactionList') then
             continue
@@ -94,9 +94,9 @@ function GetSelectedMods(AllowedMods)
             mods[mod.uid] = true
         end
     end
-    if AllowedMods then  -- AllowedMods -> table of mods keyed by mod id
+    if AllowedMods then -- AllowedMods -> table of mods keyed by mod id
         local newmods = {}
-        for id,_ in mods do
+        for id, _ in mods do
             if AllowedMods[id] then
                 newmods[id] = true
             end
@@ -170,219 +170,219 @@ end
 ---@return FactionData[]
 function OrgFactions()
     return {
-    {
-        Key = 'uef',
-        Category = 'UEF',
-        FactionInUnitBp = 'UEF',
-        IsCustomFaction = false,
-        DisplayName = "<LOC _UEF>UEF",
-        SoundPrefix = 'UEF',
-        InitialUnit = 'uel0001',
-        CampaignFileDesignator = 'E',
-        TransmissionLogColor = 'ff00c1ff',
-        Icon = "/widgets/faction-icons-alpha_bmp/uef_ico.dds",
-        VeteranIcon = "/game/veteran-logo_bmp/uef-veteran_bmp.dds",
-        SmallIcon = "/faction_icon-sm/uef_ico.dds",
-        LargeIcon = "/faction_icon-lg/uef_ico.dds",
-        TooltipID = 'lob_uef',
-        DefaultSkin = 'uef',
-        loadingMovie = '/movies/UEF_load.sfd',
-        loadingColor = 'FFbadbdb',
-        loadingTexture = '/UEF_load.dds',
-        IdleEngTextures = {
-            T1 = '/icons/units/uel0105_icon.dds',
-            T2 = '/icons/units/uel0208_icon.dds',
-            T2F = '/icons/units/xel0209_icon.dds',
-            T3 = '/icons/units/uel0309_icon.dds',
-            SCU = '/icons/units/uel0301_icon.dds',
-        },
-        IdleFactoryTextures = {
-            LAND = {
-                '/icons/units/ueb0101_icon.dds',
-                '/icons/units/ueb0201_icon.dds',
-                '/icons/units/ueb0301_icon.dds',
+        {
+            Key = 'uef',
+            Category = 'UEF',
+            FactionInUnitBp = 'UEF',
+            IsCustomFaction = false,
+            DisplayName = "<LOC _UEF>UEF",
+            SoundPrefix = 'UEF',
+            InitialUnit = 'uel0001',
+            CampaignFileDesignator = 'E',
+            TransmissionLogColor = 'ff00c1ff',
+            Icon = "/widgets/faction-icons-alpha_bmp/uef_ico.dds",
+            VeteranIcon = "/game/veteran-logo_bmp/uef-veteran_bmp.dds",
+            SmallIcon = "/faction_icon-sm/uef_ico.dds",
+            LargeIcon = "/faction_icon-lg/uef_ico.dds",
+            TooltipID = 'lob_uef',
+            DefaultSkin = 'uef',
+            loadingMovie = '/movies/UEF_load.sfd',
+            loadingColor = 'FFbadbdb',
+            loadingTexture = '/UEF_load.dds',
+            IdleEngTextures = {
+                T1 = '/icons/units/uel0105_icon.dds',
+                T2 = '/icons/units/uel0208_icon.dds',
+                T2F = '/icons/units/xel0209_icon.dds',
+                T3 = '/icons/units/uel0309_icon.dds',
+                SCU = '/icons/units/uel0301_icon.dds',
             },
-            AIR = {
-                '/icons/units/ueb0102_icon.dds',
-                '/icons/units/ueb0202_icon.dds',
-                '/icons/units/ueb0302_icon.dds',
+            IdleFactoryTextures = {
+                LAND = {
+                    '/icons/units/ueb0101_icon.dds',
+                    '/icons/units/ueb0201_icon.dds',
+                    '/icons/units/ueb0301_icon.dds',
+                },
+                AIR = {
+                    '/icons/units/ueb0102_icon.dds',
+                    '/icons/units/ueb0202_icon.dds',
+                    '/icons/units/ueb0302_icon.dds',
+                },
+                NAVAL = {
+                    '/icons/units/ueb0103_icon.dds',
+                    '/icons/units/ueb0203_icon.dds',
+                    '/icons/units/ueb0303_icon.dds',
+                },
             },
-            NAVAL = {
-                '/icons/units/ueb0103_icon.dds',
-                '/icons/units/ueb0203_icon.dds',
-                '/icons/units/ueb0303_icon.dds',
-            },
-        },
 
-        GAZ_UI_Info = {
-            BuildingIdPrefixes = {
-                'ueb',
-                'xeb',
-                'deb',
-                'zeb',
+            GAZ_UI_Info = {
+                BuildingIdPrefixes = {
+                    'ueb',
+                    'xeb',
+                    'deb',
+                    'zeb',
+                },
             },
         },
-    },
-    {
-        Key = 'aeon',
-        Category = 'AEON',
-        FactionInUnitBp = 'Aeon',
-        IsCustomFaction = false,
-        DisplayName = "<LOC _Aeon>Aeon",
-        SoundPrefix = 'Aeon',
-        InitialUnit = 'ual0001',
-        CampaignFileDesignator = 'A',
-        TransmissionLogColor = 'ffff0000',
-        Icon = "/widgets/faction-icons-alpha_bmp/aeon_ico.dds",
-        VeteranIcon = "/game/veteran-logo_bmp/aeon-veteran_bmp.dds",
-        SmallIcon = "/faction_icon-sm/aeon_ico.dds",
-        LargeIcon = "/faction_icon-lg/aeon_ico.dds",
-        TooltipID = 'lob_aeon',
-        DefaultSkin = 'aeon',
-        loadingMovie = '/movies/aeon_load.sfd',
-        loadingColor = 'FFc7e98a',
-        loadingTexture = '/aeon_load.dds',
-        IdleEngTextures = {
-            T1 = '/icons/units/ual0105_icon.dds',
-            T2 = '/icons/units/ual0208_icon.dds',
-            T2F = '/icons/units/xel0209_icon.dds',
-            T3 = '/icons/units/ual0309_icon.dds',
-            SCU = '/icons/units/ual0301_icon.dds',
-        },
-        IdleFactoryTextures = {
-            LAND = {
-                '/icons/units/uab0101_icon.dds',
-                '/icons/units/uab0201_icon.dds',
-                '/icons/units/uab0301_icon.dds',
+        {
+            Key = 'aeon',
+            Category = 'AEON',
+            FactionInUnitBp = 'Aeon',
+            IsCustomFaction = false,
+            DisplayName = "<LOC _Aeon>Aeon",
+            SoundPrefix = 'Aeon',
+            InitialUnit = 'ual0001',
+            CampaignFileDesignator = 'A',
+            TransmissionLogColor = 'ffff0000',
+            Icon = "/widgets/faction-icons-alpha_bmp/aeon_ico.dds",
+            VeteranIcon = "/game/veteran-logo_bmp/aeon-veteran_bmp.dds",
+            SmallIcon = "/faction_icon-sm/aeon_ico.dds",
+            LargeIcon = "/faction_icon-lg/aeon_ico.dds",
+            TooltipID = 'lob_aeon',
+            DefaultSkin = 'aeon',
+            loadingMovie = '/movies/aeon_load.sfd',
+            loadingColor = 'FFc7e98a',
+            loadingTexture = '/aeon_load.dds',
+            IdleEngTextures = {
+                T1 = '/icons/units/ual0105_icon.dds',
+                T2 = '/icons/units/ual0208_icon.dds',
+                T2F = '/icons/units/xel0209_icon.dds',
+                T3 = '/icons/units/ual0309_icon.dds',
+                SCU = '/icons/units/ual0301_icon.dds',
             },
-            AIR = {
-                '/icons/units/uab0102_icon.dds',
-                '/icons/units/uab0202_icon.dds',
-                '/icons/units/uab0302_icon.dds',
+            IdleFactoryTextures = {
+                LAND = {
+                    '/icons/units/uab0101_icon.dds',
+                    '/icons/units/uab0201_icon.dds',
+                    '/icons/units/uab0301_icon.dds',
+                },
+                AIR = {
+                    '/icons/units/uab0102_icon.dds',
+                    '/icons/units/uab0202_icon.dds',
+                    '/icons/units/uab0302_icon.dds',
+                },
+                NAVAL = {
+                    '/icons/units/uab0103_icon.dds',
+                    '/icons/units/uab0203_icon.dds',
+                    '/icons/units/uab0303_icon.dds',
+                },
             },
-            NAVAL = {
-                '/icons/units/uab0103_icon.dds',
-                '/icons/units/uab0203_icon.dds',
-                '/icons/units/uab0303_icon.dds',
-            },
-        },
 
-        GAZ_UI_Info = {
-            BuildingIdPrefixes = {
-                'uab',
-                'xab',
-                'dab',
-                'zab',
+            GAZ_UI_Info = {
+                BuildingIdPrefixes = {
+                    'uab',
+                    'xab',
+                    'dab',
+                    'zab',
+                },
             },
         },
-    },
-    {
-        Key = 'cybran',
-        Category = 'CYBRAN',
-        FactionInUnitBp = 'Cybran',
-        IsCustomFaction = false,
-        DisplayName = "<LOC _Cybran>Cybran",
-        SoundPrefix = 'Cybran',
-        InitialUnit = 'url0001',
-        CampaignFileDesignator = 'R',
-        TransmissionLogColor = 'ff89d300',
-        Icon = "/widgets/faction-icons-alpha_bmp/cybran_ico.dds",
-        VeteranIcon = "/game/veteran-logo_bmp/cybran-veteran_bmp.dds",
-        SmallIcon = "/faction_icon-sm/cybran_ico.dds",
-        LargeIcon = "/faction_icon-lg/cybran_ico.dds",
-        TooltipID = 'lob_cybran',
-        DefaultSkin = 'cybran',
-        loadingMovie = '/movies/cybran_load.sfd',
-        loadingColor = 'FFe24f2d',
-        loadingTexture = '/cybran_load.dds',
-        IdleEngTextures = {
-            T1 = '/icons/units/url0105_icon.dds',
-            T2 = '/icons/units/url0208_icon.dds',
-            T2F = '/icons/units/xel0209_icon.dds',
-            T3 = '/icons/units/url0309_icon.dds',
-            SCU = '/icons/units/url0301_icon.dds',
-        },
-        IdleFactoryTextures = {
-            LAND = {
-                '/icons/units/urb0101_icon.dds',
-                '/icons/units/urb0201_icon.dds',
-                '/icons/units/urb0301_icon.dds',
+        {
+            Key = 'cybran',
+            Category = 'CYBRAN',
+            FactionInUnitBp = 'Cybran',
+            IsCustomFaction = false,
+            DisplayName = "<LOC _Cybran>Cybran",
+            SoundPrefix = 'Cybran',
+            InitialUnit = 'url0001',
+            CampaignFileDesignator = 'R',
+            TransmissionLogColor = 'ff89d300',
+            Icon = "/widgets/faction-icons-alpha_bmp/cybran_ico.dds",
+            VeteranIcon = "/game/veteran-logo_bmp/cybran-veteran_bmp.dds",
+            SmallIcon = "/faction_icon-sm/cybran_ico.dds",
+            LargeIcon = "/faction_icon-lg/cybran_ico.dds",
+            TooltipID = 'lob_cybran',
+            DefaultSkin = 'cybran',
+            loadingMovie = '/movies/cybran_load.sfd',
+            loadingColor = 'FFe24f2d',
+            loadingTexture = '/cybran_load.dds',
+            IdleEngTextures = {
+                T1 = '/icons/units/url0105_icon.dds',
+                T2 = '/icons/units/url0208_icon.dds',
+                T2F = '/icons/units/xel0209_icon.dds',
+                T3 = '/icons/units/url0309_icon.dds',
+                SCU = '/icons/units/url0301_icon.dds',
             },
-            AIR = {
-                '/icons/units/urb0102_icon.dds',
-                '/icons/units/urb0202_icon.dds',
-                '/icons/units/urb0302_icon.dds',
+            IdleFactoryTextures = {
+                LAND = {
+                    '/icons/units/urb0101_icon.dds',
+                    '/icons/units/urb0201_icon.dds',
+                    '/icons/units/urb0301_icon.dds',
+                },
+                AIR = {
+                    '/icons/units/urb0102_icon.dds',
+                    '/icons/units/urb0202_icon.dds',
+                    '/icons/units/urb0302_icon.dds',
+                },
+                NAVAL = {
+                    '/icons/units/urb0103_icon.dds',
+                    '/icons/units/urb0203_icon.dds',
+                    '/icons/units/urb0303_icon.dds',
+                },
             },
-            NAVAL = {
-                '/icons/units/urb0103_icon.dds',
-                '/icons/units/urb0203_icon.dds',
-                '/icons/units/urb0303_icon.dds',
-            },
-        },
 
-        GAZ_UI_Info = {
-            BuildingIdPrefixes = {
-                'urb',
-                'xrb',
-                'drb',
-                'zrb',
+            GAZ_UI_Info = {
+                BuildingIdPrefixes = {
+                    'urb',
+                    'xrb',
+                    'drb',
+                    'zrb',
+                },
             },
         },
-    },
-    {
-        Key = 'seraphim',
-        Category = 'SERAPHIM',
-        FactionInUnitBp = 'Seraphim',
-        IsCustomFaction = false,
-        DisplayName = "<LOC _Seraphim>Seraphim",
-        SoundPrefix = 'Seraphim',
-        InitialUnit = 'xsl0001',
-        CampaignFileDesignator = 'S',
-        TransmissionLogColor = 'ff00FF00',
-        Icon = "/widgets/faction-icons-alpha_bmp/seraphim_ico.dds",
-        VeteranIcon = "/game/veteran-logo_bmp/seraphim-veteran_bmp.dds",
-        SmallIcon = "/faction_icon-sm/seraphim_ico.dds",
-        LargeIcon = "/faction_icon-lg/seraphim_ico.dds",
-        TooltipID = 'lob_seraphim',
-        DefaultSkin = 'seraphim',
-        loadingMovie = '/movies/seraphim_load.sfd',
-        loadingColor = 'FFffd700',
-        loadingTexture = '/seraphim_load.dds',
-        IdleEngTextures = {
-            T1 = '/icons/units/xsl0105_icon.dds',
-            T2 = '/icons/units/xsl0208_icon.dds',
-            T2F = '/icons/units/xel0209_icon.dds',
-            T3 = '/icons/units/xsl0309_icon.dds',
-            SCU = '/icons/units/xsl0301_icon.dds',
-        },
-        IdleFactoryTextures = {
-            LAND = {
-                '/icons/units/xsb0101_icon.dds',
-                '/icons/units/xsb0201_icon.dds',
-                '/icons/units/xsb0301_icon.dds',
+        {
+            Key = 'seraphim',
+            Category = 'SERAPHIM',
+            FactionInUnitBp = 'Seraphim',
+            IsCustomFaction = false,
+            DisplayName = "<LOC _Seraphim>Seraphim",
+            SoundPrefix = 'Seraphim',
+            InitialUnit = 'xsl0001',
+            CampaignFileDesignator = 'S',
+            TransmissionLogColor = 'ff00FF00',
+            Icon = "/widgets/faction-icons-alpha_bmp/seraphim_ico.dds",
+            VeteranIcon = "/game/veteran-logo_bmp/seraphim-veteran_bmp.dds",
+            SmallIcon = "/faction_icon-sm/seraphim_ico.dds",
+            LargeIcon = "/faction_icon-lg/seraphim_ico.dds",
+            TooltipID = 'lob_seraphim',
+            DefaultSkin = 'seraphim',
+            loadingMovie = '/movies/seraphim_load.sfd',
+            loadingColor = 'FFffd700',
+            loadingTexture = '/seraphim_load.dds',
+            IdleEngTextures = {
+                T1 = '/icons/units/xsl0105_icon.dds',
+                T2 = '/icons/units/xsl0208_icon.dds',
+                T2F = '/icons/units/xel0209_icon.dds',
+                T3 = '/icons/units/xsl0309_icon.dds',
+                SCU = '/icons/units/xsl0301_icon.dds',
             },
-            AIR = {
-                '/icons/units/xsb0102_icon.dds',
-                '/icons/units/xsb0202_icon.dds',
-                '/icons/units/xsb0302_icon.dds',
+            IdleFactoryTextures = {
+                LAND = {
+                    '/icons/units/xsb0101_icon.dds',
+                    '/icons/units/xsb0201_icon.dds',
+                    '/icons/units/xsb0301_icon.dds',
+                },
+                AIR = {
+                    '/icons/units/xsb0102_icon.dds',
+                    '/icons/units/xsb0202_icon.dds',
+                    '/icons/units/xsb0302_icon.dds',
+                },
+                NAVAL = {
+                    '/icons/units/xsb0103_icon.dds',
+                    '/icons/units/xsb0203_icon.dds',
+                    '/icons/units/xsb0303_icon.dds',
+                },
             },
-            NAVAL = {
-                '/icons/units/xsb0103_icon.dds',
-                '/icons/units/xsb0203_icon.dds',
-                '/icons/units/xsb0303_icon.dds',
-            },
-        },
 
-        GAZ_UI_Info = {
-            BuildingIdPrefixes = {
-                'xsb',
-                'usb',
-                'dsb',
-                'zsb',
+            GAZ_UI_Info = {
+                BuildingIdPrefixes = {
+                    'xsb',
+                    'usb',
+                    'dsb',
+                    'zsb',
+                },
             },
         },
-    },
-}
+    }
 end
 
 -- ----------------------------------------------------------------------------------------------------------------

--- a/lua/factions.lua
+++ b/lua/factions.lua
@@ -1,4 +1,4 @@
--- Call these in your scripts where you need them
+--#region Call these in your scripts where you need them
 
 --- Returns a list of faction data, which is mostly used for faction-specific UI but is also used to determine the initial unit to spawn.
 --- Call this in your scripts.
@@ -42,8 +42,9 @@ function GetNewFactionAIPlans(offset)
     return aiplans
 end
 
--- ----------------------------------------------------------------------------------------------------------------
--- Don't touch these!
+--#endregion
+
+--#region Don't touch these!
 
 NewFactionAiData = {}
 
@@ -385,8 +386,7 @@ function OrgFactions()
     }
 end
 
--- ----------------------------------------------------------------------------------------------------------------
--- Original faction variables
+--#region Original faction variables
 
 Factions = GetFactions()
 
@@ -407,3 +407,6 @@ for index, value in Factions do
     FactionDesToKey[value.CampaignFileDesignator] = value.Key
     FactionInUnitBpToKey[value.FactionInUnitBp] = index
 end
+--#endregion
+
+--#endregion

--- a/lua/factions.lua
+++ b/lua/factions.lua
@@ -1,11 +1,17 @@
 -- Call these in your scripts where you need them
 
+--- Returns a list of faction data, which is mostly used for faction-specific UI but is also used to determine the initial unit to spawn.
+--- Call this in your scripts.
+---@param AllowedMods? uidSet # A table of currently enabled mods, keyed by mod ID, or `true` to get all mods. Ignores mods if not used.
+---@return FactionData[]
 function GetFactions(AllowedMods)
     -- AllowedMods  -> a table of currently enabled mods, keyed by mod ID. Ignore if not used
     -- returns a list of factions. All 4 of the original factions are included plus all enabled custom factions.
     return GetCustomFactions(OrgFactions(), AllowedMods)
 end
 
+--- Gets a name for AI players. Unused, even in Nomads code.
+---@return table
 function GetNewFactionAINames()
     -- Gets a name for AI players
     local ainames = {}
@@ -15,6 +21,9 @@ function GetNewFactionAINames()
     return ainames
 end
 
+--- Gets an AI plan for computer players. Unused, even in Nomads code.
+---@param offset integer # key with which the table should begin, counting up from this value + 1
+---@return table
 function GetNewFactionAIPlans(offset)
     -- Gets an AI plan for computer players. Offset is the key with which the table should begin, counting up from
     -- that value + 1.
@@ -38,6 +47,8 @@ end
 
 NewFactionAiData = {}
 
+---@param FactionsTable FactionData[]
+---@param AllowedMods uidSet
 function GetCustomFactions(FactionsTable, AllowedMods)
     if not FactionsTable or type(FactionsTable) ~= 'table' then
         FactionsTable = {}
@@ -68,6 +79,8 @@ function GetCustomFactions(FactionsTable, AllowedMods)
     return FactionsTable
 end
 
+---@param AllowedMods uidSet
+---@return uidSet
 function GetSelectedMods(AllowedMods)
     -- We need an array with it's keys being mod uids and the values being true. but this function can be called
     -- while loading the game which means /lua/mods.lua.GetSelectedMods() doesn't work. In that case we look in
@@ -93,6 +106,9 @@ function GetSelectedMods(AllowedMods)
     return mods
 end
 
+---@param tbl table
+---@param keys string[]
+---@return boolean
 function TableHasKeys(tbl, keys)
     for _, k in keys do
         if not tbl[k] then
@@ -102,6 +118,56 @@ function TableHasKeys(tbl, keys)
     return true
 end
 
+---@class FactionData
+---@field Key FactionKey
+---@field Category FactionCategory
+---@field FactionInUnitBp FactionName
+---@field IsCustomFaction false
+---@field DisplayName UnlocalizedString # "<LOC _UEF>UEF"
+---@field SoundPrefix string # 'UEF'
+---@field InitialUnit UnitId # 'uel0001'
+---@field CampaignFileDesignator FactionDesignator
+---@field TransmissionLogColor Color
+---@field Icon FileName # ex: "/widgets/faction-icons-alpha_bmp/uef_ico.dds"
+---@field VeteranIcon FileName # ex: "/game/veteran-logo_bmp/uef-veteran_bmp.dds"
+---@field SmallIcon FileName # ex: "/faction_icon-sm/uef_ico.dds"
+---@field LargeIcon FileName # ex: "/faction_icon-lg/uef_ico.dds"
+---@field TooltipID string # 'lob_uef'
+---@field DefaultSkin Skin
+---@field loadingMovie FileName # ex: '/movies/UEF_load.sfd'
+---@field loadingColor Color
+---@field loadingTexture FileName # ex: '/UEF_load.dds'
+---@field IdleEngTextures IdleEngTextures
+---@field IdleFactoryTextures IdleFactoryTextures
+---@field GAZ_UI_Info GAZ_UI_Info
+---@field AI table # Unused, even in Nomads
+
+---@alias FactionKey 'uef' | 'aeon' | 'cybran' | 'seraphim'
+---@alias FactionName 'UEF' | 'Aeon' | 'Cybran' | 'Seraphim'
+---@alias FactionDesignator 'E' | 'A' | 'R' | 'S'
+
+---@class IdleEngTextures
+---@field T1 FileName # ex: '/icons/units/uel0105_icon.dds'
+---@field T2 FileName # ex: '/icons/units/uel0208_icon.dds'
+---@field T2F FileName # T2 field engineer. ex: '/icons/units/xel0209_icon.dds'
+---@field T3 FileName # ex: '/icons/units/uel0309_icon.dds'
+---@field SCU FileName # ex: '/icons/units/uel0301_icon.dds'
+
+--- Icons for factories of a given layer and tech level.
+---@alias IdleFactoryTextures table<LayerCategory, IdleFactoryTexturesLayer>
+--- FileName is a unit icon for the respective tech level factory for a given layer.
+---@alias IdleFactoryTexturesLayer table<1|2|3, FileName>
+
+---@class GAZ_UI_Info
+---@field BuildingIdPrefixes BuildingIdPrefixes
+
+---@alias BuildingIdPrefixes BuildingIdPrefixesUEF | BuildingIdPrefixesAeon | BuildingIdPrefixesCybran | BuildingIdPrefixesSeraphim
+---@alias BuildingIdPrefixesUEF 'ueb' | 'xeb' | 'deb' | 'zeb'
+---@alias BuildingIdPrefixesAeon 'uab' | 'xab'| 'dab'| 'zab'
+---@alias BuildingIdPrefixesCybran 'urb' | 'xrb'| 'drb'| 'zrb'
+---@alias BuildingIdPrefixesSeraphim 'xsb' | 'usb'| 'dsb'| 'zsb'
+
+---@return FactionData[]
 function OrgFactions()
     return {
     {
@@ -324,12 +390,16 @@ end
 
 Factions = GetFactions()
 
--- Map faction key to index, as this lookup is done frequently
+--- Maps faction key to faction index, as this lookup is done frequently
+---@type table<FactionKey, integer>
 FactionIndexMap = {}
 
--- File designator to faction key
+--- Maps faction campaign file designator to faction key
+---@type table<FactionDesignator, FactionKey>
 FactionDesToKey = {}
 
+--- Maps unit bp FactionName to faction index
+---@type table<FactionName, integer>
 FactionInUnitBpToKey = {}
 
 for index, value in Factions do

--- a/lua/ui/dialogs/createunit.logic.lua
+++ b/lua/ui/dialogs/createunit.logic.lua
@@ -115,12 +115,17 @@ end
 
 local UIUtil = import('/lua/ui/uiutil.lua')
 
-local FactionData = {
-    { color = 'ff00c1ff', name = 'UEF', icon = UIUtil.UIFile(UIUtil.GetFactionIcon(0)) },
-    { color = 'ff89d300', name = 'AEON', icon = UIUtil.UIFile(UIUtil.GetFactionIcon(1)) },
-    { color = 'ffff0000', name = 'CYBRAN', icon = UIUtil.UIFile(UIUtil.GetFactionIcon(2)) },
-    { color = 'FFFFBF00', name = 'SERAPHIM', icon = UIUtil.UIFile(UIUtil.GetFactionIcon(3)) },
-}
+local FactionData = {}
+local Factions = import('/lua/factions.lua').GetFactions()
+local skins = import("/lua/skins/skins.lua").skins
+---@param faction FactionData
+for _, faction in Factions do
+    table.insert(FactionData, {
+        name = faction.Category,
+        icon = UIUtil.UIFile(faction.Icon),
+        color = skins[faction.Key].factionTextColor
+    })
+end
 
 function GetUnitFactionInfo(id)
     local bp = __blueprints[id]

--- a/lua/ui/dialogs/createunit.logic.lua
+++ b/lua/ui/dialogs/createunit.logic.lua
@@ -115,7 +115,14 @@ end
 
 local UIUtil = import('/lua/ui/uiutil.lua')
 
+---@class UICreateUnitDialog_FactionData
+---@field name FactionCategory
+---@field icon FileName
+---@field color Color
+
+---@type UICreateUnitDialog_FactionData[]?
 local FactionDataCache
+---@return UICreateUnitDialog_FactionData[]
 local function GetFactionColorsAndIcons()
     if not FactionDataCache then
         FactionDataCache = {}
@@ -135,6 +142,8 @@ local function GetFactionColorsAndIcons()
     return FactionDataCache
 end
 
+---@param id UnitId
+---@return UICreateUnitDialog_FactionData | { color: false, icon: false }
 function GetUnitFactionInfo(id)
     local bp = __blueprints[id]
     if bp and bp.CategoriesHash and IsUnitPlayable(id) then

--- a/lua/ui/dialogs/createunit.logic.lua
+++ b/lua/ui/dialogs/createunit.logic.lua
@@ -146,7 +146,7 @@ end
 function GetUnitFactionInfo(id)
     local bp = __blueprints[id]
     if bp and bp.CategoriesHash and IsUnitPlayable(id) then
-        for k, faction in GetFactionColorsAndIcons() do
+        for _, faction in GetFactionColorsAndIcons() do
             if bp.CategoriesHash[faction.name] then return faction end
         end
     end

--- a/lua/ui/dialogs/createunit.logic.lua
+++ b/lua/ui/dialogs/createunit.logic.lua
@@ -115,22 +115,30 @@ end
 
 local UIUtil = import('/lua/ui/uiutil.lua')
 
-local FactionData = {}
-local Factions = import('/lua/factions.lua').GetFactions()
-local skins = import("/lua/skins/skins.lua").skins
----@param faction FactionData
-for _, faction in Factions do
-    table.insert(FactionData, {
-        name = faction.Category,
-        icon = UIUtil.UIFile(faction.Icon),
-        color = skins[faction.Key].factionTextColor
-    })
+local FactionDataCache
+local function GetFactionColorsAndIcons()
+    if not FactionDataCache then
+        FactionDataCache = {}
+        local Factions = import('/lua/factions.lua').GetFactions()
+        local skins = import("/lua/skins/skins.lua").skins
+
+        ---@param faction FactionData
+        for i, faction in Factions do
+            FactionDataCache[i] = {
+                name = faction.Category,
+                icon = UIUtil.UIFile(faction.Icon),
+                color = skins[faction.Key].factionTextColor
+            }
+        end
+    end
+
+    return FactionDataCache
 end
 
 function GetUnitFactionInfo(id)
     local bp = __blueprints[id]
     if bp and bp.CategoriesHash and IsUnitPlayable(id) then
-        for k, faction in FactionData do
+        for k, faction in GetFactionColorsAndIcons() do
             if bp.CategoriesHash[faction.name] then return faction end
         end
     end

--- a/lua/ui/dialogs/createunit.logic.lua
+++ b/lua/ui/dialogs/createunit.logic.lua
@@ -127,8 +127,8 @@ local function GetFactionColorsAndIcons()
     if not FactionDataCache then
         local Factions = import('/lua/factions.lua').GetFactions()
         local skins = import("/lua/skins/skins.lua").skins
+
         FactionDataCache = {}
-        ---@param faction FactionData
         for i, faction in Factions do
             FactionDataCache[i] = {
                 name = faction.Category,

--- a/lua/ui/dialogs/createunit.logic.lua
+++ b/lua/ui/dialogs/createunit.logic.lua
@@ -125,10 +125,9 @@ local FactionDataCache
 ---@return UICreateUnitDialog_FactionData[]
 local function GetFactionColorsAndIcons()
     if not FactionDataCache then
-        FactionDataCache = {}
         local Factions = import('/lua/factions.lua').GetFactions()
         local skins = import("/lua/skins/skins.lua").skins
-
+        FactionDataCache = {}
         ---@param faction FactionData
         for i, faction in Factions do
             FactionDataCache[i] = {

--- a/lua/ui/dialogs/createunit.lua
+++ b/lua/ui/dialogs/createunit.lua
@@ -621,6 +621,9 @@ GetNameFilters = {
     end,
 }
 
+---@param id UnitId
+---@param bitmap Bitmap
+---@param background Bitmap
 function SetUnitFactionIcon(id, bitmap, background)
     local faction = Logic.GetUnitFactionInfo(id)
     if bitmap and faction.icon and faction.color then


### PR DESCRIPTION
## Issue
The create unit dialog was missing the icon for nomads units and the tooltip when you mouse over a unit was the wrong color.

## Description of the proposed changes
- Get the icons from the factions table.
- Get the tooltip text color from the skin for the unit's faction.
- Annotate the code in `factions.lua`.

## Testing done on the proposed changes
Tested with the Nomads repo and a dev environment set up. The icon is now shown and the changed text color was not hard to read on the tooltip background for any faction.

<details> <summary> Before: </summary>

![{3F981036-CBE2-45AA-948B-9683EB0E033A}](https://github.com/user-attachments/assets/320b37f0-9538-402f-b5f9-c95d21f2140d)
![{2EBDBC33-5DF7-4B49-BE55-F04EADEF00DC}](https://github.com/user-attachments/assets/f63ef1cd-2e0c-4c34-8115-e6af00a8c246)
![{DAE495DE-0208-41D4-B750-A9EC8133F132}](https://github.com/user-attachments/assets/e363fa7d-5515-42e2-99eb-f8f5f331c828)
![{4B14E159-7775-4F7A-A5B7-790C396842FD}](https://github.com/user-attachments/assets/9d011464-72f0-4058-aa6b-9b432542e39d)
![{AA73D91F-D7D6-4DAC-ABE4-2019F3CB23A7}](https://github.com/user-attachments/assets/c17758f8-d2c3-434c-ab4e-4c84caa9ece6)


</details>

<details> <summary> After: </summary>

![{95F49CC1-29D0-4198-8C16-9108A3400AC0}](https://github.com/user-attachments/assets/6fb721f0-6747-4b4b-9227-e126848c430e)
![{A7BD2A32-ACE3-424F-900E-BD8F2B807D0B}](https://github.com/user-attachments/assets/2284a058-c152-4e43-9024-ab54efdfd87e)
![{B8C4E7F4-FE97-4675-A161-9096E7DEA1DE}](https://github.com/user-attachments/assets/5f4a9d3f-471e-4941-87f0-3afd5f4bf525)
![{57023669-8117-4254-ABC5-06A86318D104}](https://github.com/user-attachments/assets/1a9ec6f5-e971-4a3a-aca9-71b4eef5e9eb)
![{FE47922B-9AF7-4D4D-A8C8-4DDB7B68A946}](https://github.com/user-attachments/assets/e67abf70-7453-44ec-a3ff-39d2104bee95)

</details>

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
