### PR TITLE
URA0103: resolve lingering bomb issue; fix failure to destroy on water impact

### DIFF
--- a/changelog/snippets/fix.7077.md
+++ b/changelog/snippets/fix.7077.md
@@ -1,0 +1,4 @@
+- (#7077) Cybran T1 Bomber (URA0103):
+
+  - Fixed an issue where bombs would linger after impact, cluttering the screen.
+  - Fixed an issue where bombs failed to be destroyed upon water impact.

--- a/engine/Core/Blueprints/ProjectileBlueprint.lua
+++ b/engine/Core/Blueprints/ProjectileBlueprint.lua
@@ -77,7 +77,7 @@
 ---@field TurnRate number
 --- random variation around `TurnRate`
 ---@field TurnRateRange number
---- number of seconds before the projectile is destroyed
+--- number of seconds before the projectile is destroyed. Defaults to 15
 ---@field Lifetime number
 --- random variation around `Lifetime`
 ---@field LifetimeRange number

--- a/engine/Enums.lua
+++ b/engine/Enums.lua
@@ -132,8 +132,8 @@
 ---| "Invalid"
 ---| "Terrain"
 ---| "Water"
----| "Air"
----| "Underwater"
+---| "Air" # Caused by end of lifetime
+---| "Underwater" # Caused by end of lifetime
 ---| "Projectile"
 ---| "ProjectileUnderwater"
 ---| "Prop"

--- a/lua/cybranprojectiles.lua
+++ b/lua/cybranprojectiles.lua
@@ -506,21 +506,15 @@ CNeutronClusterBombProjectile = ClassProjectile(SinglePolyTrailProjectile) {
 
             if targetType ~= 'Air' then
                 local Random = Random
+                local child = self.ChildProjectile
 
-                local SpawnFragment = function(vx, vy, vz)
-                    local fragment = self:CreateChildProjectile(self.ChildProjectile)
-                    if fragment then
-                        fragment:SetVelocity(vx, vy, vz)
-                    end
-                end
-
-                SpawnFragment(0, Random(1,3), Random(1.5,3))
-                SpawnFragment(Random(1,2), Random(1,3), Random(1,2))
-                SpawnFragment(0, Random(1,3), -Random(1.5,3))
-                SpawnFragment(Random(1.5,3), Random(1,3), 0)
-                SpawnFragment(-Random(1,2), Random(1,3), -Random(1,2))
-                SpawnFragment(-Random(1.5,2.5), Random(1,3), 0)
-                SpawnFragment(-Random(1,2), Random(1,3), Random(2,4))
+                self:CreateChildProjectile(child):SetVelocity(0, Random(1,3), Random(1.5,3))
+                self:CreateChildProjectile(child):SetVelocity(Random(1,2), Random(1,3), Random(1,2))
+                self:CreateChildProjectile(child):SetVelocity(0, Random(1,3), -Random(1.5,3))
+                self:CreateChildProjectile(child):SetVelocity(Random(1.5,3), Random(1,3), 0)
+                self:CreateChildProjectile(child):SetVelocity(-Random(1,2), Random(1,3), -Random(1,2))
+                self:CreateChildProjectile(child):SetVelocity(-Random(1.5,2.5), Random(1,3), 0)
+                self:CreateChildProjectile(child):SetVelocity(-Random(1,2), Random(1,3), Random(2,4))
             end
 
             SinglePolyTrailProjectile.OnImpact(self, targetType, targetEntity)

--- a/lua/cybranprojectiles.lua
+++ b/lua/cybranprojectiles.lua
@@ -491,7 +491,7 @@ CNeutronClusterBombProjectile = ClassProjectile(SinglePolyTrailProjectile) {
     ---@param targetType ImpactType
     ---@param targetEntity Unit
     OnImpact = function(self, targetType, targetEntity)
-        if not self.Impacted then
+        if not self.Impacted and not targetEntity.DisallowCollisions then
             self.Impacted = true
 
             if targetType ~= 'Air' then

--- a/lua/cybranprojectiles.lua
+++ b/lua/cybranprojectiles.lua
@@ -498,7 +498,7 @@ CNeutronClusterBombProjectile = ClassProjectile(SinglePolyTrailProjectile) {
     --- Note: Damage is done once in AOE by main projectile. Secondary projectiles
     --- are just visual.
     ---@param self CNeutronClusterBombProjectile
-    ---@param targetType string
+    ---@param targetType ImpactType
     ---@param targetEntity Unit
     OnImpact = function(self, targetType, targetEntity)
         if self.Impacted == false then
@@ -523,7 +523,7 @@ CNeutronClusterBombProjectile = ClassProjectile(SinglePolyTrailProjectile) {
 
     --- Overiding Destruction
     ---@param self CNeutronClusterBombProjectile
-    ---@param targetType string
+    ---@param targetType ImpactType
     ---@param targetEntity Unit
     OnImpactDestroy = function(self, targetType, targetEntity)
         self.Trash:Add(ForkThread(self.DelayedDestroyThread, self))

--- a/lua/cybranprojectiles.lua
+++ b/lua/cybranprojectiles.lua
@@ -478,11 +478,11 @@ CNeutronClusterBombChildProjectile = ClassProjectile(SinglePolyTrailProjectile) 
 CNeutronClusterBombProjectile = ClassProjectile(SinglePolyTrailProjectile) {
     PolyTrail = '/effects/emitters/default_polytrail_03_emit.bp',
     ChildProjectile = '/projectiles/CIFNeutronClusterBomb02/CIFNeutronClusterBomb02_proj.bp',
+    Impacted = false,
 
     ---@param self CNeutronClusterBombProjectile
     OnCreate = function(self)
         SinglePolyTrailProjectile.OnCreate(self)
-        self.Impacted = false
     end,
 
     --- Note: Damage is done once in AOE by main projectile. Secondary projectiles

--- a/lua/cybranprojectiles.lua
+++ b/lua/cybranprojectiles.lua
@@ -483,6 +483,16 @@ CNeutronClusterBombProjectile = ClassProjectile(SinglePolyTrailProjectile) {
     OnCreate = function(self)
         SinglePolyTrailProjectile.OnCreate(self)
         self.Impacted = false
+        self.Trash:Add(ForkThread(self.FailsafeDestroyThread, self))
+    end,
+
+    --- Destroys the projectile only in rare failure cases where no impact callback happens.
+    ---@param self CNeutronClusterBombProjectile
+    FailsafeDestroyThread = function(self)
+        WaitTicks(120)
+        if not self:BeenDestroyed() then
+            self:Destroy()
+        end
     end,
 
     --- Note: Damage is done once in AOE by main projectile. Secondary projectiles
@@ -491,16 +501,28 @@ CNeutronClusterBombProjectile = ClassProjectile(SinglePolyTrailProjectile) {
     ---@param targetType string
     ---@param targetEntity Unit
     OnImpact = function(self, targetType, targetEntity)
-        if self.Impacted == false and targetType ~= 'Air' then
+        if self.Impacted == false then
             self.Impacted = true
-            local Random = Random 
-            self:CreateChildProjectile(self.ChildProjectile):SetVelocity(0,Random(1,3),Random(1.5,3))
-            self:CreateChildProjectile(self.ChildProjectile):SetVelocity(Random(1,2),Random(1,3),Random(1,2))
-            self:CreateChildProjectile(self.ChildProjectile):SetVelocity(0,Random(1,3),-Random(1.5,3))
-            self:CreateChildProjectile(self.ChildProjectile):SetVelocity(Random(1.5,3),Random(1,3),0)
-            self:CreateChildProjectile(self.ChildProjectile):SetVelocity(-Random(1,2),Random(1,3),-Random(1,2))
-            self:CreateChildProjectile(self.ChildProjectile):SetVelocity(-Random(1.5,2.5),Random(1,3),0)
-            self:CreateChildProjectile(self.ChildProjectile):SetVelocity(-Random(1,2),Random(1,3),Random(2,4))
+
+            if targetType ~= 'Air' then
+                local Random = Random
+
+                local SpawnFragment = function(vx, vy, vz)
+                    local fragment = self:CreateChildProjectile(self.ChildProjectile)
+                    if fragment then
+                        fragment:SetVelocity(vx, vy, vz)
+                    end
+                end
+
+                SpawnFragment(0, Random(1,3), Random(1.5,3))
+                SpawnFragment(Random(1,2), Random(1,3), Random(1,2))
+                SpawnFragment(0, Random(1,3), -Random(1.5,3))
+                SpawnFragment(Random(1.5,3), Random(1,3), 0)
+                SpawnFragment(-Random(1,2), Random(1,3), -Random(1,2))
+                SpawnFragment(-Random(1.5,2.5), Random(1,3), 0)
+                SpawnFragment(-Random(1,2), Random(1,3), Random(2,4))
+            end
+
             SinglePolyTrailProjectile.OnImpact(self, targetType, targetEntity)
         end
     end,

--- a/lua/cybranprojectiles.lua
+++ b/lua/cybranprojectiles.lua
@@ -483,16 +483,6 @@ CNeutronClusterBombProjectile = ClassProjectile(SinglePolyTrailProjectile) {
     OnCreate = function(self)
         SinglePolyTrailProjectile.OnCreate(self)
         self.Impacted = false
-        self.Trash:Add(ForkThread(self.FailsafeDestroyThread, self))
-    end,
-
-    --- Destroys the projectile in rare cases where no impact callback happens
-    ---@param self CNeutronClusterBombProjectile
-    FailsafeDestroyThread = function(self)
-        WaitTicks(120)
-        if not self:BeenDestroyed() then
-            self:Destroy()
-        end
     end,
 
     --- Note: Damage is done once in AOE by main projectile. Secondary projectiles

--- a/lua/cybranprojectiles.lua
+++ b/lua/cybranprojectiles.lua
@@ -491,7 +491,7 @@ CNeutronClusterBombProjectile = ClassProjectile(SinglePolyTrailProjectile) {
     ---@param targetType ImpactType
     ---@param targetEntity Unit
     OnImpact = function(self, targetType, targetEntity)
-        if self.Impacted == false then
+        if not self.Impacted then
             self.Impacted = true
 
             if targetType ~= 'Air' then

--- a/lua/cybranprojectiles.lua
+++ b/lua/cybranprojectiles.lua
@@ -486,7 +486,7 @@ CNeutronClusterBombProjectile = ClassProjectile(SinglePolyTrailProjectile) {
         self.Trash:Add(ForkThread(self.FailsafeDestroyThread, self))
     end,
 
-    --- Destroys the projectile only in rare failure cases where no impact callback happens.
+    --- Destroys the projectile in rare cases where no impact callback happens
     ---@param self CNeutronClusterBombProjectile
     FailsafeDestroyThread = function(self)
         WaitTicks(120)

--- a/projectiles/CIFNeutronClusterBomb02/CIFNeutronClusterBomb02_proj.bp
+++ b/projectiles/CIFNeutronClusterBomb02/CIFNeutronClusterBomb02_proj.bp
@@ -31,6 +31,7 @@ ProjectileBlueprint{
     Interface = { HelpText = 0 },
     Physics = {
         Acceleration = 2,
+        DestroyOnWater = true,
         InitialSpeed = 1,
         InitialSpeedRange = 0,
         MaxSpeed = 105,


### PR DESCRIPTION
## Description of the proposed changes
Fixes two separate issues:
1. Bomb projectiles not getting destroyed on water impact (they travel through the water).
2. Bomb projectiles lingering and eventually falling through the map, thereby perpetually cluttering the screen.

Example of the bomb lingering issue: #26768413 5:50 at the northern rock base.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a failsafe to remove lingering cluster bomb projectiles after a short delay.
  * Projectiles now mark impact reliably on first hit; fragment spawning only occurs for non-air impacts.
  * A specific neutron cluster bomb variant is now destroyed on water contact.

* **Documentation**
  * Added a changelog snippet describing these fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->