### PR TITLE
Adjust VeteranMassMult to better align the Vulthoo with its role as a 'Tech 2.5 unit'

### DIFF
--- a/changelog/snippets/balance.7059.md
+++ b/changelog/snippets/balance.7059.md
@@ -1,4 +1,4 @@
 - (#7059) Adjust VeteranMassMult to better align the Vulthoo with its role as a 'Tech 2.5 unit'
 
-  **Vulthoo: T2 Gunship (XSA0203):**
+  **Vulthoo: T2 Gunship (XSA0203)**
   - VeteranMassMult: 1.5 -> 1.375

--- a/changelog/snippets/balance.7059.md
+++ b/changelog/snippets/balance.7059.md
@@ -1,0 +1,4 @@
+- (#7059) Adjust VeteranMassMult to better align the Vulthoo with its role as a 'Tech 2.5 unit'
+
+  **Vulthoo: T2 Gunship (XSA0203):**
+  - VeteranMassMult: 1.5 -> 1.375

--- a/units/XSA0203/XSA0203_unit.bp
+++ b/units/XSA0203/XSA0203_unit.bp
@@ -163,6 +163,7 @@ UnitBlueprint{
         Level4 = 24,
         Level5 = 30,
     },
+    VeteranMassMult = 1.375,
     Weapon = {
         {
             AboveWaterTargetsOnly = true,


### PR DESCRIPTION
T3 gunships have TechToVetMultiplier [equal to 1.25](https://github.com/FAForever/fa/blob/45ea30ea792135955f2021d613455ad9b2e7ea42/lua/system/blueprints-units.lua#L48), while t2 have it equal to 1.5, so Vulthoo should have it equal to 1.375 to better align with its role as a 'Tech 2.5 unit'
This is an additon to PR #6560, which adjusted other stats in a similar way
<h2>Description of the proposed changes</h2>
<b>Vulthoo: T2 Gunship (XSA0203):</b>
VeteranMassMult: 1.5  --> 1.375

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the veteran mass multiplier for the Vulthoo T2 Gunship to better align with its Tech 2.5 role and improve balance.

* **Documentation**
  * Added a changelog entry documenting the Vulthoo balance adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->