### PR TITLE
Set game speed adjustable when cheats enabled

### DIFF
--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2267,6 +2267,9 @@ local function TryLaunch(skipNoObserversCheck)
         if scenarioInfo.AdaptiveMap then
             gameInfo.GameOptions["SpawnMex"] = gameInfo.SpawnMex
         end
+        if gameInfo.GameOptions["CheatsEnabled"] == "true" then
+            gameInfo.GameOptions["GameSpeed"] = "adjustable"
+        end
 
         HostUtils.SendArmySettingsToServer()
 

--- a/lua/ui/lobby/lobby.lua
+++ b/lua/ui/lobby/lobby.lua
@@ -2267,7 +2267,7 @@ local function TryLaunch(skipNoObserversCheck)
         if scenarioInfo.AdaptiveMap then
             gameInfo.GameOptions["SpawnMex"] = gameInfo.SpawnMex
         end
-        if gameInfo.GameOptions["CheatsEnabled"] == "true" then
+        if gameInfo.GameOptions["CheatsEnabled"] == "true" and singlePlayer then
             gameInfo.GameOptions["GameSpeed"] = "adjustable"
         end
 


### PR DESCRIPTION
## Description of the proposed changes
Forces game speed to be set to "adjustable" when cheats are enabled and is single player.

## Additional context
Useful for testing scenarios.


## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GameSpeed can now be adjusted while cheats are enabled in single-player games.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->