### PR TITLE
Fallback `OptionShowPlayerNames` to 'on' when it is nil

### DIFF
--- a/changelog/snippets/fix.6987.md
+++ b/changelog/snippets/fix.6987.md
@@ -1,0 +1,1 @@
+- (#6987) Fix the "Show Player Names" option crashing the game on startup when the option in the game.prefs file does not exist.

--- a/lua/ui/override/ArmiesTable.lua
+++ b/lua/ui/override/ArmiesTable.lua
@@ -40,7 +40,7 @@
 local Prefs = import("/lua/user/prefs.lua")
 
 ---@type 'on' | 'allies-only' | 'off'
-OptionShowPlayerNames = Prefs.GetFromCurrentProfile('options.options_show_player_names')
+OptionShowPlayerNames = Prefs.GetFromCurrentProfile('options.options_show_player_names') or 'on'
 
 ---@param armiesTable ArmiesTable
 ---@return ArmiesTable


### PR DESCRIPTION
Fallback `OptionShowPlayerNames` to 'on' when it is nil, because game crashes when there are no options in `game.prefs` file
Most of the time (always?) `GetFromCurrentProfile` is checked for nil, but here this safety check was forgotten

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures player names in the armies table are shown by default when profile settings are missing, preventing startup crashes and keeping player info consistently visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->