### PR TITLE
Check whether LazyVar.OnDirty exists in case it was destroyed earlier

### DIFF
--- a/changelog/snippets/fix.6885.md
+++ b/changelog/snippets/fix.6885.md
@@ -1,0 +1,1 @@
+- (#6885) Check whether LazyVar.OnDirty exists in case it was destroyed earlier.

--- a/lua/lazyvar.lua
+++ b/lua/lazyvar.lua
@@ -159,7 +159,11 @@ LazyVarMetaTable = {
 
         -- tell those that use us that we have a new value
         for k = 7, head - 1 do
-            self[k]:OnDirty()
+            local lv = self[k]
+            onDirty = lv.OnDirty
+            if onDirty then
+                onDirty(lv)
+            end
             self[k] = nil
         end
     end,
@@ -204,7 +208,11 @@ LazyVarMetaTable = {
 
         -- tell those that use us that we have a new value
         for k = 7, head - 1 do
-            self[k]:OnDirty()
+            local lv = self[k]
+            onDirty = lv.OnDirty
+            if onDirty then
+                onDirty(lv)
+            end
             self[k] = nil
         end
     end,


### PR DESCRIPTION
## Description of the proposed changes
Add extra `nil` check for `OnDirty` before calling in case is was removed.

## Testing
```lua
 local LazyVar = import('/lua/lazyvar.lua').Create

        local l1 = LazyVar(1)
        local l2 = LazyVar(2)
        local l3 = nil

        local function DeleteCreate()
            if l3 then
                l3:Destroy()
                l3 = nil
            end
            l3 = LazyVar(3)
            -- Create text's font
            l3.OnDirty = function()
                LOG(l3())
            end
            --- Set font to scale of layouter
            l3:Set(function()
                return l1()
            end)
            l3()
        end

        --Resize logic for example, when old items are deleted and then created
        local lock = true
        l2.OnDirty = function()
            if lock then
                return
            end
            DeleteCreate()
        end
        --- Set to scale of layouter
        l2:Set(function()
            return l1()
        end)
        -- compute our size
        l2()
        DeleteCreate()

        lock = false

        -- Set scale of layouter to a function
        local l4 = LazyVar(0)
        l1:Set(function()
            return l4() / 100
        end)
        l4:Set(5)
```
This code example would cause an error when used without check.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
