### PR TITLE
Salem aeon bs tempest changes

### DIFF
--- a/changelog/snippets/balance.7110.md
+++ b/changelog/snippets/balance.7110.md
@@ -1,17 +1,17 @@
-- (#7110) Changes from #7101 which the balance team has agreed on.
-
-  Salem has it's AA range reduced to weaken it's ability to shoot down air scouts to allow for better counterplay against Cybran stealth boats covering the Salems.
-  Omen has it's cost increased and its dps slightly reduced as it is currently the most powerful battleship, the new stats should make the cost match the performance better compared to other battleships.
-  Tempest is good at safely farming value and staying healthy despite it's low stats per cost compared to battleships due to its long range, high splash weapon and because it still greatly benefits from veterancy despite the previous nerf.
+- (#7110) Salem has it's AA range reduced to weaken it's ability to shoot down air scouts to allow for better counterplay against Cybran stealth boats covering the Salems.
 
   **Cybran Destroyer (URS0201):**
     - AA MaxRadius (60 -> 55) [Area: 11310 -> 9503 (-16%)]
+
+- (#7110) Omen has it's cost increased and its dps slightly reduced as it is currently the most powerful battleship, the new stats should make the cost match the performance better compared to other battleships.
 
   **Aeon Battleship (UAS0302):**
     - BuildCostEnergy (54000 -> 58000)
     - BuildCostMass (9000 -> 9500)
     - BuildTime (28800 -> 30300) [192s -> 202s w/ T3 Factory]
     - RateOfFire (10/59 -> 10/60) [DPS: 169.5 -> 166.7] [Note: the UI rounds; total DPS is 500.]
+
+- (#7110) Tempest is good at safely farming value and staying healthy despite it's low stats per cost compared to battleships due to its long range, high splash weapon and because it still greatly benefits from veterancy despite the previous nerf.
 
   **Tempest (UAS0401):**
     - BuildCostEnergy (380000 -> 400000)

--- a/changelog/snippets/balance.7110.md
+++ b/changelog/snippets/balance.7110.md
@@ -3,7 +3,7 @@
   **Cybran Destroyer (URS0201):**
     - AA MaxRadius (60 -> 55) [Area: 11310 -> 9503 (-16%)]
 
-- (#7110) Omen has its cost increased and its DPS slightly reduced as it is currently the most powerful battleship; the new stats should make the cost match the performance better compared to other battleships.
+- (#7110) Omen has its cost increased and its DPS slightly reduced as it is currently the most powerful battleship; the new higher cost matches the higher performance compared to other battleships.
 
   **Aeon Battleship (UAS0302):**
     - BuildCostEnergy (54000 -> 58000)

--- a/changelog/snippets/balance.7110.md
+++ b/changelog/snippets/balance.7110.md
@@ -1,23 +1,21 @@
 - (#7110) Changes from #7101 which the balance team has agreed on.
-Salem has it's AA range reduced to weaken it's ability to shoot down air scouts to allow for better counterplay against Cybran stealth boats covering the Salems.
 
-Cybran Destroyer (URS0201):
+  Salem has it's AA range reduced to weaken it's ability to shoot down air scouts to allow for better counterplay against Cybran stealth boats covering the Salems.
 
-    AA MaxRadius (60 -> 55) [Area: 11310 -> 9503 (-16%)]
+ **Cybran Destroyer (URS0201):**
+   - AA MaxRadius (60 -> 55) [Area: 11310 -> 9503 (-16%)]
 
-Omen has it's cost increased and its dps slightly reduced as it is currently the most powerful battleship, the new stats should make the cost match the performance better compared to other battleships.
+  Omen has it's cost increased and its dps slightly reduced as it is currently the most powerful battleship, the new stats should make the cost match the performance better compared to other battleships.
 
-Aeon Battleship (UAS0302):
+ **Aeon Battleship (UAS0302):**
+   - BuildCostEnergy (54000 -> 58000)
+   - BuildCostMass (9000 -> 9500)
+   - BuildTime (28800 -> 30300) [192s -> 202s w/ T3 Factory]
+   - RateOfFire (10/59 -> 10/60) [DPS: 169.5 -> 166.7] [Note: the UI rounds; total DPS is 500.]
 
-    BuildCostEnergy (54000 -> 58000)
-    BuildCostMass (9000 -> 9500)
-    BuildTime (28800 -> 30300) [192s -> 202s w/ T3 Factory]
-    RateOfFire (10/59 -> 10/60) [DPS: 169.5 -> 166.7] [Note: the UI rounds; total DPS is 500.]
+  Tempest is good at safely farming value and staying healthy despite it's low stats per cost compared to battleships due to its long range, high splash weapon and because it still greatly benefits from veterancy despite the previous nerf.
 
-Tempest is good at safely farming value and staying healthy despite it's low stats per cost compared to battleships due to its long range, high splash weapon and because it still greatly benefits from veterancy despite the previous nerf.
-
-Tempest (UAS0401):
-
-    BuildCostEnergy (380000 -> 400000)
-    BuildCostMass (24000 -> 25000)
-    BuildTime (38400 -> 40000) [1181.5s -> 1230.8s w/ T3 Engineer]
+**Tempest (UAS0401):**
+   - BuildCostEnergy (380000 -> 400000)
+   - BuildCostMass (24000 -> 25000)
+   - BuildTime (38400 -> 40000) [1181.5s -> 1230.8s w/ T3 Engineer]

--- a/changelog/snippets/balance.7110.md
+++ b/changelog/snippets/balance.7110.md
@@ -1,0 +1,23 @@
+- (#7110) Changes from #7101 which the balance team has agreed on.
+Salem has it's AA range reduced to weaken it's ability to shoot down air scouts to allow for better counterplay against Cybran stealth boats covering the Salems.
+
+Cybran Destroyer (URS0201):
+
+    AA MaxRadius (60 -> 55) [Area: 11310 -> 9503 (-16%)]
+
+Omen has it's cost increased and its dps slightly reduced as it is currently the most powerful battleship, the new stats should make the cost match the performance better compared to other battleships.
+
+Aeon Battleship (UAS0302):
+
+    BuildCostEnergy (54000 -> 58000)
+    BuildCostMass (9000 -> 9500)
+    BuildTime (28800 -> 30300) [192s -> 202s w/ T3 Factory]
+    RateOfFire (10/59 -> 10/60) [DPS: 169.5 -> 166.7] [Note: the UI rounds; total DPS is 500.]
+
+Tempest is good at safely farming value and staying healthy despite it's low stats per cost compared to battleships due to its long range, high splash weapon and because it still greatly benefits from veterancy despite the previous nerf.
+
+Tempest (UAS0401):
+
+    BuildCostEnergy (380000 -> 400000)
+    BuildCostMass (24000 -> 25000)
+    BuildTime (38400 -> 40000) [1181.5s -> 1230.8s w/ T3 Engineer]

--- a/changelog/snippets/balance.7110.md
+++ b/changelog/snippets/balance.7110.md
@@ -1,19 +1,19 @@
 - (#7110) Salem has its AA range reduced to weaken its ability to shoot down air scouts and allow for better counterplay against Cybran stealth boats covering the Salems.
 
   **Cybran Destroyer (URS0201):**
-    - AA MaxRadius (60 -> 55) [Area: 11310 -> 9503 (-16%)]
+    - AA Max Radius: 60 -> 55
 
 - (#7110) Omen has its cost increased and its DPS slightly reduced as it is currently the most powerful battleship; the new higher cost matches the higher performance compared to other battleships.
 
   **Aeon Battleship (UAS0302):**
-    - BuildCostEnergy (54000 -> 58000)
-    - BuildCostMass (9000 -> 9500)
-    - BuildTime (28800 -> 30300) [192s -> 202s w/ T3 Factory]
-    - RateOfFire (10/59 -> 10/60) [DPS: 169.5 -> 166.7] [Note: the UI rounds; total DPS is 500.]
+    - Mass Cost: 9000 -> 9500 (+5.6%)
+    - Energy Cost: 54000 -> 58000 (+7.4%)
+    - Build Time: 28800 -> 30300 (+5.2%)
+    - Reload time: 5.9s (169.5 DPS x3) -> 6.0s (166.7 DPS x3)
 
 - (#7110) Tempest is good at safely farming value and staying healthy despite its low stats per cost compared to battleships due to its long range, high splash weapon and because it still greatly benefits from veterancy despite the previous nerf.
 
   **Tempest (UAS0401):**
-    - BuildCostEnergy (380000 -> 400000)
-    - BuildCostMass (24000 -> 25000)
-    - BuildTime (38400 -> 40000) [1181.5s -> 1230.8s w/ T3 Engineer]
+    - Mass Cost: 24000 -> 25000 (+4.2%)
+    - Energy Cost: 380000 -> 400000 (+5.3%)
+    - Build Time: 38400 -> 40000 (+4.2%)

--- a/changelog/snippets/balance.7110.md
+++ b/changelog/snippets/balance.7110.md
@@ -1,9 +1,9 @@
-- (#7110) Salem has it's AA range reduced to weaken it's ability to shoot down air scouts to allow for better counterplay against Cybran stealth boats covering the Salems.
+- (#7110) Salem has its AA range reduced to weaken its ability to shoot down air scouts to allow for better counterplay against Cybran stealth boats covering the Salems.
 
   **Cybran Destroyer (URS0201):**
     - AA MaxRadius (60 -> 55) [Area: 11310 -> 9503 (-16%)]
 
-- (#7110) Omen has it's cost increased and its dps slightly reduced as it is currently the most powerful battleship, the new stats should make the cost match the performance better compared to other battleships.
+- (#7110) Omen has its cost increased and its dps slightly reduced as it is currently the most powerful battleship, the new stats should make the cost match the performance better compared to other battleships.
 
   **Aeon Battleship (UAS0302):**
     - BuildCostEnergy (54000 -> 58000)
@@ -11,7 +11,7 @@
     - BuildTime (28800 -> 30300) [192s -> 202s w/ T3 Factory]
     - RateOfFire (10/59 -> 10/60) [DPS: 169.5 -> 166.7] [Note: the UI rounds; total DPS is 500.]
 
-- (#7110) Tempest is good at safely farming value and staying healthy despite it's low stats per cost compared to battleships due to its long range, high splash weapon and because it still greatly benefits from veterancy despite the previous nerf.
+- (#7110) Tempest is good at safely farming value and staying healthy despite its low stats per cost compared to battleships due to its long range, high splash weapon and because it still greatly benefits from veterancy despite the previous nerf.
 
   **Tempest (UAS0401):**
     - BuildCostEnergy (380000 -> 400000)

--- a/changelog/snippets/balance.7110.md
+++ b/changelog/snippets/balance.7110.md
@@ -1,4 +1,4 @@
-- (#7110) Salem has its AA range reduced to weaken its ability to shoot down air scouts to allow for better counterplay against Cybran stealth boats covering the Salems.
+- (#7110) Salem has its AA range reduced to weaken its ability to shoot down air scouts and allow for better counterplay against Cybran stealth boats covering the Salems.
 
   **Cybran Destroyer (URS0201):**
     - AA MaxRadius (60 -> 55) [Area: 11310 -> 9503 (-16%)]

--- a/changelog/snippets/balance.7110.md
+++ b/changelog/snippets/balance.7110.md
@@ -4,16 +4,16 @@
   Omen has it's cost increased and its dps slightly reduced as it is currently the most powerful battleship, the new stats should make the cost match the performance better compared to other battleships.
   Tempest is good at safely farming value and staying healthy despite it's low stats per cost compared to battleships due to its long range, high splash weapon and because it still greatly benefits from veterancy despite the previous nerf.
 
- **Cybran Destroyer (URS0201):**
-   - AA MaxRadius (60 -> 55) [Area: 11310 -> 9503 (-16%)]
+  **Cybran Destroyer (URS0201):**
+    - AA MaxRadius (60 -> 55) [Area: 11310 -> 9503 (-16%)]
 
- **Aeon Battleship (UAS0302):**
-   - BuildCostEnergy (54000 -> 58000)
-   - BuildCostMass (9000 -> 9500)
-   - BuildTime (28800 -> 30300) [192s -> 202s w/ T3 Factory]
-   - RateOfFire (10/59 -> 10/60) [DPS: 169.5 -> 166.7] [Note: the UI rounds; total DPS is 500.]
+  **Aeon Battleship (UAS0302):**
+    - BuildCostEnergy (54000 -> 58000)
+    - BuildCostMass (9000 -> 9500)
+    - BuildTime (28800 -> 30300) [192s -> 202s w/ T3 Factory]
+    - RateOfFire (10/59 -> 10/60) [DPS: 169.5 -> 166.7] [Note: the UI rounds; total DPS is 500.]
 
-**Tempest (UAS0401):**
-   - BuildCostEnergy (380000 -> 400000)
-   - BuildCostMass (24000 -> 25000)
-   - BuildTime (38400 -> 40000) [1181.5s -> 1230.8s w/ T3 Engineer]
+  **Tempest (UAS0401):**
+    - BuildCostEnergy (380000 -> 400000)
+    - BuildCostMass (24000 -> 25000)
+    - BuildTime (38400 -> 40000) [1181.5s -> 1230.8s w/ T3 Engineer]

--- a/changelog/snippets/balance.7110.md
+++ b/changelog/snippets/balance.7110.md
@@ -3,7 +3,7 @@
   **Cybran Destroyer (URS0201):**
     - AA MaxRadius (60 -> 55) [Area: 11310 -> 9503 (-16%)]
 
-- (#7110) Omen has its cost increased and its dps slightly reduced as it is currently the most powerful battleship, the new stats should make the cost match the performance better compared to other battleships.
+- (#7110) Omen has its cost increased and its DPS slightly reduced as it is currently the most powerful battleship, the new stats should make the cost match the performance better compared to other battleships.
 
   **Aeon Battleship (UAS0302):**
     - BuildCostEnergy (54000 -> 58000)

--- a/changelog/snippets/balance.7110.md
+++ b/changelog/snippets/balance.7110.md
@@ -1,19 +1,17 @@
 - (#7110) Changes from #7101 which the balance team has agreed on.
 
   Salem has it's AA range reduced to weaken it's ability to shoot down air scouts to allow for better counterplay against Cybran stealth boats covering the Salems.
+  Omen has it's cost increased and its dps slightly reduced as it is currently the most powerful battleship, the new stats should make the cost match the performance better compared to other battleships.
+  Tempest is good at safely farming value and staying healthy despite it's low stats per cost compared to battleships due to its long range, high splash weapon and because it still greatly benefits from veterancy despite the previous nerf.
 
  **Cybran Destroyer (URS0201):**
    - AA MaxRadius (60 -> 55) [Area: 11310 -> 9503 (-16%)]
-
-  Omen has it's cost increased and its dps slightly reduced as it is currently the most powerful battleship, the new stats should make the cost match the performance better compared to other battleships.
 
  **Aeon Battleship (UAS0302):**
    - BuildCostEnergy (54000 -> 58000)
    - BuildCostMass (9000 -> 9500)
    - BuildTime (28800 -> 30300) [192s -> 202s w/ T3 Factory]
    - RateOfFire (10/59 -> 10/60) [DPS: 169.5 -> 166.7] [Note: the UI rounds; total DPS is 500.]
-
-  Tempest is good at safely farming value and staying healthy despite it's low stats per cost compared to battleships due to its long range, high splash weapon and because it still greatly benefits from veterancy despite the previous nerf.
 
 **Tempest (UAS0401):**
    - BuildCostEnergy (380000 -> 400000)

--- a/changelog/snippets/balance.7110.md
+++ b/changelog/snippets/balance.7110.md
@@ -3,7 +3,7 @@
   **Cybran Destroyer (URS0201):**
     - AA MaxRadius (60 -> 55) [Area: 11310 -> 9503 (-16%)]
 
-- (#7110) Omen has its cost increased and its DPS slightly reduced as it is currently the most powerful battleship, the new stats should make the cost match the performance better compared to other battleships.
+- (#7110) Omen has its cost increased and its DPS slightly reduced as it is currently the most powerful battleship; the new stats should make the cost match the performance better compared to other battleships.
 
   **Aeon Battleship (UAS0302):**
     - BuildCostEnergy (54000 -> 58000)

--- a/units/UAS0302/UAS0302_unit.bp
+++ b/units/UAS0302/UAS0302_unit.bp
@@ -108,9 +108,9 @@ UnitBlueprint{
         UniformScale = 0.13,
     },
     Economy = {
-        BuildCostEnergy = 54000,
-        BuildCostMass = 9000,
-        BuildTime = 28800,
+        BuildCostEnergy = 58000,
+        BuildCostMass = 9500,
+        BuildTime = 30300,
     },
     Footprint = {
         SizeX = 5,
@@ -211,7 +211,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
-            RateOfFire = 10/59, --10/integer interval in ticks
+            RateOfFire = 10/60, --10/integer interval in ticks
             RenderFireClock = true,
             SlavedToBody = true,
             SlavedToBodyArcRange = 155,
@@ -274,7 +274,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
-            RateOfFire = 10/59, --10/integer interval in ticks
+            RateOfFire = 10/60, --10/integer interval in ticks
             RenderFireClock = true,
             SlavedToBody = true,
             SlavedToBodyArcRange = 155,
@@ -337,7 +337,7 @@ UnitBlueprint{
             RackSalvoSize = 1,
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
-            RateOfFire = 10/59, --10/integer interval in ticks
+            RateOfFire = 10/60, --10/integer interval in ticks
             RenderFireClock = true,
             SlavedToBody = true,
             SlavedToBodyArcRange = 155,

--- a/units/UAS0401/UAS0401_unit.bp
+++ b/units/UAS0401/UAS0401_unit.bp
@@ -178,10 +178,10 @@ UnitBlueprint{
         UniformScale = 0.1,
     },
     Economy = {
-        BuildCostEnergy = 380000,
-        BuildCostMass = 24000,
+        BuildCostEnergy = 400000,
+        BuildCostMass = 25000,
         BuildRate = 225,
-        BuildTime = 38400,
+        BuildTime = 40000,
         BuildableCategory = {
             "BUILTBYTIER3FACTORY AEON MOBILE CONSTRUCTION",
             "BUILTBYTIER2FACTORY AEON MOBILE CONSTRUCTION",

--- a/units/UES0201/UES0201_unit.bp
+++ b/units/UES0201/UES0201_unit.bp
@@ -333,7 +333,7 @@ UnitBlueprint{
             FiringRandomness = 0,
             FiringTolerance = 1,
             Label = "FrontTurret02",
-            MaxRadius = 60,
+            MaxRadius = 55,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 60,

--- a/units/UES0201/UES0201_unit.bp
+++ b/units/UES0201/UES0201_unit.bp
@@ -333,7 +333,7 @@ UnitBlueprint{
             FiringRandomness = 0,
             FiringTolerance = 1,
             Label = "FrontTurret02",
-            MaxRadius = 55,
+            MaxRadius = 60,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 60,

--- a/units/URS0201/URS0201_unit.bp
+++ b/units/URS0201/URS0201_unit.bp
@@ -362,7 +362,7 @@ UnitBlueprint{
             FiringTolerance = 1,
             Label = "AAGun",
             LeadTarget = true,
-            MaxRadius = 60,
+            MaxRadius = 55,
             MuzzleSalvoDelay = 0,
             MuzzleSalvoSize = 1,
             MuzzleVelocity = 60,


### PR DESCRIPTION
## Description of the proposed changes
Changes from #7101 which the balance team has agreed on.
Salem has it's AA range reduced to weaken it's ability to shoot down air scouts to allow for better counterplay against Cybran stealth boats covering the Salems.

Cybran Destroyer (URS0201):
- AA MaxRadius (60 -> 55) [Area: 11310 -> 9503 (-16%)]


Omen has it's cost increased and its dps slightly reduced as it is currently the most powerful battleship, the new stats should make the cost match the performance better compared to other battleships.

Aeon Battleship (UAS0302):
 - BuildCostEnergy (54000 -> 58000)
 - BuildCostMass (9000 -> 9500)
 - BuildTime (28800 -> 30300) [192s -> 202s w/ T3 Factory]
 - RateOfFire (10/59 -> 10/60) [DPS: 169.5 -> 166.7] [Note: the UI rounds; total DPS is 500.]
 
 
Tempest is good at safely farming value and staying healthy despite it's low stats per cost compared to battleships due to its long range, high splash weapon and because it still greatly benefits from veterancy despite the previous nerf.

Tempest (UAS0401):
 - BuildCostEnergy (380000 -> 400000)
 - BuildCostMass (24000 -> 25000)
 - BuildTime (38400 -> 40000) [1181.5s -> 1230.8s w/ T3 Engineer]
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Balance Changes**
  * UAS0302: Increased build resource requirements and construction time; adjusted Oblivion Cannon fire rate
  * UAS0401: Increased build resource requirements and construction time
  * URS0201: Reduced Electron Autocannon maximum range

<!-- end of auto-generated comment: release notes by coderabbit.ai -->