### PR TITLE
Patch 3832 release notes

### DIFF
--- a/changelog/snippets/balance.7039.md
+++ b/changelog/snippets/balance.7039.md
@@ -1,1 +1,0 @@
-- (#7039) Salem Class (URS0201): Fix Nanite Torpedoes preventing the other weapons from firing during their salvo.

--- a/changelog/snippets/balance.7056.md
+++ b/changelog/snippets/balance.7056.md
@@ -1,5 +1,0 @@
-- (#7056) Reduce how often shots fly over the top of the Seraphim destroyer by lowering how high units aim at the destroyer.
-
-  **Uashavoh: T2 Destroyer (XSS0201)**
-  - Aim point above-water elevation: 0.65 -> 0.45
-    - Resulting height of hitbox above aim point: 0.25 -> 0.45

--- a/changelog/snippets/balance.7059.md
+++ b/changelog/snippets/balance.7059.md
@@ -1,4 +1,0 @@
-- (#7059) Adjust VeteranMassMult to better align the Vulthoo with its role as a 'Tech 2.5 unit'
-
-  **Vulthoo: T2 Gunship (XSA0203)**
-  - VeteranMassMult: 1.5 -> 1.375

--- a/changelog/snippets/balance.7062.md
+++ b/changelog/snippets/balance.7062.md
@@ -1,7 +1,0 @@
-- (#7062) Reduce the build time of hives, especially for the lower levels, to make them worth building over T3 engineers when you need buildpower very quickly.
-
-  **The Hive: T2 Engineering Station (XRB0104, XRB0204, XRB0304):**
-  - Build time:
-    - Level 1: 1171 -> 880
-    - Level 2: 1171 -> 1000
-    - Level 3: 1171 -> 1120

--- a/changelog/snippets/fix.7050.md
+++ b/changelog/snippets/fix.7050.md
@@ -1,3 +1,0 @@
-- (#7050) Fix campaign/coop missions not ending properly after completion
-
-  The dialog to continue to the mission after dialogue and/or score screen pops up again.

--- a/changelog/snippets/fix.7061.md
+++ b/changelog/snippets/fix.7061.md
@@ -1,1 +1,0 @@
-- (#7061) Fix wrecks from overkilled units taking extra long to reclaim.

--- a/changelog/snippets/other.6529.md
+++ b/changelog/snippets/other.6529.md
@@ -1,1 +1,0 @@
-- (#6529) Update German localization of loading tips.

--- a/docs/_posts/2026-04-01-3832.md
+++ b/docs/_posts/2026-04-01-3832.md
@@ -1,0 +1,63 @@
+---
+layout: post
+title: Game version 3832
+permalink: changelog/3832
+---
+
+# Game version 3832 (1st of April 2026)
+
+This hotfix most notably fixes the bug where a campaign mission no longer shows the 'Operation Complete/Failed' dialog.
+We also release some more bugfixes and balance changes that were made in the meantime as a bonus.
+
+With gratitude to all those who contributed to this patch and/or took the time to report issues,
+
+BlackYps
+
+## Balance
+
+- (#7056) Reduce how often shots fly over the top of the Seraphim destroyer by lowering how high units aim at the destroyer.
+
+  **Uashavoh: T2 Destroyer (XSS0201)**
+    - Aim point above-water elevation: 0.65 -> 0.45
+        - Resulting height of hitbox above aim point: 0.25 -> 0.45
+
+- (#7059) Adjust VeteranMassMult to better align the Vulthoo with its role as a 'Tech 2.5 unit'
+
+  **Vulthoo: T2 Gunship (XSA0203)**
+    - VeteranMassMult: 1.5 -> 1.375
+
+- (#7062) Reduce the build time of hives, especially for the lower levels, to make them worth building over T3 engineers when you need buildpower very quickly.
+
+  **The Hive: T2 Engineering Station (XRB0104, XRB0204, XRB0304):**
+    - Build time:
+        - Level 1: 1171 -> 880
+        - Level 2: 1171 -> 1000
+        - Level 3: 1171 -> 1120
+
+
+## Bug fixes
+
+- (#7039) Salem Class (URS0201): Fix Nanite Torpedoes preventing the other weapons from firing during their salvo.
+
+- (#7050) Fix campaign/coop missions not ending properly after completion
+
+  The dialog to continue to the mission after dialogue and/or score screen pops up again.
+
+- (#7061) Fix wrecks from overkilled units taking extra long to reclaim.
+
+
+## Other changes
+
+- (#6529) Update German localization of loading tips.
+
+
+## Contributors
+
+With thanks to the following contributors:
+
+- Jip
+- Nomander
+- ETFreeman
+- Uveso
+- BlackYps
+- Nory

--- a/lua/ui/lobby/changelogData.lua
+++ b/lua/ui/lobby/changelogData.lua
@@ -1,10 +1,27 @@
 ---@type number
-last_version = 3831
+last_version = 3832
 -- hasPrettyGithubRelease enables the button that links to the github release.
 -- hasPrettyPatchnotes enables the button that links to the patchnotes website. Hotfixes generally do not get an entry there.
 
 ---@type PatchNotes[]
 gamePatches = {
+    {
+        version = 3832,
+        name = "Hotfix",
+        hasPrettyGithubRelease = true,
+        hasPrettyPatchnotes = false,
+        description = {
+            "# Game version 3832 (1st of April 2026)",
+            "",
+            "This hotfix most notably fixes the bug where a campaign mission no longer shows the 'Operation Complete/Failed' dialog.",
+            "We also release some more bugfixes and balance changes that were made in the meantime as a bonus.",
+            "You can find the complete changelog on GitHub by clicking the button below.",
+            "",
+            "With gratitude to all those who contributed to this patch and/or took the time to report issues,",
+            "",
+            "BlackYps",
+        }
+    },
     {
         version = 3831,
         name = "Hotfix",

--- a/lua/version.lua
+++ b/lua/version.lua
@@ -34,9 +34,9 @@ local Commit = 'unknown'    -- The use of `'` instead of `"` is **intentional**
 
 --#endregion
 
-local Version = "3831"
----@alias PATCH "3831"
----@alias VERSION "1.5.3831"
+local Version = "3832"
+---@alias PATCH "3832"
+---@alias VERSION "1.5.3832"
 ---@return PATCH    # Game release
 function GetVersion()
     LOG(string.format('Supreme Commander: Forged Alliance Lua version %s at %s (%s)', Version, GameType, Commit))

--- a/mod_info.lua
+++ b/mod_info.lua
@@ -27,7 +27,7 @@
 -- - https://github.com/FAForever/fa/blob/deploy/fafdevelop/lua/MODS.LUA
 
 name = "Forged Alliance Forever"
-version = 3831          -- needs to be an integer as it is parsed as a short (16 bit integer)
+version = 3832          -- needs to be an integer as it is parsed as a short (16 bit integer)
 _faf_modname='faf'
 copyright = "Forged Alliance Forever Community"
 description = "Forged Alliance Forever extends Forged Alliance, bringing new patches, game modes, units, ladder, and much more!"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Game Version 3832 (Hotfix)

* **Bug Fixes**
  * Fixed Nanite Torpedoes preventing other weapons from firing
  * Fixed campaign/coop missions failing to end properly with dialog reappearing
  * Fixed slow reclaim times for wrecks from overkilled units

* **Balance Changes**
  * Adjusted Seraphim destroyer aiming behavior
  * Tuned gunship mass multiplier values
  * Reduced build times for T2 engineering stations

* **Localization**
  * Updated German loading tips

<!-- end of auto-generated comment: release notes by coderabbit.ai -->