### PR TITLE
Fix transfer of manually built enhancements

### DIFF
--- a/changelog/snippets/fix.7162.md
+++ b/changelog/snippets/fix.7162.md
@@ -1,0 +1,1 @@
+- (#7162) Fix transfer of units with manually built enhancements.

--- a/engine/Sim/CAiBrain.lua
+++ b/engine/Sim/CAiBrain.lua
@@ -542,4 +542,12 @@ end
 function CAiBrain:TakeResource(type, amount)
 end
 
+--- Called by the engine when a unit fails unit transfer due to issues other than unit cap.
+---@type fun(self: moho.aibrain_methods)
+CAiBrain.OnFailedUnitTransfer = nil
+
+--- Called by the engine when a unit fails to create due to unit cap.
+---@type fun(self: Unit)
+CAiBrain.OnUnitCapLimitReached = nil
+
 return CAiBrain

--- a/engine/Sim/CAiBrain.lua
+++ b/engine/Sim/CAiBrain.lua
@@ -547,7 +547,7 @@ end
 CAiBrain.OnFailedUnitTransfer = nil
 
 --- Called by the engine when a unit fails to create due to unit cap.
----@type fun(self: Unit)
+---@type fun(self: moho.aibrain_methods)
 CAiBrain.OnUnitCapLimitReached = nil
 
 return CAiBrain

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -5,6 +5,7 @@
 -- upvalues for performance
 local ArmyBrains = ArmyBrains
 local GetCurrentCommandSource = GetCurrentCommandSource
+local TableEmpty = table.empty
 
 ------------------------------------------------------------------------------------------------------------------------
 --#region General Unit Transfer Scripts
@@ -324,13 +325,10 @@ function TransferUnitsOwnership(units, toArmy, captured, noRestrictions)
         local enhancements = bp.Enhancements
         if enhancements then
             local unitEnh = SimUnitEnhancements[unit.EntityId]
-            if unitEnh then
+            if not TableEmpty(unitEnh) then
                 activeEnhancements = {}
-                for i, enh in unitEnh do
-                    activeEnhancements[i] = enh
-                end
-                if not activeEnhancements[1] then
-                    activeEnhancements = nil
+                for slot, enh in unitEnh do
+                    activeEnhancements[slot] = enh
                 end
             end
         end

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -6,6 +6,7 @@
 local ArmyBrains = ArmyBrains
 local GetCurrentCommandSource = GetCurrentCommandSource
 local TableEmpty = table.empty
+local KillThread = KillThread
 
 ------------------------------------------------------------------------------------------------------------------------
 --#region General Unit Transfer Scripts
@@ -418,9 +419,15 @@ function TransferUnitsOwnership(units, toArmy, captured, noRestrictions)
         end
 
         if activeEnhancements then
-            for _, enh in activeEnhancements do
-                newUnit:CreateEnhancement(enh)
-            end
+            local thread = newUnit.OnStopBeingBuiltEnhancementsThread
+            if thread then KillThread(thread) end
+            newUnit.OnStopBeingBuiltEnhancementsThread = newUnit:ForkThread(function()
+                WaitTicks(1)
+                for _, enh in activeEnhancements do
+                    newUnit:CreateEnhancement(enh)
+                end
+                newUnit.OnStopBeingBuiltEnhancementsThread = nil
+            end)
         end
 
         local maxHealth = newUnit:GetMaxHealth()

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -426,8 +426,10 @@ function TransferUnitsOwnership(units, toArmy, captured, noRestrictions)
             else
                 newUnit.OnStopBeingBuiltEnhancementsThread = newUnit:ForkThread(function()
                     WaitTicks(1)
-                    for _, enh in activeEnhancements do
-                        newUnit:CreateEnhancement(enh)
+                    if newUnit and not newUnit.Dead and not IsDestroyed(newUnit) then
+                        for _, enh in activeEnhancements do
+                            newUnit:CreateEnhancement(enh)
+                        end
                     end
                     newUnit.OnStopBeingBuiltEnhancementsThread = nil
                 end)

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -326,7 +326,7 @@ function TransferUnitsOwnership(units, toArmy, captured, noRestrictions)
         local enhancements = bp.Enhancements
         if enhancements then
             local unitEnh = SimUnitEnhancements[unit.EntityId]
-            if not TableEmpty(unitEnh) then
+            if unitEnh then
                 activeEnhancements = {}
                 for slot, enh in unitEnh do
                     activeEnhancements[slot] = enh
@@ -421,13 +421,17 @@ function TransferUnitsOwnership(units, toArmy, captured, noRestrictions)
         if activeEnhancements then
             local thread = newUnit.OnStopBeingBuiltEnhancementsThread
             if thread then KillThread(thread) end
-            newUnit.OnStopBeingBuiltEnhancementsThread = newUnit:ForkThread(function()
-                WaitTicks(1)
-                for _, enh in activeEnhancements do
-                    newUnit:CreateEnhancement(enh)
-                end
+            if TableEmpty(activeEnhancements) then
                 newUnit.OnStopBeingBuiltEnhancementsThread = nil
-            end)
+            else
+                newUnit.OnStopBeingBuiltEnhancementsThread = newUnit:ForkThread(function()
+                    WaitTicks(1)
+                    for _, enh in activeEnhancements do
+                        newUnit:CreateEnhancement(enh)
+                    end
+                    newUnit.OnStopBeingBuiltEnhancementsThread = nil
+                end)
+            end
         end
 
         local maxHealth = newUnit:GetMaxHealth()

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -738,6 +738,7 @@ function GiveUnitsToPlayer(data, units)
     if manualShare == 'none' or table.empty(units) then
         return
     end
+    ---@cast units -nil
     local toArmy = data.To
     local owner = units[1].Army
     if OkayToMessWithArmy(owner) and IsAlly(owner, toArmy) then

--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -253,7 +253,7 @@ IntelComponent = ClassSimple {
 
             --- display progress
             for k = 1, ticks do
-                if IsDestroyed(self) then return end
+                if self.Dead or IsDestroyed(self) then return end
 
                 -- prevent changing work progress when we are doing work (such as an enhancement)
                 if not self.WorkItem then

--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -1,6 +1,8 @@
 local Buff = import("/lua/sim/buff.lua")
 local Entity = import("/lua/sim/entity.lua").Entity
 
+local IsDestroyed = IsDestroyed
+
 ---@class ShieldEffectsComponent : Unit
 ---@field Trash TrashBag
 ---@field ShieldEffectsBag TrashBag
@@ -251,6 +253,7 @@ IntelComponent = ClassSimple {
 
             --- display progress
             for k = 1, ticks do
+                if IsDestroyed(self) then return end
 
                 -- prevent changing work progress when we are doing work (such as an enhancement)
                 if not self.WorkItem then

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -2615,10 +2615,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         local bp = self.Blueprint
         if bp.Enhancements and bp.EnhancementPresetAssigned and bp.EnhancementPresetAssigned.Enhancements then
             for k, v in bp.EnhancementPresetAssigned.Enhancements do
-                -- Enhancements may already have been created by SimUtils.TransferUnitsOwnership
-                if not self:HasEnhancement(v) then
-                    self:CreateEnhancement(v)
-                end
+                self:CreateEnhancement(v)
             end
         end
     end,

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -175,6 +175,7 @@ local cUnitGetBuildRate = cUnit.GetBuildRate
 ---@field ImmuneToStun? boolean
 ---@field Anims? Animator[] # Animators that get stopped when a unit is stunned. Not used in FAF.
 ---@field IsBeingTransferred? boolean
+---@field OnStopBeingBuiltEnhancementsThread thread?
 Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUnitComponent, FastDecayComponent) {
 
     IsUnit = true,
@@ -2490,7 +2491,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         end
 
         if bp.EnhancementPresetAssigned then
-            self:ForkThread(self.CreatePresetEnhancementsThread)
+            self.OnStopBeingBuiltEnhancementsThread = self:ForkThread(self.CreatePresetEnhancementsThread)
         end
 
         -- Don't try sending a Notify message from here if we're an ACU
@@ -2630,6 +2631,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         if self and not self.Dead then
             self:CreatePresetEnhancements()
         end
+        self.OnStopBeingBuiltEnhancementsThread = nil
     end,
 
     ---@param self Unit

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -3324,6 +3324,7 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
         end
 
         self:RequestRefreshUI()
+        return true
     end,
 
     ---@param self Unit


### PR DESCRIPTION
## Description of the proposed changes
Fixes #5233

The system was broken in 3 parts:

1. The active enhancements table was always cleared due to checking t[1] instead of table.empty(t), causing enhancements to never be transferred.
2. Preset enhancements happened 1 tick after OnCreate so they overrode active enhancements in enhancement sync
3. Preset enhancements and transferred enhancements did not check for each other in any way so it was possible to have more than 1 enhancement in a slot

- 1. is fixed by using table.empty
- 2. and 3. are fixed by overriding the thread that creates preset enhancements with a similar one that creates the active enhancements instead of the preset ones

## Testing done on the proposed changes
1. Spawn paragon/buildpower and a preset:
```
   CreateUnitAtMouse('xab1401', 0,  -11.47,   -7.75, -0.00000)
   CreateUnitAtMouse('url0001', 0,    8.53,    5.25,  0.78058)
   for i = 1, 100 do
     CreateUnitAtMouse('xrb0304', 0,   -2.47,    1.25, -0.00000)
   end
   CreateUnitAtMouse('url0301_engineer', 0,    5.40,    1.24, -0.51868)
```
2. upgrade the preset replacing one of its upgrades (EMP for the example)
3. transfer it using the following command:
```
ConExecute([[SimLua 
ForkThread(function ()
    local focus = GetFocusArmy()
    local f = import('/lua/SimUtils.lua').TransferUnitsOwnership
    local units = DebugGetSelection()
    units = f(units, focus + 1, false, true)
    WaitTicks(10)
    f(units, focus, false, true)
end)
]])
```
4. Verify that the UI shows the correct replacement upgrade that you built (ex: show EMP upgrade)
5. Verify that only the replacement upgrade is applied (ex: a cybran engineer preset with EMP replacing engineering should not have 98 buildpower).

This test works the same for ACU, except ACU has no conflict with presets to check.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unit transfers to preserve and correctly reapply blueprint enhancements after ownership changes.
  * Improved Intel recharge behavior: if a unit is destroyed mid-progress, updates stop immediately.
  * Fixed preset enhancement handling during unit build completion to ensure the deferred enhancement process is properly tracked and finishes reliably.
* **New Features**
  * Added new optional AI brain callbacks to handle failed unit transfers and unit-cap limit conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->