### PR TITLE
changed sparky Guard scan radius from 26->8

### DIFF
--- a/changelog/snippets/BalanceFix7000.md
+++ b/changelog/snippets/BalanceFix7000.md
@@ -1,1 +1,1 @@
-﻿- (#7000) GuardScanRadius from 26->8. Sparkies will not stop reclaiming to persue enemy units from such a large range anymore.
+﻿- (#7000) GuardScanRadius from 26->8. Sparkies will not stop reclaiming to pursue enemy units from such a large range anymore.

--- a/changelog/snippets/BalanceFix7000.md
+++ b/changelog/snippets/BalanceFix7000.md
@@ -1,0 +1,1 @@
+﻿- (#7000) GuardScanRadius from 26->8. Sparkies will not stop reclaiming to persue enemy units from such a large range anymore.

--- a/units/XEL0209/XEL0209_unit.bp
+++ b/units/XEL0209/XEL0209_unit.bp
@@ -1,6 +1,6 @@
 UnitBlueprint{
     Description = "<LOC uel0209_desc>Field Engineer",
-    AI = { GuardScanRadius = 26 },
+    AI = { GuardScanRadius = 8 },
     Audio = {
         AmbientMove        = Sound { Bank = 'XEL',        Cue = 'XEL0209_Move_Loop',       LodCutoff = 'UnitMove_LodCutoff' },
         CaptureLoop        = Sound { Bank = 'XEL',        Cue = 'XEL0209_Capture_Loop',    LodCutoff = 'UnitMove_LodCutoff' },


### PR DESCRIPTION
## Description of the proposed changes
Gifs:

https://github.com/user-attachments/assets/4dabb8d1-b08c-4b0b-a9df-19b361b5deea




https://github.com/user-attachments/assets/773d5aa7-6aa7-4c35-8f13-98794096313f






Notice how in the current game, Sparkies will stop reclaiming to chase a target when it reaches within 26 range (the red ring is 18 range and grey rings are 44 range).
With 8 GSR Sparkies will continue to reclaim even with an enemy in its attack range, and will fire to defend itself, while reclaiming.

[video with commentary showing 8 GSR](https://youtu.be/QGqd6XaHRF0)
[video with commentary showing 26 GSR](https://youtu.be/rjrGUzDDV80)

Guard scan radius is the distance a unit will initiate pursuit of enemies/reclaim from their patrol or attack move route. Its the reason why when you give an attack move engys may run backwards to get the trees behind them or branch off to get reclaim adjacent to the route. Implications of reducing this in non-combat scenarios will be shown.


## Testing done on the proposed changes
Checked if the feature works in a development enviromont following [this](https://faforever.github.io/fa/development/development-environment) guide.
Played some games with the a mod enabled that changed the value via blueprint hooking.
Tested Sparkies performance on reclaiming without enemies nearby and they will not voyage super far from the patrol or reclaim route like a regular engineer. Making them require more precision.
Tested Sparkies vs regular engineers in a reclaim field, Sparkies no longer, stop reclaiming to kill the opposing engineers, but once they get in range will shoot them while reclaiming.


## Additional context
Forum post discussion:

https://forum.faforever.com/topic/9827/reduce-sparky-guardscanradius-from-26-8?_=1769034106081

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted Sparkie unit's guard detection and scanning radius to a smaller, more balanced range. This prevents the unit from reclaiming friendly units or pursuing enemies across unreasonably large distances, ensuring more focused local engagement and improved gameplay balance through more tactical, localized unit behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->