### PR TITLE
Send all the player options in auto lobby when host receives them

### DIFF
--- a/lua/ui/lobby/autolobby/AutolobbyController.lua
+++ b/lua/ui/lobby/autolobby/AutolobbyController.lua
@@ -625,12 +625,12 @@ AutolobbyCommunications = Class(MohoLobbyMethods, AutolobbyServerCommunicationsC
         self.PlayerOptions[playerOptions.StartSpot] = playerOptions
 
         -- send all player options to the server, this is necessary to do immediately (for the host) so that the server knows who is (not) connected. 
-        for slot, playerOptions in self.PlayerOptions do
-            local ownerId = playerOptions.OwnerID
-            self:SendPlayerOptionToServer(ownerId, 'Team', playerOptions.Team)
-            self:SendPlayerOptionToServer(ownerId, 'Army', playerOptions.StartSpot)
-            self:SendPlayerOptionToServer(ownerId, 'StartSpot', playerOptions.StartSpot)
-            self:SendPlayerOptionToServer(ownerId, 'Faction', playerOptions.Faction)
+        for slot, otherPlayerOptions in self.PlayerOptions do
+            local ownerId = otherPlayerOptions.OwnerID
+            self:SendPlayerOptionToServer(ownerId, 'Team', otherPlayerOptions.Team)
+            self:SendPlayerOptionToServer(ownerId, 'Army', otherPlayerOptions.StartSpot)
+            self:SendPlayerOptionToServer(ownerId, 'StartSpot', otherPlayerOptions.StartSpot)
+            self:SendPlayerOptionToServer(ownerId, 'Faction', otherPlayerOptions.Faction)
         end
 
         -- sync game options with the connected peer

--- a/lua/ui/lobby/autolobby/AutolobbyController.lua
+++ b/lua/ui/lobby/autolobby/AutolobbyController.lua
@@ -624,6 +624,15 @@ AutolobbyCommunications = Class(MohoLobbyMethods, AutolobbyServerCommunicationsC
         -- put the player where it belongs
         self.PlayerOptions[playerOptions.StartSpot] = playerOptions
 
+        -- send all player options to the server, this is necessary to do immediately (for the host) so that the server knows who is (not) connected. 
+        for slot, playerOptions in self.PlayerOptions do
+            local ownerId = playerOptions.OwnerID
+            self:SendPlayerOptionToServer(ownerId, 'Team', playerOptions.Team)
+            self:SendPlayerOptionToServer(ownerId, 'Army', playerOptions.StartSpot)
+            self:SendPlayerOptionToServer(ownerId, 'StartSpot', playerOptions.StartSpot)
+            self:SendPlayerOptionToServer(ownerId, 'Faction', playerOptions.Faction)
+        end
+
         -- sync game options with the connected peer
         self:SendData(data.SenderID, { Type = "UpdateGameOptions", GameOptions = self.GameOptions })
 

--- a/lua/ui/lobby/autolobby/AutolobbyController.lua
+++ b/lua/ui/lobby/autolobby/AutolobbyController.lua
@@ -624,11 +624,19 @@ AutolobbyCommunications = Class(MohoLobbyMethods, AutolobbyServerCommunicationsC
         -- put the player where it belongs
         self.PlayerOptions[playerOptions.StartSpot] = playerOptions
 
-        -- send all player options to the server, this is necessary to do immediately (for the host) so that the server knows who is (not) connected. 
-        for slot, otherPlayerOptions in self.PlayerOptions do
+        -- Army numbers need to be calculated: they are numbered incrementally in slot order.
+        local slots = {}
+        for slotIndex, _ in pairs(self.PlayerOptions) do
+            table.insert(slots, slotIndex)
+        end
+        table.sort(slots)
+
+        -- send player options to the server
+        for armyIndex, slotIndex in ipairs(slots) do
+            local otherPlayerOptions = self.PlayerOptions[slotIndex]
             local ownerId = otherPlayerOptions.OwnerID
             self:SendPlayerOptionToServer(ownerId, 'Team', otherPlayerOptions.Team)
-            self:SendPlayerOptionToServer(ownerId, 'Army', otherPlayerOptions.StartSpot)
+            self:SendPlayerOptionToServer(ownerId, 'Army', armyIndex)
             self:SendPlayerOptionToServer(ownerId, 'StartSpot', otherPlayerOptions.StartSpot)
             self:SendPlayerOptionToServer(ownerId, 'Faction', otherPlayerOptions.Faction)
         end


### PR DESCRIPTION
## Description of the proposed changes

Closes https://github.com/FAForever/server/issues/1077.

## Testing done on the proposed changes

Launched the game through the autolobby using the [launch script](https://github.com/FAForever/fa/blob/develop/scripts/LaunchFAInstances.ps1), observed that the messages are sent in the logs.

```
DEBUG: Received data of type AddPlayer from 1 (ClientPlayer_2)                <-- here we receive data
DEBUG: Autolobby communications	IsHost
DEBUG: Autolobby communications	MakeValidPlayerName	1	ClientPlayer_2
DEBUG: Autolobby communications	IsHost
DEBUG: GpgNetSend	PlayerOption	0	Team	2                     <-- this is where we loop over all player options
DEBUG: Autolobby communications	IsHost
DEBUG: GpgNetSend	PlayerOption	0	Army	1
DEBUG: Autolobby communications	IsHost
DEBUG: GpgNetSend	PlayerOption	0	StartSpot	1
DEBUG: Autolobby communications	IsHost
DEBUG: GpgNetSend	PlayerOption	0	Faction	1
DEBUG: Autolobby communications	IsHost
DEBUG: GpgNetSend	PlayerOption	1	Team	3
DEBUG: Autolobby communications	IsHost
DEBUG: GpgNetSend	PlayerOption	1	Army	2
DEBUG: Autolobby communications	IsHost
DEBUG: GpgNetSend	PlayerOption	1	StartSpot	2
DEBUG: Autolobby communications	IsHost
DEBUG: GpgNetSend	PlayerOption	1	Faction	1
DEBUG: Autolobby communications	SendData	1	UpdateGameOptions
DEBUG: Autolobby communications	BroadcastData	UpdatePlayerOptions            <-- here we sync in-game
DEBUG: Received data of type UpdateLaunchStatus from 1 (ClientPlayer_2)
```

## Additional context

Discussion on Zulip:

- [#general > Matchmaking violation @ 💬](https://faforever.zulipchat.com/#narrow/channel/203478-general/topic/Matchmaking.20violation/near/566214270)

## Checklist

- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lobby settings are now synchronized with the server immediately when players join, including team, faction, starting position, and army ordering. This improves setup consistency and helps prevent mismatches in multiplayer lobbies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->