### PR TITLE
Annotate TargetChaser category and InheritWork unit callback

### DIFF
--- a/engine/Core/Categories.lua
+++ b/engine/Core/Categories.lua
@@ -208,6 +208,7 @@ categories = {
     TACTICAL = categoryValue,
     TACTICALMISSILEPLATFORM = categoryValue,
     TANK = categoryValue,
+    -- Unit does not mantain any formation when on attack task
     TARGETCHASER = categoryValue,
     TECH1 = categoryValue,
     TECH2 = categoryValue,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -3149,6 +3149,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
     -- GENERIC WORK
     -------------------------------------------------------------------------------------------
 
+    --- Called by the engine when a unit starts repairing a unit in the enhancing state.
     ---@param self Unit
     ---@param target Unit
     InheritWork = function(self, target)


### PR DESCRIPTION
## Description of the proposed changes
Some stuff I discovered in RE.

## Testing done on the proposed changes
- Add `TARGETCHASER` to 1 type of gunship. 
- Spawn 50 of 2 types of gunships. 
- Spawn an enemy target and make it walk around. 
- Right click the target with the gunships.
- Turn on `dbg navs` in console
- The gunships without `TARGETCHASER` will chase in formation, while those with the category will all fly at the target.

## Additional context
This may be useful for fixing the undesirable behavior from the testing. I don't know the category was not in original units. Some more investigation would be desirable for side effects.

## Checklist
- [x] Changes are annotated, including comments where useful
~~- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).~~
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
