### PR TITLE
T3 Mass Fabs: reduce death‑weapon blast radius

### DIFF
--- a/changelog/snippets/balance.7040.md
+++ b/changelog/snippets/balance.7040.md
@@ -1,5 +1,5 @@
-- (#7040) Reduce T3 mass fab blast radius from `14` to `8` to make their explosions less punishing to gunships.
+- (#7040) Reduce T3 mass fab blast radius from `14` to `10` to make their explosions less punishing to gunships.
 
   **T3 Mass Fabricators (UEB1303, URB1303, UAB1303, XSB1303):**
   - Death Weapon
-    - DamageRadius: 14 --> 8
+    - DamageRadius: 14 --> 10

--- a/changelog/snippets/balance.7040.md
+++ b/changelog/snippets/balance.7040.md
@@ -1,0 +1,5 @@
+- (#7040) Reduce T3 mass fab blast radius from `14` to `8` to make their explosions less punishing to gunships.
+
+  **T3 Mass Fabricators (UEB1303, URB1303, UAB1303, XSB1303):**
+  - Death Weapon
+    - DamageRadius: 14 --> 8

--- a/units/UAB1303/UAB1303_unit.bp
+++ b/units/UAB1303/UAB1303_unit.bp
@@ -122,7 +122,7 @@ UnitBlueprint{
         {
             Damage = 5000,
             DamageFriendly = true,
-            DamageRadius = 8,
+            DamageRadius = 10,
             DamageType = "DeathExplosion",
             DisplayName = "Death Weapon",
             DummyWeapon = true,

--- a/units/UAB1303/UAB1303_unit.bp
+++ b/units/UAB1303/UAB1303_unit.bp
@@ -122,7 +122,7 @@ UnitBlueprint{
         {
             Damage = 5000,
             DamageFriendly = true,
-            DamageRadius = 14,
+            DamageRadius = 8,
             DamageType = "DeathExplosion",
             DisplayName = "Death Weapon",
             DummyWeapon = true,

--- a/units/UEB1303/UEB1303_unit.bp
+++ b/units/UEB1303/UEB1303_unit.bp
@@ -118,7 +118,7 @@ UnitBlueprint{
         {
             Damage = 5000,
             DamageFriendly = true,
-            DamageRadius = 8,
+            DamageRadius = 10,
             DamageType = "DeathExplosion",
             DisplayName = "Death Weapon",
             DummyWeapon = true,

--- a/units/UEB1303/UEB1303_unit.bp
+++ b/units/UEB1303/UEB1303_unit.bp
@@ -118,7 +118,7 @@ UnitBlueprint{
         {
             Damage = 5000,
             DamageFriendly = true,
-            DamageRadius = 14,
+            DamageRadius = 8,
             DamageType = "DeathExplosion",
             DisplayName = "Death Weapon",
             DummyWeapon = true,

--- a/units/URB1303/URB1303_unit.bp
+++ b/units/URB1303/URB1303_unit.bp
@@ -114,7 +114,7 @@ UnitBlueprint{
         {
             Damage = 5000,
             DamageFriendly = true,
-            DamageRadius = 8,
+            DamageRadius = 10,
             DamageType = "DeathExplosion",
             DisplayName = "Death Weapon",
             DummyWeapon = true,

--- a/units/URB1303/URB1303_unit.bp
+++ b/units/URB1303/URB1303_unit.bp
@@ -114,7 +114,7 @@ UnitBlueprint{
         {
             Damage = 5000,
             DamageFriendly = true,
-            DamageRadius = 14,
+            DamageRadius = 8,
             DamageType = "DeathExplosion",
             DisplayName = "Death Weapon",
             DummyWeapon = true,

--- a/units/XSB1303/XSB1303_unit.bp
+++ b/units/XSB1303/XSB1303_unit.bp
@@ -126,7 +126,7 @@ UnitBlueprint{
         {
             Damage = 5000,
             DamageFriendly = true,
-            DamageRadius = 14,
+            DamageRadius = 8,
             DamageType = "DeathExplosion",
             DisplayName = "Death Weapon",
             DummyWeapon = true,

--- a/units/XSB1303/XSB1303_unit.bp
+++ b/units/XSB1303/XSB1303_unit.bp
@@ -126,7 +126,7 @@ UnitBlueprint{
         {
             Damage = 5000,
             DamageFriendly = true,
-            DamageRadius = 8,
+            DamageRadius = 10,
             DamageType = "DeathExplosion",
             DisplayName = "Death Weapon",
             DummyWeapon = true,


### PR DESCRIPTION
## Description of the proposed changes
The blast radius of T3 mass fabs is 14, which is higher than that of T3 Pgens (10). This makes their explosion extremely deadly to gunships. Right now, players are forced to either avoid the blast radius (difficult) or micro the gunships around the mass fabs (often impractical). Their new blast radius is set to 8.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Balance Changes**
  * Reduced death-explosion radius for four unit types: damage radius decreased from 14 to 10, shrinking their explosion footprint.
* **Changelog**
  * Updated change entry to reflect the reduced blast radius for T3 Mass Fabricators (14 → 10).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->