### PR TITLE
Nerf the Seraphim T3 Submarine Hunter and make larger formations of it less oppressive pt. 3

### DIFF
--- a/changelog/snippets/balance.6903.md
+++ b/changelog/snippets/balance.6903.md
@@ -1,0 +1,11 @@
+- (#6903) While previous nerfs have greatly reduced the oppressiveness of the Seraphim T3 Submarine Hunter, it is evident that it remains overtuned, particularly concerning its defensive capabilities. Accordingly, its health and torpedo defenses are nerfed to allow for more counterplay with Coopers, Destroyers, other subs, and torpedo bombers. It regains some of the speed it lost in (#6584), to make it feel less sluggish to use and emphasize micro.
+
+  **Yathsou: T3 Submarine Hunter (XSS0304):**
+  - Physics
+    - MaxSpeed: 4.6 --> 4.8
+    - MaxSpeedReverse: 4.6 --> 4.8
+    - MaxSteerForce: 4.6 --> 4.8
+  - Defense
+    - Health: 4000 --> 3600
+  - Ajellu Anti-Torpedo Defense (x2)
+    - Reload: 10s --> 12s

--- a/units/XSS0304/XSS0304_unit.bp
+++ b/units/XSS0304/XSS0304_unit.bp
@@ -43,8 +43,8 @@ UnitBlueprint{
     Defense = {
         AirThreatLevel = 20,
         ArmorType = "Normal",
-        Health = 4000,
-        MaxHealth = 4000,
+        Health = 3600,
+        MaxHealth = 3600,
         SubThreatLevel = 34,
     },
     Display = {
@@ -178,9 +178,9 @@ UnitBlueprint{
         Elevation = -1.5,
         MaxAcceleration = 5.5,
         MaxBrake = 5.5,
-        MaxSpeed = 4.6,
-        MaxSpeedReverse = 4.6,
-        MaxSteerForce = 4.6,
+        MaxSpeed = 4.8,
+        MaxSpeedReverse = 4.8,
+        MaxSteerForce = 4.8,
         MeshExtentsX = 0.6,
         MeshExtentsY = 0.65,
         MeshExtentsZ = 2.5,
@@ -301,7 +301,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_Countermeasure",
-            RateOfFire = 10/100, --10/integer interval in ticks
+            RateOfFire = 10/120, --10/integer interval in ticks
             TargetRestrictDisallow = "UNTARGETABLE",
             TargetRestrictOnlyAllow = "TORPEDO",
             TargetType = "RULEWTT_Projectile",
@@ -360,7 +360,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_Countermeasure",
-            RateOfFire = 10/100, --10/integer interval in ticks
+            RateOfFire = 10/120, --10/integer interval in ticks
             TargetRestrictDisallow = "UNTARGETABLE",
             TargetRestrictOnlyAllow = "TORPEDO",
             TargetType = "RULEWTT_Projectile",


### PR DESCRIPTION
## Description of the proposed changes
While previous nerfs have greatly reduced the oppressiveness of the Seraphim T3 Submarine Hunter, it is evident that it remains overtuned, particularly concerning its defensive capabilities. Accordingly, its health and torpedo defenses are nerfed to allow for more counterplay with Coopers, Destroyers, other subs, and torpedo bombers. It regains some of the speed it lost in (#6584), to make it feel less sluggish to use and emphasize micro.

**Yathsou: T3 Submarine Hunter (XSS0304):**
- Physics
  - MaxSpeed: 4.6 --> 4.8
  - MaxSpeedReverse: 4.6 --> 4.8
  - MaxSteerForce: 4.6 --> 4.8
- Defense
  - Health: 4000 --> 3600
- Ajellu Anti-Torpedo Defense (x2)
  - Reload: 10s --> 12s

## Additional context
|   | Yathsou     | Yathsou (new) |  Barracuda | Vesper  |
| -------------- | --------------- | ------------ | -------- | ------ |
| HP per mass | 1.333               | 1.2              |1.3         | 1.636 |

## Checklist
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).