### PR TITLE
Fix unitview not showing shield HP for non-back slot shield upgrades

### DIFF
--- a/changelog/snippets/fix.6950.md
+++ b/changelog/snippets/fix.6950.md
@@ -1,0 +1,1 @@
+- (#6950) Fix the rollover unit view not showing shield HP for units with non-back slot shield upgrades.

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -776,11 +776,10 @@ function UpdateWindow(info)
             end
 
             if info.shieldRatio > 0 then
-                local getEnh = import("/lua/enhancementcommon.lua")
                 local unitBp = info.userUnit:GetBlueprint()
                 local shield = unitBp.Defense.Shield
                 if not shield.ShieldMaxHealth then
-                    local enhancements = getEnh.GetEnhancements(info.entityId)
+                    local enhancements = EnhancementCommon.GetEnhancements(info.entityId)
                     local enhBps = unitBp.Enhancements
                     for _, enhName in enhancements do
                         local enhancement = enhBps[enhName]

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -796,16 +796,8 @@ function UpdateWindow(info)
                     if shieldRegenRate > 0 then
                         shieldText = shieldText .. string.format("+%d/s", shieldRegenRate)
                     end
-                    if shieldMaxHealth > 0 then
-                        controls.shieldText:Show()
-                        if shieldRegenRate > 0 then
-                            controls.shieldText:SetText(string.format("%d / %d +%d/s",
-                                math.floor(shieldMaxHealth * info.shieldRatio), shieldMaxHealth, shieldRegenRate))
-                        else
-                            controls.shieldText:SetText(string.format("%d / %d",
-                                math.floor(shieldMaxHealth * info.shieldRatio), shieldMaxHealth))
-                        end
-                    end
+                    controls.shieldText:Show()
+                    controls.shieldText:SetText(shieldText)
                 end
             end
         end

--- a/lua/ui/game/unitview.lua
+++ b/lua/ui/game/unitview.lua
@@ -390,6 +390,7 @@ function CreateQueueGrid(parent)
     controls.queue:Hide()
 end
 
+---@param info RolloverInfo
 function UpdateWindow(info)
     if info.blueprintId == 'unknown' then
         controls.name:SetText(LOC('<LOC rollover_0000>Unknown Unit'))
@@ -779,7 +780,15 @@ function UpdateWindow(info)
                 local unitBp = info.userUnit:GetBlueprint()
                 local shield = unitBp.Defense.Shield
                 if not shield.ShieldMaxHealth then
-                    shield = unitBp.Enhancements[getEnh.GetEnhancements(info.entityId).Back]
+                    local enhancements = getEnh.GetEnhancements(info.entityId)
+                    local enhBps = unitBp.Enhancements
+                    for _, enhName in enhancements do
+                        local enhancement = enhBps[enhName]
+                        if enhancement.ShieldMaxHealth > 0 then
+                            shield = enhancement
+                            break
+                        end
+                    end
                 end
                 local shieldMaxHealth, shieldRegenRate = shield.ShieldMaxHealth or 0, shield.ShieldRegenRate or 0
                 if shieldMaxHealth > 0 then

--- a/units/XSL0301/XSL0301_unit.bp
+++ b/units/XSL0301/XSL0301_unit.bp
@@ -417,9 +417,9 @@ UnitBlueprint{
             Slot = "RCH",
         },
         Shield = {
-            BuildCostEnergy = 107500,
-            BuildCostMass = 1050,
-            BuildTime = 6720,
+            BuildCostEnergy = 1,
+            BuildCostMass = 1,
+            BuildTime = 1,
             Icon = "sp",
             ImpactEffects = "SeraphimShieldHit01",
             MaintenanceConsumptionPerSecondEnergy = 300,
@@ -433,7 +433,7 @@ UnitBlueprint{
             ShieldRegenRate = 22,
             ShieldRegenStartTime = 1,
             ShowBones = { "Back_Upgrade" },
-            Slot = "Back",
+            Slot = "LCH",
             UpgradeEffectBones = { "Back_Upgrade" },
             UpgradeUnitAmbientBones = { "Torso" },
         },
@@ -449,7 +449,7 @@ UnitBlueprint{
                 "Shield",
                 "ShieldRemove",
             },
-            Slot = "Back",
+            Slot = "LCH",
         },
         Slots = {
             Back = {

--- a/units/XSL0301/XSL0301_unit.bp
+++ b/units/XSL0301/XSL0301_unit.bp
@@ -417,9 +417,9 @@ UnitBlueprint{
             Slot = "RCH",
         },
         Shield = {
-            BuildCostEnergy = 1,
-            BuildCostMass = 1,
-            BuildTime = 1,
+            BuildCostEnergy = 107500,
+            BuildCostMass = 1050,
+            BuildTime = 6720,
             Icon = "sp",
             ImpactEffects = "SeraphimShieldHit01",
             MaintenanceConsumptionPerSecondEnergy = 300,
@@ -433,7 +433,7 @@ UnitBlueprint{
             ShieldRegenRate = 22,
             ShieldRegenStartTime = 1,
             ShowBones = { "Back_Upgrade" },
-            Slot = "LCH",
+            Slot = "Back",
             UpgradeEffectBones = { "Back_Upgrade" },
             UpgradeUnitAmbientBones = { "Torso" },
         },
@@ -449,7 +449,7 @@ UnitBlueprint{
                 "Shield",
                 "ShieldRemove",
             },
-            Slot = "LCH",
+            Slot = "Back",
         },
         Slots = {
             Back = {


### PR DESCRIPTION
## Issue
The shield HP text was not being displayed for units with non-back slot shield upgrades.

## Description of the proposed changes
Check all slots for shield upgrades instead of only the back slot.

## Testing done on the proposed changes
Use the test unit with the left slot shield upgraded and see that it displays the shield HP text.
<img width="197" height="25" alt="{EAB02346-C277-45F6-91EB-4D3D342F416F}" src="https://github.com/user-attachments/assets/72bb3a1d-d40a-4f85-beba-66568ab4bfca" />

I saw no issues with other unshielded units and non-upgradeable shield units.

Test units:
```
   CreateUnitAtMouse('xab1401', 0,  -14.50,   -5.00, -0.00000)
   CreateUnitAtMouse('ual0001', 0,    2.50,    5.00, -0.00000)
   CreateUnitAtMouse('xsl0301', 0,    1.50,    1.00, -0.00000)
   CreateUnitAtMouse('uel0307', 0,   10.50,   -1.00, -0.00000)
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shield HP display in the unit view for units with non-back-slot shield upgrades so shield values show correctly.

* **Documentation**
  * Added a changelog entry documenting the fix for issue #6950.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->