### PR TITLE
Fix spooky unit db updates

### DIFF
--- a/.github/workflows/spookydb-update.yaml
+++ b/.github/workflows/spookydb-update.yaml
@@ -74,7 +74,7 @@ jobs:
         working-directory: gh-pages
         run: |
             # Check for any differences between the working directory and the latest commit
-            if git status --porcelain; then
+            if [ -z "$(git status --porcelain)" ]; then
                 echo "No changes to deploy"
                 exit 0
             fi

--- a/changelog/snippets/fix.7033.md
+++ b/changelog/snippets/fix.7033.md
@@ -1,0 +1,1 @@
+- (#7032, #7033) Fix spooky and etfreeman unit databases not being updated.


### PR DESCRIPTION
The spooky db has the same problem as etfreeman db had. See: #7032 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing spooky and etfreeman unit databases from being updated during automated deployments. The system now correctly identifies and deploys pending changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->