### PR TITLE
Don't show reclaim labels for unreclaimable but vulnerable props

### DIFF
--- a/changelog/snippets/fix.7034.md
+++ b/changelog/snippets/fix.7034.md
@@ -1,0 +1,1 @@
+- (#7034) Don't show reclaim labels for unreclaimable props.

--- a/env/UEF/Props/UEF_Bus_prop.bp
+++ b/env/UEF/Props/UEF_Bus_prop.bp
@@ -1,7 +1,6 @@
 PropBlueprint{
     Categories = {
         "OBSTRUCTSBUILDING",
-        "RECLAIMABLE",
     },
     Defense = {
         Health = 150,

--- a/env/UEF/Props/UEF_Bus_prop.bp
+++ b/env/UEF/Props/UEF_Bus_prop.bp
@@ -1,6 +1,7 @@
 PropBlueprint{
     Categories = {
         "OBSTRUCTSBUILDING",
+        "RECLAIMABLE",
     },
     Defense = {
         Health = 150,

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -36,13 +36,15 @@ Prop = Class(moho.prop_methods) {
         self.CachePosition = self:GetPosition()
 
         -- set reclaim values
-        local economy = self.Blueprint.Economy
-        local modifier = ScenarioInfo.Options.naturalReclaimModifier or 1
-        self:SetMaxReclaimValues(
-            economy.ReclaimTimeMultiplier or 1,
-            (economy.ReclaimMassMax * modifier),
-            (economy.ReclaimEnergyMax * modifier)
-        )
+        if self.Blueprint.CategoriesHash["RECLAIMABLE"] then
+            local economy = self.Blueprint.Economy
+            local modifier = ScenarioInfo.Options.naturalReclaimModifier or 1
+            self:SetMaxReclaimValues(
+                economy.ReclaimTimeMultiplier or 1,
+                (economy.ReclaimMassMax * modifier),
+                (economy.ReclaimEnergyMax * modifier)
+            )
+        end
 
         -- terrain correction
         local terrainAltitude = GetTerrainHeight(self.CachePosition[1], self.CachePosition[3])
@@ -342,7 +344,9 @@ Prop = Class(moho.prop_methods) {
             -- attempt to make the prop
             ok, out = pcall(self.CreatePropAtBone, self, ibone, blueprint)
             if ok then
-                out:SetMaxReclaimValues(time, mass, energy)
+                if out.Blueprint.CategoriesHash["RECLAIMABLE"] then
+                    out:SetMaxReclaimValues(time, mass, energy)
+                end
                 props[ibone] = out
             else
                 WARN("Unable to split a prop: " .. self.Blueprint.BlueprintId .. " -> " .. blueprint)


### PR DESCRIPTION
## Description of the proposed changes
Fixes [discord bug report](https://discord.com/channels/197033481883222026/1469997134949650583).
Check for Reclaimable category before `SetMaxReclaimValues` calls in `Prop.lua`. `SetMaxReclaimValues` is the function that sets up reclaim values and the reclaim UI labels.

## Testing done on the proposed changes
Use test commit and spawn UEF_Bus prop. It doesn't show reclaim and is unreclaimable (you cannot issue a reclaim order on it), but it can be destroyed by splash damage. Make sure to reload the game after any category changes so that the categories update engine-side.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed reclaim labels appearing on unreclaimable props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->