### PR TITLE
Adjust T2 HQ HP so that Cybran HQs do not die to 1 TML hit

### DIFF
--- a/changelog/snippets/balance.6936.md
+++ b/changelog/snippets/balance.6936.md
@@ -1,1 +1,1 @@
-- (#6936) Adjust HP of T2 Air/Land HQs so that Cybran T2 HQs do not die to 1 TML hit.
+- (#6936) Adjust HP of T2 Air/Land HQs so that Cybran T2 HQs do not die to 1 TML hit. This prevents Cybran players from being unfairly locked out of the tech needed to counter TMLs.

--- a/changelog/snippets/balance.6936.md
+++ b/changelog/snippets/balance.6936.md
@@ -1,0 +1,1 @@
+- (#6936) Adjust HP of factories so that Cybran T2 Air/Land HQs and T3 Air/Land Support Factories are not one shot by TMLs or die to one T3 pgen explosion.

--- a/changelog/snippets/balance.6936.md
+++ b/changelog/snippets/balance.6936.md
@@ -1,1 +1,1 @@
-- (#6936) Adjust HP of factories so that Cybran T2 Air/Land HQs and T3 Air/Land Support Factories are not one shot by TMLs or die to one T3 pgen explosion.
+- (#6936) Adjust HP of T2 Air/Land HQs so that Cybran T2 HQs do not die to 1 TML hit.

--- a/units/UAB0201/UAB0201_unit.bp
+++ b/units/UAB0201/UAB0201_unit.bp
@@ -40,8 +40,8 @@ UnitBlueprint{
     Defense = {
         ArmorType = "Structure",
         EconomyThreatLevel = 208,
-        Health = 6400,
-        MaxHealth = 6400,
+        Health = 6600,
+        MaxHealth = 6600,
     },
     Display = {
         Abilities = { "<LOC ability_upgradable>Upgradeable" },

--- a/units/UAB0202/UAB0202_unit.bp
+++ b/units/UAB0202/UAB0202_unit.bp
@@ -33,8 +33,8 @@ UnitBlueprint{
     Defense = {
         ArmorType = "Structure",
         EconomyThreatLevel = 208,
-        Health = 6400,
-        MaxHealth = 6400,
+        Health = 6600,
+        MaxHealth = 6600,
     },
     Display = {
         Abilities = { "<LOC ability_upgradable>Upgradeable" },

--- a/units/URB0201/URB0201_unit.bp
+++ b/units/URB0201/URB0201_unit.bp
@@ -34,8 +34,8 @@ UnitBlueprint{
     Defense = {
         ArmorType = "Structure",
         EconomyThreatLevel = 190,
-        Health = 5500,
-        MaxHealth = 5500,
+        Health = 6100,
+        MaxHealth = 6100,
         RegenRate = 20,
     },
     Display = {

--- a/units/URB0201/URB0201_unit.bp
+++ b/units/URB0201/URB0201_unit.bp
@@ -36,7 +36,7 @@ UnitBlueprint{
         EconomyThreatLevel = 190,
         Health = 6100,
         MaxHealth = 6100,
-        RegenRate = 20,
+        RegenRate = 15,
     },
     Display = {
         Abilities = { "<LOC ability_upgradable>Upgradeable" },

--- a/units/URB0202/URB0202_unit.bp
+++ b/units/URB0202/URB0202_unit.bp
@@ -43,7 +43,7 @@ UnitBlueprint{
         EconomyThreatLevel = 190,
         Health = 6100,
         MaxHealth = 6100,
-        RegenRate = 20,
+        RegenRate = 15,
     },
     Display = {
         Abilities = { "<LOC ability_upgradable>Upgradeable" },

--- a/units/URB0202/URB0202_unit.bp
+++ b/units/URB0202/URB0202_unit.bp
@@ -41,8 +41,8 @@ UnitBlueprint{
     Defense = {
         ArmorType = "Structure",
         EconomyThreatLevel = 190,
-        Health = 5500,
-        MaxHealth = 5500,
+        Health = 6100,
+        MaxHealth = 6100,
         RegenRate = 20,
     },
     Display = {

--- a/units/XSB0201/XSB0201_unit.bp
+++ b/units/XSB0201/XSB0201_unit.bp
@@ -33,8 +33,8 @@ UnitBlueprint{
     Defense = {
         ArmorType = "Structure",
         EconomyThreatLevel = 220,
-        Health = 7000,
-        MaxHealth = 7000,
+        Health = 7200,
+        MaxHealth = 7200,
     },
     Display = {
         Abilities = { "<LOC ability_upgradable>Upgradeable" },

--- a/units/XSB0202/XSB0202_unit.bp
+++ b/units/XSB0202/XSB0202_unit.bp
@@ -39,8 +39,8 @@ UnitBlueprint{
     Defense = {
         ArmorType = "Structure",
         EconomyThreatLevel = 220,
-        Health = 7000,
-        MaxHealth = 7000,
+        Health = 7200,
+        MaxHealth = 7200,
     },
     Display = {
         Abilities = { "<LOC ability_upgradable>Upgradeable" },


### PR DESCRIPTION
## Description of the proposed changes
Adjust HP of T2 Air/Land HQs so that Cybran T2 HQs do not die to 1 TML hit. This prevents Cybran players from being unfairly locked out of the tech needed to counter TMLs. Relevant [Discord thread](https://discord.com/channels/197033481883222026/1385026179521839266).

T2 HQ HPs: 5.5k, 6.4k, 7k, 8k -> 6.1k, 6.6k, 7.2k, 8k

Cybran T2 HQ Regen rate: 20 -> 15
Regen is reduced because the HP difference between Cybran and other factions is reduced.

Factories have clear multipliers for HP based on each other, but I didn't adjust everything since it would make T3 Cybran factories not die to 1 pgen explosion, which hasn't been discussed.

## Checklist
~~- [] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
