### PR TITLE
Fix treads spawning for units that are on a transport

### DIFF
--- a/changelog/fix.6881.md
+++ b/changelog/fix.6881.md
@@ -1,0 +1,1 @@
+- (#6881) Fix tread splats spawning for units that are attached to a transport

--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -417,14 +417,27 @@ TreadComponent = ClassSimple {
 
     ---@param self Unit | TreadComponent
     CreateMovementEffects = function(self)
+        -- early exit: do not create treads if we do not have the blueprint
         local treads = self.TreadBlueprint
         if not treads then
+            return
+        end
+
+        -- early exit: do not create treads if we're in the air or on water
+        local layer = self.Layer
+        if layer == "Air" or layer == "Water" then
+            return
+        end
+
+        -- early exit: do not create treads if we are attached to something (like a transport)
+        if self:IsUnitState("Attached") then
             return
         end
 
         if treads.ScrollTreads then
             self:AddThreadScroller(1.0, treads.ScrollMultiplier or 0.2)
         end
+
         local treadMarks = treads.TreadMarks
         local treadType = self.TerrainType.Treads
         if treadMarks and treadType and treadType ~= 'None' then


### PR DESCRIPTION
## Description of the proposed changes

A bug was reported on [Discord](https://discord.com/channels/197033481883222026/1388492188887023677) that treads would spawn when units are attached to transports.

![image](https://github.com/user-attachments/assets/7fd30aef-65dd-4835-bb50-f7bce2122ebf)

## Testing done on the proposed changes

Spawn in units that create treads. See if their behavior on transports is correct.

## Additional context

When the transport is idle the layer of attached units is considered to be 'Land', even though they're quite a bit up in the air. This causes movement effects to spawn in.

https://github.com/user-attachments/assets/cd7b9780-52c0-4a8a-bd5f-9632837d4e57

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
