### PR TITLE
Add a default `Share` option for single player launch

### DIFF
--- a/changelog/snippets/fix.7149.md
+++ b/changelog/snippets/fix.7149.md
@@ -1,0 +1,1 @@
+- (#7149) Fix missing share condition default causing a score board UI loading error when the game was launched using the single player command line launch option.

--- a/lua/SinglePlayerLaunch.lua
+++ b/lua/SinglePlayerLaunch.lua
@@ -168,7 +168,8 @@ local defaultOptions = {
     Victory = 'sandbox',
     CheatsEnabled = 'true',
     CivilianAlliance = 'enemy',
-    TeamShareOverflow = "enabled",
+    TeamShareOverflow = 'enabled',
+    Share = 'ShareUntilDeath',
 }
 
 --- Gets the game options with changes from the command line args:


### PR DESCRIPTION
## Description of the proposed changes
The score board was causing a UI loading error when `Share` was missing from the session info Options table. This was caused by the single player command-line launch (initiated with the `/map <filepath>` cmd line arg) not having any Share option in the defaults.

## Testing done on the proposed changes
Disable UI mods. Score board no longer errors UI when the game is launched with singleplayer cmd line launch.

## Additional context
The sim works because it enforces a Share option on sim init cross-referenced with the lobby options file, and defaults to `ShareUntilDeath` if nothing matched. The UI userinit does not enforce this.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a scoreboard UI loading error that occurred when launching the game via the single player command line option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->