### PR TITLE
Fix weapons with fire rate modifiers getting stuck waiting for energy drain

### DIFF
--- a/changelog/snippets/fix.6915.md
+++ b/changelog/snippets/fix.6915.md
@@ -1,0 +1,1 @@
+- (#6915) Fix weapons with fire rate modifiers getting stuck waiting for energy drain.

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -30,6 +30,8 @@ local MathSqrt = math.sqrt
 ---@field SalvoSpreadStart? number   if the weapon blueprint requests a trajectory fix, this is set to the value that centers the projectile spread for `CurrentSalvoNumber` shot on the optimal target position
 ---@field WeaponPackState 'Packed' | 'Unpacked' | 'Unpacking' | 'Packing'
 ---@field EconDrain? moho.EconomyEvent
+---@field AdjEnergyMod number? # Energy drain multiplier from buffs
+---@field AdjRoFMod number? # Firerate multiplier from buffs
 DefaultProjectileWeapon = ClassWeapon(Weapon) {
 
     FxRackChargeMuzzleFlash = {},
@@ -416,7 +418,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
 
     -- Determine how much Energy is required to fire
     ---@param self DefaultProjectileWeapon
-    ---@return integer
+    ---@return number
     GetWeaponEnergyRequired = function(self)
         local weapNRG = (self.EnergyRequired or 0) * (self.AdjEnergyMod or 1)
         if weapNRG < 0 then
@@ -427,7 +429,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
 
     -- Determine how much Energy should be drained per second
     ---@param self DefaultProjectileWeapon
-    ---@return integer
+    ---@return number
     GetWeaponEnergyDrain = function(self)
         local weapNRG = (self.EnergyDrainPerSecond or 0) / (self.AdjRoFMod or 1) * (self.AdjEnergyMod or 1)
         return weapNRG

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -429,7 +429,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
     ---@param self DefaultProjectileWeapon
     ---@return integer
     GetWeaponEnergyDrain = function(self)
-        local weapNRG = (self.EnergyDrainPerSecond or 0) * (self.AdjEnergyMod or 1)
+        local weapNRG = (self.EnergyDrainPerSecond or 0) / (self.AdjRoFMod or 1) * (self.AdjEnergyMod or 1)
         return weapNRG
     end,
 


### PR DESCRIPTION
## Issue
Weapons with too high fire rate bonus can get stuck waiting for their energy drain because the fire rate isn't considered in the drain/s of the economy event.
This issue arose in the past with the Salvation. It was fixed previously by increasing the drain in the blueprint, but I found it again in a mod because mods use old blueprints to override everything.

## Description of the proposed changes
Increase energy drain/s proportional to fire rate changes.

## Testing done on the proposed changes
Spawn a UEF T3 artillery and 9 adjacent T3 pgens (use spawn menu's unit count selection to stack them). It should fire when the work progress bar is full instead of pausing for a few seconds (I assume that's a target check interval).

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
