### PR TITLE
Fix ship wake effects disappearing after a while

### DIFF
--- a/changelog/snippets/fix.6981.md
+++ b/changelog/snippets/fix.6981.md
@@ -1,0 +1,1 @@
+- (#6981) Fix disappearing terrain effects (Mainly ship wake effects, but other effects might be affected as well).

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -3561,8 +3561,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     OnMotionTurnEventChange = function() end,
 
     ---@param self Unit
-    ---@param new string
-    ---@param old string
+    ---@param new TerrainType
+    ---@param old TerrainType
     OnTerrainTypeChange = function(self, new, old)
         self.TerrainType = new
         if self.MovementEffectsExist then
@@ -3729,13 +3729,13 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     ---@param effectsBag? TrashBag
     ---@param terrainType? TerrainType
     CreateTerrainTypeEffects = function(self, effectTypeGroups, fxBlockType, layer, typeSuffix, effectsBag, terrainType)
-        local effects, terrainFX, GetTerrainTypeEffects
+        local GetTerrainTypeEffects = self.GetTerrainTypeEffects
         local pos = self:GetPosition()
         local army = self.Army
+
+        local terrainFX
         if terrainType then
             terrainFX = terrainType[fxBlockType][layer]
-        else
-            GetTerrainTypeEffects = self.GetTerrainTypeEffects
         end
 
         for _, typeGroup in effectTypeGroups do
@@ -3745,11 +3745,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
                 continue
             end
 
-            if terrainType then
-                effects = terrainFX[typeGroup.Type]
-            else
-                effects = GetTerrainTypeEffects(fxBlockType, layer, pos, typeGroup.Type, typeSuffix)
-            end
+            -- Use TerrainType specific effects or fallback to 'Default' TerrainType effects
+            local effects = terrainType and terrainFX[typeGroup.Type] or GetTerrainTypeEffects(fxBlockType, layer, pos, typeGroup.Type, typeSuffix)
             if table.empty(effects) then
                 continue
             end


### PR DESCRIPTION
## Description of the proposed changes
Fixes #6980
When ships start moving the 'Default' terrain type is used for picking the effects, which has Wake effects defined.

But as the ship is moving it encounters different WaterXX terrain types and they dont specify any extra affects, so the 'Default' one should be used. That's what this change fixes.

As a side effect it might fix some other missing effects, since the 'Default' terrain type is suppose to be used when the non default one doesnt specify the effects.
## Testing done on the proposed changes
- moving using around the map and watching the movement effects

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored disappearing terrain visual effects (notably ship wake), so environmental effects remain visible and consistent during gameplay.
* **Documentation**
  * Added changelog entry documenting the fix for issue #6981.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->