### PR TITLE
Fix recall desync when an army is defeated the same tick a recall vote starts

### DIFF
--- a/changelog/snippets/fix.6898.md
+++ b/changelog/snippets/fix.6898.md
@@ -1,0 +1,1 @@
+- (#6898) Fix a desync-causing error when a player is defeated the same tick a recall vote is started.

--- a/lua/sim/Recall.lua
+++ b/lua/sim/Recall.lua
@@ -160,7 +160,6 @@ local function RecallVotingThread(requestingArmy)
             SyncRecallStatus()
         end
         requestingBrain.RecallVoteCancelled = nil
-        LOG(GetGameTick(), 'Removing RecallVoteStartTime for ' .. requestingBrain.Nickname .. ' due to RecallVoteCancelled')
         requestingBrain.RecallVoteStartTime = nil
         requestingBrain.recallVotingThread = nil
         return
@@ -223,7 +222,6 @@ local function RecallVotingThread(requestingArmy)
         -- update UI once the cooldown dissipates
         SyncRecallStatus()
     end
-    LOG(GetGameTick(), 'Removing RecallVoteStartTime for ' .. requestingBrain.Nickname .. ' due to End of Recall Vote')
     requestingBrain.RecallVoteStartTime = nil
     requestingBrain.recallVotingThread = nil
 end
@@ -266,9 +264,7 @@ end
 local function ArmyRequestRecall(army, teammates)
     local brain = GetArmyBrain(army)
     if teammates > 0 then
-        LOG(GetGameTick(), 'Request recall for ', brain.Nickname)
         brain.recallVotingThread = ForkThread(RecallVotingThread, army)
-        LOG(GetGameTick(), 'Setting RecallVoteStartTime for ' .. brain.Nickname)
         brain.RecallVoteStartTime = GetGameTick()
         if ArmyVoteRecall(army, true, false) then
             SyncOpenRecallVote(teammates + 1, army)
@@ -382,7 +378,6 @@ local function GetRecallSyncTable()
 end
 
 function ResyncRecallVoting()
-    LOG(GetGameTick(), 'Resyncing recall vote', debug.traceback())
     local focus = GetFocusArmy()
     local teamSize = 0
     local yes, no = 0, 0

--- a/lua/sim/Recall.lua
+++ b/lua/sim/Recall.lua
@@ -150,6 +150,7 @@ end
 ---@param requestingArmy number
 local function RecallVotingThread(requestingArmy)
     local requestingBrain = GetArmyBrain(requestingArmy)
+    LOG(GetGameTick(), 'Setting RecallVoteStartTime for ' .. requestingBrain.Nickname)
     requestingBrain.RecallVoteStartTime = GetGameTick()
     WaitTicks(VoteTime) -- may be interrupted if the vote closes or is canceled by an alliance break
 
@@ -160,6 +161,7 @@ local function RecallVotingThread(requestingArmy)
             SyncRecallStatus()
         end
         requestingBrain.RecallVoteCancelled = nil
+        LOG(GetGameTick(), 'Removing RecallVoteStartTime for ' .. requestingBrain.Nickname .. ' due to RecallVoteCancelled')
         requestingBrain.RecallVoteStartTime = nil
         requestingBrain.recallVotingThread = nil
         return
@@ -222,6 +224,7 @@ local function RecallVotingThread(requestingArmy)
         -- update UI once the cooldown dissipates
         SyncRecallStatus()
     end
+    LOG(GetGameTick(), 'Removing RecallVoteStartTime for ' .. requestingBrain.Nickname .. ' due to End of Recall Vote')
     requestingBrain.RecallVoteStartTime = nil
     requestingBrain.recallVotingThread = nil
 end
@@ -264,6 +267,7 @@ end
 local function ArmyRequestRecall(army, teammates)
     local brain = GetArmyBrain(army)
     if teammates > 0 then
+        LOG(GetGameTick(), 'Request recall for ', brain.Nickname)
         brain.recallVotingThread = ForkThread(RecallVotingThread, army)
         if ArmyVoteRecall(army, true, false) then
             SyncOpenRecallVote(teammates + 1, army)
@@ -377,6 +381,7 @@ local function GetRecallSyncTable()
 end
 
 function ResyncRecallVoting()
+    LOG(GetGameTick(), 'Resyncing recall vote', debug.traceback())
     local focus = GetFocusArmy()
     local teamSize = 0
     local yes, no = 0, 0

--- a/lua/sim/Recall.lua
+++ b/lua/sim/Recall.lua
@@ -150,8 +150,7 @@ end
 ---@param requestingArmy number
 local function RecallVotingThread(requestingArmy)
     local requestingBrain = GetArmyBrain(requestingArmy)
-    LOG(GetGameTick(), 'Setting RecallVoteStartTime for ' .. requestingBrain.Nickname)
-    requestingBrain.RecallVoteStartTime = GetGameTick()
+
     WaitTicks(VoteTime) -- may be interrupted if the vote closes or is canceled by an alliance break
 
     local focus = GetFocusArmy()
@@ -269,6 +268,8 @@ local function ArmyRequestRecall(army, teammates)
     if teammates > 0 then
         LOG(GetGameTick(), 'Request recall for ', brain.Nickname)
         brain.recallVotingThread = ForkThread(RecallVotingThread, army)
+        LOG(GetGameTick(), 'Setting RecallVoteStartTime for ' .. brain.Nickname)
+        brain.RecallVoteStartTime = GetGameTick()
         if ArmyVoteRecall(army, true, false) then
             SyncOpenRecallVote(teammates + 1, army)
         end


### PR DESCRIPTION
## Issue
Replay #25369183

When you spectate as Deribus:
```
warning: Error running lua script: ...\lua\sim\recall.lua(421): attempt to perform arithmetic on field `RecallVoteStartTime' (a nil value)
         stack traceback:
             ...\lua\sim\recall.lua(421): in function `ResyncRecallVoting'
             ...\lua\sim\recall.lua(50): in function <...\lua\sim\recall.lua:45>
             ...\lua\aibrain.lua(459): in function `OnDefeat'
             ...ua\sim\victorycondition\abstractvictorycondition.lua(296): in function `DefeatForArmy'
             ...\lua\sim\victorycondition\unitcondition.lua(73): in function `EvaluateVictoryCondition'
             ...ua\sim\victorycondition\abstractvictorycondition.lua(191): in function <...ua\sim\victorycondition\abstractvictorycondition.lua:189>
```

When you spectate as observer there is no error, but instead you get this after Legendlore dies and unit transfer is attempted:
```
warning: FactoryRebuildUnits failed to rebuild correctly for factory zrb9502 (entity ID 2097364).    
warning: Rebuild data:    
warning: Progress: 0.043077    
warning: BuildTime: 28.000002    
warning: Health: 17.799999
```
the rebuild fails because there is no HQ to permit unit construction.

After this, the game desyncs. Notice that the two teams and observers all have different checksums:
```
warning: Checksum for beat 9050 mismatched: a8e3ba92938b112c983aeae159318e8c (sim) != 3694b46352a8f4a50546d6ce826018c0 (TeslaMax).
warning: Checksum for beat 9050 mismatched: a8e3ba92938b112c983aeae159318e8c (sim) != 3694b46352a8f4a50546d6ce826018c0 (Deribus).
warning: Checksum for beat 9050 mismatched: a8e3ba92938b112c983aeae159318e8c (sim) != 3694b46352a8f4a50546d6ce826018c0 (masterofseasons).
warning: Checksum for beat 9050 mismatched: a8e3ba92938b112c983aeae159318e8c (sim) != 3694b46352a8f4a50546d6ce826018c0 (Ledgendlore2).
warning: Desync at beat 9056 tick 905.70001220703
warning: Checksum for beat 9100 mismatched: 0de7fef589399a5f33eed2f0981e5b5c (sim) != ccfb5d939a661d9badd8744ec8d12c53 (Nomander).
warning: Checksum for beat 9100 mismatched: 0de7fef589399a5f33eed2f0981e5b5c (sim) != ccfb5d939a661d9badd8744ec8d12c53 (Yeagerist-).
warning: Checksum for beat 9100 mismatched: 0de7fef589399a5f33eed2f0981e5b5c (sim) != 6847bc39bb476c7f1321cf6368f38ddf (TeslaMax).
warning: Checksum for beat 9100 mismatched: 0de7fef589399a5f33eed2f0981e5b5c (sim) != ccfb5d939a661d9badd8744ec8d12c53 (Mutzo).
warning: Checksum for beat 9100 mismatched: 0de7fef589399a5f33eed2f0981e5b5c (sim) != 6847bc39bb476c7f1321cf6368f38ddf (Deribus).
warning: Checksum for beat 9100 mismatched: 0de7fef589399a5f33eed2f0981e5b5c (sim) != ccfb5d939a661d9badd8744ec8d12c53 (BJ).
warning: Checksum for beat 9100 mismatched: 0de7fef589399a5f33eed2f0981e5b5c (sim) != 6847bc39bb476c7f1321cf6368f38ddf (masterofseasons).
warning: Checksum for beat 9100 mismatched: 0de7fef589399a5f33eed2f0981e5b5c (sim) != ccfb5d939a661d9badd8744ec8d12c53 (snowy801).
warning: Checksum for beat 9100 mismatched: 0de7fef589399a5f33eed2f0981e5b5c (sim) != 6847bc39bb476c7f1321cf6368f38ddf (Ledgendlore2).
warning: Desync at beat 9103 tick 910.40032958984
warning: Desync at beat 9106 tick 910.70098876953
```
Spectating as Nomander:
```
warning: Checksum for beat 9050 mismatched: a8e3ba92938b112c983aeae159318e8c (sim) != 3694b46352a8f4a50546d6ce826018c0 (TeslaMax).
warning: Checksum for beat 9050 mismatched: a8e3ba92938b112c983aeae159318e8c (sim) != 3694b46352a8f4a50546d6ce826018c0 (Deribus).
warning: Checksum for beat 9050 mismatched: a8e3ba92938b112c983aeae159318e8c (sim) != 3694b46352a8f4a50546d6ce826018c0 (masterofseasons).
warning: Checksum for beat 9050 mismatched: a8e3ba92938b112c983aeae159318e8c (sim) != 3694b46352a8f4a50546d6ce826018c0 (Ledgendlore2).
warning: Desync at beat 9056 tick 905.70001220703
warning: Checksum for beat 9100 mismatched: ccfb5d939a661d9badd8744ec8d12c53 (sim) != 6847bc39bb476c7f1321cf6368f38ddf (TeslaMax).
warning: Checksum for beat 9100 mismatched: ccfb5d939a661d9badd8744ec8d12c53 (sim) != 6847bc39bb476c7f1321cf6368f38ddf (Deribus).
warning: Checksum for beat 9100 mismatched: ccfb5d939a661d9badd8744ec8d12c53 (sim) != 6847bc39bb476c7f1321cf6368f38ddf (masterofseasons).
warning: Checksum for beat 9100 mismatched: ccfb5d939a661d9badd8744ec8d12c53 (sim) != 6847bc39bb476c7f1321cf6368f38ddf (Ledgendlore2).
warning: Desync at beat 9106 tick 910.70001220703
```

After some logging:
```
INFO: 8940    Request recall for     Deribus
INFO: 8941    Resyncing recall vote    Traceback: ...\lua\sim\recall.lua:45
WARNING: Error running lua script: ...\lua\sim\recall.lua(428): attempt to perform arithmetic on field `RecallVoteStartTime' (a nil value)
         stack traceback:
             ...\lua\sim\recall.lua(428): in function `ResyncRecallVoting'
             ...\lua\sim\recall.lua(50): in function <...\lua\sim\recall.lua:45>
             ...\lua\aibrain.lua(459): in function `OnDefeat'
             ...ua\sim\victorycondition\abstractvictorycondition.lua(296): in function `DefeatForArmy'
             ...\lua\sim\victorycondition\unitcondition.lua(73): in function `EvaluateVictoryCondition'
             ...ua\sim\victorycondition\abstractvictorycondition.lua(191): in function <...ua\sim\victorycondition\abstractvictorycondition.lua:189>
INFO: 8941    Setting RecallVoteStartTime for Deribus
```
I guess the issue is that 
1. the recall thread takes 1 tick to start due to the behavior of ForkThread.
2. The `brain.recallVotingThread` is assigned when the thread is created
3. `brain.RecallVoteStartTime` is assigned from within the thread.

## Description of the proposed changes
Assign RecallVoteStartTime when the thread is created, instead of within the thread.

## Testing done on the proposed changes
Run the replay on deploy/faf (or version 3824 in the future), and see that it desyncs in the same way as in the issue.
Cherry pick the changes to a copy of deploy/faf, and see that it no longer desyncs with the non-recalling team's players from all three perspectives (observer, non-recalling player, recalling player).

Replay's first desyncs as observer after cherry picking the changes:
```
WARNING: Checksum for beat 9050 mismatched: a8e3ba92938b112c983aeae159318e8c (sim) != 3694b46352a8f4a50546d6ce826018c0 (TeslaMax).
WARNING: Checksum for beat 9050 mismatched: a8e3ba92938b112c983aeae159318e8c (sim) != 3694b46352a8f4a50546d6ce826018c0 (Deribus).
WARNING: Checksum for beat 9050 mismatched: a8e3ba92938b112c983aeae159318e8c (sim) != 3694b46352a8f4a50546d6ce826018c0 (masterofseasons).
WARNING: Checksum for beat 9050 mismatched: a8e3ba92938b112c983aeae159318e8c (sim) != 3694b46352a8f4a50546d6ce826018c0 (Ledgendlore2).
WARNING: Desync at beat 9056 tick 905.70001220703
WARNING: Checksum for beat 9100 mismatched: ccfb5d939a661d9badd8744ec8d12c53 (sim) != 6847bc39bb476c7f1321cf6368f38ddf (TeslaMax).
WARNING: Checksum for beat 9100 mismatched: ccfb5d939a661d9badd8744ec8d12c53 (sim) != 6847bc39bb476c7f1321cf6368f38ddf (Deribus).
WARNING: Checksum for beat 9100 mismatched: ccfb5d939a661d9badd8744ec8d12c53 (sim) != 6847bc39bb476c7f1321cf6368f38ddf (masterofseasons).
WARNING: Checksum for beat 9100 mismatched: ccfb5d939a661d9badd8744ec8d12c53 (sim) != 6847bc39bb476c7f1321cf6368f38ddf (Ledgendlore2).
WARNING: Desync at beat 9106 tick 910.70001220703
```

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
