### PR TITLE
Fix unstable changelog overview file

### DIFF
--- a/.github/workflows/scripts/python/changelog_overview.py
+++ b/.github/workflows/scripts/python/changelog_overview.py
@@ -72,14 +72,14 @@ def process_markdown_file(markdown_file: Path) -> Optional[Tuple[str, date]]:
             URL = "http://faforever.github.io/fa/changelog/{url}",
             Path = "/lua/ui/lobby/changelog/generated/{markdown_file.stem}.lua"
         }},"""
-        return entry, parsed_date
+        return entry, parsed_date, int(version)
 
     except Exception as e:
         raise RuntimeError(f"Failed to process {markdown_file.name}") from e
 
 def create_overview_file(input_dir: Path, output_file: Path):
     """Creates an overview Lua file listing all changelogs with metadata."""
-    entries: list[Tuple[str, date]] = []
+    entries: list[Tuple[str, date, int]] = []
 
     logging.info(f"Scanning directory: {input_dir}")
     for markdown_file in input_dir.glob("*.md"):
@@ -91,7 +91,8 @@ def create_overview_file(input_dir: Path, output_file: Path):
         logging.warning("No valid changelog entries found.")
         return
 
-    entries.sort(key=lambda pair: pair[1], reverse=True)
+    # Sort by date and then by version
+    entries.sort(key=lambda pair: (pair[1], pair[2]), reverse=True)
 
     logging.info("Generating overview Lua content...")
     overview_content = OVERVIEW_HEADER + """
