### PR TITLE
Fix the failing build of our website

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -84,12 +84,15 @@ jobs:
 
       # Retrieve the generated changelogs
       - name: Download artifact changelog of FAF Develop
+        # No artifact exists when there are no snippets to process
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: changelog-fafdevelop
           path: docs/generated
 
       - name: Download artifact changelog of FAF Beta
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: changelog-fafbeta
@@ -98,8 +101,8 @@ jobs:
       # Append the generated changelogs to the Jekyll-compatible templates
       - name: Append the generated changelogs
         run: |
-          cat generated/changelog-fafdevelop.md >> changelog/fafdevelop.md
-          cat generated/changelog-fafbeta.md >> changelog/fafbeta.md
+          cat generated/changelog-fafdevelop.md >> changelog/fafdevelop.md || true
+          cat generated/changelog-fafbeta.md >> changelog/fafbeta.md || true
 
       # Add links to the files in the posts directory
       - name: Update changelog posts directory

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -98,8 +98,8 @@ jobs:
       # Append the generated changelogs to the Jekyll-compatible templates
       - name: Append the generated changelogs
         run: |
-          cat generated/fafdevelop.md >> changelog/fafdevelop.md
-          cat generated/fafbeta.md >> changelog/fafbeta.md
+          cat generated/changelog-fafdevelop.md >> changelog/fafdevelop.md
+          cat generated/changelog-fafbeta.md >> changelog/fafbeta.md
 
       # Add links to the files in the posts directory
       - name: Update changelog posts directory


### PR DESCRIPTION
In #7084 I changed the name of the generated changelog file, but didn't accomodate for that in the documentation build workflow that relies on these files.
I also properly fixed the problem now that the deployment would fail when there are no snippets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced the build workflow's overall robustness for changelog generation to handle missing or unavailable artifacts gracefully. The build process now continues smoothly without interruption even when certain data sources are temporarily absent. This important improvement ensures consistent and reliable automated documentation generation throughout the release pipeline for all deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FAForever/fa/pull/7120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->