### PR TITLE
Improve resolution of available support factories during ACU ehnancement to higher teches

### DIFF
--- a/changelog/snippets/performance.6892.md
+++ b/changelog/snippets/performance.6892.md
@@ -1,0 +1,3 @@
+- (#6892) Improve resolution of available support factories during ACU ehnancement to higher teches.
+
+Reduces number of required selections down to 2 (was 7) that were resolving available support factories for construction during ACU enhancement to higher teches.

--- a/changelog/snippets/performance.6892.md
+++ b/changelog/snippets/performance.6892.md
@@ -1,3 +1,3 @@
 - (#6892) Improve resolution of available support factories during ACU ehnancement to higher teches.
 
-Reduces number of required selections down to 2 (was 7) that were resolving available support factories for construction during ACU enhancement to higher teches.
+  Reduces number of required selections down to 2 (was 7) that were resolving available support factories for construction during ACU enhancement to higher teches.

--- a/lua/ui/notify/enhancementqueue.lua
+++ b/lua/ui/notify/enhancementqueue.lua
@@ -143,7 +143,7 @@ function ModifyBuildablesForACU(originalBuildables, selection)
 
                 if hashedCategories["TECH3"] then
                     supportCategory = supportCategory * (categories.TECH3 + categories.TECH2)
-                elseif hashedCategories["TECH3"] then
+                elseif hashedCategories["TECH2"] then
                     supportCategory = supportCategory * categories.TECH2
                 end
 

--- a/lua/ui/notify/enhancementqueue.lua
+++ b/lua/ui/notify/enhancementqueue.lua
@@ -156,7 +156,7 @@ function ModifyBuildablesForACU(originalBuildables, selection)
                 end
                 supportFactories = supportFactories + supportCategory
             end
-            newBuildableCategories = supportFactories * supportFactories
+            newBuildableCategories = newBuildableCategories * supportFactories
         end
 
         SelectUnits(selection)

--- a/lua/ui/notify/enhancementqueue.lua
+++ b/lua/ui/notify/enhancementqueue.lua
@@ -133,6 +133,7 @@ function ModifyBuildablesForACU(originalBuildables, selection)
         if table.empty(hqs) then
             newBuildableCategories = newBuildableCategories - categories.SUPPORTFACTORY
         else
+            local categories = categories
             local factionCategory = categories[faction]
             local supportFactories = newBuildableCategories - categories.SUPPORTFACTORY
 

--- a/lua/ui/notify/enhancementqueue.lua
+++ b/lua/ui/notify/enhancementqueue.lua
@@ -125,37 +125,36 @@ function ModifyBuildablesForACU(originalBuildables, selection)
             end
         end
 
-        local factionCategory = ParseEntityCategory(faction)
+        local factionCategory = categories[faction]
         SetIgnoreSelection(true)
 
-        -- LAND
-        UISelectionByCategory('LAND RESEARCH TECH3 ' .. faction, false, false, false, false)
-        if not GetSelectedUnits() then
-            newBuildableCategories = newBuildableCategories - (categories.LAND * categories.SUPPORTFACTORY * categories.TECH3 * factionCategory)
-            UISelectionByCategory('LAND RESEARCH TECH2 ' .. faction, false, false, false, false)
-            if not GetSelectedUnits() then
-                newBuildableCategories = newBuildableCategories - (categories.LAND * categories.SUPPORTFACTORY * categories.TECH2 * factionCategory)
-            end
-        end
+        UISelectionByCategory("RESEARCH " .. faction, false, false, false, false)
+        local hqs = GetSelectedUnits()
+        if table.empty(hqs) then
+            newBuildableCategories = newBuildableCategories - categories.SUPPORTFACTORY
+        else
+            local supportFactories = newBuildableCategories - categories.SUPPORTFACTORY
 
-        -- AIR
-        UISelectionByCategory('AIR RESEARCH TECH3 ' .. faction, false, false, false, false)
-        if not GetSelectedUnits() then
-            newBuildableCategories = newBuildableCategories - (categories.AIR * categories.SUPPORTFACTORY * categories.TECH3 * factionCategory)
-            UISelectionByCategory('AIR RESEARCH TECH2 ' .. faction, false, false, false, false)
-            if not GetSelectedUnits() then
-                newBuildableCategories = newBuildableCategories - (categories.AIR * categories.SUPPORTFACTORY * categories.TECH2 * factionCategory)
-            end
-        end
+            ---@param hq UserUnit
+            for _, hq in hqs do
+                local supportCategory = categories.SUPPORTFACTORY * factionCategory
 
-        -- Naval
-        UISelectionByCategory('NAVAL RESEARCH TECH3 ' .. faction, false, false, false, false)
-        if not GetSelectedUnits() then
-            newBuildableCategories = newBuildableCategories - (categories.NAVAL * categories.SUPPORTFACTORY * categories.TECH3 * factionCategory)
-            UISelectionByCategory('NAVAL RESEARCH TECH2 ' .. faction, false, false, false, false)
-            if not GetSelectedUnits() then
-                newBuildableCategories = newBuildableCategories - (categories.NAVAL * categories.SUPPORTFACTORY * categories.TECH2 * factionCategory)
+                if EntityCategoryContains(categories.TECH3, hq) then
+                    supportCategory = supportCategory * (categories.TECH3 + categories.TECH2)
+                elseif EntityCategoryContains(categories.TECH2, hq) then
+                    supportCategory = supportCategory * categories.TECH2
+                end
+
+                if EntityCategoryContains(categories.LAND, hq) then
+                    supportCategory = supportCategory * categories.LAND
+                elseif EntityCategoryContains(categories.AIR, hq) then
+                    supportCategory = supportCategory * categories.AIR
+                elseif EntityCategoryContains(categories.NAVAL, hq) then
+                    supportCategory = supportCategory * categories.NAVAL
+                end
+                supportFactories = supportFactories + supportCategory
             end
+            newBuildableCategories = supportFactories * supportFactories
         end
 
         SelectUnits(selection)

--- a/lua/ui/notify/enhancementqueue.lua
+++ b/lua/ui/notify/enhancementqueue.lua
@@ -148,13 +148,14 @@ function ModifyBuildablesForACU(originalBuildables, selection)
                 end
 
                 if EntityCategoryContains(categories.LAND, hq) then
-                    supportCategory = supportCategory * categories.LAND
-                elseif EntityCategoryContains(categories.AIR, hq) then
-                    supportCategory = supportCategory * categories.AIR
-                elseif EntityCategoryContains(categories.NAVAL, hq) then
-                    supportCategory = supportCategory * categories.NAVAL
+                    supportFactories = supportFactories + supportCategory * categories.LAND
                 end
-                supportFactories = supportFactories + supportCategory
+                if EntityCategoryContains(categories.AIR, hq) then
+                    supportFactories = supportFactories + supportCategory * categories.AIR
+                end
+                if EntityCategoryContains(categories.NAVAL, hq) then
+                    supportFactories = supportFactories + supportCategory * categories.NAVAL
+                end
             end
             newBuildableCategories = newBuildableCategories * supportFactories
         end

--- a/lua/ui/notify/enhancementqueue.lua
+++ b/lua/ui/notify/enhancementqueue.lua
@@ -1,5 +1,3 @@
-local EntityCategoryContains = EntityCategoryContains
-
 -- This file contains the functions needed to keep track of ACU upgrade queueing
 
 local SetIgnoreSelection = import("/lua/ui/game/gamemain.lua").SetIgnoreSelection
@@ -139,21 +137,23 @@ function ModifyBuildablesForACU(originalBuildables, selection)
 
             ---@param hq UserUnit
             for _, hq in hqs do
+                local bp = hq:GetBlueprint()
+                local hashedCategories = bp.CategoriesHash
                 local supportCategory = categories.SUPPORTFACTORY * factionCategory
 
-                if EntityCategoryContains(categories.TECH3, hq) then
+                if hashedCategories["TECH3"] then
                     supportCategory = supportCategory * (categories.TECH3 + categories.TECH2)
-                elseif EntityCategoryContains(categories.TECH2, hq) then
+                elseif hashedCategories["TECH3"] then
                     supportCategory = supportCategory * categories.TECH2
                 end
 
-                if EntityCategoryContains(categories.LAND, hq) then
+                if hashedCategories["LAND"] then
                     supportFactories = supportFactories + supportCategory * categories.LAND
                 end
-                if EntityCategoryContains(categories.AIR, hq) then
+                if hashedCategories["AIR"] then
                     supportFactories = supportFactories + supportCategory * categories.AIR
                 end
-                if EntityCategoryContains(categories.NAVAL, hq) then
+                if hashedCategories["NAVAL"] then
                     supportFactories = supportFactories + supportCategory * categories.NAVAL
                 end
             end

--- a/lua/ui/notify/enhancementqueue.lua
+++ b/lua/ui/notify/enhancementqueue.lua
@@ -1,3 +1,5 @@
+local EntityCategoryContains = EntityCategoryContains
+
 -- This file contains the functions needed to keep track of ACU upgrade queueing
 
 local SetIgnoreSelection = import("/lua/ui/game/gamemain.lua").SetIgnoreSelection
@@ -125,14 +127,13 @@ function ModifyBuildablesForACU(originalBuildables, selection)
             end
         end
 
-        local factionCategory = categories[faction]
         SetIgnoreSelection(true)
-
         UISelectionByCategory("RESEARCH " .. faction, false, false, false, false)
         local hqs = GetSelectedUnits()
         if table.empty(hqs) then
             newBuildableCategories = newBuildableCategories - categories.SUPPORTFACTORY
         else
+            local factionCategory = categories[faction]
             local supportFactories = newBuildableCategories - categories.SUPPORTFACTORY
 
             ---@param hq UserUnit


### PR DESCRIPTION
## Description of the proposed changes
Reduces number of required selections down to 2 (was 7) that were resolving available support factories for construction during ACU enhancement to higher teches.

## Testing done on the proposed changes
1. spawn all factions ACUs;
2. start upgrading them to t2 - no support factories are available;
3. spawn hqs for each factions of each type one by one checking that they appear in building list of ACUs;
4. repeat for t3 enhancement.

## Additional context.
In perfect world we'd like to report from sim that we have hq of certain category and thus have available categories for support factories.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
