### PR TITLE
Add game option to show allied intel in strategic overlay

### DIFF
--- a/changelog/snippets/feature.7054.md
+++ b/changelog/snippets/feature.7054.md
@@ -1,0 +1,3 @@
+- (#7054) Add ability to show allied intel in strategic overlay
+
+By default the intel of allied structures is shared. This default is chosen to make players aware of the new features without cluttering the screen. The game option can be found under Interface -> HUD.

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -951,12 +951,12 @@ options = {
                 title = "<LOC Show_Allied_Intel>Show intel of allies in strategic overlay",
                 key = 'intel_overlay_allies',
                 type = 'toggle',
-                default = true,
+                default = 1,
                 set = function(key, value, startup)
-                    ConExecute("ui_IntelRangeBehavior " .. tostring(value))
+                    ConExecute("ren_IntelRangeBehavior " .. tostring(value))
                 end,
                 update = function(control, value)
-                    ConExecute("ui_IntelRangeBehavior " .. tostring(value))
+                    ConExecute("ren_IntelRangeBehavior " .. tostring(value))
                 end,
                 custom = {
                     states = {

--- a/lua/options/options.lua
+++ b/lua/options/options.lua
@@ -948,6 +948,26 @@ options = {
             },
 
             {
+                title = "<LOC Show_Allied_Intel>Show intel of allies in strategic overlay",
+                key = 'intel_overlay_allies',
+                type = 'toggle',
+                default = true,
+                set = function(key, value, startup)
+                    ConExecute("ui_IntelRangeBehavior " .. tostring(value))
+                end,
+                update = function(control, value)
+                    ConExecute("ui_IntelRangeBehavior " .. tostring(value))
+                end,
+                custom = {
+                    states = {
+                        { text = "<LOC _Off>", key = 0, },
+                        { text = "<LOC _JustStructures>Only allied structures", key = 1, },
+                        { text = "<LOC _On>", key = 2, },
+                    },
+                },
+            },
+
+            {
                 title = "<LOC OPTIONS_0215>Show Waypoint ETAs",
                 key = 'display_eta',
                 type = 'toggle',

--- a/lua/ui/help/tooltips.lua
+++ b/lua/ui/help/tooltips.lua
@@ -851,6 +851,10 @@ Tooltips = {
         title = "<LOC OPTIONS_0283>UI Scale",
         description = "<LOC OPTIONS_0284>Changes the size of all UI elements. (requires game restart)",
     },
+    options_show_allied_intel_in_strategic_overlay = {
+        title = "<LOC Show_Allied_Intel_Title>Show Allied Intel in Strategic Overlay",
+        description = "<LOC Show_Allied_Intel_Description>Toggles the display of allied intel in the strategic overlay.",
+    },
     options_subtitles = {
         title = "<LOC OPTIONS_0151>Display Subtitles",
         description = "<LOC OPTIONS_0152>Toggles the display of subtitles during movies",


### PR DESCRIPTION
## Description of the proposed changes

Depends on: https://github.com/FAForever/FA-Binary-Patches/pull/142

## Testing done on the proposed changes

Change the game option and launch local multiplayer, observe that the changes are saved and applied.

## Additional context

Supports the ability to show allied intel in strategic overlay, with thanks to the efforts of RutreD! Requires the exe that is posted on Zulip.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to display allied intel in the strategic overlay. Configure this option with three states (Off, Only allied structures, On) under Interface → HUD settings. Allied intel is shared by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->