### PR TITLE
Add annotations about the sensitivity of the guard scan radius

### DIFF
--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -145,7 +145,7 @@
 ---@field GuardRadius number
 --- maximum range from the guarded unit before initiating return
 ---@field GuardReturnRadius number
---- Guard scan range for the unit. The guard scan radius is used applied for attack move and patrol orders. Through this scanning mechanic the patrolling (or attack moving) unit can find a target to chase. 
+--- Guard scan range for the unit. The guard scan radius is used by attack move and patrol orders. Through this scanning mechanic the patrolling (or attack moving) unit can find a target to chase. The scanning behavior includes neutral units.
 ---
 --- Through a binary patch the guard scan radius is reset to 0 when the unit is not patrolling and/or attack moving:
 --- - https://faforever.zulipchat.com/#narrow/channel/203495-game-development/topic/Guard.20scan.20radius/with/285967051

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -154,6 +154,8 @@
 --- Large values can be computationally expensive. This value was partially responsible for games slowing down during large ASF battles. For more information:
 --- - https://github.com/FAForever/fa/pull/3891
 --- - https://github.com/FAForever/fa/pull/3892
+---
+--- The value is automatically populated during blueprint loading to a sensible default if it is not set in the blueprint.
 ---@field GuardScanRadius number
 --- initial toggle of automatic behaviors (silo building and auto-assist)
 ---@see SetAutoMode

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -145,7 +145,15 @@
 ---@field GuardRadius number
 --- maximum range from the guarded unit before initiating return
 ---@field GuardReturnRadius number
---- guard range for the unit, automatically added if absent
+--- Guard scan range for the unit. The guard scan radius is used applied for attack move and patrol orders. Through this scanning mechanic the patrolling (or attack moving) unit can find a target to chase. 
+---
+--- Through a binary patch the guard scan radius is reset to 0 when the unit is not patrolling and/or attack moving:
+--- - https://faforever.zulipchat.com/#narrow/channel/203495-game-development/topic/Guard.20scan.20radius/with/285967051
+--- - https://github.com/FAForever/FA-Binary-Patches/blob/master/section/GuardFix.cpp
+---
+--- Large values can be computationally expensive. This value was partially responsible for games slowing down during large ASF battles. For more information:
+--- - https://github.com/FAForever/fa/pull/3891
+--- - https://github.com/FAForever/fa/pull/3892
 ---@field GuardScanRadius number
 --- initial toggle of automatic behaviors (silo building and auto-assist)
 ---@see SetAutoMode


### PR DESCRIPTION
## Description of the proposed changes

Through the discussion in https://github.com/FAForever/fa/pull/6939 I noticed that a lot of relevant information surrounding this blueprint value is lost. With these annotations I hope to prevent this loss of information for the foreseeable future.

## Checklist
- [x] Changes are annotated, including comments where useful
