### PR TITLE
Bump up delay to end game back to 3 seconds

### DIFF
--- a/changelog/snippets/fix.7050.md
+++ b/changelog/snippets/fix.7050.md
@@ -1,3 +1,3 @@
 - (#7050) Fix campaign/coop missions not ending properly after completion
 
-The dialog to continue to the mission after dialogue and/or score screen pops up again.
+  The dialog to continue to the mission after dialogue and/or score screen pops up again.

--- a/changelog/snippets/fix.7050.md
+++ b/changelog/snippets/fix.7050.md
@@ -1,0 +1,3 @@
+- (#7050) Fix campaign/coop missions not ending properly after completion
+
+The dialog to continue to the mission after dialogue and/or score screen pops up again.

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -938,6 +938,10 @@ end
 -- would have blown up.
 EndGameGracePeriod = 10
 
+-- Set to true in `AbstractVictoryCondition.EndGame` to prevent killing units after a
+-- team is victorious but before the sim is stopped.
+GameIsEnding = false
+
 --- Kills all given units, if not already dead
 ---@param toKill Entity[]
 local function KillUnits(toKill)
@@ -1072,6 +1076,8 @@ function KillArmy(self, shareOption)
 
     WaitSeconds(EndGameGracePeriod)
 
+    if GameIsEnding then return end
+
     local selfIndex = self.Army
     local brainCategories = GetAllegianceCategories(selfIndex)
 
@@ -1112,6 +1118,8 @@ end
 function KillRecalledArmy(self, shareOption)
 
     WaitSeconds(EndGameGracePeriod)
+
+    if GameIsEnding then return end
 
     local brainCategories = GetAllegianceCategories(self.Army)
 

--- a/lua/sim/VictoryCondition/AbstractVictoryCondition.lua
+++ b/lua/sim/VictoryCondition/AbstractVictoryCondition.lua
@@ -44,7 +44,7 @@ AbstractVictoryCondition = Class(DebugComponent) {
     DelayBeforeVictory = 5,
 
     --- Once the game is guaranteed to end, it will take this many seconds to end the game. This needs
-    --- to be at least three seconds for campaign/coop to end gracefully. It takes three seconds for 
+    --- to be three or more seconds for campaign/coop to end gracefully. It takes three seconds for 
     --- an operation (campaign/coop) to end via `ScenarioFramework.EndOperation`.
     DelayBeforeGameEnds = 3,
 

--- a/lua/sim/VictoryCondition/AbstractVictoryCondition.lua
+++ b/lua/sim/VictoryCondition/AbstractVictoryCondition.lua
@@ -22,6 +22,7 @@
 
 local DebugComponent = import("/lua/shared/components/DebugComponent.lua").DebugComponent
 local SyncGameResult = import("/lua/simsyncutils.lua").SyncGameResult
+local SimUtils = import("/lua/simutils.lua")
 
 -- upvalue for performance
 local TableGetn = table.getn
@@ -281,6 +282,8 @@ AbstractVictoryCondition = Class(DebugComponent) {
             KillThread(self.ProcessGameStateThreadInstance)
             self.ProcessGameStateThreadInstance = nil
         end
+
+        SimUtils.GameIsEnding = true
 
         self.Trash:Add(ForkThread(self.EndGameThread, self))
     end,

--- a/lua/sim/VictoryCondition/AbstractVictoryCondition.lua
+++ b/lua/sim/VictoryCondition/AbstractVictoryCondition.lua
@@ -43,8 +43,10 @@ AbstractVictoryCondition = Class(DebugComponent) {
     --- An attempt to end the game. The monitoring thread continues to catch draws. It will take this many seconds to declare victory and start the end game procedure.
     DelayBeforeVictory = 5,
 
-    --- Once the game is guaranteed to end, it will take this many seconds to end the game.
-    DelayBeforeGameEnds = 1,
+    --- Once the game is guaranteed to end, it will take this many seconds to end the game. This needs
+    --- to be at least three seconds for campaign/coop to end gracefully. It takes three seconds for 
+    --- an operation (campaign/coop) to end via `ScenarioFramework.EndOperation`.
+    DelayBeforeGameEnds = 3,
 
     ---@param self AbstractVictoryCondition
     __init = function(self)


### PR DESCRIPTION

## Description of the proposed changes

As posted on [Discord](https://discord.com/channels/197033481883222026/14723323538579169700), this fixes the bug where a campaign mission no longer shows the 'Operation Complete/Failed' dialog. It takes three seconds for the dialog to show, this is likely for dramatic effect. In https://github.com/FAForever/fa/pull/6965 the delay before the game ends was reduced from 3 seconds to 1 second, as a result the operation data was not synced and therefore the dialog would never show.

## Testing done on the proposed changes

Run using the [init of coop](https://github.com/FAForever/fa-coop/blob/master/init_coop.lua#L5) in dev-mode by pointing to the repositories and confirm that the dialog shows with the changes made.

## Additional context


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased post-victory wait time (1s → 3s) so campaign and co-op missions conclude cleanly and the “continue” dialog no longer reappears after the score/dialogue screens.
  * Added a shutdown safeguard to prevent unit removal/transfer during end-of-game processing, avoiding post-victory side effects.

* **Documentation**
  * Added a changelog entry describing the fix for missions not ending properly (fix #7050).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->