### PR TITLE
Remove redundant t1 Hive category

### DIFF
--- a/changelog/snippets/fix.6891.md
+++ b/changelog/snippets/fix.6891.md
@@ -1,0 +1,1 @@
+- (#6891) Remove redundant category for t1 Hive.

--- a/changelog/snippets/fix.6891.md
+++ b/changelog/snippets/fix.6891.md
@@ -1,1 +1,1 @@
-- (#6891) Remove redundant category for t1 Hive.
+- (#6891) Remove a redundant category from the unupgraded Cybran T2 Engineering Station (XRB0104).

--- a/units/XRB0104/XRB0104_unit.bp
+++ b/units/XRB0104/XRB0104_unit.bp
@@ -22,7 +22,6 @@ UnitBlueprint{
     BuildBotTotal = 1,
     BuildIconSortPriority = 200,
     Categories = {
-        "BUILTBYCOMMANDER",
         "BUILTBYTIER2COMMANDER",
         "BUILTBYTIER2ENGINEER",
         "BUILTBYTIER3COMMANDER",


### PR DESCRIPTION
## Description of the proposed changes
Remove redundant category for t1 Hive, since this category tells that t1 ACU can build it, which isn't true.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
