### PR TITLE
ACU TML Missile BT 450 -> 700

### DIFF
--- a/changelog/snippets/balance.6934.md
+++ b/changelog/snippets/balance.6934.md
@@ -1,0 +1,6 @@
+- (#6934) Increase build time for ACU TMLs so that they are less effective on the move, in combat, and from the water. You can still reach a high fire rate with engineer assistance.
+
+  Seraphim and UEF ACU (XSL0001, UEL0001) TML:
+    - Missile build time: 450 -> 700 (same as SACU)
+      - Build time with T2 suite: 10.8 -> 16.7 seconds
+      - Build time with T3 suite: 4.5 -> 7.0 seconds

--- a/changelog/snippets/balance.6934.md
+++ b/changelog/snippets/balance.6934.md
@@ -1,6 +1,6 @@
 - (#6934) Increase build time for ACU TMLs so that they are less effective on the move, in combat, and from the water. You can still reach a high fire rate with engineer assistance.
 
-  Seraphim and UEF ACU (XSL0001, UEL0001) TML:
-    - Missile build time: 450 -> 700 (same as SACU)
-      - Build time with T2 suite: 10.8 -> 16.7 seconds
-      - Build time with T3 suite: 4.5 -> 7.0 seconds
+  **Seraphim and UEF ACU (XSL0001 and UEL0001):**
+  - TML Missile build time: 450 -> 700 (same as SACU)
+    - Build time with T2 suite: 10.8 -> 16.7 seconds
+    - Build time with T3 suite: 4.5 -> 7.0 seconds

--- a/projectiles/SIFLaanseTacticalMissileCDR/SIFLaanseTacticalMissileCDR_proj.bp
+++ b/projectiles/SIFLaanseTacticalMissileCDR/SIFLaanseTacticalMissileCDR_proj.bp
@@ -27,7 +27,7 @@ ProjectileBlueprint{
     Economy = {
         BuildCostEnergy = 3600,
         BuildCostMass = 250,
-        BuildTime = 450,
+        BuildTime = 700,
     },
     General = {
         Category = "Missile",

--- a/projectiles/TIFMissileCruiseCDR/TIFMissileCruiseCDR_proj.bp
+++ b/projectiles/TIFMissileCruiseCDR/TIFMissileCruiseCDR_proj.bp
@@ -36,7 +36,7 @@ ProjectileBlueprint{
     Economy = {
         BuildCostEnergy = 3600,
         BuildCostMass = 250,
-        BuildTime = 450,
+        BuildTime = 700,
     },
     General = {
         Category = "Missile",


### PR DESCRIPTION
## Description of the proposed changes
[TML ACU/Billy Nuke](https://discord.com/channels/197033481883222026/1401830334701633609) Discord thread. This PR implements the build time nerf discussed there.

Increase build time for ACU TMLs so that they are less effective on the move, in combat, and from the water. You can still reach a high fire rate with engineer assistance.
- Seraphim and UEF ACU TML:
  - Missile build time: 450 -> 700 (same as SACU)
    - Build time with T2 suite: 10.8 -> 16.7 seconds
    - Build time with T3 suite: 4.5 -> 7.0 seconds

## Testing done on the proposed changes
It is a simple bp change.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
