### PR TITLE
Fix an edge case where announcements would break cinematics

### DIFF
--- a/changelog/snippets/fix.6905.md
+++ b/changelog/snippets/fix.6905.md
@@ -1,0 +1,1 @@
+- (#6905) Fix an edge case where announcements would break cinematic mode

--- a/lua/ui/game/announcement/AbstractAnnouncement.lua
+++ b/lua/ui/game/announcement/AbstractAnnouncement.lua
@@ -300,11 +300,12 @@ AbstractAnnouncement = ClassUI(Group) {
         ---@type LazyVar
         local animationProgress = CreateLazyVar(0)
 
-        -- use last known position of control if it is destroyed, this happens when you fail an objective.
-        local controlTopValue = control.Top()
-        local controlBottomValue = control.Bottom()
-        local controlLeftValue = control.Left()
-        local controlRightValue = control.Right()
+        -- use last known position of control if it is destroyed, this happens when you fail an objective. 
+        -- we can't initialize it with the position of the control as it may not be layout correctly yet.
+        local controlTopValue = 0
+        local controlBottomValue = 0
+        local controlLeftValue = 0
+        local controlRightValue = 0
 
         background.Top:Set(
             function()


### PR DESCRIPTION
## Description of the proposed changes

Fix an edge case where an announcement would break.

There's no guarantee that the control is layout before the animation starts. These values act as a 'last known place'. Initializing with 0 means that if the control is never valid (destroyed immediately, for example) the animation will originate from the top-left corner.

## Testing done on the proposed changes

Start the campaign map Black Day and watch it successfully finish the cinematic.


## Additional context

Related pull requests:

- https://github.com/FAForever/fa/pull/6845 (where the bug occured)
- https://github.com/FAForever/fa/pull/6813 (re-implementation of announcements to make it more flexible)

With thanks to @lL1l1 for his time and effort to help find this.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