@@ -99,7 +100,7 @@ def create_overview_file(input_dir: Path, output_file: Path):
 Overview = {
     Changelogs = {
 """
-    overview_content += "\n".join(entry for entry, _ in entries)
+    overview_content += "\n".join(entry for entry, _, _ in entries)
     overview_content += "\n    }\n}\n"
 
     output_file.write_text(overview_content)

--- a/.github/workflows/scripts/python/changelog_overview.py
+++ b/.github/workflows/scripts/python/changelog_overview.py
@@ -37,7 +37,7 @@ def extract_yaml_front_matter(content: str) -> Tuple[str, str]:
             return yaml_content, rest_of_content
     return '', content
 
-def process_markdown_file(markdown_file: Path) -> Optional[Tuple[str, date]]:
+def process_markdown_file(markdown_file: Path) -> Optional[Tuple[str, date, int]]:
     logging.info(f"Processing file: {markdown_file.name}")
 
     file_name_parts = markdown_file.stem.split('-')

--- a/lua/ui/lobby/changelog/generated/overview.lua
+++ b/lua/ui/lobby/changelog/generated/overview.lua
@@ -125,18 +125,18 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2025-04-01-3820.lua"
         },
         {
-            Version = 3818,
-            Name = "3818 - Game Patch",
-            Date = "2025-02-14",
-            URL = "http://faforever.github.io/fa/changelog/3818",
-            Path = "/lua/ui/lobby/changelog/generated/2025-02-14-3818.lua"
-        },
-        {
             Version = 3819,
             Name = "3819 - Hotfix",
             Date = "2025-02-14",
             URL = "http://faforever.github.io/fa/changelog/3819",
             Path = "/lua/ui/lobby/changelog/generated/2025-02-14-3819.lua"
+        },
+        {
+            Version = 3818,
+            Name = "3818 - Game Patch",
+            Date = "2025-02-14",
+            URL = "http://faforever.github.io/fa/changelog/3818",
+            Path = "/lua/ui/lobby/changelog/generated/2025-02-14-3818.lua"
         },
         {
             Version = 3817,
@@ -153,11 +153,11 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2024-12-10-3816.lua"
         },
         {
-            Version = 3813,
-            Name = "3813 - Game Patch",
+            Version = 3815,
+            Name = "3815 - Hotfix",
             Date = "2024-11-29",
-            URL = "http://faforever.github.io/fa/changelog/3813",
-            Path = "/lua/ui/lobby/changelog/generated/2024-11-29-3813.lua"
+            URL = "http://faforever.github.io/fa/changelog/3815",
+            Path = "/lua/ui/lobby/changelog/generated/2024-11-29-3815.lua"
         },
         {
             Version = 3814,
@@ -167,11 +167,11 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2024-11-29-3814.lua"
         },
         {
-            Version = 3815,
-            Name = "3815 - Hotfix",
+            Version = 3813,
+            Name = "3813 - Game Patch",
             Date = "2024-11-29",
-            URL = "http://faforever.github.io/fa/changelog/3815",
-            Path = "/lua/ui/lobby/changelog/generated/2024-11-29-3815.lua"
+            URL = "http://faforever.github.io/fa/changelog/3813",
+            Path = "/lua/ui/lobby/changelog/generated/2024-11-29-3813.lua"
         },
         {
             Version = 3812,
@@ -314,18 +314,18 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2023-11-15-3774.lua"
         },
         {
-            Version = 3772,
-            Name = "3772 - Hotfix",
-            Date = "2023-11-02",
-            URL = "http://faforever.github.io/fa/changelog/3772",
-            Path = "/lua/ui/lobby/changelog/generated/2023-11-02-3772.lua"
-        },
-        {
             Version = 3773,
             Name = "3773 - Hotfix",
             Date = "2023-11-02",
             URL = "http://faforever.github.io/fa/changelog/3773",
             Path = "/lua/ui/lobby/changelog/generated/2023-11-02-3773.lua"
+        },
+        {
+            Version = 3772,
+            Name = "3772 - Hotfix",
+            Date = "2023-11-02",
+            URL = "http://faforever.github.io/fa/changelog/3772",
+            Path = "/lua/ui/lobby/changelog/generated/2023-11-02-3772.lua"
         },
         {
             Version = 3771,
@@ -342,18 +342,18 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2023-09-24-3769.lua"
         },
         {
-            Version = 3767,
-            Name = "3767 - Hotfix",
-            Date = "2023-09-17",
-            URL = "http://faforever.github.io/fa/changelog/3767",
-            Path = "/lua/ui/lobby/changelog/generated/2023-09-17-3767.lua"
-        },
-        {
             Version = 3768,
             Name = "3768 - Hotfix",
             Date = "2023-09-17",
             URL = "http://faforever.github.io/fa/changelog/3768",
             Path = "/lua/ui/lobby/changelog/generated/2023-09-17-3768.lua"
+        },
+        {
+            Version = 3767,
+            Name = "3767 - Hotfix",
+            Date = "2023-09-17",
+            URL = "http://faforever.github.io/fa/changelog/3767",
+            Path = "/lua/ui/lobby/changelog/generated/2023-09-17-3767.lua"
         },
         {
             Version = 3766,
@@ -391,18 +391,18 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2023-07-22-3762.lua"
         },
         {
-            Version = 3760,
-            Name = "3760 - Hotfix",
-            Date = "2023-06-27",
-            URL = "http://faforever.github.io/fa/changelog/3760",
-            Path = "/lua/ui/lobby/changelog/generated/2023-06-27-3760.lua"
-        },
-        {
             Version = 3761,
             Name = "3761 - Game Patch",
             Date = "2023-06-27",
             URL = "http://faforever.github.io/fa/changelog/3761",
             Path = "/lua/ui/lobby/changelog/generated/2023-06-27-3761.lua"
+        },
+        {
+            Version = 3760,
+            Name = "3760 - Hotfix",
+            Date = "2023-06-27",
+            URL = "http://faforever.github.io/fa/changelog/3760",
+            Path = "/lua/ui/lobby/changelog/generated/2023-06-27-3760.lua"
         },
         {
             Version = 3758,
@@ -426,13 +426,6 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2023-03-18-3756.lua"
         },
         {
-            Version = 3754,
-            Name = "3754 - Hotfix",
-            Date = "2023-03-05",
-            URL = "http://faforever.github.io/fa/changelog/3754",
-            Path = "/lua/ui/lobby/changelog/generated/2023-03-05-3754.lua"
-        },
-        {
             Version = 3755,
             Name = "3755 - Hotfix",
             Date = "2023-03-05",
@@ -440,11 +433,11 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2023-03-05-3755.lua"
         },
         {
-            Version = 3752,
-            Name = "3752 - Hotfix",
-            Date = "2023-02-25",
-            URL = "http://faforever.github.io/fa/changelog/3752",
-            Path = "/lua/ui/lobby/changelog/generated/2023-02-25-3752.lua"
+            Version = 3754,
+            Name = "3754 - Hotfix",
+            Date = "2023-03-05",
+            URL = "http://faforever.github.io/fa/changelog/3754",
+            Path = "/lua/ui/lobby/changelog/generated/2023-03-05-3754.lua"
         },
         {
             Version = 3753,
@@ -452,6 +445,13 @@ Overview = {
             Date = "2023-02-25",
             URL = "http://faforever.github.io/fa/changelog/3753",
             Path = "/lua/ui/lobby/changelog/generated/2023-02-25-3753.lua"
+        },
+        {
+            Version = 3752,
+            Name = "3752 - Hotfix",
+            Date = "2023-02-25",
+            URL = "http://faforever.github.io/fa/changelog/3752",
+            Path = "/lua/ui/lobby/changelog/generated/2023-02-25-3752.lua"
         },
         {
             Version = 3751,
@@ -580,18 +580,18 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2022-04-22-3734.lua"
         },
         {
-            Version = 3732,
-            Name = "3732 - Game Patch",
-            Date = "2022-04-22",
-            URL = "http://faforever.github.io/fa/changelog/3732",
-            Path = "/lua/ui/lobby/changelog/generated/2022-04-22-3732.lua"
-        },
-        {
             Version = 3733,
             Name = "3733 - Hotfix",
             Date = "2022-04-22",
             URL = "http://faforever.github.io/fa/changelog/3733",
             Path = "/lua/ui/lobby/changelog/generated/2022-04-22-3733.lua"
+        },
+        {
+            Version = 3732,
+            Name = "3732 - Game Patch",
+            Date = "2022-04-22",
+            URL = "http://faforever.github.io/fa/changelog/3732",
+            Path = "/lua/ui/lobby/changelog/generated/2022-04-22-3732.lua"
         },
         {
             Version = 3731,
@@ -622,6 +622,13 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2021-12-20-3728.lua"
         },
         {
+            Version = 3727,
+            Name = "3727 - Hotfix",
+            Date = "2021-11-26",
+            URL = "http://faforever.github.io/fa/changelog/3727",
+            Path = "/lua/ui/lobby/changelog/generated/2021-11-26-3727.lua"
+        },
+        {
             Version = 3726,
             Name = "3726 - Hotfix",
             Date = "2021-11-26",
@@ -636,18 +643,18 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2021-11-26-3725.lua"
         },
         {
-            Version = 3727,
-            Name = "3727 - Hotfix",
-            Date = "2021-11-26",
-            URL = "http://faforever.github.io/fa/changelog/3727",
-            Path = "/lua/ui/lobby/changelog/generated/2021-11-26-3727.lua"
-        },
-        {
             Version = 3724,
             Name = "3724 - Game Patch",
             Date = "2021-10-04",
             URL = "http://faforever.github.io/fa/changelog/3724",
             Path = "/lua/ui/lobby/changelog/generated/2021-10-04-3724.lua"
+        },
+        {
+            Version = 3723,
+            Name = "3723 - Hotfix",
+            Date = "2021-09-19",
+            URL = "http://faforever.github.io/fa/changelog/3723",
+            Path = "/lua/ui/lobby/changelog/generated/2021-09-19-3723.lua"
         },
         {
             Version = 3722,
@@ -662,13 +669,6 @@ Overview = {
             Date = "2021-09-19",
             URL = "http://faforever.github.io/fa/changelog/3721",
             Path = "/lua/ui/lobby/changelog/generated/2021-09-19-3721.lua"
-        },
-        {
-            Version = 3723,
-            Name = "3723 - Hotfix",
-            Date = "2021-09-19",
-            URL = "http://faforever.github.io/fa/changelog/3723",
-            Path = "/lua/ui/lobby/changelog/generated/2021-09-19-3723.lua"
         },
         {
             Version = 3720,
@@ -944,18 +944,18 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2017-02-27-3676.lua"
         },
         {
-            Version = 3674,
-            Name = "3674 - Game Patch",
-            Date = "2017-02-05",
-            URL = "http://faforever.github.io/fa/changelog/3674",
-            Path = "/lua/ui/lobby/changelog/generated/2017-02-05-3674.lua"
-        },
-        {
             Version = 3675,
             Name = "3675 - Hotfix",
             Date = "2017-02-05",
             URL = "http://faforever.github.io/fa/changelog/3675",
             Path = "/lua/ui/lobby/changelog/generated/2017-02-05-3675.lua"
+        },
+        {
+            Version = 3674,
+            Name = "3674 - Game Patch",
+            Date = "2017-02-05",
+            URL = "http://faforever.github.io/fa/changelog/3674",
+            Path = "/lua/ui/lobby/changelog/generated/2017-02-05-3674.lua"
         },
         {
             Version = 3672,
@@ -972,11 +972,11 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2017-01-19-3671.lua"
         },
         {
-            Version = 3668,
-            Name = "3668 - Hotfix",
+            Version = 3670,
+            Name = "3670 - Hotfix",
             Date = "2017-01-17",
-            URL = "http://faforever.github.io/fa/changelog/3668",
-            Path = "/lua/ui/lobby/changelog/generated/2017-01-17-3668.lua"
+            URL = "http://faforever.github.io/fa/changelog/3670",
+            Path = "/lua/ui/lobby/changelog/generated/2017-01-17-3670.lua"
         },
         {
             Version = 3669,
@@ -986,11 +986,11 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2017-01-17-3669.lua"
         },
         {
-            Version = 3670,
-            Name = "3670 - Hotfix",
+            Version = 3668,
+            Name = "3668 - Hotfix",
             Date = "2017-01-17",
-            URL = "http://faforever.github.io/fa/changelog/3669",
-            Path = "/lua/ui/lobby/changelog/generated/2017-01-17-3669.lua"
+            URL = "http://faforever.github.io/fa/changelog/3668",
+            Path = "/lua/ui/lobby/changelog/generated/2017-01-17-3668.lua"
         },
         {
             Version = 3667,
@@ -1161,18 +1161,18 @@ Overview = {
             Path = "/lua/ui/lobby/changelog/generated/2014-12-24-3638.lua"
         },
         {
-            Version = 3636,
-            Name = "3636 - Game Patch",
-            Date = "2014-12-12",
-            URL = "http://faforever.github.io/fa/changelog/3636",
-            Path = "/lua/ui/lobby/changelog/generated/2014-12-12-3636.lua"
-        },
-        {
             Version = 3637,
             Name = "3637 - Hotfix",
             Date = "2014-12-12",
             URL = "http://faforever.github.io/fa/changelog/3637",
             Path = "/lua/ui/lobby/changelog/generated/2014-12-12-3637.lua"
+        },
+        {
+            Version = 3636,
+            Name = "3636 - Game Patch",
+            Date = "2014-12-12",
+            URL = "http://faforever.github.io/fa/changelog/3636",
+            Path = "/lua/ui/lobby/changelog/generated/2014-12-12-3636.lua"
         },
     }
 }


### PR DESCRIPTION
## Description of the proposed changes
The entries in the changelog overview file were sorted by date only. Because the read order of the files is not deterministic that produces unstable output, which results in useless commits by the workflow that is supposed to keep .md and .lua changelog files in sync. By additionally sorting by the version we ensure a consistent order.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved changelog processing by deriving and incorporating version numbers from changelog filenames.
  * Updated the changelog overview generation to sort entries by date first, then by version to ensure consistent ordering when dates match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->