### PR TITLE
Fix wrecks being reclaimed slower if the unit was overkilled

### DIFF
--- a/changelog/snippets/fix.7061.md
+++ b/changelog/snippets/fix.7061.md
@@ -1,0 +1,1 @@
+- (#7061) Fix wrecks from overkilled units taking extra long to reclaim.

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -675,8 +675,8 @@ function FinalizeRebuiltUnits(trackers, blockingEntities)
             -- Don't refund energy because it would be counterintuitive for wreckage
             local energy = 0
             -- global 2x time multiplier for unit wrecks, see `Unit:CreateWreckageProp`
-            local time = (bp.Wreckage.ReclaimTimeMultiplier or 1) * 2
-            CreateWreckage(bp, pos, orientation, mass, energy, time)
+            local timeMult = (bp.Wreckage.ReclaimTimeMultiplier or 1) * 2
+            CreateWreckage(bp, pos, orientation, mass, energy, timeMult)
         end
     end
 

--- a/lua/sim/Prop.lua
+++ b/lua/sim/Prop.lua
@@ -186,13 +186,13 @@ Prop = Class(moho.prop_methods) {
     --- that determine how quickly it can be reclaimed. These values are used to set the real reclaim
     --- values as fractions of the health as the wreck takes damage.
     ---@param self Prop
-    ---@param time number
+    ---@param timeMult number
     ---@param mass number
     ---@param energy number
-    SetMaxReclaimValues = function(self, time, mass, energy)
+    SetMaxReclaimValues = function(self, timeMult, mass, energy)
         self.MaxMassReclaim = mass
         self.MaxEnergyReclaim = energy
-        self.TimeReclaim = time
+        self.TimeReclaim = timeMult
         self:UpdateReclaimLeft()
 
         if self.MaxMassReclaim * self.ReclaimLeft >= 10 then

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1811,7 +1811,6 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         local overkillMultiplier = 1 - (overkillRatio or 1)
         mass = mass * overkillMultiplier * self:GetFractionComplete()
         energy = energy * overkillMultiplier * self:GetFractionComplete()
-        time = time * overkillMultiplier
 
         -- Now we adjust the global multiplier. This is used for balance purposes to adjust global reclaim rate.
         local time  = time * 2

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1767,7 +1767,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         local mass, energy = self:GetTotalResourceCosts()
         mass = mass * (bp.Wreckage.MassMult or 0)
         energy = energy * (bp.Wreckage.EnergyMult or 0)
-        local time = (bp.Wreckage.ReclaimTimeMultiplier or 1)
+        local reclaimRateDiv = (bp.Wreckage.ReclaimTimeMultiplier or 1)
         local pos = self:GetPosition()
         local wasOutside = false
         local layer = self.Layer
@@ -1813,9 +1813,9 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         energy = energy * overkillMultiplier * self:GetFractionComplete()
 
         -- Now we adjust the global multiplier. This is used for balance purposes to adjust global reclaim rate.
-        time  = time * 2
+        reclaimRateDiv  = reclaimRateDiv * 2
 
-        local prop = Wreckage.CreateWreckage(bp, pos, self:GetOrientation(), mass, energy, time, self.DeathHitBox)
+        local prop = Wreckage.CreateWreckage(bp, pos, self:GetOrientation(), mass, energy, reclaimRateDiv, self.DeathHitBox)
 
         -- Attempt to copy our animation pose to the prop. Only works if
         -- the mesh and skeletons are the same, but will not produce an error if not.

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1767,7 +1767,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         local mass, energy = self:GetTotalResourceCosts()
         mass = mass * (bp.Wreckage.MassMult or 0)
         energy = energy * (bp.Wreckage.EnergyMult or 0)
-        local reclaimRateDiv = (bp.Wreckage.ReclaimTimeMultiplier or 1)
+        local timeMult = (bp.Wreckage.ReclaimTimeMultiplier or 1)
         local pos = self:GetPosition()
         local wasOutside = false
         local layer = self.Layer
@@ -1813,9 +1813,9 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         energy = energy * overkillMultiplier * self:GetFractionComplete()
 
         -- Now we adjust the global multiplier. This is used for balance purposes to adjust global reclaim rate.
-        reclaimRateDiv  = reclaimRateDiv * 2
+        timeMult  = timeMult * 2
 
-        local prop = Wreckage.CreateWreckage(bp, pos, self:GetOrientation(), mass, energy, reclaimRateDiv, self.DeathHitBox)
+        local prop = Wreckage.CreateWreckage(bp, pos, self:GetOrientation(), mass, energy, timeMult, self.DeathHitBox)
 
         -- Attempt to copy our animation pose to the prop. Only works if
         -- the mesh and skeletons are the same, but will not produce an error if not.

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -1813,7 +1813,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         energy = energy * overkillMultiplier * self:GetFractionComplete()
 
         -- Now we adjust the global multiplier. This is used for balance purposes to adjust global reclaim rate.
-        local time  = time * 2
+        time  = time * 2
 
         local prop = Wreckage.CreateWreckage(bp, pos, self:GetOrientation(), mass, energy, time, self.DeathHitBox)
 

--- a/lua/wreckage.lua
+++ b/lua/wreckage.lua
@@ -112,10 +112,10 @@ Wreckage = Class(Prop) {
 ---@param orientation Quaternion
 ---@param mass number
 ---@param energy number
----@param time number
+---@param timeMult number
 ---@param deathHitBox? table
 ---@return Wreckage
-function CreateWreckage(bp, position, orientation, mass, energy, time, deathHitBox)
+function CreateWreckage(bp, position, orientation, mass, energy, timeMult, deathHitBox)
     local prop = CreateProp(position, bp.Wreckage.Blueprint)
     prop:SetOrientation(orientation, true)
     prop:SetScale(bp.Display.UniformScale)
@@ -150,7 +150,7 @@ function CreateWreckage(bp, position, orientation, mass, energy, time, deathHitB
 
     -- set collision box and reclaim values, the latter depends on the health of the wreck
     prop:SetPropCollision('Box', cx, cy, cz, sx, sy, sz)
-    prop:SetMaxReclaimValues(time, mass, energy)
+    prop:SetMaxReclaimValues(timeMult, mass, energy)
 
     --FIXME: SetVizToNeurals('Intel') is correct here, so you can't see enemy wreckage appearing
     -- under the fog. However the engine has a bug with prop intel that makes the wreckage


### PR DESCRIPTION
## Description of the proposed changes
Fix overkilled units being reclaimed slower by removing the time multiplication.
This mistake seems to be caused by a bad variable name, so I refactored that from "time" to "timeMult".

## Testing done on the proposed changes
Spawn these units, then ctrl-k one engi and have the percy overkill the other. Afterwards, reclaim the wrecks and check that the overkilled wreck is reclaimed much faster and check the reclaim income in the eco bar to verify that both wrecks are reclaimed at 25 mass/s.
```
   CreateUnitAtMouse('uel0105', 1,    1.20,   -0.40, -0.00019)
   CreateUnitAtMouse('uel0309', 0,   -1.80,    2.60,  0.00039)
   CreateUnitAtMouse('xel0305', 1,    1.20,   -4.40, -0.00000)
   CreateUnitAtMouse('uel0309', 0,    1.20,    2.60, -0.00050)
```

## Additional context
<!-- Add any other context about the pull request here. -->


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where wrecks from overkilled units were reclaiming at slower-than-intended speeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->