### PR TITLE
Add a call to the deployment workflow of a new unit database

### DIFF
--- a/.github/workflows/etfreeman-db-update.yaml
+++ b/.github/workflows/etfreeman-db-update.yaml
@@ -23,8 +23,8 @@ name: ETFreeman DB - update unit information
 on:
   workflow_dispatch:
   push:
-    branches:
-      - deploy/faf
+    # branches:
+    #   - deploy/faf
 
 jobs:
   deploy:

--- a/.github/workflows/etfreeman-db-update.yaml
+++ b/.github/workflows/etfreeman-db-update.yaml
@@ -23,8 +23,8 @@ name: ETFreeman DB - update unit information
 on:
   workflow_dispatch:
   push:
-    # branches:
-    #   - deploy/faf
+    branches:
+      - deploy/faf
 
 jobs:
   deploy:

--- a/.github/workflows/etfreeman-db-update.yaml
+++ b/.github/workflows/etfreeman-db-update.yaml
@@ -1,0 +1,31 @@
+# Copyright (c) 2024 Willem 'Jip' Wijnia
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: ETFreeman DB - update unit information
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - deploy/faf
+
+jobs:
+  deploy:
+    uses: FAForever/etfreeman-db/.github/workflows/deploy.yml@master


### PR DESCRIPTION
## Description of the proposed changes

Add a workflow that attempts to update/deploy the new unit database written by @K-ETFreeman . Inspired by the workflow setup of [spooky-db](https://github.com/FAForever/fa/blob/develop/.github/workflows/spookydb-update.yaml) and [unit-db](https://github.com/FAForever/fa/blob/develop/.github/workflows/unitdb-update.yaml)

## Testing done on the proposed changes







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to update database unit information, triggerable manually or on code changes.
  * Workflow delegates deployment steps to an existing deployment workflow to reuse established processes.
  * Includes a standard license header and boilerplate metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->