### PR TITLE
Hide chat in NIS mode

### DIFF
--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -289,10 +289,6 @@ function CreateChatLines()
     end
 end
 
-function OnNISBegin()
-    CloseChat()
-end
-
 function SetupChatScroll()
     GUI.chatContainer.top = 1
     GUI.chatContainer.scroll = UIUtil.CreateVertScrollbarFor(GUI.chatContainer)
@@ -881,11 +877,13 @@ function ReceiveChatFromSim(sender, msg)
     }
 
     table.insert(chatHistory, entry)
-    if ChatOptions[entry.armyID] then
-        if table.getsize(chatHistory) == 1 then
-            GUI.chatContainer:CalcVisible()
-        else
-            GUI.chatContainer:ScrollToBottom()
+    if not import("/lua/ui/game/gamemain.lua").IsNISMode() then
+        if ChatOptions[entry.armyID] then
+            if table.getsize(chatHistory) == 1 then
+                GUI.chatContainer:CalcVisible()
+            else
+                GUI.chatContainer:ScrollToBottom()
+            end
         end
     end
 end
@@ -1561,5 +1559,16 @@ function CloseChatConfig()
     if GUI.config then
         GUI.config:Destroy()
         GUI.config = nil
+    end
+end
+
+function OnNISBegin()
+    CloseChatConfig()
+    GUI.bg:Hide()
+    GUI.chatEdit.edit:AbandonFocus()
+    GUI.bg:SetNeedsFrameUpdate(false)
+    for i, v in GUI.chatLines do
+        v:SetNeedsFrameUpdate(false)
+        v:Hide()
     end
 end


### PR DESCRIPTION
## Description of the proposed changes
Hides chat in NIS mode for better immersion in coop missions.

## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat display behavior during non-interactive sequences to prevent unnecessary UI updates and unintended scrolling, ensuring a cleaner viewing experience during cinematics and other special game moments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->