### PR TITLE
Adjust default frametime to not interfere with vsync

### DIFF
--- a/changelog/snippets/fix.6932.md
+++ b/changelog/snippets/fix.6932.md
@@ -1,0 +1,1 @@
+- (#6932) Adjust default frametime to not interfere with vsync

--- a/changelog/snippets/fix.6932.md
+++ b/changelog/snippets/fix.6932.md
@@ -1,1 +1,1 @@
-- (#6932) Adjust default frametime to not interfere with vsync
+- (#6932) Adjust default maximum frame time to not interfere with vsync

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -1768,7 +1768,7 @@ options = {
                 title = "<LOC OPTIONS_FRAMETIME>Frametime",
                 key = 'frametime',
                 type = 'slider',
-                default = 16,
+                default = 8,
                 update = function(control, value)
                     logic = import("/lua/options/optionslogic.lua")
                     logic.SetValue('vsync', 0)
@@ -1789,6 +1789,12 @@ options = {
                 key = 'vsync',
                 type = 'toggle',
                 default = 1,
+                update = function(control, value)
+                    if value == 1 then
+                        logic = import("/lua/options/optionslogic.lua")
+                        logic.SetValue('frametime', 8)
+                    end
+                end,
                 set = function(key, value, startup)
                     if not startup then
                         ConExecute("SC_VerticalSync " .. tostring(value))


### PR DESCRIPTION
## Description of the proposed changes

Adjusts the default frame time that was introduced with https://github.com/FAForever/fa/commit/05610664912efb980c5566752488f6568cf4de11. It now defaults to 8 instead of 16. This prevents it from interfering with vsync behavior. This was reported on the forums:

- https://forum.faforever.com/topic/9520/supreme-commander-forged-alliance-game-not-utilizing-gpu./10


## Testing done on the proposed changes

Observe that the changes take place when editing the settings. Unfortunately, I do not observe the behavior myself.

## Checklist
- ~~Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
