### PR TITLE
Fix the Beetle's energy maintenance consumption

### DIFF
--- a/changelog/snippets/fix.6961.md
+++ b/changelog/snippets/fix.6961.md
@@ -1,0 +1,1 @@
+- (#6961) Fix the Beetle's energy maintenance consumption.

--- a/units/XRL0302/XRL0302_Script.lua
+++ b/units/XRL0302/XRL0302_Script.lua
@@ -117,6 +117,7 @@ XRL0302 = ClassUnit(CWalkingLandUnit) {
     ---@param self XRL0302
     OnCreate = function(self)
         CWalkingLandUnit.OnCreate(self)
+        self:SetMaintenanceConsumptionActive()
         self.EffectsBagXRL = TrashBag()
         self.AmbientExhaustEffectsBagXRL = TrashBag()
         self:CreateTerrainTypeEffects(self.IntelEffects.Cloak, 'FXIdle', self.Layer, nil, self.EffectsBag)


### PR DESCRIPTION
## Description of the proposed changes
Enable the energy consumption of the Beetle's cloak via its script. Finishes #6897.

## Checklist
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The Beetle unit now correctly consumes maintenance energy during operation, restoring expected in-game energy behavior.
* **Changelog**
  * Added a brief changelog entry noting the Beetle maintenance consumption fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->