### PR TITLE
Annotate `SetNavigatorPersonalPosMaxDistance` and check it exists before calling it

### DIFF
--- a/changelog/snippets/other.7155.md
+++ b/changelog/snippets/other.7155.md
@@ -1,0 +1,1 @@
+- (#7155) Annotate `SetNavigatorPersonalPosMaxDistance` and check it exists before calling it.

--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -1195,8 +1195,8 @@ function SetIgnorePlayableRect(army, ignore)
 end
 
 --- Changes the distance at which the default navigator switches to a lower resolution
---- pathfinding grid, typically resulting in units moving in columns over large distances
---- instead of maintaining their formation.
+--- pathfinding grid (from "personal" per-unit waypoints to waypoints shared by many units),
+--- typically resulting in units moving in columns over large distances instead of maintaining their formation.
 ---
 --- Default engine value is 50.
 ---

--- a/engine/Sim.lua
+++ b/engine/Sim.lua
@@ -1194,6 +1194,19 @@ end
 function SetIgnorePlayableRect(army, ignore)
 end
 
+--- Changes the distance at which the default navigator switches to a lower resolution
+--- pathfinding grid, typically resulting in units moving in columns over large distances
+--- instead of maintaining their formation.
+---
+--- Default engine value is 50.
+---
+--- Useful console commands for debugging: "dbg navwaypoints", "dbg navpath", "dbg navsteering"
+---
+--- Introduced by https://github.com/FAForever/FA-Binary-Patches/pull/132
+---@param distance number
+function SetNavigatorPersonalPosMaxDistance(distance)
+end
+
 --- sets the playable area of a map
 ---@param minX number
 ---@param minZ number

--- a/lua/simInit.lua
+++ b/lua/simInit.lua
@@ -586,7 +586,9 @@ end
 -- will be using personal positioning instead of waypoints for any move order (doesn't affect "formation move").
 -- useful console commands for debugging: "dbg navwaypoints", "dbg navpath", "dbg navsteering"
 function SetupPathfinding()
-    SetNavigatorPersonalPosMaxDistance(9999)
+    if rawget(_G, "SetNavigatorPersonalPosMaxDistance") then
+        SetNavigatorPersonalPosMaxDistance(9999)
+    end
 end
 
 -- these imports break cycle dependencies of import sequences of mods


### PR DESCRIPTION
## Description of the proposed changes
Adds annotation to fix undefined global warning.
Check it exists before calling it because its resulting in an error in the current lua deployment because exe isn't automatically deployed with it.

## Testing done on the proposed changes
no intellisense warning are given anymore

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new debug/console API to adjust the navigator’s personal-position distance threshold.
  * Documented the new setting, including its default value and related commands.

* **Bug Fixes**
  * Updated pathfinding initialization to only apply the threshold when the new navigator setting is available, avoiding failures in environments where it isn’t present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->