### PR TITLE
Fix becoming observer at end of game clearing score screen button

### DIFF
--- a/changelog/snippets/fix.7042.md
+++ b/changelog/snippets/fix.7042.md
@@ -1,0 +1,1 @@
+- (#7042) Fix the score screen button not appearing at the end of a game.

--- a/lua/ui/game/tabs.lua
+++ b/lua/ui/game/tabs.lua
@@ -1271,5 +1271,8 @@ function UpdateModeDisplay()
 end
 
 FocusArmyChanged = function()
-    ClearModeText()
+    -- Avoid clearing the score screen button at the end of the game due to being switched to observer.
+    if not SessionIsGameOver() then
+        ClearModeText()
+    end
 end


### PR DESCRIPTION
## Issue
There should be a "score" button where the main menu tab is at the top middle of the screen when a game ends, but it does not appear.

#6997 added a focus army changed callback to `tabs.lua` that clears the "Mode Display". `gameresult.lua` adds the score button to the mode display [here](https://github.com/FAForever/fa/blob/abfffe214b23d794f54eaaa2d0e92e0e24e579cf/lua/ui/game/gameresult.lua#L60). As a result, when the game ends and the player is set to observer, the score button is created and subsequently cleared.

## Description of the proposed changes
In the callback, check if the game is over before clearing the mode display.

## Testing done on the proposed changes
Run the script to test multiplayer: `./scripts/LaunchFAInstances.ps1 -players 2`
When one player ctrl-k's the score button now appears at the tab in the top middle of the screen. I also tested that without these changes the score button was not there.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed score screen button not appearing at the end of a game when a player becomes an observer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->