### PR TITLE
Fix changelog dialog crash

### DIFF
--- a/.github/workflows/scripts/python/changelog_overview.py
+++ b/.github/workflows/scripts/python/changelog_overview.py
@@ -44,6 +44,7 @@ def process_markdown_file(markdown_file: Path) -> Optional[Tuple[str, date]]:
     if len(file_name_parts) == 4:
         date_str = '-'.join(file_name_parts[:3])
         version = file_name_parts[3]
+        url = version
         try:
             parsed_date = datetime.strptime(date_str, "%Y-%m-%d").date()
         except ValueError:
@@ -53,7 +54,8 @@ def process_markdown_file(markdown_file: Path) -> Optional[Tuple[str, date]]:
         logging.warning(f"Unexpected filename format: {markdown_file.name}")
         parsed_date = date.today()
         date_str = parsed_date.isoformat()
-        version = markdown_file.stem
+        version = 1
+        url = markdown_file.stem
 
     try:
         yaml_content, _ = extract_yaml_front_matter(markdown_file.read_text())
@@ -67,7 +69,7 @@ def process_markdown_file(markdown_file: Path) -> Optional[Tuple[str, date]]:
             Version = {version},
             Name = "{name}",
             Date = "{date_str}",
-            URL = "http://faforever.github.io/fa/changelog/{version}",
+            URL = "http://faforever.github.io/fa/changelog/{url}",
             Path = "/lua/ui/lobby/changelog/generated/{markdown_file.stem}.lua"
         }},"""
         return entry, parsed_date

--- a/changelog/snippets/other.7074.md
+++ b/changelog/snippets/other.7074.md
@@ -1,2 +1,2 @@
-- (#7074) Add preliminary changelogs of fafdevelop and fafbeta to the changelog window in the lobby.
+- (#7074, #7117) Add preliminary changelogs of fafdevelop and fafbeta to the changelog window in the lobby.
   These changelogs will be updated automatically with each deployment, allowing you to easily understand what exactly has changed when playing these game modes.


### PR DESCRIPTION
Previously the filename in the version field would be interpreted as a global variable and crash the changelog dialog in the lobby.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal changelog metadata formatting to improve consistency in version field generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FAForever/fa/pull/7117)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->