### PR TITLE
Bump all workflow actions to a more recent version

### DIFF
--- a/.github/workflows/bake-blueprints.yaml
+++ b/.github/workflows/bake-blueprints.yaml
@@ -57,14 +57,14 @@ jobs:
     steps:
       # Checkout the wiki generator that we use to bake blueprints
       - name: Checkout Brewlan Wikigen Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
               repository: The-Balthazar/BrewWikiGen
               path: ./brew-wiki-gen
 
       # Checkout the FA repository
       - name: Checkout FAF Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.reference }}
           ssh-key: ${{ secrets.SSH_FAFOREVER_MACHINE_USER }}
@@ -76,7 +76,7 @@ jobs:
 
       # Install the correct version of Lua for the wiki generator
       - name: Install Lua 5.4
-        uses: leafo/gh-actions-lua@v10
+        uses: leafo/gh-actions-lua@v13
         with:
           luaVersion: "5.4"
 

--- a/.github/workflows/deploy-faf.yaml
+++ b/.github/workflows/deploy-faf.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       # https://github.com/actions/checkout/tree/v4/
       - name: Checkout FA repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ssh-key: ${{ secrets.SSH_FAFOREVER_MACHINE_USER }}
           repository: FAForever/fa

--- a/.github/workflows/deploy-fafbeta.yaml
+++ b/.github/workflows/deploy-fafbeta.yaml
@@ -57,7 +57,7 @@ jobs:
     steps:
       # https://github.com/actions/checkout/tree/v4/
       - name: Checkout FA repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ssh-key: ${{ secrets.SSH_FAFOREVER_MACHINE_USER }}
           ref: staging/fafbeta
