### PR TITLE
Revert Cybran frigate range nerf

### DIFF
--- a/units/URS0103/URS0103_unit.bp
+++ b/units/URS0103/URS0103_unit.bp
@@ -197,7 +197,7 @@ UnitBlueprint{
             FiringRandomness = 0.2,
             FiringTolerance = 2,
             Label = "ProtonCannon",
-            MaxRadius = 26,
+            MaxRadius = 28,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 30,


### PR DESCRIPTION
## Description of the proposed changes
Reverts Cybran frigate range nerf from #4565 as it left the frigates a bit lacking in terms of being able to defend poorly-maneuverable Salems in the current destroyer-focused naval strategies. It also broke some maps which placed mexes specifically so that frigates could raid them.

## Testing done on the proposed changes


## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Balance Adjustments**
  * Increased ProtonCannon weapon range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->