### PR TITLE
Add FindClient and CreateChatEdit deprecated chat api endpoints

### DIFF
--- a/changelog/snippets/features.7098.md
+++ b/changelog/snippets/features.7098.md
@@ -1,4 +1,4 @@
-- (#7098) Rework the chat window
+- (#7098, #7148) Rework the chat window
 
 The chat window is re-implemented from scratch. It is rebuilt using the MVC-principle, creating a clear separation between state, viewing the state and interacting with the state. This rework fixes a few bugs:
 

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -23,7 +23,7 @@ local LazyVarDerive = import("/lua/lazyvar.lua").Derive
 -- log doesn't drown when a mod is busy hammering a deprecated entry point.
 local _warned = {}
 local function _deprecate(name, replacement)
-    -- if _warned[name] then return end
+    if _warned[name] then return end
     _warned[name] = true
     WARN(string.format(
         "chat.lua %s is deprecated — use %s instead",

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -165,6 +165,10 @@ local function _stateProxy(name)
         __newindex = function(_, k, _)
             _deprecate(name .. '.' .. tostring(k) .. ' (assignment)', 'the new chat MVC view tree')
         end,
+        __call = function(self)
+            _deprecate(name .. ' (function call)', 'the new chat MVC view tree')
+            return self
+        end,
     })
 end
 

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -23,7 +23,7 @@ local LazyVarDerive = import("/lua/lazyvar.lua").Derive
 -- log doesn't drown when a mod is busy hammering a deprecated entry point.
 local _warned = {}
 local function _deprecate(name, replacement)
-    if _warned[name] then return end
+    -- if _warned[name] then return end
     _warned[name] = true
     WARN(string.format(
         "chat.lua %s is deprecated — use %s instead",

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -158,9 +158,9 @@ end
 
 local function _stateProxy(name)
     return setmetatable({}, {
-        __index = function(_, k)
+        __index = function(self, k)
             _deprecate(name .. '.' .. tostring(k), 'the new chat MVC view tree')
-            return nil
+            return self
         end,
         __newindex = function(_, k, _)
             _deprecate(name .. '.' .. tostring(k) .. ' (assignment)', 'the new chat MVC view tree')

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -143,20 +143,22 @@ function GetArmyData(army)
 end
 
 -------------------------------------------------------------------------------
--- Deprecated state tables
+-- Deprecated legacy API proxies
 --
--- The legacy file exposed `GUI` and `ChatLines` as live tables of MAUI
--- handles. There's no clean way to recreate that against the MVC tree —
--- the new view doesn't pin its controls to a globally-addressable
--- structure. Mods that read these tables directly were always coupled to
--- internals that could move.
+-- The legacy file exposed `GUI`, `ChatLines`, and `CreateChatEdit` as
+-- legacy chat API entry points. There's no clean way to recreate those
+-- against the MVC tree — the new view doesn't pin its controls to a
+-- globally-addressable structure. Mods that read or call these entries
+-- directly were always coupled to internals that could move.
 --
 -- We expose empty tables proxied through metatables so any access logs
--- a deprecation warning and returns nil. Existing `chat.GUI.bg` reads
--- still terminate eventually (with a clear log line) instead of pretending
--- the field exists.
+-- a deprecation warning and returns the proxy table. This preserves
+-- legacy reads and chained accesses without pretending the field exists.
+-- Function-style calls also log a deprecation warning and return the
+-- proxy, allowing old APIs to fail gracefully while steering mods toward
+-- the new chat MVC view tree.
 
-local function _stateProxy(name)
+local function _deprecationProxy(name)
     return setmetatable({}, {
         __index = function(self, k)
             _deprecate(name .. '.' .. tostring(k), 'the new chat MVC view tree')
@@ -172,6 +174,6 @@ local function _stateProxy(name)
     })
 end
 
-GUI = _stateProxy('GUI')
-ChatLines = _stateProxy('ChatLines')
-CreateChatEdit = _stateProxy('CreateChatEdit')
+GUI = _deprecationProxy('GUI')
+ChatLines = _deprecationProxy('ChatLines')
+CreateChatEdit = _deprecationProxy('CreateChatEdit')

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -93,6 +93,12 @@ function CloseChat()
     ChatController.CloseWindow()
 end
 
+---@deprecated use [ChatController.FindClients](chat/ChatController.lua) instead
+function FindClients(id)
+    _deprecate('FindClients', 'ChatController.FindClients')
+    return ChatController.FindClients(id)
+end
+
 --- @deprecated subscribe to [ChatConfigModel.GetSingleton().Committed](chat/config/ChatConfigModel.lua) via `LazyVarDerive` instead. Best-effort shim — fires the callback once with the current options so legacy callers see a value, then wires a one-way derived observer so subsequent changes propagate. Mods should migrate to a real `LazyVarDerive` they can destroy on teardown.
 function AddChatOptionSetCallback(callback, _)
     _deprecate('AddChatOptionSetCallback', 'LazyVarDerive(ChatConfigModel.GetSingleton().Committed, ...)')

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -174,3 +174,4 @@ end
 
 GUI = _stateProxy('GUI')
 ChatLines = _stateProxy('ChatLines')
+CreateChatEdit = _stateProxy('CreateChatEdit')


### PR DESCRIPTION
## Description of the proposed changes
`chat.lua`'s `FindClients` is used by scoreboard mods and `CreateChatEdit` is used by chat mods (ecomanager and swarm survival vanilla). If they are not present the game UI errors to a black screen.

`FindClients` is forwarded to the chat controller's FindClients function with a deprecation warning like other functions.

`CreateChatEdit` is used to modify the chat editing control, so it needed a state proxy.

I also improved the state proxy into a general purpose proxy that handles any of the usual nested table accesses or function calls applied to objects.

## Testing done on the proposed changes
Supreme score board no longer errors out the UI when used.

Ecomanager no longer errors out the UI when used (it has a `local oldCreateChatEdit = CreateChatEdit` line that errors previously).

Commands like `import('/lua/ui/game/chat.lua').GUI.bg.fn()` work without erroring.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog entries to reflect additional chat-related improvements
* **Chores**
  * Implemented deprecation warnings for legacy chat features to facilitate migration to current implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->