### PR TITLE
Add CreateChat proxy

### DIFF
--- a/changelog/snippets/features.7098.md
+++ b/changelog/snippets/features.7098.md
@@ -1,4 +1,4 @@
-- (#7098, #7148) Rework the chat window
+- (#7098, #7148, #7157) Rework the chat window
 
 The chat window is re-implemented from scratch. It is rebuilt using the MVC-principle, creating a clear separation between state, viewing the state and interacting with the state. This rework fixes a few bugs:
 

--- a/lua/ui/game/chat.lua
+++ b/lua/ui/game/chat.lua
@@ -177,3 +177,4 @@ end
 GUI = _deprecationProxy('GUI')
 ChatLines = _deprecationProxy('ChatLines')
 CreateChatEdit = _deprecationProxy('CreateChatEdit')
+CreateChat = _deprecationProxy('CreateChat')


### PR DESCRIPTION
## Description of the proposed changes
KnownSniper aka farmsletje had a custom mod that hooked CreateChat, so a proxy is added to prevent it from crashing UI loading.
```
info: Hooked /lua/ui/game/chat.lua with /mods/gloves/hook/lua/ui/game/chat.lua
warning: ...data\faforever\gamedata\lua.nx5\lua\ui\game\chat.lua(201): access to nonexistent global variable "CreateChat"
```

## Testing done on the proposed changes
I can't test this as I do not have the mod.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat has been reworked with improved window behavior and layout.
  * Added chat commands, extensible command support, `@`-name autocomplete, simulation-friendly messaging, and click-to-copy.
  * Chat now opens from the bottom up for a smoother experience.

* **Bug Fixes**
  * Fixed UI scaling and snap-to-frame issues in the chat window.

* **Chores**
  * Updated the changelog entry and preserved compatibility for older chat integrations with a deprecation notice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->