### PR TITLE
Fix permissions to auto-draft all PRs

### DIFF
--- a/.github/workflows/auto-draft-pr.yaml
+++ b/.github/workflows/auto-draft-pr.yaml
@@ -20,6 +20,9 @@
 
 name: Convert PRs to Draft on Opening
 
+permissions:
+  contents: write
+
 on:
   pull_request:
     types: [opened]


### PR DESCRIPTION
There is an action to draft PRs automatically which fails if a PR is not already a draft because of insufficient permissions
See https://github.com/FAForever/fa/pull/6460#issuecomment-2466610778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration to enable automated processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->