### PR TITLE
Fix the rotation direction of the normals

### DIFF
--- a/changelog/snippets/graphics.7041.md
+++ b/changelog/snippets/graphics.7041.md
@@ -1,0 +1,1 @@
+- (#7041) Fix the normals of rotated texture layers (Only affects maps that use the Terrain200 shader). 

--- a/effects/terrain.fx
+++ b/effects/terrain.fx
@@ -2993,12 +2993,10 @@ float4 Terrain200NormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
     float3 stratum6Normal = normalize(tex2D(Stratum6NormalSampler, rotated_pos * Stratum6AlbedoTile.xy).rgb * 2 - 1);
 
     // We need to rotate the normal vectors back.
-    // I thought we would have to flip the multiplication order,
-    // compared to the uv rotation, but empirically this is correct.
-    stratum0Normal.xy = mul(stratum0Normal.xy, rotationMatrix);
-    stratum2Normal.xy = mul(stratum2Normal.xy, rotationMatrix);
-    stratum4Normal.xy = mul(stratum4Normal.xy, rotationMatrix);
-    stratum6Normal.xy = mul(stratum6Normal.xy, rotationMatrix);
+    stratum0Normal.xy = mul(rotationMatrix, stratum0Normal.xy);
+    stratum2Normal.xy = mul(rotationMatrix, stratum2Normal.xy);
+    stratum4Normal.xy = mul(rotationMatrix, stratum4Normal.xy);
+    stratum6Normal.xy = mul(rotationMatrix, stratum6Normal.xy);
 
     float stratum0Height = sampleHeight(rotated_pos, Stratum0AlbedoTile.xy, Stratum0NormalTile.xy, float2(0.5, 0.0), true);
     float stratum1Height = sampleHeight(position.xy, Stratum1AlbedoTile.xy, Stratum1NormalTile.xy, float2(0.0, 0.5), true);
@@ -3211,10 +3209,10 @@ float4 Terrain200BNormalsPS ( VS_OUTPUT inV, uniform bool halfRange ) : COLOR
     float3 stratum5Normal = normalize(tex2D(Stratum5NormalSampler, position.xy * Stratum5AlbedoTile.xy).rgb * 2 - 1);
     float3 stratum6Normal = normalize(tex2D(Stratum6NormalSampler, rotated_pos * Stratum6AlbedoTile.xy).rgb * 2 - 1);
 
-    // we need to rotate the normal vectors back
-    stratum0Normal.xy = mul(stratum0Normal.xy, rotationMatrix);
-    stratum4Normal.xy = mul(stratum4Normal.xy, rotationMatrix);
-    stratum6Normal.xy = mul(stratum6Normal.xy, rotationMatrix);
+    // We need to rotate the normal vectors back.
+    stratum0Normal.xy = mul(rotationMatrix, stratum0Normal.xy);
+    stratum4Normal.xy = mul(rotationMatrix, stratum4Normal.xy);
+    stratum6Normal.xy = mul(rotationMatrix, stratum6Normal.xy);
 
     float stratum0Height = sampleHeight(rotated_pos, Stratum0AlbedoTile.xy, Stratum0NormalTile.xy, float2(0.5, 0.0), true);
     float stratum1Height = sampleHeight(position.xy, Stratum1AlbedoTile.xy, Stratum1NormalTile.xy, float2(0.0, 0.5), true);


### PR DESCRIPTION
The normals of the rotated texture layers of the Terrain200 shader need to be rotated to face the right direction. Unfortunately this rotation happened in the wrong direction. This is now fixed. Flipping the arguments of a matrix multiplication flips the rotation direction. The map editor needs the same fix.

Video of the issue:

https://github.com/user-attachments/assets/118882e0-8239-4081-99d7-fb8db9c6f84b



## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected terrain normal rotation so rotated texture layers render with proper lighting and visual appearance on affected maps using the Terrain200 shader.
* **Documentation**
  * Added a changelog snippet documenting the fix and its scope (applies to maps using the Terrain200 shader).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->