### PR TITLE
Fix manual overcharge not working

### DIFF
--- a/changelog/snippets/fix.7031.md
+++ b/changelog/snippets/fix.7031.md
@@ -1,0 +1,1 @@
+- (#7031) Fix manual overcharge not shooting.

--- a/engine/Core/Blueprints/WeaponBlueprint.lua
+++ b/engine/Core/Blueprints/WeaponBlueprint.lua
@@ -242,7 +242,7 @@
 ---@field NukeWeapon? boolean
 ---@field Overcharge? WeaponBlueprintOvercharge
 --- overcharge weapon flag
----@field OverchargeWeapon? boolean
+---@field OverChargeWeapon? boolean
 --- flag that specifies if the weapon prefers to target what the primary weapon is currently
 --- targeting
 ---@field PrefersPrimaryWeaponTarget? boolean

--- a/engine/Sim/UnitWeapon.lua
+++ b/engine/Sim/UnitWeapon.lua
@@ -13,7 +13,7 @@
 -- State 4: Finished firing
 -- If unit not busy, end the task, otherwise wait 3 ticks.
 
--- Only weapons with `ManualFire = true` and `OverchargeWeapon = false` in their blueprint can be used for tactical/nuke fire orders.
+-- Only weapons with `ManualFire = true` and `OverChargeWeapon = false` in their blueprint can be used for tactical/nuke fire orders.
 
 ---@class moho.weapon_methods
 local UnitWeapon = {}

--- a/lua/sim/weapons/DefaultProjectileWeapon.lua
+++ b/lua/sim/weapons/DefaultProjectileWeapon.lua
@@ -853,7 +853,7 @@ DefaultProjectileWeapon = ClassWeapon(Weapon) {
             -- they need a RackSalvoReloadTime that's 1/RateOfFire set to avoid firing twice on the first shot
             local unit = self.unit
             local bp = self.Blueprint
-            if bp.ManualFire and not bp.OverchargeWeapon then
+            if bp.ManualFire and not bp.OverChargeWeapon then
                 unit:SetBusy(true)
             else
                 unit:SetBusy(false)


### PR DESCRIPTION
## Description of the proposed changes
Fix typo that made manual overcharge get stuck.

## Testing done on the proposed changes
Manual overcharge works.
```
   CreateUnitAtMouse('xab1401', 0,  -18.00,    1.00, -0.00000)
   CreateUnitAtMouse('uel0001', 0,    6.00,    3.00,  2.74913)
   CreateUnitAtMouse('ueb2302', 1,   12.00,   -4.00,  3.14159)
```

## Checklist
- [x] Changes are annotated, including comments where useful: #7012 
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Manual overcharge now reliably triggers during combat.

* **Documentation**
  * Added a changelog entry describing the fix.

* **Refactor**
  * Normalized weapon metadata naming to ensure consistent behavior across systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->