### PR TITLE
Remove the Seraphim Lightning Tank's `FiringTolerance`

### DIFF
--- a/changelog/snippets/balance.6900.md
+++ b/changelog/snippets/balance.6900.md
@@ -1,0 +1,5 @@
+- (#6900) Remove the Seraphim Lightning Tank's `FiringTolerance`, as it could have caused the unit to miss aircraft. Functionally, the unit remains unchanged.
+
+  **Uyanah: T3 Lightning Tank (DSLK004):**
+  - Lightning Projector (anti-air)
+    - FiringTolerance: 2 --> 0

--- a/units/DSLK004/DSLK004_unit.bp
+++ b/units/DSLK004/DSLK004_unit.bp
@@ -246,7 +246,7 @@ UnitBlueprint{
             DisplayName = "Lightning Projector",
             FireTargetLayerCapsTable = { Land = "Air" },
             FiringRandomness = 0,
-            FiringTolerance = 2,
+            FiringTolerance = 0,
             Label = "PhasonBeamAir",
             LeadTarget = false,
             MaxRadius = 58,


### PR DESCRIPTION
## Description of the proposed changes
Beam weapons should not have firing tolerances. I assume the firing tolerance could have caused the unit to miss aircraft occasionally, but this is next to impossible to test offline. There should be no adverse consequences to removing it, so it's a best practice to do so.

## Checklist
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).