### PR TITLE
Buff the Exodus's `MaxRadius` by 5

### DIFF
--- a/units/UAS0201/UAS0201_unit.bp
+++ b/units/UAS0201/UAS0201_unit.bp
@@ -184,7 +184,7 @@ UnitBlueprint{
             FiringRandomness = 0.25,
             FiringTolerance = 2,
             Label = "FrontTurret",
-            MaxRadius = 70,
+            MaxRadius = 75,
             MuzzleChargeDelay = 0.1,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,


### PR DESCRIPTION
## Description of the proposed changes
This will make microing the Exodus more rewarding and will buff Aeon's lacking ability to bombard shores at the Tech 2 stage, which was a negative side effect of the severe range nerf it previously received. Before it's range nerf, it had 80 range, so this is only a partial revert.

In case this is merged, I will add the changelog snippet for this PR into https://github.com/FAForever/fa/pull/6962 to keep the changelog more readable.

**Exodus Class: T2 Destroyer (UAS0201):**
- Oblivion Cannon
  - MaxRadius: 70 --> 75

Since I assume this is a more controversial change, I decided against adding it to the other Exodus PR.

## Checklist
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).