### PR TITLE
Add new workflow to deploy etfreeman db similar to spooky db

### DIFF
--- a/.github/workflows/etfreeman-db-update.yaml
+++ b/.github/workflows/etfreeman-db-update.yaml
@@ -23,9 +23,67 @@ name: ETFreeman DB - update unit information
 on:
   workflow_dispatch:
   push:
-    branches:
-      - deploy/faf
+    # branches:
+    #   - deploy/faf
+
+permissions:
+  contents: read
 
 jobs:
+  build:
+    uses: FAForever/etfreeman-db/.github/workflows/build.yaml@main
+
   deploy:
-    uses: FAForever/etfreeman-db/.github/workflows/deploy.yml@main
+    name: Deploy the ETFreeman DB
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout/tree/v4/
+      - name: Checkout etfreeman-db code
+        uses: actions/checkout@v4
+        with:
+          repository: FAForever/etfreeman-db
+          path: gh-pages
+          ref: gh-pages
+          ssh-key: ${{ secrets.ETFREEMAN_DB_DEPLOYMENT_KEY }}
+
+      # https://github.com/actions/download-artifact/tree/v4/
+      - name: Download recent build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: etfreeman-db-dist
+          path: dist
+
+      # Each file is given a (random) hash pre-pended to the filename to prevent caching
+      # issues. Because of that we first need to remove all existing hashed files as otherwise
+      # they will keep accumulating forever. As much as this fits the narrative of the community
+      # (Forged Alliance >Forever<) it's not what we want here.
+      - name: Copy
+        run: |
+          # remove old files that have a hash in the name
+          rm -r gh-pages/assets/*
+
+          # copy over new files
+          cp -r dist/* gh-pages/
+
+      # By pushing the changes to the gh-pages branch, the changes will be deployed to the
+      # website. The website is hosted on GitHub Pages and is (at the moment of writing)
+      # available at:
+      # - https://faforever.github.io/etfreeman-db/
+      - name: Deploy
+        working-directory: gh-pages
+        run: |
+          # Check for any differences between the working directory and the latest commit
+          if git diff --quiet; then
+            echo "No changes to deploy"
+            exit 0
+          fi
+
+          # Configure git
+          git config user.email "administrator@faforever.com"
+          git config user.name "FAForever"
+
+          # Stage, commit and push the changes
+          git stage .
+          git commit -m 'Automated deployment of etfreeman db'
+          git push origin HEAD:gh-pages

--- a/.github/workflows/etfreeman-db-update.yaml
+++ b/.github/workflows/etfreeman-db-update.yaml
@@ -23,8 +23,8 @@ name: ETFreeman DB - update unit information
 on:
   workflow_dispatch:
   push:
-    # branches:
-    #   - deploy/faf
+    branches:
+      - deploy/faf
 
 permissions:
   contents: read

--- a/.github/workflows/etfreeman-db-update.yaml
+++ b/.github/workflows/etfreeman-db-update.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Copy
         run: |
           # remove old files that have a hash in the name
-          rm -r gh-pages/assets/*
+          rm -r -f gh-pages/assets/*
 
           # copy over new files
           cp -r dist/* gh-pages/
@@ -74,7 +74,7 @@ jobs:
         working-directory: gh-pages
         run: |
           # Check for any differences between the working directory and the latest commit
-          if git diff --quiet; then
+          if git status --porcelain; then
             echo "No changes to deploy"
             exit 0
           fi

--- a/.github/workflows/spookydb-update.yaml
+++ b/.github/workflows/spookydb-update.yaml
@@ -74,7 +74,7 @@ jobs:
         working-directory: gh-pages
         run: |
             # Check for any differences between the working directory and the latest commit
-            if git diff --quiet; then
+            if git status --porcelain; then
                 echo "No changes to deploy"
                 exit 0
             fi

--- a/changelog/snippets/other.7005.md
+++ b/changelog/snippets/other.7005.md
@@ -1,0 +1,1 @@
+- (#7005) Add support for automatically updating the new unit database by ETFreeman


### PR DESCRIPTION
## Description of the proposed changes

Updates the workflow to update the unit database of etfreeman, in a similar fashion to spooky db.

## Testing done on the proposed changes

Workflow is run during testing and observed that it works as intended. See also:

- https://github.com/FAForever/fa/actions/runs/21559191005

Tested together with @K-ETFreeman 

## Additional context

- https://github.com/FAForever/etfreeman-db
- https://faforever.github.io/etfreeman-db/#/

## Checklist

- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD to reuse an external build and add a separate build job.
  * Reworked deployment to an in-repo sequence that pulls the site branch, restores build artifacts, cleans stale assets, copies new files, and pushes changes when present.
* **Documentation**
  * Added detailed inline deployment notes and hosting context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->