### PR TITLE
Make Yolona outer damage ignore shields

### DIFF
--- a/lua/ShieldAbsorptionValues.lua
+++ b/lua/ShieldAbsorptionValues.lua
@@ -35,5 +35,6 @@ shieldAbsorptionValues = {
 	["StaticShield"] = { -- For mod support, auto-assigned if the owner has STRUCTURE category.
 		["Deathnuke"] = 1.0,
 		["Overcharge"] = 1.0,
+		["NukeIgnoreShields"] = 0.0,
 	},
 }

--- a/lua/armordefinition.lua
+++ b/lua/armordefinition.lua
@@ -20,6 +20,7 @@
 ---| "FireBeetleExplosion"
 ---| "Normal"
 ---| "Nuke"
+---| "NukeIgnoreShields"
 ---| "Overcharge"
 ---| "Reclaimed"
 ---| "Spell"

--- a/lua/proptree.lua
+++ b/lua/proptree.lua
@@ -115,7 +115,7 @@ Tree = Class(Prop) {
                 EntitySetMesh(self, self.Blueprint.Display.MeshBlueprintWrecked)
             end
 
-        elseif type == 'Nuke' and canBurn then
+        elseif (type == 'Nuke' or type == 'NukeIgnoreShields') and canBurn then
             -- slight chance we catch fire
             if Random(1, 250) < 5 then
                 self:Burn()

--- a/lua/sim/NukeDamage.lua
+++ b/lua/sim/NukeDamage.lua
@@ -30,23 +30,25 @@ NukeAOE = ClassSimple {
         if self.TotalTime == 0 then
             import("/lua/sim/damagearea.lua").DamageArea(instigator, pos, self.Radius, self.Damage, (damageType or 'Nuke'), true, true, brain, army)
         else
-            ForkThread(self.SlowNuke, self, instigator, pos)
+            ForkThread(self.SlowNuke, self, instigator, pos, damageType)
         end
     end,
 
     ---@param self NukeAOE
     ---@param instigator Unit
     ---@param pos Vector
-    SlowNuke = function(self, instigator, pos)
+    ---@param damageType? DamageType
+    SlowNuke = function(self, instigator, pos, damageType)
+        damageType = damageType or 'Nuke'
         local ringWidth = (self.Radius / self.Ticks)
         local tickLength = (self.TotalTime / self.Ticks)
 
         -- Since we're not allowed to have an inner radius of 0 in the DamageRing function,
         -- I'm manually executing the first tick of damage with a DamageArea function.
-        DamageArea(instigator, pos, ringWidth, self.Damage, 'Nuke', true, true)
+        DamageArea(instigator, pos, ringWidth, self.Damage, damageType, true, true)
         WaitSeconds(tickLength)
         for i = 2, self.Ticks do
-            DamageRing(instigator, pos, ringWidth * (i - 1), ringWidth * i, self.Damage, 'Nuke', true, true)
+            DamageRing(instigator, pos, ringWidth * (i - 1), ringWidth * i, self.Damage, damageType, true, true)
             WaitSeconds(tickLength)
         end
     end,

--- a/lua/system/blueprints-ai.lua
+++ b/lua/system/blueprints-ai.lua
@@ -201,7 +201,7 @@ function SetThreatValuesOfUnit(bp, cache)
                 local surfaceMult = 0.1
 
                 -- determines if we apply dps to economic or anti surface threat
-                local weaponIsEconomicThreat = (weapon.DamageType == 'Nuke' or weapon.ArtilleryShieldBlocks) and (not mobileUnit and weapon.MaxRadius > 150 or weapon.MinRadius > 80)
+                local weaponIsEconomicThreat = (weapon.DamageType == 'Nuke' or weapon.DamageType == 'NukeIgnoreShields' or weapon.ArtilleryShieldBlocks) and (not mobileUnit and weapon.MaxRadius > 150 or weapon.MinRadius > 80)
 
                 -- Anti air
                 if weapon.RangeCategory == 'UWRC_AntiAir' or weapon.TargetRestrictOnlyAllow == 'AIR' or StringFind(weapon.WeaponCategory or 'nope', 'Anti Air') then

--- a/units/XEA0306/XEA0306_Script.lua
+++ b/units/XEA0306/XEA0306_Script.lua
@@ -4,6 +4,7 @@
 -- Summary  :  UEF Heavy Air Transport Script
 -- Copyright © 2007 Gas Powered Games, Inc.  All rights reserved.
 -----------------------------------------------------------------
+
 local explosion = import("/lua/defaultexplosions.lua")
 local util = import("/lua/utilities.lua")
 local WeaponsFile = import("/lua/terranweapons.lua")
@@ -13,6 +14,9 @@ local TWeapons = import("/lua/terranweapons.lua")
 local TDFHeavyPlasmaCannonWeapon = TWeapons.TDFHeavyPlasmaCannonWeapon
 
 ---@class XEA0306 : AirTransport
+---@field MyShield TransportShield
+---@field LandingAnimManip moho.AnimationManipulator
+---@field UnfoldAnim moho.AnimationManipulator
 XEA0306 = ClassUnit(AirTransport) {
     AirDestructionEffectBones = { 'FrontRight_Engine_Exhaust', 'FrontLeft_Engine_Exhaust', 'BackRight_Engine_Exhaust',
         'BackLeft_Engine_Exhaust' },
@@ -36,6 +40,7 @@ XEA0306 = ClassUnit(AirTransport) {
 
     EngineRotateBones = { 'FrontRight_Engine', 'FrontLeft_Engine', 'BackRight_Engine', 'BackLeft_Engine', },
 
+    ---@param self XEA0306
     OnCreate = function(self)
         AirTransport.OnCreate(self)
 
@@ -44,6 +49,9 @@ XEA0306 = ClassUnit(AirTransport) {
         self.UnfoldAnim:SetRate(0)
     end,
 
+    ---@param self XEA0306
+    ---@param builder Unit
+    ---@param layer Layer
     OnStopBeingBuilt = function(self, builder, layer)
         AirTransport.OnStopBeingBuilt(self, builder, layer)
         self.EngineManipulators = {}
@@ -68,16 +76,28 @@ XEA0306 = ClassUnit(AirTransport) {
     end,
 
     -- When a unit attaches or detaches, tell the shield about it.
+    ---@param self XEA0306
+    ---@param attachBone Bone
+    ---@param unit Unit
     OnTransportAttach = function(self, attachBone, unit)
         AirTransport.OnTransportAttach(self, attachBone, unit)
         self.MyShield:AddProtectedUnit(unit)
     end,
 
+    ---@param self XEA0306
+    ---@param attachBone Bone
+    ---@param unit Unit
     OnTransportDetach = function(self, attachBone, unit)
         AirTransport.OnTransportDetach(self, attachBone, unit)
         self.MyShield:RemoveProtectedUnit(unit)
     end,
 
+
+    ---@param self XEA0306
+    ---@param instigator Unit
+    ---@param amount number
+    ---@param vector Vector
+    ---@param damageType DamageType
     OnDamage = function(self, instigator, amount, vector, damageType)
         if damageType == 'Nuke' or damageType == 'Deathnuke' or damageType == 'NukeIgnoreShields' then
             self.MyShield:SetContentsVulnerable(true)
@@ -99,10 +119,13 @@ XEA0306 = ClassUnit(AirTransport) {
     end,
 
     -- Override air destruction effects so we can do something custom here
+    ---@param self XEA0306
+    ---@param scale number
     CreateUnitAirDestructionEffects = function(self, scale)
         self:ForkThread(self.AirDestructionEffectsThread, self)
     end,
 
+    ---@param self XEA0306
     AirDestructionEffectsThread = function(self)
         local numExplosions = math.floor(table.getn(self.AirDestructionEffectBones) * 0.5)
         for i = 0, numExplosions do
@@ -112,6 +135,7 @@ XEA0306 = ClassUnit(AirTransport) {
         end
     end,
 
+    ---@param self XEA0306
     GetUnitSizes = function(self)
         local bp = self.Blueprint
         if self:GetFractionComplete() < 1.0 then

--- a/units/XEA0306/XEA0306_Script.lua
+++ b/units/XEA0306/XEA0306_Script.lua
@@ -79,7 +79,7 @@ XEA0306 = ClassUnit(AirTransport) {
     end,
 
     OnDamage = function(self, instigator, amount, vector, damageType)
-        if damageType == 'Nuke' or damageType == 'Deathnuke' then
+        if damageType == 'Nuke' or damageType == 'Deathnuke' or damageType == 'NukeIgnoreShields' then
             self.MyShield:SetContentsVulnerable(true)
         end
 

--- a/units/XSB2401/XSB2401_unit.bp
+++ b/units/XSB2401/XSB2401_unit.bp
@@ -168,7 +168,7 @@ UnitBlueprint{
             CollideFriendly = false,
             CountedProjectile = true,
             Damage = 0,
-            DamageType = "Nuke",
+            DamageType = "NukeIgnoreShields",
             DisplayName = "Experimental Strategic Missile Launcher",
             EnergyDrainPerSecond = 0,
             EnergyRequired = 0,


### PR DESCRIPTION
## Issue
Yolona's outer ring damage (7500) is lower than T3 shield HP, so it gets fully absorbed and deals no damage.

Making the ring damage deal damage to shields is not viable because ring damage is repeated as the nuke shockwave travels, so it would deal many instances of 7500 damage to shields.

## Description of the proposed changes
Add a new damage type for the Yolona that ignores shields.

A new damage type keeps backwards compatibility with nuclear repulsor shields because the `SlowNuke` used by Yolona overrides the damage type to `Nuke` in those mods (they hook `NukeDamage.lua` and replace the lua `DamageArea` with the engine `DamageArea`).

Switching normal nukes to the new damage type would break those mods.

## Testing done on the proposed changes
Nuke the paragon using the outer damage and confirm that it ignores the shield.

<img width="135" height="267" alt="{4FCA0683-918E-494C-8A15-4FB1D4DA84A6}" src="https://github.com/user-attachments/assets/4a5d89da-a8f6-42bb-b100-edc4f9a1cef7" />

```
   CreateUnitAtMouse('xab1401', 0,   -7.75,  -31.75, -0.00000)
   CreateUnitAtMouse('xab1401', 0,   12.25,   23.25, -0.00000)
   CreateUnitAtMouse('xsb4301', 0,   -7.75,  -13.75, -0.00000)
   CreateUnitAtMouse('xsb2401', 0,    3.25,   22.25, -0.00000)
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
