### PR TITLE
Set setons as default map for development scenarios

### DIFF
--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -66,7 +66,7 @@ consoleDepth = false  -- in order to get the console to always be on top, assign
 networkBool = LazyVar.Create()    -- boolean whether the game is local or networked
 
 -- Default scenario for skirmishes / MP Lobby
-defaultScenario = '/maps/scmp_039/scmp_039_scenario.lua'
+defaultScenario = '/maps/scmp_009/scmp_009_scenario.lua'
 requiredType = 'skirmish'
 
 --* These values MUST NOT CHANGE! They syncronize with values in UIManager.h and are used to


### PR DESCRIPTION
## Additional context
Sets default map when previous not found to Setons Clutch instead of Four-Corners.


## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default map selection for skirmish matches and multiplayer lobbies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->