### PR TITLE
Fix wrong army report to lobby server with uneven teams

### DIFF
--- a/changelog/snippets/fix.6948.md
+++ b/changelog/snippets/fix.6948.md
@@ -1,0 +1,1 @@
+- (#6948) Fix wrong army report to lobby server with uneven teams

--- a/changelog/snippets/fix.6948.md
+++ b/changelog/snippets/fix.6948.md
@@ -1,1 +1,1 @@
-- (#6948) Fix wrong army report to lobby server with uneven teams
+- (#6948) Fix wrong army report to lobby server with uneven teams.

--- a/engine/User/CLobby.lua
+++ b/engine/User/CLobby.lua
@@ -56,6 +56,7 @@ local CLobby = {}
 
 ---@class UILobbyLaunchPlayerConfiguration
 ---@field StartSpot number          # Read by Lua code to determine start locations
+---@field Team number               # Read by Lua code to determine teams
 ---@field ArmyName string           # Read by the engine, TODO
 ---@field PlayerName string         # Read by the engine, TODO
 ---@field Civilian boolean          # Read by the engine, TODO

--- a/lua/ui/lobby/autolobby/AutolobbyController.lua
+++ b/lua/ui/lobby/autolobby/AutolobbyController.lua
@@ -559,13 +559,14 @@ AutolobbyCommunications = Class(MohoLobbyMethods, AutolobbyServerCommunicationsC
                 WaitSeconds(5.0)
                 if (not IsDestroyed(self)) and self:CanLaunch(self.LaunchStatutes) then
 
-                    -- send player options to the server
+                    -- Army numbers need to be calculated: they are numbered incrementally in slot order.
                     local slots = {}
                     for slotIndex, _ in pairs(self.PlayerOptions) do
                         table.insert(slots, slotIndex)
                     end
                     table.sort(slots)
 
+                    -- send player options to the server
                     for armyIndex, slotIndex in ipairs(slots) do
                         local playerOptions = self.PlayerOptions[slotIndex]
                         local ownerId = playerOptions.OwnerID

--- a/lua/ui/lobby/autolobby/AutolobbyController.lua
+++ b/lua/ui/lobby/autolobby/AutolobbyController.lua
@@ -560,10 +560,17 @@ AutolobbyCommunications = Class(MohoLobbyMethods, AutolobbyServerCommunicationsC
                 if (not IsDestroyed(self)) and self:CanLaunch(self.LaunchStatutes) then
 
                     -- send player options to the server
-                    for slot, playerOptions in self.PlayerOptions do
+                    local slots = {}
+                    for slotIndex, _ in pairs(self.PlayerOptions) do
+                        table.insert(slots, slotIndex)
+                    end
+                    table.sort(slots)
+
+                    for armyIndex, slotIndex in ipairs(slots) do
+                        local playerOptions = self.PlayerOptions[slotIndex]
                         local ownerId = playerOptions.OwnerID
                         self:SendPlayerOptionToServer(ownerId, 'Team', playerOptions.Team)
-                        self:SendPlayerOptionToServer(ownerId, 'Army', playerOptions.StartSpot)
+                        self:SendPlayerOptionToServer(ownerId, 'Army', armyIndex)
                         self:SendPlayerOptionToServer(ownerId, 'StartSpot', playerOptions.StartSpot)
                         self:SendPlayerOptionToServer(ownerId, 'Faction', playerOptions.Faction)
                     end


### PR DESCRIPTION
Army IDs are same as the slot indexes only when the teams are the same. Not much a problem with now with FAF matchmaker, as the teams are always the same size.

But if in the future (GW or different queue) wants to have uneven teams. This code will support it to send correct army IDs.

This is how it works in custom lobbies


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect army assignment to the lobby server when teams are uneven. Enhanced team configuration handling to ensure proper army representation in lobby launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->