### PR TITLE
Fix command source not matching army index in AI games

### DIFF
--- a/changelog/snippets/fix.7038.md
+++ b/changelog/snippets/fix.7038.md
@@ -1,0 +1,1 @@
+- (#7038) Fix various sim callbacks detecting the incorrect army as the source of the callback in games with AI or observers. This fixes the issue where paintings were displayed to the incorrect players in AI games.

--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -600,12 +600,13 @@ end
 function GetArmyUnitCostTotal(army)
 end
 
---- Returns the currently active command source in the sim state. This is the n-th **human** army
---- that sent the command.
+--- Returns the currently active command source in the sim state. This is the index of the client
+--- that issued the command, which is from a list including players (human armies) and observers.
+--- The list is in the order of the lobby slots, with observers at the end.
 ---
 --- Use `GetCurrentCommandSourceArmy` from `SimUtils.lua` to reliably get the army index of the 
 --- current command source.
----@return number
+---@return integer
 function GetCurrentCommandSource()
 end
 

--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -600,8 +600,8 @@ end
 function GetArmyUnitCostTotal(army)
 end
 
---- Returns the currently active command source in the sim state. This number is the army index
---- of the army that sent the command.
+--- Returns the currently active command source in the sim state. This is the n-th **human** army
+--- that sent the command.
 ---@return number
 function GetCurrentCommandSource()
 end

--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -602,6 +602,9 @@ end
 
 --- Returns the currently active command source in the sim state. This is the n-th **human** army
 --- that sent the command.
+---
+--- Use `GetCurrentCommandSourceArmy` from `SimUtils.lua` to reliably get the army index of the 
+--- current command source.
 ---@return number
 function GetCurrentCommandSource()
 end

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -900,7 +900,6 @@ local function PassesAIAntiCheatCheck()
     return ScenarioInfo.GameHasAIs or PassesAntiCheatCheck()
 end
 
-
 local SpawnedMeshes = {}
 
 local function SpawnUnitMesh(id, x, y, z, pitch, yaw, roll)

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -1429,8 +1429,14 @@ end
 ---@param data CallbackModeratorEventData
 Callbacks.ModeratorEvent = function(data)
     -- show up in the game logs
-    local brain = GetArmyBrain(GetCurrentCommandSourceArmy())
-    SPEW(string.format("Moderator event for %s: %s", tostring(brain.Nickname), tostring(data.Message)))
+    local commandSourceNickname
+    local commandSourceArmy = GetCurrentCommandSourceArmy()
+    if commandSourceArmy then
+        commandSourceNickname = tostring(GetArmyBrain(commandSourceArmy).Nickname)
+    else
+        commandSourceNickname = string.format("Observer (source %d)", GetCurrentCommandSource())
+    end
+    SPEW(string.format("Moderator event for %s: %s", commandSourceNickname, tostring(data.Message)))
 end
 
 --#endregion

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -835,7 +835,6 @@ end
 
 do
     local OriginalFocusArmy = GetFocusArmy()
-    LOG("ORIGINAL FOCUS ARMY:", OriginalFocusArmy, OriginalFocusArmy == -1 and "Observer" or (ArmyBrains[OriginalFocusArmy].Nickname or "nil"))
 
     ---@param data UIShareableBrushStrokeCallbackMessage
     local SyncPainting = function(data)
@@ -850,33 +849,16 @@ do
     Callbacks.SharePaintingBrushStroke = function(data)
         local focusArmy = GetFocusArmy()
         local currentCommandSource = GetCurrentCommandSourceArmy()
-        LOG(string.format("Received painting callback. Focus: %d (%s), Source: %d (%s)"
-            , focusArmy
-            , ArmyBrains[focusArmy].Nickname
-            , currentCommandSource
-            , ArmyBrains[currentCommandSource].Nickname
-        ))
 
         -- spectators are able to see all paintings. We take into account
         -- the original focus army because spectators can change focus army
         if OriginalFocusArmy == -1 or focusArmy == -1 then
-            if OriginalFocusArmy == -1 then
-                LOG("Original focus is obs")
-            elseif focusArmy == -1 then
-                LOG("Focus army is obs")
-            end
             SyncPainting(data)
             return
         end
 
         -- allies are able to see each others paintings
         if IsAlly(focusArmy, currentCommandSource) then
-            LOG(string.format("Focus %d (%s) and source %d (%s) are allies"
-                , focusArmy
-                , ArmyBrains[focusArmy].Nickname
-                , currentCommandSource
-                , ArmyBrains[currentCommandSource].Nickname
-            ))
             SyncPainting(data)
             return
         end

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -848,7 +848,7 @@ do
     ---@param data UIShareableBrushStrokeCallbackMessage
     Callbacks.SharePaintingBrushStroke = function(data)
         local focusArmy = GetFocusArmy()
-        local currentCommandSource = GetCurrentCommandSourceArmy()
+        local currentCommandSourceArmy = GetCurrentCommandSourceArmy()
 
         -- spectators are able to see all paintings. We take into account
         -- the original focus army because spectators can change focus army
@@ -858,7 +858,7 @@ do
         end
 
         -- allies are able to see each others paintings
-        if IsAlly(focusArmy, currentCommandSource) then
+        if IsAlly(focusArmy, currentCommandSourceArmy) then
             SyncPainting(data)
             return
         end

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -43,6 +43,8 @@ local IssueAggressiveMove = IssueAggressiveMove
 local IssueGuard = IssueGuard
 local IssueFerry = IssueFerry
 
+local GetCurrentCommandSourceArmy = SimUtils.GetCurrentCommandSourceArmy
+
 -- upvalue categories for performance
 local CategoriesTransportation = categories.TRANSPORTATION
 
@@ -64,7 +66,7 @@ function DoCallback(name, data, units)
 
     local timeTaken = GetSystemTimeSecondsOnlyForProfileUse() - start
     if (timeTaken > 0.005) then
-        SPEW(string.format("Time to process %s from %d: %f", name, timeTaken, GetCurrentCommandSource() or -2))
+        SPEW(string.format("Time to process %s from %d: %f", name, timeTaken, GetCurrentCommandSourceArmy() or -2))
     end
 end
 
@@ -640,7 +642,7 @@ do
         -- verify selection
         selection = SecureUnits(selection)
         if (not selection) or TableEmpty(selection) then
-            if (GetFocusArmy() == GetCurrentCommandSource()) then
+            if (GetFocusArmy() == GetCurrentCommandSourceArmy()) then
                 print("Unable to interrupt path finding")
             end
 
@@ -650,7 +652,7 @@ do
         -- only apply this to engineers
         local engineers = EntityCategoryFilterDown(categories.ENGINEER + categories.COMMAND, selection)
         if table.empty(engineers) then
-            if (GetFocusArmy() == GetCurrentCommandSource()) then
+            if (GetFocusArmy() == GetCurrentCommandSourceArmy()) then
                 print("Unable to interrupt path finding")
             end
 
@@ -663,7 +665,7 @@ do
         local commandSourceGuard = CommandSourceGuards[commandSource]
 
         if commandSourceGuard and commandSourceGuard + 5 >= gameTick then
-            if (GetFocusArmy() == GetCurrentCommandSource()) then
+            if (GetFocusArmy() == GetCurrentCommandSourceArmy()) then
                 print("Unable to interrupt path finding")
             end
 
@@ -686,7 +688,7 @@ do
         -- verify selection
         selection = SecureUnits(selection)
         if (not selection) or TableEmpty(selection) then
-            if (GetFocusArmy() == GetCurrentCommandSource()) then
+            if (GetFocusArmy() == GetCurrentCommandSourceArmy()) then
                 print("Unable to discharge")
             end
 
@@ -705,7 +707,7 @@ do
         end
 
         if table.empty(unitsWithShields) then
-            if (GetFocusArmy() == GetCurrentCommandSource()) then
+            if (GetFocusArmy() == GetCurrentCommandSourceArmy()) then
                 print("Unable to discharge")
             end
 
@@ -718,7 +720,7 @@ do
         local commandSourceGuard = CommandSourceGuards[commandSource]
 
         if commandSourceGuard and commandSourceGuard + 5 >= gameTick then
-            if (GetFocusArmy() == GetCurrentCommandSource()) then
+            if (GetFocusArmy() == GetCurrentCommandSourceArmy()) then
                 print("Unable to discharge")
             end
 
@@ -838,7 +840,7 @@ do
     ---@param data UIShareableBrushStrokeCallbackMessage
     local SyncPainting = function(data)
         -- used to determine the color of the painting
-        data.ShareablePainting.PeerName = GetArmyBrain(GetCurrentCommandSource()).Nickname
+        data.ShareablePainting.PeerName = GetArmyBrain(GetCurrentCommandSourceArmy()).Nickname
 
         Sync.SharePaintingBrushStroke = Sync.SharePaintingBrushStroke or {}
         table.insert(Sync.SharePaintingBrushStroke, data)
@@ -847,7 +849,7 @@ do
     ---@param data UIShareableBrushStrokeCallbackMessage
     Callbacks.SharePaintingBrushStroke = function(data)
         local focusArmy = GetFocusArmy()
-        local currentCommandSource = GetCurrentCommandSource()
+        local currentCommandSource = GetCurrentCommandSourceArmy()
         LOG(string.format("Received painting callback. Focus: %d (%s), Source: %d (%s)"
             , focusArmy
             , ArmyBrains[focusArmy].Nickname
@@ -1434,7 +1436,7 @@ end
 ---@param data CallbackModeratorEventData
 Callbacks.ModeratorEvent = function(data)
     -- show up in the game logs
-    local brain = GetArmyBrain(GetCurrentCommandSource())
+    local brain = GetArmyBrain(GetCurrentCommandSourceArmy())
     SPEW(string.format("Moderator event for %s: %s", tostring(brain.Nickname), tostring(data.Message)))
 end
 

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -66,7 +66,18 @@ function DoCallback(name, data, units)
 
     local timeTaken = GetSystemTimeSecondsOnlyForProfileUse() - start
     if (timeTaken > 0.005) then
-        SPEW(string.format("Time to process %s from %d: %f", name, timeTaken, GetCurrentCommandSourceArmy() or -2))
+        local commandSourceNickname
+        local commandSourceArmy = GetCurrentCommandSourceArmy()
+        if commandSourceArmy then
+            commandSourceNickname = tostring(ArmyBrains[commandSourceArmy].Nickname)
+        else
+            commandSourceNickname = string.format("Observer (source %d)", GetCurrentCommandSource())
+        end
+        SPEW(string.format("Time to process \"%s\" from %s: %f"
+            , name
+            , commandSourceNickname
+            , timeTaken
+        ))
     end
 end
 

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -833,6 +833,7 @@ end
 
 do
     local OriginalFocusArmy = GetFocusArmy()
+    LOG("ORIGINAL FOCUS ARMY:", OriginalFocusArmy, OriginalFocusArmy == -1 and "Observer" or (ArmyBrains[OriginalFocusArmy].Nickname or "nil"))
 
     ---@param data UIShareableBrushStrokeCallbackMessage
     local SyncPainting = function(data)
@@ -847,16 +848,33 @@ do
     Callbacks.SharePaintingBrushStroke = function(data)
         local focusArmy = GetFocusArmy()
         local currentCommandSource = GetCurrentCommandSource()
+        LOG(string.format("Received painting callback. Focus: %d (%s), Source: %d (%s)"
+            , focusArmy
+            , ArmyBrains[focusArmy].Nickname
+            , currentCommandSource
+            , ArmyBrains[currentCommandSource].Nickname
+        ))
 
         -- spectators are able to see all paintings. We take into account
         -- the original focus army because spectators can change focus army
         if OriginalFocusArmy == -1 or focusArmy == -1 then
+            if OriginalFocusArmy == -1 then
+                LOG("Original focus is obs")
+            elseif focusArmy == -1 then
+                LOG("Focus army is obs")
+            end
             SyncPainting(data)
             return
         end
 
         -- allies are able to see each others paintings
         if IsAlly(focusArmy, currentCommandSource) then
+            LOG(string.format("Focus %d (%s) and source %d (%s) are allies"
+                , focusArmy
+                , ArmyBrains[focusArmy].Nickname
+                , currentCommandSource
+                , ArmyBrains[currentCommandSource].Nickname
+            ))
             SyncPainting(data)
             return
         end

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -1544,7 +1544,7 @@ function DrawBone(entity, bone, length)
 end
 
 local CommandSourceToArmyMap
---- Retrieves the army index corresponding to the command source index.
+--- Retrieves the army index corresponding to the given command source index.
 ---@param source integer
 ---@return integer
 function GetArmyOfCommandSource(source)
@@ -1562,6 +1562,7 @@ function GetArmyOfCommandSource(source)
     return CommandSourceToArmyMap[source]
 end
 
+--- Retrieves the army index corresponding to the current command source.
 ---@return integer
 function GetCurrentCommandSourceArmy()
     return GetArmyOfCommandSource(GetCurrentCommandSource())

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -4,6 +4,7 @@
 
 -- upvalues for performance
 local ArmyBrains = ArmyBrains
+local GetCurrentCommandSource = GetCurrentCommandSource
 
 ------------------------------------------------------------------------------------------------------------------------
 --#region General Unit Transfer Scripts
@@ -1541,3 +1542,29 @@ function DrawBone(entity, bone, length)
     -- Z axis
     DrawLine(pos, pos + forward * length, '0000ff')
 end
+
+local CommandSourceToArmyMap
+--- Retrieves the army index corresponding to the command source index.
+---@param source integer
+---@return integer
+function GetArmyOfCommandSource(source)
+    if not CommandSourceToArmyMap then
+        CommandSourceToArmyMap = {}
+        local commandSourceIndex = 1
+        for index, army in ArmyBrains do
+            if army.Human then
+                CommandSourceToArmyMap[commandSourceIndex] = index
+                commandSourceIndex = commandSourceIndex + 1
+            end
+        end
+    end
+
+    return CommandSourceToArmyMap[source]
+end
+
+---@return integer
+function GetCurrentCommandSourceArmy()
+    return GetArmyOfCommandSource(GetCurrentCommandSource())
+end
+
+

--- a/lua/sim/commands/area-reclaim-order.lua
+++ b/lua/sim/commands/area-reclaim-order.lua
@@ -31,6 +31,8 @@ local StringFormat = string.format
 
 local IssueReclaim = IssueReclaim
 
+local GetCurrentCommandSourceArmy = import("/lua/SimUtils.lua").GetCurrentCommandSourceArmy
+
 ---@type table<EntityId, boolean>
 local distances = { }
 
@@ -86,7 +88,7 @@ local function ReclaimAdjacentUnits (units, target, doPrint)
         end
     end
 
-    if doPrint and processed > 0 and (GetFocusArmy() == GetCurrentCommandSource()) then
+    if doPrint and processed > 0 and (GetFocusArmy() == GetCurrentCommandSourceArmy()) then
         print(StringFormat("Reclaiming %d adjacent units", processed))
     end
 end
@@ -197,7 +199,7 @@ function AreaReclaimProps(units, ps, pe, width, doPrint)
         end
     end
 
-    if doPrint and (GetFocusArmy() == GetCurrentCommandSource()) then
+    if doPrint and (GetFocusArmy() == GetCurrentCommandSourceArmy()) then
         if processed > 0 then
             print(StringFormat("Reclaiming %d additional props", processed))
         end


### PR DESCRIPTION
## Description of the proposed changes
Fixes #7037.
- Adds new sim util functions to get the army of a command source and of the current command source.
- Use the new functions to fix usages of `GetCommandSource` in the repository.
  - simple text replacements when it is compared against the focus army
  - fix and improve "time to process" message and moderator event message
- Fix the annotation of `GetCommandSource`

## Testing done on the proposed changes
- Following the steps in the issue, the drawings no longer appear for the incorrect player when in an AI game. 
- The discharge shields callback now correctly gives feedback that it can't discharge shields on an unupgraded ACU.
- The moderator event when an observer changes focus armies no longer causes an error.
- The "time to process" message displays the amount of time correctly.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where game commands were incorrectly attributed to the wrong source in AI and observer games, preventing visual feedback elements from displaying to the correct players and ensuring proper game state synchronization during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->