### PR TITLE
Set default tab size in markdown files to 2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,9 @@
   "Lua.format.defaultConfig": {
     "max_line_length": "unset",
   },
+  "[markdown]": {
+    "editor.tabSize": 2,
+  },
 
   // used for grammar checks of changelog
   "grammarly.files.include": [


### PR DESCRIPTION
## Description of the proposed changes
We use a tab size of 2 in changelog files. This setting enforces that.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
~~- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).~~
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated developer environment configuration for improved code formatting consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->