### PR TITLE
Increase fire beetle build time 550 -> 700

### DIFF
--- a/units/XRL0302/XRL0302_unit.bp
+++ b/units/XRL0302/XRL0302_unit.bp
@@ -91,7 +91,7 @@ UnitBlueprint{
     Economy = {
         BuildCostEnergy = 1300,
         BuildCostMass = 190,
-        BuildTime = 550,
+        BuildTime = 700,
         MaintenanceConsumptionPerSecondEnergy = 10,
         TeleportEnergyMod = 0.15,
         TeleportMassMod = 1,


### PR DESCRIPTION
## Description of the proposed changes
Implements [Discord balance discussion](https://discord.com/channels/197033481883222026/1441175190909489152).

Increase fire beetle build time by reverting the previous build time decrease in #5548. Beetles have shown themselves to be extremely powerful in defensive situations and on the T2 stage. With the deceiver nerf in #6972 nerfing beetles in combat, this build time increase makes beetles require a larger infrastructure to build in large amounts for emergency defenses or for mixing into armies.

**Fire Beetle: T2 Mobile Bomb (XRL0302)**
- Build time: 550 -> 700

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Balance Adjustments**
  * Increased the build time for XRL0302 unit from 550 to 700, affecting its production timeline during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->