### PR TITLE
Reduce loyalist gun stun duration

### DIFF
--- a/changelog/snippets/balance.7121.md
+++ b/changelog/snippets/balance.7121.md
@@ -1,0 +1,6 @@
+- (#7121) Reduce stun duration of Loyalist's Disintegrator Pulse Laser since it was extremely powerful against T2 units, Ilshavohs in particular.
+
+  **Loyalist: T3 Siege Assault Bot**
+    - Disintegrator Pulse Laser:
+      - Stun Duration against T1/T2 mobile units: 1.5s per shot (2.3s per volley) (70% stun uptime) -> 0.4s per shot (1.2s per volley) (36% stun uptime)
+

--- a/units/URL0303/URL0303_unit.bp
+++ b/units/URL0303/URL0303_unit.bp
@@ -191,7 +191,7 @@ UnitBlueprint{
                     Add = { OnImpact = true },
                     AppliedToTarget = true,
                     BuffType = "STUN",
-                    Duration = 1.5,
+                    Duration = 0.4,
                     Radius = 0,
                     TargetAllow = "TECH1,TECH2",
                     TargetDisallow = "TECH3,EXPERIMENTAL,COMMAND,NAVAL,STRUCTURE",


### PR DESCRIPTION
## Description of the proposed changes
Loyalist's Disintegrator Pulse Laser stun duration against T1/T2 mobile units per shot: 1.5s (2.3s per volley) -> 0.4s (1.2s per volley)

Loyalist was extremely strong against ilshavohs because it had a 69.7% stun uptime against T1/T2 units (2.3s stun, 3.3s reload). It could beat 2 ilshies (720 mass) by itself (480 mass) (1.5x mass disadvantage + speed advantage).

The stun duration is reduced to the minimum that I would consider to be impactful. A shorter 0.3s duration would let ilshavohs shoot during the stun which makes it deceptively ineffective, since the loyalist fires a 3-shot volley with 0.4s delay in between shots. Those 1 tick gaps would also make the stun quite useless against lower fire rate rhinos (0.6s reload), pillars (1.2s), and obsidians (3.0s).

## Testing done on the proposed changes
Now 2 ilshies can beat a loyalist with the 2nd ilshie being damaged after the fight (~40% damaged if no micro, ~8% if kiting loya).
Loyalist still wins easily in a mass-equal fight because of its extremely strong dps and hp stats per cost, since I tested that it wins even with 0 stun duration. I didn't adjust those stats because loyalist's low range and lack of regenerating shield like the Titan really hurts it against T3 units.

I also compared Titan vs ilshie effectiveness to get more context about the interaction. Titan easily loses to ilshavohs mass-for-mass and can't even kill 1 ilshie in a 1v2, but to be fair it has much longer range and a regenerating shield.

<details> <summary> Unit spawn commands </summary>

Loya vs 2 ilshies
```
   CreateUnitAtMouse('xsl0202', 1,    8.97,   -1.72,  1.60410)
   CreateUnitAtMouse('xsl0202', 1,    9.01,    1.30,  1.71691)
   CreateUnitAtMouse('url0303', 0,  -17.97,    0.42,  1.61130)
```
Titan vs 2 ilshies
```
   CreateUnitAtMouse('xsl0202', 1,    8.97,   -1.72,  1.60410)
   CreateUnitAtMouse('xsl0202', 1,    9.01,    1.30,  1.71691)
   CreateUnitAtMouse('uel0303', 0,  -17.97,    0.42,  1.61130)
```
Loyas vs ilshies equal mass
```
   CreateUnitAtMouse('xsl0202', 1,   12.34,    3.91,  1.59353)
   CreateUnitAtMouse('xsl0202', 1,   12.47,    0.60,  1.59353)
   CreateUnitAtMouse('url0303', 0,  -16.44,    0.87,  1.57062)
   CreateUnitAtMouse('url0303', 0,  -16.54,   -2.13,  1.56932)
   CreateUnitAtMouse('url0303', 0,  -16.54,    3.87,  1.57268)
   CreateUnitAtMouse('xsl0202', 1,   12.33,   -5.26,  1.59353)
   CreateUnitAtMouse('xsl0202', 1,   12.38,   -1.86,  1.71921)
```
Titans vs ilshies equal mass
```
   CreateUnitAtMouse('xsl0202', 1,   12.34,    3.91,  1.59353)
   CreateUnitAtMouse('xsl0202', 1,   12.47,    0.60,  1.59353)
   CreateUnitAtMouse('uel0303', 0,  -16.44,    0.87,  1.57062)
   CreateUnitAtMouse('uel0303', 0,  -16.54,   -2.13,  1.56932)
   CreateUnitAtMouse('uel0303', 0,  -16.54,    3.87,  1.57268)
   CreateUnitAtMouse('xsl0202', 1,   12.33,   -5.26,  1.59353)
   CreateUnitAtMouse('xsl0202', 1,   12.38,   -1.86,  1.71921)
```

</details>

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Balance**
  * Reduced the stun duration of the Loyalist T3 Siege Assault Bot's Disintegrator Pulse Laser weapon. Stun effects per shot decreased from 1.5s to 0.4s, reducing overall stun uptime from 70% to 36% against early-game units.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FAForever/fa/pull/7121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->