### PR TITLE
Reduce duration of splats made by projectiles

### DIFF
--- a/lua/sim/Projectile.lua
+++ b/lua/sim/Projectile.lua
@@ -434,6 +434,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
                 local rngRadius = altRadius * Random()
 
                 local splatRadius = 0.75 * altRadius + 0.2 * rngRadius
+                local duration = 2 + 2 * altRadius + 4 * rngRadius
 
                 CreateSplat(
                     vc, -- position
@@ -444,7 +445,7 @@ Projectile = ClassProjectile(ProjectileMethods, DebugProjectileComponent) {
                     splatRadius, -- size x
                     splatRadius, -- size z
                     10 + 30 * altRadius + 30 * rngRadius, -- lod
-                    8 + 8 * altRadius + 8 * rngRadius, -- duration
+                    duration, -- duration
                     self.Army-- owner of splat
                 )
             end


### PR DESCRIPTION
## Description of the proposed changes

Reduces the duration of splats made by projectiles. We introduced these splats to give projectiles something to leave behind when they explode. To 'influence' the visual aspect of the environment somehow. However, it appears the duration is really long on average. From 15 to 90 seconds, depending on the type of projectile. 

With these changes we reduce the time by a lot. There were reports that splats were flickering. That means there's too much going on for the game to manage.

Related: https://discord.com/channels/197033481883222026/1431095378349916261

## Testing done on the proposed changes

- Seraphim tech 3 artillery

```
INFO: /projectiles/sifsuthanusartilleryshell01/sifsuthanusartilleryshell01_proj.bp	61.527900695801	 -> 	18.7639503479
INFO: /projectiles/sifsuthanusartilleryshell01/sifsuthanusartilleryshell01_proj.bp	69.272018432617	 -> 	22.63600730896
INFO: /projectiles/sifsuthanusartilleryshell01/sifsuthanusartilleryshell01_proj.bp	49.695949554443	 -> 	12.847974777222
INFO: /projectiles/sifsuthanusartilleryshell01/sifsuthanusartilleryshell01_proj.bp	61.96985244751	 -> 	18.984926223755
INFO: /projectiles/sifsuthanusartilleryshell01/sifsuthanusartilleryshell01_proj.bp	51.62414932251	 -> 	13.812074661255
INFO: /projectiles/sifsuthanusartilleryshell01/sifsuthanusartilleryshell01_proj.bp	51.403820037842	 -> 	13.701910972595
INFO: /projectiles/sifsuthanusartilleryshell01/sifsuthanusartilleryshell01_proj.bp	85.869422912598	 -> 	30.934711456299
```

- UEF tech 1 artillery

```
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	23.328428268433	 -> 	7.6642141342163
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	19.083351135254	 -> 	5.5416750907898
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	17.808380126953	 -> 	4.9041900634766
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	18.811252593994	 -> 	5.4056258201599
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	16.3460521698	 -> 	4.1730265617371
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	20.587032318115	 -> 	6.2935161590576
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	19.030111312866	 -> 	5.5150556564331
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	18.897994995117	 -> 	5.4489970207214
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	21.593914031982	 -> 	6.7969574928284
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	22.86612701416	 -> 	7.4330635070801
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	16.53436088562	 -> 	4.2671804428101
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	20.366186141968	 -> 	6.1830930709839
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	19.865161895752	 -> 	5.932580947876
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	20.242944717407	 -> 	6.1214723587036
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	16.518728256226	 -> 	4.2593636512756
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	22.034484863281	 -> 	7.0172424316406
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	16.850700378418	 -> 	4.4253497123718
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	19.455581665039	 -> 	5.7277908325195
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	23.924781799316	 -> 	7.9623908996582
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	21.143238067627	 -> 	6.5716190338135
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	19.372924804688	 -> 	5.6864624023438
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	20.787008285522	 -> 	6.3935041427612
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	19.692874908447	 -> 	5.8464379310608
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	22.806102752686	 -> 	7.4030513763428
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	18.096109390259	 -> 	5.0480546951294
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	18.839860916138	 -> 	5.4199304580688
INFO: /projectiles/tiffragmentationsensorshell02/tiffragmentationsensorshell02_proj.bp	23.918785095215	 -> 	7.9593930244446
```

- UEF Tech 2 point defense:

```
INFO: /projectiles/tdfgauss02/tdfgauss02_proj.bp	26.544828414917	 -> 	8.4724140167236
INFO: /projectiles/tdfgauss02/tdfgauss02_proj.bp	29.437366485596	 -> 	9.9186820983887
INFO: /projectiles/tdfgauss02/tdfgauss02_proj.bp	28.735557556152	 -> 	9.5677785873413
```

- UEF Tech 3 strategic bomber:

```
INFO: /projectiles/tifsmallyieldnuclearbomb01/tifsmallyieldnuclearbomb01_proj.bp	85.541320800781	 -> 	29.770658493042
```

- Fatboy

```
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	26.960863113403	 -> 	8.4804315567017
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	26.168601989746	 -> 	8.084300994873
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	31.613891601563	 -> 	10.806945800781
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	28.755882263184	 -> 	9.3779411315918
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	31.762907028198	 -> 	10.881453514099
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	23.314832687378	 -> 	6.6574158668518
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	21.514802932739	 -> 	5.7574014663696
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	21.019285202026	 -> 	5.509642124176
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	26.288417816162	 -> 	8.1442089080811
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	23.838871002197	 -> 	6.9194355010986
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	25.736152648926	 -> 	7.8680758476257
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	27.2214012146	 -> 	8.6107006072998
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	25.528570175171	 -> 	7.7642850875854
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	23.579916000366	 -> 	6.7899580001831
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	24.254306793213	 -> 	7.1271533966064
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	28.734312057495	 -> 	9.3671560287476
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	24.287525177002	 -> 	7.143762588501
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	27.446649551392	 -> 	8.7233247756958
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	25.849029541016	 -> 	7.9245147705078
INFO: /projectiles/tdfgauss04/tdfgauss04_proj.bp	24.275653839111	 -> 	7.1378264427185
```

## Additional context


Related: https://github.com/FAForever/fa/issues/5616 and https://github.com/FAForever/fa/issues/3719

## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted projectile splash effect duration to display more appropriately based on blast radius parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->