### PR TITLE
Automatically rebuild novax satellite when destroyed for human armies

### DIFF
--- a/changelog/snippets/balance.6920.md
+++ b/changelog/snippets/balance.6920.md
@@ -1,0 +1,1 @@
+- (#6920) Automatically start rebuilding the Novax Satellite at the base station if the satellite is destroyed by artillery fire, nuclear missiles, or any other means.

--- a/loc/US/strings_db.lua
+++ b/loc/US/strings_db.lua
@@ -1509,8 +1509,8 @@ Unit_Description_0072="Stationary Heavy Artillery with excellent range and damag
 Unit_Description_0073="Strategic Missile Launcher. Automatically constructs expensive and extremely destructive strategic missiles. Toggleable missile construction."
 Unit_Description_0075="Strategic Assassination Artillery. Can hit any target on the map regardless of motion, range, or protection. Rate of fire increased when adjacent to energy production buildings."
 Unit_Description_0313="Heavy surface defense turret."
-Unit_Description_0314="Orbital Laser Bombardment Satellite. The Satellite is untargetable by any weapon, but can be impacted. If the Base Station dies, so does the Satellite."
-Unit_Description_0316="Satellite is untargetable by any weapon, but can attack enemy units and structures with very high precision. It can be destroyed only if its control center is destroyed."
+Unit_Description_0314="Orbital Laser Bombardment Satellite. The Satellite is untargetable by any weapon, but can be impacted. If the Base Station dies, so does the Satellite. Automatically starts rebuilding the Satellite if it is destroyed."
+Unit_Description_0316="Satellite is untargetable by any weapon, and can attack enemy units and structures with very high precision. Is destroyed if its control center is destroyed. Auto-rebuilds at the control center if destroyed by other means."
 
 -- UEF -- Defensive Structures
 Unit_Description_0060="Restricts the movement of enemy units and offers substantial protection from low direct fire attacks."

--- a/units/XEA0002/XEA0002_script.lua
+++ b/units/XEA0002/XEA0002_script.lua
@@ -21,9 +21,7 @@ XEA0002 = ClassUnit(TAirUnit) {
     OnDestroy = function(self)
         if not self.IsDying and self.Parent then
             self.Parent.Satellite = nil
-            if self:GetAIBrain().BrainType ~= 'Human' then
-                IssueBuildFactory({ self.Parent }, 'XEA0002', 1)
-            end
+            IssueBuildFactory({ self.Parent }, 'XEA0002', 1)
         end
         TAirUnit.OnDestroy(self)
     end,
@@ -42,9 +40,7 @@ XEA0002 = ClassUnit(TAirUnit) {
 
         if self.Parent then
             self.Parent.Satellite = nil
-            if self:GetAIBrain().BrainType ~= 'Human' then
-                IssueBuildFactory({ self.Parent }, 'XEA0002', 1)
-            end
+            IssueBuildFactory({ self.Parent }, 'XEA0002', 1)
         end
 
         TAirUnit.OnKilled(self, instigator, type, overkillRatio)

--- a/units/XEA0002/XEA0002_script.lua
+++ b/units/XEA0002/XEA0002_script.lua
@@ -9,6 +9,8 @@ local TAirUnit = import("/lua/terranunits.lua").TAirUnit
 local TOrbitalDeathLaserBeamWeapon = import("/lua/terranweapons.lua").TOrbitalDeathLaserBeamWeapon
 
 ---@class XEA0002 : TAirUnit
+---@field IsDying boolean?
+---@field Parent XEB2402? # Set in XEB2402 script
 XEA0002 = ClassUnit(TAirUnit) {
     DestroyNoFallRandomChance = 1.1,
 
@@ -18,6 +20,7 @@ XEA0002 = ClassUnit(TAirUnit) {
         OrbitalDeathLaserWeapon = ClassWeapon(TOrbitalDeathLaserBeamWeapon) {},
     },
 
+    ---@param self XEA0002
     OnDestroy = function(self)
         if not self.IsDying and self.Parent then
             self.Parent.Satellite = nil
@@ -26,6 +29,10 @@ XEA0002 = ClassUnit(TAirUnit) {
         TAirUnit.OnDestroy(self)
     end,
 
+    ---@param self XEA0002
+    ---@param instigator Unit | Projectile
+    ---@param type DamageType
+    ---@param overkillRatio number
     OnKilled = function(self, instigator, type, overkillRatio)
         if self.IsDying then
             return
@@ -94,11 +101,13 @@ XEA0002 = ClassUnit(TAirUnit) {
         end
     end,
 
+    ---@param self XEA0002
     Open = function(self)
         ChangeState(self, self.OpenState)
     end,
 
     OpenState = State() {
+        ---@param self XEA0002
         Main = function(self)
             -- Create the animator to open the fins
             self.OpenAnim = CreateAnimator(self)


### PR DESCRIPTION
## Issue
Stems from a [Discord report](https://discord.com/channels/197033481883222026/1411485032639496202). It is not always clear why your novax satellite got destroyed, and queuing the rebuild is unnecessarily difficult since the novax center doesn't allow queuing rebuilding until the current satellite is dead.

## Description of the proposed changes
Make novax automatically rebuild for human players as it does for AI.

## Testing done on the proposed changes
Use a Yolona to destroy the satellite by holding fire on the satellite and moving directly above the Yolona as it launches a nuke. The novax center automatically starts building a new satellite and assisting engineers start assisting too.

<details> <summary> Spawn units command </summary>

```
   CreateUnitAtMouse('ual0301_ras', 0,  -10.68,   29.85, -3.12756)
   CreateUnitAtMouse('ual0301_ras', 0,  -10.41,   19.62, -1.58118)
   CreateUnitAtMouse('ual0301_ras', 0,  -12.60,   17.89, -2.81816)
   CreateUnitAtMouse('ual0301_ras', 0,   -2.80,   19.88,  2.72248)
   CreateUnitAtMouse('ual0301_ras', 0,   -8.40,   19.73, -1.93133)
   CreateUnitAtMouse('ual0301_ras', 0,  -12.49,   23.64, -1.68884)
   CreateUnitAtMouse('ual0301_ras', 0,    1.60,   25.42, -0.97256)
   CreateUnitAtMouse('xeb2402', 0,   -4.19,   26.12, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 0,    2.73,   24.16, -0.00758)
   CreateUnitAtMouse('ual0301_ras', 0,   -6.56,   14.11, -1.28549)
   CreateUnitAtMouse('ual0301_ras', 1,   10.31,  -42.88, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,   10.31,  -44.04, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 0,   -2.43,   17.50, -1.14284)
   CreateUnitAtMouse('ual0301_ras', 0,  -12.41,   33.67, -1.74626)
   CreateUnitAtMouse('ual0301_ras', 0,  -12.40,   31.85, -2.24785)
   CreateUnitAtMouse('ual0301_ras', 0,   -0.43,   31.30, -0.68501)
   CreateUnitAtMouse('ual0301_ras', 0,   -2.54,   31.25, -0.38975)
   CreateUnitAtMouse('ual0301_ras', 0,    1.53,   17.42, -0.82517)
   CreateUnitAtMouse('ual0301_ras', 0,   -3.20,   14.97,  1.49535)
   CreateUnitAtMouse('ual0301_ras', 0,   -4.92,   31.17,  0.13424)
   CreateUnitAtMouse('ual0301_ras', 0,  -12.52,   25.90, -1.19907)
   CreateUnitAtMouse('ual0301_ras', 0,   -6.63,   19.33, -0.20513)
   CreateUnitAtMouse('ual0301_ras', 0,    1.56,   27.56, -1.34316)
   CreateUnitAtMouse('ual0301_ras', 0,   -1.11,   19.34,  0.99252)
   CreateUnitAtMouse('ual0301_ras', 0,    1.37,   19.85, -2.91760)
   CreateUnitAtMouse('ual0301_ras', 0,  -10.47,   17.59, -1.46536)
   CreateUnitAtMouse('ual0301_ras', 0,   -8.51,   33.59, -1.40189)
   CreateUnitAtMouse('ual0301_ras', 0,    3.65,   17.70, -1.82031)
   CreateUnitAtMouse('ual0301_ras', 0,  -10.42,   31.74, -1.99892)
   CreateUnitAtMouse('ual0301_ras', 0,   -6.46,   31.81, -2.26580)
   CreateUnitAtMouse('ual0301_ras', 0,  -12.96,   21.88,  2.34405)
   CreateUnitAtMouse('ual0301_ras', 0,   -0.27,   33.48, -1.25559)
   CreateUnitAtMouse('ual0301_ras', 0,   -8.41,   17.35, -0.80008)
   CreateUnitAtMouse('ual0301_ras', 0,   -8.40,   31.90, -2.33512)
   CreateUnitAtMouse('ual0301_ras', 0,    3.27,   23.74,  3.11909)
   CreateUnitAtMouse('ual0301_ras', 0,    1.61,   33.79, -2.10795)
   CreateUnitAtMouse('ual0301_ras', 1,   11.16,  -51.67, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,    9.50,  -53.19, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,   12.11,  -52.85, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,   10.69,  -54.49, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,   12.18,  -55.51, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,   10.61,  -56.25, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,   12.24,  -57.53, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,   10.87,  -58.68, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,   11.31,  -60.28, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,    9.14,  -50.79, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,   11.34,  -49.82, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,    9.70,  -49.11, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,   10.51,  -47.62, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,   10.31,  -46.34, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,   10.31,  -45.18, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 0,    0.84,   22.08,  1.30905)
   CreateUnitAtMouse('ual0301_ras', 0,    1.51,   31.65, -1.72785)
   CreateUnitAtMouse('ual0301_ras', 0,  -12.50,   19.93, -2.59455)
   CreateUnitAtMouse('ual0301_ras', 1,   11.31,  -60.94, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 0,   -6.46,   35.36, -0.72493)
   CreateUnitAtMouse('ual0301_ras', 0,    1.33,   23.46,  0.00000)
   CreateUnitAtMouse('xsb2401', 1,    2.31,  -55.38, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,   11.31,  -63.39, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 1,   11.31,  -62.09, -0.00000)
   CreateUnitAtMouse('ual0301_ras', 0,    1.66,   29.28,  0.00000)
   CreateUnitAtMouse('ual0301_ras', 0,   -6.42,   17.89, -2.36755)
   CreateUnitAtMouse('ual0301_ras', 0,    3.64,   29.53, -1.31655)
   CreateUnitAtMouse('ual0301_ras', 0,   -5.17,   19.59,  2.31647)
   CreateUnitAtMouse('ual0301_ras', 0,  -11.00,   27.47,  1.13852)
   CreateUnitAtMouse('ual0301_ras', 0,  -10.99,   25.68,  1.76153)
```

</details>

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
