### PR TITLE
Update blueprint modding documentation

### DIFF
--- a/changelog/snippets/other.6883.md
+++ b/changelog/snippets/other.6883.md
@@ -1,0 +1,1 @@
+- (#6883) Update blueprint modding documentation in the game repository (MODS.LUA).

--- a/lua/MODS.LUA
+++ b/lua/MODS.LUA
@@ -216,7 +216,8 @@ Merging includes workarounds for the limitations involving arrays and removing f
     - `MergeLabel` merges the blueprint with the weapon blueprint that has the same `label`.
     - When a label is not found, `AddIndex` adds the weapon at the specified index.
         - This is mostly useful for adding a weapon to index 1, which is what controls unit AI.
-    - Neither are necessary, new blueprints are added to the end of the weapon array by default.
+    - Neither fields are necessary, as by default the blueprints in `ModWeapon` are added to
+      the end of the `Weapon` array.
 
 ----------
 Balance changes

--- a/lua/MODS.LUA
+++ b/lua/MODS.LUA
@@ -193,25 +193,30 @@ The pattern for overriding a class method called `Method` in a class called `Cls
 Blueprints
 ----------
 
-If an active sim mod has any .bp files, they will be automatically ran during blueprint loading to
-register all blueprint definitions inside. The ID of the blueprint can be specified by the
-`BlueprintId` field, but if absent, it will default to the file source (lowercased). For unit
-blueprints, the source is shortened to the filename without the suffix (e.g. `"_unit.bp"`) in that
-case. If you have multiple blueprints in a file, be sure to specify each `BlueprintId`.
+If an active sim mod has any .bp files, they will be automatically run during blueprint loading
+(as lua code) to register all blueprint definitions inside. Maps can also have .bp files. 
+You do not need to place blueprints in the `/hook` folder!
+
+Each blueprint definition needs a unique blueprint ID. This is defined by the field `BlueprintId`,
+but if absent, it defaults to the file source (lowercased), or for unit blueprints, the filename 
+without the suffix (`_unit.bp`). 
+If you have multiple blueprints in a file, be sure to specify each `BlueprintId`.
 
 If the blueprint ID ends up matching the ID of an existing blueprint, then the mod's blueprint will
 replace the one currently there unless the `Merge = true` flag is set in the blueprint. This will
 make the blueprint only add or override the fields it defines (including nested tables - the entire
 subtable isn't replaced in this mode), leaving the rest intact (which could possibly also have been
-changed by other mods).
-To remove a field from the original blueprint, set the field to `"__nil"` in your merge blueprint.
-To add or remove categories from a blueprint, set `AddCategories` and `DelCategories` to tables of
-category names (strings) you want to add or remove.
-To add or merge weapons in a blueprint, place your weapon blueprint in the `ModWeapon` table with 
-`MergeLabel` corresponding to the weapon label to merge the new blueprint with, and in case the 
-label doesn't exist, use `AddIndex` to specify where in the Weapon array the new blueprint should
-be placed, which is useful to place weapons at index 1 which controls the unit AI. 
-
+changed by other mods). 
+Merging includes workarounds for the limitations involving arrays and removing fields:
+  - To remove a field from the original blueprint, set it to `"__nil"` in the merge blueprint.
+  - To add or remove categories from a blueprint, set `AddCategories` and `DelCategories` to tables
+    of category names (strings) you want to add or remove.
+  - To change weapon blueprints, use the `ModWeapon` table, which consists of weapon blueprints
+    with special fields:
+    - `MergeLabel` merges the blueprint with the weapon blueprint that has the same `label`.
+    - When a label is not found, `AddIndex` adds the weapon at the specified index.
+        - This is mostly useful for adding a weapon to index 1, which is what controls unit AI.
+    - Neither are necessary, new blueprints are added to the end of the weapon array by default.
 
 ----------
 Balance changes

--- a/lua/MODS.LUA
+++ b/lua/MODS.LUA
@@ -226,11 +226,29 @@ There are two main ways to make balance changes.
 
 First, a mod can merge or override blueprints as described above.
 
-Second, a mod can hook the `/lua/system/Blueprints.lua` file and override the `ModBlueprints`
-function to modify existing blueprints in an organized manner. Be sure to call the old function like
-this, so that other mods' changes aren't overridden:
+Second, mods can directly modify all blueprints in an organized manner using lua.
+The newer method is using the function `SetModBlueprintFunction`, which you can call from a `.bp`
+file and set a function to run. Only one function can be set to run per file.
+Example:
+```
+    -- file: /mod/**/changes.bp
+    SetModBlueprintFunction(function(all_bps)
+        for id, unitBp in all_bps.Unit do
+            -- some systematic change to each `unitBp`
+        end
+    end)
+```
+This new method can be hot-reloaded when the command line arg "/EnableDiskWatch" is present. So
+when you change your .bp file, you don't need to restart the game session to see your changes.
+It is also better organized and simpler. Unfortunately it currently doesn't support mod load order.
 
-    -- introduce new scope to gaurentee our local variables don't overwrite anything in another mod
+The older method is hooking `/lua/system/Blueprints.lua` and overriding the `ModBlueprints`
+function to modify existing blueprints. `ModBlueprints` runs before mod blueprint functions.
+Be sure to call the old `ModBlueprints` like this, so that other mods' changes aren't overridden:
+```
+    -- file: /mod/hook/lua/system/Blueprints.lua
+
+    -- introduce new scope to guarantee our local variables don't overwrite anything in another mod
     do
         local oldModBlueprints = ModBlueprints
         function ModBlueprints(all_bps)
@@ -243,7 +261,7 @@ this, so that other mods' changes aren't overridden:
             end
         end
     end
-
+```
 
 ----------
 Custom skins


### PR DESCRIPTION
## Description of the proposed changes
Responds to feedback from a [discord message](https://discord.com/channels/197033481883222026/832710161847287819/1388658835765465220) about the `ModWeapons` table.
> I guess for starters, it doesn't specify where you need to put the ModWeapon table at, whether it's an actual, full-blown table like the normal Weapons one, or if it's a nested table placed inside of it. I assumed the former, but that did through me off for a moment.  It also makes you think that MergeLabel is for both merging and adding weapons with the way it is worded. AddIndex is not very clear on what index number you should input and kind of assumes you know how the weapon table is structured already. Do you count weapons from top to bottom or from bottom to top? I know it's from top to bottom, but I'm just pointing that out. Some people need more help than others. Also, do Dummy and Teleport weapons count? And lastly, it suggests that it's useful to place weapons at index "1", which obviously didn't work out too well for me. Hope all these scatterbrained thoughts of mine helped. 

Also updates the blueprint scripting ("Balance Changes") section to include the new function `SetModBlueprintFunction`.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
