### PR TITLE
Re-add RackSalvoReloadTime to Seraphim MML to re-enable reload animation

### DIFF
--- a/changelog/snippets/fix.7013.md
+++ b/changelog/snippets/fix.7013.md
@@ -1,0 +1,1 @@
+- (#7013) Re-add reload animation for the Seraphim T2 Mobile Missile Launcher.

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -152,6 +152,10 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
     ---@param muzzle Bone
     ---@return Projectile
     CreateProjectileAtMuzzle = function(self, muzzle)
+        if self.lastT then
+            LOG(GetGameTick() - self.lastT)
+        end
+        self.lastT = GetGameTick() 
         local proj = self:CreateProjectileForWeapon(muzzle)
         if not proj or proj:BeenDestroyed() then
             return proj

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -152,10 +152,6 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
     ---@param muzzle Bone
     ---@return Projectile
     CreateProjectileAtMuzzle = function(self, muzzle)
-        if self.lastT then
-            LOG(GetGameTick() - self.lastT)
-        end
-        self.lastT = GetGameTick() 
         local proj = self:CreateProjectileForWeapon(muzzle)
         if not proj or proj:BeenDestroyed() then
             return proj

--- a/units/XSL0111/XSL0111_unit.bp
+++ b/units/XSL0111/XSL0111_unit.bp
@@ -180,7 +180,7 @@ UnitBlueprint{
             RackRecoilDistance = -1,
             RackReloadTimeout = 10,
             RackSalvoChargeTime = 0,
-            RackSalvoReloadTime = 0,
+            RackSalvoReloadTime = 6,
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_IndirectFire",

--- a/units/XSL0111/XSL0111_unit.bp
+++ b/units/XSL0111/XSL0111_unit.bp
@@ -180,7 +180,7 @@ UnitBlueprint{
             RackRecoilDistance = -1,
             RackReloadTimeout = 10,
             RackSalvoChargeTime = 0,
-            RackSalvoReloadTime = 6,
+            RackSalvoReloadTime = 5.8,
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_IndirectFire",


### PR DESCRIPTION
## Issue
Seraphim MML relies on RackSalvoReload to exist to be able to play its reload animation. It was previously removed due to a bug where it was able to fire without reloading in #5454. There were some firing cycle fixes in #6289 that now prevent that firing cycle bypass.

## Description of the proposed changes
Re-add `RackSalvoReloadTime` equal to the firing cycle reload time.

## Testing done on the proposed changes
The reload animation works again, the fire rate is completely unchanged, and it is not possible to bypass the reload by messing with the attack order.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the reload animation for the Seraphim T2 Mobile Missile Launcher.
  * Adjusted missile launcher reload timing to improve gameplay balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->