### PR TITLE
Allow docking/building of mercies on carriers and air staging.

### DIFF
--- a/engine/Core/Categories.lua
+++ b/engine/Core/Categories.lua
@@ -55,6 +55,7 @@ categories = {
     BUILTBYTIER3COMMANDER = categoryValue,
     BUILTBYTIER3ENGINEER = categoryValue,
     BUILTBYTIER3FACTORY = categoryValue,
+    --- Used by engine to disallow air units to right click into transports/air staging.
     CANNOTUSEAIRSTAGING = categoryValue,
     CANTRANSPORTCOMMANDER = categoryValue,
     CAPTURE = categoryValue,

--- a/units/DAA0206/DAA0206_unit.bp
+++ b/units/DAA0206/DAA0206_unit.bp
@@ -116,7 +116,10 @@ UnitBlueprint{
     General = {
         CommandCaps = {
             RULEUCC_Attack = true,
+            RULEUCC_CallTransport = true,
+            RULEUCC_Dock = true,
             RULEUCC_Move = true,
+            RULEUCC_Patrol = true,
             RULEUCC_RetaliateToggle = true,
             RULEUCC_Stop = true,
         },

--- a/units/DAA0206/DAA0206_unit.bp
+++ b/units/DAA0206/DAA0206_unit.bp
@@ -162,6 +162,7 @@ UnitBlueprint{
     Weapon = {
         {
             AboveWaterTargetsOnly = true,
+            AlwaysRecheckTarget = true,
             Audio = {
                 Fire = Sound { Bank = 'UAAWeapon', Cue = 'UAA0304_Bomb_Quark', LodCutoff = 'Weapon_LodCutoff' },
             },
@@ -205,7 +206,7 @@ UnitBlueprint{
             RateOfFire = 10/1, --10/integer interval in ticks
             SlavedToBody = true,
             SlavedToBodyArcRange = 35,
-            TargetCheckInterval = 999999,
+            TargetCheckInterval = 1,
             TargetPriorities = {
                 "TECH4",
                 "TECH3 STRUCTURE",
@@ -214,7 +215,6 @@ UnitBlueprint{
                 "(ALLUNITS - SPECIALLOWPRI)",
             },
             TargetRestrictDisallow = "UNTARGETABLE",
-            TrackingRadius = 0.5,
             TurretBoneMuzzle = "DAA0206",
             TurretBonePitch = "DAA0206",
             TurretBoneYaw = "DAA0206",

--- a/units/DAA0206/DAA0206_unit.bp
+++ b/units/DAA0206/DAA0206_unit.bp
@@ -45,8 +45,8 @@ UnitBlueprint{
         "SELECTABLE",
         "SHOWATTACKRETICLE",
         "TECH2",
-        "TRANSPORTBUILTBYTIER2FACTORY",
-        "TRANSPORTBUILTBYTIER3FACTORY",
+        "BUILTBYTIER2FACTORY",
+        "BUILTBYTIER3FACTORY",
         "VISIBLETORECON",
     },
     Defense = {

--- a/units/DAA0206/DAA0206_unit.bp
+++ b/units/DAA0206/DAA0206_unit.bp
@@ -118,6 +118,7 @@ UnitBlueprint{
             RULEUCC_Attack = true,
             RULEUCC_CallTransport = true,
             RULEUCC_Dock = true,
+            RULEUCC_Guard = true,
             RULEUCC_Move = true,
             RULEUCC_Patrol = true,
             RULEUCC_RetaliateToggle = true,

--- a/units/DAA0206/DAA0206_unit.bp
+++ b/units/DAA0206/DAA0206_unit.bp
@@ -39,7 +39,6 @@ UnitBlueprint{
         "AIR",
         "BOMB",
         "BOMBER",
-        "CANNOTUSEAIRSTAGING",
         "MOBILE",
         "PRODUCTDL",
         "RECLAIMABLE",

--- a/units/DAA0206/DAA0206_unit.bp
+++ b/units/DAA0206/DAA0206_unit.bp
@@ -136,7 +136,7 @@ UnitBlueprint{
     Physics = {
         AttackElevation = 0.5,
         Elevation = 12,
-        FuelRechargeRate = 0,
+        FuelRechargeRate = 5,
         FuelUseTime = 400,
         GroundCollisionOffset = -0.25,
         MaxSpeed = 13,

--- a/units/DAA0206/DAA0206_unit.bp
+++ b/units/DAA0206/DAA0206_unit.bp
@@ -215,6 +215,7 @@ UnitBlueprint{
                 "(ALLUNITS - SPECIALLOWPRI)",
             },
             TargetRestrictDisallow = "UNTARGETABLE",
+            TrackingRadius = 1.1,
             TurretBoneMuzzle = "DAA0206",
             TurretBonePitch = "DAA0206",
             TurretBoneYaw = "DAA0206",


### PR DESCRIPTION
**Intended Change**
Remove the CANNOTUSEAIRSTAGING category from the Mercy (DAA0206) so it can use air staging facilities and aircraft carriers, like most other air units.

**Reasoning**
Since the mercy rework, the mercy is now an anti t1/t2 army / structure / buildpower unit and no longer a snipe-unit so I see no reason to lock it out of carriers. I believe the main reason it was locked out was to limit their attack range with low amount of fuel before the rework. Now the mercy, while good, has an incredibly small window of opportunity that can be expanded with this change.

**Expected behavior**
The Mercy can now land on air staging and dock on / be built by aircraft carriers. No change to its health, damage, cost, build time, or any other stat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Gameplay Changes**
  * Updated air-staging interaction rules: this unit can now use air-staging right-click interactions.
  * Expanded command capabilities to include transport/docking/guard/patrol.
  * Increased fuel recharge rate.
  * Improved primary weapon target evaluation with more frequent re-checks and a larger tracking radius.
* **Documentation**
  * Added an explanatory note to engine category documentation regarding air-staging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->