@@ -96,7 +96,7 @@ jobs:
         run: rm -f lua/ui/lobby/changelog/generated/*
 
       - name: Retrieve generated lua changelog
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: lua_changelog
           path: lua/ui/lobby/changelog/generated

--- a/.github/workflows/deploy-fafdevelop.yaml
+++ b/.github/workflows/deploy-fafdevelop.yaml
@@ -57,7 +57,7 @@ jobs:
     steps:
       # https://github.com/actions/checkout/tree/v4/
       - name: Checkout FA repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ssh-key: ${{ secrets.SSH_FAFOREVER_MACHINE_USER }}
           ref: staging/fafdevelop
@@ -96,7 +96,7 @@ jobs:
         run: rm -f lua/ui/lobby/changelog/generated/*
 
       - name: Retrieve generated lua changelog
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: lua_changelog
           path: lua/ui/lobby/changelog/generated

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             docs
@@ -86,14 +86,14 @@ jobs:
       - name: Download artifact changelog of FAF Develop
         # No artifact exists when there are no snippets to process
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: changelog-fafdevelop
           path: docs/generated
 
       - name: Download artifact changelog of FAF Beta
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: changelog-fafbeta
           path: docs/generated
@@ -126,7 +126,7 @@ jobs:
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "docs/_site/"
 
@@ -149,4 +149,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs-convert-changelog.yaml
+++ b/.github/workflows/docs-convert-changelog.yaml
@@ -41,7 +41,7 @@ jobs:
           echo "SCRIPTS=.github/workflows/scripts/python" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ssh-key: ${{ secrets.SSH_FAFOREVER_MACHINE_USER }}
           ref: ${{ inputs.branch }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Download develop changelog
         if: inputs.additional-changelog == 'fafdevelop'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: changelog-fafdevelop
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Download beta changelog
         if: inputs.additional-changelog == 'fafbeta'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: changelog-fafbeta
 
@@ -78,7 +78,7 @@ jobs:
           cat changelog-fafbeta.md >> $FILE
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.8'
 
@@ -99,7 +99,7 @@ jobs:
           python3 $SCRIPTS/changelog_overview.py "docs/_posts" "${out_dir}/overview.lua"
 
       - name: Add the Lua changelog as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lua_changelog
           path: |
@@ -116,13 +116,13 @@ jobs:
           apk add bash git findutils
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             tests/run-syntax-test.sh
 
       - name: Download the Lua changelog artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: lua_changelog
 

--- a/.github/workflows/docs-generate-changelog.yaml
+++ b/.github/workflows/docs-generate-changelog.yaml
@@ -50,14 +50,14 @@ jobs:
       # We check out the scripts separate because the branch that we use to
       # generate the changelog may not contain the scripts that we want to work with.
       - name: Checkout scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: scripts
           sparse-checkout: |
             .github/workflows/scripts/bash
 
       - name: Checkout snippets
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # We need to check out the fork repo when the PR branch is on a fork.
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
@@ -90,7 +90,7 @@ jobs:
           changelog-combine.sh "$NAME"
 
       - name: Add the changelog as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.NAME }}
           path: |

--- a/.github/workflows/docs-spelling-check.yaml
+++ b/.github/workflows/docs-spelling-check.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             docs

--- a/.github/workflows/docs-synchronize-changelog.yaml
+++ b/.github/workflows/docs-synchronize-changelog.yaml
@@ -54,7 +54,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ssh-key: ${{ secrets.SSH_FAFOREVER_MACHINE_USER }}
           ref: ${{ inputs.branch || github.head_ref || github.ref_name }}
@@ -63,7 +63,7 @@ jobs:
         run: rm -f lua/ui/lobby/changelog/generated/*
 
       - name: Retrieve generated lua changelog
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: lua_changelog
           path: lua/ui/lobby/changelog/generated

--- a/.github/workflows/docs-url-check.yaml
+++ b/.github/workflows/docs-url-check.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             docs

--- a/.github/workflows/etfreeman-db-update.yaml
+++ b/.github/workflows/etfreeman-db-update.yaml
@@ -40,7 +40,7 @@ jobs:
     steps:
       # https://github.com/actions/checkout/tree/v4/
       - name: Checkout etfreeman-db code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: FAForever/etfreeman-db
           path: gh-pages
@@ -49,7 +49,7 @@ jobs:
 
       # https://github.com/actions/download-artifact/tree/v4/
       - name: Download recent build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: etfreeman-db-dist
           path: dist

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -49,7 +49,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout FA repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ssh-key: ${{ secrets.SSH_FAFOREVER_MACHINE_USER }}
           ref: staging/faf
@@ -84,7 +84,7 @@ jobs:
           git commit -m "Bump game version to ${{ steps.version.outputs.version }}"
 
       - name: Download changelog artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: changelog-faf
           path: changelog/snippets
@@ -125,7 +125,7 @@ jobs:
         # The push also triggers docs-synchronize-changelog.yaml
 
       - name: Create Pull Request
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const version = "${{ steps.version.outputs.version }}";

--- a/.github/workflows/spookydb-update.yaml
+++ b/.github/workflows/spookydb-update.yaml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # https://github.com/actions/checkout/tree/v4/
       - name: Checkout spooky db code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
             repository: FAForever/spooky-db
             path: gh-pages
@@ -45,7 +45,7 @@ jobs:
     
       # https://github.com/actions/download-artifact/tree/v4/
       - name: Download recent unit information
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
             name: spookydb-dist
             path: dist

--- a/.github/workflows/stage-fafbeta.yaml
+++ b/.github/workflows/stage-fafbeta.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
       # https://github.com/actions/checkout/tree/v4/
       - name: Checkout FA repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ssh-key: ${{ secrets.SSH_FAFOREVER_MACHINE_USER }}
           repository: FAForever/fa

--- a/.github/workflows/stage-fafdevelop.yaml
+++ b/.github/workflows/stage-fafdevelop.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
       # https://github.com/actions/checkout/tree/v4/
       - name: Checkout FA repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ssh-key: ${{ secrets.SSH_FAFOREVER_MACHINE_USER }}
           repository: FAForever/fa

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Install tooling
         run: apk add bash git findutils
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
@@ -70,7 +70,7 @@ jobs:
       - name: Install tooling
         run: apk add bash git findutils
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |
@@ -88,7 +88,7 @@ jobs:
       - name: Install tooling
         run: apk add bash git findutils
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: |

--- a/.github/workflows/wiki-generate-blueprints.yaml
+++ b/.github/workflows/wiki-generate-blueprints.yaml
@@ -34,14 +34,14 @@ jobs:
       steps:
         # Checkout repos, FA repo is sparse checkout as it is quite large
         - name: Checkout Brewlan Wikigen Repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@v7
           with:
             repository: The-Balthazar/BrewWikiGen
             path: ./brew-wiki-gen
 
         # FA repo is sparse checkout as it is quite large and we dont won't to incur higher action minutes for no reason
         - name: Checkout FAF Repository # -png folder doesnt exist yet, confirm location.
-          uses: actions/checkout@v4
+          uses: actions/checkout@v7
           with:
             path: ./fa
             sparse-checkout-cone-mode: |
@@ -56,13 +56,13 @@ jobs:
               projectiles
 
         - name: Checkout FAF Wiki Repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@v7
           with:
             repository: FAForever/fa.wiki
             path: ./fa.wiki
 
         - name: Install Lua 5.4
-          uses: leafo/gh-actions-lua@v10
+          uses: leafo/gh-actions-lua@v13
           with:
             luaVersion: "5.4"
 
@@ -76,7 +76,7 @@ jobs:
 
   
         - name: Upload as artifact
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
             name: Wiki
             path: fa.wiki

--- a/.github/workflows/wiki-generate-changelogs.yaml
+++ b/.github/workflows/wiki-generate-changelogs.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           sparse-checkout: |
             changelog/snippets
@@ -44,14 +44,14 @@ jobs:
     needs: [verify]
     steps:
       - name: Checkout FA repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: fa
           sparse-checkout: |
             changelog
 
       - name: Checkout FA Wiki repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: faforever/fa.wiki
           path: fa.wiki

--- a/.github/workflows/wiki-generate-icons.yaml
+++ b/.github/workflows/wiki-generate-icons.yaml
@@ -35,7 +35,7 @@ jobs:
       steps:
         # https://github.com/actions/checkout/tree/v4/
         - name: Checkout FAF Repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@v7
           with:
             repository: FAForever/fa
             ref: deploy/faf
@@ -60,14 +60,14 @@ jobs:
 
         # https://github.com/actions/upload-artifact/tree/v4/
         - name: Upload unit icons
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
             name: fa-unit-icons
             path: wiki/generated/units
 
         # https://github.com/actions/upload-artifact/tree/v4/
         - name: Upload strategic icons
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
             name: fa-strategic-icons
             path: wiki/generated/strategicicons


### PR DESCRIPTION
## Description of the proposed changes

Update remaining workflow actions. Recently the syntax-check workflow started to fail, see also:

- https://github.com/FAForever/fa/actions/runs/27857901153

Fixed with:

- eef2e5bdbe5aa9de1492415437f878a543648e08
- e35bc09f14ddb6cfd9f2926a754a39cebbf1fc4b

Then we ran into this:

- 301c1e326314d3aec4065b942529f7ee646f600e

## Testing done on the proposed changes

Unfortunately it is not really possible to test workflows locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions across all CI/CD workflows to latest stable versions, including checkout utilities, artifact management, environment setup, and deployment tools, for improved security and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->