### PR TITLE
Revert "Clean up the `BuildOnLayerCaps` fields"

### DIFF
--- a/changelog/snippets/fix.7159.md
+++ b/changelog/snippets/fix.7159.md
@@ -1,0 +1,1 @@
+- (#7159) Fix mods that allow building units on water causing those units to not be buildable on land due to how the expected default of a missing `BuildOnLayerCaps` table interacts with blueprint merge.

--- a/changelog/snippets/sections/graphics.7095.md
+++ b/changelog/snippets/sections/graphics.7095.md
@@ -1,1 +1,0 @@
-- (#7095) Fix the icon of the Aeon T1 power generator.

--- a/units/DRLK005/DRLK005_unit.bp
+++ b/units/DRLK005/DRLK005_unit.bp
@@ -72,6 +72,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         AlwaysAlignToTerrain = true,
         MotionType = "RULEUMT_None",

--- a/units/UAB0101/UAB0101_unit.bp
+++ b/units/UAB0101/UAB0101_unit.bp
@@ -147,6 +147,7 @@ UnitBlueprint{
     LifeBarOffset = 1.9,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = { LAYER_Land = true },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UAB0102/UAB0102_unit.bp
+++ b/units/UAB0102/UAB0102_unit.bp
@@ -140,6 +140,14 @@ UnitBlueprint{
     LifeBarOffset = 1.55,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UAB0103/UAB0103_unit.bp
+++ b/units/UAB0103/UAB0103_unit.bp
@@ -131,7 +131,14 @@ UnitBlueprint{
     LifeBarOffset = 6.5,
     LifeBarSize = 4,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MeshExtentsX = 5,

--- a/units/UAB0201/UAB0201_unit.bp
+++ b/units/UAB0201/UAB0201_unit.bp
@@ -140,6 +140,7 @@ UnitBlueprint{
     LifeBarOffset = 1.95,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = { LAYER_Land = true },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UAB0202/UAB0202_unit.bp
+++ b/units/UAB0202/UAB0202_unit.bp
@@ -140,6 +140,14 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UAB0203/UAB0203_unit.bp
+++ b/units/UAB0203/UAB0203_unit.bp
@@ -136,7 +136,14 @@ UnitBlueprint{
     LifeBarOffset = 6.5,
     LifeBarSize = 4.5,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MeshExtentsX = 5,

--- a/units/UAB0301/UAB0301_unit.bp
+++ b/units/UAB0301/UAB0301_unit.bp
@@ -138,6 +138,7 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = { LAYER_Land = true },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UAB0302/UAB0302_unit.bp
+++ b/units/UAB0302/UAB0302_unit.bp
@@ -140,6 +140,14 @@ UnitBlueprint{
     LifeBarOffset = 2.1,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UAB0303/UAB0303_unit.bp
+++ b/units/UAB0303/UAB0303_unit.bp
@@ -135,7 +135,14 @@ UnitBlueprint{
     LifeBarOffset = 6.7,
     LifeBarSize = 4.75,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MeshExtentsX = 5,

--- a/units/UAB0304/UAB0304_unit.bp
+++ b/units/UAB0304/UAB0304_unit.bp
@@ -128,6 +128,14 @@ UnitBlueprint{
     LifeBarOffset = 2.65,
     LifeBarSize = 5.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 7.5,

--- a/units/UAB1101/UAB1101_unit.bp
+++ b/units/UAB1101/UAB1101_unit.bp
@@ -88,6 +88,14 @@ UnitBlueprint{
     LifeBarOffset = 0.35,
     LifeBarSize = 0.9,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1,

--- a/units/UAB1102/UAB1102_unit.bp
+++ b/units/UAB1102/UAB1102_unit.bp
@@ -87,8 +87,12 @@ UnitBlueprint{
     LifeBarSize = 3,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnHydrocarbonDeposit",
         DragCoefficient = 0.2,

--- a/units/UAB1103/UAB1103_unit.bp
+++ b/units/UAB1103/UAB1103_unit.bp
@@ -94,8 +94,12 @@ UnitBlueprint{
     Physics = {
         AlwaysAlignToTerrain = true,
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnMassDeposit",
         DragCoefficient = 0.2,

--- a/units/UAB1104/UAB1104_unit.bp
+++ b/units/UAB1104/UAB1104_unit.bp
@@ -88,6 +88,14 @@ UnitBlueprint{
     LifeBarOffset = 0.3,
     LifeBarSize = 0.9,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1,

--- a/units/UAB1105/UAB1105_unit.bp
+++ b/units/UAB1105/UAB1105_unit.bp
@@ -92,6 +92,14 @@ UnitBlueprint{
     LifeBarOffset = 0.35,
     LifeBarSize = 0.9,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.1,

--- a/units/UAB1106/UAB1106_unit.bp
+++ b/units/UAB1106/UAB1106_unit.bp
@@ -96,8 +96,12 @@ UnitBlueprint{
     LifeBarSize = 0.9,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         DragCoefficient = 0.2,
         FlattenSkirt = true,

--- a/units/UAB1201/UAB1201_unit.bp
+++ b/units/UAB1201/UAB1201_unit.bp
@@ -106,6 +106,14 @@ UnitBlueprint{
     LifeBarOffset = 1,
     LifeBarSize = 3,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 3.5,

--- a/units/UAB1202/UAB1202_unit.bp
+++ b/units/UAB1202/UAB1202_unit.bp
@@ -97,8 +97,12 @@ UnitBlueprint{
     Physics = {
         AlwaysAlignToTerrain = true,
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnMassDeposit",
         DragCoefficient = 0.2,

--- a/units/UAB1301/UAB1301_unit.bp
+++ b/units/UAB1301/UAB1301_unit.bp
@@ -113,6 +113,14 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UAB1302/UAB1302_unit.bp
+++ b/units/UAB1302/UAB1302_unit.bp
@@ -87,8 +87,12 @@ UnitBlueprint{
     Physics = {
         AlwaysAlignToTerrain = true,
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnMassDeposit",
         DragCoefficient = 0.2,

--- a/units/UAB1303/UAB1303_unit.bp
+++ b/units/UAB1303/UAB1303_unit.bp
@@ -97,6 +97,14 @@ UnitBlueprint{
     LifeBarOffset = 0.95,
     LifeBarSize = 2.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UAB2101/UAB2101_unit.bp
+++ b/units/UAB2101/UAB2101_unit.bp
@@ -79,6 +79,14 @@ UnitBlueprint{
     LifeBarSize = 0.9,
     Physics = {
         AlwaysAlignToTerrain = true,
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MeshExtentsX = 1,
         MeshExtentsY = 1.1,

--- a/units/UAB2104/UAB2104_unit.bp
+++ b/units/UAB2104/UAB2104_unit.bp
@@ -97,7 +97,11 @@ UnitBlueprint{
     LifeBarSize = 0.9,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/UAB2108/UAB2108_unit.bp
+++ b/units/UAB2108/UAB2108_unit.bp
@@ -111,6 +111,14 @@ UnitBlueprint{
     LifeBarOffset = 0.45,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         HorizontalSkirt = true,

--- a/units/UAB2109/UAB2109_unit.bp
+++ b/units/UAB2109/UAB2109_unit.bp
@@ -101,7 +101,14 @@ UnitBlueprint{
     LifeBarOffset = 0.35,
     LifeBarSize = 0.9,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         MeshExtentsX = 1,
         MeshExtentsY = 0.75,

--- a/units/UAB2204/UAB2204_unit.bp
+++ b/units/UAB2204/UAB2204_unit.bp
@@ -103,7 +103,11 @@ UnitBlueprint{
     LifeBarSize = 1,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/UAB2205/UAB2205_unit.bp
+++ b/units/UAB2205/UAB2205_unit.bp
@@ -115,7 +115,14 @@ UnitBlueprint{
     LifeBarOffset = 0.6,
     LifeBarSize = 1.25,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.75,

--- a/units/UAB2301/UAB2301_unit.bp
+++ b/units/UAB2301/UAB2301_unit.bp
@@ -91,6 +91,14 @@ UnitBlueprint{
     LifeBarOffset = 0.6,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.75,

--- a/units/UAB2302/UAB2302_unit.bp
+++ b/units/UAB2302/UAB2302_unit.bp
@@ -97,6 +97,14 @@ UnitBlueprint{
     LifeBarOffset = 2.35,
     LifeBarSize = 5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UAB2303/UAB2303_unit.bp
+++ b/units/UAB2303/UAB2303_unit.bp
@@ -90,6 +90,14 @@ UnitBlueprint{
     LifeBarOffset = 0.8,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.75,

--- a/units/UAB2304/UAB2304_unit.bp
+++ b/units/UAB2304/UAB2304_unit.bp
@@ -91,7 +91,11 @@ UnitBlueprint{
     LifeBarSize = 1,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/UAB2305/UAB2305_unit.bp
+++ b/units/UAB2305/UAB2305_unit.bp
@@ -109,6 +109,14 @@ UnitBlueprint{
     LifeBarOffset = 1.25,
     LifeBarSize = 2.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         HorizontalSkirt = true,

--- a/units/UAB3101/UAB3101_unit.bp
+++ b/units/UAB3101/UAB3101_unit.bp
@@ -126,6 +126,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.25,

--- a/units/UAB3102/UAB3102_unit.bp
+++ b/units/UAB3102/UAB3102_unit.bp
@@ -113,7 +113,14 @@ UnitBlueprint{
     LifeBarOffset = 0.3,
     LifeBarSize = 0.75,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         MeshExtentsX = 1,
         MeshExtentsY = 0.65,

--- a/units/UAB3104/UAB3104_unit.bp
+++ b/units/UAB3104/UAB3104_unit.bp
@@ -123,6 +123,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.5,

--- a/units/UAB3201/UAB3201_unit.bp
+++ b/units/UAB3201/UAB3201_unit.bp
@@ -132,6 +132,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1.1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.5,

--- a/units/UAB3202/UAB3202_unit.bp
+++ b/units/UAB3202/UAB3202_unit.bp
@@ -112,7 +112,14 @@ UnitBlueprint{
     LifeBarOffset = 0.4,
     LifeBarSize = 1,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         MeshExtentsX = 1.5,
         MeshExtentsY = 1,

--- a/units/UAB4201/UAB4201_unit.bp
+++ b/units/UAB4201/UAB4201_unit.bp
@@ -99,7 +99,11 @@ UnitBlueprint{
     LifeBarSize = 0.9,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/UAB4202/UAB4202_unit.bp
+++ b/units/UAB4202/UAB4202_unit.bp
@@ -136,6 +136,14 @@ UnitBlueprint{
     LifeBarOffset = 0.9,
     LifeBarSize = 2.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UAB4203/UAB4203_unit.bp
+++ b/units/UAB4203/UAB4203_unit.bp
@@ -104,6 +104,14 @@ UnitBlueprint{
     LifeBarOffset = 1.2,
     LifeBarSize = 2.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 3,

--- a/units/UAB4301/UAB4301_unit.bp
+++ b/units/UAB4301/UAB4301_unit.bp
@@ -121,6 +121,14 @@ UnitBlueprint{
     LifeBarOffset = 0.9,
     LifeBarSize = 3,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UAB4302/UAB4302_unit.bp
+++ b/units/UAB4302/UAB4302_unit.bp
@@ -99,6 +99,14 @@ UnitBlueprint{
     LifeBarOffset = 0.8,
     LifeBarSize = 1.75,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 2,

--- a/units/UAB5101/UAB5101_unit.bp
+++ b/units/UAB5101/UAB5101_unit.bp
@@ -69,6 +69,14 @@ UnitBlueprint{
     LifeBarSize = 0.8,
     Physics = {
         AlwaysAlignToTerrain = true,
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MaxGroundVariation = 50,
         MeshExtentsX = 1.5,

--- a/units/UAB5102/UAB5102_unit.bp
+++ b/units/UAB5102/UAB5102_unit.bp
@@ -45,6 +45,14 @@ UnitBlueprint{
     LifeBarRender = false,
     LifeBarSize = 0,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",
         SkirtOffsetX = 0,

--- a/units/UAB5103/UAB5103_unit.bp
+++ b/units/UAB5103/UAB5103_unit.bp
@@ -50,6 +50,14 @@ UnitBlueprint{
     LifeBarOffset = 1,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",
         SkirtOffsetX = 0,

--- a/units/UAB5202/UAB5202_unit.bp
+++ b/units/UAB5202/UAB5202_unit.bp
@@ -95,6 +95,14 @@ UnitBlueprint{
     LifeBarOffset = 1.15,
     LifeBarSize = 2.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 3,

--- a/units/UAB5204/UAB5204_unit.bp
+++ b/units/UAB5204/UAB5204_unit.bp
@@ -43,6 +43,14 @@ UnitBlueprint{
     Intel = { VisionRadius = 0 },
     LifeBarHeight = 0.075,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/UEB0101/UEB0101_unit.bp
+++ b/units/UEB0101/UEB0101_unit.bp
@@ -134,6 +134,14 @@ UnitBlueprint{
     LifeBarOffset = 2.5,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UEB0102/UEB0102_unit.bp
+++ b/units/UEB0102/UEB0102_unit.bp
@@ -135,6 +135,14 @@ UnitBlueprint{
     LifeBarOffset = 1.65,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UEB0103/UEB0103_unit.bp
+++ b/units/UEB0103/UEB0103_unit.bp
@@ -131,7 +131,14 @@ UnitBlueprint{
     LifeBarOffset = 4.75,
     LifeBarSize = 4,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MeshExtentsX = 6,

--- a/units/UEB0201/UEB0201_unit.bp
+++ b/units/UEB0201/UEB0201_unit.bp
@@ -139,6 +139,14 @@ UnitBlueprint{
     LifeBarOffset = 2.5,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UEB0202/UEB0202_unit.bp
+++ b/units/UEB0202/UEB0202_unit.bp
@@ -140,6 +140,14 @@ UnitBlueprint{
     LifeBarOffset = 1.65,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UEB0203/UEB0203_unit.bp
+++ b/units/UEB0203/UEB0203_unit.bp
@@ -138,7 +138,14 @@ UnitBlueprint{
     LifeBarOffset = 4.75,
     LifeBarSize = 4.5,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",

--- a/units/UEB0301/UEB0301_unit.bp
+++ b/units/UEB0301/UEB0301_unit.bp
@@ -138,6 +138,14 @@ UnitBlueprint{
     LifeBarOffset = 2.5,
     LifeBarSize = 4.75,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UEB0302/UEB0302_unit.bp
+++ b/units/UEB0302/UEB0302_unit.bp
@@ -138,6 +138,14 @@ UnitBlueprint{
     LifeBarOffset = 2.15,
     LifeBarSize = 4.75,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UEB0303/UEB0303_unit.bp
+++ b/units/UEB0303/UEB0303_unit.bp
@@ -136,7 +136,14 @@ UnitBlueprint{
     LifeBarOffset = 4.75,
     LifeBarSize = 4.75,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",

--- a/units/UEB0304/UEB0304_unit.bp
+++ b/units/UEB0304/UEB0304_unit.bp
@@ -118,6 +118,14 @@ UnitBlueprint{
     LifeBarOffset = 2.75,
     LifeBarSize = 5.75,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/UEB1101/UEB1101_unit.bp
+++ b/units/UEB1101/UEB1101_unit.bp
@@ -76,6 +76,14 @@ UnitBlueprint{
     LifeBarOffset = 0.35,
     LifeBarSize = 0.9,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1,

--- a/units/UEB1102/UEB1102_unit.bp
+++ b/units/UEB1102/UEB1102_unit.bp
@@ -87,8 +87,12 @@ UnitBlueprint{
     LifeBarSize = 3,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnHydrocarbonDeposit",
         DragCoefficient = 0.2,

--- a/units/UEB1103/UEB1103_unit.bp
+++ b/units/UEB1103/UEB1103_unit.bp
@@ -97,8 +97,12 @@ UnitBlueprint{
     Physics = {
         AlwaysAlignToTerrain = true,
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnMassDeposit",
         DragCoefficient = 0.2,

--- a/units/UEB1104/UEB1104_unit.bp
+++ b/units/UEB1104/UEB1104_unit.bp
@@ -84,6 +84,14 @@ UnitBlueprint{
     LifeBarOffset = 0.35,
     LifeBarSize = 0.9,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.25,

--- a/units/UEB1105/UEB1105_unit.bp
+++ b/units/UEB1105/UEB1105_unit.bp
@@ -93,6 +93,14 @@ UnitBlueprint{
     LifeBarOffset = 0.45,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.25,

--- a/units/UEB1106/UEB1106_unit.bp
+++ b/units/UEB1106/UEB1106_unit.bp
@@ -98,8 +98,12 @@ UnitBlueprint{
     LifeBarSize = 0.9,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         DragCoefficient = 0.2,
         FlattenSkirt = true,

--- a/units/UEB1201/UEB1201_unit.bp
+++ b/units/UEB1201/UEB1201_unit.bp
@@ -94,6 +94,14 @@ UnitBlueprint{
     LifeBarOffset = 1.1,
     LifeBarSize = 3,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 3.1,

--- a/units/UEB1202/UEB1202_unit.bp
+++ b/units/UEB1202/UEB1202_unit.bp
@@ -99,8 +99,12 @@ UnitBlueprint{
     Physics = {
         AlwaysAlignToTerrain = true,
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnMassDeposit",
         DragCoefficient = 0.2,

--- a/units/UEB1301/UEB1301_unit.bp
+++ b/units/UEB1301/UEB1301_unit.bp
@@ -107,6 +107,14 @@ UnitBlueprint{
     LifeBarOffset = 2.2,
     LifeBarSize = 5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UEB1302/UEB1302_unit.bp
+++ b/units/UEB1302/UEB1302_unit.bp
@@ -88,8 +88,12 @@ UnitBlueprint{
     Physics = {
         AlwaysAlignToTerrain = true,
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnMassDeposit",
         DragCoefficient = 0.2,

--- a/units/UEB1303/UEB1303_unit.bp
+++ b/units/UEB1303/UEB1303_unit.bp
@@ -93,6 +93,14 @@ UnitBlueprint{
     LifeBarOffset = 0.95,
     LifeBarSize = 2.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UEB2101/UEB2101_unit.bp
+++ b/units/UEB2101/UEB2101_unit.bp
@@ -76,6 +76,14 @@ UnitBlueprint{
     LifeBarSize = 0.9,
     Physics = {
         AlwaysAlignToTerrain = true,
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MeshExtentsX = 1.1,
         MeshExtentsY = 1.15,

--- a/units/UEB2104/UEB2104_unit.bp
+++ b/units/UEB2104/UEB2104_unit.bp
@@ -94,7 +94,11 @@ UnitBlueprint{
     LifeBarSize = 0.9,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/UEB2108/UEB2108_unit.bp
+++ b/units/UEB2108/UEB2108_unit.bp
@@ -99,6 +99,14 @@ UnitBlueprint{
     LifeBarOffset = 0.45,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         HorizontalSkirt = true,

--- a/units/UEB2109/UEB2109_unit.bp
+++ b/units/UEB2109/UEB2109_unit.bp
@@ -101,7 +101,14 @@ UnitBlueprint{
     LifeBarOffset = 0.35,
     LifeBarSize = 0.9,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         MeshExtentsOffsetY = -0.5,
         MeshExtentsX = 1.2,

--- a/units/UEB2204/UEB2204_unit.bp
+++ b/units/UEB2204/UEB2204_unit.bp
@@ -104,7 +104,11 @@ UnitBlueprint{
     LifeBarSize = 1,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/UEB2205/UEB2205_unit.bp
+++ b/units/UEB2205/UEB2205_unit.bp
@@ -121,7 +121,14 @@ UnitBlueprint{
     LifeBarOffset = 0.6,
     LifeBarSize = 1.25,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.65,

--- a/units/UEB2301/UEB2301_unit.bp
+++ b/units/UEB2301/UEB2301_unit.bp
@@ -90,6 +90,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.5,

--- a/units/UEB2302/UEB2302_unit.bp
+++ b/units/UEB2302/UEB2302_unit.bp
@@ -91,6 +91,14 @@ UnitBlueprint{
     LifeBarOffset = 2.35,
     LifeBarSize = 5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UEB2303/UEB2303_unit.bp
+++ b/units/UEB2303/UEB2303_unit.bp
@@ -98,6 +98,14 @@ UnitBlueprint{
     LifeBarOffset = 0.8,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 2,

--- a/units/UEB2304/UEB2304_unit.bp
+++ b/units/UEB2304/UEB2304_unit.bp
@@ -89,7 +89,11 @@ UnitBlueprint{
     LifeBarSize = 1,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/UEB2305/UEB2305_unit.bp
+++ b/units/UEB2305/UEB2305_unit.bp
@@ -99,6 +99,14 @@ UnitBlueprint{
     LifeBarOffset = 1.25,
     LifeBarSize = 2.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         HorizontalSkirt = true,

--- a/units/UEB2401/UEB2401_unit.bp
+++ b/units/UEB2401/UEB2401_unit.bp
@@ -99,6 +99,14 @@ UnitBlueprint{
     LifeBarOffset = 2.9,
     LifeBarSize = 6.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.2,

--- a/units/UEB3101/UEB3101_unit.bp
+++ b/units/UEB3101/UEB3101_unit.bp
@@ -130,6 +130,14 @@ UnitBlueprint{
     LifeBarOffset = 0.4,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.1,

--- a/units/UEB3102/UEB3102_unit.bp
+++ b/units/UEB3102/UEB3102_unit.bp
@@ -111,7 +111,14 @@ UnitBlueprint{
     LifeBarOffset = 0.2,
     LifeBarSize = 0.75,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         MeshExtentsOffsetY = -1.2,
         MeshExtentsX = 1.25,

--- a/units/UEB3104/UEB3104_unit.bp
+++ b/units/UEB3104/UEB3104_unit.bp
@@ -116,6 +116,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 2,

--- a/units/UEB3201/UEB3201_unit.bp
+++ b/units/UEB3201/UEB3201_unit.bp
@@ -126,6 +126,14 @@ UnitBlueprint{
     LifeBarOffset = 0.4,
     LifeBarSize = 1.1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.35,

--- a/units/UEB3202/UEB3202_unit.bp
+++ b/units/UEB3202/UEB3202_unit.bp
@@ -117,7 +117,14 @@ UnitBlueprint{
     LifeBarOffset = 0.4,
     LifeBarSize = 1,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         MeshExtentsOffsetY = -1.5,
         MeshExtentsX = 1.25,

--- a/units/UEB4201/UEB4201_unit.bp
+++ b/units/UEB4201/UEB4201_unit.bp
@@ -86,7 +86,11 @@ UnitBlueprint{
     LifeBarSize = 1.25,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/UEB4202/UEB4202_unit.bp
+++ b/units/UEB4202/UEB4202_unit.bp
@@ -126,6 +126,14 @@ UnitBlueprint{
     LifeBarOffset = 0.9,
     LifeBarSize = 2.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UEB4203/UEB4203_unit.bp
+++ b/units/UEB4203/UEB4203_unit.bp
@@ -97,6 +97,14 @@ UnitBlueprint{
     LifeBarOffset = 1.2,
     LifeBarSize = 2.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 3.2,

--- a/units/UEB4301/UEB4301_unit.bp
+++ b/units/UEB4301/UEB4301_unit.bp
@@ -110,6 +110,14 @@ UnitBlueprint{
     LifeBarOffset = 1.25,
     LifeBarSize = 3,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/UEB4302/UEB4302_unit.bp
+++ b/units/UEB4302/UEB4302_unit.bp
@@ -91,6 +91,14 @@ UnitBlueprint{
     LifeBarOffset = 0.85,
     LifeBarSize = 2,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 2,

--- a/units/UEB5101/UEB5101_unit.bp
+++ b/units/UEB5101/UEB5101_unit.bp
@@ -68,6 +68,14 @@ UnitBlueprint{
     LifeBarSize = 0.8,
     Physics = {
         AlwaysAlignToTerrain = true,
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MaxGroundVariation = 50,
         MeshExtentsX = 1.1,

--- a/units/UEB5102/UEB5102_unit.bp
+++ b/units/UEB5102/UEB5102_unit.bp
@@ -45,6 +45,14 @@ UnitBlueprint{
     LifeBarRender = false,
     LifeBarSize = 0,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",
         SkirtOffsetX = 0,

--- a/units/UEB5103/UEB5103_unit.bp
+++ b/units/UEB5103/UEB5103_unit.bp
@@ -50,7 +50,11 @@ UnitBlueprint{
     LifeBarSize = 1,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/UEB5202/UEB5202_unit.bp
+++ b/units/UEB5202/UEB5202_unit.bp
@@ -95,6 +95,14 @@ UnitBlueprint{
     LifeBarOffset = 1.4,
     LifeBarSize = 3,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 3.2,

--- a/units/UEB5204/UEB5204_unit.bp
+++ b/units/UEB5204/UEB5204_unit.bp
@@ -43,6 +43,14 @@ UnitBlueprint{
     Intel = { VisionRadius = 0 },
     LifeBarHeight = 0.075,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/UEB5208/UEB5208_unit.bp
+++ b/units/UEB5208/UEB5208_unit.bp
@@ -45,6 +45,10 @@ UnitBlueprint{
         BuildOnLayerCaps = {
             LAYER_Air = true,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",

--- a/units/URA0001/URA0001_unit.bp
+++ b/units/URA0001/URA0001_unit.bp
@@ -90,6 +90,14 @@ UnitBlueprint{
     LifeBarSize = 0.01,
     Physics = {
         BankingSlope = 0.5,
+        BuildOnLayerCaps = {
+            LAYER_Air = true,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         Elevation = 3,
         MaxAcceleration = 10.5,

--- a/units/URA0004/URA0004_unit.bp
+++ b/units/URA0004/URA0004_unit.bp
@@ -78,6 +78,14 @@ UnitBlueprint{
     },
     Physics = {
         BankingSlope = 0.5,
+        BuildOnLayerCaps = {
+            LAYER_Air = true,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         Elevation = 5,
         MaxAcceleration = 10.5,

--- a/units/URB0101/URB0101_unit.bp
+++ b/units/URB0101/URB0101_unit.bp
@@ -140,6 +140,14 @@ UnitBlueprint{
     LifeBarOffset = 2.15,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/URB0102/URB0102_unit.bp
+++ b/units/URB0102/URB0102_unit.bp
@@ -142,6 +142,14 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/URB0103/URB0103_unit.bp
+++ b/units/URB0103/URB0103_unit.bp
@@ -133,7 +133,14 @@ UnitBlueprint{
     LifeBarOffset = 6,
     LifeBarSize = 4,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",

--- a/units/URB0201/URB0201_unit.bp
+++ b/units/URB0201/URB0201_unit.bp
@@ -146,6 +146,14 @@ UnitBlueprint{
     LifeBarOffset = 2.15,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/URB0202/URB0202_unit.bp
+++ b/units/URB0202/URB0202_unit.bp
@@ -145,6 +145,14 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/URB0203/URB0203_unit.bp
+++ b/units/URB0203/URB0203_unit.bp
@@ -138,7 +138,14 @@ UnitBlueprint{
     LifeBarOffset = 6,
     LifeBarSize = 4.5,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",

--- a/units/URB0301/URB0301_unit.bp
+++ b/units/URB0301/URB0301_unit.bp
@@ -145,6 +145,14 @@ UnitBlueprint{
     LifeBarOffset = 2.25,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/URB0302/URB0302_unit.bp
+++ b/units/URB0302/URB0302_unit.bp
@@ -144,6 +144,14 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/URB0303/URB0303_unit.bp
+++ b/units/URB0303/URB0303_unit.bp
@@ -137,7 +137,14 @@ UnitBlueprint{
     LifeBarOffset = 6,
     LifeBarSize = 4.75,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",

--- a/units/URB0304/URB0304_unit.bp
+++ b/units/URB0304/URB0304_unit.bp
@@ -119,6 +119,14 @@ UnitBlueprint{
     LifeBarOffset = 2.85,
     LifeBarSize = 6,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/URB1101/URB1101_unit.bp
+++ b/units/URB1101/URB1101_unit.bp
@@ -89,6 +89,14 @@ UnitBlueprint{
     LifeBarOffset = 0.4,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/URB1102/URB1102_unit.bp
+++ b/units/URB1102/URB1102_unit.bp
@@ -87,8 +87,12 @@ UnitBlueprint{
     LifeBarSize = 2.5,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnHydrocarbonDeposit",
         DragCoefficient = 0.2,

--- a/units/URB1103/URB1103_unit.bp
+++ b/units/URB1103/URB1103_unit.bp
@@ -94,8 +94,12 @@ UnitBlueprint{
     Physics = {
         AlwaysAlignToTerrain = true,
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnMassDeposit",
         DragCoefficient = 0.2,

--- a/units/URB1104/URB1104_unit.bp
+++ b/units/URB1104/URB1104_unit.bp
@@ -84,6 +84,14 @@ UnitBlueprint{
     LifeBarOffset = 0.35,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/URB1105/URB1105_unit.bp
+++ b/units/URB1105/URB1105_unit.bp
@@ -100,6 +100,14 @@ UnitBlueprint{
     LifeBarOffset = 0.45,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/URB1106/URB1106_unit.bp
+++ b/units/URB1106/URB1106_unit.bp
@@ -99,8 +99,12 @@ UnitBlueprint{
     LifeBarSize = 1,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         DragCoefficient = 0.2,
         FlattenSkirt = true,

--- a/units/URB1201/URB1201_unit.bp
+++ b/units/URB1201/URB1201_unit.bp
@@ -93,6 +93,14 @@ UnitBlueprint{
     LifeBarOffset = 1.1,
     LifeBarSize = 2.75,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/URB1202/URB1202_unit.bp
+++ b/units/URB1202/URB1202_unit.bp
@@ -96,8 +96,12 @@ UnitBlueprint{
     Physics = {
         AlwaysAlignToTerrain = true,
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnMassDeposit",
         DragCoefficient = 0.2,

--- a/units/URB1301/URB1301_unit.bp
+++ b/units/URB1301/URB1301_unit.bp
@@ -96,6 +96,14 @@ UnitBlueprint{
     LifeBarOffset = 2.25,
     LifeBarSize = 5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/URB1302/URB1302_unit.bp
+++ b/units/URB1302/URB1302_unit.bp
@@ -87,8 +87,12 @@ UnitBlueprint{
     Physics = {
         AlwaysAlignToTerrain = true,
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnMassDeposit",
         DragCoefficient = 0.2,

--- a/units/URB1303/URB1303_unit.bp
+++ b/units/URB1303/URB1303_unit.bp
@@ -92,6 +92,14 @@ UnitBlueprint{
     LifeBarOffset = 0.95,
     LifeBarSize = 2.75,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/URB2101/URB2101_unit.bp
+++ b/units/URB2101/URB2101_unit.bp
@@ -77,6 +77,14 @@ UnitBlueprint{
     LifeBarSize = 0.75,
     Physics = {
         AlwaysAlignToTerrain = true,
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",
         SkirtOffsetX = 0,

--- a/units/URB2104/URB2104_unit.bp
+++ b/units/URB2104/URB2104_unit.bp
@@ -94,7 +94,11 @@ UnitBlueprint{
     LifeBarSize = 0.75,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/URB2108/URB2108_unit.bp
+++ b/units/URB2108/URB2108_unit.bp
@@ -101,6 +101,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1.1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         HorizontalSkirt = true,

--- a/units/URB2109/URB2109_unit.bp
+++ b/units/URB2109/URB2109_unit.bp
@@ -97,7 +97,14 @@ UnitBlueprint{
     LifeBarOffset = 0.35,
     LifeBarSize = 1,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",
         SkirtOffsetX = 0,

--- a/units/URB2204/URB2204_unit.bp
+++ b/units/URB2204/URB2204_unit.bp
@@ -105,7 +105,11 @@ UnitBlueprint{
     LifeBarSize = 1.1,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/URB2205/URB2205_unit.bp
+++ b/units/URB2205/URB2205_unit.bp
@@ -116,7 +116,14 @@ UnitBlueprint{
     LifeBarOffset = 0.75,
     LifeBarSize = 1.5,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/URB2301/URB2301_unit.bp
+++ b/units/URB2301/URB2301_unit.bp
@@ -90,6 +90,14 @@ UnitBlueprint{
     LifeBarOffset = 0.45,
     LifeBarSize = 1.1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/URB2302/URB2302_unit.bp
+++ b/units/URB2302/URB2302_unit.bp
@@ -85,6 +85,14 @@ UnitBlueprint{
     LifeBarOffset = 2.15,
     LifeBarSize = 5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/URB2303/URB2303_unit.bp
+++ b/units/URB2303/URB2303_unit.bp
@@ -88,6 +88,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/URB2304/URB2304_unit.bp
+++ b/units/URB2304/URB2304_unit.bp
@@ -89,7 +89,11 @@ UnitBlueprint{
     LifeBarSize = 1.25,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/URB2305/URB2305_unit.bp
+++ b/units/URB2305/URB2305_unit.bp
@@ -107,6 +107,14 @@ UnitBlueprint{
     LifeBarOffset = 1.05,
     LifeBarSize = 3,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         HorizontalSkirt = true,

--- a/units/URB3101/URB3101_unit.bp
+++ b/units/URB3101/URB3101_unit.bp
@@ -126,6 +126,14 @@ UnitBlueprint{
     LifeBarOffset = 0.55,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/URB3102/URB3102_unit.bp
+++ b/units/URB3102/URB3102_unit.bp
@@ -111,7 +111,14 @@ UnitBlueprint{
     LifeBarOffset = 0.2,
     LifeBarSize = 0.75,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",
         SkirtOffsetX = 0,

--- a/units/URB3103/URB3103_unit.bp
+++ b/units/URB3103/URB3103_unit.bp
@@ -45,6 +45,14 @@ UnitBlueprint{
     LifeBarOffset = 0.3,
     LifeBarSize = 0.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",
         SkirtOffsetX = 0,

--- a/units/URB3104/URB3104_unit.bp
+++ b/units/URB3104/URB3104_unit.bp
@@ -116,6 +116,14 @@ UnitBlueprint{
     LifeBarOffset = 0.55,
     LifeBarSize = 1.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/URB3201/URB3201_unit.bp
+++ b/units/URB3201/URB3201_unit.bp
@@ -126,6 +126,14 @@ UnitBlueprint{
     LifeBarOffset = 0.55,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/URB3202/URB3202_unit.bp
+++ b/units/URB3202/URB3202_unit.bp
@@ -111,7 +111,14 @@ UnitBlueprint{
     LifeBarOffset = 0.25,
     LifeBarSize = 1,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",
         SkirtOffsetX = 0,

--- a/units/URB4201/URB4201_unit.bp
+++ b/units/URB4201/URB4201_unit.bp
@@ -86,7 +86,11 @@ UnitBlueprint{
     LifeBarSize = 1,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/URB4202/URB4202_unit.bp
+++ b/units/URB4202/URB4202_unit.bp
@@ -134,6 +134,14 @@ UnitBlueprint{
     LifeBarOffset = 1.25,
     LifeBarSize = 3.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/URB4203/URB4203_unit.bp
+++ b/units/URB4203/URB4203_unit.bp
@@ -97,6 +97,14 @@ UnitBlueprint{
     LifeBarOffset = 1.15,
     LifeBarSize = 2.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/URB4204/URB4204_unit.bp
+++ b/units/URB4204/URB4204_unit.bp
@@ -125,6 +125,14 @@ UnitBlueprint{
     LifeBarOffset = 1.25,
     LifeBarSize = 3.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/URB4205/URB4205_unit.bp
+++ b/units/URB4205/URB4205_unit.bp
@@ -126,6 +126,14 @@ UnitBlueprint{
     LifeBarOffset = 1.25,
     LifeBarSize = 3.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/URB4206/URB4206_unit.bp
+++ b/units/URB4206/URB4206_unit.bp
@@ -130,6 +130,14 @@ UnitBlueprint{
     LifeBarOffset = 1.25,
     LifeBarSize = 3.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/URB4207/URB4207_unit.bp
+++ b/units/URB4207/URB4207_unit.bp
@@ -117,6 +117,14 @@ UnitBlueprint{
     LifeBarOffset = 1.25,
     LifeBarSize = 3.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/URB4302/URB4302_unit.bp
+++ b/units/URB4302/URB4302_unit.bp
@@ -101,6 +101,14 @@ UnitBlueprint{
     LifeBarOffset = 0.85,
     LifeBarSize = 2,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/URB5101/URB5101_unit.bp
+++ b/units/URB5101/URB5101_unit.bp
@@ -66,6 +66,14 @@ UnitBlueprint{
     LifeBarSize = 0.8,
     Physics = {
         AlwaysAlignToTerrain = true,
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MaxGroundVariation = 50,
         MotionType = "RULEUMT_None",

--- a/units/URB5102/URB5102_unit.bp
+++ b/units/URB5102/URB5102_unit.bp
@@ -45,6 +45,14 @@ UnitBlueprint{
     LifeBarRender = false,
     LifeBarSize = 0,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",
         SkirtOffsetX = 0,

--- a/units/URB5103/URB5103_unit.bp
+++ b/units/URB5103/URB5103_unit.bp
@@ -50,6 +50,14 @@ UnitBlueprint{
     LifeBarOffset = 0.05,
     LifeBarSize = 0.75,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",
         SkirtOffsetX = 0,

--- a/units/URB5202/URB5202_unit.bp
+++ b/units/URB5202/URB5202_unit.bp
@@ -93,6 +93,14 @@ UnitBlueprint{
     LifeBarOffset = 1.7,
     LifeBarSize = 3.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/URB5204/URB5204_unit.bp
+++ b/units/URB5204/URB5204_unit.bp
@@ -43,6 +43,14 @@ UnitBlueprint{
     Intel = { VisionRadius = 0 },
     LifeBarHeight = 0.075,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/XAB1401/XAB1401_unit.bp
+++ b/units/XAB1401/XAB1401_unit.bp
@@ -106,6 +106,14 @@ UnitBlueprint{
     LifeBarOffset = 3.1,
     LifeBarSize = 5.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.2,

--- a/units/XAB2307/XAB2307_unit.bp
+++ b/units/XAB2307/XAB2307_unit.bp
@@ -96,6 +96,14 @@ UnitBlueprint{
     LifeBarOffset = 3.8,
     LifeBarSize = 5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.2,

--- a/units/XAB3301/XAB3301_unit.bp
+++ b/units/XAB3301/XAB3301_unit.bp
@@ -110,6 +110,14 @@ UnitBlueprint{
     LifeBarOffset = 0.9,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.5,

--- a/units/XEB0104/XEB0104_unit.bp
+++ b/units/XEB0104/XEB0104_unit.bp
@@ -141,6 +141,14 @@ UnitBlueprint{
     LifeBarOffset = 0.35,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 2,

--- a/units/XEB0204/XEB0204_unit.bp
+++ b/units/XEB0204/XEB0204_unit.bp
@@ -139,6 +139,14 @@ UnitBlueprint{
     LifeBarOffset = 0.35,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 2,

--- a/units/XEB2306/XEB2306_unit.bp
+++ b/units/XEB2306/XEB2306_unit.bp
@@ -89,6 +89,14 @@ UnitBlueprint{
     LifeBarOffset = 0.7,
     LifeBarSize = 0.9,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.1,

--- a/units/XEB2402/XEB2402_unit.bp
+++ b/units/XEB2402/XEB2402_unit.bp
@@ -108,6 +108,14 @@ UnitBlueprint{
     LifeBarOffset = 2.9,
     LifeBarSize = 5.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.2,

--- a/units/XRB0104/XRB0104_unit.bp
+++ b/units/XRB0104/XRB0104_unit.bp
@@ -137,6 +137,14 @@ UnitBlueprint{
     LifeBarOffset = 1.1,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 2,

--- a/units/XRB0204/XRB0204_unit.bp
+++ b/units/XRB0204/XRB0204_unit.bp
@@ -138,6 +138,14 @@ UnitBlueprint{
     LifeBarOffset = 1.1,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 2,

--- a/units/XRB0304/XRB0304_unit.bp
+++ b/units/XRB0304/XRB0304_unit.bp
@@ -133,6 +133,14 @@ UnitBlueprint{
     LifeBarOffset = 1.1,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 2,

--- a/units/XRB2308/XRB2308_unit.bp
+++ b/units/XRB2308/XRB2308_unit.bp
@@ -111,7 +111,14 @@ UnitBlueprint{
     LifeBarOffset = 1.4,
     LifeBarSize = 2.5,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/XRB2309/XRB2309_unit.bp
+++ b/units/XRB2309/XRB2309_unit.bp
@@ -117,7 +117,14 @@ UnitBlueprint{
     LifeBarOffset = 1.4,
     LifeBarSize = 2.5,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Sub = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = true,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/XRB3301/XRB3301_unit.bp
+++ b/units/XRB3301/XRB3301_unit.bp
@@ -99,6 +99,14 @@ UnitBlueprint{
     LifeBarOffset = 2.4,
     LifeBarSize = 5.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MotionType = "RULEUMT_None",

--- a/units/XRL0002/XRL0002_unit.bp
+++ b/units/XRL0002/XRL0002_unit.bp
@@ -72,6 +72,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         AlwaysAlignToTerrain = true,
         MotionType = "RULEUMT_None",

--- a/units/XRL0003/XRL0003_unit.bp
+++ b/units/XRL0003/XRL0003_unit.bp
@@ -73,8 +73,12 @@ UnitBlueprint{
     LifeBarSize = 1,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         DragCoefficient = 0.2,
         AlwaysAlignToTerrain = true,

--- a/units/XRL0004/XRL0004_unit.bp
+++ b/units/XRL0004/XRL0004_unit.bp
@@ -72,6 +72,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         AlwaysAlignToTerrain = true,
         MotionType = "RULEUMT_None",

--- a/units/XRL0005/XRL0005_unit.bp
+++ b/units/XRL0005/XRL0005_unit.bp
@@ -72,6 +72,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         AlwaysAlignToTerrain = true,
         MotionType = "RULEUMT_None",

--- a/units/XSB0101/XSB0101_unit.bp
+++ b/units/XSB0101/XSB0101_unit.bp
@@ -155,6 +155,14 @@ UnitBlueprint{
     LifeBarOffset = 1.9,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/XSB0102/XSB0102_unit.bp
+++ b/units/XSB0102/XSB0102_unit.bp
@@ -149,6 +149,14 @@ UnitBlueprint{
     LifeBarOffset = 1.55,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/XSB0103/XSB0103_unit.bp
+++ b/units/XSB0103/XSB0103_unit.bp
@@ -139,7 +139,14 @@ UnitBlueprint{
     LifeBarOffset = 6.5,
     LifeBarSize = 4,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MeshExtentsX = 5,

--- a/units/XSB0201/XSB0201_unit.bp
+++ b/units/XSB0201/XSB0201_unit.bp
@@ -149,6 +149,14 @@ UnitBlueprint{
     LifeBarOffset = 1.95,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/XSB0202/XSB0202_unit.bp
+++ b/units/XSB0202/XSB0202_unit.bp
@@ -148,6 +148,14 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/XSB0203/XSB0203_unit.bp
+++ b/units/XSB0203/XSB0203_unit.bp
@@ -146,7 +146,14 @@ UnitBlueprint{
     LifeBarOffset = 6.5,
     LifeBarSize = 4.5,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MeshExtentsX = 5,

--- a/units/XSB0301/XSB0301_unit.bp
+++ b/units/XSB0301/XSB0301_unit.bp
@@ -147,6 +147,14 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/XSB0302/XSB0302_unit.bp
+++ b/units/XSB0302/XSB0302_unit.bp
@@ -152,6 +152,14 @@ UnitBlueprint{
     LifeBarOffset = 2.1,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/XSB0303/XSB0303_unit.bp
+++ b/units/XSB0303/XSB0303_unit.bp
@@ -145,7 +145,14 @@ UnitBlueprint{
     LifeBarOffset = 6.7,
     LifeBarSize = 4.75,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MeshExtentsX = 5,

--- a/units/XSB0304/XSB0304_unit.bp
+++ b/units/XSB0304/XSB0304_unit.bp
@@ -127,6 +127,14 @@ UnitBlueprint{
     LifeBarOffset = 2.65,
     LifeBarSize = 5.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 7.5,

--- a/units/XSB1101/XSB1101_unit.bp
+++ b/units/XSB1101/XSB1101_unit.bp
@@ -92,6 +92,14 @@ UnitBlueprint{
     LifeBarOffset = 0.55,
     LifeBarSize = 0.9,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1,

--- a/units/XSB1102/XSB1102_unit.bp
+++ b/units/XSB1102/XSB1102_unit.bp
@@ -93,8 +93,12 @@ UnitBlueprint{
     LifeBarSize = 3,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnHydrocarbonDeposit",
         DragCoefficient = 0.2,

--- a/units/XSB1103/XSB1103_unit.bp
+++ b/units/XSB1103/XSB1103_unit.bp
@@ -100,8 +100,12 @@ UnitBlueprint{
     Physics = {
         AlwaysAlignToTerrain = true,
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnMassDeposit",
         DragCoefficient = 0.2,

--- a/units/XSB1104/XSB1104_unit.bp
+++ b/units/XSB1104/XSB1104_unit.bp
@@ -88,6 +88,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1.1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1,

--- a/units/XSB1105/XSB1105_unit.bp
+++ b/units/XSB1105/XSB1105_unit.bp
@@ -98,6 +98,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1.1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.1,

--- a/units/XSB1106/XSB1106_unit.bp
+++ b/units/XSB1106/XSB1106_unit.bp
@@ -99,8 +99,12 @@ UnitBlueprint{
     LifeBarSize = 0.9,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         DragCoefficient = 0.2,
         FlattenSkirt = true,

--- a/units/XSB1201/XSB1201_unit.bp
+++ b/units/XSB1201/XSB1201_unit.bp
@@ -110,6 +110,14 @@ UnitBlueprint{
     LifeBarOffset = 0.9,
     LifeBarSize = 3,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 3.5,

--- a/units/XSB1202/XSB1202_unit.bp
+++ b/units/XSB1202/XSB1202_unit.bp
@@ -102,8 +102,12 @@ UnitBlueprint{
     Physics = {
         AlwaysAlignToTerrain = true,
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnMassDeposit",
         DragCoefficient = 0.2,

--- a/units/XSB1301/XSB1301_unit.bp
+++ b/units/XSB1301/XSB1301_unit.bp
@@ -108,6 +108,14 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/XSB1302/XSB1302_unit.bp
+++ b/units/XSB1302/XSB1302_unit.bp
@@ -92,8 +92,12 @@ UnitBlueprint{
     Physics = {
         AlwaysAlignToTerrain = true,
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
             LAYER_Seabed = true,
+            LAYER_Sub = false,
+            LAYER_Water = false,
         },
         BuildRestriction = "RULEUBR_OnMassDeposit",
         DragCoefficient = 0.2,

--- a/units/XSB1303/XSB1303_unit.bp
+++ b/units/XSB1303/XSB1303_unit.bp
@@ -101,6 +101,14 @@ UnitBlueprint{
     LifeBarOffset = 1.6,
     LifeBarSize = 2.7,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/XSB2101/XSB2101_unit.bp
+++ b/units/XSB2101/XSB2101_unit.bp
@@ -90,6 +90,14 @@ UnitBlueprint{
     LifeBarSize = 0.9,
     Physics = {
         AlwaysAlignToTerrain = true,
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MeshExtentsX = 1,
         MeshExtentsY = 1.1,

--- a/units/XSB2104/XSB2104_unit.bp
+++ b/units/XSB2104/XSB2104_unit.bp
@@ -104,7 +104,11 @@ UnitBlueprint{
     LifeBarSize = 0.9,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/XSB2108/XSB2108_unit.bp
+++ b/units/XSB2108/XSB2108_unit.bp
@@ -122,6 +122,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         HorizontalSkirt = true,

--- a/units/XSB2109/XSB2109_unit.bp
+++ b/units/XSB2109/XSB2109_unit.bp
@@ -112,7 +112,14 @@ UnitBlueprint{
     LifeBarOffset = 0.4,
     LifeBarSize = 0.9,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         MeshExtentsX = 1,
         MeshExtentsY = 0.75,

--- a/units/XSB2204/XSB2204_unit.bp
+++ b/units/XSB2204/XSB2204_unit.bp
@@ -113,7 +113,11 @@ UnitBlueprint{
     LifeBarSize = 0.8,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/XSB2205/XSB2205_unit.bp
+++ b/units/XSB2205/XSB2205_unit.bp
@@ -121,7 +121,14 @@ UnitBlueprint{
     LifeBarOffset = 1.1,
     LifeBarSize = 1.6,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.75,

--- a/units/XSB2301/XSB2301_unit.bp
+++ b/units/XSB2301/XSB2301_unit.bp
@@ -101,6 +101,14 @@ UnitBlueprint{
     LifeBarOffset = 0.75,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.75,

--- a/units/XSB2302/XSB2302_unit.bp
+++ b/units/XSB2302/XSB2302_unit.bp
@@ -102,6 +102,14 @@ UnitBlueprint{
     LifeBarOffset = 1.9,
     LifeBarSize = 4.4,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/XSB2303/XSB2303_unit.bp
+++ b/units/XSB2303/XSB2303_unit.bp
@@ -100,6 +100,14 @@ UnitBlueprint{
     LifeBarOffset = 0.65,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.75,

--- a/units/XSB2304/XSB2304_unit.bp
+++ b/units/XSB2304/XSB2304_unit.bp
@@ -112,7 +112,11 @@ UnitBlueprint{
     LifeBarSize = 1.25,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/XSB2305/XSB2305_unit.bp
+++ b/units/XSB2305/XSB2305_unit.bp
@@ -109,6 +109,14 @@ UnitBlueprint{
     LifeBarOffset = 1.3,
     LifeBarSize = 1.8,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         HorizontalSkirt = true,

--- a/units/XSB2401/XSB2401_unit.bp
+++ b/units/XSB2401/XSB2401_unit.bp
@@ -128,6 +128,14 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 5.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         HorizontalSkirt = true,

--- a/units/XSB3101/XSB3101_unit.bp
+++ b/units/XSB3101/XSB3101_unit.bp
@@ -130,6 +130,14 @@ UnitBlueprint{
     LifeBarOffset = 0.4,
     LifeBarSize = 1,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.25,

--- a/units/XSB3102/XSB3102_unit.bp
+++ b/units/XSB3102/XSB3102_unit.bp
@@ -110,7 +110,14 @@ UnitBlueprint{
     LifeBarOffset = 0.45,
     LifeBarSize = 0.75,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         DragCoefficient = 0.2,
         MeshExtentsX = 1,
         MeshExtentsY = 0.65,

--- a/units/XSB3104/XSB3104_unit.bp
+++ b/units/XSB3104/XSB3104_unit.bp
@@ -137,6 +137,14 @@ UnitBlueprint{
     LifeBarOffset = 0.5,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.5,

--- a/units/XSB3201/XSB3201_unit.bp
+++ b/units/XSB3201/XSB3201_unit.bp
@@ -140,6 +140,14 @@ UnitBlueprint{
     LifeBarOffset = 0.45,
     LifeBarSize = 1.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 1.5,

--- a/units/XSB4201/XSB4201_unit.bp
+++ b/units/XSB4201/XSB4201_unit.bp
@@ -108,7 +108,11 @@ UnitBlueprint{
     LifeBarSize = 0.75,
     Physics = {
         BuildOnLayerCaps = {
+            LAYER_Air = false,
             LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
             LAYER_Water = true,
         },
         DragCoefficient = 0.2,

--- a/units/XSB4202/XSB4202_unit.bp
+++ b/units/XSB4202/XSB4202_unit.bp
@@ -137,6 +137,14 @@ UnitBlueprint{
     LifeBarOffset = 1.2,
     LifeBarSize = 2.25,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/XSB4203/XSB4203_unit.bp
+++ b/units/XSB4203/XSB4203_unit.bp
@@ -113,6 +113,14 @@ UnitBlueprint{
     LifeBarOffset = 0.75,
     LifeBarSize = 1.4,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 3,

--- a/units/XSB4301/XSB4301_unit.bp
+++ b/units/XSB4301/XSB4301_unit.bp
@@ -123,6 +123,14 @@ UnitBlueprint{
     LifeBarOffset = 1.1,
     LifeBarSize = 2.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/XSB4302/XSB4302_unit.bp
+++ b/units/XSB4302/XSB4302_unit.bp
@@ -99,6 +99,14 @@ UnitBlueprint{
     LifeBarOffset = 1,
     LifeBarSize = 1.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 2,

--- a/units/XSB5101/XSB5101_unit.bp
+++ b/units/XSB5101/XSB5101_unit.bp
@@ -82,6 +82,14 @@ UnitBlueprint{
     LifeBarSize = 0.8,
     Physics = {
         AlwaysAlignToTerrain = true,
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MaxGroundVariation = 50,
         MeshExtentsX = 1.5,

--- a/units/XSB5102/XSB5102_unit.bp
+++ b/units/XSB5102/XSB5102_unit.bp
@@ -45,6 +45,14 @@ UnitBlueprint{
     LifeBarRender = false,
     LifeBarSize = 0,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",
         SkirtOffsetX = 0,

--- a/units/XSB5202/XSB5202_unit.bp
+++ b/units/XSB5202/XSB5202_unit.bp
@@ -107,6 +107,14 @@ UnitBlueprint{
     LifeBarOffset = 1.15,
     LifeBarSize = 2.7,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MeshExtentsX = 3,

--- a/units/ZAB9501/ZAB9501_unit.bp
+++ b/units/ZAB9501/ZAB9501_unit.bp
@@ -143,6 +143,7 @@ UnitBlueprint{
     LifeBarOffset = 1.95,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = { LAYER_Land = true },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZAB9502/ZAB9502_unit.bp
+++ b/units/ZAB9502/ZAB9502_unit.bp
@@ -142,6 +142,14 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZAB9503/ZAB9503_unit.bp
+++ b/units/ZAB9503/ZAB9503_unit.bp
@@ -139,7 +139,14 @@ UnitBlueprint{
     LifeBarOffset = 6.5,
     LifeBarSize = 4.5,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MeshExtentsX = 5,

--- a/units/ZAB9601/ZAB9601_unit.bp
+++ b/units/ZAB9601/ZAB9601_unit.bp
@@ -139,6 +139,7 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = { LAYER_Land = true },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZAB9602/ZAB9602_unit.bp
+++ b/units/ZAB9602/ZAB9602_unit.bp
@@ -140,6 +140,14 @@ UnitBlueprint{
     LifeBarOffset = 2.1,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZAB9603/ZAB9603_unit.bp
+++ b/units/ZAB9603/ZAB9603_unit.bp
@@ -136,7 +136,14 @@ UnitBlueprint{
     LifeBarOffset = 6.7,
     LifeBarSize = 4.75,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MeshExtentsX = 5,

--- a/units/ZEB9501/ZEB9501_unit.bp
+++ b/units/ZEB9501/ZEB9501_unit.bp
@@ -141,6 +141,7 @@ UnitBlueprint{
     LifeBarOffset = 2.5,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = { LAYER_Land = true },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZEB9502/ZEB9502_unit.bp
+++ b/units/ZEB9502/ZEB9502_unit.bp
@@ -143,6 +143,14 @@ UnitBlueprint{
     LifeBarOffset = 1.65,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZEB9503/ZEB9503_unit.bp
+++ b/units/ZEB9503/ZEB9503_unit.bp
@@ -140,7 +140,14 @@ UnitBlueprint{
     LifeBarOffset = 4.75,
     LifeBarSize = 4.5,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",

--- a/units/ZEB9601/ZEB9601_unit.bp
+++ b/units/ZEB9601/ZEB9601_unit.bp
@@ -139,6 +139,7 @@ UnitBlueprint{
     LifeBarOffset = 2.5,
     LifeBarSize = 4.75,
     Physics = {
+        BuildOnLayerCaps = { LAYER_Land = true },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZEB9602/ZEB9602_unit.bp
+++ b/units/ZEB9602/ZEB9602_unit.bp
@@ -139,6 +139,14 @@ UnitBlueprint{
     LifeBarOffset = 2.15,
     LifeBarSize = 4.75,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZEB9603/ZEB9603_unit.bp
+++ b/units/ZEB9603/ZEB9603_unit.bp
@@ -137,7 +137,14 @@ UnitBlueprint{
     LifeBarOffset = 4.75,
     LifeBarSize = 4.75,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",

--- a/units/ZRB9501/ZRB9501_unit.bp
+++ b/units/ZRB9501/ZRB9501_unit.bp
@@ -149,6 +149,7 @@ UnitBlueprint{
     LifeBarOffset = 2.15,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = { LAYER_Land = true },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZRB9502/ZRB9502_unit.bp
+++ b/units/ZRB9502/ZRB9502_unit.bp
@@ -148,6 +148,14 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZRB9503/ZRB9503_unit.bp
+++ b/units/ZRB9503/ZRB9503_unit.bp
@@ -141,7 +141,14 @@ UnitBlueprint{
     LifeBarOffset = 6,
     LifeBarSize = 4.5,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",

--- a/units/ZRB9601/ZRB9601_unit.bp
+++ b/units/ZRB9601/ZRB9601_unit.bp
@@ -146,6 +146,7 @@ UnitBlueprint{
     LifeBarOffset = 2.25,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = { LAYER_Land = true },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZRB9602/ZRB9602_unit.bp
+++ b/units/ZRB9602/ZRB9602_unit.bp
@@ -145,6 +145,14 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZRB9603/ZRB9603_unit.bp
+++ b/units/ZRB9603/ZRB9603_unit.bp
@@ -138,7 +138,14 @@ UnitBlueprint{
     LifeBarOffset = 6,
     LifeBarSize = 4.75,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MotionType = "RULEUMT_None",

--- a/units/ZSB9501/ZSB9501_unit.bp
+++ b/units/ZSB9501/ZSB9501_unit.bp
@@ -152,6 +152,7 @@ UnitBlueprint{
     LifeBarOffset = 1.95,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = { LAYER_Land = true },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZSB9502/ZSB9502_unit.bp
+++ b/units/ZSB9502/ZSB9502_unit.bp
@@ -151,6 +151,14 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZSB9503/ZSB9503_unit.bp
+++ b/units/ZSB9503/ZSB9503_unit.bp
@@ -149,7 +149,14 @@ UnitBlueprint{
     LifeBarOffset = 6.5,
     LifeBarSize = 4.5,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MeshExtentsX = 5,

--- a/units/ZSB9601/ZSB9601_unit.bp
+++ b/units/ZSB9601/ZSB9601_unit.bp
@@ -148,6 +148,7 @@ UnitBlueprint{
     LifeBarOffset = 2,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = { LAYER_Land = true },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZSB9602/ZSB9602_unit.bp
+++ b/units/ZSB9602/ZSB9602_unit.bp
@@ -147,6 +147,14 @@ UnitBlueprint{
     LifeBarOffset = 2.1,
     LifeBarSize = 4.5,
     Physics = {
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = true,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = false,
+        },
         DragCoefficient = 0.2,
         FlattenSkirt = true,
         MaxGroundVariation = 1.1,

--- a/units/ZSB9603/ZSB9603_unit.bp
+++ b/units/ZSB9603/ZSB9603_unit.bp
@@ -146,7 +146,14 @@ UnitBlueprint{
     LifeBarOffset = 6.7,
     LifeBarSize = 4.75,
     Physics = {
-        BuildOnLayerCaps = { LAYER_Water = true },
+        BuildOnLayerCaps = {
+            LAYER_Air = false,
+            LAYER_Land = false,
+            LAYER_Orbit = false,
+            LAYER_Seabed = false,
+            LAYER_Sub = false,
+            LAYER_Water = true,
+        },
         ComputeRollOffPoint = true,
         DragCoefficient = 0.2,
         MeshExtentsX = 5,


### PR DESCRIPTION
## Description of the proposed changes
This reverts commit 2a6c6b7460cf4c0bc2c2c0bab28b451ee6ca0fd5.
Fixes #6926 

## Testing done on the proposed changes
None. Logically the fix should work because the bug is simple.

## Additional context
I merged a fix in Balthazar's wikigen repo for baking blueprints, so the workflow can be run to properly bake the blueprints this time, although bake-units.lua doesn't exist yet.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
