### PR TITLE
Fix `UnitDoTThread` dealing damage ticks before waiting

### DIFF
--- a/changelog/snippets/fix.6963.md
+++ b/changelog/snippets/fix.6963.md
@@ -1,0 +1,1 @@
+- (#6963) Fix non-area DoT damage dealing damage ticks before waiting the delay between damage ticks.

--- a/lua/sim/DefaultDamage.lua
+++ b/lua/sim/DefaultDamage.lua
@@ -42,12 +42,6 @@ function UnitDoTThread(instigator, target, pulses, pulseInterval, damage, damage
     local accum = 0
 
     for i = 1, pulses do
-        if target and not EntityBeenDestroyed(target) then
-            position[1], position[2], position[3] = EntityGetPositionXYZ(target)
-            Damage(instigator, position, target, damage, damageType)
-        else
-            break
-        end
         accum = accum + pulseInterval
         if accum > 1 then
             -- final accumulator value may be #.999 which needs to be rounded
@@ -57,6 +51,13 @@ function UnitDoTThread(instigator, target, pulses, pulseInterval, damage, damage
                 WaitTicks(accum)
                 accum = MathMod(accum, 1)
             end
+        end
+
+        if target and not EntityBeenDestroyed(target) then
+            position[1], position[2], position[3] = EntityGetPositionXYZ(target)
+            Damage(instigator, position, target, damage, damageType)
+        else
+            break
         end
     end
 end

--- a/lua/sim/DefaultDamage.lua
+++ b/lua/sim/DefaultDamage.lua
@@ -29,6 +29,8 @@ local EntityGetPositionXYZ = _G.moho.entity_methods.GetPositionXYZ
 ---@param damage number
 ---@param damageType DamageType
 function UnitDoTThread(instigator, target, pulses, pulseInterval, damage, damageType)
+    if not target or EntityBeenDestroyed(target) then return end
+
     -- localize for performance
     local position = VectorCache
     local Damage = Damage


### PR DESCRIPTION
## Description of the proposed changes
Move the damage dealing portion until after the wait, as it should be according to the function comment and the projectile dealing the very first damage tick before forking the thread..
Add a fast exit in case the target was destroyed as the thread was forked.

## Testing done on the proposed changes
Cybran torpedo launcher projectiles deal damage without errors. This very slightly adjusts cybran torpedo effectiveness by offsetting their damage ticks by 0.2 seconds (0.6s -> 0.8s total duration for 5 damage ticks).

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed non-area Damage over Time (DoT) behavior so that damage ticks now properly respect the intended delay between pulses, correcting an issue where ticks were occurring prematurely rather than at scheduled intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->