### PR TITLE
Fix continental under construction blocking pgen construction

### DIFF
--- a/changelog/snippets/fix.6884.md
+++ b/changelog/snippets/fix.6884.md
@@ -1,0 +1,1 @@
+- (#6884) Fix being unable to build adjacent to the north or south side of an air factory that is building a continental.

--- a/units/XEA0306/XEA0306_unit.bp
+++ b/units/XEA0306/XEA0306_unit.bp
@@ -218,7 +218,7 @@ UnitBlueprint{
     Footprint = {
         MaxSlope = 0.25,
         SizeX = 4,
-        SizeZ = 8,
+        SizeZ = 7,
     },
     General = {
         CommandCaps = {


### PR DESCRIPTION
## Issue
Reported on the [forums](https://forum.faforever.com/topic/9291/uef-t3-heavy-air-transport-continental-collision).
![image](https://github.com/user-attachments/assets/b76cb6b2-e43d-449f-88b4-617c37dc405b)


Continental has a footprint size Z of 8 which is equal to the factory, so it sticks out a bit and blocks pgens from being built adjacent to the factory while the continental is building.



## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Reduce the footprint size from 8 to 7 (smallest change possible).

## Testing done on the proposed changes
The continental no longer blocks adjacent pgen construction.
Spawn an engineer and factories.
```
   CreateUnitAtMouse('zeb9602', 0,    7.13,    2.71,  0.00000)
   CreateUnitAtMouse('ueb0302', 0,   -0.87,   -5.29,  0.00000)
   CreateUnitAtMouse('uel0301_ras', 0,   -6.26,    2.59, -0.00000)
```
Order the factories to build continentals.
Check with the engineer that pgens can be built on all sides.
![{4D5FD67F-0C32-43A2-A8DB-9618EFF83A40}](https://github.com/user-attachments/assets/9c773e1c-6ed3-4534-a24f-07cd1a910806)

Repeated across a few locations on the map.

The footprint isn't significantly smaller than the model:
![{57AC15DE-99B6-4252-A2D7-CC5980A8CEEE}](https://github.com/user-attachments/assets/cb895d9c-2b8c-482e-a08c-8002072e2ace)

Note: hot-reloading the blueprint doesn't seem to apply the footprint changes properly. Make sure to reload the session if you change the footprint sizes but don't see the expected results.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
