### PR TITLE
Display the `Minus` hotkey label correctly

### DIFF
--- a/changelog/snippets/fix.7043.md
+++ b/changelog/snippets/fix.7043.md
@@ -1,0 +1,1 @@
+- (#7043) Fix missing hotkey label for the 'Minus' key by mapping it to the '-' symbol.

--- a/lua/keymap/hotkeylabels.lua
+++ b/lua/keymap/hotkeylabels.lua
@@ -12,6 +12,7 @@ local signs = {
     ["Period"] = ".",
     ["Slash"] = "/",
     ["Backslash"] = "\\",
+    ["Minus"] = "-",
     ["NumPlus"] = "+",
     ["NumMinus"] = "-",
     ["NumStar"] = "*",


### PR DESCRIPTION
## Description of the proposed changes
The 'Minus' key was missing from the signs table in `hotkeylabels.lua`, causing the raw string "Minus" to be used. Since hotkey labels only support strings up to 3 characters, this triggered a `Not showing label for keybind Minus due to length` warning and prevented the label from showing.

Mapping "Minus" to "-" in the signs table resolves the issue.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Minus key in hotkey labels, enabling proper display of keyboard shortcuts using the Minus key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->