### PR TITLE
Fix Salem's overly long antitorp target check interval

### DIFF
--- a/changelog/snippets/balance.6921.md
+++ b/changelog/snippets/balance.6921.md
@@ -1,0 +1,5 @@
+- (#6921) Decrease Salem's anti-torpedo flares' target check interval from 1.0s to 0.4s (the default for anti-projectile weapons). This makes it more likely to detect torpedoes and fire the flares correctly, especially against torpedo bombers.
+
+  **Salem: T2 Destroyer (URS0201):**
+  - Anti Torpedo Solution
+    - Target Check Interval: 1.0s -> 0.4s

--- a/units/URS0201/URS0201_unit.bp
+++ b/units/URS0201/URS0201_unit.bp
@@ -504,7 +504,6 @@ UnitBlueprint{
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_Countermeasure",
             RateOfFire = 10/38, --10/integer interval in ticks
-            TargetCheckInterval = 1.0,
             TargetRestrictDisallow = "UNTARGETABLE",
             TargetRestrictOnlyAllow = "TORPEDO",
             TargetType = "RULEWTT_Projectile",


### PR DESCRIPTION
## Issue
Salem wasn't blocking torpedo bombers correctly according to this [discord report](https://discord.com/channels/197033481883222026/1410825103318716446). This is caused by Salem having a set 1.0 target check interval for its antitorpedo flares, which is much higher than the default 0.4s interval for anti-projectile weapons.

## Description of the proposed changes
Remove the target check interval so it uses the default value.

## Testing done on the proposed changes
Salem is more responsive to enemy torpedo bombers.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
