### PR TITLE
Fine-tune the LOD levels of the Evergreen tree groups to improve visibility

### DIFF
--- a/env/Evergreen/Props/Trees/Groups/Pine06_Big_GroupA_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Pine06_Big_GroupA_prop.bp
@@ -2,6 +2,7 @@ PropBlueprint{
     Categories = {
         "OBSTRUCTSBUILDING",
         "RECLAIMABLE",
+        "USEBLUEPRINTLOD",
     },
     Defense = {
         Health = 50,
@@ -24,7 +25,7 @@ PropBlueprint{
                     NormalsName = "../Pine06_normalsTS.dds",
                 },
                 {
-                    LODCutoff = 330,
+                    LODCutoff = 600,
                     ShaderName = "VertexNormal",
                     AlbedoName = "Pine06_Big_GroupA_LOD2_albedo.dds",
                 },

--- a/env/Evergreen/Props/Trees/Groups/Pine06_Big_GroupB_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Pine06_Big_GroupB_prop.bp
@@ -2,6 +2,7 @@ PropBlueprint{
     Categories = {
         "OBSTRUCTSBUILDING",
         "RECLAIMABLE",
+        "USEBLUEPRINTLOD",
     },
     Defense = {
         Health = 50,
@@ -24,7 +25,7 @@ PropBlueprint{
                     NormalsName = "../Pine06_normalsTS.dds",
                 },
                 {
-                    LODCutoff = 330,
+                    LODCutoff = 600,
                     ShaderName = "VertexNormal",
                     AlbedoName = "Pine06_Big_GroupB_LOD2_albedo.dds",
                 },

--- a/env/Evergreen/Props/Trees/Groups/Pine06_GroupA_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Pine06_GroupA_prop.bp
@@ -2,6 +2,7 @@ PropBlueprint{
     Categories = {
         "OBSTRUCTSBUILDING",
         "RECLAIMABLE",
+        "USEBLUEPRINTLOD",
     },
     Defense = {
         Health = 50,
@@ -24,7 +25,7 @@ PropBlueprint{
                     NormalsName = "../Pine06_normalsTS.dds",
                 },
                 {
-                    LODCutoff = 330,
+                    LODCutoff = 600,
                     ShaderName = "VertexNormal",
                     AlbedoName = "Pine06_GroupA_LOD2_albedo.dds",
                 },

--- a/env/Evergreen/Props/Trees/Groups/Pine06_GroupB_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Pine06_GroupB_prop.bp
@@ -2,6 +2,7 @@ PropBlueprint{
     Categories = {
         "OBSTRUCTSBUILDING",
         "RECLAIMABLE",
+        "USEBLUEPRINTLOD",
     },
     Defense = {
         Health = 50,
@@ -24,7 +25,7 @@ PropBlueprint{
                     NormalsName = "../Pine06_normalsTS.dds",
                 },
                 {
-                    LODCutoff = 330,
+                    LODCutoff = 600,
                     ShaderName = "VertexNormal",
                     AlbedoName = "Pine06_GroupB_LOD2_albedo.dds",
                 },

--- a/env/Evergreen/Props/Trees/Groups/Pine07_GroupA_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Pine07_GroupA_prop.bp
@@ -2,6 +2,7 @@ PropBlueprint{
     Categories = {
         "OBSTRUCTSBUILDING",
         "RECLAIMABLE",
+        "USEBLUEPRINTLOD",
     },
     Defense = {
         Health = 50,
@@ -24,7 +25,7 @@ PropBlueprint{
                     NormalsName = "../Pine07_normalsTS.dds",
                 },
                 {
-                    LODCutoff = 330,
+                    LODCutoff = 600,
                     ShaderName = "VertexNormal",
                     AlbedoName = "Pine07_GroupA_LOD2_albedo.dds",
                 },

--- a/env/Evergreen/Props/Trees/Groups/Pine07_GroupB_prop.bp
+++ b/env/Evergreen/Props/Trees/Groups/Pine07_GroupB_prop.bp
@@ -2,6 +2,7 @@ PropBlueprint{
     Categories = {
         "OBSTRUCTSBUILDING",
         "RECLAIMABLE",
+        "USEBLUEPRINTLOD",
     },
     Defense = {
         Health = 50,
@@ -24,7 +25,7 @@ PropBlueprint{
                     NormalsName = "../Pine07_normalsTS.dds",
                 },
                 {
-                    LODCutoff = 330,
+                    LODCutoff = 600,
                     ShaderName = "VertexNormal",
                     AlbedoName = "Pine07_GroupB_LOD2_albedo.dds",
                 },


### PR DESCRIPTION
## Description of the proposed changes
This PR aims to restore the visibility of tree groups at medium zoom levels by rendering their last LOD level earlier. Essentially, the "placement" of the last LOD level is returned to where it was before patch 3825.

Requires #6906 to function.

## Screenshots
### Current (since patch 3825)
![LOD_current](https://github.com/user-attachments/assets/ef4700e7-7db3-4ce7-a83d-371b821677f8)

### This PR (emulates patch 3824 and before):
![LOD_new_old](https://github.com/user-attachments/assets/8015aafa-5762-45d0-91f0-4b32100e7108)

## Checklist
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).