### PR TITLE
Annotation: `OnSelectionChanged` and `GetSelectedUnits`

### DIFF
--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -605,7 +605,7 @@ local hotkeyLabelsOnSelectionChanged = false
 local upgradeTab = false
 
 ---This function is called whenever the set of currently selected units changes
---- Note: `GetSelectedUnits` always returns nil within this function.
+--- **Note:** When called by the engine, `GetSelectedUnits` always results in `nil` within this function.
 ---@param oldSelection UserUnit[] What the selection was before
 ---@param newSelection UserUnit[] What the selection is now
 ---@param added UserUnit[]        Which units were added to the old selection

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -605,6 +605,7 @@ local hotkeyLabelsOnSelectionChanged = false
 local upgradeTab = false
 
 ---This function is called whenever the set of currently selected units changes
+--- Note: `GetSelectedUnits` always returns nil within this function.
 ---@param oldSelection UserUnit[] What the selection was before
 ---@param newSelection UserUnit[] What the selection is now
 ---@param added UserUnit[]        Which units were added to the old selection


### PR DESCRIPTION
## Description of the proposed changes
Add annotation about `GetSelectedUnits` being used within `OnSelectionChanged`.

## Testing done on the proposed changes
No testing needed.


## Additional context
Useful tip for modders, so they don't stumble as I did.


## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification notes to internal code comments regarding engine behavior.

**Note:** This release contains no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->