### PR TITLE
Allow queuing Aeon shield upgrades before it is built

### DIFF
--- a/changelog/snippets/fix.6916.md
+++ b/changelog/snippets/fix.6916.md
@@ -1,0 +1,1 @@
+- (#6916) Fix not being able to queue the upgrade for the Aeon T2 shield before it is built.

--- a/units/UAB4202/UAB4202_script.lua
+++ b/units/UAB4202/UAB4202_script.lua
@@ -38,6 +38,23 @@ UAB4202 = ClassUnit(AShieldStructureUnit, ShieldEffectsComponent) {
         self.ShieldEnabled = false
     end,
 
+    ---@param self AShieldStructureUnit
+    ---@param builder Unit
+    ---@param layer Layer
+    OnStopBeingBuilt = function (self, builder, layer)
+        AShieldStructureUnit.OnStopBeingBuilt(self, builder, layer)
+
+        local trash = self.Trash
+
+        local orbManip1 = CreateRotator(self, 'Orb', '-x', nil, 0, 45, 45)
+        TrashBagAdd(trash, orbManip1)
+        self.OrbManip1 = orbManip1
+
+        local orbManip2 = CreateRotator(self, 'Orb', 'z', nil, 0, 45, 45)
+        TrashBagAdd(trash, orbManip2)
+        self.OrbManip2 = orbManip2
+    end,
+
     ---@param self UAB4202
     OnShieldEnabled = function(self)
         AShieldStructureUnit.OnShieldEnabled(self)
@@ -46,14 +63,8 @@ UAB4202 = ClassUnit(AShieldStructureUnit, ShieldEffectsComponent) {
             effect:OffsetEmitter(0, -2.2, 0)
         end
 
-        local trash = self.Trash
-
         local orbManip1 = self.OrbManip1
-        if not orbManip1 then
-            orbManip1 = CreateRotator(self, 'Orb', '-x', nil, 0, 45, 45)
-            TrashBagAdd(trash, orbManip1)
-            self.OrbManip1 = orbManip1
-        else
+        if orbManip1 then
             -- Spin down very quickly since the rotator bugs out with the upgrade animation
             if self:IsUnitState('Upgrading') then
                 orbManip1:SetSpinDown(true)
@@ -65,11 +76,7 @@ UAB4202 = ClassUnit(AShieldStructureUnit, ShieldEffectsComponent) {
         end
 
         local orbManip2 = self.OrbManip2
-        if not orbManip2 then
-            orbManip2 = CreateRotator(self, 'Orb', 'z', nil, 0, 45, 45)
-            TrashBagAdd(trash, orbManip2)
-            self.OrbManip2 = orbManip2
-        else
+        if orbManip2 then
             -- Spin down very quickly since the rotator bugs out with the upgrade animation
             if self:IsUnitState('Upgrading') then
                 orbManip2:SetSpinDown(true)

--- a/units/UAB4202/UAB4202_unit.bp
+++ b/units/UAB4202/UAB4202_unit.bp
@@ -18,6 +18,7 @@ UnitBlueprint{
         "BUILTBYTIER2ENGINEER",
         "BUILTBYTIER3COMMANDER",
         "BUILTBYTIER3ENGINEER",
+        "CQUEMOV",
         "DEFENSE",
         "DRAGBUILD",
         "OVERLAYDEFENSE",


### PR DESCRIPTION
## Issue
Reported on a forum post: https://forum.faforever.com/topic/9462/new-t2-aeon-shield-is-unselectable-until-built
Aeon shield is unselectable until built, unlike other upgradable T2 shields.

## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
- Adds CQUEMOV category to allow selecting it and issuing orders before it is finished.
- Fixes animation when the upgrade is pre-queued.

## Testing done on the proposed changes
Spawn a builder, make an Aeon T2 shield, and queue the upgrade before it is finished and see that everything is ok.
```
   CreateUnitAtMouse('ual0301_ras', 0,    0.00,    0.00, -0.00000)
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
