### PR TITLE
Improve implementation of fix for unbuilt units not being destroyed in factories when mobile build orders are cancelled

### DIFF
--- a/changelog/snippets/fix.6913.md
+++ b/changelog/snippets/fix.6913.md
@@ -1,0 +1,1 @@
+- (#6913) Improve implementation of the edge case fix from #6700 related to using mobile build orders on factories.

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2386,6 +2386,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     ---@param layer Layer
     ---@return boolean
     OnStopBeingBuilt = function(self, builder, layer)
+        self:DebugLog('OnStopBeingBuilt', GetGameTick(), debug.traceback())
         if self.Dead or self:BeenDestroyed() then -- Sanity check, can prevent strange shield bugs and stuff
             self:Kill()
             return false
@@ -2537,6 +2538,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
 
     ---@param self Unit
     OnFailedToBeBuilt = function(self)
+        self:DebugLog('OnFailedToBeBuilt', GetGameTick(), debug.traceback())
         self:ForkThread(function()
             WaitTicks(1)
             if self.Dead then return end
@@ -2914,6 +2916,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     ---@param built Unit
     ---@param order string
     OnStopBuild = function(self, built, order)
+        self:DebugLog('OnStopBuild')
         self:StopBuildingEffects(built)
         self:SetActiveConsumptionInactive()
         self:DoOnUnitBuiltCallbacks(built)
@@ -2932,6 +2935,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
 
     ---@param self Unit
     OnFailedToBuild = function(self)
+        self:DebugLog('OnFailedToBuild')
         self:DoOnFailedToBuildCallbacks()
         self:StopUnitAmbientSound('ConstructLoop')
     end,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2536,6 +2536,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         self.OnBeingBuiltEffectsBag:Destroy()
     end,
 
+    --- Called by the engine when the unit's factory's build order is cancelled.
     ---@param self Unit
     OnFailedToBeBuilt = function(self)
         self:DebugLog('OnFailedToBeBuilt', GetGameTick(), debug.traceback())
@@ -2912,9 +2913,10 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         return true
     end,
 
+    --- Called by the engine when the unit finishes a build order or cancels a mobile build order.
     ---@param self Unit
     ---@param built Unit
-    ---@param order string
+    ---@param order BuildOrderType
     OnStopBuild = function(self, built, order)
         self:DebugLog('OnStopBuild')
         self:StopBuildingEffects(built)
@@ -2933,6 +2935,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         self.Brain:OnUnitStopBuild(self, built, order)
     end,
 
+    --- Called by the engine when a build order is cancelled.
     ---@param self Unit
     OnFailedToBuild = function(self)
         self:DebugLog('OnFailedToBuild')

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -138,8 +138,10 @@ FactoryUnit = ClassUnit(StructureUnit) {
         end
 
         -- Factory can stop building but still have an unbuilt unit if a mobile build order is issued and the order is cancelled
-        if unitBeingBuilt:GetFractionComplete() < 1 then
-            unitBeingBuilt:Destroy()
+        if not unitBeingBuilt.isFinishedUnit and not self.FactoryBuildFailed then
+            unitBeingBuilt:OnFailedToBeBuilt()
+            self:OnFailedToBuild()
+            return
         end
 
         if not (self.FactoryBuildFailed or IsDestroyed(self)) then

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -123,9 +123,10 @@ FactoryUnit = ClassUnit(StructureUnit) {
     end,
 
     --- Introduce a rolloff delay, where defined.
+    --- Called by the engine when the unit finishes a build order or cancels a mobile build order.
     ---@param self FactoryUnit
     ---@param unitBeingBuilt Unit
-    ---@param order string
+    ---@param order BuildOrderType
     OnStopBuild = function(self, unitBeingBuilt, order)
         StructureUnitOnStopBuild(self, unitBeingBuilt, order)
 
@@ -198,6 +199,7 @@ FactoryUnit = ClassUnit(StructureUnit) {
         self:CreateBlinkingLights()
     end,
 
+    --- Called by the engine when a build order is cancelled.
     ---@param self FactoryUnit
     OnFailedToBuild = function(self)
         StructureUnitOnFailedToBuild(self)
@@ -258,7 +260,7 @@ FactoryUnit = ClassUnit(StructureUnit) {
 
     ---@param self FactoryUnit
     ---@param unitBeingBuilt Unit
-    ---@param order boolean
+    ---@param order BuildOrderType
     ---@param rollOffPointSpin number?
     FinishBuildThread = function(self, unitBeingBuilt, order, rollOffPointSpin)
         self:SetBusy(true)


### PR DESCRIPTION
## Description of the proposed changes
- Only run code for the edge case when the build does not fail but the unit is incomplete.
- Use proper callbacks instead of relying on the normal finish build behavior to stop build fx and destroying the unit manually

## Testing done on the proposed changes
Same as in #6700:

> An unfinished unit no longer remains in the factory after the mobile build order is cancelled.
> Copy-paste command for testing:
> ```
> CreateUnitAtMouse('urb0301', 0,    0.00,    0.00, -0.00000)
> ForkThread(function() 
> WaitTicks(10) 
> ConExecute('UI_SelectByCategory +nearest FACTORY CYBRAN TECH3')
> import('/lua/ui/game/commandmode.lua').StartCommandMode('build', {name = 'url0303'}) 
> end)
> ```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
