### PR TITLE
Increase Seraphim T1 sub torpdef reload time

### DIFF
--- a/changelog/snippets/balance.6880.md
+++ b/changelog/snippets/balance.6880.md
@@ -1,0 +1,4 @@
+- (#6880) Increase Seraphim T1 sub's anti-torpedo defense's reload time so that it is less dominant against other T1 subs, which slows down the snowball of T1 subs and allows a transition into T2 counters (T2 subs, Coopers, Seraphim and Aeon destroyers).
+
+  - Seraphim T1 Submarine (XSS0203):
+    - Anti-Torpedo Defense reload time: 5 sec -> 13 sec

--- a/units/XSS0203/XSS0203_unit.bp
+++ b/units/XSS0203/XSS0203_unit.bp
@@ -307,7 +307,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_Countermeasure",
-            RateOfFire = 10/50, --10/integer interval in ticks
+            RateOfFire = 10/130, --10/integer interval in ticks
             TargetCheckInterval = 1.0,
             TargetRestrictDisallow = "UNTARGETABLE",
             TargetRestrictOnlyAllow = "TORPEDO",

--- a/units/XSS0203/XSS0203_unit.bp
+++ b/units/XSS0203/XSS0203_unit.bp
@@ -220,7 +220,6 @@ UnitBlueprint{
             Damage = 75,
             DamageType = "Normal",
             DisplayName = "Uall Cavitation Torpedo",
-            EffectiveRadius = 29,
             FireTargetLayerCapsTable = {
                 Sub = "Seabed|Sub|Water",
                 Water = "Seabed|Sub|Water",
@@ -278,7 +277,6 @@ UnitBlueprint{
             DamageType = "Normal",
             DisableWhileReloading = true,
             DisplayName = "Ajellu Anti-Torpedo Defense",
-            EffectiveRadius = 26,
             FireTargetLayerCapsTable = {
                 Sub = "Water",
                 Water = "Water",


### PR DESCRIPTION
## Issue
Sera T1 sub torpdef is overpowered: it easily beats destroyers mass for mass, dominates other T1 subs, and can even take on stationary torpedo defenses.
[Discord thread](https://discord.com/channels/197033481883222026/1373054368697421824)

## Description of the proposed changes
- Seraphim T1 Submarine (XSS0203):
  - Torpedo defense reload: 5 sec -> 13 sec

## Testing done on the proposed changes
Stacked T1 sub 10v10:
```
local n = 10
for i = 1, n do
    for j = 1, 10 do
        CreateUnitAtMouse('xss0203', 0,    (i-1-n/2) * 32,    16.00, math.pi)
        CreateUnitAtMouse('uas0203', 1,    (i-1-n/2) * 32,    -16.00, -0.00000)
    end
end
```
9.2s seems to make the outcome slightly in favor of non-sera subs. There is a breakpoint around here where Sera subs get much better or worse because they shoot down 1 critical volley I guess.

- 1 sub vs 1 uef sub (aeon sub is equal, cyb sub has more projectiles so its better):
  - 5s reload (current): sera sub wins 25 hp (micro and no micro)
  - 10s reload: uef sub wins 50 hp (micro and no micro)
  - 13s reload: uef sub 50 hp (no micro)
- 5 subs (1800 mass) vs 1 salem (2250 mass):
  - 5s reload: sera sub wins with 0 dmg taken
  - 10s reload: sera sub wins with 0 dmg taken
  - 13s reload: salem wins 125-350 hp
- 6 subs (2160 mass) vs 1 salem:
  - 13s reload: subs win taking 400 dmg
  - 14s reload: subs win taking 550 dmg (5 left)
  - 15s reload: subs win taking 950 dmg
  - 16s reload: subs win taking 1100 dmg (4 left)
  - 30s reload: salem wins 275 hp

Salems wins vs 6 UEF subs with like 2k hp.

## Balance Reasoning

13s is chosen since Sera subs get even better at higher counts, the sera player is more likely to spam tons of them compared to other factions spamming subs, and you can reload the antitorp out of combat for free HP saved.

An even slower reload is not chosen despite beating destroyers mass for mass because Cybran destros can be supported by T1/T2 subs to deplete antitorps, and other factions have their own ways to beat Sera T1 subs at T2 (UEF cooper, Aeon depth charges/T2 sub, Sera subs/extra destroyer torps). Curbing the snowball at T1 should allow a transition into T2 to be possible, even if the Sera subs can find an advantage eventually at T1.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
