### PR TITLE
Add delay before disconnected army's ACUs are killed

### DIFF
--- a/changelog/snippets/fix.7153.md
+++ b/changelog/snippets/fix.7153.md
@@ -1,1 +1,1 @@
-- (#7153) Add a delay before ACUs explode when their player disconnects. This should fix replays cuttting off at the first disconnected player.
+- (#7153) Add a delay before ACUs explode when their player disconnects. This should fix replays cutting off at the first disconnected player.

--- a/changelog/snippets/fix.7153.md
+++ b/changelog/snippets/fix.7153.md
@@ -1,0 +1,1 @@
+- (#7153) Add a delay before ACUs explode when their player disconnects. This should fix replays cuttting off at the first disconnected player.

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -994,6 +994,13 @@ end
 -- would have blown up.
 EndGameGracePeriod = 10
 
+-- Seconds to wait after an army has been abandoned (the player disconnected)
+-- before processing its units. This gives a small opportunity to avoid the ACU
+-- explosion, and prevents disconnecting players from providing the server with
+-- a cut-off replay due to the sim on their client instantly killing all other ACUs
+-- and reporting a game over state.
+AbandonedArmyGracePeriod = 3
+
 -- Set to true in `AbstractVictoryCondition.EndGame` to prevent killing units after a
 -- team is victorious but before the sim is stopped.
 GameIsEnding = false
@@ -1345,8 +1352,8 @@ function KillAbandonedArmy(self, shareOption, shareAcuOption, victoryOption)
         shareOption = ScenarioInfo.Options.Share
     end
 
-    -- Don't apply instant-effect disconnect rules for players/ACUs that might be defeated soon,
-    -- and might have intentionally disconnected.
+    WaitSeconds(AbandonedArmyGracePeriod)
+
     if shareAcuOption == 'Explode' or shareAcuOption == 'Recall' then
         local safeCommanders
         local commanders = self:GetListOfUnits(categories.COMMAND, false)

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -1021,7 +1021,7 @@ local function KillUnits(toKill)
     end
 end
 
---- Kills all given units after a delay, if not already dead.
+--- Asynchronously kills all given units after a delay, if not already dead.
 ---@param toKill Entity[]
 ---@param delaySec number
 local function DelayedKillUnits(toKill, delaySec)

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -992,6 +992,8 @@ end
 -- shortly thereafter due to the army being defeated (as is common), we then
 -- have an opportunity to see the final game state as observers before everything
 -- would have blown up.
+--
+-- This should be longer than `AbandonedArmyGracePeriod`
 EndGameGracePeriod = 10
 
 -- Seconds to wait after an army has been abandoned (the player disconnected)
@@ -999,6 +1001,8 @@ EndGameGracePeriod = 10
 -- explosion, and prevents disconnecting players from providing the server with
 -- a cut-off replay due to the sim on their client instantly killing all other ACUs
 -- and reporting a game over state.
+--
+-- This should be shorter than `EndGameGracePeriod`
 AbandonedArmyGracePeriod = 3
 
 -- Set to true in `AbstractVictoryCondition.EndGame` to prevent killing units after a
@@ -1015,6 +1019,16 @@ local function KillUnits(toKill)
             end
         end
     end
+end
+
+--- Kills all given units after a delay, if not already dead.
+---@param toKill Entity[]
+---@param delaySec number
+local function DelayedKillUnits(toKill, delaySec)
+    ForkThread(function ()
+        WaitSeconds(delaySec)
+        KillUnits(toKill)
+    end)
 end
 
 ---@param self AIBrain
@@ -1258,13 +1272,17 @@ MinimumShareTime = 5 * 60 * 10 -- 5 minutes
 function KillUnsafeCommanders(commanders, tick)
     tick = tick or GetGameTick()
     local safeCommanders = {}
+    local unsafeCommanders = {}
     for _, com in commanders do
         if com.LastTickDamaged and com.LastTickDamaged + CommanderSafeTime > tick then
-            com:Kill()
+            table.insert(unsafeCommanders, com)
         else
             table.insert(safeCommanders, com)
         end
     end
+
+    DelayedKillUnits(unsafeCommanders, AbandonedArmyGracePeriod)
+
     return safeCommanders
 end
 
@@ -1312,8 +1330,7 @@ function KillArmyOnDelayedRecall(self, shareOption, shareTime)
             local safeCommanders = KillUnsafeCommanders(sharedCommanders)
 
             if not table.empty(safeCommanders) then
-                -- note: this adds 3 seconds to the grace period
-                FakeTeleportUnits(safeCommanders, true)
+                ForkThread(FakeTeleportUnits, safeCommanders, true)
             end
         end
     end
@@ -1352,8 +1369,6 @@ function KillAbandonedArmy(self, shareOption, shareAcuOption, victoryOption)
         shareOption = ScenarioInfo.Options.Share
     end
 
-    WaitSeconds(AbandonedArmyGracePeriod)
-
     if shareAcuOption == 'Explode' or shareAcuOption == 'Recall' then
         local safeCommanders
         local commanders = self:GetListOfUnits(categories.COMMAND, false)
@@ -1361,7 +1376,7 @@ function KillAbandonedArmy(self, shareOption, shareAcuOption, victoryOption)
             safeCommanders = KillUnsafeCommanders(commanders)
         else
             -- explode all the ACUs so they don't get shared
-            KillUnits(commanders)
+            DelayedKillUnits(commanders, AbandonedArmyGracePeriod)
         end
 
         -- Only handle Assassination victory, as in other settings the player is unlikely to be defeated soon
@@ -1371,8 +1386,7 @@ function KillAbandonedArmy(self, shareOption, shareAcuOption, victoryOption)
 
         -- non-assassination modes can have armies abandon without commanders
         if shareAcuOption == 'Recall' and not table.empty(safeCommanders) then
-            -- note: this adds 3 seconds to the grace period
-            FakeTeleportUnits(safeCommanders, true)
+            ForkThread(FakeTeleportUnits, safeCommanders, true)
         end
 
         KillArmy(self, shareOption)


### PR DESCRIPTION
## Description of the proposed changes
- Adds a delay when an army is abandoned before the ACU is killed.

  Should fix online replays being cut off at the point where someone disconnected due to the disconnected player reporting a game over state.

  The way a game over state is reported is that when a player disconnects from the game, their instance of the game thinks everyone else disconnected, so it runs the abandonment code for all other players. Without a delay, this causes all ACUs to explode and the sim to tell the UI to report a game over state. It's a bit unintuitive that the sim runs and gets time to report an end state while exiting the game, but that is how SessionEndGame() works (it pauses the game and pauses are a request to the sim that happen on a small delay of sim beats).

- Move all extra delays to threads so that EndGameGracePeriod in KillArmy is a consistent delay players can rely on.

## Testing done on the proposed changes
ACUs no longer explode before exiting when testing multiplayer. I don't have a good way to test the replays because I don't understand how they're saved on the server (I looked a little at the parser and server but didn't dig into it and figure stuff out) and my idea above is just a hypothesis.


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a grace period delay before unsafe ACUs/commanders are destroyed when a player disconnects, reducing replay cutoffs triggered by the first disconnected player.
  * Improved disconnect-related ACU share handling so commander “safe teleport/recall” actions occur asynchronously, aligning timing with the new delayed destruction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->