### PR TITLE
Add missing items for TechCategory

### DIFF
--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -25,7 +25,7 @@
 ---| "RULEUTL_Munition"
 
 ---@alias EnhancementSlot "Back" | "RCH" | "LCH"
----@alias TechCategory "TECH1" | "TECH2" | "TECH3" | "EXPERIMENTAL"
+---@alias TechCategory "TECH1" | "TECH2" | "TECH3" | "EXPERIMENTAL" | 'SUBCOMMANDER' | 'COMMAND'
 ---@alias LayerCategory "AIR" | "LAND" | "NAVAL"
 ---@alias FactionCategory "UEF" | "CYBRAN" | "AEON" | "SERAPHIM" | "NOMADS"
 ---@alias IconBackgroundType "air" | "amph" | "land" | "sea"


### PR DESCRIPTION
## Description of the proposed changes
Add missing items for TechCategory of UnitBlueprint.
See `Blueprints.lua`.
```lua
            -- Add tech category
            for _, category in {'EXPERIMENTAL', 'SUBCOMMANDER', 'COMMAND', 'TECH1', 'TECH2', 'TECH3'} do
                if bp.CategoriesHash[category] then
                    bp.TechCategory = category
                    break
                end
            end
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new unit categories: SUBCOMMANDER and COMMAND, expanding the range of available unit types in gameplay.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->