### PR TITLE
Fix unkillable recalling ACU when a player disconnects in the middle of recall

### DIFF
--- a/changelog/snippets/fix.6919.md
+++ b/changelog/snippets/fix.6919.md
@@ -1,0 +1,1 @@
+- (#6919) Fix ACUs being unkillable if their player disconnects in the middle of a recall.

--- a/lua/EffectUtilities.lua
+++ b/lua/EffectUtilities.lua
@@ -1040,7 +1040,6 @@ function PlayTeleportChargingEffects(unit, teleDest, effectsBag, teleDelay)
     end
 
     if teleDelay then
-        LOG('tele delay is ', teleDelay)
         WaitSeconds(teleDelay)
     end
 
@@ -1120,8 +1119,6 @@ function PlayTeleportChargingEffects(unit, teleDest, effectsBag, teleDelay)
             teleportDestFxEntity:Destroy()
         end
     end
-
-    LOG(unit.Brain.Nickname, 'play tele charge end')
 end
 
 --- Gets a unit's teleport effect y-offset, so it appears centered

--- a/lua/EffectUtilities.lua
+++ b/lua/EffectUtilities.lua
@@ -1040,6 +1040,7 @@ function PlayTeleportChargingEffects(unit, teleDest, effectsBag, teleDelay)
     end
 
     if teleDelay then
+        LOG('tele delay is ', teleDelay)
         WaitSeconds(teleDelay)
     end
 
@@ -1119,6 +1120,8 @@ function PlayTeleportChargingEffects(unit, teleDest, effectsBag, teleDelay)
             teleportDestFxEntity:Destroy()
         end
     end
+
+    LOG(unit.Brain.Nickname, 'play tele charge end')
 end
 
 --- Gets a unit's teleport effect y-offset, so it appears centered

--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -942,12 +942,6 @@ end
 ---@param units Unit[]
 ---@param destroyUnits? boolean
 function FakeTeleportUnits(units, destroyUnits)
-    local brain = units[1].Brain.Nickname
-    LOG(string.format('brain %s: Fake teleporting %d units, and destroy is %s'
-        , brain
-        , table.getn(units)
-        , tostring(destroyUnits))
-    )
     IssueStop(units)
     IssueClearCommands(units)
     local buildingUnits = {}
@@ -958,46 +952,33 @@ function FakeTeleportUnits(units, destroyUnits)
             if unit:GetFractionComplete() < 1 then
                 buildingUnits[unit] = true
             else
-                LOG(brain, 'play tele charge')
                 unit:PlayTeleportChargeEffects(unit:GetPosition(), unit:GetOrientation())
-                LOG(brain, 'play tele charge sound')
                 unit:PlayUnitSound('GateCharge')
             end
         end
     end
-    LOG(brain, 'finished tele charge')
 
     WaitSeconds(2)
 
-    LOG(brain, 'start tele out', table.getsize(units))
-    for _, unit in pairs(units) do
+    for _, unit in units do
         if not IsDestroyed(unit) then
             if not buildingUnits[unit] then
-                LOG(brain, 'clean up tele')
                 unit:CleanupTeleportChargeEffects()
                 unit:PlayUnitSound('GateOut')
             end
-            LOG(brain, 'play tele out')
             unit:PlayTeleportOutEffects()
-        else
-            unit:DebugLog(brain, 'unit is destroyed')
         end
     end
 
     WaitSeconds(1)
 
     if destroyUnits then
-        LOG(brain, 'count of units to destroy:', table.getsize(units))
-        for _, unit in pairs(units) do
+        for _, unit in units do
             if not IsDestroyed(unit) then
-                unit:DebugLog(brain, 'destroying unit')
                 unit:Destroy()
-            else
-                unit:DebugLog(brain, 'Unit is already destroyed')
             end
         end
     end
-    LOG(brain, 'fake tele end')
 end
 
 --- Plays teleport effects for a unit

--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -942,6 +942,12 @@ end
 ---@param units Unit
 ---@param destroyUnits? boolean
 function FakeTeleportUnits(units, destroyUnits)
+    local brain = units[1].Brain.Nickname
+    LOG(string.format('brain %s: Fake teleporting %d units, and destroy is %s'
+        , brain
+        , table.getn(units)
+        , tostring(destroyUnits))
+    )
     IssueStop(units)
     IssueClearCommands(units)
     local buildingUnits = {}
@@ -952,33 +958,46 @@ function FakeTeleportUnits(units, destroyUnits)
             if unit:GetFractionComplete() < 1 then
                 buildingUnits[unit] = true
             else
+                LOG(brain, 'play tele charge')
                 unit:PlayTeleportChargeEffects(unit:GetPosition(), unit:GetOrientation())
+                LOG(brain, 'play tele charge sound')
                 unit:PlayUnitSound('GateCharge')
             end
         end
     end
+    LOG(brain, 'finished tele charge')
 
     WaitSeconds(2)
 
-    for _, unit in units do
+    LOG(brain, 'start tele out', table.getsize(units))
+    for _, unit in pairs(units) do
         if not IsDestroyed(unit) then
             if not buildingUnits[unit] then
+                LOG(brain, 'clean up tele')
                 unit:CleanupTeleportChargeEffects()
                 unit:PlayUnitSound('GateOut')
             end
+            LOG(brain, 'play tele out')
             unit:PlayTeleportOutEffects()
+        else
+            unit:DebugLog(brain, 'unit is destroyed')
         end
     end
 
     WaitSeconds(1)
 
     if destroyUnits then
-        for _, unit in units do
+        LOG(brain, 'count of units to destroy:', table.getsize(units))
+        for _, unit in pairs(units) do
             if not IsDestroyed(unit) then
+                unit:DebugLog(brain, 'destroying unit')
                 unit:Destroy()
+            else
+                unit:DebugLog(brain, 'Unit is already destroyed')
             end
         end
     end
+    LOG(brain, 'fake tele end')
 end
 
 --- Plays teleport effects for a unit

--- a/lua/ScenarioFramework.lua
+++ b/lua/ScenarioFramework.lua
@@ -939,7 +939,7 @@ function FakeTeleportUnit(unit, destroyUnit)
 end
 
 --- Run teleport effect and then optionally delete the units. The 'CanBeKilled' flag remains false if the units are not deleted
----@param units Unit
+---@param units Unit[]
 ---@param destroyUnits? boolean
 function FakeTeleportUnits(units, destroyUnits)
     local brain = units[1].Brain.Nickname

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -562,7 +562,7 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
     ---@param self AIBrain
     RecallAllCommanders = function(self)
         local commandCat = categories.COMMAND + categories.SUBCOMMANDER
-        self:ForkThread(self.RecallArmyThread, self:GetListOfUnits(commandCat, false))
+        ForkThread(self.RecallArmyThread, self, self:GetListOfUnits(commandCat, false))
     end,
 
     ---@param self AIBrain

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -474,7 +474,6 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
     ---@param self AIBrain
     AbandonedByPlayer = function(self)
         if not IsGameOver() then
-            LOG(GetGameTick(), self.Nickname, 'has been abandoned.')
             self.Status = 'Defeat'
 
             import("/lua/simutils.lua").UpdateUnitCap(self:GetArmyIndex())
@@ -511,10 +510,7 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
                     end
                 else
                     -- explode all the ACUs so they don't get shared
-                    LOG('trying to kill acus for ', self.Nickname)
-                    LOG('there are ', table.getsize(commanders))
                     for _, com in commanders do
-                        com:DebugLog('Killed by aibrain abandonment; can we be killed? ', com.CanBeKilled)
                         com:Kill()
                     end
                 end

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -474,6 +474,7 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
     ---@param self AIBrain
     AbandonedByPlayer = function(self)
         if not IsGameOver() then
+            LOG(GetGameTick(), self.Nickname, 'has been abandoned.')
             self.Status = 'Defeat'
 
             import("/lua/simutils.lua").UpdateUnitCap(self:GetArmyIndex())
@@ -510,7 +511,10 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
                     end
                 else
                     -- explode all the ACUs so they don't get shared
+                    LOG('trying to kill acus for ', self.Nickname)
+                    LOG('there are ', table.getsize(commanders))
                     for _, com in commanders do
+                        com:DebugLog('Killed by aibrain abandonment; can we be killed? ', com.CanBeKilled)
                         com:Kill()
                     end
                 end

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4872,12 +4872,12 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     end,
 
     ---@param self Unit
-    ---@param location Vector
+    ---@param destination Vector
     ---@param orientation Quaternion
     ---@param teleDelay? number
-    PlayTeleportChargeEffects = function(self, location, orientation, teleDelay)
+    PlayTeleportChargeEffects = function(self, destination, orientation, teleDelay)
         self.TeleportFxBag = self.TeleportFxBag or TrashBag()
-        EffectUtilities.PlayTeleportChargingEffects(self, location, self.TeleportFxBag, teleDelay)
+        EffectUtilities.PlayTeleportChargingEffects(self, destination, self.TeleportFxBag, teleDelay)
     end,
 
     ---@param self Unit


### PR DESCRIPTION
## Issue
The recall thread makes the recalling units unkillable for the duration of the thread, and then destroys them. The thread was also added to the brain's trash automatically through `AIBrain:ForkThread`. Defeat and abandonment immediately clear the brain's trash, which kills the recall thread since it is in the trash, and since the recalling thread is killed, the unit is stuck in an unkillable state and is not destroyed anywhere like it should be.

## Description of the proposed changes
Move the recall thread out of the brain's trash.

## Testing done on the proposed changes
In replay 25526515 Jokr now recalls properly (time is ~14:37). Here is the debug logging (notice that he abandoned in the middle of the recall thread, which was causing the bug without these changes):
```
debug: Recalling team Spreafico, Jokr at the request of Jokr (vote passed 2 to 0 [0 abstained] )
info: brain Spreafico: Fake teleporting 1 units, and destroy is true
info: Spreafico	play tele charge
info: Spreafico	play tele charge end
info: Spreafico	play tele charge sound
info: Spreafico	finished tele charge
info: brain Jokr: Fake teleporting 1 units, and destroy is true
info: Jokr	play tele charge
info: Jokr	play tele charge end
info: Jokr	play tele charge sound
info: Jokr	finished tele charge
warning: Checksum for beat 8850 mismatched: 6f347456a24550b1111b5d298b710fad (sim) != 65ee4f5cd213c3f25784cb77754614a8 (Pineapples3).
warning: Desync at beat 8852 tick 885.29998779297
warning: Checksum for beat 8850 mismatched: 6f347456a24550b1111b5d298b710fad (sim) != 65ee4f5cd213c3f25784cb77754614a8 (boy_34174).
warning: Checksum for beat 8850 mismatched: 6f347456a24550b1111b5d298b710fad (sim) != 65ee4f5cd213c3f25784cb77754614a8 (Spreafico).
warning: Checksum for beat 8850 mismatched: 6f347456a24550b1111b5d298b710fad (sim) != 65ee4f5cd213c3f25784cb77754614a8 (GeneralKnowledge).
warning: Checksum for beat 8850 mismatched: 6f347456a24550b1111b5d298b710fad (sim) != 65ee4f5cd213c3f25784cb77754614a8 (Jokr).
warning: Desync at beat 8855 tick 885.60003662109
info: Block is too late !
info: 8857	Jokr	has been abandoned.
info: trying to kill acus for 	Jokr
info: there are 	1
info: uel0001	5242880	Killed by aibrain abandonment; can we be killed? 	false
info: terminated
info: Spreafico	start tele out	1
info: Spreafico	clean up tele
info: Spreafico	play tele out
info: Jokr	start tele out	1
info: Jokr	clean up tele
info: Jokr	play tele out
info: Spreafico	count of units to destroy:	1
info: url0001	3145728	Spreafico	destroying unit
info: Spreafico	fake tele end
info: Jokr	count of units to destroy:	1
info: uel0001	5242880	Jokr	destroying unit
info: Jokr	fake tele end

```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
