### PR TITLE
Pathfinding improvement

### DIFF
--- a/changelog/snippets/fix.7020.md
+++ b/changelog/snippets/fix.7020.md
@@ -1,0 +1,1 @@
+- (#7020) Fix pathfinding by disabling column formation for long-distance moves.

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -221,6 +221,8 @@ function SetupSession()
     doscript(ScenarioInfo.script, ScenarioInfo.Env)
 
     ResetSyncTable()
+    
+    SetupPathfinding()
 end
 
 -- OnCreateArmyBrain() is called by then engine as the brains are created, and we
@@ -573,6 +575,18 @@ function OnPostLoad()
     if GetFocusArmy() ~= -1 then
         Sync.SetAlliedVictory = ArmyBrains[GetFocusArmy()].RequestingAlliedVictory or false
     end
+    
+    SetupPathfinding()
+end
+
+-- This changes default navigator's behaviour to make pathfinding more predictable and less frustrating. 
+-- Default value in the engine is 50. When distance between current units positions and 
+-- their final destination point >50, they use some weird pathfinding logic based on hidden waypoints and 
+-- start moving in columns. We disable such behaviour by setting this value to 9999, so navigator
+-- will be using personal positioning instead of waypoints for any move order (doesn't affect "formation move").
+-- useful console commands for debugging: "dbg navwaypoints", "dbg navpath", "dbg navsteering"
+function SetupPathfinding()
+    SetNavigatorPersonalPosMaxDistance(9999)
 end
 
 -- these imports break cycle dependencies of import sequences of mods


### PR DESCRIPTION
Requires https://github.com/FAForever/FA-Binary-Patches/pull/132

Discussion and vids are here: https://discord.com/channels/197033481883222026/1469005016361861445


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed long-distance pathfinding so units no longer adopt column formation for extended moves, improving movement predictability and efficiency.
  * Ensures this pathfinding behavior is applied when starting sessions and after loading saved games.

* **Documentation**
  * Added a changelog entry describing the long-distance pathfinding fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->