### PR TITLE
Fix replay ID extraction possible breaking UI

### DIFF
--- a/changelog/snippets/fix.6947.md
+++ b/changelog/snippets/fix.6947.md
@@ -1,0 +1,1 @@
+- (#6947) Fix replay ID extraction possible breaking UI

--- a/changelog/snippets/fix.6947.md
+++ b/changelog/snippets/fix.6947.md
@@ -1,1 +1,1 @@
-- (#6947) Fix replay ID extraction possible breaking UI
+- (#6947) Fix replay ID extraction possibly breaking UI.

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -1326,7 +1326,7 @@ function GetReplayId()
         id = GetFrontEndData('syncreplayid')
     elseif HasCommandLineArg("/savereplay") then
         -- /savereplay format is gpgnet://local_ip:port/replay_id/USERNAME.SCFAreplay
-        -- see https://github.com/FAForever/downlords-faf-client/blob/b819997b2c4964ae6e6801d5d2eecd232bca5688/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java--L192
+        -- see https://github.com/FAForever/downlords-faf-client/blob/d44f97dd40c011f391c8d97f122b54bb61a23c80/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java#L260
         local url = GetCommandLineArg("/savereplay", 1)[1]
         url = string.gsub(tostring(url), "\\", "/")
         id = string.match(url, ".*/([0-9]+)/[^/]*$") -- number between last two "/" "/"

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -1328,9 +1328,8 @@ function GetReplayId()
         -- /savereplay format is gpgnet://local_ip:port/replay_id/USERNAME.SCFAreplay
         -- see https://github.com/FAForever/downlords-faf-client/blob/b819997b2c4964ae6e6801d5d2eecd232bca5688/src/main/java/com/faforever/client/fa/LaunchCommandBuilder.java--L192
         local url = GetCommandLineArg("/savereplay", 1)[1]
-        local fistpos = string.find(url, "/", 10) + 1
-        local lastpos = string.find(url, "/", fistpos) - 1
-        id = string.sub(url, fistpos, lastpos)
+        url = string.gsub(tostring(url), "\\", "/")
+        id = string.match(url, ".*/([0-9]+)/[^/]*$") -- number between last two "/" "/"
     elseif HasCommandLineArg("/replayid") then
         id =  GetCommandLineArg("/replayid", 1)[1]
     end


### PR DESCRIPTION
## Description of the proposed changes
This does not affect FAF games an the previous code works, when the format of the `savereplay` is exactly as expected.

But for whoever would messing around with saving the replays only locally. It could end up trying to make arithemic operation on with nil. And that breaks the whole UI as this function is called from userInit.lua

This new version should work on all string safely, while grabbing the replay ID correctly from the specified format.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed replay ID extraction that could potentially cause UI issues during replay functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->