### PR TITLE
Fix torpedoes having difficulties hitting the Cybran Frigate when it is turning

### DIFF
--- a/changelog/snippets/fix.7087.md
+++ b/changelog/snippets/fix.7087.md
@@ -1,0 +1,1 @@
+- (#7087) Fix torpedoes having difficulties hitting the Cybran Frigate when it is turning.

--- a/changelog/snippets/fix.7087.md
+++ b/changelog/snippets/fix.7087.md
@@ -1,1 +1,1 @@
-- (#7087) Fix torpedoes having difficulties hitting the Cybran Frigate when it is turning.
+- (#7087) Fix torpedoes having difficulties hitting the Cybran Frigate (URS0103) when it is turning.

--- a/units/URS0103/URS0103_unit.bp
+++ b/units/URS0103/URS0103_unit.bp
@@ -6,8 +6,6 @@ UnitBlueprint{
             "Front_Radar",
             "Back_Radar",
             "Back_Wake",
-            "Front_Left_Wake",
-            "Front_Right_Wake",
             "URS0103",
         },
     },


### PR DESCRIPTION
## Description of the proposed changes
As per the title. Closes https://github.com/FAForever/fa/issues/6876. Caused by #5442.

## Checklist
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed two targeting elements from a unit’s active targeting list to improve targeting behavior.
  * Resolved an issue where torpedoes sometimes failed to hit the Cybran Frigate (URS0103) while it was turning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->