### PR TITLE
Fix error when ues0304 fires without a muzzle charge sequence

### DIFF
--- a/changelog/snippets/fix.6956.md
+++ b/changelog/snippets/fix.6956.md
@@ -1,0 +1,1 @@
+- (#6956) Fix error when the UEF submarine fires its missiles with a muzzle charge delay of 0 in the blueprint.

--- a/units/UES0304/UES0304_script.lua
+++ b/units/UES0304/UES0304_script.lua
@@ -24,12 +24,14 @@ UES0304 = ClassUnit(TSubUnit) {
 
             PlayFxRackReloadSequence = function(self)
                 self.Trash:Add(ForkThread(function()
-                    -- Wait 1 second for the missile to clear the hatch.
-                    WaitSeconds(1)
-                    self.Rotator:SetGoal(0)
-                    WaitFor(self.Rotator)
-                    self.Rotator:Destroy()
-                    self.Rotator = nil
+                    if self.Rotator then
+                        -- Wait 1 second for the missile to clear the hatch.
+                        WaitSeconds(1)
+                        self.Rotator:SetGoal(0)
+                        WaitFor(self.Rotator)
+                        self.Rotator:Destroy()
+                        self.Rotator = nil
+                    end
                 end))
                 TIFCruiseMissileLauncherSub.PlayFxRackReloadSequence(self)
             end,
@@ -46,12 +48,14 @@ UES0304 = ClassUnit(TSubUnit) {
 
             PlayFxRackReloadSequence = function(self)
                 self.Trash:Add(ForkThread(function()
-                    -- Wait 1 second for the missile to clear the hatch.
-                    WaitSeconds(1)
-                    self.Rotator:SetGoal(0)
-                    WaitFor(self.Rotator)
-                    self.Rotator:Destroy()
-                    self.Rotator = nil
+                    if self.Rotator then
+                        -- Wait 1 second for the missile to clear the hatch.
+                        WaitSeconds(1)
+                        self.Rotator:SetGoal(0)
+                        WaitFor(self.Rotator)
+                        self.Rotator:Destroy()
+                        self.Rotator = nil
+                    end
                 end))
                 TIFCruiseMissileLauncherSub.PlayFxRackReloadSequence(self)
             end,

--- a/units/UES0304/UES0304_script.lua
+++ b/units/UES0304/UES0304_script.lua
@@ -15,13 +15,18 @@ local EffectTemplate = import('/lua/effecttemplates.lua')
 UES0304 = ClassUnit(TSubUnit) {
     DeathThreadDestructionWaitTime = 0,
     Weapons = {
+        ---@class UES0304_CruiseMissiles : TIFCruiseMissileLauncherSub
+        ---@field Rotator? moho.RotateManipulator
         CruiseMissiles = ClassWeapon(TIFCruiseMissileLauncherSub) {
+            ---@param self UES0304_CruiseMissiles
+            ---@param muzzle Bone
             PlayFxMuzzleChargeSequence = function(self, muzzle)
                 --We don't need to wait for the rotator to finish because MuzzleChargeDelay = 1 in the bp will do that for us.
                 self.Rotator = CreateRotator(self.unit, self:GetBlueprint().RackBones[self.CurrentRackSalvoNumber].RackBone, 'z', 90, 90, 90, 90)
                 TIFCruiseMissileLauncherSub.PlayFxMuzzleChargeSequence(self, muzzle)
             end,
 
+            ---@param self UES0304_CruiseMissiles
             PlayFxRackReloadSequence = function(self)
                 self.Trash:Add(ForkThread(function()
                     if self.Rotator then
@@ -37,15 +42,19 @@ UES0304 = ClassUnit(TSubUnit) {
             end,
         },
 
+        ---@class UES0304_NukeMissiles : TIFStrategicMissileWeapon
+        ---@field Rotator? moho.RotateManipulator
         NukeMissiles = ClassWeapon(TIFStrategicMissileWeapon) {
             FxMuzzleFlash = EffectTemplate.TIFCruiseMissileLaunchUnderWater,
-
+            ---@param self UES0304_NukeMissiles
+            ---@param muzzle Bone
             PlayFxMuzzleChargeSequence = function(self, muzzle)
                 --We don't need to wait for the rotator to finish because MuzzleChargeDelay = 1 in the bp will do that for us.
                 self.Rotator = CreateRotator(self.unit, self:GetBlueprint().RackBones[self.CurrentRackSalvoNumber].RackBone, 'z', 90, 90, 90, 90)
                 TIFCruiseMissileLauncherSub.PlayFxMuzzleChargeSequence(self, muzzle)
             end,
 
+            ---@param self UES0304_NukeMissiles
             PlayFxRackReloadSequence = function(self)
                 self.Trash:Add(ForkThread(function()
                     if self.Rotator then


### PR DESCRIPTION
## Description of the proposed changes
Fixes the following error:
```
warning: Error running lua script: ...\gamedata\units.nx2\units\ues0304\ues0304_script.lua(29): attempt to call method `SetGoal' (a nil value)
         stack traceback:
         	...\gamedata\units.nx2\units\ues0304\ues0304_script.lua(29): in function <...\gamedata\units.nx2\units\ues0304\ues0304_script.lua:26>
```
From replay 25869162 (modded game with rapid fire missile sub).

## Testing done on the proposed changes
making the unit fire without a muzzle charge sequence no longer causes errors

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that occurred when the UEF submarine fired missiles with a muzzle charge delay of 0 in the unit configuration.
  * Improved weapon system reliability and stability by implementing enhanced error handling during missile launch and rotation sequences.
  * Strengthened error prevention to ensure smooth weapon operation under all configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->