### PR TITLE
Round veterancy values to nearest integer

### DIFF
--- a/changelog/snippets/fix.7075.md
+++ b/changelog/snippets/fix.7075.md
@@ -1,0 +1,4 @@
+- (#7075) Fixed veterancy health bonuses being truncated instead of rounded to the nearest whole number. Example:
+
+  - Old HP of T2 Cybran ACU with 3 vets: 15599
+  - New HP of T2 Cybran ACU with 3 vets: 15600

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -301,6 +301,9 @@ BuffEffects = {
         local unitbphealth = unit:GetBlueprint().Defense.MaxHealth or 1
         local val = BuffCalculate(unit, buffName, 'MaxHealth', unitbphealth)
 
+        -- Round to nearest integer (0.5 rounds up)
+        val = math.floor(val + 0.5)
+
         local oldmax = unit:GetMaxHealth()
         local difference = oldmax - unit:GetHealth()
 

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -301,8 +301,7 @@ BuffEffects = {
         local unitbphealth = unit:GetBlueprint().Defense.MaxHealth or 1
         local val = BuffCalculate(unit, buffName, 'MaxHealth', unitbphealth)
 
-        -- Round to nearest integer (0.5 rounds up)
-        val = math.floor(val + 0.5)
+        val = math.round(val)
 
         local oldmax = unit:GetMaxHealth()
         local difference = oldmax - unit:GetHealth()


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Example:
- Old HP of T2 Cybran ACU with 3 vets: 15599
- New HP of T2 Cybran ACU with 3 vets: 15600

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Max health calculations now round to whole numbers (no fractional HP), fixing veterancy health bonus inconsistencies and ensuring consistent unit HP values.
* **Documentation**
  * Added a changelog entry documenting the rounding fix with an example comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->