### PR TITLE
Increase the `StrategicIconSize` of the Exodus's Oblivion Cannon to `3`

### DIFF
--- a/changelog/snippets/graphics.6993.md
+++ b/changelog/snippets/graphics.6993.md
@@ -1,1 +1,1 @@
-- (#6993) Increase the `StrategicIconSize` of the Exodus' Oblivion Cannon from `2` to `3` to better align the weapon's visual representation with its overall power.
+- (#6993) Increase the `StrategicIconSize` of the Exodus's Oblivion Cannon from `2` to `3` to better align the weapon's visual representation with its overall power.

--- a/changelog/snippets/graphics.6993.md
+++ b/changelog/snippets/graphics.6993.md
@@ -1,0 +1,1 @@
+- (#6993) Increase the `StrategicIconSize` of the Exodus' Oblivion Cannon from `2` to `3` to better align the weapon's visual representation with its overall power.

--- a/projectiles/ADFOblivionCannon01/ADFOblivionCannon01_proj.bp
+++ b/projectiles/ADFOblivionCannon01/ADFOblivionCannon01_proj.bp
@@ -11,7 +11,7 @@ ProjectileBlueprint{
     },
     Display = {
         ImpactEffects = { Type = "Medium02" },
-        StrategicIconSize = 2,
+        StrategicIconSize = 3,
     },
     General = {
         Category = "Direct Fire",


### PR DESCRIPTION
## Description of the proposed changes
The projectiles of the Exodus's Oblivion Cannon only had a `StrategicIconSize` of `2`, while the Omen's Oblivion Cannons had one of `3`, even though the Omen's actually deal less damage. Increasing the `StrategicIconSize` of the Exodus' Oblivion Cannon to `3` fixes this inconsistency and also better reflects the weapon's high alpha damage.

## Checklist
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Increased the strategic icon size for the Oblivion Cannon projectile (from 2 to 3) to improve its visibility on the strategic interface.

* **Documentation**
  * Added a changelog entry noting the strategic icon size update to reflect the weapon's visual alignment with its power.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->