### PR TITLE
Only build website when game files have changed

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -22,7 +22,7 @@ name: Documentation - Build and deploy
 
 on:
   push:
-    branches: ["develop", "deploy/fafdevelop", "deploy/fafbeta"]
+    branches: ["deploy/faf", "deploy/fafdevelop", "deploy/fafbeta"]
     paths: ["docs/**", "changelog/snippets/*.md"]
 
   # Allows you to run this workflow manually from the Actions tab


### PR DESCRIPTION
The website build workflow fails when there are no balance snippets yet on deploy/fafdevelop or deploy/fafbeta. This is normal shortly after a release, but it looks concerning in the github UI.
It makes sense to only run this workflow when an actual deployment of game files has happened.
Or was there a specific reasoning to run on each develop update? @Garanas 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation deployment workflow configuration to trigger from different source branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->