### PR TITLE
Fix Cybran engis not turning wheels back to land mode

### DIFF
--- a/changelog/snippets/fix.6879.md
+++ b/changelog/snippets/fix.6879.md
@@ -1,0 +1,1 @@
+- (#6879) Fix Cybran engis not turning wheels back to land mode after exiting water.

--- a/lua/sim/units/cybran/CConstructionUnit.lua
+++ b/lua/sim/units/cybran/CConstructionUnit.lua
@@ -113,7 +113,7 @@ CConstructionUnit = ClassUnit(ConstructionUnit, CConstructionTemplate) {
         end
 
         if old ~= 'None' then
-            self.TerrainLayerTransitionThread = TrashBagAdd(trash, ForkThread(self.TransformThread, self, true))
+            self.TerrainLayerTransitionThread = TrashBagAdd(trash, ForkThread(self.TransformThread, self, (new == 'Water')))
         end
     end,
 


### PR DESCRIPTION
## Issue
Reported by @4z0t on [Discord](https://discord.com/channels/197033481883222026/984529346498813992/1387915477078114529)
![image](https://github.com/user-attachments/assets/a58ac4dd-296f-476e-8a37-7b27a97733f2)

When cybran engis move from water onto land they do not turn their wheels back to normal.

## Description of the proposed changes
Pass the status of being in the water to the transformation function only if the new layer is water.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->
Cybran engis transform to land mode after exiting from water onto land or onto a transport.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
