### PR TITLE
adding "Force reclaim" hotkey

### DIFF
--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -826,6 +826,38 @@ do
 
 end
 
+do
+
+    ---@param data { Enable: boolean, ShowMsg: boolean }
+    ---@param selection Unit[]
+    Callbacks.ForceReclaim = function(data, selection)
+        -- verify selection
+        selection = SecureUnits(selection)
+        if (not selection) or TableEmpty(selection) then
+            return
+        end
+        
+        -- verify we have engineers
+        local engineers = EntityCategoryFilterDown(categories.ENGINEER, selection)
+        if TableEmpty(engineers) then
+            return
+        end
+        
+        for k, unit in engineers do
+            unit:ForceReclaim(data.Enable)
+        end
+
+        if data.ShowMsg then
+            if data.Enable == true then
+                print(string.format("Force reclaim ENABLED for %d engineers", table.getn(engineers)))
+            else
+                print(string.format("Force reclaim DISABLED for %d engineers", table.getn(engineers)))
+            end
+        end
+    end
+end
+
+
 --#endregion
 
 

--- a/lua/keymap/keyactions.lua
+++ b/lua/keymap/keyactions.lua
@@ -1653,7 +1653,23 @@ local keyActionsOrdersAdvanced = {
     ['shift_discharge'] = {
         action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").DischargeShields()',
         category = 'ordersAdvanced',
-    }
+    },
+    ['enable_force_reclaim'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").SetForceReclaim(true)',
+        category = 'ordersAdvanced',
+    },
+    ['shift_enable_force_reclaim'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").SetForceReclaim(true)',
+        category = 'ordersAdvanced',
+    },
+    ['disable_force_reclaim'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").SetForceReclaim(false)',
+        category = 'ordersAdvanced',
+    },
+    ['shift_disable_force_reclaim'] = {
+        action = 'UI_Lua import("/lua/keymap/misckeyactions.lua").SetForceReclaim(false)',
+        category = 'ordersAdvanced',
+    },
 }
 
 local keyActionsOrdersQueueBased = {

--- a/lua/keymap/keydescriptions.lua
+++ b/lua/keymap/keydescriptions.lua
@@ -559,6 +559,11 @@ keyDescriptions = {
     ['shift_load_transports_clear'] = '<LOC key_desc_shift_load_transports_clear>Load into transports. Applies immediately',
     ['copy_orders'] = '<LOC key_desc_copy_orders>Copy orders of the unit the mouse is on top of',
     ['shift_copy_orders'] = '<LOC key_desc_shift_copy_orders>Copy orders of the unit the mouse is on top of',
+    
+    ['enable_force_reclaim'] = '<LOC key_desc_enable_force_reclaim>Enable "Force reclaim" for selected units.',
+    ['disable_force_reclaim'] = '<LOC key_desc_disable_force_reclaim>Disable "Force reclaim" for selected units.',
+    ['shift_enable_force_reclaim'] = '<LOC key_desc_shift_enable_force_reclaim>Enable "Force reclaim" for selected units.',
+    ['shift_disable_force_reclaim'] = '<LOC key_desc_shift_disable_force_reclaim>Disable "Force reclaim" for selected units',
 
     ['select_surface_bombers'] = '<LOC key_desc_0407>Select all Bombers (Normal)',
     ['select_torpedo_bombers'] = '<LOC key_desc_0408>Select all Bombers (Torpedo)',

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -557,6 +557,10 @@ AIPlatoonSimpleStructureBehavior = function()
     SimCallback({ Func = 'AIPlatoonSimpleStructureBehavior', Args = {} }, true)
 end
 
+function SetForceReclaim(enable, showMsg)
+    SimCallback({ Func = 'ForceReclaim', Args = { Enable = enable, ShowMsg = showMsg or true} }, true)
+end
+
 StoreCameraPosition = function()
     local camera = GetCamera('WorldCamera')
     local settings = camera:SaveSettings()


### PR DESCRIPTION
Engie will continue reclaiming even if both storages are full.


## Additional context
requiers https://github.com/FAForever/FA-Binary-Patches/pull/130



https://github.com/user-attachments/assets/b6b2e61b-bb19-491a-94cf-c293c9cf812f





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Force Reclaim functionality allowing players to toggle force reclaim behavior on selected units.
  * New keyboard shortcuts for enabling and disabling Force Reclaim with shift-key variants for alternative controls.
  * Status messages display the number of affected units when Force Reclaim is toggled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->