### PR TITLE
Reduce buildtime of hives

### DIFF
--- a/changelog/snippets/balance.7062.md
+++ b/changelog/snippets/balance.7062.md
@@ -1,0 +1,7 @@
+- (#7062) Reduce the build time of hives, especially for the lower levels, to make them worth building over T3 engineers when you need buildpower very quickly.
+
+  **The Hive: T2 Engineering Station (XRB0104, XRB0204, XRB0304):**
+  - Build time:
+    - Level 1: 1171 -> 880
+    - Level 2: 1171 -> 1000
+    - Level 3: 1171 -> 1120

--- a/units/XRB0104/XRB0104_unit.bp
+++ b/units/XRB0104/XRB0104_unit.bp
@@ -92,7 +92,7 @@ UnitBlueprint{
         BuildCostEnergy = 2100,
         BuildCostMass = 350,
         BuildRate = 20,
-        BuildTime = 1171,
+        BuildTime = 880,
         BuildableCategory = { "xrb0204" },
         UpgradeOnlyCategory = { "xrb0204" },
         MaxBuildDistance = 15,

--- a/units/XRB0204/XRB0204_unit.bp
+++ b/units/XRB0204/XRB0204_unit.bp
@@ -89,7 +89,7 @@ UnitBlueprint{
         BuildCostEnergy = 4200,
         BuildCostMass = 700,
         BuildRate = 37,
-        BuildTime = 1171,
+        BuildTime = 1000,
         BuildableCategory = { "xrb0304" },
         UpgradeOnlyCategory = { "xrb0304" },
         DifferentialUpgradeCostCalculation = true,

--- a/units/XRB0304/XRB0304_unit.bp
+++ b/units/XRB0304/XRB0304_unit.bp
@@ -85,7 +85,7 @@ UnitBlueprint{
         BuildCostEnergy = 6300,
         BuildCostMass = 1050,
         BuildRate = 50,
-        BuildTime = 1171,
+        BuildTime = 1120,
         DifferentialUpgradeCostCalculation = true,
         MaxBuildDistance = 25,
         RebuildBonusIds = { "xrb0104" },


### PR DESCRIPTION
## Description of the proposed changes
Implements the following suggestion from [discord](https://discord.com/channels/197033481883222026/1446014077406150799):

> After the BP nerf, higher level Hives are worse than T3 Engis in Bt/BP, so their role as emergency buildpower is now practically nonexistent. I suggest buffing the buildtime to bring them back into this role, as currently they cannot compete with engineers.
> 
> **Adjust Hives and Kennels [#4644](https://github.com/FAForever/fa/pull/4644) - Hive Changes:**
> Buildtime per level: 1171 (unchanged)
> Buildpower per level: +25 -> +20, +17, +13
> Bt/Bp: 47 -> 59, 69, 90
> 
> **T3 Engis:**
> Buildtime: 1560
> Buildpower: 32.5
> Bt/Bp: 48
> 
> **Kennels:**
> Kennels are worth comparing to as they are quite powerful when self-upgrading.
> Buildtime per level: 1000, 2000
> Buildpower per level: +20 self and +25 drone, +25 drone
> Bt/Bp: 40, 80
> 
> That 80 is quite high but since the building itself nearly doubles its buildpower the buildtime can be estimated to be lower. One such estimate would take the building's buildpower and take out its contribution during an unassisted upgrade from the total buildtime: `2000 * 25/45 = 1111` which gives a Bt/Bp of 44.
> Another estimate would be to average it out between the lvl 1 and lvl 2 upgrades to 60 bt/bp.
> If the drone is immediately used for more lvl 1 kennels instead of building the level 2 upgrade, the level 2 upgrade has essentially 0 buildtime opportunity cost.
> 
> **Suggested change for Hives:**
> Buildtime per level: 1171 -> 880, 1000, 1120
> Buildpower per level: +20, +17, +13 (unchanged)
> Bt/Bp: 59, 69, 90 -> 44, 59, 86
> Total Bt/Bp per level: 44, 51, 60
> 
> **Goals of changes:**
> - Level 1 hives are fast to build as they are low density, HP, and range. This lets them get spammed quickly near a build site like a T4.
> - Level 3 hives are made to match kennel's average bt/bp since hives are a bit better bp and I think the 60 bt/bp is an overestimate.
> - Level 2 hives naturally end up in the middle, since I didn't think of a plan for them.

## Testing done on the proposed changes
I am not sure what there is to test in a sandbox, it is a simple number change but with complex effects dependent on map type/game state/build order type.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Balance Adjustments**
  * Hive T2 Engineering Station variants now build faster across all levels (Level 1: 880s, Level 2: 1000s, Level 3: 1120s).
  * Changelog documentation updated to reflect changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->