### PR TITLE
Battleships: Disable fireclock rendering on aft turrets

### DIFF
--- a/changelog/snippets/fix.7111.md
+++ b/changelog/snippets/fix.7111.md
@@ -1,0 +1,1 @@
+- (#7111) Fixed an issue where battleships' aft turrets reset the fire clock.

--- a/units/UAS0302/UAS0302_unit.bp
+++ b/units/UAS0302/UAS0302_unit.bp
@@ -338,7 +338,6 @@ UnitBlueprint{
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
             RateOfFire = 10/60, --10/integer interval in ticks
-            RenderFireClock = true,
             SlavedToBody = true,
             SlavedToBodyArcRange = 155,
             TargetPriorities = {

--- a/units/URS0302/URS0302_unit.bp
+++ b/units/URS0302/URS0302_unit.bp
@@ -305,7 +305,6 @@ UnitBlueprint{
             RackSlavedToTurret = true,
             RangeCategory = "UWRC_DirectFire",
             RateOfFire = 10/40, --10/integer interval in ticks
-            RenderFireClock = true,
             SlavedToBody = true,
             SlavedToBodyArcRange = 130,
             TargetPriorities = {

--- a/units/XSS0302/XSS0302_unit.bp
+++ b/units/XSS0302/XSS0302_unit.bp
@@ -362,7 +362,6 @@ UnitBlueprint{
             RackSlavedToTurret = false,
             RangeCategory = "UWRC_DirectFire",
             RateOfFire = 10/40, --10/integer interval in ticks
-            RenderFireClock = true,
             SlavedToBody = true,
             SlavedToBodyArcRange = 155,
             TargetPriorities = {


### PR DESCRIPTION
## Description of the proposed changes
The aft turret usually fires after the forward turret(s), which causes the fire clock to reset when it fires, making it useless.

## Checklist
- [ ] ~Changes are annotated, including comments where useful~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] ~Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).~
