### PR TITLE
Remove time requirement for rating games when recalling

### DIFF
--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -574,6 +574,9 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
         -- TODO: create a common function for `OnDefeat` and `OnRecall`
         self.Status = "Recalled"
 
+        Sync.EnforceRating = true
+        WARN("Recall detected. Time requirement for rating games will now be removed.")
+
         local selfIndex = self:GetArmyIndex()
         UpdateUnitCap(selfIndex)
         SimPingOnArmyDefeat(selfIndex)

--- a/lua/sim/units/ACUUnit.lua
+++ b/lua/sim/units/ACUUnit.lua
@@ -108,7 +108,7 @@ ACUUnit = ClassUnit(CommandUnit) {
             local instigatorBrain = ArmyBrains[instigator.Army]
 
             Sync.EnforceRating = true
-            WARN('ACU kill detected. Rating for ranked games is now enforced.')
+            WARN("ACU kill detected. Time requirement for rating games will now be removed.")
 
             -- If we are teamkilled, filter out death explostions of allied units that were not coused by player's self destruct order
             -- Damage types:


### PR DESCRIPTION
The time requirement for ranking custom games is in place so that connection issues can be discovered early in the match and rehosted without penalty to rating. However, if a team recalls during that time frame, it is safe to presume that it was not due to any connection issues and they actually do want to forfeit the match.

This PR using the `EnforceRating` system used to do something similar for ACU kills but upon recalling. It also changes the log warning to reflect that better.

Replaces #6960

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated messaging regarding time requirements for rating games
  * Adjusted notifications for game recall events to reflect current rating enforcement policies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->