### PR TITLE
Update progress of silos when adjacent mass fabricators start working again 

### DIFF
--- a/changelog/snippets/fix.6973.md
+++ b/changelog/snippets/fix.6973.md
@@ -1,0 +1,1 @@
+- (#6973) Fix mass fabricators not updating their adjacency bonus for silos when toggled off or on.

--- a/lua/sim/units/StructureUnit.lua
+++ b/lua/sim/units/StructureUnit.lua
@@ -867,9 +867,9 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
             for k, adjacentUnit in self.AdjacentUnits do
                 for k, v in AdjacencyBuffs[adjBuffs] do
                     Buff.ApplyBuff(adjacentUnit, v, self)
-                    adjacentUnit:OnReceiveAdjacencyBuffTo(self)
-                    adjacentUnit:RequestRefreshUI()
                 end
+                adjacentUnit:OnReceiveAdjacencyBuffTo(self)
+                adjacentUnit:RequestRefreshUI()
             end
             self:RequestRefreshUI()
         end
@@ -910,10 +910,10 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
                 for key, v in AdjacencyBuffs[adjBuffs] do
                     if Buff.HasBuff(adjacentUnit, v) then
                         Buff.RemoveBuff(adjacentUnit, v, false, self)
-                        adjacentUnit:OnLostAdjacencyBuffTo(self)
-                        adjacentUnit:RequestRefreshUI()
                     end
                 end
+                adjacentUnit:OnLostAdjacencyBuffTo(self)
+                adjacentUnit:RequestRefreshUI()
             end
             self:RequestRefreshUI()
         end

--- a/lua/sim/units/StructureUnit.lua
+++ b/lua/sim/units/StructureUnit.lua
@@ -802,31 +802,13 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
 
         -- fix edge cases when buffs are applied
         if buffApplied then
-
-            -- edge case for missile construction: the buff doesn't apply to the missile under construction
-            if adjacentUnit.Blueprint.CategoriesHash["SILO"] then
-                if adjacentUnit:IsUnitState('SiloBuildingAmmo') then
-                    local autoModeEnabled = adjacentUnit.AutoModeEnabled or false
-                    local progress = adjacentUnit:GetWorkProgress()
-                    if progress < 0.99 then
-                        adjacentUnit:StopSiloBuild()
-                        if EntityCategoryContains(categories.STRATEGIC, adjacentUnit) then
-                            IssueSiloBuildNuke({adjacentUnit})
-                        else
-                            IssueSiloBuildTactical({adjacentUnit})
-                        end
-
-                        adjacentUnit:GiveNukeSiloBlocks(progress)
-                        adjacentUnit:SetAutoMode(autoModeEnabled)
-                    end
-                end
-            end
+            adjacentUnit:OnReceiveAdjacencyBuffTo(self)
         end
 
         -- refresh the UI
         self:RequestRefreshUI()
         adjacentUnit:RequestRefreshUI()
-     end,
+    end,
 
     -- Called by the engine when a structure is destroyed for each adjacent unit
     ---@param self StructureUnit
@@ -861,20 +843,7 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
 
         -- fix edge cases when buffs are removed
         if buffRemoved then
-
-            -- edge case for missile construction: the buff doesn't apply to the missile under construction
-            if adjacentUnit.Blueprint.CategoriesHash["SILO"] then
-                if adjacentUnit:IsUnitState('SiloBuildingAmmo') then
-                    local autoModeEnabled = adjacentUnit.AutoModeEnabled or false
-                    local progress = adjacentUnit:GetWorkProgress()
-                    if progress < 0.99 then
-                        adjacentUnit:StopSiloBuild()
-                        IssueSiloBuildTactical({adjacentUnit})
-                        adjacentUnit:GiveNukeSiloBlocks(progress)
-                        adjacentUnit:SetAutoMode(autoModeEnabled)
-                    end
-                end
-            end
+            adjacentUnit:OnLostAdjacencyBuffTo(self)
         end
 
         -- clean up effects
@@ -894,13 +863,38 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
 
         -- There won't be any adjacentUnit if this is a producer just built...
         if self.AdjacentUnits then
+            ---@param adjacentUnit StructureUnit
             for k, adjacentUnit in self.AdjacentUnits do
                 for k, v in AdjacencyBuffs[adjBuffs] do
                     Buff.ApplyBuff(adjacentUnit, v, self)
+                    adjacentUnit:OnReceiveAdjacencyBuffTo(self)
                     adjacentUnit:RequestRefreshUI()
                 end
             end
             self:RequestRefreshUI()
+        end
+    end,
+
+    ---@param self StructureUnit
+    ---@param adjacentUnit StructureUnit
+    OnReceiveAdjacencyBuffTo = function(self, adjacentUnit)
+        -- edge case for missile construction: the buff doesn't apply to the missile under construction
+        if self.Blueprint.CategoriesHash["SILO"] then
+            if self:IsUnitState('SiloBuildingAmmo') then
+                local autoModeEnabled = self.AutoModeEnabled or false
+                local progress = self:GetWorkProgress()
+                if progress < 0.99 then
+                    self:StopSiloBuild()
+                    if EntityCategoryContains(categories.STRATEGIC, self) then
+                        IssueSiloBuildNuke({ self })
+                    else
+                        IssueSiloBuildTactical({ self })
+                    end
+
+                    self:GiveNukeSiloBlocks(progress)
+                    self:SetAutoMode(autoModeEnabled)
+                end
+            end
         end
     end,
 
@@ -911,15 +905,35 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
         if not adjBuffs then return end
 
         if self.AdjacentUnits then
+            ---@param adjacentUnit StructureUnit
             for k, adjacentUnit in self.AdjacentUnits do
                 for key, v in AdjacencyBuffs[adjBuffs] do
                     if Buff.HasBuff(adjacentUnit, v) then
                         Buff.RemoveBuff(adjacentUnit, v, false, self)
+                        adjacentUnit:OnLostAdjacencyBuffTo(self)
                         adjacentUnit:RequestRefreshUI()
                     end
                 end
             end
             self:RequestRefreshUI()
+        end
+    end,
+
+    ---@param self StructureUnit
+    ---@param adjacentUnit StructureUnit
+    OnLostAdjacencyBuffTo = function(self, adjacentUnit)
+        -- edge case for missile construction: the buff doesn't apply to the missile under construction
+        if self.Blueprint.CategoriesHash["SILO"] then
+            if self:IsUnitState('SiloBuildingAmmo') then
+                local autoModeEnabled = self.AutoModeEnabled or false
+                local progress = self:GetWorkProgress()
+                if progress < 0.99 then
+                    self:StopSiloBuild()
+                    IssueSiloBuildTactical({ self })
+                    self:GiveNukeSiloBlocks(progress)
+                    self:SetAutoMode(autoModeEnabled)
+                end
+            end
         end
     end,
 


### PR DESCRIPTION
## Description of the proposed changes
Fixes issue with adjacent mass fabricators that do not provide adjacency bonus when they start working again after energy stall.

## Testing done on the proposed changes
* Build stationary nuke/tml
* Build mass fabricator that is adjacent to it
* The mass fabricator gives its bonus
* Make energy stall
* The bonus is no longer applied
* Make sufficient amount of energy 
* The bonus is back


## Additional context
Make sure to stall energy within building of one rocket of silo.


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed edge-case behavior so silos under construction correctly start, stop, or switch builds when adjacency bonuses are gained or lost, preserving auto-mode and UI updates.

* **Refactor**
  * Centralized adjacency handling so adjacent units receive unified notifications instead of duplicated inline logic.

* **Documentation**
  * Added changelog entry describing the fix for adjacency updates affecting silos.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->