### PR TITLE
Fix extra fab/mex adjacency

### DIFF
--- a/changelog/snippets/fix.6975.md
+++ b/changelog/snippets/fix.6975.md
@@ -1,0 +1,1 @@
+- (#6975) Fix mass fabricators and extractors applying an additional adjacency bonus when spawned in adjacent to a mass consumer.

--- a/changelog/snippets/fix.6975.md
+++ b/changelog/snippets/fix.6975.md
@@ -1,1 +1,1 @@
-- (#6975) Fix mass fabricators and extractors applying an additional adjacency bonus when spawned in adjacent to a mass consumer.
+- (#6975) Fix mass fabricators and extractors applying an additional adjacency bonus when spawned adjacent to a mass consumer through cheats or the unit transfer mechanic.

--- a/lua/sim/units/MassCollectionUnit.lua
+++ b/lua/sim/units/MassCollectionUnit.lua
@@ -9,9 +9,12 @@ local StructureUnitOnProductionPaused = StructureUnit.OnProductionPaused
 local StructureUnitOnProductionUnpaused = StructureUnit.OnProductionUnpaused
 
 ---@class MassCollectionUnit : StructureUnit
----@field ConsumptionActive boolean
 ---@field UpgradeWatcher thread
 MassCollectionUnit = ClassUnit(StructureUnit) {
+
+    -- Disabled so the base class's `OnAdjacentTo` doesn't apply adjacency buffs when the unit is spawned in.
+    -- Consumption activation and adjacency application will happen through `OnStopBeingBuilt`.
+    ConsumptionActive = false,
 
     ---@param self MassCollectionUnit
     OnConsumptionActive = function(self)

--- a/lua/sim/units/MassFabricationUnit.lua
+++ b/lua/sim/units/MassFabricationUnit.lua
@@ -10,6 +10,10 @@ local StructureUnitOnConsumptionInActive = StructureUnit.OnConsumptionInActive
 ---@class MassFabricationUnit : StructureUnit
 MassFabricationUnit = ClassUnit(StructureUnit) {
 
+    -- Disabled so the base class's `OnAdjacentTo` doesn't apply adjacency buffs when the unit is spawned in.
+    -- Consumption activation and adjacency application will happen through `OnStopBeingBuilt`.
+    ConsumptionActive = false,
+
     ---@param self MassFabricationUnit
     ---@param bit number
     OnScriptBitSet = function(self, bit)

--- a/lua/sim/units/StructureUnit.lua
+++ b/lua/sim/units/StructureUnit.lua
@@ -802,6 +802,7 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
 
         -- fix edge cases when buffs are applied
         if buffApplied then
+            LOG("OnAdjacentTo adj buff application", debug.traceback())
             adjacentUnit:OnReceiveAdjacencyBuffTo(self)
         end
 
@@ -871,7 +872,10 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
                 adjacentUnit:OnReceiveAdjacencyBuffTo(self)
                 adjacentUnit:RequestRefreshUI()
             end
+            LOG("ApplyAdjacencyBuffs", debug.traceback())
             self:RequestRefreshUI()
+        else
+            LOG("Applying adjacency but have no adjacent units", debug.traceback())
         end
     end,
 

--- a/lua/sim/units/StructureUnit.lua
+++ b/lua/sim/units/StructureUnit.lua
@@ -802,7 +802,6 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
 
         -- fix edge cases when buffs are applied
         if buffApplied then
-            LOG("OnAdjacentTo adj buff application", debug.traceback())
             adjacentUnit:OnReceiveAdjacencyBuffTo(self)
         end
 
@@ -872,10 +871,7 @@ StructureUnit = ClassUnit(Unit, BlinkingLightsUnitComponent) {
                 adjacentUnit:OnReceiveAdjacencyBuffTo(self)
                 adjacentUnit:RequestRefreshUI()
             end
-            LOG("ApplyAdjacencyBuffs", debug.traceback())
             self:RequestRefreshUI()
-        else
-            LOG("Applying adjacency but have no adjacent units", debug.traceback())
         end
     end,
 


### PR DESCRIPTION
## Description of the proposed changes
Fixes #6974. 
The issue in the implementation is that when a unit is built normally, `OnStopBeingBuilt `comes before `OnAdjacentTo`. `OnStopBeingBuilt` indirectly calls `ApplyAdjacencyBuffs`, which checks for `self.AdjacentUnits`, a value populated in `OnAdjacentTo`. Since `OnAdjacentTo` is normally called after `OnStopBeingBuilt`, that value is empty so adjacency is not applied.
But this assumption is incorrect when a unit is spawned in/transferred: `OnAdjacentTo` is called before `OnStopBeingBuilt`, so you get 1 adjacency buff from `OnAdjacentTo` and another from `self.AdjacentUnits` being populated when `OnStopBeingBuilt` is called.

## Testing done on the proposed changes
The following spawns no longer produce doubled adjacency bonuses.
```
   CreateUnitAtMouse('ueb2305', 0,    3.00,    0.00, -0.00000)
   CreateUnitAtMouse('urb1303', 0,   -3.00,    0.00, -0.00000)
```
Should show 35m/s consumption instead of 30m/s.
```
   CreateUnitAtMouse('ueb4302', 0,    1.25,    0.25, -0.00000)
   CreateUnitAtMouse('ueb1302', 0,   -1.25,   -0.25, -0.00000)
```
Should show 13.5m/s consumption instead of 12m/s.

This command transfers the selected unit to yourself (which is behavior similar to spawning in a unit). It no longer applies additional adjacency after the transfer.
```
ConExecute([[SimLua 
ForkThread(function ()
    local focus = GetFocusArmy()
    local f = import('/lua/SimUtils.lua').TransferUnitsOwnership
    local units = DebugGetSelection()
    units = f(units, focus + 1, false)
    WaitTicks(3)
    f(units, focus, false)
end)
]])
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where mass fabricators and extractors could incorrectly grant an extra adjacency bonus when spawned next to a mass consumer; the incorrect bonus is resolved.

* **Documentation**
  * Added a changelog entry documenting the fix and its effect on adjacency bonuses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->