### PR TITLE
Revert T1 interceptor and Swiftwind StartTurnDistance 10 -> 5

### DIFF
--- a/changelog/snippets/balance.6966.md
+++ b/changelog/snippets/balance.6966.md
@@ -1,0 +1,5 @@
+- (#6966) Reduce the distance at which T1 Interceptors and Swiftwinds hover instead of turning when given a move order.
+
+  **T1 Interceptors and Swiftwind (UAA0102, UEA0102, URA0102, XSA0102, XAA0202)**
+
+  - `StartTurnDistance`: 10 -> 5

--- a/units/UAA0102/UAA0102_unit.bp
+++ b/units/UAA0102/UAA0102_unit.bp
@@ -24,7 +24,7 @@ UnitBlueprint{
         LiftFactor = 5,
         MaxAirspeed = 15,
         MinAirspeed = 10,
-        StartTurnDistance = 10,
+        StartTurnDistance = 5,
         TightTurnMultiplier = 1.02,
         TurnSpeed = 1.7,
         Winged = true,

--- a/units/UEA0102/UEA0102_unit.bp
+++ b/units/UEA0102/UEA0102_unit.bp
@@ -24,7 +24,7 @@ UnitBlueprint{
         LiftFactor = 5,
         MaxAirspeed = 15,
         MinAirspeed = 10,
-        StartTurnDistance = 10,
+        StartTurnDistance = 5,
         TightTurnMultiplier = 1.02,
         TurnSpeed = 1.7,
         Winged = true,

--- a/units/URA0102/URA0102_unit.bp
+++ b/units/URA0102/URA0102_unit.bp
@@ -24,7 +24,7 @@ UnitBlueprint{
         LiftFactor = 5,
         MaxAirspeed = 15,
         MinAirspeed = 10,
-        StartTurnDistance = 10,
+        StartTurnDistance = 5,
         TightTurnMultiplier = 1.02,
         TurnSpeed = 1.7,
         Winged = true,

--- a/units/XAA0202/XAA0202_unit.bp
+++ b/units/XAA0202/XAA0202_unit.bp
@@ -21,7 +21,7 @@ UnitBlueprint{
         LiftFactor = 5,
         MaxAirspeed = 18,
         MinAirspeed = 8,
-        StartTurnDistance = 10,
+        StartTurnDistance = 5,
         TightTurnMultiplier = 1.03,
         TurnSpeed = 1.8,
         Winged = true,

--- a/units/XSA0102/XSA0102_unit.bp
+++ b/units/XSA0102/XSA0102_unit.bp
@@ -24,7 +24,7 @@ UnitBlueprint{
         LiftFactor = 5,
         MaxAirspeed = 15,
         MinAirspeed = 10,
-        StartTurnDistance = 10,
+        StartTurnDistance = 5,
         TightTurnMultiplier = 1.02,
         TurnSpeed = 1.7,
         Winged = true,


### PR DESCRIPTION
## Issue
After #5042, interceptor micro feels bad due to the unintuitive nature of the huge `StartTurnDistance`, which is the distance within which aircraft will hover instead of turn to move to a waypoint.
1. it's unintuitive for a winged aircraft to hover
2. most air have a distance of 5, so micro skills do not transfer properly.
3. there is no visual indicator for the distance so move orders meant to micro turns end up hovering inties, especially when large numbers of inties are in formation

[Related discord post.](https://discord.com/channels/197033481883222026/1438677366925688994)

## Description of the proposed changes
Revert the `StartTurnDistance` from 10 to 5 for inties and swiftwinds.

## Testing done on the proposed changes
- Inties now usually try to turn when I want them to by giving short nearby move orders.
- Inties still dock at air staging in a reasonable time (with ASF as a baseline), taking 1-2 loops around the air staging to dock.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
