### PR TITLE
Implement adjustable shield assist cost

### DIFF
--- a/changelog/snippets/features.6937.md
+++ b/changelog/snippets/features.6937.md
@@ -1,0 +1,12 @@
+- (#6937) Implement the ability to adjust shield assist costs using the following blueprint values:
+
+  - `RegenPerBuildRate`: How much HP/s is restored per unit of buildpower assisting the shield. Overrides `RegenAssistMult`.
+  - `AssistCostEnergyPerBuildRate` and `AssistCostMassPerBuildRate`: The resource cost per second per unit of buildpower assisting the shield.
+
+    Both values must be present to have an effect, otherwise it defaults to the repair cost of the shield structure (75% of its build cost).
+  
+    If both the HP and the shield of a unit are damaged, the assist cost and effects are split equally between the HP repair cost and shield assist costs.
+
+  These values should be assigned in either the `Defense.Shield` or `Enhancements.<EnhancementName>` tables of the unit blueprint. 
+  
+  Please keep in mind that shield assist only works for units with the `SHIELD` category, and only if they're not upgrading themselves/building something.

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -451,6 +451,13 @@
 --- If this shield is one that unequivocally protects all attached units.
 --- Should not be defined with `AntiArtilleryShield`, `PersonalBubble`, or `PersonalShield`.
 ---@field TransportShield? boolean
+--- Overrides `RegenAssistMult` during blueprint loading so that the given amount of regen is given
+--- per buildpower assisting the shield.
+---@field RegenPerBuildRate number
+--- Engineers spend this amount in energy * their buildpower assisting the shield.
+---@field AssistCostEnergyPerBuildRate number
+--- Engineers spend this amount in mass * their buildpower assisting the shield.
+---@field AssistCostMassPerBuildRate number
 
 ---@class UnitBlueprintBlinkingLightsData
 ---@field BLBone Bone

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -451,12 +451,18 @@
 --- If this shield is one that unequivocally protects all attached units.
 --- Should not be defined with `AntiArtilleryShield`, `PersonalBubble`, or `PersonalShield`.
 ---@field TransportShield? boolean
---- Overrides `RegenAssistMult` during blueprint loading so that the given amount of regen is given
---- per buildpower assisting the shield.
+--- How much HP/s is restored per unit of buildpower assisting the shield. 
+--- Overrides `RegenAssistMult` during blueprint loading.
 ---@field RegenPerBuildRate number
---- Engineers spend this amount in energy * their buildpower assisting the shield.
+--- The energy cost per second per unit of buildpower assisting the shield.
+--- Must be present alongside `AssistCostMassPerBuildRate` to have an effect.
+--- If both shield and unit HP are damaged, the costs/effects are split equally between HP repair cost
+--- and shield assist cost.
 ---@field AssistCostEnergyPerBuildRate number
---- Engineers spend this amount in mass * their buildpower assisting the shield.
+--- The mass cost per second per unit of buildpower assisting the shield.
+--- Must be present alongside `AssistCostEnergyPerBuildRate` to have an effect.
+--- If both shield and unit HP are damaged, the costs/effects are split equally between HP repair cost
+--- and shield assist cost.
 ---@field AssistCostMassPerBuildRate number
 
 ---@class UnitBlueprintBlinkingLightsData

--- a/engine/Sim/Unit.lua
+++ b/engine/Sim/Unit.lua
@@ -192,7 +192,11 @@ end
 function Unit:GetFireState()
 end
 
----@return Unit
+--- Gets the unit's focus unit, which is usually the unit it is building/repairing/reclaiming/capturing.
+--- The focus may be set to an Entity (usually a Shield) or a Projectile, in which case this
+--- will return nil.
+---@see SetFocusEntity
+---@return Unit?
 function Unit:GetFocusUnit()
 end
 
@@ -557,6 +561,10 @@ end
 function Unit:SetFireState(fireState)
 end
 
+--- Sets the focus entity of the unit. 
+--- Usually set by the engine when an engineer starts building/repairing/reclaiming/capturing units.
+--- Shield units set their shield entity as the focus to make it repairable.
+---@see GetFocusUnit
 ---@param focus FocusObject
 function Unit:SetFocusEntity(focus)
 end

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -158,6 +158,8 @@ end
 ---@field SkipAttachmentCheck boolean
 ---@field AbsorptionTypeDamageTypeToMulti table<DamageType, number>
 ---@field DisallowCollisions boolean
+---@field AssistCostEnergyPerBuildRate? number
+---@field AssistCostMassPerBuildRate? number
 Shield = ClassShield(moho.shield_methods, Entity) {
 
     RemainEnabledWhenAttached = false,

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -319,11 +319,27 @@ Shield = ClassShield(moho.shield_methods, Entity) {
                 -- adjust shield bar one last time
                 self:UpdateShieldRatio(health / maxHealth)
 
+                -- Manage shield assisters: shield is full HP and cannot be assisted anymore
+                if health == maxHealth
+                    and self.AssistCostEnergyPerBuildRate and self.AssistCostMassPerBuildRate
+                then
+                    for _, unit in self.Owner.Repairers do
+                        unit:UpdateConsumptionValues()
+                    end
+                end
+
                 -- suspend ourselves and wait
                 self.RegenThreadSuspended = true
                 SuspendCurrentThread()
                 self.RegenThreadSuspended = false
                 fromSuspension = true
+
+                -- Manage shield assisters: shield was damaged from full HP and can now be assisted
+                if self.AssistCostEnergyPerBuildRate and self.AssistCostMassPerBuildRate then
+                    for _, unit in self.Owner.Repairers do
+                        unit:UpdateConsumptionValues()
+                    end
+                end
             end
 
             -- if we didn't suspend then check regeneration conditions

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -195,6 +195,8 @@ Shield = ClassShield(moho.shield_methods, Entity) {
         self.PassOverkillDamage = spec.PassOverkillDamage
         self.ImpactMeshBp = spec.ImpactMesh
         self.SkipAttachmentCheck = spec.SkipAttachmentCheck
+        self.AssistCostEnergyPerBuildRate = spec.AssistCostEnergyPerBuildRate
+        self.AssistCostMassPerBuildRate = spec.AssistCostMassPerBuildRate
         self.DisallowCollisions = false
 
         if spec.ImpactEffects ~= '' then

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1478,6 +1478,16 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
 
         -- inform the brain of the event
         self.Brain:OnUnitHealthChanged(self, new, old)
+
+        -- Manage shield assisters: unit is damaged/no longer damaged so assist consumption changes
+        if new == 1 or old == 1 and self.Blueprint.CategoriesHash["SHIELD"] then
+            local myShield = self.MyShield
+            if myShield.AssistCostEnergyPerBuildRate and myShield.AssistCostMassPerBuildRate then
+                for _, unit in self.Repairers do
+                    unit:UpdateConsumptionValues()
+                end
+            end
+        end
     end,
 
     ---@param self Unit
@@ -5324,12 +5334,32 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     OnShieldEnabled = function(self) 
         -- for AI events
         self.Brain:OnUnitShieldEnabled(self)
+
+        -- Manage shield assisters: shield was enabled and may be assistable now
+        if self.Blueprint.CategoriesHash["SHIELD"] then
+            local myShield = self.MyShield
+            if myShield.AssistCostEnergyPerBuildRate and myShield.AssistCostMassPerBuildRate then
+                for _, unit in self.Repairers do
+                    unit:UpdateConsumptionValues()
+                end
+            end
+        end
     end,
 
     ---@param self Unit
     OnShieldDisabled = function(self) 
         -- for AI events
         self.Brain:OnUnitShieldDisabled(self)
+
+        -- Manage shield assisters: shield is disabled and cannot be assisted anymore
+        if self.Blueprint.CategoriesHash["SHIELD"] then
+            local myShield = self.MyShield
+            if myShield.AssistCostEnergyPerBuildRate and myShield.AssistCostMassPerBuildRate then
+                for _, unit in self.Repairers do
+                    unit:UpdateConsumptionValues()
+                end
+            end
+        end
     end,
 
     -- Called by the brain when the unit registered itself

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1279,8 +1279,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
                                         shieldAssistEnergy = shieldAssistEnergy * 0.5
                                         shieldAssistMass = shieldAssistMass * 0.5
                                     end
-                                    energy_rate = energy_rate + shieldAssistEnergy * buildRate
-                                    mass_rate = mass_rate + shieldAssistMass * buildRate
+                                    energy = energy + shieldAssistEnergy * buildRate * time
+                                    mass = mass + shieldAssistMass * buildRate * time
                                 end
                             end
                         end
@@ -1290,8 +1290,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
 
             energy = math.max(0, energy * (self.EnergyBuildAdjMod or 1))
             mass = math.max(0, mass * (self.MassBuildAdjMod or 1))
-            energy_rate = energy_rate + energy / time
-            mass_rate = mass_rate + mass / time
+            energy_rate = energy / time
+            mass_rate = mass / time
         end
 
         local myBlueprint = self.Blueprint

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -5341,9 +5341,6 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     OnShieldEnabled = function(self) 
         -- for AI events
         self.Brain:OnUnitShieldEnabled(self)
-
-        -- Manage shield assisters: shield was enabled and may be assistable now
-        self:UpdateShieldAssistersConsumption()
     end,
 
     ---@param self Unit

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1222,18 +1222,64 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
                     energy = (energy / siloBuildRate) * (self:GetBuildRate() or 0)
                     mass = (mass / siloBuildRate) * (self:GetBuildRate() or 0)
                 else
-                    time, energy, mass = self:GetBuildCosts(focus:GetBlueprint())
                     if self:IsUnitState('Repairing') and focus.isFinishedUnit then -- also applies to shield assisting
-                        energy = energy * repairRatio
-                        mass = mass * repairRatio
+                        if focus.Blueprint.CategoriesHash['SHIELD'] then
+                            local focusShield = focus.MyShield
+                            local shieldAssistEnergy = focusShield.AssistCostEnergyPerBuildRate
+                            local shieldAssistMass = focusShield.AssistCostMassPerBuildRate
+
+                            if focusShield
+                                and shieldAssistEnergy
+                                and shieldAssistMass
+                                and focusShield:IsUp()
+                                -- shield units SetFocusEntity to the shield to make it repairable
+                                -- but the shield is not a unit, so GetFocusUnit returns nil.
+                                -- So assume if its nil the shield is focused, and the shield is repairable.
+                                and focus:GetFocusUnit() == nil
+                            then
+                                -- Determine exactly what we are repairing
+                                local repairingFocusUnit = focus:GetMaxHealth() > focus:GetHealth()
+                                local repairingFocusShield = focusShield:GetMaxHealth() > focusShield:GetHealth()
+                                -- Apply unit repair costs
+                                if repairingFocusUnit then
+                                    time, energy, mass = self:GetBuildCosts(focus:GetBlueprint())
+                                    energy = energy * repairRatio
+                                    mass = mass * repairRatio
+                                    -- Engine splits repair effect 50/50 so reduce costs in that case
+                                    if repairingFocusShield then
+                                        energy = energy * 0.5
+                                        mass = mass * 0.5
+                                    end
+                                end
+                                -- Apply custom shield assist costs
+                                if repairingFocusShield then
+                                    local buildRate = self:GetBuildRate()
+                                    -- Engine splits repair effect 50/50 so reduce costs in that case
+                                    if repairingFocusUnit then
+                                        shieldAssistEnergy = shieldAssistEnergy * 0.5
+                                        shieldAssistMass = shieldAssistMass * 0.5
+                                    end
+                                    energy_rate = energy_rate + shieldAssistEnergy * buildRate
+                                    mass_rate = mass_rate + shieldAssistMass * buildRate
+                                end
+                            else
+                                time, energy, mass = self:GetBuildCosts(focus:GetBlueprint())
+                                energy = energy * repairRatio
+                                mass = mass * repairRatio
+                            end
+                        else
+                            time, energy, mass = self:GetBuildCosts(focus:GetBlueprint())
+                            energy = energy * repairRatio
+                            mass = mass * repairRatio
+                        end
                     end
                 end
             end
 
             energy = math.max(0, energy * (self.EnergyBuildAdjMod or 1))
             mass = math.max(0, mass * (self.MassBuildAdjMod or 1))
-            energy_rate = energy / time
-            mass_rate = mass / time
+            energy_rate = energy_rate + energy / time
+            mass_rate = mass_rate + mass / time
         end
 
         local myBlueprint = self.Blueprint

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1232,9 +1232,6 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
                                 and shieldAssistEnergy
                                 and shieldAssistMass
                                 and focusShield:IsUp()
-                                -- shield units SetFocusEntity to the shield to make it repairable
-                                -- but the shield is not a unit, so GetFocusUnit returns nil.
-                                -- So assume if its nil the shield is focused, and the shield is repairable.
                                 and focus:GetFocusUnit() == nil
                             then
                                 -- Determine exactly what we are repairing

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1235,55 +1235,55 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
                     mass = (mass / siloBuildRate) * (self:GetBuildRate() or 0)
                 elseif self:IsUnitState('Repairing') and focus.isFinishedUnit then
                     -- repairing a unit or assisting a shield
-                        local function SetDefaultRepairCosts()
-                            time, energy, mass = self:GetBuildCosts(focus:GetBlueprint())
-                            energy = energy * repairRatio
-                            mass = mass * repairRatio
-                        end
+                    local function SetDefaultRepairCosts()
+                        time, energy, mass = self:GetBuildCosts(focus:GetBlueprint())
+                        energy = energy * repairRatio
+                        mass = mass * repairRatio
+                    end
 
-                        if not focus.Blueprint.CategoriesHash["SHIELD"] then
-                            -- units without SHIELD category cannot be shield assisted
+                    if not focus.Blueprint.CategoriesHash["SHIELD"] then
+                        -- units without SHIELD category cannot be shield assisted
+                        SetDefaultRepairCosts()
+                    else
+                        local focusShield = focus.MyShield
+                        local shieldAssistEnergy = focusShield.AssistCostEnergyPerBuildRate
+                        local shieldAssistMass = focusShield.AssistCostMassPerBuildRate
+
+                        if not focusShield
+                            -- units default to repair cost for shield assist costs
+                            or not shieldAssistEnergy
+                            or not shieldAssistMass
+                            -- units not focused on a shield that is up cannot be shield assisted
+                            or not focusShield:IsUp()
+                            or not focus:GetFocusUnit() == nil
+                        then
                             SetDefaultRepairCosts()
                         else
-                            local focusShield = focus.MyShield
-                            local shieldAssistEnergy = focusShield.AssistCostEnergyPerBuildRate
-                            local shieldAssistMass = focusShield.AssistCostMassPerBuildRate
+                            -- Determine what we are repairing, since they have different costs
+                            local repairingFocusUnit = focus:GetMaxHealth() > focus:GetHealth()
+                            local repairingFocusShield = focusShield:GetMaxHealth() > focusShield:GetHealth()
 
-                            if not focusShield
-                                -- units default to repair cost for shield assist costs
-                                or not shieldAssistEnergy
-                                or not shieldAssistMass
-                                -- units not focused on a shield that is up cannot be shield assisted
-                                or not focusShield:IsUp()
-                                or not focus:GetFocusUnit() == nil
-                            then
+                            if repairingFocusUnit then
                                 SetDefaultRepairCosts()
-                            else
-                                -- Determine what we are repairing, since they have different costs
-                                local repairingFocusUnit = focus:GetMaxHealth() > focus:GetHealth()
-                                local repairingFocusShield = focusShield:GetMaxHealth() > focusShield:GetHealth()
-
-                                if repairingFocusUnit then
-                                    SetDefaultRepairCosts()
-                                    -- Engine splits repair effect 50/50 so reduce costs in that case
-                                    if repairingFocusShield then
-                                        energy = energy * 0.5
-                                        mass = mass * 0.5
-                                    end
-                                end
-
+                                -- Engine splits repair effect 50/50 so reduce costs in that case
                                 if repairingFocusShield then
-                                    local buildRate = self:GetBuildRate()
-                                    -- Engine splits repair effect 50/50 so reduce costs in that case
-                                    if repairingFocusUnit then
-                                        shieldAssistEnergy = shieldAssistEnergy * 0.5
-                                        shieldAssistMass = shieldAssistMass * 0.5
-                                    end
-                                    energy = energy + shieldAssistEnergy * buildRate * time
-                                    mass = mass + shieldAssistMass * buildRate * time
+                                    energy = energy * 0.5
+                                    mass = mass * 0.5
                                 end
                             end
+
+                            if repairingFocusShield then
+                                local buildRate = self:GetBuildRate()
+                                -- Engine splits repair effect 50/50 so reduce costs in that case
+                                if repairingFocusUnit then
+                                    shieldAssistEnergy = shieldAssistEnergy * 0.5
+                                    shieldAssistMass = shieldAssistMass * 0.5
+                                end
+                                energy = energy + shieldAssistEnergy * buildRate * time
+                                mass = mass + shieldAssistMass * buildRate * time
+                            end
                         end
+                    end
                 else
                     -- building a unit
                     time, energy, mass = self:GetBuildCosts(focus:GetBlueprint())

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1233,8 +1233,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
                     time, energy, mass = focus:GetBuildCosts(focus.SiloProjectile)
                     energy = (energy / siloBuildRate) * (self:GetBuildRate() or 0)
                     mass = (mass / siloBuildRate) * (self:GetBuildRate() or 0)
-                else
-                    if self:IsUnitState('Repairing') and focus.isFinishedUnit then -- also applies to shield assisting
+                elseif self:IsUnitState('Repairing') and focus.isFinishedUnit then
+                    -- repairing a unit or assisting a shield
                         local function SetDefaultRepairCosts()
                             time, energy, mass = self:GetBuildCosts(focus:GetBlueprint())
                             energy = energy * repairRatio
@@ -1284,7 +1284,11 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
                                 end
                             end
                         end
-                    end
+                else
+                    -- building a unit
+                    time, energy, mass = self:GetBuildCosts(focus:GetBlueprint())
+                    energy = energy * repairRatio
+                    mass = mass * repairRatio
                 end
             end
 

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -4609,8 +4609,9 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         end
     end,
 
+    --- Called by the engine to determine whether or not the unit's shield can be assisted
     ---@param self Unit
-    ---@return boolean
+    ---@return boolean?
     ShieldIsOn = function(self)
         if self.MyShield then
             return self.MyShield:IsOn()

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1235,32 +1235,43 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
                     mass = (mass / siloBuildRate) * (self:GetBuildRate() or 0)
                 else
                     if self:IsUnitState('Repairing') and focus.isFinishedUnit then -- also applies to shield assisting
-                        if focus.Blueprint.CategoriesHash['SHIELD'] then
+                        local function SetDefaultRepairCosts()
+                            time, energy, mass = self:GetBuildCosts(focus:GetBlueprint())
+                            energy = energy * repairRatio
+                            mass = mass * repairRatio
+                        end
+
+                        if not focus.Blueprint.CategoriesHash["SHIELD"] then
+                            -- units without SHIELD category cannot be shield assisted
+                            SetDefaultRepairCosts()
+                        else
                             local focusShield = focus.MyShield
                             local shieldAssistEnergy = focusShield.AssistCostEnergyPerBuildRate
                             local shieldAssistMass = focusShield.AssistCostMassPerBuildRate
 
-                            if focusShield
-                                and shieldAssistEnergy
-                                and shieldAssistMass
-                                and focusShield:IsUp()
-                                and focus:GetFocusUnit() == nil
+                            if not focusShield
+                                -- units default to repair cost for shield assist costs
+                                or not shieldAssistEnergy
+                                or not shieldAssistMass
+                                -- units not focused on a shield that is up cannot be shield assisted
+                                or not focusShield:IsUp()
+                                or not focus:GetFocusUnit() == nil
                             then
-                                -- Determine exactly what we are repairing
+                                SetDefaultRepairCosts()
+                            else
+                                -- Determine what we are repairing, since they have different costs
                                 local repairingFocusUnit = focus:GetMaxHealth() > focus:GetHealth()
                                 local repairingFocusShield = focusShield:GetMaxHealth() > focusShield:GetHealth()
-                                -- Apply unit repair costs
+
                                 if repairingFocusUnit then
-                                    time, energy, mass = self:GetBuildCosts(focus:GetBlueprint())
-                                    energy = energy * repairRatio
-                                    mass = mass * repairRatio
+                                    SetDefaultRepairCosts()
                                     -- Engine splits repair effect 50/50 so reduce costs in that case
                                     if repairingFocusShield then
                                         energy = energy * 0.5
                                         mass = mass * 0.5
                                     end
                                 end
-                                -- Apply custom shield assist costs
+
                                 if repairingFocusShield then
                                     local buildRate = self:GetBuildRate()
                                     -- Engine splits repair effect 50/50 so reduce costs in that case
@@ -1271,15 +1282,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
                                     energy_rate = energy_rate + shieldAssistEnergy * buildRate
                                     mass_rate = mass_rate + shieldAssistMass * buildRate
                                 end
-                            else
-                                time, energy, mass = self:GetBuildCosts(focus:GetBlueprint())
-                                energy = energy * repairRatio
-                                mass = mass * repairRatio
                             end
-                        else
-                            time, energy, mass = self:GetBuildCosts(focus:GetBlueprint())
-                            energy = energy * repairRatio
-                            mass = mass * repairRatio
                         end
                     end
                 end

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1179,6 +1179,18 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         end
     end,
 
+    ---@param self Unit
+    UpdateShieldAssistersConsumption = function(self)
+        if self.Blueprint.CategoriesHash["SHIELD"] then
+            local myShield = self.MyShield
+            if myShield.AssistCostEnergyPerBuildRate and myShield.AssistCostMassPerBuildRate then
+                for _, unit in self.Repairers do
+                    unit:UpdateConsumptionValues()
+                end
+            end
+        end
+    end,
+
     -- Called when we start building a unit, turn on/off, get/lose bonuses, or on
     -- any other change that might affect our build rate or resource use.
     ---@param self Unit
@@ -1477,13 +1489,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         self.Brain:OnUnitHealthChanged(self, new, old)
 
         -- Manage shield assisters: unit is damaged/no longer damaged so assist consumption changes
-        if new == 1 or old == 1 and self.Blueprint.CategoriesHash["SHIELD"] then
-            local myShield = self.MyShield
-            if myShield.AssistCostEnergyPerBuildRate and myShield.AssistCostMassPerBuildRate then
-                for _, unit in self.Repairers do
-                    unit:UpdateConsumptionValues()
-                end
-            end
+        if new == 1 or old == 1 then
+            self:UpdateShieldAssistersConsumption()
         end
     end,
 
@@ -5333,14 +5340,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         self.Brain:OnUnitShieldEnabled(self)
 
         -- Manage shield assisters: shield was enabled and may be assistable now
-        if self.Blueprint.CategoriesHash["SHIELD"] then
-            local myShield = self.MyShield
-            if myShield.AssistCostEnergyPerBuildRate and myShield.AssistCostMassPerBuildRate then
-                for _, unit in self.Repairers do
-                    unit:UpdateConsumptionValues()
-                end
-            end
-        end
+        self:UpdateShieldAssistersConsumption()
     end,
 
     ---@param self Unit
@@ -5349,14 +5349,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         self.Brain:OnUnitShieldDisabled(self)
 
         -- Manage shield assisters: shield is disabled and cannot be assisted anymore
-        if self.Blueprint.CategoriesHash["SHIELD"] then
-            local myShield = self.MyShield
-            if myShield.AssistCostEnergyPerBuildRate and myShield.AssistCostMassPerBuildRate then
-                for _, unit in self.Repairers do
-                    unit:UpdateConsumptionValues()
-                end
-            end
-        end
+        self:UpdateShieldAssistersConsumption()
     end,
 
     -- Called by the brain when the unit registered itself

--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -127,6 +127,43 @@ local function DetermineWeaponCategory(weapon)
     return nil
 end
 
+--- Adjusts `RegenAssistMult` of a shield blueprint according to its `RegenPerBuildRate`
+---@param unit UnitBlueprint
+---@param shieldBp UnitBlueprintDefenseShield
+local function AdjustShieldAssistCost(unit, shieldBp)
+    local regenPerBuildRate = shieldBp.RegenPerBuildRate
+    if regenPerBuildRate then
+        local regen = shieldBp.ShieldRegenRate
+        -- local economy = unit.Economy
+        -- local costMass = economy.BuildCostMass
+        -- local costEnergy = economy.BuildCostEnergy
+
+        -- RegenAssistMult is used by the engine to determine how much buildpower is needed to
+        -- provide 1x the shield's regen rate as HP restored.
+        -- Exception: RegenRate is read from the Shield's lua table during run time, so
+        -- the actual HP restored/second may vary from blueprint spec.
+
+        -- HP Restored/second = RegenRate * Buildpower / RegenAssistMult
+        --   We want to be able to assign it simply using HP Restored/s per buildpower.
+        -- HPR = RR * BP / RAM
+        -- HPR * RAM = RR * BP
+        -- RAM = RR * BP / HPR
+        -- RAM = RR * 1 / (HPR/BP)
+        -- RAM = RR / (HPR/BP)
+
+        shieldBp.RegenAssistMult = regen / shieldBp.RegenPerBuildRate
+
+        -- Mass/Second = BP * BuildCost / BT
+        -- Mass/Second/BP = BuildCost / BT
+        --   BuildCost = HPR/Mass
+        --   BT = HPR = RR/RAM
+        -- Mass/Second/BP = HPR/Mass / (RR/RAM)
+        -- Mass/Second/BP = HPR/Mass / RAM * RR
+
+        -- shieldBp.AssistCostMassPerBuildRate = shieldBp.RegenPerMassCost / shieldBp.RegenAssistMult * shieldBp.ShieldRegenRate
+    end
+end
+
 --- Post process a unit
 ---@param unit UnitBlueprint
 local function PostProcessUnit(unit)
@@ -614,6 +651,22 @@ local function PostProcessUnit(unit)
             unit.Display.AnimationDeath = nil
         end
     end
+
+    --#region Adjust shield assist effectiveness
+    -- Engine only implements assist for SHIELD category units
+    if unit.CategoriesHash["SHIELD"] then
+        if unit.Defense.Shield then
+            AdjustShieldAssistCost(unit, unit.Defense.Shield)
+        end
+        if unit.Enhancements then
+            for _, enh in unit.Enhancements do
+                if enh.ShieldSize then
+                    AdjustShieldAssistCost(unit, unit.Defense.Shield)
+                end
+            end
+        end
+    end
+    --#endregion
 end
 
 --- Feature: re-apply the ability to land on water

--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -134,10 +134,6 @@ local function AdjustShieldAssistCost(unit, shieldBp)
     local regenPerBuildRate = shieldBp.RegenPerBuildRate
     if regenPerBuildRate then
         local regen = shieldBp.ShieldRegenRate
-        -- local economy = unit.Economy
-        -- local costMass = economy.BuildCostMass
-        -- local costEnergy = economy.BuildCostEnergy
-
         -- RegenAssistMult is used by the engine to determine how much buildpower is needed to
         -- provide 1x the shield's regen rate as HP restored.
         -- Exception: RegenRate is read from the Shield's lua table during run time, so
@@ -152,15 +148,6 @@ local function AdjustShieldAssistCost(unit, shieldBp)
         -- RAM = RR / (HPR/BP)
 
         shieldBp.RegenAssistMult = regen / shieldBp.RegenPerBuildRate
-
-        -- Mass/Second = BP * BuildCost / BT
-        -- Mass/Second/BP = BuildCost / BT
-        --   BuildCost = HPR/Mass
-        --   BT = HPR = RR/RAM
-        -- Mass/Second/BP = HPR/Mass / (RR/RAM)
-        -- Mass/Second/BP = HPR/Mass / RAM * RR
-
-        -- shieldBp.AssistCostMassPerBuildRate = shieldBp.RegenPerMassCost / shieldBp.RegenAssistMult * shieldBp.ShieldRegenRate
     end
 end
 

--- a/units/UAB4202/UAB4202_unit.bp
+++ b/units/UAB4202/UAB4202_unit.bp
@@ -51,9 +51,6 @@ UnitBlueprint{
             ShieldRegenStartTime = 3,
             ShieldSize = 20,
             ShieldVerticalOffset = -3,
-            RegenPerBuildRate = 100,
-            AssistCostEnergyPerBuildRate = 10,
-            AssistCostMassPerBuildRate = 10,
         },
     },
     Display = {

--- a/units/UAB4202/UAB4202_unit.bp
+++ b/units/UAB4202/UAB4202_unit.bp
@@ -51,6 +51,9 @@ UnitBlueprint{
             ShieldRegenStartTime = 3,
             ShieldSize = 20,
             ShieldVerticalOffset = -3,
+            RegenPerBuildRate = 100,
+            AssistCostEnergyPerBuildRate = 10,
+            AssistCostMassPerBuildRate = 10,
         },
     },
     Display = {


### PR DESCRIPTION
## Issue
Cybran shields have terrible buildtime stats due to previously high shield assist costs, as written in https://github.com/FAForever/fa/pull/2703.
UEF T3 shields cost significantly more than other shields to assist. This is just a problem with `RegenAssistMult` never being touched, alongside the faction having poor shield stats.

Current assist cost stats:

Shield | AssistRegen/BP | AssistRegen/Mass
-- | -- | --
Sera T3 | 2.80 | 6.06
UEF T3 | 2.18 | 4.40
Aeon T3 | 2.50 | 5.69
Cybran ED5 | 2.33 | 5.19
Cybran T3 ED4 | 2.17 | 4.13

Buildtime stats:

Shield | BT
-- | --
Sera T3 | 5841
UEF T3 | 4988
Aeon T3 | 4097
Cybran ED5 | 7100
Cybran T3 ED4 | 3515

## Description of the proposed changes
Implements new shield blueprint fields that make it easier/possible to balance shield assist.
- `RegenPerBuildRate`: Makes it easier to think about `RegenAssistMult` by disconnecting the desired balance effect from the regen rate of the shield.
- `AssistCostEnergyPerBuildRate` and  `AssistCostMassPerBuildRate`: Makes it possible to balance shield assist cost by disconnecting the assist cost from the shield unit's cost stats.

I am interested in thoughts on how user-friendly (UI information display and game intuition), how developer-friendly, and how performant the implementation is.

## Testing done on the proposed changes
I read the decompilation that mentions the string `"RegenRate"`, which is around where the `RegenAssistMult` is used (.text:005F602E).

Re-apply the commit with the Aeon T2 shield.
Spawn in the test units:
```
   CreateUnitAtMouse('ual0301_rambo', 0,    5.07,    8.48, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,   -0.93,   -4.00, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,   -2.07,   -4.26, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,   -1.21,   -2.60, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,   -1.93,   -6.00, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,   -3.21,   -6.60, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,   -2.93,   -8.00, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,   -4.27,   -8.86, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,    3.93,    7.74, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,    4.07,    6.00, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,    2.79,    5.40, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,    1.93,    3.74, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,    3.07,    4.00, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,    2.07,    2.00, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,    1.07,   -0.00, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,    0.79,    1.40, -0.00000)
   CreateUnitAtMouse('ual0301_rambo', 0,    0.07,   -2.00, -0.00000)
   CreateUnitAtMouse('uab4202', 0,   -4.93,    2.48,  0.00000)
   CreateUnitAtMouse('ual0105', 0,   -9.74,    2.05,  0.35222)
   CreateUnitAtMouse('ual0301_rambo', 0,   -0.71,    1.58, -0.22020)
   CreateUnitAtMouse('xab1401', 0,    7.07,   -2.52,  0.00000)
```
Damage the shield by groundfiring with the SACU and assist the shield with the T1 engineer. It should repair 50 HP per tick and consume 50m/s and 50e/s, which matches up with the test stats. 
Let the shield regen to full, then reclaim the shield with an SACU to damage the unit's HP and see that the engineer consumes an additional 1.89 mass/s and 22.7 energy/s.

Damage the shield, assist, and then reclaim the unit. The engi should update its consumption correctly after the unit is damaged (50% of both the assist and repair costs). This is also an opportunity to see the engine behavior of the repair effects being split evenly when both the shield and unit are damaged: the 50 HP per tick regen will go down to 25 HP per tick after the unit is damaged.

Reclaim the unit, assist, and then damage the shield. The engi should again update the consumption correctly.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
