### PR TITLE
Expose ignoreSelection in gamemain.lua

### DIFF
--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -42,6 +42,11 @@ function SetIgnoreSelection(ignore)
     import("/lua/ui/game/commandmode.lua").SetIgnoreSelection(ignore)
 end
 
+---@return boolean
+function IsIgnoredSelection()
+    return ignoreSelection
+end
+
 -- generating hotbuild modifier shortcuts on the fly
 modifiersKeys = import("/lua/keymap/keymapper.lua").GenerateHotbuildModifiers()
 IN_AddKeyMapTable(modifiersKeys)
@@ -611,7 +616,7 @@ local upgradeTab = false
 ---@param removed UserUnit[]      Which units where removed from the old selection
 function OnSelectionChanged(oldSelection, newSelection, added, removed)
 
-    if ignoreSelection then
+    if IsIgnoredSelection() then
         return
     end
 


### PR DESCRIPTION
## Description of the proposed changes
Allow mods read `ignoreSelection` with no hooking.

## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to enhance maintainability and code organization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->