### PR TITLE
adding 'Factories share "Assist" to units' option

### DIFF
--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -665,6 +665,22 @@ options = {
                     },
                 },
             },
+            
+            {
+                title = '<LOC FACTORY_SHARE_ASSIST>Factories share "Assist" to units',
+                key = 'factoryShareAssist',
+                type = 'toggle',
+                default = "true",
+                set = function(key, value, startup)
+                    ConExecute("ui_ShareFactoryAssistCommandToUnits " .. value)
+                end,
+                custom = {
+                    states = {
+                        { text = "<LOC _Off>", key = "false" },
+                        { text = "<LOC _On>", key = "true" },
+                    },
+                },
+            },
 
             {
                 title = "<LOC ASSIST_TO_UPGRADE>Hold alt to force attack move",


### PR DESCRIPTION
Options - Gameplay - Commands (ON by default)

Since it's a simple console command, it's possible to make a hotkey instead of toggle to use both "Assist"s. But then we need a different icon for the cursor. Also default one that copies factory queue is pretty useless, so I don't want to spend any time making them both available at the same time. I'll leave it for UI mods

## Additional context
requires: https://github.com/FAForever/FA-Binary-Patches/pull/131



https://github.com/user-attachments/assets/c4a7b4be-276a-462b-8b14-731267c6c796

Exe for testing in Zulip->engine-development

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new gameplay option: "Factories share 'Assist' to units." This toggle allows players to configure whether factory units automatically share the Assist command with their allied units. When enabled, factories will share assist commands to other units. The option is enabled by default and can be adjusted in the gameplay options menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->