### PR TITLE
Improve single player command line launch

### DIFF
--- a/changelog/snippets/other.6873.md
+++ b/changelog/snippets/other.6873.md
@@ -1,0 +1,1 @@
+- (#6873) Improve singleplayer command line launch by adding a `/noAi` command line option and neutral/enemy civilian armies when launching from the command line.

--- a/docs/development/developmentEnviroment.md
+++ b/docs/development/developmentEnviroment.md
@@ -162,6 +162,13 @@ Copy that replay to the replays folder of the game:
 
 Note that the last path is incomplete: you need replace `%USER_NAME%` with your systems profile name and `%PROFILE_NAME%` with the profile name you use in the game. You can launch the game using the bat files as described earlier.
 
+## Starting a singleplayer session quickly
+
+You can start a singleplayer session quickly by adding the following command line arguments to your launch script or shortcut:
+
+- `/map <path>`: the local path to the scenario file for the map you want to launch with, for example `"/maps/SCMP_001/SCMP_001_scenario.lua"`
+- `/noAi`: by default the map's slots are filled with the default rush AI, this option removes them.
+
 ## Multiple instances
 
 You can start several processes at once when the debug facilities are enabled. You can do this by adding the following line to your preference file:

--- a/docs/development/developmentEnviroment.md
+++ b/docs/development/developmentEnviroment.md
@@ -166,8 +166,8 @@ Note that the last path is incomplete: you need replace `%USER_NAME%` with your 
 
 You can start a singleplayer session quickly by adding the following command line arguments to your launch script or shortcut:
 
-- `/map <path>`: the local path to the scenario file for the map you want to launch with, for example `"/maps/SCMP_001/SCMP_001_scenario.lua"`
-- `/noAi`: by default the map's slots are filled with the default rush AI, this option removes them.
+- `/map <pathOrFolder>`: the local path to the scenario file of the map you want to launch (ex: `"/maps/scmp_001/scmp_001_scenario.lua"`), or the folder name (ex: `"scmp_001"`). It is case insensitive.
+- `/noAi`: removes the AI that fill the map by default.
 
 ## Multiple instances
 

--- a/engine/Core.lua
+++ b/engine/Core.lua
@@ -1,8 +1,11 @@
 ---@meta
 ---@diagnostic disable: lowercase-global
 
----@class FileName: string, stringlib
----@operator concat(FileName | string): FileName
+---@class string : stringlib
+---@operator concat(FileName): FileName
+
+---@class FileName: string
+---@operator concat(string): FileName
 
 ---@class VectorBase
 ---@field [1] number    # x

--- a/engine/User.lua
+++ b/engine/User.lua
@@ -361,7 +361,7 @@ end
 ---@see GetCommandLineArgTable(option) for parsing key-values
 ---@param option string
 ---@param maxArgs number
----@return string[] | false
+---@return (string | number | integer)[] | false
 function GetCommandLineArg(option, maxArgs)
 end
 
@@ -1054,7 +1054,7 @@ end
 
 --- Return the table of scenario info that was originally passed to the sim on launch
 --- Unlike other engine functions that return tables, this function returns the same table each time it is called.
----@return UISessionSenarioInfo
+---@return UISessionScenarioInfo
 function SessionGetScenarioInfo()
 end
 

--- a/lua/MODS.LUA
+++ b/lua/MODS.LUA
@@ -682,7 +682,7 @@ end
 --- If `scenario` is a campaign type, returns only the FAF campaign mod
 --- (`6AAFE20A-E851-11DB-B8BE-ECC755D89593`) or an empty list if it is not enabled.
 --- Otherwise, returns `GetGameMods()`.
----@param scenario UIScenarioInfo
+---@param scenario UILobbyScenarioInfo
 ---@return uidSet #set of mod UID's
 function GetCampaignMods(scenario)
     local r

--- a/lua/SinglePlayerLaunch.lua
+++ b/lua/SinglePlayerLaunch.lua
@@ -3,9 +3,10 @@ local Prefs = import("/lua/user/prefs.lua")
 local MapUtils = import("/lua/ui/maputil.lua")
 local aiTypes = import("/lua/ui/lobby/aitypes.lua").aitypes
 
-local error = function(string)
+-- The engine doesn't log errors when the command line launch errors, so we fix that here. 
+local function error(string)
     WARN(string.format('Error launching session: %s\n%s', string, debug.traceback()))
-    error(string)
+    _G.error(string)
 end
 
 ---@param faction integer

--- a/lua/SinglePlayerLaunch.lua
+++ b/lua/SinglePlayerLaunch.lua
@@ -294,6 +294,20 @@ local function SetupCommandLineSkirmish(scenario, isPerfTest)
         end
     end
 
+    local index = table.getn(sessionInfo.teamInfo) + 1
+    local enemyCivOptions = GetDefaultPlayerOptions("Civilian")
+    enemyCivOptions = GetDefaultPlayerOptions("Civilian")
+    enemyCivOptions.Civilian = true
+    enemyCivOptions.ArmyName = 'ARMY_17'
+    enemyCivOptions.Human = false
+    sessionInfo.teamInfo[index] = enemyCivOptions
+    index = index + 1
+    local neutralCivOptions = GetDefaultPlayerOptions("Civilian")
+    neutralCivOptions.Civilian = true
+    neutralCivOptions.ArmyName = 'NEUTRAL_CIVILIAN'
+    neutralCivOptions.Human = false
+    sessionInfo.teamInfo[index] = neutralCivOptions
+
     Prefs.SetToCurrentProfile('LoadingFaction', faction)
 
     return sessionInfo

--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -24,7 +24,7 @@
 ---@field FogOfWar 'none' | 'explored'
 ---@field GameSpeed 'normal' | 'fast' | 'adjustable'
 ---@field ManualUnitShare 'none' | 'no_builders' | 'all'
----@field NoRushOption '1' | '2' | '3' | '4' | '5' | '10' | '15' | '20' | '25' | '30' | '35' | '40' | '45' | '50' | '55' | '60'
+---@field NoRushOption '1' | '2' | '3' | '4' | '5' | '10' | '15' | '20' | '25' | '30' | '35' | '40' | '45' | '50' | '55' | '60' | 'Off'
 ---@field PrebuiltUnits 'Off' | 'On'
 ---@field Ranked boolean
 ---@field RevealCivilians 'No' | 'Yes'
@@ -34,7 +34,7 @@
 ---@field DisconnectShare 'SameAsShare' | 'FullShare' | 'ShareUntilDeath' | 'PartialShare' | 'TransferToKiller' | 'Defectors' | 'CivilianDeserter'
 ---@field DisconnectShareCommanders 'Explode' | 'Recall' | 'RecallDelayed' | 'Permanent'
 ---@field ShareUnitCap 'none' | 'allies' | 'all'
----@field Timeouts '0' | '3'| '-1'
+---@field Timeouts '0' | '3'| '-1' | -1
 ---@field UnitCap '125' | '250' | '375' | '500' | '625' | '750' | '875' | '1000' | '1250' | '1500'
 ---@field Unranked 'No' | 'Yes'
 ---@field Victory VictoryCondition

--- a/lua/ui/maputil.lua
+++ b/lua/ui/maputil.lua
@@ -123,7 +123,7 @@
 ---@field hasBriefing boolean       # flag whether the _strings.lua file has briefing data in it
 
 --- The scenario information with additional fields, as defined once in a session
----@class UISessionSenarioInfo : UIScenarioInfoFile
+---@class UISessionScenarioInfo : UIScenarioInfoFile
 --- These are the actual `<key, value>` pairs that the lobby defines, not the option-factory type
 --- objects the lobby uses
 ---@field Options? GameOptions


### PR DESCRIPTION
## Description of the proposed changes
- `/noAi` option that disables AI from spawning with the single player launch
- Add the enemy and neutral civilian armies in single player, they seem to be missing compared to skirmish launch.
- Annotations and annotation fixes

This is the fastest way to launch into a game to test in-game changes. It would improve development speed greatly.

## Testing done on the proposed changes
Launch the game with `/map <local path to a scenario file>` and with and without `/noAi` in the launch args.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
