### PR TITLE
Fix typo: Suport -> Support in ZEB9601 description (#7100)

### DIFF
--- a/changelog/snippets/fix.7129.md
+++ b/changelog/snippets/fix.7129.md
@@ -1,0 +1,1 @@
+- (#7129) Fix typo in unlocalised version of the descriptive name of the UEF T3 Support Land Factory.

--- a/units/ZEB9601/ZEB9601_unit.bp
+++ b/units/ZEB9601/ZEB9601_unit.bp
@@ -1,5 +1,5 @@
 UnitBlueprint{
-    Description = "<LOC zeb9601_desc>Suport Land Factory",
+    Description = "<LOC zeb9601_desc>Support Land Factory",
     AI = {
         TargetBones = {
             "Attachpoint",


### PR DESCRIPTION
## Fix FAForever/fa#7100

Fixed typo in UEF Land Factory unit description: `Suport` → `Support`.

Closes #7100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a spelling error in the unit description so "Support Land Factory" displays properly.
  * Updated the changelog entry to reflect the corrected descriptive name for the UEF T3 Support Land Factory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->