### PR TITLE
Add nil check to FactoryUnit OnStopBuild

### DIFF
--- a/changelog/snippets/fix.7029.md
+++ b/changelog/snippets/fix.7029.md
@@ -1,0 +1,1 @@
+- (#7029) Fix nil value error in `FactoryUnit` `OnStopBuild`.

--- a/lua/sim/units/FactoryUnit.lua
+++ b/lua/sim/units/FactoryUnit.lua
@@ -138,7 +138,7 @@ FactoryUnit = ClassUnit(StructureUnit) {
         end
 
         -- Factory can stop building but still have an unbuilt unit if a mobile build order is issued and the order is cancelled
-        if unitBeingBuilt:GetFractionComplete() < 1 then
+        if not IsDestroyed(unitBeingBuilt) and unitBeingBuilt:GetFractionComplete() < 1 then
             unitBeingBuilt:Destroy()
         end
 


### PR DESCRIPTION
## Description of the proposed changes
Fixes this error from game #26485007
```
LUA Main thread
@c:\programdata\faforever\gamedata\lua.nx5\lua\sim\units\factoryunit.lua 129
Table, nil, "FactoryBuild", nil, nil, "attempt to call method `GetFractionComplete' (a nil value)", "...rever\gamedata\lua.nx5\lua\sim\units\factoryunit.lua(141): attempt to call method `GetFractionComplete' (a nil value)
stack traceback:
    ...rever\gamedata\lua.nx5\lua\sim\units\factoryunit.lua(141): in function <...rever\gamedata\lua.nx5\lua\sim\units\factoryunit.lua:129>"
```

## Testing done on the proposed changes
I'm not sure how to reproduce this.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical crash that occurred when canceling factory unit production. The issue caused unexpected errors during build cancellation under certain conditions, affecting factory unit reliability. This fix ensures stable gameplay and improved factory performance during all production operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->