### PR TITLE
Reduce the Additional Regen Rate the Cybran ACU's Nano-Repair System provides

### DIFF
--- a/changelog/snippets/balance.6894.md
+++ b/changelog/snippets/balance.6894.md
@@ -1,4 +1,4 @@
-- (#6894) Nerf the Cybran ACU's Personal Stealth Generator and Nano-Repair System, as both had overtuned statlines. Especially the Nano-Repair System was a very oppressive tool that caused the Cybran ACU to significantly overperform in both the Tech 2 and early Tech 3 stages.
+- (#6894) Nerf the Cybran ACU's Nano-Repair System, as it has proven to be an oppressive tool that causes the Cybran ACU to significantly overperform during both the Tech 2 and early Tech 3 stages.
 
   **Cybran ACU (URL0001)**
   - Nano-Repair System

--- a/changelog/snippets/balance.6894.md
+++ b/changelog/snippets/balance.6894.md
@@ -1,7 +1,5 @@
 - (#6894) Nerf the Cybran ACU's Personal Stealth Generator and Nano-Repair System, as both had overtuned statlines. Especially the Nano-Repair System was a very oppressive tool that caused the Cybran ACU to significantly overperform in both the Tech 2 and early Tech 3 stages.
 
   **Cybran ACU (URL0001)**
-  - Personal Stealth Generator
-    - Additional Health: 2000 --> 1500
   - Nano-Repair System
     - Additional Regen Rate: 60 HP/s --> 50 HP/s

--- a/changelog/snippets/balance.6894.md
+++ b/changelog/snippets/balance.6894.md
@@ -1,0 +1,7 @@
+- (#6894) Nerf the Cybran ACU's Personal Stealth Generator and Nano-Repair System, as both had overtuned statlines. Especially the Nano-Repair System was a very oppressive tool that caused the Cybran ACU to significantly overperform in both the Tech 2 and early Tech 3 stages.
+
+  **Cybran ACU (URL0001)**
+  - Personal Stealth Generator
+    - Additional Health: 2000 --> 1500
+  - Nano-Repair System
+    - Additional Regen Rate: 60 HP/s --> 50 HP/s

--- a/loc/US/strings_db.lua
+++ b/loc/US/strings_db.lua
@@ -1596,7 +1596,7 @@ Unit_Description_0111="Grants Tech 3 and Experimental schematic access and furth
 Unit_Description_0112="Doubles the main cannon's rate of fire, and increases its range and that of Overcharge. Increases the range of the Microwave Laser if present.\n\n+100% Main cannon rate of fire\n+8 Main cannon range\n+8 Microwave Laser range"
 Unit_Description_0113="Enhances the ACU with a Microwave Laser weapon with unbelievable firepower.\n\nMicrowave Laser DPS = 3000"
 Unit_Description_0114="Enhances the ACU with a torpedo weapon and sonar sensor.\n\nNanite Torpedo DPS = 225\nNanite Torpedo range = 60\n+34 Sonar Radius"
-Unit_Description_0465_faf="Massively increases the rate at which the ACU repairs its armour.\n\n+1500 Health\n+60 Regen"
+Unit_Description_0465_faf="Massively increases the rate at which the ACU repairs its armour as well as providing an HP boost.\n\n+1500 Health\n+50 Regen"
 
 -- CYBRAN -- Support Commander Units/Upgrades
 Unit_Description_0115="A highly versatile combat and engineering unit useful on late-stage battlefields."

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -469,7 +469,7 @@ UnitBlueprint{
             Icon = "psg",
             MaintenanceConsumptionPerSecondEnergy = 50,
             Name = "<LOC enhancements_0101>Personal Stealth Generator",
-            NewHealth = 1500,
+            NewHealth = 2000,
             ShowBones = { "Back_Upgrade" },
             Slot = "Back",
             UpgradeEffectBones = {

--- a/units/URL0001/URL0001_unit.bp
+++ b/units/URL0001/URL0001_unit.bp
@@ -323,7 +323,7 @@ UnitBlueprint{
             Icon = "srs",
             Name = "<LOC enhancements_0150_faf>Nano-Repair System",
             NewHealth = 1500,
-            NewRegenRate = 60,
+            NewRegenRate = 50,
             Prerequisite = "StealthGenerator",
             ShowBones = { "Back_Upgrade" },
             Slot = "Back",
@@ -469,7 +469,7 @@ UnitBlueprint{
             Icon = "psg",
             MaintenanceConsumptionPerSecondEnergy = 50,
             Name = "<LOC enhancements_0101>Personal Stealth Generator",
-            NewHealth = 2000,
+            NewHealth = 1500,
             ShowBones = { "Back_Upgrade" },
             Slot = "Back",
             UpgradeEffectBones = {


### PR DESCRIPTION
## Description of the proposed changes
**Cybran ACU (URL0001)**
  - Nano-Repair System
    - Additional Regen Rate: 60 HP/s --> 50 HP/s

## Nano-Repair Upgrade comparison
|                   | UEF   | Cybran         | Seraphim |
| ----------------- | ----- | -------------- | -------- |
| +HP               | 1500  | 1500           | 2000     |
| Current +Regen            | 40    | 60             | 60       |
| **Proposed +Regen** | 40    | **50** | 60       |
| Mass Cost         | 800   | 1500           | 1800     |
| Energy Cost       | 24000 | 45000          | 56000    |

## Checklist
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).