### PR TITLE
Do not produce pause/resume messages in NIS mode

### DIFF
--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -29,6 +29,16 @@ local ordersControl = false
 local OnDestroyFuncs = {}
 
 local NISActive = false
+
+function IsNISMode()
+    if NISActive == 'on' then
+        return true
+    else
+        return false
+    end
+end
+
+
 local isReplay = false
 local waitingDialog = false
 
@@ -781,7 +791,8 @@ function OnUserPause(pause)
             return
         end
 
-        if not SessionIsReplay() then
+        if not SessionIsReplay() and
+           not IsNISMode() then
             if pause then
                 SessionSendChatMessage(import('/lua/ui/game/clientutils.lua').GetAll(), {
                     to = 'all',
@@ -1029,14 +1040,6 @@ function ShowNISBars()
                 self.Height:Set(function() return curHeight * 1.25 end)
             end
         end
-    end
-end
-
-function IsNISMode()
-    if NISActive == 'on' then
-        return true
-    else
-        return false
     end
 end
 


### PR DESCRIPTION
## Description of the proposed changes
Prevent creation of pause/resume messages during coop cutscenes.
<img width="1913" height="1005" alt="image" src="https://github.com/user-attachments/assets/5f8829c9-69d1-4a2e-b669-20c5b78eb72e" />

## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pause functionality behavior across different game states.

* **Refactor**
  * Consolidated redundant code for better maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->