### PR TITLE
Fix ravager size

### DIFF
--- a/changelog/snippets/fix.6957.md
+++ b/changelog/snippets/fix.6957.md
@@ -1,0 +1,1 @@
+- (#6957) Fix the ravager blueprint size category

--- a/units/XEB2306/XEB2306_unit.bp
+++ b/units/XEB2306/XEB2306_unit.bp
@@ -18,7 +18,7 @@ UnitBlueprint{
         "PRODUCTFA",
         "RECLAIMABLE",
         "SELECTABLE",
-        "SIZE12",
+        "SIZE4",
         "SNIPEMODE",
         "SORTDEFENSE",
         "STRUCTURE",


### PR DESCRIPTION
Buliding blueprints include the SIZEx category, with SIZE4 being for units like T2 PD and T1 pgens, SIZE12 being T2 pgen sized units, etc.; in all cases I'm aware of the size reflects the building's UI size, except the ravager which shows as a SIZE12 building instead of a SIZE4 building.

This fixes the blueprint category

As a basic test I created a T3 UEF engineer and checked it could build a ravager.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fix**
  * Corrected the size category for a ravager unit to ensure its classification is accurate (no gameplay behavior changes).
* **Chores**
  * Added a changelog entry documenting the size category fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->