### PR TITLE
Fix typo: RedRock → Redrock in weatherdefinitions.lua (#7118)

### DIFF
--- a/lua/weatherdefinitions.lua
+++ b/lua/weatherdefinitions.lua
@@ -240,7 +240,7 @@ MapWeatherList = {
         CirrusMedium4096 = CirrusMedium4096Definition,
         CirrusHeavy4096 = CirrusHeavy4096Definition,
     },
-    Redrock = {
+    RedRock = {
         LightStratus = {
             {
                 EmitterBasePath .. 'weather_stratus_09_emit.bp',	-- 40x40		Med

--- a/lua/weatherdefinitions.lua
+++ b/lua/weatherdefinitions.lua
@@ -59,7 +59,7 @@ MapStyleList = {
     'Evergreen',
     'Geothermal',
     'Lava',
-    'Redrock',
+    'RedRock',
     'Tropical',
     'Tundra',
 }

--- a/lua/weatherdefinitions.lua
+++ b/lua/weatherdefinitions.lua
@@ -59,7 +59,7 @@ MapStyleList = {
     'Evergreen',
     'Geothermal',
     'Lava',
-    'RedRock',
+    'Redrock',
     'Tropical',
     'Tundra',
 }


### PR DESCRIPTION
## Fix FAForever/fa#7118

MapWeatherList used `'RedRock'` but the actual definition key is `Redrock`. Fixed to match.

Closes #7118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the casing of the "Red Rock" weather style so it is now consistently recognized and listed in weather selectors and maps, ensuring the style displays and applies correctly across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->