### PR TITLE
Improve beam weapon economy drain

### DIFF
--- a/lua/sim/weapons/DefaultBeamWeapon.lua
+++ b/lua/sim/weapons/DefaultBeamWeapon.lua
@@ -295,12 +295,13 @@ DefaultBeamWeapon = ClassWeapon(DefaultProjectileWeapon) {
     ---@return boolean
     EconomySupportsBeam = function(self)
         local aiBrain = self.Brain
-        local energyIncome = aiBrain:GetEconomyIncome('ENERGY') * 10
+        local energyRate = aiBrain:GetEconomyTrend('ENERGY') * 10
         local energyStored = aiBrain:GetEconomyStored('ENERGY')
         local energyReq = self:GetWeaponEnergyRequired()
         local energyDrain = self:GetWeaponEnergyDrain()
+        local drainDuration = math.floor(energyReq / energyDrain)
 
-        if energyStored < energyReq and energyIncome < energyDrain then
+        if (energyDrain - energyRate) * drainDuration > energyStored then
             return false
         end
         return true


### PR DESCRIPTION
## Description of the proposed changes
Allows high cost + high drain beams to be powered off of stored energy. Also prevents energy stalls from a beam firing when you have high income but low energy trend.

## Testing done on the proposed changes
Novax satellite with 72k energy requirement and 5000 energy drain can fire off of 4 storages (40k e) + adjacent t3 pgen (3125 e/s).
I went through usages of the function and didn't see any functional part that would cause the beam to stop mid-way through the firing stage.

There is a bug where waiting for drain cancels a firing tick because default fire ready state has no transition to fire state after waiting for econ drain.

## Checklist
- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
