### PR TITLE
Reduce Deceiver stealth field range 24 -> 20

### DIFF
--- a/changelog/snippets/balance.6972.md
+++ b/changelog/snippets/balance.6972.md
@@ -1,0 +1,4 @@
+- (#6972) Reduce deceiver stealth field range to make fire beetles easier to kill, make hiding armies/raids more difficult, and reduce its effectiveness in comparison to static stealth field generators.
+
+  **Deceiver: T2 Mobile Stealth Field System (URL0306):**
+  - Radar and sonar stealth field radius: 24 -> 20

--- a/units/URL0306/URL0306_unit.bp
+++ b/units/URL0306/URL0306_unit.bp
@@ -106,8 +106,8 @@ UnitBlueprint{
     Intel = {
         RadarStealth = true,
         RadarStealthField = true,
-        RadarStealthFieldRadius = 24,
-        SonarStealthFieldRadius = 24,
+        RadarStealthFieldRadius = 20,
+        SonarStealthFieldRadius = 20,
         VisionRadius = 16,
     },
     LifeBarHeight = 0.075,


### PR DESCRIPTION
## Description of the proposed changes
Reverts the deceiver range buff from the 15% vision buff (#5121 #5142) that was already reverted a while ago (#5836). This is primarily aimed at making fire beetles less powerful, but it is also a general nerf to how easily a Deceiver can cover an army.

  **Deceiver: T2 Mobile Stealth Field System (URL0306):**
  - Radar and sonar stealth field radius: 24 -> 20


## Testing done on the proposed changes
It's a simple blueprint number change and it follows the radar grid's resolution of 4 so it doesn't need other testing.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Balance**
  * Deceiver: Reduced stealth field radius from 24 to 20 for radar and sonar detection, affecting unit concealment capabilities and tactical army positioning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->