### PR TITLE
Give Cybran Carrier impact effects for its increased splash

### DIFF
--- a/changelog/snippets/balance.7055.md
+++ b/changelog/snippets/balance.7055.md
@@ -9,7 +9,7 @@
   **Aeon, and Seraphim T3 Carriers (UAS0303, XSS0303)**
     - AA Damage Radius: 0 -> 1
 
-  **Cybran T3 Carrier: Command Class (URS0303)**
+  **Cybran T3 Carrier (URS0303)**
     - AA Damage Radius: 0 -> 1.5
       The Cybran carrier has a bit more splash to make up for the decreased effectiveness of stealth late-game and lack of supporting shields and hover flak.
 
@@ -17,6 +17,6 @@
     - Torpedoes per volley: 4 -> 5
       Damage per volley is kept the same (750).
 
-  **Aeon T3 Torpedo Bomber: Solace (XAA0306)**
+  **Aeon T3 Torpedo Bomber (XAA0306)**
     - Torpedoes per volley: 5x2 -> 6x2
       Damage per volley is kept the same (5000 -> 5004).

--- a/changelog/snippets/balance.7055.md
+++ b/changelog/snippets/balance.7055.md
@@ -1,4 +1,4 @@
--(#7055) Buff torpedo bombers and nerf cruisers to make torpedo bombers better early game, while buffing carriers to give a replacement splash AA solution late-game.
+-(#7055, #7109) Buff torpedo bombers and nerf cruisers to make torpedo bombers better early game, while buffing carriers to give a replacement splash AA solution late-game.
 
   **UEF, Aeon, and Cybran T2 Cruisers (UES0202, UAS0202, URS0202)**
     - AA Damage Radius: 1 -> 0

--- a/changelog/snippets/balance.7055.md
+++ b/changelog/snippets/balance.7055.md
@@ -1,4 +1,4 @@
--(#7055, #7109) Buff torpedo bombers and nerf cruisers to make torpedo bombers better early game, while buffing carriers to give a replacement splash AA solution late-game.
+- (#7055, #7109) Buff torpedo bombers and nerf cruisers to make torpedo bombers better early game, while buffing carriers to give a replacement splash AA solution late-game.
 
   **UEF, Aeon, and Cybran T2 Cruisers (UES0202, UAS0202, URS0202)**
     - AA Damage Radius: 1 -> 0

--- a/projectiles/CAAAutocannon03/CAAAutocannon03_script.lua
+++ b/projectiles/CAAAutocannon03/CAAAutocannon03_script.lua
@@ -1,4 +1,9 @@
+local EffectTemplate = import("/lua/EffectTemplates.lua")
+
 -- Cybran Anti Air Projectile
 ---@class CAAAutocannon03: CShellAAAutoCannonProjectile
-CAAAutocannon03 = ClassProjectile(import("/lua/cybranprojectiles.lua").CShellAAAutoCannonProjectile) { }
+CAAAutocannon03 = ClassProjectile(import("/lua/cybranprojectiles.lua").CShellAAAutoCannonProjectile) {
+    FxAirUnitHitScale = 1.5,
+    FxImpactAirUnit = EffectTemplate.CNanoDartUnitHit01,
+ }
 TypeClass = CAAAutocannon03

--- a/units/URS0303/URS0303_unit.bp
+++ b/units/URS0303/URS0303_unit.bp
@@ -212,7 +212,7 @@ UnitBlueprint{
             BallisticArc = "RULEUBA_None",
             CannotAttackGround = true,
             CollideFriendly = false,
-            Damage = 20,
+            Damage = 80,
             DamageRadius = 1.5,
             DamageType = "Normal",
             DisplayName = "Electron Autocannon",
@@ -233,8 +233,23 @@ UnitBlueprint{
                 {
                     MuzzleBones = {
                         "Front_Right_AA_Muzzle_01",
+                    },
+                    RackBone = "Front_Right_AA_Turret_Barrel",
+                },
+                {
+                    MuzzleBones = {
                         "Front_Right_AA_Muzzle_02",
+                    },
+                    RackBone = "Front_Right_AA_Turret_Barrel",
+                },
+                {
+                    MuzzleBones = {
                         "Front_Right_AA_Muzzle_03",
+                    },
+                    RackBone = "Front_Right_AA_Turret_Barrel",
+                },
+                {
+                    MuzzleBones = {
                         "Front_Right_AA_Muzzle_04",
                     },
                     RackBone = "Front_Right_AA_Turret_Barrel",
@@ -276,7 +291,7 @@ UnitBlueprint{
             BallisticArc = "RULEUBA_None",
             CannotAttackGround = true,
             CollideFriendly = false,
-            Damage = 20,
+            Damage = 80,
             DamageRadius = 1.5,
             DamageType = "Normal",
             DisplayName = "Electron Autocannon",
@@ -298,8 +313,23 @@ UnitBlueprint{
                 {
                     MuzzleBones = {
                         "Back_Right_AA_Muzzle_01",
+                    },
+                    RackBone = "Back_Right_AA_Turret_Barrel",
+                },
+                {
+                    MuzzleBones = {
                         "Back_Right_AA_Muzzle_02",
+                    },
+                    RackBone = "Back_Right_AA_Turret_Barrel",
+                },
+                {
+                    MuzzleBones = {
                         "Back_Right_AA_Muzzle_03",
+                    },
+                    RackBone = "Back_Right_AA_Turret_Barrel",
+                },
+                {
+                    MuzzleBones = {
                         "Back_Right_AA_Muzzle_04",
                     },
                     RackBone = "Back_Right_AA_Turret_Barrel",
@@ -346,7 +376,7 @@ UnitBlueprint{
             BallisticArc = "RULEUBA_None",
             CannotAttackGround = true,
             CollideFriendly = false,
-            Damage = 20,
+            Damage = 80,
             DamageRadius = 1.5,
             DamageType = "Normal",
             DisplayName = "Electron Autocannon",
@@ -368,8 +398,23 @@ UnitBlueprint{
                 {
                     MuzzleBones = {
                         "Back_Left_AA_Muzzle_01",
+                    },
+                    RackBone = "Back_Left_AA_Turret_Barrel",
+                },
+                {
+                    MuzzleBones = {
                         "Back_Left_AA_Muzzle_02",
+                    },
+                    RackBone = "Back_Left_AA_Turret_Barrel",
+                },
+                {
+                    MuzzleBones = {
                         "Back_Left_AA_Muzzle_03",
+                    },
+                    RackBone = "Back_Left_AA_Turret_Barrel",
+                },
+                {
+                    MuzzleBones = {
                         "Back_Left_AA_Muzzle_04",
                     },
                     RackBone = "Back_Left_AA_Turret_Barrel",
@@ -416,7 +461,7 @@ UnitBlueprint{
             BallisticArc = "RULEUBA_None",
             CannotAttackGround = true,
             CollideFriendly = false,
-            Damage = 20,
+            Damage = 80,
             DamageRadius = 1.5,
             DamageType = "Normal",
             DisplayName = "Electron Autocannon",
@@ -438,8 +483,23 @@ UnitBlueprint{
                 {
                     MuzzleBones = {
                         "Front_Left_AA_Muzzle_01",
+                    },
+                    RackBone = "Front_Left_AA_Turret_Barrel",
+                },
+                {
+                    MuzzleBones = {
                         "Front_Left_AA_Muzzle_02",
+                    },
+                    RackBone = "Front_Left_AA_Turret_Barrel",
+                },
+                {
+                    MuzzleBones = {
                         "Front_Left_AA_Muzzle_03",
+                    },
+                    RackBone = "Front_Left_AA_Turret_Barrel",
+                },
+                {
+                    MuzzleBones = {
                         "Front_Left_AA_Muzzle_04",
                     },
                     RackBone = "Front_Left_AA_Turret_Barrel",


### PR DESCRIPTION
## Description of the proposed changes
<!-- A clear and concise description (or visuals) of what the changes imply. -->
<!-- If it closes an issue, make sure to link the issue by using "(Closes/Fixes/Resolves) #(Issue Number)" in your pull request. -->
Gives Cybran carrier the impact effect of the SAM since it now has splash damage from #7055.
The guns are changed to fire 1 projectile per fire to reduce the brightness of the new effect since 4 projectiles (from 4 guns) was overwhelmingly bright.

I considered giving it the flak impact effect but that effect matches worse with the damage radius of the weapon.

## Testing done on the proposed changes
Visual inspection firing at some spy planes.

https://github.com/user-attachments/assets/8492b023-7476-4a5b-96e1-0253a7e7fa50

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Balance Changes**
  * Anti-air "Electron Autocannon" weapons now deliver significantly increased damage output against aerial targets
  * Projectile effects updated with new visual scaling parameters and impact templates

* **Chores**
  * Changelog updated to reflect balance adjustments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->